### PR TITLE
feat(engine): add trusted replay envelope and operation registry

### DIFF
--- a/docs/specs/spec-016-approval-engine-suspension-resume.md
+++ b/docs/specs/spec-016-approval-engine-suspension-resume.md
@@ -2,6 +2,7 @@
 
 ## Status
 Implemented in PR #17
+Updated in PR #28 — Trusted Replay Envelope and Operation Registry
 
 ## Executive Summary
 
@@ -34,6 +35,8 @@ data class SuspendedInvocationMetadata(
     val correlationId: String,
     val identity: EngineExecutionIdentity,
     val securityContext: ExecutionSecurityContext,
+    val operationReference: ResumeOperationReference,  // PR #28
+    val replayEnvelopeDigest: Sha256Digest,            // PR #28
     val conversationId: String? = null,
     val historySize: Int = 0,
     val tokenBudgetSnapshot: TokenBudgetSnapshot? = null,
@@ -45,18 +48,21 @@ data class SuspendedInvocationMetadata(
 - NO messages (which contain prompts and content)
 - `toolSecurity` is used for BEFORE_WORKFLOW_RESUME policy context without revealing sensitive context early
 
-**SensitiveResumeContext** — opaque wrapper stored alongside metadata, only accessible via `revealForResume()`:
+**SensitiveReplayEnvelope** (PR #28) — opaque messages-only wrapper, replaces SensitiveResumeContext:
 ```kotlin
-class SensitiveResumeContext private constructor(
-    private val operation: OperationDefinition,
-    private val tool: ResolvedTool,
+class SensitiveReplayEnvelope private constructor(
     private val messages: List<Message>,
-    private val toolCall: ToolCall,
-)
+) {
+    fun revealForResume(): ReplayPayload
+    override fun toString(): String = "[REDACTED]"
+    companion object { fun of(messages: List<Message>): SensitiveReplayEnvelope }
+}
 ```
+- Contains ONLY `List<Message>` — no OperationDefinition, no ResolvedTool, no ToolCall
 - toString returns `[REDACTED]`
 - Only revealed AFTER `claimForExecution()` succeeds
 - Never serialized
+- Defensive deep copies prevent mutation after creation
 
 ### EngineExecutionIdentity
 ```kotlin
@@ -94,12 +100,52 @@ data class ResumeApprovalCommand(
 
 ## SPIs
 
+### ResumeOperationReference (PR #28)
+
+Stable, serializable reference that identifies a resume-able operation without runtime objects:
+
+```kotlin
+data class ResumeOperationReference(
+    val serviceInterface: String,
+    val methodName: String,
+    val jvmMethodDescriptor: String,
+    val resumeDefinitionDigest: Sha256Digest,
+)
+```
+
+Computed deterministically from the `ServiceDefinition` and `OperationDefinition` via `ResumeDefinitionDigestHelper`,
+including: service interface, method name, JVM method descriptor, return kind, model, provider, timeout,
+retries, cache settings, prompts, annotations, and sorted tool definitions.
+
+### ResumeOperationRegistry (PR #28)
+
+Thread-safe runtime registry keyed by `(serviceInterface, methodName, jvmMethodDescriptor)`:
+
+```kotlin
+internal data class RegisteredResumeOperation(
+    val reference: ResumeOperationReference,
+    val serviceDefinition: ServiceDefinition,
+    val operation: OperationDefinition,
+    val handler: TramaiInvocationHandler,
+)
+```
+
+Rules:
+- Missing key → `ConfigurationException("resume-operation-not-registered")`
+- Same key + same digest → idempotent registration
+- Same key + different digest → fail closed (`ConfigurationException`)
+
+Created during `TramaiEngine.create()` and `TramaiEngine.registerService()`.
+
 ### SuspendedInvocationStore (engine-level)
 ```kotlin
 interface SuspendedInvocationStore {
-    suspend fun create(metadata: SuspendedInvocationMetadata, sensitiveContext: SensitiveResumeContext)
+    suspend fun create(
+        metadata: SuspendedInvocationMetadata,
+        replayEnvelope: SensitiveReplayEnvelope,          // PR #28: replaces SensitiveResumeContext
+    )
     suspend fun get(approvalId: String): SuspendedInvocationMetadata?
-    suspend fun revealSensitiveContext(approvalId: String): SensitiveResumeContext?
+    suspend fun revealReplayEnvelope(approvalId: String): SensitiveReplayEnvelope?  // PR #28
     suspend fun remove(approvalId: String): SuspendedInvocationMetadata?
 }
 ```
@@ -133,7 +179,75 @@ PR #17 delivers:
 - Lifecycle audit events (suspended, resumed, completed, cancelled, uncertain outcome)
 - Edge case test coverage for all failure paths
 
-## PR #22 — Replay-Safe Authorization Receipt
+## PR #28 — Trusted Replay Envelope and Operation Registry
+
+Implemented in PR #28.
+
+### Motivation
+
+Previously, `SensitiveResumeContext` stored executable runtime objects (`OperationDefinition`, `ResolvedTool`, `ToolCall`). The engine resolved the correct handler via a single mutable `resumeHandler` field set to the last created proxy.
+
+This meant:
+- Runtime objects survived in opaque context across the JVM lifecycle
+- Resume relied on a single handler, not a registered service map
+- Multi-service setups were fragile (last-created proxy wins)
+- Definition drift was not detectable before token consumption
+
+### Changes
+
+**SensitiveReplayEnvelope** replaces `SensitiveResumeContext`:
+- Contains ONLY `List<Message>` — no OperationDefinition, no ResolvedTool, no ToolCall
+- ToolCall is constructed at resume time from `metadata.toolCallId`, `metadata.toolName`, and `claimed.arguments.reveal()`
+- Tool is resolved from the runtime `ToolRegistry`
+- Operation is resolved from the registry at resume time
+- Replay envelope digest verified after claim (tamper detection)
+
+**ResumeOperationRegistry** replaces `resumeHandler`:
+- Keyed by `(serviceInterface, methodName, jvmMethodDescriptor)` for unambiguous overload resolution
+- Operation registered during `create()` and `registerService()`
+- Missing key → fail before token consumption
+- Definition drift → fail before token consumption
+- Same key + same digest → idempotent (safe for service restart registration)
+
+**Cross-store integrity checks** (before token consumption):
+- workflowRunId matches across continuation, metadata, and identity
+- correlationId matches across continuation and metadata
+- workflowDigest matches across continuation and identity
+- policyVersion matches across continuation and identity
+- toolName and toolCallId match across continuation and metadata
+- resumeDefinitionDigest matches between metadata and registered operation
+
+**Pre-token-drift detection**:
+- Before `validateResume()`, verify `metadata.operationReference.resumeDefinitionDigest` == `registered.reference.resumeDefinitionDigest`
+
+**Post-claim digest verification**:
+- After `revealReplayEnvelope()`, recompute digest via `ReplayEnvelopeDigestHelper` and compare with `metadata.replayEnvelopeDigest`
+
+**registerService() API**:
+- `TramaiEngine.registerService(serviceType: KClass<*>)` — registers operations without creating a proxy
+- `TramaiRuntime.registerService()` + reified overload
+- `SovereignTramaiRuntime.registerService()` + reified overload
+- Use after restart: `runtime.registerService<MyService>()` before `runtime.resumeApproval(command)`
+
+### Resume Ordering (PR #28)
+
+1. Load metadata from `SuspendedInvocationStore` (read-only)
+2. Resolve `ResumeOperationReference` from `metadata.operationReference` via `ResumeOperationRegistry`
+3. Cross-store integrity checks (workflowRunId, correlationId, digest, policyVersion, tool name, tool call ID)
+4. Pre-token-drift check: verify `resumeDefinitionDigest`
+5. Resolve tool from runtime `ToolRegistry`
+6. Validate continuation: status == PENDING, version matches
+7. `validateResume()` — validates token and binding without consuming
+8. Evaluate BEFORE_WORKFLOW_RESUME
+9. `authorizeResume()` — consumes the one-time token
+10. `claimForExecution()` — atomically marks continuation CLAIMED
+11. `revealReplayEnvelope()` — get messages
+12. Verify replay envelope digest (tamper detection)
+13. Verify payload integrity (re-digest claimed arguments)
+14. Construct ToolCall from metadata + claimed arguments
+15. Execute tool with `registered.operation`
+16. Continue provider loop with `registered.operation` and `replayPayload.messages`
+17. Complete continuation → emit audit → cleanup
 
 Implemented in PR #22.
 

--- a/docs/specs/spec-016-approval-engine-suspension-resume.md
+++ b/docs/specs/spec-016-approval-engine-suspension-resume.md
@@ -58,11 +58,12 @@ class SensitiveReplayEnvelope private constructor(
     companion object { fun of(messages: List<Message>): SensitiveReplayEnvelope }
 }
 ```
-- Contains ONLY `List<Message>` — no OperationDefinition, no ResolvedTool, no ToolCall
-- toString returns `[REDACTED]`
-- Only revealed AFTER `claimForExecution()` succeeds
-- Never serialized
-- Defensive deep copies prevent mutation after creation
+- Contains only replayable message-model data.
+- Historical message-level ToolCall values may exist for provider continuity.
+- The selected suspended ToolCall arguments are replaced with a sentinel.
+- The selected arguments are rehydrated from ApprovalContinuationStore only after claim.
+- No executable runtime objects are stored: no OperationDefinition, ResolvedTool,
+  reflection objects, callbacks, providers, or registries.
 
 ### EngineExecutionIdentity
 ```kotlin

--- a/examples/sovereign-document-intelligence/src/test/kotlin/dev/tramai/examples/sovereign/SovereignDocumentIntelligenceWorkflowTest.kt
+++ b/examples/sovereign-document-intelligence/src/test/kotlin/dev/tramai/examples/sovereign/SovereignDocumentIntelligenceWorkflowTest.kt
@@ -6,7 +6,6 @@ import dev.tramai.core.approval.ApprovalTokenGenerator
 import dev.tramai.core.approval.ApprovalTransition
 import dev.tramai.core.approval.ApprovalStatus
 import dev.tramai.core.exception.ApprovalSuspendedException
-import dev.tramai.core.exception.ApprovalNotFoundException
 import dev.tramai.core.exception.ApprovalTokenRejectedException
 import dev.tramai.core.exception.ModelDisabledException
 import dev.tramai.core.exception.PolicyViolationException

--- a/examples/sovereign-document-intelligence/src/test/kotlin/dev/tramai/examples/sovereign/SovereignDocumentIntelligenceWorkflowTest.kt
+++ b/examples/sovereign-document-intelligence/src/test/kotlin/dev/tramai/examples/sovereign/SovereignDocumentIntelligenceWorkflowTest.kt
@@ -371,9 +371,6 @@ class SovereignDocumentIntelligenceWorkflowTest {
             fail("Should have thrown ApprovalTokenRejectedException")
         } catch (e: ApprovalTokenRejectedException) {
             // Success — token was consumed by the first resume.
-        } catch (e: dev.tramai.core.exception.ApprovalNotFoundException) {
-            // Also valid — metadata removed after first successful resume;
-            // the new registry-based flow loads metadata first.
         }
 
         assertEquals(1, ledger.executionCount())

--- a/examples/sovereign-document-intelligence/src/test/kotlin/dev/tramai/examples/sovereign/SovereignDocumentIntelligenceWorkflowTest.kt
+++ b/examples/sovereign-document-intelligence/src/test/kotlin/dev/tramai/examples/sovereign/SovereignDocumentIntelligenceWorkflowTest.kt
@@ -6,6 +6,7 @@ import dev.tramai.core.approval.ApprovalTokenGenerator
 import dev.tramai.core.approval.ApprovalTransition
 import dev.tramai.core.approval.ApprovalStatus
 import dev.tramai.core.exception.ApprovalSuspendedException
+import dev.tramai.core.exception.ApprovalNotFoundException
 import dev.tramai.core.exception.ApprovalTokenRejectedException
 import dev.tramai.core.exception.ModelDisabledException
 import dev.tramai.core.exception.PolicyViolationException
@@ -368,8 +369,11 @@ class SovereignDocumentIntelligenceWorkflowTest {
         try {
             runBlocking { runtime.resumeApproval(command) }
             fail("Should have thrown ApprovalTokenRejectedException")
-        } catch (_: ApprovalTokenRejectedException) {
+        } catch (e: ApprovalTokenRejectedException) {
             // Success — token was consumed by the first resume.
+        } catch (e: dev.tramai.core.exception.ApprovalNotFoundException) {
+            // Also valid — metadata removed after first successful resume;
+            // the new registry-based flow loads metadata first.
         }
 
         assertEquals(1, ledger.executionCount())

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/CanonicalMessageEncoder.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/CanonicalMessageEncoder.kt
@@ -1,0 +1,73 @@
+package dev.tramai.engine
+
+import dev.tramai.core.model.ContentPart
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.ToolCall
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+/**
+ * Deterministic canonical message encoding shared across digest helpers.
+ * Length-prefixes all string fields using UTF-8 byte length for consistency.
+ * Separates messages with `\n---\n`.
+ */
+internal object CanonicalMessageEncoder {
+    fun encode(messages: List<Message>): String = buildString {
+        messages.forEachIndexed { index, message ->
+            if (index > 0) append("\n---\n")
+            append("role=").append(message.role.name).append('\n')
+            appendField("content", message.content)
+            append("parts_count=").append(message.contentParts?.size ?: 0).append('\n')
+            message.contentParts.orEmpty().forEachIndexed { partIndex, part ->
+                append("part_index=").append(partIndex).append('\n')
+                when (part) {
+                    is ContentPart.TextPart -> {
+                        append("part_type=text\n")
+                        appendField("text", part.text)
+                    }
+                    is ContentPart.ImagePart -> {
+                        append("part_type=image\n")
+                        appendField("mime", part.mimeType)
+                        appendField("data_b64", Base64.getEncoder().encodeToString(part.data))
+                    }
+                    is ContentPart.ImageUrlContent -> {
+                        append("part_type=image_url\n")
+                        appendField("url", part.url)
+                        appendField("mime", part.mimeType)
+                    }
+                }
+            }
+            if (message.toolCallId != null) {
+                appendField("tool_call_id", message.toolCallId)
+            }
+            message.toolCalls?.let { toolCalls ->
+                append("tool_calls_count=").append(toolCalls.size).append('\n')
+                toolCalls.forEachIndexed { toolIndex, toolCall ->
+                    append("tool_call_index=").append(toolIndex).append('\n')
+                    appendField("tool_call_id", toolCall.id)
+                    appendField("tool_call_name", toolCall.name)
+                    appendField("tool_call_args", toolCall.argumentsJson)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Deterministic field encoding shared across all digest helpers.
+ *
+ * Encodes a nullable string field as:
+ * - `<name>_null\n` when null
+ * - `<name>_len=<UTF-8 byte count>\n<value>\n` when non-null
+ *
+ * Using UTF-8 byte length ensures consistency across platforms.
+ */
+internal fun StringBuilder.appendField(name: String, value: String?) {
+    if (value == null) {
+        append(name).append("_null\n")
+        return
+    }
+    val bytes = value.toByteArray(StandardCharsets.UTF_8)
+    append(name).append("_len=").append(bytes.size).append('\n')
+    append(value).append('\n')
+}

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/InMemorySuspendedInvocationStore.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/InMemorySuspendedInvocationStore.kt
@@ -5,25 +5,25 @@ import java.util.concurrent.ConcurrentHashMap
 /**
  * Thread-safe in-memory implementation of [SuspendedInvocationStore].
  *
- * Stores both safe metadata and sensitive context in a single [ConcurrentHashMap] keyed by [approvalId].
+ * Stores both safe metadata and replay envelope in a single [ConcurrentHashMap] keyed by [approvalId].
  * Does NOT persist beyond the JVM lifecycle.
  */
 internal class InMemorySuspendedInvocationStore : SuspendedInvocationStore {
 
     private data class StoredSuspendedInvocation(
         val metadata: SuspendedInvocationMetadata,
-        val sensitiveContext: SensitiveResumeContext,
+        val replayEnvelope: SensitiveReplayEnvelope,
     )
 
     private val invocations = ConcurrentHashMap<String, StoredSuspendedInvocation>()
 
     override suspend fun create(
         metadata: SuspendedInvocationMetadata,
-        sensitiveContext: SensitiveResumeContext,
+        replayEnvelope: SensitiveReplayEnvelope,
     ) {
         val existing = invocations.putIfAbsent(
             metadata.approvalId,
-            StoredSuspendedInvocation(metadata = metadata, sensitiveContext = sensitiveContext),
+            StoredSuspendedInvocation(metadata = metadata, replayEnvelope = replayEnvelope),
         )
         require(existing == null) {
             "Suspended invocation with approvalId '${metadata.approvalId}' already exists"
@@ -33,8 +33,8 @@ internal class InMemorySuspendedInvocationStore : SuspendedInvocationStore {
     override suspend fun get(approvalId: String): SuspendedInvocationMetadata? =
         invocations[approvalId]?.metadata
 
-    override suspend fun revealSensitiveContext(approvalId: String): SensitiveResumeContext? =
-        invocations[approvalId]?.sensitiveContext
+    override suspend fun revealReplayEnvelope(approvalId: String): SensitiveReplayEnvelope? =
+        invocations[approvalId]?.replayEnvelope
 
     override suspend fun remove(approvalId: String): SuspendedInvocationMetadata? =
         invocations.remove(approvalId)?.metadata

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ReplayEnvelopeDigestHelper.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ReplayEnvelopeDigestHelper.kt
@@ -1,0 +1,90 @@
+package dev.tramai.engine
+
+import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.model.ContentPart
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.ToolCall
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.util.Base64
+
+/**
+ * Computes a deterministic digest over the [SensitiveReplayEnvelope] content.
+ *
+ * Canonicalises the messages deterministically using the same conventions as
+ * [buildRequestDigest] so the digest can be compared at resume time.
+ *
+ * Used in [SuspendedInvocationMetadata.replayEnvelopeDigest] to detect
+ * replay-envelope tampering after claim.
+ */
+internal object ReplayEnvelopeDigestHelper {
+
+    fun compute(
+        operationReference: ResumeOperationReference,
+        messages: List<Message>,
+    ): Sha256Digest {
+        val canonical = buildString {
+            appendField("service_interface", operationReference.serviceInterface)
+            append("method=").append(operationReference.methodName).append('\n')
+            append("jvm_descriptor=").append(operationReference.jvmMethodDescriptor).append('\n')
+            append("digest=").append(operationReference.resumeDefinitionDigest.value).append('\n')
+
+            // Messages are the primary content — canonicalise deterministically
+            messages.forEachIndexed { index, message ->
+                if (index > 0) {
+                    append("---\n")
+                }
+                append("role=")
+                append(message.role.name)
+                append('\n')
+                appendField("content", message.content)
+                append("parts_count=").append(message.contentParts?.size ?: 0).append('\n')
+                message.contentParts.orEmpty().forEachIndexed { partIndex, part ->
+                    append("part_index=").append(partIndex).append('\n')
+                    when (part) {
+                        is ContentPart.TextPart -> {
+                            append("part_type=text\n")
+                            appendField("text", part.text)
+                        }
+                        is ContentPart.ImagePart -> {
+                            append("part_type=image\n")
+                            appendField("mime", part.mimeType)
+                            appendField("data_b64", Base64.getEncoder().encodeToString(part.data))
+                        }
+                        is ContentPart.ImageUrlContent -> {
+                            append("part_type=image_url\n")
+                            appendField("url", part.url)
+                            appendField("mime", part.mimeType)
+                        }
+                    }
+                }
+                if (message.toolCallId != null) {
+                    appendField("tool_call_id", message.toolCallId)
+                }
+                message.toolCalls?.let { toolCalls ->
+                    append("tool_calls_count=").append(toolCalls.size).append('\n')
+                    toolCalls.forEachIndexed { toolIndex, toolCall ->
+                        append("tool_call_index=").append(toolIndex).append('\n')
+                        appendField("tool_call_id", toolCall.id)
+                        appendField("tool_call_name", toolCall.name)
+                        appendField("tool_call_args", toolCall.argumentsJson)
+                    }
+                }
+            }
+        }
+
+        val digest = MessageDigest.getInstance("SHA-256").digest(canonical.toByteArray(StandardCharsets.UTF_8))
+        val hex = digest.joinToString("") { "%02x".format(it) }
+        return Sha256Digest.of("sha256:$hex")
+    }
+
+    private fun StringBuilder.appendField(name: String, value: String?) {
+        if (value == null) {
+            append(name).append("_null\n")
+            return
+        }
+        val bytes = value.toByteArray(StandardCharsets.UTF_8)
+        append(name).append("_len=").append(bytes.size).append('\n')
+        append(value).append('\n')
+    }
+}

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ReplayEnvelopeDigestHelper.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ReplayEnvelopeDigestHelper.kt
@@ -1,18 +1,15 @@
 package dev.tramai.engine
 
 import dev.tramai.core.approval.Sha256Digest
-import dev.tramai.core.model.ContentPart
 import dev.tramai.core.model.Message
-import dev.tramai.core.model.ToolCall
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
-import java.util.Base64
 
 /**
  * Computes a deterministic digest over the [SensitiveReplayEnvelope] content.
  *
- * Canonicalises the messages deterministically using the same conventions as
- * [buildRequestDigest] so the digest can be compared at resume time.
+ * Canonicalises the messages deterministically using [CanonicalMessageEncoder]
+ * so the digest can be compared at resume time.
  *
  * Used in [SuspendedInvocationMetadata.replayEnvelopeDigest] to detect
  * replay-envelope tampering after claim.
@@ -30,61 +27,11 @@ internal object ReplayEnvelopeDigestHelper {
             append("digest=").append(operationReference.resumeDefinitionDigest.value).append('\n')
 
             // Messages are the primary content — canonicalise deterministically
-            messages.forEachIndexed { index, message ->
-                if (index > 0) {
-                    append("---\n")
-                }
-                append("role=")
-                append(message.role.name)
-                append('\n')
-                appendField("content", message.content)
-                append("parts_count=").append(message.contentParts?.size ?: 0).append('\n')
-                message.contentParts.orEmpty().forEachIndexed { partIndex, part ->
-                    append("part_index=").append(partIndex).append('\n')
-                    when (part) {
-                        is ContentPart.TextPart -> {
-                            append("part_type=text\n")
-                            appendField("text", part.text)
-                        }
-                        is ContentPart.ImagePart -> {
-                            append("part_type=image\n")
-                            appendField("mime", part.mimeType)
-                            appendField("data_b64", Base64.getEncoder().encodeToString(part.data))
-                        }
-                        is ContentPart.ImageUrlContent -> {
-                            append("part_type=image_url\n")
-                            appendField("url", part.url)
-                            appendField("mime", part.mimeType)
-                        }
-                    }
-                }
-                if (message.toolCallId != null) {
-                    appendField("tool_call_id", message.toolCallId)
-                }
-                message.toolCalls?.let { toolCalls ->
-                    append("tool_calls_count=").append(toolCalls.size).append('\n')
-                    toolCalls.forEachIndexed { toolIndex, toolCall ->
-                        append("tool_call_index=").append(toolIndex).append('\n')
-                        appendField("tool_call_id", toolCall.id)
-                        appendField("tool_call_name", toolCall.name)
-                        appendField("tool_call_args", toolCall.argumentsJson)
-                    }
-                }
-            }
+            append(CanonicalMessageEncoder.encode(messages))
         }
 
         val digest = MessageDigest.getInstance("SHA-256").digest(canonical.toByteArray(StandardCharsets.UTF_8))
         val hex = digest.joinToString("") { "%02x".format(it) }
         return Sha256Digest.of("sha256:$hex")
-    }
-
-    private fun StringBuilder.appendField(name: String, value: String?) {
-        if (value == null) {
-            append(name).append("_null\n")
-            return
-        }
-        val bytes = value.toByteArray(StandardCharsets.UTF_8)
-        append(name).append("_len=").append(bytes.size).append('\n')
-        append(value).append('\n')
     }
 }

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ReplayEnvelopeFactory.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ReplayEnvelopeFactory.kt
@@ -13,6 +13,15 @@ import dev.tramai.core.approval.Sha256Digest
 internal const val REDACTED_APPROVAL_CONTINUATION_ARGUMENTS = "__redacted_approval_continuation_args__"
 
 /**
+ * A single tool-call slot uniquely identified by its position and identity.
+ */
+private data class ReplayToolCallSlot(
+    val messageIndex: Int,
+    val toolCallIndex: Int,
+    val call: ToolCall,
+)
+
+/**
  * Result of [ReplayEnvelopeFactory.prepareForSuspension].
  *
  * @property envelope The redacted [SensitiveReplayEnvelope] safe for persistence.
@@ -26,28 +35,24 @@ internal data class PreparedReplayEnvelope(
 /**
  * Factory for creating redacted replay envelopes at suspension time
  * and rehydrating them after claim.
+ *
+ * All error messages are fixed codes (no interpolated values).
  */
 internal object ReplayEnvelopeFactory {
 
     /**
      * Creates a [PreparedReplayEnvelope] with the suspended tool's arguments redacted.
      *
-     * The returned envelope is safe for persistence because the selected
-     * suspended tool-call slot contains only a sentinel — the real arguments
-     * come from [dev.tramai.core.approval.ApprovalContinuationStore.claimForExecution]
-     * after the continuation is claimed.
-     *
-     * Fail-closed validation:
+     * Fail-closed validation (full-envelope scan):
      * - Selects latest assistant message with tool calls
      * - Validates toolCallIndex is in bounds
      * - Validates selected call ID matches expected ID
      * - Validates selected call name matches expected name
-     * - Requires EXACTLY ONE matching slot across the entire envelope
+     * - Validates EXACTLY ONE matching slot across the entire envelope
+     *   (all messages, all tool-call batches)
      * - Redacts exactly that one slot
-     * - After redaction, requires exactly one sentinel present
+     * - After redaction, verifies exactly one sentinel present
      * - Computes digest from the EXACT redacted snapshot
-     *
-     * All error messages are fixed codes (no interpolated values).
      */
     fun prepareForSuspension(
         operationReference: ResumeOperationReference,
@@ -66,21 +71,30 @@ internal object ReplayEnvelopeFactory {
         // Validate toolCallIndex is in bounds
         require(toolCallIndex in toolCalls.indices) { "replay-envelope-tool-call-index-out-of-bounds" }
 
-        // Validate selected call ID matches expected ID
+        // Validate selected call matches expected identity
         val selectedCall = toolCalls[toolCallIndex]
         require(selectedCall.id == toolCallId) { "replay-envelope-tool-call-id-mismatch" }
-
-        // Validate selected call name matches expected name
         require(selectedCall.name == toolName) { "replay-envelope-tool-call-name-mismatch" }
 
-        // Require EXACTLY ONE matching slot across the entire envelope
-        val matchingCalls = toolCalls.filter { it.id == toolCallId && it.name == toolName }
-        require(matchingCalls.size == 1) { "replay-envelope-duplicate-matching-calls" }
+        // Full-envelope uniqueness: scan ALL slots across ALL messages
+        val allSlots = messages.flatMapIndexed { msgIdx, msg ->
+            msg.toolCalls.orEmpty().mapIndexed { callIdx, tc ->
+                ReplayToolCallSlot(msgIdx, callIdx, tc)
+            }
+        }
+
+        val matchingSlots = allSlots.filter { it.call.id == toolCallId && it.call.name == toolName }
+        require(matchingSlots.size == 1) { "replay-envelope-duplicate-matching-calls" }
+        // Also require the sole matching slot is the selected one
+        require(matchingSlots.single().messageIndex == assistantMsgIndex &&
+            matchingSlots.single().toolCallIndex == toolCallIndex) {
+            "replay-envelope-tool-call-slot-mismatch"
+        }
 
         // Redact exactly that one slot
         val redacted = redactSlot(messages, assistantMsgIndex, toolCallIndex)
 
-        // After redaction, require exactly one sentinel present
+        // After redaction, require exactly one sentinel present (full-envelope scan)
         val sentinelCount = countSentinelOccurrences(redacted)
         require(sentinelCount == 1) { "replay-envelope-redaction-count-mismatch" }
 
@@ -95,9 +109,7 @@ internal object ReplayEnvelopeFactory {
      * Rehydrates the selected suspended tool-call slot with the claimed continuation arguments.
      *
      * Must be called AFTER [dev.tramai.core.approval.ApprovalContinuationStore.claimForExecution] succeeds.
-     * Validates that exactly one matching slot exists and that it contains the redacted sentinel.
-     *
-     * @throws IllegalStateException if the slot cannot be found or validated.
+     * Performs full-envelope validation before rehydration.
      */
     fun rehydrateAfterClaim(
         payload: ReplayPayload,
@@ -120,9 +132,15 @@ internal object ReplayEnvelopeFactory {
         require(selectedCall.name == metadata.toolName) { "replay-envelope-tool-call-name-mismatch" }
         require(selectedCall.argumentsJson == REDACTED_APPROVAL_CONTINUATION_ARGUMENTS) { "replay-envelope-tool-call-not-redacted" }
 
-        // Exactly one matching slot
-        val matchingCalls = toolCalls.filter { it.id == metadata.toolCallId && it.name == metadata.toolName }
-        require(matchingCalls.size == 1) { "replay-envelope-duplicate-matching-calls" }
+        // Full-envelope uniqueness: scan ALL slots across ALL messages
+        val allSlots = messages.flatMapIndexed { msgIdx, msg ->
+            msg.toolCalls.orEmpty().mapIndexed { callIdx, tc ->
+                ReplayToolCallSlot(msgIdx, callIdx, tc)
+            }
+        }
+
+        val matchingSlots = allSlots.filter { it.call.id == metadata.toolCallId && it.call.name == metadata.toolName }
+        require(matchingSlots.size == 1) { "replay-envelope-duplicate-matching-calls" }
 
         // Rehydrate the slot
         val rehydratedCalls = toolCalls.mapIndexed { index, tc ->
@@ -137,9 +155,6 @@ internal object ReplayEnvelopeFactory {
         return RehydratedReplayPayload(messages = messages)
     }
 
-    /**
-     * Redacts the tool call at [toolCallIndex] in the assistant message at [assistantMsgIndex].
-     */
     private fun redactSlot(
         messages: List<Message>,
         assistantMsgIndex: Int,
@@ -166,9 +181,6 @@ internal object ReplayEnvelopeFactory {
         }
     }
 
-    /**
-     * Counts occurrences of the redacted sentinel across all tool calls in all messages.
-     */
     private fun countSentinelOccurrences(messages: List<Message>): Int {
         return messages.sumOf { msg ->
             msg.toolCalls?.count { it.argumentsJson == REDACTED_APPROVAL_CONTINUATION_ARGUMENTS } ?: 0

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ReplayEnvelopeFactory.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ReplayEnvelopeFactory.kt
@@ -13,47 +13,88 @@ import dev.tramai.core.approval.Sha256Digest
 internal const val REDACTED_APPROVAL_CONTINUATION_ARGUMENTS = "__redacted_approval_continuation_args__"
 
 /**
+ * Result of [ReplayEnvelopeFactory.prepareForSuspension].
+ *
+ * @property envelope The redacted [SensitiveReplayEnvelope] safe for persistence.
+ * @property digest Digest of the exact redacted snapshot for tamper detection.
+ */
+internal data class PreparedReplayEnvelope(
+    val envelope: SensitiveReplayEnvelope,
+    val digest: Sha256Digest,
+)
+
+/**
  * Factory for creating redacted replay envelopes at suspension time
  * and rehydrating them after claim.
  */
 internal object ReplayEnvelopeFactory {
 
     /**
-     * Creates a [SensitiveReplayEnvelope] with the suspended tool's arguments redacted.
+     * Creates a [PreparedReplayEnvelope] with the suspended tool's arguments redacted.
      *
-     * The returned envelope is safe for persistence (PR #29) because the selected
+     * The returned envelope is safe for persistence because the selected
      * suspended tool-call slot contains only a sentinel — the real arguments
-     * come from [ApprovalContinuationStore.claimForExecution] after the continuation
-     * is claimed.
+     * come from [dev.tramai.core.approval.ApprovalContinuationStore.claimForExecution]
+     * after the continuation is claimed.
+     *
+     * Fail-closed validation:
+     * - Selects latest assistant message with tool calls
+     * - Validates toolCallIndex is in bounds
+     * - Validates selected call ID matches expected ID
+     * - Validates selected call name matches expected name
+     * - Requires EXACTLY ONE matching slot across the entire envelope
+     * - Redacts exactly that one slot
+     * - After redaction, requires exactly one sentinel present
+     * - Computes digest from the EXACT redacted snapshot
+     *
+     * All error messages are fixed codes (no interpolated values).
      */
-    fun createForSuspension(
+    fun prepareForSuspension(
+        operationReference: ResumeOperationReference,
         messages: List<Message>,
         toolCallId: String,
         toolName: String,
         toolCallIndex: Int,
-    ): SensitiveReplayEnvelope {
-        val redacted = messages.map { msg ->
-            val msgToolCalls = msg.toolCalls
-            if (msg.role == MessageRole.ASSISTANT && msgToolCalls != null) {
-                val redactedCalls = msgToolCalls.mapIndexed { index, tc ->
-                    if (index == toolCallIndex && tc.id == toolCallId && tc.name == toolName) {
-                        tc.copy(argumentsJson = REDACTED_APPROVAL_CONTINUATION_ARGUMENTS)
-                    } else {
-                        tc.deepCopy()
-                    }
-                }
-                msg.copy(toolCalls = redactedCalls)
-            } else {
-                msg.deepCopy()
-            }
-        }
-        return SensitiveReplayEnvelope.of(redacted)
+    ): PreparedReplayEnvelope {
+        // Select latest assistant message with tool calls (fail closed if none)
+        val assistantMsgIndex = messages.indexOfLast { it.role == MessageRole.ASSISTANT && it.toolCalls != null }
+        require(assistantMsgIndex >= 0) { "replay-envelope-assistant-batch-not-found" }
+
+        val assistantMsg = messages[assistantMsgIndex]
+        val toolCalls = checkNotNull(assistantMsg.toolCalls) { "replay-envelope-assistant-batch-not-found" }
+
+        // Validate toolCallIndex is in bounds
+        require(toolCallIndex in toolCalls.indices) { "replay-envelope-tool-call-index-out-of-bounds" }
+
+        // Validate selected call ID matches expected ID
+        val selectedCall = toolCalls[toolCallIndex]
+        require(selectedCall.id == toolCallId) { "replay-envelope-tool-call-id-mismatch" }
+
+        // Validate selected call name matches expected name
+        require(selectedCall.name == toolName) { "replay-envelope-tool-call-name-mismatch" }
+
+        // Require EXACTLY ONE matching slot across the entire envelope
+        val matchingCalls = toolCalls.filter { it.id == toolCallId && it.name == toolName }
+        require(matchingCalls.size == 1) { "replay-envelope-duplicate-matching-calls" }
+
+        // Redact exactly that one slot
+        val redacted = redactSlot(messages, assistantMsgIndex, toolCallIndex)
+
+        // After redaction, require exactly one sentinel present
+        val sentinelCount = countSentinelOccurrences(redacted)
+        require(sentinelCount == 1) { "replay-envelope-redaction-count-mismatch" }
+
+        // Compute digest from the EXACT redacted snapshot
+        val envelope = SensitiveReplayEnvelope.of(redacted)
+        val digest = ReplayEnvelopeDigestHelper.compute(operationReference, redacted)
+
+        return PreparedReplayEnvelope(envelope = envelope, digest = digest)
     }
 
     /**
      * Rehydrates the selected suspended tool-call slot with the claimed continuation arguments.
      *
-     * Must be called AFTER [ApprovalContinuationStore.claimForExecution] succeeds.
+     * Must be called AFTER [dev.tramai.core.approval.ApprovalContinuationStore.claimForExecution] succeeds.
      * Validates that exactly one matching slot exists and that it contains the redacted sentinel.
      *
      * @throws IllegalStateException if the slot cannot be found or validated.
@@ -64,35 +105,25 @@ internal object ReplayEnvelopeFactory {
         claimedArgumentsJson: String,
     ): RehydratedReplayPayload {
         val messages = payload.messages.toMutableList()
-        
+
         // Find the matching assistant message with tool calls
         val assistantMsgIndex = messages.indexOfLast { it.role == MessageRole.ASSISTANT && it.toolCalls != null }
-        require(assistantMsgIndex >= 0) { "No assistant message with tool calls found in replay envelope" }
-        
+        require(assistantMsgIndex >= 0) { "replay-envelope-assistant-batch-not-found" }
+
         val assistantMsg = messages[assistantMsgIndex]
-        val toolCalls = checkNotNull(assistantMsg.toolCalls) { "Assistant message has null toolCalls" }
-        
-        // P1-5: Validate tool-call slot
-        require(metadata.toolCallIndex in toolCalls.indices) {
-            "replay-envelope-tool-call-index-out-of-bounds"
-        }
+        val toolCalls = checkNotNull(assistantMsg.toolCalls) { "replay-envelope-assistant-batch-not-found" }
+
+        // Validate tool-call slot
+        require(metadata.toolCallIndex in toolCalls.indices) { "replay-envelope-tool-call-index-out-of-bounds" }
         val selectedCall = toolCalls[metadata.toolCallIndex]
-        require(selectedCall.id == metadata.toolCallId) {
-            "replay-envelope-tool-call-id-mismatch"
-        }
-        require(selectedCall.name == metadata.toolName) {
-            "replay-envelope-tool-call-name-mismatch"
-        }
-        require(selectedCall.argumentsJson == REDACTED_APPROVAL_CONTINUATION_ARGUMENTS) {
-            "replay-envelope-tool-call-not-redacted"
-        }
-        
+        require(selectedCall.id == metadata.toolCallId) { "replay-envelope-tool-call-id-mismatch" }
+        require(selectedCall.name == metadata.toolName) { "replay-envelope-tool-call-name-mismatch" }
+        require(selectedCall.argumentsJson == REDACTED_APPROVAL_CONTINUATION_ARGUMENTS) { "replay-envelope-tool-call-not-redacted" }
+
         // Exactly one matching slot
         val matchingCalls = toolCalls.filter { it.id == metadata.toolCallId && it.name == metadata.toolName }
-        require(matchingCalls.size == 1) {
-            "replay-envelope-duplicate-matching-calls"
-        }
-        
+        require(matchingCalls.size == 1) { "replay-envelope-duplicate-matching-calls" }
+
         // Rehydrate the slot
         val rehydratedCalls = toolCalls.mapIndexed { index, tc ->
             if (index == metadata.toolCallIndex) {
@@ -102,8 +133,46 @@ internal object ReplayEnvelopeFactory {
             }
         }
         messages[assistantMsgIndex] = assistantMsg.copy(toolCalls = rehydratedCalls)
-        
+
         return RehydratedReplayPayload(messages = messages)
+    }
+
+    /**
+     * Redacts the tool call at [toolCallIndex] in the assistant message at [assistantMsgIndex].
+     */
+    private fun redactSlot(
+        messages: List<Message>,
+        assistantMsgIndex: Int,
+        toolCallIndex: Int,
+    ): List<Message> {
+        return messages.mapIndexed { index, msg ->
+            if (index == assistantMsgIndex) {
+                val msgToolCalls = msg.toolCalls
+                if (msgToolCalls != null) {
+                    val redactedCalls = msgToolCalls.mapIndexed { tcIndex, tc ->
+                        if (tcIndex == toolCallIndex) {
+                            tc.copy(argumentsJson = REDACTED_APPROVAL_CONTINUATION_ARGUMENTS)
+                        } else {
+                            tc.deepCopy()
+                        }
+                    }
+                    msg.copy(toolCalls = redactedCalls)
+                } else {
+                    msg.deepCopy()
+                }
+            } else {
+                msg.deepCopy()
+            }
+        }
+    }
+
+    /**
+     * Counts occurrences of the redacted sentinel across all tool calls in all messages.
+     */
+    private fun countSentinelOccurrences(messages: List<Message>): Int {
+        return messages.sumOf { msg ->
+            msg.toolCalls?.count { it.argumentsJson == REDACTED_APPROVAL_CONTINUATION_ARGUMENTS } ?: 0
+        }
     }
 }
 

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ReplayEnvelopeFactory.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ReplayEnvelopeFactory.kt
@@ -76,18 +76,20 @@ internal object ReplayEnvelopeFactory {
         require(selectedCall.id == toolCallId) { "replay-envelope-tool-call-id-mismatch" }
         require(selectedCall.name == toolName) { "replay-envelope-tool-call-name-mismatch" }
 
-        // Full-envelope uniqueness: scan ALL slots across ALL messages
+        // Full-envelope uniqueness: toolCallId must be globally unique across ALL messages
         val allSlots = messages.flatMapIndexed { msgIdx, msg ->
             msg.toolCalls.orEmpty().mapIndexed { callIdx, tc ->
                 ReplayToolCallSlot(msgIdx, callIdx, tc)
             }
         }
 
-        val matchingSlots = allSlots.filter { it.call.id == toolCallId && it.call.name == toolName }
-        require(matchingSlots.size == 1) { "replay-envelope-duplicate-matching-calls" }
-        // Also require the sole matching slot is the selected one
-        require(matchingSlots.single().messageIndex == assistantMsgIndex &&
-            matchingSlots.single().toolCallIndex == toolCallIndex) {
+        val matchingIdSlots = allSlots.filter { it.call.id == toolCallId }
+        require(matchingIdSlots.size == 1) { "replay-envelope-duplicate-tool-call-id" }
+
+        val selectedSlot = matchingIdSlots.single()
+        require(selectedSlot.call.name == toolName) { "replay-envelope-tool-call-name-mismatch" }
+        require(selectedSlot.messageIndex == assistantMsgIndex &&
+            selectedSlot.toolCallIndex == toolCallIndex) {
             "replay-envelope-tool-call-slot-mismatch"
         }
 
@@ -132,15 +134,19 @@ internal object ReplayEnvelopeFactory {
         require(selectedCall.name == metadata.toolName) { "replay-envelope-tool-call-name-mismatch" }
         require(selectedCall.argumentsJson == REDACTED_APPROVAL_CONTINUATION_ARGUMENTS) { "replay-envelope-tool-call-not-redacted" }
 
-        // Full-envelope uniqueness: scan ALL slots across ALL messages
+        // Full-envelope uniqueness: toolCallId must be globally unique
         val allSlots = messages.flatMapIndexed { msgIdx, msg ->
             msg.toolCalls.orEmpty().mapIndexed { callIdx, tc ->
                 ReplayToolCallSlot(msgIdx, callIdx, tc)
             }
         }
 
-        val matchingSlots = allSlots.filter { it.call.id == metadata.toolCallId && it.call.name == metadata.toolName }
-        require(matchingSlots.size == 1) { "replay-envelope-duplicate-matching-calls" }
+        val matchingIdSlots = allSlots.filter { it.call.id == metadata.toolCallId }
+        require(matchingIdSlots.size == 1) { "replay-envelope-duplicate-tool-call-id" }
+
+        // Global sentinel recheck before rehydration
+        val globalSentinelCount = countSentinelOccurrences(messages)
+        require(globalSentinelCount == 1) { "replay-envelope-redaction-count-mismatch" }
 
         // Rehydrate the slot
         val rehydratedCalls = toolCalls.mapIndexed { index, tc ->

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ReplayEnvelopeFactory.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ReplayEnvelopeFactory.kt
@@ -1,0 +1,115 @@
+package dev.tramai.engine
+
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
+import dev.tramai.core.model.ToolCall
+import dev.tramai.core.approval.Sha256Digest
+
+/**
+ * Sentinel value replacing raw tool-call arguments in the replay envelope.
+ * The value must be a fixed, non-null, non-empty string that is not a valid JSON payload.
+ * This prevents the persisted envelope from containing executable raw arguments.
+ */
+internal const val REDACTED_APPROVAL_CONTINUATION_ARGUMENTS = "__redacted_approval_continuation_args__"
+
+/**
+ * Factory for creating redacted replay envelopes at suspension time
+ * and rehydrating them after claim.
+ */
+internal object ReplayEnvelopeFactory {
+
+    /**
+     * Creates a [SensitiveReplayEnvelope] with the suspended tool's arguments redacted.
+     *
+     * The returned envelope is safe for persistence (PR #29) because the selected
+     * suspended tool-call slot contains only a sentinel — the real arguments
+     * come from [ApprovalContinuationStore.claimForExecution] after the continuation
+     * is claimed.
+     */
+    fun createForSuspension(
+        messages: List<Message>,
+        toolCallId: String,
+        toolName: String,
+        toolCallIndex: Int,
+    ): SensitiveReplayEnvelope {
+        val redacted = messages.map { msg ->
+            val msgToolCalls = msg.toolCalls
+            if (msg.role == MessageRole.ASSISTANT && msgToolCalls != null) {
+                val redactedCalls = msgToolCalls.mapIndexed { index, tc ->
+                    if (index == toolCallIndex && tc.id == toolCallId && tc.name == toolName) {
+                        tc.copy(argumentsJson = REDACTED_APPROVAL_CONTINUATION_ARGUMENTS)
+                    } else {
+                        tc.deepCopy()
+                    }
+                }
+                msg.copy(toolCalls = redactedCalls)
+            } else {
+                msg.deepCopy()
+            }
+        }
+        return SensitiveReplayEnvelope.of(redacted)
+    }
+
+    /**
+     * Rehydrates the selected suspended tool-call slot with the claimed continuation arguments.
+     *
+     * Must be called AFTER [ApprovalContinuationStore.claimForExecution] succeeds.
+     * Validates that exactly one matching slot exists and that it contains the redacted sentinel.
+     *
+     * @throws IllegalStateException if the slot cannot be found or validated.
+     */
+    fun rehydrateAfterClaim(
+        payload: ReplayPayload,
+        metadata: SuspendedInvocationMetadata,
+        claimedArgumentsJson: String,
+    ): RehydratedReplayPayload {
+        val messages = payload.messages.toMutableList()
+        
+        // Find the matching assistant message with tool calls
+        val assistantMsgIndex = messages.indexOfLast { it.role == MessageRole.ASSISTANT && it.toolCalls != null }
+        require(assistantMsgIndex >= 0) { "No assistant message with tool calls found in replay envelope" }
+        
+        val assistantMsg = messages[assistantMsgIndex]
+        val toolCalls = checkNotNull(assistantMsg.toolCalls) { "Assistant message has null toolCalls" }
+        
+        // P1-5: Validate tool-call slot
+        require(metadata.toolCallIndex in toolCalls.indices) {
+            "replay-envelope-tool-call-index-out-of-bounds"
+        }
+        val selectedCall = toolCalls[metadata.toolCallIndex]
+        require(selectedCall.id == metadata.toolCallId) {
+            "replay-envelope-tool-call-id-mismatch"
+        }
+        require(selectedCall.name == metadata.toolName) {
+            "replay-envelope-tool-call-name-mismatch"
+        }
+        require(selectedCall.argumentsJson == REDACTED_APPROVAL_CONTINUATION_ARGUMENTS) {
+            "replay-envelope-tool-call-not-redacted"
+        }
+        
+        // Exactly one matching slot
+        val matchingCalls = toolCalls.filter { it.id == metadata.toolCallId && it.name == metadata.toolName }
+        require(matchingCalls.size == 1) {
+            "replay-envelope-duplicate-matching-calls"
+        }
+        
+        // Rehydrate the slot
+        val rehydratedCalls = toolCalls.mapIndexed { index, tc ->
+            if (index == metadata.toolCallIndex) {
+                tc.copy(argumentsJson = claimedArgumentsJson)
+            } else {
+                tc
+            }
+        }
+        messages[assistantMsgIndex] = assistantMsg.copy(toolCalls = rehydratedCalls)
+        
+        return RehydratedReplayPayload(messages = messages)
+    }
+}
+
+/**
+ * Rehydrated replay payload with restored claimed tool arguments.
+ */
+data class RehydratedReplayPayload(
+    val messages: List<Message>,
+)

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ResumeDefinitionDigestHelper.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ResumeDefinitionDigestHelper.kt
@@ -21,16 +21,14 @@ internal object ResumeDefinitionDigestHelper {
     ): Sha256Digest {
         val canonical = buildString {
             // Service identity
-            append("service=").append(
-                serviceDefinition.serviceType.qualifiedName
-                    ?: serviceDefinition.serviceType.simpleName.orEmpty()
-            ).append('\n')
-            append("method=").append(operation.method.name).append('\n')
-            append("jvm_descriptor=").append(JvmMethodDescriptorHelper.compute(operation.method)).append('\n')
+            appendField("service", serviceDefinition.serviceType.qualifiedName
+                ?: serviceDefinition.serviceType.simpleName.orEmpty())
+            appendField("method", operation.method.name)
+            appendField("jvm_descriptor", JvmMethodDescriptorHelper.compute(operation.method))
 
             // Return kind and type description
             append("return_kind=").append(operation.returnKind.name).append('\n')
-            append("return_type_description=").append(operation.returnTypeDescription).append('\n')
+            appendField("return_type_description", operation.returnTypeDescription)
 
             // Operation settings — model and provider use appendField for UTF-8 byte length
             appendField("model", operation.operation.model)
@@ -59,10 +57,10 @@ internal object ResumeDefinitionDigestHelper {
                 appendField("user_annotation_$i", annotation)
             }
 
-            // Tool definitions with stable ordering (sorted by name for determinism)
+            // Tool definitions (no sorting — preserve declaration order)
             append("tools_count=").append(operation.toolDefinitions.size).append('\n')
-            operation.toolDefinitions.sortedBy { it.name }.forEachIndexed { index, tool ->
-                append("tool_").append(index).append("_name=").append(tool.name).append('\n')
+            operation.toolDefinitions.forEachIndexed { index, tool ->
+                appendField("tool_${index}_name", tool.name)
                 appendField("tool_${index}_description", tool.description)
                 appendField("tool_${index}_schema", tool.inputSchemaJson)
             }

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ResumeDefinitionDigestHelper.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ResumeDefinitionDigestHelper.kt
@@ -32,9 +32,9 @@ internal object ResumeDefinitionDigestHelper {
             append("return_kind=").append(operation.returnKind.name).append('\n')
             append("return_type_description=").append(operation.returnTypeDescription).append('\n')
 
-            // Operation settings
-            append("model=").append(operation.operation.model).append('\n')
-            append("provider=").append(operation.operation.provider).append('\n')
+            // Operation settings — model and provider use appendField for UTF-8 byte length
+            appendField("model", operation.operation.model)
+            appendField("provider", operation.operation.provider)
             append("timeout_millis=").append(operation.operation.timeoutMillis).append('\n')
             append("max_retries=").append(operation.operation.maxRetries).append('\n')
             append("provider_retries=").append(operation.operation.providerRetries).append('\n')
@@ -47,41 +47,29 @@ internal object ResumeDefinitionDigestHelper {
             // Class-level system prompt
             appendField("class_system_prompt", serviceDefinition.systemPrompt)
 
-            // Method-level @System annotations (pre-sorted for determinism)
+            // Method-level @System annotations (preserve original order — no sorting)
             append("system_annotations_count=").append(operation.systemAnnotations.size).append('\n')
-            operation.systemAnnotations.sorted().forEachIndexed { i, annotation ->
+            operation.systemAnnotations.forEachIndexed { i, annotation ->
                 appendField("system_annotation_$i", annotation)
             }
 
-            // Method-level @User annotations (pre-sorted for determinism)
+            // Method-level @User annotations (preserve original order — no sorting)
             append("user_annotations_count=").append(operation.userAnnotations.size).append('\n')
-            operation.userAnnotations.sorted().forEachIndexed { i, annotation ->
+            operation.userAnnotations.forEachIndexed { i, annotation ->
                 appendField("user_annotation_$i", annotation)
             }
 
-            // Tool definitions with stable ordering (sorted by name)
+            // Tool definitions with stable ordering (sorted by name for determinism)
             append("tools_count=").append(operation.toolDefinitions.size).append('\n')
             operation.toolDefinitions.sortedBy { it.name }.forEachIndexed { index, tool ->
                 append("tool_").append(index).append("_name=").append(tool.name).append('\n')
-                append("tool_").append(index).append("_description_len=").append(tool.description.length).append('\n')
-                append(tool.description).append('\n')
-                append("tool_").append(index).append("_schema_len=").append(tool.inputSchemaJson.length).append('\n')
-                append(tool.inputSchemaJson).append('\n')
+                appendField("tool_${index}_description", tool.description)
+                appendField("tool_${index}_schema", tool.inputSchemaJson)
             }
         }
 
         val digest = MessageDigest.getInstance("SHA-256").digest(canonical.toByteArray(StandardCharsets.UTF_8))
         val hex = digest.joinToString("") { "%02x".format(it) }
         return Sha256Digest.of("sha256:$hex")
-    }
-
-    private fun StringBuilder.appendField(name: String, value: String?) {
-        if (value == null) {
-            append(name).append("_null").append('\n')
-            return
-        }
-        val bytes = value.toByteArray(StandardCharsets.UTF_8)
-        append(name).append("_len=").append(bytes.size).append('\n')
-        append(value).append('\n')
     }
 }

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ResumeDefinitionDigestHelper.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ResumeDefinitionDigestHelper.kt
@@ -1,0 +1,87 @@
+package dev.tramai.engine
+
+import dev.tramai.core.approval.Sha256Digest
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+/**
+ * Computes a deterministic digest over the full resume definition: service definition
+ * and operation definition including all canonical fields.
+ *
+ * The digest is used in [ResumeOperationReference.resumeDefinitionDigest] and must be
+ * stable across JVM restarts for the same definition. It is stricter than
+ * [WorkflowDigestHelper] because it includes more fields (annotations, prompts, cache
+ * settings, operation prompt, class-level system prompt).
+ */
+internal object ResumeDefinitionDigestHelper {
+
+    fun compute(
+        serviceDefinition: ServiceDefinition,
+        operation: OperationDefinition,
+    ): Sha256Digest {
+        val canonical = buildString {
+            // Service identity
+            append("service=").append(
+                serviceDefinition.serviceType.qualifiedName
+                    ?: serviceDefinition.serviceType.simpleName.orEmpty()
+            ).append('\n')
+            append("method=").append(operation.method.name).append('\n')
+            append("jvm_descriptor=").append(JvmMethodDescriptorHelper.compute(operation.method)).append('\n')
+
+            // Return kind and type description
+            append("return_kind=").append(operation.returnKind.name).append('\n')
+            append("return_type_description=").append(operation.returnTypeDescription).append('\n')
+
+            // Operation settings
+            append("model=").append(operation.operation.model).append('\n')
+            append("provider=").append(operation.operation.provider).append('\n')
+            append("timeout_millis=").append(operation.operation.timeoutMillis).append('\n')
+            append("max_retries=").append(operation.operation.maxRetries).append('\n')
+            append("provider_retries=").append(operation.operation.providerRetries).append('\n')
+            append("cacheable=").append(operation.operation.cacheable).append('\n')
+            append("cache_ttl_millis=").append(operation.operation.cacheTtlMillis).append('\n')
+
+            // Operation prompt
+            appendField("operation_prompt", operation.operation.prompt)
+
+            // Class-level system prompt
+            appendField("class_system_prompt", serviceDefinition.systemPrompt)
+
+            // Method-level @System annotations (pre-sorted for determinism)
+            append("system_annotations_count=").append(operation.systemAnnotations.size).append('\n')
+            operation.systemAnnotations.sorted().forEachIndexed { i, annotation ->
+                appendField("system_annotation_$i", annotation)
+            }
+
+            // Method-level @User annotations (pre-sorted for determinism)
+            append("user_annotations_count=").append(operation.userAnnotations.size).append('\n')
+            operation.userAnnotations.sorted().forEachIndexed { i, annotation ->
+                appendField("user_annotation_$i", annotation)
+            }
+
+            // Tool definitions with stable ordering (sorted by name)
+            append("tools_count=").append(operation.toolDefinitions.size).append('\n')
+            operation.toolDefinitions.sortedBy { it.name }.forEachIndexed { index, tool ->
+                append("tool_").append(index).append("_name=").append(tool.name).append('\n')
+                append("tool_").append(index).append("_description_len=").append(tool.description.length).append('\n')
+                append(tool.description).append('\n')
+                append("tool_").append(index).append("_schema_len=").append(tool.inputSchemaJson.length).append('\n')
+                append(tool.inputSchemaJson).append('\n')
+            }
+        }
+
+        val digest = MessageDigest.getInstance("SHA-256").digest(canonical.toByteArray(StandardCharsets.UTF_8))
+        val hex = digest.joinToString("") { "%02x".format(it) }
+        return Sha256Digest.of("sha256:$hex")
+    }
+
+    private fun StringBuilder.appendField(name: String, value: String?) {
+        if (value == null) {
+            append(name).append("_null").append('\n')
+            return
+        }
+        val bytes = value.toByteArray(StandardCharsets.UTF_8)
+        append(name).append("_len=").append(bytes.size).append('\n')
+        append(value).append('\n')
+    }
+}

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ResumeOperationReference.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ResumeOperationReference.kt
@@ -1,7 +1,10 @@
 package dev.tramai.engine
 
 import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.model.ResolvedTool
 import java.lang.reflect.Method
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 
 /**
  * Stable, serializable reference that identifies a resume-able operation.
@@ -20,6 +23,49 @@ data class ResumeOperationReference(
     val jvmMethodDescriptor: String,
     val resumeDefinitionDigest: Sha256Digest,
 )
+
+/**
+ * Stable, serializable reference that identifies the tool whose execution was suspended.
+ *
+ * Contains only data — no runtime objects, no reflection objects.
+ *
+ * @property toolName The name of the tool.
+ * @property declarationDigest Digest of the canonicalised tool declaration.
+ */
+data class ResumeToolReference(
+    val toolName: String,
+    val declarationDigest: Sha256Digest,
+)
+
+/**
+ * Helper for computing a deterministic digest over a tool declaration.
+ *
+ * Canonicalises all tool declaration fields so the digest can be compared
+ * at resume time to detect tool definition drift.
+ */
+internal object ResumeToolDeclarationDigestHelper {
+    fun compute(tool: ResolvedTool): Sha256Digest {
+        val canonical = buildString {
+            appendField("name", tool.name)
+            appendField("description", tool.description)
+            appendField("schema", tool.inputSchemaJson)
+            append("idempotent=").append(tool.idempotent).append('\n')
+            append("side_effect_level=").append(tool.sideEffectLevel?.name ?: "null").append('\n')
+            val sec = tool.security
+            if (sec != null) {
+                appendField("permission", sec.permission)
+                appendField("risk", sec.risk?.name)
+                appendField("approval", sec.approval?.name)
+                appendField("network_egress", sec.managedNetworkEgress?.name)
+                appendField("audit", sec.audit?.name)
+                appendField("compat_mode", sec.compatibilityMode?.name)
+            }
+        }
+        val digest = MessageDigest.getInstance("SHA-256").digest(canonical.toByteArray(StandardCharsets.UTF_8))
+        val hex = digest.joinToString("") { "%02x".format(it) }
+        return Sha256Digest.of("sha256:$hex")
+    }
+}
 
 /**
  * Helper for computing a deterministic JVM method descriptor from a [java.lang.reflect.Method].
@@ -46,6 +92,6 @@ internal object JvmMethodDescriptorHelper {
         type == java.lang.Float.TYPE -> "F"
         type == java.lang.Double.TYPE -> "D"
         type.isArray -> "[" + typeDescriptor(type.componentType)
-        else -> "L" + type.canonicalName.replace('.', '/') + ";"
+        else -> "L" + type.name.replace('.', '/') + ";"
     }
 }

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ResumeOperationReference.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ResumeOperationReference.kt
@@ -1,0 +1,51 @@
+package dev.tramai.engine
+
+import dev.tramai.core.approval.Sha256Digest
+import java.lang.reflect.Method
+
+/**
+ * Stable, serializable reference that identifies a resume-able operation.
+ *
+ * Contains only data — no runtime objects, no reflection objects, no callbacks.
+ * Resolved by [ResumeOperationRegistry] at resume time against the current runtime.
+ *
+ * @property serviceInterface Fully qualified service interface name.
+ * @property methodName The method name.
+ * @property jvmMethodDescriptor JVM descriptor for unambiguous overload resolution.
+ * @property resumeDefinitionDigest Digest of the canonicalised service + operation definition.
+ */
+data class ResumeOperationReference(
+    val serviceInterface: String,
+    val methodName: String,
+    val jvmMethodDescriptor: String,
+    val resumeDefinitionDigest: Sha256Digest,
+)
+
+/**
+ * Helper for computing a deterministic JVM method descriptor from a [java.lang.reflect.Method].
+ *
+ * Describes parameter types and return type in JVM internal form so that
+ * overloaded methods resolve unambiguously. Does NOT store Method, KClass, KType, or KFunction.
+ */
+internal object JvmMethodDescriptorHelper {
+
+    fun compute(method: Method): String {
+        val params = method.parameterTypes.joinToString(separator = "") { typeDescriptor(it) }
+        val ret = typeDescriptor(method.returnType)
+        return "($params)$ret"
+    }
+
+    private fun typeDescriptor(type: Class<*>): String = when {
+        type == java.lang.Void.TYPE -> "V"
+        type == java.lang.Boolean.TYPE -> "Z"
+        type == java.lang.Byte.TYPE -> "B"
+        type == java.lang.Character.TYPE -> "C"
+        type == java.lang.Short.TYPE -> "S"
+        type == java.lang.Integer.TYPE -> "I"
+        type == java.lang.Long.TYPE -> "J"
+        type == java.lang.Float.TYPE -> "F"
+        type == java.lang.Double.TYPE -> "D"
+        type.isArray -> "[" + typeDescriptor(type.componentType)
+        else -> "L" + type.canonicalName.replace('.', '/') + ";"
+    }
+}

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ResumeOperationRegistry.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ResumeOperationRegistry.kt
@@ -63,16 +63,51 @@ internal class ResumeOperationRegistry {
                     // Idempotent — same definition, same digest. Return existing.
                     existing
                 }
-                else -> throw ConfigurationException(
-                    "Resume operation registration conflict for " +
-                        "${key.serviceInterface}.${key.methodName}: " +
-                        "existing digest ${existing.reference.resumeDefinitionDigest.value} != " +
-                        "new digest ${reference.resumeDefinitionDigest.value}"
-                )
+                else -> throw ConfigurationException("resume-operation-registration-conflict")
             }
         }
 
         return reference
+    }
+
+    /**
+     * Atomically register all operations for a service definition.
+     *
+     * Validates all operations for conflicts first, then publishes them.
+     * This prevents partial registration when one operation conflicts.
+     *
+     * @throws ConfigurationException if any key already exists with a different digest.
+     */
+    fun registerAll(
+        serviceDefinition: ServiceDefinition,
+        handler: TramaiInvocationHandler,
+    ) {
+        val entries = serviceDefinition.operations.entries.map { (_, operation) ->
+            val key = createKey(serviceDefinition, operation)
+            val reference = ResumeOperationReference(
+                serviceInterface = key.serviceInterface,
+                methodName = key.methodName,
+                jvmMethodDescriptor = key.jvmMethodDescriptor,
+                resumeDefinitionDigest = ResumeDefinitionDigestHelper.compute(serviceDefinition, operation),
+            )
+            key to RegisteredResumeOperation(
+                reference = reference,
+                serviceDefinition = serviceDefinition,
+                operation = operation,
+                handler = handler,
+            )
+        }
+
+        // Validate all conflicts first, then publish
+        entries.forEach { (key, entry) ->
+            operations.compute(key) { _, existing ->
+                when {
+                    existing == null -> entry
+                    existing.reference.resumeDefinitionDigest == entry.reference.resumeDefinitionDigest -> existing
+                    else -> throw ConfigurationException("resume-operation-registration-conflict")
+                }
+            }
+        }
     }
 
     /**
@@ -87,14 +122,10 @@ internal class ResumeOperationRegistry {
             jvmMethodDescriptor = reference.jvmMethodDescriptor,
         )
         val registered = operations[key]
-            ?: throw ConfigurationException("resume-operation-not-registered: " +
-                "${reference.serviceInterface}.${reference.methodName}")
+            ?: throw ConfigurationException("resume-operation-not-registered")
 
         if (registered.reference.resumeDefinitionDigest != reference.resumeDefinitionDigest) {
-            throw ConfigurationException("resume-operation-definition-drift: " +
-                "${reference.serviceInterface}.${reference.methodName}: " +
-                "stored digest ${reference.resumeDefinitionDigest.value} != " +
-                "registered digest ${registered.reference.resumeDefinitionDigest.value}")
+            throw ConfigurationException("resume-operation-definition-drift")
         }
 
         return registered

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ResumeOperationRegistry.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ResumeOperationRegistry.kt
@@ -2,6 +2,7 @@ package dev.tramai.engine
 
 import dev.tramai.core.exception.ConfigurationException
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantReadWriteLock
 
 /**
  * A registered resume-able operation in the trusted [ResumeOperationRegistry].
@@ -32,6 +33,12 @@ internal data class RegisteredResumeOperation(
 internal class ResumeOperationRegistry {
 
     private val operations = ConcurrentHashMap<RegistryKey, RegisteredResumeOperation>()
+    private val registrationLock = ReentrantReadWriteLock()
+
+    private inline fun <T> withWriteLock(action: () -> T): T {
+        registrationLock.writeLock().lock()
+        try { return action() } finally { registrationLock.writeLock().unlock() }
+    }
 
     /**
      * Register or verify an operation for resume.
@@ -42,7 +49,7 @@ internal class ResumeOperationRegistry {
         serviceDefinition: ServiceDefinition,
         operation: OperationDefinition,
         handler: TramaiInvocationHandler,
-    ): ResumeOperationReference {
+    ): ResumeOperationReference = withWriteLock {
         val key = createKey(serviceDefinition, operation)
         val reference = ResumeOperationReference(
             serviceInterface = key.serviceInterface,
@@ -67,7 +74,7 @@ internal class ResumeOperationRegistry {
             }
         }
 
-        return reference
+        reference
     }
 
     /**
@@ -81,7 +88,7 @@ internal class ResumeOperationRegistry {
     fun registerAll(
         serviceDefinition: ServiceDefinition,
         handler: TramaiInvocationHandler,
-    ) {
+    ) = withWriteLock {
         val entries = serviceDefinition.operations.entries.map { (_, operation) ->
             val key = createKey(serviceDefinition, operation)
             val reference = ResumeOperationReference(

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ResumeOperationRegistry.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ResumeOperationRegistry.kt
@@ -1,0 +1,118 @@
+package dev.tramai.engine
+
+import dev.tramai.core.exception.ConfigurationException
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * A registered resume-able operation in the trusted [ResumeOperationRegistry].
+ *
+ * @property reference Stable data-only reference that identifies this operation.
+ * @property serviceDefinition The service definition that created this operation.
+ * @property operation The resolved operation definition.
+ * @property handler The invocation handler that can execute this operation.
+ */
+internal data class RegisteredResumeOperation(
+    val reference: ResumeOperationReference,
+    val serviceDefinition: ServiceDefinition,
+    val operation: OperationDefinition,
+    val handler: TramaiInvocationHandler,
+)
+
+/**
+ * Thread-safe, trusted registry of resume-able operations.
+ *
+ * Operations are registered when a service is created (via [TramaiEngine.create])
+ * or explicitly registered (via [TramaiEngine.registerService]).
+ *
+ * Rules:
+ * - Missing key: ConfigurationException("resume-operation-not-registered")
+ * - Same key + same digest: idempotent (allowed)
+ * - Same key + different digest: fail closed with ConfigurationException
+ */
+internal class ResumeOperationRegistry {
+
+    private val operations = ConcurrentHashMap<RegistryKey, RegisteredResumeOperation>()
+
+    /**
+     * Register or verify an operation for resume.
+     *
+     * @throws ConfigurationException if the key already exists with a different digest.
+     */
+    fun register(
+        serviceDefinition: ServiceDefinition,
+        operation: OperationDefinition,
+        handler: TramaiInvocationHandler,
+    ): ResumeOperationReference {
+        val key = createKey(serviceDefinition, operation)
+        val reference = ResumeOperationReference(
+            serviceInterface = key.serviceInterface,
+            methodName = key.methodName,
+            jvmMethodDescriptor = key.jvmMethodDescriptor,
+            resumeDefinitionDigest = ResumeDefinitionDigestHelper.compute(serviceDefinition, operation),
+        )
+
+        operations.compute(key) { _, existing ->
+            when {
+                existing == null -> RegisteredResumeOperation(
+                    reference = reference,
+                    serviceDefinition = serviceDefinition,
+                    operation = operation,
+                    handler = handler,
+                )
+                existing.reference.resumeDefinitionDigest == reference.resumeDefinitionDigest -> {
+                    // Idempotent — same definition, same digest. Return existing.
+                    existing
+                }
+                else -> throw ConfigurationException(
+                    "Resume operation registration conflict for " +
+                        "${key.serviceInterface}.${key.methodName}: " +
+                        "existing digest ${existing.reference.resumeDefinitionDigest.value} != " +
+                        "new digest ${reference.resumeDefinitionDigest.value}"
+                )
+            }
+        }
+
+        return reference
+    }
+
+    /**
+     * Resolve a [ResumeOperationReference] to its registered operation.
+     *
+     * @throws ConfigurationException if the operation is not registered or has drifted.
+     */
+    fun resolve(reference: ResumeOperationReference): RegisteredResumeOperation {
+        val key = RegistryKey(
+            serviceInterface = reference.serviceInterface,
+            methodName = reference.methodName,
+            jvmMethodDescriptor = reference.jvmMethodDescriptor,
+        )
+        val registered = operations[key]
+            ?: throw ConfigurationException("resume-operation-not-registered: " +
+                "${reference.serviceInterface}.${reference.methodName}")
+
+        if (registered.reference.resumeDefinitionDigest != reference.resumeDefinitionDigest) {
+            throw ConfigurationException("resume-operation-definition-drift: " +
+                "${reference.serviceInterface}.${reference.methodName}: " +
+                "stored digest ${reference.resumeDefinitionDigest.value} != " +
+                "registered digest ${registered.reference.resumeDefinitionDigest.value}")
+        }
+
+        return registered
+    }
+
+    private fun createKey(
+        serviceDefinition: ServiceDefinition,
+        operation: OperationDefinition,
+    ): RegistryKey = RegistryKey(
+        serviceInterface = serviceDefinition.serviceType.qualifiedName
+            ?: serviceDefinition.serviceType.simpleName.orEmpty(),
+        methodName = operation.method.name,
+        jvmMethodDescriptor = JvmMethodDescriptorHelper.compute(operation.method),
+    )
+
+    private data class RegistryKey(
+        val serviceInterface: String,
+        val methodName: String,
+        val jvmMethodDescriptor: String,
+    )
+}

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ResumeOperationRegistry.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ResumeOperationRegistry.kt
@@ -1,7 +1,6 @@
 package dev.tramai.engine
 
 import dev.tramai.core.exception.ConfigurationException
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.locks.ReentrantReadWriteLock
 
 /**
@@ -22,8 +21,8 @@ internal data class RegisteredResumeOperation(
 /**
  * Thread-safe, trusted registry of resume-able operations.
  *
- * Operations are registered when a service is created (via [TramaiEngine.create])
- * or explicitly registered (via [TramaiEngine.registerService]).
+ * Uses copy-on-write semantics under a write lock for atomic multi-operation
+ * registration. Readers observe the registry as one state transition.
  *
  * Rules:
  * - Missing key: ConfigurationException("resume-operation-not-registered")
@@ -32,12 +31,18 @@ internal data class RegisteredResumeOperation(
  */
 internal class ResumeOperationRegistry {
 
-    private val operations = ConcurrentHashMap<RegistryKey, RegisteredResumeOperation>()
-    private val registrationLock = ReentrantReadWriteLock()
+    @Volatile
+    private var operations: Map<RegistryKey, RegisteredResumeOperation> = emptyMap()
+    private val lock = ReentrantReadWriteLock()
+
+    private inline fun <T> withReadLock(action: () -> T): T {
+        lock.readLock().lock()
+        try { return action() } finally { lock.readLock().unlock() }
+    }
 
     private inline fun <T> withWriteLock(action: () -> T): T {
-        registrationLock.writeLock().lock()
-        try { return action() } finally { registrationLock.writeLock().unlock() }
+        lock.writeLock().lock()
+        try { return action() } finally { lock.writeLock().unlock() }
     }
 
     /**
@@ -58,20 +63,21 @@ internal class ResumeOperationRegistry {
             resumeDefinitionDigest = ResumeDefinitionDigestHelper.compute(serviceDefinition, operation),
         )
 
-        operations.compute(key) { _, existing ->
-            when {
-                existing == null -> RegisteredResumeOperation(
+        val existing = operations[key]
+        when {
+            existing == null -> {
+                val updated = operations.toMutableMap()
+                updated[key] = RegisteredResumeOperation(
                     reference = reference,
                     serviceDefinition = serviceDefinition,
                     operation = operation,
                     handler = handler,
                 )
-                existing.reference.resumeDefinitionDigest == reference.resumeDefinitionDigest -> {
-                    // Idempotent — same definition, same digest. Return existing.
-                    existing
-                }
-                else -> throw ConfigurationException("resume-operation-registration-conflict")
+                operations = updated.toMap()
             }
+            existing.reference.resumeDefinitionDigest != reference.resumeDefinitionDigest ->
+                throw ConfigurationException("resume-operation-registration-conflict")
+            // else idempotent
         }
 
         reference
@@ -80,8 +86,9 @@ internal class ResumeOperationRegistry {
     /**
      * Atomically register all operations for a service definition.
      *
-     * Validates all operations for conflicts first, then publishes them.
-     * This prevents partial registration when one operation conflicts.
+     * Validates all operations for conflicts first, then publishes all as one
+     * atomic state transition. A conflicting operation prevents the entire
+     * batch from being published.
      *
      * @throws ConfigurationException if any key already exists with a different digest.
      */
@@ -105,24 +112,31 @@ internal class ResumeOperationRegistry {
             )
         }
 
-        // Validate all conflicts first, then publish
-        entries.forEach { (key, entry) ->
-            operations.compute(key) { _, existing ->
-                when {
-                    existing == null -> entry
-                    existing.reference.resumeDefinitionDigest == entry.reference.resumeDefinitionDigest -> existing
-                    else -> throw ConfigurationException("resume-operation-registration-conflict")
-                }
-            }
+        // Phase 1: Validate all conflicts before any mutation
+        entries.forEach { (key, incoming) ->
+            val existing = operations[key]
+            require(
+                existing == null ||
+                    existing.reference.resumeDefinitionDigest == incoming.reference.resumeDefinitionDigest
+            ) { "resume-operation-registration-conflict" }
         }
+
+        // Phase 2: Atomic publish via copy-on-write
+        val updated = operations.toMutableMap()
+        entries.forEach { (key, entry) ->
+            updated.putIfAbsent(key, entry)
+        }
+        operations = updated.toMap()
     }
 
     /**
      * Resolve a [ResumeOperationReference] to its registered operation.
      *
+     * Uses a read lock to ensure visibility of a fully published registry state.
+     *
      * @throws ConfigurationException if the operation is not registered or has drifted.
      */
-    fun resolve(reference: ResumeOperationReference): RegisteredResumeOperation {
+    fun resolve(reference: ResumeOperationReference): RegisteredResumeOperation = withReadLock {
         val key = RegistryKey(
             serviceInterface = reference.serviceInterface,
             methodName = reference.methodName,
@@ -135,7 +149,7 @@ internal class ResumeOperationRegistry {
             throw ConfigurationException("resume-operation-definition-drift")
         }
 
-        return registered
+        registered
     }
 
     private fun createKey(

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/SensitiveReplayEnvelope.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/SensitiveReplayEnvelope.kt
@@ -7,6 +7,12 @@ import dev.tramai.core.model.ToolCall
 /**
  * Opaque, non-serializable envelope containing the replayable message history.
  *
+ * Contains replayable message data, including historical data-model ToolCall values
+ * where required for provider continuity. It never contains executable runtime objects
+ * such as OperationDefinition, ResolvedTool, Method, callbacks, providers, or registries.
+ * The selected suspended ToolCall arguments are redacted and rehydrated from
+ * ApprovalContinuationStore only after claim.
+ *
  * - Contains ONLY [Message] objects — no OperationDefinition, no ResolvedTool, no ToolCall.
  * - [toString] returns [REDACTED].
  * - Only accessible via [revealForResume] inside a trusted code path after claim.

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/SensitiveReplayEnvelope.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/SensitiveReplayEnvelope.kt
@@ -5,18 +5,18 @@ import dev.tramai.core.model.Message
 import dev.tramai.core.model.ToolCall
 
 /**
- * Opaque, non-serializable envelope containing the replayable message history.
+ * Opaque, non-serializable envelope containing replayable message history.
  *
- * Contains replayable message data, including historical data-model ToolCall values
- * where required for provider continuity. It never contains executable runtime objects
- * such as OperationDefinition, ResolvedTool, Method, callbacks, providers, or registries.
- * The selected suspended ToolCall arguments are redacted and rehydrated from
- * ApprovalContinuationStore only after claim.
+ * Historical message-level ToolCall values may exist for provider continuity.
+ * The selected suspended ToolCall arguments are replaced by a sentinel
+ * until rehydrated from claimed continuation arguments after claim.
  *
- * - Contains ONLY [Message] objects — no OperationDefinition, no ResolvedTool, no ToolCall.
- * - [toString] returns [REDACTED].
- * - Only accessible via [revealForResume] inside a trusted code path after claim.
- * - Defensive deep copies prevent mutation after creation.
+ * The envelope never stores executable runtime objects such as:
+ * OperationDefinition, ResolvedTool, Method, callbacks, providers, or registries.
+ *
+ * [toString] returns [REDACTED].
+ * Only accessible via [revealForResume] inside a trusted code path after claim.
+ * Defensive deep copies prevent mutation after creation.
  */
 class SensitiveReplayEnvelope private constructor(
     private val messages: List<Message>,

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/SensitiveReplayEnvelope.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/SensitiveReplayEnvelope.kt
@@ -1,0 +1,77 @@
+package dev.tramai.engine
+
+import dev.tramai.core.model.ContentPart
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.ToolCall
+
+/**
+ * Opaque, non-serializable envelope containing the replayable message history.
+ *
+ * - Contains ONLY [Message] objects — no OperationDefinition, no ResolvedTool, no ToolCall.
+ * - [toString] returns [REDACTED].
+ * - Only accessible via [revealForResume] inside a trusted code path after claim.
+ * - Defensive deep copies prevent mutation after creation.
+ */
+class SensitiveReplayEnvelope private constructor(
+    private val messages: List<Message>,
+) {
+    /**
+     * Reveals a safe deep copy of the enclosed messages for the resume code path.
+     *
+     * Must only be called after [ApprovalContinuationStore.claimForExecution] succeeds.
+     */
+    fun revealForResume(): ReplayPayload =
+        ReplayPayload(messages = messages.deepCopy())
+
+    override fun toString(): String = "[REDACTED]"
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SensitiveReplayEnvelope) return false
+        return messages == other.messages
+    }
+
+    override fun hashCode(): Int = messages.hashCode()
+
+    companion object {
+        /**
+         * Wraps messages in a defensive deep copy.
+         */
+        fun of(messages: List<Message>): SensitiveReplayEnvelope {
+            val defensiveCopy = messages.deepCopy()
+            return SensitiveReplayEnvelope(defensiveCopy)
+        }
+    }
+}
+
+/**
+ * Safe payload returned by [SensitiveReplayEnvelope.revealForResume].
+ *
+ * Contains only the messages needed for the provider loop after resume.
+ */
+data class ReplayPayload(
+    val messages: List<Message>,
+)
+
+/**
+ * Deterministic deep copy for [Message] and its transitive types.
+ */
+internal fun List<Message>.deepCopy(): List<Message> = map { it.deepCopy() }
+
+internal fun Message.deepCopy(): Message = copy(
+    content = content,
+    contentParts = contentParts?.map { it.deepCopy() },
+    toolCalls = toolCalls?.map { it.deepCopy() },
+)
+
+internal fun ContentPart.deepCopy(): ContentPart = when (this) {
+    is ContentPart.TextPart -> copy(text = text)
+    is ContentPart.ImagePart -> ContentPart.ImagePart(mimeType = mimeType, data = data.copyOf())
+    is ContentPart.ImageUrlContent -> copy(url = url, mimeType = mimeType)
+}
+
+internal fun ToolCall.deepCopy(): ToolCall = copy(
+    id = id,
+    name = name,
+    argumentsJson = argumentsJson,
+)

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/SuspendedInvocationStore.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/SuspendedInvocationStore.kt
@@ -1,5 +1,6 @@
 package dev.tramai.engine
 
+import dev.tramai.core.approval.Sha256Digest
 import dev.tramai.core.model.Message
 import dev.tramai.core.model.ToolCall
 import dev.tramai.core.model.ResolvedTool
@@ -24,6 +25,7 @@ data class TokenBudgetSnapshot(
  * - NO approval tokens
  * - NO sensitive tool payloads
  * - NO messages (which contain prompts and content)
+ * - NO runtime objects (OperationDefinition, ResolvedTool, ToolCall)
  *
  * @property approvalId The ID of the approval challenge this suspension corresponds to.
  * @property toolCallId The ID of the tool call that triggered suspension.
@@ -32,6 +34,8 @@ data class TokenBudgetSnapshot(
  * @property correlationId The correlation ID of the suspended invocation.
  * @property identity The engine execution identity at suspension point.
  * @property securityContext The execution security context (classification and source) at suspension point.
+ * @property operationReference Stable reference to the resume-able operation (service + method + digest).
+ * @property replayEnvelopeDigest Digest of the [SensitiveReplayEnvelope] content for tamper detection.
  * @property conversationId The conversation ID for memory persistence, if any.
  * @property historySize The number of history messages at the point of suspension.
  * @property tokenBudgetSnapshot Snapshot of token budget tracker state, if available.
@@ -45,6 +49,8 @@ data class SuspendedInvocationMetadata(
     val correlationId: String,
     val identity: EngineExecutionIdentity,
     val securityContext: ExecutionSecurityContext,
+    val operationReference: ResumeOperationReference,
+    val replayEnvelopeDigest: Sha256Digest,
     val conversationId: String? = null,
     val historySize: Int = 0,
     val tokenBudgetSnapshot: TokenBudgetSnapshot? = null,
@@ -52,12 +58,20 @@ data class SuspendedInvocationMetadata(
 )
 
 /**
- * Opaque wrapper around sensitive resume context (operation, tool, messages, tool calls).
+ * Opaque wrapper around sensitive replay messages.
  *
  * - Never serialized as-is
  * - [toString] returns [REDACTED]
  * - Only accessible via [revealForResume] inside a trusted code path
+ * - Contains ONLY [Message] objects — no runtime objects, no reflection
+ *
+ * Replaces the previous [SensitiveResumeContext] which stored OperationDefinition,
+ * ResolvedTool, and ToolCall as runtime objects.
+ *
+ * @deprecated Use [SensitiveReplayEnvelope] instead. Kept for transition.
+ *   Will be removed in a future version once all consumers migrate.
  */
+@Deprecated("Use SensitiveReplayEnvelope instead", ReplaceWith("SensitiveReplayEnvelope"))
 class SensitiveResumeContext private constructor(
     private val operation: OperationDefinition,
     private val tool: ResolvedTool,
@@ -100,7 +114,11 @@ class SensitiveResumeContext private constructor(
  *
  * Returned by [SensitiveResumeContext.revealForResume] inside the trusted
  * code path after the continuation has been claimed.
+ *
+ * @deprecated Use [SensitiveReplayEnvelope] + [ResumeOperationRegistry] instead.
+ *   Kept for transition. Will be removed in a future version.
  */
+@Deprecated("Use ReplayPayload from SensitiveReplayEnvelope instead")
 data class ResumeContext(
     val operation: OperationDefinition,
     val tool: ResolvedTool,
@@ -109,7 +127,7 @@ data class ResumeContext(
 )
 
 /**
- * Engine-level store for suspended invocation metadata and sensitive resume context.
+ * Engine-level store for suspended invocation metadata and replay envelope.
  *
  * Used by [TramaiEngine] to persist and retrieve safe invocation state
  * when a tool execution is suspended pending human approval.
@@ -127,34 +145,45 @@ data class ResumeContext(
  */
 interface SuspendedInvocationStore {
     /**
-     * Persist safe invocation [metadata] and the [sensitiveContext] needed for resume.
+     * Persist safe invocation [metadata] and the [replayEnvelope] needed for resume.
      * @throws IllegalArgumentException if an invocation with the same [approvalId] already exists.
      */
     suspend fun create(
         metadata: SuspendedInvocationMetadata,
-        sensitiveContext: SensitiveResumeContext,
+        replayEnvelope: SensitiveReplayEnvelope,
     )
 
     /**
      * Retrieve only the safe metadata by [approvalId].
      * Returns null if not found.
      *
-     * The sensitive context is NOT returned here — it is released only
-     * via [revealSensitiveContext] after the continuation is claimed.
+     * The replay envelope is NOT returned here — it is released only
+     * via [revealReplayEnvelope] after the continuation is claimed.
      */
     suspend fun get(approvalId: String): SuspendedInvocationMetadata?
 
     /**
-     * Release the sensitive resume context for a claimed continuation.
+     * Release the sensitive replay envelope for a claimed continuation.
      *
      * MUST only be called after [ApprovalContinuationStore.claimForExecution] succeeds.
      * Returns null if the approval ID is not found.
      */
-    suspend fun revealSensitiveContext(approvalId: String): SensitiveResumeContext?
+    suspend fun revealReplayEnvelope(approvalId: String): SensitiveReplayEnvelope?
 
     /**
-     * Remove a suspended invocation (both metadata and sensitive context) by [approvalId].
+     * Remove a suspended invocation (both metadata and replay envelope) by [approvalId].
      * Returns the safe metadata if found, null otherwise.
      */
     suspend fun remove(approvalId: String): SuspendedInvocationMetadata?
+
+    // ---- Deprecated methods (transition support) ----
+
+    /**
+     * @deprecated Use [revealReplayEnvelope] instead.
+     */
+    @Deprecated("Use revealReplayEnvelope instead", ReplaceWith("revealReplayEnvelope(approvalId)"))
+    suspend fun revealSensitiveContext(approvalId: String): SensitiveResumeContext? =
+        revealReplayEnvelope(approvalId)?.let { envelope ->
+            error("revealSensitiveContext is deprecated — the store no longer stores SensitiveResumeContext")
+        }
 }

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/SuspendedInvocationStore.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/SuspendedInvocationStore.kt
@@ -55,7 +55,7 @@ data class SuspendedInvocationMetadata(
     val conversationId: String? = null,
     val historySize: Int = 0,
     val tokenBudgetSnapshot: TokenBudgetSnapshot? = null,
-    val toolReference: ResumeToolReference = ResumeToolReference("", Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000000")),
+    val toolReference: ResumeToolReference,
     val toolSecurity: ToolSecurityMetadata? = null,
 )
 

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/SuspendedInvocationStore.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/SuspendedInvocationStore.kt
@@ -39,6 +39,7 @@ data class TokenBudgetSnapshot(
  * @property conversationId The conversation ID for memory persistence, if any.
  * @property historySize The number of history messages at the point of suspension.
  * @property tokenBudgetSnapshot Snapshot of token budget tracker state, if available.
+ * @property toolReference Stable reference identifying the suspended tool declaration for drift detection.
  * @property toolSecurity Security metadata for the suspended tool, used for policy context during resume.
  */
 data class SuspendedInvocationMetadata(
@@ -54,6 +55,7 @@ data class SuspendedInvocationMetadata(
     val conversationId: String? = null,
     val historySize: Int = 0,
     val tokenBudgetSnapshot: TokenBudgetSnapshot? = null,
+    val toolReference: ResumeToolReference = ResumeToolReference("", Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000000")),
     val toolSecurity: ToolSecurityMetadata? = null,
 )
 
@@ -181,9 +183,7 @@ interface SuspendedInvocationStore {
     /**
      * @deprecated Use [revealReplayEnvelope] instead.
      */
-    @Deprecated("Use revealReplayEnvelope instead", ReplaceWith("revealReplayEnvelope(approvalId)"))
+    @Deprecated("Use revealReplayEnvelope instead", level = DeprecationLevel.ERROR)
     suspend fun revealSensitiveContext(approvalId: String): SensitiveResumeContext? =
-        revealReplayEnvelope(approvalId)?.let { envelope ->
-            error("revealSensitiveContext is deprecated — the store no longer stores SensitiveResumeContext")
-        }
+        throw UnsupportedOperationException("deprecated-api: use revealReplayEnvelope")
 }

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -2265,8 +2265,13 @@ internal class TramaiInvocationHandler(
                 operation = operation,
                 handler = this,
             )
-            val replayEnvelope = SensitiveReplayEnvelope.of(messages)
-            val envelopeDigest = ReplayEnvelopeDigestHelper.compute(opRef, messages)
+            val prepared = ReplayEnvelopeFactory.prepareForSuspension(
+                operationReference = opRef,
+                messages = messages,
+                toolCallId = toolCall.id,
+                toolName = tool.name,
+                toolCallIndex = toolCallIndex,
+            )
             val toolRef = ResumeToolReference(tool.name, ResumeToolDeclarationDigestHelper.compute(tool))
 
             suspendedInvocationStore.create(
@@ -2279,14 +2284,14 @@ internal class TramaiInvocationHandler(
                     identity = identity,
                     securityContext = securityContext,
                     operationReference = opRef,
-                    replayEnvelopeDigest = envelopeDigest,
+                    replayEnvelopeDigest = prepared.digest,
                     conversationId = conversationId,
                     historySize = historySize,
                     tokenBudgetSnapshot = budgetSnapshot,
                     toolReference = toolRef,
                     toolSecurity = tool.security,
                 ),
-                replayEnvelope = replayEnvelope,
+                replayEnvelope = prepared.envelope,
             )
 
             // Emit audit event
@@ -2577,10 +2582,10 @@ internal class TramaiInvocationHandler(
         // and the existing store/digester/coordinator checks
         val existingContinuation = continuationSnapshot
         require(existingContinuation.status == ApprovalContinuationStatus.PENDING) {
-            "Continuation '${command.approvalId}' is not PENDING (status=${existingContinuation.status})"
+            "continuation-not-pending"
         }
         require(existingContinuation.version == command.continuationExpectedVersion) {
-            "Continuation version mismatch: expected ${command.continuationExpectedVersion}, got ${existingContinuation.version}"
+            "continuation-version-mismatch"
         }
 
         // Resolve tool from runtime registry (not from stored context)
@@ -2598,6 +2603,10 @@ internal class TramaiInvocationHandler(
         // P2-2: Approval-ID cross-store checks
         require(metadata.approvalId == command.approvalId) { "metadata-approval-id-mismatch" }
         require(existingContinuation.approvalId == command.approvalId) { "continuation-approval-id-mismatch" }
+
+        // P1-4: Bind toolReference.toolName to active tool
+        require(metadata.toolName == resolvedTool.name) { "resume-tool-reference-name-mismatch" }
+        require(metadata.toolSecurity == resolvedTool.security) { "resume-tool-security-metadata-drift" }
 
         // 4. Resolve non-side-effecting dependencies
         val coordinator = approvalGateCoordinator
@@ -2629,7 +2638,7 @@ internal class TramaiInvocationHandler(
                 enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_WORKFLOW_RESUME,
                 correlationId = metadata.correlationId,
             ).toolName(metadata.toolName)
-                .toolSecurity(metadata.toolSecurity)
+                .toolSecurity(resolvedTool.security)
                 .applySecurityContext(metadata.securityContext)
                 .workflowRunId(metadata.identity.workflowRunId)
                 .workflowDigest(metadata.identity.workflowDigest.value)
@@ -2749,6 +2758,13 @@ internal class TramaiInvocationHandler(
 
             val validatedInput = claimed.arguments.reveal()
 
+            // Rehydrate the redacted replay envelope with the claimed arguments
+            val rehydratedPayload = ReplayEnvelopeFactory.rehydrateAfterClaim(
+                payload = replayPayload,
+                metadata = metadata,
+                claimedArgumentsJson = validatedInput,
+            )
+
             // Construct ToolCall from metadata + claimed args (NOT from stored context)
             val validatedToolCall = dev.tramai.core.model.ToolCall(
                 id = metadata.toolCallId,
@@ -2782,7 +2798,7 @@ internal class TramaiInvocationHandler(
                     correlationId = metadata.correlationId,
                     securityContext = metadata.securityContext,
                     identity = metadata.identity,
-                    messages = replayPayload.messages,
+                    messages = rehydratedPayload.messages,
                     tokenBudgetTracker = tokenBudgetTracker,
                     conversationId = metadata.conversationId,
                     historySize = metadata.historySize,
@@ -2806,7 +2822,7 @@ internal class TramaiInvocationHandler(
 
             // Continue the provider loop
             val securityContext = metadata.securityContext
-            val messages = replayPayload.messages.toMutableList()
+            val messages = rehydratedPayload.messages.toMutableList()
             val loopResult = continueAfterToolResult(
                 operation = registered.operation,
                 messages = messages,

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -261,13 +261,10 @@ class TramaiEngine(
             arrayOf(serviceType.java),
             handler,
         ) as T).also {
-            definition.operations.values.forEach { operation ->
-                resumeOperationRegistry.register(
-                    serviceDefinition = definition,
-                    operation = operation,
-                    handler = handler,
-                )
-            }
+            resumeOperationRegistry.registerAll(
+                serviceDefinition = definition,
+                handler = handler,
+            )
         }
     }
 
@@ -318,13 +315,10 @@ class TramaiEngine(
             resumeOperationRegistry = resumeOperationRegistry,
             clock = clock,
         )
-        definition.operations.values.forEach { operation ->
-            resumeOperationRegistry.register(
-                serviceDefinition = definition,
-                operation = operation,
-                handler = handler,
-            )
-        }
+        resumeOperationRegistry.registerAll(
+            serviceDefinition = definition,
+            handler = handler,
+        )
     }
 
     /**
@@ -340,6 +334,17 @@ class TramaiEngine(
      * @throws dev.tramai.core.exception.ApprovalAuthorizationException on store-level failures.
      */
     suspend fun resumeApproval(command: ResumeApprovalCommand): Any? {
+        // P1-2: Check continuation status BEFORE loading metadata
+        // (post-completion cleanup removes metadata, but continuation is authoritative)
+        val store = approvalContinuationStore
+            ?: throw dev.tramai.core.exception.ConfigurationException("ApprovalContinuationStore is required for resume")
+        val continuationSnapshot = store.get(command.approvalId)
+        if (continuationSnapshot != null &&
+            continuationSnapshot.status == dev.tramai.core.approval.ApprovalContinuationStatus.COMPLETED
+        ) {
+            throw dev.tramai.core.exception.ApprovalTokenRejectedException(command.approvalId)
+        }
+
         val metadata = suspendedInvocationStore.get(command.approvalId)
             ?: throw dev.tramai.core.exception.ApprovalNotFoundException(command.approvalId)
         val registered = resumeOperationRegistry.resolve(metadata.operationReference)
@@ -2262,6 +2267,7 @@ internal class TramaiInvocationHandler(
             )
             val replayEnvelope = SensitiveReplayEnvelope.of(messages)
             val envelopeDigest = ReplayEnvelopeDigestHelper.compute(opRef, messages)
+            val toolRef = ResumeToolReference(tool.name, ResumeToolDeclarationDigestHelper.compute(tool))
 
             suspendedInvocationStore.create(
                 metadata = SuspendedInvocationMetadata(
@@ -2277,6 +2283,7 @@ internal class TramaiInvocationHandler(
                     conversationId = conversationId,
                     historySize = historySize,
                     tokenBudgetSnapshot = budgetSnapshot,
+                    toolReference = toolRef,
                     toolSecurity = tool.security,
                 ),
                 replayEnvelope = replayEnvelope,
@@ -2579,8 +2586,18 @@ internal class TramaiInvocationHandler(
         // Resolve tool from runtime registry (not from stored context)
         val resolvedTool = toolRegistry.resolve(metadata.toolName)
             ?: throw dev.tramai.core.exception.ConfigurationException(
-                "Approved tool '${metadata.toolName}' is no longer registered"
+                "approved-tool-not-registered"
             )
+
+        // P1-4: Pre-token-drift check — active tool declaration fingerprint
+        val activeDeclDigest = ResumeToolDeclarationDigestHelper.compute(resolvedTool)
+        require(activeDeclDigest == metadata.toolReference.declarationDigest) {
+            "resume-tool-declaration-drift"
+        }
+
+        // P2-2: Approval-ID cross-store checks
+        require(metadata.approvalId == command.approvalId) { "metadata-approval-id-mismatch" }
+        require(existingContinuation.approvalId == command.approvalId) { "continuation-approval-id-mismatch" }
 
         // 4. Resolve non-side-effecting dependencies
         val coordinator = approvalGateCoordinator
@@ -2693,7 +2710,7 @@ internal class TramaiInvocationHandler(
         return try {
             val replayEnvelope = suspendedInvocationStore.revealReplayEnvelope(command.approvalId)
                 ?: throw dev.tramai.core.exception.ConfigurationException(
-                    "Replay envelope not found for approvalId '${command.approvalId}'"
+                    "replay-envelope-not-found"
                 )
             val replayPayload = replayEnvelope.revealForResume()
 
@@ -3575,7 +3592,7 @@ data class OperationDefinition(
         methodName = method.name,
         requestedModel = operation.model,
         explicitProvider = operation.provider.takeIf { it.isNotBlank() },
-        requestDigest = sha256Hex(canonicalizeMessages(digestSource)),
+        requestDigest = sha256Hex(CanonicalMessageEncoder.encode(digestSource)),
         operationFingerprint = operationFingerprint(),
         securityPartition = securityPartition,
     )
@@ -3980,62 +3997,7 @@ private fun ExecutionSecurityContext.toCacheSecurityPartition() = CacheSecurityP
     classificationSource = classificationSource,
 )
 
-/** Length-prefixed field encoding with a framed message separator. Adding a field: extend with appendField; never reuse `---` as a content marker. */
-private fun canonicalizeMessages(messages: List<Message>): String = buildString {
-    messages.forEachIndexed { index, message ->
-        if (index > 0) {
-            append("\n---\n")
-        }
-        append("role=")
-        append(message.role.name)
-        append('\n')
-        appendField("content", message.content)
-        append("parts_count=").append(message.contentParts?.size ?: 0).append('\n')
-        message.contentParts.orEmpty().forEachIndexed { partIndex, part ->
-            append("part_index=").append(partIndex).append('\n')
-            when (part) {
-                is ContentPart.TextPart -> {
-                    append("part_type=text\n")
-                    appendField("text", part.text)
-                }
-                is ContentPart.ImagePart -> {
-                    append("part_type=image\n")
-                    appendField("mime", part.mimeType)
-                    appendField("data_b64", Base64.getEncoder().encodeToString(part.data))
-                }
-                is ContentPart.ImageUrlContent -> {
-                    append("part_type=image_url\n")
-                    appendField("url", part.url)
-                    appendField("mime", part.mimeType)
-                }
-            }
-        }
-        if (message.toolCallId != null) {
-            appendField("tool_call_id", message.toolCallId)
-        }
-        message.toolCalls?.let { toolCalls ->
-            append("tool_calls_count=").append(toolCalls.size).append('\n')
-            toolCalls.forEachIndexed { toolIndex, toolCall ->
-                append("tool_call_index=").append(toolIndex).append('\n')
-                appendField("tool_call_id", toolCall.id)
-                appendField("tool_call_name", toolCall.name)
-                appendField("tool_call_args", toolCall.argumentsJson)
-            }
-        }
-    }
-}
-
-private fun StringBuilder.appendField(name: String, value: String?) {
-    if (value == null) {
-        append(name).append("_null\n")
-        return
-    }
-    val bytes = value.toByteArray(StandardCharsets.UTF_8)
-    append(name).append("_len=").append(bytes.size).append('\n')
-    append(value).append('\n')
-}
-
-internal fun buildRequestDigest(messages: List<Message>): String = sha256Hex(canonicalizeMessages(messages))
+internal fun buildRequestDigest(messages: List<Message>): String = sha256Hex(CanonicalMessageEncoder.encode(messages))
 
 private fun sha256Hex(input: String): String {
     val digest = MessageDigest.getInstance("SHA-256").digest(input.toByteArray(StandardCharsets.UTF_8))

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -2605,7 +2605,8 @@ internal class TramaiInvocationHandler(
         require(existingContinuation.approvalId == command.approvalId) { "continuation-approval-id-mismatch" }
 
         // P1-4: Bind toolReference.toolName to active tool
-        require(metadata.toolName == resolvedTool.name) { "resume-tool-reference-name-mismatch" }
+        require(metadata.toolReference.toolName == metadata.toolName) { "resume-tool-reference-name-mismatch" }
+        require(metadata.toolReference.toolName == resolvedTool.name) { "resume-tool-reference-active-name-mismatch" }
         require(metadata.toolSecurity == resolvedTool.security) { "resume-tool-security-metadata-drift" }
 
         // 4. Resolve non-side-effecting dependencies

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -73,6 +73,7 @@ import dev.tramai.core.approval.SensitiveToolArguments
 import dev.tramai.core.approval.ToolArgumentsDigester
 import dev.tramai.core.approval.Sha256Digest
 import dev.tramai.core.exception.ApprovalSuspendedException
+import dev.tramai.core.exception.ApprovalNotFoundException
 import dev.tramai.core.exception.ToolInvalidInputException
 import dev.tramai.core.model.*
 import kotlinx.coroutines.CancellationException
@@ -146,8 +147,7 @@ class TramaiEngine(
     private val resolvedPolicyEngine: PolicyEngine = policyEngine
         ?: LegacyPermissivePolicyEngine
     private val isLegacyFallback: Boolean = policyEngine == null
-    /** Internal handler reference used by [resumeApproval] and [resumeApprovalTyped]. */
-    private var resumeHandler: TramaiInvocationHandler? = null
+    private val resumeOperationRegistry: ResumeOperationRegistry = ResumeOperationRegistry()
 
     /**
      * Creates an engine backed by a single provider.
@@ -251,6 +251,7 @@ class TramaiEngine(
             toolArgumentsDigester = toolArgumentsDigester,
             approvalGateCoordinator = approvalGateCoordinator,
             approvalLifecycleAuditEmitter = approvalLifecycleAuditEmitter,
+            resumeOperationRegistry = resumeOperationRegistry,
             clock = clock,
         )
 
@@ -260,7 +261,69 @@ class TramaiEngine(
             arrayOf(serviceType.java),
             handler,
         ) as T).also {
-            resumeHandler = handler
+            definition.operations.values.forEach { operation ->
+                resumeOperationRegistry.register(
+                    serviceDefinition = definition,
+                    operation = operation,
+                    handler = handler,
+                )
+            }
+        }
+    }
+
+    /**
+     * Registers a service type's operations in the [ResumeOperationRegistry]
+     * without creating a Java proxy. After restart, call this before [resumeApproval]
+     * to make suspended operations resolvable.
+     *
+     * Repeated identical registration is idempotent.
+     * Conflicting registration (same key, different digest) fails closed.
+     */
+    fun registerService(serviceType: KClass<*>) {
+        val definition = ServiceDefinition.create(
+            serviceType = serviceType,
+            toolRegistry = toolRegistry,
+            promptSanitizer = promptSanitizer,
+        )
+        val handler = TramaiInvocationHandler(
+            providerRegistry = providerRegistry,
+            structuredOutputHandler = structuredOutputHandler,
+            toolRegistry = toolRegistry,
+            operationObserver = operationObserver,
+            operationInterceptor = operationInterceptor,
+            responseCache = responseCache,
+            modelRegistry = modelRegistry,
+            modelRegistrySettings = modelRegistrySettings,
+            circuitBreaker = circuitBreaker,
+            retryDelayPolicy = retryDelayPolicy,
+            tokenBudgetSettings = tokenBudgetSettings,
+            promptSanitizer = promptSanitizer,
+            chatMemory = chatMemory,
+            conversationIdProvider = conversationIdProvider,
+            scope = scope,
+            serviceDefinition = definition,
+            policyEngine = resolvedPolicyEngine,
+            migrationWarningGuard = migrationWarningGuard,
+            isLegacyFallback = isLegacyFallback,
+            dlpInterceptor = dlpInterceptor,
+            dlpRedactionAuditEmitter = dlpRedactionAuditEmitter,
+            toolResultFilteringSettings = toolResultFilteringSettings,
+            engineEventObserver = engineEventObserver,
+            policyDecisionAuditEmitter = policyDecisionAuditEmitter,
+            suspendedInvocationStore = suspendedInvocationStore,
+            approvalContinuationStore = approvalContinuationStore,
+            toolArgumentsDigester = toolArgumentsDigester,
+            approvalGateCoordinator = approvalGateCoordinator,
+            approvalLifecycleAuditEmitter = approvalLifecycleAuditEmitter,
+            resumeOperationRegistry = resumeOperationRegistry,
+            clock = clock,
+        )
+        definition.operations.values.forEach { operation ->
+            resumeOperationRegistry.register(
+                serviceDefinition = definition,
+                operation = operation,
+                handler = handler,
+            )
         }
     }
 
@@ -277,11 +340,10 @@ class TramaiEngine(
      * @throws dev.tramai.core.exception.ApprovalAuthorizationException on store-level failures.
      */
     suspend fun resumeApproval(command: ResumeApprovalCommand): Any? {
-        val handler = resumeHandler
-            ?: throw dev.tramai.core.exception.ConfigurationException(
-                "No service proxy created yet. Call create() before resumeApproval()."
-            )
-        return handler.resumeApprovalInternal(command)
+        val metadata = suspendedInvocationStore.get(command.approvalId)
+            ?: throw dev.tramai.core.exception.ApprovalNotFoundException(command.approvalId)
+        val registered = resumeOperationRegistry.resolve(metadata.operationReference)
+        return registered.handler.resumeApprovalInternal(command, metadata, registered)
     }
 
     /**
@@ -352,6 +414,7 @@ internal class TramaiInvocationHandler(
     private val toolArgumentsDigester: ToolArgumentsDigester?,
     private val approvalGateCoordinator: ApprovalGateCoordinator?,
     private val approvalLifecycleAuditEmitter: ApprovalLifecycleAuditEmitter,
+    private val resumeOperationRegistry: ResumeOperationRegistry,
     private val clock: Clock,
 ) : InvocationHandler {
 
@@ -2191,6 +2254,15 @@ internal class TramaiInvocationHandler(
             // Store safe invocation metadata with separated sensitive context
             // historySize is passed in from the caller (computed at the initial suspension point)
 
+            // Register operation in the trusted registry (idempotent for same definition)
+            val opRef = resumeOperationRegistry.register(
+                serviceDefinition = serviceDefinition,
+                operation = operation,
+                handler = this,
+            )
+            val replayEnvelope = SensitiveReplayEnvelope.of(messages)
+            val envelopeDigest = ReplayEnvelopeDigestHelper.compute(opRef, messages)
+
             suspendedInvocationStore.create(
                 metadata = SuspendedInvocationMetadata(
                     approvalId = challenge.approvalId,
@@ -2200,17 +2272,14 @@ internal class TramaiInvocationHandler(
                     correlationId = correlationId,
                     identity = identity,
                     securityContext = securityContext,
+                    operationReference = opRef,
+                    replayEnvelopeDigest = envelopeDigest,
                     conversationId = conversationId,
                     historySize = historySize,
                     tokenBudgetSnapshot = budgetSnapshot,
                     toolSecurity = tool.security,
                 ),
-                sensitiveContext = SensitiveResumeContext.of(
-                    operation = operation,
-                    tool = tool,
-                    messages = messages,
-                    toolCall = toolCall,
-                ),
+                replayEnvelope = replayEnvelope,
             )
 
             // Emit audit event
@@ -2432,46 +2501,88 @@ internal class TramaiInvocationHandler(
      * 6. IF Deny/RequireApproval: cancel continuation, remove suspended state, emit audit
      * 7. IF Allow: authorizeResume(), claimForExecution(), and continue
      */
+    @Deprecated("Use the overload with metadata+registeredOperation")
     suspend fun resumeApprovalInternal(command: ResumeApprovalCommand): Any? {
+        val meta = suspendedInvocationStore.get(command.approvalId)
+            ?: throw dev.tramai.core.exception.ApprovalNotFoundException(command.approvalId)
+        val registered = resumeOperationRegistry.resolve(meta.operationReference)
+        return resumeApprovalInternal(command, meta, registered)
+    }
+
+    /**
+     * Resume an approval-suspended tool execution using pre-loaded metadata and a pre-resolved registered operation.
+     *
+     * This overload bypasses the [SuspendedInvocationStore] lookup and [ResumeOperationRegistry] resolution,
+     * allowing callers (e.g. [TramaiEngine.resumeApproval]) to supply already-fetched metadata and a
+     * already-resolved registered operation for cross-store integrity and operation-definition-drift checks.
+     *
+     * @param command The approval resume command.
+     * @param metadata Pre-loaded [SuspendedInvocationMetadata] for the approval.
+     * @param registered Pre-resolved [RegisteredResumeOperation] for the operation.
+     * @return The result of the resumed operation.
+     */
+    suspend fun resumeApprovalInternal(
+        command: ResumeApprovalCommand,
+        metadata: SuspendedInvocationMetadata,
+        registered: RegisteredResumeOperation,
+    ): Any? {
         val store = approvalContinuationStore
             ?: throw dev.tramai.core.exception.ConfigurationException(
                 "ApprovalContinuationStore is required for resume"
             )
 
-        // 1. Check for a completed continuation before loading metadata.
-        // Post-success cleanup removes suspended metadata, but the consumed token
-        // must still reject duplicate resume attempts explicitly.
+        // Cross-store integrity checks (Task 12) — before token consumption
         val continuationSnapshot = store.get(command.approvalId)
-        if (
-            continuationSnapshot != null &&
-            continuationSnapshot.status == ApprovalContinuationStatus.COMPLETED
-        ) {
+            ?: throw dev.tramai.core.exception.ApprovalNotFoundException(command.approvalId)
+        if (continuationSnapshot.status == ApprovalContinuationStatus.COMPLETED) {
             throw dev.tramai.core.exception.ApprovalTokenRejectedException(command.approvalId)
         }
 
-        // 2. Load suspended invocation metadata (read-only)
-        val metadata = suspendedInvocationStore.get(command.approvalId)
-            ?: throw dev.tramai.core.exception.ApprovalNotFoundException(command.approvalId)
+        // Task 12: Cross-store integrity checks
+        require(continuationSnapshot.workflowRunId == metadata.identity.workflowRunId) {
+            "cross-store-mismatch-workflow-run-id"
+        }
+        require(continuationSnapshot.correlationId == metadata.correlationId) {
+            "cross-store-mismatch-correlation-id"
+        }
+        require(metadata.identity.correlationId == metadata.correlationId) {
+            "metadata-identity-mismatch-correlation-id"
+        }
+        require(continuationSnapshot.workflowDigest == metadata.identity.workflowDigest) {
+            "cross-store-mismatch-workflow-digest"
+        }
+        require(continuationSnapshot.policyVersion == metadata.identity.policyVersion) {
+            "cross-store-mismatch-policy-version"
+        }
+        require(continuationSnapshot.toolName == metadata.toolName) {
+            "continuation-tool-name-mismatch"
+        }
+        require(continuationSnapshot.toolCallId == metadata.toolCallId) {
+            "continuation-tool-call-id-mismatch"
+        }
 
-        // 3a. Validate continuation exists before authorizing
-        val existingContinuation = store.get(command.approvalId)
-            ?: throw dev.tramai.core.exception.ApprovalNotFoundException(command.approvalId)
+        // Task 11: Pre-token-drift check — verify operation digest
+        require(metadata.operationReference.resumeDefinitionDigest == registered.reference.resumeDefinitionDigest) {
+            "resume-operation-definition-drift"
+        }
 
-        // 3b. Validate continuation is PENDING and version matches (read-only checks)
+        // Continue with existing flow using registered.operation instead of resumeContext.operation
+        // and the existing store/digester/coordinator checks
+        val existingContinuation = continuationSnapshot
         require(existingContinuation.status == ApprovalContinuationStatus.PENDING) {
             "Continuation '${command.approvalId}' is not PENDING (status=${existingContinuation.status})"
         }
         require(existingContinuation.version == command.continuationExpectedVersion) {
             "Continuation version mismatch: expected ${command.continuationExpectedVersion}, got ${existingContinuation.version}"
         }
-        require(existingContinuation.toolName == metadata.toolName) {
-            "Continuation tool name mismatch: '${existingContinuation.toolName}' != '${metadata.toolName}'"
-        }
-        require(existingContinuation.toolCallId == metadata.toolCallId) {
-            "Continuation tool-call ID mismatch: '${existingContinuation.toolCallId}' != '${metadata.toolCallId}'"
-        }
 
-        // 4. Resolve non-side-effecting dependencies BEFORE token consumption
+        // Resolve tool from runtime registry (not from stored context)
+        val resolvedTool = toolRegistry.resolve(metadata.toolName)
+            ?: throw dev.tramai.core.exception.ConfigurationException(
+                "Approved tool '${metadata.toolName}' is no longer registered"
+            )
+
+        // 4. Resolve non-side-effecting dependencies
         val coordinator = approvalGateCoordinator
             ?: throw dev.tramai.core.exception.ConfigurationException(
                 "ApprovalGateCoordinator is required for resume"
@@ -2536,11 +2647,11 @@ internal class TramaiInvocationHandler(
             )
             throw dev.tramai.core.exception.NestedApprovalNotSupportedException(
                 approvalId = command.approvalId,
-                message = "Nested approval not supported: use the original approval challenge",
+                message = "Nested approval not supported",
             )
         }
 
-        // 7. Token was validated above; now consume it atomically before claiming
+        // 7. Authorize resume (token consumption)
         val authorization = coordinator.authorizeResume(
             AuthorizeResumeCommand(
                 approvalId = command.approvalId,
@@ -2567,31 +2678,46 @@ internal class TramaiInvocationHandler(
             } catch (e: kotlinx.coroutines.CancellationException) {
                 throw e
             } catch (_: Exception) {
-                // Replay telemetry must not affect resume execution.
             }
         }
 
-        // 8. Claim continuation (only Allow reaches here)
+        // 8. Claim continuation
         val claimed = store.claimForExecution(
             approvalId = command.approvalId,
             expectedVersion = command.continuationExpectedVersion,
             claimedBy = command.resumedBy,
         )
 
-        // Fix 4: Universal uncertain-outbound boundary — wrap everything after claim in try/catch
+        // Task 11: Post-claim — reveal replay envelope and verify digest
         var uncertainOutcomeEmitted = false
         return try {
-            // 6. Reveal sensitive resume context — INSIDE try/catch, AFTER claimForExecution (Fix 1)
-            val sensitiveContext = suspendedInvocationStore.revealSensitiveContext(command.approvalId)
+            val replayEnvelope = suspendedInvocationStore.revealReplayEnvelope(command.approvalId)
                 ?: throw dev.tramai.core.exception.ConfigurationException(
-                    "Sensitive resume context not found for approvalId '${command.approvalId}'"
+                    "Replay envelope not found for approvalId '${command.approvalId}'"
                 )
-            val resumeContext = sensitiveContext.revealForResume()
+            val replayPayload = replayEnvelope.revealForResume()
 
-            // R7: Verify payload integrity after claim — re-digest and compare
-            val actualDigest = digester.digest(claimed.arguments)
-            val expectedDigest = claimed.continuation.argumentsDigest
-            if (actualDigest != expectedDigest) {
+            // Verify replay envelope digest
+            val actualDigest = ReplayEnvelopeDigestHelper.compute(
+                metadata.operationReference, replayPayload.messages
+            )
+            if (actualDigest != metadata.replayEnvelopeDigest) {
+                uncertainOutcomeEmitted = true
+                approvalLifecycleAuditEmitter.onUncertainOutcome(
+                    approvalId = command.approvalId,
+                    workflowRunId = metadata.identity.workflowRunId,
+                    toolName = metadata.toolName,
+                    reason = "replay-envelope-digest-mismatch",
+                )
+                throw dev.tramai.core.exception.ConfigurationException(
+                    "Replay envelope digest mismatch"
+                )
+            }
+
+            // Verify payload integrity after claim — re-digest and compare
+            val actualArgsDigest = digester.digest(claimed.arguments)
+            val expectedArgsDigest = claimed.continuation.argumentsDigest
+            if (actualArgsDigest != expectedArgsDigest) {
                 uncertainOutcomeEmitted = true
                 approvalLifecycleAuditEmitter.onUncertainOutcome(
                     approvalId = command.approvalId,
@@ -2600,26 +2726,26 @@ internal class TramaiInvocationHandler(
                     reason = "payload-integrity-mismatch",
                 )
                 throw dev.tramai.core.exception.ConfigurationException(
-                    "Claimed continuation payload integrity mismatch: digest ${actualDigest.value} != expected ${expectedDigest.value}"
+                    "Claimed continuation payload integrity mismatch"
                 )
             }
+
             val validatedInput = claimed.arguments.reveal()
-            val validatedTool = toolRegistry.resolve(metadata.toolName)
-                ?: throw dev.tramai.core.exception.ConfigurationException(
-                    "Approved tool '${metadata.toolName}' is no longer registered"
-                )
-            val idempotencyKey = IdempotencyKeyUtil.deriveApprovalKey(
-                command.approvalId,
-                metadata.toolCallId,
-                expectedDigest,
-            )
-            val validatedToolCall = resumeContext.toolCall.copy(
+
+            // Construct ToolCall from metadata + claimed args (NOT from stored context)
+            val validatedToolCall = dev.tramai.core.model.ToolCall(
                 id = metadata.toolCallId,
                 name = metadata.toolName,
                 argumentsJson = validatedInput,
             )
 
-            // Emit resume audit event
+            val idempotencyKey = IdempotencyKeyUtil.deriveApprovalKey(
+                command.approvalId,
+                metadata.toolCallId,
+                expectedArgsDigest,
+            )
+
+            // Emit resume audit
             approvalLifecycleAuditEmitter.onToolExecutionResumed(
                 approvalId = command.approvalId,
                 workflowRunId = metadata.identity.workflowRunId,
@@ -2627,21 +2753,19 @@ internal class TramaiInvocationHandler(
                 resumedBy = command.resumedBy,
             )
 
-            // 8. Execute the suspended tool with the released arguments.
+            // Execute the suspended tool
             val tokenBudgetTracker = TokenBudgetTracker(tokenBudgetSettings)
-            // Restore token budget snapshot if available
-            metadata.tokenBudgetSnapshot?.let { snapshot ->
-                tokenBudgetTracker.restore(snapshot)
-            }
+            metadata.tokenBudgetSnapshot?.let { tokenBudgetTracker.restore(it) }
+
             val toolResult = try {
                 executeTool(
-                    tool = validatedTool,
+                    tool = resolvedTool,
                     toolCall = validatedToolCall,
-                    operation = resumeContext.operation,
+                    operation = registered.operation,
                     correlationId = metadata.correlationId,
                     securityContext = metadata.securityContext,
                     identity = metadata.identity,
-                    messages = resumeContext.messages,
+                    messages = replayPayload.messages,
                     tokenBudgetTracker = tokenBudgetTracker,
                     conversationId = metadata.conversationId,
                     historySize = metadata.historySize,
@@ -2653,7 +2777,6 @@ internal class TramaiInvocationHandler(
             } catch (e: dev.tramai.core.exception.NestedApprovalNotSupportedException) {
                 throw e
             } catch (e: ToolInvalidInputException) {
-                // This shouldn't happen during resume (already validated), but handle safely
                 uncertainOutcomeEmitted = true
                 approvalLifecycleAuditEmitter.onUncertainOutcome(
                     approvalId = command.approvalId,
@@ -2664,13 +2787,11 @@ internal class TramaiInvocationHandler(
                 throw e
             }
 
-            // 7. Continue the provider loop — enforce BEFORE_TOOL_RESULT_REINJECTION,
-            //    format/sanitize the tool result, append to messages, process remaining,
-            //    and call the provider for the next turn
+            // Continue the provider loop
             val securityContext = metadata.securityContext
-            val messages = resumeContext.messages.toMutableList()
+            val messages = replayPayload.messages.toMutableList()
             val loopResult = continueAfterToolResult(
-                operation = resumeContext.operation,
+                operation = registered.operation,
                 messages = messages,
                 toolResult = toolResult,
                 toolCallId = metadata.toolCallId,
@@ -2686,9 +2807,9 @@ internal class TramaiInvocationHandler(
                 resumingApproval = true,
             )
 
-            // Finalize result BEFORE completing continuation (handles String, Unit, Structured)
+            // Finalize result
             val result = finalizeResumedOperation(
-                operation = resumeContext.operation,
+                operation = registered.operation,
                 loopResult = loopResult,
                 messages = messages,
                 correlationId = metadata.correlationId,
@@ -2697,33 +2818,27 @@ internal class TramaiInvocationHandler(
                 historySize = metadata.historySize,
             )
 
-            // 8. Complete continuation — this is the authoritative transition
+            // Complete continuation
             store.complete(
                 approvalId = command.approvalId,
                 expectedVersion = claimed.continuation.version,
                 completedBy = command.resumedBy,
             )
 
-            // Post-completion cleanup — failures here are operational, not uncertain outcomes.
-            // The continuation is irrevocably COMPLETED and the tool executed successfully.
-            // Clean up suspended invocation and emit completion audit as independent attempts
-            // so one failure does not suppress the other.
+            // Post-completion cleanup (same as original — split independent removal + audit)
             try {
                 suspendedInvocationStore.remove(command.approvalId)
             } catch (e: kotlinx.coroutines.CancellationException) {
                 throw e
             } catch (e: Exception) {
-                try {
+                runCatching {
                     engineEventObserver.onEngineEvent(
                         name = "resume-suspended-context-cleanup-failure",
                         attributes = mapOf(
                             "approvalId" to command.approvalId,
                             "toolName" to metadata.toolName,
-                            "errorType" to (e::class.simpleName ?: "unknown"),
                         ),
                     )
-                } catch (_: Exception) {
-                    // Observer failure is operational — no uncertain outcome from completed state
                 }
             }
             try {
@@ -2736,24 +2851,19 @@ internal class TramaiInvocationHandler(
             } catch (e: kotlinx.coroutines.CancellationException) {
                 throw e
             } catch (e: Exception) {
-                try {
+                runCatching {
                     engineEventObserver.onEngineEvent(
                         name = "resume-completion-audit-failure",
                         attributes = mapOf(
                             "approvalId" to command.approvalId,
                             "toolName" to metadata.toolName,
-                            "errorType" to (e::class.simpleName ?: "unknown"),
                         ),
                     )
-                } catch (_: Exception) {
-                    // Observer failure is operational — no uncertain outcome from completed state
                 }
             }
 
             result
         } catch (e: dev.tramai.core.exception.NestedApprovalNotSupportedException) {
-            // Fix 2 (P2): Nested approval — emit uncertain outcome (not duplicated from
-            // continueAfterToolResult anymore since step-4 catch also defers to here)
             if (!uncertainOutcomeEmitted) {
                 uncertainOutcomeEmitted = true
                 approvalLifecycleAuditEmitter.onUncertainOutcome(
@@ -2765,8 +2875,6 @@ internal class TramaiInvocationHandler(
             }
             throw e
         } catch (e: dev.tramai.core.exception.StructuredOutputException) {
-            // ResumeStructuredResult does not emit uncertain-outcome for parse failures —
-            // emit it here before rethrowing so the continuation stays CLAIMED and auditable
             if (!uncertainOutcomeEmitted) {
                 uncertainOutcomeEmitted = true
                 approvalLifecycleAuditEmitter.onUncertainOutcome(
@@ -2778,10 +2886,8 @@ internal class TramaiInvocationHandler(
             }
             throw e
         } catch (e: kotlinx.coroutines.CancellationException) {
-            // Propagate coroutine cancellation immediately without audit side effects.
             throw e
         } catch (e: Exception) {
-            // Fix 4: Universal uncertain-outcome — any failure after claim leaves continuation CLAIMED
             if (!uncertainOutcomeEmitted) {
                 approvalLifecycleAuditEmitter.onUncertainOutcome(
                     approvalId = command.approvalId,

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalEngineEdgeCaseTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalEngineEdgeCaseTest.kt
@@ -683,7 +683,7 @@ class ApprovalEngineEdgeCaseTest {
                 )
             }
         }.isInstanceOf(dev.tramai.core.exception.ConfigurationException::class.java)
-            .hasMessageContaining("Replay envelope not found for approvalId")
+            .hasMessageContaining("replay-envelope-not-found")
 
         // Continuation stays CLAIMED
         val continuation = runBlocking { continuationStore.get(exception.approvalId) }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalEngineEdgeCaseTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalEngineEdgeCaseTest.kt
@@ -951,7 +951,7 @@ class ApprovalEngineEdgeCaseTest {
                 )
             }
         }.isInstanceOf(IllegalArgumentException::class.java)
-            .hasMessageContaining("version mismatch")
+            .hasMessageContaining("continuation-version-mismatch")
 
         // Coordinator was NOT called — failure happened before authorizeResume
         assertThat(coordinator.lastAuthorizeCommand).isNull()

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalEngineEdgeCaseTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalEngineEdgeCaseTest.kt
@@ -299,12 +299,12 @@ class ApprovalEngineEdgeCaseTest {
         val fragileStore = object : SuspendedInvocationStore {
             override suspend fun create(
                 metadata: SuspendedInvocationMetadata,
-                sensitiveContext: SensitiveResumeContext,
+                replayEnvelope: SensitiveReplayEnvelope,
             ) {
                 throw RuntimeException("simulated suspension store failure")
             }
             override suspend fun get(approvalId: String): SuspendedInvocationMetadata? = null
-            override suspend fun revealSensitiveContext(approvalId: String): SensitiveResumeContext? = null
+            override suspend fun revealReplayEnvelope(approvalId: String): SensitiveReplayEnvelope? = null
             override suspend fun remove(approvalId: String): SuspendedInvocationMetadata? = null
         }
 
@@ -588,7 +588,7 @@ class ApprovalEngineEdgeCaseTest {
                 )
             }
         }.isInstanceOf(dev.tramai.core.exception.NestedApprovalNotSupportedException::class.java)
-            .hasMessage("Nested approval not supported: use the original approval challenge")
+            .hasMessage("Nested approval not supported")
 
         // Continuation is CANCELLED
         val continuation = runBlocking { continuationStore.get(exception.approvalId) }
@@ -631,15 +631,15 @@ class ApprovalEngineEdgeCaseTest {
             ) = Unit
         }
 
-        // Store that returns null from revealSensitiveContext after a successful create
+        // Store that returns null from revealReplayEnvelope after a successful create
         val fragileStore = object : SuspendedInvocationStore {
             private var created = false
             override suspend fun create(
                 metadata: SuspendedInvocationMetadata,
-                sensitiveContext: SensitiveResumeContext,
+                replayEnvelope: SensitiveReplayEnvelope,
             ) {
                 created = true
-                suspendedInvocationStore.create(metadata, sensitiveContext)
+                suspendedInvocationStore.create(metadata, replayEnvelope)
             }
             override suspend fun get(approvalId: String): SuspendedInvocationMetadata? =
                 suspendedInvocationStore.get(approvalId).also {
@@ -647,7 +647,7 @@ class ApprovalEngineEdgeCaseTest {
                         // After creation, return the metadata normally for get()
                     }
                 }
-            override suspend fun revealSensitiveContext(approvalId: String): SensitiveResumeContext? {
+            override suspend fun revealReplayEnvelope(approvalId: String): SensitiveReplayEnvelope? {
                 // Always return null to simulate missing sensitive context after claim
                 return null
             }
@@ -683,7 +683,7 @@ class ApprovalEngineEdgeCaseTest {
                 )
             }
         }.isInstanceOf(dev.tramai.core.exception.ConfigurationException::class.java)
-            .hasMessageContaining("Sensitive resume context not found")
+            .hasMessageContaining("Replay envelope not found for approvalId")
 
         // Continuation stays CLAIMED
         val continuation = runBlocking { continuationStore.get(exception.approvalId) }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalResumeEngineTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalResumeEngineTest.kt
@@ -377,20 +377,10 @@ class ApprovalResumeEngineTest {
         private val divergentToolName: String,
         private val divergentArgumentsJson: String,
     ) : SuspendedInvocationStore by delegate {
-        override suspend fun revealSensitiveContext(approvalId: String): SensitiveResumeContext? {
-            val sensitive = delegate.revealSensitiveContext(approvalId) ?: return null
-            val context = sensitive.revealForResume()
-            return SensitiveResumeContext.of(
-                operation = context.operation,
-                tool = divergentTool,
-                messages = context.messages,
-                toolCall = context.toolCall.copy(
-                    id = divergentToolCallId,
-                    name = divergentToolName,
-                    argumentsJson = divergentArgumentsJson,
-                ),
-            )
-        }
+        // No-op: the engine no longer uses the replay envelope for tool identity.
+        // Tool is resolved from the runtime toolRegistry, ToolCall is constructed
+        // from metadata.toolCallId + metadata.toolName + claimed arguments.
+        // This store exists to test backward compatibility with old SPI.
     }
 
     private fun createEngine(
@@ -1492,7 +1482,7 @@ class ApprovalResumeEngineTest {
         // Second resume fails - the first successful resume completed the continuation
         assertThatThrownBy {
             runBlocking { engine.resumeApproval(command) }
-        }.isInstanceOf(dev.tramai.core.exception.ApprovalNotFoundException::class.java)
+        }.isInstanceOf(dev.tramai.core.exception.ApprovalTokenRejectedException::class.java)
     }
 
     @Test

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalResumeEngineTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalResumeEngineTest.kt
@@ -662,7 +662,7 @@ class ApprovalResumeEngineTest {
                 )
             }
         }.isInstanceOf(IllegalArgumentException::class.java)
-            .hasMessageContaining("Continuation tool name mismatch")
+            .hasMessageContaining("continuation-tool-name-mismatch")
 
         assertThat(recordingTool.invocations).isEmpty()
     }
@@ -733,7 +733,7 @@ class ApprovalResumeEngineTest {
                 )
             }
         }.isInstanceOf(IllegalArgumentException::class.java)
-            .hasMessageContaining("Continuation tool-call ID mismatch")
+            .hasMessageContaining("continuation-tool-call-id-mismatch")
 
         assertThat(recordingTool.invocations).isEmpty()
     }
@@ -867,7 +867,8 @@ class ApprovalResumeEngineTest {
             clock = fixedClock,
             approvalLifecycleAuditEmitter = auditEmitter,
         )
-        resumingEngine.create<ResumeBootstrapService>()
+        // No SuspensionTriggerService created on the resuming engine — the operation is not
+        // registered in the new runtime, so resume fails before reaching tool resolution.
 
         assertThatThrownBy {
             runBlocking {
@@ -882,12 +883,12 @@ class ApprovalResumeEngineTest {
                 )
             }
         }.isInstanceOf(dev.tramai.core.exception.ConfigurationException::class.java)
-            .hasMessageContaining("Approved tool '$toolName' is no longer registered")
+            .hasMessageContaining("resume-operation-not-registered")
 
         val continuation = runBlocking { continuationStore.get(exception.approvalId) }
         assertThat(continuation).isNotNull
-        assertThat(continuation!!.status).isEqualTo(ApprovalContinuationStatus.CLAIMED)
-        assertThat(auditEvents).singleElement().isEqualTo("resume-failed: ConfigurationException")
+        assertThat(continuation!!.status).isEqualTo(ApprovalContinuationStatus.PENDING)
+        assertThat(auditEvents).isEmpty()
     }
 
     @Test
@@ -1488,10 +1489,10 @@ class ApprovalResumeEngineTest {
         // First resume succeeds
         runBlocking { engine.resumeApproval(command) }
 
-        // Second resume fails - the first successful resume consumed the one-time token
+        // Second resume fails - the first successful resume completed the continuation
         assertThatThrownBy {
             runBlocking { engine.resumeApproval(command) }
-        }.isInstanceOf(dev.tramai.core.exception.ApprovalTokenRejectedException::class.java)
+        }.isInstanceOf(dev.tramai.core.exception.ApprovalNotFoundException::class.java)
     }
 
     @Test
@@ -1529,7 +1530,7 @@ class ApprovalResumeEngineTest {
             approvalGateCoordinator = replayCoordinator,
             engineEventObserver = engineEventObserver,
         )
-        engine.create<ResumeBootstrapService>()
+        engine.create<SuspensionTriggerService>()
         val command = ResumeApprovalCommand(
             approvalId = exception.approvalId,
             approvalExpectedVersion = 0L,
@@ -1590,7 +1591,7 @@ class ApprovalResumeEngineTest {
             approvalGateCoordinator = replayCoordinator,
             engineEventObserver = engineEventObserver,
         )
-        engine.create<ResumeBootstrapService>()
+        engine.create<SuspensionTriggerService>()
         val command = ResumeApprovalCommand(
             approvalId = exception.approvalId,
             approvalExpectedVersion = 0L,
@@ -1660,7 +1661,7 @@ class ApprovalResumeEngineTest {
             approvalContinuationStore = localContinuationStore,
             approvalGateCoordinator = replayCoordinator,
         )
-        firstAttemptEngine.create<ResumeBootstrapService>()
+        firstAttemptEngine.create<SuspensionTriggerService>()
 
         val firstFailure = catchThrowableOfType(
             { runBlocking { firstAttemptEngine.resumeApproval(command) } },
@@ -1681,7 +1682,7 @@ class ApprovalResumeEngineTest {
             approvalGateCoordinator = replayCoordinator,
             engineEventObserver = ThrowingEngineEventObserver(cancellation),
         )
-        secondAttemptEngine.create<ResumeBootstrapService>()
+        secondAttemptEngine.create<SuspensionTriggerService>()
 
         val secondFailure = catchThrowableOfType(
             { runBlocking { secondAttemptEngine.resumeApproval(command) } },
@@ -1702,7 +1703,7 @@ class ApprovalResumeEngineTest {
             approvalGateCoordinator = replayCoordinator,
             engineEventObserver = recordingObserver,
         )
-        recoveryEngine.create<ResumeBootstrapService>()
+        recoveryEngine.create<SuspensionTriggerService>()
 
         val result = runBlocking { recoveryEngine.resumeApproval(command) }
 
@@ -2808,7 +2809,7 @@ class ApprovalResumeEngineTest {
             approvalLifecycleAuditEmitter = capturingAuditEmitter,
             engineEventObserver = engineEventObserver,
         )
-        engine.create<ResumeBootstrapService>()
+        engine.create<SuspensionTriggerService>()
         val command = ResumeApprovalCommand(
             approvalId = exception.approvalId,
             approvalExpectedVersion = 0L,

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/TrustedReplayEnvelopeRegistryTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/TrustedReplayEnvelopeRegistryTest.kt
@@ -1,12 +1,32 @@
 package dev.tramai.engine
 
 import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.memory.UuidConversationIdProvider
 import dev.tramai.core.model.Message
 import dev.tramai.core.model.MessageRole
 import dev.tramai.core.model.ToolCall
+import dev.tramai.core.model.ToolDefinition
+import dev.tramai.core.observation.NoOpOperationInterceptor
+import dev.tramai.core.observation.NoOpOperationObserver
+import dev.tramai.core.policy.PolicyDecision
+import dev.tramai.core.policy.PolicyEngine
+import dev.tramai.core.provider.ProviderRegistry
+import dev.tramai.core.security.NoOpDlpInterceptor
+import dev.tramai.core.security.NoOpDlpRedactionAuditEmitter
+import dev.tramai.core.security.PromptSanitizer
+import dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter
+import dev.tramai.core.policy.NoOpPolicyDecisionAuditEmitter
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.Dispatchers
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import java.time.Clock
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Tests for PR #28 types: ReplayEnvelopeFactory, ResumeOperationRegistry,
@@ -20,7 +40,7 @@ class TrustedReplayEnvelopeRegistryTest {
     fun `prepareForSuspension redacts selected slot`() {
         val toolCallId = "call-1"
         val toolName = "lookup"
-        val opRef = resumeOpRef()
+        val opRef = testOpRef()
         val messages = listOf(
             Message(role = MessageRole.USER, content = "hello"),
             Message(
@@ -38,7 +58,7 @@ class TrustedReplayEnvelopeRegistryTest {
 
     @Test
     fun `digest computed from redacted snapshot differs from raw`() {
-        val opRef = resumeOpRef()
+        val opRef = testOpRef()
         val messages = listOf(assistantMsg(ToolCall("c1", "lookup", """{"x":"secret"}""")))
         val rawDigest = ReplayEnvelopeDigestHelper.compute(opRef, messages)
         val prepared = ReplayEnvelopeFactory.prepareForSuspension(opRef, messages, "c1", "lookup", 0)
@@ -47,11 +67,11 @@ class TrustedReplayEnvelopeRegistryTest {
 
     @Test
     fun `rehydration restores claimed arguments`() {
-        val opRef = resumeOpRef()
+        val opRef = testOpRef()
         val messages = listOf(assistantMsg(ToolCall("c1", "lookup", """{"x":"secret"}""")))
         val prepared = ReplayEnvelopeFactory.prepareForSuspension(opRef, messages, "c1", "lookup", 0)
         val payload = prepared.envelope.revealForResume()
-        val meta = metadata(opRef, prepared.digest, "c1", "lookup", 0)
+        val meta = testMetadata(opRef, prepared.digest, "c1", "lookup", 0)
         val rehydrated = ReplayEnvelopeFactory.rehydrateAfterClaim(payload, meta, """{"x":"restored"}""")
         val tc = rehydrated.messages.last { it.role == MessageRole.ASSISTANT && it.toolCalls != null }.toolCalls!![0]
         assertThat(tc.argumentsJson).isEqualTo("""{"x":"restored"}""")
@@ -59,7 +79,7 @@ class TrustedReplayEnvelopeRegistryTest {
 
     @Test
     fun `historic duplicate same id same name fails`() {
-        val opRef = resumeOpRef()
+        val opRef = testOpRef()
         val msgs = listOf(assistantMsg(ToolCall("c1", "lookup", """{"x":"1"}""")), assistantMsg(ToolCall("c1", "lookup", """{"x":"2"}""")))
         assertThatThrownBy { ReplayEnvelopeFactory.prepareForSuspension(opRef, msgs, "c1", "lookup", 0) }
             .hasMessageContaining("replay-envelope-duplicate-tool-call-id")
@@ -67,7 +87,7 @@ class TrustedReplayEnvelopeRegistryTest {
 
     @Test
     fun `historic duplicate same id different name fails`() {
-        val opRef = resumeOpRef()
+        val opRef = testOpRef()
         val msgs = listOf(assistantMsg(ToolCall("c1", "lookupCustomer", """{"x":"1"}""")), assistantMsg(ToolCall("c1", "executePayment", """{"x":"2"}""")))
         assertThatThrownBy { ReplayEnvelopeFactory.prepareForSuspension(opRef, msgs, "c1", "executePayment", 0) }
             .hasMessageContaining("replay-envelope-duplicate-tool-call-id")
@@ -75,24 +95,24 @@ class TrustedReplayEnvelopeRegistryTest {
 
     @Test
     fun `historic duplicate same id different name fails rehydration`() {
-        val opRef = resumeOpRef()
+        val opRef = testOpRef()
         val msgs = listOf(assistantMsg(ToolCall("c1", "lookupCustomer", """{"x":"hist"}""")), assistantMsg(ToolCall("c1", "executePayment", REDACTED_APPROVAL_CONTINUATION_ARGUMENTS)))
         val payload = ReplayPayload(messages = msgs)
-        val meta = metadata(opRef, Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"), "c1", "executePayment", 0)
+        val meta = testMetadata(opRef, Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"), "c1", "executePayment", 0)
         assertThatThrownBy { ReplayEnvelopeFactory.rehydrateAfterClaim(payload, meta, "{}") }
             .hasMessageContaining("replay-envelope-duplicate-tool-call-id")
     }
 
     @Test
     fun `missing assistant batch fails`() {
-        assertThatThrownBy { ReplayEnvelopeFactory.prepareForSuspension(resumeOpRef(), listOf(Message.text("hi")), "c1", "t", 0) }
+        assertThatThrownBy { ReplayEnvelopeFactory.prepareForSuspension(testOpRef(), listOf(Message.text("hi")), "c1", "t", 0) }
             .hasMessageContaining("replay-envelope-assistant-batch-not-found")
     }
 
     @Test
     fun `corrupt index fails rehydration`() {
         val msgs = listOf(assistantMsg(ToolCall("c1", "t", REDACTED_APPROVAL_CONTINUATION_ARGUMENTS)))
-        val meta = metadata(resumeOpRef(), Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"), "c1", "t", 5)
+        val meta = testMetadata(testOpRef(), Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"), "c1", "t", 5)
         assertThatThrownBy { ReplayEnvelopeFactory.rehydrateAfterClaim(ReplayPayload(msgs), meta, "{}") }
             .hasMessageContaining("replay-envelope-tool-call-index-out-of-bounds")
     }
@@ -100,14 +120,14 @@ class TrustedReplayEnvelopeRegistryTest {
     @Test
     fun `corrupt id fails rehydration`() {
         val msgs = listOf(assistantMsg(ToolCall("wrong", "t", REDACTED_APPROVAL_CONTINUATION_ARGUMENTS)))
-        val meta = metadata(resumeOpRef(), Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"), "c1", "t", 0)
+        val meta = testMetadata(testOpRef(), Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"), "c1", "t", 0)
         assertThatThrownBy { ReplayEnvelopeFactory.rehydrateAfterClaim(ReplayPayload(msgs), meta, "{}") }
             .hasMessageContaining("replay-envelope-tool-call-id-mismatch")
     }
 
     @Test
     fun `different ids same name remains valid`() {
-        val opRef = resumeOpRef()
+        val opRef = testOpRef()
         val msgs = listOf(assistantMsg(ToolCall("c1", "lookup", """{"x":"1"}""")), assistantMsg(ToolCall("c2", "lookup", """{"x":"2"}""")))
         val prepared = ReplayEnvelopeFactory.prepareForSuspension(opRef, msgs, "c2", "lookup", 0)
         val payload = prepared.envelope.revealForResume()
@@ -116,20 +136,156 @@ class TrustedReplayEnvelopeRegistryTest {
         assertThat(tc.argumentsJson).isEqualTo(REDACTED_APPROVAL_CONTINUATION_ARGUMENTS)
     }
 
+    @Test
+    fun `extra sentinel in historical message fails rehydration`() {
+        val opRef = testOpRef()
+        val msgs = listOf(
+            assistantMsg(ToolCall("c2", "other", REDACTED_APPROVAL_CONTINUATION_ARGUMENTS)),
+            assistantMsg(ToolCall("c1", "lookup", REDACTED_APPROVAL_CONTINUATION_ARGUMENTS)),
+        )
+        val payload = ReplayPayload(messages = msgs)
+        val meta = testMetadata(opRef,
+            Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
+            "c1", "lookup", 0)
+        assertThatThrownBy { ReplayEnvelopeFactory.rehydrateAfterClaim(payload, meta, "{}") }
+            .hasMessageContaining("replay-envelope-redaction-count-mismatch")
+    }
+
     // ── ResumeOperationRegistry tests ────────────────────────────────
 
     @Test
     fun `registry missing key fails`() {
         val registry = ResumeOperationRegistry()
-        assertThatThrownBy { registry.resolve(resumeOpRef()) }
+        assertThatThrownBy { registry.resolve(testOpRef()) }
             .hasMessageContaining("resume-operation-not-registered")
     }
 
     @Test
     fun `registry conflict cannot partially publish`() {
-        // Can't easily test with real ServiceDefinition in unit test,
-        // but the copy-on-write pattern guarantees atomic publication.
-        assertThat(true).isTrue
+        // Construct a multi-operation ServiceDefinition where one op conflicts
+        val registry = ResumeOperationRegistry()
+        val svcClass = AtomicSvc::class.java
+        val fooMethod = svcClass.getMethod("foo")
+        val barMethod = svcClass.getMethod("bar")
+        val svcQualifiedName = AtomicSvc::class.qualifiedName ?: ""
+
+        // Define original foo and bar OperationDefinition instances
+        val origFooOp = operationAnnotation("gpt-4", "original foo prompt")
+        val conflictFooOp = operationAnnotation("gpt-4", "different foo prompt -- digest differs")
+        val barOp = operationAnnotation("gpt-4", "do bar task")
+        val emptyTools = emptyList<ToolDefinition>()
+
+        val origFooDef = OperationDefinition(
+            method = fooMethod, operation = origFooOp,
+            classLevelSystemPrompt = null, systemAnnotations = emptyList(),
+            userAnnotations = emptyList(), isSuspend = false,
+            parameterNames = emptyList(), returnKind = ReturnKind.STRING,
+            returnType = null, returnTypeDescription = "String",
+            toolDefinitions = emptyTools, promptSanitizer = null,
+        )
+        val conflictFooDef = OperationDefinition(
+            method = fooMethod, operation = conflictFooOp,
+            classLevelSystemPrompt = null, systemAnnotations = emptyList(),
+            userAnnotations = emptyList(), isSuspend = false,
+            parameterNames = emptyList(), returnKind = ReturnKind.STRING,
+            returnType = null, returnTypeDescription = "String",
+            toolDefinitions = emptyTools, promptSanitizer = null,
+        )
+        val barDef = OperationDefinition(
+            method = barMethod, operation = barOp,
+            classLevelSystemPrompt = null, systemAnnotations = emptyList(),
+            userAnnotations = emptyList(), isSuspend = false,
+            parameterNames = emptyList(), returnKind = ReturnKind.STRING,
+            returnType = null, returnTypeDescription = "String",
+            toolDefinitions = emptyTools, promptSanitizer = null,
+        )
+
+        val fooOnlySvc = ServiceDefinition(svcClass.kotlin, null, mapOf(fooMethod to origFooDef))
+        val handler = dummyHandler(fooOnlySvc, registry)
+
+        // Register foo with the original definition
+        val registeredRef = registry.register(fooOnlySvc, origFooDef, handler)
+
+        // RegisterAll with foo (conflicting) + bar (new)
+        val bulkSvc = ServiceDefinition(svcClass.kotlin, null, mapOf(
+            fooMethod to conflictFooDef,
+            barMethod to barDef,
+        ))
+        val bulkHandler = dummyHandler(bulkSvc, registry)
+
+        assertThatThrownBy { registry.registerAll(bulkSvc, bulkHandler) }
+            .hasMessageContaining("resume-operation-registration-conflict")
+
+        // Foo is still resolvable (previous snapshot unchanged)
+        val stillRegistered = registry.resolve(registeredRef)
+        assertThat(stillRegistered).isNotNull
+        assertThat(stillRegistered.reference.methodName).isEqualTo("foo")
+
+        // Bar was NOT added by the failed registerAll
+        val barRef = ResumeOperationReference(
+            serviceInterface = svcQualifiedName,
+            methodName = "bar",
+            jvmMethodDescriptor = JvmMethodDescriptorHelper.compute(barMethod),
+            resumeDefinitionDigest = ResumeDefinitionDigestHelper.compute(bulkSvc, barDef),
+        )
+        assertThatThrownBy { registry.resolve(barRef) }
+            .hasMessageContaining("resume-operation-not-registered")
+    }
+
+    @Test
+    fun `identical registerAll call is idempotent`() {
+        val registry = ResumeOperationRegistry()
+        val svcClass = AtomicSvc::class.java
+        val fooMethod = svcClass.getMethod("foo")
+        val barMethod = svcClass.getMethod("bar")
+        val svcQualifiedName = AtomicSvc::class.qualifiedName ?: ""
+        val op = operationAnnotation("gpt-4", "idempotent test")
+        val emptyTools = emptyList<ToolDefinition>()
+
+        val fooDef = OperationDefinition(
+            method = fooMethod, operation = op,
+            classLevelSystemPrompt = null, systemAnnotations = emptyList(),
+            userAnnotations = emptyList(), isSuspend = false,
+            parameterNames = emptyList(), returnKind = ReturnKind.STRING,
+            returnType = null, returnTypeDescription = "String",
+            toolDefinitions = emptyTools, promptSanitizer = null,
+        )
+        val barDef = OperationDefinition(
+            method = barMethod, operation = op,
+            classLevelSystemPrompt = null, systemAnnotations = emptyList(),
+            userAnnotations = emptyList(), isSuspend = false,
+            parameterNames = emptyList(), returnKind = ReturnKind.STRING,
+            returnType = null, returnTypeDescription = "String",
+            toolDefinitions = emptyTools, promptSanitizer = null,
+        )
+        val svcDef = ServiceDefinition(svcClass.kotlin, null, mapOf(
+            fooMethod to fooDef,
+            barMethod to barDef,
+        ))
+        val handler = dummyHandler(svcDef, registry)
+
+        // First call succeeds
+        registry.registerAll(svcDef, handler)
+        val fooRef = ResumeOperationReference(
+            serviceInterface = svcQualifiedName,
+            methodName = "foo",
+            jvmMethodDescriptor = JvmMethodDescriptorHelper.compute(fooMethod),
+            resumeDefinitionDigest = ResumeDefinitionDigestHelper.compute(svcDef, fooDef),
+        )
+        assertThat(registry.resolve(fooRef)).isNotNull
+
+        // Second identical call must not throw
+        registry.registerAll(svcDef, handler)
+
+        // Both operations still resolvable
+        assertThat(registry.resolve(fooRef)).isNotNull
+        val barRef = ResumeOperationReference(
+            serviceInterface = svcQualifiedName,
+            methodName = "bar",
+            jvmMethodDescriptor = JvmMethodDescriptorHelper.compute(barMethod),
+            resumeDefinitionDigest = ResumeDefinitionDigestHelper.compute(svcDef, barDef),
+        )
+        assertThat(registry.resolve(barRef)).isNotNull
     }
 
     // ── JvmMethodDescriptorHelper tests ──────────────────────────────
@@ -152,17 +308,24 @@ class TrustedReplayEnvelopeRegistryTest {
         assertThat(d).contains("[Ljava/lang/String;")
     }
 
+    // ── Test interfaces ──────────────────────────────────────────────
+
     private interface TestSvc {
         fun nestedParam(input: NestedInput): String
         fun arrayParams(ints: IntArray, strings: Array<String>): Unit
     }
 
+    private interface AtomicSvc {
+        fun foo(): String
+        fun bar(): String
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────
 
-    private fun resumeOpRef() = ResumeOperationReference("t.S", "m", "()V",
+    private fun testOpRef() = ResumeOperationReference("t.S", "m", "()V",
         Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"))
 
-    private fun metadata(opRef: ResumeOperationReference, digest: Sha256Digest, id: String, name: String, idx: Int) =
+    private fun testMetadata(opRef: ResumeOperationReference, digest: Sha256Digest, id: String, name: String, idx: Int) =
         SuspendedInvocationMetadata(
             approvalId = "a1", toolCallId = id, toolName = name, toolCallIndex = idx,
             correlationId = "c1",
@@ -176,4 +339,67 @@ class TrustedReplayEnvelopeRegistryTest {
         )
 
     private fun assistantMsg(tc: ToolCall) = Message(role = MessageRole.ASSISTANT, content = "", toolCalls = listOf(tc))
+
+    /** Creates a dynamic proxy [dev.tramai.core.annotations.Operation] with the given values. */
+    private fun operationAnnotation(model: String, prompt: String): dev.tramai.core.annotations.Operation {
+        return Proxy.newProxyInstance(
+            dev.tramai.core.annotations.Operation::class.java.classLoader,
+            arrayOf(dev.tramai.core.annotations.Operation::class.java),
+            InvocationHandler { proxy, method, args ->
+                when (method.name) {
+                    "prompt" -> prompt
+                    "model" -> model
+                    "provider" -> ""
+                    "tools" -> emptyArray<String>()
+                    "maxRetries" -> 0
+                    "providerRetries" -> 0
+                    "timeoutMillis" -> 30_000L
+                    "cacheable" -> false
+                    "cacheTtlMillis" -> 60_000L
+                    "annotationType" -> dev.tramai.core.annotations.Operation::class.java
+                    "equals" -> proxy === args!![0]
+                    "hashCode" -> System.identityHashCode(proxy)
+                    "toString" -> "@Operation(model=$model, prompt=$prompt)"
+                    else -> method.defaultValue
+                }
+            },
+        ) as dev.tramai.core.annotations.Operation
+    }
+
+    /** Creates a [TramaiInvocationHandler] with minimal viable defaults (never dereferenced during registration). */
+    private fun dummyHandler(svcDef: ServiceDefinition, registry: ResumeOperationRegistry): TramaiInvocationHandler {
+        return TramaiInvocationHandler(
+            providerRegistry = ProviderRegistry.builder().build(),
+            structuredOutputHandler = null,
+            toolRegistry = ToolRegistry(),
+            operationObserver = NoOpOperationObserver,
+            operationInterceptor = NoOpOperationInterceptor,
+            responseCache = NoOpOperationResponseCache,
+            modelRegistry = dev.tramai.core.model.NoOpModelRegistry,
+            modelRegistrySettings = dev.tramai.core.model.ModelRegistrySettings(),
+            circuitBreaker = ProviderCircuitBreaker(CircuitBreakerSettings()),
+            retryDelayPolicy = ProviderRetryDelayPolicy(RetryPolicySettings()),
+            tokenBudgetSettings = TokenBudgetSettings(),
+            promptSanitizer = null,
+            chatMemory = null,
+            conversationIdProvider = UuidConversationIdProvider(),
+            scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+            serviceDefinition = svcDef,
+            policyEngine = PolicyEngine { _ -> PolicyDecision.Allow },
+            migrationWarningGuard = AtomicBoolean(false),
+            isLegacyFallback = false,
+            dlpInterceptor = NoOpDlpInterceptor,
+            dlpRedactionAuditEmitter = NoOpDlpRedactionAuditEmitter,
+            toolResultFilteringSettings = ToolResultFilteringSettings(),
+            engineEventObserver = NoOpEngineEventObserver,
+            policyDecisionAuditEmitter = NoOpPolicyDecisionAuditEmitter,
+            suspendedInvocationStore = InMemorySuspendedInvocationStore(),
+            approvalContinuationStore = null,
+            toolArgumentsDigester = null,
+            approvalGateCoordinator = null,
+            approvalLifecycleAuditEmitter = NoOpApprovalLifecycleAuditEmitter,
+            resumeOperationRegistry = registry,
+            clock = Clock.systemUTC(),
+        )
+    }
 }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/TrustedReplayEnvelopeRegistryTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/TrustedReplayEnvelopeRegistryTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test
 
 /**
  * Tests for PR #28 types: ReplayEnvelopeFactory, ResumeOperationRegistry,
- * JvmMethodDescriptorHelper, ResumeDefinitionDigestHelper.
+ * JvmMethodDescriptorHelper.
  */
 class TrustedReplayEnvelopeRegistryTest {
 
@@ -20,340 +20,100 @@ class TrustedReplayEnvelopeRegistryTest {
     fun `prepareForSuspension redacts selected slot`() {
         val toolCallId = "call-1"
         val toolName = "lookup"
-        val opRef = ResumeOperationReference(
-            serviceInterface = "test.Service",
-            methodName = "execute",
-            jvmMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/String;",
-            resumeDefinitionDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
-        )
+        val opRef = resumeOpRef()
         val messages = listOf(
             Message(role = MessageRole.USER, content = "hello"),
             Message(
-                role = MessageRole.ASSISTANT,
-                content = "",
-                toolCalls = listOf(
-                    ToolCall(id = toolCallId, name = toolName, argumentsJson = """{"input":"secret"}"""),
-                ),
+                role = MessageRole.ASSISTANT, content = "",
+                toolCalls = listOf(ToolCall(id = toolCallId, name = toolName, argumentsJson = """{"input":"secret"}""")),
             ),
         )
-
-        val prepared = ReplayEnvelopeFactory.prepareForSuspension(
-            operationReference = opRef,
-            messages = messages,
-            toolCallId = toolCallId,
-            toolName = toolName,
-            toolCallIndex = 0,
-        )
-
+        val prepared = ReplayEnvelopeFactory.prepareForSuspension(opRef, messages, toolCallId, toolName, 0)
         val payload = prepared.envelope.revealForResume()
-        val assistantMsg = payload.messages.last { it.role == MessageRole.ASSISTANT && it.toolCalls != null }
-        val toolCall = assistantMsg.toolCalls!![0]
-        assertThat(toolCall.argumentsJson).isEqualTo(REDACTED_APPROVAL_CONTINUATION_ARGUMENTS)
-        assertThat(toolCall.id).isEqualTo(toolCallId)
-        assertThat(toolCall.name).isEqualTo(toolName)
+        val tc = payload.messages.last { it.role == MessageRole.ASSISTANT && it.toolCalls != null }.toolCalls!![0]
+        assertThat(tc.argumentsJson).isEqualTo(REDACTED_APPROVAL_CONTINUATION_ARGUMENTS)
+        assertThat(tc.id).isEqualTo(toolCallId)
+        assertThat(tc.name).isEqualTo(toolName)
     }
 
     @Test
-    fun `prepareForSuspension digest differs from raw digest`() {
-        val toolCallId = "call-1"
-        val toolName = "lookup"
-        val opRef = ResumeOperationReference(
-            serviceInterface = "test.Service",
-            methodName = "execute",
-            jvmMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/String;",
-            resumeDefinitionDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
-        )
-        val messages = listOf(
-            Message(
-                role = MessageRole.ASSISTANT,
-                content = "",
-                toolCalls = listOf(
-                    ToolCall(id = toolCallId, name = toolName, argumentsJson = """{"input":"secret"}"""),
-                ),
-            ),
-        )
-
+    fun `digest computed from redacted snapshot differs from raw`() {
+        val opRef = resumeOpRef()
+        val messages = listOf(assistantMsg(ToolCall("c1", "lookup", """{"x":"secret"}""")))
         val rawDigest = ReplayEnvelopeDigestHelper.compute(opRef, messages)
-        val prepared = ReplayEnvelopeFactory.prepareForSuspension(
-            operationReference = opRef,
-            messages = messages,
-            toolCallId = toolCallId,
-            toolName = toolName,
-            toolCallIndex = 0,
-        )
-
+        val prepared = ReplayEnvelopeFactory.prepareForSuspension(opRef, messages, "c1", "lookup", 0)
         assertThat(prepared.digest).isNotEqualTo(rawDigest)
     }
 
     @Test
-    fun `rehydration restores selected slot after claim`() {
-        val toolCallId = "call-1"
-        val toolName = "lookup"
-        val opRef = ResumeOperationReference(
-            serviceInterface = "test.Service",
-            methodName = "execute",
-            jvmMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/String;",
-            resumeDefinitionDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
-        )
-        val messages = listOf(
-            Message(role = MessageRole.USER, content = "hello"),
-            Message(
-                role = MessageRole.ASSISTANT,
-                content = "",
-                toolCalls = listOf(
-                    ToolCall(id = toolCallId, name = toolName, argumentsJson = """{"input":"secret"}"""),
-                ),
-            ),
-        )
-
-        val prepared = ReplayEnvelopeFactory.prepareForSuspension(
-            operationReference = opRef,
-            messages = messages,
-            toolCallId = toolCallId,
-            toolName = toolName,
-            toolCallIndex = 0,
-        )
-
+    fun `rehydration restores claimed arguments`() {
+        val opRef = resumeOpRef()
+        val messages = listOf(assistantMsg(ToolCall("c1", "lookup", """{"x":"secret"}""")))
+        val prepared = ReplayEnvelopeFactory.prepareForSuspension(opRef, messages, "c1", "lookup", 0)
         val payload = prepared.envelope.revealForResume()
-        val metadata = SuspendedInvocationMetadata(
-            approvalId = "approval-1",
-            toolCallId = toolCallId,
-            toolName = toolName,
-            toolCallIndex = 0,
-            correlationId = "corr-1",
-            identity = EngineExecutionIdentity(
-                workflowRunId = "wf-1",
-                correlationId = "corr-1",
-                workflowDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
-                policyVersion = "1.0",
-                actorId = "admin",
-            ),
-            securityContext = ExecutionSecurityContext(),
-            operationReference = opRef,
-            replayEnvelopeDigest = prepared.digest,
-            toolReference = ResumeToolReference(toolName, Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001")),
-        )
-
-        val rehydrated = ReplayEnvelopeFactory.rehydrateAfterClaim(
-            payload = payload,
-            metadata = metadata,
-            claimedArgumentsJson = """{"input":"restored"}""",
-        )
-
-        val rehydratedMsg = rehydrated.messages.last { it.role == MessageRole.ASSISTANT && it.toolCalls != null }
-        val rehydratedCall = rehydratedMsg.toolCalls!![0]
-        assertThat(rehydratedCall.argumentsJson).isEqualTo("""{"input":"restored"}""")
-        assertThat(rehydratedCall.id).isEqualTo(toolCallId)
-        assertThat(rehydratedCall.name).isEqualTo(toolName)
+        val meta = metadata(opRef, prepared.digest, "c1", "lookup", 0)
+        val rehydrated = ReplayEnvelopeFactory.rehydrateAfterClaim(payload, meta, """{"x":"restored"}""")
+        val tc = rehydrated.messages.last { it.role == MessageRole.ASSISTANT && it.toolCalls != null }.toolCalls!![0]
+        assertThat(tc.argumentsJson).isEqualTo("""{"x":"restored"}""")
     }
 
     @Test
-    fun `historical duplicate toolCallId across batches fails`() {
-        val duplicateId = "call-duplicate"
-        val toolName = "lookup"
-        val opRef = ResumeOperationReference(
-            serviceInterface = "test.Service",
-            methodName = "execute",
-            jvmMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/String;",
-            resumeDefinitionDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
-        )
-        val messages = listOf(
-            Message(
-                role = MessageRole.ASSISTANT,
-                content = "",
-                toolCalls = listOf(
-                    ToolCall(id = duplicateId, name = toolName, argumentsJson = """{"input":"historical"}"""),
-                ),
-            ),
-            Message(
-                role = MessageRole.ASSISTANT,
-                content = "",
-                toolCalls = listOf(
-                    ToolCall(id = duplicateId, name = toolName, argumentsJson = """{"input":"current"}"""),
-                ),
-            ),
-        )
-
-        assertThatThrownBy {
-            ReplayEnvelopeFactory.prepareForSuspension(
-                operationReference = opRef,
-                messages = messages,
-                toolCallId = duplicateId,
-                toolName = toolName,
-                toolCallIndex = 0,
-            )
-        }.hasMessageContaining("replay-envelope-duplicate-matching-calls")
+    fun `historic duplicate same id same name fails`() {
+        val opRef = resumeOpRef()
+        val msgs = listOf(assistantMsg(ToolCall("c1", "lookup", """{"x":"1"}""")), assistantMsg(ToolCall("c1", "lookup", """{"x":"2"}""")))
+        assertThatThrownBy { ReplayEnvelopeFactory.prepareForSuspension(opRef, msgs, "c1", "lookup", 0) }
+            .hasMessageContaining("replay-envelope-duplicate-tool-call-id")
     }
 
     @Test
-    fun `historical duplicate identity fails rehydration`() {
-        val duplicateId = "call-duplicate"
-        val toolName = "lookup"
-        val opRef = ResumeOperationReference(
-            serviceInterface = "test.Service",
-            methodName = "execute",
-            jvmMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/String;",
-            resumeDefinitionDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
-        )
-        val messages = listOf(
-            Message(
-                role = MessageRole.ASSISTANT,
-                content = "",
-                toolCalls = listOf(
-                    ToolCall(id = duplicateId, name = toolName, argumentsJson = """{"input":"historical"}"""),
-                ),
-            ),
-            Message(
-                role = MessageRole.ASSISTANT,
-                content = "",
-                toolCalls = listOf(
-                    ToolCall(id = duplicateId, name = toolName, argumentsJson = REDACTED_APPROVAL_CONTINUATION_ARGUMENTS),
-                ),
-            ),
-        )
-
-        val payload = ReplayPayload(messages = messages)
-        val metadata = SuspendedInvocationMetadata(
-            approvalId = "approval-1",
-            toolCallId = duplicateId,
-            toolName = toolName,
-            toolCallIndex = 0,
-            correlationId = "corr-1",
-            identity = EngineExecutionIdentity(
-                workflowRunId = "wf-1",
-                correlationId = "corr-1",
-                workflowDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
-                policyVersion = "1.0",
-                actorId = "admin",
-            ),
-            securityContext = ExecutionSecurityContext(),
-            operationReference = opRef,
-            replayEnvelopeDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
-            toolReference = ResumeToolReference(toolName, Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001")),
-        )
-
-        assertThatThrownBy {
-            ReplayEnvelopeFactory.rehydrateAfterClaim(
-                payload = payload,
-                metadata = metadata,
-                claimedArgumentsJson = """{"input":"restored"}""",
-            )
-        }.hasMessageContaining("replay-envelope-duplicate-matching-calls")
+    fun `historic duplicate same id different name fails`() {
+        val opRef = resumeOpRef()
+        val msgs = listOf(assistantMsg(ToolCall("c1", "lookupCustomer", """{"x":"1"}""")), assistantMsg(ToolCall("c1", "executePayment", """{"x":"2"}""")))
+        assertThatThrownBy { ReplayEnvelopeFactory.prepareForSuspension(opRef, msgs, "c1", "executePayment", 0) }
+            .hasMessageContaining("replay-envelope-duplicate-tool-call-id")
     }
 
     @Test
-    fun `missing assistant batch fails creation`() {
-        val opRef = ResumeOperationReference(
-            serviceInterface = "test.Service",
-            methodName = "execute",
-            jvmMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/String;",
-            resumeDefinitionDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
-        )
-        assertThatThrownBy {
-            ReplayEnvelopeFactory.prepareForSuspension(
-                operationReference = opRef,
-                messages = listOf(Message(role = MessageRole.USER, content = "hello")),
-                toolCallId = "call-1",
-                toolName = "lookup",
-                toolCallIndex = 0,
-            )
-        }.hasMessageContaining("replay-envelope-assistant-batch-not-found")
+    fun `historic duplicate same id different name fails rehydration`() {
+        val opRef = resumeOpRef()
+        val msgs = listOf(assistantMsg(ToolCall("c1", "lookupCustomer", """{"x":"hist"}""")), assistantMsg(ToolCall("c1", "executePayment", REDACTED_APPROVAL_CONTINUATION_ARGUMENTS)))
+        val payload = ReplayPayload(messages = msgs)
+        val meta = metadata(opRef, Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"), "c1", "executePayment", 0)
+        assertThatThrownBy { ReplayEnvelopeFactory.rehydrateAfterClaim(payload, meta, "{}") }
+            .hasMessageContaining("replay-envelope-duplicate-tool-call-id")
+    }
+
+    @Test
+    fun `missing assistant batch fails`() {
+        assertThatThrownBy { ReplayEnvelopeFactory.prepareForSuspension(resumeOpRef(), listOf(Message.text("hi")), "c1", "t", 0) }
+            .hasMessageContaining("replay-envelope-assistant-batch-not-found")
     }
 
     @Test
     fun `corrupt index fails rehydration`() {
-        val toolCallId = "call-1"
-        val toolName = "lookup"
-        val opRef = ResumeOperationReference(
-            serviceInterface = "test.Service",
-            methodName = "execute",
-            jvmMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/String;",
-            resumeDefinitionDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
-        )
-        val messages = listOf(
-            Message(
-                role = MessageRole.ASSISTANT,
-                content = "",
-                toolCalls = listOf(
-                    ToolCall(id = toolCallId, name = toolName, argumentsJson = REDACTED_APPROVAL_CONTINUATION_ARGUMENTS),
-                ),
-            ),
-        )
-        val payload = ReplayPayload(messages = messages)
-        val metadata = SuspendedInvocationMetadata(
-            approvalId = "approval-1",
-            toolCallId = toolCallId,
-            toolName = toolName,
-            toolCallIndex = 5,
-            correlationId = "corr-1",
-            identity = EngineExecutionIdentity(
-                workflowRunId = "wf-1",
-                correlationId = "corr-1",
-                workflowDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
-                policyVersion = "1.0",
-                actorId = "admin",
-            ),
-            securityContext = ExecutionSecurityContext(),
-            operationReference = opRef,
-            replayEnvelopeDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
-            toolReference = ResumeToolReference(toolName, Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001")),
-        )
-
-        assertThatThrownBy {
-            ReplayEnvelopeFactory.rehydrateAfterClaim(
-                payload = payload,
-                metadata = metadata,
-                claimedArgumentsJson = "{}",
-            )
-        }.hasMessageContaining("replay-envelope-tool-call-index-out-of-bounds")
+        val msgs = listOf(assistantMsg(ToolCall("c1", "t", REDACTED_APPROVAL_CONTINUATION_ARGUMENTS)))
+        val meta = metadata(resumeOpRef(), Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"), "c1", "t", 5)
+        assertThatThrownBy { ReplayEnvelopeFactory.rehydrateAfterClaim(ReplayPayload(msgs), meta, "{}") }
+            .hasMessageContaining("replay-envelope-tool-call-index-out-of-bounds")
     }
 
     @Test
-    fun `corrupt ID fails rehydration`() {
-        val toolCallId = "call-1"
-        val toolName = "lookup"
-        val opRef = ResumeOperationReference(
-            serviceInterface = "test.Service",
-            methodName = "execute",
-            jvmMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/String;",
-            resumeDefinitionDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
-        )
-        val messages = listOf(
-            Message(
-                role = MessageRole.ASSISTANT,
-                content = "",
-                toolCalls = listOf(
-                    ToolCall(id = "wrong-id", name = toolName, argumentsJson = REDACTED_APPROVAL_CONTINUATION_ARGUMENTS),
-                ),
-            ),
-        )
-        val payload = ReplayPayload(messages = messages)
-        val metadata = SuspendedInvocationMetadata(
-            approvalId = "approval-1",
-            toolCallId = toolCallId,
-            toolName = toolName,
-            toolCallIndex = 0,
-            correlationId = "corr-1",
-            identity = EngineExecutionIdentity(
-                workflowRunId = "wf-1",
-                correlationId = "corr-1",
-                workflowDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
-                policyVersion = "1.0",
-                actorId = "admin",
-            ),
-            securityContext = ExecutionSecurityContext(),
-            operationReference = opRef,
-            replayEnvelopeDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
-            toolReference = ResumeToolReference(toolName, Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001")),
-        )
+    fun `corrupt id fails rehydration`() {
+        val msgs = listOf(assistantMsg(ToolCall("wrong", "t", REDACTED_APPROVAL_CONTINUATION_ARGUMENTS)))
+        val meta = metadata(resumeOpRef(), Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"), "c1", "t", 0)
+        assertThatThrownBy { ReplayEnvelopeFactory.rehydrateAfterClaim(ReplayPayload(msgs), meta, "{}") }
+            .hasMessageContaining("replay-envelope-tool-call-id-mismatch")
+    }
 
-        assertThatThrownBy {
-            ReplayEnvelopeFactory.rehydrateAfterClaim(
-                payload = payload,
-                metadata = metadata,
-                claimedArgumentsJson = "{}",
-            )
-        }.hasMessageContaining("replay-envelope-tool-call-id-mismatch")
+    @Test
+    fun `different ids same name remains valid`() {
+        val opRef = resumeOpRef()
+        val msgs = listOf(assistantMsg(ToolCall("c1", "lookup", """{"x":"1"}""")), assistantMsg(ToolCall("c2", "lookup", """{"x":"2"}""")))
+        val prepared = ReplayEnvelopeFactory.prepareForSuspension(opRef, msgs, "c2", "lookup", 0)
+        val payload = prepared.envelope.revealForResume()
+        val tc = payload.messages.last { it.role == MessageRole.ASSISTANT }.toolCalls!![0]
+        assertThat(tc.id).isEqualTo("c2")
+        assertThat(tc.argumentsJson).isEqualTo(REDACTED_APPROVAL_CONTINUATION_ARGUMENTS)
     }
 
     // ── ResumeOperationRegistry tests ────────────────────────────────
@@ -361,16 +121,15 @@ class TrustedReplayEnvelopeRegistryTest {
     @Test
     fun `registry missing key fails`() {
         val registry = ResumeOperationRegistry()
-        val reference = ResumeOperationReference(
-            serviceInterface = "test.Missing",
-            methodName = "execute",
-            jvmMethodDescriptor = "()V",
-            resumeDefinitionDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
-        )
+        assertThatThrownBy { registry.resolve(resumeOpRef()) }
+            .hasMessageContaining("resume-operation-not-registered")
+    }
 
-        assertThatThrownBy {
-            registry.resolve(reference)
-        }.hasMessageContaining("resume-operation-not-registered")
+    @Test
+    fun `registry conflict cannot partially publish`() {
+        // Can't easily test with real ServiceDefinition in unit test,
+        // but the copy-on-write pattern guarantees atomic publication.
+        assertThat(true).isTrue
     }
 
     // ── JvmMethodDescriptorHelper tests ──────────────────────────────
@@ -378,25 +137,43 @@ class TrustedReplayEnvelopeRegistryTest {
     class NestedInput
 
     @Test
-    fun `descriptor nested class uses binary name`() {
-        val method = TestNestedService::class.java.methods.find { it.name == "nestedParam" }
-            ?: throw AssertionError("Method not found")
-        val descriptor = JvmMethodDescriptorHelper.compute(method)
-        assertThat(descriptor).contains("TrustedReplayEnvelopeRegistryTest\$NestedInput")
-        assertThat(descriptor).doesNotContain("TrustedReplayEnvelopeRegistryTest.NestedInput")
+    fun `nested class uses binary name`() {
+        val m = TestSvc::class.java.methods.find { it.name == "nestedParam" }!!
+        val d = JvmMethodDescriptorHelper.compute(m)
+        assertThat(d).contains("TrustedReplayEnvelopeRegistryTest\$NestedInput")
+        assertThat(d).doesNotContain("TrustedReplayEnvelopeRegistryTest.NestedInput")
     }
 
     @Test
-    fun `descriptor primitive arrays`() {
-        val method = TestNestedService::class.java.methods.find { it.name == "arrayParams" }
-            ?: throw AssertionError("Method not found")
-        val descriptor = JvmMethodDescriptorHelper.compute(method)
-        assertThat(descriptor).contains("([I")
-        assertThat(descriptor).contains("[Ljava/lang/String;")
+    fun `primitive arrays`() {
+        val m = TestSvc::class.java.methods.find { it.name == "arrayParams" }!!
+        val d = JvmMethodDescriptorHelper.compute(m)
+        assertThat(d).contains("([I")
+        assertThat(d).contains("[Ljava/lang/String;")
     }
 
-    private interface TestNestedService {
+    private interface TestSvc {
         fun nestedParam(input: NestedInput): String
         fun arrayParams(ints: IntArray, strings: Array<String>): Unit
     }
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    private fun resumeOpRef() = ResumeOperationReference("t.S", "m", "()V",
+        Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"))
+
+    private fun metadata(opRef: ResumeOperationReference, digest: Sha256Digest, id: String, name: String, idx: Int) =
+        SuspendedInvocationMetadata(
+            approvalId = "a1", toolCallId = id, toolName = name, toolCallIndex = idx,
+            correlationId = "c1",
+            identity = EngineExecutionIdentity("wf1", "c1",
+                Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
+                "1.0", "admin"),
+            securityContext = dev.tramai.engine.ExecutionSecurityContext(),
+            operationReference = opRef, replayEnvelopeDigest = digest,
+            toolReference = ResumeToolReference(name,
+                Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001")),
+        )
+
+    private fun assistantMsg(tc: ToolCall) = Message(role = MessageRole.ASSISTANT, content = "", toolCalls = listOf(tc))
 }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/TrustedReplayEnvelopeRegistryTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/TrustedReplayEnvelopeRegistryTest.kt
@@ -1,0 +1,402 @@
+package dev.tramai.engine
+
+import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
+import dev.tramai.core.model.ToolCall
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for PR #28 types: ReplayEnvelopeFactory, ResumeOperationRegistry,
+ * JvmMethodDescriptorHelper, ResumeDefinitionDigestHelper.
+ */
+class TrustedReplayEnvelopeRegistryTest {
+
+    // ── ReplayEnvelopeFactory tests ──────────────────────────────────
+
+    @Test
+    fun `prepareForSuspension redacts selected slot`() {
+        val toolCallId = "call-1"
+        val toolName = "lookup"
+        val opRef = ResumeOperationReference(
+            serviceInterface = "test.Service",
+            methodName = "execute",
+            jvmMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/String;",
+            resumeDefinitionDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
+        )
+        val messages = listOf(
+            Message(role = MessageRole.USER, content = "hello"),
+            Message(
+                role = MessageRole.ASSISTANT,
+                content = "",
+                toolCalls = listOf(
+                    ToolCall(id = toolCallId, name = toolName, argumentsJson = """{"input":"secret"}"""),
+                ),
+            ),
+        )
+
+        val prepared = ReplayEnvelopeFactory.prepareForSuspension(
+            operationReference = opRef,
+            messages = messages,
+            toolCallId = toolCallId,
+            toolName = toolName,
+            toolCallIndex = 0,
+        )
+
+        val payload = prepared.envelope.revealForResume()
+        val assistantMsg = payload.messages.last { it.role == MessageRole.ASSISTANT && it.toolCalls != null }
+        val toolCall = assistantMsg.toolCalls!![0]
+        assertThat(toolCall.argumentsJson).isEqualTo(REDACTED_APPROVAL_CONTINUATION_ARGUMENTS)
+        assertThat(toolCall.id).isEqualTo(toolCallId)
+        assertThat(toolCall.name).isEqualTo(toolName)
+    }
+
+    @Test
+    fun `prepareForSuspension digest differs from raw digest`() {
+        val toolCallId = "call-1"
+        val toolName = "lookup"
+        val opRef = ResumeOperationReference(
+            serviceInterface = "test.Service",
+            methodName = "execute",
+            jvmMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/String;",
+            resumeDefinitionDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
+        )
+        val messages = listOf(
+            Message(
+                role = MessageRole.ASSISTANT,
+                content = "",
+                toolCalls = listOf(
+                    ToolCall(id = toolCallId, name = toolName, argumentsJson = """{"input":"secret"}"""),
+                ),
+            ),
+        )
+
+        val rawDigest = ReplayEnvelopeDigestHelper.compute(opRef, messages)
+        val prepared = ReplayEnvelopeFactory.prepareForSuspension(
+            operationReference = opRef,
+            messages = messages,
+            toolCallId = toolCallId,
+            toolName = toolName,
+            toolCallIndex = 0,
+        )
+
+        assertThat(prepared.digest).isNotEqualTo(rawDigest)
+    }
+
+    @Test
+    fun `rehydration restores selected slot after claim`() {
+        val toolCallId = "call-1"
+        val toolName = "lookup"
+        val opRef = ResumeOperationReference(
+            serviceInterface = "test.Service",
+            methodName = "execute",
+            jvmMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/String;",
+            resumeDefinitionDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
+        )
+        val messages = listOf(
+            Message(role = MessageRole.USER, content = "hello"),
+            Message(
+                role = MessageRole.ASSISTANT,
+                content = "",
+                toolCalls = listOf(
+                    ToolCall(id = toolCallId, name = toolName, argumentsJson = """{"input":"secret"}"""),
+                ),
+            ),
+        )
+
+        val prepared = ReplayEnvelopeFactory.prepareForSuspension(
+            operationReference = opRef,
+            messages = messages,
+            toolCallId = toolCallId,
+            toolName = toolName,
+            toolCallIndex = 0,
+        )
+
+        val payload = prepared.envelope.revealForResume()
+        val metadata = SuspendedInvocationMetadata(
+            approvalId = "approval-1",
+            toolCallId = toolCallId,
+            toolName = toolName,
+            toolCallIndex = 0,
+            correlationId = "corr-1",
+            identity = EngineExecutionIdentity(
+                workflowRunId = "wf-1",
+                correlationId = "corr-1",
+                workflowDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
+                policyVersion = "1.0",
+                actorId = "admin",
+            ),
+            securityContext = ExecutionSecurityContext(),
+            operationReference = opRef,
+            replayEnvelopeDigest = prepared.digest,
+            toolReference = ResumeToolReference(toolName, Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001")),
+        )
+
+        val rehydrated = ReplayEnvelopeFactory.rehydrateAfterClaim(
+            payload = payload,
+            metadata = metadata,
+            claimedArgumentsJson = """{"input":"restored"}""",
+        )
+
+        val rehydratedMsg = rehydrated.messages.last { it.role == MessageRole.ASSISTANT && it.toolCalls != null }
+        val rehydratedCall = rehydratedMsg.toolCalls!![0]
+        assertThat(rehydratedCall.argumentsJson).isEqualTo("""{"input":"restored"}""")
+        assertThat(rehydratedCall.id).isEqualTo(toolCallId)
+        assertThat(rehydratedCall.name).isEqualTo(toolName)
+    }
+
+    @Test
+    fun `historical duplicate toolCallId across batches fails`() {
+        val duplicateId = "call-duplicate"
+        val toolName = "lookup"
+        val opRef = ResumeOperationReference(
+            serviceInterface = "test.Service",
+            methodName = "execute",
+            jvmMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/String;",
+            resumeDefinitionDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
+        )
+        val messages = listOf(
+            Message(
+                role = MessageRole.ASSISTANT,
+                content = "",
+                toolCalls = listOf(
+                    ToolCall(id = duplicateId, name = toolName, argumentsJson = """{"input":"historical"}"""),
+                ),
+            ),
+            Message(
+                role = MessageRole.ASSISTANT,
+                content = "",
+                toolCalls = listOf(
+                    ToolCall(id = duplicateId, name = toolName, argumentsJson = """{"input":"current"}"""),
+                ),
+            ),
+        )
+
+        assertThatThrownBy {
+            ReplayEnvelopeFactory.prepareForSuspension(
+                operationReference = opRef,
+                messages = messages,
+                toolCallId = duplicateId,
+                toolName = toolName,
+                toolCallIndex = 0,
+            )
+        }.hasMessageContaining("replay-envelope-duplicate-matching-calls")
+    }
+
+    @Test
+    fun `historical duplicate identity fails rehydration`() {
+        val duplicateId = "call-duplicate"
+        val toolName = "lookup"
+        val opRef = ResumeOperationReference(
+            serviceInterface = "test.Service",
+            methodName = "execute",
+            jvmMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/String;",
+            resumeDefinitionDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
+        )
+        val messages = listOf(
+            Message(
+                role = MessageRole.ASSISTANT,
+                content = "",
+                toolCalls = listOf(
+                    ToolCall(id = duplicateId, name = toolName, argumentsJson = """{"input":"historical"}"""),
+                ),
+            ),
+            Message(
+                role = MessageRole.ASSISTANT,
+                content = "",
+                toolCalls = listOf(
+                    ToolCall(id = duplicateId, name = toolName, argumentsJson = REDACTED_APPROVAL_CONTINUATION_ARGUMENTS),
+                ),
+            ),
+        )
+
+        val payload = ReplayPayload(messages = messages)
+        val metadata = SuspendedInvocationMetadata(
+            approvalId = "approval-1",
+            toolCallId = duplicateId,
+            toolName = toolName,
+            toolCallIndex = 0,
+            correlationId = "corr-1",
+            identity = EngineExecutionIdentity(
+                workflowRunId = "wf-1",
+                correlationId = "corr-1",
+                workflowDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
+                policyVersion = "1.0",
+                actorId = "admin",
+            ),
+            securityContext = ExecutionSecurityContext(),
+            operationReference = opRef,
+            replayEnvelopeDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
+            toolReference = ResumeToolReference(toolName, Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001")),
+        )
+
+        assertThatThrownBy {
+            ReplayEnvelopeFactory.rehydrateAfterClaim(
+                payload = payload,
+                metadata = metadata,
+                claimedArgumentsJson = """{"input":"restored"}""",
+            )
+        }.hasMessageContaining("replay-envelope-duplicate-matching-calls")
+    }
+
+    @Test
+    fun `missing assistant batch fails creation`() {
+        val opRef = ResumeOperationReference(
+            serviceInterface = "test.Service",
+            methodName = "execute",
+            jvmMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/String;",
+            resumeDefinitionDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
+        )
+        assertThatThrownBy {
+            ReplayEnvelopeFactory.prepareForSuspension(
+                operationReference = opRef,
+                messages = listOf(Message(role = MessageRole.USER, content = "hello")),
+                toolCallId = "call-1",
+                toolName = "lookup",
+                toolCallIndex = 0,
+            )
+        }.hasMessageContaining("replay-envelope-assistant-batch-not-found")
+    }
+
+    @Test
+    fun `corrupt index fails rehydration`() {
+        val toolCallId = "call-1"
+        val toolName = "lookup"
+        val opRef = ResumeOperationReference(
+            serviceInterface = "test.Service",
+            methodName = "execute",
+            jvmMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/String;",
+            resumeDefinitionDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
+        )
+        val messages = listOf(
+            Message(
+                role = MessageRole.ASSISTANT,
+                content = "",
+                toolCalls = listOf(
+                    ToolCall(id = toolCallId, name = toolName, argumentsJson = REDACTED_APPROVAL_CONTINUATION_ARGUMENTS),
+                ),
+            ),
+        )
+        val payload = ReplayPayload(messages = messages)
+        val metadata = SuspendedInvocationMetadata(
+            approvalId = "approval-1",
+            toolCallId = toolCallId,
+            toolName = toolName,
+            toolCallIndex = 5,
+            correlationId = "corr-1",
+            identity = EngineExecutionIdentity(
+                workflowRunId = "wf-1",
+                correlationId = "corr-1",
+                workflowDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
+                policyVersion = "1.0",
+                actorId = "admin",
+            ),
+            securityContext = ExecutionSecurityContext(),
+            operationReference = opRef,
+            replayEnvelopeDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
+            toolReference = ResumeToolReference(toolName, Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001")),
+        )
+
+        assertThatThrownBy {
+            ReplayEnvelopeFactory.rehydrateAfterClaim(
+                payload = payload,
+                metadata = metadata,
+                claimedArgumentsJson = "{}",
+            )
+        }.hasMessageContaining("replay-envelope-tool-call-index-out-of-bounds")
+    }
+
+    @Test
+    fun `corrupt ID fails rehydration`() {
+        val toolCallId = "call-1"
+        val toolName = "lookup"
+        val opRef = ResumeOperationReference(
+            serviceInterface = "test.Service",
+            methodName = "execute",
+            jvmMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/String;",
+            resumeDefinitionDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
+        )
+        val messages = listOf(
+            Message(
+                role = MessageRole.ASSISTANT,
+                content = "",
+                toolCalls = listOf(
+                    ToolCall(id = "wrong-id", name = toolName, argumentsJson = REDACTED_APPROVAL_CONTINUATION_ARGUMENTS),
+                ),
+            ),
+        )
+        val payload = ReplayPayload(messages = messages)
+        val metadata = SuspendedInvocationMetadata(
+            approvalId = "approval-1",
+            toolCallId = toolCallId,
+            toolName = toolName,
+            toolCallIndex = 0,
+            correlationId = "corr-1",
+            identity = EngineExecutionIdentity(
+                workflowRunId = "wf-1",
+                correlationId = "corr-1",
+                workflowDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
+                policyVersion = "1.0",
+                actorId = "admin",
+            ),
+            securityContext = ExecutionSecurityContext(),
+            operationReference = opRef,
+            replayEnvelopeDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
+            toolReference = ResumeToolReference(toolName, Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001")),
+        )
+
+        assertThatThrownBy {
+            ReplayEnvelopeFactory.rehydrateAfterClaim(
+                payload = payload,
+                metadata = metadata,
+                claimedArgumentsJson = "{}",
+            )
+        }.hasMessageContaining("replay-envelope-tool-call-id-mismatch")
+    }
+
+    // ── ResumeOperationRegistry tests ────────────────────────────────
+
+    @Test
+    fun `registry missing key fails`() {
+        val registry = ResumeOperationRegistry()
+        val reference = ResumeOperationReference(
+            serviceInterface = "test.Missing",
+            methodName = "execute",
+            jvmMethodDescriptor = "()V",
+            resumeDefinitionDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000001"),
+        )
+
+        assertThatThrownBy {
+            registry.resolve(reference)
+        }.hasMessageContaining("resume-operation-not-registered")
+    }
+
+    // ── JvmMethodDescriptorHelper tests ──────────────────────────────
+
+    class NestedInput
+
+    @Test
+    fun `descriptor nested class uses binary name`() {
+        val method = TestNestedService::class.java.methods.find { it.name == "nestedParam" }
+            ?: throw AssertionError("Method not found")
+        val descriptor = JvmMethodDescriptorHelper.compute(method)
+        assertThat(descriptor).contains("TrustedReplayEnvelopeRegistryTest\$NestedInput")
+        assertThat(descriptor).doesNotContain("TrustedReplayEnvelopeRegistryTest.NestedInput")
+    }
+
+    @Test
+    fun `descriptor primitive arrays`() {
+        val method = TestNestedService::class.java.methods.find { it.name == "arrayParams" }
+            ?: throw AssertionError("Method not found")
+        val descriptor = JvmMethodDescriptorHelper.compute(method)
+        assertThat(descriptor).contains("([I")
+        assertThat(descriptor).contains("[Ljava/lang/String;")
+    }
+
+    private interface TestNestedService {
+        fun nestedParam(input: NestedInput): String
+        fun arrayParams(ints: IntArray, strings: Array<String>): Unit
+    }
+}

--- a/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/SovereignTramai.kt
+++ b/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/SovereignTramai.kt
@@ -418,6 +418,21 @@ class SovereignTramaiRuntime internal constructor(
         delegate.create(serviceType)
 
     /**
+     * Registers a service type without creating a proxy.
+     *
+     * Delegates to [TramaiRuntime.registerService].
+     *
+     * Use after runtime restart before calling [resumeApproval]:
+     * ```
+     * runtime.registerService<InvoiceIntelligenceService>()
+     * runtime.resumeApprovalTyped<InvoiceAssessment>(command)
+     * ```
+     */
+    fun registerService(serviceType: KClass<*>) {
+        delegate.registerService(serviceType)
+    }
+
+    /**
      * Resumes an approval-suspended tool execution.
      */
     suspend fun resumeApproval(command: ResumeApprovalCommand): Any? =
@@ -440,3 +455,9 @@ class SovereignTramaiRuntime internal constructor(
  * Reified convenience overload for [SovereignTramaiRuntime.create].
  */
 inline fun <reified T : Any> SovereignTramaiRuntime.create(): T = create(T::class)
+
+/**
+ * Reified convenience overload for [SovereignTramaiRuntime.registerService].
+ */
+inline fun <reified T : Any> SovereignTramaiRuntime.registerService(): Unit =
+    registerService(T::class)

--- a/tramai-standalone/src/main/kotlin/dev/tramai/standalone/TramaiRuntime.kt
+++ b/tramai-standalone/src/main/kotlin/dev/tramai/standalone/TramaiRuntime.kt
@@ -22,6 +22,24 @@ class TramaiRuntime internal constructor(
         engine.create(serviceType)
 
     /**
+     * Registers a service type without creating a proxy, so that its operations
+     * are available for resume via the trusted [ResumeOperationRegistry].
+     *
+     * Repeated identical registration is allowed (idempotent).
+     * Conflicting registration (same service/method with different definition)
+     * fails closed.
+     *
+     * Use after runtime restart before calling [resumeApproval]:
+     * ```
+     * runtime.registerService<InvoiceIntelligenceService>()
+     * runtime.resumeApprovalTyped<InvoiceAssessment>(command)
+     * ```
+     */
+    fun registerService(serviceType: KClass<*>) {
+        engine.registerService(serviceType)
+    }
+
+    /**
      * Resumes an approval-suspended tool execution.
      */
     suspend fun resumeApproval(command: ResumeApprovalCommand): Any? =
@@ -44,3 +62,9 @@ class TramaiRuntime internal constructor(
  * Reified convenience overload for [TramaiRuntime.create].
  */
 inline fun <reified T : Any> TramaiRuntime.create(): T = create(T::class)
+
+/**
+ * Reified convenience overload for [TramaiRuntime.registerService].
+ */
+inline fun <reified T : Any> TramaiRuntime.registerService(): Unit =
+    registerService(T::class)


### PR DESCRIPTION
## Summary

Refactor TramAI approval resume so suspended workflows no longer depend on serialized runtime objects or a single mutable in-memory resume handler.

PR #27 introduced encrypted file-backed persistence for approvals, continuations, and audit evidence. PR #28 prepares the engine for durable suspended replay by introducing a redacted replay envelope, stable operation references, trusted multi-service operation registration, explicit service registration after restart, and pre-token integrity checks.

## Architecture

### New Types

- **`ResumeOperationReference`** — stable data-only operation identity (`serviceInterface`, `methodName`, `jvmMethodDescriptor`, `resumeDefinitionDigest`)
- **`ResumeToolReference`** — active tool identity and declaration digest
- **`JvmMethodDescriptorHelper`** — deterministic JVM descriptors for unambiguous overload resolution
- **`ResumeDefinitionDigestHelper`** — canonical digest over service and operation semantics while preserving declared ordering
- **`ResumeToolDeclarationDigestHelper`** — canonical digest over name, description, schema, idempotency, side-effect level, and security declaration
- **`SensitiveReplayEnvelope`** — opaque replayable message-model data only; no executable runtime objects
- **`ReplayEnvelopeFactory`** — fail-closed redaction before storage and post-claim rehydration
- **`ReplayEnvelopeDigestHelper`** — deterministic digest over the exact redacted replay snapshot
- **`CanonicalMessageEncoder`** — shared message canonicalization
- **`ResumeOperationRegistry`** — copy-on-write registry keyed by (`serviceInterface`, `methodName`, `jvmMethodDescriptor`)

## API Changes

- Added `TramaiEngine.registerService(serviceType)`, `TramaiRuntime.registerService()`, and `SovereignTramaiRuntime.registerService()` with reified Kotlin helpers
- Updated `SuspendedInvocationStore.create()` to take `SensitiveReplayEnvelope`
- Added `revealReplayEnvelope()` and deprecated the old sensitive-context path without revealing data
- Extended `SuspendedInvocationMetadata` with operation reference, replay-envelope digest, and tool declaration reference
- Removed the mutable last-proxy `resumeHandler`

## Security Properties

- Selected suspended `ToolCall.argumentsJson` is replaced with a sentinel before storage
- `toolCallId` is globally unique across the full replay envelope, independent of tool name
- Replay digest is computed from the exact redacted snapshot
- Post-claim rehydration restores arguments only from `ApprovalContinuationStore`
- Global sentinel count is revalidated before rehydration
- `COMPLETED` duplicate resumes reject explicitly before metadata loading
- Cross-store checks cover approval ID, workflow run ID, correlation ID, workflow digest, policy version, tool name, and tool-call ID
- Operation-definition drift rejects before token consumption
- Active tool declaration drift rejects before token consumption
- Stored tool-security metadata is bound to active runtime security metadata
- Policy evaluation uses active runtime tool security
- Multi-operation service registration validates conflicts before one copy-on-write registry swap

## Resume Ordering

1. Load continuation snapshot and reject completed duplicates explicitly
2. Load safe suspended metadata
3. Resolve trusted operation from registry
4. Validate cross-store identity and operation drift
5. Resolve active runtime tool and validate declaration/security drift
6. Validate token and evaluate `BEFORE_WORKFLOW_RESUME`
7. Authorize token consumption and claim continuation
8. Reveal redacted replay envelope and verify digest
9. Validate replay slot identity and global sentinel invariants
10. Rehydrate selected slot from claimed continuation arguments
11. Execute tool, continue provider loop, complete continuation, audit, and clean up

## Threat Boundary

The replay envelope contains replayable message-model data, including historical data-model `ToolCall` values required for provider continuity. It never contains executable runtime objects such as `OperationDefinition`, `ResolvedTool`, reflection objects, callbacks, providers, or registries.

The selected suspended tool-call arguments are redacted before storage and rehydrated only after a successful continuation claim.

## Validation

- `./gradlew test --rerun-tasks` ✅
- `./gradlew :tramai-security:test --rerun-tasks` ✅
- CI Run 180 ✅

## PR #29 Deferred

- `FileSuspendedInvocationStore`
- encrypted disk persistence for replay envelopes
- `suspended/` directory integration in `tramai-persistence-file`
- restart-safe file-backed end-to-end integration test
- automatic startup resume

## Changed Files

17 files changed.