### PR TITLE
feat(security): propagate classified request context before provider …

### DIFF
--- a/docs/security/DELIVERY-PLAN.md
+++ b/docs/security/DELIVERY-PLAN.md
@@ -46,15 +46,6 @@ Translates the Phase 1 roadmap into concrete epics, issues, and acceptance crite
 - Migration warning logged once per engine instance
 - `LegacyPermissivePolicyEngine` available for explicit opt-in
 
-**Known gap — classified request propagation and response provenance:**
-The current engine does not yet propagate classified request context through
-every provider invocation path. `BEFORE_PROVIDER_INVOCATION` still does not
-consistently receive request classification, so full data-sovereignty
-enforcement is not implemented yet. Additionally, response-return hooks
-(raw, structured, streaming, cached) build enforcement contexts without
-`providerId`, `modelName`, or `dataClassification`, so `evaluateResponseReturn`
-cannot enforce local-boundary rules consistently.
-
 **Implemented in feat/classified-request-egress (PR #5):**
 Topic 1.6 ✅ — classified request context (via `ClassifiedDocument<T>`)
 propagated through all provider invocation paths for raw, structured,
@@ -63,14 +54,15 @@ and streaming execution.
 Topic 1.7 ✅ — classification egress enforced at `BEFORE_PROVIDER_INVOCATION`
 and `BEFORE_RESPONSE_RETURN` via `evaluateClassificationEgress()`.
 
-Topic 1.8 remains open — response provenance and cache-entry provenance.
-Classified cache reuse is disabled until Topic 1.8 is complete.
+Topic 1.8 remains open — cache-entry provenance. Classified cache reuse
+is deliberately disabled until Topic 1.8 is complete.
 
 Implementation note:
 - classification derives from `ClassifiedDocument<T>` wrapper
 - no annotation-based classification exists
 - no automatic rule-based classification exists yet
-- cache provenance remains intentionally deferred
+- ranking is exhaustive over the current enums; new values require an explicit rank
+- among equal classifications, the least-authoritative source is retained for conservative audit metadata (authority order: DECLARED > RULE_BASED > LOCAL_MODEL_ASSISTED)
 
 Remaining follow-up:
 - `Topic 1.8`: Propagate selected-provider provenance into response-return checks (raw, structured, streaming, cached). For cached values, store or reconstruct `providerId`, `modelName`, `dataClassification`, and `classificationSource`.

--- a/docs/security/DELIVERY-PLAN.md
+++ b/docs/security/DELIVERY-PLAN.md
@@ -55,13 +55,16 @@ enforcement is not implemented yet. Additionally, response-return hooks
 `providerId`, `modelName`, or `dataClassification`, so `evaluateResponseReturn`
 cannot enforce local-boundary rules consistently.
 
-**Implemented in feat/classified-request-egress:**
+**Implemented in feat/classified-request-egress (PR #5):**
 Topic 1.6 ✅ — classified request context (via `ClassifiedDocument<T>`)
-propagated through all provider invocation paths.
-Topic 1.7 ✅ — classification egress enforced at `BEFORE_PROVIDER_INVOCATION`.
+propagated through all provider invocation paths for raw, structured,
+and streaming execution.
 
-Topic 1.8 remains open — response provenance and cache-entry provenance need
-a separate PR.
+Topic 1.7 ✅ — classification egress enforced at `BEFORE_PROVIDER_INVOCATION`
+and `BEFORE_RESPONSE_RETURN` via `evaluateClassificationEgress()`.
+
+Topic 1.8 remains open — response provenance and cache-entry provenance.
+Classified cache reuse is disabled until Topic 1.8 is complete.
 
 Implementation note:
 - classification derives from `ClassifiedDocument<T>` wrapper

--- a/docs/security/DELIVERY-PLAN.md
+++ b/docs/security/DELIVERY-PLAN.md
@@ -55,9 +55,21 @@ enforcement is not implemented yet. Additionally, response-return hooks
 `providerId`, `modelName`, or `dataClassification`, so `evaluateResponseReturn`
 cannot enforce local-boundary rules consistently.
 
-Closing these gaps requires:
-- `Topic 1.6`: Propagate classified request context (payload/metadata, not a new annotation) through provider invocation for all paths.
-- `Topic 1.7`: Enforce egress policy at `BEFORE_PROVIDER_INVOCATION` once classification context is available.
+**Implemented in feat/classified-request-egress:**
+Topic 1.6 ✅ — classified request context (via `ClassifiedDocument<T>`)
+propagated through all provider invocation paths.
+Topic 1.7 ✅ — classification egress enforced at `BEFORE_PROVIDER_INVOCATION`.
+
+Topic 1.8 remains open — response provenance and cache-entry provenance need
+a separate PR.
+
+Implementation note:
+- classification derives from `ClassifiedDocument<T>` wrapper
+- no annotation-based classification exists
+- no automatic rule-based classification exists yet
+- cache provenance remains intentionally deferred
+
+Remaining follow-up:
 - `Topic 1.8`: Propagate selected-provider provenance into response-return checks (raw, structured, streaming, cached). For cached values, store or reconstruct `providerId`, `modelName`, `dataClassification`, and `classificationSource`.
 
 ---

--- a/tramai-core/src/main/kotlin/dev/tramai/core/model/ClassifiedDocument.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/model/ClassifiedDocument.kt
@@ -13,4 +13,6 @@ data class ClassifiedDocument<T>(
     val payload: T,
     val classification: DataClassification,
     val source: ClassificationSource,
-)
+) {
+    override fun toString(): String = "ClassifiedDocument(classification=$classification, source=$source)"
+}

--- a/tramai-core/src/main/kotlin/dev/tramai/core/model/ClassifiedDocument.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/model/ClassifiedDocument.kt
@@ -1,0 +1,16 @@
+package dev.tramai.core.model
+
+import dev.tramai.core.policy.ClassificationSource
+import dev.tramai.core.policy.DataClassification
+
+/**
+ * Wraps any payload with caller-supplied data-classification metadata.
+ *
+ * This metadata travels with the payload so engine and policy components can
+ * enforce request egress constraints without depending on security-module APIs.
+ */
+data class ClassifiedDocument<T>(
+    val payload: T,
+    val classification: DataClassification,
+    val source: ClassificationSource,
+)

--- a/tramai-core/src/test/kotlin/dev/tramai/core/model/ClassifiedDocumentTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/model/ClassifiedDocumentTest.kt
@@ -1,0 +1,69 @@
+package dev.tramai.core.model
+
+import dev.tramai.core.policy.ClassificationSource
+import dev.tramai.core.policy.DataClassification
+import org.assertj.core.api.Assertions.assertThat
+import kotlin.test.Test
+
+class ClassifiedDocumentTest {
+
+    @Test
+    fun `equal wrappers compare by payload classification and source`() {
+        val left = ClassifiedDocument(
+            payload = "payload",
+            classification = DataClassification.CONFIDENTIAL,
+            source = ClassificationSource.DECLARED,
+        )
+        val right = ClassifiedDocument(
+            payload = "payload",
+            classification = DataClassification.CONFIDENTIAL,
+            source = ClassificationSource.DECLARED,
+        )
+
+        assertThat(left).isEqualTo(right)
+        assertThat(left.hashCode()).isEqualTo(right.hashCode())
+    }
+
+    @Test
+    fun `different classification produces inequality`() {
+        val left = ClassifiedDocument(
+            payload = "payload",
+            classification = DataClassification.PUBLIC,
+            source = ClassificationSource.DECLARED,
+        )
+        val right = ClassifiedDocument(
+            payload = "payload",
+            classification = DataClassification.RESTRICTED,
+            source = ClassificationSource.DECLARED,
+        )
+
+        assertThat(left).isNotEqualTo(right)
+    }
+
+    @Test
+    fun `different source produces inequality`() {
+        val left = ClassifiedDocument(
+            payload = "payload",
+            classification = DataClassification.INTERNAL,
+            source = ClassificationSource.DECLARED,
+        )
+        val right = ClassifiedDocument(
+            payload = "payload",
+            classification = DataClassification.INTERNAL,
+            source = ClassificationSource.RULE_BASED,
+        )
+
+        assertThat(left).isNotEqualTo(right)
+    }
+
+    @Test
+    fun `nullable payload is supported`() {
+        val document = ClassifiedDocument<String?>(
+            payload = null,
+            classification = DataClassification.PUBLIC,
+            source = ClassificationSource.DECLARED,
+        )
+
+        assertThat(document.payload).isNull()
+    }
+}

--- a/tramai-core/src/test/kotlin/dev/tramai/core/model/ClassifiedDocumentTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/model/ClassifiedDocumentTest.kt
@@ -66,4 +66,18 @@ class ClassifiedDocumentTest {
 
         assertThat(document.payload).isNull()
     }
+
+    @Test
+    fun `toString redacts payload content`() {
+        val document = ClassifiedDocument(
+            payload = "sensitive",
+            classification = DataClassification.RESTRICTED,
+            source = ClassificationSource.DECLARED,
+        )
+
+        assertThat(document.toString()).doesNotContain("sensitive")
+        assertThat(document.toString())
+            .contains("classification=RESTRICTED")
+            .contains("source=DECLARED")
+    }
 }

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ExecutionSecurityContext.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ExecutionSecurityContext.kt
@@ -9,16 +9,35 @@ internal data class ExecutionSecurityContext(
     val classificationSource: ClassificationSource? = null,
 ) {
     companion object {
+        private val classificationRank = mapOf(
+            DataClassification.PUBLIC to 0,
+            DataClassification.INTERNAL to 1,
+            DataClassification.CONFIDENTIAL to 2,
+            DataClassification.RESTRICTED to 3,
+        )
+
+        private val sourcePrecedence = mapOf(
+            ClassificationSource.DECLARED to 2,
+            ClassificationSource.RULE_BASED to 1,
+            ClassificationSource.LOCAL_MODEL_ASSISTED to 0,
+        )
+
         fun fromArguments(args: Array<out Any?>): ExecutionSecurityContext {
             var highestClassification: DataClassification? = null
             var highestSource: ClassificationSource? = null
+            var highestSourceRank = Int.MAX_VALUE
 
             for (arg in args) {
-                if (arg is ClassifiedDocument<*> &&
-                    (highestClassification == null || arg.classification.ordinal > highestClassification.ordinal)
-                ) {
-                    highestClassification = arg.classification
-                    highestSource = arg.source
+                if (arg is ClassifiedDocument<*>) {
+                    val rank = classificationRank[arg.classification] ?: 0
+                    val highestRank = highestClassification?.let { classificationRank[it] ?: 0 } ?: -1
+                    val sourceRank = sourcePrecedence[arg.source] ?: Int.MAX_VALUE
+
+                    if (rank > highestRank || (rank == highestRank && sourceRank < highestSourceRank)) {
+                        highestClassification = arg.classification
+                        highestSource = arg.source
+                        highestSourceRank = sourceRank
+                    }
                 }
             }
 

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ExecutionSecurityContext.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ExecutionSecurityContext.kt
@@ -4,46 +4,70 @@ import dev.tramai.core.model.ClassifiedDocument
 import dev.tramai.core.policy.ClassificationSource
 import dev.tramai.core.policy.DataClassification
 
+/**
+ * Strict ordering for [DataClassification] used to pick the highest
+ * classification across multiple [ClassifiedDocument] arguments.
+ *
+ * Defined as an exhaustive `when` over the enum so that adding a new
+ * classification value becomes a compile-time error until its ranking
+ * semantics are explicitly defined.
+ */
+internal val DataClassification.rank: Int
+    get() = when (this) {
+        DataClassification.PUBLIC -> 0
+        DataClassification.INTERNAL -> 1
+        DataClassification.CONFIDENTIAL -> 2
+        DataClassification.RESTRICTED -> 3
+    }
+
+/**
+ * Lower value = LESS authoritative source.
+ *
+ * Authority order (most to least): DECLARED > RULE_BASED > LOCAL_MODEL_ASSISTED
+ *
+ * For conservative audit metadata we retain the LEAST authoritative source
+ * when multiple [ClassifiedDocument]s share the same highest
+ * classification. Exhaustive `when` so new sources require explicit ranking.
+ */
+internal val ClassificationSource.authorityRank: Int
+    get() = when (this) {
+        ClassificationSource.DECLARED -> 2
+        ClassificationSource.RULE_BASED -> 1
+        ClassificationSource.LOCAL_MODEL_ASSISTED -> 0
+    }
+
 internal data class ExecutionSecurityContext(
     val dataClassification: DataClassification? = null,
     val classificationSource: ClassificationSource? = null,
 ) {
     companion object {
-        private val classificationRank = mapOf(
-            DataClassification.PUBLIC to 0,
-            DataClassification.INTERNAL to 1,
-            DataClassification.CONFIDENTIAL to 2,
-            DataClassification.RESTRICTED to 3,
-        )
-
-        private val sourcePrecedence = mapOf(
-            ClassificationSource.DECLARED to 2,
-            ClassificationSource.RULE_BASED to 1,
-            ClassificationSource.LOCAL_MODEL_ASSISTED to 0,
-        )
-
         fun fromArguments(args: Array<out Any?>): ExecutionSecurityContext {
             var highestClassification: DataClassification? = null
-            var highestSource: ClassificationSource? = null
-            var highestSourceRank = -1
+            var leastAuthoritativeSource: ClassificationSource? = null
+            var leastAuthoritativeSourceRank = Int.MAX_VALUE
 
             for (arg in args) {
-                if (arg is ClassifiedDocument<*>) {
-                    val rank = classificationRank[arg.classification] ?: 0
-                    val highestRank = highestClassification?.let { classificationRank[it] ?: 0 } ?: -1
-                    val sourceRank = sourcePrecedence[arg.source] ?: -1
+                if (arg !is ClassifiedDocument<*>) continue
+                val rank = arg.classification.rank
+                val highestRank = highestClassification?.rank ?: -1
+                val sourceRank = arg.source.authorityRank
 
-                    if (rank > highestRank || (rank == highestRank && sourceRank > highestSourceRank)) {
+                when {
+                    rank > highestRank -> {
                         highestClassification = arg.classification
-                        highestSource = arg.source
-                        highestSourceRank = sourceRank
+                        leastAuthoritativeSource = arg.source
+                        leastAuthoritativeSourceRank = sourceRank
+                    }
+                    rank == highestRank && sourceRank < leastAuthoritativeSourceRank -> {
+                        leastAuthoritativeSource = arg.source
+                        leastAuthoritativeSourceRank = sourceRank
                     }
                 }
             }
 
             return ExecutionSecurityContext(
                 dataClassification = highestClassification,
-                classificationSource = highestSource,
+                classificationSource = leastAuthoritativeSource,
             )
         }
     }

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ExecutionSecurityContext.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ExecutionSecurityContext.kt
@@ -25,15 +25,15 @@ internal data class ExecutionSecurityContext(
         fun fromArguments(args: Array<out Any?>): ExecutionSecurityContext {
             var highestClassification: DataClassification? = null
             var highestSource: ClassificationSource? = null
-            var highestSourceRank = Int.MAX_VALUE
+            var highestSourceRank = -1
 
             for (arg in args) {
                 if (arg is ClassifiedDocument<*>) {
                     val rank = classificationRank[arg.classification] ?: 0
                     val highestRank = highestClassification?.let { classificationRank[it] ?: 0 } ?: -1
-                    val sourceRank = sourcePrecedence[arg.source] ?: Int.MAX_VALUE
+                    val sourceRank = sourcePrecedence[arg.source] ?: -1
 
-                    if (rank > highestRank || (rank == highestRank && sourceRank < highestSourceRank)) {
+                    if (rank > highestRank || (rank == highestRank && sourceRank > highestSourceRank)) {
                         highestClassification = arg.classification
                         highestSource = arg.source
                         highestSourceRank = sourceRank

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ExecutionSecurityContext.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ExecutionSecurityContext.kt
@@ -1,0 +1,31 @@
+package dev.tramai.engine
+
+import dev.tramai.core.model.ClassifiedDocument
+import dev.tramai.core.policy.ClassificationSource
+import dev.tramai.core.policy.DataClassification
+
+internal data class ExecutionSecurityContext(
+    val dataClassification: DataClassification? = null,
+    val classificationSource: ClassificationSource? = null,
+) {
+    companion object {
+        fun fromArguments(args: Array<out Any?>): ExecutionSecurityContext {
+            var highestClassification: DataClassification? = null
+            var highestSource: ClassificationSource? = null
+
+            for (arg in args) {
+                if (arg is ClassifiedDocument<*> &&
+                    (highestClassification == null || arg.classification.ordinal > highestClassification.ordinal)
+                ) {
+                    highestClassification = arg.classification
+                    highestSource = arg.source
+                }
+            }
+
+            return ExecutionSecurityContext(
+                dataClassification = highestClassification,
+                classificationSource = highestSource,
+            )
+        }
+    }
+}

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -24,6 +24,7 @@ import dev.tramai.core.model.ModelRequest
 import dev.tramai.core.model.ModelResponse
 import dev.tramai.core.model.StreamChunk
 import dev.tramai.core.model.ContentPart
+import dev.tramai.core.model.ClassifiedDocument
 import dev.tramai.core.model.ToolCall
 import dev.tramai.core.model.ToolDefinition
 import dev.tramai.core.model.ToolExecutionContext
@@ -774,15 +775,17 @@ private class TramaiInvocationHandler(
         val correlationId = java.util.UUID.randomUUID().toString()
 
         // Enforce BEFORE_RESPONSE_RETURN before returning cached value
-        operation.cachedValue(arguments)?.let { cached ->
-            policyHelper.enforce(
-                policyHelper.buildContext(
-                    enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
-                    correlationId = correlationId,
-                ).applySecurityContext(securityContext)
-                    .build()
-            )
-            return cached as String
+        if (securityContext.dataClassification == null) {
+            operation.cachedValue(arguments)?.let { cached ->
+                policyHelper.enforce(
+                    policyHelper.buildContext(
+                        enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
+                        correlationId = correlationId,
+                    ).applySecurityContext(securityContext)
+                        .build()
+                )
+                return cached as String
+            }
         }
 
         val messages = operation.initialMessages(arguments).toMutableList()
@@ -822,7 +825,11 @@ private class TramaiInvocationHandler(
         }
 
         result.observation.onCallCompleted(parseSuccess = null)
-        return result.response.content.also { operation.cacheValue(arguments, it) }
+        return result.response.content.also {
+            if (securityContext.dataClassification == null) {
+                operation.cacheValue(arguments, it)
+            }
+        }
     }
 
     private suspend fun executeStructured(
@@ -839,15 +846,17 @@ private class TramaiInvocationHandler(
         val correlationId = java.util.UUID.randomUUID().toString()
 
         // Enforce BEFORE_RESPONSE_RETURN before returning cached value
-        operation.cachedValue(arguments, contract.schemaJson)?.let { cached ->
-            policyHelper.enforce(
-                policyHelper.buildContext(
-                    enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
-                    correlationId = correlationId,
-                ).applySecurityContext(securityContext)
-                    .build()
-            )
-            return cached
+        if (securityContext.dataClassification == null) {
+            operation.cachedValue(arguments, contract.schemaJson)?.let { cached ->
+                policyHelper.enforce(
+                    policyHelper.buildContext(
+                        enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
+                        correlationId = correlationId,
+                    ).applySecurityContext(securityContext)
+                        .build()
+                )
+                return cached
+            }
         }
 
         val messages = operation.initialMessages(arguments, contract.schemaJson).toMutableList()
@@ -965,7 +974,9 @@ private class TramaiInvocationHandler(
                     conversationId = conversationId,
                     messagesBeforeCall = messagesBeforeCall,
                 )
-                operation.cacheValue(arguments, analysis.value, schemaJson)
+                if (securityContext.dataClassification == null) {
+                    operation.cacheValue(arguments, analysis.value, schemaJson)
+                }
 
                 analysis.value
             }
@@ -1700,7 +1711,10 @@ private data class OperationDefinition(
         systemAnnotations.isNotEmpty() || userAnnotations.isNotEmpty()
 
     private fun sanitizedArgumentValues(arguments: List<Any?>): List<String> = arguments.map { argument ->
-        val rendered = argument?.toString() ?: ""
+        val rendered = when (argument) {
+            is ClassifiedDocument<*> -> argument.payload?.toString() ?: ""
+            else -> argument?.toString() ?: ""
+        }
         promptSanitizer?.sanitize(rendered) ?: rendered
     }
 

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -263,6 +263,7 @@ private class TramaiInvocationHandler(
         tokenBudgetTracker: TokenBudgetTracker,
         conversationId: String?,
     ): Flow<StreamChunk> {
+        val securityContext = ExecutionSecurityContext.fromArguments(arguments.toTypedArray())
         val memoryInjection = injectMemoryMessages(operation, arguments, conversationId)
         val historySize = memoryInjection?.first?.size ?: 0
         val memoryMessages = memoryInjection?.second
@@ -275,7 +276,9 @@ private class TramaiInvocationHandler(
                 policyHelper.buildContext(
                     enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_PROVIDER_RESOLUTION,
                     correlationId = correlationId,
-                ).modelName(operation.operation.model).build()
+                ).modelName(operation.operation.model)
+                    .applySecurityContext(securityContext)
+                    .build()
             )
 
             val candidates = providerRegistry.resolveCandidates(operation.operation)
@@ -298,6 +301,7 @@ private class TramaiInvocationHandler(
                                 previousModelName = route.effectiveModelName,
                                 nextProviderId = nextRoute.providerName,
                                 reason = "circuit-breaker-open",
+                                securityContext = securityContext,
                             )
                         } catch (policyError: PolicyViolationException) {
                             policyError.addSuppressed(lastCircuitOpen)
@@ -314,6 +318,7 @@ private class TramaiInvocationHandler(
                         correlationId = correlationId,
                     ).providerId(route.providerName)
                         .modelName(route.effectiveModelName)
+                        .applySecurityContext(securityContext)
                         .build()
                 )
 
@@ -324,7 +329,10 @@ private class TramaiInvocationHandler(
                         policyHelper.buildContext(
                             enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_TOOL_EXPOSURE,
                             correlationId = correlationId,
-                        ).toolName(toolDef.name).toolSecurity(tool?.security).build()
+                        ).toolName(toolDef.name)
+                            .toolSecurity(tool?.security)
+                            .applySecurityContext(securityContext)
+                            .build()
                     )
                 }
 
@@ -333,7 +341,10 @@ private class TramaiInvocationHandler(
                     policyHelper.buildContext(
                         enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
                         correlationId = correlationId,
-                    ).providerId(route.providerName).modelName(route.effectiveModelName).build()
+                    ).providerId(route.providerName)
+                        .modelName(route.effectiveModelName)
+                        .applySecurityContext(securityContext)
+                        .build()
                 )
 
                 val streamCapable = route.provider as? StreamCapable
@@ -381,6 +392,7 @@ private class TramaiInvocationHandler(
                                     previousModelName = route.effectiveModelName,
                                     nextProviderId = nextRoute.providerName,
                                     reason = "streaming-startup-failure",
+                                    securityContext = securityContext,
                                 )
                             } catch (policyError: PolicyViolationException) {
                                 policyError.addSuppressed(result.error)
@@ -678,11 +690,12 @@ private class TramaiInvocationHandler(
         previousModelName: String?,
         nextProviderId: String,
         reason: String,
+        securityContext: ExecutionSecurityContext,
     ) {
         val ctx = policyHelper.buildContext(
             enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_FALLBACK,
             correlationId = correlationId,
-        )
+        ).applySecurityContext(securityContext)
         if (previousProviderId != null) ctx.providerId(previousProviderId)
         if (previousModelName != null) ctx.modelName(previousModelName)
         ctx.fallbackProviderId(nextProviderId)
@@ -757,6 +770,7 @@ private class TramaiInvocationHandler(
         tokenBudgetTracker: TokenBudgetTracker,
         conversationId: String?,
     ): String {
+        val securityContext = ExecutionSecurityContext.fromArguments(arguments.toTypedArray())
         val correlationId = java.util.UUID.randomUUID().toString()
 
         // Enforce BEFORE_RESPONSE_RETURN before returning cached value
@@ -765,7 +779,8 @@ private class TramaiInvocationHandler(
                 policyHelper.buildContext(
                     enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
                     correlationId = correlationId,
-                ).build()
+                ).applySecurityContext(securityContext)
+                    .build()
             )
             return cached as String
         }
@@ -775,14 +790,23 @@ private class TramaiInvocationHandler(
             ?: (emptyList<Message>() to messages.toList())
         val effectiveMutableMessages = effectiveMessages.toMutableList()
 
-        val result = executeWithTools(operation, effectiveMutableMessages, tokenBudgetTracker, correlationId)
+        val result = executeWithTools(
+            operation = operation,
+            messages = effectiveMutableMessages,
+            tokenBudgetTracker = tokenBudgetTracker,
+            correlationId = correlationId,
+            securityContext = securityContext,
+        )
 
         // Enforce BEFORE_RESPONSE_RETURN
         policyHelper.enforce(
             policyHelper.buildContext(
                 enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
                 correlationId = correlationId,
-            ).build()
+            ).providerId(result.providerId)
+                .modelName(result.modelName)
+                .applySecurityContext(securityContext)
+                .build()
         )
 
         // Memory: persist response if chatMemory is configured
@@ -807,6 +831,7 @@ private class TramaiInvocationHandler(
         tokenBudgetTracker: TokenBudgetTracker,
         conversationId: String?,
     ): Any {
+        val securityContext = ExecutionSecurityContext.fromArguments(arguments.toTypedArray())
         val handler = structuredOutputHandler ?: throw ConfigurationException(
             "Structured return type ${operation.returnTypeDescription} requires a StructuredOutputHandler implementation from tramai-structured",
         )
@@ -819,7 +844,8 @@ private class TramaiInvocationHandler(
                 policyHelper.buildContext(
                     enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
                     correlationId = correlationId,
-                ).build()
+                ).applySecurityContext(securityContext)
+                    .build()
             )
             return cached
         }
@@ -843,6 +869,7 @@ private class TramaiInvocationHandler(
             tokenBudgetTracker = tokenBudgetTracker,
             conversationId = conversationId,
             correlationId = correlationId,
+            securityContext = securityContext,
         )
     }
 
@@ -856,6 +883,7 @@ private class TramaiInvocationHandler(
         tokenBudgetTracker: TokenBudgetTracker,
         conversationId: String?,
         correlationId: String,
+        securityContext: ExecutionSecurityContext,
     ): Any {
         val maxAttempts = operation.operation.maxRetries + 1
         val targetType = requireNotNull(operation.returnType) {
@@ -876,6 +904,7 @@ private class TramaiInvocationHandler(
                 attemptIndex = attemptIndex,
                 maxAttempts = maxAttempts,
                 correlationId = correlationId,
+                securityContext = securityContext,
             )
             if (value != null) {
                 return value
@@ -898,9 +927,16 @@ private class TramaiInvocationHandler(
         attemptIndex: Int,
         maxAttempts: Int,
         correlationId: String,
+        securityContext: ExecutionSecurityContext,
     ): Any? {
         val messagesBeforeCall = messages.size
-        val result = executeWithTools(operation, messages, tokenBudgetTracker, correlationId)
+        val result = executeWithTools(
+            operation = operation,
+            messages = messages,
+            tokenBudgetTracker = tokenBudgetTracker,
+            correlationId = correlationId,
+            securityContext = securityContext,
+        )
         return when (
             val analysis = handler.analyze(
                 rawResponse = result.response.content,
@@ -914,7 +950,10 @@ private class TramaiInvocationHandler(
                     policyHelper.buildContext(
                         enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
                         correlationId = correlationId,
-                    ).build()
+                    ).providerId(result.providerId)
+                        .modelName(result.modelName)
+                        .applySecurityContext(securityContext)
+                        .build()
                 )
 
                 result.observation.onCallCompleted(parseSuccess = true)
@@ -996,6 +1035,7 @@ private class TramaiInvocationHandler(
         messages: MutableList<Message>,
         tokenBudgetTracker: TokenBudgetTracker,
         correlationId: String,
+        securityContext: ExecutionSecurityContext,
     ): ProviderCallResult {
         val maxToolLoops = 5 // Guard against infinite tool loops
         val attemptCounter = AttemptCounter()
@@ -1005,6 +1045,7 @@ private class TramaiInvocationHandler(
                 messages = messages,
                 attemptCounter = attemptCounter,
                 correlationId = correlationId,
+                securityContext = securityContext,
             )
             try {
                 enforceTokenBudget(
@@ -1033,7 +1074,7 @@ private class TramaiInvocationHandler(
                 content = result.response.content,
                 toolCalls = toolCalls,
             )
-            processToolCalls(operation, toolCalls, messages, correlationId)
+            processToolCalls(operation, toolCalls, messages, correlationId, securityContext)
         }
         error("Exceeded maximum tool call loops ($maxToolLoops)")
     }
@@ -1043,13 +1084,14 @@ private class TramaiInvocationHandler(
         toolCalls: List<ToolCall>,
         messages: MutableList<Message>,
         correlationId: String,
+        securityContext: ExecutionSecurityContext,
     ) {
         for (toolCall in toolCalls) {
             val tool = toolRegistry.resolve(toolCall.name)
             val toolResult = if (tool == null) {
                 ToolResult.PermanentFailure("Tool '${toolCall.name}' not found")
             } else {
-                executeTool(tool, toolCall, operation, correlationId)
+                executeTool(tool, toolCall, operation, correlationId, securityContext)
             }
 
             // Enforce BEFORE_TOOL_RESULT_REINJECTION
@@ -1057,7 +1099,10 @@ private class TramaiInvocationHandler(
                 policyHelper.buildContext(
                     enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_TOOL_RESULT_REINJECTION,
                     correlationId = correlationId,
-                ).toolName(toolCall.name).toolSecurity(tool?.security).build()
+                ).toolName(toolCall.name)
+                    .toolSecurity(tool?.security)
+                    .applySecurityContext(securityContext)
+                    .build()
             )
 
             messages += formatToolResult(toolResult, toolCall.id)
@@ -1107,6 +1152,7 @@ private class TramaiInvocationHandler(
         messages: List<Message>,
         attemptCounter: AttemptCounter,
         correlationId: String,
+        securityContext: ExecutionSecurityContext,
     ): ProviderCallResult {
         var lastFallbackFailure: Throwable? = null
         var lastCircuitOpen: CircuitBreakerOpenException? = null
@@ -1114,7 +1160,10 @@ private class TramaiInvocationHandler(
         val base = policyHelper.buildContext(
             enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_PROVIDER_RESOLUTION,
             correlationId = correlationId,
-        ).providerId(null).modelName(operation.operation.model).build()
+        ).providerId(null)
+            .modelName(operation.operation.model)
+            .applySecurityContext(securityContext)
+            .build()
         policyHelper.enforce(base)
 
         val candidates = providerRegistry.resolveCandidates(operation.operation)
@@ -1133,6 +1182,7 @@ private class TramaiInvocationHandler(
                             previousModelName = route.effectiveModelName,
                             nextProviderId = nextRoute.providerName,
                             reason = "circuit-breaker-open",
+                            securityContext = securityContext,
                         )
                     } catch (policyError: PolicyViolationException) {
                         policyError.addSuppressed(lastCircuitOpen)
@@ -1150,7 +1200,10 @@ private class TramaiInvocationHandler(
                         policyHelper.buildContext(
                             enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_TOOL_EXPOSURE,
                             correlationId = correlationId,
-                        ).toolName(toolDef.name).toolSecurity(tool?.security).build()
+                        ).toolName(toolDef.name)
+                            .toolSecurity(tool?.security)
+                            .applySecurityContext(securityContext)
+                            .build()
                     )
                 }
 
@@ -1169,6 +1222,7 @@ private class TramaiInvocationHandler(
                     attemptCounter = attemptCounter,
                     routeIndex = routeIndex,
                     correlationId = correlationId,
+                    securityContext = securityContext,
                 )
             } catch (error: Throwable) {
                 if (!shouldFallbackFrom(error)) {
@@ -1184,6 +1238,7 @@ private class TramaiInvocationHandler(
                             previousModelName = route.effectiveModelName,
                             nextProviderId = nextRoute.providerName,
                             reason = "provider-failure",
+                            securityContext = securityContext,
                         )
                     } catch (policyError: PolicyViolationException) {
                         // Fallback denied — propagate policy violation with original error as suppressed
@@ -1211,6 +1266,7 @@ private class TramaiInvocationHandler(
         attemptCounter: AttemptCounter,
         routeIndex: Int,
         correlationId: String,
+        securityContext: ExecutionSecurityContext,
     ): ProviderCallResult {
         val maxAttempts = operation.operation.providerRetries + 1
 
@@ -1243,10 +1299,13 @@ private class TramaiInvocationHandler(
             try {
                 // Enforce BEFORE_PROVIDER_INVOCATION
                 policyHelper.enforce(
-                    policyHelper.buildContext(
-                        enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
-                        correlationId = correlationId,
-                    ).providerId(providerId).modelName(request.model).build()
+                policyHelper.buildContext(
+                    enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                    correlationId = correlationId,
+                ).providerId(providerId)
+                    .modelName(request.model)
+                    .applySecurityContext(securityContext)
+                    .build()
                 )
 
                 val rawResponse = callProviderOnce(providerId, provider, interceptedRequest, operation)
@@ -1296,6 +1355,7 @@ private class TramaiInvocationHandler(
         toolCall: ToolCall,
         operation: OperationDefinition,
         correlationId: String,
+        securityContext: ExecutionSecurityContext,
     ): ToolResult {
         val input = toolCall.argumentsJson
         val maxAttempts = if (tool.idempotent) IDEMPOTENT_TOOL_MAX_ATTEMPTS else 1
@@ -1313,7 +1373,10 @@ private class TramaiInvocationHandler(
                 policyHelper.buildContext(
                     enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_TOOL_EXECUTION,
                     correlationId = correlationId,
-                ).toolName(tool.name).toolSecurity(tool.security).build()
+                ).toolName(tool.name)
+                    .toolSecurity(tool.security)
+                    .applySecurityContext(securityContext)
+                    .build()
             )
 
             val result = try {
@@ -2104,6 +2167,11 @@ private enum class ReturnKind {
     STRUCTURED,
     STREAMING,
 }
+
+private fun PolicyContextBuilder.applySecurityContext(
+    securityContext: ExecutionSecurityContext,
+): PolicyContextBuilder = dataClassification(securityContext.dataClassification)
+    .classificationSource(securityContext.classificationSource)
 
 private const val INITIAL_PROVIDER_RETRY_DELAY_MILLIS = 50L
 private const val MAX_PROVIDER_RETRY_DELAY_MILLIS = 1_000L

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ExecutionSecurityContextTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ExecutionSecurityContextTest.kt
@@ -1,0 +1,74 @@
+package dev.tramai.engine
+
+import dev.tramai.core.model.ClassifiedDocument
+import dev.tramai.core.policy.ClassificationSource
+import dev.tramai.core.policy.DataClassification
+import org.assertj.core.api.Assertions.assertThat
+import kotlin.test.Test
+
+class ExecutionSecurityContextTest {
+
+    @Test
+    fun `no classified arguments yields empty context`() {
+        val context = ExecutionSecurityContext.fromArguments(arrayOf<Any?>("plain", 42, null))
+
+        assertThat(context.dataClassification).isNull()
+        assertThat(context.classificationSource).isNull()
+    }
+
+    @Test
+    fun `single restricted argument preserves classification and source`() {
+        val context = ExecutionSecurityContext.fromArguments(
+            arrayOf(
+                ClassifiedDocument(
+                    payload = "secret",
+                    classification = DataClassification.RESTRICTED,
+                    source = ClassificationSource.DECLARED,
+                ),
+            ),
+        )
+
+        assertThat(context.dataClassification).isEqualTo(DataClassification.RESTRICTED)
+        assertThat(context.classificationSource).isEqualTo(ClassificationSource.DECLARED)
+    }
+
+    @Test
+    fun `highest classification wins across multiple classified arguments`() {
+        val context = ExecutionSecurityContext.fromArguments(
+            arrayOf(
+                ClassifiedDocument(
+                    payload = "public",
+                    classification = DataClassification.PUBLIC,
+                    source = ClassificationSource.DECLARED,
+                ),
+                ClassifiedDocument(
+                    payload = "confidential",
+                    classification = DataClassification.CONFIDENTIAL,
+                    source = ClassificationSource.RULE_BASED,
+                ),
+            ),
+        )
+
+        assertThat(context.dataClassification).isEqualTo(DataClassification.CONFIDENTIAL)
+    }
+
+    @Test
+    fun `highest classification source is preserved`() {
+        val context = ExecutionSecurityContext.fromArguments(
+            arrayOf(
+                ClassifiedDocument(
+                    payload = "internal",
+                    classification = DataClassification.INTERNAL,
+                    source = ClassificationSource.DECLARED,
+                ),
+                ClassifiedDocument(
+                    payload = "restricted",
+                    classification = DataClassification.RESTRICTED,
+                    source = ClassificationSource.LOCAL_MODEL_ASSISTED,
+                ),
+            ),
+        )
+
+        assertThat(context.classificationSource).isEqualTo(ClassificationSource.LOCAL_MODEL_ASSISTED)
+    }
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ExecutionSecurityContextTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ExecutionSecurityContextTest.kt
@@ -73,23 +73,28 @@ class ExecutionSecurityContextTest {
     }
 
     @Test
-    fun `equal classification prefers declared source over less authoritative sources`() {
+    fun `equal classification preserves least authoritative source conservatively`() {
         val context = ExecutionSecurityContext.fromArguments(
             arrayOf(
-                ClassifiedDocument(
-                    payload = "internal-local",
-                    classification = DataClassification.INTERNAL,
-                    source = ClassificationSource.LOCAL_MODEL_ASSISTED,
-                ),
                 ClassifiedDocument(
                     payload = "internal-declared",
                     classification = DataClassification.INTERNAL,
                     source = ClassificationSource.DECLARED,
                 ),
+                ClassifiedDocument(
+                    payload = "internal-rule",
+                    classification = DataClassification.INTERNAL,
+                    source = ClassificationSource.RULE_BASED,
+                ),
+                ClassifiedDocument(
+                    payload = "internal-local",
+                    classification = DataClassification.INTERNAL,
+                    source = ClassificationSource.LOCAL_MODEL_ASSISTED,
+                ),
             ),
         )
 
         assertThat(context.dataClassification).isEqualTo(DataClassification.INTERNAL)
-        assertThat(context.classificationSource).isEqualTo(ClassificationSource.DECLARED)
+        assertThat(context.classificationSource).isEqualTo(ClassificationSource.LOCAL_MODEL_ASSISTED)
     }
 }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ExecutionSecurityContextTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ExecutionSecurityContextTest.kt
@@ -71,4 +71,25 @@ class ExecutionSecurityContextTest {
 
         assertThat(context.classificationSource).isEqualTo(ClassificationSource.LOCAL_MODEL_ASSISTED)
     }
+
+    @Test
+    fun `equal classification prefers declared source over less authoritative sources`() {
+        val context = ExecutionSecurityContext.fromArguments(
+            arrayOf(
+                ClassifiedDocument(
+                    payload = "internal-local",
+                    classification = DataClassification.INTERNAL,
+                    source = ClassificationSource.LOCAL_MODEL_ASSISTED,
+                ),
+                ClassifiedDocument(
+                    payload = "internal-declared",
+                    classification = DataClassification.INTERNAL,
+                    source = ClassificationSource.DECLARED,
+                ),
+            ),
+        )
+
+        assertThat(context.dataClassification).isEqualTo(DataClassification.INTERNAL)
+        assertThat(context.classificationSource).isEqualTo(ClassificationSource.DECLARED)
+    }
 }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/PolicyEnforcementTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/PolicyEnforcementTest.kt
@@ -151,7 +151,7 @@ class PolicyEnforcementTest {
 
     @AiService
     interface TestService {
-        @Operation(prompt = "test", model = "test-model", tools = ["echo"])
+        @Operation(prompt = "test", model = "test-model", tools = ["echo"], providerRetries = 0)
         suspend fun analyze(input: String): String
     }
 
@@ -175,7 +175,7 @@ class PolicyEnforcementTest {
 
     @AiService
     interface ClassifiedTestService {
-        @Operation(prompt = "test", model = "test-model")
+        @Operation(prompt = "test", model = "test-model", providerRetries = 0)
         suspend fun analyze(input: ClassifiedDocument<String>): String
     }
 
@@ -195,6 +195,30 @@ class PolicyEnforcementTest {
     interface CachedStructuredService {
         @Operation(prompt = "test", model = "test-model", cacheable = true, cacheTtlMillis = 60_000, maxRetries = 0)
         suspend fun analyze(input: String): TestPayload
+    }
+
+    @AiService
+    interface CachedClassifiedTestService {
+        @Operation(
+            prompt = "test",
+            model = "test-model",
+            cacheable = true,
+            cacheTtlMillis = 60_000,
+            providerRetries = 0,
+        )
+        suspend fun analyze(input: ClassifiedDocument<String>): String
+    }
+
+    @AiService
+    interface CachedClassifiedStructuredService {
+        @Operation(
+            prompt = "test",
+            model = "test-model",
+            cacheable = true,
+            cacheTtlMillis = 60_000,
+            maxRetries = 0,
+        )
+        suspend fun analyze(input: ClassifiedDocument<String>): TestPayload
     }
 
     data class TestPayload(val answer: String)
@@ -927,6 +951,70 @@ class PolicyEnforcementTest {
         assertThatThrownBy { runBlocking { service2.analyze("test") } }
             .isInstanceOf(PolicyViolationException::class.java)
             .hasMessageContaining("cache struct blocked")
+    }
+
+    @Test
+    fun `classified raw cacheable calls bypass cache reuse`() = runBlocking {
+        val provider = CountingProvider()
+        val engine = TramaiEngine(
+            provider = provider,
+            responseCache = InMemoryOperationResponseCache(),
+            policyEngine = object : PolicyEngine {
+                override suspend fun evaluate(context: PolicyContext): PolicyDecision = PolicyDecision.Allow
+            },
+        )
+        val service: CachedClassifiedTestService = engine.create()
+        val input = ClassifiedDocument(
+            payload = "secret",
+            classification = DataClassification.RESTRICTED,
+            source = ClassificationSource.DECLARED,
+        )
+
+        val first = service.analyze(input)
+        val second = service.analyze(input)
+
+        assertThat(first).isEqualTo("ok")
+        assertThat(second).isEqualTo("ok")
+        assertThat(provider.callCount.get()).isEqualTo(2)
+    }
+
+    @Test
+    fun `classified structured cacheable calls bypass cache reuse`() = runBlocking {
+        val handler = object : StructuredOutputHandler {
+            override fun analyze(rawResponse: String, targetType: kotlin.reflect.KType): StructuredOutputResult =
+                StructuredOutputResult.Success(TestPayload("parsed"), rawResponse)
+
+            override fun createContract(targetType: kotlin.reflect.KType) =
+                StructuredOutputContract(targetType, "{ }")
+
+            override fun generateSchema(type: kotlin.reflect.KType) = "{ }"
+
+            override fun deserialize(input: Any, targetType: kotlin.reflect.KType) = TestPayload("parsed")
+
+            override fun serialize(value: Any): Any = mapOf("answer" to "parsed")
+        }
+        val provider = CountingProvider()
+        val engine = TramaiEngine(
+            provider = provider,
+            structuredOutputHandler = handler,
+            responseCache = InMemoryOperationResponseCache(),
+            policyEngine = object : PolicyEngine {
+                override suspend fun evaluate(context: PolicyContext): PolicyDecision = PolicyDecision.Allow
+            },
+        )
+        val service: CachedClassifiedStructuredService = engine.create()
+        val input = ClassifiedDocument(
+            payload = "secret",
+            classification = DataClassification.RESTRICTED,
+            source = ClassificationSource.DECLARED,
+        )
+
+        val first = service.analyze(input)
+        val second = service.analyze(input)
+
+        assertThat(first.answer).isEqualTo("parsed")
+        assertThat(second.answer).isEqualTo("parsed")
+        assertThat(provider.callCount.get()).isEqualTo(2)
     }
 
     // -- Context semantics tests -----------------------------------------------

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/PolicyEnforcementTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/PolicyEnforcementTest.kt
@@ -6,6 +6,7 @@ import dev.tramai.core.exception.ApprovalRequiredException
 import dev.tramai.core.exception.PolicyViolationException
 import dev.tramai.core.exception.ProviderException
 import dev.tramai.core.memory.ChatMemory
+import dev.tramai.core.model.ClassifiedDocument
 import dev.tramai.core.model.Message
 import dev.tramai.core.model.ModelRequest
 import dev.tramai.core.model.ModelResponse
@@ -15,6 +16,8 @@ import dev.tramai.core.model.ToolExecutionContext
 import dev.tramai.core.model.ResolvedTool
 import dev.tramai.core.model.ToolResult
 import dev.tramai.core.policy.ApprovalRequirement
+import dev.tramai.core.policy.ClassificationSource
+import dev.tramai.core.policy.DataClassification
 import dev.tramai.core.policy.EnforcementPoint
 import dev.tramai.core.policy.PolicyContext
 import dev.tramai.core.policy.PolicyDecision
@@ -168,6 +171,24 @@ class PolicyEnforcementTest {
     interface StructuredTestService {
         @Operation(prompt = "test", model = "test-model", maxRetries = 0)
         suspend fun analyze(input: String): TestPayload
+    }
+
+    @AiService
+    interface ClassifiedTestService {
+        @Operation(prompt = "test", model = "test-model")
+        suspend fun analyze(input: ClassifiedDocument<String>): String
+    }
+
+    @AiService
+    interface ClassifiedStreamingTestService {
+        @Operation(prompt = "test", model = "test-model")
+        suspend fun stream(input: ClassifiedDocument<String>): Flow<StreamChunk>
+    }
+
+    @AiService
+    interface ClassifiedStructuredTestService {
+        @Operation(prompt = "test", model = "test-model", maxRetries = 0)
+        suspend fun analyze(input: ClassifiedDocument<String>): TestPayload
     }
 
     @AiService
@@ -327,6 +348,189 @@ class PolicyEnforcementTest {
         val result = service.analyze("test")
         assertThat(result).isEqualTo("fallback-ok")
         assertThat(fallbackProvider.callCount.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `RESTRICTED request to trusted local provider is allowed`() = runBlocking {
+        val provider = CountingProvider(id = "local-provider")
+        val engine = TramaiEngine(
+            provider = provider,
+            policyEngine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedModels = setOf("test-model"),
+                    allowedProviders = setOf("local-provider"),
+                    trustedLocalProviders = setOf("local-provider"),
+                ),
+            ),
+        )
+        val service = engine.create<ClassifiedTestService>()
+
+        val result = service.analyze(
+            ClassifiedDocument(
+                payload = "secret",
+                classification = DataClassification.RESTRICTED,
+                source = ClassificationSource.DECLARED,
+            ),
+        )
+
+        assertThat(result).isEqualTo("ok")
+        assertThat(provider.callCount.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `RESTRICTED request to approved untrusted cloud provider is denied before invocation`() = runBlocking {
+        val provider = CountingProvider(id = "cloud-provider")
+        val engine = TramaiEngine(
+            provider = provider,
+            policyEngine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedModels = setOf("test-model"),
+                    allowedProviders = setOf("cloud-provider"),
+                ),
+            ),
+        )
+        val service = engine.create<ClassifiedTestService>()
+
+        assertThatThrownBy {
+            runBlocking {
+                service.analyze(
+                    ClassifiedDocument(
+                        payload = "secret",
+                        classification = DataClassification.RESTRICTED,
+                        source = ClassificationSource.DECLARED,
+                    ),
+                )
+            }
+        }.isInstanceOf(PolicyViolationException::class.java)
+            .hasMessageContaining("RESTRICTED data may not be sent to provider 'cloud-provider'")
+        assertThat(provider.callCount.get()).isEqualTo(0)
+    }
+
+    @Test
+    fun `RESTRICTED request does not silently fall back from local provider to cloud`() = runBlocking {
+        val localProvider = object : ModelProvider {
+            val callCount = AtomicInteger(0)
+            override fun providerId() = "local-provider"
+            override suspend fun complete(request: ModelRequest): ModelResponse {
+                callCount.incrementAndGet()
+                throw ProviderException("local failed", retryable = true)
+            }
+        }
+        val cloudProvider = CountingProvider(id = "cloud-provider")
+        val engine = TramaiEngine(
+            providerRegistry = ProviderRegistry.builder()
+                .provider("local-provider", localProvider, default = true)
+                .model("test-model", "local-provider")
+                .fallbackProvider("test-model", "cloud-provider")
+                .provider("cloud-provider", cloudProvider)
+                .build(),
+            policyEngine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedModels = setOf("test-model"),
+                    allowedProviders = setOf("local-provider", "cloud-provider"),
+                    allowedFallbackProviders = setOf("cloud-provider"),
+                    trustedLocalProviders = setOf("local-provider"),
+                ),
+            ),
+        )
+        val service = engine.create<ClassifiedTestService>()
+
+        assertThatThrownBy {
+            runBlocking {
+                service.analyze(
+                    ClassifiedDocument(
+                        payload = "secret",
+                        classification = DataClassification.RESTRICTED,
+                        source = ClassificationSource.DECLARED,
+                    ),
+                )
+            }
+        }.isInstanceOf(PolicyViolationException::class.java)
+            .hasMessageContaining("RESTRICTED data may not be sent to provider 'cloud-provider'")
+        assertThat(localProvider.callCount.get()).isEqualTo(1)
+        assertThat(cloudProvider.callCount.get()).isEqualTo(0)
+    }
+
+    @Test
+    fun `INTERNAL request to cloud provider without permission is denied`() = runBlocking {
+        val provider = CountingProvider(id = "cloud-provider")
+        val engine = TramaiEngine(
+            provider = provider,
+            policyEngine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedModels = setOf("test-model"),
+                    allowedProviders = setOf("cloud-provider"),
+                ),
+            ),
+        )
+        val service = engine.create<ClassifiedTestService>()
+
+        assertThatThrownBy {
+            runBlocking {
+                service.analyze(
+                    ClassifiedDocument(
+                        payload = "internal",
+                        classification = DataClassification.INTERNAL,
+                        source = ClassificationSource.DECLARED,
+                    ),
+                )
+            }
+        }.isInstanceOf(PolicyViolationException::class.java)
+            .hasMessageContaining("Data classification 'INTERNAL' is not allowed for provider 'cloud-provider'")
+        assertThat(provider.callCount.get()).isEqualTo(0)
+    }
+
+    @Test
+    fun `INTERNAL request to cloud provider with permission is allowed`() = runBlocking {
+        val provider = CountingProvider(id = "cloud-provider")
+        val engine = TramaiEngine(
+            provider = provider,
+            policyEngine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedModels = setOf("test-model"),
+                    allowedProviders = setOf("cloud-provider"),
+                    allowCloudForClassifications = setOf(DataClassification.PUBLIC, DataClassification.INTERNAL),
+                ),
+            ),
+        )
+        val service = engine.create<ClassifiedTestService>()
+
+        val result = service.analyze(
+            ClassifiedDocument(
+                payload = "internal",
+                classification = DataClassification.INTERNAL,
+                source = ClassificationSource.DECLARED,
+            ),
+        )
+
+        assertThat(result).isEqualTo("ok")
+        assertThat(provider.callCount.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `PUBLIC request to approved cloud provider is allowed`() = runBlocking {
+        val provider = CountingProvider(id = "cloud-provider")
+        val engine = TramaiEngine(
+            provider = provider,
+            policyEngine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedModels = setOf("test-model"),
+                    allowedProviders = setOf("cloud-provider"),
+                ),
+            ),
+        )
+        val service = engine.create<ClassifiedTestService>()
+
+        val result = service.analyze(
+            ClassifiedDocument(
+                payload = "public",
+                classification = DataClassification.PUBLIC,
+                source = ClassificationSource.DECLARED,
+            ),
+        )
+
+        assertThat(result).isEqualTo("ok")
+        assertThat(provider.callCount.get()).isEqualTo(1)
     }
 
     // -- Tool tests ------------------------------------------------------------
@@ -542,6 +746,35 @@ class PolicyEnforcementTest {
             .hasMessageContaining("stream tools blocked")
     }
 
+    @Test
+    fun `streaming RESTRICTED request to untrusted provider is denied before stream starts`() = runBlocking {
+        val provider = streamingProvider(id = "cloud-provider")
+        val engine = TramaiEngine(
+            provider = provider,
+            policyEngine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedModels = setOf("test-model"),
+                    allowedProviders = setOf("cloud-provider"),
+                ),
+            ),
+        )
+        val service = engine.create<ClassifiedStreamingTestService>()
+
+        assertThatThrownBy {
+            runBlocking {
+                service.stream(
+                    ClassifiedDocument(
+                        payload = "secret",
+                        classification = DataClassification.RESTRICTED,
+                        source = ClassificationSource.DECLARED,
+                    ),
+                ).toList()
+            }
+        }.isInstanceOf(PolicyViolationException::class.java)
+            .hasMessageContaining("RESTRICTED data may not be sent to provider 'cloud-provider'")
+        assertThat(provider.callCount.get()).isEqualTo(0)
+    }
+
     // -- Structured output tests -----------------------------------------------
 
     @Test
@@ -571,6 +804,46 @@ class PolicyEnforcementTest {
         assertThatThrownBy { runBlocking { service.analyze("test") } }
             .isInstanceOf(PolicyViolationException::class.java)
             .hasMessageContaining("struct response blocked")
+    }
+
+    @Test
+    fun `structured RESTRICTED request to untrusted provider is denied before invocation`() = runBlocking {
+        val handler = object : StructuredOutputHandler {
+            override fun analyze(rawResponse: String, targetType: kotlin.reflect.KType): StructuredOutputResult {
+                return StructuredOutputResult.Success(TestPayload("parsed"), rawResponse)
+            }
+            override fun createContract(targetType: kotlin.reflect.KType) =
+                StructuredOutputContract(targetType, "{ }")
+            override fun generateSchema(type: kotlin.reflect.KType) = "{ }"
+            override fun deserialize(input: Any, targetType: kotlin.reflect.KType) = TestPayload("parsed")
+            override fun serialize(value: Any): Any = mapOf("answer" to "parsed")
+        }
+        val provider = CountingProvider(id = "cloud-provider")
+        val engine = TramaiEngine(
+            provider = provider,
+            structuredOutputHandler = handler,
+            policyEngine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedModels = setOf("test-model"),
+                    allowedProviders = setOf("cloud-provider"),
+                ),
+            ),
+        )
+        val service = engine.create<ClassifiedStructuredTestService>()
+
+        assertThatThrownBy {
+            runBlocking {
+                service.analyze(
+                    ClassifiedDocument(
+                        payload = "secret",
+                        classification = DataClassification.RESTRICTED,
+                        source = ClassificationSource.DECLARED,
+                    ),
+                )
+            }
+        }.isInstanceOf(PolicyViolationException::class.java)
+            .hasMessageContaining("RESTRICTED data may not be sent to provider 'cloud-provider'")
+        assertThat(provider.callCount.get()).isEqualTo(0)
     }
 
     // -- Cache tests -----------------------------------------------------------

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/TramaiEngineTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/TramaiEngineTest.kt
@@ -13,6 +13,7 @@ import dev.tramai.core.exception.ProviderException
 import dev.tramai.core.exception.StructuredOutputException
 import dev.tramai.core.exception.TokenBudgetExceededException
 import dev.tramai.core.exception.TimeoutException
+import dev.tramai.core.model.ClassifiedDocument
 import dev.tramai.core.model.Message
 import dev.tramai.core.model.MessageRole
 import dev.tramai.core.model.ModelRequest
@@ -27,6 +28,8 @@ import dev.tramai.core.observation.OperationCallContext
 import dev.tramai.core.observation.OperationObservation
 import dev.tramai.core.observation.OperationObserver
 import dev.tramai.core.observation.OperationInterceptor
+import dev.tramai.core.policy.ClassificationSource
+import dev.tramai.core.policy.DataClassification
 import dev.tramai.core.provider.ModelProvider
 import dev.tramai.core.provider.ProviderRegistry
 import dev.tramai.core.provider.StreamCapable
@@ -67,6 +70,29 @@ class TramaiEngineTest {
             .contains("Analyze the invoice")
             .contains("invoiceId")
             .contains("invoice-123")
+    }
+
+    @Test
+    fun `renders classified document payloads into prompts without wrapper metadata`() {
+        val provider = RecordingProvider { ModelResponse(content = "hardcoded response") }
+        val engine = TramaiEngine(provider)
+        val service = engine.create<ClassifiedPayloadAnalyzer>()
+
+        runBlocking {
+            service.analyze(
+                ClassifiedDocument(
+                    payload = "secret content",
+                    classification = DataClassification.RESTRICTED,
+                    source = ClassificationSource.DECLARED,
+                ),
+            )
+        }
+
+        assertThat(provider.requests).hasSize(1)
+        assertThat(provider.requests.single().messages.last().content)
+            .contains("secret content")
+            .doesNotContain("ClassifiedDocument(")
+            .doesNotContain("classification=")
     }
 
     @Test
@@ -1212,6 +1238,15 @@ private interface SuspendAnalyzer {
         model = "claude-sonnet-4-20250514",
     )
     suspend fun analyze(invoiceId: String): String
+}
+
+@AiService
+private interface ClassifiedPayloadAnalyzer {
+    @Operation(
+        prompt = "Analyze the classified payload",
+        model = "claude-sonnet-4-20250514",
+    )
+    suspend fun analyze(document: ClassifiedDocument<String>): String
 }
 
 @AiService

--- a/tramai-security/src/main/kotlin/dev/tramai/security/DefaultPolicyEngine.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/DefaultPolicyEngine.kt
@@ -9,10 +9,10 @@ import dev.tramai.core.policy.*
  * Unknown tools, models, and providers are denied. HIGH/CRITICAL-risk
  * tools and tools with non-AUTO approval modes require human approval.
  *
- * RESTRICTED-data enforcement is partially implemented: when a data
- * classification is attached to the context, egress is controlled via
- * trustedLocalProviders, but classified-input propagation through
- * every provider invocation path remains follow-up work.
+ * Classified-request egress is enforced when classification metadata is
+ * attached to the [PolicyContext]. RESTRICTED data is limited to trusted
+ * local providers, while other non-public classifications require explicit
+ * cloud permission for non-local providers.
  */
 class DefaultPolicyEngine(
     private val config: PolicyConfiguration,
@@ -55,6 +55,10 @@ class DefaultPolicyEngine(
 
     private fun evaluateProviderInvocation(ctx: PolicyContext): PolicyDecision {
         val providerId = ctx.providerId
+        evaluateClassificationEgress(
+            classification = ctx.dataClassification,
+            providerId = providerId,
+        )?.let { return it }
         if (providerId == null) {
             return PolicyDecision.Deny(
                 "Provider invocation requires a provider ID",
@@ -195,32 +199,44 @@ class DefaultPolicyEngine(
     // ─── Response return ────────────────────────────────────────────────────
 
     private fun evaluateResponseReturn(ctx: PolicyContext): PolicyDecision {
-        val classification = ctx.dataClassification ?: return PolicyDecision.Allow
+        return evaluateClassificationEgress(
+            classification = ctx.dataClassification,
+            providerId = ctx.providerId,
+        ) ?: PolicyDecision.Allow
+    }
+
+    private fun evaluateClassificationEgress(
+        classification: DataClassification?,
+        providerId: String?,
+    ): PolicyDecision? {
+        if (classification == null) return null
+
+        if (providerId == null) {
+            return PolicyDecision.Deny(
+                "Classified request ($classification) requires a provider ID for egress control",
+                "classification-provider-missing",
+            )
+        }
 
         if (classification == DataClassification.RESTRICTED) {
-            val providerId = ctx.providerId
-            // RESTRICTED data must not leave local trust boundary
-            if (providerId == null || providerId !in config.trustedLocalProviders) {
+            if (providerId !in config.trustedLocalProviders) {
                 return PolicyDecision.Deny(
-                    "RESTRICTED data may not be sent to provider '${providerId ?: "<unknown>"}'",
-                    if (providerId == null) "classification-egress-blocked" else "restricted-data-egress-blocked",
+                    "RESTRICTED data may not be sent to provider '$providerId'",
+                    "restricted-data-egress-blocked",
                 )
             }
+            return null
         }
 
-        if (classification != DataClassification.PUBLIC &&
-            classification !in config.allowCloudForClassifications
-        ) {
-            val providerId = ctx.providerId
-            val isLocal = providerId != null && providerId in config.trustedLocalProviders
-            if (!isLocal) {
-                return PolicyDecision.Deny(
-                    "Data classification '$classification' is not allowed for provider '${providerId ?: "<unknown>"}'",
-                    "classification-egress-blocked",
-                )
-            }
+        if (providerId in config.trustedLocalProviders) return null
+
+        if (classification !in config.allowCloudForClassifications) {
+            return PolicyDecision.Deny(
+                "Data classification '$classification' is not allowed for provider '$providerId'",
+                "classification-egress-blocked",
+            )
         }
 
-        return PolicyDecision.Allow
+        return null
     }
 }

--- a/tramai-security/src/test/kotlin/dev/tramai/security/DefaultPolicyEngineTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/DefaultPolicyEngineTest.kt
@@ -309,6 +309,54 @@ class DefaultPolicyEngineTest {
     }
 
     @Test
+    fun `classified provider invocation without provider id is denied`() {
+        runBlocking {
+            val decision = secureEngine.evaluate(
+                ctx(
+                    EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                    dataClassification = DataClassification.INTERNAL,
+                )
+            )
+            assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("classification-provider-missing")
+        }
+    }
+
+    @Test
+    fun `RESTRICTED provider invocation to non-local provider is denied before allowlist`() {
+        runBlocking {
+            val engine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedProviders = setOf("openai"),
+                )
+            )
+            val decision = engine.evaluate(
+                ctx(
+                    EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                    providerId = "openai",
+                    dataClassification = DataClassification.RESTRICTED,
+                )
+            )
+            assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("restricted-data-egress-blocked")
+        }
+    }
+
+    @Test
+    fun `response return for classified request without provider id is denied`() {
+        runBlocking {
+            val decision = secureEngine.evaluate(
+                ctx(
+                    EnforcementPoint.BEFORE_RESPONSE_RETURN,
+                    dataClassification = DataClassification.INTERNAL,
+                )
+            )
+            assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("classification-provider-missing")
+        }
+    }
+
+    @Test
     fun `tool result reinjection is allowed`() {
         runBlocking {
             val decision = secureEngine.evaluate(
@@ -526,7 +574,7 @@ class DefaultPolicyEngineTest {
                 )
             )
             assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
-            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("classification-egress-blocked")
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("classification-provider-missing")
         }
     }
 
@@ -541,7 +589,7 @@ class DefaultPolicyEngineTest {
                 )
             )
             assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
-            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("classification-egress-blocked")
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("classification-provider-missing")
         }
     }
 


### PR DESCRIPTION
…invocation

- Add ClassifiedDocument<T> generic wrapper in tramai-core
- Add ExecutionSecurityContext for extracting classification from args
- Propagate dataClassification + classificationSource through all engine paths (raw, streaming, structured, tool loops, fallback, cache hits, response return)
- Enforce classification egress at BEFORE_PROVIDER_INVOCATION
- Share evaluateClassificationEgress() between invocation and response-return
- No silent fallback: RESTRICTED never reaches untrusted providers
- Mark Topic 1.6 + 1.7 complete in delivery plan
- Topic 1.8 (response provenance) remains deferred

Tests: 8 e2e classification tests + 4 unit ExecutionSecurityContext tests + 3 DefaultPolicyEngine tests