### PR TITLE
feat(engine): add provenance-aware secure cache entries

### DIFF
--- a/docs/security/DELIVERY-PLAN.md
+++ b/docs/security/DELIVERY-PLAN.md
@@ -374,14 +374,27 @@ Epics 1, 2, 2B, 3, and 4 can partially overlap. Epic 5 requires the relevant ver
 - `CachedOperationResult` wraps the stored value with `CachedResponseProvenance(providerId, modelName, dataClassification, classificationSource)`.
 
 **Authorization on cache hit:**
-- Every cache hit re-evaluates `BEFORE_RESPONSE_RETURN` using the **cached** `providerId`/`modelName` and the **current** request's `ExecutionSecurityContext`.
+- Every cache hit re-evaluates three policy gates using the cached `providerId`/`modelName` and the **current** request's `ExecutionSecurityContext`:
+  - `BEFORE_PROVIDER_RESOLUTION` — model allowlist re-check
+  - `BEFORE_PROVIDER_INVOCATION` — provider allowlist re-check
+  - `BEFORE_RESPONSE_RETURN` — classified egress re-check
+- Each gate is tagged with `attribute("cacheReuse", "true")` for audit.
+- The cached envelope is validated against the security partition before any policy call (`IllegalStateException` on mismatch).
 - Policy changes after a cache write take effect on the next hit.
-- Classified cache reuse is enabled; provenance + re-evaluation make it safe.
+- Classified cache reuse is enabled for pure, non-streaming, non-conversational operations without tools or custom interceptors.
+
+**Cache eligibility (`isSafeCacheEligible`):**
+- `operation.cacheable` is true
+- return type is not `STREAMING`
+- no tools declared on the operation
+- no `chatMemory` in scope (active conversation)
+- engine is using the default `NoOpOperationInterceptor`
 
 **Limitations:**
 - `requestDigest` is SHA-256, not a keyed hash. A configurable HMAC strategy is intentionally deferred.
 - Streaming responses are not cached (no change).
 - A `RESTRICTED` request whose cached response came from a cloud provider is denied on re-use without re-invoking the provider.
+- Operations using custom `OperationInterceptor` implementations bypass cache until interceptor-aware cache fingerprints and cached-response hooks exist.
 
 **Removed:**
 - The temporary `securityContext.dataClassification == null` bypass in raw + structured cache read/write paths.

--- a/docs/security/DELIVERY-PLAN.md
+++ b/docs/security/DELIVERY-PLAN.md
@@ -54,9 +54,6 @@ and streaming execution.
 Topic 1.7 ✅ — classification egress enforced at `BEFORE_PROVIDER_INVOCATION`
 and `BEFORE_RESPONSE_RETURN` via `evaluateClassificationEgress()`.
 
-Topic 1.8 remains open — cache-entry provenance. Classified cache reuse
-is deliberately disabled until Topic 1.8 is complete.
-
 Implementation note:
 - classification derives from `ClassifiedDocument<T>` wrapper
 - no annotation-based classification exists
@@ -65,7 +62,7 @@ Implementation note:
 - among equal classifications, the least-authoritative source is retained for conservative audit metadata (authority order: DECLARED > RULE_BASED > LOCAL_MODEL_ASSISTED)
 
 Remaining follow-up:
