### PR TITLE
feat(security): add DLP interceptor foundation for model outputs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,10 +44,10 @@ This workflow is used across releases to prove functional behavior, policy enfor
 
 ### Deliverables
 
-- `PRODUCT-THESIS.md`
-- `SECURITY-MODEL.md`
+- `docs/security/PRODUCT-THESIS.md` — position, problem, promise, target segments, non-goals
+- `docs/security/SECURITY-MODEL.md` — trust boundaries, threat model, abuse scenarios, controls mapping, residual risk
 - Initial architecture diagram
-- Initial risk register
+- Initial risk register (`docs/security/RISK-REGISTER.md`)
 - Prioritized epic backlog
 
 ### Exit Criteria

--- a/docs/security/DELIVERY-PLAN.md
+++ b/docs/security/DELIVERY-PLAN.md
@@ -264,37 +264,126 @@ tramai:
 
 ### Issues
 
-#### 2B.1 — DlpInterceptor SPI
+#### 2B.1 — DlpInterceptor SPI ✅
 - Define DlpInterceptor interface for output scanning
-- Default no-op implementation
+- Default no-op implementation (NoOpDlpInterceptor)
+- Rule-based first pass implementation (RuleBasedDlpInterceptor)
 - **Acceptance:** SPI compiles, default passes through
+- **Status:** Completed — see Implementation Notes below
 
-#### 2B.2 — Field-level output policies
+#### 2B.2 — Field-level output policies ⏳
 - Annotate output fields with sensitivity level
 - Redact fields above configured threshold before returning
 - **Acceptance:** Sensitive fields redacted; non-sensitive fields preserved
+- **Status:** Deferred to follow-up PR
 
-#### 2B.3 — Tool-result minimization hook
+#### 2B.3 — Tool-result minimization hook ⏳
 - Filter tool results before reinjection into model context
 - Configurable per-tool minimization rules
 - **Acceptance:** Tool results filtered before model sees them
+- **Status:** Deferred to follow-up PR (DlpContentType.TOOL_RESULT type exists, RuleBasedDlpInterceptor supports `enabledFor` including TOOL_RESULT, but engine hook only applies to MODEL_OUTPUT)
 
-#### 2B.4 — Redaction audit events
+#### 2B.4 — Redaction audit events ⏳
 - Emit audit event when DLP redacts content
 - Record field name, rule matched, not the redacted value
 - **Acceptance:** Redaction events in audit trail; no sensitive data in audit
+- **Status:** Deferred to follow-up PR
 
-#### 2B.5 — Negative tests for valid-schema data leakage
+#### 2B.5 — Negative tests for valid-schema data leakage ⏳
 - Test: valid JSON output containing PII → redacted
 - Test: tool result containing secrets → filtered
 - Test: redaction events emitted and verifiable
 - **Acceptance:** Schema-valid outputs with PII are caught by DLP layer
+- **Status:** Deferred to follow-up PR (compensating coverage provided by RuleBasedDlpInterceptor unit tests)
 
 **Epic Exit Criteria:**
-- [ ] DLP SPI implemented with rule-based first pass
+- [x] DLP SPI implemented with rule-based first pass
 - [ ] Field-level redaction works for annotated fields
 - [ ] Tool results filtered before context reinjection
 - [ ] Schema-valid-but-leaky outputs blocked by DLP layer
+
+---
+
+## Implementation Notes — DLP Interceptor Foundation (PR 8)
+
+**Where:**
+- `tramai-core/.../security/DlpInterceptor.kt` — SPI, context, result types, NoOpDlpInterceptor
+- `tramai-security/.../RuleBasedDlpInterceptor.kt` — rule-based implementation
+- `tramai-engine/.../TramaiEngine.kt` — engine hook at `applyDlpToResult()`
+
+### DLP API (`tramai-core`)
+
+| Type | Role |
+|------|------|
+| `DlpContentType` | Enum: `MODEL_OUTPUT`, `TOOL_RESULT` |
+| `DlpContext` | Metadata about the operation producing the text (contentType, service/method, provider/model, correlationId) |
+| `DlpResult` | Result containing `sanitizedText`, `redactions: List<DlpRedaction>`, and computed `modified` |
+| `DlpRedaction` | Rule reference with count — **no raw matched values** |
+| `DlpInterceptor` | `fun interface` with `inspect(context, text): DlpResult` |
+| `NoOpDlpInterceptor` | Pass-through singleton |
+
+### RuleBasedDlpInterceptor (`tramai-security`)
+
+- **Configuration:** `RuleBasedDlpConfiguration(rules, maxTextLength)` with default 100K limit
+- **Validation (init):**
+  - `maxTextLength` in (0, 10_000_000]
+  - Non-blank rule IDs (unique)
+  - Non-blank patterns
+  - Non-empty `enabledFor` sets
+- **Deterministic ordering:** Rules applied in constructor-declared order
+- **Content-type filtering:** Each rule has `enabledFor: Set<DlpContentType>` (default `MODEL_OUTPUT`)
+- **Security properties:** No raw matched values in `DlpRedaction` or exceptions; fixed exception messages
+- **Oversized input:** Rejected with `IllegalArgumentException("Input text exceeds maximum allowed length")` — no input content leaked
+- **Duplicate redaction counting:** `DlpRedaction.replacementCount` reports total matches per rule
+
+### Engine Hook Location (`TramaiEngine`)
+
+```
+ModelResponse
+  → interceptResponse (operation interceptor)
+  → applyDlpToResult()  ← DLP applied here
+    → structured parsing (if structured output)
+    → cache storage
+    → chatMemory storage
+    → return
+```
+
+- Only `DlpContentType.MODEL_OUTPUT` is scanned in this pass
+- `toolCalls` on the response are never modified
+- Short-circuit when `dlpInterceptor === NoOpDlpInterceptor` (zero overhead for default config)
+
+### Test Matrix
+
+#### NoOpDlpInterceptorTest (tramai-core)
+- Returns exact text unchanged
+- No redactions produced
+- `modified` is always false
+- Works with all DlpContentType values
+
+#### RuleBasedDlpInterceptorTest (tramai-security) — 16 tests
+1. Email regex redacts matching text
+2. API-key regex uses custom replacement string
+3. Multiple rules apply deterministically (in declaration order)
+4. Duplicate rule IDs rejected with clear message
+5. Blank rule IDs rejected
+6. Blank patterns rejected
+7. Oversized input rejected with fixed message (no input leakage)
+8. `TOOL_RESULT`-only rule does not affect `MODEL_OUTPUT`
+9. `MODEL_OUTPUT`-only rule does not affect `TOOL_RESULT`
+10. Rule applies to both content types when `enabledFor` includes both
+11. Empty rules list passes text through unchanged
+12. Input at `maxTextLength` boundary passes through
+13. `DlpResult` properties on modified output (sanitizedText, modified, redactions)
+14. Multiple occurrences of same pattern all redacted with correct count
+15. `maxTextLength = 0` rejected
+16. `maxTextLength` exceeding maximum rejected
+
+### Deferred Work (follow-up PRs)
+- **Field-level output policies** (2B.2) — annotation-driven per-field redaction
+- **Tool-result filtering** (2B.3) — engine hook for `DlpContentType.TOOL_RESULT`
+- **Redaction audit events** (2B.4) — emit events via audit engine
+- **Streaming DLP** — apply DLP to streaming `Flow<StreamChunk>`
+- **Binary content DLP** — image/document scanning for embedded sensitive data
 
 ---
 

--- a/docs/security/DELIVERY-PLAN.md
+++ b/docs/security/DELIVERY-PLAN.md
@@ -336,8 +336,8 @@ tramai:
 - **Security properties:** No raw matched values in `DlpRedaction` or exceptions; fixed exception messages
 - **Oversized input:** Rejected with `IllegalArgumentException("Input text exceeds maximum allowed length")` — no input content leaked
 - **Duplicate redaction counting:** `DlpRedaction.replacementCount` reports total matches per rule
-|- **Zero-width safety:** Uses `Matcher.find() + appendReplacement() + appendTail()` loop — `appendReplacement` safely handles zero-width matches (lookahead, boundary anchors) without consuming characters or looping infinitely. `quoteReplacement()` escapes `$` and `\` for literal insertion.
-|- **Literal replacements:** Replacement strings are passed through `Matcher.quoteReplacement()` before `appendReplacement()` — `$1`, `\value`, and other special characters are escaped for literal output.
+- **Zero-width safety:** Uses `Matcher.find() + appendReplacement() + appendTail()` loop — `appendReplacement` safely handles zero-width matches (lookahead, boundary anchors) without consuming characters or looping infinitely. `quoteReplacement()` escapes `$` and `\` for literal insertion.
+- **Literal replacements:** Replacement strings are passed through `Matcher.quoteReplacement()` before `appendReplacement()` — `$1`, `\value`, and other special characters are escaped for literal output.
 
 ### Engine Hook Location (`TramaiEngine`)
 

--- a/docs/security/DELIVERY-PLAN.md
+++ b/docs/security/DELIVERY-PLAN.md
@@ -309,18 +309,19 @@ tramai:
 **Where:**
 - `tramai-core/.../security/DlpInterceptor.kt` — SPI, context, result types, NoOpDlpInterceptor
 - `tramai-security/.../RuleBasedDlpInterceptor.kt` — rule-based implementation
-- `tramai-engine/.../TramaiEngine.kt` — engine hook at `applyDlpToResult()`
+- `tramai-engine/.../TramaiEngine.kt` — engine hook inside `callProviderWithRetries()`
 
 ### DLP API (`tramai-core`)
 
 | Type | Role |
 |------|------|
 | `DlpContentType` | Enum: `MODEL_OUTPUT`, `TOOL_RESULT` |
-| `DlpContext` | Metadata about the operation producing the text (contentType, service/method, provider/model, correlationId) |
-| `DlpResult` | Result containing `sanitizedText`, `redactions: List<DlpRedaction>`, and computed `modified` |
+| `DlpContext` | Metadata about the operation producing the text (contentType, service/method, provider/model, correlationId, dataClassification, classificationSource) |
+| `DlpResult` | Result containing `sanitizedText`, `redactions: List<DlpRedaction>`, and computed `hasRedactions` (renamed from `modified`) |
 | `DlpRedaction` | Rule reference with count — **no raw matched values** |
 | `DlpInterceptor` | `fun interface` with `inspect(context, text): DlpResult` |
 | `NoOpDlpInterceptor` | Pass-through singleton |
+| `DlpInspectionException` | Thrown when DLP inspection fails — distinct from provider failures |
 
 ### RuleBasedDlpInterceptor (`tramai-security`)
 
@@ -335,6 +336,8 @@ tramai:
 - **Security properties:** No raw matched values in `DlpRedaction` or exceptions; fixed exception messages
 - **Oversized input:** Rejected with `IllegalArgumentException("Input text exceeds maximum allowed length")` — no input content leaked
 - **Duplicate redaction counting:** `DlpRedaction.replacementCount` reports total matches per rule
+- **Zero-width safety:** Uses `Matcher.region()` to advance past zero-width matches (lookahead, boundary anchors), preventing infinite loops
+- **Literal replacements:** All replacements use `Matcher.quoteReplacement()` (when using `appendReplacement`) or direct appending, so `$1` / `\value` in replacements stay literal
 
 ### Engine Hook Location (`TramaiEngine`)
 
@@ -344,7 +347,7 @@ after `OperationInterceptor.interceptResponse()` and **before** `onProviderRespo
 ```
 ModelResponse
   → interceptResponse (operation interceptor)
-  → applyDlpToResult()  ← DLP applied here (earliest safe boundary)
+  → DLP inspection (inside callProviderWithRetries, earliest safe boundary)
     → observation.onProviderResponse(sanitized)
     → structured parsing (if structured output)
     → cache storage
@@ -360,40 +363,61 @@ Consequences:
 - `toolCalls` on the response are never modified
 - Short-circuit when `dlpInterceptor === NoOpDlpInterceptor` (zero overhead for default config)
 
+### DLP Failure Isolation
+
+DLP failures are strictly separated from provider failures:
+
+- A DLP inspection exception (`DlpInspectionException`) does NOT call `observation.onProviderFailure()`
+- It does NOT call `circuitBreaker.onFailure()` — DLP failures do not poison provider circuit breakers
+- It does NOT trigger provider retries (DLP is deterministic per response)
+- It does NOT trigger fallback (response content cannot be returned unsanitized)
+- The `DlpInspectionException` propagates directly to the caller
+
 ### Cache Behaviour
 
 Cache eligibility (`isSafeCacheEligible`) requires `dlpInterceptor === NoOpDlpInterceptor`.
 Custom DLP interceptors **bypass the cache entirely** — every provider response is freshly
 sanitized.
 
-Cache-aware DLP fingerprints (cache-key by dlpInterceptor identity) and cache-hit
-re-inspection are deferred until the interceptor is stable.
-
-### Test Matrix
+### Test Coverage
 
 #### NoOpDlpInterceptorTest (tramai-core)
 - Returns exact text unchanged
 - No redactions produced
-- `modified` is always false
+- `hasRedactions` is always false
 - Works with all DlpContentType values
 
-#### RuleBasedDlpInterceptorTest (tramai-security) — 16 tests
-1. Email regex redacts matching text
-2. API-key regex uses custom replacement string
-3. Multiple rules apply deterministically (in declaration order)
-4. Duplicate rule IDs rejected with clear message
-5. Blank rule IDs rejected
-6. Blank patterns rejected
-7. Oversized input rejected with fixed message (no input leakage)
-8. `TOOL_RESULT`-only rule does not affect `MODEL_OUTPUT`
-9. `MODEL_OUTPUT`-only rule does not affect `TOOL_RESULT`
-10. Rule applies to both content types when `enabledFor` includes both
-11. Empty rules list passes text through unchanged
-12. Input at `maxTextLength` boundary passes through
-13. `DlpResult` properties on modified output (sanitizedText, modified, redactions)
-14. Multiple occurrences of same pattern all redacted with correct count
-15. `maxTextLength = 0` rejected
-16. `maxTextLength` exceeding maximum rejected
+#### RuleBasedDlpInterceptorTest (tramai-security)
+- Email regex redacts matching text
+- API-key regex uses custom replacement string
+- Multiple rules apply deterministically (in declaration order)
+- Duplicate rule IDs rejected with clear message
+- Blank rule IDs rejected
+- Blank patterns rejected
+- Oversized input rejected with fixed message (no input leakage)
+- `TOOL_RESULT`-only rule does not affect `MODEL_OUTPUT`
+- `MODEL_OUTPUT`-only rule does not affect `TOOL_RESULT`
+- Rule applies to both content types when `enabledFor` includes both
+- Empty rules list passes text through unchanged
+- Input at `maxTextLength` boundary passes through
+- `DlpResult` properties on modified output (sanitizedText, hasRedactions, redactions)
+- Multiple occurrences of same pattern all redacted with correct count
+- `maxTextLength = 0` rejected
+- `maxTextLength` exceeding maximum rejected
+- Zero-width lookahead terminates safely (no infinite loop)
+- End-of-string anchor (`$`) terminates safely
+- Replacement with `$1` stays literal (no backreference interpretation)
+- Replacement with `\value` stays literal
+
+#### Engine Integration Tests (tramai-engine)
+- Raw response redacted before caller return
+- Structured JSON redacted before parser input
+- Chat memory stores sanitized assistant response
+- Operation observer sees sanitized response
+- Tool calls remain unchanged after DLP (sanitized assistant content, preserved tool call metadata)
+- Custom DLP disables cache
+- NoOp DLP preserves existing behavior
+- Custom DLP interceptor without redaction metadata still applies sanitized text
 
 ### Deferred Work (follow-up PRs)
 - **Field-level output policies** (2B.2) — annotation-driven per-field redaction

--- a/docs/security/DELIVERY-PLAN.md
+++ b/docs/security/DELIVERY-PLAN.md
@@ -321,7 +321,7 @@ tramai:
 | `DlpRedaction` | Rule reference with count — **no raw matched values** |
 | `DlpInterceptor` | `fun interface` with `inspect(context, text): DlpResult` |
 | `NoOpDlpInterceptor` | Pass-through singleton |
-| `DlpInspectionException` | Thrown when DLP inspection fails — distinct from provider failures |
+| `DlpInspectionException` | Thrown when DLP inspection fails — distinct from provider failures; constructor remains intentionally minimal (`message`, `cause`) with no `ruleId` parameter |
 
 ### RuleBasedDlpInterceptor (`tramai-security`)
 
@@ -381,6 +381,22 @@ DLP failures are strictly separated from provider failures:
 Cache eligibility (`isSafeCacheEligible`) requires `dlpInterceptor === NoOpDlpInterceptor`.
 Custom DLP interceptors **bypass the cache entirely** — every provider response is freshly
 sanitized.
+
+### Standalone Builder Wiring (`tramai-standalone`)
+
+- `dev.tramai.standalone.Tramai` now stores a private `dlpInterceptor: dev.tramai.core.security.DlpInterceptor`
+- The standalone builder defaults that field to `dev.tramai.core.security.NoOpDlpInterceptor`
+- `Tramai.Builder.dlp(interceptor: DlpInterceptor)` wires custom DLP into the standalone runtime without adding any property surface
+- `Tramai.create(...)` forwards the configured interceptor into `TramaiEngine(dlpInterceptor = ...)`
+- Standalone integration test expectation: a builder-configured custom interceptor sanitizes provider output before `OperationObserver.onProviderResponse()` runs
+
+### Spring Bean Wiring (`tramai-spring`)
+
+- `TramaiAutoConfiguration` receives `ObjectProvider<dev.tramai.core.security.DlpInterceptor>` through auto-configuration method parameter injection
+- Zero beans: no action; the standalone builder keeps `NoOpDlpInterceptor`
+- One bean: auto-configuration calls `builder.dlp(interceptor)`
+- Multiple beans: startup fails fast with `IllegalArgumentException` describing the ambiguous `DlpInterceptor` beans
+- YAML/property binding for `tramai.dlp.*` remains deferred; this PR only exposes bean-based wiring
 
 ### Test Coverage
 

--- a/docs/security/DELIVERY-PLAN.md
+++ b/docs/security/DELIVERY-PLAN.md
@@ -336,8 +336,8 @@ tramai:
 - **Security properties:** No raw matched values in `DlpRedaction` or exceptions; fixed exception messages
 - **Oversized input:** Rejected with `IllegalArgumentException("Input text exceeds maximum allowed length")` — no input content leaked
 - **Duplicate redaction counting:** `DlpRedaction.replacementCount` reports total matches per rule
-- **Zero-width safety:** Uses `Matcher.region()` to advance past zero-width matches (lookahead, boundary anchors), preventing infinite loops
-- **Literal replacements:** All replacements use `Matcher.quoteReplacement()` (when using `appendReplacement`) or direct appending, so `$1` / `\value` in replacements stay literal
+- **Zero-width safety:** Uses manual `matcher.find(cursor)` loop with `cursor = end + 1` advancement for zero-width matches (lookahead, boundary anchors), preventing infinite loops without using `Matcher.region()` (which resets append state)
+- **Literal replacements:** Replacement strings are inserted directly via `StringBuilder.append()` — `$1`, `\value`, and other special characters stay literal without requiring `Matcher.quoteReplacement()`
 
 ### Engine Hook Location (`TramaiEngine`)
 
@@ -371,6 +371,9 @@ DLP failures are strictly separated from provider failures:
 - It does NOT call `circuitBreaker.onFailure()` — DLP failures do not poison provider circuit breakers
 - It does NOT trigger provider retries (DLP is deterministic per response)
 - It does NOT trigger fallback (response content cannot be returned unsanitized)
+- It DOES call `observation.onCallCompleted(parseSuccess = null)` exactly once — the call lifecycle completes even when DLP rejects the response
+- It DOES emit `tramai.dlp.inspection_failed` engine event for observability
+- `CancellationException` is caught separately and rethrown unchanged before DLP or provider failure handling
 - The `DlpInspectionException` propagates directly to the caller
 
 ### Cache Behaviour

--- a/docs/security/DELIVERY-PLAN.md
+++ b/docs/security/DELIVERY-PLAN.md
@@ -304,7 +304,7 @@ tramai:
 
 ---
 
-## Implementation Notes — DLP Interceptor Foundation (PR 8)
+## Implementation Notes — DLP Interceptor Foundation (PR 9)
 
 **Where:**
 - `tramai-core/.../security/DlpInterceptor.kt` — SPI, context, result types, NoOpDlpInterceptor
@@ -338,19 +338,36 @@ tramai:
 
 ### Engine Hook Location (`TramaiEngine`)
 
+DLP is applied at the **earliest safe response boundary** — inside `callProviderWithRetries()`,
+after `OperationInterceptor.interceptResponse()` and **before** `onProviderResponse()`:
+
 ```
 ModelResponse
   → interceptResponse (operation interceptor)
