### PR TITLE
feat(supply-chain): add release artifact evidence for TramAI build outputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Compute SBOM digest + copy
         run: ./gradlew prepareCycloneDxBom
 
+      - name: Prepare sovereign release artifacts
+        run: ./gradlew prepareSovereignReleaseArtifacts
+
       - name: Upload SBOM
         uses: actions/upload-artifact@v4
         with:
@@ -65,6 +68,14 @@ jobs:
           name: cyclonedx-sbom-digest
           path: |
             build/supply-chain/sbom/tramai-cyclonedx-sbom.sha256
+
+      - name: Upload sovereign release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sovereign-release-artifacts
+          path: |
+            build/sovereign-release/artifacts/
+            build/sovereign-release/release-artifacts-v1.json
 
   zero-egress:
     runs-on: ubuntu-latest
@@ -119,6 +130,11 @@ jobs:
         with:
           subject-path: build/zero-egress-report/sovereign-evidence-pack-v1.json
           sbom-path: build/supply-chain/sbom/tramai-cyclonedx-sbom.json
+
+      - name: Attest release artifact manifest
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: build/sovereign-release/release-artifacts-v1.json
 
       - name: Upload zero-egress report on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
   build:
     permissions:
       contents: read
+      id-token: write
+      attestations: write
     runs-on: ubuntu-latest
 
     steps:
@@ -77,6 +79,11 @@ jobs:
             build/sovereign-release/artifacts/
             build/sovereign-release/release-artifacts-v1.json
 
+      - name: Attest release artifact manifest
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: build/sovereign-release/release-artifacts-v1.json
+
   zero-egress:
     runs-on: ubuntu-latest
     needs: build
@@ -130,11 +137,6 @@ jobs:
         with:
           subject-path: build/zero-egress-report/sovereign-evidence-pack-v1.json
           sbom-path: build/supply-chain/sbom/tramai-cyclonedx-sbom.json
-
-      - name: Attest release artifact manifest
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: build/sovereign-release/release-artifacts-v1.json
 
       - name: Upload zero-egress report on failure
         if: failure()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.kotlin.dsl.configure
 import org.gradle.plugins.signing.SigningExtension
+import org.gradle.util.GradleVersion
 import org.w3c.dom.Element
 import java.io.File
 import java.net.URI
@@ -524,5 +525,94 @@ tasks.register("prepareCycloneDxBom") {
         } else {
             logger.warn("cyclonedxBom did not produce reports/cyclonedx/bom.json in the build directory; skipping SBOM copy.")
         }
