### PR TITLE
feat(evidence): verify release artifact manifest against bundled JARs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Prepare sovereign release artifacts
         run: ./gradlew prepareSovereignReleaseArtifacts
 
+      - name: Verify sovereign release manifest
+        run: ./gradlew verifySovereignReleaseManifest
+
       - name: Upload SBOM
         uses: actions/upload-artifact@v4
         with:
@@ -124,6 +127,9 @@ jobs:
 
       - name: Assemble sovereign evidence bundle
         run: ./gradlew prepareSovereignEvidenceBundle
+
+      - name: Verify sovereign evidence bundle release manifest
+        run: ./gradlew verifySovereignEvidenceBundleReleaseManifest
 
       - name: Upload sovereign evidence bundle
         uses: actions/upload-artifact@v4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -738,10 +738,22 @@ fun verifyReleaseManifest(manifestDir: File, artifactsDir: File) {
         val sizeBytes = entry["sizeBytes"]?.let { it as? Number }
             ?: throw GradleException("sovereign-release-manifest-invalid-artifact-entry (index $i): missing or non-Numeric sizeBytes")
 
-        val classifier = entry["classifier"]?.let { it as? String }
+        val rawClassifier = entry["classifier"]
+        val classifier = when (rawClassifier) {
+            null -> null
+            is String -> rawClassifier
+            else -> throw GradleException(
+                "sovereign-release-manifest-invalid-artifact-entry (index $i): classifier must be String or null, got ${rawClassifier::class.simpleName}"
+            )
+        }
 
-        // 8. Unsafe file name — reject path traversal characters
-        require(!fileName.contains("/") && !fileName.contains("\\") && !fileName.contains("..")) {
+        // 8. Unsafe file name — reject blank, path traversal, and directory separators
+        require(
+            fileName.isNotBlank() &&
+            !fileName.contains("/") &&
+            !fileName.contains("\\") &&
+            !fileName.contains("..")
+        ) {
             "sovereign-release-manifest-unsafe-file-name: $fileName"
         }
 
@@ -750,9 +762,12 @@ fun verifyReleaseManifest(manifestDir: File, artifactsDir: File) {
             "sovereign-release-manifest-invalid-digest-format: $sha256 (missing 'sha256:' prefix)"
         }
         val hexPart = sha256.removePrefix("sha256:")
-        require(hexPart.length == 64 && hexPart.all { it in '0'..'9' || it in 'a'..'f' }) {
+        val digestRegex = Regex("^[a-fA-F0-9]{64}$")
+        require(digestRegex.matches(hexPart)) {
             "sovereign-release-manifest-invalid-digest-format: $sha256 (expected 64 hex chars, got ${hexPart.length})"
         }
+        // Normalise to lowercase for comparison after validation
+        val normalisedHex = hexPart.lowercase()
 
         // 10. Size must be a positive integer
         val size = sizeBytes.toLong()
@@ -794,7 +809,7 @@ fun verifyReleaseManifest(manifestDir: File, artifactsDir: File) {
         val digest = java.security.MessageDigest.getInstance("SHA-256")
         val computedHex = digest.digest(jarFile.readBytes())
             .joinToString("") { "%02x".format(it) }
-        require(computedHex == hexPart) {
+        require(computedHex == normalisedHex) {
             "sovereign-release-artifact-digest-mismatch: $fileName"
         }
     }
@@ -817,7 +832,6 @@ fun verifyReleaseManifest(manifestDir: File, artifactsDir: File) {
 tasks.register("verifySovereignReleaseManifest") {
     group = "verification"
     description = "Verifies that build/sovereign-release/release-artifacts-v1.json is internally consistent with the JAR files in build/sovereign-release/artifacts/."
-    dependsOn(":prepareSovereignReleaseArtifacts")
 
     doLast {
         val buildDir = rootProject.layout.buildDirectory.get().asFile
@@ -890,7 +904,6 @@ tasks.register("prepareSovereignEvidenceBundle") {
 tasks.register("verifySovereignEvidenceBundleReleaseManifest") {
     group = "verification"
     description = "Verifies that build/sovereign-evidence/release/release-artifacts-v1.json is internally consistent with the JAR files in build/sovereign-evidence/release/artifacts/."
-    dependsOn(":prepareSovereignEvidenceBundle")
 
     doLast {
         val buildDir = rootProject.layout.buildDirectory.get().asFile

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ import org.gradle.kotlin.dsl.configure
 import org.gradle.plugins.signing.SigningExtension
 import org.gradle.util.GradleVersion
 import org.w3c.dom.Element
+import groovy.json.JsonSlurper
 import java.io.File
 import java.net.URI
 import javax.xml.parsers.DocumentBuilderFactory
@@ -591,8 +592,13 @@ tasks.register("prepareSovereignReleaseArtifacts") {
             val moduleName = proj.name
             val libsDir = proj.layout.buildDirectory.dir("libs").get().asFile
             if (!libsDir.exists()) return@forEach
+            val expectedJarPrefixes = listOf(
+                "$moduleName-$version.jar",
+                "$moduleName-$version-sources.jar",
+                "$moduleName-$version-javadoc.jar",
+            )
 
-            libsDir.listFiles { f -> f.name.endsWith(".jar") }
+            libsDir.listFiles { f -> f.name in expectedJarPrefixes }
                 ?.forEach { jarFile ->
                 val copied = jarFile.copyTo(artifactsDir.resolve(jarFile.name), overwrite = true)
 
@@ -659,6 +665,168 @@ tasks.register("prepareSovereignReleaseArtifacts") {
     }
 }
 
+// ──────────────────────────────────────────────
+// Manifest verifier helper
+// ──────────────────────────────────────────────
+
+/**
+ * Verifies that [manifestDir]/release-artifacts-v1.json is internally consistent
+ * with the JAR files in [artifactsDir].
+ *
+ * Every error is communicated through a [GradleException] whose message starts
+ * with one of the required error codes listed in the PR #37 spec.
+ */
+fun verifyReleaseManifest(manifestDir: File, artifactsDir: File) {
+    val manifestFile = manifestDir.resolve("release-artifacts-v1.json")
+
+    // 1. Manifest file must exist
+    require(manifestFile.exists()) {
+        "sovereign-release-manifest-missing: ${manifestFile.absolutePath}"
+    }
+
+    // 2. Artifacts directory must exist
+    require(artifactsDir.isDirectory()) {
+        "sovereign-release-artifacts-dir-missing: ${artifactsDir.absolutePath}"
+    }
+
+    // 3. Parse JSON (fail closed on malformed content)
+    val manifest: Map<String, Any>
+    try {
+        @Suppress("UNCHECKED_CAST")
+        manifest = JsonSlurper().parse(manifestFile) as Map<String, Any>
+    } catch (e: Exception) {
+        throw GradleException("sovereign-release-manifest-invalid-json", e)
+    }
+
+    // 4. Schema version must be supported (currently 1)
+    val schemaVersion = (manifest["schemaVersion"] as? Number)?.toInt()
+        ?: throw GradleException("sovereign-release-manifest-unsupported-schema-version")
+    require(schemaVersion == 1) {
+        "sovereign-release-manifest-unsupported-schema-version: $schemaVersion"
+    }
+
+    // 5. artifacts array must be present
+    val rawArtifacts = manifest["artifacts"]
+        ?: throw GradleException("sovereign-release-manifest-missing-artifacts")
+
+    // 6. artifacts array must not be empty
+    @Suppress("UNCHECKED_CAST")
+    val artifactList = rawArtifacts as? List<Map<String, Any>>
+        ?: throw GradleException("sovereign-release-manifest-invalid-json: artifacts is not an array")
+    require(artifactList.isNotEmpty()) {
+        "sovereign-release-manifest-empty-artifacts"
+    }
+
+    val seenFileNames = mutableSetOf<String>()
+    val seenCoordinates = mutableSetOf<String>()
+    val manifestFileNames = mutableSetOf<String>()
+
+    for ((i, entry) in artifactList.withIndex()) {
+        // 7. Each entry must be a map with required fields
+        val fileName = entry["fileName"]?.let { it as? String }
+            ?: throw GradleException("sovereign-release-manifest-invalid-artifact-entry (index $i): missing or non-String fileName")
+        val groupId = entry["groupId"]?.let { it as? String }
+            ?: throw GradleException("sovereign-release-manifest-invalid-artifact-entry (index $i): missing or non-String groupId")
+        val artifactId = entry["artifactId"]?.let { it as? String }
+            ?: throw GradleException("sovereign-release-manifest-invalid-artifact-entry (index $i): missing or non-String artifactId")
+        val version = entry["version"]?.let { it as? String }
+            ?: throw GradleException("sovereign-release-manifest-invalid-artifact-entry (index $i): missing or non-String version")
+        val extension = entry["extension"]?.let { it as? String }
+            ?: throw GradleException("sovereign-release-manifest-invalid-artifact-entry (index $i): missing or non-String extension")
+        val sha256 = entry["sha256"]?.let { it as? String }
+            ?: throw GradleException("sovereign-release-manifest-invalid-artifact-entry (index $i): missing or non-String sha256")
+        val sizeBytes = entry["sizeBytes"]?.let { it as? Number }
+            ?: throw GradleException("sovereign-release-manifest-invalid-artifact-entry (index $i): missing or non-Numeric sizeBytes")
+
+        val classifier = entry["classifier"]?.let { it as? String }
+
+        // 8. Unsafe file name — reject path traversal characters
+        require(!fileName.contains("/") && !fileName.contains("\\") && !fileName.contains("..")) {
+            "sovereign-release-manifest-unsafe-file-name: $fileName"
+        }
+
+        // 9. Digest must be sha256: followed by 64 lowercase hex chars
+        require(sha256.startsWith("sha256:")) {
+            "sovereign-release-manifest-invalid-digest-format: $sha256 (missing 'sha256:' prefix)"
+        }
+        val hexPart = sha256.removePrefix("sha256:")
+        require(hexPart.length == 64 && hexPart.all { it in '0'..'9' || it in 'a'..'f' }) {
+            "sovereign-release-manifest-invalid-digest-format: $sha256 (expected 64 hex chars, got ${hexPart.length})"
+        }
+
+        // 10. Size must be a positive integer
+        val size = sizeBytes.toLong()
+        require(size > 0) {
+            "sovereign-release-manifest-invalid-size: $size (must be positive)"
+        }
+
+        // 11. Only JAR extensions are supported in the release manifest
+        require(extension == "jar") {
+            "sovereign-release-manifest-unsupported-extension: $extension (only 'jar' is supported)"
+        }
+
+        // 12. Duplicate fileName rejection
+        require(seenFileNames.add(fileName)) {
+            "sovereign-release-manifest-duplicate-file-name: $fileName"
+        }
+
+        // 13. Duplicate Maven coordinate rejection
+        val coordinate = "$groupId:$artifactId:$version:${classifier ?: ""}:$extension"
+        require(seenCoordinates.add(coordinate)) {
+            "sovereign-release-manifest-duplicate-coordinate: $coordinate"
+        }
+
+        manifestFileNames.add(fileName)
+
+        // 14. File must exist on disk
+        val jarFile = artifactsDir.resolve(fileName)
+        require(jarFile.exists()) {
+            "sovereign-release-artifact-missing: $fileName"
+        }
+
+        // 15. File size must match
+        val actualSize = jarFile.length()
+        require(actualSize == size) {
+            "sovereign-release-artifact-size-mismatch: $fileName (expected $size bytes, actual $actualSize)"
+        }
+
+        // 16. SHA-256 digest must match
+        val digest = java.security.MessageDigest.getInstance("SHA-256")
+        val computedHex = digest.digest(jarFile.readBytes())
+            .joinToString("") { "%02x".format(it) }
+        require(computedHex == hexPart) {
+            "sovereign-release-artifact-digest-mismatch: $fileName"
+        }
+    }
+
+    // 17. Reject unlisted .jar files in the artifacts directory
+    val actualJars = artifactsDir.listFiles { f -> f.name.endsWith(".jar") }?.toList() ?: emptyList()
+    for (jarFile in actualJars) {
+        require(jarFile.name in manifestFileNames) {
+            "sovereign-release-artifact-unlisted: ${jarFile.name}"
+        }
+    }
+
+    logger.lifecycle("Release manifest verification passed: ${artifactList.size} artifact(s) validated.")
+}
+
+// ──────────────────────────────────────────────
+// Task: verifySovereignReleaseManifest
+// ──────────────────────────────────────────────
+
+tasks.register("verifySovereignReleaseManifest") {
+    group = "verification"
+    description = "Verifies that build/sovereign-release/release-artifacts-v1.json is internally consistent with the JAR files in build/sovereign-release/artifacts/."
+    dependsOn(":prepareSovereignReleaseArtifacts")
+
+    doLast {
+        val buildDir = rootProject.layout.buildDirectory.get().asFile
+        val manifestDir = buildDir.resolve("sovereign-release")
+        val artifactsDir = manifestDir.resolve("artifacts")
+        verifyReleaseManifest(manifestDir, artifactsDir)
+    }
+}
+
 tasks.register("prepareSovereignEvidenceBundle") {
     group = "verification"
     description = "Assembles all sovereign audit outputs into build/sovereign-evidence/."
@@ -712,5 +880,22 @@ tasks.register("prepareSovereignEvidenceBundle") {
 
         logger.lifecycle("Sovereign evidence bundle assembled: ${outputDir.absolutePath}")
         logger.lifecycle("  Files: ${outputDir.walkTopDown().count { it.isFile }}")
+    }
+}
+
+// ──────────────────────────────────────────────
+// Task: verifySovereignEvidenceBundleReleaseManifest
+// ──────────────────────────────────────────────
+
+tasks.register("verifySovereignEvidenceBundleReleaseManifest") {
+    group = "verification"
+    description = "Verifies that build/sovereign-evidence/release/release-artifacts-v1.json is internally consistent with the JAR files in build/sovereign-evidence/release/artifacts/."
+    dependsOn(":prepareSovereignEvidenceBundle")
+
+    doLast {
+        val buildDir = rootProject.layout.buildDirectory.get().asFile
+        val manifestDir = buildDir.resolve("sovereign-evidence/release")
+        val artifactsDir = manifestDir.resolve("artifacts")
+        verifyReleaseManifest(manifestDir, artifactsDir)
     }
 }


### PR DESCRIPTION
## Summary

Adds two root Gradle tasks that verify `release-artifacts-v1.json` is internally consistent with the JAR files it describes:

- **`verifySovereignReleaseManifest`** — checks `build/sovereign-release/`
- **`verifySovereignEvidenceBundleReleaseManifest`** — checks `build/sovereign-evidence/release/`

## What it verifies

| # | Check | Error Code |
|---|-------|------------|
| 1 | Manifest file exists | `sovereign-release-manifest-missing` |
| 2 | Artifacts directory exists | `sovereign-release-artifacts-dir-missing` |
| 3 | Valid JSON parseable | `sovereign-release-manifest-invalid-json` |
| 4 | Schema version == 1 | `sovereign-release-manifest-unsupported-schema-version` |
| 5 | `artifacts` array present | `sovereign-release-manifest-missing-artifacts` |
| 6 | `artifacts` not empty | `sovereign-release-manifest-empty-artifacts` |
| 7 | Each entry has required fields | `sovereign-release-manifest-invalid-artifact-entry` |
| 8 | No path traversal in fileName | `sovereign-release-manifest-unsafe-file-name` |
| 9 | Digest is `sha256:<64hex>` | `sovereign-release-manifest-invalid-digest-format` |
| 10 | sizeBytes > 0 | `sovereign-release-manifest-invalid-size` |
| 11 | extension == "jar" | `sovereign-release-manifest-unsupported-extension` |
| 12 | No duplicate fileName | `sovereign-release-manifest-duplicate-file-name` |
| 13 | No duplicate groupId:artifactId:version:classifier:extension | `sovereign-release-manifest-duplicate-coordinate` |
| 14 | Each listed JAR exists on disk | `sovereign-release-artifact-missing` |
| 15 | Actual size matches sizeBytes | `sovereign-release-artifact-size-mismatch` |
| 16 | Actual SHA-256 matches manifest | `sovereign-release-artifact-digest-mismatch` |
| 17 | No unlisted .jar files in artifacts dir | `sovereign-release-artifact-unlisted` |

## CI changes

- **build job:** `verifySovereignReleaseManifest` after `prepareSovereignReleaseArtifacts`
- **zero-egress job:** `verifySovereignEvidenceBundleReleaseManifest` after `prepareSovereignEvidenceBundle`

## Verified

```
✓ ./gradlew test --rerun-tasks
✓ ./gradlew prepareSovereignReleaseArtifacts
✓ ./gradlew verifySovereignReleaseManifest  (24 artifacts)
✓ ./scripts/verify-zero-egress.sh  (GREEN)
✓ ./gradlew prepareSovereignEvidenceBundle
✓ ./gradlew verifySovereignEvidenceBundleReleaseManifest
```

## Tamper checks (manual)

| Tamper | Expected Error | Result |
|--------|---------------|--------|
| Byte-flip a JAR in place (size-preserving) | `sovereign-release-artifact-digest-mismatch` | ✅ |
| Delete a listed JAR | `sovereign-release-artifact-missing` | ✅ |
| Add an unlisted `.jar` file | `sovereign-release-artifact-unlisted` | ✅ |