### PR TITLE
fix(approval): make resume authorization replay-safe before continuation claim

### DIFF
--- a/docs/security/DELIVERY-PLAN.md
+++ b/docs/security/DELIVERY-PLAN.md
@@ -609,21 +609,22 @@ PENDING ──┬── Approve ──→ APPROVED (terminal)
 
 ### Simplified Optimistic Concurrency
 
-`transition()` and `consumeApproved()` use `ConcurrentHashMap.compute()` for atomic read-modify-write:
+`transition()` and `consumeApprovedOrReplay()` use `ConcurrentHashMap.compute()` for atomic read-modify-write:
 - No CAS retry loop or `maxCasRetries` parameter
 - Version check inside the compute lambda (atomic with the update)
 - `compute()` returns `null` when the key is absent, detected as "not found"
 
 ### consumeApproved — Atomic Single-Use Consumption
 
-`InMemoryApprovalStore.consumeApproved()` implements single-use consumption:
-- Version-gated via `ConcurrentHashMap.compute()` (same atomicity model as transition)
-- Requires `status = APPROVED`, `consumedAt == null`, and `now < expiresAt`
+`InMemoryApprovalStore.consumeApprovedOrReplay()` implements replay-safe consumption:
+- Fresh consumption (replayed=false): version-gated via `ConcurrentHashMap.compute()`, requires `status = APPROVED`, `consumedAt == null`, and `now < expiresAt`
+- Exact replay (replayed=true): requires `status = APPROVED`, `consumedAt != null`, same `consumedBy`, version matches `expectedVersion + 1`
 - Constant-time token-digest comparison via `MessageDigest.isEqual()` to prevent timing attacks
-- Records `consumedBy` and `consumedAt` atomically with the version increment
-- Second consume of the same approval fails with clear message
+- Records `consumedBy` and `consumedAt` atomically with the version increment (fresh only)
+- Replay never increments version or replaces consumedAt
+- Second consume of the same approval with different consumer or wrong version fails with clear message
 
-This is a **store-level atomic primitive**. Raw-token presentation (matching a raw bearer token against `approvalTokenDigest`) is handled at the coordinator level in PR #15 via `DefaultApprovalGateCoordinator.authorizeResume()`. Engine-level resume flow is deferred to PR #16.
+This is a **store-level atomic primitive**. Raw-token presentation (matching a raw bearer token against `approvalTokenDigest`) is handled at the coordinator level in PR #15 via `DefaultApprovalGateCoordinator.authorizeResume()`. PR #22 makes authorizeResume() replay-safe by returning `ApprovalConsumptionReceipt(request, replayed)`.
 
 ### No Engine Integration Yet
 
@@ -666,7 +667,7 @@ AuthorizeResumeCommand
   → ApprovalGateCoordinator.authorizeResume()
     → store.get() → revalidate exact binding (5 fields)
     → validate decision → digest presented token
-    → store.consumeApproved() → return safe ApprovalAuthorization
+    → store.consumeApprovedOrReplay() → return ApprovalAuthorization(replayed)
 ```
 
 ### ApprovalToken Security
@@ -692,7 +693,7 @@ AuthorizeResumeCommand
 
 ### Binding Revalidation
 
-`authorizeResume()` checks all 5 binding fields **before** calling `consumeApproved()`:
+`authorizeResume()` checks all 5 binding fields **before** calling `consumeApprovedOrReplay()`:
 1. workflowRunId
 2. toolName
 3. argumentsDigest
@@ -750,7 +751,7 @@ for security properties. Default implementations in `tramai-security` meet all i
 
 ### Decision Validator Extension Point
 
-`ApprovalDecisionValidator.validate(request, consumedBy)` is invoked immediately before `store.consumeApproved()`:
+`ApprovalDecisionValidator.validate(request, consumedBy)` is invoked immediately before `store.consumeApprovedOrReplay()`:
 
 - `AllowAnyApprovalDecisionValidator` — default, preserves backward compatibility
 - `RequireDistinctRequesterAndConsumer` — enforces separation of duties
@@ -813,14 +814,14 @@ private fun observeFailure(
 }
 ```
 
-- Called in every catch block: `createApproval()`, `authorizeResume()` store.get, `authorizeResume()` store.consumeApproved.
+- Called in every catch block: `createApproval()`, `authorizeResume()` store.get, `authorizeResume()` store.consumeApprovedOrReplay.
 - If the observer throws a `RuntimeException`, it is silently swallowed. The caller always receives the safe exception.
 - If the observer throws `Error`, it propagates uncaught — the coordinator call itself will throw the `Error`.
 - Tests verify that an observer throwing `RuntimeException("observer-secret-marker")` does not leak the marker into the exception message, `toString()`, or cause chain.
 
-### Consumed-Result Contract Validation (PR #15)
+### Consumed-Result Contract Validation (PR #15, PR #22)
 
-After `store.consumeApproved()` returns, the coordinator performs a full contract validation against the command and the stored request:
+After `store.consumeApprovedOrReplay()` returns, the coordinator performs a full contract validation against the command and the stored request:
 
 ```kotlin
 if (consumed.approvalId != command.approvalId) throw ApprovalAuthorizationException(command.approvalId)
@@ -852,7 +853,7 @@ private fun containsSecret(throwable: Throwable, secret: String): Boolean {
 }
 ```
 
-- 4 tests verify that `"secret"` is absent from the full exception tree for leaky store.get(), store.create(), store.consumeApproved(), and throwing observer paths.
+- 4 tests verify that `"secret"` is absent from the full exception tree for leaky store.get(), store.create(), store.consumeApprovedOrReplay(), and throwing observer paths.
 
 ### Test Coverage (58+ tests)
 

--- a/docs/specs/spec-016-approval-engine-suspension-resume.md
+++ b/docs/specs/spec-016-approval-engine-suspension-resume.md
@@ -133,6 +133,51 @@ PR #17 delivers:
 - Lifecycle audit events (suspended, resumed, completed, cancelled, uncertain outcome)
 - Edge case test coverage for all failure paths
 
+## PR #22 — Replay-Safe Authorization Receipt
+
+Implemented in PR #22.
+
+### Problem
+
+The original resume authorization flow called `consumeApproved()` (a one-time, destructive consume) before `claimForExecution()`. If `consumeApproved()` succeeded but `claimForExecution()` failed before mutating the continuation store, the one-time token was consumed but the continuation remained PENDING. The caller had no way to recover — retrying the exact same resume command would fail because the token was already consumed.
+
+### Solution: `consumeApprovedOrReplay()`
+
+Replace `consumeApproved()` with `consumeApprovedOrReplay()` that returns `ApprovalConsumptionReceipt(request, replayed)`.
+
+**Fresh consumption semantics:**
+- status == APPROVED
+- request.version == expectedVersion
+- consumedAt == null, consumedBy == null
+- now < expiresAt
+- Token digest matches (constant-time)
+- Persists consumedBy, consumedAt, version + 1
+- Returns replayed=false
+
+**Exact-replay semantics:**
+- status == APPROVED
+- consumedAt != null
+- stored consumedBy == command consumedBy
+- stored version == expectedVersion + 1
+- Token digest matches (constant-time)
+- Returns existing request UNCHANGED (no version increment, no consumedAt replacement)
+- Returns replayed=true
+
+### Engine Integration
+
+`TramaiEngine.authorizeResume()` captures the `replayed` flag. When `replayed == true`, the engine emits `tramai.approval.authorization_replayed` with safe attributes only (approvalId, workflowRunId, toolName). The emitter failure never blocks execution.
+
+### Guarantees
+
+- Wrong tokens fail BEFORE policy evaluation
+- Exact replay never mutates consumedAt or version
+- CLAIMED continuations are never automatically retried
+- Concurrent exact replays: one fresh consume, remaining replays
+- Concurrent different actors: only original consumer accepted
+- Replay after approval expiry returns same receipt (continuation store is authoritative for execution expiry)
+- CancellationException propagates unchanged
+- Checked adapter failures sanitized without secret leakage
+
 ## v1 Limitations
 
 - **conversationId threading**: conversationId is threaded through the execution chain but the initial suspension must have been triggered by a path that has it. The normal `executeRaw`/`executeStructured` paths pass it; direct `suspendToolExecution` callers that don't supply it will get null.