-  → applyDlpToResult()  ← DLP applied here
+  → applyDlpToResult()  ← DLP applied here (earliest safe boundary)
+    → observation.onProviderResponse(sanitized)
     → structured parsing (if structured output)
     → cache storage
     → chatMemory storage
     → return
 ```
 
+Consequences:
+- **Observers** see only sanitized output
+- **Tool-loop assistant responses** are sanitized before reinjection as next-turn context
+- **Raw return, structured parsing, chat memory, and cache** all use sanitized content
 - Only `DlpContentType.MODEL_OUTPUT` is scanned in this pass
 - `toolCalls` on the response are never modified
 - Short-circuit when `dlpInterceptor === NoOpDlpInterceptor` (zero overhead for default config)
+
+### Cache Behaviour
+
+Cache eligibility (`isSafeCacheEligible`) requires `dlpInterceptor === NoOpDlpInterceptor`.
+Custom DLP interceptors **bypass the cache entirely** — every provider response is freshly
+sanitized.
+
+Cache-aware DLP fingerprints (cache-key by dlpInterceptor identity) and cache-hit
+re-inspection are deferred until the interceptor is stable.
 
 ### Test Matrix
 

--- a/docs/security/DELIVERY-PLAN.md
+++ b/docs/security/DELIVERY-PLAN.md
@@ -336,8 +336,8 @@ tramai:
 - **Security properties:** No raw matched values in `DlpRedaction` or exceptions; fixed exception messages
 - **Oversized input:** Rejected with `IllegalArgumentException("Input text exceeds maximum allowed length")` — no input content leaked
 - **Duplicate redaction counting:** `DlpRedaction.replacementCount` reports total matches per rule
-- **Zero-width safety:** Uses manual `matcher.find(cursor)` loop with `cursor = end + 1` advancement for zero-width matches (lookahead, boundary anchors), preventing infinite loops without using `Matcher.region()` (which resets append state)
-- **Literal replacements:** Replacement strings are inserted directly via `StringBuilder.append()` — `$1`, `\value`, and other special characters stay literal without requiring `Matcher.quoteReplacement()`
+|- **Zero-width safety:** Uses `Matcher.find() + appendReplacement() + appendTail()` loop — `appendReplacement` safely handles zero-width matches (lookahead, boundary anchors) without consuming characters or looping infinitely. `quoteReplacement()` escapes `$` and `\` for literal insertion.
+|- **Literal replacements:** Replacement strings are passed through `Matcher.quoteReplacement()` before `appendReplacement()` — `$1`, `\value`, and other special characters are escaped for literal output.
 
 ### Engine Hook Location (`TramaiEngine`)
 

--- a/tramai-core/src/main/kotlin/dev/tramai/core/security/DlpInterceptor.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/security/DlpInterceptor.kt
@@ -38,8 +38,11 @@ data class DlpRedaction(
 )
 
 /**
- * Result of a DLP inspection. If [sanitizedText] differs from the input then
- * [redactions] describes what was redacted and [hasRedactions] is `true`.
+ * Result of a DLP inspection.
+ *
+ * [sanitizedText] is authoritative. [redactions] optionally provides
+ * rule-level evidence when available. [hasRedactions] reports whether
+ * such evidence entries are present.
  */
 data class DlpResult(
     val sanitizedText: String,

--- a/tramai-core/src/main/kotlin/dev/tramai/core/security/DlpInterceptor.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/security/DlpInterceptor.kt
@@ -20,6 +20,8 @@ data class DlpContext(
     val modelName: String? = null,
     val toolName: String? = null,
     val correlationId: String,
+    val dataClassification: String? = null,
+    val classificationSource: String? = null,
 )
 
 /**

--- a/tramai-core/src/main/kotlin/dev/tramai/core/security/DlpInterceptor.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/security/DlpInterceptor.kt
@@ -1,5 +1,8 @@
 package dev.tramai.core.security
 
+import dev.tramai.core.policy.ClassificationSource
+import dev.tramai.core.policy.DataClassification
+
 /**
  * Content type for DLP scanning, distinguishing model outputs from tool results.
  */
@@ -20,8 +23,8 @@ data class DlpContext(
     val modelName: String? = null,
     val toolName: String? = null,
     val correlationId: String,
-    val dataClassification: String? = null,
-    val classificationSource: String? = null,
+    val dataClassification: DataClassification? = null,
+    val classificationSource: ClassificationSource? = null,
 )
 
 /**
@@ -36,14 +39,25 @@ data class DlpRedaction(
 
 /**
  * Result of a DLP inspection. If [sanitizedText] differs from the input then
- * [redactions] describes what was redacted and [modified] is `true`.
+ * [redactions] describes what was redacted and [hasRedactions] is `true`.
  */
 data class DlpResult(
     val sanitizedText: String,
     val redactions: List<DlpRedaction> = emptyList(),
 ) {
-    val modified: Boolean get() = redactions.isNotEmpty()
+    val hasRedactions: Boolean get() = redactions.isNotEmpty()
 }
+
+/**
+ * Exception thrown when DLP inspection fails. This is distinct from provider
+ * failures — a DLP failure does not count toward provider circuit breakers
+ * and does not trigger fallback or retry.
+ */
+class DlpInspectionException(
+    ruleId: String? = null,
+    message: String = "DLP inspection failed",
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)
 
 /**
  * Service-provider interface for DLP (Data Loss Prevention) interceptors.

--- a/tramai-core/src/main/kotlin/dev/tramai/core/security/DlpInterceptor.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/security/DlpInterceptor.kt
@@ -1,0 +1,66 @@
+package dev.tramai.core.security
+
+/**
+ * Content type for DLP scanning, distinguishing model outputs from tool results.
+ */
+enum class DlpContentType {
+    MODEL_OUTPUT,
+    TOOL_RESULT,
+}
+
+/**
+ * Execution context for a DLP inspection, providing metadata about the operation
+ * that produced the text being scanned.
+ */
+data class DlpContext(
+    val contentType: DlpContentType,
+    val operationInterface: String,
+    val operationMethod: String,
+    val providerId: String? = null,
+    val modelName: String? = null,
+    val toolName: String? = null,
+    val correlationId: String,
+)
+
+/**
+ * Summary of a single DLP redaction. Contains the rule identifier and replacement
+ * count but deliberately excludes any raw matched values or input text to prevent
+ * accidental sensitive data leakage through audit or exception paths.
+ */
+data class DlpRedaction(
+    val ruleId: String,
+    val replacementCount: Int,
+)
+
+/**
+ * Result of a DLP inspection. If [sanitizedText] differs from the input then
+ * [redactions] describes what was redacted and [modified] is `true`.
+ */
+data class DlpResult(
+    val sanitizedText: String,
+    val redactions: List<DlpRedaction> = emptyList(),
+) {
+    val modified: Boolean get() = redactions.isNotEmpty()
+}
+
+/**
+ * Service-provider interface for DLP (Data Loss Prevention) interceptors.
+ *
+ * Implementations inspect and optionally sanitize model outputs and tool results
+ * before they reach downstream consumers, structured parsers, or cache storage.
+ */
+fun interface DlpInterceptor {
+    /**
+     * Inspect and optionally sanitize [text] within the given [context].
+     *
+     * @return a [DlpResult] describing any redactions that were applied.
+     */
+    fun inspect(context: DlpContext, text: String): DlpResult
+}
+
+/**
+ * No-op DLP interceptor that passes all text through unmodified.
+ */
+object NoOpDlpInterceptor : DlpInterceptor {
+    override fun inspect(context: DlpContext, text: String): DlpResult = DlpResult(text)
+}

--- a/tramai-core/src/main/kotlin/dev/tramai/core/security/DlpInterceptor.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/security/DlpInterceptor.kt
@@ -54,7 +54,6 @@ data class DlpResult(
  * and does not trigger fallback or retry.
  */
 class DlpInspectionException(
-    ruleId: String? = null,
     message: String = "DLP inspection failed",
     cause: Throwable? = null,
 ) : RuntimeException(message, cause)

--- a/tramai-core/src/test/kotlin/dev/tramai/core/security/NoOpDlpInterceptorTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/security/NoOpDlpInterceptorTest.kt
@@ -26,12 +26,12 @@ class NoOpDlpInterceptorTest {
     }
 
     @Test
-    fun `modified is false`() {
+    fun `hasRedactions is false`() {
         val result = interceptor.inspect(
             DlpContext(contentType = DlpContentType.MODEL_OUTPUT, operationInterface = "test", operationMethod = "m", correlationId = "c3"),
             "hello"
         )
-        assertThat(result.modified).isFalse()
+        assertThat(result.hasRedactions).isFalse()
     }
 
     @Test
@@ -42,7 +42,7 @@ class NoOpDlpInterceptorTest {
                 "some text"
             )
             assertThat(result.sanitizedText).isEqualTo("some text")
-            assertThat(result.modified).isFalse()
+            assertThat(result.hasRedactions).isFalse()
         }
     }
 }

--- a/tramai-core/src/test/kotlin/dev/tramai/core/security/NoOpDlpInterceptorTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/security/NoOpDlpInterceptorTest.kt
@@ -1,0 +1,48 @@
+package dev.tramai.core.security
+
+import org.assertj.core.api.Assertions.assertThat
+import kotlin.test.Test
+
+class NoOpDlpInterceptorTest {
+
+    private val interceptor = NoOpDlpInterceptor
+
+    @Test
+    fun `returns exact text`() {
+        val result = interceptor.inspect(
+            DlpContext(contentType = DlpContentType.MODEL_OUTPUT, operationInterface = "test", operationMethod = "m", correlationId = "c1"),
+            "hello world"
+        )
+        assertThat(result.sanitizedText).isEqualTo("hello world")
+    }
+
+    @Test
+    fun `has no redactions`() {
+        val result = interceptor.inspect(
+            DlpContext(contentType = DlpContentType.MODEL_OUTPUT, operationInterface = "test", operationMethod = "m", correlationId = "c2"),
+            "hello"
+        )
+        assertThat(result.redactions).isEmpty()
+    }
+
+    @Test
+    fun `modified is false`() {
+        val result = interceptor.inspect(
+            DlpContext(contentType = DlpContentType.MODEL_OUTPUT, operationInterface = "test", operationMethod = "m", correlationId = "c3"),
+            "hello"
+        )
+        assertThat(result.modified).isFalse()
+    }
+
+    @Test
+    fun `works with all content types`() {
+        for (ct in DlpContentType.entries) {
+            val result = interceptor.inspect(
+                DlpContext(contentType = ct, operationInterface = "test", operationMethod = "m", correlationId = "c4"),
+                "some text"
+            )
+            assertThat(result.sanitizedText).isEqualTo("some text")
+            assertThat(result.modified).isFalse()
+        }
+    }
+}

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -815,13 +815,7 @@ private class TramaiInvocationHandler(
             securityContext = securityContext,
         )
 
-        // DLP: sanitize model output before policy re-check, memory, cache, and return
-        val sanitizedResponse = applyDlpToResult(
-            result = result,
-            operation = operation,
-            correlationId = correlationId,
-            securityContext = securityContext,
-        )
+        // DLP is already applied inside callProviderWithRetries — use the sanitized response directly
 
         // Enforce BEFORE_RESPONSE_RETURN
         policyHelper.enforce(
@@ -838,7 +832,7 @@ private class TramaiInvocationHandler(
         if (chatMemory != null && conversationId != null) {
             val assistantMessage = Message(
                 role = MessageRole.ASSISTANT,
-                content = sanitizedResponse.content,
+                content = result.response.content,
                 toolCalls = result.response.toolCalls,
             )
             // Persist non-system messages from this turn (tool rounds + final assistant)
@@ -847,7 +841,7 @@ private class TramaiInvocationHandler(
         }
 
         result.observation.onCallCompleted(parseSuccess = null)
-        return sanitizedResponse.content.also {
+        return result.response.content.also {
             cacheKey?.let { key ->
                 operation.cacheValue(key, it, result.providerId, result.modelName, securityContext, conversationId)
             }
@@ -965,17 +959,11 @@ private class TramaiInvocationHandler(
             securityContext = securityContext,
         )
 
-        // DLP: sanitize model output before structured parsing, memory, cache, and return
-        val sanitizedResponse = applyDlpToResult(
-            result = result,
-            operation = operation,
-            correlationId = correlationId,
-            securityContext = securityContext,
-        )
+        // DLP is already applied inside callProviderWithRetries — use the sanitized response directly
 
         return when (
             val analysis = handler.analyze(
-                rawResponse = sanitizedResponse.content,
+                rawResponse = result.response.content,
                 targetType = targetType,
             )
         ) {
@@ -996,7 +984,7 @@ private class TramaiInvocationHandler(
 
                 persistStructuredSuccess(
                     result = result,
-                    sanitizedContent = sanitizedResponse.content,
+                    sanitizedContent = result.response.content,
                     messages = messages,
                     historySize = historySize,
                     conversationId = conversationId,
@@ -1073,7 +1061,7 @@ private class TramaiInvocationHandler(
         )
 
         val dlpResult = dlpInterceptor.inspect(context, response.content)
-        return if (dlpResult.modified) {
+        return if (dlpResult.sanitizedText != response.content) {
             response.copy(content = dlpResult.sanitizedText)
         } else {
             response
@@ -1389,9 +1377,32 @@ private class TramaiInvocationHandler(
                 val rawResponse = callProviderOnce(providerId, provider, interceptedRequest, operation)
                 val interceptedResponse = operationInterceptor.interceptResponse(callContext, rawResponse)
 
-                observation.onProviderResponse(interceptedResponse)
+                // DLP: sanitize model output at the earliest safe boundary
+                val sanitizedResponse = if (dlpInterceptor !== NoOpDlpInterceptor) {
+                    val dlpContext = DlpContext(
+                        contentType = DlpContentType.MODEL_OUTPUT,
+                        operationInterface = serviceDefinition.serviceType.qualifiedName
+                            ?: serviceDefinition.serviceType.simpleName.orEmpty(),
+                        operationMethod = operation.method.name,
+                        providerId = providerId,
+                        modelName = request.model,
+                        correlationId = correlationId,
+                        dataClassification = securityContext.dataClassification?.name,
+                        classificationSource = securityContext.classificationSource?.name,
+                    )
+                    val dlpResult = dlpInterceptor.inspect(dlpContext, interceptedResponse.content)
+                    if (dlpResult.sanitizedText != interceptedResponse.content) {
+                        interceptedResponse.copy(content = dlpResult.sanitizedText)
+                    } else {
+                        interceptedResponse
+                    }
+                } else {
+                    interceptedResponse
+                }
+
+                observation.onProviderResponse(sanitizedResponse)
                 return ProviderCallResult(
-                    response = interceptedResponse,
+                    response = sanitizedResponse,
                     observation = observation,
                     providerId = providerId,
                     modelName = request.model,
@@ -1772,7 +1783,8 @@ private class TramaiInvocationHandler(
     ): Boolean =
         operation.isOperationCacheEligible() &&
             conversationId == null &&
-            operationInterceptor === NoOpOperationInterceptor
+            operationInterceptor === NoOpOperationInterceptor &&
+            dlpInterceptor === NoOpDlpInterceptor
 }
 
 private data class ServiceDefinition(

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -984,7 +984,6 @@ private class TramaiInvocationHandler(
 
                 persistStructuredSuccess(
                     result = result,
-                    sanitizedContent = result.response.content,
                     messages = messages,
                     historySize = historySize,
                     conversationId = conversationId,
@@ -1012,14 +1011,13 @@ private class TramaiInvocationHandler(
 
     private fun persistStructuredSuccess(
         result: ProviderCallResult,
-        sanitizedContent: String? = null,
         messages: MutableList<Message>,
         historySize: Int,
         conversationId: String?,
         messagesBeforeCall: Int,
     ) {
         if (chatMemory == null || conversationId == null) return
-        val content = sanitizedContent ?: result.response.content
+        val content = result.response.content
         val assistantMessage = Message(
             role = MessageRole.ASSISTANT,
             content = content,
@@ -1029,43 +1027,6 @@ private class TramaiInvocationHandler(
             .filter { it.role != MessageRole.SYSTEM }
         val toolMessages = messages.drop(messagesBeforeCall)
         chatMemory.add(conversationId, userPrompt + toolMessages + assistantMessage)
-    }
-
-    /**
-     * Applies DLP sanitization to the [ProviderCallResult.response] content if the
-     * interceptor is not the no-op default. Returns the original [result.response]
-     * unmodified if no DLP is configured or if the response content is null.
-     *
-     * Only [DlpContentType.MODEL_OUTPUT] is scanned in this pass.
-     * [ToolCall]s attached to the response are never modified.
-     */
-    private fun applyDlpToResult(
-        result: ProviderCallResult,
-        operation: OperationDefinition,
-        correlationId: String,
-        securityContext: ExecutionSecurityContext,
-    ): ModelResponse {
-        val response = result.response
-        if (dlpInterceptor === NoOpDlpInterceptor) {
-            return response
-        }
-
-        val context = DlpContext(
-            contentType = DlpContentType.MODEL_OUTPUT,
-            operationInterface = serviceDefinition.serviceType.qualifiedName
-                ?: serviceDefinition.serviceType.simpleName.orEmpty(),
-            operationMethod = operation.method.name,
-            providerId = result.providerId,
-            modelName = result.modelName,
-            correlationId = correlationId,
-        )
-
-        val dlpResult = dlpInterceptor.inspect(context, response.content)
-        return if (dlpResult.sanitizedText != response.content) {
-            response.copy(content = dlpResult.sanitizedText)
-        } else {
-            response
-        }
     }
 
     private fun handleStructuredFailure(
@@ -1378,26 +1339,42 @@ private class TramaiInvocationHandler(
                 val interceptedResponse = operationInterceptor.interceptResponse(callContext, rawResponse)
 
                 // DLP: sanitize model output at the earliest safe boundary
-                val sanitizedResponse = if (dlpInterceptor !== NoOpDlpInterceptor) {
-                    val dlpContext = DlpContext(
-                        contentType = DlpContentType.MODEL_OUTPUT,
-                        operationInterface = serviceDefinition.serviceType.qualifiedName
-                            ?: serviceDefinition.serviceType.simpleName.orEmpty(),
-                        operationMethod = operation.method.name,
-                        providerId = providerId,
-                        modelName = request.model,
-                        correlationId = correlationId,
-                        dataClassification = securityContext.dataClassification?.name,
-                        classificationSource = securityContext.classificationSource?.name,
-                    )
-                    val dlpResult = dlpInterceptor.inspect(dlpContext, interceptedResponse.content)
-                    if (dlpResult.sanitizedText != interceptedResponse.content) {
-                        interceptedResponse.copy(content = dlpResult.sanitizedText)
+                val sanitizedResponse = try {
+                    if (dlpInterceptor !== NoOpDlpInterceptor) {
+                        val dlpContext = DlpContext(
+                            contentType = DlpContentType.MODEL_OUTPUT,
+                            operationInterface = serviceDefinition.serviceType.qualifiedName
+                                ?: serviceDefinition.serviceType.simpleName.orEmpty(),
+                            operationMethod = operation.method.name,
+                            providerId = providerId,
+                            modelName = request.model,
+                            correlationId = correlationId,
+                            dataClassification = securityContext.dataClassification,
+                            classificationSource = securityContext.classificationSource,
+                        )
+                        val dlpResult = dlpInterceptor.inspect(dlpContext, interceptedResponse.content)
+                        if (dlpResult.sanitizedText != interceptedResponse.content) {
+                            interceptedResponse.copy(content = dlpResult.sanitizedText)
+                        } else {
+                            interceptedResponse
+                        }
                     } else {
                         interceptedResponse
                     }
-                } else {
-                    interceptedResponse
+                } catch (e: Exception) {
+                    // DLP failures are separate from provider failures:
+                    //   - Do NOT call observation.onProviderFailure(...)
+                    //   - Do NOT call circuitBreaker.onFailure(...)
+                    //   - Do NOT retry (DLP is deterministic per response)
+                    //   - Do NOT fallback (response content cannot be returned unsanitized)
+                    observation.onEngineEvent(
+                        name = "tramai.dlp.inspection_failed",
+                        attributes = mapOf("providerId" to providerId, "correlationId" to correlationId),
+                    )
+                    throw dev.tramai.core.security.DlpInspectionException(
+                        message = "DLP inspection failed for provider '$providerId'",
+                        cause = e,
+                    )
                 }
 
                 observation.onProviderResponse(sanitizedResponse)
@@ -1407,6 +1384,11 @@ private class TramaiInvocationHandler(
                     providerId = providerId,
                     modelName = request.model,
                 )
+            } catch (error: dev.tramai.core.security.DlpInspectionException) {
+                // DLP failures propagate directly — NOT a provider failure.
+                // Do NOT call observation.onProviderFailure, circuitBreaker.onFailure,
+                // or retry.
+                throw error
             } catch (error: Throwable) {
                 observation.onProviderFailure(error)
                 observation.onCallCompleted(parseSuccess = null)

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -42,6 +42,10 @@ import dev.tramai.core.provider.ProviderRegistry
 import dev.tramai.core.provider.ResolvedProviderRoute
 import dev.tramai.core.provider.StreamCapable
 import dev.tramai.core.policy.PolicyEngine
+import dev.tramai.core.security.DlpContentType
+import dev.tramai.core.security.DlpContext
+import dev.tramai.core.security.DlpInterceptor
+import dev.tramai.core.security.NoOpDlpInterceptor
 import dev.tramai.core.security.PromptSanitizer
 import dev.tramai.core.structured.StructuredOutputHandler
 import dev.tramai.core.structured.StructuredOutputResult
@@ -90,6 +94,7 @@ class TramaiEngine(
     private val job: Job = SupervisorJob(),
     private val scope: CoroutineScope = CoroutineScope(job + Dispatchers.Default),
     private val policyEngine: dev.tramai.core.policy.PolicyEngine? = null,
+    private val dlpInterceptor: DlpInterceptor = NoOpDlpInterceptor,
 ) : AutoCloseable {
     private val circuitBreaker = ProviderCircuitBreaker(circuitBreakerSettings)
     private val retryDelayPolicy = ProviderRetryDelayPolicy(retryPolicySettings)
@@ -117,6 +122,7 @@ class TramaiEngine(
         job: Job = SupervisorJob(),
         scope: CoroutineScope = CoroutineScope(job + Dispatchers.Default),
         policyEngine: dev.tramai.core.policy.PolicyEngine? = null,
+        dlpInterceptor: DlpInterceptor = NoOpDlpInterceptor,
     ) : this(
         providerRegistry = ProviderRegistry.singleProvider(provider),
         structuredOutputHandler = structuredOutputHandler,
@@ -133,6 +139,7 @@ class TramaiEngine(
         job = job,
         scope = scope,
         policyEngine = policyEngine,
+        dlpInterceptor = dlpInterceptor,
     )
 
     /**
@@ -162,6 +169,7 @@ class TramaiEngine(
             policyEngine = resolvedPolicyEngine,
             migrationWarningGuard = migrationWarningGuard,
             isLegacyFallback = isLegacyFallback,
+            dlpInterceptor = dlpInterceptor,
         )
 
         @Suppress("UNCHECKED_CAST")
@@ -203,6 +211,7 @@ private class TramaiInvocationHandler(
     policyEngine: PolicyEngine,
     private val migrationWarningGuard: java.util.concurrent.atomic.AtomicBoolean,
     isLegacyFallback: Boolean,
+    private val dlpInterceptor: DlpInterceptor,
 ) : InvocationHandler {
 
     private val policyHelper = PolicyEnforcementHelper(policyEngine, migrationWarningGuard, isLegacyFallback = isLegacyFallback)
@@ -806,6 +815,14 @@ private class TramaiInvocationHandler(
             securityContext = securityContext,
         )
 
+        // DLP: sanitize model output before policy re-check, memory, cache, and return
+        val sanitizedResponse = applyDlpToResult(
+            result = result,
+            operation = operation,
+            correlationId = correlationId,
+            securityContext = securityContext,
+        )
+
         // Enforce BEFORE_RESPONSE_RETURN
         policyHelper.enforce(
             policyHelper.buildContext(
@@ -821,7 +838,7 @@ private class TramaiInvocationHandler(
         if (chatMemory != null && conversationId != null) {
             val assistantMessage = Message(
                 role = MessageRole.ASSISTANT,
-                content = result.response.content,
+                content = sanitizedResponse.content,
                 toolCalls = result.response.toolCalls,
             )
             // Persist non-system messages from this turn (tool rounds + final assistant)
@@ -830,7 +847,7 @@ private class TramaiInvocationHandler(
         }
 
         result.observation.onCallCompleted(parseSuccess = null)
-        return result.response.content.also {
+        return sanitizedResponse.content.also {
             cacheKey?.let { key ->
                 operation.cacheValue(key, it, result.providerId, result.modelName, securityContext, conversationId)
             }
@@ -947,9 +964,18 @@ private class TramaiInvocationHandler(
             correlationId = correlationId,
             securityContext = securityContext,
         )
+
+        // DLP: sanitize model output before structured parsing, memory, cache, and return
+        val sanitizedResponse = applyDlpToResult(
+            result = result,
+            operation = operation,
+            correlationId = correlationId,
+            securityContext = securityContext,
+        )
+
         return when (
             val analysis = handler.analyze(
-                rawResponse = result.response.content,
+                rawResponse = sanitizedResponse.content,
                 targetType = targetType,
             )
         ) {
@@ -970,6 +996,7 @@ private class TramaiInvocationHandler(
 
                 persistStructuredSuccess(
                     result = result,
+                    sanitizedContent = sanitizedResponse.content,
                     messages = messages,
                     historySize = historySize,
                     conversationId = conversationId,
@@ -997,21 +1024,60 @@ private class TramaiInvocationHandler(
 
     private fun persistStructuredSuccess(
         result: ProviderCallResult,
+        sanitizedContent: String? = null,
         messages: MutableList<Message>,
         historySize: Int,
         conversationId: String?,
         messagesBeforeCall: Int,
     ) {
         if (chatMemory == null || conversationId == null) return
+        val content = sanitizedContent ?: result.response.content
         val assistantMessage = Message(
             role = MessageRole.ASSISTANT,
-            content = result.response.content,
+            content = content,
             toolCalls = result.response.toolCalls,
         )
         val userPrompt = messages.subList(historySize, messagesBeforeCall)
             .filter { it.role != MessageRole.SYSTEM }
         val toolMessages = messages.drop(messagesBeforeCall)
         chatMemory.add(conversationId, userPrompt + toolMessages + assistantMessage)
+    }
+
+    /**
+     * Applies DLP sanitization to the [ProviderCallResult.response] content if the
+     * interceptor is not the no-op default. Returns the original [result.response]
+     * unmodified if no DLP is configured or if the response content is null.
+     *
+     * Only [DlpContentType.MODEL_OUTPUT] is scanned in this pass.
+     * [ToolCall]s attached to the response are never modified.
+     */
+    private fun applyDlpToResult(
+        result: ProviderCallResult,
+        operation: OperationDefinition,
+        correlationId: String,
+        securityContext: ExecutionSecurityContext,
+    ): ModelResponse {
+        val response = result.response
+        if (dlpInterceptor === NoOpDlpInterceptor) {
+            return response
+        }
+
+        val context = DlpContext(
+            contentType = DlpContentType.MODEL_OUTPUT,
+            operationInterface = serviceDefinition.serviceType.qualifiedName
+                ?: serviceDefinition.serviceType.simpleName.orEmpty(),
+            operationMethod = operation.method.name,
+            providerId = result.providerId,
+            modelName = result.modelName,
+            correlationId = correlationId,
+        )
+
+        val dlpResult = dlpInterceptor.inspect(context, response.content)
+        return if (dlpResult.modified) {
+            response.copy(content = dlpResult.sanitizedText)
+        } else {
+            response
+        }
     }
 
     private fun handleStructuredFailure(

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -1361,6 +1361,8 @@ private class TramaiInvocationHandler(
                     } else {
                         interceptedResponse
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     // DLP failures are separate from provider failures:
                     //   - Do NOT call observation.onProviderFailure(...)
@@ -1387,7 +1389,10 @@ private class TramaiInvocationHandler(
             } catch (error: dev.tramai.core.security.DlpInspectionException) {
                 // DLP failures propagate directly — NOT a provider failure.
                 // Do NOT call observation.onProviderFailure, circuitBreaker.onFailure,
-                // or retry.
+                // or retry. Record call completion once.
+                observation.onCallCompleted(parseSuccess = null)
+                throw error
+            } catch (error: CancellationException) {
                 throw error
             } catch (error: Throwable) {
                 observation.onProviderFailure(error)

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/TramaiEngineTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/TramaiEngineTest.kt
@@ -33,6 +33,14 @@ import dev.tramai.core.policy.DataClassification
 import dev.tramai.core.provider.ModelProvider
 import dev.tramai.core.provider.ProviderRegistry
 import dev.tramai.core.provider.StreamCapable
+import dev.tramai.core.security.DlpContentType
+import dev.tramai.core.security.DlpContext
+import dev.tramai.core.security.DlpInterceptor
+import dev.tramai.core.security.DlpResult
+import dev.tramai.core.security.NoOpDlpInterceptor
+import dev.tramai.security.DlpRule
+import dev.tramai.security.RuleBasedDlpConfiguration
+import dev.tramai.security.RuleBasedDlpInterceptor
 import dev.tramai.structured.JacksonStructuredOutputHandler
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -1228,6 +1236,208 @@ class TramaiEngineTest {
             )
         }
     }
+
+    // ── DLP Integration Tests ───────────────────────────────────────────
+
+    @Nested
+    inner class DlpIntegration {
+
+        private val emailRule = DlpRule(
+            id = "email",
+            pattern = "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}",
+            replacement = "[EMAIL]",
+        )
+
+        private fun dlpInterceptor() = RuleBasedDlpInterceptor(
+            RuleBasedDlpConfiguration(rules = listOf(emailRule)),
+        )
+
+        @Test
+        fun `raw response is redacted before caller return`() {
+            val provider = RecordingProvider {
+                ModelResponse(content = "Contact me at user@example.com for info")
+            }
+            val engine = TramaiEngine(provider = provider, dlpInterceptor = dlpInterceptor())
+            val service = engine.create<DlpRawService>()
+
+            val result = runBlocking { service.process("input") }
+
+            assertThat(result).isEqualTo("Contact me at [EMAIL] for info")
+            assertThat(result).doesNotContain("user@example.com")
+        }
+
+        @Test
+        fun `structured JSON redacted before parser input`() {
+            val provider = RecordingProvider {
+                ModelResponse(content = """{"email":"alice@example.com","status":"ok"}""")
+            }
+            val engine = TramaiEngine(
+                provider = provider,
+                structuredOutputHandler = JacksonStructuredOutputHandler(),
+                dlpInterceptor = dlpInterceptor(),
+            )
+            val service = engine.create<DlpStructuredService>()
+
+            val result = runBlocking { service.process("input") }
+
+            // Parsed result should use the redacted content
+            assertThat(result.email).isEqualTo("[EMAIL]")
+            assertThat(result.status).isEqualTo("ok")
+        }
+
+        @Test
+        fun `chat memory stores sanitized assistant response`() {
+            val memory = TestChatMemory()
+            val provider = RecordingProvider {
+                ModelResponse(content = "My email is bob@example.com")
+            }
+            val engine = TramaiEngine(
+                provider = provider,
+                chatMemory = memory,
+                dlpInterceptor = dlpInterceptor(),
+            )
+            val service = engine.create<DlpMemoryService>()
+
+            runBlocking { service.chat(sessionId = "s1", message = "What is your email?") }
+
+            val history = memory.get("s1")
+            assertThat(history).hasSize(2)
+            val assistantMsg = history.last { it.role == MessageRole.ASSISTANT }
+            assertThat(assistantMsg.content).isEqualTo("My email is [EMAIL]")
+            assertThat(assistantMsg.content).doesNotContain("bob@example.com")
+        }
+
+        @Test
+        fun `operation observer sees sanitized response`() {
+            val observer = RecordingObserver()
+            val provider = RecordingProvider {
+                ModelResponse(content = "User: alice@example.com")
+            }
+            val engine = TramaiEngine(
+                provider = provider,
+                operationObserver = observer,
+                dlpInterceptor = dlpInterceptor(),
+            )
+            val service = engine.create<DlpRawService>()
+
+            runBlocking { service.process("input") }
+
+            val record = observer.records.single()
+            assertThat(record.response?.content).isEqualTo("User: [EMAIL]")
+            assertThat(record.response?.content).doesNotContain("alice@example.com")
+        }
+
+        @Test
+        fun `toolCalls remain unchanged after DLP`() {
+            val tool = object : ResolvedTool {
+                override val name: String = "lookup"
+                override val description: String = "Looks up data"
+                override val inputSchemaJson: String = """{"type":"object"}"""
+                override val idempotent: Boolean = false
+                override val sideEffectLevel: dev.tramai.core.model.SideEffectLevel =
+                    dev.tramai.core.model.SideEffectLevel.READ_ONLY
+
+                override suspend fun execute(
+                    input: Any,
+                    context: ToolExecutionContext,
+                ): ToolResult = ToolResult.Success("""{"value":"resolved"}""")
+            }
+            val provider = ToolCallingRecordingProvider(
+                ModelResponse(
+                    content = "check user@example.com",
+                    toolCalls = listOf(ToolCall("tc-1", "lookup", """{"query":"user"}""")),
+                ),
+                ModelResponse(content = "done with user@example.com"),
+            )
+            val engine = TramaiEngine(
+                provider = provider,
+                toolRegistry = ToolRegistry(mapOf(tool.name to tool)),
+                dlpInterceptor = dlpInterceptor(),
+            )
+            val service = engine.create<DlpToolService>()
+
+            val result = runBlocking { service.answer("input") }
+
+            assertThat(result).isEqualTo("done with [EMAIL]")
+            // Verify tool was invoked (toolCalls remain unchanged by DLP)
+            // Two requests: one with tool call, one with tool result injected
+            assertThat(provider.requests).hasSize(2)
+        }
+
+        @Test
+        fun `custom DLP disables cache`() {
+            val provider = RecordingProvider(
+                SequenceResponder(
+                    suspend { ModelResponse(content = "first call user@example.com") },
+                    suspend { ModelResponse(content = "second call user@example.com") },
+                )::next,
+            )
+            val cache = InMemoryOperationResponseCache()
+            val dlp1 = NoOpDlpInterceptor
+            val engine1 = TramaiEngine(
+                provider = provider,
+                responseCache = cache,
+                dlpInterceptor = dlp1,
+            )
+            val service1 = engine1.create<DlpCacheableService>()
+
+            val first = runBlocking { service1.process("key") }
+            val second = runBlocking { service1.process("key") }
+
+            // NoOp DLP should cache
+            assertThat(first).isEqualTo("first call user@example.com")
+            assertThat(second).isEqualTo("first call user@example.com")
+            assertThat(provider.requests).hasSize(1)
+
+            // Create a second engine with custom DLP sharing the same cache
+            val provider2 = RecordingProvider(
+                SequenceResponder(
+                    suspend { ModelResponse(content = "first call user@example.com") },
+                    suspend { ModelResponse(content = "second call user@example.com") },
+                )::next,
+            )
+            val engine2 = TramaiEngine(
+                provider = provider2,
+                responseCache = cache,
+                dlpInterceptor = dlpInterceptor(),
+            )
+            val service2 = engine2.create<DlpCacheableService>()
+
+            val result = runBlocking { service2.process("key") }
+
+            // Custom DLP should bypass cache and invoke provider
+            assertThat(result).isEqualTo("first call [EMAIL]")
+            assertThat(provider2.requests).hasSize(1)
+        }
+
+        @Test
+        fun `NoOp DLP preserves existing behavior`() {
+            val provider = RecordingProvider { ModelResponse(content = "normal response") }
+            val engine = TramaiEngine(provider = provider, dlpInterceptor = NoOpDlpInterceptor)
+            val service = engine.create<DlpRawService>()
+
+            val result = runBlocking { service.process("input") }
+
+            assertThat(result).isEqualTo("normal response")
+            assertThat(provider.requests).hasSize(1)
+        }
+
+        @Test
+        fun `custom DLP interceptor without redaction metadata still applies sanitized text`() {
+            val customInterceptor = object : DlpInterceptor {
+                override fun inspect(context: DlpContext, text: String): DlpResult {
+                    return DlpResult(sanitizedText = "[REDACTED]")
+                }
+            }
+            val provider = RecordingProvider { ModelResponse(content = "some secret content") }
+            val engine = TramaiEngine(provider = provider, dlpInterceptor = customInterceptor)
+            val service = engine.create<DlpRawService>()
+
+            val result = runBlocking { service.process("input") }
+
+            assertThat(result).isEqualTo("[REDACTED]")
+        }
+    }
 }
 
 @AiService
@@ -1378,6 +1588,63 @@ private interface FallbackService {
     )
     suspend fun analyze(invoiceId: String): String
 }
+
+@AiService
+private interface DlpRawService {
+    @Operation(
+        prompt = "Process the input",
+        model = "claude-sonnet-4-20250514",
+    )
+    suspend fun process(input: String): String
+}
+
+@AiService
+@SystemPrompt("Return structured JSON.")
+private interface DlpStructuredService {
+    @Operation(
+        prompt = "Return status as JSON",
+        model = "claude-sonnet-4-20250514",
+    )
+    suspend fun process(input: String): DlpStatusResult
+}
+
+@AiService
+@SystemPrompt("You are a helpful assistant.")
+private interface DlpMemoryService {
+    @Operation(
+        prompt = "Respond to the user's message",
+        model = "claude-sonnet-4-20250514",
+    )
+    suspend fun chat(
+        @ConversationId sessionId: String,
+        message: String,
+    ): String
+}
+
+@AiService
+private interface DlpToolService {
+    @Operation(
+        prompt = "Use the lookup tool",
+        model = "claude-sonnet-4-20250514",
+        tools = ["lookup"],
+    )
+    suspend fun answer(question: String): String
+}
+
+@AiService
+private interface DlpCacheableService {
+    @Operation(
+        prompt = "Return a cached answer",
+        model = "claude-sonnet-4-20250514",
+        cacheable = true,
+    )
+    suspend fun process(input: String): String
+}
+
+private data class DlpStatusResult(
+    val email: String,
+    val status: String,
+)
 
 private interface NotAnAiService {
     @Operation(

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/TramaiEngineTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/TramaiEngineTest.kt
@@ -1362,6 +1362,18 @@ class TramaiEngineTest {
             // Verify tool was invoked (toolCalls remain unchanged by DLP)
             // Two requests: one with tool call, one with tool result injected
             assertThat(provider.requests).hasSize(2)
+
+            // After tool execution, the second provider request should have sanitized assistant content
+            val secondRequest = provider.requests[1]
+            val assistantMessage = secondRequest.messages.last { it.role == MessageRole.ASSISTANT }
+            assertThat(assistantMessage.content).doesNotContain("user@example.com")
+            assertThat(assistantMessage.content).contains("[EMAIL]")
+
+            // ToolCall metadata must be preserved
+            val toolCallMessage = secondRequest.messages.last { it.role == MessageRole.ASSISTANT }
+            assertThat(toolCallMessage.toolCalls).hasSize(1)
+            assertThat(toolCallMessage.toolCalls?.single()?.id).isEqualTo("tc-1")
+            assertThat(toolCallMessage.toolCalls?.single()?.name).isEqualTo("lookup")
         }
 
         @Test

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/TramaiEngineTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/TramaiEngineTest.kt
@@ -1489,6 +1489,7 @@ class TramaiEngineTest {
             assertThat(record.providerFailure).isNull()
             assertThat(record.response).isNull()
             assertThat(record.parseSuccess).isNull()
+            assertThat(record.completionCount).isEqualTo(1)
 
             // Engine event "tramai.dlp.inspection_failed" emitted
             assertThat(record.engineEvents.map { it.name })
@@ -1896,6 +1897,7 @@ private class RecordingObserver : OperationObserver {
 
             override fun onCallCompleted(parseSuccess: Boolean?) {
                 record.parseSuccess = parseSuccess
+                record.completionCount++
             }
         }
     }
@@ -1905,6 +1907,7 @@ private class RecordingObserver : OperationObserver {
         var response: ModelResponse? = null,
         var providerFailure: Throwable? = null,
         var parseSuccess: Boolean? = null,
+        var completionCount: Int = 0,
         val engineEvents: MutableList<EngineEventRecord> = mutableListOf(),
     )
 }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/TramaiEngineTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/TramaiEngineTest.kt
@@ -1483,10 +1483,11 @@ class TramaiEngineTest {
             // Circuit breaker remains closed (DLP failure is not a provider failure)
             engine.close()
 
-            // Observer: no provider failure recorded, call completed with null parseSuccess
+            // Observer: no provider failure or response recorded, call completed with null parseSuccess
             assertThat(observer.records).hasSize(1)
             val record = observer.records.single()
             assertThat(record.providerFailure).isNull()
+            assertThat(record.response).isNull()
             assertThat(record.parseSuccess).isNull()
 
             // Engine event "tramai.dlp.inspection_failed" emitted

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/TramaiEngineTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/TramaiEngineTest.kt
@@ -1449,6 +1449,50 @@ class TramaiEngineTest {
 
             assertThat(result).isEqualTo("[REDACTED]")
         }
+
+        @Test
+        fun `DLP failure emits engine event records call completion and does not poison circuit breaker`() {
+            val failingInterceptor = object : DlpInterceptor {
+                override fun inspect(context: DlpContext, text: String): DlpResult {
+                    throw RuntimeException("DLP engine failure")
+                }
+            }
+            val observer = RecordingObserver()
+            val provider = RecordingProvider { ModelResponse(content = "sensitive data") }
+            val circuitBreakerSettings = CircuitBreakerSettings(
+                failureThreshold = 1,
+                openDurationMillis = 100_000,
+            )
+            val engine = TramaiEngine(
+                provider = provider,
+                operationObserver = observer,
+                dlpInterceptor = failingInterceptor,
+                circuitBreakerSettings = circuitBreakerSettings,
+            )
+            val service = engine.create<DlpRawService>()
+
+            val exception = runCatching { runBlocking { service.process("input") } }
+                .exceptionOrNull()
+
+            assertThat(exception).isInstanceOf(dev.tramai.core.security.DlpInspectionException::class.java)
+            assertThat(exception).hasMessageContaining("DLP inspection failed")
+
+            // Provider was called exactly once (no retry, no fallback)
+            assertThat(provider.requests).hasSize(1)
+
+            // Circuit breaker remains closed (DLP failure is not a provider failure)
+            engine.close()
+
+            // Observer: no provider failure recorded, call completed with null parseSuccess
+            assertThat(observer.records).hasSize(1)
+            val record = observer.records.single()
+            assertThat(record.providerFailure).isNull()
+            assertThat(record.parseSuccess).isNull()
+
+            // Engine event "tramai.dlp.inspection_failed" emitted
+            assertThat(record.engineEvents.map { it.name })
+                .contains("tramai.dlp.inspection_failed")
+        }
     }
 }
 

--- a/tramai-security/src/main/kotlin/dev/tramai/security/RuleBasedDlpInterceptor.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/RuleBasedDlpInterceptor.kt
@@ -7,26 +7,11 @@ import dev.tramai.core.security.DlpRedaction
 import dev.tramai.core.security.DlpResult
 import java.util.regex.Pattern
 
-/**
- * Configuration for [RuleBasedDlpInterceptor].
- *
- * @property rules Ordered list of DLP rules applied deterministically in declaration order.
- * @property maxTextLength Maximum allowed text length for inspection. Inputs exceeding
- *   this limit are rejected to guard against resource exhaustion from regex backtracking.
- */
 data class RuleBasedDlpConfiguration(
     val rules: List<DlpRule> = emptyList(),
     val maxTextLength: Int = 100_000,
 )
 
-/**
- * A single DLP rule backed by a regex pattern.
- *
- * @property id Unique identifier for this rule.
- * @property pattern Regex pattern used to match sensitive content.
- * @property replacement Replacement string for matched content.
- * @property enabledFor The set of content types this rule applies to.
- */
 data class DlpRule(
     val id: String,
     val pattern: String,
@@ -34,25 +19,6 @@ data class DlpRule(
     val enabledFor: Set<DlpContentType> = setOf(DlpContentType.MODEL_OUTPUT),
 )
 
-/**
- * Rule-based DLP interceptor that applies a configurable set of regex rules to
- * sanitize model outputs and (optionally) tool results.
- *
- * Rules are applied deterministically in declaration order. Each rule filters by
- * [DlpContentType] based on its [DlpRule.enabledFor] set.
- *
- * ## Trust Model
- *
- * Regex patterns are trusted administrative configuration, not end-user input.
- * Administrators are responsible for ensuring patterns are well-formed and do not
- * introduce ReDoS vulnerabilities. Input text is always the untrusted party.
- *
- * ## Security Properties
- *
- * - No raw matched values or input text are included in [DlpRedaction] or exceptions.
- * - The [sanitizedText] in [DlpResult] is the only output carrying transformed content.
- * - Exceptions use fixed messages to avoid leaking input content.
- */
 class RuleBasedDlpInterceptor(
     configuration: RuleBasedDlpConfiguration,
 ) : DlpInterceptor {
@@ -61,28 +27,14 @@ class RuleBasedDlpInterceptor(
     private val maxTextLength: Int
 
     init {
-        require(configuration.maxTextLength > 0) {
-            "maxTextLength must be greater than zero"
-        }
-        require(configuration.maxTextLength <= 10_000_000) {
-            "maxTextLength exceeds maximum allowed value"
-        }
-
+        require(configuration.maxTextLength > 0) { "maxTextLength must be greater than zero" }
+        require(configuration.maxTextLength <= 10_000_000) { "maxTextLength exceeds maximum allowed value" }
         val ids = mutableSetOf<String>()
         compiledRules = configuration.rules.map { rule ->
-            require(rule.id.isNotBlank()) {
-                "DLP rule ID must not be blank"
-            }
-            require(ids.add(rule.id)) {
-                "Duplicate DLP rule ID: '${rule.id}'"
-            }
-            require(rule.pattern.isNotBlank()) {
-                "DLP rule pattern must not be blank for rule '${rule.id}'"
-            }
-            require(rule.enabledFor.isNotEmpty()) {
-                "DLP rule '${rule.id}' must have at least one enabled content type"
-            }
-
+            require(rule.id.isNotBlank()) { "DLP rule ID must not be blank" }
+            require(ids.add(rule.id)) { "Duplicate DLP rule ID: '${rule.id}'" }
+            require(rule.pattern.isNotBlank()) { "DLP rule pattern must not be blank for rule '${rule.id}'" }
+            require(rule.enabledFor.isNotEmpty()) { "DLP rule '${rule.id}' must have at least one enabled content type" }
             CompiledDlpRule(
                 id = rule.id,
                 pattern = Pattern.compile(rule.pattern),
@@ -107,24 +59,19 @@ class RuleBasedDlpInterceptor(
             val matcher = rule.pattern.matcher(result)
             val sb = StringBuilder()
             var count = 0
-            var searchStart = 0
+            var cursor = 0
 
-            while (matcher.find(searchStart)) {
-                // Append text from last position to start of match
-                sb.append(result, searchStart, matcher.start())
+            while (matcher.find(cursor)) {
+                sb.append(result, cursor, matcher.start())
                 sb.append(rule.replacement)
                 count++
-
                 val matchEnd = matcher.end()
-                searchStart = if (matcher.start() == matchEnd) {
-                    // Zero-width match — advance by one character to avoid infinite loop
-                    matchEnd + 1
-                } else {
-                    matchEnd
-                }
+                cursor = if (matcher.start() == matchEnd) matchEnd + 1 else matchEnd
+                if (cursor > result.length) break
             }
-            // Append remaining text after last match
-            sb.append(result, searchStart, result.length)
+            if (cursor < result.length) {
+                sb.append(result, cursor, result.length)
+            }
 
             if (count > 0) {
                 result = sb.toString()

--- a/tramai-security/src/main/kotlin/dev/tramai/security/RuleBasedDlpInterceptor.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/RuleBasedDlpInterceptor.kt
@@ -5,6 +5,7 @@ import dev.tramai.core.security.DlpContext
 import dev.tramai.core.security.DlpInterceptor
 import dev.tramai.core.security.DlpRedaction
 import dev.tramai.core.security.DlpResult
+import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 data class RuleBasedDlpConfiguration(
@@ -59,22 +60,12 @@ class RuleBasedDlpInterceptor(
             val matcher = rule.pattern.matcher(result)
             val sb = StringBuilder()
             var count = 0
-            var cursor = 0
 
-            while (matcher.find(cursor)) {
-                sb.append(result, cursor, matcher.start())
-                sb.append(rule.replacement)
+            while (matcher.find()) {
+                matcher.appendReplacement(sb, Matcher.quoteReplacement(rule.replacement))
                 count++
-                cursor = if (matcher.start() == matcher.end()) {
-                    matcher.end() + 1
-                } else {
-                    matcher.end()
-                }
-                if (cursor > result.length) break
             }
-            if (cursor < result.length) {
-                sb.append(result, cursor, result.length)
-            }
+            matcher.appendTail(sb)
 
             if (count > 0) {
                 result = sb.toString()

--- a/tramai-security/src/main/kotlin/dev/tramai/security/RuleBasedDlpInterceptor.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/RuleBasedDlpInterceptor.kt
@@ -94,51 +94,45 @@ class RuleBasedDlpInterceptor(
     }
 
     override fun inspect(context: DlpContext, text: String): DlpResult {
-        val sanitized = sanitize(context, text)
-        if (sanitized !== text && sanitized != text) {
-            // Compute redactions by re-running rules to count replacements
-            val redactions = mutableListOf<DlpRedaction>()
-            var working = text
-            for (rule in compiledRules) {
-                if (rule.enabledFor.contains(context.contentType)) {
-                    val count = countMatches(rule.pattern, working)
-                    if (count > 0) {
-                        val matcher = rule.pattern.matcher(working)
-                        working = matcher.replaceAll(rule.replacement)
-                        redactions.add(DlpRedaction(ruleId = rule.id, replacementCount = count))
-                    }
-                }
-            }
-            return DlpResult(sanitizedText = working, redactions = redactions)
-        }
-        return DlpResult(text)
-    }
-
-    private fun sanitize(context: DlpContext, text: String): String {
         if (text.length > maxTextLength) {
             throw IllegalArgumentException("Input text exceeds maximum allowed length")
         }
 
+        val redactions = mutableListOf<DlpRedaction>()
         var result = text
+
         for (rule in compiledRules) {
-            if (rule.enabledFor.contains(context.contentType)) {
-                val matcher = rule.pattern.matcher(result)
-                result = matcher.replaceAll(rule.replacement)
+            if (!rule.enabledFor.contains(context.contentType)) continue
+
+            val matcher = rule.pattern.matcher(result)
+            val sb = StringBuilder()
+            var count = 0
+            var searchStart = 0
+
+            while (matcher.find(searchStart)) {
+                // Append text from last position to start of match
+                sb.append(result, searchStart, matcher.start())
+                sb.append(rule.replacement)
+                count++
+
+                val matchEnd = matcher.end()
+                searchStart = if (matcher.start() == matchEnd) {
+                    // Zero-width match — advance by one character to avoid infinite loop
+                    matchEnd + 1
+                } else {
+                    matchEnd
+                }
+            }
+            // Append remaining text after last match
+            sb.append(result, searchStart, result.length)
+
+            if (count > 0) {
+                result = sb.toString()
+                redactions.add(DlpRedaction(ruleId = rule.id, replacementCount = count))
             }
         }
-        return result
-    }
 
-    private fun countMatches(pattern: Pattern, text: String): Int {
-        var count = 0
-        var matcher = pattern.matcher(text)
-        var start = 0
-        while (matcher.find(start)) {
-            count++
-            start = matcher.end()
-            if (start >= text.length) break
-        }
-        return count
+        return DlpResult(sanitizedText = result, redactions = redactions)
     }
 
     private data class CompiledDlpRule(

--- a/tramai-security/src/main/kotlin/dev/tramai/security/RuleBasedDlpInterceptor.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/RuleBasedDlpInterceptor.kt
@@ -1,0 +1,150 @@
+package dev.tramai.security
+
+import dev.tramai.core.security.DlpContentType
+import dev.tramai.core.security.DlpContext
+import dev.tramai.core.security.DlpInterceptor
+import dev.tramai.core.security.DlpRedaction
+import dev.tramai.core.security.DlpResult
+import java.util.regex.Pattern
+
+/**
+ * Configuration for [RuleBasedDlpInterceptor].
+ *
+ * @property rules Ordered list of DLP rules applied deterministically in declaration order.
+ * @property maxTextLength Maximum allowed text length for inspection. Inputs exceeding
+ *   this limit are rejected to guard against resource exhaustion from regex backtracking.
+ */
+data class RuleBasedDlpConfiguration(
+    val rules: List<DlpRule> = emptyList(),
+    val maxTextLength: Int = 100_000,
+)
+
+/**
+ * A single DLP rule backed by a regex pattern.
+ *
+ * @property id Unique identifier for this rule.
+ * @property pattern Regex pattern used to match sensitive content.
+ * @property replacement Replacement string for matched content.
+ * @property enabledFor The set of content types this rule applies to.
+ */
+data class DlpRule(
+    val id: String,
+    val pattern: String,
+    val replacement: String = "[REDACTED]",
+    val enabledFor: Set<DlpContentType> = setOf(DlpContentType.MODEL_OUTPUT),
+)
+
+/**
+ * Rule-based DLP interceptor that applies a configurable set of regex rules to
+ * sanitize model outputs and (optionally) tool results.
+ *
+ * Rules are applied deterministically in declaration order. Each rule filters by
+ * [DlpContentType] based on its [DlpRule.enabledFor] set.
+ *
+ * ## Trust Model
+ *
+ * Regex patterns are trusted administrative configuration, not end-user input.
+ * Administrators are responsible for ensuring patterns are well-formed and do not
+ * introduce ReDoS vulnerabilities. Input text is always the untrusted party.
+ *
+ * ## Security Properties
+ *
+ * - No raw matched values or input text are included in [DlpRedaction] or exceptions.
+ * - The [sanitizedText] in [DlpResult] is the only output carrying transformed content.
+ * - Exceptions use fixed messages to avoid leaking input content.
+ */
+class RuleBasedDlpInterceptor(
+    configuration: RuleBasedDlpConfiguration,
+) : DlpInterceptor {
+
+    private val compiledRules: List<CompiledDlpRule>
+    private val maxTextLength: Int
+
+    init {
+        require(configuration.maxTextLength > 0) {
+            "maxTextLength must be greater than zero"
+        }
+        require(configuration.maxTextLength <= 10_000_000) {
+            "maxTextLength exceeds maximum allowed value"
+        }
+
+        val ids = mutableSetOf<String>()
+        compiledRules = configuration.rules.map { rule ->
+            require(rule.id.isNotBlank()) {
+                "DLP rule ID must not be blank"
+            }
+            require(ids.add(rule.id)) {
+                "Duplicate DLP rule ID: '${rule.id}'"
+            }
+            require(rule.pattern.isNotBlank()) {
+                "DLP rule pattern must not be blank for rule '${rule.id}'"
+            }
+            require(rule.enabledFor.isNotEmpty()) {
+                "DLP rule '${rule.id}' must have at least one enabled content type"
+            }
+
+            CompiledDlpRule(
+                id = rule.id,
+                pattern = Pattern.compile(rule.pattern),
+                replacement = rule.replacement,
+                enabledFor = rule.enabledFor.toSet(),
+            )
+        }
+        this.maxTextLength = configuration.maxTextLength
+    }
+
+    override fun inspect(context: DlpContext, text: String): DlpResult {
+        val sanitized = sanitize(context, text)
+        if (sanitized !== text && sanitized != text) {
+            // Compute redactions by re-running rules to count replacements
+            val redactions = mutableListOf<DlpRedaction>()
+            var working = text
+            for (rule in compiledRules) {
+                if (rule.enabledFor.contains(context.contentType)) {
+                    val count = countMatches(rule.pattern, working)
+                    if (count > 0) {
+                        val matcher = rule.pattern.matcher(working)
+                        working = matcher.replaceAll(rule.replacement)
+                        redactions.add(DlpRedaction(ruleId = rule.id, replacementCount = count))
+                    }
+                }
+            }
+            return DlpResult(sanitizedText = working, redactions = redactions)
+        }
+        return DlpResult(text)
+    }
+
+    private fun sanitize(context: DlpContext, text: String): String {
+        if (text.length > maxTextLength) {
+            throw IllegalArgumentException("Input text exceeds maximum allowed length")
+        }
+
+        var result = text
+        for (rule in compiledRules) {
+            if (rule.enabledFor.contains(context.contentType)) {
+                val matcher = rule.pattern.matcher(result)
+                result = matcher.replaceAll(rule.replacement)
+            }
+        }
+        return result
+    }
+
+    private fun countMatches(pattern: Pattern, text: String): Int {
+        var count = 0
+        var matcher = pattern.matcher(text)
+        var start = 0
+        while (matcher.find(start)) {
+            count++
+            start = matcher.end()
+            if (start >= text.length) break
+        }
+        return count
+    }
+
+    private data class CompiledDlpRule(
+        val id: String,
+        val pattern: Pattern,
+        val replacement: String,
+        val enabledFor: Set<DlpContentType>,
+    )
+}

--- a/tramai-security/src/main/kotlin/dev/tramai/security/RuleBasedDlpInterceptor.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/RuleBasedDlpInterceptor.kt
@@ -65,8 +65,11 @@ class RuleBasedDlpInterceptor(
                 sb.append(result, cursor, matcher.start())
                 sb.append(rule.replacement)
                 count++
-                val matchEnd = matcher.end()
-                cursor = if (matcher.start() == matchEnd) matchEnd + 1 else matchEnd
+                cursor = if (matcher.start() == matcher.end()) {
+                    matcher.end() + 1
+                } else {
+                    matcher.end()
+                }
                 if (cursor > result.length) break
             }
             if (cursor < result.length) {

--- a/tramai-security/src/test/kotlin/dev/tramai/security/RuleBasedDlpInterceptorTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/RuleBasedDlpInterceptorTest.kt
@@ -1,0 +1,313 @@
+package dev.tramai.security
+
+import dev.tramai.core.security.DlpContentType
+import dev.tramai.core.security.DlpContext
+import dev.tramai.core.security.DlpInterceptor
+import dev.tramai.core.security.DlpResult
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import kotlin.test.Test
+
+class RuleBasedDlpInterceptorTest {
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private fun context(
+        contentType: DlpContentType = DlpContentType.MODEL_OUTPUT,
+        corrId: String = "test-corr",
+    ) = DlpContext(
+        contentType = contentType,
+        operationInterface = "TestService",
+        operationMethod = "process",
+        correlationId = corrId,
+    )
+
+    private data class DslConfig(
+        var rules: MutableList<DlpRule> = mutableListOf(),
+        var maxTextLength: Int = 100_000,
+    )
+
+    private fun interceptor(
+        block: DslConfig.() -> Unit,
+    ): DlpInterceptor {
+        val cfg = DslConfig().apply(block)
+        return RuleBasedDlpInterceptor(
+            RuleBasedDlpConfiguration(rules = cfg.rules.toList(), maxTextLength = cfg.maxTextLength),
+        )
+    }
+
+    private fun DslConfig.rule(
+        id: String,
+        pattern: String,
+        replacement: String = "[REDACTED]",
+        enabledFor: Set<DlpContentType> = setOf(DlpContentType.MODEL_OUTPUT),
+    ) {
+        rules.add(DlpRule(id = id, pattern = pattern, replacement = replacement, enabledFor = enabledFor))
+    }
+
+    // ── 1. Email regex redacts text ─────────────────────────────────────────
+
+    @Test
+    fun `email regex redacts matching text`() {
+        val dlp = interceptor {
+            maxTextLength = 10_000
+            rule(id = "email", pattern = "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}")
+        }
+
+        val result = dlp.inspect(context(), "Contact me at user@example.com for info")
+
+        assertThat(result.sanitizedText).isEqualTo("Contact me at [REDACTED] for info")
+        assertThat(result.modified).isTrue()
+        assertThat(result.redactions).hasSize(1)
+        assertThat(result.redactions[0].ruleId).isEqualTo("email")
+        assertThat(result.redactions[0].replacementCount).isEqualTo(1)
+    }
+
+    // ── 2. API-key regex uses custom replacement ─────────────────────────────
+
+    @Test
+    fun `api key regex uses custom replacement`() {
+        val dlp = interceptor {
+            maxTextLength = 10_000
+            rule(id = "api-key", pattern = "sk-[A-Za-z0-9]{20,}", replacement = "***API-KEY***")
+        }
+
+        val result = dlp.inspect(context(), "Key: sk-abcDEFghiJKLmnoPQRst and more")
+
+        assertThat(result.sanitizedText).isEqualTo("Key: ***API-KEY*** and more")
+        assertThat(result.modified).isTrue()
+        assertThat(result.redactions[0].replacementCount).isEqualTo(1)
+    }
+
+    // ── 3. Multiple rules apply deterministically (in order) ─────────────────
+
+    @Test
+    fun `multiple rules apply deterministically in order`() {
+        val dlp = interceptor {
+            maxTextLength = 10_000
+            rule(id = "email", pattern = "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}")
+            rule(id = "ssn", pattern = "\\d{3}-\\d{2}-\\d{4}")
+        }
+
+        val text = "User: alice@example.com, SSN: 123-45-6789"
+        val result = dlp.inspect(context(), text)
+
+        assertThat(result.sanitizedText).isEqualTo("User: [REDACTED], SSN: [REDACTED]")
+        assertThat(result.modified).isTrue()
+        assertThat(result.redactions).hasSize(2)
+        assertThat(result.redactions[0].ruleId).isEqualTo("email")
+        assertThat(result.redactions[1].ruleId).isEqualTo("ssn")
+    }
+
+    // ── 4. Duplicate rule ID rejected ────────────────────────────────────────
+
+    @Test
+    fun `duplicate rule ID is rejected`() {
+        assertThatThrownBy {
+            RuleBasedDlpInterceptor(
+                RuleBasedDlpConfiguration(
+                    rules = listOf(
+                        DlpRule(id = "dup", pattern = "aaa"),
+                        DlpRule(id = "dup", pattern = "bbb"),
+                    ),
+                ),
+            )
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Duplicate DLP rule ID")
+            .hasMessageContaining("dup")
+    }
+
+    // ── 5. Blank ID rejected ─────────────────────────────────────────────────
+
+    @Test
+    fun `blank rule ID is rejected`() {
+        assertThatThrownBy {
+            RuleBasedDlpInterceptor(
+                RuleBasedDlpConfiguration(
+                    rules = listOf(DlpRule(id = "  ", pattern = "aaa")),
+                ),
+            )
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("DLP rule ID must not be blank")
+    }
+
+    // ── 6. Blank pattern rejected ────────────────────────────────────────────
+
+    @Test
+    fun `blank pattern is rejected`() {
+        assertThatThrownBy {
+            RuleBasedDlpInterceptor(
+                RuleBasedDlpConfiguration(
+                    rules = listOf(DlpRule(id = "blank-pat", pattern = "  ")),
+                ),
+            )
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("DLP rule pattern must not be blank")
+            .hasMessageContaining("blank-pat")
+    }
+
+    // ── 7. Oversized input rejected without leaking input ────────────────────
+
+    @Test
+    fun `oversized input is rejected with fixed message`() {
+        val dlp = RuleBasedDlpInterceptor(
+            RuleBasedDlpConfiguration(maxTextLength = 10),
+        )
+
+        assertThatThrownBy {
+            dlp.inspect(context(), "a".repeat(11))
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("Input text exceeds maximum allowed length")
+    }
+
+    // ── 8. TOOL_RESULT rule not applied to MODEL_OUTPUT unless enabled ───────
+
+    @Test
+    fun `TOOL_RESULT only rule does not affect MODEL_OUTPUT`() {
+        val dlp = interceptor {
+            maxTextLength = 10_000
+            rule(
+                id = "tool-secret",
+                pattern = "SECRET",
+                enabledFor = setOf(DlpContentType.TOOL_RESULT),
+            )
+        }
+
+        val result = dlp.inspect(context(contentType = DlpContentType.MODEL_OUTPUT), "Contains SECRET data")
+
+        assertThat(result.sanitizedText).isEqualTo("Contains SECRET data")
+        assertThat(result.modified).isFalse()
+        assertThat(result.redactions).isEmpty()
+    }
+
+    // ── 9. Content type filtering: MODEL_OUTPUT only rule doesn't affect TOOL_RESULT ──
+
+    @Test
+    fun `MODEL_OUTPUT only rule does not affect TOOL_RESULT`() {
+        val dlp = interceptor {
+            maxTextLength = 10_000
+            rule(
+                id = "model-secret",
+                pattern = "MODEL_SECRET",
+                enabledFor = setOf(DlpContentType.MODEL_OUTPUT),
+            )
+        }
+
+        val result = dlp.inspect(context(contentType = DlpContentType.TOOL_RESULT), "Contains MODEL_SECRET data")
+
+        assertThat(result.sanitizedText).isEqualTo("Contains MODEL_SECRET data")
+        assertThat(result.modified).isFalse()
+    }
+
+    // ── 10. Rule applies to both content types when enabled for both ─────────
+
+    @Test
+    fun `rule applies to both content types when enabled for both`() {
+        val dlp = interceptor {
+            maxTextLength = 10_000
+            rule(
+                id = "universal",
+                pattern = "TOP_SECRET",
+                enabledFor = setOf(DlpContentType.MODEL_OUTPUT, DlpContentType.TOOL_RESULT),
+            )
+        }
+
+        for (ct in DlpContentType.entries) {
+            val result = dlp.inspect(context(contentType = ct), "This is TOP_SECRET")
+            assertThat(result.sanitizedText).isEqualTo("This is [REDACTED]")
+            assertThat(result.modified).isTrue()
+        }
+    }
+
+    // ── 11. Empty rules list passes through ──────────────────────────────────
+
+    @Test
+    fun `empty rules list passes text through unchanged`() {
+        val dlp = interceptor {
+            maxTextLength = 10_000
+        }
+
+        val result = dlp.inspect(context(), "Anything goes through")
+
+        assertThat(result.sanitizedText).isEqualTo("Anything goes through")
+        assertThat(result.modified).isFalse()
+        assertThat(result.redactions).isEmpty()
+    }
+
+    // ── 12. maxTextLength boundary: input at limit passes ────────────────────
+
+    @Test
+    fun `input at max text length boundary passes through`() {
+        val dlp = interceptor {
+            maxTextLength = 5
+        }
+
+        val result = dlp.inspect(context(), "12345")
+
+        assertThat(result.sanitizedText).isEqualTo("12345")
+        assertThat(result.modified).isFalse()
+    }
+
+    // ── 13. DlpResult properties on modified output ──────────────────────────
+
+    @Test
+    fun `DlpResult reports correct properties when modified`() {
+        val dlp = interceptor {
+            maxTextLength = 10_000
+            rule(id = "phone", pattern = "\\d{3}-\\d{3}-\\d{4}")
+        }
+
+        val result = dlp.inspect(context(), "Call 555-123-4567 now")
+
+        assertThat(result.sanitizedText).isEqualTo("Call [REDACTED] now")
+        assertThat(result.modified).isTrue()
+        assertThat(result.redactions).hasSize(1)
+        assertThat(result.redactions[0].ruleId).isEqualTo("phone")
+        assertThat(result.redactions[0].replacementCount).isEqualTo(1)
+    }
+
+    // ── 14. Multiple occurrences of same pattern ─────────────────────────────
+
+    @Test
+    fun `multiple occurrences of same pattern are all redacted`() {
+        val dlp = interceptor {
+            maxTextLength = 10_000
+            rule(id = "email", pattern = "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}")
+        }
+
+        val result = dlp.inspect(context(), "a@b.com and c@d.com and e@f.com")
+
+        assertThat(result.sanitizedText).isEqualTo("[REDACTED] and [REDACTED] and [REDACTED]")
+        assertThat(result.redactions[0].replacementCount).isEqualTo(3)
+    }
+
+    // ── 15. maxTextLength = 0 rejected ───────────────────────────────────────
+
+    @Test
+    fun `maxTextLength of zero is rejected`() {
+        assertThatThrownBy {
+            RuleBasedDlpInterceptor(
+                RuleBasedDlpConfiguration(maxTextLength = 0),
+            )
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("maxTextLength must be greater than zero")
+    }
+
+    // ── 16. maxTextLength exceeds maximum rejected ───────────────────────────
+
+    @Test
+    fun `maxTextLength exceeding maximum is rejected`() {
+        assertThatThrownBy {
+            RuleBasedDlpInterceptor(
+                RuleBasedDlpConfiguration(maxTextLength = 10_000_001),
+            )
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("maxTextLength exceeds maximum allowed value")
+    }
+}

--- a/tramai-security/src/test/kotlin/dev/tramai/security/RuleBasedDlpInterceptorTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/RuleBasedDlpInterceptorTest.kt
@@ -242,7 +242,7 @@ class RuleBasedDlpInterceptorTest {
             rule(id = "lookahead", pattern = "(?=\\d)")
         }
         val result = dlp.inspect(context(), "abc123def456")
-        assertThat(result.sanitizedText).isEqualTo("abc[REDACTED][REDACTED][REDACTED]def[REDACTED][REDACTED][REDACTED]")
+        assertThat(result.sanitizedText).isEqualTo("abc[REDACTED]1[REDACTED]2[REDACTED]3def[REDACTED]4[REDACTED]5[REDACTED]6")
         assertThat(result.hasRedactions).isTrue()
         assertThat(result.redactions).hasSize(1)
         assertThat(result.redactions[0].replacementCount).isEqualTo(6)
@@ -298,8 +298,8 @@ class RuleBasedDlpInterceptorTest {
             rule(id = "start-anchor", pattern = "^")
         }
         val result = dlp.inspect(context(), "abc")
-        // Zero-width ^ match at position 0 advances cursor to 1, consuming 'a'
-        assertThat(result.sanitizedText).isEqualTo("[REDACTED]bc")
+        // Zero-width ^ match at position 0 inserts [REDACTED] without consuming characters
+        assertThat(result.sanitizedText).isEqualTo("[REDACTED]abc")
         assertThat(result.hasRedactions).isTrue()
         assertThat(result.redactions[0].replacementCount).isEqualTo(1)
     }
@@ -311,8 +311,8 @@ class RuleBasedDlpInterceptorTest {
             rule(id = "digit-lookahead", pattern = "(?=\\d)")
         }
         val result = dlp.inspect(context(), "abc123")
-        // Zero-width skip consumes the next character after each match
-        assertThat(result.sanitizedText).isEqualTo("abc[REDACTED][REDACTED][REDACTED]")
+        // Zero-width lookahead inserts [REDACTED] before each digit without consuming it
+        assertThat(result.sanitizedText).isEqualTo("abc[REDACTED]1[REDACTED]2[REDACTED]3")
         assertThat(result.hasRedactions).isTrue()
         assertThat(result.redactions[0].replacementCount).isEqualTo(3)
     }

--- a/tramai-security/src/test/kotlin/dev/tramai/security/RuleBasedDlpInterceptorTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/RuleBasedDlpInterceptorTest.kt
@@ -310,4 +310,62 @@ class RuleBasedDlpInterceptorTest {
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("maxTextLength exceeds maximum allowed value")
     }
+
+    // ── 17. Zero-width pattern terminates safely ─────────────────────────────
+
+    @Test
+    fun `zero-width pattern terminates safely without infinite loop`() {
+        val dlp = interceptor {
+            maxTextLength = 10_000
+            rule(id = "lookahead", pattern = "(?=\\d)")
+        }
+
+        // The zero-width lookahead should not cause infinite loop
+        val result = dlp.inspect(context(), "abc123def456")
+
+        assertThat(result.sanitizedText).isEqualTo("abc[REDACTED][REDACTED][REDACTED]def[REDACTED][REDACTED][REDACTED]")
+        assertThat(result.modified).isTrue()
+        assertThat(result.redactions).hasSize(1)
+        assertThat(result.redactions[0].replacementCount).isEqualTo(6)
+    }
+
+    // ── 18. Replacement with $1 stays literal ────────────────────────────────
+
+    @Test
+    fun `replacement with dollar-group reference stays literal`() {
+        val dlp = interceptor {
+            maxTextLength = 10_000
+            rule(id = "mask", pattern = "(\\d{4})-(\\d{4})-(\\d{4})-(\\d{4})", replacement = "MASK-$1")
+        }
+
+        // $1 in the replacement should stay as literal "$1" due to quoteReplacement,
+        // not reinsert the captured group
+        val result = dlp.inspect(context(), "Card: 4111-1111-1111-1111")
+
+        assertThat(result.sanitizedText).isEqualTo("Card: MASK-$1")
+        assertThat(result.modified).isTrue()
+    }
+
+    // ── 19. Multiple replacements counted correctly ──────────────────────────
+
+    @Test
+    fun `multiple replacements across overlapping rules are counted correctly`() {
+        val dlp = interceptor {
+            maxTextLength = 10_000
+            rule(id = "email", pattern = "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}")
+            rule(id = "phone", pattern = "\\d{3}-\\d{3}-\\d{4}")
+        }
+
+        val result = dlp.inspect(
+            context(),
+            "Contact: alice@example.com or bob@test.org, Phone: 555-123-4567",
+        )
+
+        assertThat(result.sanitizedText).isEqualTo("Contact: [REDACTED] or [REDACTED], Phone: [REDACTED]")
+        assertThat(result.redactions).hasSize(2)
+        assertThat(result.redactions[0].ruleId).isEqualTo("email")
+        assertThat(result.redactions[0].replacementCount).isEqualTo(2)
+        assertThat(result.redactions[1].ruleId).isEqualTo("phone")
+        assertThat(result.redactions[1].replacementCount).isEqualTo(1)
+    }
 }

--- a/tramai-security/src/test/kotlin/dev/tramai/security/RuleBasedDlpInterceptorTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/RuleBasedDlpInterceptorTest.kt
@@ -249,12 +249,13 @@ class RuleBasedDlpInterceptorTest {
     }
 
     @Test
-    fun `replacement with dollar-group reference stays literal`() {
+    fun `replacement with dollar and backslash stays literal`() {
         val dlp = interceptor {
             maxTextLength = 10_000
             rule(id = "masks", pattern = "(\\d{4})-(\\d{4})-(\\d{4})-(\\d{4})", replacement = "MASK-$1")
         }
         val result = dlp.inspect(context(), "Card: 4111-1111-1111-1111")
+        // Replacement is used literally (not as a regex group reference)
         assertThat(result.sanitizedText).isEqualTo("Card: MASK-$1")
         assertThat(result.hasRedactions).isTrue()
     }
@@ -291,10 +292,36 @@ class RuleBasedDlpInterceptorTest {
     }
 
     @Test
+    fun `start of string anchor terminates safely`() {
+        val dlp = interceptor {
+            maxTextLength = 10_000
+            rule(id = "start-anchor", pattern = "^")
+        }
+        val result = dlp.inspect(context(), "abc")
+        // Zero-width ^ match at position 0 advances cursor to 1, consuming 'a'
+        assertThat(result.sanitizedText).isEqualTo("[REDACTED]bc")
+        assertThat(result.hasRedactions).isTrue()
+        assertThat(result.redactions[0].replacementCount).isEqualTo(1)
+    }
+
+    @Test
     fun `zero-width lookahead replaces each digit position`() {
         val dlp = interceptor {
             maxTextLength = 10_000
             rule(id = "digit-lookahead", pattern = "(?=\\d)")
+        }
+        val result = dlp.inspect(context(), "abc123")
+        // Zero-width skip consumes the next character after each match
+        assertThat(result.sanitizedText).isEqualTo("abc[REDACTED][REDACTED][REDACTED]")
+        assertThat(result.hasRedactions).isTrue()
+        assertThat(result.redactions[0].replacementCount).isEqualTo(3)
+    }
+
+    @Test
+    fun `consuming digit pattern removes all digits`() {
+        val dlp = interceptor {
+            maxTextLength = 10_000
+            rule(id = "digit", pattern = "\\d")
         }
         val result = dlp.inspect(context(), "abc123")
         assertThat(result.sanitizedText).isEqualTo("abc[REDACTED][REDACTED][REDACTED]")

--- a/tramai-security/src/test/kotlin/dev/tramai/security/RuleBasedDlpInterceptorTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/RuleBasedDlpInterceptorTest.kt
@@ -10,8 +10,6 @@ import kotlin.test.Test
 
 class RuleBasedDlpInterceptorTest {
 
-    // ── Helpers ──────────────────────────────────────────────────────────────
-
     private fun context(
         contentType: DlpContentType = DlpContentType.MODEL_OUTPUT,
         corrId: String = "test-corr",
@@ -45,41 +43,31 @@ class RuleBasedDlpInterceptorTest {
         rules.add(DlpRule(id = id, pattern = pattern, replacement = replacement, enabledFor = enabledFor))
     }
 
-    // ── 1. Email regex redacts text ─────────────────────────────────────────
-
     @Test
     fun `email regex redacts matching text`() {
         val dlp = interceptor {
             maxTextLength = 10_000
             rule(id = "email", pattern = "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}")
         }
-
         val result = dlp.inspect(context(), "Contact me at user@example.com for info")
-
         assertThat(result.sanitizedText).isEqualTo("Contact me at [REDACTED] for info")
-        assertThat(result.modified).isTrue()
+        assertThat(result.hasRedactions).isTrue()
         assertThat(result.redactions).hasSize(1)
         assertThat(result.redactions[0].ruleId).isEqualTo("email")
         assertThat(result.redactions[0].replacementCount).isEqualTo(1)
     }
 
-    // ── 2. API-key regex uses custom replacement ─────────────────────────────
-
     @Test
     fun `api key regex uses custom replacement`() {
         val dlp = interceptor {
             maxTextLength = 10_000
-            rule(id = "api-key", pattern = "sk-[A-Za-z0-9]{20,}", replacement = "***API-KEY***")
+            rule(id = "api-key", pattern = "sk-[A-Za-z0-9]{10,}", replacement = "***API-KEY***")
         }
-
-        val result = dlp.inspect(context(), "Key: sk-abcDEFghiJKLmnoPQRst and more")
-
+        val result = dlp.inspect(context(), "Key: sk-abc123def456ghi and more")
         assertThat(result.sanitizedText).isEqualTo("Key: ***API-KEY*** and more")
-        assertThat(result.modified).isTrue()
+        assertThat(result.hasRedactions).isTrue()
         assertThat(result.redactions[0].replacementCount).isEqualTo(1)
     }
-
-    // ── 3. Multiple rules apply deterministically (in order) ─────────────────
 
     @Test
     fun `multiple rules apply deterministically in order`() {
@@ -88,18 +76,14 @@ class RuleBasedDlpInterceptorTest {
             rule(id = "email", pattern = "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}")
             rule(id = "ssn", pattern = "\\d{3}-\\d{2}-\\d{4}")
         }
-
         val text = "User: alice@example.com, SSN: 123-45-6789"
         val result = dlp.inspect(context(), text)
-
         assertThat(result.sanitizedText).isEqualTo("User: [REDACTED], SSN: [REDACTED]")
-        assertThat(result.modified).isTrue()
+        assertThat(result.hasRedactions).isTrue()
         assertThat(result.redactions).hasSize(2)
         assertThat(result.redactions[0].ruleId).isEqualTo("email")
         assertThat(result.redactions[1].ruleId).isEqualTo("ssn")
     }
-
-    // ── 4. Duplicate rule ID rejected ────────────────────────────────────────
 
     @Test
     fun `duplicate rule ID is rejected`() {
@@ -118,8 +102,6 @@ class RuleBasedDlpInterceptorTest {
             .hasMessageContaining("dup")
     }
 
-    // ── 5. Blank ID rejected ─────────────────────────────────────────────────
-
     @Test
     fun `blank rule ID is rejected`() {
         assertThatThrownBy {
@@ -132,8 +114,6 @@ class RuleBasedDlpInterceptorTest {
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("DLP rule ID must not be blank")
     }
-
-    // ── 6. Blank pattern rejected ────────────────────────────────────────────
 
     @Test
     fun `blank pattern is rejected`() {
@@ -149,14 +129,9 @@ class RuleBasedDlpInterceptorTest {
             .hasMessageContaining("blank-pat")
     }
 
-    // ── 7. Oversized input rejected without leaking input ────────────────────
-
     @Test
     fun `oversized input is rejected with fixed message`() {
-        val dlp = RuleBasedDlpInterceptor(
-            RuleBasedDlpConfiguration(maxTextLength = 10),
-        )
-
+        val dlp = RuleBasedDlpInterceptor(RuleBasedDlpConfiguration(maxTextLength = 10))
         assertThatThrownBy {
             dlp.inspect(context(), "a".repeat(11))
         }
@@ -164,95 +139,58 @@ class RuleBasedDlpInterceptorTest {
             .hasMessage("Input text exceeds maximum allowed length")
     }
 
-    // ── 8. TOOL_RESULT rule not applied to MODEL_OUTPUT unless enabled ───────
-
     @Test
     fun `TOOL_RESULT only rule does not affect MODEL_OUTPUT`() {
         val dlp = interceptor {
             maxTextLength = 10_000
-            rule(
-                id = "tool-secret",
-                pattern = "SECRET",
-                enabledFor = setOf(DlpContentType.TOOL_RESULT),
-            )
+            rule(id = "tool-secret", pattern = "SECRET", enabledFor = setOf(DlpContentType.TOOL_RESULT))
         }
-
         val result = dlp.inspect(context(contentType = DlpContentType.MODEL_OUTPUT), "Contains SECRET data")
-
         assertThat(result.sanitizedText).isEqualTo("Contains SECRET data")
-        assertThat(result.modified).isFalse()
+        assertThat(result.hasRedactions).isFalse()
         assertThat(result.redactions).isEmpty()
     }
-
-    // ── 9. Content type filtering: MODEL_OUTPUT only rule doesn't affect TOOL_RESULT ──
 
     @Test
     fun `MODEL_OUTPUT only rule does not affect TOOL_RESULT`() {
         val dlp = interceptor {
             maxTextLength = 10_000
-            rule(
-                id = "model-secret",
-                pattern = "MODEL_SECRET",
-                enabledFor = setOf(DlpContentType.MODEL_OUTPUT),
-            )
+            rule(id = "model-secret", pattern = "MODEL_SECRET", enabledFor = setOf(DlpContentType.MODEL_OUTPUT))
         }
-
         val result = dlp.inspect(context(contentType = DlpContentType.TOOL_RESULT), "Contains MODEL_SECRET data")
-
         assertThat(result.sanitizedText).isEqualTo("Contains MODEL_SECRET data")
-        assertThat(result.modified).isFalse()
+        assertThat(result.hasRedactions).isFalse()
     }
-
-    // ── 10. Rule applies to both content types when enabled for both ─────────
 
     @Test
     fun `rule applies to both content types when enabled for both`() {
         val dlp = interceptor {
             maxTextLength = 10_000
-            rule(
-                id = "universal",
-                pattern = "TOP_SECRET",
-                enabledFor = setOf(DlpContentType.MODEL_OUTPUT, DlpContentType.TOOL_RESULT),
-            )
+            rule(id = "universal", pattern = "TOP_SECRET", enabledFor = setOf(DlpContentType.MODEL_OUTPUT, DlpContentType.TOOL_RESULT))
         }
-
         for (ct in DlpContentType.entries) {
             val result = dlp.inspect(context(contentType = ct), "This is TOP_SECRET")
             assertThat(result.sanitizedText).isEqualTo("This is [REDACTED]")
-            assertThat(result.modified).isTrue()
+            assertThat(result.hasRedactions).isTrue()
         }
     }
-
-    // ── 11. Empty rules list passes through ──────────────────────────────────
 
     @Test
     fun `empty rules list passes text through unchanged`() {
-        val dlp = interceptor {
-            maxTextLength = 10_000
-        }
-
+        val dlp = interceptor { maxTextLength = 10_000 }
         val result = dlp.inspect(context(), "Anything goes through")
-
         assertThat(result.sanitizedText).isEqualTo("Anything goes through")
-        assertThat(result.modified).isFalse()
+        assertThat(result.hasRedactions).isFalse()
         assertThat(result.redactions).isEmpty()
     }
 
-    // ── 12. maxTextLength boundary: input at limit passes ────────────────────
-
     @Test
     fun `input at max text length boundary passes through`() {
-        val dlp = interceptor {
-            maxTextLength = 5
-        }
-
+        val dlp = interceptor { maxTextLength = 5 }
         val result = dlp.inspect(context(), "12345")
-
         assertThat(result.sanitizedText).isEqualTo("12345")
-        assertThat(result.modified).isFalse()
+        assertThat(result.hasRedactions).isFalse()
     }
-
-    // ── 13. DlpResult properties on modified output ──────────────────────────
 
     @Test
     fun `DlpResult reports correct properties when modified`() {
@@ -260,17 +198,13 @@ class RuleBasedDlpInterceptorTest {
             maxTextLength = 10_000
             rule(id = "phone", pattern = "\\d{3}-\\d{3}-\\d{4}")
         }
-
         val result = dlp.inspect(context(), "Call 555-123-4567 now")
-
         assertThat(result.sanitizedText).isEqualTo("Call [REDACTED] now")
-        assertThat(result.modified).isTrue()
+        assertThat(result.hasRedactions).isTrue()
         assertThat(result.redactions).hasSize(1)
         assertThat(result.redactions[0].ruleId).isEqualTo("phone")
         assertThat(result.redactions[0].replacementCount).isEqualTo(1)
     }
-
-    // ── 14. Multiple occurrences of same pattern ─────────────────────────────
 
     @Test
     fun `multiple occurrences of same pattern are all redacted`() {
@@ -278,40 +212,28 @@ class RuleBasedDlpInterceptorTest {
             maxTextLength = 10_000
             rule(id = "email", pattern = "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}")
         }
-
         val result = dlp.inspect(context(), "a@b.com and c@d.com and e@f.com")
-
         assertThat(result.sanitizedText).isEqualTo("[REDACTED] and [REDACTED] and [REDACTED]")
         assertThat(result.redactions[0].replacementCount).isEqualTo(3)
     }
 
-    // ── 15. maxTextLength = 0 rejected ───────────────────────────────────────
-
     @Test
     fun `maxTextLength of zero is rejected`() {
         assertThatThrownBy {
-            RuleBasedDlpInterceptor(
-                RuleBasedDlpConfiguration(maxTextLength = 0),
-            )
+            RuleBasedDlpInterceptor(RuleBasedDlpConfiguration(maxTextLength = 0))
         }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("maxTextLength must be greater than zero")
     }
 
-    // ── 16. maxTextLength exceeds maximum rejected ───────────────────────────
-
     @Test
     fun `maxTextLength exceeding maximum is rejected`() {
         assertThatThrownBy {
-            RuleBasedDlpInterceptor(
-                RuleBasedDlpConfiguration(maxTextLength = 10_000_001),
-            )
+            RuleBasedDlpInterceptor(RuleBasedDlpConfiguration(maxTextLength = 10_000_001))
         }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("maxTextLength exceeds maximum allowed value")
     }
-
-    // ── 17. Zero-width pattern terminates safely ─────────────────────────────
 
     @Test
     fun `zero-width pattern terminates safely without infinite loop`() {
@@ -319,34 +241,23 @@ class RuleBasedDlpInterceptorTest {
             maxTextLength = 10_000
             rule(id = "lookahead", pattern = "(?=\\d)")
         }
-
-        // The zero-width lookahead should not cause infinite loop
         val result = dlp.inspect(context(), "abc123def456")
-
         assertThat(result.sanitizedText).isEqualTo("abc[REDACTED][REDACTED][REDACTED]def[REDACTED][REDACTED][REDACTED]")
-        assertThat(result.modified).isTrue()
+        assertThat(result.hasRedactions).isTrue()
         assertThat(result.redactions).hasSize(1)
         assertThat(result.redactions[0].replacementCount).isEqualTo(6)
     }
-
-    // ── 18. Replacement with $1 stays literal ────────────────────────────────
 
     @Test
     fun `replacement with dollar-group reference stays literal`() {
         val dlp = interceptor {
             maxTextLength = 10_000
-            rule(id = "mask", pattern = "(\\d{4})-(\\d{4})-(\\d{4})-(\\d{4})", replacement = "MASK-$1")
+            rule(id = "masks", pattern = "(\\d{4})-(\\d{4})-(\\d{4})-(\\d{4})", replacement = "MASK-$1")
         }
-
-        // $1 in the replacement should stay as literal "$1" due to quoteReplacement,
-        // not reinsert the captured group
         val result = dlp.inspect(context(), "Card: 4111-1111-1111-1111")
-
         assertThat(result.sanitizedText).isEqualTo("Card: MASK-$1")
-        assertThat(result.modified).isTrue()
+        assertThat(result.hasRedactions).isTrue()
     }
-
-    // ── 19. Multiple replacements counted correctly ──────────────────────────
 
     @Test
     fun `multiple replacements across overlapping rules are counted correctly`() {
@@ -355,17 +266,50 @@ class RuleBasedDlpInterceptorTest {
             rule(id = "email", pattern = "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}")
             rule(id = "phone", pattern = "\\d{3}-\\d{3}-\\d{4}")
         }
-
         val result = dlp.inspect(
             context(),
             "Contact: alice@example.com or bob@test.org, Phone: 555-123-4567",
         )
-
         assertThat(result.sanitizedText).isEqualTo("Contact: [REDACTED] or [REDACTED], Phone: [REDACTED]")
         assertThat(result.redactions).hasSize(2)
         assertThat(result.redactions[0].ruleId).isEqualTo("email")
         assertThat(result.redactions[0].replacementCount).isEqualTo(2)
         assertThat(result.redactions[1].ruleId).isEqualTo("phone")
         assertThat(result.redactions[1].replacementCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `end of string anchor terminates safely`() {
+        val dlp = interceptor {
+            maxTextLength = 10_000
+            rule(id = "end-anchor", pattern = "$")
+        }
+        val result = dlp.inspect(context(), "abc")
+        assertThat(result.sanitizedText).isEqualTo("abc[REDACTED]")
+        assertThat(result.hasRedactions).isTrue()
+        assertThat(result.redactions[0].replacementCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `zero-width lookahead replaces each digit position`() {
+        val dlp = interceptor {
+            maxTextLength = 10_000
+            rule(id = "digit-lookahead", pattern = "(?=\\d)")
+        }
+        val result = dlp.inspect(context(), "abc123")
+        assertThat(result.sanitizedText).isEqualTo("abc[REDACTED][REDACTED][REDACTED]")
+        assertThat(result.hasRedactions).isTrue()
+        assertThat(result.redactions[0].replacementCount).isEqualTo(3)
+    }
+
+    @Test
+    fun `literal replacement with backslash value stays literal`() {
+        val dlp = interceptor {
+            maxTextLength = 10_000
+            rule(id = "literal-replace", pattern = "secret", replacement = "MASK-\\value")
+        }
+        val result = dlp.inspect(context(), "this is secret data")
+        assertThat(result.sanitizedText).isEqualTo("this is MASK-\\value data")
+        assertThat(result.hasRedactions).isTrue()
     }
 }

--- a/tramai-spring/src/main/kotlin/dev/tramai/spring/TramaiAutoConfiguration.kt
+++ b/tramai-spring/src/main/kotlin/dev/tramai/spring/TramaiAutoConfiguration.kt
@@ -9,6 +9,7 @@ import dev.tramai.core.observation.NoOpOperationInterceptor
 import dev.tramai.core.observation.OperationInterceptor
 import dev.tramai.anthropic.AnthropicProvider
 import dev.tramai.core.provider.ModelProvider
+import dev.tramai.core.security.DlpInterceptor
 import dev.tramai.openai.CodexAuthFileTokenSource
 import dev.tramai.openai.ExperimentalCodexAuth
 import dev.tramai.openai.OpenAiCompatibleProvider
@@ -45,6 +46,7 @@ class TramaiAutoConfiguration {
         modelProviders: ObjectProvider<ModelProvider>,
         operationResponseCache: ObjectProvider<OperationResponseCache>,
         operationInterceptors: ObjectProvider<OperationInterceptor>,
+        dlpInterceptors: ObjectProvider<DlpInterceptor>,
         secretResolvers: ObjectProvider<SecretValueResolver>,
         applicationContext: org.springframework.context.ApplicationContext,
     ): Tramai {
@@ -92,6 +94,7 @@ class TramaiAutoConfiguration {
                 CompositeOperationInterceptor(interceptorChain)
             },
         )
+        resolveDlpInterceptor(applicationContext, dlpInterceptors)?.let(builder::dlp)
 
         // Register property-backed providers first so explicit provider beans can override them when needed.
         resolveSecret(
@@ -277,6 +280,24 @@ class TramaiAutoConfiguration {
 
         return secretResolver.resolve(trimmedRef)
             ?: throw IllegalStateException("No SecretValueResolver could resolve '$trimmedRef' for $fieldName")
+    }
+
+    private fun resolveDlpInterceptor(
+        applicationContext: org.springframework.context.ApplicationContext,
+        dlpInterceptors: ObjectProvider<DlpInterceptor>,
+    ): DlpInterceptor? {
+        val interceptors = dlpInterceptors.orderedStream().toList()
+        if (interceptors.isEmpty()) {
+            return null
+        }
+        if (interceptors.size == 1) {
+            return interceptors.single()
+        }
+
+        val beanNames = applicationContext.getBeanNamesForType(DlpInterceptor::class.java).sorted()
+        throw IllegalArgumentException(
+            "Multiple DlpInterceptor beans found: ${beanNames.joinToString(", ")}. Define exactly one DlpInterceptor bean or none.",
+        )
     }
 
     private fun createVaultSecretValueResolver(

--- a/tramai-spring/src/test/kotlin/dev/tramai/spring/TramaiAutoConfigurationTest.kt
+++ b/tramai-spring/src/test/kotlin/dev/tramai/spring/TramaiAutoConfigurationTest.kt
@@ -12,6 +12,9 @@ import dev.tramai.core.model.ModelResponse
 import dev.tramai.core.observation.OperationCallContext
 import dev.tramai.core.observation.OperationInterceptor
 import dev.tramai.core.provider.ModelProvider
+import dev.tramai.core.security.DlpContext
+import dev.tramai.core.security.DlpInterceptor
+import dev.tramai.core.security.DlpResult
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -21,6 +24,7 @@ import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.annotation.Bean
 import java.net.InetSocketAddress
+import java.util.function.Supplier
 import kotlin.test.Test
 
 class TramaiAutoConfigurationTest {
@@ -420,6 +424,69 @@ class TramaiAutoConfigurationTest {
                 .doesNotContain("secret-id")
         }
     }
+
+    @Test
+    fun `wires a single custom DLP bean into the engine`() {
+        val contextRunner = ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(TramaiAutoConfiguration::class.java),
+            )
+            .withUserConfiguration(TestApplication::class.java)
+            .withBean(DlpProvider::class.java)
+            .withBean("dlpInterceptor", DlpInterceptor::class.java, Supplier {
+                DlpInterceptor { _: DlpContext, _: String ->
+                    DlpResult(sanitizedText = "[REDACTED]")
+                }
+            })
+            .withPropertyValues(
+                "tramai.default-provider=dlp-provider",
+                "tramai.models.gpt-5.1-chat-latest=dlp-provider",
+            )
+
+        contextRunner.run { context ->
+            val analyzer = context.getBean(TestInvoiceAnalyzer::class.java)
+            val provider = context.getBean(DlpProvider::class.java)
+
+            val result = runBlocking { analyzer.analyze("invoice-123") }
+
+            assertThat(result).isEqualTo("[REDACTED]")
+            assertThat(provider.requests).hasSize(1)
+        }
+    }
+
+    @Test
+    fun `rejects multiple DLP beans with a clear startup error`() {
+        val contextRunner = ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(TramaiAutoConfiguration::class.java),
+            )
+            .withUserConfiguration(TestApplication::class.java)
+            .withBean(DlpProvider::class.java)
+            .withBean("firstDlpInterceptor", DlpInterceptor::class.java, Supplier {
+                DlpInterceptor { _: DlpContext, text: String ->
+                    DlpResult(sanitizedText = text)
+                }
+            })
+            .withBean("secondDlpInterceptor", DlpInterceptor::class.java, Supplier {
+                DlpInterceptor { _: DlpContext, text: String ->
+                    DlpResult(sanitizedText = text)
+                }
+            })
+            .withPropertyValues(
+                "tramai.default-provider=dlp-provider",
+                "tramai.models.gpt-5.1-chat-latest=dlp-provider",
+            )
+
+        contextRunner.run { context ->
+            assertThat(context).hasFailed()
+            val failure = requireNotNull(context.startupFailure)
+            assertThat(failure)
+                .hasRootCauseInstanceOf(IllegalArgumentException::class.java)
+                .hasRootCauseMessage(
+                    "Multiple DlpInterceptor beans found: firstDlpInterceptor, secondDlpInterceptor. Define exactly one DlpInterceptor bean or none.",
+                )
+        }
+    }
 }
 
 @AiService
@@ -567,6 +634,17 @@ class InterceptingProvider : ModelProvider {
     }
 
     override fun providerId(): String = "intercepted"
+}
+
+class DlpProvider : ModelProvider {
+    val requests = mutableListOf<ModelRequest>()
+
+    override suspend fun complete(request: ModelRequest): ModelResponse {
+        requests += request
+        return ModelResponse(content = "sensitive spring payload")
+    }
+
+    override fun providerId(): String = "dlp-provider"
 }
 
 private fun respond(

--- a/tramai-standalone/src/main/kotlin/dev/tramai/standalone/Tramai.kt
+++ b/tramai-standalone/src/main/kotlin/dev/tramai/standalone/Tramai.kt
@@ -14,6 +14,8 @@ import dev.tramai.core.observation.OperationInterceptor
 import dev.tramai.core.observation.OperationObserver
 import dev.tramai.core.provider.ModelProvider
 import dev.tramai.core.provider.ProviderRegistry
+import dev.tramai.core.security.DlpInterceptor
+import dev.tramai.core.security.NoOpDlpInterceptor
 import dev.tramai.core.security.PromptSanitizer
 import dev.tramai.engine.CircuitBreakerSettings
 import dev.tramai.engine.NoOpOperationResponseCache
@@ -38,6 +40,7 @@ class Tramai private constructor(
     private val circuitBreakerSettings: CircuitBreakerSettings,
     private val retryPolicySettings: RetryPolicySettings,
     private val tokenBudgetSettings: TokenBudgetSettings,
+    private val dlpInterceptor: DlpInterceptor,
     private val promptSanitizer: PromptSanitizer?,
     private val chatMemory: ChatMemory?,
 ) {
@@ -54,6 +57,7 @@ class Tramai private constructor(
         circuitBreakerSettings = circuitBreakerSettings,
         retryPolicySettings = retryPolicySettings,
         tokenBudgetSettings = tokenBudgetSettings,
+        dlpInterceptor = dlpInterceptor,
         promptSanitizer = promptSanitizer,
         chatMemory = chatMemory,
     ).create(serviceType)
@@ -78,6 +82,7 @@ class Tramai private constructor(
         private var circuitBreakerSettings: CircuitBreakerSettings = CircuitBreakerSettings()
         private var retryPolicySettings: RetryPolicySettings = RetryPolicySettings()
         private var tokenBudgetSettings: TokenBudgetSettings = TokenBudgetSettings()
+        private var dlpInterceptor: DlpInterceptor = NoOpDlpInterceptor
         private var promptSanitizer: PromptSanitizer? = null
         private val handler = JacksonStructuredOutputHandler()
         private var chatMemory: ChatMemory? = null
@@ -190,6 +195,13 @@ class Tramai private constructor(
         }
 
         /**
+         * Configures the DLP interceptor applied to model output before observer, parser, and caller access.
+         */
+        fun dlp(interceptor: DlpInterceptor): Builder = apply {
+            this.dlpInterceptor = interceptor
+        }
+
+        /**
          * Configures the sanitizer applied to user-supplied operation arguments before prompt construction.
          */
         fun promptSanitizer(promptSanitizer: PromptSanitizer?): Builder = apply {
@@ -220,6 +232,7 @@ class Tramai private constructor(
             circuitBreakerSettings = circuitBreakerSettings,
             retryPolicySettings = retryPolicySettings,
             tokenBudgetSettings = tokenBudgetSettings,
+            dlpInterceptor = dlpInterceptor,
             promptSanitizer = promptSanitizer,
             chatMemory = chatMemory,
         )

--- a/tramai-standalone/src/test/kotlin/dev/tramai/standalone/TramaiTest.kt
+++ b/tramai-standalone/src/test/kotlin/dev/tramai/standalone/TramaiTest.kt
@@ -9,7 +9,13 @@ import dev.tramai.core.model.ModelResponse
 import dev.tramai.core.model.ToolCall
 import dev.tramai.core.model.ToolExecutionContext
 import dev.tramai.core.model.TramaiTool
+import dev.tramai.core.observation.OperationCallContext
+import dev.tramai.core.observation.OperationObservation
+import dev.tramai.core.observation.OperationObserver
 import dev.tramai.core.provider.ModelProvider
+import dev.tramai.core.security.DlpContext
+import dev.tramai.core.security.DlpInterceptor
+import dev.tramai.core.security.DlpResult
 import dev.tramai.engine.CircuitBreakerSettings
 import dev.tramai.engine.InMemoryOperationResponseCache
 import dev.tramai.engine.TokenBudgetSettings
@@ -198,6 +204,28 @@ class TramaiTest {
         assertThat(second).isEqualTo("cached-1")
         assertThat(provider.requests).hasSize(1)
     }
+
+    @Test
+    fun `builder configured DLP sanitizes provider response before observer sees it`() {
+        val observer = ResponseRecordingObserver()
+        val provider = RecordingProvider("anthropic") { ModelResponse(content = "sensitive output") }
+        val dlp = DlpInterceptor { _: DlpContext, _: String ->
+            DlpResult(sanitizedText = "[REDACTED]")
+        }
+
+        val tramai = Tramai.builder()
+            .provider(provider, default = true)
+            .model("claude-sonnet-4-20250514", "anthropic")
+            .observer(observer)
+            .dlp(dlp)
+            .build()
+        val service = tramai.create(SuspendService::class)
+
+        val result = runBlocking { service.respond("world") }
+
+        assertThat(result).isEqualTo("[REDACTED]")
+        assertThat(observer.responses).containsExactly("[REDACTED]")
+    }
 }
 
 @AiService
@@ -327,4 +355,23 @@ private class ToolLoopProvider(
     }
 
     override fun providerId(): String = "mock"
+}
+
+private class ResponseRecordingObserver : OperationObserver {
+    val responses = mutableListOf<String>()
+
+    override fun onCallStarted(context: OperationCallContext): OperationObservation = object : OperationObservation {
+        override fun onProviderResponse(response: ModelResponse) {
+            responses += response.content
+        }
+
+        override fun onProviderFailure(error: Throwable) = Unit
+
+        override fun onStructuredParseFailure(
+            rawResponse: String,
+            errorSummary: String,
+        ) = Unit
+
+        override fun onCallCompleted(parseSuccess: Boolean?) = Unit
+    }
 }


### PR DESCRIPTION
## Summary

Implement Epic 2B.1: DLP interceptor foundation for model output sanitization.

## DLP API

Added in `tramai-core/.../security/DlpInterceptor.kt`:

- **`DlpContentType`** — `MODEL_OUTPUT`, `TOOL_RESULT`
- **`DlpContext`** — content type, operation interface/method, provider, model, correlation ID, data classification/source
- **`DlpRedaction`** — ruleId + replacementCount only (no raw matched values)
- **`DlpResult`** — sanitizedText + redactions + hasRedactions
- **`DlpInterceptor`** — fun interface with inspect(context, text): DlpResult
- **`NoOpDlpInterceptor`** — pass-through singleton (zero overhead when no DLP configured)

## RuleBasedDlpInterceptor (`tramai-security`)

Deterministic regex-based DLP with:
- Content-type filtering (default `MODEL_OUTPUT` only)
- Single-pass replace-and-count with zero-width pattern safety
- Input length validation (no content leaked in exceptions)
- Blank/duplicate ID and pattern rejection
- `Matcher.quoteReplacement` — replacement strings are literal, not regex groups

## Engine Hook

DLP is applied at the **earliest safe boundary** — inside `callProviderWithRetries()`, after `OperationInterceptor.interceptResponse()` and **before** `onProviderResponse()`.

Consequences:
- Observers see only sanitized output
- Tool-loop assistant responses are sanitized before reinjection
- Raw return, structured parsing, chat memory, and cache all use sanitized content
- ToolCalls are never modified

## Cache Behaviour

Custom DLP interceptors bypass the cache entirely. Cache-aware DLP fingerprints are deferred.

## Test Coverage

**tramai-core** (NoOpDlpInterceptorTest): 4 tests — pass-through, redactions, modified flag, all content types.

**tramai-security** (RuleBasedDlpInterceptorTest): 19 tests — email/API-key regex, custom replacement, deterministic ordering, duplicate/blank validation, oversized input, content-type filtering, zero-width pattern safety, literal replacement handling, multiple occurrences.

**tramai-engine** (TramaiEngineTest — DlpIntegration): 8 tests — raw response redaction, structured JSON redaction, chat memory sanitization, observer sanitization, toolCalls preserved, custom DLP cache bypass, NoOp preservation, sanitized text without redaction metadata.

## Deferred Work

- Field-level output policies (2B.2)
- Tool-result filtering (2B.3)
- Audit events per redaction (2B.4)
- Streaming DLP
- Binary/image scanning
- Cache-aware DLP fingerprints