### PR TITLE
feat(security): verify local model artifacts against approved manifests

### DIFF
--- a/docs/board/tasks/task-pr30-local-model-artifact-verification.md
+++ b/docs/board/tasks/task-pr30-local-model-artifact-verification.md
@@ -1,7 +1,7 @@
 # Task PR #30 — Local-Model Artifact Manifest and Byte-Level Verification
 
 ## Status
-**Planned**
+**Merged** (squash commit onto master expected via PR #30)
 
 ## Branch
 `feat/local-model-artifact-verification`

--- a/docs/board/tasks/task-pr30-local-model-artifact-verification.md
+++ b/docs/board/tasks/task-pr30-local-model-artifact-verification.md
@@ -1,0 +1,119 @@
+# Task PR #30 — Local-Model Artifact Manifest and Byte-Level Verification
+
+## Status
+**Planned**
+
+## Branch
+`feat/local-model-artifact-verification`
+
+## Spec Cross-Reference
+SPEC-018: Local Model Artifact Verification
+
+## Summary
+Implement a local-model artifact verification layer that proves declared local artifact bytes match an approved cryptographic manifest before sovereign runtime use. Reuses the existing `RegisteredModel.artifactDigest` extension point.
+
+## File Changes
+
+### New files
+1. `tramai-core/.../LocalModelArtifactManifestV1.kt` — Manifest + file DTOs with aggregate digest computation
+2. `tramai-core/.../VerifiedLocalModelArtifact.kt` — Immutable verification receipt
+3. `tramai-core/.../ModelArtifactVerifier.kt` — SPI + NoOp default + settings
+4. `tramai-security/.../FileSystemModelArtifactVerifier.kt` — Strict streaming filesystem verifier
+5. `docs/board/tasks/task-pr30-local-model-artifact-verification.md` — this file
+
+### Modified files
+6. `tramai-sovereign/.../SovereignTramai.kt` — Add builder methods + build-time verification for LOCAL routes
+7. `tramai-core/.../RegisteredModel.kt` — Add Javadoc clarifying `artifactDigest` meaning (canonical manifest digest)
+8. `docs/modules/tramai-security.md` — Add verification section
+9. `docs/modules/tramai-sovereign.md` — Add builder API section
+10. `docs/specs/spec-018-local-model-artifact-verification.md` — this spec
+
+### Test files
+11. `tramai-core/.../LocalModelArtifactManifestV1Test.kt` — Manifest validation tests
+12. `tramai-security/.../FileSystemModelArtifactVerifierTest.kt` — Filesystem hardening tests
+13. `tramai-sovereign/.../SovereignTramaiArtifactVerificationTest.kt` — Runtime integration tests
+
+## Implementation Phases
+
+### Phase 1: Core Contracts (tramai-core)
+
+**Scope:** Domain models, SPI, manifest canonical bytes, validation utility
+
+**Acceptance criteria:**
+- [ ] Extract `validateField()` as a package-level utility function (reused by RegisteredModel, LocalModelArtifactManifestV1, LocalModelArtifactFileV1)
+- [ ] `LocalModelArtifactManifestV1` created with required `schemaVersion`, identity fields, artifact list, `canonicalBytes(): ByteArray` (UTF-8 encoded, no hashing)
+- [ ] `LocalModelArtifactFileV1` created with relative path, size, digest; validates no absolute/traversal paths
+- [ ] Manifest `init` validates: schemaVersion=1, non-blank IDs, non-empty artifacts, no duplicate paths (case-sensitive)
+- [ ] File DTO `init` validates: non-empty relative path, no absolute/`../` traversal, no control chars, non-negative size
+- [ ] `canonicalBytes()` produces deterministic UTF-8 byte output sorted by relativePath
+- [ ] `schemaVersion` is required (no default) to prevent aggregate-digest drift
+- [ ] `VerifiedLocalModelArtifact` data class with registryEntryId, manifestDigest, verifiedAt, artifactCount, totalSizeBytes
+- [ ] `ModelArtifactVerifier` interface with `suspend fun verify(RegisteredModel): VerifiedLocalModelArtifact?`
+- [ ] `NoOpModelArtifactVerifier` object (returns `null`, matching NoOpModelRegistry pattern)
+- [ ] `ModelArtifactVerificationSettings` data class with `enabled=false`, `requireDigestForLocalModels=false`
+- [ ] Manifest unit tests pass (10+ scenarios including canonicalBytes, empty artifacts, duplicate paths)
+- [ ] `./gradlew :tramai-core:test --rerun-tasks` green
+
+### Phase 2: Filesystem Verifier (tramai-security)
+
+**Scope:** Strict streaming filesystem model artifact verifier
+
+**Acceptance criteria:**
+- [ ] `FileSystemModelArtifactVerifier` created in `tramai.security.verification` package
+- [ ] Takes `allowedRootDirectories: Set<Path>`, `manifests: Map<String, LocalModelArtifactManifestV1>`, `clock: Clock`
+- [ ] No auto-discovery of manifests — receives parsed map at construction
+- [ ] Verifies: manifest lookup → identity drift check → aggregate digest check (SHA-256 of `manifest.canonicalBytes()`) → file-by-file streaming SHA-256
+- [ ] Filesystem hardening: rejects missing files, dir substitution, size mismatches, byte tampering
+- [ ] **Symlink policy**: resolves symlinks; rejects only if resolved path escapes allowed roots (allows symlinks within root)
+- [ ] Parent-chain symlink detection via `path.toRealPath() != path.toAbsolutePath().normalize()`
+- [ ] Streaming hashing with 64KB buffer; no full memory load for large files
+- [ ] `Math.addExact()` for `totalSizeBytes` to prevent integer overflow
+- [ ] Fixed safe exception codes only (no raw filesystem paths in messages)
+- [ ] UTF-8 encoding explicitly declared for canonical bytes
+- [ ] Filesystem hardening tests pass (12+ scenarios)
+- [ ] `./gradlew :tramai-security:test --rerun-tasks` green
+
+### Phase 3: Sovereign Runtime Binding (tramai-sovereign)
+
+**Scope:** Builder API extension, build-time verification for LOCAL routes
+
+**Acceptance criteria:**
+- [ ] `SovereignTramai.Builder` stores nullable `modelArtifactVerifier: ModelArtifactVerifier?` (not NoOp sentinel)
+- [ ] `SovereignTramai.Builder.modelArtifactVerifier(verifier)` method added (matches existing delegation pattern)
+- [ ] `SovereignTramai.Builder.modelArtifactVerificationSettings(settings)` method added
+- [ ] Defaults: `null`, `ModelArtifactVerificationSettings(enabled = false)`
+- [ ] `build()`: when enabled + verifier configured → use `runBlocking` to:
+  - Iterate `primaryModelRoutes`
+  - Lookup each via `modelRegistry.findApprovedModel(providerName, modelName)`
+  - Check trust zone from `profile.providerZones`
+  - For LOCAL zone: call `modelArtifactVerifier.verify(registeredModel)`, reject on failure
+- [ ] `requireDigestForLocalModels=true`: rejects LOCAL models without `artifactDigest`
+- [ ] CLOUD-zone models: skipped (existing behavior preserved)
+- [ ] Verification receipts stored on `SovereignTramai`, exposed via `verificationReceipts(): List<VerifiedLocalModelArtifact>`
+- [ ] No `verifyAll()` on runtime — receipts are build-time only
+- [ ] Verification disabled: backward-compatible behavior preserved
+- [ ] Sovereign runtime integration tests pass (8 scenarios)
+- [ ] `./gradlew :tramai-sovereign:test --rerun-tasks` green
+
+### Phase 4: Documentation
+
+**Scope:** Module docs, spec status update
+
+**Acceptance criteria:**
+- [ ] `docs/modules/tramai-security.md` updated with verification section
+- [ ] `docs/modules/tramai-sovereign.md` updated with builder API section
+- [ ] SPEC-018 status set to `implemented` after merge
+- [ ] Task doc status set to `Merged` after merge
+
+## Exit Criteria
+
+- [ ] All 3 test suites green: `tramai-core`, `tramai-security`, `tramai-sovereign`
+- [ ] Root test suite green: `./gradlew test --rerun-tasks`
+- [ ] Local model with valid manifest: runtime builds
+- [ ] Local model without digest when verification required: runtime rejects
+- [ ] Local model with unknown manifest: runtime rejects
+- [ ] Local model with modified bytes: runtime rejects before provider invocation
+- [ ] Cloud model without local artifact manifest: existing behavior preserved
+- [ ] Verification disabled: backward-compatible behavior preserved
+- [ ] No raw filesystem paths in exception messages
+- [ ] Streaming hashing for large files (no full memory load)

--- a/docs/board/tasks/task-pr30-local-model-artifact-verification.md
+++ b/docs/board/tasks/task-pr30-local-model-artifact-verification.md
@@ -50,7 +50,7 @@ Implement a local-model artifact verification layer that proves declared local a
 - [ ] `VerifiedLocalModelArtifact` data class with registryEntryId, manifestDigest, verifiedAt, artifactCount, totalSizeBytes
 - [ ] `ModelArtifactVerifier` interface with `suspend fun verify(RegisteredModel): VerifiedLocalModelArtifact?`
 - [ ] `NoOpModelArtifactVerifier` object (returns `null`, matching NoOpModelRegistry pattern)
-- [ ] `ModelArtifactVerificationSettings` data class with `enabled=false`, `requireDigestForLocalModels=false`
+- [ ] `ModelArtifactVerificationSettings` data class with `enabled=false`, `requireDigestForLocalModels=true`
 - [ ] Manifest unit tests pass (10+ scenarios including canonicalBytes, empty artifacts, duplicate paths)
 - [ ] `./gradlew :tramai-core:test --rerun-tasks` green
 
@@ -84,9 +84,9 @@ Implement a local-model artifact verification layer that proves declared local a
 - [ ] Defaults: `null`, `ModelArtifactVerificationSettings(enabled = false)`
 - [ ] `build()`: when enabled + verifier configured → use `runBlocking` to:
   - Iterate `primaryModelRoutes`
-  - Lookup each via `modelRegistry.findApprovedModel(providerName, modelName)`
-  - Check trust zone from `profile.providerZones`
-  - For LOCAL zone: call `modelArtifactVerifier.verify(registeredModel)`, reject on failure
+  - Lookup each via `modelRegistry.findApprovedModel(providerName, modelName)` *only after* trust zone confirms LOCAL
+  - Check trust zone from `profile.providerZones` first; skip CLOUD-zone providers without any registry access
+  - For LOCAL zone: call `modelRegistry.findApprovedModel(...)`, then `modelArtifactVerifier.verify(registeredModel)`, reject on failure
 - [ ] `requireDigestForLocalModels=true`: rejects LOCAL models without `artifactDigest`
 - [ ] CLOUD-zone models: skipped (existing behavior preserved)
 - [ ] Verification receipts stored on `SovereignTramai`, exposed via `verificationReceipts(): List<VerifiedLocalModelArtifact>`

--- a/docs/specs/spec-018-local-model-artifact-verification.md
+++ b/docs/specs/spec-018-local-model-artifact-verification.md
@@ -130,6 +130,7 @@ data class LocalModelArtifactFileV1(
 data class VerifiedLocalModelArtifact(
     val registryEntryId: String,
     val manifestDigest: ModelArtifactDigest,
+    val modelName: String,
     val verifiedAt: Instant,
     val artifactCount: Int,
     val totalSizeBytes: Long,  // computed with Math.addExact() to prevent overflow
@@ -147,18 +148,13 @@ interface ModelArtifactVerifier {
      * @throws IllegalArgumentException / IllegalStateException with fixed
      *   reason codes on any verification failure.
      */
-    suspend fun verify(registeredModel: RegisteredModel): VerifiedLocalModelArtifact
+    suspend fun verify(registeredModel: RegisteredModel): VerifiedLocalModelArtifact?
 }
-```
 
-### NoOpModelArtifactVerifier (matches NoOpModelRegistry pattern)
-
-```kotlin
 object NoOpModelArtifactVerifier : ModelArtifactVerifier {
     override suspend fun verify(registeredModel: RegisteredModel): VerifiedLocalModelArtifact? = null
 }
 ```
-
 Returns `null` to match the `NoOpModelRegistry.findApprovedModel()` returning `null` pattern. The `verify()` method has a nullable return type on the `NoOp` path.
 
 ### ModelArtifactVerificationSettings
@@ -166,11 +162,11 @@ Returns `null` to match the `NoOpModelRegistry.findApprovedModel()` returning `n
 ```kotlin
 data class ModelArtifactVerificationSettings(
     val enabled: Boolean = false,
-    val requireDigestForLocalModels: Boolean = false,
+    val requireDigestForLocalModels: Boolean = true,
 )
 ```
 
-`requireDigestForLocalModels` defaults to `false` to avoid breaking existing LOCAL providers that lack digest values. When both `enabled=true` and the verifier is configured, operators should set this to `true` for defense-in-depth.
+`requireDigestForLocalModels` defaults to `true` for secure default. Once an operator opts into verification (`enabled = true`), the secure default provides registry-pinned verification. Set to `false` for transitional mode: per-file bytes verified against the supplied manifest, but the registry does not cryptographically pin that manifest.
 
 ## RegisteredModel.artifactDigest Canonical Meaning
 
@@ -245,13 +241,11 @@ For each `verify(registeredModel)` call:
 
 ### Symlink Policy
 
-Allow symlinks whose resolved target is within an allowed root directory.
-Reject symlinks whose resolved target escapes all allowed roots.
+Strict policy: **reject all symlinks** in the artifact path or parent chain.
 
-Implementation: `Files.isSymbolicLink()` for direct symlink detection,
-`path.toRealPath() != path.toAbsolutePath().normalize()` for parent-chain
-symlink detection. TOCTOU: file replaced between symlink check and read
-is a known limitation (startup-only verification).
+Implementation: `path.toRealPath() != path.toAbsolutePath().normalize()` detects symlinks anywhere in the path chain without distinguishing file-level from parent-directory symlinks.
+
+A relaxed symlink mode (allow symlinks whose resolved target is within an allowed root) may be added later if a real deployment requires it.
 
 ### Streaming Hashing
 
@@ -272,7 +266,7 @@ Files.newInputStream(path).use { input ->
 | Threat | Defense |
 |--------|---------|
 | Path traversal | Reject absolute paths and paths escaping an allowed root |
-| Symlink substitution | Resolve symlinks; reject if resolved path escapes allowed roots |
+| Symlink substitution | Reject all symlinks (strict policy) |
 | Missing file | Reject |
 | Directory substituted for file | Reject |
 | Unexpected file size | Reject before and after hashing |
@@ -299,6 +293,7 @@ Fixed safe codes only:
 - `artifact-traversal-rejected`
 - `artifact-directory-substituted-for-file`
 - `artifact-not-a-regular-file`
+- `artifact-total-size-overflow`
 - `artifact-verification-not-configured`
 
 ## Sovereign Runtime Binding

--- a/docs/specs/spec-018-local-model-artifact-verification.md
+++ b/docs/specs/spec-018-local-model-artifact-verification.md
@@ -266,14 +266,18 @@ A relaxed symlink mode (allow symlinks whose resolved target is within an allowe
 ### Streaming Hashing
 
 ```kotlin
-Files.newInputStream(path).use { input ->
-    val digest = MessageDigest.getInstance("SHA-256")
-    val buffer = ByteArray(65536) // 64KB
-    while (true) {
-        val read = input.read(buffer)
-        if (read < 0) break
-        digest.update(buffer, 0, read)
+try {
+    Files.newInputStream(path).use { input ->
+        val digest = MessageDigest.getInstance("SHA-256")
+        val buffer = ByteArray(65536) // 64KB
+        while (true) {
+            val read = input.read(buffer)
+            if (read < 0) break
+            digest.update(buffer, 0, read)
+        }
     }
+} catch (_: Exception) {
+    error("artifact-file-access-failed")
 }
 ```
 
@@ -339,16 +343,14 @@ In `SovereignTramai.Builder.build()`:
 When `verificationSettings.enabled`:
 - `checkNotNull(modelArtifactVerifier)` — fail closed if verifier is missing
 - Use `runBlocking` (single blocking call at startup) to iterate **unique** (providerName, modelName) targets from primary AND fallback routes
-- For each: `modelRegistry.findApprovedModel(providerName, modelName)`
-- Check the provider's trust zone from `profile.providerZones`
-- For LOCAL-zone providers with `requireDigestForLocalModels == true`:
-  - Require `registeredModel.artifactDigest != null` (``IllegalStateException`` if missing)
-- For LOCAL-zone providers (any):
+- For each: check trust zone from `profile.providerZones` first
+- For CLOUD-zone providers: skip without touching the model registry
+- For LOCAL-zone providers: `modelRegistry.findApprovedModel(providerName, modelName)` then verify
+  - If `requireDigestForLocalModels == true`: require `registeredModel.artifactDigest != null` (``IllegalStateException`` if missing)
   - Call `modelArtifactVerifier.verify(registeredModel)`
   - Sanitize SPI exceptions through a fixed-code allowlist; drop arbitrary ModelRegistry SPI cause
   - If returns `null` or throws: fail `build()` with `IllegalStateException`
   - Collect receipts
-- For CLOUD-zone providers: skip artifact verification
 - Store receipts on `SovereignTramai` for the runtime lifetime
 
 ```kotlin
@@ -464,5 +466,5 @@ No `verifyAll()` on `SovereignTramaiRuntime` — it's on `SovereignTramai` only,
 | PR | Scope |
 |----|-------|
 | PR #29 | ✅ Encrypted suspended invocation store and restart-safe recovery |
-| PR #30 | 🔄 Local-model artifact manifest and byte-level verification |
+| PR #30 | ✅ Completed — local-model artifact manifest and byte-level verification |
 | PR #31 | Offline runtime profile and zero-egress verification harness |

--- a/docs/specs/spec-018-local-model-artifact-verification.md
+++ b/docs/specs/spec-018-local-model-artifact-verification.md
@@ -319,18 +319,19 @@ fun modelArtifactVerificationSettings(settings: ModelArtifactVerificationSetting
 
 In `SovereignTramai.Builder.build()`:
 
-When `verificationSettings.enabled && modelArtifactVerifier != null`:
-- Use `runBlocking` (single blocking call at startup) to:
-  - Iterate `primaryModelRoutes` (modelName → providerName)
-  - For each: `modelRegistry.findApprovedModel(providerName, modelName)`
-  - Check the provider's trust zone from `profile.providerZones`
-  - For LOCAL-zone providers with `requireDigestForLocalModels == true`:
-    - Require `registeredModel.artifactDigest != null` (``IllegalStateException`` if missing)
-  - For LOCAL-zone providers (any):
-    - Call `modelArtifactVerifier.verify(registeredModel)`
-    - If returns `null` or throws: fail `build()` with `IllegalStateException`
-    - Collect receipts
-  - For CLOUD-zone providers: skip artifact verification
+When `verificationSettings.enabled`:
+- `checkNotNull(modelArtifactVerifier)` — fail closed if verifier is missing
+- Use `runBlocking` (single blocking call at startup) to iterate **unique** (providerName, modelName) targets from primary AND fallback routes
+- For each: `modelRegistry.findApprovedModel(providerName, modelName)`
+- Check the provider's trust zone from `profile.providerZones`
+- For LOCAL-zone providers with `requireDigestForLocalModels == true`:
+  - Require `registeredModel.artifactDigest != null` (``IllegalStateException`` if missing)
+- For LOCAL-zone providers (any):
+  - Call `modelArtifactVerifier.verify(registeredModel)`
+  - Sanitize SPI exceptions through a fixed-code allowlist; drop arbitrary ModelRegistry SPI cause
+  - If returns `null` or throws: fail `build()` with `IllegalStateException`
+  - Collect receipts
+- For CLOUD-zone providers: skip artifact verification
 - Store receipts on `SovereignTramai` for the runtime lifetime
 
 ```kotlin

--- a/docs/specs/spec-018-local-model-artifact-verification.md
+++ b/docs/specs/spec-018-local-model-artifact-verification.md
@@ -1,0 +1,455 @@
+# SPEC-018: Local Model Artifact Verification
+
+**Status:** proposed
+**PR:** #30
+**Branch:** feat/local-model-artifact-verification
+
+## Problem Statement
+
+The approved-model registry (SPEC-017) validates configured provider–model identity and declared registry revision metadata. However, it does not cryptographically prove the deployed model bytes on disk.
+
+A declared `RegisteredModel` with `artifactDigest = sha256:abc...` is trusted as configured. The framework cannot yet prove:
+
+> *"The local artifact file(s) on this filesystem match the approved cryptographic manifest."*
+
+## Scope
+
+Implement a local model artifact verification layer that:
+
+1. Defines a versioned multi-file manifest contract (`LocalModelArtifactManifestV1`)
+2. Specifies the meaning of `RegisteredModel.artifactDigest` (canonical manifest digest, hashed at the security layer)
+3. Adds a `ModelArtifactVerifier` SPI in `tramai-core`
+4. Provides a strict `FileSystemModelArtifactVerifier` in `tramai-security`
+5. Binds verification to sovereign runtime build-time using `runBlocking` (single-block at startup)
+6. Produces an immutable `VerifiedLocalModelArtifact` receipt per verified model, stored on `SovereignTramai`
+
+## Non-Goals
+
+This PR does NOT implement:
+- Model downloads or remote registry synchronization
+- Cloud attestation, TPM integration, or GPU detection
+- Docker-image verification or Kubernetes admission control
+- Background filesystem watcher or periodic re-attestation
+- Ollama API introspection or automatic model-server launch
+- Zero-egress network harness or offline runtime composition
+- Proving an external inference server loaded the verified bytes
+
+### Known Limitation: TOCTOU Gap
+
+Artifact verification happens once at startup (build time). A file replaced between verification and first inference, or between inferences, is not detected. This is a conscious trade-off for startup-only verification. Deferred: periodic re-attestation and filesystem watchers.
+
+## Core Contracts (tramai-core)
+
+### Package-level field validation utility
+
+Extract the `validateField` logic from `RegisteredModel` into a package-level function:
+
+```kotlin
+internal fun validateField(fieldName: String, value: String) {
+    require(value.isNotBlank()) { "$fieldName must not be blank" }
+    require(value == value.trim()) { "$fieldName must not have surrounding whitespace" }
+    require(value.length <= 256) { "$fieldName must be at most 256 characters" }
+    require(value.none(Char::isISOControl)) { "$fieldName must not contain control characters" }
+}
+```
+
+Used by `RegisteredModel`, `LocalModelArtifactManifestV1`, and `LocalModelArtifactFileV1`.
+
+### LocalModelArtifactManifestV1
+
+```kotlin
+data class LocalModelArtifactManifestV1(
+    val schemaVersion: Int,  // NO default — required to prevent aggregate-digest drift
+    val registryEntryId: String,
+    val providerId: String,
+    val modelName: String,
+    val revision: String,
+    val artifacts: List<LocalModelArtifactFileV1>,
+) {
+    init {
+        require(schemaVersion == 1) { "Schema version must be 1" }
+        validateField("registryEntryId", registryEntryId)
+        validateField("providerId", providerId)
+        validateField("modelName", modelName)
+        validateField("revision", revision)
+        require(artifacts.isNotEmpty()) { "At least one artifact file is required" }
+        val paths = artifacts.map { it.relativePath }
+        require(paths.distinct().size == paths.size) {
+            "Duplicate artifact paths (case-sensitive comparison)"
+        }
+    }
+
+    /**
+     * Returns the canonical UTF-8 byte representation of this manifest
+     * for use by the security layer's aggregate digest computation.
+     */
+    fun canonicalBytes(): ByteArray {
+        val sb = StringBuilder()
+        sb.append("schemaVersion=").append(schemaVersion).append('\n')
+        sb.append("registryEntryId=").append(registryEntryId).append('\n')
+        sb.append("providerId=").append(providerId).append('\n')
+        sb.append("modelName=").append(modelName).append('\n')
+        sb.append("revision=").append(revision).append('\n')
+        sb.append("artifact_count=").append(artifacts.size).append('\n')
+        artifacts.sortedBy { it.relativePath }.forEach { artifact ->
+            sb.append("  relativePath=").append(artifact.relativePath).append('\n')
+            sb.append("  sizeBytes=").append(artifact.sizeBytes).append('\n')
+            sb.append("  digest=").append(artifact.digest.value).append('\n')
+        }
+        return sb.toString().toByteArray(Charsets.UTF_8)
+    }
+}
+```
+
+### LocalModelArtifactFileV1
+
+```kotlin
+data class LocalModelArtifactFileV1(
+    val relativePath: String,
+    val sizeBytes: Long,
+    val digest: ModelArtifactDigest,
+) {
+    init {
+        validateField("relativePath", relativePath)
+        require(relativePath.isNotEmpty()) { "Path must not be empty" }
+        require(!relativePath.startsWith("/")) { "Path must be relative (no absolute paths)" }
+        // Block both Unix ../ and Windows ..\ traversal
+        require(!relativePath.startsWith("..")) { "Path must not traverse upward" }
+        require(!relativePath.contains("/../") && !relativePath.contains("\\..\\")) {
+            "Path must not contain upward traversal"
+        }
+        require(relativePath.none(Char::isISOControl)) { "Path must not contain control characters" }
+        require(sizeBytes >= 0) { "sizeBytes must not be negative" }
+    }
+}
+```
+
+### VerifiedLocalModelArtifact
+
+```kotlin
+data class VerifiedLocalModelArtifact(
+    val registryEntryId: String,
+    val manifestDigest: ModelArtifactDigest,
+    val verifiedAt: Instant,
+    val artifactCount: Int,
+    val totalSizeBytes: Long,  // computed with Math.addExact() to prevent overflow
+)
+```
+
+### ModelArtifactVerifier SPI
+
+```kotlin
+interface ModelArtifactVerifier {
+    /**
+     * Verifies that all artifact files declared in the manifest for
+     * [registeredModel] match their expected digests and sizes.
+     *
+     * @throws IllegalArgumentException / IllegalStateException with fixed
+     *   reason codes on any verification failure.
+     */
+    suspend fun verify(registeredModel: RegisteredModel): VerifiedLocalModelArtifact
+}
+```
+
+### NoOpModelArtifactVerifier (matches NoOpModelRegistry pattern)
+
+```kotlin
+object NoOpModelArtifactVerifier : ModelArtifactVerifier {
+    override suspend fun verify(registeredModel: RegisteredModel): VerifiedLocalModelArtifact? = null
+}
+```
+
+Returns `null` to match the `NoOpModelRegistry.findApprovedModel()` returning `null` pattern. The `verify()` method has a nullable return type on the `NoOp` path.
+
+### ModelArtifactVerificationSettings
+
+```kotlin
+data class ModelArtifactVerificationSettings(
+    val enabled: Boolean = false,
+    val requireDigestForLocalModels: Boolean = false,
+)
+```
+
+`requireDigestForLocalModels` defaults to `false` to avoid breaking existing LOCAL providers that lack digest values. When both `enabled=true` and the verifier is configured, operators should set this to `true` for defense-in-depth.
+
+## RegisteredModel.artifactDigest Canonical Meaning
+
+`RegisteredModel.artifactDigest` stores the SHA-256 of the **canonical UTF-8 byte representation** of the `LocalModelArtifactManifestV1`, not the digest of any single file.
+
+The digest is computed in the security layer (not in tramai-core) by hashing `manifest.canonicalBytes()` with `MessageDigest.getInstance("SHA-256")`.
+
+Canonical input (UTF-8 encoded):
+
+```
+schemaVersion=1
+registryEntryId=<id>
+providerId=<id>
+modelName=<name>
+revision=<rev>
+artifact_count=<N>
+<sorted by relativePath:>
+  relativePath=<path>
+  sizeBytes=<N>
+  digest=<digest>
+  ... (repeat per artifact)
+```
+
+## ModelArtifactVerifier SPI (tramai-core)
+
+Defined in tramai-core for dependency reasons (tramai-sovereign depends on tramai-core, not tramai-security). Implementation in tramai-security.
+
+```kotlin
+interface ModelArtifactVerifier {
+    suspend fun verify(registeredModel: RegisteredModel): VerifiedLocalModelArtifact?
+}
+```
+
+`NoOpModelArtifactVerifier` returns `null` (not configured).
+
+## FileSystemModelArtifactVerifier (tramai-security)
+
+```kotlin
+class FileSystemModelArtifactVerifier(
+    private val allowedRootDirectories: Set<Path>,
+    private val manifests: Map<String, LocalModelArtifactManifestV1>,
+    private val clock: Clock = Clock.systemUTC(),
+) : ModelArtifactVerifier
+```
+
+### Manifest Loading
+
+The `manifests: Map<String, LocalModelArtifactManifestV1>` is populated at build time by the consumer. The expected source is a JSON file per registry entry, loaded by the application and deserialized. `FileSystemModelArtifactVerifier` does NOT auto-discover or load manifest files — it receives the parsed map.
+
+The application is responsible for:
+1. Defining a manifest JSON file for each LOCAL model (e.g., `manifests/registry-entry-id.json`)
+2. Loading and deserializing it to `LocalModelArtifactManifestV1`
+3. Constructing `FileSystemModelArtifactVerifier` with the map
+
+Future work may add auto-discovery from a convention-based directory.
+
+### Verification Algorithm
+
+For each `verify(registeredModel)` call:
+
+1. **Lookup manifest** by `registeredModel.registryEntryId` in `manifests`
+2. **Manifest identity drift check**: manifest's `registryEntryId`, `providerId`, `modelName`, `revision` must match the registered model
+3. **Aggregate digest check**: SHA-256 of `manifest.canonicalBytes()` must equal `registeredModel.artifactDigest.value`
+4. **Filesystem hardening**: for each artifact file path, try against each `allowedRootDirectory`:
+   - Resolve `root.resolve(relativePath)` and check it exists under the root (no traversal)
+   - Reject symlinks in the artifact path OR its parent chain by comparing `path.toRealPath()` with `path.toAbsolutePath().normalize()`
+   - Reject missing files
+   - Reject directories substituted for files
+   - Reject unexpected file size (checked before AND after hashing)
+   - Stream SHA-256 with 64KB buffer and compare against declared digest
+5. **Return** `VerifiedLocalModelArtifact` receipt with `Math.addExact()` for total size
+
+### Symlink Policy
+
+Allow symlinks whose resolved target is within an allowed root directory.
+Reject symlinks whose resolved target escapes all allowed roots.
+
+Implementation: `Files.isSymbolicLink()` for direct symlink detection,
+`path.toRealPath() != path.toAbsolutePath().normalize()` for parent-chain
+symlink detection. TOCTOU: file replaced between symlink check and read
+is a known limitation (startup-only verification).
+
+### Streaming Hashing
+
+```kotlin
+Files.newInputStream(path).use { input ->
+    val digest = MessageDigest.getInstance("SHA-256")
+    val buffer = ByteArray(65536) // 64KB
+    while (true) {
+        val read = input.read(buffer)
+        if (read < 0) break
+        digest.update(buffer, 0, read)
+    }
+}
+```
+
+### Filesystem Hardening Rules
+
+| Threat | Defense |
+|--------|---------|
+| Path traversal | Reject absolute paths and paths escaping an allowed root |
+| Symlink substitution | Resolve symlinks; reject if resolved path escapes allowed roots |
+| Missing file | Reject |
+| Directory substituted for file | Reject |
+| Unexpected file size | Reject before and after hashing |
+| Byte tampering | Stream SHA-256 and reject mismatch |
+| Duplicate paths | Reject manifest construction (case-sensitive) |
+| Blank or malformed paths | Reject |
+| Control characters | Reject |
+| Manifest identity drift | Reject |
+| Registry digest mismatch | Reject |
+| Integer overflow | `Math.addExact()` for `totalSizeBytes` |
+| Secret leakage | Fixed reason codes only; no raw filesystem paths in public exceptions |
+| UTF-8 encoding | Canonical bytes explicitly UTF-8; digest computed on UTF-8 bytes |
+
+### Exception Messages
+
+Fixed safe codes only:
+- `artifact-manifest-not-found`
+- `artifact-manifest-identity-drift`
+- `artifact-aggregate-digest-mismatch`
+- `artifact-file-not-found`
+- `artifact-file-symlink-rejected`
+- `artifact-parent-directory-symlink-rejected`
+- `artifact-file-size-mismatch`
+- `artifact-file-digest-mismatch`
+- `artifact-traversal-rejected`
+- `artifact-directory-substituted-for-file`
+- `artifact-verification-not-configured`
+
+## Sovereign Runtime Binding
+
+### Builder API Extension
+
+Add to `SovereignTramai.Builder`:
+
+```kotlin
+private var modelArtifactVerifier: ModelArtifactVerifier? = null
+private var verificationSettings: ModelArtifactVerificationSettings = ModelArtifactVerificationSettings()
+
+fun modelArtifactVerifier(verifier: ModelArtifactVerifier): Builder = apply {
+    this.modelArtifactVerifier = verifier
+}
+
+fun modelArtifactVerificationSettings(settings: ModelArtifactVerificationSettings): Builder = apply {
+    this.verificationSettings = settings
+}
+```
+
+### build() Behavior
+
+In `SovereignTramai.Builder.build()`:
+
+When `verificationSettings.enabled && modelArtifactVerifier != null`:
+- Use `runBlocking` (single blocking call at startup) to:
+  - Iterate `primaryModelRoutes` (modelName → providerName)
+  - For each: `modelRegistry.findApprovedModel(providerName, modelName)`
+  - Check the provider's trust zone from `profile.providerZones`
+  - For LOCAL-zone providers with `requireDigestForLocalModels == true`:
+    - Require `registeredModel.artifactDigest != null` (``IllegalStateException`` if missing)
+  - For LOCAL-zone providers (any):
+    - Call `modelArtifactVerifier.verify(registeredModel)`
+    - If returns `null` or throws: fail `build()` with `IllegalStateException`
+    - Collect receipts
+  - For CLOUD-zone providers: skip artifact verification
+- Store receipts on `SovereignTramai` for the runtime lifetime
+
+```kotlin
+// In build():
+private val verificationReceipts: List<VerifiedLocalModelArtifact> = ...
+```
+
+### Verification Timing
+
+- **Verify during sovereign runtime build** — single `runBlocking` call at startup
+- **Store receipts on `SovereignTramai`** — accessible via `receipts()` method
+- **Fail startup on mismatch** — framework refuses to start with compromised artifacts
+- **No rehashing on every inference** — receipts are immutable and retained for the runtime lifetime
+
+### Receipt Access
+
+```kotlin
+class SovereignTramai private constructor(
+    private val delegate: Tramai,
+    private val verificationReceipts: List<VerifiedLocalModelArtifact>,
+) {
+    /** Returns immutable verification receipts from build-time artifact verification. */
+    fun verificationReceipts(): List<VerifiedLocalModelArtifact> = verificationReceipts
+    // ...
+}
+```
+
+No `verifyAll()` on `SovereignTramaiRuntime` — it's on `SovereignTramai` only, populated at build time. Deferred: runtime re-verification as a follow-up capability.
+
+## Test Matrix
+
+### Manifest Tests (tramai-core)
+
+| Test | Expected |
+|------|----------|
+| Valid single-file GGUF-style artifact | Pass |
+| Valid multi-file artifact set | Pass |
+| Duplicate artifact path | Reject |
+| Blank path | Reject |
+| Absolute path | Reject |
+| `../` traversal | Reject |
+| Invalid schema version | Reject |
+| Manifest identity differs from registry identity | Reject |
+| Aggregate manifest digest mismatch | Reject |
+| `canonicalBytes()` produces deterministic UTF-8 output | Pass |
+| Missing artifact list (empty) | Reject |
+| `schemaVersion` required (no default) | Constructor must specify |
+
+### Filesystem Tests (tramai-security)
+
+| Test | Expected |
+|------|----------|
+| Correct bytes and size | Pass |
+| One modified byte | Reject |
+| File truncated | Reject |
+| Extra bytes appended | Reject |
+| Missing file | Reject |
+| Directory substitution | Reject |
+| Artifact symlink to allowed root | Pass (resolved path within root) |
+| Artifact symlink escaping allowed root | Reject |
+| Parent-directory symlink to allowed root | Pass (resolved path within root) |
+| Parent-directory symlink escaping allowed root | Reject |
+| Artifact outside allowed root | Reject |
+| Large artifact hashed incrementally | Pass without full-memory loading |
+| Empty file (0 bytes) | Pass |
+| `totalSizeBytes` overflow detection | `Math.addExact()` throws |
+| Error message contains no filesystem paths | Security test: only fixed codes |
+| Concurrent verification (same model, two threads) | Pass (suspend-safe reads) |
+
+### Sovereign Runtime Integration Tests (tramai-sovereign)
+
+| Test | Expected |
+|------|----------|
+| Local model with valid manifest | Runtime builds, receipts present |
+| Local model without digest when `requireDigestForLocalModels=true` | Runtime rejects |
+| Local model with unknown manifest | Runtime rejects |
+| Local model with modified bytes | Runtime rejects before provider invocation |
+| Cloud model without local artifact manifest | Existing behavior preserved |
+| Verification disabled (`enabled=false`) | Backward-compatible behavior preserved |
+| No verifier configured (default) | Backward-compatible behavior preserved |
+| Receipts accessible after build | `verificationReceipts()` returns non-empty list |
+
+## Module Changes
+
+### tramai-core
+- Extract `validateField()` as package-level utility function
+- Add `LocalModelArtifactManifestV1`, `LocalModelArtifactFileV1`
+- Add `VerifiedLocalModelArtifact`
+- Add `ModelArtifactVerifier` SPI
+- Add `NoOpModelArtifactVerifier` (returns `null`)
+- Add `ModelArtifactVerificationSettings`
+
+### tramai-security
+- Add `FileSystemModelArtifactVerifier`
+- Add `FileSystemModelArtifactVerifier` unit tests
+
+### tramai-sovereign
+- Add builder extension: `.modelArtifactVerifier()`, `.modelArtifactVerificationSettings()`
+- Wire verification into `build()` using `runBlocking` for LOCAL-zone routes
+- Store `verificationReceipts: List<VerifiedLocalModelArtifact>` on `SovereignTramai`
+- Expose `verificationReceipts()` method
+- Add integration tests
+
+## Documentation
+
+- `docs/specs/spec-018-local-model-artifact-verification.md` — this file
+- `docs/board/tasks/task-pr30-local-model-artifact-verification.md` — task tracking
+- `docs/modules/tramai-security.md` — add verification section
+- `docs/modules/tramai-sovereign.md` — add builder API + receipt section
+
+## Roadmap After PR #30
+
+| PR | Scope |
+|----|-------|
+| PR #29 | ✅ Encrypted suspended invocation store and restart-safe recovery |
+| PR #30 | 🔄 Local-model artifact manifest and byte-level verification |
+| PR #31 | Offline runtime profile and zero-egress verification harness |

--- a/docs/specs/spec-018-local-model-artifact-verification.md
+++ b/docs/specs/spec-018-local-model-artifact-verification.md
@@ -294,11 +294,11 @@ Fixed safe codes only:
 - `artifact-aggregate-digest-mismatch`
 - `artifact-file-not-found`
 - `artifact-file-symlink-rejected`
-- `artifact-parent-directory-symlink-rejected`
 - `artifact-file-size-mismatch`
 - `artifact-file-digest-mismatch`
 - `artifact-traversal-rejected`
 - `artifact-directory-substituted-for-file`
+- `artifact-not-a-regular-file`
 - `artifact-verification-not-configured`
 
 ## Sovereign Runtime Binding

--- a/docs/specs/spec-018-local-model-artifact-verification.md
+++ b/docs/specs/spec-018-local-model-artifact-verification.md
@@ -58,22 +58,25 @@ Used by `RegisteredModel`, `LocalModelArtifactManifestV1`, and `LocalModelArtifa
 ### LocalModelArtifactManifestV1
 
 ```kotlin
-data class LocalModelArtifactManifestV1(
+class LocalModelArtifactManifestV1(
     val schemaVersion: Int,  // NO default — required to prevent aggregate-digest drift
     val registryEntryId: String,
     val providerId: String,
     val modelName: String,
     val revision: String,
-    val artifacts: List<LocalModelArtifactFileV1>,
+    artifacts: List<LocalModelArtifactFileV1>,
 ) {
+    val artifacts: List<LocalModelArtifactFileV1> =
+        java.util.Collections.unmodifiableList(java.util.ArrayList(artifacts))
+
     init {
         require(schemaVersion == 1) { "Schema version must be 1" }
         validateField("registryEntryId", registryEntryId)
         validateField("providerId", providerId)
         validateField("modelName", modelName)
         validateField("revision", revision)
-        require(artifacts.isNotEmpty()) { "At least one artifact file is required" }
-        val paths = artifacts.map { it.relativePath }
+        require(this.artifacts.isNotEmpty()) { "At least one artifact file is required" }
+        val paths = this.artifacts.map { it.relativePath }
         require(paths.distinct().size == paths.size) {
             "Duplicate artifact paths (case-sensitive comparison)"
         }
@@ -112,13 +115,26 @@ data class LocalModelArtifactFileV1(
     init {
         validateField("relativePath", relativePath)
         require(relativePath.isNotEmpty()) { "Path must not be empty" }
-        require(!relativePath.startsWith("/")) { "Path must be relative (no absolute paths)" }
-        // Block both Unix ../ and Windows ..\ traversal
-        require(!relativePath.startsWith("..")) { "Path must not traverse upward" }
-        require(!relativePath.contains("/../") && !relativePath.contains("\\..\\")) {
+        require(!relativePath.startsWith("/")) { "Path must be relative (no Unix absolute paths)" }
+        require(!relativePath.startsWith("\\\\")) { "Path must be relative (no UNC paths)" }
+        require(relativePath.length < 2 || relativePath[1] != ':') {
+            "Path must be relative (no Windows drive prefixes)"
+        }
+        val normalized = relativePath.replace('\\\\', '/')
+        require(!normalized.startsWith("..")) { "Path must not traverse upward" }
+        require(!normalized.contains("/../") && !normalized.endsWith("/..")) {
             "Path must not contain upward traversal"
         }
-        require(relativePath.none(Char::isISOControl)) { "Path must not contain control characters" }
+        require(!normalized.contains("/./") && !normalized.startsWith("./") && normalized != ".") {
+            "Path must not contain self-reference segments"
+        }
+        require(!normalized.contains("//")) {
+            "Path must not contain empty segments (double slashes)"
+        }
+        require(normalized.none(Char::isISOControl)) { "Path must not contain control characters" }
+        require(normalized == relativePath) {
+            "Path must use forward-slash separator consistently"
+        }
         require(sizeBytes >= 0) { "sizeBytes must not be negative" }
     }
 }
@@ -290,6 +306,7 @@ Fixed safe codes only:
 - `artifact-file-symlink-rejected`
 - `artifact-file-size-mismatch`
 - `artifact-file-digest-mismatch`
+- `artifact-file-access-failed`
 - `artifact-traversal-rejected`
 - `artifact-directory-substituted-for-file`
 - `artifact-not-a-regular-file`

--- a/docs/specs/spec-018-local-model-artifact-verification.md
+++ b/docs/specs/spec-018-local-model-artifact-verification.md
@@ -1,6 +1,6 @@
 # SPEC-018: Local Model Artifact Verification
 
-**Status:** proposed
+**Status:** implemented (PR #30)
 **PR:** #30
 **Branch:** feat/local-model-artifact-verification
 

--- a/tramai-core/src/main/kotlin/dev/tramai/core/model/LocalModelArtifactFileV1.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/model/LocalModelArtifactFileV1.kt
@@ -1,0 +1,19 @@
+package dev.tramai.core.model
+
+data class LocalModelArtifactFileV1(
+    val relativePath: String,
+    val sizeBytes: Long,
+    val digest: ModelArtifactDigest,
+) {
+    init {
+        validateField("relativePath", relativePath)
+        require(relativePath.isNotEmpty()) { "Path must not be empty" }
+        require(!relativePath.startsWith("/")) { "Path must be relative (no absolute paths)" }
+        require(!relativePath.startsWith("..")) { "Path must not traverse upward" }
+        require(!relativePath.contains("/../") && !relativePath.contains("\\..\\")) {
+            "Path must not contain upward traversal"
+        }
+        require(relativePath.none(Char::isISOControl)) { "Path must not contain control characters" }
+        require(sizeBytes >= 0) { "sizeBytes must not be negative" }
+    }
+}

--- a/tramai-core/src/main/kotlin/dev/tramai/core/model/LocalModelArtifactFileV1.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/model/LocalModelArtifactFileV1.kt
@@ -8,12 +8,43 @@ data class LocalModelArtifactFileV1(
     init {
         validateField("relativePath", relativePath)
         require(relativePath.isNotEmpty()) { "Path must not be empty" }
-        require(!relativePath.startsWith("/")) { "Path must be relative (no absolute paths)" }
-        require(!relativePath.startsWith("..")) { "Path must not traverse upward" }
-        require(!relativePath.contains("/../") && !relativePath.contains("\\..\\")) {
+
+        // Reject absolute paths on all platforms
+        require(!relativePath.startsWith("/")) { "Path must be relative (no Unix absolute paths)" }
+        require(!relativePath.startsWith("\\\\")) { "Path must be relative (no UNC paths)" }
+
+        // Block Windows drive letters (C:\...)
+        require(relativePath.length < 2 || relativePath[1] != ':') {
+            "Path must be relative (no Windows drive prefixes)"
+        }
+
+        // Normalize to forward-slash representation
+        val normalized = relativePath.replace('\\', '/')
+
+        // Reject traversal
+        require(!normalized.startsWith("..")) { "Path must not traverse upward" }
+        require(!normalized.contains("/../") && !normalized.endsWith("/..")) {
             "Path must not contain upward traversal"
         }
-        require(relativePath.none(Char::isISOControl)) { "Path must not contain control characters" }
+
+        // Reject self-references
+        require(!normalized.contains("/./") && !normalized.startsWith("./") && normalized != ".") {
+            "Path must not contain self-reference segments"
+        }
+
+        // Reject empty segments (double slashes)
+        require(!normalized.contains("//")) {
+            "Path must not contain empty segments (double slashes)"
+        }
+
+        require(normalized.none(Char::isISOControl)) { "Path must not contain control characters" }
+
+        // Verify normalized representation is identical to declared Path
+        // This catches any path that resolves differently than written
+        require(normalized == relativePath) {
+            "Path must use forward-slash separator consistently"
+        }
+
         require(sizeBytes >= 0) { "sizeBytes must not be negative" }
     }
 }

--- a/tramai-core/src/main/kotlin/dev/tramai/core/model/LocalModelArtifactManifestV1.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/model/LocalModelArtifactManifestV1.kt
@@ -1,0 +1,39 @@
+package dev.tramai.core.model
+
+data class LocalModelArtifactManifestV1(
+    val schemaVersion: Int,
+    val registryEntryId: String,
+    val providerId: String,
+    val modelName: String,
+    val revision: String,
+    val artifacts: List<LocalModelArtifactFileV1>,
+) {
+    init {
+        require(schemaVersion == 1) { "Schema version must be 1" }
+        validateField("registryEntryId", registryEntryId)
+        validateField("providerId", providerId)
+        validateField("modelName", modelName)
+        validateField("revision", revision)
+        require(artifacts.isNotEmpty()) { "At least one artifact file is required" }
+        val paths = artifacts.map { it.relativePath }
+        require(paths.distinct().size == paths.size) {
+            "Duplicate artifact paths (case-sensitive comparison)"
+        }
+    }
+
+    fun canonicalBytes(): ByteArray {
+        val sb = StringBuilder()
+        sb.append("schemaVersion=").append(schemaVersion).append('\n')
+        sb.append("registryEntryId=").append(registryEntryId).append('\n')
+        sb.append("providerId=").append(providerId).append('\n')
+        sb.append("modelName=").append(modelName).append('\n')
+        sb.append("revision=").append(revision).append('\n')
+        sb.append("artifact_count=").append(artifacts.size).append('\n')
+        artifacts.sortedBy { it.relativePath }.forEach { artifact ->
+            sb.append("  relativePath=").append(artifact.relativePath).append('\n')
+            sb.append("  sizeBytes=").append(artifact.sizeBytes).append('\n')
+            sb.append("  digest=").append(artifact.digest.value).append('\n')
+        }
+        return sb.toString().toByteArray(Charsets.UTF_8)
+    }
+}

--- a/tramai-core/src/main/kotlin/dev/tramai/core/model/LocalModelArtifactManifestV1.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/model/LocalModelArtifactManifestV1.kt
@@ -1,16 +1,14 @@
 package dev.tramai.core.model
 
-data class LocalModelArtifactManifestV1(
+class LocalModelArtifactManifestV1(
     val schemaVersion: Int,
     val registryEntryId: String,
     val providerId: String,
     val modelName: String,
     val revision: String,
-    val artifacts: List<LocalModelArtifactFileV1>,
+    artifacts: List<LocalModelArtifactFileV1>,
 ) {
-    private val _artifacts: List<LocalModelArtifactFileV1> = artifacts.toList()
-
-    val safeArtifacts: List<LocalModelArtifactFileV1> get() = _artifacts
+    val artifacts: List<LocalModelArtifactFileV1> = artifacts.toList()
 
     init {
         require(schemaVersion == 1) { "Schema version must be 1" }
@@ -18,8 +16,8 @@ data class LocalModelArtifactManifestV1(
         validateField("providerId", providerId)
         validateField("modelName", modelName)
         validateField("revision", revision)
-        require(_artifacts.isNotEmpty()) { "At least one artifact file is required" }
-        val paths = _artifacts.map { it.relativePath }
+        require(this.artifacts.isNotEmpty()) { "At least one artifact file is required" }
+        val paths = this.artifacts.map { it.relativePath }
         require(paths.distinct().size == paths.size) {
             "Duplicate artifact paths (case-sensitive comparison)"
         }
@@ -32,8 +30,8 @@ data class LocalModelArtifactManifestV1(
         sb.append("providerId=").append(providerId).append('\n')
         sb.append("modelName=").append(modelName).append('\n')
         sb.append("revision=").append(revision).append('\n')
-        sb.append("artifact_count=").append(_artifacts.size).append('\n')
-        _artifacts.sortedBy { it.relativePath }.forEach { artifact ->
+        sb.append("artifact_count=").append(artifacts.size).append('\n')
+        artifacts.sortedBy { it.relativePath }.forEach { artifact ->
             sb.append("  relativePath=").append(artifact.relativePath).append('\n')
             sb.append("  sizeBytes=").append(artifact.sizeBytes).append('\n')
             sb.append("  digest=").append(artifact.digest.value).append('\n')

--- a/tramai-core/src/main/kotlin/dev/tramai/core/model/LocalModelArtifactManifestV1.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/model/LocalModelArtifactManifestV1.kt
@@ -1,5 +1,7 @@
 package dev.tramai.core.model
 
+import java.util.Collections
+
 class LocalModelArtifactManifestV1(
     val schemaVersion: Int,
     val registryEntryId: String,
@@ -8,7 +10,8 @@ class LocalModelArtifactManifestV1(
     val revision: String,
     artifacts: List<LocalModelArtifactFileV1>,
 ) {
-    val artifacts: List<LocalModelArtifactFileV1> = artifacts.toList()
+    val artifacts: List<LocalModelArtifactFileV1> =
+        Collections.unmodifiableList(ArrayList(artifacts))
 
     init {
         require(schemaVersion == 1) { "Schema version must be 1" }

--- a/tramai-core/src/main/kotlin/dev/tramai/core/model/LocalModelArtifactManifestV1.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/model/LocalModelArtifactManifestV1.kt
@@ -8,14 +8,18 @@ data class LocalModelArtifactManifestV1(
     val revision: String,
     val artifacts: List<LocalModelArtifactFileV1>,
 ) {
+    private val _artifacts: List<LocalModelArtifactFileV1> = artifacts.toList()
+
+    val safeArtifacts: List<LocalModelArtifactFileV1> get() = _artifacts
+
     init {
         require(schemaVersion == 1) { "Schema version must be 1" }
         validateField("registryEntryId", registryEntryId)
         validateField("providerId", providerId)
         validateField("modelName", modelName)
         validateField("revision", revision)
-        require(artifacts.isNotEmpty()) { "At least one artifact file is required" }
-        val paths = artifacts.map { it.relativePath }
+        require(_artifacts.isNotEmpty()) { "At least one artifact file is required" }
+        val paths = _artifacts.map { it.relativePath }
         require(paths.distinct().size == paths.size) {
             "Duplicate artifact paths (case-sensitive comparison)"
         }
@@ -28,8 +32,8 @@ data class LocalModelArtifactManifestV1(
         sb.append("providerId=").append(providerId).append('\n')
         sb.append("modelName=").append(modelName).append('\n')
         sb.append("revision=").append(revision).append('\n')
-        sb.append("artifact_count=").append(artifacts.size).append('\n')
-        artifacts.sortedBy { it.relativePath }.forEach { artifact ->
+        sb.append("artifact_count=").append(_artifacts.size).append('\n')
+        _artifacts.sortedBy { it.relativePath }.forEach { artifact ->
             sb.append("  relativePath=").append(artifact.relativePath).append('\n')
             sb.append("  sizeBytes=").append(artifact.sizeBytes).append('\n')
             sb.append("  digest=").append(artifact.digest.value).append('\n')

--- a/tramai-core/src/main/kotlin/dev/tramai/core/model/ModelArtifactVerificationSettings.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/model/ModelArtifactVerificationSettings.kt
@@ -2,5 +2,5 @@ package dev.tramai.core.model
 
 data class ModelArtifactVerificationSettings(
     val enabled: Boolean = false,
-    val requireDigestForLocalModels: Boolean = false,
+    val requireDigestForLocalModels: Boolean = true,
 )

--- a/tramai-core/src/main/kotlin/dev/tramai/core/model/ModelArtifactVerificationSettings.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/model/ModelArtifactVerificationSettings.kt
@@ -1,0 +1,6 @@
+package dev.tramai.core.model
+
+data class ModelArtifactVerificationSettings(
+    val enabled: Boolean = false,
+    val requireDigestForLocalModels: Boolean = false,
+)

--- a/tramai-core/src/main/kotlin/dev/tramai/core/model/ModelArtifactVerifier.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/model/ModelArtifactVerifier.kt
@@ -1,0 +1,9 @@
+package dev.tramai.core.model
+
+interface ModelArtifactVerifier {
+    suspend fun verify(registeredModel: RegisteredModel): VerifiedLocalModelArtifact?
+}
+
+object NoOpModelArtifactVerifier : ModelArtifactVerifier {
+    override suspend fun verify(registeredModel: RegisteredModel): VerifiedLocalModelArtifact? = null
+}

--- a/tramai-core/src/main/kotlin/dev/tramai/core/model/ModelFieldValidation.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/model/ModelFieldValidation.kt
@@ -1,0 +1,8 @@
+package dev.tramai.core.model
+
+internal fun validateField(fieldName: String, value: String) {
+    require(value.isNotBlank()) { "$fieldName must not be blank" }
+    require(value == value.trim()) { "$fieldName must not have surrounding whitespace" }
+    require(value.length <= 256) { "$fieldName must be at most 256 characters" }
+    require(value.none(Char::isISOControl)) { "$fieldName must not contain control characters" }
+}

--- a/tramai-core/src/main/kotlin/dev/tramai/core/model/RegisteredModel.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/model/RegisteredModel.kt
@@ -14,11 +14,4 @@ data class RegisteredModel(
         validateField("modelName", modelName)
         validateField("revision", revision)
     }
-
-    private fun validateField(fieldName: String, value: String) {
-        require(value.isNotBlank()) { "$fieldName must not be blank" }
-        require(value == value.trim()) { "$fieldName must not have surrounding whitespace" }
-        require(value.length <= 256) { "$fieldName must be at most 256 characters" }
-        require(value.none(Char::isISOControl)) { "$fieldName must not contain control characters" }
-    }
 }

--- a/tramai-core/src/main/kotlin/dev/tramai/core/model/VerifiedLocalModelArtifact.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/model/VerifiedLocalModelArtifact.kt
@@ -1,0 +1,12 @@
+package dev.tramai.core.model
+
+import java.time.Instant
+
+data class VerifiedLocalModelArtifact(
+    val registryEntryId: String,
+    val manifestDigest: ModelArtifactDigest,
+    val modelName: String,
+    val verifiedAt: Instant,
+    val artifactCount: Int,
+    val totalSizeBytes: Long,
+)

--- a/tramai-core/src/test/kotlin/dev/tramai/core/model/LocalModelArtifactFileV1Test.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/model/LocalModelArtifactFileV1Test.kt
@@ -51,6 +51,36 @@ class LocalModelArtifactFileV1Test {
         assertInvalidPath("models/\nmodel.gguf")
     }
 
+    @Test
+    fun `Windows drive prefix is rejected`() {
+        assertInvalidPath("C:/models/model.gguf")
+    }
+
+    @Test
+    fun `UNC path is rejected`() {
+        assertInvalidPath("\\\\server\\share\\model.gguf")
+    }
+
+    @Test
+    fun `backslash separator is rejected`() {
+        assertInvalidPath("models\\model.gguf")
+    }
+
+    @Test
+    fun `self reference segment is rejected`() {
+        assertInvalidPath("models/./model.gguf")
+    }
+
+    @Test
+    fun `double slash is rejected`() {
+        assertInvalidPath("models//model.gguf")
+    }
+
+    @Test
+    fun `trailing double-dot is rejected`() {
+        assertInvalidPath("models/..")
+    }
+
     private fun assertInvalidPath(path: String) {
         assertThatThrownBy {
             LocalModelArtifactFileV1(

--- a/tramai-core/src/test/kotlin/dev/tramai/core/model/LocalModelArtifactFileV1Test.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/model/LocalModelArtifactFileV1Test.kt
@@ -1,0 +1,64 @@
+package dev.tramai.core.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import kotlin.test.Test
+
+class LocalModelArtifactFileV1Test {
+
+    @Test
+    fun `valid dto constructs value`() {
+        val file = LocalModelArtifactFileV1(
+            relativePath = "models/model.gguf",
+            sizeBytes = 42L,
+            digest = ModelArtifactDigest.of("sha256:${"a".repeat(64)}"),
+        )
+
+        assertThat(file.relativePath).isEqualTo("models/model.gguf")
+        assertThat(file.sizeBytes).isEqualTo(42L)
+        assertThat(file.digest.value).isEqualTo("sha256:${"a".repeat(64)}")
+    }
+
+    @Test
+    fun `blank path is rejected`() {
+        assertInvalidPath(" ")
+    }
+
+    @Test
+    fun `absolute path is rejected`() {
+        assertInvalidPath("/models/model.gguf")
+    }
+
+    @Test
+    fun `traversal path is rejected`() {
+        assertInvalidPath("../models/model.gguf")
+    }
+
+    @Test
+    fun `negative sizeBytes is rejected`() {
+        assertThatThrownBy {
+            LocalModelArtifactFileV1(
+                relativePath = "models/model.gguf",
+                sizeBytes = -1L,
+                digest = ModelArtifactDigest.of("sha256:${"a".repeat(64)}"),
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("sizeBytes")
+    }
+
+    @Test
+    fun `control chars are rejected`() {
+        assertInvalidPath("models/\nmodel.gguf")
+    }
+
+    private fun assertInvalidPath(path: String) {
+        assertThatThrownBy {
+            LocalModelArtifactFileV1(
+                relativePath = path,
+                sizeBytes = 1L,
+                digest = ModelArtifactDigest.of("sha256:${"a".repeat(64)}"),
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Path")
+    }
+}

--- a/tramai-core/src/test/kotlin/dev/tramai/core/model/LocalModelArtifactManifestV1Test.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/model/LocalModelArtifactManifestV1Test.kt
@@ -1,0 +1,180 @@
+package dev.tramai.core.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import kotlin.test.Test
+
+class LocalModelArtifactManifestV1Test {
+
+    @Test
+    fun `valid single file manifest constructs canonical bytes`() {
+        val manifest = LocalModelArtifactManifestV1(
+            schemaVersion = 1,
+            registryEntryId = "entry-1",
+            providerId = "provider-1",
+            modelName = "model-1",
+            revision = "rev-1",
+            artifacts = listOf(
+                artifact("models/model-a.gguf", 10L, "a"),
+            ),
+        )
+
+        assertThat(manifest.canonicalBytes().toString(Charsets.UTF_8)).isEqualTo(
+            """
+            schemaVersion=1
+            registryEntryId=entry-1
+            providerId=provider-1
+            modelName=model-1
+            revision=rev-1
+            artifact_count=1
+              relativePath=models/model-a.gguf
+              sizeBytes=10
+              digest=sha256:${"a".repeat(64)}
+            """.trimIndent() + "\n",
+        )
+    }
+
+    @Test
+    fun `valid multi file manifest canonicalizes sorted artifact order`() {
+        val manifest = LocalModelArtifactManifestV1(
+            schemaVersion = 1,
+            registryEntryId = "entry-1",
+            providerId = "provider-1",
+            modelName = "model-1",
+            revision = "rev-1",
+            artifacts = listOf(
+                artifact("z-last.gguf", 30L, "c"),
+                artifact("a-first.gguf", 10L, "a"),
+                artifact("m-middle.gguf", 20L, "b"),
+            ),
+        )
+
+        assertThat(manifest.canonicalBytes().toString(Charsets.UTF_8)).isEqualTo(
+            """
+            schemaVersion=1
+            registryEntryId=entry-1
+            providerId=provider-1
+            modelName=model-1
+            revision=rev-1
+            artifact_count=3
+              relativePath=a-first.gguf
+              sizeBytes=10
+              digest=sha256:${"a".repeat(64)}
+              relativePath=m-middle.gguf
+              sizeBytes=20
+              digest=sha256:${"b".repeat(64)}
+              relativePath=z-last.gguf
+              sizeBytes=30
+              digest=sha256:${"c".repeat(64)}
+            """.trimIndent() + "\n",
+        )
+    }
+
+    @Test
+    fun `duplicate paths are rejected`() {
+        assertThatThrownBy {
+            LocalModelArtifactManifestV1(
+                schemaVersion = 1,
+                registryEntryId = "entry-1",
+                providerId = "provider-1",
+                modelName = "model-1",
+                revision = "rev-1",
+                artifacts = listOf(
+                    artifact("dup.gguf", 10L, "a"),
+                    artifact("dup.gguf", 20L, "b"),
+                ),
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Duplicate artifact paths")
+    }
+
+    @Test
+    fun `blank path is rejected`() {
+        assertThatThrownBy {
+            LocalModelArtifactManifestV1(
+                schemaVersion = 1,
+                registryEntryId = "entry-1",
+                providerId = "provider-1",
+                modelName = "model-1",
+                revision = "rev-1",
+                artifacts = listOf(
+                    artifact(" ", 10L, "a"),
+                ),
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("relativePath")
+    }
+
+    @Test
+    fun `absolute path is rejected`() {
+        assertThatThrownBy {
+            LocalModelArtifactManifestV1(
+                schemaVersion = 1,
+                registryEntryId = "entry-1",
+                providerId = "provider-1",
+                modelName = "model-1",
+                revision = "rev-1",
+                artifacts = listOf(
+                    artifact("/tmp/model.gguf", 10L, "a"),
+                ),
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("absolute")
+    }
+
+    @Test
+    fun `traversal path is rejected`() {
+        assertThatThrownBy {
+            LocalModelArtifactManifestV1(
+                schemaVersion = 1,
+                registryEntryId = "entry-1",
+                providerId = "provider-1",
+                modelName = "model-1",
+                revision = "rev-1",
+                artifacts = listOf(
+                    artifact("../model.gguf", 10L, "a"),
+                ),
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("traverse")
+    }
+
+    @Test
+    fun `invalid schemaVersion is rejected`() {
+        assertThatThrownBy {
+            LocalModelArtifactManifestV1(
+                schemaVersion = 2,
+                registryEntryId = "entry-1",
+                providerId = "provider-1",
+                modelName = "model-1",
+                revision = "rev-1",
+                artifacts = listOf(
+                    artifact("model.gguf", 10L, "a"),
+                ),
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Schema version")
+    }
+
+    @Test
+    fun `empty artifacts are rejected`() {
+        assertThatThrownBy {
+            LocalModelArtifactManifestV1(
+                schemaVersion = 1,
+                registryEntryId = "entry-1",
+                providerId = "provider-1",
+                modelName = "model-1",
+                revision = "rev-1",
+                artifacts = emptyList(),
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("At least one artifact file is required")
+    }
+
+    private fun artifact(relativePath: String, sizeBytes: Long, fill: String): LocalModelArtifactFileV1 =
+        LocalModelArtifactFileV1(
+            relativePath = relativePath,
+            sizeBytes = sizeBytes,
+            digest = ModelArtifactDigest.of("sha256:${fill.repeat(64)}"),
+        )
+}

--- a/tramai-core/src/test/kotlin/dev/tramai/core/model/LocalModelArtifactManifestV1Test.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/model/LocalModelArtifactManifestV1Test.kt
@@ -193,6 +193,28 @@ class LocalModelArtifactManifestV1Test {
         assertThat(manifest.artifacts[0].relativePath).isEqualTo("original.gguf")
     }
 
+    @Test
+    fun `exposed artifact snapshot cannot be mutated through JVM list API`() {
+        val manifest = LocalModelArtifactManifestV1(
+            schemaVersion = 1,
+            registryEntryId = "entry-1",
+            providerId = "provider-1",
+            modelName = "model-1",
+            revision = "rev-1",
+            artifacts = listOf(
+                artifact("first.gguf", 10L, "a"),
+                artifact("second.gguf", 20L, "b"),
+            ),
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        val exposed = manifest.artifacts as MutableList<LocalModelArtifactFileV1>
+
+        assertThatThrownBy {
+            exposed[0] = artifact("substituted.gguf", 99L, "c")
+        }.isInstanceOf(UnsupportedOperationException::class.java)
+    }
+
     private fun artifact(relativePath: String, sizeBytes: Long, fill: String): LocalModelArtifactFileV1 =
         LocalModelArtifactFileV1(
             relativePath = relativePath,

--- a/tramai-core/src/test/kotlin/dev/tramai/core/model/LocalModelArtifactManifestV1Test.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/model/LocalModelArtifactManifestV1Test.kt
@@ -171,6 +171,28 @@ class LocalModelArtifactManifestV1Test {
             .hasMessageContaining("At least one artifact file is required")
     }
 
+    @Test
+    fun `mutable source list after construction does not affect immutable manifest`() {
+        val artifactList = mutableListOf(
+            artifact("original.gguf", 10L, "a"),
+        )
+        val manifest = LocalModelArtifactManifestV1(
+            schemaVersion = 1,
+            registryEntryId = "entry-1",
+            providerId = "provider-1",
+            modelName = "model-1",
+            revision = "rev-1",
+            artifacts = artifactList,
+        )
+        val canonicalBefore = manifest.canonicalBytes()
+        artifactList.clear()
+        artifactList += artifact("substituted.gguf", 99L, "b")
+        val canonicalAfter = manifest.canonicalBytes()
+        assertThat(canonicalBefore).isEqualTo(canonicalAfter)
+        assertThat(manifest.artifacts).hasSize(1)
+        assertThat(manifest.artifacts[0].relativePath).isEqualTo("original.gguf")
+    }
+
     private fun artifact(relativePath: String, sizeBytes: Long, fill: String): LocalModelArtifactFileV1 =
         LocalModelArtifactFileV1(
             relativePath = relativePath,

--- a/tramai-security/src/main/kotlin/dev/tramai/security/verification/FileSystemModelArtifactVerifier.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/verification/FileSystemModelArtifactVerifier.kt
@@ -36,22 +36,24 @@ class FileSystemModelArtifactVerifier(
             }
         }
 
-        var totalSizeBytes = 0L
-        manifest.artifacts.toList().forEach { artifact ->
-            verifyArtifactFile(artifact)
-            totalSizeBytes = try {
-                Math.addExact(totalSizeBytes, artifact.sizeBytes)
+        // Precompute aggregate declared size before any filesystem work
+        val artifacts = manifest.artifacts
+        val totalSizeBytes = artifacts.fold(0L) { total, artifact ->
+            try {
+                Math.addExact(total, artifact.sizeBytes)
             } catch (_: ArithmeticException) {
                 error("artifact-total-size-overflow")
             }
         }
+
+        artifacts.forEach(::verifyArtifactFile)
 
         return VerifiedLocalModelArtifact(
             registryEntryId = registeredModel.registryEntryId,
             manifestDigest = manifestDigest,
             modelName = registeredModel.modelName,
             verifiedAt = clock.instant(),
-            artifactCount = manifest.artifacts.size,
+            artifactCount = artifacts.size,
             totalSizeBytes = totalSizeBytes,
         )
     }

--- a/tramai-security/src/main/kotlin/dev/tramai/security/verification/FileSystemModelArtifactVerifier.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/verification/FileSystemModelArtifactVerifier.kt
@@ -13,7 +13,7 @@ import java.time.Clock
 
 class FileSystemModelArtifactVerifier(
     allowedRootDirectories: Set<Path>,
-    private val manifests: Map<String, LocalModelArtifactManifestV1>,
+    manifests: Map<String, LocalModelArtifactManifestV1>,
     private val clock: Clock = Clock.systemUTC(),
 ) : ModelArtifactVerifier {
 
@@ -21,18 +21,29 @@ class FileSystemModelArtifactVerifier(
         .map { it.toAbsolutePath().normalize() }
         .toSet()
 
+    private val manifests = manifests.toMap()
+
     override suspend fun verify(registeredModel: RegisteredModel): VerifiedLocalModelArtifact? {
         val manifest = manifests[registeredModel.registryEntryId] ?: return null
 
         ensureIdentityMatches(manifest, registeredModel)
         val manifestDigest = sha256Digest(manifest.canonicalBytes())
-        val expectedManifestDigest = registeredModel.artifactDigest?.value
-        check(expectedManifestDigest == manifestDigest.value) { "artifact-aggregate-digest-mismatch" }
+
+        // Verify aggregate digest only when the registry pins one
+        registeredModel.artifactDigest?.let { expected ->
+            check(expected == manifestDigest) {
+                "artifact-aggregate-digest-mismatch"
+            }
+        }
 
         var totalSizeBytes = 0L
-        manifest.artifacts.forEach { artifact ->
+        manifest.artifacts.toList().forEach { artifact ->
             verifyArtifactFile(artifact)
-            totalSizeBytes = Math.addExact(totalSizeBytes, artifact.sizeBytes)
+            totalSizeBytes = try {
+                Math.addExact(totalSizeBytes, artifact.sizeBytes)
+            } catch (_: ArithmeticException) {
+                error("artifact-total-size-overflow")
+            }
         }
 
         return VerifiedLocalModelArtifact(
@@ -64,27 +75,22 @@ class FileSystemModelArtifactVerifier(
     }
 
     private fun verifyArtifactFile(artifact: LocalModelArtifactFileV1) {
-        var sawTraversal = false
-        var sawEscapingSymlink = false
-
         for (root in allowedRoots) {
             val candidate = root.resolve(artifact.relativePath)
             val normalizedCandidate = candidate.toAbsolutePath().normalize()
             if (!normalizedCandidate.startsWith(root)) {
-                sawTraversal = true
-                continue
+                continue // traversal — try next root
             }
 
             if (!Files.exists(normalizedCandidate)) {
                 continue
             }
 
+            // Strict symlink policy: reject any symlink in the path chain
             val realPath = runCatching { normalizedCandidate.toRealPath() }
                 .getOrElse { error("artifact-file-symlink-rejected") }
-            val resolvedWithinAllowedRoot = allowedRoots.any { realPath.startsWith(it) }
-            if (!resolvedWithinAllowedRoot) {
-                sawEscapingSymlink = true
-                continue
+            if (realPath != normalizedCandidate.toAbsolutePath().normalize()) {
+                error("artifact-file-symlink-rejected")
             }
 
             if (!Files.isRegularFile(normalizedCandidate)) {
@@ -98,19 +104,17 @@ class FileSystemModelArtifactVerifier(
             check(actualSizeBeforeHash == artifact.sizeBytes) { "artifact-file-size-mismatch" }
 
             val actualDigest = hashFile(normalizedCandidate)
-            check(actualDigest == artifact.digest.value) { "artifact-file-digest-mismatch" }
+            check(actualDigest == artifact.digest) { "artifact-file-digest-mismatch" }
 
             val actualSizeAfterHash = Files.size(normalizedCandidate)
             check(actualSizeAfterHash == artifact.sizeBytes) { "artifact-file-size-mismatch" }
             return
         }
 
-        check(!sawTraversal) { "artifact-traversal-rejected" }
-        check(!sawEscapingSymlink) { "artifact-file-symlink-rejected" }
         error("artifact-file-not-found")
     }
 
-    private fun hashFile(path: Path): String {
+    private fun hashFile(path: Path): ModelArtifactDigest {
         val digest = MessageDigest.getInstance("SHA-256")
         Files.newInputStream(path).use { input ->
             val buffer = ByteArray(HASH_BUFFER_SIZE)
@@ -122,7 +126,7 @@ class FileSystemModelArtifactVerifier(
                 digest.update(buffer, 0, read)
             }
         }
-        return digest.digest().toHexString()
+        return ModelArtifactDigest.of("sha256:${digest.digest().toHexString()}")
     }
 
     private fun sha256Digest(bytes: ByteArray): ModelArtifactDigest {

--- a/tramai-security/src/main/kotlin/dev/tramai/security/verification/FileSystemModelArtifactVerifier.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/verification/FileSystemModelArtifactVerifier.kt
@@ -1,0 +1,139 @@
+package dev.tramai.security.verification
+
+import dev.tramai.core.model.LocalModelArtifactFileV1
+import dev.tramai.core.model.LocalModelArtifactManifestV1
+import dev.tramai.core.model.ModelArtifactDigest
+import dev.tramai.core.model.ModelArtifactVerifier
+import dev.tramai.core.model.RegisteredModel
+import dev.tramai.core.model.VerifiedLocalModelArtifact
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+import java.time.Clock
+
+class FileSystemModelArtifactVerifier(
+    allowedRootDirectories: Set<Path>,
+    private val manifests: Map<String, LocalModelArtifactManifestV1>,
+    private val clock: Clock = Clock.systemUTC(),
+) : ModelArtifactVerifier {
+
+    private val allowedRoots = allowedRootDirectories
+        .map { it.toAbsolutePath().normalize() }
+        .toSet()
+
+    override suspend fun verify(registeredModel: RegisteredModel): VerifiedLocalModelArtifact? {
+        val manifest = manifests[registeredModel.registryEntryId] ?: return null
+
+        ensureIdentityMatches(manifest, registeredModel)
+        val manifestDigest = sha256Digest(manifest.canonicalBytes())
+        val expectedManifestDigest = registeredModel.artifactDigest?.value
+        check(expectedManifestDigest == manifestDigest.value) { "artifact-aggregate-digest-mismatch" }
+
+        var totalSizeBytes = 0L
+        manifest.artifacts.forEach { artifact ->
+            verifyArtifactFile(artifact)
+            totalSizeBytes = Math.addExact(totalSizeBytes, artifact.sizeBytes)
+        }
+
+        return VerifiedLocalModelArtifact(
+            registryEntryId = registeredModel.registryEntryId,
+            manifestDigest = manifestDigest,
+            modelName = registeredModel.modelName,
+            verifiedAt = clock.instant(),
+            artifactCount = manifest.artifacts.size,
+            totalSizeBytes = totalSizeBytes,
+        )
+    }
+
+    private fun ensureIdentityMatches(
+        manifest: LocalModelArtifactManifestV1,
+        registeredModel: RegisteredModel,
+    ) {
+        check(manifest.registryEntryId == registeredModel.registryEntryId) {
+            "artifact-manifest-identity-drift"
+        }
+        check(manifest.providerId == registeredModel.providerId) {
+            "artifact-manifest-identity-drift"
+        }
+        check(manifest.modelName == registeredModel.modelName) {
+            "artifact-manifest-identity-drift"
+        }
+        check(manifest.revision == registeredModel.revision) {
+            "artifact-manifest-identity-drift"
+        }
+    }
+
+    private fun verifyArtifactFile(artifact: LocalModelArtifactFileV1) {
+        var sawTraversal = false
+        var sawEscapingSymlink = false
+
+        for (root in allowedRoots) {
+            val candidate = root.resolve(artifact.relativePath)
+            val normalizedCandidate = candidate.toAbsolutePath().normalize()
+            if (!normalizedCandidate.startsWith(root)) {
+                sawTraversal = true
+                continue
+            }
+
+            if (!Files.exists(normalizedCandidate)) {
+                continue
+            }
+
+            val realPath = normalizedCandidate.toRealPath()
+            val resolvedWithinAllowedRoot = allowedRoots.any { realPath.startsWith(it) }
+            if (!resolvedWithinAllowedRoot) {
+                sawEscapingSymlink = true
+                continue
+            }
+
+            if (!Files.isRegularFile(normalizedCandidate)) {
+                check(!Files.isDirectory(normalizedCandidate)) {
+                    "artifact-directory-substituted-for-file"
+                }
+                check(resolvedWithinAllowedRoot) { "artifact-file-symlink-rejected" }
+            }
+
+            val actualSizeBeforeHash = Files.size(normalizedCandidate)
+            check(actualSizeBeforeHash == artifact.sizeBytes) { "artifact-file-size-mismatch" }
+
+            val actualDigest = hashFile(normalizedCandidate)
+            check(actualDigest == artifact.digest.value) { "artifact-file-digest-mismatch" }
+
+            val actualSizeAfterHash = Files.size(normalizedCandidate)
+            check(actualSizeAfterHash == artifact.sizeBytes) { "artifact-file-size-mismatch" }
+            return
+        }
+
+        check(!sawTraversal) { "artifact-traversal-rejected" }
+        check(!sawEscapingSymlink) { "artifact-file-symlink-rejected" }
+        error("artifact-file-not-found")
+    }
+
+    private fun hashFile(path: Path): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        Files.newInputStream(path).use { input ->
+            val buffer = ByteArray(HASH_BUFFER_SIZE)
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) {
+                    break
+                }
+                digest.update(buffer, 0, read)
+            }
+        }
+        return digest.digest().toHexString()
+    }
+
+    private fun sha256Digest(bytes: ByteArray): ModelArtifactDigest {
+        val digest = MessageDigest.getInstance("SHA-256")
+        return ModelArtifactDigest.of("sha256:${digest.digest(bytes).toHexString()}")
+    }
+
+    private fun ByteArray.toHexString(): String = joinToString(separator = "") { byte ->
+        "%02x".format(byte)
+    }
+
+    private companion object {
+        const val HASH_BUFFER_SIZE = 64 * 1024
+    }
+}

--- a/tramai-security/src/main/kotlin/dev/tramai/security/verification/FileSystemModelArtifactVerifier.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/verification/FileSystemModelArtifactVerifier.kt
@@ -124,20 +124,19 @@ class FileSystemModelArtifactVerifier(
 
     private fun hashFile(path: Path): ModelArtifactDigest {
         val digest = MessageDigest.getInstance("SHA-256")
-        val stream = try {
-            Files.newInputStream(path)
+        try {
+            Files.newInputStream(path).use { input ->
+                val buffer = ByteArray(HASH_BUFFER_SIZE)
+                while (true) {
+                    val read = input.read(buffer)
+                    if (read < 0) {
+                        break
+                    }
+                    digest.update(buffer, 0, read)
+                }
+            }
         } catch (_: Exception) {
             error("artifact-file-access-failed")
-        }
-        stream.use { input ->
-            val buffer = ByteArray(HASH_BUFFER_SIZE)
-            while (true) {
-                val read = input.read(buffer)
-                if (read < 0) {
-                    break
-                }
-                digest.update(buffer, 0, read)
-            }
         }
         return ModelArtifactDigest.of("sha256:${digest.digest().toHexString()}")
     }

--- a/tramai-security/src/main/kotlin/dev/tramai/security/verification/FileSystemModelArtifactVerifier.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/verification/FileSystemModelArtifactVerifier.kt
@@ -79,7 +79,8 @@ class FileSystemModelArtifactVerifier(
                 continue
             }
 
-            val realPath = normalizedCandidate.toRealPath()
+            val realPath = runCatching { normalizedCandidate.toRealPath() }
+                .getOrElse { error("artifact-file-symlink-rejected") }
             val resolvedWithinAllowedRoot = allowedRoots.any { realPath.startsWith(it) }
             if (!resolvedWithinAllowedRoot) {
                 sawEscapingSymlink = true
@@ -90,7 +91,7 @@ class FileSystemModelArtifactVerifier(
                 check(!Files.isDirectory(normalizedCandidate)) {
                     "artifact-directory-substituted-for-file"
                 }
-                check(resolvedWithinAllowedRoot) { "artifact-file-symlink-rejected" }
+                error("artifact-not-a-regular-file")
             }
 
             val actualSizeBeforeHash = Files.size(normalizedCandidate)

--- a/tramai-security/src/main/kotlin/dev/tramai/security/verification/FileSystemModelArtifactVerifier.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/verification/FileSystemModelArtifactVerifier.kt
@@ -102,13 +102,13 @@ class FileSystemModelArtifactVerifier(
                 error("artifact-not-a-regular-file")
             }
 
-            val actualSizeBeforeHash = Files.size(normalizedCandidate)
+            val actualSizeBeforeHash = safeFileSize(normalizedCandidate)
             check(actualSizeBeforeHash == artifact.sizeBytes) { "artifact-file-size-mismatch" }
 
             val actualDigest = hashFile(normalizedCandidate)
             check(actualDigest == artifact.digest) { "artifact-file-digest-mismatch" }
 
-            val actualSizeAfterHash = Files.size(normalizedCandidate)
+            val actualSizeAfterHash = safeFileSize(normalizedCandidate)
             check(actualSizeAfterHash == artifact.sizeBytes) { "artifact-file-size-mismatch" }
             return
         }
@@ -116,9 +116,20 @@ class FileSystemModelArtifactVerifier(
         error("artifact-file-not-found")
     }
 
+    private fun safeFileSize(path: Path): Long = try {
+        Files.size(path)
+    } catch (_: Exception) {
+        error("artifact-file-access-failed")
+    }
+
     private fun hashFile(path: Path): ModelArtifactDigest {
         val digest = MessageDigest.getInstance("SHA-256")
-        Files.newInputStream(path).use { input ->
+        val stream = try {
+            Files.newInputStream(path)
+        } catch (_: Exception) {
+            error("artifact-file-access-failed")
+        }
+        stream.use { input ->
             val buffer = ByteArray(HASH_BUFFER_SIZE)
             while (true) {
                 val read = input.read(buffer)

--- a/tramai-security/src/test/kotlin/dev/tramai/security/verification/FileSystemModelArtifactVerifierTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/verification/FileSystemModelArtifactVerifierTest.kt
@@ -134,7 +134,7 @@ class FileSystemModelArtifactVerifierTest {
     }
 
     @Test
-    fun `symlink within allowed root passes`() = runBlocking {
+    fun `symlink within allowed root rejects`() = runBlocking {
         val root = Files.createTempDirectory("artifact-root")
         val target = createFile(root, "real/model.bin", "allowed".toByteArray(StandardCharsets.UTF_8))
         val link = root.resolve("links/model.bin")
@@ -148,9 +148,13 @@ class FileSystemModelArtifactVerifierTest {
             ),
         )
 
-        val receipt = verifier(root, manifest).verify(registeredModelFor(manifest))
-
-        assertThat(receipt).isNotNull
+        assertThatIllegalStateException()
+            .isThrownBy {
+                runBlocking {
+                    verifier(root, manifest).verify(registeredModelFor(manifest))
+                }
+            }
+            .withMessage("artifact-file-symlink-rejected")
     }
 
     @Test
@@ -177,7 +181,7 @@ class FileSystemModelArtifactVerifierTest {
     }
 
     @Test
-    fun `parent symlink passes when target stays within allowed root`() = runBlocking {
+    fun `parent symlink rejects when target stays within allowed root`() = runBlocking {
         val root = Files.createTempDirectory("artifact-root")
         val targetDir = root.resolve("actual")
         Files.createDirectories(targetDir)
@@ -191,9 +195,49 @@ class FileSystemModelArtifactVerifierTest {
             ),
         )
 
-        val receipt = verifier(root, manifest).verify(registeredModelFor(manifest))
+        assertThatIllegalStateException()
+            .isThrownBy {
+                runBlocking {
+                    verifier(root, manifest).verify(registeredModelFor(manifest))
+                }
+            }
+            .withMessage("artifact-file-symlink-rejected")
+    }
 
-        assertThat(receipt).isNotNull
+    @Test
+    fun `total size overflow rejects`() = runBlocking {
+        val root = Files.createTempDirectory("artifact-root")
+        val firstContent = byteArrayOf(1)
+        val secondContent = byteArrayOf(2)
+        createFile(root, "first.bin", firstContent)
+        createFile(root, "second.bin", secondContent)
+        val manifest = LocalModelArtifactManifestV1(
+            schemaVersion = 1,
+            registryEntryId = "entry-1",
+            providerId = "provider-1",
+            modelName = "model-1",
+            revision = "rev-1",
+            artifacts = listOf(
+                LocalModelArtifactFileV1(
+                    relativePath = "first.bin",
+                    sizeBytes = Long.MAX_VALUE,
+                    digest = digestOfBytes(firstContent),
+                ),
+                LocalModelArtifactFileV1(
+                    relativePath = "second.bin",
+                    sizeBytes = 1,
+                    digest = digestOfBytes(secondContent),
+                ),
+            ),
+        )
+
+        assertThatIllegalStateException()
+            .isThrownBy {
+                runBlocking {
+                    verifier(root, manifest).verify(registeredModelFor(manifest))
+                }
+            }
+            .withMessage("artifact-total-size-overflow")
     }
 
     @Test

--- a/tramai-security/src/test/kotlin/dev/tramai/security/verification/FileSystemModelArtifactVerifierTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/verification/FileSystemModelArtifactVerifierTest.kt
@@ -205,6 +205,22 @@ class FileSystemModelArtifactVerifierTest {
     }
 
     @Test
+    fun `digest optional mode verifies bytes without registry pinned digest`() = runBlocking {
+        val root = Files.createTempDirectory("artifact-root")
+        val content = "transitional bytes".toByteArray(StandardCharsets.UTF_8)
+        root.resolve("model.bin").writeBytes(content)
+        val manifest = manifestFor(root, "model.bin", "entry-1", "provider-1", "model-1", "rev-1")
+        val registeredModel = registeredModelFor(manifest).copy(artifactDigest = null)
+
+        val receipt = verifier(root, manifest).verify(registeredModel)
+
+        assertThat(receipt).isNotNull
+        assertThat(receipt?.artifactCount).isEqualTo(1)
+        assertThat(receipt?.totalSizeBytes).isEqualTo(content.size.toLong())
+        assertThat(receipt?.manifestDigest).isEqualTo(manifestDigest(manifest))
+    }
+
+    @Test
     fun `total size overflow rejects`() = runBlocking {
         val root = Files.createTempDirectory("artifact-root")
         val firstContent = byteArrayOf(1)

--- a/tramai-security/src/test/kotlin/dev/tramai/security/verification/FileSystemModelArtifactVerifierTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/verification/FileSystemModelArtifactVerifierTest.kt
@@ -1,0 +1,356 @@
+package dev.tramai.security.verification
+
+import dev.tramai.core.model.LocalModelArtifactFileV1
+import dev.tramai.core.model.LocalModelArtifactManifestV1
+import dev.tramai.core.model.ModelArtifactDigest
+import dev.tramai.core.model.RegisteredModel
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeBytes
+import kotlin.test.Test
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
+
+class FileSystemModelArtifactVerifierTest {
+
+    @Test
+    fun `valid single file passes`() = runBlocking {
+        val root = Files.createTempDirectory("artifact-root")
+        val content = "hello verifier".toByteArray(StandardCharsets.UTF_8)
+        root.resolve("model.bin").writeBytes(content)
+        val manifest = manifestFor(root, "model.bin", "entry-1", "provider-1", "model-1", "rev-1")
+        val registeredModel = registeredModelFor(manifest)
+        val clock = Clock.fixed(Instant.parse("2026-06-13T10:15:30Z"), ZoneOffset.UTC)
+
+        val receipt = FileSystemModelArtifactVerifier(
+            allowedRootDirectories = setOf(root),
+            manifests = mapOf(manifest.registryEntryId to manifest),
+            clock = clock,
+        ).verify(registeredModel)
+
+        assertThat(receipt).isNotNull
+        assertThat(receipt?.registryEntryId).isEqualTo("entry-1")
+        assertThat(receipt?.modelName).isEqualTo("model-1")
+        assertThat(receipt?.artifactCount).isEqualTo(1)
+        assertThat(receipt?.totalSizeBytes).isEqualTo(content.size.toLong())
+        assertThat(receipt?.verifiedAt).isEqualTo(clock.instant())
+        assertThat(receipt?.manifestDigest).isEqualTo(manifestDigest(manifest))
+    }
+
+    @Test
+    fun `modified byte rejects with digest mismatch`() = runBlocking {
+        val root = Files.createTempDirectory("artifact-root")
+        val path = root.resolve("model.bin")
+        path.writeBytes("original".toByteArray(StandardCharsets.UTF_8))
+        val manifest = manifestFor(root, "model.bin")
+        path.writeBytes("originaL".toByteArray(StandardCharsets.UTF_8))
+
+        assertThatIllegalStateException()
+            .isThrownBy {
+                runBlocking {
+                    verifier(root, manifest).verify(registeredModelFor(manifest))
+                }
+            }
+            .withMessage("artifact-file-digest-mismatch")
+    }
+
+    @Test
+    fun `missing file rejects with file not found`() = runBlocking {
+        val root = Files.createTempDirectory("artifact-root")
+        val path = createFile(root, "missing.bin", byteArrayOf(1))
+        val manifest = manifestFor(root, "missing.bin")
+        Files.deleteIfExists(path)
+
+        assertThatIllegalStateException()
+            .isThrownBy {
+                runBlocking {
+                    verifier(root, manifest).verify(registeredModelFor(manifest))
+                }
+            }
+            .withMessage("artifact-file-not-found")
+    }
+
+    @Test
+    fun `empty file passes`() = runBlocking {
+        val root = Files.createTempDirectory("artifact-root")
+        root.resolve("empty.bin").writeBytes(byteArrayOf())
+        val manifest = manifestFor(root, "empty.bin")
+
+        val receipt = verifier(root, manifest).verify(registeredModelFor(manifest))
+
+        assertThat(receipt?.totalSizeBytes).isEqualTo(0)
+        assertThat(receipt?.artifactCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `file size mismatch rejects`() = runBlocking {
+        val root = Files.createTempDirectory("artifact-root")
+        val path = root.resolve("model.bin")
+        path.writeBytes("abc".toByteArray(StandardCharsets.UTF_8))
+        val digest = fileDigest(path)
+        val manifest = manifestWithFile(
+            artifact = LocalModelArtifactFileV1(
+                relativePath = "model.bin",
+                sizeBytes = 99,
+                digest = digest,
+            ),
+        )
+
+        assertThatIllegalStateException()
+            .isThrownBy {
+                runBlocking {
+                    verifier(root, manifest).verify(registeredModelFor(manifest))
+                }
+            }
+            .withMessage("artifact-file-size-mismatch")
+    }
+
+    @Test
+    fun `directory substitution rejects`() = runBlocking {
+        val root = Files.createTempDirectory("artifact-root")
+        root.resolve("model-dir").createDirectories()
+        val manifest = manifestWithFile(
+            artifact = LocalModelArtifactFileV1(
+                relativePath = "model-dir",
+                sizeBytes = 0,
+                digest = digestOfBytes(byteArrayOf()),
+            ),
+        )
+
+        assertThatIllegalStateException()
+            .isThrownBy {
+                runBlocking {
+                    verifier(root, manifest).verify(registeredModelFor(manifest))
+                }
+            }
+            .withMessage("artifact-directory-substituted-for-file")
+    }
+
+    @Test
+    fun `symlink within allowed root passes`() = runBlocking {
+        val root = Files.createTempDirectory("artifact-root")
+        val target = createFile(root, "real/model.bin", "allowed".toByteArray(StandardCharsets.UTF_8))
+        val link = root.resolve("links/model.bin")
+        Files.createDirectories(link.parent)
+        Files.createSymbolicLink(link, link.parent.relativize(target))
+        val manifest = manifestWithFile(
+            artifact = LocalModelArtifactFileV1(
+                relativePath = "links/model.bin",
+                sizeBytes = Files.size(target),
+                digest = fileDigest(target),
+            ),
+        )
+
+        val receipt = verifier(root, manifest).verify(registeredModelFor(manifest))
+
+        assertThat(receipt).isNotNull
+    }
+
+    @Test
+    fun `symlink escaping root rejects`() = runBlocking {
+        val root = Files.createTempDirectory("artifact-root")
+        val outsideRoot = Files.createTempDirectory("artifact-outside")
+        val target = createFile(outsideRoot, "escape.bin", "escape".toByteArray(StandardCharsets.UTF_8))
+        Files.createSymbolicLink(root.resolve("escape.bin"), target)
+        val manifest = manifestWithFile(
+            artifact = LocalModelArtifactFileV1(
+                relativePath = "escape.bin",
+                sizeBytes = Files.size(target),
+                digest = fileDigest(target),
+            ),
+        )
+
+        assertThatIllegalStateException()
+            .isThrownBy {
+                runBlocking {
+                    verifier(root, manifest).verify(registeredModelFor(manifest))
+                }
+            }
+            .withMessage("artifact-file-symlink-rejected")
+    }
+
+    @Test
+    fun `parent symlink passes when target stays within allowed root`() = runBlocking {
+        val root = Files.createTempDirectory("artifact-root")
+        val targetDir = root.resolve("actual")
+        Files.createDirectories(targetDir)
+        val target = createFile(root, "actual/model.bin", "parent-link".toByteArray(StandardCharsets.UTF_8))
+        Files.createSymbolicLink(root.resolve("linked"), root.relativize(targetDir))
+        val manifest = manifestWithFile(
+            artifact = LocalModelArtifactFileV1(
+                relativePath = "linked/model.bin",
+                sizeBytes = Files.size(target),
+                digest = fileDigest(target),
+            ),
+        )
+
+        val receipt = verifier(root, manifest).verify(registeredModelFor(manifest))
+
+        assertThat(receipt).isNotNull
+    }
+
+    @Test
+    fun `unknown manifest returns null`() = runBlocking {
+        val root = Files.createTempDirectory("artifact-root")
+        val manifest = manifestForExistingBytes(
+            relativePath = "model.bin",
+            content = "bytes".toByteArray(StandardCharsets.UTF_8),
+            root = root,
+            registryEntryId = "entry-1",
+        )
+
+        val result = FileSystemModelArtifactVerifier(
+            allowedRootDirectories = setOf(root),
+            manifests = emptyMap(),
+        ).verify(registeredModelFor(manifest))
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `identity drift rejects`() = runBlocking {
+        val root = Files.createTempDirectory("artifact-root")
+        val manifest = manifestForExistingBytes(
+            relativePath = "model.bin",
+            content = "bytes".toByteArray(StandardCharsets.UTF_8),
+            root = root,
+        )
+        val registeredModel = registeredModelFor(manifest).copy(providerId = "provider-2")
+
+        assertThatIllegalStateException()
+            .isThrownBy {
+                runBlocking {
+                    verifier(root, manifest).verify(registeredModel)
+                }
+            }
+            .withMessage("artifact-manifest-identity-drift")
+    }
+
+    @Test
+    fun `aggregate digest mismatch rejects`() = runBlocking {
+        val root = Files.createTempDirectory("artifact-root")
+        val manifest = manifestForExistingBytes(
+            relativePath = "model.bin",
+            content = "bytes".toByteArray(StandardCharsets.UTF_8),
+            root = root,
+        )
+        val registeredModel = registeredModelFor(manifest).copy(
+            artifactDigest = ModelArtifactDigest.of("sha256:${"f".repeat(64)}"),
+        )
+
+        assertThatIllegalStateException()
+            .isThrownBy {
+                runBlocking {
+                    verifier(root, manifest).verify(registeredModel)
+                }
+            }
+            .withMessage("artifact-aggregate-digest-mismatch")
+    }
+
+    private fun verifier(
+        root: Path,
+        manifest: LocalModelArtifactManifestV1,
+    ) = FileSystemModelArtifactVerifier(
+        allowedRootDirectories = setOf(root),
+        manifests = mapOf(manifest.registryEntryId to manifest),
+        clock = Clock.fixed(Instant.parse("2026-06-13T00:00:00Z"), ZoneOffset.UTC),
+    )
+
+    private fun manifestFor(
+        root: Path,
+        relativePath: String,
+        registryEntryId: String = "entry-1",
+        providerId: String = "provider-1",
+        modelName: String = "model-1",
+        revision: String = "rev-1",
+    ): LocalModelArtifactManifestV1 {
+        val path = root.resolve(relativePath)
+        return manifestForExistingPath(path, relativePath, registryEntryId, providerId, modelName, revision)
+    }
+
+    private fun manifestForExistingBytes(
+        relativePath: String,
+        content: ByteArray,
+        root: Path,
+        registryEntryId: String = "entry-1",
+        providerId: String = "provider-1",
+        modelName: String = "model-1",
+        revision: String = "rev-1",
+    ): LocalModelArtifactManifestV1 {
+        val path = createFile(root, relativePath, content)
+        return manifestForExistingPath(path, relativePath, registryEntryId, providerId, modelName, revision)
+    }
+
+    private fun manifestForExistingPath(
+        path: Path,
+        relativePath: String,
+        registryEntryId: String,
+        providerId: String,
+        modelName: String,
+        revision: String,
+    ): LocalModelArtifactManifestV1 = manifestWithFile(
+        registryEntryId = registryEntryId,
+        providerId = providerId,
+        modelName = modelName,
+        revision = revision,
+        artifact = LocalModelArtifactFileV1(
+            relativePath = relativePath,
+            sizeBytes = Files.size(path),
+            digest = fileDigest(path),
+        ),
+    )
+
+    private fun manifestWithFile(
+        artifact: LocalModelArtifactFileV1,
+        registryEntryId: String = "entry-1",
+        providerId: String = "provider-1",
+        modelName: String = "model-1",
+        revision: String = "rev-1",
+    ): LocalModelArtifactManifestV1 {
+        return LocalModelArtifactManifestV1(
+            schemaVersion = 1,
+            registryEntryId = registryEntryId,
+            providerId = providerId,
+            modelName = modelName,
+            revision = revision,
+            artifacts = listOf(artifact),
+        )
+    }
+
+    private fun registeredModelFor(manifest: LocalModelArtifactManifestV1): RegisteredModel = RegisteredModel(
+        registryEntryId = manifest.registryEntryId,
+        providerId = manifest.providerId,
+        modelName = manifest.modelName,
+        revision = manifest.revision,
+        artifactDigest = manifestDigest(manifest),
+    )
+
+    private fun manifestDigest(manifest: LocalModelArtifactManifestV1): ModelArtifactDigest =
+        digestOfBytes(manifest.canonicalBytes())
+
+    private fun fileDigest(path: Path): ModelArtifactDigest =
+        digestOfBytes(Files.readAllBytes(path))
+
+    private fun digestOfBytes(bytes: ByteArray): ModelArtifactDigest {
+        val digest = MessageDigest.getInstance("SHA-256")
+        return ModelArtifactDigest.of("sha256:${digest.digest(bytes).toHexString()}")
+    }
+
+    private fun createFile(root: Path, relativePath: String, content: ByteArray): Path {
+        val path = root.resolve(relativePath)
+        Files.createDirectories(path.parent)
+        Files.write(path, content)
+        return path
+    }
+
+    private fun ByteArray.toHexString(): String = joinToString(separator = "") { byte ->
+        "%02x".format(byte)
+    }
+}

--- a/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/SovereignTramai.kt
+++ b/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/SovereignTramai.kt
@@ -31,6 +31,7 @@ import dev.tramai.security.audit.AuditStore
 import dev.tramai.standalone.Tramai
 import dev.tramai.standalone.TramaiRuntime
 import java.time.Clock
+import java.util.Collections
 import kotlinx.coroutines.runBlocking
 import kotlin.reflect.KClass
 
@@ -67,8 +68,10 @@ import kotlin.reflect.KClass
  */
 class SovereignTramai private constructor(
     private val delegate: Tramai,
-    private val verificationReceipts: List<VerifiedLocalModelArtifact>,
+    verificationReceipts: List<VerifiedLocalModelArtifact>,
 ) {
+    private val verificationReceipts: List<VerifiedLocalModelArtifact> =
+        Collections.unmodifiableList(ArrayList(verificationReceipts))
     /**
      * Creates a service proxy for the given service type.
      */
@@ -455,6 +458,7 @@ class SovereignTramai private constructor(
                 "artifact-file-symlink-rejected",
                 "artifact-file-size-mismatch",
                 "artifact-file-digest-mismatch",
+                "artifact-file-access-failed",
                 "artifact-traversal-rejected",
                 "artifact-directory-substituted-for-file",
                 "artifact-not-a-regular-file",

--- a/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/SovereignTramai.kt
+++ b/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/SovereignTramai.kt
@@ -3,8 +3,11 @@ package dev.tramai.sovereign
 import dev.tramai.core.approval.ApprovalContinuationStore
 import dev.tramai.core.approval.ApprovalGateCoordinator
 import dev.tramai.core.approval.ToolArgumentsDigester
+import dev.tramai.core.model.ModelArtifactVerificationSettings
+import dev.tramai.core.model.ModelArtifactVerifier
 import dev.tramai.core.model.ModelRegistry
 import dev.tramai.core.model.ModelRegistrySettings
+import dev.tramai.core.model.VerifiedLocalModelArtifact
 import dev.tramai.core.model.TramaiTool
 import dev.tramai.core.observation.OperationInterceptor
 import dev.tramai.core.observation.OperationObserver
@@ -28,6 +31,7 @@ import dev.tramai.security.audit.AuditStore
 import dev.tramai.standalone.Tramai
 import dev.tramai.standalone.TramaiRuntime
 import java.time.Clock
+import kotlinx.coroutines.runBlocking
 import kotlin.reflect.KClass
 
 /**
@@ -63,6 +67,7 @@ import kotlin.reflect.KClass
  */
 class SovereignTramai private constructor(
     private val delegate: Tramai,
+    private val verificationReceipts: List<VerifiedLocalModelArtifact>,
 ) {
     /**
      * Creates a service proxy for the given service type.
@@ -74,6 +79,11 @@ class SovereignTramai private constructor(
      * both service creation and approval-resume operations.
      */
     fun runtime(): SovereignTramaiRuntime = SovereignTramaiRuntime(delegate.runtime())
+
+    /**
+     * Returns immutable verification receipts from build-time artifact verification.
+     */
+    fun verificationReceipts(): List<VerifiedLocalModelArtifact> = verificationReceipts
 
     companion object {
         @JvmStatic
@@ -101,6 +111,9 @@ class SovereignTramai private constructor(
         private val fallbackRoutes = mutableListOf<FallbackRoute>()
         private var defaultProviderName: String? = null
         private var clock: Clock = Clock.systemUTC()
+        private var modelArtifactVerifier: ModelArtifactVerifier? = null
+        private var verificationSettings: ModelArtifactVerificationSettings =
+            ModelArtifactVerificationSettings()
 
         // --- Required inputs ---
 
@@ -234,6 +247,16 @@ class SovereignTramai private constructor(
 
         fun engineEventObserver(observer: EngineEventObserver): Builder = apply {
             standaloneBuilder.engineEventObserver(observer)
+        }
+
+        fun modelArtifactVerifier(verifier: ModelArtifactVerifier): Builder = apply {
+            this.modelArtifactVerifier = verifier
+        }
+
+        fun modelArtifactVerificationSettings(
+            settings: ModelArtifactVerificationSettings,
+        ): Builder = apply {
+            this.verificationSettings = settings
         }
 
         // --- Approval suspension delegation ---
@@ -377,6 +400,11 @@ class SovereignTramai private constructor(
                 }
             }
 
+            val verificationReceipts = verifyLocalModelArtifacts(
+                profile = profile,
+                modelRegistry = modelRegistry!!,
+            )
+
             val policyConfig: PolicyConfiguration = profile.toPolicyConfiguration()
             val policyEngine = DefaultPolicyEngine(policyConfig)
             val auditEng = AuditEngine(store = auditStore!!, clock = clock)
@@ -391,7 +419,59 @@ class SovereignTramai private constructor(
                 .approvalLifecycleAudit(approvalLifecycleEmitter)
                 .build()
 
-            return SovereignTramai(tramai)
+            return SovereignTramai(
+                delegate = tramai,
+                verificationReceipts = verificationReceipts,
+            )
+        }
+
+        private fun verifyLocalModelArtifacts(
+            profile: SovereignProfileConfiguration,
+            modelRegistry: ModelRegistry,
+        ): List<VerifiedLocalModelArtifact> {
+            val verifier = modelArtifactVerifier ?: return emptyList()
+            if (!verificationSettings.enabled) {
+                return emptyList()
+            }
+
+            return runBlocking {
+                val receipts = mutableListOf<VerifiedLocalModelArtifact>()
+                for ((modelName, providerName) in primaryModelRoutes) {
+                    val registeredModel = try {
+                        modelRegistry.findApprovedModel(providerName, modelName)
+                    } catch (exception: Exception) {
+                        throw IllegalStateException(
+                            "artifact-approved-model-lookup-failed",
+                            exception,
+                        )
+                    } ?: throw IllegalStateException("artifact-approved-model-not-found")
+
+                    val trustZone = profile.providerZones.getValue(providerName)
+                    if (trustZone != ProviderTrustZone.LOCAL) {
+                        continue
+                    }
+
+                    if (
+                        verificationSettings.requireDigestForLocalModels &&
+                        registeredModel.artifactDigest == null
+                    ) {
+                        throw IllegalStateException("artifact-digest-required-for-local-model")
+                    }
+
+                    val receipt = try {
+                        verifier.verify(registeredModel)
+                    } catch (exception: IllegalStateException) {
+                        throw IllegalStateException(exception.message ?: "artifact-verification-failed", exception)
+                    } catch (exception: IllegalArgumentException) {
+                        throw IllegalStateException(exception.message ?: "artifact-verification-failed", exception)
+                    } catch (exception: Exception) {
+                        throw IllegalStateException("artifact-verification-failed", exception)
+                    } ?: throw IllegalStateException("artifact-manifest-not-found")
+
+                    receipts += receipt
+                }
+                receipts.toList()
+            }
         }
     }
 }

--- a/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/SovereignTramai.kt
+++ b/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/SovereignTramai.kt
@@ -472,6 +472,11 @@ class SovereignTramai private constructor(
             return runBlocking {
                 val receipts = mutableListOf<VerifiedLocalModelArtifact>()
                 for ((providerName, modelName) in verificationTargets) {
+                    val trustZone = profile.providerZones.getValue(providerName)
+                    if (trustZone != ProviderTrustZone.LOCAL) {
+                        continue
+                    }
+
                     val registeredModel = try {
                         modelRegistry.findApprovedModel(providerName, modelName)
                     } catch (exception: kotlinx.coroutines.CancellationException) {
@@ -481,11 +486,6 @@ class SovereignTramai private constructor(
                             "artifact-approved-model-lookup-failed",
                         )
                     } ?: throw IllegalStateException("artifact-approved-model-not-found")
-
-                    val trustZone = profile.providerZones.getValue(providerName)
-                    if (trustZone != ProviderTrustZone.LOCAL) {
-                        continue
-                    }
 
                     if (
                         verificationSettings.requireDigestForLocalModels &&

--- a/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/SovereignTramai.kt
+++ b/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/SovereignTramai.kt
@@ -429,16 +429,49 @@ class SovereignTramai private constructor(
             profile: SovereignProfileConfiguration,
             modelRegistry: ModelRegistry,
         ): List<VerifiedLocalModelArtifact> {
-            val verifier = modelArtifactVerifier ?: return emptyList()
             if (!verificationSettings.enabled) {
                 return emptyList()
             }
 
+            val verifier = checkNotNull(modelArtifactVerifier) {
+                "artifact-verification-not-configured"
+            }
+
+            // Collect unique (providerName, modelName) targets from primary AND fallback routes
+            val verificationTargets = buildSet {
+                primaryModelRoutes.forEach { (modelName, providerName) ->
+                    add(providerName to modelName)
+                }
+                fallbackRoutes.forEach { route ->
+                    add(route.providerName to route.fallbackModelName)
+                }
+            }
+
+            val safeCodes = setOf(
+                "artifact-manifest-not-found",
+                "artifact-manifest-identity-drift",
+                "artifact-aggregate-digest-mismatch",
+                "artifact-file-not-found",
+                "artifact-file-symlink-rejected",
+                "artifact-file-size-mismatch",
+                "artifact-file-digest-mismatch",
+                "artifact-traversal-rejected",
+                "artifact-directory-substituted-for-file",
+                "artifact-not-a-regular-file",
+                "artifact-total-size-overflow",
+            )
+
+            fun sanitizedArtifactReason(exception: Exception): String =
+                exception.message?.takeIf { it in safeCodes }
+                    ?: "artifact-verification-failed"
+
             return runBlocking {
                 val receipts = mutableListOf<VerifiedLocalModelArtifact>()
-                for ((modelName, providerName) in primaryModelRoutes) {
+                for ((providerName, modelName) in verificationTargets) {
                     val registeredModel = try {
                         modelRegistry.findApprovedModel(providerName, modelName)
+                    } catch (exception: kotlinx.coroutines.CancellationException) {
+                        throw exception
                     } catch (exception: Exception) {
                         throw IllegalStateException(
                             "artifact-approved-model-lookup-failed",
@@ -460,12 +493,18 @@ class SovereignTramai private constructor(
 
                     val receipt = try {
                         verifier.verify(registeredModel)
+                    } catch (exception: kotlinx.coroutines.CancellationException) {
+                        throw exception
                     } catch (exception: IllegalStateException) {
-                        throw IllegalStateException(exception.message ?: "artifact-verification-failed", exception)
+                        throw IllegalStateException(
+                            sanitizedArtifactReason(exception),
+                        )
                     } catch (exception: IllegalArgumentException) {
-                        throw IllegalStateException(exception.message ?: "artifact-verification-failed", exception)
+                        throw IllegalStateException(
+                            sanitizedArtifactReason(exception),
+                        )
                     } catch (exception: Exception) {
-                        throw IllegalStateException("artifact-verification-failed", exception)
+                        throw IllegalStateException("artifact-verification-failed")
                     } ?: throw IllegalStateException("artifact-manifest-not-found")
 
                     receipts += receipt

--- a/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/SovereignTramai.kt
+++ b/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/SovereignTramai.kt
@@ -472,10 +472,9 @@ class SovereignTramai private constructor(
                         modelRegistry.findApprovedModel(providerName, modelName)
                     } catch (exception: kotlinx.coroutines.CancellationException) {
                         throw exception
-                    } catch (exception: Exception) {
+                    } catch (_: Exception) {
                         throw IllegalStateException(
                             "artifact-approved-model-lookup-failed",
-                            exception,
                         )
                     } ?: throw IllegalStateException("artifact-approved-model-not-found")
 

--- a/tramai-sovereign/src/test/kotlin/dev/tramai/sovereign/SovereignTramaiArtifactVerificationTest.kt
+++ b/tramai-sovereign/src/test/kotlin/dev/tramai/sovereign/SovereignTramaiArtifactVerificationTest.kt
@@ -1,0 +1,236 @@
+package dev.tramai.sovereign
+
+import dev.tramai.core.model.ModelArtifactDigest
+import dev.tramai.core.model.ModelArtifactVerificationSettings
+import dev.tramai.core.model.ModelArtifactVerifier
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.model.RegisteredModel
+import dev.tramai.core.model.VerifiedLocalModelArtifact
+import dev.tramai.core.provider.ModelProvider
+import dev.tramai.security.ProviderTrustZone
+import dev.tramai.security.audit.InMemoryAuditStore
+import dev.tramai.security.model.InMemoryModelRegistry
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class SovereignTramaiArtifactVerificationTest {
+
+    private val fixedInstant = Instant.parse("2026-01-02T03:04:05Z")
+    private val fixedClock = Clock.fixed(fixedInstant, ZoneId.of("UTC"))
+
+    @Test
+    fun `local model with valid manifest builds and stores receipts`() {
+        val registeredModel = localRegisteredModel(
+            artifactDigest = ModelArtifactDigest.of("sha256:${"a".repeat(64)}"),
+        )
+        val verifier = RecordingVerifier { model ->
+            VerifiedLocalModelArtifact(
+                registryEntryId = model.registryEntryId,
+                manifestDigest = model.artifactDigest!!,
+                modelName = model.modelName,
+                verifiedAt = fixedClock.instant(),
+                artifactCount = 2,
+                totalSizeBytes = 1024,
+            )
+        }
+
+        val tramai = localBuilder(registeredModel)
+            .clock(fixedClock)
+            .modelArtifactVerifier(verifier)
+            .modelArtifactVerificationSettings(
+                ModelArtifactVerificationSettings(
+                    enabled = true,
+                    requireDigestForLocalModels = true,
+                ),
+            )
+            .build()
+
+        assertThat(verifier.seenModels).containsExactly(registeredModel)
+        assertThat(tramai.verificationReceipts()).containsExactly(
+            VerifiedLocalModelArtifact(
+                registryEntryId = "local-entry",
+                manifestDigest = registeredModel.artifactDigest!!,
+                modelName = "test-model",
+                verifiedAt = fixedInstant,
+                artifactCount = 2,
+                totalSizeBytes = 1024,
+            ),
+        )
+    }
+
+    @Test
+    fun `local model without digest when required rejects before build`() {
+        val registeredModel = localRegisteredModel(artifactDigest = null)
+        val verifier = RecordingVerifier { error("verifier should not be invoked") }
+
+        assertThatThrownBy {
+            localBuilder(registeredModel)
+                .modelArtifactVerifier(verifier)
+                .modelArtifactVerificationSettings(
+                    ModelArtifactVerificationSettings(
+                        enabled = true,
+                        requireDigestForLocalModels = true,
+                    ),
+                )
+                .build()
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("artifact-digest-required-for-local-model")
+
+        assertThat(verifier.seenModels).isEmpty()
+    }
+
+    @Test
+    fun `local model with unknown manifest rejects`() {
+        val registeredModel = localRegisteredModel(
+            artifactDigest = ModelArtifactDigest.of("sha256:${"b".repeat(64)}"),
+        )
+        val verifier = RecordingVerifier { null }
+
+        assertThatThrownBy {
+            localBuilder(registeredModel)
+                .modelArtifactVerifier(verifier)
+                .modelArtifactVerificationSettings(
+                    ModelArtifactVerificationSettings(enabled = true),
+                )
+                .build()
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("artifact-manifest-not-found")
+
+        assertThat(verifier.seenModels).containsExactly(registeredModel)
+    }
+
+    @Test
+    fun `cloud model without local artifact manifest preserves existing behavior`() = runBlocking {
+        val registeredModel = RegisteredModel(
+            registryEntryId = "cloud-entry",
+            providerId = "cloud-provider",
+            modelName = "test-model",
+            revision = "1.0",
+        )
+        val verifier = RecordingVerifier { null }
+
+        val tramai = cloudBuilder(registeredModel)
+            .modelArtifactVerifier(verifier)
+            .modelArtifactVerificationSettings(
+                ModelArtifactVerificationSettings(
+                    enabled = true,
+                    requireDigestForLocalModels = true,
+                ),
+            )
+            .build()
+
+        val result = tramai.create<EchoService>().echo("hello")
+
+        assertThat(result).isEqualTo("mock response for test-model")
+        assertThat(verifier.seenModels).isEmpty()
+        assertThat(tramai.verificationReceipts()).isEmpty()
+    }
+
+    @Test
+    fun `verification disabled preserves backward compatible behavior`() = runBlocking {
+        val registeredModel = localRegisteredModel(artifactDigest = null)
+        val verifier = RecordingVerifier { error("verifier should not be invoked") }
+
+        val tramai = localBuilder(registeredModel)
+            .modelArtifactVerifier(verifier)
+            .modelArtifactVerificationSettings(
+                ModelArtifactVerificationSettings(
+                    enabled = false,
+                    requireDigestForLocalModels = true,
+                ),
+            )
+            .build()
+
+        val result = tramai.create<EchoService>().echo("hello")
+
+        assertThat(result).isEqualTo("mock response for test-model")
+        assertThat(verifier.seenModels).isEmpty()
+        assertThat(tramai.verificationReceipts()).isEmpty()
+    }
+
+    @Test
+    fun `no verifier configured preserves backward compatible behavior`() = runBlocking {
+        val registeredModel = localRegisteredModel(artifactDigest = null)
+
+        val tramai = localBuilder(registeredModel)
+            .modelArtifactVerificationSettings(
+                ModelArtifactVerificationSettings(
+                    enabled = true,
+                    requireDigestForLocalModels = true,
+                ),
+            )
+            .build()
+
+        val result = tramai.create<EchoService>().echo("hello")
+
+        assertThat(result).isEqualTo("mock response for test-model")
+        assertThat(tramai.verificationReceipts()).isEmpty()
+    }
+
+    private fun localBuilder(registeredModel: RegisteredModel): SovereignTramai.Builder {
+        val registry = InMemoryModelRegistry.builder()
+            .register(registeredModel)
+            .build()
+        val profile = SovereignProfileConfiguration(
+            allowedModels = setOf("test-model"),
+            allowedProviders = setOf("local-provider"),
+            providerZones = mapOf("local-provider" to ProviderTrustZone.LOCAL),
+        )
+        return SovereignTramai.builder()
+            .profile(profile)
+            .modelRegistry(registry)
+            .auditStore(InMemoryAuditStore())
+            .provider(FakeProvider("local-provider"), name = "local-provider", default = true)
+            .model("test-model", "local-provider")
+    }
+
+    private fun cloudBuilder(registeredModel: RegisteredModel): SovereignTramai.Builder {
+        val registry = InMemoryModelRegistry.builder()
+            .register(registeredModel)
+            .build()
+        val profile = SovereignProfileConfiguration(
+            allowedModels = setOf("test-model"),
+            allowedProviders = setOf("cloud-provider"),
+            providerZones = mapOf("cloud-provider" to ProviderTrustZone.GLOBAL_CLOUD),
+        )
+        return SovereignTramai.builder()
+            .profile(profile)
+            .modelRegistry(registry)
+            .auditStore(InMemoryAuditStore())
+            .provider(FakeProvider("cloud-provider"), name = "cloud-provider", default = true)
+            .model("test-model", "cloud-provider")
+    }
+
+    private fun localRegisteredModel(artifactDigest: ModelArtifactDigest?): RegisteredModel =
+        RegisteredModel(
+            registryEntryId = "local-entry",
+            providerId = "local-provider",
+            modelName = "test-model",
+            revision = "1.0",
+            artifactDigest = artifactDigest,
+        )
+
+    private class RecordingVerifier(
+        private val block: suspend (RegisteredModel) -> VerifiedLocalModelArtifact?,
+    ) : ModelArtifactVerifier {
+        val seenModels = mutableListOf<RegisteredModel>()
+
+        override suspend fun verify(registeredModel: RegisteredModel): VerifiedLocalModelArtifact? {
+            seenModels += registeredModel
+            return block(registeredModel)
+        }
+    }
+
+    private class FakeProvider(private val name: String) : ModelProvider {
+        override suspend fun complete(request: ModelRequest): ModelResponse =
+            ModelResponse(content = "mock response for ${request.model}")
+
+        override fun providerId(): String = name
+    }
+}

--- a/tramai-sovereign/src/test/kotlin/dev/tramai/sovereign/SovereignTramaiArtifactVerificationTest.kt
+++ b/tramai-sovereign/src/test/kotlin/dev/tramai/sovereign/SovereignTramaiArtifactVerificationTest.kt
@@ -3,6 +3,7 @@ package dev.tramai.sovereign
 import dev.tramai.core.model.ModelArtifactDigest
 import dev.tramai.core.model.ModelArtifactVerificationSettings
 import dev.tramai.core.model.ModelArtifactVerifier
+import dev.tramai.core.model.ModelRegistry
 import dev.tramai.core.model.ModelRequest
 import dev.tramai.core.model.ModelResponse
 import dev.tramai.core.model.RegisteredModel
@@ -140,6 +141,72 @@ class SovereignTramaiArtifactVerificationTest {
                 .build()
         }.isInstanceOf(IllegalStateException::class.java)
             .hasMessage("artifact-verification-not-configured")
+    }
+
+    @Test
+    fun `digest optional transitional mode builds and verifies file bytes without registry pinning`() {
+        val registeredModel = localRegisteredModel(artifactDigest = null)
+        val verifier = RecordingVerifier { model ->
+            VerifiedLocalModelArtifact(
+                registryEntryId = model.registryEntryId,
+                manifestDigest = ModelArtifactDigest.of("sha256:${"d".repeat(64)}"),
+                modelName = model.modelName,
+                verifiedAt = fixedClock.instant(),
+                artifactCount = 1,
+                totalSizeBytes = 512,
+            )
+        }
+
+        val tramai = localBuilder(registeredModel)
+            .clock(fixedClock)
+            .modelArtifactVerifier(verifier)
+            .modelArtifactVerificationSettings(
+                ModelArtifactVerificationSettings(
+                    enabled = true,
+                    requireDigestForLocalModels = false,
+                ),
+            )
+            .build()
+
+        assertThat(verifier.seenModels).containsExactly(registeredModel)
+        assertThat(tramai.verificationReceipts()).isNotEmpty
+    }
+
+    @Test
+    fun `model registry SPI exception sanitized through cause chain`() {
+        val registeredModel = localRegisteredModel(
+            artifactDigest = ModelArtifactDigest.of("sha256:${"a".repeat(64)}"),
+        )
+        val verifier = RecordingVerifier { null }
+
+        assertThatThrownBy {
+            SovereignTramai.builder()
+                .profile(
+                    SovereignProfileConfiguration(
+                        allowedModels = setOf("test-model"),
+                        allowedProviders = setOf("local-provider"),
+                        providerZones = mapOf("local-provider" to ProviderTrustZone.LOCAL),
+                    ),
+                )
+                .modelRegistry(object : ModelRegistry {
+                    override suspend fun findApprovedModel(
+                        providerId: String,
+                        modelName: String,
+                    ): RegisteredModel? {
+                        throw IllegalStateException("/secret/model/path.gguf")
+                    }
+                })
+                .auditStore(InMemoryAuditStore())
+                .provider(FakeProvider("local-provider"), name = "local-provider", default = true)
+                .model("test-model", "local-provider")
+                .clock(fixedClock)
+                .modelArtifactVerifier(verifier)
+                .modelArtifactVerificationSettings(
+                    ModelArtifactVerificationSettings(enabled = true),
+                )
+                .build()
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("artifact-approved-model-lookup-failed")
     }
 
     @Test

--- a/tramai-sovereign/src/test/kotlin/dev/tramai/sovereign/SovereignTramaiArtifactVerificationTest.kt
+++ b/tramai-sovereign/src/test/kotlin/dev/tramai/sovereign/SovereignTramaiArtifactVerificationTest.kt
@@ -106,6 +106,26 @@ class SovereignTramaiArtifactVerificationTest {
     }
 
     @Test
+    fun `local model with verifier throwing modified byte error rejects before build`() {
+        val registeredModel = localRegisteredModel(
+            artifactDigest = ModelArtifactDigest.of("sha256:${"b".repeat(64)}"),
+        )
+        val verifier = RecordingVerifier { throw IllegalStateException("artifact-file-digest-mismatch") }
+
+        assertThatThrownBy {
+            localBuilder(registeredModel)
+                .modelArtifactVerifier(verifier)
+                .modelArtifactVerificationSettings(
+                    ModelArtifactVerificationSettings(enabled = true),
+                )
+                .build()
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("artifact-file-digest-mismatch")
+
+        assertThat(verifier.seenModels).containsExactly(registeredModel)
+    }
+
+    @Test
     fun `cloud model without local artifact manifest preserves existing behavior`() = runBlocking {
         val registeredModel = RegisteredModel(
             registryEntryId = "cloud-entry",

--- a/tramai-sovereign/src/test/kotlin/dev/tramai/sovereign/SovereignTramaiArtifactVerificationTest.kt
+++ b/tramai-sovereign/src/test/kotlin/dev/tramai/sovereign/SovereignTramaiArtifactVerificationTest.kt
@@ -14,6 +14,7 @@ import dev.tramai.security.model.InMemoryModelRegistry
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -126,6 +127,22 @@ class SovereignTramaiArtifactVerificationTest {
     }
 
     @Test
+    fun `enabled equals true without verifier rejects before build`() {
+        val registeredModel = localRegisteredModel(
+            artifactDigest = ModelArtifactDigest.of("sha256:${"a".repeat(64)}"),
+        )
+
+        assertThatThrownBy {
+            localBuilder(registeredModel)
+                .modelArtifactVerificationSettings(
+                    ModelArtifactVerificationSettings(enabled = true),
+                )
+                .build()
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("artifact-verification-not-configured")
+    }
+
+    @Test
     fun `cloud model without local artifact manifest preserves existing behavior`() = runBlocking {
         val registeredModel = RegisteredModel(
             registryEntryId = "cloud-entry",
@@ -175,22 +192,211 @@ class SovereignTramaiArtifactVerificationTest {
     }
 
     @Test
-    fun `no verifier configured preserves backward compatible behavior`() = runBlocking {
-        val registeredModel = localRegisteredModel(artifactDigest = null)
+    fun `cancellation from verifier propagates unchanged`() {
+        val registeredModel = localRegisteredModel(
+            artifactDigest = ModelArtifactDigest.of("sha256:${"a".repeat(64)}"),
+        )
+        val verifier = RecordingVerifier {
+            throw CancellationException("verifier cancelled")
+        }
 
-        val tramai = localBuilder(registeredModel)
+        assertThatThrownBy {
+            localBuilder(registeredModel)
+                .clock(fixedClock)
+                .modelArtifactVerifier(verifier)
+                .modelArtifactVerificationSettings(
+                    ModelArtifactVerificationSettings(enabled = true),
+                )
+                .build()
+        }.isInstanceOf(CancellationException::class.java)
+            .hasMessage("verifier cancelled")
+    }
+
+    @Test
+    fun `custom verifier path leakage sanitized via safe-code allowlist`() {
+        val registeredModel = localRegisteredModel(
+            artifactDigest = ModelArtifactDigest.of("sha256:${"a".repeat(64)}"),
+        )
+        val verifier = RecordingVerifier {
+            throw IllegalStateException("/mnt/models/customer-secret.gguf")
+        }
+
+        assertThatThrownBy {
+            localBuilder(registeredModel)
+                .clock(fixedClock)
+                .modelArtifactVerifier(verifier)
+                .modelArtifactVerificationSettings(
+                    ModelArtifactVerificationSettings(enabled = true),
+                )
+                .build()
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("artifact-verification-failed")
+    }
+
+    @Test
+    fun `GLOBAL_CLOUD primary with LOCAL fallback and valid manifest produces LOCAL receipt`() {
+        val localRegistered = RegisteredModel(
+            registryEntryId = "local-entry",
+            providerId = "fallback-provider",
+            modelName = "test-model-fallback",
+            revision = "1.0",
+            artifactDigest = ModelArtifactDigest.of("sha256:${"a".repeat(64)}"),
+        )
+        val cloudRegistered = RegisteredModel(
+            registryEntryId = "cloud-entry",
+            providerId = "cloud-provider",
+            modelName = "test-model",
+            revision = "1.0",
+        )
+
+        val registry = InMemoryModelRegistry.builder()
+            .register(localRegistered)
+            .register(cloudRegistered)
+            .build()
+
+        val profile = SovereignProfileConfiguration(
+            allowedModels = setOf("test-model", "test-model-fallback"),
+            allowedProviders = setOf("cloud-provider", "fallback-provider"),
+            allowedFallbackProviders = setOf("fallback-provider"),
+            providerZones = mapOf(
+                "cloud-provider" to ProviderTrustZone.GLOBAL_CLOUD,
+                "fallback-provider" to ProviderTrustZone.LOCAL,
+            ),
+        )
+
+        var invokedWith: RegisteredModel? = null
+        val verifier = RecordingVerifier { model ->
+            invokedWith = model
+            VerifiedLocalModelArtifact(
+                registryEntryId = model.registryEntryId,
+                manifestDigest = model.artifactDigest!!,
+                modelName = model.modelName,
+                verifiedAt = fixedClock.instant(),
+                artifactCount = 1,
+                totalSizeBytes = 512,
+            )
+        }
+
+        val tramai = SovereignTramai.builder()
+            .profile(profile)
+            .modelRegistry(registry)
+            .auditStore(InMemoryAuditStore())
+            .provider(FakeProvider("cloud-provider"), name = "cloud-provider", default = true)
+            .provider(FakeProvider("fallback-provider"), name = "fallback-provider")
+            .model("test-model", "cloud-provider")
+            .model("test-model-fallback", "fallback-provider")
+            .fallbackModel("test-model", "test-model-fallback", "fallback-provider")
+            .clock(fixedClock)
+            .modelArtifactVerifier(verifier)
             .modelArtifactVerificationSettings(
-                ModelArtifactVerificationSettings(
-                    enabled = true,
-                    requireDigestForLocalModels = true,
-                ),
+                ModelArtifactVerificationSettings(enabled = true),
             )
             .build()
 
-        val result = tramai.create<EchoService>().echo("hello")
+        assertThat(invokedWith).isNotNull
+        assertThat(invokedWith?.registryEntryId).isEqualTo("local-entry")
+        assertThat(tramai.verificationReceipts()).hasSize(1)
+    }
 
-        assertThat(result).isEqualTo("mock response for test-model")
-        assertThat(tramai.verificationReceipts()).isEmpty()
+    @Test
+    fun `GLOBAL_CLOUD primary with LOCAL fallback and missing manifest rejects`() {
+        val cloudRegistered = RegisteredModel(
+            registryEntryId = "cloud-entry",
+            providerId = "cloud-provider",
+            modelName = "test-model",
+            revision = "1.0",
+        )
+        val localRegistered = RegisteredModel(
+            registryEntryId = "local-entry",
+            providerId = "fallback-provider",
+            modelName = "test-model-fallback",
+            revision = "1.0",
+            artifactDigest = ModelArtifactDigest.of("sha256:${"b".repeat(64)}"),
+        )
+
+        val registry = InMemoryModelRegistry.builder()
+            .register(cloudRegistered)
+            .register(localRegistered)
+            .build()
+
+        val profile = SovereignProfileConfiguration(
+            allowedModels = setOf("test-model", "test-model-fallback"),
+            allowedProviders = setOf("cloud-provider", "fallback-provider"),
+            allowedFallbackProviders = setOf("fallback-provider"),
+            providerZones = mapOf(
+                "cloud-provider" to ProviderTrustZone.GLOBAL_CLOUD,
+                "fallback-provider" to ProviderTrustZone.LOCAL,
+            ),
+        )
+
+        val verifier = RecordingVerifier { null }
+
+        assertThatThrownBy {
+            SovereignTramai.builder()
+                .profile(profile)
+                .modelRegistry(registry)
+                .auditStore(InMemoryAuditStore())
+                .provider(FakeProvider("cloud-provider"), name = "cloud-provider", default = true)
+                .provider(FakeProvider("fallback-provider"), name = "fallback-provider")
+                .model("test-model", "cloud-provider")
+                .model("test-model-fallback", "fallback-provider")
+                .fallbackModel("test-model", "test-model-fallback", "fallback-provider")
+                .clock(fixedClock)
+                .modelArtifactVerifier(verifier)
+                .modelArtifactVerificationSettings(
+                    ModelArtifactVerificationSettings(enabled = true),
+                )
+                .build()
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("artifact-manifest-not-found")
+    }
+
+    @Test
+    fun `LOCAL primary and LOCAL fallback referencing same pair verifies once`() {
+        val registeredModel = localRegisteredModel(
+            artifactDigest = ModelArtifactDigest.of("sha256:${"a".repeat(64)}"),
+        )
+
+        val registry = InMemoryModelRegistry.builder()
+            .register(registeredModel)
+            .build()
+
+        val profile = SovereignProfileConfiguration(
+            allowedModels = setOf("test-model"),
+            allowedProviders = setOf("local-provider"),
+            allowedFallbackProviders = setOf("local-provider"),
+            providerZones = mapOf("local-provider" to ProviderTrustZone.LOCAL),
+        )
+
+        val seenModels = mutableListOf<RegisteredModel>()
+        val verifier = RecordingVerifier { model ->
+            seenModels += model
+            VerifiedLocalModelArtifact(
+                registryEntryId = model.registryEntryId,
+                manifestDigest = model.artifactDigest!!,
+                modelName = model.modelName,
+                verifiedAt = fixedClock.instant(),
+                artifactCount = 1,
+                totalSizeBytes = 512,
+            )
+        }
+
+        val tramai = SovereignTramai.builder()
+            .profile(profile)
+            .modelRegistry(registry)
+            .auditStore(InMemoryAuditStore())
+            .provider(FakeProvider("local-provider"), name = "local-provider", default = true)
+            .model("test-model", "local-provider")
+            .fallbackProvider("test-model", "local-provider")
+            .clock(fixedClock)
+            .modelArtifactVerifier(verifier)
+            .modelArtifactVerificationSettings(
+                ModelArtifactVerificationSettings(enabled = true),
+            )
+            .build()
+
+        assertThat(seenModels).hasSize(1)
+        assertThat(tramai.verificationReceipts()).hasSize(1)
     }
 
     private fun localBuilder(registeredModel: RegisteredModel): SovereignTramai.Builder {

--- a/tramai-sovereign/src/test/kotlin/dev/tramai/sovereign/SovereignTramaiArtifactVerificationTest.kt
+++ b/tramai-sovereign/src/test/kotlin/dev/tramai/sovereign/SovereignTramaiArtifactVerificationTest.kt
@@ -466,6 +466,40 @@ class SovereignTramaiArtifactVerificationTest {
         assertThat(tramai.verificationReceipts()).hasSize(1)
     }
 
+    @Test
+    fun `GLOBAL_CLOUD route does not call registry when verification is enabled`() {
+        val verifier = RecordingVerifier { error("verifier should not be invoked") }
+
+        val tramai = SovereignTramai.builder()
+            .profile(
+                SovereignProfileConfiguration(
+                    allowedModels = setOf("test-model"),
+                    allowedProviders = setOf("cloud-provider"),
+                    providerZones = mapOf("cloud-provider" to ProviderTrustZone.GLOBAL_CLOUD),
+                ),
+            )
+            .modelRegistry(object : ModelRegistry {
+                override suspend fun findApprovedModel(
+                    providerId: String,
+                    modelName: String,
+                ): RegisteredModel {
+                    error("Registry should not be called for CLOUD routes")
+                }
+            })
+            .auditStore(InMemoryAuditStore())
+            .provider(FakeProvider("cloud-provider"), name = "cloud-provider", default = true)
+            .model("test-model", "cloud-provider")
+            .clock(fixedClock)
+            .modelArtifactVerifier(verifier)
+            .modelArtifactVerificationSettings(
+                ModelArtifactVerificationSettings(enabled = true),
+            )
+            .build()
+
+        assertThat(tramai.verificationReceipts()).isEmpty()
+        assertThat(verifier.seenModels).isEmpty()
+    }
+
     private fun localBuilder(registeredModel: RegisteredModel): SovereignTramai.Builder {
         val registry = InMemoryModelRegistry.builder()
             .register(registeredModel)


### PR DESCRIPTION
## Summary

Add a local model artifact verification layer that proves declared local artifact bytes on disk match an approved cryptographic manifest before sovereign runtime use. Reuses the existing `RegisteredModel.artifactDigest` extension point.

SPEC-018: Local Model Artifact Verification

## Changed Files (15)

| File | Type | Description |
|------|------|-------------|
| `tramai-core/.../ModelFieldValidation.kt` | **NEW** | Extracted `validateField()` as package-level utility |
| `tramai-core/.../LocalModelArtifactManifestV1.kt` | **NEW** | Immutable multi-file manifest with `canonicalBytes(): ByteArray` |
| `tramai-core/.../LocalModelArtifactFileV1.kt` | **NEW** | Artifact file DTO with cross-platform path validation |
| `tramai-core/.../VerifiedLocalModelArtifact.kt` | **NEW** | Immutable verification receipt |
| `tramai-core/.../ModelArtifactVerifier.kt` | **NEW** | SPI + NoOpModelArtifactVerifier (returns null) |
| `tramai-core/.../ModelArtifactVerificationSettings.kt` | **NEW** | `enabled=false`, `requireDigestForLocalModels=true` |
| `tramai-core/.../RegisteredModel.kt` | MODIFIED | Uses extracted `validateField()` |
| `tramai-security/.../FileSystemModelArtifactVerifier.kt` | **NEW** | Streaming SHA-256 verifier with strict filesystem hardening |
| `tramai-sovereign/.../SovereignTramai.kt` | MODIFIED | Builder: `modelArtifactVerifier()`, `modelArtifactVerificationSettings()`, `verificationReceipts()`, fallback route verification |
| `docs/specs/spec-018-local-model-artifact-verification.md` | **NEW** | Full spec |
| `docs/board/tasks/task-pr30-local-model-artifact-verification.md` | **NEW** | Task tracking |

## Security Invariants

- **Immutable manifest snapshot**: `class` not `data class` — `artifacts.toList()` in body, single immutable copy used for digest, verification, and receipt
- **Precomputed size overflow**: aggregate computed before file I/O; `Math.addExact` → `artifact-total-size-overflow`
- **Strict symlink policy**: reject all symlinks via `toRealPath() != normalize()`
- **Cross-platform path validation**: rejects UNC, Windows drive letters, backslash separators, empty/self segments, double slashes
- **Fixed safe-code allowlist**: SPI exceptions sanitized; `CancellationException` propagated; ModelRegistry SPI cause dropped
- **Streaming SHA-256**: 64KB buffer, no loading multi-GB model files into memory
- **Fallback routes verified**: unique primary + fallback LOCAL targets checked at build time
- **Fail closed**: `enabled=true` without verifier rejected at build time
- **Registry-pinned default**: `requireDigestForLocalModels=true` for cryptographic pinning

## Verification

```
./gradlew test --rerun-tasks                    ✅ (all modules)
./gradlew :tramai-core:test --rerun-tasks       ✅ (10+ manifest tests)
./gradlew :tramai-security:test  --rerun-tasks  ✅ (13 verifier tests)
./gradlew :tramai-sovereign:test --rerun-tasks  ✅ (14 integration tests)
```

## Closes

Closes SPEC-018 Local Model Artifact Verification