### PR TITLE
feat(persistence-file): add encrypted suspended replay store and restart-safe recovery

### DIFF
--- a/docs/board/tasks/task-pr29-file-suspended-restart-recovery.md
+++ b/docs/board/tasks/task-pr29-file-suspended-restart-recovery.md
@@ -1,0 +1,85 @@
+# Task PR #29 — Encrypted FileSuspendedInvocationStore and Restart-Safe Recovery
+
+## Status
+In Progress
+
+## Branch
+feat/file-suspended-invocation-restart-recovery
+
+## Summary
+Add the fourth encrypted file-backed sovereign store (`FileSuspendedInvocationStore`), a trusted replay-envelope persistence bridge, full bundle integration, and a JVM-restart-style integration test proving workflow resume after process termination.
+
+## File Changes
+
+### New files
+1. `tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/ReplayEnvelopePersistenceCodec.kt` — Trusted bridge exporting/restoring redacted Message snapshots
+2. `tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStore.kt` — AES-256-GCM encrypted store implementing `SuspendedInvocationStore`
+3. `docs/board/tasks/task-pr29-file-suspended-restart-recovery.md` — this file
+
+### Modified files
+4. `tramai-persistence-file/build.gradle.kts` — add `api(project(":tramai-engine"))` dependency
+5. `tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/PersistedDtos.kt` — add suspended invocation V1 DTOs with domain conversions
+6. `tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/FileBackedSovereignStores.kt` — add `suspendedInvocationStore` to bundle, create `suspended/` subdir, verify on open
+7. `docs/modules/tramai-persistence-file.md` — update to reflect PR #29 scope, shift deferred work
+8. `docs/specs/spec-016-approval-engine-suspension-resume.md` — update status to include PR #29
+
+## Implementation Details
+
+### 1. Build dependency (build.gradle.kts)
+Add: `api(project(":tramai-engine"))`
+This is a one-way dependency: `tramai-engine` does NOT depend on `tramai-persistence-file`.
+
+### 2. Persisted DTOs (PersistedDtos.kt)
+Add V1 DTOs for all engine types needed:
+- `PersistedSuspendedInvocationRecordV1` — top-level record
+- `PersistedSuspendedInvocationMetadataV1` — all metadata fields
+- `PersistedEngineExecutionIdentityV1`
+- `PersistedExecutionSecurityContextV1`
+- `PersistedResumeOperationReferenceV1`
+- `PersistedResumeToolReferenceV1`
+- `PersistedTokenBudgetSnapshotV1`
+- `PersistedToolSecurityMetadataV1`
+- `PersistedReplayEnvelopeV1`
+- `PersistedMessageV1`
+- `PersistedToolCallV1`
+- `PersistedContentPartV1` (tagged: text/image/image_url)
+
+Domain conversion functions: `toDomain()` and `toPersistedV1()` for each.
+
+### 3. ReplayEnvelopePersistenceCodec
+Narrow trusted bridge with two operations:
+- `snapshotForPersistence(metadata, envelope): List<Message>` — validates all invariants (sentinel count, slot identity, digest binding) and returns the messages for DTO encoding
+- `restoreFromPersistence(metadata, messages): SensitiveReplayEnvelope` — validates all invariants on the read side and returns a reconstructed opaque envelope
+
+### 4. FileSuspendedInvocationStore
+Follows the same pattern as `FileApprovalStore`:
+- `RECORD_TYPE = "suspended-invocation"`
+- `SUSPENDED_DIR = "suspended"`
+- Filename: `sha256("suspended-invocation:" + approvalId).tram.enc`
+- Create-only persistence via `FileStoreUtil.atomicEncryptCreate(...)`
+- `verifyAll()` scans every file, decrypts, validates schema version, ID↔filename digest binding, replay digest, sentinel count
+- All validation uses fixed reason codes (no interpolated values)
+- Uses `FileStoreLease.withOpenOperation` for guarded access
+
+### 5. FileBackedSovereignStores integration
+- Add `suspendedInvocationStore: SuspendedInvocationStore` to the bundle
+- Add `"suspended"` to `subdirs` list
+- Instantiate `FileSuspendedInvocationStore(root, key, configuration, lease)`
+- Verify on open when `verifyOnOpen = true`
+
+### 6. Documentation updates
+- `docs/modules/tramai-persistence-file.md`: update deferred work, add suspended/ to file layout
+- `docs/specs/spec-016-approval-engine-suspension-resume.md`: mark PR #29 in status
+
+## Key Design Decisions
+
+- Use `atomicEncryptCreate` (not `atomicEncryptWrite`) — create-only, no replacement
+- Never interpolate IDs into exception messages — fixed reason codes only
+- Replay envelope is persisted as validated redacted Message snapshots, not runtime objects
+- Raw selected tool arguments stay exclusively in `FileApprovalContinuationStore`
+
+## Verification
+```bash
+./gradlew :tramai-persistence-file:compileKotlin
+./gradlew :tramai-persistence-file:test --rerun-tasks
+```

--- a/docs/board/tasks/task-pr29-file-suspended-restart-recovery.md
+++ b/docs/board/tasks/task-pr29-file-suspended-restart-recovery.md
@@ -1,7 +1,7 @@
 # Task PR #29 — Encrypted FileSuspendedInvocationStore and Restart-Safe Recovery
 
 ## Status
-**Complete** — Merged
+**Complete** — Pending merge
 
 ## Branch
 feat/file-suspended-invocation-restart-recovery
@@ -80,6 +80,6 @@ Follows the same pattern as `FileApprovalStore`:
 
 ## Verification
 ```bash
-./gradlew :tramai-persistence-file:compileKotlin
+./gradlew :tramai-persistence-file:compileKotlin :tramai-persistence-file:compileTestKotlin --rerun-tasks 2>&1 | grep -E "error|Error|warning"
 ./gradlew :tramai-persistence-file:test --rerun-tasks
 ```

--- a/docs/board/tasks/task-pr29-file-suspended-restart-recovery.md
+++ b/docs/board/tasks/task-pr29-file-suspended-restart-recovery.md
@@ -1,7 +1,7 @@
 # Task PR #29 — Encrypted FileSuspendedInvocationStore and Restart-Safe Recovery
 
 ## Status
-In Progress
+**Complete** — Merged
 
 ## Branch
 feat/file-suspended-invocation-restart-recovery

--- a/docs/modules/tramai-persistence-file.md
+++ b/docs/modules/tramai-persistence-file.md
@@ -1,9 +1,9 @@
 # Module: `tramai-persistence-file`
 
-> **One-liner:** Encrypted-at-rest, single-node file persistence for TramAI sovereign state — `FileApprovalStore`, `FileApprovalContinuationStore`, and `FileAuditStore` backed by AES-256-GCM encrypted files on a POSIX filesystem.
+> **One-liner:** Encrypted-at-rest, single-node file persistence for TramAI sovereign state — `FileApprovalStore`, `FileApprovalContinuationStore`, `FileSuspendedInvocationStore`, and `FileAuditStore` backed by AES-256-GCM encrypted files on a POSIX filesystem.
 > **Module type:** `persistence` + `storage`
-> **Dependencies:** `tramai-core`, `tramai-security`
-> **Source files:** 13 files — `FileBackedSovereignStores.kt`, `FileApprovalStore.kt`, `FileApprovalContinuationStore.kt`, `FileAuditStore.kt`, `AesGcmFileEncryption.kt`, `EncryptedFileEnvelopeV1.kt`, `FileBackedStoreConfiguration.kt`, `FileStoreEncryptionConfiguration.kt`, `FileStoreException.kt`, `FileStoreSha256.kt`, `FileStoreUtil.kt`, `PersistedDtos.kt`, `StoreManifestV1.kt`
+> **Dependencies:** `tramai-core`, `tramai-engine`, `tramai-security`
+> **Source files:** 15 files + new files
 
 ## Purpose
 
@@ -52,6 +52,8 @@ Key ownership is the caller's responsibility. The module provides `FileStoreEncr
 │   └── <sha256-hex>.tram.enc # One encrypted file per approval request
 ├── continuations/
 │   └── <sha256-hex>.tram.enc # One encrypted file per continuation
+├── suspended/
+│   └── <sha256-hex>.tram.enc # One encrypted file per suspended invocation
 └── audit/
     └── <sha256-stream-id>/
         ├── 00000000000000000001-<sha256-event-id>.tram.enc
@@ -206,10 +208,10 @@ stores.close()
 1. Create root directory with `0700` permissions if absent.
 2. Verify root is a directory, not a symlink, with `0700` permissions.
 3. Acquire exclusive lock on `.tramai.lock` (throws `FileStoreLockUnavailableException` if held).
-4. Create subdirectories (`approvals/`, `continuations/`, `audit/`) with `0700` permissions.
+4. Create subdirectories (`approvals/`, `continuations/`, `suspended/`, `audit/`) with `0700` permissions.
 5. Validate or create `manifest.json` (format version must be 1).
 6. Resolve the encryption key.
-7. Construct and wire the three file-backed store stubs.
+7. Construct and wire the four file-backed store stubs.
 8. If `verifyOnOpen` is true, verify all existing records.
 9. On any failure, release the lock before the exception propagates.
 
@@ -221,10 +223,8 @@ stores.close()
 - No distributed locking
 - No key rotation
 - No JDBC / PostgreSQL / cloud KMS integration
-- **No full JVM-restart workflow resume** — `FileSuspendedInvocationStore` and durable replay envelopes are deferred to PR #28
 
 ## Deferred Work
 
-- **PR #28**: Durable suspended-invocation replay envelope and restart-safe workflow recovery
-- **PR #29**: Local-model artifact manifest and byte-level verification
-- **PR #30**: Offline runtime profile and zero-egress verification harness
+- **PR #30**: Local-model artifact manifest and byte-level verification
+- **PR #31**: Offline runtime profile and zero-egress verification harness

--- a/docs/specs/spec-016-approval-engine-suspension-resume.md
+++ b/docs/specs/spec-016-approval-engine-suspension-resume.md
@@ -3,6 +3,7 @@
 ## Status
 Implemented in PR #17
 Updated in PR #28 — Trusted Replay Envelope and Operation Registry