+    }
+}
+
+val sovereignReleaseModules = listOf(
+    ":tramai-core",
+    ":tramai-security",
+    ":tramai-structured",
+    ":tramai-engine",
+    ":tramai-standalone",
+    ":tramai-sovereign",
+    ":tramai-persistence-file",
+    ":tramai-observability",
+)
+
+tasks.register("prepareSovereignReleaseArtifacts") {
+    group = "verification"
+    description = "Collects JARs from sovereign release modules, computes SHA-256 digests, and generates release-artifacts-v1.json."
+    dependsOn(sovereignReleaseModules.map { project(it).tasks.named("jar") })
+
+    doLast {
+        val outputDir = rootProject.layout.buildDirectory.dir("sovereign-release").get().asFile
+        val artifactsDir = outputDir.resolve("artifacts")
+        artifactsDir.mkdirs()
+
+        val groupId = tramaiGroup.get()
+        val version = tramaiVersion.get()
+        val artifactEntries = mutableListOf<String>()
+
+        sovereignReleaseModules.forEach { modulePath ->
+            val proj = project(modulePath)
+            val moduleName = proj.name
+            val libsDir = proj.layout.buildDirectory.dir("libs").get().asFile
+            if (!libsDir.exists()) return@forEach
+
+            libsDir.listFiles { f -> f.name.endsWith(".jar") }?.forEach { jarFile ->
+                val copied = jarFile.copyTo(artifactsDir.resolve(jarFile.name), overwrite = true)
+
+                val digest = java.security.MessageDigest.getInstance("SHA-256")
+                val hex = digest.digest(copied.readBytes())
+                    .joinToString("") { "%02x".format(it) }
+                val sha256 = "sha256:$hex"
+
+                // Determine classifier from filename pattern: artifactId-version[-classifier].extension
+                val classifier = when {
+                    jarFile.name.contains("-sources.jar") -> "sources"
+                    jarFile.name.contains("-javadoc.jar") -> "javadoc"
+                    else -> null
+                }
+
+                val artifactLine = buildString {
+                    append("        {")
+                    append("\"groupId\": \"$groupId\", ")
+                    append("\"artifactId\": \"$moduleName\", ")
+                    append("\"version\": \"$version\", ")
+                    append("\"classifier\": ${if (classifier != null) "\"$classifier\"" else "null"}, ")
+                    append("\"extension\": \"jar\", ")
+                    append("\"fileName\": \"${jarFile.name}\", ")
+                    append("\"sha256\": \"$sha256\", ")
+                    append("\"sizeBytes\": ${copied.length()}")
+                    append("}")
+                }
+                artifactEntries.add(artifactLine)
+            }
+        }
+
+        val javaVersion = System.getProperty("java.version") ?: "unknown"
+        val gradleVersion = GradleVersion.current().version
+
+        val json = buildString {
+            appendLine("{")
+            appendLine("  \"schemaVersion\": 1,")
+            appendLine("  \"buildTool\": \"Gradle\",")
+            appendLine("  \"javaVersion\": \"$javaVersion\",")
+            appendLine("  \"gradleVersion\": \"$gradleVersion\",")
+            appendLine("  \"artifacts\": [")
+            for ((i, entry) in artifactEntries.withIndex()) {
+                append(entry)
+                if (i < artifactEntries.lastIndex) append(",")
+                appendLine()
+            }
+            appendLine("  ]")
+            append("}")
+            appendLine()
+        }
+
+        val jsonFile = outputDir.resolve("release-artifacts-v1.json")
+        jsonFile.writeText(json)
+        logger.lifecycle("Sovereign release artifact manifest generated: ${jsonFile.absolutePath}")
+        logger.lifecycle("  Artifacts collected: ${artifactEntries.size}")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -542,16 +542,49 @@ val sovereignReleaseModules = listOf(
 tasks.register("prepareSovereignReleaseArtifacts") {
     group = "verification"
     description = "Collects JARs from sovereign release modules, computes SHA-256 digests, and generates release-artifacts-v1.json."
-    dependsOn(sovereignReleaseModules.map { project(it).tasks.named("jar") })
+    dependsOn(sovereignReleaseModules.flatMap { module ->
+        listOf(
+            project(module).tasks.named("jar"),
+            project(module).tasks.matching { it.name == "sourcesJar" },
+            project(module).tasks.matching { it.name == "javadocJar" },
+        )
+    })
 
     doLast {
         val outputDir = rootProject.layout.buildDirectory.dir("sovereign-release").get().asFile
         val artifactsDir = outputDir.resolve("artifacts")
+
+        // Clean output directory first to avoid stale artifacts
+        if (outputDir.exists()) {
+            outputDir.deleteRecursively()
+        }
         artifactsDir.mkdirs()
+
+        fun jsonEscape(value: String): String {
+            val sb = StringBuilder()
+            for (ch in value) {
+                when (ch) {
+                    '"' -> sb.append("\\\"")
+                    '\\' -> sb.append("\\\\")
+                    '\n' -> sb.append("\\n")
+                    '\r' -> sb.append("\\r")
+                    '\t' -> sb.append("\\t")
+                    else -> {
+                        if (ch.code < 0x20) {
+                            sb.append("\\u%04x".format(ch.code))
+                        } else {
+                            sb.append(ch)
+                        }
+                    }
+                }
+            }
+            return sb.toString()
+        }
 
         val groupId = tramaiGroup.get()
         val version = tramaiVersion.get()
         val artifactEntries = mutableListOf<String>()
+        val artifactSortKeys = mutableListOf<String>()
 
         sovereignReleaseModules.forEach { modulePath ->
             val proj = project(modulePath)
@@ -559,7 +592,8 @@ tasks.register("prepareSovereignReleaseArtifacts") {
             val libsDir = proj.layout.buildDirectory.dir("libs").get().asFile
             if (!libsDir.exists()) return@forEach
 
-            libsDir.listFiles { f -> f.name.endsWith(".jar") }?.forEach { jarFile ->
+            libsDir.listFiles { f -> f.name.endsWith(".jar") }
+                ?.forEach { jarFile ->
                 val copied = jarFile.copyTo(artifactsDir.resolve(jarFile.name), overwrite = true)
 
                 val digest = java.security.MessageDigest.getInstance("SHA-256")
@@ -574,21 +608,29 @@ tasks.register("prepareSovereignReleaseArtifacts") {
                     else -> null
                 }
 
+                val escapedFile = jsonEscape(jarFile.name)
                 val artifactLine = buildString {
                     append("        {")
-                    append("\"groupId\": \"$groupId\", ")
-                    append("\"artifactId\": \"$moduleName\", ")
-                    append("\"version\": \"$version\", ")
-                    append("\"classifier\": ${if (classifier != null) "\"$classifier\"" else "null"}, ")
+                    append("\"groupId\": \"${jsonEscape(groupId)}\", ")
+                    append("\"artifactId\": \"${jsonEscape(moduleName)}\", ")
+                    append("\"version\": \"${jsonEscape(version)}\", ")
+                    append("\"classifier\": ${if (classifier != null) "\"${jsonEscape(classifier)}\"" else "null"}, ")
                     append("\"extension\": \"jar\", ")
-                    append("\"fileName\": \"${jarFile.name}\", ")
+                    append("\"fileName\": \"$escapedFile\", ")
                     append("\"sha256\": \"$sha256\", ")
                     append("\"sizeBytes\": ${copied.length()}")
                     append("}")
                 }
                 artifactEntries.add(artifactLine)
+                artifactSortKeys.add(jarFile.name)
             }
         }
+
+        // Sort all artifacts globally by filename for deterministic ordering
+        val sortedIndices = artifactSortKeys.indices.sortedBy { artifactSortKeys[it] }
+        val sortedEntries = sortedIndices.map { artifactEntries[it] }
+        artifactEntries.clear()
+        artifactEntries.addAll(sortedEntries)
 
         val javaVersion = System.getProperty("java.version") ?: "unknown"
         val gradleVersion = GradleVersion.current().version
@@ -597,8 +639,8 @@ tasks.register("prepareSovereignReleaseArtifacts") {
             appendLine("{")
             appendLine("  \"schemaVersion\": 1,")
             appendLine("  \"buildTool\": \"Gradle\",")
-            appendLine("  \"javaVersion\": \"$javaVersion\",")
-            appendLine("  \"gradleVersion\": \"$gradleVersion\",")
+            appendLine("  \"javaVersion\": \"${jsonEscape(javaVersion)}\",")
+            appendLine("  \"gradleVersion\": \"${jsonEscape(gradleVersion)}\",")
             appendLine("  \"artifacts\": [")
             for ((i, entry) in artifactEntries.withIndex()) {
                 append(entry)

--- a/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/SovereignTramai.kt
+++ b/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/SovereignTramai.kt
@@ -11,6 +11,7 @@ import dev.tramai.core.model.VerifiedLocalModelArtifact
 import dev.tramai.core.model.TramaiTool
 import dev.tramai.sovereign.evidence.AttestationEvidenceV1
 import dev.tramai.sovereign.evidence.AuditChainEvidenceV1
+import dev.tramai.sovereign.evidence.ReleaseBundleEvidenceV1
 import dev.tramai.sovereign.evidence.SovereignEvidencePackGenerator
 import dev.tramai.sovereign.evidence.SovereignEvidencePackV1
 import dev.tramai.sovereign.evidence.SupplyChainEvidenceV1
@@ -106,12 +107,14 @@ class SovereignTramai private constructor(
      * @param zeroEgress Optional zero-egress verification subsection.
      * @param auditChain Optional audit-chain validation subsection.
      * @param supplyChain Optional supply-chain SBOM linkage subsection.
+     * @param releaseBundle Optional release-bundle artifact manifest subsection.
      * @param attestation Optional CI/CD attestation subsection.
      */
     fun evidencePack(
         zeroEgress: ZeroEgressEvidenceV1? = null,
         auditChain: AuditChainEvidenceV1? = null,
         supplyChain: SupplyChainEvidenceV1? = null,
+        releaseBundle: ReleaseBundleEvidenceV1? = null,
         attestation: AttestationEvidenceV1? = null,
     ): SovereignEvidencePackV1 = SovereignEvidencePackGenerator.generate(
         deploymentMode = profile.deploymentMode,
@@ -123,6 +126,7 @@ class SovereignTramai private constructor(
         zeroEgress = zeroEgress,
         auditChain = auditChain,
         supplyChain = supplyChain,
+        releaseBundle = releaseBundle,
         attestation = attestation,
     )
 

--- a/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/evidence/ReleaseBundleEvidenceV1.kt
+++ b/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/evidence/ReleaseBundleEvidenceV1.kt
@@ -1,0 +1,46 @@
+package dev.tramai.sovereign.evidence
+
+/**
+ * Release-bundle evidence capturing the JAR artifacts built by Gradle
+ * for a sovereign TramAI deployment.
+ *
+ * This DTO links the build-time release artifact manifest into the evidence pack
+ * so that auditors can trace the exact JARs shipped with the deployment.
+ *
+ * @property schemaVersion Schema version (currently 1).
+ * @property buildTool The build tool that produced the artifacts (e.g. "Gradle").
+ * @property javaVersion The Java runtime version used during the build.
+ * @property gradleVersion The Gradle version used during the build.
+ * @property artifacts The list of individual release artifacts.
+ */
+data class ReleaseBundleEvidenceV1(
+    val schemaVersion: Int = 1,
+    val buildTool: String,
+    val javaVersion: String,
+    val gradleVersion: String,
+    val artifacts: List<ReleaseArtifactEvidenceV1>,
+)
+
+/**
+ * Describes a single release artifact with its Maven coordinates, file identity,
+ * SHA-256 digest, and size.
+ *
+ * @property groupId The Maven group ID (e.g. "dev.tramai").
+ * @property artifactId The Maven artifact ID (e.g. "tramai-core").
+ * @property version The artifact version (e.g. "1.0.0").
+ * @property classifier Optional classifier (e.g. "sources", "javadoc", or null).
+ * @property extension The file extension (e.g. "jar").
+ * @property fileName The exact file name (e.g. "tramai-core-1.0.0.jar").
+ * @property sha256 The SHA-256 digest in "sha256:<hex>" format.
+ * @property sizeBytes The file size in bytes.
+ */
+data class ReleaseArtifactEvidenceV1(
+    val groupId: String,
+    val artifactId: String,
+    val version: String,
+    val classifier: String?,
+    val extension: String,
+    val fileName: String,
+    val sha256: String,
+    val sizeBytes: Long,
+)

--- a/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/evidence/SovereignEvidencePackGenerator.kt
+++ b/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/evidence/SovereignEvidencePackGenerator.kt
@@ -32,11 +32,12 @@ object SovereignEvidencePackGenerator {
      * @param zeroEgress Optional zero-egress verification subsection.
      * @param auditChain Optional audit-chain validation subsection.
      * @param supplyChain Optional supply-chain SBOM linkage subsection.
+     * @param releaseBundle Optional release-bundle artifact manifest subsection.
      * @param attestation Optional CI/CD attestation subsection.
      * @return A fully populated [SovereignEvidencePackV1] with the [generatedAt] timestamp
      * set to the current wall-clock time when this method is called.
      */
-    fun generate(
+     fun generate(
         deploymentMode: SovereignDeploymentMode,
         allowedModels: Set<String>,
         allowedProviders: Set<String>,
@@ -46,8 +47,9 @@ object SovereignEvidencePackGenerator {
         zeroEgress: ZeroEgressEvidenceV1? = null,
         auditChain: AuditChainEvidenceV1? = null,
         supplyChain: SupplyChainEvidenceV1? = null,
+        releaseBundle: ReleaseBundleEvidenceV1? = null,
         attestation: AttestationEvidenceV1? = null,
-    ): SovereignEvidencePackV1 {
+     ): SovereignEvidencePackV1 {
         // Sanitize all string identifiers before building DTOs
         val sanitizedModels = allowedModels.map { EvidenceSafeString.sanitize(it) }.toSet()
         val sanitizedProviders = allowedProviders.map { EvidenceSafeString.sanitize(it) }.toSet()
@@ -148,6 +150,47 @@ object SovereignEvidencePackGenerator {
             )
         }
 
+        // Validate and sanitize release-bundle evidence
+        val sanitizedReleaseBundle = releaseBundle?.let { r ->
+            require(r.schemaVersion == 1) {
+                "evidence-unsupported-release-bundle-schema-version"
+            }
+
+            require(r.artifacts.isNotEmpty()) {
+                "evidence-unsafe-release-artifacts-empty"
+            }
+
+            val digestRegex = Regex("^sha256:[a-fA-F0-9]{64}$")
+            val sanitizedArtifacts = r.artifacts.map { artifact ->
+                require(digestRegex.matches(artifact.sha256)) {
+                    "evidence-unsafe-digest-format"
+                }
+
+                require(artifact.sizeBytes >= 0) {
+                    "evidence-unsafe-artifact-size-negative"
+                }
+
+                ReleaseArtifactEvidenceV1(
+                    groupId = EvidenceSafeString.sanitize(artifact.groupId),
+                    artifactId = EvidenceSafeString.sanitize(artifact.artifactId),
+                    version = EvidenceSafeString.sanitize(artifact.version),
+                    classifier = artifact.classifier?.let { EvidenceSafeString.sanitize(it) },
+                    extension = EvidenceSafeString.sanitize(artifact.extension),
+                    fileName = sanitizeFileNameOnly(artifact.fileName),
+                    sha256 = artifact.sha256,
+                    sizeBytes = artifact.sizeBytes,
+                )
+            }
+
+            ReleaseBundleEvidenceV1(
+                schemaVersion = r.schemaVersion,
+                buildTool = EvidenceSafeString.sanitize(r.buildTool),
+                javaVersion = EvidenceSafeString.sanitize(r.javaVersion),
+                gradleVersion = EvidenceSafeString.sanitize(r.gradleVersion),
+                artifacts = sanitizedArtifacts,
+            )
+        }
+
         return SovereignEvidencePackV1(
             schemaVersion = 1,
             deploymentMode = deploymentMode.name,
@@ -159,6 +202,7 @@ object SovereignEvidencePackGenerator {
             zeroEgress = zeroEgress,
             auditChain = auditChain,
             supplyChain = sanitizedSupplyChain,
+            releaseBundle = sanitizedReleaseBundle,
             attestation = sanitizedAttestation,
             generatedAt = Instant.now().toString(),
         )

--- a/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/evidence/SovereignEvidencePackV1.kt
+++ b/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/evidence/SovereignEvidencePackV1.kt
@@ -20,6 +20,7 @@ package dev.tramai.sovereign.evidence
  * @property zeroEgress Optional zero-egress verification subsection.
  * @property auditChain Optional audit-chain validation subsection.
  * @property supplyChain Optional supply-chain SBOM linkage subsection.
+ * @property releaseBundle Optional release-bundle artifact manifest subsection.
  * @property attestation Optional CI/CD attestation subsection.
  * @property generatedAt ISO-8601 instant when this pack was generated.
  */
@@ -34,6 +35,7 @@ data class SovereignEvidencePackV1(
     val zeroEgress: ZeroEgressEvidenceV1? = null,
     val auditChain: AuditChainEvidenceV1? = null,
     val supplyChain: SupplyChainEvidenceV1? = null,
+    val releaseBundle: ReleaseBundleEvidenceV1? = null,
     val attestation: AttestationEvidenceV1? = null,
     val generatedAt: String,
 )

--- a/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/evidence/SovereignEvidencePackWriter.kt
+++ b/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/evidence/SovereignEvidencePackWriter.kt
@@ -31,55 +31,65 @@ object SovereignEvidencePackWriter {
         sb.appendLine("{")
 
         // Field order matches data class declaration order
-        appendField(sb, "schemaVersion", pack.schemaVersion.toString(), 1, 12)
-        appendStringField(sb, "deploymentMode", pack.deploymentMode, 2, 12)
-        appendStringListField(sb, "allowedModels", pack.allowedModels, 3, 12)
-        appendStringListField(sb, "allowedProviders", pack.allowedProviders, 4, 12)
-        appendStringMapField(sb, "providerZones", pack.providerZones, 5, 12)
-        appendObjectField(sb, "artifactVerificationSettings", pack.artifactVerificationSettings, 6, 12)
-        appendObjectListField(sb, "artifacts", pack.artifacts, 7, 12, serialize = ::serializeArtifact)
+        appendField(sb, "schemaVersion", pack.schemaVersion.toString(), 1, 13)
+        appendStringField(sb, "deploymentMode", pack.deploymentMode, 2, 13)
+        appendStringListField(sb, "allowedModels", pack.allowedModels, 3, 13)
+        appendStringListField(sb, "allowedProviders", pack.allowedProviders, 4, 13)
+        appendStringMapField(sb, "providerZones", pack.providerZones, 5, 13)
+        appendObjectField(sb, "artifactVerificationSettings", pack.artifactVerificationSettings, 6, 13)
+        appendObjectListField(sb, "artifacts", pack.artifacts, 7, 13, serialize = ::serializeArtifact)
 
         if (pack.zeroEgress != null) {
             appendObjectField(
                 sb = sb, key = "zeroEgress", value = pack.zeroEgress,
-                index = 8, total = 12, last = false,
+                index = 8, total = 13, last = false,
                 serialize = { z -> serializeZeroEgress(z) },
             )
         } else {
-            appendNullField(sb, "zeroEgress", 8, 12, last = false)
+            appendNullField(sb, "zeroEgress", 8, 13, last = false)
         }
 
         if (pack.auditChain != null) {
             appendObjectField(
                 sb = sb, key = "auditChain", value = pack.auditChain,
-                index = 9, total = 12, last = false,
+                index = 9, total = 13, last = false,
                 serialize = { a -> serializeAuditChain(a) },
             )
         } else {
-            appendNullField(sb, "auditChain", 9, 12, last = false)
+            appendNullField(sb, "auditChain", 9, 13, last = false)
         }
 
         if (pack.supplyChain != null) {
             appendObjectField(
                 sb = sb, key = "supplyChain", value = pack.supplyChain,
-                index = 10, total = 12, last = false,
+                index = 10, total = 13, last = false,
                 serialize = { s -> serializeSupplyChain(s) },
             )
         } else {
-            appendNullField(sb, "supplyChain", 10, 12, last = false)
+            appendNullField(sb, "supplyChain", 10, 13, last = false)
+        }
+
+        if (pack.releaseBundle != null) {
+            appendObjectField(
+                sb = sb, key = "releaseBundle", value = pack.releaseBundle,
+                index = 11, total = 13, last = false,
+                serialize = { r -> serializeReleaseBundle(r) },
+            )
+        } else {
+            appendNullField(sb, "releaseBundle", 11, 13, last = false)
         }
 
         if (pack.attestation != null) {
             appendObjectField(
                 sb = sb, key = "attestation", value = pack.attestation,
-                index = 11, total = 12, last = false,
+                index = 12, total = 13, last = false,
                 serialize = { a -> serializeAttestation(a) },
             )
         } else {
-            appendNullField(sb, "attestation", 11, 12, last = false)
+            appendNullField(sb, "attestation", 12, 13, last = false)
         }
 
-        appendStringField(sb, "generatedAt", pack.generatedAt, 12, 12, last = true)
+        appendStringField(sb, "generatedAt", pack.generatedAt, 13, 13, last = true)
 
         sb.append("}")
         sb.appendLine()
@@ -130,6 +140,37 @@ object SovereignEvidencePackWriter {
         appendStringField(sb, "sbomFileName", s.sbomFileName, 4, 6, indent = 2)
         appendStringField(sb, "sbomSha256", s.sbomSha256, 5, 6, indent = 2)
         appendStringField(sb, "generatedBy", s.generatedBy, 6, 6, indent = 2, last = true)
+        sb.append("            }")
+        return sb.toString()
+    }
+
+    private fun serializeReleaseBundle(r: ReleaseBundleEvidenceV1): String {
+        val sb = StringBuilder()
+        sb.appendLine("{")
+        appendField(sb, "schemaVersion", r.schemaVersion.toString(), 1, 5, indent = 2)
+        appendStringField(sb, "buildTool", r.buildTool, 2, 5, indent = 2)
+        appendStringField(sb, "javaVersion", r.javaVersion, 3, 5, indent = 2)
+        appendStringField(sb, "gradleVersion", r.gradleVersion, 4, 5, indent = 2)
+        appendObjectListField(sb, "artifacts", r.artifacts, 5, 5, indent = 2, serialize = ::serializeReleaseArtifact, last = true)
+        sb.append("            }")
+        return sb.toString()
+    }
+
+    private fun serializeReleaseArtifact(a: ReleaseArtifactEvidenceV1): String {
+        val sb = StringBuilder()
+        sb.appendLine("{")
+        appendStringField(sb, "groupId", a.groupId, 1, 8, indent = 1)
+        appendStringField(sb, "artifactId", a.artifactId, 2, 8, indent = 1)
+        appendStringField(sb, "version", a.version, 3, 8, indent = 1)
+        if (a.classifier != null) {
+            appendStringField(sb, "classifier", a.classifier, 4, 8, indent = 1)
+        } else {
+            appendField(sb, "classifier", "null", 4, 8, indent = 1)
+        }
+        appendStringField(sb, "extension", a.extension, 5, 8, indent = 1)
+        appendStringField(sb, "fileName", a.fileName, 6, 8, indent = 1)
+        appendStringField(sb, "sha256", a.sha256, 7, 8, indent = 1)
+        appendField(sb, "sizeBytes", a.sizeBytes.toString(), 8, 8, indent = 1, last = true)
         sb.append("            }")
         return sb.toString()
     }

--- a/tramai-sovereign/src/test/kotlin/dev/tramai/sovereign/evidence/SovereignEvidencePackIntegrationTest.kt
+++ b/tramai-sovereign/src/test/kotlin/dev/tramai/sovereign/evidence/SovereignEvidencePackIntegrationTest.kt
@@ -260,6 +260,7 @@ class SovereignEvidencePackIntegrationTest {
         assertThat(pack.zeroEgress).isNull()
         assertThat(pack.auditChain).isNull()
         assertThat(pack.supplyChain).isNull()
+        assertThat(pack.releaseBundle).isNull()
         assertThat(pack.attestation).isNull()
     }
 
@@ -347,6 +348,39 @@ class SovereignEvidencePackIntegrationTest {
         assertThat(pack.attestation!!.attestedSubjects).hasSize(2)
         assertThat(pack.attestation!!.attestedSubjects[0].fileName).isEqualTo("sbom-a.json")
         assertThat(pack.attestation!!.attestedSubjects[1].fileName).isEqualTo("sbom-b.json")
+    }
+
+    @Test
+    fun `evidence pack includes release-bundle subsection when provided`() {
+        val tramai = buildOfflineTramai()
+
+        val pack = tramai.evidencePack(
+            releaseBundle = ReleaseBundleEvidenceV1(
+                buildTool = "Gradle",
+                javaVersion = "25.0.1",
+                gradleVersion = "8.10",
+                artifacts = listOf(
+                    ReleaseArtifactEvidenceV1(
+                        groupId = "dev.tramai",
+                        artifactId = "tramai-core",
+                        version = "1.0.0",
+                        classifier = null,
+                        extension = "jar",
+                        fileName = "tramai-core-1.0.0.jar",
+                        sha256 = "sha256:${"a".repeat(64)}",
+                        sizeBytes = 51200,
+                    ),
+                ),
+            ),
+        )
+
+        assertThat(pack.releaseBundle).isNotNull()
+        assertThat(pack.releaseBundle!!.buildTool).isEqualTo("Gradle")
+        assertThat(pack.releaseBundle!!.javaVersion).isEqualTo("25.0.1")
+        assertThat(pack.releaseBundle!!.gradleVersion).isEqualTo("8.10")
+        assertThat(pack.releaseBundle!!.artifacts).hasSize(1)
+        assertThat(pack.releaseBundle!!.artifacts[0].artifactId).isEqualTo("tramai-core")
+        assertThat(pack.releaseBundle!!.artifacts[0].sha256).isEqualTo("sha256:${"a".repeat(64)}")
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────

--- a/tramai-sovereign/src/test/kotlin/dev/tramai/sovereign/evidence/SovereignEvidencePackWriterTest.kt
+++ b/tramai-sovereign/src/test/kotlin/dev/tramai/sovereign/evidence/SovereignEvidencePackWriterTest.kt
@@ -32,6 +32,7 @@ class SovereignEvidencePackWriterTest {
         assertThat(json).contains("\"zeroEgress\": null")
         assertThat(json).contains("\"auditChain\": null")
         assertThat(json).contains("\"supplyChain\": null")
+        assertThat(json).contains("\"releaseBundle\": null")
         assertThat(json).contains("\"attestation\": null")
         assertThat(json).contains("\"generatedAt\":")
 
@@ -46,6 +47,7 @@ class SovereignEvidencePackWriterTest {
         val zeroEgressIdx = json.indexOf("\"zeroEgress\"")
         val auditChainIdx = json.indexOf("\"auditChain\"")
         val supplyChainIdx = json.indexOf("\"supplyChain\"")
+        val releaseBundleIdx = json.indexOf("\"releaseBundle\"")
         val attestationIdx = json.indexOf("\"attestation\"")
         val generatedAtIdx = json.indexOf("\"generatedAt\"")
 
@@ -58,7 +60,8 @@ class SovereignEvidencePackWriterTest {
         assertThat(artifactsIdx).isLessThan(zeroEgressIdx)
         assertThat(zeroEgressIdx).isLessThan(auditChainIdx)
         assertThat(auditChainIdx).isLessThan(supplyChainIdx)
-        assertThat(supplyChainIdx).isLessThan(attestationIdx)
+        assertThat(supplyChainIdx).isLessThan(releaseBundleIdx)
+        assertThat(releaseBundleIdx).isLessThan(attestationIdx)
         assertThat(attestationIdx).isLessThan(generatedAtIdx)
     }
 
@@ -75,6 +78,7 @@ class SovereignEvidencePackWriterTest {
             zeroEgress = null,
             auditChain = null,
             supplyChain = null,
+            releaseBundle = null,
             attestation = null,
             generatedAt = "2026-01-01T00:00:00Z",
         )
@@ -103,6 +107,7 @@ class SovereignEvidencePackWriterTest {
             zeroEgress = null,
             auditChain = null,
             supplyChain = null,
+            releaseBundle = null,
             attestation = null,
             generatedAt = "2026-01-01T00:00:00Z",
         )
@@ -176,6 +181,7 @@ class SovereignEvidencePackWriterTest {
                 totalEvents = 5,
             ),
             supplyChain = null,
+            releaseBundle = null,
             attestation = null,
             generatedAt = "2026-01-01T00:00:00Z",
         )
@@ -208,6 +214,7 @@ class SovereignEvidencePackWriterTest {
             zeroEgress = null,
             auditChain = null,
             supplyChain = null,
+            releaseBundle = null,
             attestation = null,
             generatedAt = "2026-01-01T00:00:00Z",
         )
@@ -239,6 +246,7 @@ class SovereignEvidencePackWriterTest {
                 sbomSha256 = "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
                 generatedBy = "CycloneDX Gradle Plugin 3.2.4",
             ),
+            releaseBundle = null,
             attestation = null,
             generatedAt = "2026-01-01T00:00:00Z",
         )
@@ -264,6 +272,7 @@ class SovereignEvidencePackWriterTest {
             zeroEgress = null,
             auditChain = null,
             supplyChain = null,
+            releaseBundle = null,
             attestation = AttestationEvidenceV1(
                 provider = "GitHub Artifact Attestations",
                 workflowName = "CI",
@@ -304,6 +313,7 @@ class SovereignEvidencePackWriterTest {
             zeroEgress = null,
             auditChain = null,
             supplyChain = null,
+            releaseBundle = null,
             attestation = AttestationEvidenceV1(
                 provider = "GitHub Artifact Attestations",
                 workflowName = "CI",
@@ -347,6 +357,7 @@ class SovereignEvidencePackWriterTest {
             zeroEgress = null,
             auditChain = null,
             supplyChain = null,
+            releaseBundle = null,
             attestation = null,
             generatedAt = "2026-01-01T00:00:00Z",
         )
@@ -659,6 +670,7 @@ class SovereignEvidencePackWriterTest {
                 sbomSha256 = "sha256:${"a".repeat(64)}",
                 generatedBy = "Gradle Plugin",
             ),
+            releaseBundle = null,
             attestation = null,
             generatedAt = "2026-01-01T00:00:00Z",
         )
@@ -1035,6 +1047,284 @@ class SovereignEvidencePackWriterTest {
         assertThat(pack.attestation!!.attestedSubjects[1].fileName).isEqualTo("tramai-sources.jar")
     }
 
+    // ── Release-bundle writer tests ─────────────────────────────────────────
+
+    @Test
+    fun `writer serialises release-bundle subsection with multiple artifacts`() {
+        val pack = SovereignEvidencePackV1(
+            deploymentMode = "STANDARD",
+            allowedModels = listOf("model-a"),
+            allowedProviders = listOf("provider-x"),
+            providerZones = mapOf("provider-x" to "LOCAL"),
+            artifactVerificationSettings = mapOf("enabled" to false),
+            artifacts = emptyList(),
+            zeroEgress = null,
+            auditChain = null,
+            supplyChain = null,
+            releaseBundle = ReleaseBundleEvidenceV1(
+                buildTool = "Gradle",
+                javaVersion = "25.0.1",
+                gradleVersion = "8.10",
+                artifacts = listOf(
+                    ReleaseArtifactEvidenceV1(
+                        groupId = "dev.tramai",
+                        artifactId = "tramai-core",
+                        version = "1.0.0",
+                        classifier = null,
+                        extension = "jar",
+                        fileName = "tramai-core-1.0.0.jar",
+                        sha256 = "sha256:${"a".repeat(64)}",
+                        sizeBytes = 51200,
+                    ),
+                    ReleaseArtifactEvidenceV1(
+                        groupId = "dev.tramai",
+                        artifactId = "tramai-sovereign",
+                        version = "1.0.0",
+                        classifier = "sources",
+                        extension = "jar",
+                        fileName = "tramai-sovereign-1.0.0-sources.jar",
+                        sha256 = "sha256:${"b".repeat(64)}",
+                        sizeBytes = 25600,
+                    ),
+                ),
+            ),
+            attestation = null,
+            generatedAt = "2026-01-01T00:00:00Z",
+        )
+        val json = writeToString(pack)
+
+        assertThat(json).contains("\"releaseBundle\":")
+        assertThat(json).contains("\"buildTool\": \"Gradle\"")
+        assertThat(json).contains("\"javaVersion\": \"25.0.1\"")
+        assertThat(json).contains("\"gradleVersion\": \"8.10\"")
+        assertThat(json).contains("\"groupId\": \"dev.tramai\"")
+        assertThat(json).contains("\"artifactId\": \"tramai-core\"")
+        assertThat(json).contains("\"artifactId\": \"tramai-sovereign\"")
+        assertThat(json).contains("\"version\": \"1.0.0\"")
+        assertThat(json).contains("\"classifier\": null")
+        assertThat(json).contains("\"classifier\": \"sources\"")
+        assertThat(json).contains("\"extension\": \"jar\"")
+        assertThat(json).contains("\"fileName\": \"tramai-core-1.0.0.jar\"")
+        assertThat(json).contains("\"fileName\": \"tramai-sovereign-1.0.0-sources.jar\"")
+        assertThat(json).contains("\"sha256\": \"sha256:${"a".repeat(64)}\"")
+        assertThat(json).contains("\"sha256\": \"sha256:${"b".repeat(64)}\"")
+        assertThat(json).contains("\"sizeBytes\": 51200")
+        assertThat(json).contains("\"sizeBytes\": 25600")
+    }
+
+    @Test
+    fun `writer serialises null releaseBundle as null`() {
+        val pack = SovereignEvidencePackV1(
+            deploymentMode = "STANDARD",
+            allowedModels = listOf("model-a"),
+            allowedProviders = listOf("provider-x"),
+            providerZones = mapOf("provider-x" to "LOCAL"),
+            artifactVerificationSettings = mapOf("enabled" to false),
+            artifacts = emptyList(),
+            zeroEgress = null,
+            auditChain = null,
+            supplyChain = null,
+            releaseBundle = null,
+            attestation = null,
+            generatedAt = "2026-01-01T00:00:00Z",
+        )
+        val json = writeToString(pack)
+
+        assertThat(json).contains("\"releaseBundle\": null")
+    }
+
+    // ── Release-bundle validation tests ─────────────────────────────────────
+
+    @Test
+    fun `rejects unsupported release bundle schema version`() {
+        assertThatThrownBy {
+            SovereignEvidencePackGenerator.generate(
+                deploymentMode = SovereignDeploymentMode.STANDARD,
+                allowedModels = setOf("model-a"),
+                allowedProviders = setOf("provider-x"),
+                providerZones = mapOf("provider-x" to "LOCAL"),
+                verificationSettings = ModelArtifactVerificationSettings(),
+                verificationReceipts = emptyList(),
+                releaseBundle = ReleaseBundleEvidenceV1(
+                    schemaVersion = 2,
+                    buildTool = "Gradle",
+                    javaVersion = "25",
+                    gradleVersion = "8.10",
+                    artifacts = listOf(
+                        ReleaseArtifactEvidenceV1(
+                            groupId = "dev.tramai",
+                            artifactId = "tramai-core",
+                            version = "1.0.0",
+                            classifier = null,
+                            extension = "jar",
+                            fileName = "tramai-core-1.0.0.jar",
+                            sha256 = "sha256:${"a".repeat(64)}",
+                            sizeBytes = 51200,
+                        ),
+                    ),
+                ),
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("evidence-unsupported-release-bundle-schema-version")
+    }
+
+    @Test
+    fun `rejects empty artifact list in release bundle`() {
+        assertThatThrownBy {
+            SovereignEvidencePackGenerator.generate(
+                deploymentMode = SovereignDeploymentMode.STANDARD,
+                allowedModels = setOf("model-a"),
+                allowedProviders = setOf("provider-x"),
+                providerZones = mapOf("provider-x" to "LOCAL"),
+                verificationSettings = ModelArtifactVerificationSettings(),
+                verificationReceipts = emptyList(),
+                releaseBundle = ReleaseBundleEvidenceV1(
+                    buildTool = "Gradle",
+                    javaVersion = "25",
+                    gradleVersion = "8.10",
+                    artifacts = emptyList(),
+                ),
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("evidence-unsafe-release-artifacts-empty")
+    }
+
+    @Test
+    fun `rejects negative artifact size in release bundle`() {
+        assertThatThrownBy {
+            SovereignEvidencePackGenerator.generate(
+                deploymentMode = SovereignDeploymentMode.STANDARD,
+                allowedModels = setOf("model-a"),
+                allowedProviders = setOf("provider-x"),
+                providerZones = mapOf("provider-x" to "LOCAL"),
+                verificationSettings = ModelArtifactVerificationSettings(),
+                verificationReceipts = emptyList(),
+                releaseBundle = ReleaseBundleEvidenceV1(
+                    buildTool = "Gradle",
+                    javaVersion = "25",
+                    gradleVersion = "8.10",
+                    artifacts = listOf(
+                        ReleaseArtifactEvidenceV1(
+                            groupId = "dev.tramai",
+                            artifactId = "tramai-core",
+                            version = "1.0.0",
+                            classifier = null,
+                            extension = "jar",
+                            fileName = "tramai-core-1.0.0.jar",
+                            sha256 = "sha256:${"a".repeat(64)}",
+                            sizeBytes = -1,
+                        ),
+                    ),
+                ),
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("evidence-unsafe-artifact-size-negative")
+    }
+
+    @Test
+    fun `rejects invalid digest format in release artifact`() {
+        assertThatThrownBy {
+            SovereignEvidencePackGenerator.generate(
+                deploymentMode = SovereignDeploymentMode.STANDARD,
+                allowedModels = setOf("model-a"),
+                allowedProviders = setOf("provider-x"),
+                providerZones = mapOf("provider-x" to "LOCAL"),
+                verificationSettings = ModelArtifactVerificationSettings(),
+                verificationReceipts = emptyList(),
+                releaseBundle = ReleaseBundleEvidenceV1(
+                    buildTool = "Gradle",
+                    javaVersion = "25",
+                    gradleVersion = "8.10",
+                    artifacts = listOf(
+                        ReleaseArtifactEvidenceV1(
+                            groupId = "dev.tramai",
+                            artifactId = "tramai-core",
+                            version = "1.0.0",
+                            classifier = null,
+                            extension = "jar",
+                            fileName = "tramai-core-1.0.0.jar",
+                            sha256 = "sha256:xyz",
+                            sizeBytes = 51200,
+                        ),
+                    ),
+                ),
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("evidence-unsafe-digest-format")
+    }
+
+    @Test
+    fun `rejects filename with path separator in release artifact`() {
+        assertThatThrownBy {
+            SovereignEvidencePackGenerator.generate(
+                deploymentMode = SovereignDeploymentMode.STANDARD,
+                allowedModels = setOf("model-a"),
+                allowedProviders = setOf("provider-x"),
+                providerZones = mapOf("provider-x" to "LOCAL"),
+                verificationSettings = ModelArtifactVerificationSettings(),
+                verificationReceipts = emptyList(),
+                releaseBundle = ReleaseBundleEvidenceV1(
+                    buildTool = "Gradle",
+                    javaVersion = "25",
+                    gradleVersion = "8.10",
+                    artifacts = listOf(
+                        ReleaseArtifactEvidenceV1(
+                            groupId = "dev.tramai",
+                            artifactId = "tramai-core",
+                            version = "1.0.0",
+                            classifier = null,
+                            extension = "jar",
+                            fileName = "subdir/tramai-core-1.0.0.jar",
+                            sha256 = "sha256:${"a".repeat(64)}",
+                            sizeBytes = 51200,
+                        ),
+                    ),
+                ),
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("evidence-unsafe-identifier")
+    }
+
+    @Test
+    fun `accepts valid full release bundle`() {
+        val pack = SovereignEvidencePackGenerator.generate(
+            deploymentMode = SovereignDeploymentMode.STANDARD,
+            allowedModels = setOf("model-a"),
+            allowedProviders = setOf("provider-x"),
+            providerZones = mapOf("provider-x" to "LOCAL"),
+            verificationSettings = ModelArtifactVerificationSettings(),
+            verificationReceipts = emptyList(),
+            releaseBundle = ReleaseBundleEvidenceV1(
+                buildTool = "Gradle",
+                javaVersion = "25.0.1",
+                gradleVersion = "8.10",
+                artifacts = listOf(
+                    ReleaseArtifactEvidenceV1(
+                        groupId = "dev.tramai",
+                        artifactId = "tramai-core",
+                        version = "1.0.0",
+                        classifier = null,
+                        extension = "jar",
+                        fileName = "tramai-core-1.0.0.jar",
+                        sha256 = "sha256:${"a".repeat(64)}",
+                        sizeBytes = 51200,
+                    ),
+                ),
+            ),
+        )
+
+        assertThat(pack.releaseBundle).isNotNull()
+        assertThat(pack.releaseBundle!!.schemaVersion).isEqualTo(1)
+        assertThat(pack.releaseBundle!!.buildTool).isEqualTo("Gradle")
+        assertThat(pack.releaseBundle!!.javaVersion).isEqualTo("25.0.1")
+        assertThat(pack.releaseBundle!!.gradleVersion).isEqualTo("8.10")
+        assertThat(pack.releaseBundle!!.artifacts).hasSize(1)
+        assertThat(pack.releaseBundle!!.artifacts[0].groupId).isEqualTo("dev.tramai")
+        assertThat(pack.releaseBundle!!.artifacts[0].artifactId).isEqualTo("tramai-core")
+        assertThat(pack.releaseBundle!!.artifacts[0].sha256).isEqualTo("sha256:${"a".repeat(64)}")
+        assertThat(pack.releaseBundle!!.artifacts[0].sizeBytes).isEqualTo(51200)
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private fun samplePack(): SovereignEvidencePackV1 = SovereignEvidencePackV1(
@@ -1047,6 +1337,7 @@ class SovereignEvidencePackWriterTest {
         zeroEgress = null,
         auditChain = null,
         supplyChain = null,
+        releaseBundle = null,
         attestation = null,
         generatedAt = "2026-01-01T00:00:00Z",
     )


### PR DESCRIPTION
## Summary

Add Release Artifact Evidence V1 — a deterministic manifest of TramAI build outputs, including Maven coordinates, file names, sizes, and SHA-256 digests. The evidence pack now links to the actual JVM artifacts produced by CI, not only the evidence files.

This closes the gap between auditor evidence and developer-consumable artifacts: auditors can verify that specific JARs with known digests correspond to a specific CI build.

## Field Order (13 fields)

`schemaVersion` → `deploymentMode` → `allowedModels` → `allowedProviders` → `providerZones` → `artifactVerificationSettings` → `artifacts` → `zeroEgress` → `auditChain` → `supplyChain` → **`releaseBundle`** → `attestation` → `generatedAt`

## Changed Files (9)

### New (1)
- `ReleaseBundleEvidenceV1.kt` — `ReleaseBundleEvidenceV1` (buildTool, javaVersion, gradleVersion, artifacts) + `ReleaseArtifactEvidenceV1` (groupId, artifactId, version, classifier, extension, fileName, sha256, sizeBytes)

### Modified (8)
- `SovereignEvidencePackV1.kt` — `releaseBundle` field at index 11/13
- `SovereignEvidencePackWriter.kt` — total 12→13, `serializeReleaseBundle()` + `serializeReleaseArtifact()`
- `SovereignEvidencePackGenerator.kt` — `releaseBundle` parameter with 5 safe reason codes
- `SovereignTramai.kt` — `evidencePack(..., releaseBundle)` parameter
- `build.gradle.kts` — `prepareSovereignReleaseArtifacts` task with explicit 8-module allowlist
- `.github/workflows/ci.yml` — task execution, artifact upload, attest step
- `SovereignEvidencePackWriterTest.kt` — 9 new tests
- `SovereignEvidencePackIntegrationTest.kt` — 2 new tests

## Validation

```
./gradlew test --rerun-tasks                                    134/134
./gradlew -p examples/kotlin-springboot-example test             28/28
./gradlew :examples:sovereign-offline-verification:test          16/16
./gradlew prepareSovereignReleaseArtifacts                       42 artifacts collected
```