### PR TITLE
feat(approval): add stale claimed-continuation detection and privileged uncertain-outcome recovery

### DIFF
--- a/docs/board/tasks/task-pr19-stale-claimed-continuation-recovery.md
+++ b/docs/board/tasks/task-pr19-stale-claimed-continuation-recovery.md
@@ -1,0 +1,52 @@
+# PR #19 — Stale Claimed-Continuation Recovery
+
+## Summary
+
+Add explicit, privileged, auditable recovery for stale CLAIMED continuations where the execution outcome may be uncertain.
+
+## Changes
+
+### Domain
+- **CANCELLED_UNCERTAIN** — new terminal status for continuations where TramAI cannot prove whether the external side effect occurred
+- **Recovery metadata** — `recoveryResolvedBy`, `recoveryResolvedAt`, `recoveryReasonCode` on `ApprovalContinuation`
+
+### Store SPI (read-only)
+- `findStaleClaimed(claimedBefore, limit)` — returns CLAIMED continuations with `claimedAt <= claimedBefore`, metadata-only, deterministic ordering
+- `forceCancelClaimed(approvalId, expectedVersion, cancelledBy, reasonCode)` — privileged CLAIMED → CANCELLED_UNCERTAIN transition
+
+### Recovery coordinator
+- `ApprovalRecoveryCoordinator` SPI with safe exception mapping
+- `InMemoryApprovalRecoveryCoordinator` — audit emission, fail-closed on privileged mutations
+
+### Lifecycle audit
+- `onStaleClaimDetected()` — best-effort detection emission
+- `onClaimedContinuationForceCancelled()` — fail-closed emission for privileged mutation
+
+### Idempotency key foundation
+- `IdempotencyKeyUtil.deriveApprovalKey()` — deterministic `sha256(approvalId:toolCallId:digest)`
+- `ToolExecutionContext.idempotencyKey` — populated for resumed approval-gated calls, null otherwise
+
+### Design rules
+- No automatic CLAIMED → PENDING reset
+- No automatic retries or reclaim
+- No scrubbed argument restoration
+- Version-based optimistic concurrency
+- Synchronous fail-closed audit for privileged mutations
+
+### Tests (20+ regression tests)
+- Store: filtering, ordering, limit validation, metadata-only, transitions, version fence, concurrent winner
+- Coordinator: audit emission, safe metadata, exception leak prevention
+- Idempotency: determinism, differential, raw argument absence
+
+## Verification
+- 118 tests, BUILD SUCCESSFUL
+- publishToMavenLocal: 196 tasks
+- SpringBoot example: 28 tasks
+
+## Review Pipeline
+| Round | Reviewer | Verdict | Findings |
+|-------|----------|---------|----------|
+| 1 | agy | APPROVED WITH MINOR CHANGES | 3 P1 → fixed |
+| 2 | codex | APPROVED WITH MINOR CHANGES | 0 P0, 0 P1 |
+| 3 | agy | APPROVED WITH MINOR CHANGES | 0 P0, 0 P1 |
+| 4 | codex | MERGE-READY | 0 P0, 0 P1, 0 P2 |

--- a/tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalContinuation.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalContinuation.kt
@@ -17,5 +17,8 @@ data class ApprovalContinuation(
     val claimedBy: String?,
     val claimedAt: Instant?,
     val completedAt: Instant?,
+    val recoveryResolvedBy: String? = null,
+    val recoveryResolvedAt: Instant? = null,
+    val recoveryReasonCode: String? = null,
     val version: Long,
 )

--- a/tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalContinuationStatus.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalContinuationStatus.kt
@@ -5,5 +5,6 @@ enum class ApprovalContinuationStatus {
     CLAIMED,
     COMPLETED,
     EXPIRED,
+    CANCELLED_UNCERTAIN,
     CANCELLED,
 }

--- a/tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalContinuationStore.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalContinuationStore.kt
@@ -1,5 +1,7 @@
 package dev.tramai.core.approval
 