+Updated in PR #29 — Encrypted FileSuspendedInvocationStore and restart-safe recovery
 
 ## Executive Summary
 

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ReplayEnvelopeFactory.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ReplayEnvelopeFactory.kt
@@ -62,7 +62,7 @@ internal object ReplayEnvelopeFactory {
         toolCallIndex: Int,
     ): PreparedReplayEnvelope {
         // Select latest assistant message with tool calls (fail closed if none)
-        val assistantMsgIndex = messages.indexOfLast { it.role == MessageRole.ASSISTANT && it.toolCalls != null }
+        val assistantMsgIndex = messages.indexOfLast { it.role == MessageRole.ASSISTANT && !it.toolCalls.isNullOrEmpty() }
         require(assistantMsgIndex >= 0) { "replay-envelope-assistant-batch-not-found" }
 
         val assistantMsg = messages[assistantMsgIndex]
@@ -121,7 +121,7 @@ internal object ReplayEnvelopeFactory {
         val messages = payload.messages.toMutableList()
 
         // Find the matching assistant message with tool calls
-        val assistantMsgIndex = messages.indexOfLast { it.role == MessageRole.ASSISTANT && it.toolCalls != null }
+        val assistantMsgIndex = messages.indexOfLast { it.role == MessageRole.ASSISTANT && !it.toolCalls.isNullOrEmpty() }
         require(assistantMsgIndex >= 0) { "replay-envelope-assistant-batch-not-found" }
 
         val assistantMsg = messages[assistantMsgIndex]

--- a/tramai-persistence-file/build.gradle.kts
+++ b/tramai-persistence-file/build.gradle.kts
@@ -19,6 +19,7 @@ kotlin {
 
 dependencies {
     api(project(":tramai-core"))
+    api(project(":tramai-engine"))
     api(project(":tramai-security"))
 
     implementation(libs.coroutines.core)

--- a/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/FileBackedSovereignStores.kt
+++ b/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/FileBackedSovereignStores.kt
@@ -2,6 +2,7 @@ package dev.tramai.persistence.file
 
 import dev.tramai.core.approval.ApprovalContinuationStore
 import dev.tramai.core.approval.ApprovalStore
+import dev.tramai.engine.SuspendedInvocationStore
 import dev.tramai.security.audit.AuditStore
 import java.io.RandomAccessFile
 import java.nio.ByteBuffer
@@ -18,12 +19,12 @@ import kotlin.io.path.isSymbolicLink
 import kotlin.io.path.notExists
 
 /**
- * Bundle of all three sovereign file-backed stores, sharing a single root directory
+ * Bundle of all four sovereign file-backed stores, sharing a single root directory
  * and an exclusive file lock.
  *
  * On construction, [open] validates the root directory, acquires an exclusive lock
  * on `.tramai.lock`, creates or validates subdirectories (`approvals/`, `continuations/`,
- * `audit/`), initialises or validates the `manifest.json`, optionally verifies all
+ * `audit/`, `suspended/`), initialises or validates the `manifest.json`, optionally verifies all
  * existing records, and returns a fully wired [AutoCloseable] handle.
  *
  * ## Thread safety
@@ -40,11 +41,13 @@ import kotlin.io.path.notExists
  * @property approvalStore Store for [ApprovalRequest] records.
  * @property approvalContinuationStore Store for [ApprovalContinuation] records.
  * @property auditStore Store for [AuditEvent] records.
+ * @property suspendedInvocationStore Store for suspended invocation metadata and replay envelopes.
  */
 class FileBackedSovereignStores private constructor(
     val approvalStore: ApprovalStore,
     val approvalContinuationStore: ApprovalContinuationStore,
     val auditStore: AuditStore,
+    val suspendedInvocationStore: SuspendedInvocationStore,
     private val lockFile: RandomAccessFile,
     private val lock: FileLock,
     private val rootDir: Path,
@@ -62,10 +65,10 @@ class FileBackedSovereignStores private constructor(
          * 1. Create root directory with 0700 permissions if absent.
          * 2. Verify root is a directory, not a symlink, with 0700 permissions.
          * 3. Acquire exclusive lock on `.tramai.lock` (rejects if already held).
-         * 4. Create subdirectories (`approvals/`, `continuations/`, `audit/`) with 0700 permissions.
+         * 4. Create subdirectories (`approvals/`, `continuations/`, `audit/`, `suspended/`) with 0700 permissions.
          * 5. Validate or create `manifest.json` (format version must be 1).
          * 6. Resolve and validate the encryption key (must be AES, 256-bit).
-         * 7. Construct and wire the three file-backed stores with a shared [FileStoreLease].
+         * 7. Construct and wire the four file-backed stores with a shared [FileStoreLease].
          * 8. If [FileBackedStoreConfiguration.verifyOnOpen] is true, verify all existing records.
          *
          * On any failure the lock is released before the exception propagates.
@@ -130,7 +133,7 @@ class FileBackedSovereignStores private constructor(
                 }
 
                 // ── 4. Create subdirectories with strict permissions ──
-                val subdirs = listOf("approvals", "continuations", "audit")
+                val subdirs = listOf("approvals", "continuations", "audit", "suspended")
                 for (dir in subdirs) {
                     val path = root.resolve(dir)
                     if (path.notExists()) {
@@ -188,18 +191,21 @@ class FileBackedSovereignStores private constructor(
                 val fileBackedApprovalStore = FileApprovalStore(root, key, configuration, lease)
                 val fileBackedContinuationStore = FileApprovalContinuationStore(root, key, configuration, lease)
                 val fileBackedAuditStore = FileAuditStore(root, key, configuration, lease)
+                val fileBackedSuspendedStore = FileSuspendedInvocationStore(root, key, configuration, lease)
 
                 // ── 7. If verifyOnOpen, verify all records ──
                 if (configuration.verifyOnOpen) {
                     fileBackedApprovalStore.verifyAll()
                     fileBackedContinuationStore.verifyAll()
                     fileBackedAuditStore.verifyAll()
+                    fileBackedSuspendedStore.verifyAll()
                 }
 
                 return FileBackedSovereignStores(
                     approvalStore = fileBackedApprovalStore,
                     approvalContinuationStore = fileBackedContinuationStore,
                     auditStore = fileBackedAuditStore,
+                    suspendedInvocationStore = fileBackedSuspendedStore,
                     lockFile = lockFileNonNull,
                     lock = fileLockNonNull,
                     rootDir = root,

--- a/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStore.kt
+++ b/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStore.kt
@@ -1,0 +1,259 @@
+package dev.tramai.persistence.file
+
+import dev.tramai.engine.SensitiveReplayEnvelope
+import dev.tramai.engine.SuspendedInvocationMetadata
+import dev.tramai.engine.SuspendedInvocationStore
+import java.nio.file.FileAlreadyExistsException
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantLock
+import javax.crypto.SecretKey
+import kotlin.io.path.exists
+
+class FileSuspendedInvocationStore internal constructor(
+    root: Path,
+    key: SecretKey,
+    configuration: FileBackedStoreConfiguration,
+    private val lease: FileStoreLease,
+) : SuspendedInvocationStore {
+
+    companion object {
+        private const val RECORD_TYPE = "suspended-invocation"
+        private const val SUSPENDED_DIR = "suspended"
+        private const val FILE_EXTENSION = ".tram.enc"
+        private val COMMITTED_FILENAME = Regex("[a-f0-9]{64}\\.tram\\.enc")
+        private const val MAX_ID_LENGTH = 256
+    }
+
+    private val suspendedDir: Path = root.resolve(SUSPENDED_DIR)
+    private val keyId: String = configuration.encryption.activeKeyId
+    private val encryptionKey: SecretKey = key
+    private val locks = ConcurrentHashMap<String, ReentrantLock>()
+
+    private fun storePath(approvalId: String): Path {
+        val digest = FileStoreSha256.digest(RECORD_TYPE, approvalId)
+        return suspendedDir.resolve("$digest$FILE_EXTENSION")
+    }
+
+    private fun recordKeyDigest(approvalId: String): String =
+        FileStoreSha256.digest(RECORD_TYPE, approvalId)
+
+    private fun getLock(approvalId: String): ReentrantLock =
+        locks.computeIfAbsent(approvalId) { ReentrantLock() }
+
+    private fun readCurrent(approvalId: String): PersistedSuspendedInvocationRecordV1? {
+        val path = storePath(approvalId)
+        if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) return null
+        FileStoreUtil.validateRegularFile(path, "suspended-invocation")
+        val rkd = recordKeyDigest(approvalId)
+        val plaintext = try {
+            FileStoreUtil.readAndDecrypt(path, RECORD_TYPE, rkd, encryptionKey, keyId)
+        } catch (e: FileStoreCorruptionException) {
+            throw FileStoreCorruptionException("suspended-invocation-record-corrupted", e)
+        } catch (e: Exception) {
+            throw FileStoreCorruptionException("suspended-invocation-record-corrupted", e)
+        }
+        val record = try {
+            PersistedSuspendedInvocationRecordV1.fromJson(String(plaintext, Charsets.UTF_8))
+        } catch (e: Exception) {
+            throw FileStoreCorruptionException("suspended-invocation-record-corrupted", e)
+        }
+        validateRecordSchemas(record)
+        val expectedDigest = FileStoreSha256.digest(RECORD_TYPE, record.metadata.approvalId)
+        require(expectedDigest == rkd) { "suspended-invocation-id-filename-digest-mismatch" }
+        return record
+    }
+
+    fun verifyAll() = lease.withOpenOperation {
+        if (!suspendedDir.exists()) return@withOpenOperation
+        FileStoreUtil.validateManagedDirectory(suspendedDir, "suspended")
+        for (entry in FileStoreUtil.strictCommittedEntries(
+            suspendedDir,
+            COMMITTED_FILENAME,
+            "suspended-invocation",
+        )) {
+            val fileName = entry.fileName.toString()
+            val digestHex = fileName.removeSuffix(FILE_EXTENSION)
+            require(digestHex.length == 64 && digestHex.all { it in '0'..'9' || it in 'a'..'f' }) {
+                throw FileStoreCorruptionException("suspended-invocation-invalid-filename")
+            }
+            FileStoreUtil.validateRegularFile(entry, "suspended-invocation")
+            val plaintext = try {
+                FileStoreUtil.readAndDecrypt(entry, RECORD_TYPE, digestHex, encryptionKey, keyId)
+            } catch (e: FileStoreCorruptionException) {
+                throw FileStoreCorruptionException("suspended-invocation-record-corrupted", e)
+            } catch (e: Exception) {
+                throw FileStoreCorruptionException("suspended-invocation-record-corrupted", e)
+            }
+            val record = try {
+                PersistedSuspendedInvocationRecordV1.fromJson(String(plaintext, Charsets.UTF_8))
+            } catch (e: Exception) {
+                throw FileStoreCorruptionException("suspended-invocation-record-corrupted", e)
+            }
+            validateRecordSchemas(record)
+            val expectedDigest = FileStoreSha256.digest(RECORD_TYPE, record.metadata.approvalId)
+            require(expectedDigest == digestHex) {
+                throw FileStoreCorruptionException("suspended-invocation-id-filename-digest-mismatch")
+            }
+            val metadata = try {
+                record.metadata.toDomain()
+            } catch (e: Exception) {
+                throw FileStoreCorruptionException("suspended-invocation-domain-conversion-failed", e)
+            }
+            val replayEnvelope = try {
+                record.replayEnvelope.toDomain()
+            } catch (e: Exception) {
+                throw FileStoreCorruptionException("suspended-invocation-domain-conversion-failed", e)
+            }
+            try {
+                ReplayEnvelopePersistenceCodec.snapshotForPersistence(metadata, replayEnvelope)
+            } catch (e: Exception) {
+                throw FileStoreCorruptionException("suspended-invocation-replay-envelope-invalid", e)
+            }
+        }
+    }
+
+    override suspend fun create(
+        metadata: SuspendedInvocationMetadata,
+        replayEnvelope: SensitiveReplayEnvelope,
+    ) = lease.withOpenOperation {
+        FileStoreUtil.validateManagedDirectory(suspendedDir, "suspended")
+        validateIdField(metadata.approvalId, "approvalId", MAX_ID_LENGTH)
+        validateIdField(metadata.toolCallId, "toolCallId", MAX_ID_LENGTH)
+        validateIdField(metadata.toolName, "toolName", MAX_ID_LENGTH)
+        validateIdField(metadata.correlationId, "correlationId", MAX_ID_LENGTH)
+
+        val lock = getLock(metadata.approvalId)
+        lock.lock()
+        try {
+            val messages = ReplayEnvelopePersistenceCodec.snapshotForPersistence(metadata, replayEnvelope)
+            val record = PersistedSuspendedInvocationRecordV1(
+                schemaVersion = 1,
+                metadata = metadata.toPersistedV1(),
+                replayEnvelope = PersistedReplayEnvelopeV1(
+                    schemaVersion = 1,
+                    messages = messages.map { it.toPersistedV1() },
+                ),
+            )
+            val path = storePath(metadata.approvalId)
+            val rkd = recordKeyDigest(metadata.approvalId)
+            val jsonBytes = record.toJson().toByteArray(Charsets.UTF_8)
+            try {
+                FileStoreUtil.atomicEncryptCreate(
+                    path,
+                    RECORD_TYPE,
+                    rkd,
+                    keyId,
+                    encryptionKey,
+                    jsonBytes,
+                )
+            } catch (_: FileAlreadyExistsException) {
+                throw IllegalArgumentException("suspended-invocation-already-exists")
+            }
+        } finally {
+            lock.unlock()
+        }
+    }
+
+    override suspend fun get(approvalId: String): SuspendedInvocationMetadata? = lease.withOpenOperation {
+        FileStoreUtil.validateManagedDirectory(suspendedDir, "suspended")
+        validateIdField(approvalId, "approvalId", MAX_ID_LENGTH)
+        val lock = getLock(approvalId)
+        lock.lock()
+        try {
+            return readCurrent(approvalId)?.metadata?.toDomain()
+        } finally {
+            lock.unlock()
+        }
+    }
+
+    override suspend fun revealReplayEnvelope(approvalId: String): SensitiveReplayEnvelope? = lease.withOpenOperation {
+        FileStoreUtil.validateManagedDirectory(suspendedDir, "suspended")
+        validateIdField(approvalId, "approvalId", MAX_ID_LENGTH)
+        val lock = getLock(approvalId)
+        lock.lock()
+        try {
+            val record = readCurrent(approvalId) ?: return null
+            val metadata = record.metadata.toDomain()
+            val messages = record.replayEnvelope.messages.map { it.toDomain() }
+            return ReplayEnvelopePersistenceCodec.restoreFromPersistence(metadata, messages)
+        } finally {
+            lock.unlock()
+        }
+    }
+
+    override suspend fun remove(approvalId: String): SuspendedInvocationMetadata? = lease.withOpenOperation {
+        FileStoreUtil.validateManagedDirectory(suspendedDir, "suspended")
+        validateIdField(approvalId, "approvalId", MAX_ID_LENGTH)
+        val lock = getLock(approvalId)
+        lock.lock()
+        try {
+            val record = readCurrent(approvalId) ?: return null
+            Files.delete(storePath(approvalId))
+            FileStoreUtil.forceParentDirectory(suspendedDir)
+            return record.metadata.toDomain()
+        } finally {
+            lock.unlock()
+        }
+    }
+
+    private fun validateRecordSchemas(record: PersistedSuspendedInvocationRecordV1) {
+        require(record.schemaVersion == 1) {
+            throw FileStoreUnsupportedFormatException("unsupported-suspended-invocation-schema-version")
+        }
+        require(record.metadata.schemaVersion == 1) {
+            throw FileStoreUnsupportedFormatException("unsupported-suspended-invocation-metadata-schema-version")
+        }
+        require(record.metadata.identity.schemaVersion == 1) {
+            throw FileStoreUnsupportedFormatException("unsupported-engine-execution-identity-schema-version")
+        }
+        require(record.metadata.securityContext.schemaVersion == 1) {
+            throw FileStoreUnsupportedFormatException("unsupported-execution-security-context-schema-version")
+        }
+        require(record.metadata.operationReference.schemaVersion == 1) {
+            throw FileStoreUnsupportedFormatException("unsupported-resume-operation-reference-schema-version")
+        }
+        require(record.metadata.toolReference.schemaVersion == 1) {
+            throw FileStoreUnsupportedFormatException("unsupported-resume-tool-reference-schema-version")
+        }
+        record.metadata.tokenBudgetSnapshot?.let {
+            require(it.schemaVersion == 1) {
+                throw FileStoreUnsupportedFormatException("unsupported-token-budget-snapshot-schema-version")
+            }
+        }
+        record.metadata.toolSecurity?.let {
+            require(it.schemaVersion == 1) {
+                throw FileStoreUnsupportedFormatException("unsupported-tool-security-metadata-schema-version")
+            }
+        }
+        require(record.replayEnvelope.schemaVersion == 1) {
+            throw FileStoreUnsupportedFormatException("unsupported-replay-envelope-schema-version")
+        }
+        record.replayEnvelope.messages.forEach { message ->
+            require(message.schemaVersion == 1) {
+                throw FileStoreUnsupportedFormatException("unsupported-replay-message-schema-version")
+            }
+            message.toolCalls?.forEach { toolCall ->
+                require(toolCall.schemaVersion == 1) {
+                    throw FileStoreUnsupportedFormatException("unsupported-replay-tool-call-schema-version")
+                }
+            }
+            message.contentParts?.forEach { contentPart ->
+                require(contentPart.schemaVersion == 1) {
+                    throw FileStoreUnsupportedFormatException("unsupported-replay-content-part-schema-version")
+                }
+            }
+        }
+    }
+
+    private fun validateIdField(value: String, fieldName: String, maxLength: Int): String {
+        val trimmed = value.trim()
+        require(trimmed.isNotBlank()) { "$fieldName must not be blank" }
+        require(trimmed.none { it.isISOControl() }) { "$fieldName must not contain control characters" }
+        require(trimmed.length <= maxLength) { "$fieldName exceeds maximum length of $maxLength" }
+        require(trimmed == value) { "$fieldName must not contain surrounding whitespace" }
+        return trimmed
+    }
+}

--- a/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStore.kt
+++ b/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStore.kt
@@ -205,7 +205,11 @@ class FileSuspendedInvocationStore internal constructor(
             val record = readCurrent(approvalId) ?: return null
             Files.delete(storePath(approvalId))
             FileStoreUtil.forceParentDirectory(suspendedDir)
-            return record.metadata.toDomain()
+            return try {
+                record.metadata.toDomain()
+            } catch (e: Exception) {
+                throw FileStoreCorruptionException("suspended-invocation-record-corrupted", e)
+            }
         } finally {
             lock.unlock()
         }

--- a/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStore.kt
+++ b/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStore.kt
@@ -19,6 +19,11 @@ class FileSuspendedInvocationStore internal constructor(
     private val lease: FileStoreLease,
 ) : SuspendedInvocationStore {
 
+    internal data class ValidatedSuspendedInvocationRecord(
+        val metadata: SuspendedInvocationMetadata,
+        val envelope: SensitiveReplayEnvelope,
+    )
+
     companion object {
         private const val RECORD_TYPE = "suspended-invocation"
         private const val SUSPENDED_DIR = "suspended"
@@ -68,6 +73,36 @@ class FileSuspendedInvocationStore internal constructor(
         return record
     }
 
+    internal fun decodeAndValidateRecord(
+        record: PersistedSuspendedInvocationRecordV1,
+    ): ValidatedSuspendedInvocationRecord {
+        try {
+            validateRecordSchemas(record)
+        } catch (e: Exception) {
+            throw FileStoreCorruptionException("suspended-invocation-record-corrupted", e)
+        }
+
+        val metadata = try {
+            record.metadata.toDomain()
+        } catch (e: Exception) {
+            throw FileStoreCorruptionException("suspended-invocation-domain-conversion-failed", e)
+        }
+
+        val messages = try {
+            record.replayEnvelope.messages.map { it.toDomain() }
+        } catch (e: Exception) {
+            throw FileStoreCorruptionException("suspended-invocation-domain-conversion-failed", e)
+        }
+
+        val envelope = try {
+            ReplayEnvelopePersistenceCodec.restoreFromPersistence(metadata, messages)
+        } catch (e: Exception) {
+            throw FileStoreCorruptionException("suspended-invocation-replay-envelope-invalid", e)
+        }
+
+        return ValidatedSuspendedInvocationRecord(metadata, envelope)
+    }
+
     fun verifyAll() = lease.withOpenOperation {
         if (!suspendedDir.exists()) return@withOpenOperation
         FileStoreUtil.validateManagedDirectory(suspendedDir, "suspended")
@@ -94,23 +129,14 @@ class FileSuspendedInvocationStore internal constructor(
             } catch (e: Exception) {
                 throw FileStoreCorruptionException("suspended-invocation-record-corrupted", e)
             }
-            validateRecordSchemas(record)
             val expectedDigest = FileStoreSha256.digest(RECORD_TYPE, record.metadata.approvalId)
             if (expectedDigest != digestHex) {
                 throw FileStoreCorruptionException("suspended-invocation-id-filename-digest-mismatch")
             }
-            val metadata = try {
-                record.metadata.toDomain()
-            } catch (e: Exception) {
-                throw FileStoreCorruptionException("suspended-invocation-domain-conversion-failed", e)
-            }
-            val replayEnvelope = try {
-                record.replayEnvelope.toDomain()
-            } catch (e: Exception) {
-                throw FileStoreCorruptionException("suspended-invocation-domain-conversion-failed", e)
-            }
+            validateRecordSchemas(record)
+            val validated = decodeAndValidateRecord(record)
             try {
-                ReplayEnvelopePersistenceCodec.snapshotForPersistence(metadata, replayEnvelope)
+                ReplayEnvelopePersistenceCodec.snapshotForPersistence(validated.metadata, validated.envelope)
             } catch (e: Exception) {
                 throw FileStoreCorruptionException("suspended-invocation-replay-envelope-invalid", e)
             }
@@ -167,11 +193,7 @@ class FileSuspendedInvocationStore internal constructor(
         lock.lock()
         try {
             val record = readCurrent(approvalId) ?: return null
-            return try {
-                record.metadata.toDomain()
-            } catch (e: Exception) {
-                throw FileStoreCorruptionException("suspended-invocation-record-corrupted", e)
-            }
+            return decodeAndValidateRecord(record).metadata
         } finally {
             lock.unlock()
         }
@@ -184,13 +206,7 @@ class FileSuspendedInvocationStore internal constructor(
         lock.lock()
         try {
             val record = readCurrent(approvalId) ?: return null
-            return try {
-                val metadata = record.metadata.toDomain()
-                val messages = record.replayEnvelope.messages.map { it.toDomain() }
-                ReplayEnvelopePersistenceCodec.restoreFromPersistence(metadata, messages)
-            } catch (e: Exception) {
-                throw FileStoreCorruptionException("suspended-invocation-record-corrupted", e)
-            }
+            return decodeAndValidateRecord(record).envelope
         } finally {
             lock.unlock()
         }
@@ -203,13 +219,10 @@ class FileSuspendedInvocationStore internal constructor(
         lock.lock()
         try {
             val record = readCurrent(approvalId) ?: return null
+            val validated = decodeAndValidateRecord(record)
             Files.delete(storePath(approvalId))
             FileStoreUtil.forceParentDirectory(suspendedDir)
-            return try {
-                record.metadata.toDomain()
-            } catch (e: Exception) {
-                throw FileStoreCorruptionException("suspended-invocation-record-corrupted", e)
-            }
+            return validated.metadata
         } finally {
             lock.unlock()
         }

--- a/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStore.kt
+++ b/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStore.kt
@@ -62,7 +62,9 @@ class FileSuspendedInvocationStore internal constructor(
         }
         validateRecordSchemas(record)
         val expectedDigest = FileStoreSha256.digest(RECORD_TYPE, record.metadata.approvalId)
-        require(expectedDigest == rkd) { "suspended-invocation-id-filename-digest-mismatch" }
+        if (expectedDigest != rkd) {
+            throw FileStoreCorruptionException("suspended-invocation-id-filename-digest-mismatch")
+        }
         return record
     }
 
@@ -76,7 +78,7 @@ class FileSuspendedInvocationStore internal constructor(
         )) {
             val fileName = entry.fileName.toString()
             val digestHex = fileName.removeSuffix(FILE_EXTENSION)
-            require(digestHex.length == 64 && digestHex.all { it in '0'..'9' || it in 'a'..'f' }) {
+            if (digestHex.length != 64 || digestHex.any { it !in '0'..'9' && it !in 'a'..'f' }) {
                 throw FileStoreCorruptionException("suspended-invocation-invalid-filename")
             }
             FileStoreUtil.validateRegularFile(entry, "suspended-invocation")
@@ -94,7 +96,7 @@ class FileSuspendedInvocationStore internal constructor(
             }
             validateRecordSchemas(record)
             val expectedDigest = FileStoreSha256.digest(RECORD_TYPE, record.metadata.approvalId)
-            require(expectedDigest == digestHex) {
+            if (expectedDigest != digestHex) {
                 throw FileStoreCorruptionException("suspended-invocation-id-filename-digest-mismatch")
             }
             val metadata = try {
@@ -124,6 +126,7 @@ class FileSuspendedInvocationStore internal constructor(
         validateIdField(metadata.toolCallId, "toolCallId", MAX_ID_LENGTH)
         validateIdField(metadata.toolName, "toolName", MAX_ID_LENGTH)
         validateIdField(metadata.correlationId, "correlationId", MAX_ID_LENGTH)
+        metadata.conversationId?.let { validateIdField(it, "conversationId", MAX_ID_LENGTH) }
 
         val lock = getLock(metadata.approvalId)
         lock.lock()
@@ -163,7 +166,12 @@ class FileSuspendedInvocationStore internal constructor(
         val lock = getLock(approvalId)
         lock.lock()
         try {
-            return readCurrent(approvalId)?.metadata?.toDomain()
+            val record = readCurrent(approvalId) ?: return null
+            return try {
+                record.metadata.toDomain()
+            } catch (e: Exception) {
+                throw FileStoreCorruptionException("suspended-invocation-record-corrupted", e)
+            }
         } finally {
             lock.unlock()
         }
@@ -176,9 +184,13 @@ class FileSuspendedInvocationStore internal constructor(
         lock.lock()
         try {
             val record = readCurrent(approvalId) ?: return null
-            val metadata = record.metadata.toDomain()
-            val messages = record.replayEnvelope.messages.map { it.toDomain() }
-            return ReplayEnvelopePersistenceCodec.restoreFromPersistence(metadata, messages)
+            return try {
+                val metadata = record.metadata.toDomain()
+                val messages = record.replayEnvelope.messages.map { it.toDomain() }
+                ReplayEnvelopePersistenceCodec.restoreFromPersistence(metadata, messages)
+            } catch (e: Exception) {
+                throw FileStoreCorruptionException("suspended-invocation-record-corrupted", e)
+            }
         } finally {
             lock.unlock()
         }
@@ -200,48 +212,48 @@ class FileSuspendedInvocationStore internal constructor(
     }
 
     private fun validateRecordSchemas(record: PersistedSuspendedInvocationRecordV1) {
-        require(record.schemaVersion == 1) {
+        if (record.schemaVersion != 1) {
             throw FileStoreUnsupportedFormatException("unsupported-suspended-invocation-schema-version")
         }
-        require(record.metadata.schemaVersion == 1) {
+        if (record.metadata.schemaVersion != 1) {
             throw FileStoreUnsupportedFormatException("unsupported-suspended-invocation-metadata-schema-version")
         }
-        require(record.metadata.identity.schemaVersion == 1) {
+        if (record.metadata.identity.schemaVersion != 1) {
             throw FileStoreUnsupportedFormatException("unsupported-engine-execution-identity-schema-version")
         }
-        require(record.metadata.securityContext.schemaVersion == 1) {
+        if (record.metadata.securityContext.schemaVersion != 1) {
             throw FileStoreUnsupportedFormatException("unsupported-execution-security-context-schema-version")
         }
-        require(record.metadata.operationReference.schemaVersion == 1) {
+        if (record.metadata.operationReference.schemaVersion != 1) {
             throw FileStoreUnsupportedFormatException("unsupported-resume-operation-reference-schema-version")
         }
-        require(record.metadata.toolReference.schemaVersion == 1) {
+        if (record.metadata.toolReference.schemaVersion != 1) {
             throw FileStoreUnsupportedFormatException("unsupported-resume-tool-reference-schema-version")
         }
         record.metadata.tokenBudgetSnapshot?.let {
-            require(it.schemaVersion == 1) {
+            if (it.schemaVersion != 1) {
                 throw FileStoreUnsupportedFormatException("unsupported-token-budget-snapshot-schema-version")
             }
         }
         record.metadata.toolSecurity?.let {
-            require(it.schemaVersion == 1) {
+            if (it.schemaVersion != 1) {
                 throw FileStoreUnsupportedFormatException("unsupported-tool-security-metadata-schema-version")
             }
         }
-        require(record.replayEnvelope.schemaVersion == 1) {
+        if (record.replayEnvelope.schemaVersion != 1) {
             throw FileStoreUnsupportedFormatException("unsupported-replay-envelope-schema-version")
         }
         record.replayEnvelope.messages.forEach { message ->
-            require(message.schemaVersion == 1) {
+            if (message.schemaVersion != 1) {
                 throw FileStoreUnsupportedFormatException("unsupported-replay-message-schema-version")
             }
             message.toolCalls?.forEach { toolCall ->
-                require(toolCall.schemaVersion == 1) {
+                if (toolCall.schemaVersion != 1) {
                     throw FileStoreUnsupportedFormatException("unsupported-replay-tool-call-schema-version")
                 }
             }
             message.contentParts?.forEach { contentPart ->
-                require(contentPart.schemaVersion == 1) {
+                if (contentPart.schemaVersion != 1) {
                     throw FileStoreUnsupportedFormatException("unsupported-replay-content-part-schema-version")
                 }
             }

--- a/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/PersistedDtos.kt
+++ b/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/PersistedDtos.kt
@@ -511,7 +511,7 @@ data class PersistedContentPartV1(
 // Domain conversions — SuspendedInvocationMetadata
 // ====================================================================
 
-fun PersistedSuspendedInvocationMetadataV1.toDomain(): SuspendedInvocationMetadata =
+internal fun PersistedSuspendedInvocationMetadataV1.toDomain(): SuspendedInvocationMetadata =
     SuspendedInvocationMetadata(
         approvalId = approvalId,
         toolCallId = toolCallId,
@@ -529,7 +529,7 @@ fun PersistedSuspendedInvocationMetadataV1.toDomain(): SuspendedInvocationMetada
         toolSecurity = toolSecurity?.toDomain(),
     )
 
-fun SuspendedInvocationMetadata.toPersistedV1(): PersistedSuspendedInvocationMetadataV1 =
+internal fun SuspendedInvocationMetadata.toPersistedV1(): PersistedSuspendedInvocationMetadataV1 =
     PersistedSuspendedInvocationMetadataV1(
         schemaVersion = 1,
         approvalId = approvalId,
@@ -548,7 +548,7 @@ fun SuspendedInvocationMetadata.toPersistedV1(): PersistedSuspendedInvocationMet
         toolSecurity = toolSecurity?.toPersistedV1(),
     )
 
-fun PersistedEngineExecutionIdentityV1.toDomain(): EngineExecutionIdentity = EngineExecutionIdentity(
+internal fun PersistedEngineExecutionIdentityV1.toDomain(): EngineExecutionIdentity = EngineExecutionIdentity(
     workflowRunId = workflowRunId,
     correlationId = correlationId,
     workflowDigest = Sha256Digest.of(workflowDigest),
@@ -556,7 +556,7 @@ fun PersistedEngineExecutionIdentityV1.toDomain(): EngineExecutionIdentity = Eng
     actorId = actorId,
 )
 
-fun EngineExecutionIdentity.toPersistedV1(): PersistedEngineExecutionIdentityV1 =
+internal fun EngineExecutionIdentity.toPersistedV1(): PersistedEngineExecutionIdentityV1 =
     PersistedEngineExecutionIdentityV1(
         schemaVersion = 1,
         workflowRunId = workflowRunId,
@@ -566,26 +566,26 @@ fun EngineExecutionIdentity.toPersistedV1(): PersistedEngineExecutionIdentityV1 
         actorId = actorId,
     )
 
-fun PersistedExecutionSecurityContextV1.toDomain(): ExecutionSecurityContext = ExecutionSecurityContext(
+internal fun PersistedExecutionSecurityContextV1.toDomain(): ExecutionSecurityContext = ExecutionSecurityContext(
     dataClassification = dataClassification?.let(DataClassification::valueOf),
     classificationSource = classificationSource?.let(ClassificationSource::valueOf),
 )
 
-fun ExecutionSecurityContext.toPersistedV1(): PersistedExecutionSecurityContextV1 =
+internal fun ExecutionSecurityContext.toPersistedV1(): PersistedExecutionSecurityContextV1 =
     PersistedExecutionSecurityContextV1(
         schemaVersion = 1,
         dataClassification = dataClassification?.name,
         classificationSource = classificationSource?.name,
     )
 
-fun PersistedResumeOperationReferenceV1.toDomain(): ResumeOperationReference = ResumeOperationReference(
+internal fun PersistedResumeOperationReferenceV1.toDomain(): ResumeOperationReference = ResumeOperationReference(
     serviceInterface = serviceInterface,
     methodName = methodName,
     jvmMethodDescriptor = jvmMethodDescriptor,
     resumeDefinitionDigest = Sha256Digest.of(resumeDefinitionDigest),
 )
 
-fun ResumeOperationReference.toPersistedV1(): PersistedResumeOperationReferenceV1 =
+internal fun ResumeOperationReference.toPersistedV1(): PersistedResumeOperationReferenceV1 =
     PersistedResumeOperationReferenceV1(
         schemaVersion = 1,
         serviceInterface = serviceInterface,
@@ -594,19 +594,19 @@ fun ResumeOperationReference.toPersistedV1(): PersistedResumeOperationReferenceV
         resumeDefinitionDigest = resumeDefinitionDigest.value,
     )
 
-fun PersistedResumeToolReferenceV1.toDomain(): ResumeToolReference = ResumeToolReference(
+internal fun PersistedResumeToolReferenceV1.toDomain(): ResumeToolReference = ResumeToolReference(
     toolName = toolName,
     declarationDigest = Sha256Digest.of(declarationDigest),
 )
 
-fun ResumeToolReference.toPersistedV1(): PersistedResumeToolReferenceV1 =
+internal fun ResumeToolReference.toPersistedV1(): PersistedResumeToolReferenceV1 =
     PersistedResumeToolReferenceV1(
         schemaVersion = 1,
         toolName = toolName,
         declarationDigest = declarationDigest.value,
     )
 
-fun PersistedTokenBudgetSnapshotV1.toDomain(): TokenBudgetSnapshot = TokenBudgetSnapshot(
+internal fun PersistedTokenBudgetSnapshotV1.toDomain(): TokenBudgetSnapshot = TokenBudgetSnapshot(
     totalInputTokens = totalInputTokens,
     totalOutputTokens = totalOutputTokens,
     totalInputCost = totalInputCost,
@@ -614,7 +614,7 @@ fun PersistedTokenBudgetSnapshotV1.toDomain(): TokenBudgetSnapshot = TokenBudget
     warnIfExceeded = warnIfExceeded,
 )
 
-fun TokenBudgetSnapshot.toPersistedV1(): PersistedTokenBudgetSnapshotV1 =
+internal fun TokenBudgetSnapshot.toPersistedV1(): PersistedTokenBudgetSnapshotV1 =
     PersistedTokenBudgetSnapshotV1(
         schemaVersion = 1,
         totalInputTokens = totalInputTokens,
@@ -624,7 +624,7 @@ fun TokenBudgetSnapshot.toPersistedV1(): PersistedTokenBudgetSnapshotV1 =
         warnIfExceeded = warnIfExceeded,
     )
 
-fun PersistedToolSecurityMetadataV1.toDomain(): ToolSecurityMetadata = ToolSecurityMetadata(
+internal fun PersistedToolSecurityMetadataV1.toDomain(): ToolSecurityMetadata = ToolSecurityMetadata(
     permission = permission,
     risk = RiskLevel.valueOf(risk),
     approval = ApprovalMode.valueOf(approval),
@@ -633,7 +633,7 @@ fun PersistedToolSecurityMetadataV1.toDomain(): ToolSecurityMetadata = ToolSecur
     compatibilityMode = CompatibilityMode.valueOf(compatibilityMode),
 )
 
-fun ToolSecurityMetadata.toPersistedV1(): PersistedToolSecurityMetadataV1 =
+internal fun ToolSecurityMetadata.toPersistedV1(): PersistedToolSecurityMetadataV1 =
     PersistedToolSecurityMetadataV1(
         schemaVersion = 1,
         permission = permission,
@@ -644,16 +644,10 @@ fun ToolSecurityMetadata.toPersistedV1(): PersistedToolSecurityMetadataV1 =
         compatibilityMode = compatibilityMode.name,
     )
 
-fun PersistedReplayEnvelopeV1.toDomain(): SensitiveReplayEnvelope =
+internal fun PersistedReplayEnvelopeV1.toDomain(): SensitiveReplayEnvelope =
     SensitiveReplayEnvelope.of(messages.map { it.toDomain() })
 
-fun SensitiveReplayEnvelope.toPersistedV1(): PersistedReplayEnvelopeV1 =
-    PersistedReplayEnvelopeV1(
-        schemaVersion = 1,
-        messages = revealForResume().messages.map { it.toPersistedV1() },
-    )
-
-fun PersistedMessageV1.toDomain(): Message = Message(
+internal fun PersistedMessageV1.toDomain(): Message = Message(
     role = MessageRole.valueOf(role),
     content = content,
     contentParts = contentParts?.map { it.toDomain() },
@@ -661,7 +655,7 @@ fun PersistedMessageV1.toDomain(): Message = Message(
     toolCalls = toolCalls?.map { it.toDomain() },
 )
 
-fun Message.toPersistedV1(): PersistedMessageV1 = PersistedMessageV1(
+internal fun Message.toPersistedV1(): PersistedMessageV1 = PersistedMessageV1(
     schemaVersion = 1,
     role = role.name,
     content = content,
@@ -670,20 +664,20 @@ fun Message.toPersistedV1(): PersistedMessageV1 = PersistedMessageV1(
     toolCalls = toolCalls?.map { it.toPersistedV1() },
 )
 
-fun PersistedToolCallV1.toDomain(): ToolCall = ToolCall(
+internal fun PersistedToolCallV1.toDomain(): ToolCall = ToolCall(
     id = id,
     name = name,
     argumentsJson = argumentsJson,
 )
 
-fun ToolCall.toPersistedV1(): PersistedToolCallV1 = PersistedToolCallV1(
+internal fun ToolCall.toPersistedV1(): PersistedToolCallV1 = PersistedToolCallV1(
     schemaVersion = 1,
     id = id,
     name = name,
     argumentsJson = argumentsJson,
 )
 
-fun PersistedContentPartV1.toDomain(): ContentPart = when (type) {
+internal fun PersistedContentPartV1.toDomain(): ContentPart = when (type) {
     "text" -> ContentPart.TextPart(
         text = requireNotNull(text) { "persisted-content-part-text-missing" },
     )
@@ -700,7 +694,7 @@ fun PersistedContentPartV1.toDomain(): ContentPart = when (type) {
     else -> error("persisted-content-part-type-unsupported")
 }
 
-fun ContentPart.toPersistedV1(): PersistedContentPartV1 = when (this) {
+internal fun ContentPart.toPersistedV1(): PersistedContentPartV1 = when (this) {
     is ContentPart.TextPart -> PersistedContentPartV1(
         schemaVersion = 1,
         type = "text",

--- a/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/PersistedDtos.kt
+++ b/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/PersistedDtos.kt
@@ -7,9 +7,29 @@ import dev.tramai.core.approval.ApprovalContinuationStatus
 import dev.tramai.core.approval.ApprovalRequest
 import dev.tramai.core.approval.ApprovalStatus
 import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.model.ContentPart
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
+import dev.tramai.core.model.ToolCall
+import dev.tramai.core.policy.AuditDetail
+import dev.tramai.core.policy.ClassificationSource
+import dev.tramai.core.policy.CompatibilityMode
+import dev.tramai.core.policy.DataClassification
+import dev.tramai.core.policy.ManagedNetworkEgress
+import dev.tramai.core.policy.RiskLevel
+import dev.tramai.core.policy.ToolSecurityMetadata
+import dev.tramai.core.policy.ApprovalMode
+import dev.tramai.engine.EngineExecutionIdentity
+import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.ResumeOperationReference
+import dev.tramai.engine.ResumeToolReference
+import dev.tramai.engine.SensitiveReplayEnvelope
+import dev.tramai.engine.SuspendedInvocationMetadata
+import dev.tramai.engine.TokenBudgetSnapshot
 import dev.tramai.security.audit.AuditEvent
 import dev.tramai.security.audit.AuditHashAlgorithm
 import java.time.Instant
+import java.util.Base64
 
 // ====================================================================
 // Approval Store DTOs
@@ -308,3 +328,401 @@ fun AuditEvent.toPersistedV1(): PersistedAuditEventV1 = PersistedAuditEventV1(
     reasonCode = reasonCode,
     metadata = metadata,
 )
+
+// ====================================================================
+// Suspended Invocation DTOs
+// ====================================================================
+
+data class PersistedSuspendedInvocationRecordV1(
+    @get:JsonProperty("schemaVersion") val schemaVersion: Int,
+    @JsonProperty("metadata") val metadata: PersistedSuspendedInvocationMetadataV1,
+    @JsonProperty("replayEnvelope") val replayEnvelope: PersistedReplayEnvelopeV1,
+) {
+    fun toJson(): String = FILE_STORE_JSON.writeValueAsString(this)
+
+    companion object {
+        fun fromJson(json: String): PersistedSuspendedInvocationRecordV1 = strictReadValue(json)
+    }
+}
+
+data class PersistedSuspendedInvocationMetadataV1(
+    @get:JsonProperty("schemaVersion") val schemaVersion: Int,
+    @JsonProperty("approvalId") val approvalId: String,
+    @JsonProperty("toolCallId") val toolCallId: String,
+    @JsonProperty("toolName") val toolName: String,
+    @JsonProperty("toolCallIndex") val toolCallIndex: Int,
+    @JsonProperty("correlationId") val correlationId: String,
+    @JsonProperty("identity") val identity: PersistedEngineExecutionIdentityV1,
+    @JsonProperty("securityContext") val securityContext: PersistedExecutionSecurityContextV1,
+    @JsonProperty("operationReference") val operationReference: PersistedResumeOperationReferenceV1,
+    @JsonProperty("replayEnvelopeDigest") val replayEnvelopeDigest: String,
+    @JsonProperty("conversationId") val conversationId: String?,
+    @JsonProperty("historySize") val historySize: Int,
+    @JsonProperty("tokenBudgetSnapshot") val tokenBudgetSnapshot: PersistedTokenBudgetSnapshotV1?,
+    @JsonProperty("toolReference") val toolReference: PersistedResumeToolReferenceV1,
+    @JsonProperty("toolSecurity") val toolSecurity: PersistedToolSecurityMetadataV1?,
+) {
+    fun toJson(): String = FILE_STORE_JSON.writeValueAsString(this)
+
+    companion object {
+        fun fromJson(json: String): PersistedSuspendedInvocationMetadataV1 = strictReadValue(json)
+    }
+}
+
+data class PersistedEngineExecutionIdentityV1(
+    @get:JsonProperty("schemaVersion") val schemaVersion: Int,
+    @JsonProperty("workflowRunId") val workflowRunId: String,
+    @JsonProperty("correlationId") val correlationId: String,
+    @JsonProperty("workflowDigest") val workflowDigest: String,
+    @JsonProperty("policyVersion") val policyVersion: String,
+    @JsonProperty("actorId") val actorId: String,
+) {
+    fun toJson(): String = FILE_STORE_JSON.writeValueAsString(this)
+
+    companion object {
+        fun fromJson(json: String): PersistedEngineExecutionIdentityV1 = strictReadValue(json)
+    }
+}
+
+data class PersistedExecutionSecurityContextV1(
+    @get:JsonProperty("schemaVersion") val schemaVersion: Int,
+    @JsonProperty("dataClassification") val dataClassification: String?,
+    @JsonProperty("classificationSource") val classificationSource: String?,
+) {
+    fun toJson(): String = FILE_STORE_JSON.writeValueAsString(this)
+
+    companion object {
+        fun fromJson(json: String): PersistedExecutionSecurityContextV1 = strictReadValue(json)
+    }
+}
+
+data class PersistedResumeOperationReferenceV1(
+    @get:JsonProperty("schemaVersion") val schemaVersion: Int,
+    @JsonProperty("serviceInterface") val serviceInterface: String,
+    @JsonProperty("methodName") val methodName: String,
+    @JsonProperty("jvmMethodDescriptor") val jvmMethodDescriptor: String,
+    @JsonProperty("resumeDefinitionDigest") val resumeDefinitionDigest: String,
+) {
+    fun toJson(): String = FILE_STORE_JSON.writeValueAsString(this)
+
+    companion object {
+        fun fromJson(json: String): PersistedResumeOperationReferenceV1 = strictReadValue(json)
+    }
+}
+
+data class PersistedResumeToolReferenceV1(
+    @get:JsonProperty("schemaVersion") val schemaVersion: Int,
+    @JsonProperty("toolName") val toolName: String,
+    @JsonProperty("declarationDigest") val declarationDigest: String,
+) {
+    fun toJson(): String = FILE_STORE_JSON.writeValueAsString(this)
+
+    companion object {
+        fun fromJson(json: String): PersistedResumeToolReferenceV1 = strictReadValue(json)
+    }
+}
+
+data class PersistedTokenBudgetSnapshotV1(
+    @get:JsonProperty("schemaVersion") val schemaVersion: Int,
+    @JsonProperty("totalInputTokens") val totalInputTokens: Long,
+    @JsonProperty("totalOutputTokens") val totalOutputTokens: Long,
+    @JsonProperty("totalInputCost") val totalInputCost: Double,
+    @JsonProperty("totalOutputCost") val totalOutputCost: Double,
+    @JsonProperty("warnIfExceeded") val warnIfExceeded: Boolean,
+) {
+    fun toJson(): String = FILE_STORE_JSON.writeValueAsString(this)
+
+    companion object {
+        fun fromJson(json: String): PersistedTokenBudgetSnapshotV1 = strictReadValue(json)
+    }
+}
+
+data class PersistedToolSecurityMetadataV1(
+    @get:JsonProperty("schemaVersion") val schemaVersion: Int,
+    @JsonProperty("permission") val permission: String,
+    @JsonProperty("risk") val risk: String,
+    @JsonProperty("approval") val approval: String,
+    @JsonProperty("managedNetworkEgress") val managedNetworkEgress: String,
+    @JsonProperty("audit") val audit: String,
+    @JsonProperty("compatibilityMode") val compatibilityMode: String,
+) {
+    fun toJson(): String = FILE_STORE_JSON.writeValueAsString(this)
+
+    companion object {
+        fun fromJson(json: String): PersistedToolSecurityMetadataV1 = strictReadValue(json)
+    }
+}
+
+data class PersistedReplayEnvelopeV1(
+    @get:JsonProperty("schemaVersion") val schemaVersion: Int,
+    @JsonProperty("messages") val messages: List<PersistedMessageV1>,
+) {
+    fun toJson(): String = FILE_STORE_JSON.writeValueAsString(this)
+
+    companion object {
+        fun fromJson(json: String): PersistedReplayEnvelopeV1 = strictReadValue(json)
+    }
+}
+
+data class PersistedMessageV1(
+    @get:JsonProperty("schemaVersion") val schemaVersion: Int,
+    @JsonProperty("role") val role: String,
+    @JsonProperty("content") val content: String,
+    @JsonProperty("contentParts") val contentParts: List<PersistedContentPartV1>?,
+    @JsonProperty("toolCallId") val toolCallId: String?,
+    @JsonProperty("toolCalls") val toolCalls: List<PersistedToolCallV1>?,
+) {
+    fun toJson(): String = FILE_STORE_JSON.writeValueAsString(this)
+
+    companion object {
+        fun fromJson(json: String): PersistedMessageV1 = strictReadValue(json)
+    }
+}
+
+data class PersistedToolCallV1(
+    @get:JsonProperty("schemaVersion") val schemaVersion: Int,
+    @JsonProperty("id") val id: String,
+    @JsonProperty("name") val name: String,
+    @JsonProperty("argumentsJson") val argumentsJson: String,
+) {
+    fun toJson(): String = FILE_STORE_JSON.writeValueAsString(this)
+
+    companion object {
+        fun fromJson(json: String): PersistedToolCallV1 = strictReadValue(json)
+    }
+}
+
+data class PersistedContentPartV1(
+    @get:JsonProperty("schemaVersion") val schemaVersion: Int,
+    @JsonProperty("type") val type: String,
+    @JsonProperty("text") val text: String?,
+    @JsonProperty("mimeType") val mimeType: String?,
+    @JsonProperty("dataBase64") val dataBase64: String?,
+    @JsonProperty("url") val url: String?,
+) {
+    fun toJson(): String = FILE_STORE_JSON.writeValueAsString(this)
+
+    companion object {
+        fun fromJson(json: String): PersistedContentPartV1 = strictReadValue(json)
+    }
+}
+
+// ====================================================================
+// Domain conversions — SuspendedInvocationMetadata
+// ====================================================================
+
+fun PersistedSuspendedInvocationMetadataV1.toDomain(): SuspendedInvocationMetadata =
+    SuspendedInvocationMetadata(
+        approvalId = approvalId,
+        toolCallId = toolCallId,
+        toolName = toolName,
+        toolCallIndex = toolCallIndex,
+        correlationId = correlationId,
+        identity = identity.toDomain(),
+        securityContext = securityContext.toDomain(),
+        operationReference = operationReference.toDomain(),
+        replayEnvelopeDigest = Sha256Digest.of(replayEnvelopeDigest),
+        conversationId = conversationId,
+        historySize = historySize,
+        tokenBudgetSnapshot = tokenBudgetSnapshot?.toDomain(),
+        toolReference = toolReference.toDomain(),
+        toolSecurity = toolSecurity?.toDomain(),
+    )
+
+fun SuspendedInvocationMetadata.toPersistedV1(): PersistedSuspendedInvocationMetadataV1 =
+    PersistedSuspendedInvocationMetadataV1(
+        schemaVersion = 1,
+        approvalId = approvalId,
+        toolCallId = toolCallId,
+        toolName = toolName,
+        toolCallIndex = toolCallIndex,
+        correlationId = correlationId,
+        identity = identity.toPersistedV1(),
+        securityContext = securityContext.toPersistedV1(),
+        operationReference = operationReference.toPersistedV1(),
+        replayEnvelopeDigest = replayEnvelopeDigest.value,
+        conversationId = conversationId,
+        historySize = historySize,
+        tokenBudgetSnapshot = tokenBudgetSnapshot?.toPersistedV1(),
+        toolReference = toolReference.toPersistedV1(),
+        toolSecurity = toolSecurity?.toPersistedV1(),
+    )
+
+fun PersistedEngineExecutionIdentityV1.toDomain(): EngineExecutionIdentity = EngineExecutionIdentity(
+    workflowRunId = workflowRunId,
+    correlationId = correlationId,
+    workflowDigest = Sha256Digest.of(workflowDigest),
+    policyVersion = policyVersion,
+    actorId = actorId,
+)
+
+fun EngineExecutionIdentity.toPersistedV1(): PersistedEngineExecutionIdentityV1 =
+    PersistedEngineExecutionIdentityV1(
+        schemaVersion = 1,
+        workflowRunId = workflowRunId,
+        correlationId = correlationId,
+        workflowDigest = workflowDigest.value,
+        policyVersion = policyVersion,
+        actorId = actorId,
+    )
+
+fun PersistedExecutionSecurityContextV1.toDomain(): ExecutionSecurityContext = ExecutionSecurityContext(
+    dataClassification = dataClassification?.let(DataClassification::valueOf),
+    classificationSource = classificationSource?.let(ClassificationSource::valueOf),
+)
+
+fun ExecutionSecurityContext.toPersistedV1(): PersistedExecutionSecurityContextV1 =
+    PersistedExecutionSecurityContextV1(
+        schemaVersion = 1,
+        dataClassification = dataClassification?.name,
+        classificationSource = classificationSource?.name,
+    )
+
+fun PersistedResumeOperationReferenceV1.toDomain(): ResumeOperationReference = ResumeOperationReference(
+    serviceInterface = serviceInterface,
+    methodName = methodName,
+    jvmMethodDescriptor = jvmMethodDescriptor,
+    resumeDefinitionDigest = Sha256Digest.of(resumeDefinitionDigest),
+)
+
+fun ResumeOperationReference.toPersistedV1(): PersistedResumeOperationReferenceV1 =
+    PersistedResumeOperationReferenceV1(
+        schemaVersion = 1,
+        serviceInterface = serviceInterface,
+        methodName = methodName,
+        jvmMethodDescriptor = jvmMethodDescriptor,
+        resumeDefinitionDigest = resumeDefinitionDigest.value,
+    )
+
+fun PersistedResumeToolReferenceV1.toDomain(): ResumeToolReference = ResumeToolReference(
+    toolName = toolName,
+    declarationDigest = Sha256Digest.of(declarationDigest),
+)
+
+fun ResumeToolReference.toPersistedV1(): PersistedResumeToolReferenceV1 =
+    PersistedResumeToolReferenceV1(
+        schemaVersion = 1,
+        toolName = toolName,
+        declarationDigest = declarationDigest.value,
+    )
+
+fun PersistedTokenBudgetSnapshotV1.toDomain(): TokenBudgetSnapshot = TokenBudgetSnapshot(
+    totalInputTokens = totalInputTokens,
+    totalOutputTokens = totalOutputTokens,
+    totalInputCost = totalInputCost,
+    totalOutputCost = totalOutputCost,
+    warnIfExceeded = warnIfExceeded,
+)
+
+fun TokenBudgetSnapshot.toPersistedV1(): PersistedTokenBudgetSnapshotV1 =
+    PersistedTokenBudgetSnapshotV1(
+        schemaVersion = 1,
+        totalInputTokens = totalInputTokens,
+        totalOutputTokens = totalOutputTokens,
+        totalInputCost = totalInputCost,
+        totalOutputCost = totalOutputCost,
+        warnIfExceeded = warnIfExceeded,
+    )
+
+fun PersistedToolSecurityMetadataV1.toDomain(): ToolSecurityMetadata = ToolSecurityMetadata(
+    permission = permission,
+    risk = RiskLevel.valueOf(risk),
+    approval = ApprovalMode.valueOf(approval),
+    managedNetworkEgress = ManagedNetworkEgress.valueOf(managedNetworkEgress),
+    audit = AuditDetail.valueOf(audit),
+    compatibilityMode = CompatibilityMode.valueOf(compatibilityMode),
+)
+
+fun ToolSecurityMetadata.toPersistedV1(): PersistedToolSecurityMetadataV1 =
+    PersistedToolSecurityMetadataV1(
+        schemaVersion = 1,
+        permission = permission,
+        risk = risk.name,
+        approval = approval.name,
+        managedNetworkEgress = managedNetworkEgress.name,
+        audit = audit.name,
+        compatibilityMode = compatibilityMode.name,
+    )
+
+fun PersistedReplayEnvelopeV1.toDomain(): SensitiveReplayEnvelope =
+    SensitiveReplayEnvelope.of(messages.map { it.toDomain() })
+
+fun SensitiveReplayEnvelope.toPersistedV1(): PersistedReplayEnvelopeV1 =
+    PersistedReplayEnvelopeV1(
+        schemaVersion = 1,
+        messages = revealForResume().messages.map { it.toPersistedV1() },
+    )
+
+fun PersistedMessageV1.toDomain(): Message = Message(
+    role = MessageRole.valueOf(role),
+    content = content,
+    contentParts = contentParts?.map { it.toDomain() },
+    toolCallId = toolCallId,
+    toolCalls = toolCalls?.map { it.toDomain() },
+)
+
+fun Message.toPersistedV1(): PersistedMessageV1 = PersistedMessageV1(
+    schemaVersion = 1,
+    role = role.name,
+    content = content,
+    contentParts = contentParts?.map { it.toPersistedV1() },
+    toolCallId = toolCallId,
+    toolCalls = toolCalls?.map { it.toPersistedV1() },
+)
+
+fun PersistedToolCallV1.toDomain(): ToolCall = ToolCall(
+    id = id,
+    name = name,
+    argumentsJson = argumentsJson,
+)
+
+fun ToolCall.toPersistedV1(): PersistedToolCallV1 = PersistedToolCallV1(
+    schemaVersion = 1,
+    id = id,
+    name = name,
+    argumentsJson = argumentsJson,
+)
+
+fun PersistedContentPartV1.toDomain(): ContentPart = when (type) {
+    "text" -> ContentPart.TextPart(
+        text = requireNotNull(text) { "persisted-content-part-text-missing" },
+    )
+    "image" -> ContentPart.ImagePart(
+        mimeType = requireNotNull(mimeType) { "persisted-content-part-image-mime-missing" },
+        data = Base64.getDecoder().decode(
+            requireNotNull(dataBase64) { "persisted-content-part-image-data-missing" },
+        ).copyOf(),
+    )
+    "image_url" -> ContentPart.ImageUrlContent(
+        url = requireNotNull(url) { "persisted-content-part-image-url-missing" },
+        mimeType = mimeType,
+    )
+    else -> error("persisted-content-part-type-unsupported")
+}
+
+fun ContentPart.toPersistedV1(): PersistedContentPartV1 = when (this) {
+    is ContentPart.TextPart -> PersistedContentPartV1(
+        schemaVersion = 1,
+        type = "text",
+        text = text,
+        mimeType = null,
+        dataBase64 = null,
+        url = null,
+    )
+    is ContentPart.ImagePart -> PersistedContentPartV1(
+        schemaVersion = 1,
+        type = "image",
+        text = null,
+        mimeType = mimeType,
+        dataBase64 = Base64.getEncoder().encodeToString(data),
+        url = null,
+    )
+    is ContentPart.ImageUrlContent -> PersistedContentPartV1(
+        schemaVersion = 1,
+        type = "image_url",
+        text = null,
+        mimeType = mimeType,
+        dataBase64 = null,
+        url = url,
+    )
+}

--- a/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/ReplayEnvelopePersistenceCodec.kt
+++ b/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/ReplayEnvelopePersistenceCodec.kt
@@ -11,7 +11,7 @@ import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 import java.util.Base64
 
-object ReplayEnvelopePersistenceCodec {
+internal object ReplayEnvelopePersistenceCodec {
 
     private const val REDACTED_APPROVAL_CONTINUATION_ARGUMENTS =
         "__redacted_approval_continuation_args__"
@@ -50,7 +50,7 @@ object ReplayEnvelopePersistenceCodec {
         val selectedSlot = matchingSlots.single()
         require(metadata.toolCallIndex >= 0) { "suspended-replay-envelope-tool-call-index-out-of-bounds" }
         require(selectedSlot.toolCallIndex == metadata.toolCallIndex) {
-            "suspended-replay-envelope-tool-call-index-out-of-bounds"
+            "suspended-replay-envelope-tool-call-index-mismatch"
         }
         require(selectedSlot.call.name == metadata.toolName) {
             "suspended-replay-envelope-tool-call-name-mismatch"

--- a/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/ReplayEnvelopePersistenceCodec.kt
+++ b/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/ReplayEnvelopePersistenceCodec.kt
@@ -37,6 +37,8 @@ object ReplayEnvelopePersistenceCodec {
         metadata: SuspendedInvocationMetadata,
         messages: List<Message>,
     ) {
+        require(metadata.historySize >= 0) { "suspended-replay-envelope-history-size-negative" }
+        require(messages.size > metadata.historySize) { "suspended-replay-envelope-history-size-mismatch" }
         val allSlots = messages.flatMapIndexed { messageIndex, message ->
             message.toolCalls.orEmpty().mapIndexed { toolCallIndex, call ->
                 ReplayToolCallSlot(messageIndex, toolCallIndex, call)
@@ -49,9 +51,6 @@ object ReplayEnvelopePersistenceCodec {
         require(metadata.toolCallIndex >= 0) { "suspended-replay-envelope-tool-call-index-out-of-bounds" }
         require(selectedSlot.toolCallIndex == metadata.toolCallIndex) {
             "suspended-replay-envelope-tool-call-index-out-of-bounds"
-        }
-        require(selectedSlot.call.id == metadata.toolCallId) {
-            "suspended-replay-envelope-tool-call-id-mismatch"
         }
         require(selectedSlot.call.name == metadata.toolName) {
             "suspended-replay-envelope-tool-call-name-mismatch"

--- a/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/ReplayEnvelopePersistenceCodec.kt
+++ b/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/ReplayEnvelopePersistenceCodec.kt
@@ -58,7 +58,7 @@ internal object ReplayEnvelopePersistenceCodec {
 
         // The redacted slot must be in the latest assistant message with tool calls
         val latestAssistantIdx = messages.indexOfLast {
-            it.role == dev.tramai.core.model.MessageRole.ASSISTANT && it.toolCalls != null
+            it.role == dev.tramai.core.model.MessageRole.ASSISTANT && !it.toolCalls.isNullOrEmpty()
         }
         require(latestAssistantIdx >= 0) { "suspended-replay-envelope-assistant-batch-not-found" }
         require(selectedSlot.messageIndex == latestAssistantIdx) {
@@ -85,7 +85,7 @@ internal object ReplayEnvelopePersistenceCodec {
         }
     }
 
-    private fun computeReplayEnvelopeDigest(
+    internal fun computeReplayEnvelopeDigest(
         operationReference: ResumeOperationReference,
         messages: List<Message>,
     ): Sha256Digest {

--- a/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/ReplayEnvelopePersistenceCodec.kt
+++ b/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/ReplayEnvelopePersistenceCodec.kt
@@ -56,6 +56,15 @@ object ReplayEnvelopePersistenceCodec {
             "suspended-replay-envelope-tool-call-name-mismatch"
         }
 
+        // The redacted slot must be in the latest assistant message with tool calls
+        val latestAssistantIdx = messages.indexOfLast {
+            it.role == dev.tramai.core.model.MessageRole.ASSISTANT && it.toolCalls != null
+        }
+        require(latestAssistantIdx >= 0) { "suspended-replay-envelope-assistant-batch-not-found" }
+        require(selectedSlot.messageIndex == latestAssistantIdx) {
+            "suspended-replay-envelope-tool-call-slot-mismatch"
+        }
+
         val sentinelSlots = allSlots.filter {
             it.call.argumentsJson == REDACTED_APPROVAL_CONTINUATION_ARGUMENTS
         }

--- a/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/ReplayEnvelopePersistenceCodec.kt
+++ b/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/ReplayEnvelopePersistenceCodec.kt
@@ -1,0 +1,152 @@
+package dev.tramai.persistence.file
+
+import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.model.ContentPart
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.ToolCall
+import dev.tramai.engine.ResumeOperationReference
+import dev.tramai.engine.SensitiveReplayEnvelope
+import dev.tramai.engine.SuspendedInvocationMetadata
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.util.Base64
+
+object ReplayEnvelopePersistenceCodec {
+
+    private const val REDACTED_APPROVAL_CONTINUATION_ARGUMENTS =
+        "__redacted_approval_continuation_args__"
+
+    fun snapshotForPersistence(
+        metadata: SuspendedInvocationMetadata,
+        envelope: SensitiveReplayEnvelope,
+    ): List<Message> {
+        val messages = envelope.revealForResume().messages
+        validateEnvelope(metadata, messages)
+        return messages
+    }
+
+    fun restoreFromPersistence(
+        metadata: SuspendedInvocationMetadata,
+        messages: List<Message>,
+    ): SensitiveReplayEnvelope {
+        validateEnvelope(metadata, messages)
+        return SensitiveReplayEnvelope.of(messages)
+    }
+
+    private fun validateEnvelope(
+        metadata: SuspendedInvocationMetadata,
+        messages: List<Message>,
+    ) {
+        val allSlots = messages.flatMapIndexed { messageIndex, message ->
+            message.toolCalls.orEmpty().mapIndexed { toolCallIndex, call ->
+                ReplayToolCallSlot(messageIndex, toolCallIndex, call)
+            }
+        }
+        val matchingSlots = allSlots.filter { it.call.id == metadata.toolCallId }
+        require(matchingSlots.size == 1) { "suspended-replay-envelope-tool-call-id-mismatch" }
+
+        val selectedSlot = matchingSlots.single()
+        require(metadata.toolCallIndex >= 0) { "suspended-replay-envelope-tool-call-index-out-of-bounds" }
+        require(selectedSlot.toolCallIndex == metadata.toolCallIndex) {
+            "suspended-replay-envelope-tool-call-index-out-of-bounds"
+        }
+        require(selectedSlot.call.id == metadata.toolCallId) {
+            "suspended-replay-envelope-tool-call-id-mismatch"
+        }
+        require(selectedSlot.call.name == metadata.toolName) {
+            "suspended-replay-envelope-tool-call-name-mismatch"
+        }
+
+        val sentinelSlots = allSlots.filter {
+            it.call.argumentsJson == REDACTED_APPROVAL_CONTINUATION_ARGUMENTS
+        }
+        require(sentinelSlots.size == 1) {
+            "suspended-replay-envelope-redaction-count-mismatch"
+        }
+        val sentinelSlot = sentinelSlots.single()
+        require(
+            sentinelSlot.messageIndex == selectedSlot.messageIndex &&
+                sentinelSlot.toolCallIndex == selectedSlot.toolCallIndex,
+        ) {
+            "suspended-replay-envelope-redaction-count-mismatch"
+        }
+
+        val digest = computeReplayEnvelopeDigest(metadata.operationReference, messages)
+        require(digest == metadata.replayEnvelopeDigest) {
+            "suspended-replay-envelope-digest-mismatch"
+        }
+    }
+
+    private fun computeReplayEnvelopeDigest(
+        operationReference: ResumeOperationReference,
+        messages: List<Message>,
+    ): Sha256Digest {
+        val canonical = buildString {
+            appendField("service_interface", operationReference.serviceInterface)
+            append("method=").append(operationReference.methodName).append('\n')
+            append("jvm_descriptor=").append(operationReference.jvmMethodDescriptor).append('\n')
+            append("digest=").append(operationReference.resumeDefinitionDigest.value).append('\n')
+            append(encodeCanonicalMessages(messages))
+        }
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest(canonical.toByteArray(StandardCharsets.UTF_8))
+        val hex = digest.joinToString("") { "%02x".format(it) }
+        return Sha256Digest.of("sha256:$hex")
+    }
+
+    private fun encodeCanonicalMessages(messages: List<Message>): String = buildString {
+        messages.forEachIndexed { index, message ->
+            if (index > 0) append("\n---\n")
+            append("role=").append(message.role.name).append('\n')
+            appendField("content", message.content)
+            append("parts_count=").append(message.contentParts?.size ?: 0).append('\n')
+            message.contentParts.orEmpty().forEachIndexed { partIndex, part ->
+                append("part_index=").append(partIndex).append('\n')
+                when (part) {
+                    is ContentPart.TextPart -> {
+                        append("part_type=text\n")
+                        appendField("text", part.text)
+                    }
+                    is ContentPart.ImagePart -> {
+                        append("part_type=image\n")
+                        appendField("mime", part.mimeType)
+                        appendField("data_b64", Base64.getEncoder().encodeToString(part.data))
+                    }
+                    is ContentPart.ImageUrlContent -> {
+                        append("part_type=image_url\n")
+                        appendField("url", part.url)
+                        appendField("mime", part.mimeType)
+                    }
+                }
+            }
+            if (message.toolCallId != null) {
+                appendField("tool_call_id", message.toolCallId)
+            }
+            message.toolCalls?.let { toolCalls ->
+                append("tool_calls_count=").append(toolCalls.size).append('\n')
+                toolCalls.forEachIndexed { toolIndex, toolCall ->
+                    append("tool_call_index=").append(toolIndex).append('\n')
+                    appendField("tool_call_id", toolCall.id)
+                    appendField("tool_call_name", toolCall.name)
+                    appendField("tool_call_args", toolCall.argumentsJson)
+                }
+            }
+        }
+    }
+
+    private fun StringBuilder.appendField(name: String, value: String?) {
+        if (value == null) {
+            append(name).append("_null\n")
+            return
+        }
+        val bytes = value.toByteArray(StandardCharsets.UTF_8)
+        append(name).append("_len=").append(bytes.size).append('\n')
+        append(value).append('\n')
+    }
+
+    private data class ReplayToolCallSlot(
+        val messageIndex: Int,
+        val toolCallIndex: Int,
+        val call: ToolCall,
+    )
+}

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileBackedSovereignStoresTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileBackedSovereignStoresTest.kt
@@ -1,15 +1,39 @@
 package dev.tramai.persistence.file
 
+import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
+import dev.tramai.core.model.ToolCall
+import dev.tramai.core.policy.ApprovalMode
+import dev.tramai.core.policy.AuditDetail
+import dev.tramai.core.policy.ClassificationSource
+import dev.tramai.core.policy.CompatibilityMode
+import dev.tramai.core.policy.DataClassification
+import dev.tramai.core.policy.ManagedNetworkEgress
+import dev.tramai.core.policy.RiskLevel
+import dev.tramai.core.policy.ToolSecurityMetadata
+import dev.tramai.engine.EngineExecutionIdentity
+import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.ResumeOperationReference
+import dev.tramai.engine.ResumeToolReference
+import dev.tramai.engine.SensitiveReplayEnvelope
+import dev.tramai.engine.SuspendedInvocationMetadata
+import dev.tramai.engine.TokenBudgetSnapshot
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.attribute.PosixFilePermissions
+import java.security.MessageDigest
+import java.util.Base64
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
 import kotlin.io.path.*
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 import kotlin.test.assertTrue
 
 class FileBackedSovereignStoresTest {
@@ -143,13 +167,30 @@ class FileBackedSovereignStoresTest {
             assertNotNull(stores.approvalStore, "approvalStore must be non-null")
             assertNotNull(stores.approvalContinuationStore, "approvalContinuationStore must be non-null")
             assertNotNull(stores.auditStore, "auditStore must be non-null")
+            assertNotNull(stores.suspendedInvocationStore, "suspendedInvocationStore must be non-null")
 
             assertTrue(stores.approvalStore is FileApprovalStore)
             assertTrue(stores.approvalContinuationStore is FileApprovalContinuationStore)
             assertTrue(stores.auditStore is FileAuditStore)
+            assertTrue(stores.suspendedInvocationStore is FileSuspendedInvocationStore)
         } finally {
             stores.close()
         }
+    }
+
+    @Test
+    fun `open creates suspended directory with 0700 permissions`() {
+        val config = createConfig()
+        val stores = FileBackedSovereignStores.open(config)
+        stores.close()
+
+        val suspendedDir = rootDir.resolve("suspended")
+        assertTrue(suspendedDir.exists(), "suspended directory must exist after open")
+        assertTrue(suspendedDir.isDirectory(), "suspended must be a directory")
+        assertTrue(
+            Files.getPosixFilePermissions(suspendedDir) == PosixFilePermissions.fromString("rwx------"),
+            "suspended permissions must be 0700",
+        )
     }
 
     @Test
@@ -172,6 +213,54 @@ class FileBackedSovereignStoresTest {
         val stores = FileBackedSovereignStores.open(config)
         stores.close()
         stores.close()
+    }
+
+    @Test
+    fun `corrupted suspended record fails startup verification`() = runBlocking {
+        val config = createConfig()
+        val approvalId = "bundle-suspended-corrupt-1"
+
+        FileBackedSovereignStores.open(config).use { stores ->
+            val (metadata, envelope) = createValidSuspendedRecord(approvalId)
+            stores.suspendedInvocationStore.create(metadata, envelope)
+        }
+
+        val path = suspendedRecordPath(approvalId)
+        val encrypted = EncryptedFileEnvelopeV1.fromJson(path.readText())
+        Files.writeString(
+            path,
+            encrypted.copy(ciphertextBase64 = encrypted.ciphertextBase64.dropLast(1) + "X").toJson(),
+        )
+
+        assertThrows<FileStoreCorruptionException> {
+            FileBackedSovereignStores.open(
+                FileBackedStoreConfiguration(
+                    rootDirectory = rootDir,
+                    encryption = FileStoreEncryptionConfiguration(
+                        activeKeyId = "test-key",
+                        keyProvider = keyProvider,
+                    ),
+                    verifyOnOpen = true,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `operations after close are rejected on suspended store`() = runBlocking {
+        val stores = FileBackedSovereignStores.open(createConfig())
+        val suspendedStore = stores.suspendedInvocationStore
+        stores.close()
+
+        assertThrows<IllegalStateException> {
+            runBlocking { suspendedStore.get("approval-closed") }
+        }
+        assertThrows<IllegalStateException> {
+            runBlocking { suspendedStore.revealReplayEnvelope("approval-closed") }
+        }
+        assertThrows<IllegalStateException> {
+            runBlocking { suspendedStore.remove("approval-closed") }
+        }
     }
 
     // ── activeKeyId validation ──────────────────────────────────────────
@@ -445,5 +534,132 @@ class FileBackedSovereignStoresTest {
         assertThrows<FileStorePermissionException> {
             FileBackedSovereignStores.open(createConfig(setupRoot))
         }
+    }
+
+    private fun suspendedRecordPath(approvalId: String): Path =
+        rootDir.resolve(
+            "suspended/${FileStoreSha256.digest("suspended-invocation", approvalId)}.tram.enc",
+        )
+
+    private fun createValidSuspendedRecord(
+        approvalId: String,
+    ): Pair<SuspendedInvocationMetadata, SensitiveReplayEnvelope> {
+        val toolName = "bundle_lookup"
+        val toolCallId = "bundle-tool-call-1"
+        val operationReference = ResumeOperationReference(
+            serviceInterface = "dev.tramai.persistence.file.BundleTestService",
+            methodName = "resume",
+            jvmMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/String;",
+            resumeDefinitionDigest = Sha256Digest.of(
+                "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+            ),
+        )
+        val messages = listOf(
+            Message(
+                role = MessageRole.USER,
+                content = "bundle prompt",
+            ),
+            Message(
+                role = MessageRole.ASSISTANT,
+                content = "",
+                toolCalls = listOf(
+                    ToolCall(
+                        id = toolCallId,
+                        name = toolName,
+                        argumentsJson = "__redacted_approval_continuation_args__",
+                    ),
+                ),
+            ),
+        )
+        val metadata = SuspendedInvocationMetadata(
+            approvalId = approvalId,
+            toolCallId = toolCallId,
+            toolName = toolName,
+            toolCallIndex = 0,
+            correlationId = "bundle-correlation-1",
+            identity = EngineExecutionIdentity(
+                workflowRunId = "bundle-workflow-1",
+                correlationId = "bundle-correlation-1",
+                workflowDigest = Sha256Digest.of(
+                    "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+                ),
+                policyVersion = "policy-v1",
+                actorId = "bundle-actor",
+            ),
+            securityContext = ExecutionSecurityContext(
+                dataClassification = DataClassification.CONFIDENTIAL,
+                classificationSource = ClassificationSource.RULE_BASED,
+            ),
+            operationReference = operationReference,
+            replayEnvelopeDigest = computeReplayEnvelopeDigest(operationReference, messages),
+            conversationId = "bundle-conversation-1",
+            historySize = 1,
+            tokenBudgetSnapshot = TokenBudgetSnapshot(
+                totalInputTokens = 1,
+                totalOutputTokens = 2,
+                totalInputCost = 0.01,
+                totalOutputCost = 0.02,
+                warnIfExceeded = true,
+            ),
+            toolReference = ResumeToolReference(
+                toolName = toolName,
+                declarationDigest = Sha256Digest.of(
+                    "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+                ),
+            ),
+            toolSecurity = ToolSecurityMetadata(
+                permission = "bundle.read",
+                risk = RiskLevel.LOW,
+                approval = ApprovalMode.HUMAN_REQUIRED,
+                managedNetworkEgress = ManagedNetworkEgress.DENY,
+                audit = AuditDetail.FULL,
+                compatibilityMode = CompatibilityMode.STRICT,
+            ),
+        )
+        return metadata to SensitiveReplayEnvelope.of(messages)
+    }
+
+    private fun computeReplayEnvelopeDigest(
+        operationReference: ResumeOperationReference,
+        messages: List<Message>,
+    ): Sha256Digest {
+        val canonical = buildString {
+            appendField("service_interface", operationReference.serviceInterface)
+            append("method=").append(operationReference.methodName).append('\n')
+            append("jvm_descriptor=").append(operationReference.jvmMethodDescriptor).append('\n')
+            append("digest=").append(operationReference.resumeDefinitionDigest.value).append('\n')
+            append(encodeCanonicalMessages(messages))
+        }
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest(canonical.toByteArray(StandardCharsets.UTF_8))
+        val hex = digest.joinToString("") { "%02x".format(it) }
+        return Sha256Digest.of("sha256:$hex")
+    }
+
+    private fun encodeCanonicalMessages(messages: List<Message>): String = buildString {
+        messages.forEachIndexed { index, message ->
+            if (index > 0) append("\n---\n")
+            append("role=").append(message.role.name).append('\n')
+            appendField("content", message.content)
+            message.toolCalls?.let { toolCalls ->
+                append("tool_calls_count=").append(toolCalls.size).append('\n')
+                toolCalls.forEachIndexed { toolIndex, toolCall ->
+                    append("tool_call_index=").append(toolIndex).append('\n')
+                    appendField("tool_call_id", toolCall.id)
+                    appendField("tool_call_name", toolCall.name)
+                    appendField("tool_call_args", toolCall.argumentsJson)
+                }
+            }
+        }
+    }
+
+    private fun StringBuilder.appendField(name: String, value: String?) {
+        if (value == null) {
+            append(name).append("_null\n")
+            return
+        }
+        val bytes = value.toByteArray(StandardCharsets.UTF_8)
+        append(name).append("_len=").append(bytes.size).append('\n')
+        append(value).append('\n')
     }
 }

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileBackedSovereignStoresTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileBackedSovereignStoresTest.kt
@@ -23,17 +23,13 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.attribute.PosixFilePermissions
-import java.security.MessageDigest
-import java.util.Base64
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
 import kotlin.io.path.*
 import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 import kotlin.test.assertTrue
 
 class FileBackedSovereignStoresTest {
@@ -591,7 +587,7 @@ class FileBackedSovereignStoresTest {
                 classificationSource = ClassificationSource.RULE_BASED,
             ),
             operationReference = operationReference,
-            replayEnvelopeDigest = computeReplayEnvelopeDigest(operationReference, messages),
+            replayEnvelopeDigest = ReplayEnvelopePersistenceCodec.computeReplayEnvelopeDigest(operationReference, messages),
             conversationId = "bundle-conversation-1",
             historySize = 1,
             tokenBudgetSnapshot = TokenBudgetSnapshot(
@@ -617,49 +613,5 @@ class FileBackedSovereignStoresTest {
             ),
         )
         return metadata to SensitiveReplayEnvelope.of(messages)
-    }
-
-    private fun computeReplayEnvelopeDigest(
-        operationReference: ResumeOperationReference,
-        messages: List<Message>,
-    ): Sha256Digest {
-        val canonical = buildString {
-            appendField("service_interface", operationReference.serviceInterface)
-            append("method=").append(operationReference.methodName).append('\n')
-            append("jvm_descriptor=").append(operationReference.jvmMethodDescriptor).append('\n')
-            append("digest=").append(operationReference.resumeDefinitionDigest.value).append('\n')
-            append(encodeCanonicalMessages(messages))
-        }
-        val digest = MessageDigest.getInstance("SHA-256")
-            .digest(canonical.toByteArray(StandardCharsets.UTF_8))
-        val hex = digest.joinToString("") { "%02x".format(it) }
-        return Sha256Digest.of("sha256:$hex")
-    }
-
-    private fun encodeCanonicalMessages(messages: List<Message>): String = buildString {
-        messages.forEachIndexed { index, message ->
-            if (index > 0) append("\n---\n")
-            append("role=").append(message.role.name).append('\n')
-            appendField("content", message.content)
-            message.toolCalls?.let { toolCalls ->
-                append("tool_calls_count=").append(toolCalls.size).append('\n')
-                toolCalls.forEachIndexed { toolIndex, toolCall ->
-                    append("tool_call_index=").append(toolIndex).append('\n')
-                    appendField("tool_call_id", toolCall.id)
-                    appendField("tool_call_name", toolCall.name)
-                    appendField("tool_call_args", toolCall.argumentsJson)
-                }
-            }
-        }
-    }
-
-    private fun StringBuilder.appendField(name: String, value: String?) {
-        if (value == null) {
-            append(name).append("_null\n")
-            return
-        }
-        val bytes = value.toByteArray(StandardCharsets.UTF_8)
-        append(name).append("_len=").append(bytes.size).append('\n')
-        append(value).append('\n')
     }
 }

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStoreRestartTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStoreRestartTest.kt
@@ -444,6 +444,117 @@ class FileSuspendedInvocationStoreRestartTest {
         }
     }
 
+    @Test
+    fun `malformed authenticated replay record rejects resume before token consumption`() {
+        val config = createConfig()
+        val toolA = RestartCalculatorTool()
+
+        val suspension = FileBackedSovereignStores.open(config).use { storesA ->
+            createEngine(
+                provider = RestartTestProvider(),
+                toolRegistry = toolRegistryFor(toolA),
+                stores = storesA,
+            ).use { engineA ->
+                val exception = triggerSuspension(engineA)
+                val approved = approve(storesA, exception.approvalId)
+                val approvalId = exception.approvalId
+
+                // Corrupt the suspended record: replace the redacted argument
+                // with a non-sentinel value so replay-envelope validation fails
+                val path = rootDir.resolve(
+                    "suspended/${dev.tramai.persistence.file.FileStoreSha256.digest("suspended-invocation", approvalId)}.tram.enc",
+                )
+                val envelopeJson = java.nio.file.Files.readString(path)
+                val envelope = dev.tramai.persistence.file.EncryptedFileEnvelopeV1.fromJson(envelopeJson)
+                val plaintext = dev.tramai.persistence.file.AesGcmFileEncryption.decrypt(
+                    secretKey, envelope, "suspended-invocation",
+                    dev.tramai.persistence.file.FileStoreSha256.digest("suspended-invocation", approvalId),
+                    "restart-test-key",
+                )
+                val record = dev.tramai.persistence.file.PersistedSuspendedInvocationRecordV1.fromJson(
+                    plaintext.decodeToString(),
+                )
+                // Make the tool call's argumentsJson non-redacted (remove sentinel)
+                val corruptedMessages = record.replayEnvelope.messages.map { message ->
+                    message.copy(
+                        toolCalls = message.toolCalls?.map { tc ->
+                            tc.copy(argumentsJson = """{"x":99,"y":100}""")
+                        },
+                    )
+                }
+                val corruptedRecord = record.copy(
+                    replayEnvelope = record.replayEnvelope.copy(messages = corruptedMessages),
+                )
+                val (newNonce, newCiphertext) = dev.tramai.persistence.file.AesGcmFileEncryption.encrypt(
+                    secretKey, "suspended-invocation",
+                    dev.tramai.persistence.file.FileStoreSha256.digest("suspended-invocation", approvalId),
+                    "restart-test-key",
+                    corruptedRecord.toJson().toByteArray(),
+                )
+                java.nio.file.Files.writeString(
+                    path,
+                    dev.tramai.persistence.file.EncryptedFileEnvelopeV1(
+                        envelopeVersion = 1,
+                        recordType = "suspended-invocation",
+                        recordKeyDigest = dev.tramai.persistence.file.FileStoreSha256.digest(
+                            "suspended-invocation", approvalId,
+                        ),
+                        keyId = "restart-test-key",
+                        nonceBase64 = newNonce,
+                        ciphertextBase64 = newCiphertext,
+                    ).toJson(),
+                )
+                java.nio.file.Files.setPosixFilePermissions(
+                    path, java.nio.file.attribute.PosixFilePermissions.fromString("rw-------"),
+                )
+
+                SuspendedWorkflow(
+                    approvalId = approvalId,
+                    approvalVersion = approved.version,
+                    continuationVersion = exception.continuationVersion,
+                    approvalToken = exception.challenge.token,
+                    workflowRunId = exception.workflowRunId,
+                )
+            }
+        }
+
+        val toolB = RestartCalculatorTool()
+
+        FileBackedSovereignStores.open(config).use { storesB ->
+            createEngine(
+                provider = RestartTestProvider(),
+                toolRegistry = toolRegistryFor(toolB),
+                stores = storesB,
+            ).use { engineB ->
+                engineB.registerService(RestartTestService::class)
+
+                assertThatThrownBy {
+                    runBlocking {
+                        engineB.resumeApproval(
+                            ResumeApprovalCommand(
+                                approvalId = suspension.approvalId,
+                                approvalExpectedVersion = suspension.approvalVersion,
+                                continuationExpectedVersion = suspension.continuationVersion,
+                                presentedToken = suspension.approvalToken,
+                                resumedBy = "admin",
+                            ),
+                        )
+                    }
+                }.isInstanceOf(dev.tramai.persistence.file.FileStoreCorruptionException::class.java)
+                    .hasMessageContaining("suspended-invocation-replay-envelope-invalid")
+
+                val continuation = runBlocking { storesB.approvalContinuationStore.get(suspension.approvalId) }
+                assertThat(continuation).isNotNull
+                assertThat(continuation!!.status).isEqualTo(ApprovalContinuationStatus.PENDING)
+                assertThat(toolB.executeCount.get()).isEqualTo(0)
+                assertThatThrownBy {
+                    runBlocking { storesB.suspendedInvocationStore.get(suspension.approvalId) }
+                }.isInstanceOf(dev.tramai.persistence.file.FileStoreCorruptionException::class.java)
+                    .hasMessageContaining("suspended-invocation-replay-envelope-invalid")
+            }
+        }
+    }
+
     private fun createConfig() = FileBackedStoreConfiguration(
         rootDirectory = rootDir,
         encryption = FileStoreEncryptionConfiguration(

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStoreRestartTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStoreRestartTest.kt
@@ -1,0 +1,589 @@
+package dev.tramai.persistence.file
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.annotations.SystemPrompt
+import dev.tramai.core.approval.ApprovalContinuationStatus
+import dev.tramai.core.approval.ApprovalTransition
+import dev.tramai.core.exception.ApprovalSuspendedException
+import dev.tramai.core.exception.ConfigurationException
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.model.ResolvedTool
+import dev.tramai.core.model.SideEffectLevel
+import dev.tramai.core.model.ToolCall
+import dev.tramai.core.model.ToolExecutionContext
+import dev.tramai.core.model.ToolResult
+import dev.tramai.core.model.TramaiTool
+import dev.tramai.core.policy.ApprovalMode
+import dev.tramai.core.policy.ApprovalRequirement
+import dev.tramai.core.policy.AuditDetail
+import dev.tramai.core.policy.CompatibilityMode
+import dev.tramai.core.policy.EnforcementPoint
+import dev.tramai.core.policy.ManagedNetworkEgress
+import dev.tramai.core.policy.PolicyContext
+import dev.tramai.core.policy.PolicyDecision
+import dev.tramai.core.policy.PolicyEngine
+import dev.tramai.core.policy.RiskLevel
+import dev.tramai.core.policy.ToolSecurityMetadata
+import dev.tramai.core.provider.ModelProvider
+import dev.tramai.engine.ResumeApprovalCommand
+import dev.tramai.engine.ToolRegistry
+import dev.tramai.engine.TramaiEngine
+import dev.tramai.engine.create
+import dev.tramai.security.approval.DefaultApprovalGateCoordinator
+import dev.tramai.security.approval.SecureRandomApprovalTokenGenerator
+import dev.tramai.security.approval.Sha256ApprovalTokenDigester
+import dev.tramai.security.approval.Sha256ToolArgumentsDigester
+import dev.tramai.security.approval.UuidApprovalIdGenerator
+import dev.tramai.security.audit.AuditEngine
+import dev.tramai.security.audit.AuditEngineApprovalLifecycleAuditEmitter
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.core.api.Assertions.fail
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.lang.reflect.InvocationTargetException
+import java.net.URLClassLoader
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.util.concurrent.atomic.AtomicInteger
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.tools.ToolProvider
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.exists
+import kotlin.reflect.KClass
+
+class FileSuspendedInvocationStoreRestartTest {
+
+    private val fixedClock = Clock.fixed(
+        Instant.now().minus(Duration.ofMinutes(1)),
+        ZoneId.of("UTC"),
+    )
+
+    private val secretKey: SecretKey = KeyGenerator.getInstance("AES").apply { init(256) }.generateKey()
+    private val keyProvider = FileStoreEncryptionKeyProvider { secretKey }
+    private val rootDir: Path = Files.createTempDirectory("tramai-restart-").toAbsolutePath()
+
+    @AfterEach
+    fun cleanup() {
+        if (rootDir.exists()) {
+            rootDir.toFile().deleteRecursively()
+        }
+    }
+
+    @AiService
+    @SystemPrompt("You are a helpful assistant.")
+    interface RestartTestService {
+        @Operation(
+            prompt = "Execute the calculator tool",
+            model = "test-model",
+            tools = ["restart_calculator"],
+        )
+        suspend fun calculate(input: String): String
+    }
+
+    data class CalculatorInput(val x: Int, val y: Int)
+
+    data class CalculatorResult(val result: Int)
+
+    private open class RestartCalculatorTool(
+        private val permission: String = "calculator.execute",
+        private val sideEffectLevelOverride: SideEffectLevel = SideEffectLevel.READ_ONLY,
+        private val securityOverride: ToolSecurityMetadata = ToolSecurityMetadata(
+            permission = permission,
+            risk = RiskLevel.LOW,
+            approval = ApprovalMode.HUMAN_REQUIRED,
+            managedNetworkEgress = ManagedNetworkEgress.DENY,
+            audit = AuditDetail.FULL,
+            compatibilityMode = CompatibilityMode.STRICT,
+        ),
+    ) : TramaiTool<CalculatorInput, CalculatorResult> {
+        val executeCount = AtomicInteger(0)
+
+        override val name: String = "restart_calculator"
+        override val description: String = "Calculates a result"
+        override val inputType: KClass<CalculatorInput> = CalculatorInput::class
+        override val idempotent: Boolean = true
+        override val sideEffectLevel: SideEffectLevel = sideEffectLevelOverride
+        override val security: ToolSecurityMetadata = securityOverride
+
+        override suspend fun execute(
+            input: CalculatorInput,
+            context: ToolExecutionContext,
+        ): CalculatorResult {
+            executeCount.incrementAndGet()
+            return CalculatorResult(result = input.x + input.y)
+        }
+
+        fun toResolvedTool(): ResolvedTool = object : ResolvedTool {
+            override val name: String = this@RestartCalculatorTool.name
+            override val description: String = this@RestartCalculatorTool.description
+            override val inputSchemaJson: String =
+                """{"type":"object","properties":{"x":{"type":"integer"},"y":{"type":"integer"}},"required":["x","y"]}"""
+            override val idempotent: Boolean = this@RestartCalculatorTool.idempotent
+            override val sideEffectLevel: SideEffectLevel = this@RestartCalculatorTool.sideEffectLevel
+            override val security: ToolSecurityMetadata = this@RestartCalculatorTool.security
+
+            override suspend fun execute(
+                input: Any,
+                context: ToolExecutionContext,
+            ): ToolResult {
+                val parsed: CalculatorInput = FILE_STORE_JSON.readValue(input as String)
+                val result = this@RestartCalculatorTool.execute(parsed, context)
+                return ToolResult.Success(FILE_STORE_JSON.writeValueAsString(result))
+            }
+        }
+    }
+
+    private class RestartTestProvider(
+        private val toolCallId: String = "restart-tc-1",
+        private val toolName: String = "restart_calculator",
+        private val toolArguments: String = """{"x":2,"y":3}""",
+        startingCallCount: Int = 0,
+    ) : ModelProvider {
+        var callCount = startingCallCount
+
+        override suspend fun complete(request: ModelRequest): ModelResponse {
+            callCount++
+            return if (callCount == 1) {
+                ModelResponse(
+                    content = "",
+                    toolCalls = listOf(ToolCall(toolCallId, toolName, toolArguments)),
+                )
+            } else {
+                ModelResponse(content = "Final result: success")
+            }
+        }
+
+        override fun providerId(): String = "restart-test-provider"
+    }
+
+    private class RestartPolicyEngine : PolicyEngine {
+        override suspend fun evaluate(context: PolicyContext): PolicyDecision {
+            return when (context.enforcementPoint) {
+                EnforcementPoint.BEFORE_TOOL_EXECUTION -> {
+                    PolicyDecision.RequireApproval(
+                        ApprovalRequirement(
+                            toolName = context.toolName ?: "restart_calculator",
+                            argumentsDigest = "",
+                            reason = "restart-test-approval",
+                            timeoutMillis = 900_000,
+                        ),
+                    )
+                }
+                EnforcementPoint.BEFORE_WORKFLOW_RESUME -> PolicyDecision.Allow
+                else -> PolicyDecision.Allow
+            }
+        }
+    }
+
+    @Test
+    fun `workflow suspended in runtime A resumes safely in runtime B after reopening encrypted stores`() {
+        val config = createConfig()
+        val providerA = RestartTestProvider()
+        val toolA = RestartCalculatorTool()
+
+        val suspension = FileBackedSovereignStores.open(config).use { storesA ->
+            val engineA = createEngine(
+                provider = providerA,
+                toolRegistry = toolRegistryFor(toolA),
+                stores = storesA,
+            )
+            val exception = triggerSuspension(engineA)
+            val approved = approve(storesA, exception.approvalId)
+
+            SuspendedWorkflow(
+                approvalId = exception.approvalId,
+                approvalVersion = approved.version,
+                continuationVersion = exception.continuationVersion,
+                approvalToken = exception.challenge.token,
+                workflowRunId = exception.workflowRunId,
+            )
+        }
+
+        val providerB = RestartTestProvider(startingCallCount = 1)
+        val toolB = RestartCalculatorTool()
+
+        FileBackedSovereignStores.open(config).use { storesB ->
+            val engineB = createEngine(
+                provider = providerB,
+                toolRegistry = toolRegistryFor(toolB),
+                stores = storesB,
+            )
+            engineB.registerService(RestartTestService::class)
+
+            val result = runBlocking {
+                engineB.resumeApproval(
+                    ResumeApprovalCommand(
+                        approvalId = suspension.approvalId,
+                        approvalExpectedVersion = suspension.approvalVersion,
+                        continuationExpectedVersion = suspension.continuationVersion,
+                        presentedToken = suspension.approvalToken,
+                        resumedBy = "admin",
+                    ),
+                )
+            }
+
+            assertThat(result).isEqualTo("Final result: success")
+            assertThat(toolB.executeCount.get()).isEqualTo(1)
+
+            val continuation = runBlocking { storesB.approvalContinuationStore.get(suspension.approvalId) }
+            assertThat(continuation).isNotNull
+            assertThat(continuation!!.status).isEqualTo(ApprovalContinuationStatus.COMPLETED)
+
+            val suspended = runBlocking { storesB.suspendedInvocationStore.get(suspension.approvalId) }
+            assertThat(suspended).isNull()
+
+            val auditEvents = runBlocking { storesB.auditStore.readStream(suspension.workflowRunId) }
+            assertThat(auditEvents).isNotEmpty
+        }
+    }
+
+    @Test
+    fun `resume fails closed when runtime B has not registered the suspended service and succeeds after registration`() {
+        val config = createConfig()
+        val toolA = RestartCalculatorTool()
+
+        val suspension = FileBackedSovereignStores.open(config).use { storesA ->
+            val engineA = createEngine(
+                provider = RestartTestProvider(),
+                toolRegistry = toolRegistryFor(toolA),
+                stores = storesA,
+            )
+            val exception = triggerSuspension(engineA)
+            val approved = approve(storesA, exception.approvalId)
+            SuspendedWorkflow(
+                approvalId = exception.approvalId,
+                approvalVersion = approved.version,
+                continuationVersion = exception.continuationVersion,
+                approvalToken = exception.challenge.token,
+                workflowRunId = exception.workflowRunId,
+            )
+        }
+
+        val toolB = RestartCalculatorTool()
+
+        FileBackedSovereignStores.open(config).use { storesB ->
+            val engineB = createEngine(
+                provider = RestartTestProvider(startingCallCount = 1),
+                toolRegistry = toolRegistryFor(toolB),
+                stores = storesB,
+            )
+
+            assertThatThrownBy {
+                runBlocking {
+                    engineB.resumeApproval(
+                        ResumeApprovalCommand(
+                            approvalId = suspension.approvalId,
+                            approvalExpectedVersion = suspension.approvalVersion,
+                            continuationExpectedVersion = suspension.continuationVersion,
+                            presentedToken = suspension.approvalToken,
+                            resumedBy = "admin",
+                        ),
+                    )
+                }
+            }.isInstanceOf(ConfigurationException::class.java)
+                .hasMessageContaining("resume-operation-not-registered")
+
+            val pending = runBlocking { storesB.approvalContinuationStore.get(suspension.approvalId) }
+            assertThat(pending).isNotNull
+            assertThat(pending!!.status).isEqualTo(ApprovalContinuationStatus.PENDING)
+            assertThat(toolB.executeCount.get()).isEqualTo(0)
+            assertThat(runBlocking { storesB.suspendedInvocationStore.get(suspension.approvalId) }).isNotNull
+
+            engineB.registerService(RestartTestService::class)
+
+            val result = runBlocking {
+                engineB.resumeApproval(
+                    ResumeApprovalCommand(
+                        approvalId = suspension.approvalId,
+                        approvalExpectedVersion = suspension.approvalVersion,
+                        continuationExpectedVersion = suspension.continuationVersion,
+                        presentedToken = suspension.approvalToken,
+                        resumedBy = "admin",
+                    ),
+                )
+            }
+
+            assertThat(result).isEqualTo("Final result: success")
+            assertThat(toolB.executeCount.get()).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `resume fails closed before token consumption when tool declaration drifts across restart`() {
+        val config = createConfig()
+        val toolA = RestartCalculatorTool()
+
+        val suspension = FileBackedSovereignStores.open(config).use { storesA ->
+            val engineA = createEngine(
+                provider = RestartTestProvider(),
+                toolRegistry = toolRegistryFor(toolA),
+                stores = storesA,
+            )
+            val exception = triggerSuspension(engineA)
+            val approved = approve(storesA, exception.approvalId)
+            SuspendedWorkflow(
+                approvalId = exception.approvalId,
+                approvalVersion = approved.version,
+                continuationVersion = exception.continuationVersion,
+                approvalToken = exception.challenge.token,
+                workflowRunId = exception.workflowRunId,
+            )
+        }
+
+        val driftedTool = RestartCalculatorTool(permission = "different.execute")
+
+        FileBackedSovereignStores.open(config).use { storesB ->
+            val engineB = createEngine(
+                provider = RestartTestProvider(),
+                toolRegistry = toolRegistryFor(driftedTool),
+                stores = storesB,
+            )
+            engineB.registerService(RestartTestService::class)
+
+            assertThatThrownBy {
+                runBlocking {
+                    engineB.resumeApproval(
+                        ResumeApprovalCommand(
+                            approvalId = suspension.approvalId,
+                            approvalExpectedVersion = suspension.approvalVersion,
+                            continuationExpectedVersion = suspension.continuationVersion,
+                            presentedToken = suspension.approvalToken,
+                            resumedBy = "admin",
+                        ),
+                    )
+                }
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("resume-tool-declaration-drift")
+
+            val continuation = runBlocking { storesB.approvalContinuationStore.get(suspension.approvalId) }
+            assertThat(continuation).isNotNull
+            assertThat(continuation!!.status).isEqualTo(ApprovalContinuationStatus.PENDING)
+            assertThat(driftedTool.executeCount.get()).isEqualTo(0)
+            assertThat(runBlocking { storesB.suspendedInvocationStore.get(suspension.approvalId) }).isNotNull
+        }
+    }
+
+    @Test
+    fun `resume fails closed before token consumption when operation definition drifts across restart`() {
+        val config = createConfig()
+        val serviceName = "dev.tramai.persistence.file.DynamicRestartService"
+        val toolA = RestartCalculatorTool()
+
+        val suspension = FileBackedSovereignStores.open(config).use { storesA ->
+            val serviceA = compileDynamicService(
+                fqcn = serviceName,
+                model = "test-model",
+            )
+            val engineA = createEngine(
+                provider = RestartTestProvider(),
+                toolRegistry = toolRegistryFor(toolA),
+                stores = storesA,
+            )
+            val exception = triggerDynamicSuspension(engineA, serviceA)
+            val approved = approve(storesA, exception.approvalId)
+            SuspendedWorkflow(
+                approvalId = exception.approvalId,
+                approvalVersion = approved.version,
+                continuationVersion = exception.continuationVersion,
+                approvalToken = exception.challenge.token,
+                workflowRunId = exception.workflowRunId,
+            )
+        }
+
+        val toolB = RestartCalculatorTool()
+
+        FileBackedSovereignStores.open(config).use { storesB ->
+            val serviceB = compileDynamicService(
+                fqcn = serviceName,
+                model = "changed-model",
+            )
+            val engineB = createEngine(
+                provider = RestartTestProvider(),
+                toolRegistry = toolRegistryFor(toolB),
+                stores = storesB,
+            )
+            engineB.registerService(serviceB)
+
+            assertThatThrownBy {
+                runBlocking {
+                    engineB.resumeApproval(
+                        ResumeApprovalCommand(
+                            approvalId = suspension.approvalId,
+                            approvalExpectedVersion = suspension.approvalVersion,
+                            continuationExpectedVersion = suspension.continuationVersion,
+                            presentedToken = suspension.approvalToken,
+                            resumedBy = "admin",
+                        ),
+                    )
+                }
+            }.isInstanceOf(ConfigurationException::class.java)
+                .hasMessageContaining("resume-operation-definition-drift")
+
+            val continuation = runBlocking { storesB.approvalContinuationStore.get(suspension.approvalId) }
+            assertThat(continuation).isNotNull
+            assertThat(continuation!!.status).isEqualTo(ApprovalContinuationStatus.PENDING)
+            assertThat(toolB.executeCount.get()).isEqualTo(0)
+            assertThat(runBlocking { storesB.suspendedInvocationStore.get(suspension.approvalId) }).isNotNull
+        }
+    }
+
+    private fun createConfig() = FileBackedStoreConfiguration(
+        rootDirectory = rootDir,
+        encryption = FileStoreEncryptionConfiguration(
+            activeKeyId = "restart-test-key",
+            keyProvider = keyProvider,
+        ),
+        verifyOnOpen = false,
+    )
+
+    private fun toolRegistryFor(tool: RestartCalculatorTool): ToolRegistry =
+        ToolRegistry(mapOf(tool.name to tool.toResolvedTool()))
+
+    private fun createEngine(
+        provider: ModelProvider,
+        toolRegistry: ToolRegistry,
+        stores: FileBackedSovereignStores,
+    ): TramaiEngine {
+        val coordinator = DefaultApprovalGateCoordinator(
+            store = stores.approvalStore,
+            approvalIdGenerator = UuidApprovalIdGenerator(),
+            approvalTokenGenerator = SecureRandomApprovalTokenGenerator(),
+            approvalTokenDigester = Sha256ApprovalTokenDigester(),
+            clock = fixedClock,
+        )
+        val auditEmitter = AuditEngineApprovalLifecycleAuditEmitter(
+            AuditEngine(stores.auditStore, clock = fixedClock),
+        )
+        return TramaiEngine(
+            provider = provider,
+            toolRegistry = toolRegistry,
+            policyEngine = RestartPolicyEngine(),
+            suspendedInvocationStore = stores.suspendedInvocationStore,
+            approvalContinuationStore = stores.approvalContinuationStore,
+            toolArgumentsDigester = Sha256ToolArgumentsDigester(),
+            approvalGateCoordinator = coordinator,
+            approvalLifecycleAuditEmitter = auditEmitter,
+            clock = fixedClock,
+        )
+    }
+
+    private fun triggerSuspension(engine: TramaiEngine): ApprovalSuspendedException {
+        val proxy = engine.create<RestartTestService>()
+        return try {
+            runBlocking { proxy.calculate("test") }
+            fail("Expected ApprovalSuspendedException")
+        } catch (e: ApprovalSuspendedException) {
+            e
+        }
+    }
+
+    private fun approve(
+        stores: FileBackedSovereignStores,
+        approvalId: String,
+    ) = runBlocking {
+        val current = stores.approvalStore.get(approvalId)
+        requireNotNull(current) { "Expected approval request to exist" }
+        stores.approvalStore.transition(
+            approvalId = approvalId,
+            expectedVersion = current.version,
+            transition = ApprovalTransition.Approve(
+                decidedBy = "admin",
+                comment = "approved for restart test",
+            ),
+        )
+    }
+
+    private fun compileDynamicService(
+        fqcn: String,
+        model: String,
+    ): KClass<*> {
+        val compiler = checkNotNull(ToolProvider.getSystemJavaCompiler()) {
+            "JDK compiler is required for dynamic service drift tests"
+        }
+        val sourceRoot = Files.createTempDirectory(rootDir, "dynamic-service-src-")
+        val classesRoot = Files.createTempDirectory(rootDir, "dynamic-service-classes-")
+        val packageName = fqcn.substringBeforeLast('.')
+        val simpleName = fqcn.substringAfterLast('.')
+        val sourcePath = sourceRoot.resolve(fqcn.replace('.', '/') + ".java")
+        Files.createDirectories(sourcePath.parent)
+        Files.writeString(
+            sourcePath,
+            """
+            package $packageName;
+
+            import dev.tramai.core.annotations.AiService;
+            import dev.tramai.core.annotations.Operation;
+            import dev.tramai.core.annotations.SystemPrompt;
+
+            @AiService
+            @SystemPrompt("You are a helpful assistant.")
+            public interface $simpleName {
+                @Operation(
+                    prompt = "Execute the calculator tool",
+                    model = "$model",
+                    tools = {"restart_calculator"}
+                )
+                String calculate(String input);
+            }
+            """.trimIndent(),
+        )
+
+        compiler.getStandardFileManager(null, null, null).use { fileManager ->
+            val units = fileManager.getJavaFileObjects(sourcePath.toFile())
+            val classpath = System.getProperty("java.class.path")
+            val task = compiler.getTask(
+                null,
+                fileManager,
+                null,
+                listOf("-classpath", classpath, "-d", classesRoot.absolutePathString()),
+                null,
+                units,
+            )
+            check(task.call()) { "Failed to compile dynamic service $fqcn" }
+        }
+
+        val loader = URLClassLoader(arrayOf(classesRoot.toUri().toURL()), javaClass.classLoader)
+        return loader.loadClass(fqcn).kotlin
+    }
+
+    private fun triggerDynamicSuspension(
+        engine: TramaiEngine,
+        serviceType: KClass<*>,
+    ): ApprovalSuspendedException {
+        @Suppress("UNCHECKED_CAST")
+        val proxy = engine.create(serviceType as KClass<Any>)
+        val method = serviceType.java.getMethod("calculate", String::class.java)
+        val cause = try {
+            method.invoke(proxy, "test")
+            fail("Expected ApprovalSuspendedException")
+        } catch (e: Throwable) {
+            unwrapInvocationThrowable(e)
+        }
+        assertThat(cause).isInstanceOf(ApprovalSuspendedException::class.java)
+        return cause as ApprovalSuspendedException
+    }
+
+    private fun unwrapInvocationThrowable(throwable: Throwable): Throwable =
+        when (throwable) {
+            is InvocationTargetException -> throwable.targetException
+            else -> throwable
+        }
+
+    private data class SuspendedWorkflow(
+        val approvalId: String,
+        val approvalVersion: Long,
+        val continuationVersion: Long,
+        val approvalToken: dev.tramai.core.approval.ApprovalToken,
+        val workflowRunId: String,
+    )
+}

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStoreRestartTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStoreRestartTest.kt
@@ -192,58 +192,60 @@ class FileSuspendedInvocationStoreRestartTest {
         val toolA = RestartCalculatorTool()
 
         val suspension = FileBackedSovereignStores.open(config).use { storesA ->
-            val engineA = createEngine(
+            createEngine(
                 provider = providerA,
                 toolRegistry = toolRegistryFor(toolA),
                 stores = storesA,
-            )
-            val exception = triggerSuspension(engineA)
-            val approved = approve(storesA, exception.approvalId)
+            ).use { engineA ->
+                val exception = triggerSuspension(engineA)
+                val approved = approve(storesA, exception.approvalId)
 
-            SuspendedWorkflow(
-                approvalId = exception.approvalId,
-                approvalVersion = approved.version,
-                continuationVersion = exception.continuationVersion,
-                approvalToken = exception.challenge.token,
-                workflowRunId = exception.workflowRunId,
-            )
+                SuspendedWorkflow(
+                    approvalId = exception.approvalId,
+                    approvalVersion = approved.version,
+                    continuationVersion = exception.continuationVersion,
+                    approvalToken = exception.challenge.token,
+                    workflowRunId = exception.workflowRunId,
+                )
+            }
         }
 
         val providerB = RestartTestProvider(startingCallCount = 1)
         val toolB = RestartCalculatorTool()
 
         FileBackedSovereignStores.open(config).use { storesB ->
-            val engineB = createEngine(
+            createEngine(
                 provider = providerB,
                 toolRegistry = toolRegistryFor(toolB),
                 stores = storesB,
-            )
-            engineB.registerService(RestartTestService::class)
+            ).use { engineB ->
+                engineB.registerService(RestartTestService::class)
 
-            val result = runBlocking {
-                engineB.resumeApproval(
-                    ResumeApprovalCommand(
-                        approvalId = suspension.approvalId,
-                        approvalExpectedVersion = suspension.approvalVersion,
-                        continuationExpectedVersion = suspension.continuationVersion,
-                        presentedToken = suspension.approvalToken,
-                        resumedBy = "admin",
-                    ),
-                )
+                val result = runBlocking {
+                    engineB.resumeApproval(
+                        ResumeApprovalCommand(
+                            approvalId = suspension.approvalId,
+                            approvalExpectedVersion = suspension.approvalVersion,
+                            continuationExpectedVersion = suspension.continuationVersion,
+                            presentedToken = suspension.approvalToken,
+                            resumedBy = "admin",
+                        ),
+                    )
+                }
+
+                assertThat(result).isEqualTo("Final result: success")
+                assertThat(toolB.executeCount.get()).isEqualTo(1)
+
+                val continuation = runBlocking { storesB.approvalContinuationStore.get(suspension.approvalId) }
+                assertThat(continuation).isNotNull
+                assertThat(continuation!!.status).isEqualTo(ApprovalContinuationStatus.COMPLETED)
+
+                val suspended = runBlocking { storesB.suspendedInvocationStore.get(suspension.approvalId) }
+                assertThat(suspended).isNull()
+
+                val auditEvents = runBlocking { storesB.auditStore.readStream(suspension.workflowRunId) }
+                assertThat(auditEvents).isNotEmpty
             }
-
-            assertThat(result).isEqualTo("Final result: success")
-            assertThat(toolB.executeCount.get()).isEqualTo(1)
-
-            val continuation = runBlocking { storesB.approvalContinuationStore.get(suspension.approvalId) }
-            assertThat(continuation).isNotNull
-            assertThat(continuation!!.status).isEqualTo(ApprovalContinuationStatus.COMPLETED)
-
-            val suspended = runBlocking { storesB.suspendedInvocationStore.get(suspension.approvalId) }
-            assertThat(suspended).isNull()
-
-            val auditEvents = runBlocking { storesB.auditStore.readStream(suspension.workflowRunId) }
-            assertThat(auditEvents).isNotEmpty
         }
     }
 
@@ -253,33 +255,55 @@ class FileSuspendedInvocationStoreRestartTest {
         val toolA = RestartCalculatorTool()
 
         val suspension = FileBackedSovereignStores.open(config).use { storesA ->
-            val engineA = createEngine(
+            createEngine(
                 provider = RestartTestProvider(),
                 toolRegistry = toolRegistryFor(toolA),
                 stores = storesA,
-            )
-            val exception = triggerSuspension(engineA)
-            val approved = approve(storesA, exception.approvalId)
-            SuspendedWorkflow(
-                approvalId = exception.approvalId,
-                approvalVersion = approved.version,
-                continuationVersion = exception.continuationVersion,
-                approvalToken = exception.challenge.token,
-                workflowRunId = exception.workflowRunId,
-            )
+            ).use { engineA ->
+                val exception = triggerSuspension(engineA)
+                val approved = approve(storesA, exception.approvalId)
+                SuspendedWorkflow(
+                    approvalId = exception.approvalId,
+                    approvalVersion = approved.version,
+                    continuationVersion = exception.continuationVersion,
+                    approvalToken = exception.challenge.token,
+                    workflowRunId = exception.workflowRunId,
+                )
+            }
         }
 
         val toolB = RestartCalculatorTool()
 
         FileBackedSovereignStores.open(config).use { storesB ->
-            val engineB = createEngine(
+            createEngine(
                 provider = RestartTestProvider(startingCallCount = 1),
                 toolRegistry = toolRegistryFor(toolB),
                 stores = storesB,
-            )
+            ).use { engineB ->
+                assertThatThrownBy {
+                    runBlocking {
+                        engineB.resumeApproval(
+                            ResumeApprovalCommand(
+                                approvalId = suspension.approvalId,
+                                approvalExpectedVersion = suspension.approvalVersion,
+                                continuationExpectedVersion = suspension.continuationVersion,
+                                presentedToken = suspension.approvalToken,
+                                resumedBy = "admin",
+                            ),
+                        )
+                    }
+                }.isInstanceOf(ConfigurationException::class.java)
+                    .hasMessageContaining("resume-operation-not-registered")
 
-            assertThatThrownBy {
-                runBlocking {
+                val pending = runBlocking { storesB.approvalContinuationStore.get(suspension.approvalId) }
+                assertThat(pending).isNotNull
+                assertThat(pending!!.status).isEqualTo(ApprovalContinuationStatus.PENDING)
+                assertThat(toolB.executeCount.get()).isEqualTo(0)
+                assertThat(runBlocking { storesB.suspendedInvocationStore.get(suspension.approvalId) }).isNotNull
+
+                engineB.registerService(RestartTestService::class)
+
+                val result = runBlocking {
                     engineB.resumeApproval(
                         ResumeApprovalCommand(
                             approvalId = suspension.approvalId,
@@ -290,31 +314,10 @@ class FileSuspendedInvocationStoreRestartTest {
                         ),
                     )
                 }
-            }.isInstanceOf(ConfigurationException::class.java)
-                .hasMessageContaining("resume-operation-not-registered")
 
-            val pending = runBlocking { storesB.approvalContinuationStore.get(suspension.approvalId) }
-            assertThat(pending).isNotNull
-            assertThat(pending!!.status).isEqualTo(ApprovalContinuationStatus.PENDING)
-            assertThat(toolB.executeCount.get()).isEqualTo(0)
-            assertThat(runBlocking { storesB.suspendedInvocationStore.get(suspension.approvalId) }).isNotNull
-
-            engineB.registerService(RestartTestService::class)
-
-            val result = runBlocking {
-                engineB.resumeApproval(
-                    ResumeApprovalCommand(
-                        approvalId = suspension.approvalId,
-                        approvalExpectedVersion = suspension.approvalVersion,
-                        continuationExpectedVersion = suspension.continuationVersion,
-                        presentedToken = suspension.approvalToken,
-                        resumedBy = "admin",
-                    ),
-                )
+                assertThat(result).isEqualTo("Final result: success")
+                assertThat(toolB.executeCount.get()).isEqualTo(1)
             }
-
-            assertThat(result).isEqualTo("Final result: success")
-            assertThat(toolB.executeCount.get()).isEqualTo(1)
         }
     }
 
@@ -324,52 +327,54 @@ class FileSuspendedInvocationStoreRestartTest {
         val toolA = RestartCalculatorTool()
 
         val suspension = FileBackedSovereignStores.open(config).use { storesA ->
-            val engineA = createEngine(
+            createEngine(
                 provider = RestartTestProvider(),
                 toolRegistry = toolRegistryFor(toolA),
                 stores = storesA,
-            )
-            val exception = triggerSuspension(engineA)
-            val approved = approve(storesA, exception.approvalId)
-            SuspendedWorkflow(
-                approvalId = exception.approvalId,
-                approvalVersion = approved.version,
-                continuationVersion = exception.continuationVersion,
-                approvalToken = exception.challenge.token,
-                workflowRunId = exception.workflowRunId,
-            )
+            ).use { engineA ->
+                val exception = triggerSuspension(engineA)
+                val approved = approve(storesA, exception.approvalId)
+                SuspendedWorkflow(
+                    approvalId = exception.approvalId,
+                    approvalVersion = approved.version,
+                    continuationVersion = exception.continuationVersion,
+                    approvalToken = exception.challenge.token,
+                    workflowRunId = exception.workflowRunId,
+                )
+            }
         }
 
         val driftedTool = RestartCalculatorTool(permission = "different.execute")
 
         FileBackedSovereignStores.open(config).use { storesB ->
-            val engineB = createEngine(
+            createEngine(
                 provider = RestartTestProvider(),
                 toolRegistry = toolRegistryFor(driftedTool),
                 stores = storesB,
-            )
-            engineB.registerService(RestartTestService::class)
+            ).use { engineB ->
+                engineB.registerService(RestartTestService::class)
 
-            assertThatThrownBy {
-                runBlocking {
-                    engineB.resumeApproval(
-                        ResumeApprovalCommand(
-                            approvalId = suspension.approvalId,
-                            approvalExpectedVersion = suspension.approvalVersion,
-                            continuationExpectedVersion = suspension.continuationVersion,
-                            presentedToken = suspension.approvalToken,
-                            resumedBy = "admin",
-                        ),
-                    )
-                }
-            }.isInstanceOf(IllegalArgumentException::class.java)
-                .hasMessageContaining("resume-tool-declaration-drift")
+                assertThatThrownBy {
+                    runBlocking {
+                        engineB.resumeApproval(
+                            ResumeApprovalCommand(
+                                approvalId = suspension.approvalId,
+                                approvalExpectedVersion = suspension.approvalVersion,
+                                continuationExpectedVersion = suspension.continuationVersion,
+                                presentedToken = suspension.approvalToken,
+                                resumedBy = "admin",
+                            ),
+                        )
+                    }
+                }.isInstanceOf(IllegalArgumentException::class.java)
+                    .hasMessageContaining("resume-tool-declaration-drift")
 
-            val continuation = runBlocking { storesB.approvalContinuationStore.get(suspension.approvalId) }
-            assertThat(continuation).isNotNull
-            assertThat(continuation!!.status).isEqualTo(ApprovalContinuationStatus.PENDING)
-            assertThat(driftedTool.executeCount.get()).isEqualTo(0)
-            assertThat(runBlocking { storesB.suspendedInvocationStore.get(suspension.approvalId) }).isNotNull
+                val continuation = runBlocking { storesB.approvalContinuationStore.get(suspension.approvalId) }
+                assertThat(continuation).isNotNull
+                assertThat(continuation!!.status).isEqualTo(ApprovalContinuationStatus.PENDING)
+                assertThat(driftedTool.executeCount.get()).isEqualTo(0)
+                assertThat(runBlocking { storesB.suspendedInvocationStore.get(suspension.approvalId) }).isNotNull
+            }
         }
     }
 
@@ -384,20 +389,21 @@ class FileSuspendedInvocationStoreRestartTest {
                 fqcn = serviceName,
                 model = "test-model",
             )
-            val engineA = createEngine(
+            createEngine(
                 provider = RestartTestProvider(),
                 toolRegistry = toolRegistryFor(toolA),
                 stores = storesA,
-            )
-            val exception = triggerDynamicSuspension(engineA, serviceA)
-            val approved = approve(storesA, exception.approvalId)
-            SuspendedWorkflow(
-                approvalId = exception.approvalId,
-                approvalVersion = approved.version,
-                continuationVersion = exception.continuationVersion,
-                approvalToken = exception.challenge.token,
-                workflowRunId = exception.workflowRunId,
-            )
+            ).use { engineA ->
+                val exception = triggerDynamicSuspension(engineA, serviceA)
+                val approved = approve(storesA, exception.approvalId)
+                SuspendedWorkflow(
+                    approvalId = exception.approvalId,
+                    approvalVersion = approved.version,
+                    continuationVersion = exception.continuationVersion,
+                    approvalToken = exception.challenge.token,
+                    workflowRunId = exception.workflowRunId,
+                )
+            }
         }
 
         val toolB = RestartCalculatorTool()
@@ -407,33 +413,34 @@ class FileSuspendedInvocationStoreRestartTest {
                 fqcn = serviceName,
                 model = "changed-model",
             )
-            val engineB = createEngine(
+            createEngine(
                 provider = RestartTestProvider(),
                 toolRegistry = toolRegistryFor(toolB),
                 stores = storesB,
-            )
-            engineB.registerService(serviceB)
+            ).use { engineB ->
+                engineB.registerService(serviceB)
 
-            assertThatThrownBy {
-                runBlocking {
-                    engineB.resumeApproval(
-                        ResumeApprovalCommand(
-                            approvalId = suspension.approvalId,
-                            approvalExpectedVersion = suspension.approvalVersion,
-                            continuationExpectedVersion = suspension.continuationVersion,
-                            presentedToken = suspension.approvalToken,
-                            resumedBy = "admin",
-                        ),
-                    )
-                }
-            }.isInstanceOf(ConfigurationException::class.java)
-                .hasMessageContaining("resume-operation-definition-drift")
+                assertThatThrownBy {
+                    runBlocking {
+                        engineB.resumeApproval(
+                            ResumeApprovalCommand(
+                                approvalId = suspension.approvalId,
+                                approvalExpectedVersion = suspension.approvalVersion,
+                                continuationExpectedVersion = suspension.continuationVersion,
+                                presentedToken = suspension.approvalToken,
+                                resumedBy = "admin",
+                            ),
+                        )
+                    }
+                }.isInstanceOf(ConfigurationException::class.java)
+                    .hasMessageContaining("resume-operation-definition-drift")
 
-            val continuation = runBlocking { storesB.approvalContinuationStore.get(suspension.approvalId) }
-            assertThat(continuation).isNotNull
-            assertThat(continuation!!.status).isEqualTo(ApprovalContinuationStatus.PENDING)
-            assertThat(toolB.executeCount.get()).isEqualTo(0)
-            assertThat(runBlocking { storesB.suspendedInvocationStore.get(suspension.approvalId) }).isNotNull
+                val continuation = runBlocking { storesB.approvalContinuationStore.get(suspension.approvalId) }
+                assertThat(continuation).isNotNull
+                assertThat(continuation!!.status).isEqualTo(ApprovalContinuationStatus.PENDING)
+                assertThat(toolB.executeCount.get()).isEqualTo(0)
+                assertThat(runBlocking { storesB.suspendedInvocationStore.get(suspension.approvalId) }).isNotNull
+            }
         }
     }
 
@@ -552,8 +559,12 @@ class FileSuspendedInvocationStoreRestartTest {
             check(task.call()) { "Failed to compile dynamic service $fqcn" }
         }
 
-        val loader = URLClassLoader(arrayOf(classesRoot.toUri().toURL()), javaClass.classLoader)
-        return loader.loadClass(fqcn).kotlin
+        return URLClassLoader(
+            arrayOf(classesRoot.toUri().toURL()),
+            javaClass.classLoader,
+        ).use { loader ->
+            loader.loadClass(fqcn).kotlin
+        }
     }
 
     private fun triggerDynamicSuspension(

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStoreTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStoreTest.kt
@@ -26,12 +26,9 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.attribute.PosixFilePermissions
-import java.security.MessageDigest
-import java.util.Base64
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
 import kotlin.io.path.exists
@@ -394,7 +391,9 @@ class FileSuspendedInvocationStoreTest {
         assertEquals(createdMessages, revealedMessages)
         assertEquals(
             metadata.replayEnvelopeDigest,
-            computeReplayEnvelopeDigest(metadata.operationReference, revealedMessages),
+            ReplayEnvelopePersistenceCodec.computeReplayEnvelopeDigest(
+                metadata.operationReference, revealedMessages,
+            ),
         )
     }
 
@@ -454,7 +453,7 @@ class FileSuspendedInvocationStoreTest {
                 classificationSource = ClassificationSource.RULE_BASED,
             ),
             operationReference = operationReference,
-            replayEnvelopeDigest = computeReplayEnvelopeDigest(operationReference, messages),
+            replayEnvelopeDigest = ReplayEnvelopePersistenceCodec.computeReplayEnvelopeDigest(operationReference, messages),
             conversationId = "conversation-1",
             historySize = 1,
             tokenBudgetSnapshot = TokenBudgetSnapshot(
@@ -522,72 +521,5 @@ class FileSuspendedInvocationStoreTest {
             ).toJson(),
         )
         Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rw-------"))
-    }
-
-    private fun computeReplayEnvelopeDigest(
-        operationReference: ResumeOperationReference,
-        messages: List<Message>,
-    ): Sha256Digest {
-        val canonical = buildString {
-            appendField("service_interface", operationReference.serviceInterface)
-            append("method=").append(operationReference.methodName).append('\n')
-            append("jvm_descriptor=").append(operationReference.jvmMethodDescriptor).append('\n')
-            append("digest=").append(operationReference.resumeDefinitionDigest.value).append('\n')
-            append(encodeCanonicalMessages(messages))
-        }
-        val digest = MessageDigest.getInstance("SHA-256")
-            .digest(canonical.toByteArray(StandardCharsets.UTF_8))
-        val hex = digest.joinToString("") { "%02x".format(it) }
-        return Sha256Digest.of("sha256:$hex")
-    }
-
-    private fun encodeCanonicalMessages(messages: List<Message>): String = buildString {
-        messages.forEachIndexed { index, message ->
-            if (index > 0) append("\n---\n")
-            append("role=").append(message.role.name).append('\n')
-            appendField("content", message.content)
-            append("parts_count=").append(message.contentParts?.size ?: 0).append('\n')
-            message.contentParts.orEmpty().forEachIndexed { partIndex, part ->
-                append("part_index=").append(partIndex).append('\n')
-                when (part) {
-                    is dev.tramai.core.model.ContentPart.TextPart -> {
-                        append("part_type=text\n")
-                        appendField("text", part.text)
-                    }
-                    is dev.tramai.core.model.ContentPart.ImagePart -> {
-                        append("part_type=image\n")
-                        appendField("mime", part.mimeType)
-                        appendField("data_b64", java.util.Base64.getEncoder().encodeToString(part.data))
-                    }
-                    is dev.tramai.core.model.ContentPart.ImageUrlContent -> {
-                        append("part_type=image_url\n")
-                        appendField("url", part.url)
-                        appendField("mime", part.mimeType)
-                    }
-                }
-            }
-            if (message.toolCallId != null) {
-                appendField("tool_call_id", message.toolCallId)
-            }
-            message.toolCalls?.let { toolCalls ->
-                append("tool_calls_count=").append(toolCalls.size).append('\n')
-                toolCalls.forEachIndexed { toolIndex, toolCall ->
-                    append("tool_call_index=").append(toolIndex).append('\n')
-                    appendField("tool_call_id", toolCall.id)
-                    appendField("tool_call_name", toolCall.name)
-                    appendField("tool_call_args", toolCall.argumentsJson)
-                }
-            }
-        }
-    }
-
-    private fun StringBuilder.appendField(name: String, value: String?) {
-        if (value == null) {
-            append(name).append("_null\n")
-            return
-        }
-        val bytes = value.toByteArray(StandardCharsets.UTF_8)
-        append(name).append("_len=").append(bytes.size).append('\n')
-        append(value).append('\n')
     }
 }

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStoreTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStoreTest.kt
@@ -1,0 +1,593 @@
+package dev.tramai.persistence.file
+
+import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
+import dev.tramai.core.model.ToolCall
+import dev.tramai.core.policy.ApprovalMode
+import dev.tramai.core.policy.AuditDetail
+import dev.tramai.core.policy.ClassificationSource
+import dev.tramai.core.policy.CompatibilityMode
+import dev.tramai.core.policy.DataClassification
+import dev.tramai.core.policy.ManagedNetworkEgress
+import dev.tramai.core.policy.RiskLevel
+import dev.tramai.core.policy.ToolSecurityMetadata
+import dev.tramai.engine.EngineExecutionIdentity
+import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.ResumeOperationReference
+import dev.tramai.engine.ResumeToolReference
+import dev.tramai.engine.SensitiveReplayEnvelope
+import dev.tramai.engine.SuspendedInvocationMetadata
+import dev.tramai.engine.TokenBudgetSnapshot
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermissions
+import java.security.MessageDigest
+import java.util.Base64
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class FileSuspendedInvocationStoreTest {
+
+    private val rootDir: Path = Files.createTempDirectory("tramai-suspended-test-").toAbsolutePath()
+
+    private fun testKey(): SecretKey =
+        KeyGenerator.getInstance("AES").apply { init(256) }.generateKey()
+
+    private val testKey = testKey()
+    private val keyProvider = FileStoreEncryptionKeyProvider { testKey }
+
+    private fun createConfig(
+        verifyOnOpen: Boolean = false,
+        keyProvider: FileStoreEncryptionKeyProvider = this.keyProvider,
+    ) = FileBackedStoreConfiguration(
+        rootDirectory = rootDir,
+        encryption = FileStoreEncryptionConfiguration(
+            activeKeyId = "test-key",
+            keyProvider = keyProvider,
+        ),
+        verifyOnOpen = verifyOnOpen,
+    )
+
+    private fun createStore(
+        key: SecretKey = testKey,
+        lease: FileStoreLease = FileStoreLease(),
+    ) = FileSuspendedInvocationStore(rootDir, key, createConfig(), lease)
+
+    @BeforeEach
+    fun setup() {
+        Files.createDirectories(rootDir.resolve("suspended"))
+        Files.setPosixFilePermissions(
+            rootDir.resolve("suspended"),
+            PosixFilePermissions.fromString("rwx------"),
+        )
+    }
+
+    @AfterEach
+    fun cleanup() {
+        if (rootDir.exists()) {
+            rootDir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `lifecycle create get reveal remove`() = runBlocking {
+        val store = createStore()
+        val (metadata, envelope) = createValidRecord()
+
+        store.create(metadata, envelope)
+
+        val retrieved = store.get(metadata.approvalId)
+        assertNotNull(retrieved)
+        assertEquals(metadata.approvalId, retrieved.approvalId)
+
+        val revealed = store.revealReplayEnvelope(metadata.approvalId)
+        assertNotNull(revealed)
+        assertEquals(
+            envelope.revealForResume().messages,
+            revealed.revealForResume().messages,
+        )
+
+        val removed = store.remove(metadata.approvalId)
+        assertNotNull(removed)
+        assertEquals(metadata.approvalId, removed.approvalId)
+        assertNull(store.get(metadata.approvalId))
+    }
+
+    @Test
+    fun `restart reopen preserves suspended invocation`() = runBlocking {
+        val (metadata, envelope) = createValidRecord()
+
+        createStore().create(metadata, envelope)
+
+        val reopened = createStore()
+        val retrieved = reopened.get(metadata.approvalId)
+        assertNotNull(retrieved)
+        assertEquals(metadata.approvalId, retrieved.approvalId)
+        assertNotNull(reopened.revealReplayEnvelope(metadata.approvalId))
+    }
+
+    @Test
+    fun `encrypted file does not expose sensitive plaintext`() = runBlocking {
+        val store = createStore()
+        val workflowRunId = "workflow-run-sensitive-123"
+        val correlationId = "corr-sensitive-456"
+        val promptSecret = "TOP-SECRET-PROMPT"
+        val (metadata, envelope) = createValidRecord(
+            approvalId = "approval-confidentiality-1",
+            workflowRunId = workflowRunId,
+            correlationId = correlationId,
+            promptSecret = promptSecret,
+        )
+
+        store.create(metadata, envelope)
+
+        val fileContent = recordPath(metadata.approvalId).readText()
+        assertFalse(fileContent.contains(promptSecret))
+        assertFalse(fileContent.contains("""{"accountId":"A-42","amount":99}"""))
+        assertFalse(fileContent.contains(workflowRunId))
+        assertFalse(fileContent.contains(correlationId))
+    }
+
+    @Test
+    fun `duplicate create rejected`() = runBlocking {
+        val store = createStore()
+        val (metadata, envelope) = createValidRecord()
+
+        store.create(metadata, envelope)
+
+        assertThrows<IllegalArgumentException> {
+            runBlocking { store.create(metadata, envelope) }
+        }
+    }
+
+    @Test
+    fun `wrong key rejects suspended invocation reads`() = runBlocking {
+        val store = createStore()
+        val (metadata, envelope) = createValidRecord()
+        store.create(metadata, envelope)
+
+        val wrongStore = createStore(key = testKey())
+
+        assertThrows<FileStoreCorruptionException> {
+            runBlocking { wrongStore.get(metadata.approvalId) }
+        }
+        assertThrows<FileStoreCorruptionException> {
+            runBlocking { wrongStore.revealReplayEnvelope(metadata.approvalId) }
+        }
+    }
+
+    @Test
+    fun `ciphertext tampering rejected`() = runBlocking {
+        val store = createStore()
+        val (metadata, envelope) = createValidRecord()
+        store.create(metadata, envelope)
+
+        val path = recordPath(metadata.approvalId)
+        val encrypted = EncryptedFileEnvelopeV1.fromJson(path.readText())
+        val corrupted = encrypted.copy(
+            ciphertextBase64 = encrypted.ciphertextBase64.dropLast(1) + "X",
+        )
+        Files.writeString(path, corrupted.toJson())
+
+        assertThrows<FileStoreCorruptionException> {
+            runBlocking { store.get(metadata.approvalId) }
+        }
+        assertThrows<FileStoreCorruptionException> {
+            runBlocking { store.revealReplayEnvelope(metadata.approvalId) }
+        }
+    }
+
+    @Test
+    fun `filename substitution rejected`() = runBlocking {
+        val store = createStore()
+        val (metadata, envelope) = createValidRecord(approvalId = "approval-substitution-a")
+        store.create(metadata, envelope)
+
+        val originalPath = recordPath(metadata.approvalId)
+        val substitutedApprovalId = "approval-substitution-b"
+        Files.move(originalPath, recordPath(substitutedApprovalId))
+
+        assertNull(store.get(metadata.approvalId))
+        assertThrows<FileStoreCorruptionException> {
+            runBlocking { store.get(substitutedApprovalId) }
+        }
+    }
+
+    @Test
+    fun `startup verification fails for corrupted suspended record`() = runBlocking {
+        val (metadata, envelope) = createValidRecord(approvalId = "approval-verify-open-1")
+        createStore().create(metadata, envelope)
+
+        val path = recordPath(metadata.approvalId)
+        val encrypted = EncryptedFileEnvelopeV1.fromJson(path.readText())
+        val corrupted = encrypted.copy(
+            ciphertextBase64 = encrypted.ciphertextBase64.dropLast(1) + "X",
+        )
+        Files.writeString(path, corrupted.toJson())
+
+        assertThrows<FileStoreCorruptionException> {
+            FileBackedSovereignStores.open(createConfig(verifyOnOpen = true))
+        }
+    }
+
+    @Test
+    fun `unexpected file in suspended directory rejected`() = runBlocking {
+        val store = createStore()
+        Files.writeString(rootDir.resolve("suspended/foo.txt"), "unexpected")
+
+        assertThrows<FileStoreCorruptionException> {
+            store.verifyAll()
+        }
+    }
+
+    @Test
+    fun `unexpected directory in suspended directory rejected`() = runBlocking {
+        val store = createStore()
+        Files.createDirectories(rootDir.resolve("suspended/extra"))
+
+        assertThrows<FileStoreCorruptionException> {
+            store.verifyAll()
+        }
+    }
+
+    @Test
+    fun `bad permissions on suspended file rejected`() = runBlocking {
+        val store = createStore()
+        val (metadata, envelope) = createValidRecord()
+        store.create(metadata, envelope)
+        Files.setPosixFilePermissions(recordPath(metadata.approvalId), PosixFilePermissions.fromString("rw-r--r--"))
+
+        assertThrows<FileStorePermissionException> {
+            runBlocking { store.get(metadata.approvalId) }
+        }
+        assertThrows<FileStorePermissionException> {
+            runBlocking { store.revealReplayEnvelope(metadata.approvalId) }
+        }
+    }
+
+    @Test
+    fun `symlinked suspended record file rejected`() = runBlocking {
+        val store = createStore()
+        val (metadata, envelope) = createValidRecord()
+        store.create(metadata, envelope)
+
+        val path = recordPath(metadata.approvalId)
+        val target = rootDir.resolve("symlink-target.bin")
+        Files.writeString(target, "not-a-record")
+        Files.delete(path)
+        Files.createSymbolicLink(path, target)
+
+        assertThrows<FileStorePermissionException> {
+            runBlocking { store.get(metadata.approvalId) }
+        }
+        assertThrows<FileStorePermissionException> {
+            store.verifyAll()
+        }
+    }
+
+    @Test
+    fun `symlinked suspended directory rejected`() = runBlocking {
+        val store = createStore()
+        val realDir = rootDir.resolve("external-suspended")
+        Files.createDirectories(realDir)
+        rootDir.resolve("suspended").toFile().deleteRecursively()
+        Files.createSymbolicLink(rootDir.resolve("suspended"), realDir)
+
+        assertThrows<FileStorePermissionException> {
+            runBlocking { store.get("approval-any") }
+        }
+        assertThrows<FileStorePermissionException> {
+            store.verifyAll()
+        }
+    }
+
+    @Test
+    fun `operations after lease close rejected`() = runBlocking {
+        val lease = FileStoreLease()
+        val store = createStore(lease = lease)
+        lease.close()
+
+        assertThrows<IllegalStateException> {
+            runBlocking { store.get("approval-closed") }
+        }
+        assertThrows<IllegalStateException> {
+            runBlocking { store.revealReplayEnvelope("approval-closed") }
+        }
+        assertThrows<IllegalStateException> {
+            runBlocking { store.remove("approval-closed") }
+        }
+    }
+
+    @Test
+    fun `concurrent creates have exactly one winner`() = runBlocking {
+        val store = createStore()
+        val (metadata, envelope) = createValidRecord(approvalId = "approval-concurrent-1")
+
+        coroutineScope {
+            val outcomes = listOf(
+                async {
+                    try {
+                        store.create(metadata, envelope)
+                        "winner"
+                    } catch (_: IllegalArgumentException) {
+                        "loser"
+                    }
+                },
+                async {
+                    try {
+                        store.create(metadata, envelope)
+                        "winner"
+                    } catch (_: IllegalArgumentException) {
+                        "loser"
+                    }
+                },
+            ).map { it.await() }
+
+            assertEquals(1, outcomes.count { it == "winner" })
+        }
+    }
+
+    @Test
+    fun `get and remove validate replay record before returning metadata or deleting`() = runBlocking {
+        val store = createStore()
+        val (metadata, envelope) = createValidRecord(approvalId = "approval-validated-read-1")
+        store.create(metadata, envelope)
+        corruptPersistedRecord(metadata.approvalId) { record ->
+            record.copy(
+                replayEnvelope = record.replayEnvelope.copy(
+                    messages = record.replayEnvelope.messages.mapIndexed { index, message ->
+                        if (index == 1) {
+                            message.copy(
+                                toolCalls = message.toolCalls?.map { it.copy(argumentsJson = """{"unsafe":true}""") },
+                            )
+                        } else {
+                            message
+                        }
+                    },
+                ),
+            )
+        }
+
+        assertThrows<FileStoreCorruptionException> {
+            runBlocking { store.get(metadata.approvalId) }
+        }
+        assertTrue(recordPath(metadata.approvalId).exists())
+
+        assertThrows<FileStoreCorruptionException> {
+            runBlocking { store.remove(metadata.approvalId) }
+        }
+        assertTrue(recordPath(metadata.approvalId).exists())
+        assertThrows<FileStoreCorruptionException> {
+            runBlocking { store.revealReplayEnvelope(metadata.approvalId) }
+        }
+    }
+
+    @Test
+    fun `cross module replay digest contract holds across persist and reveal`() = runBlocking {
+        val store = createStore()
+        val (metadata, envelope) = createValidRecord(approvalId = "approval-digest-contract-1")
+
+        val createdMessages = ReplayEnvelopePersistenceCodec.snapshotForPersistence(metadata, envelope)
+        store.create(metadata, envelope)
+
+        val reopened = createStore()
+        val restored = reopened.revealReplayEnvelope(metadata.approvalId)
+        assertNotNull(restored)
+
+        val revealedMessages = restored.revealForResume().messages
+        assertEquals(createdMessages, revealedMessages)
+        assertEquals(
+            metadata.replayEnvelopeDigest,
+            computeReplayEnvelopeDigest(metadata.operationReference, revealedMessages),
+        )
+    }
+
+    private fun createValidRecord(): Pair<SuspendedInvocationMetadata, SensitiveReplayEnvelope> =
+        createValidRecord(approvalId = "approval-valid-1")
+
+    private fun createValidRecord(
+        approvalId: String,
+        workflowRunId: String = "workflow-run-1",
+        correlationId: String = "correlation-1",
+        promptSecret: String = "review-sensitive-prompt",
+    ): Pair<SuspendedInvocationMetadata, SensitiveReplayEnvelope> {
+        val toolName = "sensitive_lookup"
+        val toolCallId = "tool-call-1"
+        val operationReference = ResumeOperationReference(
+            serviceInterface = "dev.tramai.persistence.file.SuspendedTestService",
+            methodName = "resume",
+            jvmMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/String;",
+            resumeDefinitionDigest = Sha256Digest.of(
+                "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+            ),
+        )
+        val messages = listOf(
+            Message(
+                role = MessageRole.USER,
+                content = "$promptSecret workflow=$workflowRunId correlation=$correlationId",
+            ),
+            Message(
+                role = MessageRole.ASSISTANT,
+                content = "",
+                toolCalls = listOf(
+                    ToolCall(
+                        id = toolCallId,
+                        name = toolName,
+                        argumentsJson = "__redacted_approval_continuation_args__",
+                    ),
+                ),
+            ),
+        )
+        val metadata = SuspendedInvocationMetadata(
+            approvalId = approvalId,
+            toolCallId = toolCallId,
+            toolName = toolName,
+            toolCallIndex = 0,
+            correlationId = correlationId,
+            identity = EngineExecutionIdentity(
+                workflowRunId = workflowRunId,
+                correlationId = correlationId,
+                workflowDigest = Sha256Digest.of(
+                    "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+                ),
+                policyVersion = "policy-v1",
+                actorId = "actor-1",
+            ),
+            securityContext = ExecutionSecurityContext(
+                dataClassification = DataClassification.CONFIDENTIAL,
+                classificationSource = ClassificationSource.RULE_BASED,
+            ),
+            operationReference = operationReference,
+            replayEnvelopeDigest = computeReplayEnvelopeDigest(operationReference, messages),
+            conversationId = "conversation-1",
+            historySize = 1,
+            tokenBudgetSnapshot = TokenBudgetSnapshot(
+                totalInputTokens = 10,
+                totalOutputTokens = 20,
+                totalInputCost = 0.1,
+                totalOutputCost = 0.2,
+                warnIfExceeded = true,
+            ),
+            toolReference = ResumeToolReference(
+                toolName = toolName,
+                declarationDigest = Sha256Digest.of(
+                    "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+                ),
+            ),
+            toolSecurity = ToolSecurityMetadata(
+                permission = "files.read",
+                risk = RiskLevel.MEDIUM,
+                approval = ApprovalMode.HUMAN_REQUIRED,
+                managedNetworkEgress = ManagedNetworkEgress.ALLOWLIST_ONLY,
+                audit = AuditDetail.FULL,
+                compatibilityMode = CompatibilityMode.STRICT,
+            ),
+        )
+        return metadata to SensitiveReplayEnvelope.of(messages)
+    }
+
+    private fun recordPath(approvalId: String): Path =
+        rootDir.resolve(
+            "suspended/${FileStoreSha256.digest("suspended-invocation", approvalId)}.tram.enc",
+        )
+
+    private fun corruptPersistedRecord(
+        approvalId: String,
+        mutate: (PersistedSuspendedInvocationRecordV1) -> PersistedSuspendedInvocationRecordV1,
+    ) {
+        val path = recordPath(approvalId)
+        val recordKeyDigest = FileStoreSha256.digest("suspended-invocation", approvalId)
+        val plaintext = FileStoreUtil.readAndDecrypt(
+            path,
+            "suspended-invocation",
+            recordKeyDigest,
+            testKey,
+            "test-key",
+        )
+        val mutated = mutate(
+            PersistedSuspendedInvocationRecordV1.fromJson(plaintext.toString(Charsets.UTF_8)),
+        )
+        val (nonceBase64, ciphertextBase64) = AesGcmFileEncryption.encrypt(
+            key = testKey,
+            recordType = "suspended-invocation",
+            recordKeyDigest = recordKeyDigest,
+            keyId = "test-key",
+            plaintextBytes = mutated.toJson().toByteArray(Charsets.UTF_8),
+        )
+        Files.writeString(
+            path,
+            EncryptedFileEnvelopeV1(
+                envelopeVersion = 1,
+                recordType = "suspended-invocation",
+                recordKeyDigest = recordKeyDigest,
+                keyId = "test-key",
+                nonceBase64 = nonceBase64,
+                ciphertextBase64 = ciphertextBase64,
+            ).toJson(),
+        )
+        Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rw-------"))
+    }
+
+    private fun computeReplayEnvelopeDigest(
+        operationReference: ResumeOperationReference,
+        messages: List<Message>,
+    ): Sha256Digest {
+        val canonical = buildString {
+            appendField("service_interface", operationReference.serviceInterface)
+            append("method=").append(operationReference.methodName).append('\n')
+            append("jvm_descriptor=").append(operationReference.jvmMethodDescriptor).append('\n')
+            append("digest=").append(operationReference.resumeDefinitionDigest.value).append('\n')
+            append(encodeCanonicalMessages(messages))
+        }
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest(canonical.toByteArray(StandardCharsets.UTF_8))
+        val hex = digest.joinToString("") { "%02x".format(it) }
+        return Sha256Digest.of("sha256:$hex")
+    }
+
+    private fun encodeCanonicalMessages(messages: List<Message>): String = buildString {
+        messages.forEachIndexed { index, message ->
+            if (index > 0) append("\n---\n")
+            append("role=").append(message.role.name).append('\n')
+            appendField("content", message.content)
+            append("parts_count=").append(message.contentParts?.size ?: 0).append('\n')
+            message.contentParts.orEmpty().forEachIndexed { partIndex, part ->
+                append("part_index=").append(partIndex).append('\n')
+                when (part) {
+                    is dev.tramai.core.model.ContentPart.TextPart -> {
+                        append("part_type=text\n")
+                        appendField("text", part.text)
+                    }
+                    is dev.tramai.core.model.ContentPart.ImagePart -> {
+                        append("part_type=image\n")
+                        appendField("mime", part.mimeType)
+                        appendField("data_b64", java.util.Base64.getEncoder().encodeToString(part.data))
+                    }
+                    is dev.tramai.core.model.ContentPart.ImageUrlContent -> {
+                        append("part_type=image_url\n")
+                        appendField("url", part.url)
+                        appendField("mime", part.mimeType)
+                    }
+                }
+            }
+            if (message.toolCallId != null) {
+                appendField("tool_call_id", message.toolCallId)
+            }
+            message.toolCalls?.let { toolCalls ->
+                append("tool_calls_count=").append(toolCalls.size).append('\n')
+                toolCalls.forEachIndexed { toolIndex, toolCall ->
+                    append("tool_call_index=").append(toolIndex).append('\n')
+                    appendField("tool_call_id", toolCall.id)
+                    appendField("tool_call_name", toolCall.name)
+                    appendField("tool_call_args", toolCall.argumentsJson)
+                }
+            }
+        }
+    }
+
+    private fun StringBuilder.appendField(name: String, value: String?) {
+        if (value == null) {
+            append(name).append("_null\n")
+            return
+        }
+        val bytes = value.toByteArray(StandardCharsets.UTF_8)
+        append(name).append("_len=").append(bytes.size).append('\n')
+        append(value).append('\n')
+    }
+}

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/PersistedDtosTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/PersistedDtosTest.kt
@@ -460,7 +460,10 @@ class PersistedDtosTest {
         val persistedRecord = PersistedSuspendedInvocationRecordV1(
             schemaVersion = 1,
             metadata = metadata.toPersistedV1(),
-            replayEnvelope = envelope.toPersistedV1(),
+            replayEnvelope = PersistedReplayEnvelopeV1(
+                schemaVersion = 1,
+                messages = envelope.revealForResume().messages.map { it.toPersistedV1() },
+            ),
         )
 
         val restoredRecord = PersistedSuspendedInvocationRecordV1.fromJson(persistedRecord.toJson())

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/PersistedDtosTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/PersistedDtosTest.kt
@@ -432,7 +432,7 @@ class PersistedDtosTest {
                 "sha256:2222222222222222222222222222222222222222222222222222222222222222",
             ),
             conversationId = "conversation-1",
-            historySize = 7,
+            historySize = 0,
             tokenBudgetSnapshot = TokenBudgetSnapshot(
                 totalInputTokens = 10,
                 totalOutputTokens = 20,

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/PersistedDtosTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/PersistedDtosTest.kt
@@ -6,12 +6,32 @@ import dev.tramai.core.approval.ApprovalContinuationStatus
 import dev.tramai.core.approval.ApprovalRequest
 import dev.tramai.core.approval.ApprovalStatus
 import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.model.ContentPart
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
+import dev.tramai.core.model.ToolCall
+import dev.tramai.core.policy.ApprovalMode
+import dev.tramai.core.policy.AuditDetail
+import dev.tramai.core.policy.ClassificationSource
+import dev.tramai.core.policy.CompatibilityMode
+import dev.tramai.core.policy.DataClassification
+import dev.tramai.core.policy.ManagedNetworkEgress
+import dev.tramai.core.policy.RiskLevel
+import dev.tramai.core.policy.ToolSecurityMetadata
+import dev.tramai.engine.EngineExecutionIdentity
+import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.ResumeOperationReference
+import dev.tramai.engine.ResumeToolReference
+import dev.tramai.engine.SensitiveReplayEnvelope
+import dev.tramai.engine.SuspendedInvocationMetadata
+import dev.tramai.engine.TokenBudgetSnapshot
 import dev.tramai.security.audit.AuditEvent
 import dev.tramai.security.audit.AuditHashAlgorithm
 import dev.tramai.security.audit.CURRENT_AUDIT_SCHEMA_VERSION
 import dev.tramai.security.audit.calculateHash
 import org.junit.jupiter.api.Test
 import java.time.Instant
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -357,5 +377,102 @@ class PersistedDtosTest {
         assertEquals(eventWithHash.eventHash, restored.eventHash)
         assertEquals(eventWithHash.metadata, restored.metadata)
         assertEquals(eventWithHash.timestamp, restored.timestamp)
+    }
+
+    @Test
+    fun `Suspended invocation DTOs round trip domain and json`() {
+        val messages = listOf(
+            Message(
+                role = MessageRole.USER,
+                content = "",
+                contentParts = listOf(
+                    ContentPart.TextPart("describe"),
+                    ContentPart.ImagePart("image/png", byteArrayOf(1, 2, 3, 4)),
+                    ContentPart.ImageUrlContent("https://example.com/x.png", "image/png"),
+                ),
+            ),
+            Message(
+                role = MessageRole.ASSISTANT,
+                content = "",
+                toolCalls = listOf(
+                    ToolCall(
+                        id = "call-1",
+                        name = "safeTool",
+                        argumentsJson = "__redacted_approval_continuation_args__",
+                    ),
+                ),
+            ),
+        )
+        val metadata = SuspendedInvocationMetadata(
+            approvalId = "approval-1",
+            toolCallId = "call-1",
+            toolName = "safeTool",
+            toolCallIndex = 0,
+            correlationId = "corr-1",
+            identity = EngineExecutionIdentity(
+                workflowRunId = "wf-1",
+                correlationId = "corr-1",
+                workflowDigest = testDigest,
+                policyVersion = "policy-v1",
+                actorId = "actor-1",
+            ),
+            securityContext = ExecutionSecurityContext(
+                dataClassification = DataClassification.CONFIDENTIAL,
+                classificationSource = ClassificationSource.RULE_BASED,
+            ),
+            operationReference = ResumeOperationReference(
+                serviceInterface = "dev.example.Service",
+                methodName = "run",
+                jvmMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/String;",
+                resumeDefinitionDigest = Sha256Digest.of(
+                    "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+                ),
+            ),
+            replayEnvelopeDigest = Sha256Digest.of(
+                "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+            ),
+            conversationId = "conversation-1",
+            historySize = 7,
+            tokenBudgetSnapshot = TokenBudgetSnapshot(
+                totalInputTokens = 10,
+                totalOutputTokens = 20,
+                totalInputCost = 0.1,
+                totalOutputCost = 0.2,
+                warnIfExceeded = true,
+            ),
+            toolReference = ResumeToolReference(
+                toolName = "safeTool",
+                declarationDigest = Sha256Digest.of(
+                    "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+                ),
+            ),
+            toolSecurity = ToolSecurityMetadata(
+                permission = "files.read",
+                risk = RiskLevel.MEDIUM,
+                approval = ApprovalMode.HUMAN_REQUIRED,
+                managedNetworkEgress = ManagedNetworkEgress.ALLOWLIST_ONLY,
+                audit = AuditDetail.FULL,
+                compatibilityMode = CompatibilityMode.STRICT,
+            ),
+        )
+        val envelope = SensitiveReplayEnvelope.of(messages)
+
+        val persistedRecord = PersistedSuspendedInvocationRecordV1(
+            schemaVersion = 1,
+            metadata = metadata.toPersistedV1(),
+            replayEnvelope = envelope.toPersistedV1(),
+        )
+
+        val restoredRecord = PersistedSuspendedInvocationRecordV1.fromJson(persistedRecord.toJson())
+        val restoredMetadata = restoredRecord.metadata.toDomain()
+        val restoredMessages = restoredRecord.replayEnvelope.toDomain().revealForResume().messages
+
+        assertEquals(metadata, restoredMetadata)
+        assertEquals(messages[0].role, restoredMessages[0].role)
+        assertEquals(messages[0].contentParts?.size, restoredMessages[0].contentParts?.size)
+        val restoredImage = restoredMessages[0].contentParts?.get(1) as ContentPart.ImagePart
+        assertContentEquals(byteArrayOf(1, 2, 3, 4), restoredImage.data)
+        assertEquals("safeTool", restoredMessages[1].toolCalls?.single()?.name)
+        assertEquals("__redacted_approval_continuation_args__", restoredMessages[1].toolCalls?.single()?.argumentsJson)
     }
 }


### PR DESCRIPTION
## Summary

Add the fourth encrypted file-backed sovereign store — `FileSuspendedInvocationStore` — implementing the `SuspendedInvocationStore` SPI with AES-256-GCM encryption, a trusted replay-envelope persistence bridge, full integration into `FileBackedSovereignStores`, and four restart-safe recovery integration tests.

## Changes

| File | Type | Description |
|------|------|-------------|
| `FileSuspendedInvocationStore.kt` | NEW | AES-256-GCM encrypted store with create-only persistence and startup verification |
| `ReplayEnvelopePersistenceCodec.kt` | NEW | Trusted bridge validating sentinel count, slot identity, digest binding, operation binding |
| `PersistedDtos.kt` | MODIFIED | +418 lines of V1 DTOs + bidirectional domain conversions for 12 engine types |
| `FileBackedSovereignStores.kt` | MODIFIED | Integrated 4th store: `suspended/` subdir, verifyOnOpen, shared lease |
| `build.gradle.kts` | MODIFIED | `api(project(":tramai-engine"))" — one-way dependency |
| `FileSuspendedInvocationStoreRestartTest.kt` | NEW | 4 restart-safe integration tests (589 lines) |
| Module docs, spec-016 | MODIFIED | Updated file layout, store count, deferred work numbering |

## Restart Tests

1. **Runtime A → Runtime B happy path**: Close stores, reopen with fresh engine, register service, resume. Proves exactly-once tool execution, COMPLETED continuation, removed suspended record, valid audit chain.
2. **Missing service registration**: Rejects before token consumption. Continuation stays PENDING, tool count 0. After `registerService`, succeeds.
3. **Tool declaration drift**: Changed security metadata causes rejection before consumption.
4. **Operation definition drift**: Changed model name causes rejection before consumption.

## Verification

```
./gradlew test --rerun-tasks                                                ✅ (130 tasks)
./gradlew :tramai-persistence-file:test --rerun-tasks                       ✅
./gradlew :tramai-engine:test --rerun-tasks                                 ✅
./gradlew :tramai-sovereign:test --rerun-tasks                              ✅
./gradlew :examples:sovereign-document-intelligence:test                    ✅
```

## Closes

Closes issue ref for PR #29