### PR TITLE
feat(security): add classification-aware provider routing matrix

### DIFF
--- a/docs/security/DELIVERY-PLAN.md
+++ b/docs/security/DELIVERY-PLAN.md
@@ -244,12 +244,12 @@ tramai:
           pattern: "\\b\\d{3}-\\d{2}-\\d{4}\\b"
 ```
 
-#### 2.5 — Classification routing tests ✅
+#### 2.5 — Classification routing tests 🔄
 - Each classification level routed correctly
 - Fallback blocked for restricted classifications
 - Provider policy annotation overrides defaults — deferred (annotation-based operation-level overrides not yet implemented)
-- **Acceptance:** Classification matrix tests pass; 16 routing-specific tests in `DefaultPolicyEngineTest`
-- **Status:** Matrix-level tests complete (15 routing tests + 1 backward-compat test). Annotation override tests deferred to separate PR.
+- **Acceptance:** Classification matrix unit tests pass; fallback and cache integration tests pass
+- **Status:** Matrix-level unit tests complete. Engine-level fallback and cache integration tests are required. Annotation override tests deferred to separate PR.
 
 **Epic Exit Criteria:**
 - [x] RESTRICTED data never reaches unauthorized provider

--- a/docs/security/DELIVERY-PLAN.md
+++ b/docs/security/DELIVERY-PLAN.md
@@ -244,12 +244,12 @@ tramai:
           pattern: "\\b\\d{3}-\\d{2}-\\d{4}\\b"
 ```
 
-#### 2.5 — Classification routing tests 🔄
+#### 2.5 — Classification routing tests ✅
 - Each classification level routed correctly
 - Fallback blocked for restricted classifications
 - Provider policy annotation overrides defaults — deferred (annotation-based operation-level overrides not yet implemented)
 - **Acceptance:** Classification matrix unit tests pass; fallback and cache integration tests pass
-- **Status:** Matrix-level unit tests complete. Engine-level fallback and cache integration tests are required. Annotation override tests deferred to separate PR.
+- **Status:** Matrix-level unit tests complete. Engine-level fallback and cache integration tests complete. Annotation override tests deferred to separate PR.
 
 **Epic Exit Criteria:**
 - [x] RESTRICTED data never reaches unauthorized provider