--- a/docs/specs/spec-016-approval-engine-suspension-resume.md
+++ b/docs/specs/spec-016-approval-engine-suspension-resume.md
@@ -175,6 +175,8 @@ Replace `consumeApproved()` with `consumeApprovedOrReplay()` that returns `Appro
 - Concurrent exact replays: one fresh consume, remaining replays
 - Concurrent different actors: only original consumer accepted
 - Replay after approval expiry returns same receipt (continuation store is authoritative for execution expiry)
+- **The durable receipt guarantees authorization consumption recovery, not unconditional workflow completion.**
+  Policy, validator, and BEFORE_WORKFLOW_RESUME are re-evaluated on each retry — this is fail-closed by design.
 - CancellationException propagates unchanged
 - Checked adapter failures sanitized without secret leakage
 

--- a/tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalGateCoordinator.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalGateCoordinator.kt
@@ -47,6 +47,7 @@ data class ApprovalAuthorization(
     val consumedBy: String,
     val consumedAt: Instant,
     val version: Long,
+    val replayed: Boolean = false,
 )
 
 data class ApprovalValidation(

--- a/tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalStore.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalStore.kt
@@ -45,26 +45,47 @@ interface ApprovalStore {
     ): ApprovalRequest
 
     /**
-     * Consume an approved approval request exactly once.
+     * Consume an approved approval request, or return the durable receipt for an exact replay.
      *
-     * Validates that the presented token digest matches the stored [ApprovalBinding.approvalTokenDigest]
-     * using constant-time comparison. On success, marks the request as consumed by persisting
-     * [consumedBy] and [consumedAt] and incrementing the version.
+     * This method intentionally replaces the previous `consumeApproved(...)` SPI and is therefore
+     * a pre-release SPI break for downstream implementers.
      *
-     * @param approvalId The approval to consume.
-     * @param expectedVersion The version the caller expects.
-     * @param presentedTokenDigest The SHA-256 digest of the approval token presented by the caller.
-     * @param consumedBy Identifier of the consuming actor. Must not be blank, must not exceed
-     *                    the maximum ID length, must not contain control characters,
-     *                    and must not have surrounding whitespace.
-     * @return The updated [ApprovalRequest] with consumption fields set.
-     * @throws IllegalArgumentException if the approval does not exist, version mismatch,
-     *         status is not APPROVED, already consumed, expired, or token digest does not match.
+     * Fresh consumption succeeds only when all of the following hold:
+     * - status == APPROVED
+     * - request.version == expectedVersion
+     * - consumedAt == null
+     * - consumedBy == null
+     * - now < expiresAt
+     * - presentedTokenDigest matches the stored [ApprovalBinding.approvalTokenDigest] using
+     *   constant-time comparison
+     *
+     * On fresh success, implementations persist [consumedBy], persist consumedAt, increment the
+     * version by exactly one, and return [ApprovalConsumptionReceipt.replayed] = false.
+     *
+     * Exact replay succeeds only when all of the following hold:
+     * - status == APPROVED
+     * - consumedAt != null
+     * - stored consumedBy == command consumedBy
+     * - stored version == expectedVersion + 1
+     * - presentedTokenDigest matches the stored digest using constant-time comparison
+     *
+     * On exact replay success, implementations MUST return the existing durable request unchanged,
+     * without incrementing version or replacing consumedAt, and set
+     * [ApprovalConsumptionReceipt.replayed] = true.
+     *
+     * Implementations must reject every non-exact replay safely. Exact replay receipts may be
+     * returned after approval expiry; the continuation store remains authoritative for execution
+     * expiry.
      */
-    suspend fun consumeApproved(
+    suspend fun consumeApprovedOrReplay(
         approvalId: String,
         expectedVersion: Long,
         presentedTokenDigest: Sha256Digest,
         consumedBy: String,
-    ): ApprovalRequest
+    ): ApprovalConsumptionReceipt
 }
+
+data class ApprovalConsumptionReceipt(
+    val request: ApprovalRequest,
+    val replayed: Boolean,
+)

--- a/tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalStore.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalStore.kt
@@ -5,6 +5,10 @@ package dev.tramai.core.approval
  *
  * Implementations must be thread-safe and provide atomic
  * read-modify-write semantics for [transition].
+ *
+ * Implementations must rethrow [kotlinx.coroutines.CancellationException]
+ * unchanged. All other exceptions are domain-specific and must extend
+ * [RuntimeException] or [dev.tramai.core.exception.TramaiException].
  */
 interface ApprovalStore {
 
@@ -76,6 +80,9 @@ interface ApprovalStore {
      * Implementations must reject every non-exact replay safely. Exact replay receipts may be
      * returned after approval expiry; the continuation store remains authoritative for execution
      * expiry.
+     *
+     * @throws kotlinx.coroutines.CancellationException thrown unchanged if the
+     *   coroutine is cancelled during execution.
      */
     suspend fun consumeApprovedOrReplay(
         approvalId: String,

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -2463,7 +2463,7 @@ internal class TramaiInvocationHandler(
         }
 
         // 6. Token was validated above; now consume it atomically before claiming
-        coordinator.authorizeResume(
+        val authorization = coordinator.authorizeResume(
             AuthorizeResumeCommand(
                 approvalId = command.approvalId,
                 expectedVersion = command.approvalExpectedVersion,
@@ -2476,6 +2476,20 @@ internal class TramaiInvocationHandler(
                 workflowDigest = metadata.identity.workflowDigest,
             )
         )
+        if (authorization.replayed) {
+            try {
+                engineEventObserver.onEngineEvent(
+                    name = "tramai.approval.authorization_replayed",
+                    attributes = mapOf(
+                        "approvalId" to command.approvalId,
+                        "workflowRunId" to metadata.identity.workflowRunId,
+                        "toolName" to metadata.toolName,
+                    ),
+                )
+            } catch (_: Exception) {
+                // Replay telemetry must not affect resume execution.
+            }
+        }
 
         // 7. Claim continuation (only Allow reaches here)
         val claimed = store.claimForExecution(

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -2486,6 +2486,8 @@ internal class TramaiInvocationHandler(
                         "toolName" to metadata.toolName,
                     ),
                 )
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
             } catch (_: Exception) {
                 // Replay telemetry must not affect resume execution.
             }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalResumeEngineTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalResumeEngineTest.kt
@@ -47,6 +47,9 @@ import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.io.IOException
 import kotlin.test.Test
 
 class ApprovalResumeEngineTest {
@@ -107,6 +110,93 @@ class ApprovalResumeEngineTest {
             expectedVersion: Long,
             reason: String,
         ) = Unit
+    }
+
+    private class ReplaySafeApprovalGateCoordinator(
+        private val mode: Mode = Mode.NORMAL,
+    ) : ApprovalGateCoordinator {
+        enum class Mode {
+            NORMAL,
+            THROW_AFTER_DURABLE_CONSUME_ONCE,
+        }
+
+        private val durableReceipts = linkedMapOf<String, ApprovalAuthorization>()
+        var validateCalls: Int = 0
+        var authorizeCalls: Int = 0
+
+        override suspend fun createApproval(command: CreateApprovalCommand): ApprovalChallenge {
+            error("Not used in resume tests")
+        }
+
+        override suspend fun validateResume(command: ValidateResumeCommand): ApprovalValidation {
+            validateCalls++
+            if (command.presentedToken.reveal() == "wrong-token") {
+                throw dev.tramai.core.exception.ApprovalTokenRejectedException(command.approvalId)
+            }
+            return ApprovalValidation(
+                approvalId = command.approvalId,
+                validatedBy = command.consumedBy,
+                validatedAt = Clock.systemUTC().instant(),
+                version = command.expectedVersion,
+            )
+        }
+
+        override suspend fun authorizeResume(command: AuthorizeResumeCommand): ApprovalAuthorization {
+            authorizeCalls++
+            val existing = durableReceipts[command.approvalId]
+            if (existing != null) {
+                if (existing.consumedBy != command.consumedBy || command.expectedVersion + 1 != existing.version) {
+                    throw dev.tramai.core.exception.ApprovalAuthorizationException(command.approvalId)
+                }
+                return existing.copy(replayed = true)
+            }
+
+            val authorization = ApprovalAuthorization(
+                approvalId = command.approvalId,
+                consumedBy = command.consumedBy,
+                consumedAt = Clock.systemUTC().instant(),
+                version = command.expectedVersion + 1,
+            )
+            durableReceipts[command.approvalId] = authorization
+            if (mode == Mode.THROW_AFTER_DURABLE_CONSUME_ONCE) {
+                throw IOException("adapter-secret-marker")
+            }
+            return authorization
+        }
+
+        override suspend fun cancelApproval(
+            approvalId: String,
+            expectedVersion: Long,
+            reason: String,
+        ) = Unit
+    }
+
+    private class ThrowingOnceClaimStore(
+        private val delegate: InMemoryApprovalContinuationStore,
+    ) : dev.tramai.core.approval.ApprovalContinuationStore by delegate {
+        private val failed = AtomicBoolean(false)
+
+        override suspend fun claimForExecution(
+            approvalId: String,
+            expectedVersion: Long,
+            claimedBy: String,
+        ): dev.tramai.core.approval.ClaimedApprovalContinuation {
+            if (failed.compareAndSet(false, true)) {
+                throw RuntimeException("claim-before-mutation")
+            }
+            return delegate.claimForExecution(approvalId, expectedVersion, claimedBy)
+        }
+    }
+
+    private class RecordingEngineEventObserver : EngineEventObserver {
+        val events = mutableListOf<Pair<String, Map<String, Any?>>>()
+
+        override fun onEngineEvent(
+            name: String,
+            attributes: Map<String, Any?>,
+        ) {
+            events += name to attributes
+        }
     }
 
     /**

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalResumeEngineTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalResumeEngineTest.kt
@@ -3,11 +3,10 @@ package dev.tramai.engine
 import dev.tramai.core.annotations.AiService
 import dev.tramai.core.annotations.Operation
 import dev.tramai.core.annotations.SystemPrompt
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.catchThrowableOfType
 import dev.tramai.core.approval.ApprovalContinuation
 import dev.tramai.core.approval.ApprovalContinuationStatus
 import dev.tramai.core.approval.ApprovalGateCoordinator
+import dev.tramai.core.approval.ApprovalTransition
 import dev.tramai.core.approval.ForceCancelClaimedCommand
 import dev.tramai.core.approval.IdempotencyKeyUtil
 import dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter
@@ -35,12 +34,18 @@ import dev.tramai.core.policy.PolicyDecision
 import dev.tramai.core.policy.PolicyEngine
 import dev.tramai.core.policy.ApprovalRequirement
 import dev.tramai.core.structured.StructuredOutputResult
+import dev.tramai.security.approval.DefaultApprovalGateCoordinator
 import dev.tramai.security.approval.InMemoryApprovalContinuationStore
+import dev.tramai.security.approval.InMemoryApprovalStore
 import dev.tramai.security.approval.InMemoryApprovalRecoveryCoordinator
+import dev.tramai.security.approval.SecureRandomApprovalTokenGenerator
 import dev.tramai.security.approval.Sha256ToolArgumentsDigester
+import dev.tramai.security.approval.Sha256ApprovalTokenDigester
+import dev.tramai.security.approval.UuidApprovalIdGenerator
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.catchThrowableOfType
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.fail
 import java.nio.charset.StandardCharsets
@@ -50,7 +55,6 @@ import java.time.Instant
 import java.time.ZoneId
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicInteger
 import java.io.IOException
 import kotlin.test.Test
 
@@ -230,6 +234,17 @@ class ApprovalResumeEngineTest {
             attributes: Map<String, Any?>,
         ) {
             events += name to attributes
+        }
+    }
+
+    private class ThrowingEngineEventObserver(
+        private val exception: CancellationException,
+    ) : EngineEventObserver {
+        override fun onEngineEvent(
+            name: String,
+            attributes: Map<String, Any?>,
+        ) {
+            throw exception
         }
     }
 
@@ -1554,6 +1569,188 @@ class ApprovalResumeEngineTest {
         assertThat(replayEvent.second).containsEntry("toolName", toolName)
         assertThat(replayEvent.second.keys).containsExactlyInAnyOrder("approvalId", "workflowRunId", "toolName")
         assertThat(replayEvent.second.values.map { it?.toString() }).doesNotContain(exception.challenge.token.reveal())
+    }
+
+    @Test
+    fun `resumeApproval rethrows cancellation from replay telemetry and recovers on later retry`() {
+        val replayCoordinator = ReplaySafeApprovalGateCoordinator(clock = fixedClock)
+        val localSuspendedStore = InMemorySuspendedInvocationStore()
+        val localContinuationStore = ThrowingOnceClaimStore(
+            delegate = InMemoryApprovalContinuationStore(clock = fixedClock),
+        )
+        val localTool = RecordingTool(name = toolName)
+        var localProviderCallCount = 0
+        val provider = RecordingProvider { _ ->
+            localProviderCallCount++
+            if (localProviderCallCount == 1) {
+                ModelResponse(
+                    content = "",
+                    toolCalls = listOf(ToolCall(toolCallId, toolName, toolArguments)),
+                )
+            } else {
+                ModelResponse(content = "Final result: success")
+            }
+        }
+        val suspendingEngine = createEngine(
+            provider = provider,
+            toolRegistry = ToolRegistry(mapOf(localTool.name to localTool)),
+            suspendedInvocationStore = localSuspendedStore,
+            approvalContinuationStore = localContinuationStore,
+            approvalGateCoordinator = PermitApprovalGateCoordinator(fixedClock),
+        )
+        val exception = triggerSuspension(suspendingEngine)
+        val command = ResumeApprovalCommand(
+            approvalId = exception.approvalId,
+            approvalExpectedVersion = 0L,
+            continuationExpectedVersion = 0L,
+            presentedToken = exception.challenge.token,
+            resumedBy = resumedBy,
+        )
+
+        val firstAttemptEngine = createEngine(
+            provider = provider,
+            toolRegistry = ToolRegistry(mapOf(localTool.name to localTool)),
+            suspendedInvocationStore = localSuspendedStore,
+            approvalContinuationStore = localContinuationStore,
+            approvalGateCoordinator = replayCoordinator,
+        )
+        firstAttemptEngine.create<ResumeBootstrapService>()
+
+        val firstFailure = catchThrowableOfType(
+            { runBlocking { firstAttemptEngine.resumeApproval(command) } },
+            RuntimeException::class.java,
+        )
+        assertThat(firstFailure).isNotNull
+        assertThat(firstFailure).hasMessage("claim-before-mutation")
+        assertThat(localTool.invocations).isEmpty()
+        assertThat(runBlocking { localContinuationStore.get(exception.approvalId) }!!.status)
+            .isEqualTo(ApprovalContinuationStatus.PENDING)
+
+        val cancellation = CancellationException("replay-event-cancelled")
+        val secondAttemptEngine = createEngine(
+            provider = provider,
+            toolRegistry = ToolRegistry(mapOf(localTool.name to localTool)),
+            suspendedInvocationStore = localSuspendedStore,
+            approvalContinuationStore = localContinuationStore,
+            approvalGateCoordinator = replayCoordinator,
+            engineEventObserver = ThrowingEngineEventObserver(cancellation),
+        )
+        secondAttemptEngine.create<ResumeBootstrapService>()
+
+        val secondFailure = catchThrowableOfType(
+            { runBlocking { secondAttemptEngine.resumeApproval(command) } },
+            CancellationException::class.java,
+        )
+        assertThat(secondFailure).isSameAs(cancellation)
+        assertThat(localTool.invocations).isEmpty()
+        val pendingContinuationAfterCancellation = runBlocking { localContinuationStore.get(exception.approvalId) }
+        assertThat(pendingContinuationAfterCancellation).isNotNull
+        assertThat(pendingContinuationAfterCancellation!!.status).isEqualTo(ApprovalContinuationStatus.PENDING)
+
+        val recordingObserver = RecordingEngineEventObserver()
+        val recoveryEngine = createEngine(
+            provider = provider,
+            toolRegistry = ToolRegistry(mapOf(localTool.name to localTool)),
+            suspendedInvocationStore = localSuspendedStore,
+            approvalContinuationStore = localContinuationStore,
+            approvalGateCoordinator = replayCoordinator,
+            engineEventObserver = recordingObserver,
+        )
+        recoveryEngine.create<ResumeBootstrapService>()
+
+        val result = runBlocking { recoveryEngine.resumeApproval(command) }
+
+        assertThat(result).isEqualTo("Final result: success")
+        assertThat(localTool.invocations).hasSize(1)
+        assertThat(runBlocking { localContinuationStore.get(exception.approvalId) }!!.status)
+            .isEqualTo(ApprovalContinuationStatus.COMPLETED)
+        assertThat(replayCoordinator.authorizeCalls).isEqualTo(3)
+        val replayEvent = recordingObserver.events.single { it.first == "tramai.approval.authorization_replayed" }
+        assertThat(replayEvent.second).containsEntry("approvalId", exception.approvalId)
+        assertThat(replayEvent.second).containsEntry("toolName", toolName)
+    }
+
+    @Test
+    fun `resumeApproval recovers from first claim failure using real approval coordinator and stores`() {
+        val approvalStore = InMemoryApprovalStore(clock = fixedClock)
+        val realContinuationStore = InMemoryApprovalContinuationStore(clock = fixedClock)
+        val wrappedContinuationStore = ThrowingOnceClaimStore(delegate = realContinuationStore)
+        val approvalCoordinator = DefaultApprovalGateCoordinator(
+            store = approvalStore,
+            approvalIdGenerator = UuidApprovalIdGenerator(),
+            approvalTokenGenerator = SecureRandomApprovalTokenGenerator(),
+            approvalTokenDigester = Sha256ApprovalTokenDigester(),
+            clock = fixedClock,
+        )
+        val recordingObserver = RecordingEngineEventObserver()
+        val localTool = RecordingTool(name = toolName)
+        var localProviderCallCount = 0
+        val provider = RecordingProvider { _ ->
+            localProviderCallCount++
+            if (localProviderCallCount == 1) {
+                ModelResponse(
+                    content = "",
+                    toolCalls = listOf(ToolCall(toolCallId, toolName, toolArguments)),
+                )
+            } else {
+                ModelResponse(content = "Final result: success")
+            }
+        }
+        val suspendedStore = InMemorySuspendedInvocationStore()
+        val engine = createEngine(
+            provider = provider,
+            toolRegistry = ToolRegistry(mapOf(localTool.name to localTool)),
+            suspendedInvocationStore = suspendedStore,
+            approvalContinuationStore = wrappedContinuationStore,
+            approvalGateCoordinator = approvalCoordinator,
+            engineEventObserver = recordingObserver,
+        )
+
+        val exception = triggerSuspension(engine)
+        runBlocking {
+            approvalStore.transition(
+                approvalId = exception.approvalId,
+                expectedVersion = 0L,
+                transition = ApprovalTransition.Approve(
+                    decidedBy = "approver",
+                    comment = "approved",
+                ),
+            )
+        }
+        val command = ResumeApprovalCommand(
+            approvalId = exception.approvalId,
+            approvalExpectedVersion = 1L,
+            continuationExpectedVersion = 0L,
+            presentedToken = exception.challenge.token,
+            resumedBy = resumedBy,
+        )
+        engine.create<ResumeBootstrapService>()
+
+        val firstFailure = catchThrowableOfType(
+            { runBlocking { engine.resumeApproval(command) } },
+            RuntimeException::class.java,
+        )
+        assertThat(firstFailure).isNotNull
+        assertThat(firstFailure).hasMessage("claim-before-mutation")
+
+        val consumedApproval = runBlocking { approvalStore.get(exception.approvalId) }
+        assertThat(consumedApproval).isNotNull
+        assertThat(consumedApproval!!.consumedBy).isEqualTo(resumedBy)
+        assertThat(consumedApproval.version).isEqualTo(2L)
+        val pendingContinuation = runBlocking { realContinuationStore.get(exception.approvalId) }
+        assertThat(pendingContinuation).isNotNull
+        assertThat(pendingContinuation!!.status).isEqualTo(ApprovalContinuationStatus.PENDING)
+        assertThat(localTool.invocations).isEmpty()
+
+        val result = runBlocking { engine.resumeApproval(command) }
+
+        assertThat(result).isEqualTo("Final result: success")
+        assertThat(localTool.invocations).hasSize(1)
+        assertThat(runBlocking { realContinuationStore.get(exception.approvalId) }!!.status)
+            .isEqualTo(ApprovalContinuationStatus.COMPLETED)
+        val replayEvents = recordingObserver.events.filter { it.first == "tramai.approval.authorization_replayed" }
+        assertThat(replayEvents).hasSize(1)
+        assertThat(replayEvents.single().second).containsEntry("approvalId", exception.approvalId)
     }
 
     // ════════════════════════════════════════════════════════════════

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalResumeEngineTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalResumeEngineTest.kt
@@ -43,6 +43,8 @@ import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.fail
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
@@ -64,13 +66,16 @@ class ApprovalResumeEngineTest {
     private val resumedBy = "admin"
 
     /** Fake ApprovalGateCoordinator that always authorizes resume. */
-    private class PermitApprovalGateCoordinator : ApprovalGateCoordinator {
+    private class PermitApprovalGateCoordinator(
+        private val clock: Clock,
+    ) : ApprovalGateCoordinator {
         var lastAuthorizeCommand: AuthorizeResumeCommand? = null
         var lastValidateCommand: ValidateResumeCommand? = null
         var lastCreateCommand: CreateApprovalCommand? = null
         var nextChallengeId: String = UUID.randomUUID().toString()
         var validateCalls: Int = 0
         var authorizeCalls: Int = 0
+        private val replayedApprovalIds = linkedSetOf<String>()
 
         override suspend fun createApproval(command: CreateApprovalCommand): ApprovalChallenge {
             lastCreateCommand = command
@@ -89,7 +94,7 @@ class ApprovalResumeEngineTest {
             return ApprovalValidation(
                 approvalId = command.approvalId,
                 validatedBy = command.consumedBy,
-                validatedAt = Clock.systemUTC().instant(),
+                validatedAt = clock.instant(),
                 version = command.expectedVersion,
             )
         }
@@ -97,11 +102,13 @@ class ApprovalResumeEngineTest {
         override suspend fun authorizeResume(command: AuthorizeResumeCommand): ApprovalAuthorization {
             authorizeCalls++
             lastAuthorizeCommand = command
+            val replayed = !replayedApprovalIds.add(command.approvalId)
             return ApprovalAuthorization(
                 approvalId = command.approvalId,
                 consumedBy = command.consumedBy,
-                consumedAt = Clock.systemUTC().instant(),
-                version = command.expectedVersion,
+                consumedAt = clock.instant(),
+                version = command.expectedVersion + 1,
+                replayed = replayed,
             )
         }
 
@@ -113,6 +120,7 @@ class ApprovalResumeEngineTest {
     }
 
     private class ReplaySafeApprovalGateCoordinator(
+        private val clock: Clock,
         private val mode: Mode = Mode.NORMAL,
     ) : ApprovalGateCoordinator {
         enum class Mode {
@@ -121,6 +129,8 @@ class ApprovalResumeEngineTest {
         }
 
         private val durableReceipts = linkedMapOf<String, ApprovalAuthorization>()
+        private val durableTokenDigests = linkedMapOf<String, Sha256Digest>()
+        private val threwAfterDurableConsume = AtomicBoolean(false)
         var validateCalls: Int = 0
         var authorizeCalls: Int = 0
 
@@ -136,7 +146,7 @@ class ApprovalResumeEngineTest {
             return ApprovalValidation(
                 approvalId = command.approvalId,
                 validatedBy = command.consumedBy,
-                validatedAt = Clock.systemUTC().instant(),
+                validatedAt = clock.instant(),
                 version = command.expectedVersion,
             )
         }
@@ -145,7 +155,20 @@ class ApprovalResumeEngineTest {
             authorizeCalls++
             val existing = durableReceipts[command.approvalId]
             if (existing != null) {
-                if (existing.consumedBy != command.consumedBy || command.expectedVersion + 1 != existing.version) {
+                val storedTokenDigest = requireNotNull(durableTokenDigests[command.approvalId]) {
+                    "Missing durable token digest for replayed approval '${command.approvalId}'"
+                }
+                val presentedTokenDigest = tokenDigest(command.presentedToken)
+                // Defense in depth: these post-consume checks protect against test-store contract
+                // violations after the durable consume already happened.
+                if (
+                    existing.consumedBy != command.consumedBy ||
+                    command.expectedVersion + 1 != existing.version ||
+                    !MessageDigest.isEqual(
+                        storedTokenDigest.value.toByteArray(StandardCharsets.US_ASCII),
+                        presentedTokenDigest.value.toByteArray(StandardCharsets.US_ASCII),
+                    )
+                ) {
                     throw dev.tramai.core.exception.ApprovalAuthorizationException(command.approvalId)
                 }
                 return existing.copy(replayed = true)
@@ -154,11 +177,15 @@ class ApprovalResumeEngineTest {
             val authorization = ApprovalAuthorization(
                 approvalId = command.approvalId,
                 consumedBy = command.consumedBy,
-                consumedAt = Clock.systemUTC().instant(),
+                consumedAt = clock.instant(),
                 version = command.expectedVersion + 1,
             )
             durableReceipts[command.approvalId] = authorization
-            if (mode == Mode.THROW_AFTER_DURABLE_CONSUME_ONCE) {
+            durableTokenDigests[command.approvalId] = tokenDigest(command.presentedToken)
+            if (
+                mode == Mode.THROW_AFTER_DURABLE_CONSUME_ONCE &&
+                threwAfterDurableConsume.compareAndSet(false, true)
+            ) {
                 throw IOException("adapter-secret-marker")
             }
             return authorization
@@ -169,6 +196,13 @@ class ApprovalResumeEngineTest {
             expectedVersion: Long,
             reason: String,
         ) = Unit
+
+        private fun tokenDigest(token: ApprovalToken): Sha256Digest {
+            val bytes = MessageDigest.getInstance("SHA-256")
+                .digest(token.reveal().toByteArray(StandardCharsets.UTF_8))
+            val hex = bytes.joinToString(separator = "") { byte -> "%02x".format(byte) }
+            return Sha256Digest.of("sha256:$hex")
+        }
     }
 
     private class ThrowingOnceClaimStore(
@@ -250,7 +284,7 @@ class ApprovalResumeEngineTest {
 
     private val tool = RecordingTool()
     private val toolRegistry = ToolRegistry(mapOf(tool.name to tool))
-    private val coordinator = PermitApprovalGateCoordinator()
+    private val coordinator = PermitApprovalGateCoordinator(fixedClock)
     private val continuationStore = InMemoryApprovalContinuationStore(clock = fixedClock)
     private val digester = Sha256ToolArgumentsDigester()
     private val suspendedInvocationStore = InMemorySuspendedInvocationStore()
@@ -298,14 +332,25 @@ class ApprovalResumeEngineTest {
         }
     }
 
-    private fun createEngine(): TramaiEngine = TramaiEngine(
+    private fun createEngine(
+        provider: dev.tramai.core.provider.ModelProvider = this.provider,
+        toolRegistry: ToolRegistry = this.toolRegistry,
+        policyEngine: PolicyEngine = this.policyEngine,
+        suspendedInvocationStore: SuspendedInvocationStore = this.suspendedInvocationStore,
+        approvalContinuationStore: dev.tramai.core.approval.ApprovalContinuationStore = continuationStore,
+        approvalGateCoordinator: ApprovalGateCoordinator = coordinator,
+        engineEventObserver: EngineEventObserver = NoOpEngineEventObserver,
+        approvalLifecycleAuditEmitter: dev.tramai.core.approval.ApprovalLifecycleAuditEmitter = NoOpApprovalLifecycleAuditEmitter,
+    ): TramaiEngine = TramaiEngine(
         provider = provider,
         toolRegistry = toolRegistry,
         policyEngine = policyEngine,
         suspendedInvocationStore = suspendedInvocationStore,
-        approvalContinuationStore = continuationStore,
+        approvalContinuationStore = approvalContinuationStore,
         toolArgumentsDigester = digester,
-        approvalGateCoordinator = coordinator,
+        approvalGateCoordinator = approvalGateCoordinator,
+        engineEventObserver = engineEventObserver,
+        approvalLifecycleAuditEmitter = approvalLifecycleAuditEmitter,
         clock = fixedClock,
     )
 
@@ -409,7 +454,7 @@ class ApprovalResumeEngineTest {
             ),
             approvalContinuationStore = continuationStore,
             toolArgumentsDigester = digester,
-            approvalGateCoordinator = PermitApprovalGateCoordinator(),
+            approvalGateCoordinator = PermitApprovalGateCoordinator(fixedClock),
             clock = fixedClock,
         )
 
@@ -464,7 +509,7 @@ class ApprovalResumeEngineTest {
             ),
             approvalContinuationStore = continuationStore,
             toolArgumentsDigester = digester,
-            approvalGateCoordinator = PermitApprovalGateCoordinator(),
+            approvalGateCoordinator = PermitApprovalGateCoordinator(fixedClock),
             clock = fixedClock,
         )
 
@@ -537,7 +582,7 @@ class ApprovalResumeEngineTest {
             suspendedInvocationStore = InMemorySuspendedInvocationStore(),
             approvalContinuationStore = divergentContinuationStore,
             toolArgumentsDigester = digester,
-            approvalGateCoordinator = PermitApprovalGateCoordinator(),
+            approvalGateCoordinator = PermitApprovalGateCoordinator(fixedClock),
             clock = fixedClock,
         )
 
@@ -608,7 +653,7 @@ class ApprovalResumeEngineTest {
             suspendedInvocationStore = InMemorySuspendedInvocationStore(),
             approvalContinuationStore = divergentContinuationStore,
             toolArgumentsDigester = digester,
-            approvalGateCoordinator = PermitApprovalGateCoordinator(),
+            approvalGateCoordinator = PermitApprovalGateCoordinator(fixedClock),
             clock = fixedClock,
         )
 
@@ -664,7 +709,7 @@ class ApprovalResumeEngineTest {
             ),
             approvalContinuationStore = continuationStore,
             toolArgumentsDigester = digester,
-            approvalGateCoordinator = PermitApprovalGateCoordinator(),
+            approvalGateCoordinator = PermitApprovalGateCoordinator(fixedClock),
             clock = fixedClock,
         )
 
@@ -743,7 +788,7 @@ class ApprovalResumeEngineTest {
             suspendedInvocationStore = suspendedStore,
             approvalContinuationStore = continuationStore,
             toolArgumentsDigester = digester,
-            approvalGateCoordinator = PermitApprovalGateCoordinator(),
+            approvalGateCoordinator = PermitApprovalGateCoordinator(fixedClock),
             clock = fixedClock,
             approvalLifecycleAuditEmitter = auditEmitter,
         )
@@ -757,7 +802,7 @@ class ApprovalResumeEngineTest {
             suspendedInvocationStore = suspendedStore,
             approvalContinuationStore = continuationStore,
             toolArgumentsDigester = digester,
-            approvalGateCoordinator = PermitApprovalGateCoordinator(),
+            approvalGateCoordinator = PermitApprovalGateCoordinator(fixedClock),
             clock = fixedClock,
             approvalLifecycleAuditEmitter = auditEmitter,
         )
@@ -882,7 +927,7 @@ class ApprovalResumeEngineTest {
             suspendedInvocationStore = InMemorySuspendedInvocationStore(),
             approvalContinuationStore = continuationStore,
             toolArgumentsDigester = digester,
-            approvalGateCoordinator = PermitApprovalGateCoordinator(),
+            approvalGateCoordinator = PermitApprovalGateCoordinator(fixedClock),
             clock = fixedClock,
             approvalLifecycleAuditEmitter = auditEmitter,
         )
@@ -984,7 +1029,7 @@ class ApprovalResumeEngineTest {
             suspendedInvocationStore = InMemorySuspendedInvocationStore(),
             approvalContinuationStore = continuationStore,
             toolArgumentsDigester = digester,
-            approvalGateCoordinator = PermitApprovalGateCoordinator(),
+            approvalGateCoordinator = PermitApprovalGateCoordinator(fixedClock),
             clock = fixedClock,
             approvalLifecycleAuditEmitter = auditEmitter,
         )
@@ -1159,7 +1204,7 @@ class ApprovalResumeEngineTest {
             suspendedInvocationStore = InMemorySuspendedInvocationStore(),
             approvalContinuationStore = InMemoryApprovalContinuationStore(clock = fixedClock),
             toolArgumentsDigester = digester,
-            approvalGateCoordinator = PermitApprovalGateCoordinator(),
+            approvalGateCoordinator = PermitApprovalGateCoordinator(fixedClock),
             clock = fixedClock,
         )
 
@@ -1386,6 +1431,129 @@ class ApprovalResumeEngineTest {
         assertThatThrownBy {
             runBlocking { engine.resumeApproval(command) }
         }.isInstanceOf(dev.tramai.core.exception.ApprovalNotFoundException::class.java)
+    }
+
+    @Test
+    fun `resumeApproval retries exact same command after durable consume adapter failure and emits replay event`() {
+        val engineEventObserver = RecordingEngineEventObserver()
+        val replayCoordinator = ReplaySafeApprovalGateCoordinator(
+            clock = fixedClock,
+            mode = ReplaySafeApprovalGateCoordinator.Mode.THROW_AFTER_DURABLE_CONSUME_ONCE,
+        )
+        val localSuspendedStore = InMemorySuspendedInvocationStore()
+        val localContinuationStore = InMemoryApprovalContinuationStore(clock = fixedClock)
+        var localProviderCallCount = 0
+        val provider = RecordingProvider { _ ->
+            localProviderCallCount++
+            if (localProviderCallCount == 1) {
+                ModelResponse(
+                    content = "",
+                    toolCalls = listOf(ToolCall(toolCallId, toolName, toolArguments)),
+                )
+            } else {
+                ModelResponse(content = "Final result: success")
+            }
+        }
+        val suspendingEngine = createEngine(
+            provider = provider,
+            suspendedInvocationStore = localSuspendedStore,
+            approvalContinuationStore = localContinuationStore,
+            approvalGateCoordinator = PermitApprovalGateCoordinator(fixedClock),
+        )
+        val exception = triggerSuspension(suspendingEngine)
+        val engine = createEngine(
+            provider = provider,
+            suspendedInvocationStore = localSuspendedStore,
+            approvalContinuationStore = localContinuationStore,
+            approvalGateCoordinator = replayCoordinator,
+            engineEventObserver = engineEventObserver,
+        )
+        engine.create<ResumeBootstrapService>()
+        val command = ResumeApprovalCommand(
+            approvalId = exception.approvalId,
+            approvalExpectedVersion = 0L,
+            continuationExpectedVersion = 0L,
+            presentedToken = exception.challenge.token,
+            resumedBy = resumedBy,
+        )
+
+        val firstFailure = catchThrowableOfType(
+            { runBlocking { engine.resumeApproval(command) } },
+            IOException::class.java,
+        )
+        assertThat(firstFailure).isNotNull
+        assertThat(firstFailure).hasMessage("adapter-secret-marker")
+
+        val result = runBlocking { engine.resumeApproval(command) }
+
+        assertThat(result).isEqualTo("Final result: success")
+        assertThat(replayCoordinator.authorizeCalls).isEqualTo(2)
+        val replayEvent = engineEventObserver.events.single { it.first == "tramai.approval.authorization_replayed" }
+        assertThat(replayEvent.second).containsEntry("approvalId", exception.approvalId)
+        assertThat(replayEvent.second).containsEntry("toolName", toolName)
+        assertThat(replayEvent.second.keys).containsExactlyInAnyOrder("approvalId", "workflowRunId", "toolName")
+        assertThat(replayEvent.second.values.map { it?.toString() }).doesNotContain(exception.challenge.token.reveal())
+    }
+
+    @Test
+    fun `resumeApproval retries exact same command after claim failure once and emits replay event`() {
+        val engineEventObserver = RecordingEngineEventObserver()
+        val replayCoordinator = ReplaySafeApprovalGateCoordinator(clock = fixedClock)
+        val localSuspendedStore = InMemorySuspendedInvocationStore()
+        val localContinuationStore = ThrowingOnceClaimStore(
+            delegate = InMemoryApprovalContinuationStore(clock = fixedClock),
+        )
+        var localProviderCallCount = 0
+        val provider = RecordingProvider { _ ->
+            localProviderCallCount++
+            if (localProviderCallCount == 1) {
+                ModelResponse(
+                    content = "",
+                    toolCalls = listOf(ToolCall(toolCallId, toolName, toolArguments)),
+                )
+            } else {
+                ModelResponse(content = "Final result: success")
+            }
+        }
+        val suspendingEngine = createEngine(
+            provider = provider,
+            suspendedInvocationStore = localSuspendedStore,
+            approvalContinuationStore = localContinuationStore,
+            approvalGateCoordinator = PermitApprovalGateCoordinator(fixedClock),
+        )
+        val exception = triggerSuspension(suspendingEngine)
+        val engine = createEngine(
+            provider = provider,
+            suspendedInvocationStore = localSuspendedStore,
+            approvalContinuationStore = localContinuationStore,
+            approvalGateCoordinator = replayCoordinator,
+            engineEventObserver = engineEventObserver,
+        )
+        engine.create<ResumeBootstrapService>()
+        val command = ResumeApprovalCommand(
+            approvalId = exception.approvalId,
+            approvalExpectedVersion = 0L,
+            continuationExpectedVersion = 0L,
+            presentedToken = exception.challenge.token,
+            resumedBy = resumedBy,
+        )
+
+        val firstFailure = catchThrowableOfType(
+            { runBlocking { engine.resumeApproval(command) } },
+            RuntimeException::class.java,
+        )
+        assertThat(firstFailure).isNotNull
+        assertThat(firstFailure).hasMessage("claim-before-mutation")
+
+        val result = runBlocking { engine.resumeApproval(command) }
+
+        assertThat(result).isEqualTo("Final result: success")
+        assertThat(replayCoordinator.authorizeCalls).isEqualTo(2)
+        val replayEvent = engineEventObserver.events.single { it.first == "tramai.approval.authorization_replayed" }
+        assertThat(replayEvent.second).containsEntry("approvalId", exception.approvalId)
+        assertThat(replayEvent.second).containsEntry("toolName", toolName)
+        assertThat(replayEvent.second.keys).containsExactlyInAnyOrder("approvalId", "workflowRunId", "toolName")
+        assertThat(replayEvent.second.values.map { it?.toString() }).doesNotContain(exception.challenge.token.reveal())
     }
 
     // ════════════════════════════════════════════════════════════════
@@ -1635,7 +1803,7 @@ class ApprovalResumeEngineTest {
         val mtToolRegistry = ToolRegistry(mapOf(mtTool.name to mtTool))
         val mtPolicyEngine = MultiToolPolicyEngine()
         val mtProvider = MultiToolProvider()
-        val mtCoordinator = PermitApprovalGateCoordinator()
+        val mtCoordinator = PermitApprovalGateCoordinator(fixedClock)
 
         val engine = TramaiEngine(
             provider = mtProvider,
@@ -1730,7 +1898,7 @@ class ApprovalResumeEngineTest {
 
         val nestedTool = RecordingTool(name = "test_calculator")
         val nestedToolRegistry = ToolRegistry(mapOf(nestedTool.name to nestedTool))
-        val nestedCoordinator = PermitApprovalGateCoordinator()
+        val nestedCoordinator = PermitApprovalGateCoordinator(fixedClock)
         val nestedContinuationStore = InMemoryApprovalContinuationStore(clock = fixedClock)
 
         val engine = TramaiEngine(
@@ -1926,7 +2094,7 @@ class ApprovalResumeEngineTest {
             suspendedInvocationStore = freshSuspendedStore,
             approvalContinuationStore = freshContinuationStore,
             toolArgumentsDigester = digester,
-            approvalGateCoordinator = PermitApprovalGateCoordinator(),
+            approvalGateCoordinator = PermitApprovalGateCoordinator(fixedClock),
             clock = fixedClock,
             approvalLifecycleAuditEmitter = auditEmitter,
         )
@@ -2027,7 +2195,7 @@ class ApprovalResumeEngineTest {
             suspendedInvocationStore = freshSuspendedStore,
             approvalContinuationStore = freshContinuationStore,
             toolArgumentsDigester = digester,
-            approvalGateCoordinator = PermitApprovalGateCoordinator(),
+            approvalGateCoordinator = PermitApprovalGateCoordinator(fixedClock),
             clock = fixedClock,
             approvalLifecycleAuditEmitter = auditEmitter,
         )
@@ -2116,7 +2284,7 @@ class ApprovalResumeEngineTest {
             suspendedInvocationStore = freshSuspendedStore,
             approvalContinuationStore = freshContinuationStore,
             toolArgumentsDigester = Sha256ToolArgumentsDigester(),
-            approvalGateCoordinator = PermitApprovalGateCoordinator(),
+            approvalGateCoordinator = PermitApprovalGateCoordinator(fixedClock),
             clock = fixedClock,
         )
 

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/TramaiEngineTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/TramaiEngineTest.kt
@@ -63,6 +63,7 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Nested
 import java.time.Clock
@@ -77,10 +78,21 @@ import kotlin.test.Test
 class TramaiEngineTest {
 
     companion object {
+        private var originalLevel: Level? = null
+
         @JvmStatic
         @BeforeAll
         fun suppressPolicyMigrationWarnings() {
-            Logger.getLogger(PolicyEnforcementHelper::class.java.name).level = Level.OFF
+            val logger = Logger.getLogger(PolicyEnforcementHelper::class.java.name)
+            originalLevel = logger.level
+            logger.level = Level.OFF
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun restoreLoggerLevel() {
+            val logger = Logger.getLogger(PolicyEnforcementHelper::class.java.name)
+            originalLevel?.let { logger.level = it }
         }
     }
 

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/TramaiEngineTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/TramaiEngineTest.kt
@@ -63,15 +63,26 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Nested
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
 import java.util.Collections
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.logging.Level
+import java.util.logging.Logger
 import kotlin.test.Test
 
 class TramaiEngineTest {
+
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun suppressPolicyMigrationWarnings() {
+            Logger.getLogger(PolicyEnforcementHelper::class.java.name).level = Level.OFF
+        }
+    }
 
     @Test
     fun `creates a suspend proxy and returns provider content`() {

--- a/tramai-security/src/main/kotlin/dev/tramai/security/approval/DefaultApprovalGateCoordinator.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/approval/DefaultApprovalGateCoordinator.kt
@@ -3,7 +3,6 @@ package dev.tramai.security.approval
 import dev.tramai.core.approval.ApprovalAuthorization
 import dev.tramai.core.approval.ApprovalBinding
 import dev.tramai.core.approval.ApprovalChallenge
-import dev.tramai.core.approval.ApprovalConsumptionReceipt
 import dev.tramai.core.approval.ApprovalDecisionValidator
 import dev.tramai.core.approval.ApprovalGateCoordinator
 import dev.tramai.core.approval.ApprovalIdGenerator
@@ -31,7 +30,6 @@ import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 import java.time.Clock
 import java.time.Duration
-import java.time.Instant
 import kotlinx.coroutines.CancellationException
 
 class DefaultApprovalGateCoordinator(

--- a/tramai-security/src/main/kotlin/dev/tramai/security/approval/DefaultApprovalGateCoordinator.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/approval/DefaultApprovalGateCoordinator.kt
@@ -3,6 +3,7 @@ package dev.tramai.security.approval
 import dev.tramai.core.approval.ApprovalAuthorization
 import dev.tramai.core.approval.ApprovalBinding
 import dev.tramai.core.approval.ApprovalChallenge
+import dev.tramai.core.approval.ApprovalConsumptionReceipt
 import dev.tramai.core.approval.ApprovalDecisionValidator
 import dev.tramai.core.approval.ApprovalGateCoordinator
 import dev.tramai.core.approval.ApprovalIdGenerator
@@ -26,8 +27,12 @@ import dev.tramai.core.exception.ApprovalStoreNotConsumableException
 import dev.tramai.core.exception.ApprovalStoreNotFoundException
 import dev.tramai.core.exception.ApprovalStoreTokenRejectedException
 import dev.tramai.core.exception.ApprovalTokenRejectedException
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 import java.time.Clock
 import java.time.Duration
+import java.time.Instant
+import kotlinx.coroutines.CancellationException
 
 class DefaultApprovalGateCoordinator(
     private val store: ApprovalStore,
@@ -87,7 +92,9 @@ class DefaultApprovalGateCoordinator(
 
         try {
             store.create(request)
-        } catch (e: RuntimeException) {
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
             observeFailure("createApproval", approvalId, e)
             throw when (e) {
                 is ApprovalStoreConflictException -> ApprovalCreationException(approvalId)
@@ -121,7 +128,9 @@ class DefaultApprovalGateCoordinator(
                     comment = "cancelled: $reason",
                 ),
             )
-        } catch (e: RuntimeException) {
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
             observeFailure("cancelApproval", approvalId, e)
             throw mapStoreError(approvalId, e)
         }
@@ -141,30 +150,39 @@ class DefaultApprovalGateCoordinator(
             operationName = "authorizeResume",
         )
 
-        val consumed = try {
-            store.consumeApproved(
+        val receipt = try {
+            store.consumeApprovedOrReplay(
                 approvalId = command.approvalId,
                 expectedVersion = command.expectedVersion,
                 presentedTokenDigest = presentedTokenDigest,
                 consumedBy = command.consumedBy,
             )
-        } catch (e: RuntimeException) {
-            observeFailure("authorizeResume.consumeApproved", command.approvalId, e)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            observeFailure("authorizeResume.consumeApprovedOrReplay", command.approvalId, e)
             throw mapStoreError(command.approvalId, e)
         }
+        val consumed = receipt.request
 
         if (consumed.approvalId != command.approvalId) throw ApprovalAuthorizationException(command.approvalId)
         if (consumed.binding != request.binding) throw ApprovalAuthorizationException(command.approvalId)
         if (consumed.status != ApprovalStatus.APPROVED) throw ApprovalAuthorizationException(command.approvalId)
         if (consumed.consumedBy != command.consumedBy) throw ApprovalAuthorizationException(command.approvalId)
         if (consumed.consumedAt == null) throw ApprovalAuthorizationException(command.approvalId)
-        if (consumed.version != Math.addExact(command.expectedVersion, 1L)) throw ApprovalAuthorizationException(command.approvalId)
+        val expectedConsumedVersion = try {
+            Math.addExact(command.expectedVersion, 1L)
+        } catch (_: ArithmeticException) {
+            throw ApprovalAuthorizationException(command.approvalId)
+        }
+        if (consumed.version != expectedConsumedVersion) throw ApprovalAuthorizationException(command.approvalId)
 
         return ApprovalAuthorization(
             approvalId = consumed.approvalId,
             consumedBy = consumed.consumedBy!!,
             consumedAt = consumed.consumedAt!!,
             version = consumed.version,
+            replayed = receipt.replayed,
         )
     }
 
@@ -239,7 +257,9 @@ class DefaultApprovalGateCoordinator(
 
         val request = try {
             store.get(approvalId)
-        } catch (e: RuntimeException) {
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
             observeFailure("$operationName.get", approvalId, e)
             throw mapStoreError(approvalId, e)
         } ?: throw ApprovalNotFoundException(approvalId)
@@ -254,13 +274,60 @@ class DefaultApprovalGateCoordinator(
             workflowDigest = workflowDigest,
         )
         val presentedTokenDigest = approvalTokenDigester.digest(presentedToken)
+        validateAuthorizationCandidate(
+            request = request,
+            approvalId = approvalId,
+            expectedVersion = expectedVersion,
+            presentedTokenDigest = presentedTokenDigest,
+            consumedBy = consumedBy,
+        )
         decisionValidator.validate(request, consumedBy)
         return request to presentedTokenDigest
     }
 
+    private fun validateAuthorizationCandidate(
+        request: ApprovalRequest,
+        approvalId: String,
+        expectedVersion: Long,
+        presentedTokenDigest: dev.tramai.core.approval.Sha256Digest,
+        consumedBy: String,
+    ) {
+        if (!tokenDigestsMatch(presentedTokenDigest, request.binding.approvalTokenDigest)) {
+            throw ApprovalTokenRejectedException(approvalId)
+        }
+        if (request.status != ApprovalStatus.APPROVED) {
+            throw ApprovalAuthorizationException(approvalId)
+        }
+
+        if (request.consumedAt == null && request.consumedBy == null) {
+            if (request.version != expectedVersion) {
+                throw ApprovalAuthorizationException(approvalId)
+            }
+            if (!clock.instant().isBefore(request.expiresAt)) {
+                throw ApprovalAuthorizationException(approvalId)
+            }
+            return
+        }
+
+        if (request.consumedAt == null || request.consumedBy == null) {
+            throw ApprovalAuthorizationException(approvalId)
+        }
+        if (request.consumedBy != consumedBy) {
+            throw ApprovalAuthorizationException(approvalId)
+        }
+        val replayVersion = try {
+            Math.addExact(expectedVersion, 1L)
+        } catch (_: ArithmeticException) {
+            throw ApprovalAuthorizationException(approvalId)
+        }
+        if (request.version != replayVersion) {
+            throw ApprovalAuthorizationException(approvalId)
+        }
+    }
+
     private fun mapStoreError(
         approvalId: String,
-        exception: RuntimeException,
+        exception: Exception,
     ): RuntimeException {
         return when (exception) {
             is ApprovalStoreNotFoundException -> ApprovalNotFoundException(approvalId)
@@ -274,10 +341,10 @@ class DefaultApprovalGateCoordinator(
     private fun observeFailure(
         operation: String,
         approvalId: String?,
-        failure: RuntimeException,
+        failure: Exception,
     ) {
         try {
-            failureObserver?.record(operation, approvalId, failure)
+            failureObserver?.record(operation, approvalId, failure as? RuntimeException ?: RuntimeException(failure))
         } catch (_: RuntimeException) {
             // Diagnostic observers must not replace safe public failures.
         }
@@ -291,4 +358,13 @@ class DefaultApprovalGateCoordinator(
         require(trimmed == value) { "$fieldName must not contain surrounding whitespace" }
         return trimmed
     }
+
+    private fun tokenDigestsMatch(
+        presentedTokenDigest: dev.tramai.core.approval.Sha256Digest,
+        storedTokenDigest: dev.tramai.core.approval.Sha256Digest,
+    ): Boolean =
+        MessageDigest.isEqual(
+            presentedTokenDigest.value.toByteArray(StandardCharsets.US_ASCII),
+            storedTokenDigest.value.toByteArray(StandardCharsets.US_ASCII),
+        )
 }

--- a/tramai-security/src/main/kotlin/dev/tramai/security/approval/InMemoryApprovalStore.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/approval/InMemoryApprovalStore.kt
@@ -1,6 +1,7 @@
 package dev.tramai.security.approval
 
 import dev.tramai.core.approval.ApprovalRequest
+import dev.tramai.core.approval.ApprovalConsumptionReceipt
 import dev.tramai.core.approval.ApprovalStatus
 import dev.tramai.core.approval.ApprovalStore
 import dev.tramai.core.approval.ApprovalTransition
@@ -16,6 +17,7 @@ import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 
 class InMemoryApprovalStore(
     private val clock: Clock = Clock.systemUTC(),
@@ -144,43 +146,59 @@ class InMemoryApprovalStore(
         return result ?: throw ApprovalStoreNotFoundException(approvalId)
     }
 
-    override suspend fun consumeApproved(
+    override suspend fun consumeApprovedOrReplay(
         approvalId: String,
         expectedVersion: Long,
         presentedTokenDigest: Sha256Digest,
         consumedBy: String,
-    ): ApprovalRequest {
+    ): ApprovalConsumptionReceipt {
         validateIdField(approvalId, "approvalId", maxIdLength)
         validateIdField(consumedBy, "consumedBy", maxIdLength)
 
+        val replayed = AtomicBoolean(false)
         val result = store.compute(approvalId) { _, current ->
             val req = current ?: throw ApprovalStoreNotFoundException(approvalId)
 
-            if (req.version != expectedVersion) throw ApprovalStoreConflictException(approvalId)
-
             if (req.status != ApprovalStatus.APPROVED) throw ApprovalStoreNotConsumableException(approvalId)
 
-            val now = clock.instant()
-            if (now >= req.expiresAt) throw ApprovalStoreNotConsumableException(approvalId)
-
-            if (req.consumedAt != null) throw ApprovalStoreNotConsumableException(approvalId)
-
-            // Constant-time comparison of token digests
-            if (!MessageDigest.isEqual(
-                    presentedTokenDigest.value.toByteArray(StandardCharsets.US_ASCII),
-                    req.binding.approvalTokenDigest.value.toByteArray(StandardCharsets.US_ASCII),
-                )) {
+            if (!tokenDigestsMatch(presentedTokenDigest, req.binding.approvalTokenDigest)) {
                 throw ApprovalStoreTokenRejectedException(approvalId)
             }
 
-            req.copy(
-                consumedBy = consumedBy,
-                consumedAt = now,
-                version = incrementVersion(approvalId, req.version),
-            )
+            if (req.consumedAt == null && req.consumedBy == null) {
+                if (req.version != expectedVersion) throw ApprovalStoreConflictException(approvalId)
+
+                val now = clock.instant()
+                if (now >= req.expiresAt) throw ApprovalStoreNotConsumableException(approvalId)
+
+                replayed.set(false)
+                req.copy(
+                    consumedBy = consumedBy,
+                    consumedAt = now,
+                    version = incrementVersion(approvalId, req.version),
+                )
+            } else {
+                if (req.consumedAt == null || req.consumedBy == null) {
+                    throw ApprovalStoreNotConsumableException(approvalId)
+                }
+                if (req.consumedBy != consumedBy) throw ApprovalStoreNotConsumableException(approvalId)
+
+                val replayVersion = try {
+                    Math.addExact(expectedVersion, 1L)
+                } catch (_: ArithmeticException) {
+                    throw ApprovalStoreConflictException(approvalId)
+                }
+                if (req.version != replayVersion) throw ApprovalStoreConflictException(approvalId)
+
+                replayed.set(true)
+                req
+            }
         }
 
-        return result ?: throw ApprovalStoreNotFoundException(approvalId)
+        return ApprovalConsumptionReceipt(
+            request = result ?: throw ApprovalStoreNotFoundException(approvalId),
+            replayed = replayed.get(),
+        )
     }
 
     private fun incrementVersion(
@@ -197,6 +215,15 @@ class InMemoryApprovalStore(
                 approvalId,
             )
         }
+
+    private fun tokenDigestsMatch(
+        presentedTokenDigest: Sha256Digest,
+        storedTokenDigest: Sha256Digest,
+    ): Boolean =
+        MessageDigest.isEqual(
+            presentedTokenDigest.value.toByteArray(StandardCharsets.US_ASCII),
+            storedTokenDigest.value.toByteArray(StandardCharsets.US_ASCII),
+        )
 
     private fun resolveNextStatus(
         current: ApprovalRequest,

--- a/tramai-security/src/test/kotlin/dev/tramai/security/approval/DefaultApprovalGateCoordinatorTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/approval/DefaultApprovalGateCoordinatorTest.kt
@@ -1369,7 +1369,7 @@ class DefaultApprovalGateCoordinatorTest {
 }
 
 private class CoordinatorMutableClock(
-    private var now: Instant,
+    @Volatile private var now: Instant,
     private val zone: ZoneId = ZoneId.of("UTC"),
 ) : Clock() {
     override fun instant(): Instant = now

--- a/tramai-security/src/test/kotlin/dev/tramai/security/approval/DefaultApprovalGateCoordinatorTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/approval/DefaultApprovalGateCoordinatorTest.kt
@@ -1,6 +1,7 @@
 package dev.tramai.security.approval
 
 import dev.tramai.core.approval.ApprovalBinding
+import dev.tramai.core.approval.ApprovalConsumptionReceipt
 import dev.tramai.core.approval.ApprovalIdGenerator
 import dev.tramai.core.approval.ApprovalRequest
 import dev.tramai.core.approval.ApprovalStatus
@@ -12,6 +13,7 @@ import dev.tramai.core.approval.ApprovalTransition
 import dev.tramai.core.approval.AuthorizeResumeCommand
 import dev.tramai.core.approval.CreateApprovalCommand
 import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.approval.ValidateResumeCommand
 import dev.tramai.core.exception.ApprovalAuthorizationException
 import dev.tramai.core.exception.ApprovalBindingMismatchException
 import dev.tramai.core.exception.ApprovalCreationException
@@ -28,11 +30,14 @@ import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
 import java.util.concurrent.CountDownLatch
+import java.io.IOException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.catchThrowableOfType
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -177,6 +182,7 @@ class DefaultApprovalGateCoordinatorTest {
         assertThat(authorization.consumedBy).isEqualTo("consumer-1")
         assertThat(authorization.consumedAt).isEqualTo(clock.instant())
         assertThat(authorization.version).isEqualTo(2L)
+        assertThat(authorization.replayed).isFalse()
     }
 
     @Test
@@ -247,12 +253,63 @@ class DefaultApprovalGateCoordinatorTest {
     }
 
     @Test
-    fun `second consume rejected`() : Unit = runBlocking {
+    fun `validateResume rejects wrong token`() : Unit = runBlocking {
+        val challenge = approvedChallenge()
+
+        assertThatThrownBy {
+            runBlocking {
+                coordinator.validateResume(
+                    validateCommand(challenge, presentedToken = ApprovalToken.parsePresented("wrong-token")),
+                )
+            }
+        }
+            .isInstanceOf(ApprovalTokenRejectedException::class.java)
+    }
+
+    @Test
+    fun `validateResume accepts exact replay candidate`() : Unit = runBlocking {
+        val challenge = approvedChallenge()
+        coordinator.authorizeResume(authorizeCommand(challenge))
+
+        val validation = coordinator.validateResume(validateCommand(challenge))
+
+        assertThat(validation.approvalId).isEqualTo(fixedApprovalId)
+        assertThat(validation.validatedBy).isEqualTo("consumer-1")
+        assertThat(validation.version).isEqualTo(1L)
+    }
+
+    @Test
+    fun `same command replay succeeds with replayed true`() : Unit = runBlocking {
+        val challenge = approvedChallenge()
+        val first = coordinator.authorizeResume(authorizeCommand(challenge))
+        val replay = coordinator.authorizeResume(authorizeCommand(challenge))
+
+        assertThat(first.replayed).isFalse()
+        assertThat(replay.replayed).isTrue()
+        assertThat(replay.version).isEqualTo(2L)
+        assertThat(replay.consumedAt).isEqualTo(first.consumedAt)
+    }
+
+    @Test
+    fun `changed expected version after consumption is rejected`() : Unit = runBlocking {
         val challenge = approvedChallenge()
         coordinator.authorizeResume(authorizeCommand(challenge))
 
         assertThatThrownBy {
             runBlocking { coordinator.authorizeResume(authorizeCommand(challenge, expectedVersion = 2L)) }
+        }
+            .isInstanceOf(ApprovalAuthorizationException::class.java)
+    }
+
+    @Test
+    fun `changed actor rejected after consumption`() : Unit = runBlocking {
+        val challenge = approvedChallenge()
+        coordinator.authorizeResume(authorizeCommand(challenge))
+
+        assertThatThrownBy {
+            runBlocking {
+                coordinator.authorizeResume(authorizeCommand(challenge, consumedBy = "consumer-2"))
+            }
         }
             .isInstanceOf(ApprovalAuthorizationException::class.java)
     }
@@ -339,6 +396,19 @@ class DefaultApprovalGateCoordinatorTest {
     }
 
     @Test
+    fun `validateResume changed binding is rejected`() : Unit = runBlocking {
+        val challenge = approvedChallenge()
+
+        assertThatThrownBy {
+            runBlocking {
+                coordinator.validateResume(validateCommand(challenge, toolName = "tool-2"))
+            }
+        }
+            .isInstanceOf(ApprovalBindingMismatchException::class.java)
+            .hasMessage("Approval binding mismatch for '$fixedApprovalId': toolName")
+    }
+
+    @Test
     fun `binding mismatch leaves unconsumed`() : Unit = runBlocking {
         val challenge = approvedChallenge()
 
@@ -365,7 +435,7 @@ class DefaultApprovalGateCoordinatorTest {
     }
 
     @Test
-    fun `concurrent calls exactly one succeeds`() : Unit = runBlocking {
+    fun `concurrent identical calls yield one fresh authorization and one replay`() : Unit = runBlocking {
         val challenge = approvedChallenge()
         val start = CountDownLatch(1)
 
@@ -383,9 +453,36 @@ class DefaultApprovalGateCoordinatorTest {
         start.countDown()
         val settled = results.awaitAll()
 
+        assertThat(settled.count { it.isSuccess }).isEqualTo(2)
+        assertThat(settled.count { it.isFailure }).isEqualTo(0)
+        val authorizations = settled.map { it.getOrThrow() }
+        assertThat(authorizations.count { !it.replayed }).isEqualTo(1)
+        assertThat(authorizations.count { it.replayed }).isEqualTo(1)
+        assertThat(store.get(fixedApprovalId)!!.consumedAt).isNotNull()
+    }
+
+    @Test
+    fun `concurrent different actors allow only original consumer`() : Unit = runBlocking {
+        val challenge = approvedChallenge()
+        val start = CountDownLatch(1)
+
+        val results = listOf(
+            async(Dispatchers.Default) {
+                start.await()
+                runCatching { coordinator.authorizeResume(authorizeCommand(challenge, consumedBy = "consumer-1")) }
+            },
+            async(Dispatchers.Default) {
+                start.await()
+                runCatching { coordinator.authorizeResume(authorizeCommand(challenge, consumedBy = "consumer-2")) }
+            },
+        )
+
+        start.countDown()
+        val settled = results.awaitAll()
+
         assertThat(settled.count { it.isSuccess }).isEqualTo(1)
         assertThat(settled.count { it.isFailure }).isEqualTo(1)
-        assertThat(store.get(fixedApprovalId)!!.consumedAt).isNotNull()
+        assertThat(settled.single { it.isSuccess }.getOrThrow().consumedBy).isIn("consumer-1", "consumer-2")
     }
 
     @Test
@@ -600,12 +697,12 @@ class DefaultApprovalGateCoordinatorTest {
             store.transition(fixedApprovalId, 0L, ApprovalTransition.Approve("approver", "approved"))
         }
         val notConsumableStore = object : ApprovalStore by store {
-            override suspend fun consumeApproved(
+            override suspend fun consumeApprovedOrReplay(
                 approvalId: String,
                 expectedVersion: Long,
                 presentedTokenDigest: Sha256Digest,
                 consumedBy: String,
-            ): ApprovalRequest {
+            ): ApprovalConsumptionReceipt {
                 throw ApprovalStoreNotConsumableException("test-id")
             }
         }
@@ -618,12 +715,12 @@ class DefaultApprovalGateCoordinatorTest {
 
         // ApprovalStoreTokenRejectedException should be mapped to ApprovalTokenRejectedException
         val tokenRejectedStore = object : ApprovalStore by store {
-            override suspend fun consumeApproved(
+            override suspend fun consumeApprovedOrReplay(
                 approvalId: String,
                 expectedVersion: Long,
                 presentedTokenDigest: Sha256Digest,
                 consumedBy: String,
-            ): ApprovalRequest {
+            ): ApprovalConsumptionReceipt {
                 throw ApprovalStoreTokenRejectedException("test-id")
             }
         }
@@ -725,6 +822,43 @@ class DefaultApprovalGateCoordinatorTest {
     }
 
     @Test
+    fun `checked IOException is sanitized without secret leakage`() : Unit = runBlocking {
+        val leakyStore = object : ApprovalStore by store {
+            override suspend fun get(approvalId: String): ApprovalRequest? {
+                throw IOException("io-secret-marker")
+            }
+        }
+        val coord = coordinator(store = leakyStore)
+
+        val ex = runCatching {
+            coord.authorizeResume(authorizeCommand(approvedChallenge()))
+        }.exceptionOrNull()
+
+        assertThat(ex).isInstanceOf(ApprovalAuthorizationException::class.java)
+        assertThat(ex).hasMessage("Approval authorization failed")
+        assertThat(ex!!.message).doesNotContain("io-secret-marker")
+        assertThat(ex.cause).isNull()
+    }
+
+    @Test
+    fun `CancellationException propagates unchanged`() : Unit = runBlocking {
+        val cancellation = CancellationException("cancel-secret")
+        val cancellingStore = object : ApprovalStore by store {
+            override suspend fun get(approvalId: String): ApprovalRequest? {
+                throw cancellation
+            }
+        }
+        val coord = coordinator(store = cancellingStore)
+
+        val ex = catchThrowableOfType(
+            { runBlocking { coord.authorizeResume(authorizeCommand(approvedChallenge())) } },
+            CancellationException::class.java,
+        )
+
+        assertThat(ex).isSameAs(cancellation)
+    }
+
+    @Test
     fun `Error from observer is not swallowed`() : Unit = runBlocking {
         val throwingObserver = ApprovalFailureObserver { _, _, _ ->
             throw Error("fatal-error")
@@ -801,12 +935,12 @@ class DefaultApprovalGateCoordinatorTest {
 
         // Also test consumeApproved path
         val leakyConsumeStore = object : ApprovalStore by store {
-            override suspend fun consumeApproved(
+            override suspend fun consumeApprovedOrReplay(
                 approvalId: String,
                 expectedVersion: Long,
                 presentedTokenDigest: Sha256Digest,
                 consumedBy: String,
-            ): ApprovalRequest {
+            ): ApprovalConsumptionReceipt {
                 throw RuntimeException("store-secret-marker")
             }
         }
@@ -843,19 +977,19 @@ class DefaultApprovalGateCoordinatorTest {
     @Test
     fun `custom store with wrong approvalId throws ApprovalAuthorizationException`() : Unit = runBlocking {
         val fakeStore = object : ApprovalStore by store {
-            override suspend fun consumeApproved(
+            override suspend fun consumeApprovedOrReplay(
                 approvalId: String,
                 expectedVersion: Long,
                 presentedTokenDigest: Sha256Digest,
                 consumedBy: String,
-            ): ApprovalRequest {
+            ): ApprovalConsumptionReceipt {
                 val stored = store.get(approvalId)!!
-                return stored.copy(
+                return receipt(stored.copy(
                     approvalId = "different-id",
                     consumedBy = consumedBy,
                     consumedAt = clock.instant(),
                     version = stored.version + 1,
-                )
+                ))
             }
         }
         val fakeCoordinator = coordinator(store = fakeStore)
@@ -871,19 +1005,19 @@ class DefaultApprovalGateCoordinatorTest {
     @Test
     fun `custom store with altered binding throws ApprovalAuthorizationException`() : Unit = runBlocking {
         val fakeStore = object : ApprovalStore by store {
-            override suspend fun consumeApproved(
+            override suspend fun consumeApprovedOrReplay(
                 approvalId: String,
                 expectedVersion: Long,
                 presentedTokenDigest: Sha256Digest,
                 consumedBy: String,
-            ): ApprovalRequest {
+            ): ApprovalConsumptionReceipt {
                 val stored = store.get(approvalId)!!
-                return stored.copy(
+                return receipt(stored.copy(
                     binding = stored.binding.copy(toolName = "hacked-tool"),
                     consumedBy = consumedBy,
                     consumedAt = clock.instant(),
                     version = stored.version + 1,
-                )
+                ))
             }
         }
         val fakeCoordinator = coordinator(store = fakeStore)
@@ -899,19 +1033,19 @@ class DefaultApprovalGateCoordinatorTest {
     @Test
     fun `custom store with PENDING status throws ApprovalAuthorizationException`() : Unit = runBlocking {
         val fakeStore = object : ApprovalStore by store {
-            override suspend fun consumeApproved(
+            override suspend fun consumeApprovedOrReplay(
                 approvalId: String,
                 expectedVersion: Long,
                 presentedTokenDigest: Sha256Digest,
                 consumedBy: String,
-            ): ApprovalRequest {
+            ): ApprovalConsumptionReceipt {
                 val stored = store.get(approvalId)!!
-                return stored.copy(
+                return receipt(stored.copy(
                     status = ApprovalStatus.PENDING,
                     consumedBy = consumedBy,
                     consumedAt = clock.instant(),
                     version = stored.version + 1,
-                )
+                ))
             }
         }
         val fakeCoordinator = coordinator(store = fakeStore)
@@ -927,18 +1061,18 @@ class DefaultApprovalGateCoordinatorTest {
     @Test
     fun `custom store with wrong consumedBy throws ApprovalAuthorizationException`() : Unit = runBlocking {
         val fakeStore = object : ApprovalStore by store {
-            override suspend fun consumeApproved(
+            override suspend fun consumeApprovedOrReplay(
                 approvalId: String,
                 expectedVersion: Long,
                 presentedTokenDigest: Sha256Digest,
                 consumedBy: String,
-            ): ApprovalRequest {
+            ): ApprovalConsumptionReceipt {
                 val stored = store.get(approvalId)!!
-                return stored.copy(
+                return receipt(stored.copy(
                     consumedBy = "wrong-consumer",
                     consumedAt = clock.instant(),
                     version = stored.version + 1,
-                )
+                ))
             }
         }
         val fakeCoordinator = coordinator(store = fakeStore)
@@ -954,18 +1088,18 @@ class DefaultApprovalGateCoordinatorTest {
     @Test
     fun `custom store with null consumedBy throws ApprovalAuthorizationException`() : Unit = runBlocking {
         val fakeStore = object : ApprovalStore by store {
-            override suspend fun consumeApproved(
+            override suspend fun consumeApprovedOrReplay(
                 approvalId: String,
                 expectedVersion: Long,
                 presentedTokenDigest: Sha256Digest,
                 consumedBy: String,
-            ): ApprovalRequest {
+            ): ApprovalConsumptionReceipt {
                 val stored = store.get(approvalId)!!
-                return stored.copy(
+                return receipt(stored.copy(
                     consumedBy = null,
                     consumedAt = clock.instant(),
                     version = stored.version + 1,
-                )
+                ))
             }
         }
         val fakeCoordinator = coordinator(store = fakeStore)
@@ -981,18 +1115,18 @@ class DefaultApprovalGateCoordinatorTest {
     @Test
     fun `custom store with null consumedAt throws ApprovalAuthorizationException`() : Unit = runBlocking {
         val fakeStore = object : ApprovalStore by store {
-            override suspend fun consumeApproved(
+            override suspend fun consumeApprovedOrReplay(
                 approvalId: String,
                 expectedVersion: Long,
                 presentedTokenDigest: Sha256Digest,
                 consumedBy: String,
-            ): ApprovalRequest {
+            ): ApprovalConsumptionReceipt {
                 val stored = store.get(approvalId)!!
-                return stored.copy(
+                return receipt(stored.copy(
                     consumedBy = consumedBy,
                     consumedAt = null,
                     version = stored.version + 1,
-                )
+                ))
             }
         }
         val fakeCoordinator = coordinator(store = fakeStore)
@@ -1008,18 +1142,18 @@ class DefaultApprovalGateCoordinatorTest {
     @Test
     fun `custom store with wrong version throws ApprovalAuthorizationException`() : Unit = runBlocking {
         val fakeStore = object : ApprovalStore by store {
-            override suspend fun consumeApproved(
+            override suspend fun consumeApprovedOrReplay(
                 approvalId: String,
                 expectedVersion: Long,
                 presentedTokenDigest: Sha256Digest,
                 consumedBy: String,
-            ): ApprovalRequest {
+            ): ApprovalConsumptionReceipt {
                 val stored = store.get(approvalId)!!
-                return stored.copy(
+                return receipt(stored.copy(
                     consumedBy = consumedBy,
                     consumedAt = clock.instant(),
                     version = stored.version, // not incremented
-                )
+                ))
             }
         }
         val fakeCoordinator = coordinator(store = fakeStore)
@@ -1088,12 +1222,12 @@ class DefaultApprovalGateCoordinatorTest {
     @Test
     fun `leaky store consumeApproved secret not in exception tree`() : Unit = runBlocking {
         val leakyStore = object : ApprovalStore by store {
-            override suspend fun consumeApproved(
+            override suspend fun consumeApprovedOrReplay(
                 approvalId: String,
                 expectedVersion: Long,
                 presentedTokenDigest: Sha256Digest,
                 consumedBy: String,
-            ): ApprovalRequest {
+            ): ApprovalConsumptionReceipt {
                 throw RuntimeException("secret-digest-value")
             }
         }
@@ -1195,6 +1329,36 @@ class DefaultApprovalGateCoordinatorTest {
         argumentsDigest = argumentsDigest,
         policyVersion = policyVersion,
         workflowDigest = workflowDigest,
+    )
+
+    private fun validateCommand(
+        challenge: dev.tramai.core.approval.ApprovalChallenge,
+        expectedVersion: Long = 1L,
+        presentedToken: ApprovalToken = challenge.token,
+        consumedBy: String = "consumer-1",
+        workflowRunId: String = "wf-run-1",
+        toolName: String = "tool-1",
+        argumentsDigest: Sha256Digest = argumentsDigest(),
+        policyVersion: String = "policy-v1",
+        workflowDigest: Sha256Digest = workflowDigest(),
+    ) = ValidateResumeCommand(
+        approvalId = challenge.approvalId,
+        expectedVersion = expectedVersion,
+        presentedToken = presentedToken,
+        consumedBy = consumedBy,
+        workflowRunId = workflowRunId,
+        toolName = toolName,
+        argumentsDigest = argumentsDigest,
+        policyVersion = policyVersion,
+        workflowDigest = workflowDigest,
+    )
+
+    private fun receipt(
+        request: ApprovalRequest,
+        replayed: Boolean = false,
+    ) = ApprovalConsumptionReceipt(
+        request = request,
+        replayed = replayed,
     )
 
     private fun argumentsDigest(): Sha256Digest =

--- a/tramai-security/src/test/kotlin/dev/tramai/security/approval/InMemoryApprovalStoreTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/approval/InMemoryApprovalStoreTest.kt
@@ -976,9 +976,9 @@ class InMemoryApprovalStoreTest {
         assertThatThrownBy {
                 runBlocking {
                     store.consumeApprovedOrReplay(
-                        "req-1", 2L,
+                        "req-1", 3L,
                         Sha256Digest.of("sha256:2222222222222222222222222222222222222222222222222222222222222222"),
-                        "consumer-2",
+                        "consumer-1",
                     )
                 }
             }

--- a/tramai-security/src/test/kotlin/dev/tramai/security/approval/InMemoryApprovalStoreTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/approval/InMemoryApprovalStoreTest.kt
@@ -1,6 +1,7 @@
 package dev.tramai.security.approval
 
 import dev.tramai.core.approval.ApprovalBinding
+import dev.tramai.core.approval.ApprovalConsumptionReceipt
 import dev.tramai.core.approval.ApprovalRequest
 import dev.tramai.core.approval.ApprovalStatus
 import dev.tramai.core.approval.ApprovalTransition
@@ -91,6 +92,19 @@ class InMemoryApprovalStoreTest {
         consumedAt = null,
         version = version,
     )
+
+    private suspend fun InMemoryApprovalStore.consumeApproved(
+        approvalId: String,
+        expectedVersion: Long,
+        presentedTokenDigest: Sha256Digest,
+        consumedBy: String,
+    ): ApprovalRequest =
+        consumeApprovedOrReplay(
+            approvalId = approvalId,
+            expectedVersion = expectedVersion,
+            presentedTokenDigest = presentedTokenDigest,
+            consumedBy = consumedBy,
+        ).request
 
     // -----------------------------------------------------------------------
     // Happy path
@@ -911,11 +925,49 @@ class InMemoryApprovalStoreTest {
     }
 
     @Test
-    fun `second consume of same approval fails`() : Unit = runBlocking {
+    fun `fresh consume returns replayed false`() : Unit = runBlocking {
+        store.create(aPendingRequest(approvalId = "fresh-receipt"))
+        store.transition("fresh-receipt", 0L, ApprovalTransition.Approve("user-2"))
+
+        val receipt = store.consumeApprovedOrReplay(
+            "fresh-receipt",
+            1L,
+            Sha256Digest.of("sha256:2222222222222222222222222222222222222222222222222222222222222222"),
+            "consumer-1",
+        )
+
+        assertThat(receipt.replayed).isFalse()
+        assertThat(receipt.request.version).isEqualTo(2L)
+    }
+
+    @Test
+    fun `exact replay returns replayed true without changing durable receipt`() : Unit = runBlocking {
         val request = aPendingRequest()
         store.create(request)
         store.transition("req-1", 0L, ApprovalTransition.Approve("user-2"))
-        store.consumeApproved(
+        val first = store.consumeApprovedOrReplay(
+            "req-1", 1L,
+            Sha256Digest.of("sha256:2222222222222222222222222222222222222222222222222222222222222222"),
+            "consumer-1",
+        )
+        val replay = store.consumeApprovedOrReplay(
+            "req-1", 1L,
+            Sha256Digest.of("sha256:2222222222222222222222222222222222222222222222222222222222222222"),
+            "consumer-1",
+        )
+
+        assertThat(first.replayed).isFalse()
+        assertThat(replay.replayed).isTrue()
+        assertThat(replay.request.version).isEqualTo(2L)
+        assertThat(replay.request.consumedAt).isEqualTo(first.request.consumedAt)
+    }
+
+    @Test
+    fun `changed expected version after consumption fails`() : Unit = runBlocking {
+        val request = aPendingRequest()
+        store.create(request)
+        store.transition("req-1", 0L, ApprovalTransition.Approve("user-2"))
+        store.consumeApprovedOrReplay(
             "req-1", 1L,
             Sha256Digest.of("sha256:2222222222222222222222222222222222222222222222222222222222222222"),
             "consumer-1",
@@ -923,14 +975,43 @@ class InMemoryApprovalStoreTest {
 
         assertThatThrownBy {
                 runBlocking {
-                    store.consumeApproved(
+                    store.consumeApprovedOrReplay(
                         "req-1", 2L,
                         Sha256Digest.of("sha256:2222222222222222222222222222222222222222222222222222222222222222"),
                         "consumer-2",
                     )
                 }
             }
-            .isInstanceOf(ApprovalStoreNotConsumableException::class.java)
+            .isInstanceOf(ApprovalStoreConflictException::class.java)
+    }
+
+    @Test
+    fun `replay after expiry returns same receipt`() : Unit = runBlocking {
+        val mutableClock = MutableClock(Instant.parse("2026-06-04T08:00:00Z"))
+        val store2 = InMemoryApprovalStore(clock = mutableClock, maxCreationTtl = Duration.ofHours(2))
+        store2.create(aPendingRequest(
+            approvalId = "expired-replay",
+            requestedAt = Instant.parse("2026-06-04T08:00:00Z"),
+            expiresAt = Instant.parse("2026-06-04T08:10:00Z"),
+        ))
+        store2.transition("expired-replay", 0L, ApprovalTransition.Approve("user-2"))
+        val first = store2.consumeApprovedOrReplay(
+            "expired-replay", 1L,
+            Sha256Digest.of("sha256:2222222222222222222222222222222222222222222222222222222222222222"),
+            "consumer-1",
+        )
+
+        mutableClock.advance(Duration.ofMinutes(20))
+
+        val replay = store2.consumeApprovedOrReplay(
+            "expired-replay", 1L,
+            Sha256Digest.of("sha256:2222222222222222222222222222222222222222222222222222222222222222"),
+            "consumer-1",
+        )
+
+        assertThat(replay.replayed).isTrue()
+        assertThat(replay.request.version).isEqualTo(first.request.version)
+        assertThat(replay.request.consumedAt).isEqualTo(first.request.consumedAt)
     }
 
     @Test
@@ -1037,13 +1118,13 @@ class InMemoryApprovalStoreTest {
     }
 
     @Test
-    fun `concurrent consume calls exactly one succeeds`() : Unit = runBlocking {
+    fun `concurrent exact calls yield one fresh receipt and remaining replay receipts`() : Unit = runBlocking {
         val concurrencyStore = InMemoryApprovalStore(clock = fixedClock, maxCreationTtl = Duration.ofHours(2))
         val request = aPendingRequest(approvalId = "concurrent-consume")
         concurrencyStore.create(request)
         concurrencyStore.transition("concurrent-consume", 0L, ApprovalTransition.Approve("user-2"))
 
-        val results = mutableListOf<Result<ApprovalRequest>>()
+        val results = mutableListOf<Result<ApprovalConsumptionReceipt>>()
         val barrier = CountDownLatch(2)
 
         val job1 = launch(kotlinx.coroutines.Dispatchers.Default) {
@@ -1051,7 +1132,7 @@ class InMemoryApprovalStoreTest {
             barrier.await()
 
             try {
-                val r = concurrencyStore.consumeApproved(
+                val r = concurrencyStore.consumeApprovedOrReplay(
                     "concurrent-consume", 1L,
                     Sha256Digest.of("sha256:2222222222222222222222222222222222222222222222222222222222222222"),
                     "consumer-a",
@@ -1067,10 +1148,10 @@ class InMemoryApprovalStoreTest {
             barrier.await()
 
             try {
-                val r = concurrencyStore.consumeApproved(
+                val r = concurrencyStore.consumeApprovedOrReplay(
                     "concurrent-consume", 1L,
                     Sha256Digest.of("sha256:2222222222222222222222222222222222222222222222222222222222222222"),
-                    "consumer-b",
+                    "consumer-a",
                 )
                 synchronized(results) { results.add(Result.success(r)) }
             } catch (e: Exception) {
@@ -1082,17 +1163,82 @@ class InMemoryApprovalStoreTest {
         job2.join()
 
         val successes = results.filter { it.isSuccess }
-        val failures = results.filter { it.isFailure }
+        assertThat(successes).hasSize(2)
+        assertThat(successes.count { !it.getOrThrow().replayed }).isEqualTo(1)
+        assertThat(successes.count { it.getOrThrow().replayed }).isEqualTo(1)
+        assertThat(successes.map { it.getOrThrow().request.version }).containsOnly(2L)
+    }
 
-        assertThat(successes).hasSize(1)
-        assertThat(failures).hasSize(1)
+    @Test
+    fun `concurrent different actors allow only original consumer`() : Unit = runBlocking {
+        val concurrencyStore = InMemoryApprovalStore(clock = fixedClock, maxCreationTtl = Duration.ofHours(2))
+        val request = aPendingRequest(approvalId = "concurrent-different-actors")
+        concurrencyStore.create(request)
+        concurrencyStore.transition("concurrent-different-actors", 0L, ApprovalTransition.Approve("user-2"))
 
-        val winner = successes.single().getOrThrow()
-        assertThat(winner.consumedBy).isIn("consumer-a", "consumer-b")
-        assertThat(winner.version).isEqualTo(2L)
+        val results = mutableListOf<Result<ApprovalConsumptionReceipt>>()
+        val barrier = CountDownLatch(2)
 
-        val loser = failures.single().exceptionOrNull()
-        assertThat(loser).isInstanceOf(ApprovalStoreConflictException::class.java)
+        val job1 = launch(kotlinx.coroutines.Dispatchers.Default) {
+            barrier.countDown()
+            barrier.await()
+            val result = runCatching {
+                concurrencyStore.consumeApprovedOrReplay(
+                    "concurrent-different-actors", 1L,
+                    Sha256Digest.of("sha256:2222222222222222222222222222222222222222222222222222222222222222"),
+                    "consumer-a",
+                )
+            }
+            synchronized(results) { results.add(result) }
+        }
+
+        val job2 = launch(kotlinx.coroutines.Dispatchers.Default) {
+            barrier.countDown()
+            barrier.await()
+            val result = runCatching {
+                concurrencyStore.consumeApprovedOrReplay(
+                    "concurrent-different-actors", 1L,
+                    Sha256Digest.of("sha256:2222222222222222222222222222222222222222222222222222222222222222"),
+                    "consumer-b",
+                )
+            }
+            synchronized(results) { results.add(result) }
+        }
+
+        job1.join()
+        job2.join()
+
+        assertThat(results.count { it.isSuccess }).isEqualTo(1)
+        assertThat(results.count { it.isFailure }).isEqualTo(1)
+    }
+
+    @Test
+    fun `overflow safe conflict on replay version validation`() : Unit = runBlocking {
+        store.create(aPendingRequest(approvalId = "overflow-replay"))
+        store.transition("overflow-replay", 0L, ApprovalTransition.Approve("user-2"))
+
+        val updated = store.get("overflow-replay")!!.copy(
+            consumedBy = "consumer-1",
+            consumedAt = fixedClock.instant(),
+            version = 5L,
+        )
+        val mapField = InMemoryApprovalStore::class.java.getDeclaredField("store")
+        mapField.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val backingMap = mapField.get(store) as java.util.concurrent.ConcurrentHashMap<String, ApprovalRequest>
+        backingMap["overflow-replay"] = updated
+
+        assertThatThrownBy {
+            runBlocking {
+                store.consumeApprovedOrReplay(
+                    "overflow-replay",
+                    Long.MAX_VALUE,
+                    Sha256Digest.of("sha256:2222222222222222222222222222222222222222222222222222222222222222"),
+                    "consumer-1",
+                )
+            }
+        }
+            .isInstanceOf(ApprovalStoreConflictException::class.java)
     }
 
     // -----------------------------------------------------------------------

--- a/tramai-security/src/test/kotlin/dev/tramai/security/approval/InMemoryApprovalStoreTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/approval/InMemoryApprovalStoreTest.kt
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test
  * Used to test time-dependent behavior without reflection.
  */
 class MutableClock(
-    private var now: Instant,
+    @Volatile private var now: Instant,
     private val zone: ZoneId = ZoneId.of("UTC"),
 ) : Clock() {
     override fun instant(): Instant = now


### PR DESCRIPTION
## Summary

Close the approval-resume liveness gap where authorizeResume() consumes the one-time approval token before claimForExecution() claims the continuation. If consumption succeeds but claiming fails before mutation, the continuation remains PENDING while the token is consumed. Retrying the exact same resume command must recover by returning the durable authorization receipt.

## Changes (11 files, +917/−124)

**ApprovalStore.kt (tramai-core):** ApprovalConsumptionReceipt, consumeApprovedOrReplay SPI, CancellationException contract
**ApprovalGateCoordinator.kt (tramai-core):** replayed flag in ApprovalAuthorization
**InMemoryApprovalStore.kt (tramai-security):** atomic consumeApprovedOrReplay via ConcurrentHashMap.compute()
**DefaultApprovalGateCoordinator.kt (tramai-security):** replay-safe authorizeResume, read-only validateResume
**TramaiEngine.kt (tramai-engine):** replayed capture, authorization_replayed event, CancellationException rethrow

## Verification

- ./gradlew test --rerun-tasks --no-build-cache ✅ (118 tasks)
- ./gradlew publishToMavenLocal ✅ (196 tasks)
- Example Spring Boot tests ✅
- Stress: *concurrent* x 50 ✅ 50/50

## Review Pipeline (8 rounds)

1. AGY → NOT MERGE-READY → ALL FIXED
2. Codex → 0 P0 + 0 P1 → ADDRESSED
3. AGY → MERGE-READY
4. Codex (Final Gate) → APPROVED
5. External Merge Gate → 1 P1 + 4 P2 → ALL FIXED
6. AGY (Patch) → MERGE-READY
7. Codex (Patch) → 0 P0 + 0 P1
8. Codex (Final Gate) → APPROVED

## Constraints Honored
No cross-store transaction, no automatic retry of CLAIMED continuations, no Model Registry changes, no example workflow changes, wrong tokens fail before BEFORE_WORKFLOW_RESUME, exact replay never mutates consumedAt or version, no direct push to master.

> DO NOT MERGE — review and manual approval required.
