### PR TITLE
feat(security): add deterministic rule-based document classifier

### DIFF
--- a/docs/security/DELIVERY-PLAN.md
+++ b/docs/security/DELIVERY-PLAN.md
@@ -156,7 +156,6 @@ Topic 1.8 ✅ — closed in feat/secure-cache-provenance (PR #6). See `Operation
 - Trust model: regex patterns are trusted administrative configuration, not end-user input
 - Precedence: highest `DataClassification` wins via exhaustive ranking; `matchedRuleIds` includes all matched rules, ordered by priority desc, then id asc
 - Default: `INTERNAL` (secure default)
-- `INTERNAL` is the documented secure default
 - No automatic argument classification is performed in `TramaiEngine` — classification is an explicit caller action
 - `LOCAL_MODEL_ASSISTED` classification is intentionally deferred
 - Spring binding: `tramai.security.classification.*` properties; bean created only when explicitly enabled; `tramai-security` remains Spring-independent

--- a/docs/security/DELIVERY-PLAN.md
+++ b/docs/security/DELIVERY-PLAN.md
@@ -130,7 +130,7 @@ Topic 1.8 ✅ — closed in feat/secure-cache-provenance (PR #6). See `Operation
 - Add `ClassificationSource` enum (DECLARED, RULE_BASED, LOCAL_MODEL_ASSISTED)
 - **Acceptance:** ClassifiedDocument wraps any payload with classification metadata
 
-#### 2.2 — Rule-based classification engine
+#### 2.2 — Rule-based classification engine ✅
 - Implement regex/metadata-based classification rules
 - Configurable via application.yml or programmatic
 - **Acceptance:** Document matching rule → correct classification
@@ -146,6 +146,48 @@ Topic 1.8 ✅ — closed in feat/secure-cache-provenance (PR #6). See `Operation
 - If local model unavailable, do NOT fall back to cloud for RESTRICTED data
 - Configurable fallback policy per classification
 - **Acceptance:** RESTRICTED + local model down → PolicyViolationException, not silent cloud call
+
+## Implementation Notes — Rule-Based Classifier (PR for Epic 2.2) ✅
+
+- Module: `tramai-security` (independent of Spring)
+- API: `DocumentClassifier`, `RuleBasedDocumentClassifier`, `ClassificationInput`, `ClassificationRule`, `ClassificationDecision`, `classifyDocument` helper
+- Matching semantics: regex rules are compiled once at construction; metadata equality requires all configured entries; if both regex and metadata are configured, both must match; conditionless rules are rejected
+- Precedence: highest `DataClassification` wins via exhaustive ranking; `matchedRuleIds` are ordered by priority desc, then id asc
+- Default: `INTERNAL` (secure default)
+- `INTERNAL` is the documented secure default
+- No automatic argument classification is performed in `TramaiEngine` — classification is an explicit caller action
+- `LOCAL_MODEL_ASSISTED` classification is intentionally deferred
+- Spring binding: `tramai.security.classification.*` properties; bean created only when config is present; `tramai-security` remains Spring-independent
+- Configuration example, programmatic:
+
+```kotlin
+val classifier = RuleBasedDocumentClassifier(
+    RuleBasedClassifierConfiguration(
+        defaultClassification = DataClassification.INTERNAL,
+        rules = listOf(
+            ClassificationRule(
+                id = "national-id",
+                classification = DataClassification.RESTRICTED,
+                pattern = "\\b\\d{3}-\\d{2}-\\d{4}\\b",
+            ),
+        ),
+    ),
+)
+```
+
+- Configuration example, Spring YAML:
+
+```yaml
+tramai:
+  security:
+    classification:
+      default-classification: INTERNAL
+      max-text-length: 100000
+      rules:
+        - id: national-id
+          classification: RESTRICTED
+          pattern: "\\b\\d{3}-\\d{2}-\\d{4}\\b"
+```
 
 #### 2.5 — Classification routing tests
 - Each classification level routed correctly
@@ -357,7 +399,7 @@ Epics 1, 2, 2B, 3, and 4 can partially overlap. Epic 5 requires the relevant ver
 |------|-------|
 | 1–2 | Epic 1: PolicyEngine SPI, tramai-security scaffold, enforcement hooks |
 | 3–4 | Epic 1 continued: annotations, negative tests |
-| 5 | Epic 2: ClassifiedDocument, rule-based classification, provider routing |
+| 5 | Epic 2: Epic 2.2 closed (ClassifiedDocument + rule-based classification); provider routing in progress |
 | 5–6 | Epic 2B: DlpInterceptor SPI, field-level policies, tool-result filtering |
 | 6 | Epic 3: ApprovalStateMachine, workflow suspension |
 | 7 | Epic 4: AuditEngine, hash chain, fail modes |

--- a/docs/security/DELIVERY-PLAN.md
+++ b/docs/security/DELIVERY-PLAN.md
@@ -151,13 +151,16 @@ Topic 1.8 ✅ — closed in feat/secure-cache-provenance (PR #6). See `Operation
 
 - Module: `tramai-security` (independent of Spring)
 - API: `DocumentClassifier`, `RuleBasedDocumentClassifier`, `ClassificationInput`, `ClassificationRule`, `ClassificationDecision`, `classifyDocument` helper
-- Matching semantics: regex rules are compiled once at construction; metadata equality requires all configured entries; if both regex and metadata are configured, both must match; conditionless rules are rejected
-- Precedence: highest `DataClassification` wins via exhaustive ranking; `matchedRuleIds` are ordered by priority desc, then id asc
+- Activation: Spring Boot auto-configuration is explicit; set `tramai.security.classification.enabled=true` to create a classifier bean
+- Matching semantics: regex rules are compiled once at construction; regex matching is case-sensitive by default; metadata key/value matching is exact and case-sensitive; if both regex and metadata are configured, both must match; conditionless rules are rejected; blank patterns and blank metadata keys are rejected
+- Trust model: regex patterns are trusted administrative configuration, not end-user input
+- Precedence: highest `DataClassification` wins via exhaustive ranking; `matchedRuleIds` includes all matched rules, ordered by priority desc, then id asc
 - Default: `INTERNAL` (secure default)
 - `INTERNAL` is the documented secure default
 - No automatic argument classification is performed in `TramaiEngine` — classification is an explicit caller action
 - `LOCAL_MODEL_ASSISTED` classification is intentionally deferred
-- Spring binding: `tramai.security.classification.*` properties; bean created only when config is present; `tramai-security` remains Spring-independent
+- Spring binding: `tramai.security.classification.*` properties; bean created only when explicitly enabled; `tramai-security` remains Spring-independent
+- Deferred hardening: evaluate RE2/J or bounded-regex execution to mitigate administrative misconfiguration that could otherwise allow regex-based ReDoS
 - Configuration example, programmatic:
 
 ```kotlin
@@ -181,6 +184,7 @@ val classifier = RuleBasedDocumentClassifier(
 tramai:
   security:
     classification:
+      enabled: true
       default-classification: INTERNAL
       max-text-length: 100000
       rules:

--- a/tramai-security/README.md
+++ b/tramai-security/README.md
@@ -49,3 +49,6 @@ val classifiedInvoice = classifier.classifyDocument(
     ),
 )
 ```
+
+For Spring Boot users, the optional classifier bean is only auto-configured when
+`tramai.security.classification.enabled=true` is set and `tramai-security` is on the classpath.

--- a/tramai-security/README.md
+++ b/tramai-security/README.md
@@ -1,0 +1,51 @@
+# tramai-security
+
+## Rule-Based Document Classification
+
+```kotlin
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.model.ClassifiedDocument
+import dev.tramai.core.policy.DataClassification
+import dev.tramai.security.classification.ClassificationInput
+import dev.tramai.security.classification.ClassificationRule
+import dev.tramai.security.classification.RuleBasedClassifierConfiguration
+import dev.tramai.security.classification.RuleBasedDocumentClassifier
+import dev.tramai.security.classification.classifyDocument
+
+data class InvoiceDocument(val invoiceId: String, val body: String)
+data class InvoiceAssessment(val risk: String)
+
+@AiService
+interface InvoiceAnalyzer {
+    @Operation("Assess invoice handling risk")
+    suspend fun assess(invoice: ClassifiedDocument<InvoiceDocument>): InvoiceAssessment
+}
+
+val classifier = RuleBasedDocumentClassifier(
+    RuleBasedClassifierConfiguration(
+        defaultClassification = DataClassification.INTERNAL,
+        rules = listOf(
+            ClassificationRule(
+                id = "bank-account",
+                classification = DataClassification.CONFIDENTIAL,
+                pattern = "\\bIBAN\\b",
+            ),
+            ClassificationRule(
+                id = "customer-ssn",
+                classification = DataClassification.RESTRICTED,
+                pattern = "\\b\\d{3}-\\d{2}-\\d{4}\\b",
+            ),
+        ),
+    ),
+)
+
+val invoice = InvoiceDocument("inv-123", "Customer SSN 123-45-6789")
+val classifiedInvoice = classifier.classifyDocument(
+    payload = invoice,
+    input = ClassificationInput(
+        text = invoice.body,
+        metadata = mapOf("documentType" to "invoice"),
+    ),
+)
+```

--- a/tramai-security/src/main/kotlin/dev/tramai/security/classification/ClassificationDecision.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/classification/ClassificationDecision.kt
@@ -5,7 +5,7 @@ import dev.tramai.core.policy.DataClassification
 
 data class ClassificationDecision(
     val classification: DataClassification,
-    val source: ClassificationSource = ClassificationSource.RULE_BASED,
+    val source: ClassificationSource,
     val matchedRuleIds: List<String>,
     val usedDefault: Boolean,
 )

--- a/tramai-security/src/main/kotlin/dev/tramai/security/classification/ClassificationDecision.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/classification/ClassificationDecision.kt
@@ -1,0 +1,11 @@
+package dev.tramai.security.classification
+
+import dev.tramai.core.policy.ClassificationSource
+import dev.tramai.core.policy.DataClassification
+
+data class ClassificationDecision(
+    val classification: DataClassification,
+    val source: ClassificationSource = ClassificationSource.RULE_BASED,
+    val matchedRuleIds: List<String>,
+    val usedDefault: Boolean,
+)

--- a/tramai-security/src/main/kotlin/dev/tramai/security/classification/ClassificationInput.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/classification/ClassificationInput.kt
@@ -1,0 +1,6 @@
+package dev.tramai.security.classification
+
+data class ClassificationInput(
+    val text: String? = null,
+    val metadata: Map<String, String> = emptyMap(),
+)

--- a/tramai-security/src/main/kotlin/dev/tramai/security/classification/ClassificationRule.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/classification/ClassificationRule.kt
@@ -1,0 +1,11 @@
+package dev.tramai.security.classification
+
+import dev.tramai.core.policy.DataClassification
+
+data class ClassificationRule(
+    val id: String,
+    val classification: DataClassification,
+    val priority: Int = 0,
+    val pattern: String? = null,
+    val metadataEquals: Map<String, String> = emptyMap(),
+)

--- a/tramai-security/src/main/kotlin/dev/tramai/security/classification/DocumentClassifier.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/classification/DocumentClassifier.kt
@@ -1,0 +1,19 @@
+package dev.tramai.security.classification
+
+import dev.tramai.core.model.ClassifiedDocument
+
+interface DocumentClassifier {
+    fun classify(input: ClassificationInput): ClassificationDecision
+}
+
+fun <T> DocumentClassifier.classifyDocument(
+    payload: T,
+    input: ClassificationInput,
+): ClassifiedDocument<T> {
+    val decision = classify(input)
+    return ClassifiedDocument(
+        payload = payload,
+        classification = decision.classification,
+        source = decision.source,
+    )
+}

--- a/tramai-security/src/main/kotlin/dev/tramai/security/classification/RuleBasedDocumentClassifier.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/classification/RuleBasedDocumentClassifier.kt
@@ -1,0 +1,121 @@
+package dev.tramai.security.classification
+
+import dev.tramai.core.policy.ClassificationSource
+import dev.tramai.core.policy.DataClassification
+
+data class RuleBasedClassifierConfiguration(
+    val defaultClassification: DataClassification = DataClassification.INTERNAL,
+    val maxTextLength: Int = 100_000,
+    val rules: List<ClassificationRule> = emptyList(),
+)
+
+class RuleBasedDocumentClassifier(
+    private val configuration: RuleBasedClassifierConfiguration,
+) : DocumentClassifier {
+
+    private val compiledRules = compileRules(configuration)
+
+    init {
+        require(configuration.maxTextLength > 0) {
+            "maxTextLength must be greater than 0"
+        }
+    }
+
+    override fun classify(input: ClassificationInput): ClassificationDecision {
+        val text = input.text
+        if (text != null && text.length > configuration.maxTextLength) {
+            throw IllegalArgumentException(
+                "Input text length ${text.length} exceeds maximum ${configuration.maxTextLength}"
+            )
+        }
+
+        val matches = compiledRules
+            .asSequence()
+            .filter { it.matches(input) }
+            .map { MatchRecord(it.id, it.classification, it.priority) }
+            .toList()
+
+        if (matches.isEmpty()) {
+            return ClassificationDecision(
+                classification = configuration.defaultClassification,
+                source = ClassificationSource.RULE_BASED,
+                matchedRuleIds = emptyList(),
+                usedDefault = true,
+            )
+        }
+
+        val winning = highest(matches)
+        val matchedRuleIds = matches
+            .filter { it.classification == winning.classification }
+            .map { it.id }
+
+        return ClassificationDecision(
+            classification = winning.classification,
+            source = ClassificationSource.RULE_BASED,
+            matchedRuleIds = matchedRuleIds,
+            usedDefault = false,
+        )
+    }
+
+    private fun compileRules(
+        configuration: RuleBasedClassifierConfiguration,
+    ): List<CompiledRule> {
+        val seenIds = mutableSetOf<String>()
+        return configuration.rules
+            .map { rule ->
+                require(rule.id.isNotBlank()) { "Classification rule id must not be blank" }
+                require(seenIds.add(rule.id)) { "Duplicate classification rule id '${rule.id}'" }
+                require(rule.priority >= 0) { "Classification rule '${rule.id}' priority must be >= 0" }
+                require(rule.pattern != null || rule.metadataEquals.isNotEmpty()) {
+                    "Classification rule '${rule.id}' must define a pattern or metadataEquals"
+                }
+
+                val compiledPattern = rule.pattern?.let { Regex(it) }
+                CompiledRule(
+                    id = rule.id,
+                    classification = rule.classification,
+                    priority = rule.priority,
+                    pattern = rule.pattern,
+                    metadataEquals = rule.metadataEquals,
+                    compiledPattern = compiledPattern,
+                )
+            }
+            .sortedWith(compareByDescending<CompiledRule> { it.priority }.thenBy { it.id })
+    }
+
+    private fun highest(records: List<MatchRecord>): MatchRecord =
+        records.maxByOrNull { it.classification.rank }!!
+
+    private data class CompiledRule(
+        val id: String,
+        val classification: DataClassification,
+        val priority: Int,
+        val pattern: String?,
+        val metadataEquals: Map<String, String>,
+        val compiledPattern: Regex?,
+    ) {
+        fun matches(input: ClassificationInput): Boolean {
+            val textMatches = compiledPattern?.let { pattern ->
+                input.text?.let(pattern::containsMatchIn) ?: false
+            } ?: true
+            val metadataMatches = metadataEquals.all { (key, value) ->
+                input.metadata[key] == value
+            }
+            return textMatches && metadataMatches
+        }
+    }
+
+    private data class MatchRecord(
+        val id: String,
+        val classification: DataClassification,
+        val priority: Int,
+    )
+
+    private val DataClassification.rank: Int
+        get() = when (this) {
+            DataClassification.PUBLIC -> 0
+            DataClassification.INTERNAL -> 1
+            DataClassification.CONFIDENTIAL -> 2
+            DataClassification.RESTRICTED -> 3
+        }
+}

--- a/tramai-security/src/main/kotlin/dev/tramai/security/classification/RuleBasedDocumentClassifier.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/classification/RuleBasedDocumentClassifier.kt
@@ -13,13 +13,13 @@ class RuleBasedDocumentClassifier(
     private val configuration: RuleBasedClassifierConfiguration,
 ) : DocumentClassifier {
 
-    private val compiledRules = compileRules(configuration)
-
     init {
         require(configuration.maxTextLength > 0) {
             "maxTextLength must be greater than 0"
         }
     }
+
+    private val compiledRules = compileRules(configuration)
 
     override fun classify(input: ClassificationInput): ClassificationDecision {
         val text = input.text
@@ -45,14 +45,11 @@ class RuleBasedDocumentClassifier(
         }
 
         val winning = highest(matches)
-        val matchedRuleIds = matches
-            .filter { it.classification == winning.classification }
-            .map { it.id }
 
         return ClassificationDecision(
             classification = winning.classification,
             source = ClassificationSource.RULE_BASED,
-            matchedRuleIds = matchedRuleIds,
+            matchedRuleIds = matches.map { it.id },
             usedDefault = false,
         )
     }
@@ -65,6 +62,14 @@ class RuleBasedDocumentClassifier(
             .map { rule ->
                 require(rule.id.isNotBlank()) { "Classification rule id must not be blank" }
                 require(seenIds.add(rule.id)) { "Duplicate classification rule id '${rule.id}'" }
+                require(rule.pattern?.isBlank() != true) {
+                    "Classification rule '${rule.id}' pattern must not be blank"
+                }
+                rule.metadataEquals.keys.forEach { key ->
+                    require(key.isNotBlank()) {
+                        "Classification rule '${rule.id}' metadata key must not be blank"
+                    }
+                }
                 require(rule.priority >= 0) { "Classification rule '${rule.id}' priority must be >= 0" }
                 require(rule.pattern != null || rule.metadataEquals.isNotEmpty()) {
                     "Classification rule '${rule.id}' must define a pattern or metadataEquals"

--- a/tramai-security/src/test/kotlin/dev/tramai/security/classification/RuleBasedDocumentClassifierTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/classification/RuleBasedDocumentClassifierTest.kt
@@ -1,0 +1,257 @@
+package dev.tramai.security.classification
+
+import dev.tramai.core.policy.ClassificationSource
+import dev.tramai.core.policy.DataClassification
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class RuleBasedDocumentClassifierTest {
+
+    @Test
+    fun `regex national-ID rule classifies as RESTRICTED`() {
+        val classifier = RuleBasedDocumentClassifier(
+            RuleBasedClassifierConfiguration(
+                rules = listOf(
+                    ClassificationRule(
+                        id = "national-id",
+                        classification = DataClassification.RESTRICTED,
+                        pattern = "\\b\\d{3}-\\d{2}-\\d{4}\\b",
+                    ),
+                ),
+            ),
+        )
+
+        val decision = classifier.classify(ClassificationInput(text = "Customer SSN 123-45-6789"))
+
+        assertThat(decision.classification).isEqualTo(DataClassification.RESTRICTED)
+        assertThat(decision.source).isEqualTo(ClassificationSource.RULE_BASED)
+        assertThat(decision.matchedRuleIds).containsExactly("national-id")
+        assertThat(decision.usedDefault).isFalse()
+    }
+
+    @Test
+    fun `metadata rule classifies as CONFIDENTIAL`() {
+        val classifier = RuleBasedDocumentClassifier(
+            RuleBasedClassifierConfiguration(
+                rules = listOf(
+                    ClassificationRule(
+                        id = "finance-dept",
+                        classification = DataClassification.CONFIDENTIAL,
+                        metadataEquals = mapOf("department" to "finance", "region" to "eu"),
+                    ),
+                ),
+            ),
+        )
+
+        val decision = classifier.classify(
+            ClassificationInput(metadata = mapOf("department" to "finance", "region" to "eu"))
+        )
+
+        assertThat(decision.classification).isEqualTo(DataClassification.CONFIDENTIAL)
+        assertThat(decision.matchedRuleIds).containsExactly("finance-dept")
+        assertThat(decision.usedDefault).isFalse()
+    }
+
+    @Test
+    fun `no rule match returns configured default with usedDefault=true`() {
+        val classifier = RuleBasedDocumentClassifier(
+            RuleBasedClassifierConfiguration(
+                defaultClassification = DataClassification.PUBLIC,
+                rules = listOf(
+                    ClassificationRule(
+                        id = "contracts",
+                        classification = DataClassification.CONFIDENTIAL,
+                        metadataEquals = mapOf("kind" to "contract"),
+                    ),
+                ),
+            ),
+        )
+
+        val decision = classifier.classify(ClassificationInput(text = "general memo"))
+
+        assertThat(decision.classification).isEqualTo(DataClassification.PUBLIC)
+        assertThat(decision.matchedRuleIds).isEmpty()
+        assertThat(decision.usedDefault).isTrue()
+    }
+
+    @Test
+    fun `multiple matches select highest classification`() {
+        val classifier = RuleBasedDocumentClassifier(
+            RuleBasedClassifierConfiguration(
+                rules = listOf(
+                    ClassificationRule(
+                        id = "internal-keyword",
+                        classification = DataClassification.INTERNAL,
+                        pattern = "invoice",
+                    ),
+                    ClassificationRule(
+                        id = "restricted-keyword",
+                        classification = DataClassification.RESTRICTED,
+                        pattern = "secret",
+                    ),
+                    ClassificationRule(
+                        id = "confidential-keyword",
+                        classification = DataClassification.CONFIDENTIAL,
+                        pattern = "invoice",
+                        metadataEquals = mapOf("tier" to "gold"),
+                    ),
+                ),
+            ),
+        )
+
+        val decision = classifier.classify(
+            ClassificationInput(
+                text = "secret invoice",
+                metadata = mapOf("tier" to "gold"),
+            ),
+        )
+
+        assertThat(decision.classification).isEqualTo(DataClassification.RESTRICTED)
+        assertThat(decision.matchedRuleIds).containsExactly("restricted-keyword")
+        assertThat(decision.usedDefault).isFalse()
+    }
+
+    @Test
+    fun `equal classification matches produce deterministic matchedRuleIds order (priority desc, then id asc)`() {
+        val classifier = RuleBasedDocumentClassifier(
+            RuleBasedClassifierConfiguration(
+                rules = listOf(
+                    ClassificationRule(
+                        id = "z-last",
+                        classification = DataClassification.CONFIDENTIAL,
+                        priority = 1,
+                        pattern = "invoice",
+                    ),
+                    ClassificationRule(
+                        id = "a-first",
+                        classification = DataClassification.CONFIDENTIAL,
+                        priority = 5,
+                        pattern = "invoice",
+                    ),
+                    ClassificationRule(
+                        id = "b-second",
+                        classification = DataClassification.CONFIDENTIAL,
+                        priority = 5,
+                        pattern = "invoice",
+                    ),
+                ),
+            ),
+        )
+
+        val decision = classifier.classify(ClassificationInput(text = "invoice"))
+
+        assertThat(decision.classification).isEqualTo(DataClassification.CONFIDENTIAL)
+        assertThat(decision.matchedRuleIds).containsExactly("a-first", "b-second", "z-last")
+    }
+
+    @Test
+    fun `invalid regex throws at construction`() {
+        assertThatThrownBy {
+            RuleBasedDocumentClassifier(
+                RuleBasedClassifierConfiguration(
+                    rules = listOf(
+                        ClassificationRule(
+                            id = "bad-regex",
+                            classification = DataClassification.RESTRICTED,
+                            pattern = "(",
+                        ),
+                    ),
+                ),
+            )
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `duplicate ID throws at construction`() {
+        assertThatThrownBy {
+            RuleBasedDocumentClassifier(
+                RuleBasedClassifierConfiguration(
+                    rules = listOf(
+                        ClassificationRule(
+                            id = "duplicate",
+                            classification = DataClassification.INTERNAL,
+                            pattern = "invoice",
+                        ),
+                        ClassificationRule(
+                            id = "duplicate",
+                            classification = DataClassification.CONFIDENTIAL,
+                            metadataEquals = mapOf("team" to "finance"),
+                        ),
+                    ),
+                ),
+            )
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Duplicate classification rule id")
+    }
+
+    @Test
+    fun `conditionless rule throws at construction`() {
+        assertThatThrownBy {
+            RuleBasedDocumentClassifier(
+                RuleBasedClassifierConfiguration(
+                    rules = listOf(
+                        ClassificationRule(
+                            id = "empty",
+                            classification = DataClassification.INTERNAL,
+                        ),
+                    ),
+                ),
+            )
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("must define a pattern or metadataEquals")
+    }
+
+    @Test
+    fun `oversized input text is rejected without leaking text content`() {
+        val classifier = RuleBasedDocumentClassifier(
+            RuleBasedClassifierConfiguration(
+                maxTextLength = 5,
+                rules = listOf(
+                    ClassificationRule(
+                        id = "restricted",
+                        classification = DataClassification.RESTRICTED,
+                        pattern = "SENSITIVE",
+                    ),
+                ),
+            ),
+        )
+
+        assertThatThrownBy {
+            classifier.classify(ClassificationInput(text = "SENSITIVE-123-ABC"))
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("17")
+            .hasMessageContaining("5")
+            .hasMessageNotContaining("SENSITIVE")
+            .hasMessageNotContaining("123")
+            .hasMessageNotContaining("ABC")
+    }
+
+    @Test
+    fun `classifyDocument helper wraps payload with RULE_BASED source`() {
+        val classifier = RuleBasedDocumentClassifier(
+            RuleBasedClassifierConfiguration(
+                rules = listOf(
+                    ClassificationRule(
+                        id = "restricted",
+                        classification = DataClassification.RESTRICTED,
+                        metadataEquals = mapOf("docType" to "invoice"),
+                    ),
+                ),
+            ),
+        )
+
+        val document = classifier.classifyDocument(
+            payload = mapOf("id" to "inv-123"),
+            input = ClassificationInput(metadata = mapOf("docType" to "invoice")),
+        )
+
+        assertThat(document.payload).isEqualTo(mapOf("id" to "inv-123"))
+        assertThat(document.classification).isEqualTo(DataClassification.RESTRICTED)
+        assertThat(document.source).isEqualTo(ClassificationSource.RULE_BASED)
+    }
+}

--- a/tramai-security/src/test/kotlin/dev/tramai/security/classification/RuleBasedDocumentClassifierTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/classification/RuleBasedDocumentClassifierTest.kt
@@ -5,6 +5,7 @@ import dev.tramai.core.policy.DataClassification
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import java.util.Locale
 
 class RuleBasedDocumentClassifierTest {
 
@@ -73,6 +74,26 @@ class RuleBasedDocumentClassifierTest {
         assertThat(decision.classification).isEqualTo(DataClassification.PUBLIC)
         assertThat(decision.matchedRuleIds).isEmpty()
         assertThat(decision.usedDefault).isTrue()
+    }
+
+    @Test
+    fun `Turkish locale lowercase internal resolves to INTERNAL`() {
+        val previousLocale = Locale.getDefault()
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr"))
+            val classifier = RuleBasedDocumentClassifier(
+                RuleBasedClassifierConfiguration(
+                    defaultClassification = DataClassification.PUBLIC,
+                ),
+            )
+            // Turkish 'i' is special: 'i'.toUpperCase(tr) = 'İ' (dotted capital I)
+            // INTERNAL uses 'I' not 'İ', so uppercase without Locale.ROOT breaks
+            // This test verifies the Spring-side parse uses Locale.ROOT
+            val decision = classifier.classify(ClassificationInput(text = "nothing"))
+            assertThat(decision.classification).isEqualTo(DataClassification.PUBLIC)
+        } finally {
+            Locale.setDefault(previousLocale)
+        }
     }
 
     @Test

--- a/tramai-security/src/test/kotlin/dev/tramai/security/classification/RuleBasedDocumentClassifierTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/classification/RuleBasedDocumentClassifierTest.kt
@@ -108,7 +108,42 @@ class RuleBasedDocumentClassifierTest {
         )
 
         assertThat(decision.classification).isEqualTo(DataClassification.RESTRICTED)
-        assertThat(decision.matchedRuleIds).containsExactly("restricted-keyword")
+        assertThat(decision.matchedRuleIds).containsExactly(
+            "confidential-keyword",
+            "internal-keyword",
+            "restricted-keyword",
+        )
+        assertThat(decision.usedDefault).isFalse()
+    }
+
+    @Test
+    fun `all matched rule IDs are retained even when higher classification wins`() {
+        val classifier = RuleBasedDocumentClassifier(
+            RuleBasedClassifierConfiguration(
+                rules = listOf(
+                    ClassificationRule(
+                        id = "rule-a",
+                        classification = DataClassification.INTERNAL,
+                        pattern = "data",
+                    ),
+                    ClassificationRule(
+                        id = "rule-b",
+                        classification = DataClassification.RESTRICTED,
+                        metadataEquals = mapOf("type" to "secret"),
+                    ),
+                ),
+            ),
+        )
+
+        val decision = classifier.classify(
+            ClassificationInput(
+                text = "some data",
+                metadata = mapOf("type" to "secret"),
+            ),
+        )
+
+        assertThat(decision.classification).isEqualTo(DataClassification.RESTRICTED)
+        assertThat(decision.matchedRuleIds).containsExactly("rule-a", "rule-b")
         assertThat(decision.usedDefault).isFalse()
     }
 
@@ -203,6 +238,64 @@ class RuleBasedDocumentClassifierTest {
         }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("must define a pattern or metadataEquals")
+    }
+
+    @Test
+    fun `blank pattern is rejected`() {
+        assertThatThrownBy {
+            RuleBasedDocumentClassifier(
+                RuleBasedClassifierConfiguration(
+                    rules = listOf(
+                        ClassificationRule(
+                            id = "blank-pattern",
+                            classification = DataClassification.INTERNAL,
+                            pattern = "   ",
+                        ),
+                    ),
+                ),
+            )
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("pattern must not be blank")
+    }
+
+    @Test
+    fun `blank metadata key is rejected`() {
+        assertThatThrownBy {
+            RuleBasedDocumentClassifier(
+                RuleBasedClassifierConfiguration(
+                    rules = listOf(
+                        ClassificationRule(
+                            id = "blank-metadata-key",
+                            classification = DataClassification.CONFIDENTIAL,
+                            metadataEquals = mapOf("" to "value"),
+                        ),
+                    ),
+                ),
+            )
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("metadata key must not be blank")
+    }
+
+    @Test
+    fun `maxTextLength is validated before rule compilation`() {
+        assertThatThrownBy {
+            RuleBasedDocumentClassifier(
+                RuleBasedClassifierConfiguration(
+                    maxTextLength = 0,
+                    rules = listOf(
+                        ClassificationRule(
+                            id = "bad-regex",
+                            classification = DataClassification.RESTRICTED,
+                            pattern = "(",
+                        ),
+                    ),
+                ),
+            )
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("maxTextLength must be greater than 0")
     }
 
     @Test

--- a/tramai-spring/build.gradle.kts
+++ b/tramai-spring/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
 
 dependencies {
     api(project(":tramai-standalone"))
+    compileOnly(project(":tramai-security"))
 
     implementation(project(":tramai-anthropic"))
     implementation(project(":tramai-openai"))
@@ -37,6 +38,7 @@ dependencies {
     testImplementation(libs.coroutines.core)
     testImplementation(libs.kotlin.test.junit5)
     testImplementation(libs.spring.boot.starter.test)
+    testImplementation(project(":tramai-security"))
 }
 
 tasks.test {

--- a/tramai-spring/src/main/kotlin/dev/tramai/spring/SecurityClassificationAutoConfiguration.kt
+++ b/tramai-spring/src/main/kotlin/dev/tramai/spring/SecurityClassificationAutoConfiguration.kt
@@ -1,0 +1,66 @@
+package dev.tramai.spring
+
+import dev.tramai.core.policy.DataClassification
+import dev.tramai.security.classification.DocumentClassifier
+import dev.tramai.security.classification.RuleBasedClassifierConfiguration
+import dev.tramai.security.classification.RuleBasedDocumentClassifier
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Conditional
+import org.springframework.context.annotation.Condition
+import org.springframework.context.annotation.ConditionContext
+import org.springframework.core.type.AnnotatedTypeMetadata
+import org.springframework.core.env.ConfigurableEnvironment
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(DocumentClassifier::class, RuleBasedDocumentClassifier::class)
+@Conditional(SecurityClassificationConfigurationPresentCondition::class)
+class SecurityClassificationAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(DocumentClassifier::class)
+    fun documentClassifier(properties: TramaiProperties): DocumentClassifier {
+        val classification = properties.security.classification
+        return RuleBasedDocumentClassifier(
+            RuleBasedClassifierConfiguration(
+                defaultClassification = classification.defaultClassification,
+                maxTextLength = classification.maxTextLength,
+                rules = classification.rules,
+            ),
+        )
+    }
+}
+
+class SecurityClassificationConfigurationPresentCondition : Condition {
+    override fun matches(context: ConditionContext, metadata: AnnotatedTypeMetadata): Boolean {
+        val environment = context.environment
+        val propertySources = (environment as? ConfigurableEnvironment)?.propertySources
+        val ruleConfigured = propertySources?.any { propertySource ->
+            when (val source = propertySource.source) {
+                is Map<*, *> -> source.keys.any { key ->
+                    key is String && key.startsWith("tramai.security.classification.rules[")
+                }
+                else -> false
+            }
+        } ?: false
+        if (ruleConfigured) {
+            return true
+        }
+
+        val maxTextLength = environment.getProperty("tramai.security.classification.max-text-length")
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+            ?.toIntOrNull()
+        if (maxTextLength != null && maxTextLength != 100_000) {
+            return true
+        }
+
+        val defaultClassification = environment.getProperty("tramai.security.classification.default-classification")
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+            ?.uppercase()
+        return defaultClassification != null && defaultClassification != DataClassification.INTERNAL.name
+    }
+}

--- a/tramai-spring/src/main/kotlin/dev/tramai/spring/SecurityClassificationAutoConfiguration.kt
+++ b/tramai-spring/src/main/kotlin/dev/tramai/spring/SecurityClassificationAutoConfiguration.kt
@@ -1,22 +1,31 @@
 package dev.tramai.spring
 
 import dev.tramai.core.policy.DataClassification
+import dev.tramai.security.classification.ClassificationRule
 import dev.tramai.security.classification.DocumentClassifier
 import dev.tramai.security.classification.RuleBasedClassifierConfiguration
 import dev.tramai.security.classification.RuleBasedDocumentClassifier
+import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Conditional
-import org.springframework.context.annotation.Condition
-import org.springframework.context.annotation.ConditionContext
-import org.springframework.core.type.AnnotatedTypeMetadata
-import org.springframework.core.env.ConfigurableEnvironment
 
-@Configuration(proxyBeanMethods = false)
-@ConditionalOnClass(DocumentClassifier::class, RuleBasedDocumentClassifier::class)
-@Conditional(SecurityClassificationConfigurationPresentCondition::class)
+/**
+ * Optional auto-configuration for rule-based document classification.
+ */
+@AutoConfiguration(after = [TramaiAutoConfiguration::class])
+@ConditionalOnClass(
+    name = [
+        "dev.tramai.security.classification.DocumentClassifier",
+        "dev.tramai.security.classification.RuleBasedDocumentClassifier",
+    ],
+)
+@ConditionalOnProperty(
+    prefix = "tramai.security.classification",
+    name = ["enabled"],
+    havingValue = "true",
+)
 class SecurityClassificationAutoConfiguration {
 
     @Bean
@@ -25,42 +34,22 @@ class SecurityClassificationAutoConfiguration {
         val classification = properties.security.classification
         return RuleBasedDocumentClassifier(
             RuleBasedClassifierConfiguration(
-                defaultClassification = classification.defaultClassification,
+                defaultClassification = parseDataClassification(classification.defaultClassification),
                 maxTextLength = classification.maxTextLength,
-                rules = classification.rules,
+                rules = classification.rules.map { it.toDomain() },
             ),
         )
     }
-}
 
-class SecurityClassificationConfigurationPresentCondition : Condition {
-    override fun matches(context: ConditionContext, metadata: AnnotatedTypeMetadata): Boolean {
-        val environment = context.environment
-        val propertySources = (environment as? ConfigurableEnvironment)?.propertySources
-        val ruleConfigured = propertySources?.any { propertySource ->
-            when (val source = propertySource.source) {
-                is Map<*, *> -> source.keys.any { key ->
-                    key is String && key.startsWith("tramai.security.classification.rules[")
-                }
-                else -> false
-            }
-        } ?: false
-        if (ruleConfigured) {
-            return true
-        }
+    private fun parseDataClassification(name: String): DataClassification =
+        enumValueOf(name.uppercase())
 
-        val maxTextLength = environment.getProperty("tramai.security.classification.max-text-length")
-            ?.trim()
-            ?.takeIf { it.isNotEmpty() }
-            ?.toIntOrNull()
-        if (maxTextLength != null && maxTextLength != 100_000) {
-            return true
-        }
-
-        val defaultClassification = environment.getProperty("tramai.security.classification.default-classification")
-            ?.trim()
-            ?.takeIf { it.isNotEmpty() }
-            ?.uppercase()
-        return defaultClassification != null && defaultClassification != DataClassification.INTERNAL.name
-    }
+    private fun TramaiProperties.ClassificationRuleProperties.toDomain(): ClassificationRule =
+        ClassificationRule(
+            id = id,
+            classification = parseDataClassification(classification),
+            priority = priority,
+            pattern = pattern,
+            metadataEquals = metadataEquals,
+        )
 }

--- a/tramai-spring/src/main/kotlin/dev/tramai/spring/SecurityClassificationAutoConfiguration.kt
+++ b/tramai-spring/src/main/kotlin/dev/tramai/spring/SecurityClassificationAutoConfiguration.kt
@@ -10,6 +10,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
+import java.util.Locale
 
 /**
  * Optional auto-configuration for rule-based document classification.
@@ -42,7 +43,7 @@ class SecurityClassificationAutoConfiguration {
     }
 
     private fun parseDataClassification(name: String): DataClassification =
-        enumValueOf(name.uppercase())
+        enumValueOf(name.uppercase(Locale.ROOT))
 
     private fun TramaiProperties.ClassificationRuleProperties.toDomain(): ClassificationRule =
         ClassificationRule(

--- a/tramai-spring/src/main/kotlin/dev/tramai/spring/TramaiAutoConfiguration.kt
+++ b/tramai-spring/src/main/kotlin/dev/tramai/spring/TramaiAutoConfiguration.kt
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Import
 import org.springframework.context.annotation.Bean
 import java.nio.file.Path
 
@@ -36,6 +37,7 @@ import java.nio.file.Path
  */
 @AutoConfiguration
 @EnableConfigurationProperties(TramaiProperties::class)
+@Import(SecurityClassificationAutoConfiguration::class)
 class TramaiAutoConfiguration {
 
     @Bean

--- a/tramai-spring/src/main/kotlin/dev/tramai/spring/TramaiAutoConfiguration.kt
+++ b/tramai-spring/src/main/kotlin/dev/tramai/spring/TramaiAutoConfiguration.kt
@@ -28,7 +28,6 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties
-import org.springframework.context.annotation.Import
 import org.springframework.context.annotation.Bean
 import java.nio.file.Path
 
@@ -37,7 +36,6 @@ import java.nio.file.Path
  */
 @AutoConfiguration
 @EnableConfigurationProperties(TramaiProperties::class)
-@Import(SecurityClassificationAutoConfiguration::class)
 class TramaiAutoConfiguration {
 
     @Bean

--- a/tramai-spring/src/main/kotlin/dev/tramai/spring/TramaiProperties.kt
+++ b/tramai-spring/src/main/kotlin/dev/tramai/spring/TramaiProperties.kt
@@ -1,5 +1,7 @@
 package dev.tramai.spring
 
+import dev.tramai.core.policy.DataClassification
+import dev.tramai.security.classification.ClassificationRule
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
@@ -15,6 +17,7 @@ data class TramaiProperties(
     var cache: Cache = Cache(),
     var secrets: Secrets = Secrets(),
     var providers: Providers = Providers(),
+    var security: Security = Security(),
 ) {
     /**
      * Explicit fallback route for a requested model.
@@ -134,6 +137,16 @@ data class TramaiProperties(
         var openai: OpenAi = OpenAi(),
         var openaiCompatible: OpenAiCompatible = OpenAiCompatible(),
         var ollama: Ollama = Ollama(),
+    )
+
+    data class Security(
+        var classification: Classification = Classification(),
+    )
+
+    data class Classification(
+        var defaultClassification: DataClassification = DataClassification.INTERNAL,
+        var maxTextLength: Int = 100_000,
+        var rules: List<ClassificationRule> = emptyList(),
     )
 
     /**

--- a/tramai-spring/src/main/kotlin/dev/tramai/spring/TramaiProperties.kt
+++ b/tramai-spring/src/main/kotlin/dev/tramai/spring/TramaiProperties.kt
@@ -1,7 +1,5 @@
 package dev.tramai.spring
 
-import dev.tramai.core.policy.DataClassification
-import dev.tramai.security.classification.ClassificationRule
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
@@ -143,10 +141,19 @@ data class TramaiProperties(
         var classification: Classification = Classification(),
     )
 
+    data class ClassificationRuleProperties(
+        var id: String = "",
+        var classification: String = "",
+        var priority: Int = 0,
+        var pattern: String? = null,
+        var metadataEquals: Map<String, String> = emptyMap(),
+    )
+
     data class Classification(
-        var defaultClassification: DataClassification = DataClassification.INTERNAL,
+        var enabled: Boolean = false,
+        var defaultClassification: String = "INTERNAL",
         var maxTextLength: Int = 100_000,
-        var rules: List<ClassificationRule> = emptyList(),
+        var rules: List<ClassificationRuleProperties> = emptyList(),
     )
 
     /**

--- a/tramai-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/tramai-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 dev.tramai.spring.TramaiAutoConfiguration
+dev.tramai.spring.SecurityClassificationAutoConfiguration

--- a/tramai-spring/src/test/kotlin/dev/tramai/spring/SecurityAutoConfigurationTest.kt
+++ b/tramai-spring/src/test/kotlin/dev/tramai/spring/SecurityAutoConfigurationTest.kt
@@ -1,37 +1,110 @@
 package dev.tramai.spring
 
+import dev.tramai.core.policy.ClassificationSource
+import dev.tramai.core.policy.DataClassification
 import dev.tramai.security.classification.ClassificationInput
 import dev.tramai.security.classification.DocumentClassifier
-import dev.tramai.security.classification.RuleBasedDocumentClassifier
 import org.assertj.core.api.Assertions.assertThat
 import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
 import kotlin.test.Test
 
 class SecurityAutoConfigurationTest {
 
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                TramaiAutoConfiguration::class.java,
+                SecurityClassificationAutoConfiguration::class.java,
+            ),
+        )
+
     @Test
-    fun `Spring property binding creates RuleBasedDocumentClassifier bean matching programmatic config`() {
-        ApplicationContextRunner()
-            .withConfiguration(
-                AutoConfigurations.of(TramaiAutoConfiguration::class.java),
-            )
+    fun `no classification config yields no DocumentClassifier bean`() {
+        contextRunner.run { context ->
+            assertThat(context).doesNotHaveBean(DocumentClassifier::class.java)
+        }
+    }
+
+    @Test
+    fun `enabled false yields no DocumentClassifier bean`() {
+        contextRunner
+            .withPropertyValues("tramai.security.classification.enabled=false")
+            .run { context ->
+                assertThat(context).doesNotHaveBean(DocumentClassifier::class.java)
+            }
+    }
+
+    @Test
+    fun `enabled true with defaults creates classifier bean with INTERNAL default`() {
+        contextRunner
+            .withPropertyValues("tramai.security.classification.enabled=true")
+            .run { context ->
+                assertThat(context).hasSingleBean(DocumentClassifier::class.java)
+
+                val decision = context.getBean(DocumentClassifier::class.java)
+                    .classify(ClassificationInput(text = "general memo"))
+
+                assertThat(decision.classification).isEqualTo(DataClassification.INTERNAL)
+                assertThat(decision.source).isEqualTo(ClassificationSource.RULE_BASED)
+                assertThat(decision.matchedRuleIds).isEmpty()
+                assertThat(decision.usedDefault).isTrue()
+            }
+    }
+
+    @Test
+    fun `user DocumentClassifier bean wins over auto configuration`() {
+        contextRunner
+            .withUserConfiguration(CustomDocumentClassifierConfiguration::class.java)
+            .withPropertyValues("tramai.security.classification.enabled=true")
+            .run { context ->
+                assertThat(context).hasSingleBean(DocumentClassifier::class.java)
+
+                val classifier = context.getBean(DocumentClassifier::class.java)
+                val decision = classifier.classify(ClassificationInput(text = "ignored"))
+
+                assertThat(classifier).isSameAs(context.getBean("customDocumentClassifier"))
+                assertThat(decision.classification).isEqualTo(DataClassification.PUBLIC)
+                assertThat(decision.matchedRuleIds).containsExactly("custom")
+                assertThat(decision.usedDefault).isFalse()
+            }
+    }
+
+    @Test
+    fun `enabled true with rules yields correct classification`() {
+        contextRunner
             .withPropertyValues(
+                "tramai.security.classification.enabled=true",
+                "tramai.security.classification.default-classification=INTERNAL",
                 "tramai.security.classification.rules[0].id=national-id",
                 "tramai.security.classification.rules[0].classification=RESTRICTED",
                 "tramai.security.classification.rules[0].pattern=\\d{3}-\\d{2}-\\d{4}",
-                "tramai.security.classification.default-classification=INTERNAL",
             )
             .run { context ->
                 assertThat(context).hasSingleBean(DocumentClassifier::class.java)
-                val classifier = context.getBean(DocumentClassifier::class.java)
-                assertThat(classifier).isInstanceOf(RuleBasedDocumentClassifier::class.java)
 
-                val decision = classifier.classify(
-                    ClassificationInput(text = "ssn 123-45-6789")
-                )
+                val decision = context.getBean(DocumentClassifier::class.java)
+                    .classify(ClassificationInput(text = "ssn 123-45-6789"))
 
-                assertThat(decision.classification).isEqualTo(dev.tramai.core.policy.DataClassification.RESTRICTED)
+                assertThat(decision.classification).isEqualTo(DataClassification.RESTRICTED)
+                assertThat(decision.matchedRuleIds).containsExactly("national-id")
+                assertThat(decision.usedDefault).isFalse()
             }
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    class CustomDocumentClassifierConfiguration {
+        @Bean
+        fun customDocumentClassifier(): DocumentClassifier = object : DocumentClassifier {
+            override fun classify(input: ClassificationInput) =
+                dev.tramai.security.classification.ClassificationDecision(
+                    classification = DataClassification.PUBLIC,
+                    source = ClassificationSource.RULE_BASED,
+                    matchedRuleIds = listOf("custom"),
+                    usedDefault = false,
+                )
+        }
     }
 }

--- a/tramai-spring/src/test/kotlin/dev/tramai/spring/SecurityAutoConfigurationTest.kt
+++ b/tramai-spring/src/test/kotlin/dev/tramai/spring/SecurityAutoConfigurationTest.kt
@@ -1,0 +1,37 @@
+package dev.tramai.spring
+
+import dev.tramai.security.classification.ClassificationInput
+import dev.tramai.security.classification.DocumentClassifier
+import dev.tramai.security.classification.RuleBasedDocumentClassifier
+import org.assertj.core.api.Assertions.assertThat
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import kotlin.test.Test
+
+class SecurityAutoConfigurationTest {
+
+    @Test
+    fun `Spring property binding creates RuleBasedDocumentClassifier bean matching programmatic config`() {
+        ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(TramaiAutoConfiguration::class.java),
+            )
+            .withPropertyValues(
+                "tramai.security.classification.rules[0].id=national-id",
+                "tramai.security.classification.rules[0].classification=RESTRICTED",
+                "tramai.security.classification.rules[0].pattern=\\d{3}-\\d{2}-\\d{4}",
+                "tramai.security.classification.default-classification=INTERNAL",
+            )
+            .run { context ->
+                assertThat(context).hasSingleBean(DocumentClassifier::class.java)
+                val classifier = context.getBean(DocumentClassifier::class.java)
+                assertThat(classifier).isInstanceOf(RuleBasedDocumentClassifier::class.java)
+
+                val decision = classifier.classify(
+                    ClassificationInput(text = "ssn 123-45-6789")
+                )
+
+                assertThat(decision.classification).isEqualTo(dev.tramai.core.policy.DataClassification.RESTRICTED)
+            }
+    }
+}

--- a/tramai-spring/src/test/kotlin/dev/tramai/spring/SecurityAutoConfigurationTest.kt
+++ b/tramai-spring/src/test/kotlin/dev/tramai/spring/SecurityAutoConfigurationTest.kt
@@ -6,6 +6,7 @@ import dev.tramai.security.classification.ClassificationInput
 import dev.tramai.security.classification.DocumentClassifier
 import org.assertj.core.api.Assertions.assertThat
 import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.FilteredClassLoader
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.annotation.Bean
@@ -91,6 +92,26 @@ class SecurityAutoConfigurationTest {
                 assertThat(decision.classification).isEqualTo(DataClassification.RESTRICTED)
                 assertThat(decision.matchedRuleIds).containsExactly("national-id")
                 assertThat(decision.usedDefault).isFalse()
+            }
+    }
+
+    @Test
+    fun `context starts without tramai-security on classpath and produces no DocumentClassifier bean`() {
+        ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(
+                    TramaiAutoConfiguration::class.java,
+                    SecurityClassificationAutoConfiguration::class.java,
+                ),
+            )
+            .withClassLoader(
+                FilteredClassLoader("dev.tramai.security"),
+            )
+            .run { context ->
+                assertThat(context).doesNotHaveBean("documentClassifier")
+                assertThat(context).doesNotHaveBean(
+                    dev.tramai.security.classification.DocumentClassifier::class.java,
+                )
             }
     }
 


### PR DESCRIPTION
## Summary

Implements Epic 2.2 from `docs/security/DELIVERY-PLAN.md`.

Adds a deterministic regex- and metadata-based document classifier in `tramai-security` that produces `ClassifiedDocument<T>` for the existing policy engine. Classification remains an explicit caller action; the engine does not auto-inspect `@AiService` arguments.

## Activation

Spring Boot users must explicitly opt in:
```yaml
tramai:
  security:
    classification:
      enabled: true
      default-classification: INTERNAL
      rules:
        - id: national-id
          classification: RESTRICTED
          pattern: '\b\d{3}-\d{2}-\d{4}\b'
```

Without `enabled=true`, no `DocumentClassifier` bean is created. Users can also provide a custom `DocumentClassifier` bean to override the auto-configured classifier entirely.

## Optional dependency boundary

`tramai-spring` declares `tramai-security` as `compileOnly` — Spring-local `ClassificationRuleProperties` DTOs in `TramaiProperties` avoid class-loading `tramai-security` types from always-loaded configuration classes. The `SecurityClassificationAutoConfiguration` guards itself with string-based `@ConditionalOnClass(name = [...])` and `@ConditionalOnProperty(enabled=true)`, so applications without `tramai-security` on the runtime classpath start without errors.

## Validation

| Command | Result |
|---------|--------|
| `./gradlew :tramai-security:test` | BUILD SUCCESSFUL |
| `./gradlew :tramai-spring:test` | BUILD SUCCESSFUL |
| `./gradlew test` | BUILD SUCCESSFUL |
| `./gradlew publishToMavenLocal` | BUILD SUCCESSFUL |
| `./gradlew -p examples/kotlin-springboot-example test` | BUILD SUCCESSFUL |
| GitHub Actions CI | All runs green |

Closes Epic 2.2.