-- `Topic 1.8`: Propagate selected-provider provenance into response-return checks (raw, structured, streaming, cached). For cached values, store or reconstruct `providerId`, `modelName`, `dataClassification`, and `classificationSource`.
+Topic 1.8 ✅ — closed in feat/secure-cache-provenance (PR #6). See `CACHE-PROVENANCE.md` if present, otherwise see test names in `PolicyEnforcementTest.kt`.
 
 ---
 
@@ -367,5 +364,27 @@ Epics 1, 2, 2B, 3, and 4 can partially overlap. Epic 5 requires the relevant ver
 | 8 | Epic 5: Sovereign Invoice Analyzer demo, integration tests, evidence pack |
 
 ---
+
+## Implementation Notes — Secure Cache Provenance (PR 6) ✅
+
+**Where:** `tramai-engine/.../OperationResponseCache.kt`, `InMemoryOperationResponseCache.kt`, `TramaiEngine.kt`.
+
+**Cache data model:**
+- `OperationCacheKey` now carries `requestDigest: String` (SHA-256 hex of canonical rendered messages) and `securityPartition: CacheSecurityPartition` (dataClassification + classificationSource).
+- `CachedOperationResult` wraps the stored value with `CachedResponseProvenance(providerId, modelName, dataClassification, classificationSource)`.
+
+**Authorization on cache hit:**
+- Every cache hit re-evaluates `BEFORE_RESPONSE_RETURN` using the **cached** `providerId`/`modelName` and the **current** request's `ExecutionSecurityContext`.
+- Policy changes after a cache write take effect on the next hit.
+- Classified cache reuse is enabled; provenance + re-evaluation make it safe.
+
+**Limitations:**
+- `requestDigest` is SHA-256, not a keyed hash. A configurable HMAC strategy is intentionally deferred.
+- Streaming responses are not cached (no change).
+- A `RESTRICTED` request whose cached response came from a cloud provider is denied on re-use without re-invoking the provider.
+
+**Removed:**
+- The temporary `securityContext.dataClassification == null` bypass in raw + structured cache read/write paths.
+- The `classified raw cacheable calls bypass cache reuse` and `classified structured cacheable calls bypass cache reuse` tests (bypass closed).
 
 *Phase 0 delivery plan. Issues created in GitHub with labels: `phase-1`, `epic-{n}`. See ROADMAP.md for Phase 1 exit criteria.*

--- a/docs/security/DELIVERY-PLAN.md
+++ b/docs/security/DELIVERY-PLAN.md
@@ -62,7 +62,7 @@ Implementation note:
 - among equal classifications, the least-authoritative source is retained for conservative audit metadata (authority order: DECLARED > RULE_BASED > LOCAL_MODEL_ASSISTED)
 
 Remaining follow-up:
-Topic 1.8 ✅ — closed in feat/secure-cache-provenance (PR #6). See `CACHE-PROVENANCE.md` if present, otherwise see test names in `PolicyEnforcementTest.kt`.
+Topic 1.8 ✅ — closed in feat/secure-cache-provenance (PR #6). See `OperationResponseCache.kt`, `InMemoryOperationResponseCache.kt`, and the eight cache-provenance tests in `PolicyEnforcementTest.kt`.
 
 ---
 

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/InMemoryOperationResponseCache.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/InMemoryOperationResponseCache.kt
@@ -18,30 +18,41 @@ class InMemoryOperationResponseCache(
     }
 
     @Synchronized
-    override fun get(key: OperationCacheKey): Any? {
+    override fun get(key: OperationCacheKey): CachedOperationResult? {
         val entry = entries[key] ?: return null
         if (clockMillis() >= entry.expiresAtMillis) {
             entries.remove(key)
             return null
         }
-        return entry.value
+        return CachedOperationResult(
+            value = entry.value,
+            provenance = entry.provenance,
+        )
     }
 
     @Synchronized
     override fun put(
         key: OperationCacheKey,
-        value: Any,
+        value: CachedOperationResult,
         ttlMillis: Long,
     ) {
         require(ttlMillis > 0) { "Cache TTL must be greater than zero" }
         entries[key] = CacheEntry(
-            value = value,
+            value = value.value,
             expiresAtMillis = clockMillis() + ttlMillis,
+            provenance = value.provenance,
         )
     }
+
+    @Synchronized
+    internal fun snapshotKeys(): Set<OperationCacheKey> = entries.keys.toSet()
+
+    @Synchronized
+    internal fun peek(key: OperationCacheKey): CachedOperationResult? = get(key)
 }
 
 private data class CacheEntry(
     val value: Any,
     val expiresAtMillis: Long,
+    val provenance: CachedResponseProvenance,
 )

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/OperationResponseCache.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/OperationResponseCache.kt
@@ -1,40 +1,60 @@
 package dev.tramai.engine
 
+import dev.tramai.core.policy.ClassificationSource
+import dev.tramai.core.policy.DataClassification
+
 /**
  * Engine-owned cache for successful non-streaming operation results.
  */
 interface OperationResponseCache {
-    fun get(key: OperationCacheKey): Any?
+    fun get(key: OperationCacheKey): CachedOperationResult?
 
     fun put(
         key: OperationCacheKey,
-        value: Any,
+        value: CachedOperationResult,
         ttlMillis: Long,
     )
 }
 
 /**
  * Stable cache key derived from logical operation identity and rendered request content.
+ *
+ * `requestDigest` is a SHA-256 digest of canonically rendered messages. It is
+ * not encryption. The digest avoids retaining raw prompt content directly in
+ * the key; a configurable HMAC strategy is intentionally deferred.
  */
 data class OperationCacheKey(
     val serviceInterface: String,
     val methodName: String,
     val requestedModel: String,
     val explicitProvider: String?,
-    val messages: List<CachedMessage>,
+    val requestDigest: String,
+    val securityPartition: CacheSecurityPartition,
 )
 
-data class CachedMessage(
-    val role: String,
-    val content: String,
+data class CachedResponseProvenance(
+    val providerId: String,
+    val modelName: String,
+    val dataClassification: DataClassification?,
+    val classificationSource: ClassificationSource?,
+)
+
+data class CachedOperationResult(
+    val value: Any,
+    val provenance: CachedResponseProvenance,
+)
+
+data class CacheSecurityPartition(
+    val dataClassification: DataClassification?,
+    val classificationSource: ClassificationSource?,
 )
 
 object NoOpOperationResponseCache : OperationResponseCache {
-    override fun get(key: OperationCacheKey): Any? = null
+    override fun get(key: OperationCacheKey): CachedOperationResult? = null
 
     override fun put(
         key: OperationCacheKey,
-        value: Any,
+        value: CachedOperationResult,
         ttlMillis: Long,
     ) = Unit
 }

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/OperationResponseCache.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/OperationResponseCache.kt
@@ -24,11 +24,13 @@ interface OperationResponseCache {
  * the key; a configurable HMAC strategy is intentionally deferred.
  */
 data class OperationCacheKey(
+    val schemaVersion: Int = 1,
     val serviceInterface: String,
     val methodName: String,
     val requestedModel: String,
     val explicitProvider: String?,
     val requestDigest: String,
+    val operationFingerprint: String,
     val securityPartition: CacheSecurityPartition,
 )
 

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -63,6 +63,7 @@ import java.lang.reflect.Method
 import java.lang.reflect.Proxy
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
+import java.util.Base64
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
 import kotlin.reflect.KClass
@@ -775,9 +776,16 @@ private class TramaiInvocationHandler(
     ): String {
         val securityContext = ExecutionSecurityContext.fromArguments(arguments.toTypedArray())
         val correlationId = java.util.UUID.randomUUID().toString()
+        val initialMessages = operation.initialMessages(arguments)
+        val (history, effectiveMessages) = injectMemoryMessages(initialMessages, conversationId)
+            ?: (emptyList<Message>() to initialMessages)
+        val cacheKey = operation.buildCacheKey(
+            digestSource = effectiveMessages,
+            securityPartition = securityContext.toCacheSecurityPartition(),
+        )
 
         // Enforce BEFORE_RESPONSE_RETURN before returning cached value
-        operation.cachedValue(arguments)?.let { cached ->
+        operation.cachedValue(cacheKey)?.let { cached ->
             policyHelper.enforce(
                 policyHelper.buildContext(
                     enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
@@ -790,9 +798,6 @@ private class TramaiInvocationHandler(
             return cached.value as String
         }
 
-        val messages = operation.initialMessages(arguments).toMutableList()
-        val (history, effectiveMessages) = injectMemoryMessages(messages, conversationId)
-            ?: (emptyList<Message>() to messages.toList())
         val effectiveMutableMessages = effectiveMessages.toMutableList()
 
         val result = executeWithTools(
@@ -828,7 +833,7 @@ private class TramaiInvocationHandler(
 
         result.observation.onCallCompleted(parseSuccess = null)
         return result.response.content.also {
-            operation.cacheValue(arguments, it, result.providerId, result.modelName)
+            operation.cacheValue(cacheKey, it, result.providerId, result.modelName, securityContext)
         }
     }
 
@@ -844,9 +849,16 @@ private class TramaiInvocationHandler(
         )
         val contract = operation.structuredContract(handler)
         val correlationId = java.util.UUID.randomUUID().toString()
+        val initialMessages = operation.initialMessages(arguments, contract.schemaJson)
+        val (history, effectiveMessages) = injectMemoryMessages(initialMessages, conversationId)
+            ?: (emptyList<Message>() to initialMessages)
+        val cacheKey = operation.buildCacheKey(
+            digestSource = effectiveMessages,
+            securityPartition = securityContext.toCacheSecurityPartition(),
+        )
 
         // Enforce BEFORE_RESPONSE_RETURN before returning cached value
-        operation.cachedValue(arguments, contract.schemaJson)?.let { cached ->
+        operation.cachedValue(cacheKey)?.let { cached ->
             policyHelper.enforce(
                 policyHelper.buildContext(
                     enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
@@ -859,19 +871,13 @@ private class TramaiInvocationHandler(
             return cached.value
         }
 
-        val messages = operation.initialMessages(arguments, contract.schemaJson).toMutableList()
-        val (history, effectiveMessages) = injectMemoryMessages(messages, conversationId)
-            ?: (emptyList<Message>() to messages.toList())
-
         // Re-initialize messages list with history-injected content
+        val messages = effectiveMessages.toMutableList()
         val initialTurnCount = history.size
-        messages.clear()
-        messages.addAll(effectiveMessages)
 
         return executeStructuredRetryLoop(
             operation = operation,
-            arguments = arguments,
-            schemaJson = contract.schemaJson,
+            cacheKey = cacheKey,
             handler = handler,
             messages = messages,
             historySize = initialTurnCount,
@@ -884,8 +890,7 @@ private class TramaiInvocationHandler(
 
     private suspend fun executeStructuredRetryLoop(
         operation: OperationDefinition,
-        arguments: List<Any?>,
-        schemaJson: String,
+        cacheKey: OperationCacheKey,
         handler: StructuredOutputHandler,
         messages: MutableList<Message>,
         historySize: Int,
@@ -902,8 +907,7 @@ private class TramaiInvocationHandler(
         repeat(maxAttempts) { attemptIndex ->
             val value = executeStructuredAttempt(
                 operation = operation,
-                arguments = arguments,
-                schemaJson = schemaJson,
+                cacheKey = cacheKey,
                 handler = handler,
                 messages = messages,
                 historySize = historySize,
@@ -925,8 +929,7 @@ private class TramaiInvocationHandler(
 
     private suspend fun executeStructuredAttempt(
         operation: OperationDefinition,
-        arguments: List<Any?>,
-        schemaJson: String,
+        cacheKey: OperationCacheKey,
         handler: StructuredOutputHandler,
         messages: MutableList<Message>,
         historySize: Int,
@@ -974,7 +977,7 @@ private class TramaiInvocationHandler(
                     conversationId = conversationId,
                     messagesBeforeCall = messagesBeforeCall,
                 )
-                operation.cacheValue(arguments, analysis.value, result.providerId, result.modelName, schemaJson)
+                operation.cacheValue(cacheKey, analysis.value, result.providerId, result.modelName, securityContext)
 
                 analysis.value
             }
@@ -1592,27 +1595,25 @@ private class TramaiInvocationHandler(
     }
 
     private fun OperationDefinition.cachedValue(
-        arguments: List<Any?>,
-        schemaJson: String? = null,
+        key: OperationCacheKey,
     ): CachedOperationResult? = if (isCacheEligible) {
-        responseCache.get(cacheKey(arguments, schemaJson))
+        responseCache.get(key)
     } else {
         null
     }
 
     private fun OperationDefinition.cacheValue(
-        arguments: List<Any?>,
+        key: OperationCacheKey,
         value: Any,
         providerId: String,
         modelName: String,
-        schemaJson: String? = null,
+        securityContext: ExecutionSecurityContext,
     ) {
         if (!isCacheEligible) {
             return
         }
-        val securityContext = ExecutionSecurityContext.fromArguments(arguments.toTypedArray())
         responseCache.put(
-            key = cacheKey(arguments, schemaJson),
+            key = key,
             value = CachedOperationResult(
                 value = value,
                 provenance = CachedResponseProvenance(
@@ -1858,15 +1859,21 @@ private data class OperationDefinition(
     fun cacheKey(
         arguments: List<Any?>,
         schemaJson: String? = null,
+    ): OperationCacheKey = buildCacheKey(
+        digestSource = initialMessages(arguments, schemaJson),
+        securityPartition = ExecutionSecurityContext.fromArguments(arguments.toTypedArray()).toCacheSecurityPartition(),
+    )
+
+    internal fun buildCacheKey(
+        digestSource: List<Message>,
+        securityPartition: CacheSecurityPartition,
     ): OperationCacheKey = OperationCacheKey(
         serviceInterface = method.declaringClass.name,
         methodName = method.name,
         requestedModel = operation.model,
         explicitProvider = operation.provider.takeIf { it.isNotBlank() },
-        // The cache key is intentionally derived from the request that reaches
-        // the model so redactions remain stable across repeated calls.
-        requestDigest = sha256Hex(canonicalizeMessages(initialMessages(arguments, schemaJson))),
-        securityPartition = ExecutionSecurityContext.fromArguments(arguments.toTypedArray()).toCacheSecurityPartition(),
+        requestDigest = sha256Hex(canonicalizeMessages(digestSource)),
+        securityPartition = securityPartition,
     )
 
     fun structuredContract(handler: StructuredOutputHandler) = handler.createContract(
@@ -1997,7 +2004,10 @@ internal fun buildOperationCacheKeyForTesting(
         ?: throw IllegalArgumentException("No method named '$methodName' on ${serviceType.java.name}")
     val operation = definition.operations[method]
         ?: throw IllegalArgumentException("No operation metadata for ${serviceType.java.name}.$methodName")
-    return operation.cacheKey(arguments, schemaJson)
+    return operation.buildCacheKey(
+        digestSource = operation.initialMessages(arguments, schemaJson),
+        securityPartition = ExecutionSecurityContext.fromArguments(arguments.toTypedArray()).toCacheSecurityPartition(),
+    )
 }
 
 private data class ProviderCallResult(
@@ -2218,8 +2228,37 @@ private fun ExecutionSecurityContext.toCacheSecurityPartition() = CacheSecurityP
     classificationSource = classificationSource,
 )
 
-private fun canonicalizeMessages(messages: List<Message>): String = messages.joinToString("\u001E") { message ->
-    "${message.role.name}\u001F${message.content}"
+/** Length-prefixed format — collision-free without escaping. Adding a field: extend the per-message block, never reuse `---` as a content marker. */
+private fun canonicalizeMessages(messages: List<Message>): String = buildString {
+    messages.forEachIndexed { index, message ->
+        if (index > 0) {
+            append("\n---\n")
+        }
+        append("role=")
+        append(message.role.name)
+        append('\n')
+        append("content_len=")
+        append(message.content.toByteArray(StandardCharsets.UTF_8).size)
+        append('\n')
+        append(message.content)
+        message.contentParts?.let { parts ->
+            val partsCanonical = parts.joinToString("|") { part ->
+                when (part) {
+                    is ContentPart.TextPart -> "T:${part.text}"
+                    is ContentPart.ImagePart -> {
+                        val encoded = Base64.getEncoder().encodeToString(part.data)
+                        "I:${part.mimeType}:$encoded"
+                    }
+                    is ContentPart.ImageUrlContent -> "U:${part.url}:${part.mimeType}"
+                }
+            }
+            append('\n')
+            append("parts_len=")
+            append(partsCanonical.toByteArray(StandardCharsets.UTF_8).size)
+            append('\n')
+            append(partsCanonical)
+        }
+    }
 }
 
 private fun sha256Hex(input: String): String {

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -779,7 +779,7 @@ private class TramaiInvocationHandler(
         val initialMessages = operation.initialMessages(arguments)
         val (history, effectiveMessages) = injectMemoryMessages(initialMessages, conversationId)
             ?: (emptyList<Message>() to initialMessages)
-        val cacheKey = operation.takeIf { it.isSafeCacheEligible(conversationId) }?.buildCacheKey(
+        val cacheKey = operation.takeIf { isSafeCacheEligible(it, conversationId) }?.buildCacheKey(
             digestSource = effectiveMessages,
             securityPartition = securityContext.toCacheSecurityPartition(),
         )
@@ -852,7 +852,7 @@ private class TramaiInvocationHandler(
         val initialMessages = operation.initialMessages(arguments, contract.schemaJson)
         val (history, effectiveMessages) = injectMemoryMessages(initialMessages, conversationId)
             ?: (emptyList<Message>() to initialMessages)
-        val cacheKey = operation.takeIf { it.isSafeCacheEligible(conversationId) }?.buildCacheKey(
+        val cacheKey = operation.takeIf { isSafeCacheEligible(it, conversationId) }?.buildCacheKey(
             digestSource = effectiveMessages,
             securityPartition = securityContext.toCacheSecurityPartition(),
         )
@@ -1653,7 +1653,7 @@ private class TramaiInvocationHandler(
     private fun OperationDefinition.cachedValue(
         key: OperationCacheKey,
         conversationId: String?,
-    ): CachedOperationResult? = if (isSafeCacheEligible(conversationId)) {
+    ): CachedOperationResult? = if (isSafeCacheEligible(this, conversationId)) {
         responseCache.get(key)
     } else {
         null
@@ -1667,7 +1667,7 @@ private class TramaiInvocationHandler(
         securityContext: ExecutionSecurityContext,
         conversationId: String?,
     ) {
-        if (!isSafeCacheEligible(conversationId)) {
+        if (!isSafeCacheEligible(this, conversationId)) {
             return
         }
         responseCache.put(
@@ -1684,6 +1684,29 @@ private class TramaiInvocationHandler(
             ttlMillis = operation.cacheTtlMillis,
         )
     }
+
+    /**
+     * Cache eligibility including the conversation-memory and custom-interceptor
+     * gates. Both gates are engine-scoped, not operation-scoped, so they live
+     * on the handler.
+     *
+     * - **No chat memory** in scope: a cache hit would skip the
+     *   `chatMemory.add(...)` that a fresh execution performs.
+     * - **No custom interceptor**: a cache hit would skip
+     *   `operationInterceptor.interceptRequest(...)` and
+     *   `operationInterceptor.interceptResponse(...)`, allowing stale
+     *   redacted/audited responses to bypass current rules.
+     *
+     * Interceptor-aware caching is deferred to a follow-up that introduces a
+     * dedicated cache-aware interceptor SPI.
+     */
+    private fun isSafeCacheEligible(
+        operation: OperationDefinition,
+        conversationId: String?,
+    ): Boolean =
+        operation.isOperationCacheEligible() &&
+            conversationId == null &&
+            operationInterceptor === NoOpOperationInterceptor
 }
 
 private data class ServiceDefinition(
@@ -1755,11 +1778,18 @@ private data class OperationDefinition(
     val toolDefinitions: List<ToolDefinition>,
     val promptSanitizer: PromptSanitizer?,
 ) {
-    fun isSafeCacheEligible(conversationId: String?): Boolean =
+    /**
+     * Operation-static cache eligibility (no chat memory, no tools, no streaming,
+     * no custom [dev.tramai.core.observation.OperationInterceptor]).
+     *
+     * The interceptor-aware portion of the check lives on the invocation handler
+     * because the interceptor is engine-scoped, not operation-scoped. Use the
+     * handler's [isSafeCacheEligible] when evaluating an actual cache read/write.
+     */
+    fun isOperationCacheEligible(): Boolean =
         operation.cacheable &&
             returnKind != ReturnKind.STREAMING &&
-            toolDefinitions.isEmpty() &&
-            conversationId == null
+            toolDefinitions.isEmpty()
 
     /**
      * The effective system message, resolved by precedence:
@@ -2307,7 +2337,7 @@ private fun ExecutionSecurityContext.toCacheSecurityPartition() = CacheSecurityP
     classificationSource = classificationSource,
 )
 
-/** Length-prefixed, no delimiters. Adding a field: extend with appendField; never reuse `---` as a content marker. */
+/** Length-prefixed field encoding with a framed message separator. Adding a field: extend with appendField; never reuse `---` as a content marker. */
 private fun canonicalizeMessages(messages: List<Message>): String = buildString {
     messages.forEachIndexed { index, message ->
         if (index > 0) {

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -779,23 +779,21 @@ private class TramaiInvocationHandler(
         val initialMessages = operation.initialMessages(arguments)
         val (history, effectiveMessages) = injectMemoryMessages(initialMessages, conversationId)
             ?: (emptyList<Message>() to initialMessages)
-        val cacheKey = operation.buildCacheKey(
+        val cacheKey = operation.takeIf { it.isSafeCacheEligible(conversationId) }?.buildCacheKey(
             digestSource = effectiveMessages,
             securityPartition = securityContext.toCacheSecurityPartition(),
         )
 
-        // Enforce BEFORE_RESPONSE_RETURN before returning cached value
-        operation.cachedValue(cacheKey)?.let { cached ->
-            policyHelper.enforce(
-                policyHelper.buildContext(
-                    enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
+        cacheKey?.let { key ->
+            operation.cachedValue(key, conversationId)?.let { cached ->
+                authorizeCachedResult(
+                    cacheKey = key,
+                    cached = cached,
+                    securityContext = securityContext,
                     correlationId = correlationId,
-                ).providerId(cached.provenance.providerId)
-                    .modelName(cached.provenance.modelName)
-                    .applySecurityContext(securityContext)
-                    .build()
-            )
-            return cached.value as String
+                )
+                return cached.value as String
+            }
         }
 
         val effectiveMutableMessages = effectiveMessages.toMutableList()
@@ -833,7 +831,9 @@ private class TramaiInvocationHandler(
 
         result.observation.onCallCompleted(parseSuccess = null)
         return result.response.content.also {
-            operation.cacheValue(cacheKey, it, result.providerId, result.modelName, securityContext)
+            cacheKey?.let { key ->
+                operation.cacheValue(key, it, result.providerId, result.modelName, securityContext, conversationId)
+            }
         }
     }
 
@@ -852,23 +852,21 @@ private class TramaiInvocationHandler(
         val initialMessages = operation.initialMessages(arguments, contract.schemaJson)
         val (history, effectiveMessages) = injectMemoryMessages(initialMessages, conversationId)
             ?: (emptyList<Message>() to initialMessages)
-        val cacheKey = operation.buildCacheKey(
+        val cacheKey = operation.takeIf { it.isSafeCacheEligible(conversationId) }?.buildCacheKey(
             digestSource = effectiveMessages,
             securityPartition = securityContext.toCacheSecurityPartition(),
         )
 
-        // Enforce BEFORE_RESPONSE_RETURN before returning cached value
-        operation.cachedValue(cacheKey)?.let { cached ->
-            policyHelper.enforce(
-                policyHelper.buildContext(
-                    enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
+        cacheKey?.let { key ->
+            operation.cachedValue(key, conversationId)?.let { cached ->
+                authorizeCachedResult(
+                    cacheKey = key,
+                    cached = cached,
+                    securityContext = securityContext,
                     correlationId = correlationId,
-                ).providerId(cached.provenance.providerId)
-                    .modelName(cached.provenance.modelName)
-                    .applySecurityContext(securityContext)
-                    .build()
-            )
-            return cached.value
+                )
+                return cached.value
+            }
         }
 
         // Re-initialize messages list with history-injected content
@@ -890,7 +888,7 @@ private class TramaiInvocationHandler(
 
     private suspend fun executeStructuredRetryLoop(
         operation: OperationDefinition,
-        cacheKey: OperationCacheKey,
+        cacheKey: OperationCacheKey?,
         handler: StructuredOutputHandler,
         messages: MutableList<Message>,
         historySize: Int,
@@ -929,7 +927,7 @@ private class TramaiInvocationHandler(
 
     private suspend fun executeStructuredAttempt(
         operation: OperationDefinition,
-        cacheKey: OperationCacheKey,
+        cacheKey: OperationCacheKey?,
         handler: StructuredOutputHandler,
         messages: MutableList<Message>,
         historySize: Int,
@@ -977,7 +975,9 @@ private class TramaiInvocationHandler(
                     conversationId = conversationId,
                     messagesBeforeCall = messagesBeforeCall,
                 )
-                operation.cacheValue(cacheKey, analysis.value, result.providerId, result.modelName, securityContext)
+                cacheKey?.let { key ->
+                    operation.cacheValue(key, analysis.value, result.providerId, result.modelName, securityContext, conversationId)
+                }
 
                 analysis.value
             }
@@ -1594,9 +1594,66 @@ private class TramaiInvocationHandler(
         return conversationIdProvider.resolve()
     }
 
+    private suspend fun authorizeCachedResult(
+        cacheKey: OperationCacheKey,
+        cached: CachedOperationResult,
+        securityContext: ExecutionSecurityContext,
+        correlationId: String,
+    ) {
+        validateCachedEntry(cacheKey, cached)
+        policyHelper.enforce(
+            policyHelper.buildContext(
+                enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_PROVIDER_RESOLUTION,
+                correlationId = correlationId,
+            ).modelName(cacheKey.requestedModel)
+                .applySecurityContext(securityContext)
+                .attribute("cacheReuse", "true")
+                .build()
+        )
+        policyHelper.enforce(
+            policyHelper.buildContext(
+                enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                correlationId = correlationId,
+            ).providerId(cached.provenance.providerId)
+                .modelName(cached.provenance.modelName)
+                .applySecurityContext(securityContext)
+                .attribute("cacheReuse", "true")
+                .build()
+        )
+        policyHelper.enforce(
+            policyHelper.buildContext(
+                enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
+                correlationId = correlationId,
+            ).providerId(cached.provenance.providerId)
+                .modelName(cached.provenance.modelName)
+                .applySecurityContext(securityContext)
+                .attribute("cacheReuse", "true")
+                .build()
+        )
+    }
+
+    private fun validateCachedEntry(
+        key: OperationCacheKey,
+        cached: CachedOperationResult,
+    ) {
+        val provenance = cached.provenance
+        if (provenance.providerId.isBlank() ||
+            provenance.modelName.isBlank() ||
+            provenance.dataClassification != key.securityPartition.dataClassification ||
+            provenance.classificationSource != key.securityPartition.classificationSource
+        ) {
+            throw IllegalStateException(
+                "Cached entry envelope mismatch: key partition " +
+                    "${key.securityPartition} != cached provenance partition " +
+                    "(${provenance.dataClassification}, ${provenance.classificationSource})",
+            )
+        }
+    }
+
     private fun OperationDefinition.cachedValue(
         key: OperationCacheKey,
-    ): CachedOperationResult? = if (isCacheEligible) {
+        conversationId: String?,
+    ): CachedOperationResult? = if (isSafeCacheEligible(conversationId)) {
         responseCache.get(key)
     } else {
         null
@@ -1608,8 +1665,9 @@ private class TramaiInvocationHandler(
         providerId: String,
         modelName: String,
         securityContext: ExecutionSecurityContext,
+        conversationId: String?,
     ) {
-        if (!isCacheEligible) {
+        if (!isSafeCacheEligible(conversationId)) {
             return
         }
         responseCache.put(
@@ -1697,8 +1755,11 @@ private data class OperationDefinition(
     val toolDefinitions: List<ToolDefinition>,
     val promptSanitizer: PromptSanitizer?,
 ) {
-    val isCacheEligible: Boolean
-        get() = operation.cacheable && returnKind != ReturnKind.STREAMING && toolDefinitions.isEmpty()
+    fun isSafeCacheEligible(conversationId: String?): Boolean =
+        operation.cacheable &&
+            returnKind != ReturnKind.STREAMING &&
+            toolDefinitions.isEmpty() &&
+            conversationId == null
 
     /**
      * The effective system message, resolved by precedence:
@@ -1873,8 +1934,25 @@ private data class OperationDefinition(
         requestedModel = operation.model,
         explicitProvider = operation.provider.takeIf { it.isNotBlank() },
         requestDigest = sha256Hex(canonicalizeMessages(digestSource)),
+        operationFingerprint = operationFingerprint(),
         securityPartition = securityPartition,
     )
+
+    private fun operationFingerprint(): String {
+        val canonical = buildString {
+            append("tools_count=").append(toolDefinitions.size).append('\n')
+            toolDefinitions.forEachIndexed { index, tool ->
+                append("tool_").append(index).append("_name_len=").append(tool.name.length).append('\n')
+                append(tool.name).append('\n')
+                append("tool_").append(index).append("_schema_len=").append(tool.inputSchemaJson.length).append('\n')
+                append(tool.inputSchemaJson).append('\n')
+            }
+            append("timeout_millis=").append(operation.timeoutMillis).append('\n')
+            append("cacheable=").append(operation.cacheable).append('\n')
+            append("cache_ttl_millis=").append(operation.cacheTtlMillis).append('\n')
+        }
+        return sha256Hex(canonical)
+    }
 
     fun structuredContract(handler: StructuredOutputHandler) = handler.createContract(
         requireNotNull(returnType) {
@@ -1994,10 +2072,11 @@ internal fun buildOperationCacheKeyForTesting(
     arguments: List<Any?>,
     schemaJson: String? = null,
     promptSanitizer: PromptSanitizer? = null,
+    toolRegistry: ToolRegistry = ToolRegistry(),
 ): OperationCacheKey {
     val definition = ServiceDefinition.create(
         serviceType = serviceType,
-        toolRegistry = ToolRegistry(),
+        toolRegistry = toolRegistry,
         promptSanitizer = promptSanitizer,
     )
     val method = serviceType.java.methods.firstOrNull { it.name == methodName }
@@ -2228,7 +2307,7 @@ private fun ExecutionSecurityContext.toCacheSecurityPartition() = CacheSecurityP
     classificationSource = classificationSource,
 )
 
-/** Length-prefixed format — collision-free without escaping. Adding a field: extend the per-message block, never reuse `---` as a content marker. */
+/** Length-prefixed, no delimiters. Adding a field: extend with appendField; never reuse `---` as a content marker. */
 private fun canonicalizeMessages(messages: List<Message>): String = buildString {
     messages.forEachIndexed { index, message ->
         if (index > 0) {
@@ -2237,29 +2316,53 @@ private fun canonicalizeMessages(messages: List<Message>): String = buildString 
         append("role=")
         append(message.role.name)
         append('\n')
-        append("content_len=")
-        append(message.content.toByteArray(StandardCharsets.UTF_8).size)
-        append('\n')
-        append(message.content)
-        message.contentParts?.let { parts ->
-            val partsCanonical = parts.joinToString("|") { part ->
-                when (part) {
-                    is ContentPart.TextPart -> "T:${part.text}"
-                    is ContentPart.ImagePart -> {
-                        val encoded = Base64.getEncoder().encodeToString(part.data)
-                        "I:${part.mimeType}:$encoded"
-                    }
-                    is ContentPart.ImageUrlContent -> "U:${part.url}:${part.mimeType}"
+        appendField("content", message.content)
+        append("parts_count=").append(message.contentParts?.size ?: 0).append('\n')
+        message.contentParts.orEmpty().forEachIndexed { partIndex, part ->
+            append("part_index=").append(partIndex).append('\n')
+            when (part) {
+                is ContentPart.TextPart -> {
+                    append("part_type=text\n")
+                    appendField("text", part.text)
+                }
+                is ContentPart.ImagePart -> {
+                    append("part_type=image\n")
+                    appendField("mime", part.mimeType)
+                    appendField("data_b64", Base64.getEncoder().encodeToString(part.data))
+                }
+                is ContentPart.ImageUrlContent -> {
+                    append("part_type=image_url\n")
+                    appendField("url", part.url)
+                    appendField("mime", part.mimeType)
                 }
             }
-            append('\n')
-            append("parts_len=")
-            append(partsCanonical.toByteArray(StandardCharsets.UTF_8).size)
-            append('\n')
-            append(partsCanonical)
+        }
+        if (message.toolCallId != null) {
+            appendField("tool_call_id", message.toolCallId)
+        }
+        message.toolCalls?.let { toolCalls ->
+            append("tool_calls_count=").append(toolCalls.size).append('\n')
+            toolCalls.forEachIndexed { toolIndex, toolCall ->
+                append("tool_call_index=").append(toolIndex).append('\n')
+                appendField("tool_call_id", toolCall.id)
+                appendField("tool_call_name", toolCall.name)
+                appendField("tool_call_args", toolCall.argumentsJson)
+            }
         }
     }
 }
+
+private fun StringBuilder.appendField(name: String, value: String?) {
+    if (value == null) {
+        append(name).append("_null\n")
+        return
+    }
+    val bytes = value.toByteArray(StandardCharsets.UTF_8)
+    append(name).append("_len=").append(bytes.size).append('\n')
+    append(value).append('\n')
+}
+
+internal fun buildRequestDigest(messages: List<Message>): String = sha256Hex(canonicalizeMessages(messages))
 
 private fun sha256Hex(input: String): String {
     val digest = MessageDigest.getInstance("SHA-256").digest(input.toByteArray(StandardCharsets.UTF_8))

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -61,6 +61,8 @@ import kotlinx.coroutines.withTimeout
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Method
 import java.lang.reflect.Proxy
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
 import kotlin.reflect.KClass
@@ -775,17 +777,17 @@ private class TramaiInvocationHandler(
         val correlationId = java.util.UUID.randomUUID().toString()
 
         // Enforce BEFORE_RESPONSE_RETURN before returning cached value
-        if (securityContext.dataClassification == null) {
-            operation.cachedValue(arguments)?.let { cached ->
-                policyHelper.enforce(
-                    policyHelper.buildContext(
-                        enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
-                        correlationId = correlationId,
-                    ).applySecurityContext(securityContext)
-                        .build()
-                )
-                return cached as String
-            }
+        operation.cachedValue(arguments)?.let { cached ->
+            policyHelper.enforce(
+                policyHelper.buildContext(
+                    enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
+                    correlationId = correlationId,
+                ).providerId(cached.provenance.providerId)
+                    .modelName(cached.provenance.modelName)
+                    .applySecurityContext(securityContext)
+                    .build()
+            )
+            return cached.value as String
         }
 
         val messages = operation.initialMessages(arguments).toMutableList()
@@ -826,9 +828,7 @@ private class TramaiInvocationHandler(
 
         result.observation.onCallCompleted(parseSuccess = null)
         return result.response.content.also {
-            if (securityContext.dataClassification == null) {
-                operation.cacheValue(arguments, it)
-            }
+            operation.cacheValue(arguments, it, result.providerId, result.modelName)
         }
     }
 
@@ -846,17 +846,17 @@ private class TramaiInvocationHandler(
         val correlationId = java.util.UUID.randomUUID().toString()
 
         // Enforce BEFORE_RESPONSE_RETURN before returning cached value
-        if (securityContext.dataClassification == null) {
-            operation.cachedValue(arguments, contract.schemaJson)?.let { cached ->
-                policyHelper.enforce(
-                    policyHelper.buildContext(
-                        enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
-                        correlationId = correlationId,
-                    ).applySecurityContext(securityContext)
-                        .build()
-                )
-                return cached
-            }
+        operation.cachedValue(arguments, contract.schemaJson)?.let { cached ->
+            policyHelper.enforce(
+                policyHelper.buildContext(
+                    enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
+                    correlationId = correlationId,
+                ).providerId(cached.provenance.providerId)
+                    .modelName(cached.provenance.modelName)
+                    .applySecurityContext(securityContext)
+                    .build()
+            )
+            return cached.value
         }
 
         val messages = operation.initialMessages(arguments, contract.schemaJson).toMutableList()
@@ -974,9 +974,7 @@ private class TramaiInvocationHandler(
                     conversationId = conversationId,
                     messagesBeforeCall = messagesBeforeCall,
                 )
-                if (securityContext.dataClassification == null) {
-                    operation.cacheValue(arguments, analysis.value, schemaJson)
-                }
+                operation.cacheValue(arguments, analysis.value, result.providerId, result.modelName, schemaJson)
 
                 analysis.value
             }
@@ -1596,7 +1594,7 @@ private class TramaiInvocationHandler(
     private fun OperationDefinition.cachedValue(
         arguments: List<Any?>,
         schemaJson: String? = null,
-    ): Any? = if (isCacheEligible) {
+    ): CachedOperationResult? = if (isCacheEligible) {
         responseCache.get(cacheKey(arguments, schemaJson))
     } else {
         null
@@ -1605,14 +1603,25 @@ private class TramaiInvocationHandler(
     private fun OperationDefinition.cacheValue(
         arguments: List<Any?>,
         value: Any,
+        providerId: String,
+        modelName: String,
         schemaJson: String? = null,
     ) {
         if (!isCacheEligible) {
             return
         }
+        val securityContext = ExecutionSecurityContext.fromArguments(arguments.toTypedArray())
         responseCache.put(
             key = cacheKey(arguments, schemaJson),
-            value = value,
+            value = CachedOperationResult(
+                value = value,
+                provenance = CachedResponseProvenance(
+                    providerId = providerId,
+                    modelName = modelName,
+                    dataClassification = securityContext.dataClassification,
+                    classificationSource = securityContext.classificationSource,
+                ),
+            ),
             ttlMillis = operation.cacheTtlMillis,
         )
     }
@@ -1854,12 +1863,10 @@ private data class OperationDefinition(
         methodName = method.name,
         requestedModel = operation.model,
         explicitProvider = operation.provider.takeIf { it.isNotBlank() },
-        messages = initialMessages(arguments, schemaJson).map { message ->
-            CachedMessage(
-                role = message.role.name,
-                content = message.content,
-            )
-        },
+        // The cache key is intentionally derived from the request that reaches
+        // the model so redactions remain stable across repeated calls.
+        requestDigest = sha256Hex(canonicalizeMessages(initialMessages(arguments, schemaJson))),
+        securityPartition = ExecutionSecurityContext.fromArguments(arguments.toTypedArray()).toCacheSecurityPartition(),
     )
 
     fun structuredContract(handler: StructuredOutputHandler) = handler.createContract(
@@ -1972,6 +1979,25 @@ private data class OperationDefinition(
         private fun Method.isSuspendSignature(): Boolean =
             parameterTypes.lastOrNull()?.name == "kotlin.coroutines.Continuation"
     }
+}
+
+internal fun buildOperationCacheKeyForTesting(
+    serviceType: KClass<*>,
+    methodName: String,
+    arguments: List<Any?>,
+    schemaJson: String? = null,
+    promptSanitizer: PromptSanitizer? = null,
+): OperationCacheKey {
+    val definition = ServiceDefinition.create(
+        serviceType = serviceType,
+        toolRegistry = ToolRegistry(),
+        promptSanitizer = promptSanitizer,
+    )
+    val method = serviceType.java.methods.firstOrNull { it.name == methodName }
+        ?: throw IllegalArgumentException("No method named '$methodName' on ${serviceType.java.name}")
+    val operation = definition.operations[method]
+        ?: throw IllegalArgumentException("No operation metadata for ${serviceType.java.name}.$methodName")
+    return operation.cacheKey(arguments, schemaJson)
 }
 
 private data class ProviderCallResult(
@@ -2186,6 +2212,20 @@ private fun PolicyContextBuilder.applySecurityContext(
     securityContext: ExecutionSecurityContext,
 ): PolicyContextBuilder = dataClassification(securityContext.dataClassification)
     .classificationSource(securityContext.classificationSource)
+
+private fun ExecutionSecurityContext.toCacheSecurityPartition() = CacheSecurityPartition(
+    dataClassification = dataClassification,
+    classificationSource = classificationSource,
+)
+
+private fun canonicalizeMessages(messages: List<Message>): String = messages.joinToString("\u001E") { message ->
+    "${message.role.name}\u001F${message.content}"
+}
+
+private fun sha256Hex(input: String): String {
+    val digest = MessageDigest.getInstance("SHA-256").digest(input.toByteArray(StandardCharsets.UTF_8))
+    return digest.joinToString(separator = "") { byte -> "%02x".format(byte) }
+}
 
 private const val INITIAL_PROVIDER_RETRY_DELAY_MILLIS = 50L
 private const val MAX_PROVIDER_RETRY_DELAY_MILLIS = 1_000L

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/PolicyEnforcementTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/PolicyEnforcementTest.kt
@@ -237,11 +237,26 @@ class PolicyEnforcementTest {
     private fun engineWithCache(
         policyEngine: PolicyEngine? = null,
         provider: ModelProvider = providerThatReturns("ok"),
+        responseCache: OperationResponseCache = InMemoryOperationResponseCache(),
     ) = TramaiEngine(
         provider = provider,
-        responseCache = InMemoryOperationResponseCache(),
+        responseCache = responseCache,
         policyEngine = policyEngine,
     )
+
+    private fun parsedStructuredOutputHandler(answer: String = "parsed") = object : StructuredOutputHandler {
+        override fun analyze(rawResponse: String, targetType: kotlin.reflect.KType): StructuredOutputResult =
+            StructuredOutputResult.Success(TestPayload(answer), rawResponse)
+
+        override fun createContract(targetType: kotlin.reflect.KType) =
+            StructuredOutputContract(targetType, "{ }")
+
+        override fun generateSchema(type: kotlin.reflect.KType) = "{ }"
+
+        override fun deserialize(input: Any, targetType: kotlin.reflect.KType) = TestPayload(answer)
+
+        override fun serialize(value: Any): Any = mapOf("answer" to answer)
+    }
 
     // -- Core enforcement tests ------------------------------------------------
 
@@ -873,134 +888,59 @@ class PolicyEnforcementTest {
     // -- Cache tests -----------------------------------------------------------
 
     @Test
-    fun `cached raw response denied after policy change`() = runBlocking {
-        // Phase 1: allow + cache the result
+    fun `unclassified raw cache hit does not invoke provider twice`() = runBlocking {
         val provider = CountingProvider()
-        val allowEngine = engineWithCache(
+        val service = engineWithCache(
             policyEngine = object : PolicyEngine {
                 override suspend fun evaluate(context: PolicyContext): PolicyDecision =
                     PolicyDecision.Allow
             },
             provider = provider,
-        )
-        val service1 = allowEngine.create<CachedTestService>()
-        val result1 = service1.cachedCall("test")
-        assertThat(result1).isEqualTo("ok")
+        ).create<CachedTestService>()
+
+        assertThat(service.cachedCall("test")).isEqualTo("ok")
+        assertThat(service.cachedCall("test")).isEqualTo("ok")
         assertThat(provider.callCount.get()).isEqualTo(1)
-
-        // Phase 2: deny BEFORE_RESPONSE_RETURN with a new engine instance
-        val denyEngine = engineWithCache(
-            policyEngine = object : PolicyEngine {
-                override suspend fun evaluate(context: PolicyContext): PolicyDecision =
-                    if (context.enforcementPoint == EnforcementPoint.BEFORE_RESPONSE_RETURN) {
-                        PolicyDecision.Deny("cache response blocked", "CACHE_DENY")
-                    } else PolicyDecision.Allow
-            },
-            provider = provider,
-        )
-        val service2 = denyEngine.create<CachedTestService>()
-
-        assertThatThrownBy { runBlocking { service2.cachedCall("test") } }
-            .isInstanceOf(PolicyViolationException::class.java)
-            .hasMessageContaining("cache response blocked")
     }
 
     @Test
-    fun `cached structured response denied`() = runBlocking {
-        val handler = object : StructuredOutputHandler {
-            override fun analyze(rawResponse: String, targetType: kotlin.reflect.KType): StructuredOutputResult {
-                return StructuredOutputResult.Success(TestPayload("parsed"), rawResponse)
-            }
-            override fun createContract(targetType: kotlin.reflect.KType) =
-                StructuredOutputContract(targetType, "{ }")
-            override fun generateSchema(type: kotlin.reflect.KType) = "{ }"
-            override fun deserialize(input: Any, targetType: kotlin.reflect.KType) = TestPayload("parsed")
-            override fun serialize(value: Any): Any = mapOf("answer" to "parsed")
-        }
-
-        // Phase 1: allow + cache
-        val provider = CountingProvider()
-        val allowEngine = TramaiEngine(
+    fun `classified RESTRICTED local raw cache hit does not invoke provider twice`() = runBlocking {
+        val provider = CountingProvider(id = "local-provider")
+        val service = engineWithCache(
+            policyEngine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedModels = setOf("test-model"),
+                    allowedProviders = setOf("local-provider"),
+                    trustedLocalProviders = setOf("local-provider"),
+                ),
+            ),
             provider = provider,
-            structuredOutputHandler = handler,
-            responseCache = InMemoryOperationResponseCache(),
-            policyEngine = object : PolicyEngine {
-                override suspend fun evaluate(context: PolicyContext): PolicyDecision =
-                    PolicyDecision.Allow
-            },
-        )
-        val service1: CachedStructuredService = allowEngine.create()
-        val result1 = service1.analyze("test")
-        assertThat(result1.answer).isEqualTo("parsed")
-        assertThat(provider.callCount.get()).isEqualTo(1)
-
-        // Phase 2: deny
-        val denyEngine = TramaiEngine(
-            provider = provider,
-            structuredOutputHandler = handler,
-            responseCache = InMemoryOperationResponseCache(),
-            policyEngine = object : PolicyEngine {
-                override suspend fun evaluate(context: PolicyContext): PolicyDecision =
-                    if (context.enforcementPoint == EnforcementPoint.BEFORE_RESPONSE_RETURN) {
-                        PolicyDecision.Deny("cache struct blocked", "CACHE_STRUCT_DENY")
-                    } else PolicyDecision.Allow
-            },
-        )
-        val service2: CachedStructuredService = denyEngine.create()
-
-        assertThatThrownBy { runBlocking { service2.analyze("test") } }
-            .isInstanceOf(PolicyViolationException::class.java)
-            .hasMessageContaining("cache struct blocked")
-    }
-
-    @Test
-    fun `classified raw cacheable calls bypass cache reuse`() = runBlocking {
-        val provider = CountingProvider()
-        val engine = TramaiEngine(
-            provider = provider,
-            responseCache = InMemoryOperationResponseCache(),
-            policyEngine = object : PolicyEngine {
-                override suspend fun evaluate(context: PolicyContext): PolicyDecision = PolicyDecision.Allow
-            },
-        )
-        val service: CachedClassifiedTestService = engine.create()
+        ).create<CachedClassifiedTestService>()
         val input = ClassifiedDocument(
             payload = "secret",
             classification = DataClassification.RESTRICTED,
             source = ClassificationSource.DECLARED,
         )
 
-        val first = service.analyze(input)
-        val second = service.analyze(input)
-
-        assertThat(first).isEqualTo("ok")
-        assertThat(second).isEqualTo("ok")
-        assertThat(provider.callCount.get()).isEqualTo(2)
+        assertThat(service.analyze(input)).isEqualTo("ok")
+        assertThat(service.analyze(input)).isEqualTo("ok")
+        assertThat(provider.callCount.get()).isEqualTo(1)
     }
 
     @Test
-    fun `classified structured cacheable calls bypass cache reuse`() = runBlocking {
-        val handler = object : StructuredOutputHandler {
-            override fun analyze(rawResponse: String, targetType: kotlin.reflect.KType): StructuredOutputResult =
-                StructuredOutputResult.Success(TestPayload("parsed"), rawResponse)
-
-            override fun createContract(targetType: kotlin.reflect.KType) =
-                StructuredOutputContract(targetType, "{ }")
-
-            override fun generateSchema(type: kotlin.reflect.KType) = "{ }"
-
-            override fun deserialize(input: Any, targetType: kotlin.reflect.KType) = TestPayload("parsed")
-
-            override fun serialize(value: Any): Any = mapOf("answer" to "parsed")
-        }
-        val provider = CountingProvider()
+    fun `classified RESTRICTED local structured cache hit does not invoke provider twice`() = runBlocking {
+        val provider = CountingProvider(id = "local-provider")
         val engine = TramaiEngine(
             provider = provider,
-            structuredOutputHandler = handler,
+            structuredOutputHandler = parsedStructuredOutputHandler(),
             responseCache = InMemoryOperationResponseCache(),
-            policyEngine = object : PolicyEngine {
-                override suspend fun evaluate(context: PolicyContext): PolicyDecision = PolicyDecision.Allow
-            },
+            policyEngine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedModels = setOf("test-model"),
+                    allowedProviders = setOf("local-provider"),
+                    trustedLocalProviders = setOf("local-provider"),
+                ),
+            ),
         )
         val service: CachedClassifiedStructuredService = engine.create()
         val input = ClassifiedDocument(
@@ -1009,12 +949,188 @@ class PolicyEnforcementTest {
             source = ClassificationSource.DECLARED,
         )
 
-        val first = service.analyze(input)
-        val second = service.analyze(input)
+        assertThat(service.analyze(input).answer).isEqualTo("parsed")
+        assertThat(service.analyze(input).answer).isEqualTo("parsed")
+        assertThat(provider.callCount.get()).isEqualTo(1)
+    }
 
-        assertThat(first.answer).isEqualTo("parsed")
-        assertThat(second.answer).isEqualTo("parsed")
+    @Test
+    fun `same payload under PUBLIC then RESTRICTED produces separate cache entries`() = runBlocking {
+        val provider = CountingProvider(id = "local-provider")
+        val cache = InMemoryOperationResponseCache()
+        val engine = TramaiEngine(
+            provider = provider,
+            responseCache = cache,
+            policyEngine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedModels = setOf("test-model"),
+                    allowedProviders = setOf("local-provider"),
+                    trustedLocalProviders = setOf("local-provider"),
+                ),
+            ),
+        )
+        val service: CachedClassifiedTestService = engine.create()
+        val publicInput = ClassifiedDocument(
+            payload = "same-payload",
+            classification = DataClassification.PUBLIC,
+            source = ClassificationSource.DECLARED,
+        )
+        val restrictedInput = publicInput.copy(classification = DataClassification.RESTRICTED)
+
+        assertThat(service.analyze(publicInput)).isEqualTo("ok")
+        assertThat(service.analyze(restrictedInput)).isEqualTo("ok")
+
         assertThat(provider.callCount.get()).isEqualTo(2)
+        val publicKey = buildOperationCacheKeyForTesting(
+            serviceType = CachedClassifiedTestService::class,
+            methodName = "analyze",
+            arguments = listOf(publicInput),
+        )
+        val restrictedKey = buildOperationCacheKeyForTesting(
+            serviceType = CachedClassifiedTestService::class,
+            methodName = "analyze",
+            arguments = listOf(restrictedInput),
+        )
+        assertThat(publicKey.requestDigest).isEqualTo(restrictedKey.requestDigest)
+        assertThat(publicKey.securityPartition).isNotEqualTo(restrictedKey.securityPartition)
+        assertThat(cache.snapshotKeys()).contains(publicKey, restrictedKey)
+    }
+
+    @Test
+    fun `cached cloud response cannot be reused for RESTRICTED request`() = runBlocking {
+        val cache = InMemoryOperationResponseCache()
+        val provider = CountingProvider(id = "cloud-provider")
+        val allowEngine = engineWithCache(
+            policyEngine = object : PolicyEngine {
+                override suspend fun evaluate(context: PolicyContext): PolicyDecision = PolicyDecision.Allow
+            },
+            provider = provider,
+            responseCache = cache,
+        )
+        val allowService = allowEngine.create<CachedClassifiedTestService>()
+        val restrictedInput = ClassifiedDocument(
+            payload = "secret",
+            classification = DataClassification.RESTRICTED,
+            source = ClassificationSource.DECLARED,
+        )
+
+        assertThat(allowService.analyze(restrictedInput)).isEqualTo("ok")
+        assertThat(provider.callCount.get()).isEqualTo(1)
+
+        val denyEngine = engineWithCache(
+            policyEngine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedModels = setOf("test-model"),
+                    allowedProviders = setOf("cloud-provider"),
+                ),
+            ),
+            provider = provider,
+            responseCache = cache,
+        )
+        val denyService = denyEngine.create<CachedClassifiedTestService>()
+
+        assertThatThrownBy { runBlocking { denyService.analyze(restrictedInput) } }
+            .isInstanceOf(PolicyViolationException::class.java)
+            .hasMessageContaining("RESTRICTED data may not be sent to provider 'cloud-provider'")
+        assertThat(provider.callCount.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `policy change after cache write denies subsequent cache hit`() = runBlocking {
+        val provider = CountingProvider()
+        val cache = InMemoryOperationResponseCache()
+        val allowEngine = engineWithCache(
+            policyEngine = object : PolicyEngine {
+                override suspend fun evaluate(context: PolicyContext): PolicyDecision = PolicyDecision.Allow
+            },
+            provider = provider,
+            responseCache = cache,
+        )
+        val allowService = allowEngine.create<CachedTestService>()
+        assertThat(allowService.cachedCall("test")).isEqualTo("ok")
+        assertThat(provider.callCount.get()).isEqualTo(1)
+
+        val denyEngine = engineWithCache(
+            policyEngine = object : PolicyEngine {
+                override suspend fun evaluate(context: PolicyContext): PolicyDecision =
+                    if (context.enforcementPoint == EnforcementPoint.BEFORE_RESPONSE_RETURN) {
+                        PolicyDecision.Deny("cache response blocked", "CACHE_DENY")
+                    } else {
+                        PolicyDecision.Allow
+                    }
+            },
+            provider = provider,
+            responseCache = cache,
+        )
+        val denyService = denyEngine.create<CachedTestService>()
+
+        assertThatThrownBy { runBlocking { denyService.cachedCall("test") } }
+            .isInstanceOf(PolicyViolationException::class.java)
+            .hasMessageContaining("cache response blocked")
+        assertThat(provider.callCount.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `cache key contains digest not raw prompt`() {
+        val firstKey = buildOperationCacheKeyForTesting(
+            serviceType = CachedTestService::class,
+            methodName = "cachedCall",
+            arguments = listOf("secret"),
+        )
+        val secondKey = buildOperationCacheKeyForTesting(
+            serviceType = CachedTestService::class,
+            methodName = "cachedCall",
+            arguments = listOf("secret"),
+        )
+        val differentKey = buildOperationCacheKeyForTesting(
+            serviceType = CachedTestService::class,
+            methodName = "cachedCall",
+            arguments = listOf("different"),
+        )
+
+        assertThat(firstKey.requestDigest.matches(Regex("^[a-f0-9]{64}$"))).isTrue()
+        assertThat(firstKey.requestDigest).isEqualTo(secondKey.requestDigest)
+        assertThat(firstKey.requestDigest).isNotEqualTo(differentKey.requestDigest)
+        assertThat(firstKey.requestDigest).doesNotContain("secret")
+    }
+
+    @Test
+    fun `provenance on cached raw and structured results includes providerId and modelName`() = runBlocking {
+        val rawCache = InMemoryOperationResponseCache()
+        val rawProvider = CountingProvider(id = "raw-provider")
+        val rawService = engineWithCache(
+            policyEngine = object : PolicyEngine {
+                override suspend fun evaluate(context: PolicyContext): PolicyDecision = PolicyDecision.Allow
+            },
+            provider = rawProvider,
+            responseCache = rawCache,
+        ).create<CachedTestService>()
+        assertThat(rawService.cachedCall("test")).isEqualTo("ok")
+
+        val rawKey = rawCache.snapshotKeys().single()
+        val rawEntry = rawCache.peek(rawKey)
+        assertThat(rawEntry).isNotNull()
+        assertThat(rawEntry!!.provenance.providerId).isEqualTo("raw-provider")
+        assertThat(rawEntry.provenance.modelName).isEqualTo("test-model")
+
+        val structuredCache = InMemoryOperationResponseCache()
+        val structuredProvider = CountingProvider(id = "structured-provider")
+        val structuredEngine = TramaiEngine(
+            provider = structuredProvider,
+            structuredOutputHandler = parsedStructuredOutputHandler(),
+            responseCache = structuredCache,
+            policyEngine = object : PolicyEngine {
+                override suspend fun evaluate(context: PolicyContext): PolicyDecision = PolicyDecision.Allow
+            },
+        )
+        val structuredService: CachedStructuredService = structuredEngine.create()
+        assertThat(structuredService.analyze("test").answer).isEqualTo("parsed")
+
+        val structuredKey = structuredCache.snapshotKeys().single()
+        val structuredEntry = structuredCache.peek(structuredKey)
+        assertThat(structuredEntry).isNotNull()
+        assertThat(structuredEntry!!.provenance.providerId).isEqualTo("structured-provider")
+        assertThat(structuredEntry.provenance.modelName).isEqualTo("test-model")
     }
 
     // -- Context semantics tests -----------------------------------------------
@@ -1221,8 +1337,8 @@ class PolicyEnforcementTest {
         val provider = CountingProvider()
 
         val cache = object : OperationResponseCache {
-            override fun get(key: OperationCacheKey): Any? = null
-            override fun put(key: OperationCacheKey, value: Any, ttlMillis: Long) {
+            override fun get(key: OperationCacheKey): CachedOperationResult? = null
+            override fun put(key: OperationCacheKey, value: CachedOperationResult, ttlMillis: Long) {
                 cachePutCalled = true
             }
         }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/PolicyEnforcementTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/PolicyEnforcementTest.kt
@@ -9,6 +9,7 @@ import dev.tramai.core.exception.PolicyViolationException
 import dev.tramai.core.exception.ProviderException
 import dev.tramai.core.memory.ChatMemory
 import dev.tramai.core.model.ClassifiedDocument
+import dev.tramai.core.model.ContentPart
 import dev.tramai.core.model.Message
 import dev.tramai.core.model.MessageRole
 import dev.tramai.core.model.ModelRequest
@@ -171,6 +172,12 @@ class PolicyEnforcementTest {
     }
 
     @AiService
+    interface CachedToolTestService {
+        @Operation(prompt = "test", model = "test-model", tools = ["echo"], cacheable = true, cacheTtlMillis = 60_000)
+        suspend fun cachedCall(input: String): String
+    }
+
+    @AiService
     interface StructuredTestService {
         @Operation(prompt = "test", model = "test-model", maxRetries = 0)
         suspend fun analyze(input: String): TestPayload
@@ -238,6 +245,18 @@ class PolicyEnforcementTest {
             @ConversationId sessionId: String,
             input: String,
         ): String
+    }
+
+    @AiService
+    interface FingerprintWithoutToolsService {
+        @Operation(prompt = "test", model = "test-model", cacheable = true, cacheTtlMillis = 60_000)
+        suspend fun cachedCall(input: String): String
+    }
+
+    @AiService
+    interface FingerprintWithToolsService {
+        @Operation(prompt = "test", model = "test-model", tools = ["echo"], cacheable = true, cacheTtlMillis = 60_000)
+        suspend fun cachedCall(input: String): String
     }
 
     data class TestPayload(val answer: String)
@@ -1043,21 +1062,10 @@ class PolicyEnforcementTest {
     }
 
     @Test
-    fun `same current turn with different chat history produces separate cache entries`() = runBlocking {
+    fun `cacheable operation with active chatMemory bypasses cache`() = runBlocking {
         val provider = CountingProvider()
         val memory = object : ChatMemory {
-            private val store = mapOf(
-                "session-a" to listOf(
-                    Message(MessageRole.USER, "Earlier context A"),
-                    Message(MessageRole.ASSISTANT, "Assistant memory A"),
-                ),
-                "session-b" to listOf(
-                    Message(MessageRole.USER, "Earlier context B"),
-                    Message(MessageRole.ASSISTANT, "Assistant memory B"),
-                ),
-            )
-
-            override fun get(conversationId: String): List<Message> = store[conversationId].orEmpty()
+            override fun get(conversationId: String): List<Message> = emptyList()
 
             override fun add(conversationId: String, messages: List<Message>) = Unit
 
@@ -1076,7 +1084,7 @@ class PolicyEnforcementTest {
         val service: CachedConversationService = engine.create()
 
         assertThat(service.analyze("session-a", "same-turn")).isEqualTo("ok")
-        assertThat(service.analyze("session-b", "same-turn")).isEqualTo("ok")
+        assertThat(service.analyze("session-a", "same-turn")).isEqualTo("ok")
         assertThat(provider.callCount.get()).isEqualTo(2)
     }
 
@@ -1116,6 +1124,100 @@ class PolicyEnforcementTest {
     }
 
     @Test
+    fun `cached provider removed from allowlist denies cache hit and skips provider`() = runBlocking {
+        val cache = InMemoryOperationResponseCache()
+        val provider = CountingProvider(id = "cloud-provider")
+        val allowEngine = engineWithCache(
+            policyEngine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedModels = setOf("test-model"),
+                    allowedProviders = setOf("cloud-provider"),
+                    allowCloudForClassifications = setOf(DataClassification.PUBLIC),
+                ),
+            ),
+            provider = provider,
+            responseCache = cache,
+        )
+        val allowService = allowEngine.create<CachedTestService>()
+        assertThat(allowService.cachedCall("test")).isEqualTo("ok")
+        assertThat(provider.callCount.get()).isEqualTo(1)
+
+        val denyEngine = engineWithCache(
+            policyEngine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedModels = setOf("test-model"),
+                    allowedProviders = emptySet(),
+                    allowCloudForClassifications = setOf(DataClassification.PUBLIC),
+                ),
+            ),
+            provider = provider,
+            responseCache = cache,
+        )
+        val denyService = denyEngine.create<CachedTestService>()
+
+        assertThatThrownBy { runBlocking { denyService.cachedCall("test") } }
+            .isInstanceOf(PolicyViolationException::class.java)
+            .hasMessageContaining("Provider 'cloud-provider' is not in the allowed-providers registry")
+        assertThat(provider.callCount.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `cached model removed from allowlist denies cache hit and skips provider`() = runBlocking {
+        val cache = InMemoryOperationResponseCache()
+        val provider = CountingProvider(id = "cloud-provider")
+        val allowEngine = engineWithCache(
+            policyEngine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedModels = setOf("test-model"),
+                    allowedProviders = setOf("cloud-provider"),
+                    allowCloudForClassifications = setOf(DataClassification.PUBLIC),
+                ),
+            ),
+            provider = provider,
+            responseCache = cache,
+        )
+        val allowService = allowEngine.create<CachedTestService>()
+        assertThat(allowService.cachedCall("test")).isEqualTo("ok")
+        assertThat(provider.callCount.get()).isEqualTo(1)
+
+        val denyEngine = engineWithCache(
+            policyEngine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedModels = emptySet(),
+                    allowedProviders = setOf("cloud-provider"),
+                    allowCloudForClassifications = setOf(DataClassification.PUBLIC),
+                ),
+            ),
+            provider = provider,
+            responseCache = cache,
+        )
+        val denyService = denyEngine.create<CachedTestService>()
+
+        assertThatThrownBy { runBlocking { denyService.cachedCall("test") } }
+            .isInstanceOf(PolicyViolationException::class.java)
+            .hasMessageContaining("Model 'test-model' is not in the allowed-models registry")
+        assertThat(provider.callCount.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `cacheable operation with tools bypasses cache`() = runBlocking {
+        val provider = CountingProvider()
+        val engine = TramaiEngine(
+            provider = provider,
+            toolRegistry = ToolRegistry(mapOf("echo" to echoTool)),
+            responseCache = InMemoryOperationResponseCache(),
+            policyEngine = object : PolicyEngine {
+                override suspend fun evaluate(context: PolicyContext): PolicyDecision = PolicyDecision.Allow
+            },
+        )
+        val service: CachedToolTestService = engine.create()
+
+        assertThat(service.cachedCall("test")).isEqualTo("ok")
+        assertThat(service.cachedCall("test")).isEqualTo("ok")
+        assertThat(provider.callCount.get()).isEqualTo(2)
+    }
+
+    @Test
     fun `cache key contains digest not raw prompt`() {
         val firstKey = buildOperationCacheKeyForTesting(
             serviceType = CachedTestService::class,
@@ -1137,6 +1239,156 @@ class PolicyEnforcementTest {
         assertThat(firstKey.requestDigest).isEqualTo(secondKey.requestDigest)
         assertThat(firstKey.requestDigest).isNotEqualTo(differentKey.requestDigest)
         assertThat(firstKey.requestDigest).doesNotContain("secret")
+    }
+
+    @Test
+    fun `text part containing delimiter characters does not collide with multiple parts`() {
+        val singlePartDigest = buildRequestDigest(
+            listOf(
+                Message(
+                    role = MessageRole.USER,
+                    content = "",
+                    contentParts = listOf(ContentPart.TextPart("a|T:b")),
+                ),
+            ),
+        )
+        val splitPartsDigest = buildRequestDigest(
+            listOf(
+                Message(
+                    role = MessageRole.USER,
+                    content = "",
+                    contentParts = listOf(
+                        ContentPart.TextPart("a"),
+                        ContentPart.TextPart("b"),
+                    ),
+                ),
+            ),
+        )
+
+        assertThat(singlePartDigest).isNotEqualTo(splitPartsDigest)
+    }
+
+    @Test
+    fun `image url and mime containing special characters produce distinct digests`() {
+        val firstDigest = buildRequestDigest(
+            listOf(
+                Message(
+                    role = MessageRole.USER,
+                    content = "",
+                    contentParts = listOf(
+                        ContentPart.ImageUrlContent(
+                            url = "https://example.com/a|b?x=1\ny=2",
+                            mimeType = "image/png|variant",
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val secondDigest = buildRequestDigest(
+            listOf(
+                Message(
+                    role = MessageRole.USER,
+                    content = "",
+                    contentParts = listOf(
+                        ContentPart.ImageUrlContent(
+                            url = "https://example.com/a:b?x=1\ny=2",
+                            mimeType = "image/png:variant",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        assertThat(firstDigest).isNotEqualTo(secondDigest)
+    }
+
+    @Test
+    fun `same text with different toolCallId produces different digest`() {
+        val firstDigest = buildRequestDigest(
+            listOf(Message(role = MessageRole.TOOL, content = "same", toolCallId = "call-1")),
+        )
+        val secondDigest = buildRequestDigest(
+            listOf(Message(role = MessageRole.TOOL, content = "same", toolCallId = "call-2")),
+        )
+
+        assertThat(firstDigest).isNotEqualTo(secondDigest)
+    }
+
+    @Test
+    fun `same text with different assistant toolCalls produces different digest`() {
+        val firstDigest = buildRequestDigest(
+            listOf(
+                Message(
+                    role = MessageRole.ASSISTANT,
+                    content = "same",
+                    toolCalls = listOf(ToolCall("1", "refund-order", "{}")),
+                ),
+            ),
+        )
+        val secondDigest = buildRequestDigest(
+            listOf(
+                Message(
+                    role = MessageRole.ASSISTANT,
+                    content = "same",
+                    toolCalls = listOf(ToolCall("1", "lookup-order", "{}")),
+                ),
+            ),
+        )
+
+        assertThat(firstDigest).isNotEqualTo(secondDigest)
+    }
+
+    @Test
+    fun `operationFingerprint changes when tools change`() {
+        val withoutTools = buildOperationCacheKeyForTesting(
+            serviceType = FingerprintWithoutToolsService::class,
+            methodName = "cachedCall",
+            arguments = listOf("test"),
+        )
+        val withTools = buildOperationCacheKeyForTesting(
+            serviceType = FingerprintWithToolsService::class,
+            methodName = "cachedCall",
+            arguments = listOf("test"),
+            toolRegistry = ToolRegistry(mapOf("echo" to echoTool)),
+        )
+
+        assertThat(withoutTools.operationFingerprint).isNotEqualTo(withTools.operationFingerprint)
+    }
+
+    @Test
+    fun `corrupted cached envelope with mismatched partition is rejected without policy call`() = runBlocking {
+        val provider = CountingProvider()
+        val policyCalls = AtomicInteger(0)
+        val cache = object : OperationResponseCache {
+            override fun get(key: OperationCacheKey): CachedOperationResult = CachedOperationResult(
+                value = "ok",
+                provenance = CachedResponseProvenance(
+                    providerId = "cloud-provider",
+                    modelName = "test-model",
+                    dataClassification = DataClassification.RESTRICTED,
+                    classificationSource = ClassificationSource.DECLARED,
+                ),
+            )
+
+            override fun put(key: OperationCacheKey, value: CachedOperationResult, ttlMillis: Long) = Unit
+        }
+        val engine = TramaiEngine(
+            provider = provider,
+            responseCache = cache,
+            policyEngine = object : PolicyEngine {
+                override suspend fun evaluate(context: PolicyContext): PolicyDecision {
+                    policyCalls.incrementAndGet()
+                    return PolicyDecision.Allow
+                }
+            },
+        )
+        val service: CachedTestService = engine.create()
+
+        assertThatThrownBy { runBlocking { service.cachedCall("test") } }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Cached entry envelope mismatch")
+        assertThat(policyCalls.get()).isEqualTo(0)
+        assertThat(provider.callCount.get()).isEqualTo(0)
     }
 
     @Test

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/PolicyEnforcementTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/PolicyEnforcementTest.kt
@@ -1,13 +1,16 @@
 package dev.tramai.engine
 
 import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.ConversationId
 import dev.tramai.core.annotations.Operation
+import dev.tramai.core.annotations.User as UserMessage
 import dev.tramai.core.exception.ApprovalRequiredException
 import dev.tramai.core.exception.PolicyViolationException
 import dev.tramai.core.exception.ProviderException
 import dev.tramai.core.memory.ChatMemory
 import dev.tramai.core.model.ClassifiedDocument
 import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
 import dev.tramai.core.model.ModelRequest
 import dev.tramai.core.model.ModelResponse
 import dev.tramai.core.model.StreamChunk
@@ -219,6 +222,22 @@ class PolicyEnforcementTest {
             maxRetries = 0,
         )
         suspend fun analyze(input: ClassifiedDocument<String>): TestPayload
+    }
+
+    @AiService
+    interface CachedConversationService {
+        @UserMessage("Analyze {input}")
+        @Operation(
+            prompt = "",
+            model = "test-model",
+            cacheable = true,
+            cacheTtlMillis = 60_000,
+            providerRetries = 0,
+        )
+        suspend fun analyze(
+            @ConversationId sessionId: String,
+            input: String,
+        ): String
     }
 
     data class TestPayload(val answer: String)
@@ -957,10 +976,9 @@ class PolicyEnforcementTest {
     @Test
     fun `same payload under PUBLIC then RESTRICTED produces separate cache entries`() = runBlocking {
         val provider = CountingProvider(id = "local-provider")
-        val cache = InMemoryOperationResponseCache()
         val engine = TramaiEngine(
             provider = provider,
-            responseCache = cache,
+            responseCache = InMemoryOperationResponseCache(),
             policyEngine = DefaultPolicyEngine(
                 PolicyConfiguration.secure().copy(
                     allowedModels = setOf("test-model"),
@@ -977,27 +995,16 @@ class PolicyEnforcementTest {
         )
         val restrictedInput = publicInput.copy(classification = DataClassification.RESTRICTED)
 
-        assertThat(service.analyze(publicInput)).isEqualTo("ok")
-        assertThat(service.analyze(restrictedInput)).isEqualTo("ok")
+        val first = service.analyze(publicInput)
+        val second = service.analyze(restrictedInput)
 
+        assertThat(first).isEqualTo("ok")
+        assertThat(second).isEqualTo("ok")
         assertThat(provider.callCount.get()).isEqualTo(2)
-        val publicKey = buildOperationCacheKeyForTesting(
-            serviceType = CachedClassifiedTestService::class,
-            methodName = "analyze",
-            arguments = listOf(publicInput),
-        )
-        val restrictedKey = buildOperationCacheKeyForTesting(
-            serviceType = CachedClassifiedTestService::class,
-            methodName = "analyze",
-            arguments = listOf(restrictedInput),
-        )
-        assertThat(publicKey.requestDigest).isEqualTo(restrictedKey.requestDigest)
-        assertThat(publicKey.securityPartition).isNotEqualTo(restrictedKey.securityPartition)
-        assertThat(cache.snapshotKeys()).contains(publicKey, restrictedKey)
     }
 
     @Test
-    fun `cached cloud response cannot be reused for RESTRICTED request`() = runBlocking {
+    fun `cache hit is re-authorized against current policy`() = runBlocking {
         val cache = InMemoryOperationResponseCache()
         val provider = CountingProvider(id = "cloud-provider")
         val allowEngine = engineWithCache(
@@ -1033,6 +1040,44 @@ class PolicyEnforcementTest {
             .isInstanceOf(PolicyViolationException::class.java)
             .hasMessageContaining("RESTRICTED data may not be sent to provider 'cloud-provider'")
         assertThat(provider.callCount.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `same current turn with different chat history produces separate cache entries`() = runBlocking {
+        val provider = CountingProvider()
+        val memory = object : ChatMemory {
+            private val store = mapOf(
+                "session-a" to listOf(
+                    Message(MessageRole.USER, "Earlier context A"),
+                    Message(MessageRole.ASSISTANT, "Assistant memory A"),
+                ),
+                "session-b" to listOf(
+                    Message(MessageRole.USER, "Earlier context B"),
+                    Message(MessageRole.ASSISTANT, "Assistant memory B"),
+                ),
+            )
+
+            override fun get(conversationId: String): List<Message> = store[conversationId].orEmpty()
+
+            override fun add(conversationId: String, messages: List<Message>) = Unit
+
+            override fun add(conversationId: String, message: Message) = Unit
+
+            override fun clear(conversationId: String) = Unit
+        }
+        val engine = TramaiEngine(
+            provider = provider,
+            responseCache = InMemoryOperationResponseCache(),
+            chatMemory = memory,
+            policyEngine = object : PolicyEngine {
+                override suspend fun evaluate(context: PolicyContext): PolicyDecision = PolicyDecision.Allow
+            },
+        )
+        val service: CachedConversationService = engine.create()
+
+        assertThat(service.analyze("session-a", "same-turn")).isEqualTo("ok")
+        assertThat(service.analyze("session-b", "same-turn")).isEqualTo("ok")
+        assertThat(provider.callCount.get()).isEqualTo(2)
     }
 
     @Test

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/PolicyEnforcementTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/PolicyEnforcementTest.kt
@@ -19,6 +19,7 @@ import dev.tramai.core.model.ToolCall
 import dev.tramai.core.model.ToolExecutionContext
 import dev.tramai.core.model.ResolvedTool
 import dev.tramai.core.model.ToolResult
+import dev.tramai.core.observation.OperationInterceptor
 import dev.tramai.core.policy.ApprovalRequirement
 import dev.tramai.core.policy.ClassificationSource
 import dev.tramai.core.policy.DataClassification
@@ -1211,6 +1212,28 @@ class PolicyEnforcementTest {
             },
         )
         val service: CachedToolTestService = engine.create()
+
+        assertThat(service.cachedCall("test")).isEqualTo("ok")
+        assertThat(service.cachedCall("test")).isEqualTo("ok")
+        assertThat(provider.callCount.get()).isEqualTo(2)
+    }
+
+    @Test
+    fun `cacheable operation with custom interceptor bypasses cache`() = runBlocking {
+        val provider = CountingProvider()
+        // A non-singleton interceptor — the engine checks reference-equality
+        // against NoOpOperationInterceptor, so a fresh anonymous instance
+        // always forces a cache bypass.
+        val customInterceptor = object : OperationInterceptor {}
+        val engine = TramaiEngine(
+            provider = provider,
+            responseCache = InMemoryOperationResponseCache(),
+            operationInterceptor = customInterceptor,
+            policyEngine = object : PolicyEngine {
+                override suspend fun evaluate(context: PolicyContext): PolicyDecision = PolicyDecision.Allow
+            },
+        )
+        val service: CachedTestService = engine.create()
 
         assertThat(service.cachedCall("test")).isEqualTo("ok")
         assertThat(service.cachedCall("test")).isEqualTo("ok")

--- a/tramai-spring/src/test/kotlin/dev/tramai/spring/TramaiAutoConfigurationTest.kt
+++ b/tramai-spring/src/test/kotlin/dev/tramai/spring/TramaiAutoConfigurationTest.kt
@@ -384,9 +384,14 @@ class TramaiAutoConfigurationTest {
             val first = runBlocking { analyzer.analyze("invoice-123") }
             val second = runBlocking { analyzer.analyze("invoice-123") }
 
+            // Spring component scan picks up InterceptorConfiguration in the same
+            // package, registering a custom OperationInterceptor. With a custom
+            // interceptor configured, the engine's isSafeCacheEligible() returns
+            // false and the response cache is bypassed — each invocation reaches
+            // the provider so the current interceptor rules are always applied.
             assertThat(first).isEqualTo("cached spring hello 1")
-            assertThat(second).isEqualTo("cached spring hello 1")
-            assertThat(provider.requests).hasSize(1)
+            assertThat(second).isEqualTo("cached spring hello 2")
+            assertThat(provider.requests).hasSize(2)
         }
     }
 


### PR DESCRIPTION
## Summary

Restores classified-response caching safely by adding a **cache provenance SPI**: every cached entry carries the provider, model, classification, and source that produced it, and every cache hit is re-authorized against the current policy before the value is returned.

Topic 1.8 (cache-entry provenance) from `docs/security/DELIVERY-PLAN.md` is now closed.

## Data model

- `OperationCacheKey` carries a SHA-256 `requestDigest` (length-prefixed UTF-8 canonical of messages), an `operationFingerprint` (canonical tool definitions + timeout + cache settings), a `schemaVersion`, and a `CacheSecurityPartition` (dataClassification + classificationSource).
- `CachedOperationResult` wraps the stored value with `CachedResponseProvenance(providerId, modelName, dataClassification, classificationSource)`.

## Authorization on cache hit

Every cache hit re-evaluates three policy gates, tagged with `attribute("cacheReuse", "true")`:

- `BEFORE_PROVIDER_RESOLUTION` — model allowlist re-check
- `BEFORE_PROVIDER_INVOCATION` — provider allowlist re-check
- `BEFORE_RESPONSE_RETURN` — classified egress re-check

The cached envelope is validated against the security partition before any policy call (`IllegalStateException` on mismatch).

## Cache eligibility

Caching is enabled only for operations that are:
- `cacheable` and not streaming
- have no tools declared
- have no `chatMemory` in scope
- run with the default `NoOpOperationInterceptor`

## Digest details

`requestDigest` is a SHA-256 of a length-prefixed UTF-8 canonical of:
- message role
- text content
- multi-modal `contentParts` (Text, Image bytes base64, Image URL + MIME)
- `toolCallId`
- assistant `toolCalls` (id, name, argumentsJson)

The encoding is collision-free: every variable-length field is length-prefixed, and the only structural separator is the framed `\n---\n` between messages.

## Test matrix

- 8 cache-provenance tests in `f005028` (raw/structured cache hit, partition separation, policy change, key structure)
- 1 chat-history partition test in `61ee5cb`
- 9 round-2 tests in `03b0237` (allowlist re-check, eligibility, multi-modal digest, tool-message digest, fingerprint, integrity)
- 1 interceptor bypass test in `a439d61`
- Spring auto-config test updated to expect the new (correct) bypass behavior

Deferred: HMAC-strategy for `requestDigest`, `CacheAwareOperationInterceptor` SPI, audit/approval persistence, `BEFORE_WORKFLOW_RESUME`.

## Validation

- `./gradlew test` — BUILD SUCCESSFUL (118 tasks)
- `./gradlew publishToMavenLocal` — BUILD SUCCESSFUL (196 tasks)
- `./gradlew -p examples/kotlin-springboot-example test` — BUILD SUCCESSFUL
- CI: https://github.com/GionaGranchelli/tramAI/actions/runs/26806308748 — success

## Commits

- `f005028` — feat: provenance-aware secure cache entries (initial)
- `61ee5cb` — fix: length-prefixed digest + chat history in key (Gemini review)
- `03b0237` — fix: 3-gate reauthorization + eligibility + fully length-prefixed digest + fingerprint + integrity
- `a439d61` — fix: bypass cache for custom OperationInterceptor