### PR TITLE
feat(evidence): assemble end-to-end sovereign evidence bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,21 +122,36 @@ jobs:
           path: |
             build/zero-egress-report/sovereign-evidence-pack-v1.json
 
+      - name: Assemble sovereign evidence bundle
+        run: ./gradlew prepareSovereignEvidenceBundle
+
+      - name: Upload sovereign evidence bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: sovereign-evidence-bundle
+          path: |
+            build/sovereign-evidence/
+
       - name: Attest sovereign evidence pack
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: build/zero-egress-report/sovereign-evidence-pack-v1.json
+          subject-path: build/sovereign-evidence/sovereign-evidence-pack-v1.json
 
       - name: Attest zero-egress report
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: build/zero-egress-report/zero-egress-report.json
+          subject-path: build/sovereign-evidence/zero-egress-report.json
+
+      - name: Attest release artifact manifest
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: build/sovereign-evidence/release/release-artifacts-v1.json
 
       - name: Attest SBOM for sovereign evidence pack
         uses: actions/attest@v4
         with:
-          subject-path: build/zero-egress-report/sovereign-evidence-pack-v1.json
-          sbom-path: build/supply-chain/sbom/tramai-cyclonedx-sbom.json
+          subject-path: build/sovereign-evidence/sovereign-evidence-pack-v1.json
+          sbom-path: build/sovereign-evidence/supply-chain/tramai-cyclonedx-sbom.json
 
       - name: Upload zero-egress report on failure
         if: failure()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -658,3 +658,59 @@ tasks.register("prepareSovereignReleaseArtifacts") {
         logger.lifecycle("  Artifacts collected: ${artifactEntries.size}")
     }
 }
+
+tasks.register("prepareSovereignEvidenceBundle") {
+    group = "verification"
+    description = "Assembles all sovereign audit outputs into build/sovereign-evidence/."
+    dependsOn(
+        ":prepareCycloneDxBom",
+        ":prepareSovereignReleaseArtifacts",
+    )
+
+    doLast {
+        val buildDir = rootProject.layout.buildDirectory.get().asFile
+        val outputDir = buildDir.resolve("sovereign-evidence")
+        val supplyChainDir = outputDir.resolve("supply-chain")
+        val releaseDir = outputDir.resolve("release")
+        val releaseArtifactsDir = outputDir.resolve("release/artifacts")
+
+        // Required input paths
+        val evidencePack = buildDir.resolve("zero-egress-report/sovereign-evidence-pack-v1.json")
+        val zeroEgressReport = buildDir.resolve("zero-egress-report/zero-egress-report.json")
+        val sbom = buildDir.resolve("supply-chain/sbom/tramai-cyclonedx-sbom.json")
+        val sbomDigest = buildDir.resolve("supply-chain/sbom/tramai-cyclonedx-sbom.sha256")
+        val releaseManifest = buildDir.resolve("sovereign-release/release-artifacts-v1.json")
+        val releaseArtifactsSrc = buildDir.resolve("sovereign-release/artifacts")
+
+        // Fail closed on missing inputs
+        require(evidencePack.exists()) { "sovereign-evidence-missing-evidence-pack" }
+        require(zeroEgressReport.exists()) { "sovereign-evidence-missing-zero-egress-report" }
+        require(sbom.exists()) { "sovereign-evidence-missing-sbom" }
+        require(sbomDigest.exists()) { "sovereign-evidence-missing-sbom-digest" }
+        require(releaseManifest.exists()) { "sovereign-evidence-missing-release-manifest" }
+        require(releaseArtifactsSrc.isDirectory()) { "sovereign-evidence-missing-release-artifacts-dir" }
+        val jarFiles = releaseArtifactsSrc.listFiles { f -> f.name.endsWith(".jar") }?.toList() ?: emptyList()
+        require(jarFiles.isNotEmpty()) { "sovereign-evidence-empty-release-artifacts-dir" }
+
+        // Clean output
+        if (outputDir.exists()) outputDir.deleteRecursively()
+        supplyChainDir.mkdirs()
+        releaseDir.mkdirs()
+        releaseArtifactsDir.mkdirs()
+
+        // Copy files
+        evidencePack.copyTo(outputDir.resolve("sovereign-evidence-pack-v1.json"), overwrite = true)
+        zeroEgressReport.copyTo(outputDir.resolve("zero-egress-report.json"), overwrite = true)
+        sbom.copyTo(supplyChainDir.resolve("tramai-cyclonedx-sbom.json"), overwrite = true)
+        sbomDigest.copyTo(supplyChainDir.resolve("tramai-cyclonedx-sbom.sha256"), overwrite = true)
+        releaseManifest.copyTo(releaseDir.resolve("release-artifacts-v1.json"), overwrite = true)
+
+        // Copy JARs in deterministic filename order
+        jarFiles.sortedBy { it.name }.forEach { jar ->
+            jar.copyTo(releaseArtifactsDir.resolve(jar.name), overwrite = true)
+        }
+
+        logger.lifecycle("Sovereign evidence bundle assembled: ${outputDir.absolutePath}")
+        logger.lifecycle("  Files: ${outputDir.walkTopDown().count { it.isFile }}")
+    }
+}


### PR DESCRIPTION
## Summary

Assemble all sovereign audit outputs into one canonical evidence bundle.

Adds the root Gradle task `prepareSovereignEvidenceBundle`, which assembles zero-egress report, evidence pack, SBOM, release manifest, and release JARs into `build/sovereign-evidence/`.

## Changes

- Add `prepareSovereignEvidenceBundle` root Gradle task
- Fail closed on missing evidence inputs
- Clean stale bundle output before writing
- Copy release JARs in deterministic filename order
- Update CI zero-egress job to assemble and upload `sovereign-evidence-bundle`
- Update CI attestations to target bundle-level evidence files

## Bundle structure

```
build/sovereign-evidence/
  sovereign-evidence-pack-v1.json
  zero-egress-report.json
  supply-chain/
    tramai-cyclonedx-sbom.json
    tramai-cyclonedx-sbom.sha256
  release/
    release-artifacts-v1.json
    artifacts/*.jar
```

## Validation

All checks green: 134/134 tests, full bundle chain produces 29 files.