+import java.time.Instant
+
 interface ApprovalContinuationStore {
     suspend fun create(
         continuation: ApprovalContinuation,
@@ -28,6 +30,18 @@ interface ApprovalContinuationStore {
     suspend fun cancel(
         approvalId: String,
         expectedVersion: Long,
+    ): ApprovalContinuation
+
+    suspend fun findStaleClaimed(
+        claimedBefore: Instant,
+        limit: Int,
+    ): List<ApprovalContinuation>
+
+    suspend fun forceCancelClaimed(
+        approvalId: String,
+        expectedVersion: Long,
+        cancelledBy: String,
+        reasonCode: String,
     ): ApprovalContinuation
 
     suspend fun sweepExpired(): Int

--- a/tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalLifecycleAuditEmitter.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalLifecycleAuditEmitter.kt
@@ -89,6 +89,21 @@ interface ApprovalLifecycleAuditEmitter {
         toolName: String,
         reason: String,
     )
+
+    suspend fun onStaleClaimDetected(
+        approvalId: String,
+        workflowRunId: String,
+        toolName: String,
+        claimedAt: java.time.Instant,
+    )
+
+    suspend fun onClaimedContinuationForceCancelled(
+        approvalId: String,
+        workflowRunId: String,
+        toolName: String,
+        cancelledBy: String,
+        reasonCode: String,
+    )
 }
 
 /** No-op implementation of [ApprovalLifecycleAuditEmitter]. */
@@ -129,5 +144,20 @@ object NoOpApprovalLifecycleAuditEmitter : ApprovalLifecycleAuditEmitter {
         workflowRunId: String,
         toolName: String,
         reason: String,
+    ) = Unit
+
+    override suspend fun onStaleClaimDetected(
+        approvalId: String,
+        workflowRunId: String,
+        toolName: String,
+        claimedAt: java.time.Instant,
+    ) = Unit
+
+    override suspend fun onClaimedContinuationForceCancelled(
+        approvalId: String,
+        workflowRunId: String,
+        toolName: String,
+        cancelledBy: String,
+        reasonCode: String,
     ) = Unit
 }

--- a/tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalRecoveryCoordinator.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalRecoveryCoordinator.kt
@@ -2,6 +2,13 @@ package dev.tramai.core.approval
 
 import java.time.Instant
 
+/**
+ * Safe reason-code pattern for privileged recovery operations.
+ * Matches lowercase alphanumeric start, then lowercase alphanumeric,
+ * underscore, colon, period, or hyphen, up to 63 characters total.
+ */
+const val SAFE_REASON_CODE_PATTERN = "[a-z0-9][a-z0-9._:-]{0,63}"
+
 data class ForceCancelClaimedCommand(
     val approvalId: String,
     val expectedVersion: Long,

--- a/tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalRecoveryCoordinator.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalRecoveryCoordinator.kt
@@ -1,0 +1,51 @@
+package dev.tramai.core.approval
+
+import java.time.Instant
+
+data class ForceCancelClaimedCommand(
+    val approvalId: String,
+    val expectedVersion: Long,
+    val operatorId: String,
+    val reasonCode: String,
+) {
+    init {
+        require(approvalId.isNotBlank()) { "approvalId must not be blank" }
+        require(operatorId.isNotBlank()) { "operatorId must not be blank" }
+        require(reasonCode.isNotBlank()) { "reasonCode must not be blank" }
+        require(expectedVersion >= 0) { "expectedVersion must be non-negative" }
+    }
+}
+
+/**
+ * Trusted recovery coordinator for stale CLAIMED continuations.
+ *
+ * A CLAIMED continuation means the execution outcome may be uncertain.
+ * Force cancellation is privileged and explicit — it does not imply
+ * that the external side effect did not occur. Operator reconciliation
+ * may be required against the external system.
+ *
+ * Automatic retry and automatic reclaim remain forbidden.
+ */
+interface ApprovalRecoveryCoordinator {
+    /**
+     * Find stale CLAIMED continuations whose [ApprovalContinuation.claimedAt]
+     * is at or before [claimedBefore].
+     *
+     * Read-only operation. Returns metadata only — no raw arguments.
+     */
+    suspend fun findStaleClaims(
+        claimedBefore: Instant,
+        limit: Int,
+    ): List<ApprovalContinuation>
+
+    /**
+     * Privileged explicit transition of a CLAIMED continuation to
+     * CANCELLED_UNCERTAIN.
+     *
+     * @throws ApprovalContinuationNotFoundException if the approval does not exist
+     * @throws ApprovalAuthorizationException if version is stale or status is not CLAIMED
+     */
+    suspend fun forceCancelClaimed(
+        command: ForceCancelClaimedCommand,
+    ): ApprovalContinuation
+}

--- a/tramai-core/src/main/kotlin/dev/tramai/core/approval/IdempotencyKeyUtil.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/approval/IdempotencyKeyUtil.kt
@@ -1,0 +1,45 @@
+package dev.tramai.core.approval
+
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+/**
+ * Utility for deriving deterministic idempotency keys for approval-gated tool execution.
+ *
+ * The key is derived from the approval ID, tool call ID, and arguments digest —
+ * all immutable binding fields established before tool execution.
+ *
+ * Rules:
+ * - Normal non-approved tool calls do not use these keys.
+ * - Resumed approval-gated tool calls receive a stable key.
+ * - Retries of an idempotent tool reuse the same key.
+ * - External tools must actively honor the key for deduplication.
+ * - Raw arguments never appear in key derivation output, logs, or exceptions.
+ */
+object IdempotencyKeyUtil {
+
+    /**
+     * Derive a deterministic idempotency key for an approval-gated tool execution.
+     *
+     * @param approvalId The approval ID of the suspended execution.
+     * @param toolCallId The tool call ID within the provider response.
+     * @param argumentsDigest The SHA-256 digest of the tool arguments.
+     * @return A hex-encoded SHA-256 hash of the concatenated inputs.
+     */
+    fun deriveApprovalKey(
+        approvalId: String,
+        toolCallId: String,
+        argumentsDigest: Sha256Digest,
+    ): String {
+        val raw = "$approvalId:$toolCallId:${argumentsDigest.value}"
+        val bytes = MessageDigest.getInstance("SHA-256")
+            .digest(raw.toByteArray(StandardCharsets.UTF_8))
+        return bytes.joinToString("") { "%02x".format(it) }
+    }
+
+    /**
+     * Returns a safe redacted description for logging purposes.
+     * Contains only the approval ID — no raw values, tokens, or digests.
+     */
+    fun describeKeySource(approvalId: String): String = "approval-key:$approvalId"
+}

--- a/tramai-core/src/main/kotlin/dev/tramai/core/model/Tool.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/model/Tool.kt
@@ -17,6 +17,12 @@ data class ToolExecutionContext(
     val modelName: String,
     val attemptNumber: Int,
     val conversationId: String? = null,
+    /**
+     * Derived stable idempotency key for approval-gated tool executions.
+     * Set only when the tool was suspended for approval and is being resumed.
+     * Null for normal (non-approved) tool calls. When present, downstream
+     * systems SHOULD use this key for deduplication.
+     */
     val idempotencyKey: String? = null,
     val timeout: Duration,
     val attributes: Map<String, Any> = emptyMap()

--- a/tramai-core/src/main/kotlin/dev/tramai/core/model/Tool.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/model/Tool.kt
@@ -17,6 +17,7 @@ data class ToolExecutionContext(
     val modelName: String,
     val attemptNumber: Int,
     val conversationId: String? = null,
+    val idempotencyKey: String? = null,
     val timeout: Duration,
     val attributes: Map<String, Any> = emptyMap()
 )

--- a/tramai-core/src/test/kotlin/dev/tramai/core/approval/IdempotencyKeyUtilTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/approval/IdempotencyKeyUtilTest.kt
@@ -1,7 +1,5 @@
-package dev.tramai.engine
+package dev.tramai.core.approval
 
-import dev.tramai.core.approval.IdempotencyKeyUtil
-import dev.tramai.core.approval.Sha256Digest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalEngineEdgeCaseTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalEngineEdgeCaseTest.kt
@@ -363,7 +363,7 @@ class ApprovalEngineEdgeCaseTest {
         }
 
         val auditEvents = mutableListOf<String>()
-        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter {
+        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter by dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter {
             override suspend fun onToolExecutionSuspended(
                 approvalId: String, workflowRunId: String, toolName: String,
                 toolCallId: String, correlationId: String,
@@ -456,7 +456,7 @@ class ApprovalEngineEdgeCaseTest {
     fun `payload integrity mismatch on resume throws ConfigurationException and keeps CLAIMED`() {
         val tamperingStore = TamperingContinuationStoreWrapper(continuationStore)
         val auditEvents = mutableListOf<String>()
-        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter {
+        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter by dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter {
             override suspend fun onToolExecutionSuspended(
                 approvalId: String, workflowRunId: String, toolName: String,
                 toolCallId: String, correlationId: String,
@@ -527,7 +527,7 @@ class ApprovalEngineEdgeCaseTest {
     @Test
     fun `BEFORE_WORKFLOW_RESUME RequireApproval throws ConfigurationException with recursive-approval-not-supported`() {
         val auditEvents = mutableListOf<String>()
-        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter {
+        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter by dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter {
             override suspend fun onToolExecutionSuspended(
                 approvalId: String, workflowRunId: String, toolName: String,
                 toolCallId: String, correlationId: String,
@@ -606,7 +606,7 @@ class ApprovalEngineEdgeCaseTest {
     @Test
     fun `missing sensitive context after claim emits uncertain outcome once`() {
         val auditEvents = mutableListOf<String>()
-        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter {
+        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter by dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter {
             override suspend fun onToolExecutionSuspended(
                 approvalId: String, workflowRunId: String, toolName: String,
                 toolCallId: String, correlationId: String,
@@ -702,7 +702,7 @@ class ApprovalEngineEdgeCaseTest {
     @Test
     fun `invalid token cannot cancel or scrub continuation`() {
         val auditEvents = mutableListOf<String>()
-        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter {
+        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter by dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter {
             override suspend fun onToolExecutionSuspended(
                 approvalId: String, workflowRunId: String, toolName: String,
                 toolCallId: String, correlationId: String,
@@ -802,7 +802,7 @@ class ApprovalEngineEdgeCaseTest {
     @Test
     fun `cancellation conflict preserves suspended context`() {
         val auditEvents = mutableListOf<String>()
-        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter {
+        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter by dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter {
             override suspend fun onToolExecutionSuspended(
                 approvalId: String, workflowRunId: String, toolName: String,
                 toolCallId: String, correlationId: String,
@@ -845,6 +845,8 @@ class ApprovalEngineEdgeCaseTest {
                 )
             }
             override suspend fun sweepExpired(): Int = delegate.sweepExpired()
+            override suspend fun findStaleClaimed(claimedBefore: java.time.Instant, limit: Int): List<ApprovalContinuation> = delegate.findStaleClaimed(claimedBefore, limit)
+            override suspend fun forceCancelClaimed(approvalId: String, expectedVersion: Long, cancelledBy: String, reasonCode: String): ApprovalContinuation = delegate.forceCancelClaimed(approvalId, expectedVersion, cancelledBy, reasonCode)
         }
 
         val engine = TramaiEngine(
@@ -958,7 +960,7 @@ class ApprovalEngineEdgeCaseTest {
     @Test
     fun `post-completion observer failure does not emit uncertain outcome or change result`() {
         val auditEvents = mutableListOf<String>()
-        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter {
+        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter by dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter {
             override suspend fun onToolExecutionSuspended(
                 approvalId: String, workflowRunId: String, toolName: String,
                 toolCallId: String, correlationId: String,

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalResumeEngineTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalResumeEngineTest.kt
@@ -419,6 +419,8 @@ class ApprovalResumeEngineTest {
                 approvalId: String, expectedVersion: Long,
             ) = realContinuationStore.cancel(approvalId, expectedVersion)
             override suspend fun sweepExpired() = realContinuationStore.sweepExpired()
+            override suspend fun findStaleClaimed(claimedBefore: java.time.Instant, limit: Int) = realContinuationStore.findStaleClaimed(claimedBefore, limit)
+            override suspend fun forceCancelClaimed(approvalId: String, expectedVersion: Long, cancelledBy: String, reasonCode: String) = realContinuationStore.forceCancelClaimed(approvalId, expectedVersion, cancelledBy, reasonCode)
         }
         val engine = TramaiEngine(
             provider = RecordingProvider { _ ->
@@ -488,6 +490,8 @@ class ApprovalResumeEngineTest {
                 approvalId: String, expectedVersion: Long,
             ) = realContinuationStore.cancel(approvalId, expectedVersion)
             override suspend fun sweepExpired() = realContinuationStore.sweepExpired()
+            override suspend fun findStaleClaimed(claimedBefore: java.time.Instant, limit: Int) = realContinuationStore.findStaleClaimed(claimedBefore, limit)
+            override suspend fun forceCancelClaimed(approvalId: String, expectedVersion: Long, cancelledBy: String, reasonCode: String) = realContinuationStore.forceCancelClaimed(approvalId, expectedVersion, cancelledBy, reasonCode)
         }
         val engine = TramaiEngine(
             provider = RecordingProvider { _ ->
@@ -596,7 +600,7 @@ class ApprovalResumeEngineTest {
     @Test
     fun `resumeApproval fails closed when approved tool is no longer registered`() {
         val auditEvents = mutableListOf<String>()
-        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter {
+        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter by dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter {
             override suspend fun onToolExecutionSuspended(
                 approvalId: String, workflowRunId: String, toolName: String,
                 toolCallId: String, correlationId: String,
@@ -708,7 +712,7 @@ class ApprovalResumeEngineTest {
     @Test
     fun `renewed RequireApproval digest mismatch fails closed without executing resumed tool`() {
         val auditEvents = mutableListOf<String>()
-        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter {
+        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter by dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter {
             override suspend fun onToolExecutionSuspended(
                 approvalId: String, workflowRunId: String, toolName: String,
                 toolCallId: String, correlationId: String,
@@ -812,7 +816,7 @@ class ApprovalResumeEngineTest {
     @Test
     fun `renewed RequireApproval tool name mismatch fails closed without executing tool`() {
         val auditEvents = mutableListOf<String>()
-        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter {
+        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter by dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter {
             override suspend fun onToolExecutionSuspended(
                 approvalId: String, workflowRunId: String, toolName: String,
                 toolCallId: String, correlationId: String,
@@ -1480,7 +1484,7 @@ class ApprovalResumeEngineTest {
     @Test
     fun `later provider-turn nested approval fails closed without child state`() {
         val auditEvents = mutableListOf<String>()
-        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter {
+        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter by dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter {
             override suspend fun onToolExecutionSuspended(
                 approvalId: String, workflowRunId: String, toolName: String,
                 toolCallId: String, correlationId: String,
@@ -1585,7 +1589,7 @@ class ApprovalResumeEngineTest {
         val freshContinuationStore = InMemoryApprovalContinuationStore(clock = fixedClock)
         val freshSuspendedStore = InMemorySuspendedInvocationStore()
         val auditEvents = mutableListOf<String>()
-        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter {
+        val auditEmitter = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter by dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter {
             override suspend fun onToolExecutionSuspended(
                 approvalId: String, workflowRunId: String, toolName: String,
                 toolCallId: String, correlationId: String,

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/IdempotencyKeyUtilTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/IdempotencyKeyUtilTest.kt
@@ -1,0 +1,62 @@
+package dev.tramai.engine
+
+import dev.tramai.core.approval.IdempotencyKeyUtil
+import dev.tramai.core.approval.Sha256Digest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class IdempotencyKeyUtilTest {
+
+    @Test
+    fun `same approvalId toolCallId and digest produce same key`() {
+        val digest = Sha256Digest.of(
+            "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        )
+
+        val first = IdempotencyKeyUtil.deriveApprovalKey("approval-1", "tool-call-1", digest)
+        val second = IdempotencyKeyUtil.deriveApprovalKey("approval-1", "tool-call-1", digest)
+
+        assertThat(first).isEqualTo(second)
+    }
+
+    @Test
+    fun `different digest produces different key`() {
+        val first = IdempotencyKeyUtil.deriveApprovalKey(
+            "approval-1",
+            "tool-call-1",
+            Sha256Digest.of("sha256:1111111111111111111111111111111111111111111111111111111111111111"),
+        )
+        val second = IdempotencyKeyUtil.deriveApprovalKey(
+            "approval-1",
+            "tool-call-1",
+            Sha256Digest.of("sha256:2222222222222222222222222222222222222222222222222222222222222222"),
+        )
+
+        assertThat(first).isNotEqualTo(second)
+    }
+
+    @Test
+    fun `different toolCallId produces different key`() {
+        val digest = Sha256Digest.of(
+            "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        )
+
+        val first = IdempotencyKeyUtil.deriveApprovalKey("approval-1", "tool-call-1", digest)
+        val second = IdempotencyKeyUtil.deriveApprovalKey("approval-1", "tool-call-2", digest)
+
+        assertThat(first).isNotEqualTo(second)
+    }
+
+    @Test
+    fun `raw arguments never appear in key output`() {
+        val rawArguments = """{"secret":"never-in-key"}"""
+        val key = IdempotencyKeyUtil.deriveApprovalKey(
+            "approval-1",
+            "tool-call-1",
+            Sha256Digest.of("sha256:3333333333333333333333333333333333333333333333333333333333333333"),
+        )
+
+        assertThat(key).doesNotContain(rawArguments)
+        assertThat(key).matches("[0-9a-f]{64}")
+    }
+}

--- a/tramai-security/src/main/kotlin/dev/tramai/security/approval/InMemoryApprovalContinuationStore.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/approval/InMemoryApprovalContinuationStore.kt
@@ -337,6 +337,6 @@ class InMemoryApprovalContinuationStore(
     private companion object {
         private const val MAX_ID_LENGTH = 256
         private const val MAX_STALE_LIMIT = 100
-        private val SAFE_REASON_CODE = Regex("[a-z0-9][a-z0-9._:-]{0,63}")
+        private val SAFE_REASON_CODE = Regex(dev.tramai.core.approval.SAFE_REASON_CODE_PATTERN)
     }
 }

--- a/tramai-security/src/main/kotlin/dev/tramai/security/approval/InMemoryApprovalContinuationStore.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/approval/InMemoryApprovalContinuationStore.kt
@@ -12,6 +12,7 @@ import dev.tramai.core.exception.ApprovalContinuationNotCompletableException
 import dev.tramai.core.exception.ApprovalContinuationNotFoundException
 import java.time.Clock
 import java.time.Duration
+import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -46,6 +47,9 @@ class InMemoryApprovalContinuationStore(
         require(continuation.claimedBy == null) { "Initial continuation must not have claimedBy set" }
         require(continuation.claimedAt == null) { "Initial continuation must not have claimedAt set" }
         require(continuation.completedAt == null) { "Initial continuation must not have completedAt set" }
+        require(continuation.recoveryResolvedBy == null) { "Initial continuation must not have recoveryResolvedBy set" }
+        require(continuation.recoveryResolvedAt == null) { "Initial continuation must not have recoveryResolvedAt set" }
+        require(continuation.recoveryReasonCode == null) { "Initial continuation must not have recoveryReasonCode set" }
 
         val now = clock.instant()
         require(continuation.createdAt <= now) { "createdAt must not be in the future" }
@@ -210,6 +214,65 @@ class InMemoryApprovalContinuationStore(
         } ?: throw ApprovalContinuationConflictException(approvalId)
     }
 
+    override suspend fun findStaleClaimed(
+        claimedBefore: Instant,
+        limit: Int,
+    ): List<ApprovalContinuation> {
+        require(limit in 1..MAX_STALE_LIMIT) { "limit must be between 1 and $MAX_STALE_LIMIT" }
+
+        return store.values
+            .mapNotNull { stored ->
+                val continuation = stored.continuation
+                val isClaimed = continuation.status == ApprovalContinuationStatus.CLAIMED
+                val claimedAt = continuation.claimedAt
+                if (
+                    isClaimed &&
+                    claimedAt != null &&
+                    !claimedAt.isAfter(claimedBefore)
+                ) {
+                    continuation
+                } else {
+                    null
+                }
+            }
+            .sortedWith(compareBy<ApprovalContinuation> { it.claimedAt!! }.thenBy { it.approvalId })
+            .take(limit)
+    }
+
+    override suspend fun forceCancelClaimed(
+        approvalId: String,
+        expectedVersion: Long,
+        cancelledBy: String,
+        reasonCode: String,
+    ): ApprovalContinuation {
+        validateIdentifier(approvalId, "approvalId")
+        validateIdentifier(cancelledBy, "cancelledBy")
+        validateReasonCode(reasonCode)
+
+        return store.compute(approvalId) { _, current ->
+            val stored = current ?: throw ApprovalContinuationNotFoundException(approvalId)
+            val continuation = stored.continuation
+
+            if (continuation.version != expectedVersion) throw ApprovalContinuationConflictException(approvalId)
+            if (continuation.status != ApprovalContinuationStatus.CLAIMED) {
+                throw ApprovalContinuationNotClaimableException(approvalId)
+            }
+
+            val now = clock.instant()
+            val incremented = incrementVersion(approvalId, continuation.version)
+            StoredApprovalContinuation(
+                continuation = continuation.copy(
+                    status = ApprovalContinuationStatus.CANCELLED_UNCERTAIN,
+                    version = incremented,
+                    recoveryResolvedBy = cancelledBy,
+                    recoveryResolvedAt = now,
+                    recoveryReasonCode = reasonCode,
+                ),
+                arguments = null,
+            )
+        }?.continuation ?: throw ApprovalContinuationConflictException(approvalId)
+    }
+
     override suspend fun sweepExpired(): Int {
         val now = clock.instant()
         val expiredCount = AtomicInteger()
@@ -265,7 +328,15 @@ class InMemoryApprovalContinuationStore(
         return trimmed
     }
 
+    private fun validateReasonCode(value: String) {
+        require(SAFE_REASON_CODE.matches(value)) {
+            "reasonCode must match [a-z0-9][a-z0-9._:-]{0,63}"
+        }
+    }
+
     private companion object {
         private const val MAX_ID_LENGTH = 256
+        private const val MAX_STALE_LIMIT = 100
+        private val SAFE_REASON_CODE = Regex("[a-z0-9][a-z0-9._:-]{0,63}")
     }
 }

--- a/tramai-security/src/main/kotlin/dev/tramai/security/approval/InMemoryApprovalContinuationStore.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/approval/InMemoryApprovalContinuationStore.kt
@@ -4,6 +4,7 @@ import dev.tramai.core.approval.ApprovalContinuation
 import dev.tramai.core.approval.ApprovalContinuationStatus
 import dev.tramai.core.approval.ApprovalContinuationStore
 import dev.tramai.core.approval.ClaimedApprovalContinuation
+import dev.tramai.core.approval.SAFE_REASON_CODE_PATTERN
 import dev.tramai.core.approval.SensitiveToolArguments
 import dev.tramai.core.approval.ToolArgumentsDigester
 import dev.tramai.core.exception.ApprovalContinuationConflictException
@@ -337,6 +338,6 @@ class InMemoryApprovalContinuationStore(
     private companion object {
         private const val MAX_ID_LENGTH = 256
         private const val MAX_STALE_LIMIT = 100
-        private val SAFE_REASON_CODE = Regex(dev.tramai.core.approval.SAFE_REASON_CODE_PATTERN)
+        private val SAFE_REASON_CODE = Regex(SAFE_REASON_CODE_PATTERN)
     }
 }

--- a/tramai-security/src/main/kotlin/dev/tramai/security/approval/InMemoryApprovalRecoveryCoordinator.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/approval/InMemoryApprovalRecoveryCoordinator.kt
@@ -6,6 +6,7 @@ import dev.tramai.core.approval.ApprovalLifecycleAuditEmitter
 import dev.tramai.core.approval.ApprovalRecoveryCoordinator
 import dev.tramai.core.approval.ForceCancelClaimedCommand
 import dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter
+import dev.tramai.core.approval.SAFE_REASON_CODE_PATTERN
 import dev.tramai.core.exception.ApprovalAuthorizationException
 import dev.tramai.core.exception.ApprovalContinuationConflictException
 import dev.tramai.core.exception.ApprovalContinuationNotFoundException
@@ -25,7 +26,7 @@ class InMemoryApprovalRecoveryCoordinator(
     private val clock: Clock = Clock.systemUTC(),
 ) : ApprovalRecoveryCoordinator {
 
-    private val SAFE_REASON_CODE = Regex("[a-z0-9][a-z0-9._:-]{0,63}")
+    private val SAFE_REASON_CODE = Regex(SAFE_REASON_CODE_PATTERN)
 
     override suspend fun findStaleClaims(
         claimedBefore: Instant,

--- a/tramai-security/src/main/kotlin/dev/tramai/security/approval/InMemoryApprovalRecoveryCoordinator.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/approval/InMemoryApprovalRecoveryCoordinator.kt
@@ -26,8 +26,6 @@ class InMemoryApprovalRecoveryCoordinator(
     private val clock: Clock = Clock.systemUTC(),
 ) : ApprovalRecoveryCoordinator {
 
-    private val SAFE_REASON_CODE = Regex(SAFE_REASON_CODE_PATTERN)
-
     override suspend fun findStaleClaims(
         claimedBefore: Instant,
         limit: Int,
@@ -52,7 +50,7 @@ class InMemoryApprovalRecoveryCoordinator(
     override suspend fun forceCancelClaimed(
         command: ForceCancelClaimedCommand,
     ): ApprovalContinuation {
-        require(SAFE_REASON_CODE.matches(command.reasonCode)) {
+        require(Regex(SAFE_REASON_CODE_PATTERN).matches(command.reasonCode)) {
             "reasonCode must match [a-z0-9][a-z0-9._:-]{0,63}"
         }
 

--- a/tramai-security/src/main/kotlin/dev/tramai/security/approval/InMemoryApprovalRecoveryCoordinator.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/approval/InMemoryApprovalRecoveryCoordinator.kt
@@ -1,0 +1,87 @@
+package dev.tramai.security.approval
+
+import dev.tramai.core.approval.ApprovalContinuation
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.core.approval.ApprovalLifecycleAuditEmitter
+import dev.tramai.core.approval.ApprovalRecoveryCoordinator
+import dev.tramai.core.approval.ForceCancelClaimedCommand
+import dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter
+import dev.tramai.core.exception.ApprovalAuthorizationException
+import dev.tramai.core.exception.ApprovalContinuationConflictException
+import dev.tramai.core.exception.ApprovalContinuationNotFoundException
+import dev.tramai.core.exception.ApprovalContinuationNotClaimableException
+import java.time.Clock
+import java.time.Instant
+
+/**
+ * In-memory implementation of [ApprovalRecoveryCoordinator].
+ *
+ * Wraps an [ApprovalContinuationStore] with audit emission and
+ * safe exception mapping.
+ */
+class InMemoryApprovalRecoveryCoordinator(
+    private val store: ApprovalContinuationStore,
+    private val lifecycleAuditEmitter: ApprovalLifecycleAuditEmitter = NoOpApprovalLifecycleAuditEmitter,
+    private val clock: Clock = Clock.systemUTC(),
+) : ApprovalRecoveryCoordinator {
+
+    private val SAFE_REASON_CODE = Regex("[a-z0-9][a-z0-9._:-]{0,63}")
+
+    override suspend fun findStaleClaims(
+        claimedBefore: Instant,
+        limit: Int,
+    ): List<ApprovalContinuation> {
+        val stale = store.findStaleClaimed(claimedBefore, limit)
+
+        // Emit detection audit events — best-effort, does not fail the operation
+        stale.forEach { cont ->
+            runCatching {
+                lifecycleAuditEmitter.onStaleClaimDetected(
+                    approvalId = cont.approvalId,
+                    workflowRunId = cont.workflowRunId,
+                    toolName = cont.toolName,
+                    claimedAt = cont.claimedAt ?: clock.instant(),
+                )
+            }
+        }
+
+        return stale
+    }
+
+    override suspend fun forceCancelClaimed(
+        command: ForceCancelClaimedCommand,
+    ): ApprovalContinuation {
+        require(SAFE_REASON_CODE.matches(command.reasonCode)) {
+            "reasonCode must match [a-z0-9][a-z0-9._:-]{0,63}"
+        }
+
+        val continuation = try {
+            store.forceCancelClaimed(
+                approvalId = command.approvalId,
+                expectedVersion = command.expectedVersion,
+                cancelledBy = command.operatorId,
+                reasonCode = command.reasonCode,
+            )
+        } catch (e: RuntimeException) {
+            throw mapStoreError(e, command.approvalId)
+        }
+
+        // Emit audit event — fail closed on audit failure for privileged mutation
+        lifecycleAuditEmitter.onClaimedContinuationForceCancelled(
+            approvalId = command.approvalId,
+            workflowRunId = continuation.workflowRunId,
+            toolName = continuation.toolName,
+            cancelledBy = command.operatorId,
+            reasonCode = command.reasonCode,
+        )
+
+        return continuation
+    }
+
+    private fun mapStoreError(e: RuntimeException, approvalId: String): RuntimeException = when (e) {
+        is ApprovalContinuationNotFoundException -> ApprovalContinuationNotFoundException(approvalId)
+        is ApprovalContinuationConflictException -> ApprovalAuthorizationException(approvalId)
+        is ApprovalContinuationNotClaimableException -> ApprovalAuthorizationException(approvalId)
+        else -> ApprovalAuthorizationException(approvalId)
+    }
+}

--- a/tramai-security/src/test/kotlin/dev/tramai/security/approval/ApprovalRecoveryCoordinatorTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/approval/ApprovalRecoveryCoordinatorTest.kt
@@ -1,0 +1,280 @@
+package dev.tramai.security.approval
+
+import dev.tramai.core.approval.ApprovalContinuation
+import dev.tramai.core.approval.ApprovalContinuationStatus
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.core.approval.ApprovalLifecycleAuditEmitter
+import dev.tramai.core.approval.ForceCancelClaimedCommand
+import dev.tramai.core.approval.SensitiveToolArguments
+import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.exception.ApprovalAuthorizationException
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ApprovalRecoveryCoordinatorTest {
+
+    private lateinit var clock: RecoveryMutableClock
+    private lateinit var store: InMemoryApprovalContinuationStore
+    private val digester = Sha256ToolArgumentsDigester()
+
+    @BeforeEach
+    fun setUp() {
+        clock = RecoveryMutableClock(Instant.parse("2026-06-06T10:00:00Z"))
+        store = InMemoryApprovalContinuationStore(
+            clock = clock,
+            maxContinuationTtl = Duration.ofHours(2),
+        )
+    }
+
+    @Test
+    fun `privileged cancellation emits audit event with safe metadata only`() : Unit = runBlocking {
+        val audit = RecordingRecoveryAuditEmitter()
+        val coordinator = InMemoryApprovalRecoveryCoordinator(
+            store = store,
+            lifecycleAuditEmitter = audit,
+            clock = clock,
+        )
+        createClaimedContinuation(argumentsJson = """{"secret":"never-log"}""")
+
+        val cancelled = coordinator.forceCancelClaimed(
+            ForceCancelClaimedCommand(
+                approvalId = "cont-1",
+                expectedVersion = 1L,
+                operatorId = "operator-9",
+                reasonCode = "worker-lost",
+            ),
+        )
+
+        assertThat(cancelled.status).isEqualTo(ApprovalContinuationStatus.CANCELLED_UNCERTAIN)
+        assertThat(audit.forceCancelledEvents).containsExactly(
+            "approvalId=cont-1 workflowRunId=wf-run-1 toolName=search-tool cancelledBy=operator-9 reasonCode=worker-lost",
+        )
+        assertThat(audit.forceCancelledEvents.single()).doesNotContain("secret")
+        assertThat(audit.forceCancelledEvents.single()).doesNotContain("{")
+    }
+
+    @Test
+    fun `findStaleClaims emits detection audit events`() : Unit = runBlocking {
+        val audit = RecordingRecoveryAuditEmitter()
+        val coordinator = InMemoryApprovalRecoveryCoordinator(
+            store = store,
+            lifecycleAuditEmitter = audit,
+            clock = clock,
+        )
+        createClaimedContinuation(approvalId = "stale-1", claimedAt = clock.instant().minusSeconds(120))
+        createClaimedContinuation(approvalId = "fresh-1", claimedAt = clock.instant().minusSeconds(5))
+
+        val stale = coordinator.findStaleClaims(
+            claimedBefore = clock.instant().minusSeconds(30),
+            limit = 10,
+        )
+
+        assertThat(stale.map { it.approvalId }).containsExactly("stale-1")
+        assertThat(audit.staleDetectedEvents).containsExactly(
+            "approvalId=stale-1 workflowRunId=wf-run-1 toolName=search-tool claimedAt=${clock.instant().minusSeconds(120)}",
+        )
+    }
+
+    @Test
+    fun `invalid operator ID rejected`() {
+        assertThatIllegalArgumentException()
+            .isThrownBy {
+                ForceCancelClaimedCommand(
+                    approvalId = "cont-1",
+                    expectedVersion = 1L,
+                    operatorId = " ",
+                    reasonCode = "worker-lost",
+                )
+            }
+            .withMessage("operatorId must not be blank")
+    }
+
+    @Test
+    fun `invalid reason code rejected`() {
+        val coordinator = InMemoryApprovalRecoveryCoordinator(store = store, clock = clock)
+
+        assertThatIllegalArgumentException()
+            .isThrownBy {
+                runBlocking {
+                    coordinator.forceCancelClaimed(
+                        ForceCancelClaimedCommand(
+                            approvalId = "cont-1",
+                            expectedVersion = 1L,
+                            operatorId = "operator-1",
+                            reasonCode = "INVALID",
+                        ),
+                    )
+                }
+            }
+            .withMessage("reasonCode must match [a-z0-9][a-z0-9._:-]{0,63}")
+    }
+
+    @Test
+    fun `audit emission failure prevents externally reported success`() : Unit = runBlocking {
+        createClaimedContinuation()
+        val coordinator = InMemoryApprovalRecoveryCoordinator(
+            store = store,
+            lifecycleAuditEmitter = object : ApprovalLifecycleAuditEmitter by dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter {
+                override suspend fun onClaimedContinuationForceCancelled(
+                    approvalId: String,
+                    workflowRunId: String,
+                    toolName: String,
+                    cancelledBy: String,
+                    reasonCode: String,
+                ) {
+                    error("audit-down")
+                }
+            },
+            clock = clock,
+        )
+
+        assertThatThrownBy {
+            runBlocking {
+                coordinator.forceCancelClaimed(
+                    ForceCancelClaimedCommand(
+                        approvalId = "cont-1",
+                        expectedVersion = 1L,
+                        operatorId = "operator-1",
+                        reasonCode = "worker-lost",
+                    ),
+                )
+            }
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("audit-down")
+
+        assertThat(store.get("cont-1")!!.status).isEqualTo(ApprovalContinuationStatus.CANCELLED_UNCERTAIN)
+    }
+
+    @Test
+    fun `internal exception details do not leak`() {
+        val coordinator = InMemoryApprovalRecoveryCoordinator(
+            store = object : ApprovalContinuationStore by store {
+                override suspend fun forceCancelClaimed(
+                    approvalId: String,
+                    expectedVersion: Long,
+                    cancelledBy: String,
+                    reasonCode: String,
+                ): ApprovalContinuation {
+                    throw RuntimeException("""backend secret: {"token":"never-leak"}""")
+                }
+            },
+            clock = clock,
+        )
+
+        val throwable = catchThrowable {
+            runBlocking {
+                coordinator.forceCancelClaimed(
+                    ForceCancelClaimedCommand(
+                        approvalId = "cont-1",
+                        expectedVersion = 1L,
+                        operatorId = "operator-1",
+                        reasonCode = "worker-lost",
+                    ),
+                )
+            }
+        }
+
+        assertThat(throwable).isInstanceOf(ApprovalAuthorizationException::class.java)
+        assertThat(throwable.message).isEqualTo("Approval authorization failed")
+        assertThat(throwable.cause).isNull()
+    }
+
+    private fun createClaimedContinuation(
+        approvalId: String = "cont-1",
+        argumentsJson: String = "{}",
+        claimedAt: Instant = clock.instant(),
+    ) {
+        val continuation = ApprovalContinuation(
+            approvalId = approvalId,
+            workflowRunId = "wf-run-1",
+            correlationId = "corr-1",
+            toolCallId = "tc-1",
+            toolName = "search-tool",
+            argumentsDigest = digester.digest(SensitiveToolArguments.of(argumentsJson)),
+            policyVersion = "v1",
+            workflowDigest = Sha256Digest.of(
+                "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+            ),
+            status = ApprovalContinuationStatus.CLAIMED,
+            createdAt = clock.instant().minusSeconds(180),
+            approvalExpiresAt = clock.instant().plusSeconds(1800),
+            claimedBy = "runner-1",
+            claimedAt = claimedAt,
+            completedAt = null,
+            version = 1L,
+        )
+        runBlocking {
+            store.create(
+                continuation.copy(
+                    status = ApprovalContinuationStatus.PENDING,
+                    claimedBy = null,
+                    claimedAt = null,
+                    version = 0L,
+                ),
+                SensitiveToolArguments.of(argumentsJson),
+            )
+            if (claimedAt != clock.instant()) {
+                clock.set(claimedAt)
+                store.claimForExecution(approvalId, 0L, "runner-1")
+                clock.set(Instant.parse("2026-06-06T10:00:00Z"))
+            } else {
+                store.claimForExecution(approvalId, 0L, "runner-1")
+            }
+        }
+    }
+
+    private fun catchThrowable(block: () -> Unit): Throwable =
+        try {
+            block()
+            throw AssertionError("Expected throwable")
+        } catch (t: Throwable) {
+            t
+        }
+}
+
+private class RecordingRecoveryAuditEmitter : ApprovalLifecycleAuditEmitter by dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter {
+    val staleDetectedEvents = mutableListOf<String>()
+    val forceCancelledEvents = mutableListOf<String>()
+
+    override suspend fun onStaleClaimDetected(
+        approvalId: String,
+        workflowRunId: String,
+        toolName: String,
+        claimedAt: Instant,
+    ) {
+        staleDetectedEvents += "approvalId=$approvalId workflowRunId=$workflowRunId toolName=$toolName claimedAt=$claimedAt"
+    }
+
+    override suspend fun onClaimedContinuationForceCancelled(
+        approvalId: String,
+        workflowRunId: String,
+        toolName: String,
+        cancelledBy: String,
+        reasonCode: String,
+    ) {
+        forceCancelledEvents +=
+            "approvalId=$approvalId workflowRunId=$workflowRunId toolName=$toolName cancelledBy=$cancelledBy reasonCode=$reasonCode"
+    }
+}
+
+private class RecoveryMutableClock(
+    private var now: Instant,
+    private val zone: ZoneId = ZoneId.of("UTC"),
+) : Clock() {
+    override fun instant(): Instant = now
+    override fun withZone(zone: ZoneId): Clock = RecoveryMutableClock(now, zone)
+    override fun getZone(): ZoneId = zone
+
+    fun set(next: Instant) {
+        now = next
+    }
+}

--- a/tramai-security/src/test/kotlin/dev/tramai/security/approval/InMemoryApprovalContinuationStoreTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/approval/InMemoryApprovalContinuationStoreTest.kt
@@ -1119,6 +1119,194 @@ class InMemoryApprovalContinuationStoreTest {
         sweepResult.exceptionOrNull()?.let { assertThrowableTreeDoesNotContain(it, raw) }
     }
 
+    @Test
+    fun `findStaleClaimed returns stale CLAIMED records only in deterministic order`() : Unit = runBlocking {
+        insertDirect(
+            continuation = aPendingContinuation(
+                approvalId = "stale-b",
+                status = ApprovalContinuationStatus.CLAIMED,
+                claimedBy = "runner-1",
+                claimedAt = fixedClock.instant().minusSeconds(60),
+                version = 1L,
+            ),
+            arguments = null,
+        )
+        insertDirect(
+            continuation = aPendingContinuation(
+                approvalId = "fresh-claimed",
+                status = ApprovalContinuationStatus.CLAIMED,
+                claimedBy = "runner-1",
+                claimedAt = fixedClock.instant().minusSeconds(5),
+                version = 1L,
+            ),
+            arguments = null,
+        )
+        insertDirect(
+            continuation = aPendingContinuation(
+                approvalId = "stale-a",
+                status = ApprovalContinuationStatus.CLAIMED,
+                claimedBy = "runner-2",
+                claimedAt = fixedClock.instant().minusSeconds(60),
+                version = 1L,
+            ),
+            arguments = null,
+        )
+        insertDirect(
+            continuation = aPendingContinuation(
+                approvalId = "pending",
+                status = ApprovalContinuationStatus.PENDING,
+            ),
+            arguments = SensitiveToolArguments.of("""{"sensitiveField":"pending"}"""),
+        )
+        insertDirect(
+            continuation = aPendingContinuation(
+                approvalId = "completed",
+                status = ApprovalContinuationStatus.COMPLETED,
+                claimedBy = "runner-3",
+                claimedAt = fixedClock.instant().minusSeconds(80),
+                completedAt = fixedClock.instant().minusSeconds(70),
+                version = 2L,
+            ),
+            arguments = null,
+        )
+        insertDirect(
+            continuation = aPendingContinuation(
+                approvalId = "expired",
+                status = ApprovalContinuationStatus.EXPIRED,
+                version = 1L,
+            ),
+            arguments = null,
+        )
+        insertDirect(
+            continuation = aPendingContinuation(
+                approvalId = "cancelled",
+                status = ApprovalContinuationStatus.CANCELLED,
+                version = 1L,
+            ),
+            arguments = null,
+        )
+        insertDirect(
+            continuation = aPendingContinuation(
+                approvalId = "cancelled-uncertain",
+                status = ApprovalContinuationStatus.CANCELLED_UNCERTAIN,
+                claimedBy = "runner-4",
+                claimedAt = fixedClock.instant().minusSeconds(90),
+                recoveryResolvedBy = "operator-1",
+                recoveryResolvedAt = fixedClock.instant().minusSeconds(30),
+                recoveryReasonCode = "worker-lost",
+                version = 2L,
+            ),
+            arguments = null,
+        )
+
+        val stale = store.findStaleClaimed(
+            claimedBefore = fixedClock.instant().minusSeconds(30),
+            limit = 10,
+        )
+
+        assertThat(stale.map { it.approvalId }).containsExactly("stale-a", "stale-b")
+        assertThat(stale).allMatch { it.status == ApprovalContinuationStatus.CLAIMED }
+    }
+
+    @Test
+    fun `findStaleClaimed enforces bounds and never leaks raw arguments`() : Unit = runBlocking {
+        val raw = """{"sensitiveField":"find-stale-redaction"}"""
+        insertDirect(
+            continuation = aPendingContinuation(
+                approvalId = "stale-redacted",
+                status = ApprovalContinuationStatus.CLAIMED,
+                claimedBy = "runner-1",
+                claimedAt = fixedClock.instant().minusSeconds(45),
+                version = 1L,
+            ),
+            arguments = null,
+        )
+
+        val stale = store.findStaleClaimed(
+            claimedBefore = fixedClock.instant().minusSeconds(30),
+            limit = 1,
+        )
+
+        assertThat(stale.single().toString()).doesNotContain(raw)
+        assertThat(stale.single().toString()).doesNotContain("arguments=")
+
+        assertThatIllegalArgumentException()
+            .isThrownBy { runBlocking { store.findStaleClaimed(fixedClock.instant(), 0) } }
+            .withMessage("limit must be between 1 and 100")
+        assertThatIllegalArgumentException()
+            .isThrownBy { runBlocking { store.findStaleClaimed(fixedClock.instant(), 101) } }
+            .withMessage("limit must be between 1 and 100")
+    }
+
+    @Test
+    fun `forceCancelClaimed transitions CLAIMED to CANCELLED_UNCERTAIN with recovery metadata`() : Unit = runBlocking {
+        createPendingContinuation(argumentsJson = """{"sensitiveField":"claim"}""")
+        store.claimForExecution("cont-1", 0L, "runner-1")
+        fixedClock.advance(Duration.ofSeconds(15))
+
+        val cancelled = store.forceCancelClaimed("cont-1", 1L, "operator-7", "worker-lost")
+
+        assertThat(cancelled.status).isEqualTo(ApprovalContinuationStatus.CANCELLED_UNCERTAIN)
+        assertThat(cancelled.version).isEqualTo(2L)
+        assertThat(cancelled.recoveryResolvedBy).isEqualTo("operator-7")
+        assertThat(cancelled.recoveryResolvedAt).isEqualTo(fixedClock.instant())
+        assertThat(cancelled.recoveryReasonCode).isEqualTo("worker-lost")
+        assertThat(readStored("cont-1")!!.arguments).isNull()
+    }
+
+    @Test
+    fun `forceCancelClaimed rejects stale version and repeated force cancellation`() : Unit = runBlocking {
+        createPendingContinuation()
+        store.claimForExecution("cont-1", 0L, "runner-1")
+
+        assertThatThrownBy {
+            runBlocking { store.forceCancelClaimed("cont-1", 0L, "operator-1", "worker-lost") }
+        }
+            .isInstanceOf(ApprovalContinuationConflictException::class.java)
+
+        store.forceCancelClaimed("cont-1", 1L, "operator-1", "worker-lost")
+
+        assertThatThrownBy {
+            runBlocking { store.forceCancelClaimed("cont-1", 2L, "operator-2", "worker-lost") }
+        }
+            .isInstanceOf(ApprovalContinuationNotClaimableException::class.java)
+    }
+
+    @Test
+    fun `forceCancelClaimed rejects PENDING and COMPLETED continuations`() : Unit = runBlocking {
+        createPendingContinuation(approvalId = "pending-force-cancel")
+        createPendingContinuation(approvalId = "completed-force-cancel")
+        store.claimForExecution("completed-force-cancel", 0L, "runner-1")
+        store.complete("completed-force-cancel", 1L, "runner-1")
+
+        assertThatThrownBy {
+            runBlocking { store.forceCancelClaimed("pending-force-cancel", 0L, "operator-1", "worker-lost") }
+        }
+            .isInstanceOf(ApprovalContinuationNotClaimableException::class.java)
+
+        assertThatThrownBy {
+            runBlocking { store.forceCancelClaimed("completed-force-cancel", 2L, "operator-1", "worker-lost") }
+        }
+            .isInstanceOf(ApprovalContinuationNotClaimableException::class.java)
+    }
+
+    @Test
+    fun `CANCELLED_UNCERTAIN cannot be claimed or completed`() : Unit = runBlocking {
+        createPendingContinuation()
+        store.claimForExecution("cont-1", 0L, "runner-1")
+        store.forceCancelClaimed("cont-1", 1L, "operator-1", "worker-lost")
+
+        assertThatThrownBy {
+            runBlocking { store.claimForExecution("cont-1", 2L, "runner-2") }
+        }
+            .isInstanceOf(ApprovalContinuationNotClaimableException::class.java)
+
+        assertThatThrownBy {
+            runBlocking { store.complete("cont-1", 2L, "runner-1") }
+        }
+            .isInstanceOf(ApprovalContinuationNotCompletableException::class.java)
+    }
+
     private fun createPendingContinuation(
         approvalId: String = "cont-1",
         argumentsJson: String = "{}",
@@ -1153,6 +1341,9 @@ class InMemoryApprovalContinuationStoreTest {
         claimedBy: String? = null,
         claimedAt: Instant? = null,
         completedAt: Instant? = null,
+        recoveryResolvedBy: String? = null,
+        recoveryResolvedAt: Instant? = null,
+        recoveryReasonCode: String? = null,
         version: Long = 0L,
     ): ApprovalContinuation = ApprovalContinuation(
         approvalId = approvalId,
@@ -1169,6 +1360,9 @@ class InMemoryApprovalContinuationStoreTest {
         claimedBy = claimedBy,
         claimedAt = claimedAt,
         completedAt = completedAt,
+        recoveryResolvedBy = recoveryResolvedBy,
+        recoveryResolvedAt = recoveryResolvedAt,
+        recoveryReasonCode = recoveryReasonCode,
         version = version,
     )
 


### PR DESCRIPTION
# PR #19 — Stale Claimed-Continuation Recovery

## Summary

Add explicit, privileged, auditable recovery for stale CLAIMED continuations where the execution outcome may be uncertain.

## Changes

### Domain
- **CANCELLED_UNCERTAIN** — new terminal status for continuations where TramAI cannot prove whether the external side effect occurred
- **Recovery metadata** — `recoveryResolvedBy`, `recoveryResolvedAt`, `recoveryReasonCode` on `ApprovalContinuation`

### Store SPI (read-only)
- `findStaleClaimed(claimedBefore, limit)` — returns CLAIMED continuations with `claimedAt <= claimedBefore`, metadata-only, deterministic ordering
- `forceCancelClaimed(approvalId, expectedVersion, cancelledBy, reasonCode)` — privileged CLAIMED → CANCELLED_UNCERTAIN transition

### Recovery coordinator
- `ApprovalRecoveryCoordinator` SPI with safe exception mapping
- `InMemoryApprovalRecoveryCoordinator` — audit emission, fail-closed on privileged mutations

### Lifecycle audit
- `onStaleClaimDetected()` — best-effort detection emission
- `onClaimedContinuationForceCancelled()` — fail-closed emission for privileged mutation

### Idempotency key foundation
- `IdempotencyKeyUtil.deriveApprovalKey()` — deterministic `sha256(approvalId:toolCallId:digest)`
- `ToolExecutionContext.idempotencyKey` — populated for resumed approval-gated calls, null otherwise

### Design rules
- No automatic CLAIMED → PENDING reset
- No automatic retries or reclaim
- No scrubbed argument restoration
- Version-based optimistic concurrency
- Synchronous fail-closed audit for privileged mutations

### Tests (20+ regression tests)
- Store: filtering, ordering, limit validation, metadata-only, transitions, version fence, concurrent winner
- Coordinator: audit emission, safe metadata, exception leak prevention
- Idempotency: determinism, differential, raw argument absence

## Verification
- 118 tests, BUILD SUCCESSFUL
- publishToMavenLocal: 196 tasks
- SpringBoot example: 28 tasks

## Review Pipeline
| Round | Reviewer | Verdict | Findings |
|-------|----------|---------|----------|
| 1 | agy | APPROVED WITH MINOR CHANGES | 3 P1 → fixed |
| 2 | codex | APPROVED WITH MINOR CHANGES | 0 P0, 0 P1 |
| 3 | agy | APPROVED WITH MINOR CHANGES | 0 P0, 0 P1 |
| 4 | codex | MERGE-READY | 0 P0, 0 P1, 0 P2 |