--- a/docs/security/DELIVERY-PLAN.md
+++ b/docs/security/DELIVERY-PLAN.md
@@ -135,17 +135,69 @@ Topic 1.8 ✅ — closed in feat/secure-cache-provenance (PR #6). See `Operation
 - Configurable via application.yml or programmatic
 - **Acceptance:** Document matching rule → correct classification
 
-#### 2.3 — Provider routing by classification
+#### 2.3 — Provider routing by classification ✅
 - RESTRICTED → LOCAL_ONLY, block cloud
 - CONFIDENTIAL → LOCAL_ONLY or EU_ONLY
 - INTERNAL → APPROVED_CLOUD
 - PUBLIC → ANY_APPROVED
 - **Acceptance:** Wrong provider for classification → Deny
+- **Implementation:** `ProviderRoutingConfiguration`, `ProviderTrustZone`, `ClassificationRoutingRule` in `tramai-security`; `evaluateProviderRouting()` in `DefaultPolicyEngine` evaluated at `BEFORE_PROVIDER_INVOCATION`, `BEFORE_FALLBACK`, `BEFORE_RESPONSE_RETURN`.
 
-#### 2.4 — No silent fallback
+#### 2.4 — No silent fallback ✅
 - If local model unavailable, do NOT fall back to cloud for RESTRICTED data
-- Configurable fallback policy per classification
+- Configurable fallback policy per classification via `ClassificationRoutingRule.allowedFallbackZones`
 - **Acceptance:** RESTRICTED + local model down → PolicyViolationException, not silent cloud call
+- **Implementation:** Fallback zone set evaluated at `BEFORE_FALLBACK` enforcement point; RESTRICTED has `allowedFallbackZones = emptySet()` in sovereign defaults
+
+## Implementation Notes — Classification-Aware Provider Routing Matrix (PR for Epic 2.3/2.4) ✅
+
+**Where:** `tramai-security/.../ProviderRoutingConfiguration.kt`, `DefaultPolicyEngine.kt`
+
+### Routing Model
+
+Three new types in `tramai-security`:
+
+- **`ProviderTrustZone`** — `LOCAL`, `EU_CLOUD`, `GLOBAL_CLOUD`
+- **`ClassificationRoutingRule`** — `allowedZones` (primary) + `allowedFallbackZones` (fallback)
+- **`ProviderRoutingConfiguration`** — `providerZones: Map<String, ProviderTrustZone>`, `rules: Map<DataClassification, ClassificationRoutingRule>`, `enabled: Boolean`
+
+### Sovereign Default Routing Matrix
+
+| Classification | allowedZones | allowedFallbackZones |
+|---|---|---|
+| RESTRICTED | LOCAL | (empty — no fallback) |
+| CONFIDENTIAL | LOCAL, EU_CLOUD | LOCAL, EU_CLOUD |
+| INTERNAL | LOCAL, EU_CLOUD, GLOBAL_CLOUD | LOCAL, EU_CLOUD, GLOBAL_CLOUD |
+| PUBLIC | LOCAL, EU_CLOUD, GLOBAL_CLOUD | LOCAL, EU_CLOUD, GLOBAL_CLOUD |
+
+### Enforcement Points
+
+`evaluateProviderRouting()` is called at:
+1. `BEFORE_PROVIDER_INVOCATION` — checks primary routing
+2. `BEFORE_FALLBACK` — checks fallback routing (uses `allowedFallbackZones`)
+3. `BEFORE_RESPONSE_RETURN` — re-checks on response return (cache reauthorization)
+
+### Stable Reason Codes
+
+- `classification-provider-missing` — classified request without provider ID
+- `provider-zone-missing` — classified request where provider has no zone mapping
+- `classification-routing-rule-missing` — classification has no routing rule
+- `classification-routing-blocked` — provider zone not in `allowedZones`
+- `classification-fallback-blocked` — provider zone not in `allowedFallbackZones`
+
+### Compatibility Strategy
+
+- `ProviderRoutingConfiguration.enabled = false` by default
+- Legacy `trustedLocalProviders` and `allowCloudForClassifications` fields retained with `@Deprecated` annotations
+- When `enabled = true`, the routing matrix is authoritative and legacy fields are ignored for routing
+- When `enabled = false`, the legacy `evaluateClassificationEgress()` logic continues to work unchanged
+- `PolicyConfiguration.preview()` keeps `enabled = false` for 0.4.x backward compatibility
+
+### Deferred Work
+- Annotation-based operation-level provider policy overrides (@ProviderPolicy on methods) are intentionally deferred to a separate PR
+- Provider zone auto-detection (classpath scanning, SPI) is not implemented — zones must be configured explicitly
+
+---
 
 ## Implementation Notes — Rule-Based Classifier (PR for Epic 2.2) ✅
 
@@ -192,16 +244,17 @@ tramai:
           pattern: "\\b\\d{3}-\\d{2}-\\d{4}\\b"
 ```
 
-#### 2.5 — Classification routing tests
+#### 2.5 — Classification routing tests ✅
 - Each classification level routed correctly
 - Fallback blocked for restricted classifications
-- Provider policy annotation overrides defaults
-- **Acceptance:** Classification matrix tests pass
+- Provider policy annotation overrides defaults — deferred (annotation-based operation-level overrides not yet implemented)
+- **Acceptance:** Classification matrix tests pass; 16 routing-specific tests in `DefaultPolicyEngineTest`
+- **Status:** Matrix-level tests complete (15 routing tests + 1 backward-compat test). Annotation override tests deferred to separate PR.
 
 **Epic Exit Criteria:**
-- [ ] RESTRICTED data never reaches unauthorized provider
-- [ ] Classification routing works for all 4 levels (reference defaults; organizations may override)
-- [ ] No silent fallback from local to cloud for restricted data
+- [x] RESTRICTED data never reaches unauthorized provider
+- [x] Classification routing works for all 4 levels (reference defaults; organizations may override)
+- [x] No silent fallback from local to cloud for restricted data
 
 ---
 

--- a/examples/kotlin-springboot-example/src/test/kotlin/dev/tramai/examples/springboot/ExampleApplicationTest.kt
+++ b/examples/kotlin-springboot-example/src/test/kotlin/dev/tramai/examples/springboot/ExampleApplicationTest.kt
@@ -387,7 +387,7 @@ class ExampleApplicationTest {
 
         var cancelledPayload: String? = null
         var pollDelay = 10L
-        repeat(200) {
+        repeat(300) {
             val resultPayload = asyncJson(get("/invoice/workflow/result/$workflowId"))
                 .andExpect(status().isOk)
                 .andReturn()

--- a/examples/kotlin-springboot-example/src/test/kotlin/dev/tramai/examples/springboot/ExampleApplicationTest.kt
+++ b/examples/kotlin-springboot-example/src/test/kotlin/dev/tramai/examples/springboot/ExampleApplicationTest.kt
@@ -387,7 +387,7 @@ class ExampleApplicationTest {
 
         var cancelledPayload: String? = null
         var pollDelay = 10L
-        repeat(300) {
+        repeat(200) {
             val resultPayload = asyncJson(get("/invoice/workflow/result/$workflowId"))
                 .andExpect(status().isOk)
                 .andReturn()
@@ -399,7 +399,7 @@ class ExampleApplicationTest {
                 return@repeat
             }
             Thread.sleep(pollDelay)
-            pollDelay = (pollDelay * 1.5).toLong().coerceAtMost(200)
+            pollDelay = (pollDelay * 1.5).toLong().coerceAtMost(500)
         }
 
         val cancelled = objectMapper.readTree(cancelledPayload ?: error("workflow did not cancel in time"))

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/PolicyEnforcementTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/PolicyEnforcementTest.kt
@@ -35,6 +35,8 @@ import dev.tramai.core.structured.StructuredOutputResult
 import dev.tramai.core.structured.StructuredOutputContract
 import dev.tramai.security.DefaultPolicyEngine
 import dev.tramai.security.PolicyConfiguration
+import dev.tramai.security.ProviderRoutingConfiguration
+import dev.tramai.security.ProviderTrustZone
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.toList
@@ -2017,5 +2019,168 @@ class PolicyEnforcementTest {
 
         val result = service.analyze("test")
         assertThat(result).isEqualTo("done")
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Epic 2.3 / 2.4 — Engine-level classification routing matrix tests
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun `RESTRICTED local failure to GLOBAL_CLOUD fallback is denied via routing matrix`() = runBlocking {
+        val localProvider = object : ModelProvider {
+            val callCount = AtomicInteger(0)
+            override fun providerId() = "local-provider"
+            override suspend fun complete(request: ModelRequest): ModelResponse {
+                callCount.incrementAndGet()
+                throw ProviderException("local failed", retryable = true)
+            }
+        }
+        val cloudProvider = CountingProvider(id = "cloud-provider")
+
+        val engine = TramaiEngine(
+            providerRegistry = ProviderRegistry.builder()
+                .provider("local-provider", localProvider, default = true)
+                .model("test-model", "local-provider")
+                .fallbackProvider("test-model", "cloud-provider")
+                .provider("cloud-provider", cloudProvider)
+                .build(),
+            policyEngine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedModels = setOf("test-model"),
+                    allowedProviders = setOf("local-provider", "cloud-provider"),
+                    allowedFallbackProviders = setOf("cloud-provider"),
+                    providerRouting = ProviderRoutingConfiguration(
+                        providerZones = mapOf(
+                            "local-provider" to ProviderTrustZone.LOCAL,
+                            "cloud-provider" to ProviderTrustZone.GLOBAL_CLOUD,
+                        ),
+                        enabled = true,
+                    ),
+                ),
+            ),
+        )
+        val service = engine.create<ClassifiedTestService>()
+
+        assertThatThrownBy {
+            runBlocking {
+                service.analyze(
+                    ClassifiedDocument(
+                        payload = "secret",
+                        classification = DataClassification.RESTRICTED,
+                        source = ClassificationSource.DECLARED,
+                    ),
+                )
+            }
+        }.isInstanceOf(PolicyViolationException::class.java)
+            .hasMessageContaining("not allowed for fallback")
+        assertThat(localProvider.callCount.get()).isEqualTo(1)
+        assertThat(cloudProvider.callCount.get()).isEqualTo(0)
+    }
+
+    @Test
+    fun `CONFIDENTIAL local failure to EU_CLOUD fallback is allowed via routing matrix`() = runBlocking {
+        val localProvider = object : ModelProvider {
+            val callCount = AtomicInteger(0)
+            override fun providerId() = "local-provider"
+            override suspend fun complete(request: ModelRequest): ModelResponse {
+                callCount.incrementAndGet()
+                throw ProviderException("local failed", retryable = true)
+            }
+        }
+        val euProvider = CountingProvider(id = "eu-provider")
+
+        val engine = TramaiEngine(
+            providerRegistry = ProviderRegistry.builder()
+                .provider("local-provider", localProvider, default = true)
+                .model("test-model", "local-provider")
+                .fallbackProvider("test-model", "eu-provider")
+                .provider("eu-provider", euProvider)
+                .build(),
+            policyEngine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedModels = setOf("test-model"),
+                    allowedProviders = setOf("local-provider", "eu-provider"),
+                    allowedFallbackProviders = setOf("eu-provider"),
+                    providerRouting = ProviderRoutingConfiguration(
+                        providerZones = mapOf(
+                            "local-provider" to ProviderTrustZone.LOCAL,
+                            "eu-provider" to ProviderTrustZone.EU_CLOUD,
+                        ),
+                        enabled = true,
+                    ),
+                ),
+            ),
+        )
+        val service = engine.create<ClassifiedTestService>()
+
+        val result = service.analyze(
+            ClassifiedDocument(
+                payload = "confidential",
+                classification = DataClassification.CONFIDENTIAL,
+                source = ClassificationSource.DECLARED,
+            ),
+        )
+
+        assertThat(result).isEqualTo("ok")
+        assertThat(localProvider.callCount.get()).isEqualTo(1)
+        assertThat(euProvider.callCount.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `cache hit is invalidated when provider zone changes to restricted classification`() = runBlocking {
+        val cache = InMemoryOperationResponseCache()
+        val provider = CountingProvider(id = "ollama")
+
+        // Engine 1: provider=ollama, LOCAL zone, RESTRICTED → allowed
+        val engine1 = TramaiEngine(
+            provider = provider,
+            responseCache = cache,
+            policyEngine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedModels = setOf("test-model"),
+                    allowedProviders = setOf("ollama"),
+                    trustedLocalProviders = setOf("ollama"),
+                    providerRouting = ProviderRoutingConfiguration(
+                        providerZones = mapOf("ollama" to ProviderTrustZone.LOCAL),
+                        enabled = true,
+                    ),
+                ),
+            ),
+        )
+        val service1 = engine1.create<CachedClassifiedTestService>()
+        val input = ClassifiedDocument(
+            payload = "cache-test",
+            classification = DataClassification.RESTRICTED,
+            source = ClassificationSource.DECLARED,
+        )
+
+        assertThat(service1.analyze(input)).isEqualTo("ok")
+        assertThat(provider.callCount.get()).isEqualTo(1)
+
+        // Engine 2: same provider now mapped to GLOBAL_CLOUD, RESTRICTED → denied
+        val engine2 = TramaiEngine(
+            provider = provider,
+            responseCache = cache,
+            policyEngine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedModels = setOf("test-model"),
+                    allowedProviders = setOf("ollama"),
+                    trustedLocalProviders = setOf("ollama"),
+                    providerRouting = ProviderRoutingConfiguration(
+                        providerZones = mapOf("ollama" to ProviderTrustZone.GLOBAL_CLOUD),
+                        enabled = true,
+                    ),
+                ),
+            ),
+        )
+        val service2 = engine2.create<CachedClassifiedTestService>()
+
+        assertThatThrownBy {
+            runBlocking { service2.analyze(input) }
+        }.isInstanceOf(PolicyViolationException::class.java)
+            .hasMessageContaining("not allowed for invocation")
+
+        // Provider should NOT have been invoked again (cache hit denied by policy)
+        assertThat(provider.callCount.get()).isEqualTo(1)
     }
 }

--- a/tramai-observability/src/test/kotlin/dev/tramai/observability/OpenTelemetryOperationObserverTest.kt
+++ b/tramai-observability/src/test/kotlin/dev/tramai/observability/OpenTelemetryOperationObserverTest.kt
@@ -215,8 +215,8 @@ class OpenTelemetryOperationObserverTest {
             val result = runBlocking { service.respond("world") }
 
             assertThat(result).isEqualTo("hello")
-            assertThat(otlpMeterProvider.forceFlush().join(5, TimeUnit.SECONDS).isSuccess()).isTrue()
-            assertThat(exportLatch.await(5, TimeUnit.SECONDS)).isTrue()
+            assertThat(otlpMeterProvider.forceFlush().join(15, TimeUnit.SECONDS).isSuccess()).isTrue()
+            assertThat(exportLatch.await(15, TimeUnit.SECONDS)).isTrue()
             assertThat(capturedRequestPath).isEqualTo("/v1/metrics")
             assertThat(capturedContentType).startsWith("application/x-protobuf")
             assertThat(capturedBody).isNotEmpty()

--- a/tramai-security/src/main/kotlin/dev/tramai/security/DefaultPolicyEngine.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/DefaultPolicyEngine.kt
@@ -9,10 +9,16 @@ import dev.tramai.core.policy.*
  * Unknown tools, models, and providers are denied. HIGH/CRITICAL-risk
  * tools and tools with non-AUTO approval modes require human approval.
  *
- * Classified-request egress is enforced when classification metadata is
- * attached to the [PolicyContext]. RESTRICTED data is limited to trusted
- * local providers, while other non-public classifications require explicit
- * cloud permission for non-local providers.
+ * ## Classification-aware provider routing (Epic 2.3 / 2.4)
+ *
+ * When [PolicyConfiguration.providerRouting] is enabled, the routing
+ * matrix determines which provider trust zones are allowed for each
+ * [DataClassification] at primary invocation and fallback. This
+ * supplements the legacy [PolicyConfiguration.trustedLocalProviders]
+ * and [PolicyConfiguration.allowCloudForClassifications] checks.
+ *
+ * When the matrix is disabled (default), the legacy classification
+ * egress logic in [evaluateClassificationEgress] is used.
  */
 class DefaultPolicyEngine(
     private val config: PolicyConfiguration,
@@ -55,10 +61,23 @@ class DefaultPolicyEngine(
 
     private fun evaluateProviderInvocation(ctx: PolicyContext): PolicyDecision {
         val providerId = ctx.providerId
-        evaluateClassificationEgress(
+
+        // Classification-aware routing matrix (Epic 2.3) — checked before allowlist
+        evaluateProviderRouting(
             classification = ctx.dataClassification,
             providerId = providerId,
+            isFallback = false,
         )?.let { return it }
+
+        // Legacy classification egress (only when routing matrix is disabled,
+        // since evaluateProviderRouting returns null when routing is not enabled)
+        if (!config.providerRouting.enabled) {
+            evaluateClassificationEgress(
+                classification = ctx.dataClassification,
+                providerId = providerId,
+            )?.let { return it }
+        }
+
         if (providerId == null) {
             return PolicyDecision.Deny(
                 "Provider invocation requires a provider ID",
@@ -78,6 +97,14 @@ class DefaultPolicyEngine(
 
     private fun evaluateFallback(ctx: PolicyContext): PolicyDecision {
         val fallbackId = ctx.fallbackProviderId
+
+        // Classification-aware routing matrix (Epic 2.4) — checked before allowlist
+        evaluateProviderRouting(
+            classification = ctx.dataClassification,
+            providerId = fallbackId,
+            isFallback = true,
+        )?.let { return it }
+
         if (fallbackId == null) {
             return PolicyDecision.Deny(
                 "No fallback provider specified",
@@ -199,11 +226,91 @@ class DefaultPolicyEngine(
     // ─── Response return ────────────────────────────────────────────────────
 
     private fun evaluateResponseReturn(ctx: PolicyContext): PolicyDecision {
-        return evaluateClassificationEgress(
+        // Classification-aware routing matrix (Epic 2.3) — re-check on return
+        evaluateProviderRouting(
             classification = ctx.dataClassification,
             providerId = ctx.providerId,
-        ) ?: PolicyDecision.Allow
+            isFallback = false,
+        )?.let { return it }
+
+        // Legacy classification egress (only when routing matrix is disabled)
+        if (!config.providerRouting.enabled) {
+            return evaluateClassificationEgress(
+                classification = ctx.dataClassification,
+                providerId = ctx.providerId,
+            ) ?: PolicyDecision.Allow
+        }
+        return PolicyDecision.Allow
     }
+
+    // ─── Classification-aware provider routing matrix (Epic 2.3 / 2.4) ─────
+
+    /**
+     * Evaluates the classification-aware routing matrix for the given
+     * [classification], [providerId], and fallback context.
+     *
+     * Returns a [PolicyDecision.Deny] when routing is violated, or `null`
+     * to indicate the check is inconclusive (either no classification is
+     * present, or routing is disabled) — the caller should then fall back
+     * to legacy checks.
+     *
+     * **Reason codes:**
+     * - `classification-provider-missing`: classified request without provider ID
+     * - `provider-zone-missing`: classified request where the provider has no zone mapping
+     * - `classification-routing-rule-missing`: classification has no routing rule defined
+     * - `classification-routing-blocked`: provider zone not in [allowedZones]
+     * - `classification-fallback-blocked`: provider zone not in [allowedFallbackZones]
+     */
+    private fun evaluateProviderRouting(
+        classification: DataClassification?,
+        providerId: String?,
+        isFallback: Boolean,
+    ): PolicyDecision? {
+        // Routing matrix disabled — defer to legacy checks
+        if (!config.providerRouting.enabled) return null
+
+        // No classification — preserve current registry behavior
+        if (classification == null) return null
+
+        // Classified request without a provider ID
+        if (providerId == null) {
+            return PolicyDecision.Deny(
+                "Classified request ($classification) requires a provider ID for routing",
+                "classification-provider-missing",
+            )
+        }
+
+        val zone = config.providerRouting.providerZones[providerId]
+        if (zone == null) {
+            return PolicyDecision.Deny(
+                "Provider '$providerId' has no trust zone configured for classification routing",
+                "provider-zone-missing",
+            )
+        }
+
+        val rule = config.providerRouting.rules[classification]
+        if (rule == null) {
+            return PolicyDecision.Deny(
+                "No routing rule defined for classification '$classification'",
+                "classification-routing-rule-missing",
+            )
+        }
+
+        val allowedSet = if (isFallback) rule.allowedFallbackZones else rule.allowedZones
+        val reasonCode = if (isFallback) "classification-fallback-blocked" else "classification-routing-blocked"
+
+        if (zone !in allowedSet) {
+            val direction = if (isFallback) "fallback" else "invocation"
+            return PolicyDecision.Deny(
+                "Provider '$providerId' (zone=$zone) is not allowed for $direction of '$classification' data",
+                reasonCode,
+            )
+        }
+
+        return null
+    }
+
+    // ─── Legacy classification egress ───────────────────────────────────────
 
     private fun evaluateClassificationEgress(
         classification: DataClassification?,

--- a/tramai-security/src/main/kotlin/dev/tramai/security/DefaultPolicyEngine.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/DefaultPolicyEngine.kt
@@ -14,8 +14,8 @@ import dev.tramai.core.policy.*
  * When [PolicyConfiguration.providerRouting] is enabled, the routing
  * matrix determines which provider trust zones are allowed for each
  * [DataClassification] at primary invocation and fallback. This
- * supplements the legacy [PolicyConfiguration.trustedLocalProviders]
- * and [PolicyConfiguration.allowCloudForClassifications] checks.
+ * replaces legacy classification-egress fields when enabled;
+ * registry allowlists remain independent.
  *
  * When the matrix is disabled (default), the legacy classification
  * egress logic in [evaluateClassificationEgress] is used.
@@ -62,15 +62,31 @@ class DefaultPolicyEngine(
     private fun evaluateProviderInvocation(ctx: PolicyContext): PolicyDecision {
         val providerId = ctx.providerId
 
-        // Classification-aware routing matrix (Epic 2.3) — checked before allowlist
+        // 1. Provider ID must be present
+        if (providerId == null) {
+            return PolicyDecision.Deny(
+                "Provider invocation requires a provider ID",
+                "provider-id-missing",
+            )
+        }
+
+        // 2. Provider must be in the allowlist
+        if (providerId !in config.allowedProviders && "*" !in config.allowedProviders) {
+            return PolicyDecision.Deny(
+                "Provider '$providerId' is not in the allowed-providers registry",
+                "unknown-provider",
+            )
+        }
+
+        // 3. Classification-aware routing matrix (Epic 2.3)
         evaluateProviderRouting(
             classification = ctx.dataClassification,
             providerId = providerId,
             isFallback = false,
         )?.let { return it }
 
-        // Legacy classification egress (only when routing matrix is disabled,
-        // since evaluateProviderRouting returns null when routing is not enabled)
+        // 4. Legacy classification egress (only when routing matrix is disabled,
+        //    since evaluateProviderRouting returns null when routing is not enabled)
         if (!config.providerRouting.enabled) {
             evaluateClassificationEgress(
                 classification = ctx.dataClassification,
@@ -78,18 +94,6 @@ class DefaultPolicyEngine(
             )?.let { return it }
         }
 
-        if (providerId == null) {
-            return PolicyDecision.Deny(
-                "Provider invocation requires a provider ID",
-                "provider-id-missing",
-            )
-        }
-        if (providerId !in config.allowedProviders && "*" !in config.allowedProviders) {
-            return PolicyDecision.Deny(
-                "Provider '$providerId' is not in the allowed-providers registry",
-                "unknown-provider",
-            )
-        }
         return PolicyDecision.Allow
     }
 
@@ -98,25 +102,29 @@ class DefaultPolicyEngine(
     private fun evaluateFallback(ctx: PolicyContext): PolicyDecision {
         val fallbackId = ctx.fallbackProviderId
 
-        // Classification-aware routing matrix (Epic 2.4) — checked before allowlist
-        evaluateProviderRouting(
-            classification = ctx.dataClassification,
-            providerId = fallbackId,
-            isFallback = true,
-        )?.let { return it }
-
+        // 1. Fallback provider ID must be present
         if (fallbackId == null) {
             return PolicyDecision.Deny(
                 "No fallback provider specified",
                 "no-fallback-provider",
             )
         }
+
+        // 2. Fallback provider must be in the allowlist
         if (fallbackId !in config.allowedFallbackProviders && "*" !in config.allowedFallbackProviders) {
             return PolicyDecision.Deny(
                 "Fallback provider '$fallbackId' is not authorized",
                 "fallback-not-authorized",
             )
         }
+
+        // 3. Classification-aware routing matrix (Epic 2.4)
+        evaluateProviderRouting(
+            classification = ctx.dataClassification,
+            providerId = fallbackId,
+            isFallback = true,
+        )?.let { return it }
+
         return PolicyDecision.Allow
     }
 

--- a/tramai-security/src/main/kotlin/dev/tramai/security/DefaultPolicyEngine.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/DefaultPolicyEngine.kt
@@ -62,37 +62,46 @@ class DefaultPolicyEngine(
     private fun evaluateProviderInvocation(ctx: PolicyContext): PolicyDecision {
         val providerId = ctx.providerId
 
-        // 1. Provider ID must be present
+        if (!config.providerRouting.enabled) {
+            // Legacy mode: classification egress first, then registry checks
+            evaluateClassificationEgress(
+                classification = ctx.dataClassification,
+                providerId = providerId,
+            )?.let { return it }
+
+            if (providerId == null) {
+                return PolicyDecision.Deny(
+                    "Provider invocation requires a provider ID",
+                    "provider-id-missing",
+                )
+            }
+            if (providerId !in config.allowedProviders && "*" !in config.allowedProviders) {
+                return PolicyDecision.Deny(
+                    "Provider '$providerId' is not in the allowed-providers registry",
+                    "unknown-provider",
+                )
+            }
+            return PolicyDecision.Allow
+        }
+
+        // Matrix-enabled mode: provider ID check -> allowlist -> routing matrix (Epic 2.3)
         if (providerId == null) {
             return PolicyDecision.Deny(
                 "Provider invocation requires a provider ID",
                 "provider-id-missing",
             )
         }
-
-        // 2. Provider must be in the allowlist
         if (providerId !in config.allowedProviders && "*" !in config.allowedProviders) {
             return PolicyDecision.Deny(
                 "Provider '$providerId' is not in the allowed-providers registry",
                 "unknown-provider",
             )
         }
-
-        // 3. Classification-aware routing matrix (Epic 2.3)
         evaluateProviderRouting(
             classification = ctx.dataClassification,
             providerId = providerId,
             isFallback = false,
         )?.let { return it }
-
-        // 4. Legacy classification egress (only when routing matrix is disabled,
-        //    since evaluateProviderRouting returns null when routing is not enabled)
-        if (!config.providerRouting.enabled) {
-            evaluateClassificationEgress(
-                classification = ctx.dataClassification,
-                providerId = providerId,
-            )?.let { return it }
-        }
 
         return PolicyDecision.Allow
     }
@@ -102,22 +111,36 @@ class DefaultPolicyEngine(
     private fun evaluateFallback(ctx: PolicyContext): PolicyDecision {
         val fallbackId = ctx.fallbackProviderId
 
-        // 1. Fallback provider ID must be present
+        if (!config.providerRouting.enabled) {
+            // Legacy mode: registry checks only, no routing matrix
+            if (fallbackId == null) {
+                return PolicyDecision.Deny(
+                    "No fallback provider specified",
+                    "no-fallback-provider",
+                )
+            }
+            if (fallbackId !in config.allowedFallbackProviders && "*" !in config.allowedFallbackProviders) {
+                return PolicyDecision.Deny(
+                    "Fallback provider '$fallbackId' is not authorized",
+                    "fallback-not-authorized",
+                )
+            }
+            return PolicyDecision.Allow
+        }
+
+        // Matrix-enabled mode: registry checks + routing matrix (Epic 2.4)
         if (fallbackId == null) {
             return PolicyDecision.Deny(
                 "No fallback provider specified",
                 "no-fallback-provider",
             )
         }
-
-        // 2. Fallback provider must be in the allowlist
         if (fallbackId !in config.allowedFallbackProviders && "*" !in config.allowedFallbackProviders) {
             return PolicyDecision.Deny(
                 "Fallback provider '$fallbackId' is not authorized",
                 "fallback-not-authorized",
             )
         }
-
         // 3. Classification-aware routing matrix (Epic 2.4)
         evaluateProviderRouting(
             classification = ctx.dataClassification,
@@ -234,20 +257,19 @@ class DefaultPolicyEngine(
     // ─── Response return ────────────────────────────────────────────────────
 
     private fun evaluateResponseReturn(ctx: PolicyContext): PolicyDecision {
-        // Classification-aware routing matrix (Epic 2.3) — re-check on return
-        evaluateProviderRouting(
-            classification = ctx.dataClassification,
-            providerId = ctx.providerId,
-            isFallback = false,
-        )?.let { return it }
-
-        // Legacy classification egress (only when routing matrix is disabled)
         if (!config.providerRouting.enabled) {
+            // Legacy mode: only classification egress
             return evaluateClassificationEgress(
                 classification = ctx.dataClassification,
                 providerId = ctx.providerId,
             ) ?: PolicyDecision.Allow
         }
+        // Matrix-enabled mode: provider routing check (Epic 2.3)
+        evaluateProviderRouting(
+            classification = ctx.dataClassification,
+            providerId = ctx.providerId,
+            isFallback = false,
+        )?.let { return it }
         return PolicyDecision.Allow
     }
 

--- a/tramai-security/src/main/kotlin/dev/tramai/security/PolicyConfiguration.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/PolicyConfiguration.kt
@@ -8,6 +8,19 @@ import dev.tramai.core.policy.RiskLevel
  *
  * All sets are empty by default, producing full deny-by-default behavior.
  * Add entries to explicitly allow specific tools, models, or providers.
+ *
+ * ## Classification-Aware Provider Routing (Epic 2.3 / 2.4)
+ *
+ * The [providerRouting] field provides a matrix-based routing model where
+ * each [DataClassification] maps to allowed [ProviderTrustZone] sets for
+ * primary and fallback invocation. When [ProviderRoutingConfiguration.enabled]
+ * is true, this matrix is authoritative for classification-based routing.
+ *
+ * **Backward compatibility:** [trustedLocalProviders] and
+ * [allowCloudForClassifications] are retained as deprecated compatibility
+ * fields. When [providerRouting.enabled] is true, the matrix overrides them.
+ * When false (default), the legacy classification egress logic in
+ * [DefaultPolicyEngine] uses the old fields.
  */
 data class PolicyConfiguration(
     /** Tools whose execution is permitted. Empty = deny all tools. */
@@ -24,10 +37,31 @@ data class PolicyConfiguration(
     val allowLegacyToolsWithoutSecurityMetadata: Boolean = false,
     /** Risk levels that require human approval before tool execution. */
     val requireApprovalForRiskLevel: Set<RiskLevel> = setOf(RiskLevel.HIGH, RiskLevel.CRITICAL),
-    /** Data classifications permitted for non-local providers. */
+    /**
+     * Data classifications permitted for non-local providers.
+     *
+     * @deprecated Use [providerRouting] with classification-aware routing matrix instead.
+     * When [providerRouting.enabled] is true, this field is ignored for routing decisions.
+     */
+    @Deprecated("Use providerRouting instead", ReplaceWith("providerRouting"))
     val allowCloudForClassifications: Set<DataClassification> = setOf(DataClassification.PUBLIC),
-    /** Providers treated as inside the local trust boundary. */
+    /**
+     * Providers treated as inside the local trust boundary.
+     *
+     * @deprecated Use [providerRouting] with [ProviderTrustZone.LOCAL] zone mapping instead.
+     * When [providerRouting.enabled] is true, this field is ignored for routing decisions.
+     */
+    @Deprecated("Use providerRouting instead", ReplaceWith("providerRouting"))
     val trustedLocalProviders: Set<String> = emptySet(),
+    /**
+     * Classification-aware provider routing matrix.
+     *
+     * When [ProviderRoutingConfiguration.enabled] is true, this matrix
+     * overrides the legacy [trustedLocalProviders] and
+     * [allowCloudForClassifications] fields for routing decisions.
+     * Disabled by default for backward compatibility.
+     */
+    val providerRouting: ProviderRoutingConfiguration = ProviderRoutingConfiguration(),
 ) {
     companion object {
         /**
@@ -36,6 +70,10 @@ data class PolicyConfiguration(
          * CRITICAL-risk tools still require approval.
          * RESTRICTED data remains limited to trusted local providers when
          * classification context is available.
+         *
+         * The [providerRouting] matrix is **not** enabled in preview mode
+         * to preserve 0.4.x behavior. Legacy [trustedLocalProviders] and
+         * [allowCloudForClassifications] remain authoritative.
          */
         fun preview() = PolicyConfiguration(
             allowedTools = setOf("*"),
@@ -47,6 +85,15 @@ data class PolicyConfiguration(
             requireApprovalForRiskLevel = setOf(RiskLevel.CRITICAL),
             allowCloudForClassifications = DataClassification.entries.toSet(),
             trustedLocalProviders = setOf("ollama", "vllm", "llama.cpp", "local"),
+            providerRouting = ProviderRoutingConfiguration(
+                providerZones = mapOf(
+                    "ollama" to ProviderTrustZone.LOCAL,
+                    "vllm" to ProviderTrustZone.LOCAL,
+                    "llama.cpp" to ProviderTrustZone.LOCAL,
+                    "local" to ProviderTrustZone.LOCAL,
+                ),
+                enabled = false,
+            ),
         )
 
         /** Deny-by-default with no exclusions. */

--- a/tramai-security/src/main/kotlin/dev/tramai/security/ProviderRoutingConfiguration.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/ProviderRoutingConfiguration.kt
@@ -76,7 +76,7 @@ data class ProviderRoutingConfiguration(
          * - PUBLIC: any zone, fallback to any zone
          */
         fun sovereignDefaults(): Map<DataClassification, ClassificationRoutingRule> {
-            val allZones = ProviderTrustZone.entries.toSet()
+            val allZones = setOf(ProviderTrustZone.LOCAL, ProviderTrustZone.EU_CLOUD, ProviderTrustZone.GLOBAL_CLOUD)
             val localOnly = setOf(ProviderTrustZone.LOCAL)
             val localAndEu = setOf(ProviderTrustZone.LOCAL, ProviderTrustZone.EU_CLOUD)
             return mapOf(

--- a/tramai-security/src/main/kotlin/dev/tramai/security/ProviderRoutingConfiguration.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/ProviderRoutingConfiguration.kt
@@ -52,6 +52,20 @@ data class ProviderRoutingConfiguration(
     val rules: Map<DataClassification, ClassificationRoutingRule> = sovereignDefaults(),
     val enabled: Boolean = false,
 ) {
+    init {
+        rules.forEach { (classification, rule) ->
+            require(rule.allowedFallbackZones.all { it in rule.allowedZones }) {
+                "allowedFallbackZones ($classification) must be subset of allowedZones: " +
+                "allowedZones=${rule.allowedZones}, allowedFallbackZones=${rule.allowedFallbackZones}"
+            }
+        }
+        providerZones.forEach { (key, _) ->
+            require(key.isNotBlank()) {
+                "Provider zone key must not be blank"
+            }
+        }
+    }
+
     companion object {
         /**
          * Sovereign defaults for classification-aware routing.

--- a/tramai-security/src/main/kotlin/dev/tramai/security/ProviderRoutingConfiguration.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/ProviderRoutingConfiguration.kt
@@ -1,0 +1,88 @@
+package dev.tramai.security
+
+import dev.tramai.core.policy.DataClassification
+
+/**
+ * Defines the trust zone of a provider — used by the classification-aware
+ * routing matrix to decide which providers are eligible for a given
+ * [DataClassification].
+ */
+enum class ProviderTrustZone {
+    /** Same-host or isolated network boundary (Ollama, vLLM, llama.cpp). */
+    LOCAL,
+    /** Cloud providers hosted within the EU trust boundary. */
+    EU_CLOUD,
+    /** Global cloud providers outside EU jurisdiction. */
+    GLOBAL_CLOUD,
+}
+
+/**
+ * Routing rule for a single [DataClassification].
+ *
+ * [allowedZones] defines which provider trust zones may handle this
+ * classification for primary (non-fallback) invocation.
+ *
+ * [allowedFallbackZones] defines which provider trust zones may handle
+ * this classification during fallback (when the primary provider fails).
+ * Can be a subset of [allowedZones] — or empty to deny all fallback for
+ * sensitive classifications.
+ */
+data class ClassificationRoutingRule(
+    val allowedZones: Set<ProviderTrustZone>,
+    val allowedFallbackZones: Set<ProviderTrustZone>,
+)
+
+/**
+ * Configuration for classification-aware provider routing.
+ *
+ * When [enabled] is true, [DefaultPolicyEngine] evaluates every
+ * [DataClassification]-bearing request against the rule matrix before
+ * allowing provider invocation or fallback.
+ *
+ * @param providerZones maps provider IDs (e.g., "openai", "ollama") to
+ *   their trust zone.
+ * @param rules maps each [DataClassification] to its routing constraints.
+ *   Defaults to sovereign defaults via [sovereignDefaults].
+ * @param enabled when false (default), routing matrix checks are skipped
+ *   and the engine falls back to the legacy [PolicyConfiguration.trustedLocalProviders]
+ *   and [PolicyConfiguration.allowCloudForClassifications] logic.
+ */
+data class ProviderRoutingConfiguration(
+    val providerZones: Map<String, ProviderTrustZone> = emptyMap(),
+    val rules: Map<DataClassification, ClassificationRoutingRule> = sovereignDefaults(),
+    val enabled: Boolean = false,
+) {
+    companion object {
+        /**
+         * Sovereign defaults for classification-aware routing.
+         *
+         * - RESTRICTED: local only, no fallback to any cloud
+         * - CONFIDENTIAL: local or EU cloud, fallback to local or EU cloud only
+         * - INTERNAL: any zone, fallback to any zone
+         * - PUBLIC: any zone, fallback to any zone
+         */
+        fun sovereignDefaults(): Map<DataClassification, ClassificationRoutingRule> {
+            val allZones = ProviderTrustZone.entries.toSet()
+            val localOnly = setOf(ProviderTrustZone.LOCAL)
+            val localAndEu = setOf(ProviderTrustZone.LOCAL, ProviderTrustZone.EU_CLOUD)
+            return mapOf(
+                DataClassification.RESTRICTED to ClassificationRoutingRule(
+                    allowedZones = localOnly,
+                    allowedFallbackZones = emptySet(),
+                ),
+                DataClassification.CONFIDENTIAL to ClassificationRoutingRule(
+                    allowedZones = localAndEu,
+                    allowedFallbackZones = localAndEu,
+                ),
+                DataClassification.INTERNAL to ClassificationRoutingRule(
+                    allowedZones = allZones,
+                    allowedFallbackZones = allZones,
+                ),
+                DataClassification.PUBLIC to ClassificationRoutingRule(
+                    allowedZones = allZones,
+                    allowedFallbackZones = allZones,
+                ),
+            )
+        }
+    }
+}

--- a/tramai-security/src/test/kotlin/dev/tramai/security/DefaultPolicyEngineTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/DefaultPolicyEngineTest.kt
@@ -309,7 +309,7 @@ class DefaultPolicyEngineTest {
     }
 
     @Test
-    fun `classified provider invocation without provider id is denied`() {
+    fun `classified provider invocation without provider id is denied with provider-id-missing`() {
         runBlocking {
             val decision = secureEngine.evaluate(
                 ctx(
@@ -318,7 +318,7 @@ class DefaultPolicyEngineTest {
                 )
             )
             assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
-            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("classification-provider-missing")
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("provider-id-missing")
         }
     }
 
@@ -827,6 +827,7 @@ class DefaultPolicyEngineTest {
         runBlocking {
             val engine = DefaultPolicyEngine(
                 PolicyConfiguration.secure().copy(
+                    allowedProviders = setOf("ollama"),
                     providerRouting = ProviderRoutingConfiguration(
                         providerZones = emptyMap(), // no zones configured
                         enabled = true,
@@ -851,6 +852,7 @@ class DefaultPolicyEngineTest {
         runBlocking {
             val engine = DefaultPolicyEngine(
                 PolicyConfiguration.secure().copy(
+                    allowedProviders = setOf("ollama"),
                     providerRouting = ProviderRoutingConfiguration(
                         providerZones = mapOf("ollama" to ProviderTrustZone.LOCAL),
                         rules = emptyMap(), // no rules defined
@@ -979,7 +981,7 @@ class DefaultPolicyEngineTest {
     }
 
     @Test
-    fun `classified request with null providerId returns classification-provider-missing when routing enabled`() {
+    fun `classified request with null providerId returns provider-id-missing when routing enabled`() {
         runBlocking {
             val decision = routingEngine.evaluate(
                 routingCtx(
@@ -989,7 +991,7 @@ class DefaultPolicyEngineTest {
                 )
             )
             assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
-            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("classification-provider-missing")
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("provider-id-missing")
         }
     }
 
@@ -1007,6 +1009,106 @@ class DefaultPolicyEngineTest {
             // allowlist check. Since routingEngine has wildcard allowedProviders,
             // it gets all the way to Allow.
             assertThat(decision).isEqualTo(PolicyDecision.Allow)
+        }
+    }
+
+    @Test
+    fun `classified fallback with null fallbackId returns no-fallback-provider`() {
+        runBlocking {
+            val decision = routingEngine.evaluate(
+                routingCtx(
+                    EnforcementPoint.BEFORE_FALLBACK,
+                    providerId = "ollama",
+                    fallbackProviderId = null,
+                    dataClassification = DataClassification.RESTRICTED,
+                )
+            )
+            assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("no-fallback-provider")
+        }
+    }
+
+    @Test
+    fun `zone-mapped but unregistered provider is denied with unknown-provider`() {
+        runBlocking {
+            val engine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedProviders = emptySet(),
+                    providerRouting = ProviderRoutingConfiguration(
+                        providerZones = mapOf("ollama" to ProviderTrustZone.LOCAL),
+                        enabled = true,
+                    ),
+                )
+            )
+            val decision = engine.evaluate(
+                routingCtx(
+                    EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                    providerId = "ollama",
+                    dataClassification = DataClassification.PUBLIC,
+                )
+            )
+            assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("unknown-provider")
+        }
+    }
+
+    @Test
+    fun `zone-allowed but unregistered fallback is denied with fallback-not-authorized`() {
+        runBlocking {
+            val engine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedFallbackProviders = emptySet(),
+                    providerRouting = ProviderRoutingConfiguration(
+                        providerZones = mapOf("eu-openai" to ProviderTrustZone.EU_CLOUD),
+                        enabled = true,
+                    ),
+                )
+            )
+            val decision = engine.evaluate(
+                routingCtx(
+                    EnforcementPoint.BEFORE_FALLBACK,
+                    fallbackProviderId = "eu-openai",
+                    dataClassification = DataClassification.CONFIDENTIAL,
+                )
+            )
+            assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("fallback-not-authorized")
+        }
+    }
+
+    @Test
+    fun `routing rule with fallback zones not subset of allowed zones throws IllegalArgumentException`() {
+        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            ProviderRoutingConfiguration(
+                providerZones = mapOf("ollama" to ProviderTrustZone.LOCAL),
+                rules = mapOf(
+                    DataClassification.RESTRICTED to ClassificationRoutingRule(
+                        allowedZones = setOf(ProviderTrustZone.LOCAL),
+                        allowedFallbackZones = setOf(ProviderTrustZone.GLOBAL_CLOUD),
+                    ),
+                ),
+                enabled = true,
+            )
+        }
+    }
+
+    @Test
+    fun `provider routing configuration with blank provider key throws IllegalArgumentException`() {
+        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            ProviderRoutingConfiguration(
+                providerZones = mapOf("" to ProviderTrustZone.LOCAL),
+                enabled = true,
+            )
+        }
+    }
+
+    @Test
+    fun `provider routing configuration with blank provider key spaces throws IllegalArgumentException`() {
+        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            ProviderRoutingConfiguration(
+                providerZones = mapOf("  " to ProviderTrustZone.LOCAL),
+                enabled = true,
+            )
         }
     }
 }

--- a/tramai-security/src/test/kotlin/dev/tramai/security/DefaultPolicyEngineTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/DefaultPolicyEngineTest.kt
@@ -646,4 +646,367 @@ class DefaultPolicyEngineTest {
             assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("model-name-missing")
         }
     }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Epic 2.3 / 2.4 — Classification-aware provider routing matrix tests
+    // ═══════════════════════════════════════════════════════════════════════
+
+    private val routingEngine = DefaultPolicyEngine(
+        PolicyConfiguration.secure().copy(
+            allowedProviders = setOf("*"),
+            allowedFallbackProviders = setOf("*"),
+            allowedModels = setOf("*"),
+            providerRouting = ProviderRoutingConfiguration(
+                providerZones = mapOf(
+                    "ollama" to ProviderTrustZone.LOCAL,
+                    "eu-openai" to ProviderTrustZone.EU_CLOUD,
+                    "openai" to ProviderTrustZone.GLOBAL_CLOUD,
+                ),
+                enabled = true,
+            ),
+        )
+    )
+
+    private fun routingCtx(
+        enforcementPoint: EnforcementPoint,
+        providerId: String? = null,
+        fallbackProviderId: String? = null,
+        dataClassification: DataClassification? = null,
+    ) = PolicyContext(
+        enforcementPoint = enforcementPoint,
+        correlationId = "routing-test",
+        actorId = "test",
+        policyVersion = "1.0.0",
+        providerId = providerId,
+        fallbackProviderId = fallbackProviderId,
+        dataClassification = dataClassification,
+    )
+
+    // 1. RESTRICTED → local allowed
+    @Test
+    fun `RESTRICTED classification with LOCAL zone is allowed for primary invocation`() {
+        runBlocking {
+            val decision = routingEngine.evaluate(
+                routingCtx(
+                    EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                    providerId = "ollama",
+                    dataClassification = DataClassification.RESTRICTED,
+                )
+            )
+            assertThat(decision).isEqualTo(PolicyDecision.Allow)
+        }
+    }
+
+    // 2. RESTRICTED → EU denied
+    @Test
+    fun `RESTRICTED classification with EU_CLOUD zone is denied for primary invocation`() {
+        runBlocking {
+            val decision = routingEngine.evaluate(
+                routingCtx(
+                    EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                    providerId = "eu-openai",
+                    dataClassification = DataClassification.RESTRICTED,
+                )
+            )
+            assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("classification-routing-blocked")
+        }
+    }
+
+    // 3. RESTRICTED → global denied
+    @Test
+    fun `RESTRICTED classification with GLOBAL_CLOUD zone is denied for primary invocation`() {
+        runBlocking {
+            val decision = routingEngine.evaluate(
+                routingCtx(
+                    EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                    providerId = "openai",
+                    dataClassification = DataClassification.RESTRICTED,
+                )
+            )
+            assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("classification-routing-blocked")
+        }
+    }
+
+    // 4. CONFIDENTIAL → local allowed
+    @Test
+    fun `CONFIDENTIAL classification with LOCAL zone is allowed for primary invocation`() {
+        runBlocking {
+            val decision = routingEngine.evaluate(
+                routingCtx(
+                    EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                    providerId = "ollama",
+                    dataClassification = DataClassification.CONFIDENTIAL,
+                )
+            )
+            assertThat(decision).isEqualTo(PolicyDecision.Allow)
+        }
+    }
+
+    // 5. CONFIDENTIAL → EU allowed
+    @Test
+    fun `CONFIDENTIAL classification with EU_CLOUD zone is allowed for primary invocation`() {
+        runBlocking {
+            val decision = routingEngine.evaluate(
+                routingCtx(
+                    EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                    providerId = "eu-openai",
+                    dataClassification = DataClassification.CONFIDENTIAL,
+                )
+            )
+            assertThat(decision).isEqualTo(PolicyDecision.Allow)
+        }
+    }
+
+    // 6. CONFIDENTIAL → global denied
+    @Test
+    fun `CONFIDENTIAL classification with GLOBAL_CLOUD zone is denied for primary invocation`() {
+        runBlocking {
+            val decision = routingEngine.evaluate(
+                routingCtx(
+                    EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                    providerId = "openai",
+                    dataClassification = DataClassification.CONFIDENTIAL,
+                )
+            )
+            assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("classification-routing-blocked")
+        }
+    }
+
+    // 7. INTERNAL → global allowed
+    @Test
+    fun `INTERNAL classification with GLOBAL_CLOUD zone is allowed for primary invocation`() {
+        runBlocking {
+            val decision = routingEngine.evaluate(
+                routingCtx(
+                    EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                    providerId = "openai",
+                    dataClassification = DataClassification.INTERNAL,
+                )
+            )
+            assertThat(decision).isEqualTo(PolicyDecision.Allow)
+        }
+    }
+
+    // 8. PUBLIC → global allowed
+    @Test
+    fun `PUBLIC classification with GLOBAL_CLOUD zone is allowed for primary invocation`() {
+        runBlocking {
+            val decision = routingEngine.evaluate(
+                routingCtx(
+                    EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                    providerId = "openai",
+                    dataClassification = DataClassification.PUBLIC,
+                )
+            )
+            assertThat(decision).isEqualTo(PolicyDecision.Allow)
+        }
+    }
+
+    // 9. Unknown provider denied independently of zone
+    @Test
+    fun `unknown provider with routing enabled and INTERNAL data is denied due to missing zone`() {
+        runBlocking {
+            val decision = routingEngine.evaluate(
+                routingCtx(
+                    EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                    providerId = "unknown-provider",
+                    dataClassification = DataClassification.INTERNAL,
+                )
+            )
+            assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("provider-zone-missing")
+        }
+    }
+
+    // 10. Missing provider zone denied
+    @Test
+    fun `provider without zone mapping is denied for classified request`() {
+        runBlocking {
+            val engine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    providerRouting = ProviderRoutingConfiguration(
+                        providerZones = emptyMap(), // no zones configured
+                        enabled = true,
+                    ),
+                )
+            )
+            val decision = engine.evaluate(
+                routingCtx(
+                    EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                    providerId = "ollama",
+                    dataClassification = DataClassification.PUBLIC,
+                )
+            )
+            assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("provider-zone-missing")
+        }
+    }
+
+    // 11. Missing routing rule denied
+    @Test
+    fun `classification without routing rule is denied`() {
+        runBlocking {
+            val engine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    providerRouting = ProviderRoutingConfiguration(
+                        providerZones = mapOf("ollama" to ProviderTrustZone.LOCAL),
+                        rules = emptyMap(), // no rules defined
+                        enabled = true,
+                    ),
+                )
+            )
+            val decision = engine.evaluate(
+                routingCtx(
+                    EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                    providerId = "ollama",
+                    dataClassification = DataClassification.PUBLIC,
+                )
+            )
+            assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("classification-routing-rule-missing")
+        }
+    }
+
+    // 12. RESTRICTED local failure → global fallback denied (assert fallback call count == 0)
+    @Test
+    fun `RESTRICTED classification global fallback is denied at BEFORE_FALLBACK`() {
+        runBlocking {
+            val decision = routingEngine.evaluate(
+                routingCtx(
+                    EnforcementPoint.BEFORE_FALLBACK,
+                    providerId = "ollama",
+                    fallbackProviderId = "openai",
+                    dataClassification = DataClassification.RESTRICTED,
+                )
+            )
+            assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("classification-fallback-blocked")
+        }
+    }
+
+    // 13. CONFIDENTIAL local failure → EU fallback allowed
+    @Test
+    fun `CONFIDENTIAL classification EU_CLOUD fallback is allowed at BEFORE_FALLBACK`() {
+        runBlocking {
+            val decision = routingEngine.evaluate(
+                routingCtx(
+                    EnforcementPoint.BEFORE_FALLBACK,
+                    providerId = "ollama",
+                    fallbackProviderId = "eu-openai",
+                    dataClassification = DataClassification.CONFIDENTIAL,
+                )
+            )
+            assertThat(decision).isEqualTo(PolicyDecision.Allow)
+        }
+    }
+
+    // 14. Secure cached result reauthorization honors current zone policy
+    @Test
+    fun `cached result reauthorization honors current zone policy at response return`() {
+        runBlocking {
+            // When routing is enabled, response return re-checks the matrix
+            val decision = routingEngine.evaluate(
+                routingCtx(
+                    EnforcementPoint.BEFORE_RESPONSE_RETURN,
+                    providerId = "openai",
+                    dataClassification = DataClassification.CONFIDENTIAL,
+                )
+            )
+            assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("classification-routing-blocked")
+        }
+    }
+
+    // 15. Cache reuse denied after provider zone changes
+    @Test
+    fun `cache reuse is denied when provider zone changes to restricted zone`() {
+        runBlocking {
+            // Simulate reauthorization against current policy: provider
+            // was previously LOCAL but zone config now maps it to GLOBAL_CLOUD
+            val engine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    providerRouting = ProviderRoutingConfiguration(
+                        providerZones = mapOf("ollama" to ProviderTrustZone.GLOBAL_CLOUD),
+                        enabled = true,
+                    ),
+                )
+            )
+            val decision = engine.evaluate(
+                routingCtx(
+                    EnforcementPoint.BEFORE_RESPONSE_RETURN,
+                    providerId = "ollama",
+                    dataClassification = DataClassification.RESTRICTED,
+                )
+            )
+            assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("classification-routing-blocked")
+        }
+    }
+
+    // 16. Preview backward compatibility works
+    @Test
+    fun `preview mode preserves legacy routing behavior when matrix is disabled`() {
+        runBlocking {
+            // Preview has trustedLocalProviders but providerRouting.enabled=false
+            val decision = previewEngine.evaluate(
+                ctx(
+                    EnforcementPoint.BEFORE_RESPONSE_RETURN,
+                    providerId = "ollama",
+                    dataClassification = DataClassification.RESTRICTED,
+                )
+            )
+            // With matrix disabled, legacy egress logic uses trustedLocalProviders
+            assertThat(decision).isEqualTo(PolicyDecision.Allow)
+        }
+    }
+
+    @Test
+    fun `preview mode RESTRICTED data to non-local provider is still denied with legacy logic`() {
+        runBlocking {
+            val decision = previewEngine.evaluate(
+                ctx(
+                    EnforcementPoint.BEFORE_RESPONSE_RETURN,
+                    providerId = "openai",
+                    dataClassification = DataClassification.RESTRICTED,
+                )
+            )
+            assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("restricted-data-egress-blocked")
+        }
+    }
+
+    @Test
+    fun `classified request with null providerId returns classification-provider-missing when routing enabled`() {
+        runBlocking {
+            val decision = routingEngine.evaluate(
+                routingCtx(
+                    EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                    providerId = null,
+                    dataClassification = DataClassification.INTERNAL,
+                )
+            )
+            assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("classification-provider-missing")
+        }
+    }
+
+    @Test
+    fun `unclassified request passes through routing matrix without denial`() {
+        runBlocking {
+            val decision = routingEngine.evaluate(
+                routingCtx(
+                    EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                    providerId = "openai",
+                    dataClassification = null,
+                )
+            )
+            // No classification → routing matrix returns null → falls through to
+            // allowlist check. Since routingEngine has wildcard allowedProviders,
+            // it gets all the way to Allow.
+            assertThat(decision).isEqualTo(PolicyDecision.Allow)
+        }
+    }
 }

--- a/tramai-security/src/test/kotlin/dev/tramai/security/DefaultPolicyEngineTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/DefaultPolicyEngineTest.kt
@@ -309,7 +309,7 @@ class DefaultPolicyEngineTest {
     }
 
     @Test
-    fun `classified provider invocation without provider id is denied with provider-id-missing`() {
+    fun `classified provider invocation without provider id is denied with classification-provider-missing`() {
         runBlocking {
             val decision = secureEngine.evaluate(
                 ctx(
@@ -318,7 +318,7 @@ class DefaultPolicyEngineTest {
                 )
             )
             assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
-            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("provider-id-missing")
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("classification-provider-missing")
         }
     }
 
@@ -872,7 +872,7 @@ class DefaultPolicyEngineTest {
         }
     }
 
-    // 12. RESTRICTED local failure → global fallback denied (assert fallback call count == 0)
+    // 12. RESTRICTED local failure → global fallback denied
     @Test
     fun `RESTRICTED classification global fallback is denied at BEFORE_FALLBACK`() {
         runBlocking {
@@ -1109,6 +1109,95 @@ class DefaultPolicyEngineTest {
                 providerZones = mapOf("  " to ProviderTrustZone.LOCAL),
                 enabled = true,
             )
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Regression tests — Legacy mode semantics (providerRouting disabled)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun `matrix disabled + INTERNAL + null provider ID yields classification-provider-missing`() {
+        runBlocking {
+            // providerRouting.enabled = false (default on secure engine)
+            // classification = INTERNAL, providerId = null
+            // Legacy mode should check egress first → classification-provider-missing
+            val decision = secureEngine.evaluate(
+                ctx(
+                    EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                    dataClassification = DataClassification.INTERNAL,
+                    providerId = null,
+                )
+            )
+            assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("classification-provider-missing")
+        }
+    }
+
+    @Test
+    fun `matrix disabled + RESTRICTED + unknown cloud provider yields restricted-data-egress-blocked`() {
+        runBlocking {
+            // providerRouting.enabled = false
+            // trustedLocalProviders = ["ollama"], classification = RESTRICTED, providerId = "openai"
+            // Legacy mode: egress check before allowlist → restricted-data-egress-blocked
+            val engine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    trustedLocalProviders = setOf("ollama"),
+                )
+            )
+            val decision = engine.evaluate(
+                ctx(
+                    EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                    dataClassification = DataClassification.RESTRICTED,
+                    providerId = "openai",
+                )
+            )
+            assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("restricted-data-egress-blocked")
+        }
+    }
+
+    @Test
+    fun `matrix enabled + INTERNAL + null provider ID yields provider-id-missing`() {
+        runBlocking {
+            // providerRouting.enabled = true, classification = INTERNAL, providerId = null
+            // Matrix mode: null check before routing → provider-id-missing
+            val decision = routingEngine.evaluate(
+                routingCtx(
+                    EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                    providerId = null,
+                    dataClassification = DataClassification.INTERNAL,
+                )
+            )
+            assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("provider-id-missing")
+        }
+    }
+
+    @Test
+    fun `matrix enabled + mapped but unregistered provider yields unknown-provider`() {
+        runBlocking {
+            // providerRouting.enabled = true, providerZones = {"ollama" -> LOCAL}
+            // allowedProviders = ["other-provider"], classification = INTERNAL, providerId = "ollama"
+            // Matrix mode: allowlist before routing → unknown-provider
+            val engine = DefaultPolicyEngine(
+                PolicyConfiguration.secure().copy(
+                    allowedProviders = setOf("other-provider"),
+                    providerRouting = ProviderRoutingConfiguration(
+                        providerZones = mapOf("ollama" to ProviderTrustZone.LOCAL),
+                        enabled = true,
+                    ),
+                )
+            )
+            val decision = engine.evaluate(
+                routingCtx(
+                    EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                    providerId = "ollama",
+                    dataClassification = DataClassification.INTERNAL,
+                )
+            )
+            assertThat(decision).isInstanceOf(PolicyDecision.Deny::class.java)
+            assertThat((decision as PolicyDecision.Deny).reasonCode).isEqualTo("unknown-provider")
         }
     }
 }


### PR DESCRIPTION
## Summary

Implements Epic 2.3 (Provider routing by classification) and Epic 2.4 (No silent fallback) from the security delivery plan.

## Routing Model

Three new types in `tramai-security/src/main/kotlin/dev/tramai/security/ProviderRoutingConfiguration.kt`:

- **`ProviderTrustZone`** — `LOCAL`, `EU_CLOUD`, `GLOBAL_CLOUD`
- **`ClassificationRoutingRule`** — `allowedZones` (primary) + `allowedFallbackZones` (fallback)
- **`ProviderRoutingConfiguration`** — `providerZones: Map<String, ProviderTrustZone>`, `rules: Map<DataClassification, ClassificationRoutingRule>`, `enabled: Boolean`

### Sovereign Default Routing Matrix

| Classification | allowedZones | allowedFallbackZones |
|---|---|---|
| RESTRICTED | LOCAL | (empty — no fallback) |
| CONFIDENTIAL | LOCAL, EU_CLOUD | LOCAL, EU_CLOUD |
| INTERNAL | LOCAL, EU_CLOUD, GLOBAL_CLOUD | LOCAL, EU_CLOUD, GLOBAL_CLOUD |
| PUBLIC | LOCAL, EU_CLOUD, GLOBAL_CLOUD | LOCAL, EU_CLOUD, GLOBAL_CLOUD |

### Enforcement Points

`evaluateProviderRouting()` is called at `BEFORE_PROVIDER_INVOCATION`, `BEFORE_FALLBACK`, `BEFORE_RESPONSE_RETURN` in `DefaultPolicyEngine`.

### Backward Compatibility

- Matrix is **disabled by default** (`enabled = false`) — zero behavioral change in 0.4.x
- `evaluateClassificationEgress()` runs first in legacy mode, preserving stable reason codes
- Matrix mode: provider ID → allowlist → routing matrix

### Stable Reason Codes

- `classification-provider-missing`
- `provider-zone-missing`
- `classification-routing-rule-missing`
- `classification-routing-blocked`
- `classification-fallback-blocked`

## Compatibility Strategy

- `ProviderRoutingConfiguration.enabled = false` by default (disabled)
- Legacy `trustedLocalProviders` and `allowCloudForClassifications` fields retained with `@Deprecated` annotations
- When `enabled = true`, the routing matrix is authoritative and legacy fields are ignored for routing
- When `enabled = false`, legacy `evaluateClassificationEgress()` continues to work unchanged — classification egress checked before registry allowlists, same as 0.4.x
- `PolicyConfiguration.preview()` keeps `enabled = false` for 0.4.x backward compatibility

## Test Coverage

**Unit tests** (`DefaultPolicyEngineTest`): Full classification-zone matrix, fallback enforcement, error conditions (null provider, missing zone, missing rule), config validation (zone subset, blank keys), preview backward compatibility, and legacy semantics regression tests.

**Engine integration tests** (`PolicyEnforcementTest`): RESTRICTED → GLOBAL_CLOUD fallback denied (provider never called), CONFIDENTIAL → EU_CLOUD fallback allowed, cache reauthorization after zone change.

## Deferred Work

- Annotation-based operation-level provider policy overrides (e.g., `@ProviderPolicy` on methods) are intentionally deferred to a separate PR
- Provider zone auto-detection (classpath scanning, SPI) is not implemented — zones must be configured explicitly