### PR TITLE
feat(evidence): auto-load verified release bundle into evidence pack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,8 +114,19 @@ jobs:
       - name: Compute SBOM digest + copy
         run: ./gradlew prepareCycloneDxBom
 
+      - name: Prepare sovereign release artifacts
+        run: ./gradlew prepareSovereignReleaseArtifacts
+
+      - name: Verify sovereign release manifest
+        run: ./gradlew verifySovereignReleaseManifest
+
       - name: Run zero-egress verification harness
         run: ./scripts/verify-zero-egress.sh
+        env:
+          TRAMAI_RELEASE_BUNDLE_MANIFEST: ${{ github.workspace }}/build/sovereign-release/release-artifacts-v1.json
+
+      - name: Verify evidence pack contains release bundle
+        run: ./gradlew verifySovereignEvidencePackContainsReleaseBundle
 
       - name: Upload evidence pack
         if: always()

--- a/.hermes/plans/2026-06-15_143000-pr38-auto-load-release-bundle.md
+++ b/.hermes/plans/2026-06-15_143000-pr38-auto-load-release-bundle.md
@@ -1,0 +1,96 @@
+# PR #38 — Auto-load Release Bundle Implementation Plan
+
+> **Goal:** Automatically load `build/sovereign-release/release-artifacts-v1.json` into `ReleaseBundleEvidenceV1` and include it in the generated evidence pack.
+
+**Architecture:** The loader lives in tramai-sovereign with manual JSON parsing (no heavy JSON dependency — matches the project's existing manual JSON pattern in `SovereignEvidencePackWriter`). The offline verification harness reads the manifest via `--release-bundle-manifest=` CLI arg, loads it, and passes to `SovereignEvidencePackGenerator.generate(..., releaseBundle = ...)`.
+
+---
+
+## Files Changed
+
+| File | Action | Reason |
+|------|--------|--------|
+| `tramai-sovereign/src/main/kotlin/.../evidence/ReleaseBundleEvidenceLoader.kt` | CREATE | JSON parser for release-artifacts-v1.json → ReleaseBundleEvidenceV1 |
+| `examples/.../offline/OfflineVerificationMain.kt` | MODIFY | Add --release-bundle-manifest arg |
+| `scripts/verify-zero-egress.sh` | MODIFY | Pass `$TRAMAI_RELEASE_BUNDLE_MANIFEST` as `--release-bundle-manifest=` |
+| `build.gradle.kts` | MODIFY | Make prepareSovereignEvidenceBundle pure; add verifySovereignEvidencePackContainsReleaseBundle |
+| `.github/workflows/ci.yml` | MODIFY | Add release manifest steps to zero-egress job |
+| `tramai-sovereign/src/test/kotlin/.../evidence/ReleaseBundleEvidenceLoaderTest.kt` | CREATE | Loader unit tests |
+| `tramai-sovereign/src/test/kotlin/.../evidence/SovereignEvidencePackIntegrationTest.kt` | MODIFY | Add integration test for release bundle |
+
+---
+
+## Quick-start sequence
+
+1. Create loader + write unit tests
+2. Update OfflineVerificationMain to accept `--release-bundle-manifest=`
+3. Update verify-zero-egress.sh
+4. Make prepareSovereignEvidenceBundle pure + add verification task
+5. Update CI
+6. Add integration test
+7. Run full validation
+
+---
+
+## Phase 1: ReleaseBundleEvidenceLoader
+
+**File:** `tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/evidence/ReleaseBundleEvidenceLoader.kt`
+
+Manual JSON parser for `release-artifacts-v1.json`. Since tramai-sovereign has no JSON library dependency, parse the known deterministic format character-by-character (matching the project's manual approach in `SovereignEvidencePackWriter`).
+
+Validation rules (matching the spec error codes):
+- File missing → `release-bundle-evidence-missing`
+- Invalid JSON → `release-bundle-evidence-invalid-json`
+- schemaVersion != 1 → `release-bundle-evidence-unsupported-schema-version`
+- artifacts field missing → `release-bundle-evidence-missing-artifacts`
+- artifacts list empty → `release-bundle-evidence-empty-artifacts`
+- Missing/invalid field → `release-bundle-evidence-invalid-artifact-entry`
+- Blank fileName / path traversal → `release-bundle-evidence-unsafe-file-name`
+- Invalid digest format → `release-bundle-evidence-invalid-digest-format`
+- sizeBytes <= 0 → `release-bundle-evidence-invalid-size`
+- extension != "jar" → `release-bundle-evidence-unsupported-extension`
+- Duplicate fileName → `release-bundle-evidence-duplicate-file-name`
+- Duplicate coordinate → `release-bundle-evidence-duplicate-coordinate`
+
+API:
+```kotlin
+object ReleaseBundleEvidenceLoader {
+    @JvmStatic
+    fun load(path: Path): ReleaseBundleEvidenceV1
+}
+```
+
+## Phase 2: OfflineVerificationMain
+
+Add to `OfflineVerificationMain.kt`:
+- Parse `--release-bundle-manifest=` argument
+- Load via `ReleaseBundleEvidenceLoader.load(...)` 
+- Pass to `tramai.evidencePack(releaseBundle = loadedReleaseBundle, ...)`
+
+## Phase 3: verify-zero-egress.sh
+
+If `TRAMAI_RELEASE_BUNDLE_MANIFEST` is set, mount the manifest file into the Docker container and pass `--release-bundle-manifest=` to the application.
+
+## Phase 4: build.gradle.kts
+
+1. Remove `dependsOn(":prepareCycloneDxBom", ":prepareSovereignReleaseArtifacts")` from `prepareSovereignEvidenceBundle`
+2. Add `verifySovereignEvidencePackContainsReleaseBundle` task:
+   - Reads `build/zero-egress-report/sovereign-evidence-pack-v1.json`
+   - Checks `"releaseBundle"` is not null
+   - Fails with `sovereign-evidence-pack-missing-release-bundle`
+
+## Phase 5: CI (ci.yml)
+
+Zero-egress job becomes:
+```
+prepareSovereignReleaseArtifacts
+verifySovereignReleaseManifest
+verify-zero-egress.sh (with TRAMAI_RELEASE_BUNDLE_MANIFEST)
+prepareSovereignEvidenceBundle
+verifySovereignEvidenceBundleReleaseManifest
+```
+
+## Phase 6: Tests
+
+- Loader unit tests: 18+ test cases covering all error codes
+- Integration test: generate evidence pack with release bundle, assert `"releaseBundle"` present

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -844,10 +844,6 @@ tasks.register("verifySovereignReleaseManifest") {
 tasks.register("prepareSovereignEvidenceBundle") {
     group = "verification"
     description = "Assembles all sovereign audit outputs into build/sovereign-evidence/."
-    dependsOn(
-        ":prepareCycloneDxBom",
-        ":prepareSovereignReleaseArtifacts",
-    )
 
     doLast {
         val buildDir = rootProject.layout.buildDirectory.get().asFile
@@ -910,5 +906,34 @@ tasks.register("verifySovereignEvidenceBundleReleaseManifest") {
         val manifestDir = buildDir.resolve("sovereign-evidence/release")
         val artifactsDir = manifestDir.resolve("artifacts")
         verifyReleaseManifest(manifestDir, artifactsDir)
+    }
+}
+
+// ──────────────────────────────────────────────
+// Task: verifySovereignEvidencePackContainsReleaseBundle
+// ──────────────────────────────────────────────
+
+tasks.register("verifySovereignEvidencePackContainsReleaseBundle") {
+    group = "verification"
+    description = "Verifies that build/zero-egress-report/sovereign-evidence-pack-v1.json contains releaseBundle."
+
+    doLast {
+        val buildDir = rootProject.layout.buildDirectory.get().asFile
+        val evidencePackPath = buildDir.resolve("zero-egress-report/sovereign-evidence-pack-v1.json")
+
+        require(evidencePackPath.exists()) {
+            "sovereign-evidence-pack-missing: ${evidencePackPath.absolutePath}"
+        }
+
+        val text = evidencePackPath.readText()
+        val hasReleaseBundle = text.contains("\"releaseBundle\":") &&
+            !text.contains("\"releaseBundle\": null") &&
+            !text.contains("\"releaseBundle\": null,")
+
+        require(hasReleaseBundle) {
+            "sovereign-evidence-pack-missing-release-bundle: ${evidencePackPath.absolutePath}"
+        }
+
+        logger.lifecycle("Evidence pack contains releaseBundle: ${evidencePackPath.absolutePath}")
     }
 }

--- a/examples/sovereign-offline-verification/src/main/kotlin/dev/tramai/examples/offline/OfflineVerificationMain.kt
+++ b/examples/sovereign-offline-verification/src/main/kotlin/dev/tramai/examples/offline/OfflineVerificationMain.kt
@@ -17,6 +17,8 @@ import dev.tramai.sovereign.SovereignTramai
 import dev.tramai.sovereign.evidence.AttestationEvidenceV1
 import dev.tramai.sovereign.evidence.AttestedSubjectV1
 import dev.tramai.sovereign.evidence.AuditChainEvidenceV1
+import dev.tramai.sovereign.evidence.ReleaseBundleEvidenceLoader
+import dev.tramai.sovereign.evidence.ReleaseBundleEvidenceV1
 import dev.tramai.sovereign.evidence.SovereignEvidencePackWriter
 import dev.tramai.sovereign.evidence.SupplyChainEvidenceV1
 import dev.tramai.sovereign.evidence.ZeroEgressEvidenceV1
@@ -83,8 +85,21 @@ private fun run(args: Array<String>): Int {
         null
     }
 
+    // Parse optional release bundle manifest argument
+    val releaseBundleManifestArg = args.firstOrNull { it.startsWith("--release-bundle-manifest=") }
+    val releaseBundle = if (releaseBundleManifestArg != null) {
+        val manifestPathStr = releaseBundleManifestArg.substringAfter("--release-bundle-manifest=")
+        val manifestPath = Path.of(manifestPathStr)
+        println("Loading release bundle manifest: $manifestPath")
+        val loaded = ReleaseBundleEvidenceLoader.load(manifestPath)
+        println("Release bundle loaded: ${loaded.artifacts.size} artifact(s)")
+        loaded
+    } else {
+        null
+    }
+
     val result = kotlin.runCatching {
-        executeVerification(reportPath, evidencePath, supplyChain)
+        executeVerification(reportPath, evidencePath, supplyChain, releaseBundle)
     }
 
     return if (result.isSuccess) {
@@ -104,11 +119,12 @@ internal fun executeVerification(
     reportPath: Path,
     evidencePath: Path,
     supplyChain: SupplyChainEvidenceV1? = null,
+    releaseBundle: ReleaseBundleEvidenceV1? = null,
 ) {
     // b. Create temporary directory for artifact file
     val tempDir = Files.createTempDirectory("tramai-offline-verification-")
     try {
-        executeVerificationInternal(tempDir, reportPath, evidencePath, supplyChain)
+        executeVerificationInternal(tempDir, reportPath, evidencePath, supplyChain, releaseBundle)
     } finally {
         // Clean up temp directory
         tempDir.toFile().deleteRecursively()
@@ -121,6 +137,7 @@ internal fun executeVerificationInternal(
     reportPath: Path,
     evidencePath: Path,
     supplyChain: SupplyChainEvidenceV1? = null,
+    releaseBundle: ReleaseBundleEvidenceV1? = null,
 ) {
     // c. Write dummy artifact file
     val artifactContent = "offline-test-model-artifact-content"
@@ -293,6 +310,7 @@ internal fun executeVerificationInternal(
                 totalEvents = allEvents.size,
             ),
             supplyChain = supplyChain,
+            releaseBundle = releaseBundle,
         )
         SovereignEvidencePackWriter.write(evidencePack, evidencePath)
 
@@ -366,6 +384,7 @@ internal fun executeVerificationInternal(
                     totalEvents = allEvents.size,
                 ),
                 supplyChain = supplyChain,
+                releaseBundle = releaseBundle,
                 attestation = attestation,
             )
             SovereignEvidencePackWriter.write(evidencePack, evidencePath)

--- a/scripts/verify-zero-egress.sh
+++ b/scripts/verify-zero-egress.sh
@@ -16,6 +16,21 @@ chmod 0777 "$REPORT_DIR"
 SBOM_DIR="${REPO_ROOT}/build/supply-chain/sbom"
 mkdir -p "$SBOM_DIR"
 
+RELEASE_MANIFEST="${TRAMAI_RELEASE_BUNDLE_MANIFEST:-}"
+RELEASE_MANIFEST_VOLUME=""
+RELEASE_MANIFEST_ARG=""
+if [[ -n "$RELEASE_MANIFEST" ]]; then
+  if [[ -f "$RELEASE_MANIFEST" ]]; then
+    MANIFEST_DIR="$(cd "$(dirname "$RELEASE_MANIFEST")" && pwd)"
+    MANIFEST_FILE="$(basename "$RELEASE_MANIFEST")"
+    RELEASE_MANIFEST_VOLUME="--volume $MANIFEST_DIR:/release-manifest:ro"
+    RELEASE_MANIFEST_ARG="--release-bundle-manifest=/release-manifest/$MANIFEST_FILE"
+    echo "Release bundle manifest: $RELEASE_MANIFEST"
+  else
+    echo "WARNING: TRAMAI_RELEASE_BUNDLE_MANIFEST=$RELEASE_MANIFEST not found, skipping"
+  fi
+fi
+
 trap '' EXIT
 
 echo "=== Building application distribution ==="
@@ -35,9 +50,11 @@ docker run --rm \
   --network=none \
   --volume "$REPORT_DIR:/out" \
   --volume "$SBOM_DIR:/sbom:ro" \
+  $RELEASE_MANIFEST_VOLUME \
   tramai-sovereign-offline-verification:local \
   --sbom-path=/sbom/tramai-cyclonedx-sbom.json \
-  --sbom-digest-path=/sbom/tramai-cyclonedx-sbom.sha256
+  --sbom-digest-path=/sbom/tramai-cyclonedx-sbom.sha256 \
+  $RELEASE_MANIFEST_ARG
 
 REPORT_FILE="$REPORT_DIR/zero-egress-report.json"
 if [[ ! -f "$REPORT_FILE" ]]; then

--- a/scripts/verify-zero-egress.sh
+++ b/scripts/verify-zero-egress.sh
@@ -17,14 +17,14 @@ SBOM_DIR="${REPO_ROOT}/build/supply-chain/sbom"
 mkdir -p "$SBOM_DIR"
 
 RELEASE_MANIFEST="${TRAMAI_RELEASE_BUNDLE_MANIFEST:-}"
-RELEASE_MANIFEST_VOLUME=""
-RELEASE_MANIFEST_ARG=""
+DOCKER_VOLUME_ARGS=()
+APP_RELEASE_ARGS=()
 if [[ -n "$RELEASE_MANIFEST" ]]; then
   if [[ -f "$RELEASE_MANIFEST" ]]; then
     MANIFEST_DIR="$(cd "$(dirname "$RELEASE_MANIFEST")" && pwd)"
     MANIFEST_FILE="$(basename "$RELEASE_MANIFEST")"
-    RELEASE_MANIFEST_VOLUME="--volume $MANIFEST_DIR:/release-manifest:ro"
-    RELEASE_MANIFEST_ARG="--release-bundle-manifest=/release-manifest/$MANIFEST_FILE"
+    DOCKER_VOLUME_ARGS+=("--volume" "$MANIFEST_DIR:/release-manifest:ro")
+    APP_RELEASE_ARGS+=("--release-bundle-manifest=/release-manifest/$MANIFEST_FILE")
     echo "Release bundle manifest: $RELEASE_MANIFEST"
   else
     echo "WARNING: TRAMAI_RELEASE_BUNDLE_MANIFEST=$RELEASE_MANIFEST not found, skipping"
@@ -50,11 +50,11 @@ docker run --rm \
   --network=none \
   --volume "$REPORT_DIR:/out" \
   --volume "$SBOM_DIR:/sbom:ro" \
-  $RELEASE_MANIFEST_VOLUME \
+  "${DOCKER_VOLUME_ARGS[@]}" \
   tramai-sovereign-offline-verification:local \
   --sbom-path=/sbom/tramai-cyclonedx-sbom.json \
   --sbom-digest-path=/sbom/tramai-cyclonedx-sbom.sha256 \
-  $RELEASE_MANIFEST_ARG
+  "${APP_RELEASE_ARGS[@]}"
 
 REPORT_FILE="$REPORT_DIR/zero-egress-report.json"
 if [[ ! -f "$REPORT_FILE" ]]; then

--- a/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/evidence/ReleaseBundleEvidenceLoader.kt
+++ b/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/evidence/ReleaseBundleEvidenceLoader.kt
@@ -1,0 +1,312 @@
+package dev.tramai.sovereign.evidence
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Loads a [ReleaseBundleEvidenceV1] from a `release-artifacts-v1.json` file.
+ *
+ * This is a build-time loader that maps the verified artifact manifest
+ * (produced by Gradle's `prepareSovereignReleaseArtifacts` and verified by
+ * PR #37's verifier tasks) into the evidence pack DTO.
+ *
+ * The loader validates manifest *shape* — it does NOT recompute JAR file hashes.
+ * Hash/file verification is owned by the Gradle verifier tasks.
+ *
+ * Uses manual JSON parsing (matching the project's `SovereignEvidencePackWriter`
+ * approach) to avoid pulling in a heavy JSON dependency at runtime.
+ */
+object ReleaseBundleEvidenceLoader {
+
+    private val digestRegex = Regex("^sha256:[a-fA-F0-9]{64}$")
+    private val safeFileNameRegex = Regex("^[^/\\\\]+$")
+
+    /**
+     * Reads and validates [path] as `release-artifacts-v1.json`,
+     * returning a [ReleaseBundleEvidenceV1].
+     *
+     * @throws IllegalStateException with a deterministic error code on any validation failure.
+     */
+    @JvmStatic
+    fun load(path: Path): ReleaseBundleEvidenceV1 {
+        if (!Files.exists(path)) {
+            throw IllegalStateException("release-bundle-evidence-missing: $path")
+        }
+
+        val text: String = try {
+            Files.readString(path)
+        } catch (e: Exception) {
+            throw IllegalStateException("release-bundle-evidence-invalid-json", e)
+        }
+
+        val parser = JsonParser(text)
+        val root = try {
+            parser.parseValue()
+        } catch (e: IllegalStateException) {
+            throw e
+        } catch (e: Exception) {
+            throw IllegalStateException("release-bundle-evidence-invalid-json", e)
+        }
+
+        val obj = root as? Map<*, *>
+            ?: throw IllegalStateException("release-bundle-evidence-invalid-json: root is not an object")
+
+        val schemaVersion = (obj["schemaVersion"] as? Number)?.toInt()
+            ?: throw IllegalStateException("release-bundle-evidence-unsupported-schema-version")
+        if (schemaVersion != 1) {
+            throw IllegalStateException("release-bundle-evidence-unsupported-schema-version: $schemaVersion")
+        }
+
+        val buildTool = stringField(obj, "buildTool")
+        val javaVersion = stringField(obj, "javaVersion")
+        val gradleVersion = stringField(obj, "gradleVersion")
+
+        val rawArtifacts = obj["artifacts"]
+            ?: throw IllegalStateException("release-bundle-evidence-missing-artifacts")
+        val artifactList = rawArtifacts as? List<*>
+            ?: throw IllegalStateException("release-bundle-evidence-invalid-json: artifacts is not an array")
+
+        if (artifactList.isEmpty()) {
+            throw IllegalStateException("release-bundle-evidence-empty-artifacts")
+        }
+
+        val seenFileNames = mutableSetOf<String>()
+        val seenCoordinates = mutableSetOf<String>()
+        val resultArtifacts = mutableListOf<ReleaseArtifactEvidenceV1>()
+
+        for ((i, rawEntry) in artifactList.withIndex()) {
+            val entry = rawEntry as? Map<*, *>
+                ?: throw IllegalStateException("release-bundle-evidence-invalid-artifact-entry (index $i)")
+
+            val groupId = stringField(entry, "groupId", i)
+            val artifactId = stringField(entry, "artifactId", i)
+            val version = stringField(entry, "version", i)
+            val fileName = stringField(entry, "fileName", i)
+            val sha256 = stringField(entry, "sha256", i)
+            val extension = stringField(entry, "extension", i)
+            val sizeBytes = numericField(entry, "sizeBytes", i)
+
+            val rawClassifier = entry["classifier"]
+            val classifier = when (rawClassifier) {
+                null -> null
+                is String -> rawClassifier
+                else -> throw IllegalStateException(
+                    "release-bundle-evidence-invalid-artifact-entry (index $i): classifier must be String or null"
+                )
+            }
+
+            // Unsafe file name
+            if (fileName.isBlank() || !safeFileNameRegex.matches(fileName)) {
+                throw IllegalStateException("release-bundle-evidence-unsafe-file-name: $fileName")
+            }
+
+            // Digest format
+            if (!digestRegex.matches(sha256)) {
+                throw IllegalStateException("release-bundle-evidence-invalid-digest-format: $sha256")
+            }
+
+            // Size must be positive
+            val size = sizeBytes.toLong()
+            if (size <= 0) {
+                throw IllegalStateException("release-bundle-evidence-invalid-size: $size")
+            }
+
+            // Only JAR extension supported
+            if (extension != "jar") {
+                throw IllegalStateException("release-bundle-evidence-unsupported-extension: $extension")
+            }
+
+            // Duplicate fileName
+            if (!seenFileNames.add(fileName)) {
+                throw IllegalStateException("release-bundle-evidence-duplicate-file-name: $fileName")
+            }
+
+            // Duplicate coordinate
+            val coordinate = "$groupId:$artifactId:$version:${classifier ?: ""}:$extension"
+            if (!seenCoordinates.add(coordinate)) {
+                throw IllegalStateException("release-bundle-evidence-duplicate-coordinate: $coordinate")
+            }
+
+            resultArtifacts.add(
+                ReleaseArtifactEvidenceV1(
+                    groupId = groupId,
+                    artifactId = artifactId,
+                    version = version,
+                    classifier = classifier,
+                    extension = extension,
+                    fileName = fileName,
+                    sha256 = sha256,
+                    sizeBytes = size,
+                )
+            )
+        }
+
+        return ReleaseBundleEvidenceV1(
+            schemaVersion = schemaVersion,
+            buildTool = buildTool,
+            javaVersion = javaVersion,
+            gradleVersion = gradleVersion,
+            artifacts = resultArtifacts,
+        )
+    }
+
+    private fun stringField(obj: Map<*, *>, key: String, index: Int? = null): String {
+        val prefix = if (index != null) " (index $index)" else ""
+        return (obj[key] as? String)
+            ?: throw IllegalStateException("release-bundle-evidence-invalid-artifact-entry$prefix: missing or non-String $key")
+    }
+
+    private fun numericField(obj: Map<*, *>, key: String, index: Int? = null): Number {
+        val prefix = if (index != null) " (index $index)" else ""
+        return (obj[key] as? Number)
+            ?: throw IllegalStateException("release-bundle-evidence-invalid-artifact-entry$prefix: missing or non-Numeric $key")
+    }
+
+    // ── Minimal recursive-descent JSON parser ──────────────────────────────
+    // Handles the subset of JSON used by release-artifacts-v1.json:
+    // objects, arrays, strings, numbers, booleans, and null.
+
+    private class JsonParser(private val text: String) {
+        private var pos = 0
+
+        fun parseValue(): Any? {
+            skipWhitespace()
+            if (pos >= text.length) return null
+            return when (val ch = text[pos]) {
+                '{' -> parseObject()
+                '[' -> parseArray()
+                '"' -> parseString()
+                't', 'f' -> parseBoolean()
+                'n' -> parseNull()
+                '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' -> parseNumber()
+                else -> throw IllegalStateException("release-bundle-evidence-invalid-json: unexpected '${ch}' at position $pos")
+            }
+        }
+
+        private fun parseObject(): Map<String, Any?> {
+            expect('{')
+            val map = linkedMapOf<String, Any?>()
+            skipWhitespace()
+            if (peek() == '}') { pos++; return map }
+            while (true) {
+                skipWhitespace()
+                val key = parseString()
+                skipWhitespace()
+                expect(':')
+                skipWhitespace()
+                val value = parseValue()
+                map[key] = value
+                skipWhitespace()
+                val ch = peek()
+                if (ch == '}') { pos++; return map }
+                if (ch == ',') { pos++; continue }
+                throw IllegalStateException("release-bundle-evidence-invalid-json: expected ',' or '}' at position $pos")
+            }
+        }
+
+        private fun parseArray(): List<Any?> {
+            expect('[')
+            val list = mutableListOf<Any?>()
+            skipWhitespace()
+            if (peek() == ']') { pos++; return list }
+            while (true) {
+                skipWhitespace()
+                list.add(parseValue())
+                skipWhitespace()
+                val ch = peek()
+                if (ch == ']') { pos++; return list }
+                if (ch == ',') { pos++; continue }
+                throw IllegalStateException("release-bundle-evidence-invalid-json: expected ',' or ']' at position $pos")
+            }
+        }
+
+        private fun parseString(): String {
+            expect('"')
+            val sb = StringBuilder()
+            while (pos < text.length) {
+                val ch = text[pos]
+                if (ch == '"') { pos++; return sb.toString() }
+                if (ch == '\\') {
+                    pos++
+                    val esc = text.getOrElse(pos) {
+                        throw IllegalStateException("release-bundle-evidence-invalid-json: unexpected end in escape")
+                    }
+                    sb.append(
+                        when (esc) {
+                            '"' -> '"'; '\\' -> '\\'; '/' -> '/'
+                            'n' -> '\n'; 'r' -> '\r'; 't' -> '\t'
+                            'u' -> {
+                                val hex = text.substring(pos + 1, pos + 5)
+                                pos += 4
+                                hex.toInt(16).toChar()
+                            }
+                            else -> throw IllegalStateException("release-bundle-evidence-invalid-json: unknown escape '\\$esc'")
+                        }
+                    )
+                    pos++
+                } else {
+                    sb.append(ch)
+                    pos++
+                }
+            }
+            throw IllegalStateException("release-bundle-evidence-invalid-json: unclosed string")
+        }
+
+        private fun parseNumber(): Number {
+            val start = pos
+            if (text[pos] == '-') pos++
+            while (pos < text.length && text[pos].isDigit()) pos++
+            if (pos < text.length && text[pos] == '.') {
+                pos++
+                while (pos < text.length && text[pos].isDigit()) pos++
+            }
+            if (pos < text.length && (text[pos] == 'e' || text[pos] == 'E')) {
+                pos++
+                if (pos < text.length && (text[pos] == '+' || text[pos] == '-')) pos++
+                while (pos < text.length && text[pos].isDigit()) pos++
+            }
+            val numStr = text.substring(start, pos)
+            return if (numStr.contains('.') || numStr.contains('e') || numStr.contains('E')) {
+                numStr.toDouble()
+            } else {
+                numStr.toLong()
+            }
+        }
+
+        private fun parseBoolean(): Boolean {
+            return if (text.startsWith("true", pos)) {
+                pos += 4; true
+            } else if (text.startsWith("false", pos)) {
+                pos += 5; false
+            } else {
+                throw IllegalStateException("release-bundle-evidence-invalid-json at position $pos")
+            }
+        }
+
+        private fun parseNull(): Nothing? {
+            if (text.startsWith("null", pos)) {
+                pos += 4; return null
+            }
+            throw IllegalStateException("release-bundle-evidence-invalid-json at position $pos")
+        }
+
+        private fun expect(ch: Char) {
+            skipWhitespace()
+            if (pos >= text.length || text[pos] != ch) {
+                throw IllegalStateException(
+                    "release-bundle-evidence-invalid-json: expected '$ch' at position $pos"
+                )
+            }
+            pos++
+        }
+
+        private fun peek(): Char {
+            skipWhitespace()
+            return text.getOrElse(pos) { '?' }
+        }
+
+        private fun skipWhitespace() {
+            while (pos < text.length && text[pos].isWhitespace()) pos++
+        }
+    }
+}

--- a/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/evidence/ReleaseBundleEvidenceLoader.kt
+++ b/tramai-sovereign/src/main/kotlin/dev/tramai/sovereign/evidence/ReleaseBundleEvidenceLoader.kt
@@ -41,7 +41,7 @@ object ReleaseBundleEvidenceLoader {
 
         val parser = JsonParser(text)
         val root = try {
-            parser.parseValue()
+            parser.parseDocument()
         } catch (e: IllegalStateException) {
             throw e
         } catch (e: Exception) {
@@ -182,6 +182,23 @@ object ReleaseBundleEvidenceLoader {
                 else -> throw IllegalStateException("release-bundle-evidence-invalid-json: unexpected '${ch}' at position $pos")
             }
         }
+
+        /**
+         * Parses a complete JSON document: one value followed by optional
+         * trailing whitespace and then end-of-file. Rejects trailing content
+         * after the first JSON value.
+         */
+        fun parseDocument(): Any? {
+            skipWhitespace()
+            val value = parseValue()
+            skipWhitespace()
+            if (!isAtEnd()) {
+                throw IllegalStateException("release-bundle-evidence-invalid-json: trailing content at position $pos")
+            }
+            return value
+        }
+
+        private fun isAtEnd(): Boolean = pos >= text.length
 
         private fun parseObject(): Map<String, Any?> {
             expect('{')

--- a/tramai-sovereign/src/test/kotlin/dev/tramai/sovereign/evidence/ReleaseBundleEvidenceLoaderTest.kt
+++ b/tramai-sovereign/src/test/kotlin/dev/tramai/sovereign/evidence/ReleaseBundleEvidenceLoaderTest.kt
@@ -1,0 +1,278 @@
+package dev.tramai.sovereign.evidence
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Unit tests for [ReleaseBundleEvidenceLoader].
+ */
+class ReleaseBundleEvidenceLoaderTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private val validManifest = """
+        {
+          "schemaVersion": 1,
+          "buildTool": "Gradle",
+          "javaVersion": "25.0.1",
+          "gradleVersion": "8.10",
+          "artifacts": [
+            {
+              "groupId": "dev.tramai",
+              "artifactId": "tramai-core",
+              "version": "0.3.1",
+              "classifier": null,
+              "extension": "jar",
+              "fileName": "tramai-core-0.3.1.jar",
+              "sha256": "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+              "sizeBytes": 289479
+            },
+            {
+              "groupId": "dev.tramai",
+              "artifactId": "tramai-core",
+              "version": "0.3.1",
+              "classifier": "sources",
+              "extension": "jar",
+              "fileName": "tramai-core-0.3.1-sources.jar",
+              "sha256": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+              "sizeBytes": 61200
+            }
+          ]
+        }
+    """.trimIndent()
+
+    private fun writeManifest(content: String = validManifest): Path {
+        val path = tempDir.resolve("release-artifacts-v1.json")
+        Files.writeString(path, content)
+        return path
+    }
+
+    // ── Happy path ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `valid manifest loads successfully`() {
+        val path = writeManifest()
+        val result = ReleaseBundleEvidenceLoader.load(path)
+
+        assertThat(result.schemaVersion).isEqualTo(1)
+        assertThat(result.buildTool).isEqualTo("Gradle")
+        assertThat(result.javaVersion).isEqualTo("25.0.1")
+        assertThat(result.gradleVersion).isEqualTo("8.10")
+        assertThat(result.artifacts).hasSize(2)
+
+        assertThat(result.artifacts[0].groupId).isEqualTo("dev.tramai")
+        assertThat(result.artifacts[0].artifactId).isEqualTo("tramai-core")
+        assertThat(result.artifacts[0].version).isEqualTo("0.3.1")
+        assertThat(result.artifacts[0].classifier).isNull()
+        assertThat(result.artifacts[0].extension).isEqualTo("jar")
+        assertThat(result.artifacts[0].fileName).isEqualTo("tramai-core-0.3.1.jar")
+        assertThat(result.artifacts[0].sha256).isEqualTo("sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+        assertThat(result.artifacts[0].sizeBytes).isEqualTo(289479)
+
+        assertThat(result.artifacts[1].classifier).isEqualTo("sources")
+        assertThat(result.artifacts[1].sizeBytes).isEqualTo(61200)
+    }
+
+    // ── File missing ────────────────────────────────────────────────────────
+
+    @Test
+    fun `missing file throws release-bundle-evidence-missing`() {
+        val missing = tempDir.resolve("nonexistent.json")
+        assertThatThrownBy { ReleaseBundleEvidenceLoader.load(missing) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("release-bundle-evidence-missing")
+    }
+
+    // ── Invalid JSON ────────────────────────────────────────────────────────
+
+    @Test
+    fun `invalid JSON throws release-bundle-evidence-invalid-json`() {
+        val path = writeManifest("not valid json")
+        assertThatThrownBy { ReleaseBundleEvidenceLoader.load(path) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("release-bundle-evidence-invalid-json")
+    }
+
+    // ── Schema version ──────────────────────────────────────────────────────
+
+    @Test
+    fun `schema version not 1 throws unsupported-schema-version`() {
+        val path = writeManifest("""
+            {"schemaVersion": 2, "buildTool": "Gradle", "javaVersion": "25", "gradleVersion": "8", "artifacts": []}
+        """.trimIndent())
+        assertThatThrownBy { ReleaseBundleEvidenceLoader.load(path) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("release-bundle-evidence-unsupported-schema-version")
+    }
+
+    @Test
+    fun `missing schema version throws unsupported-schema-version`() {
+        val path = writeManifest("""
+            {"buildTool": "Gradle", "javaVersion": "25", "gradleVersion": "8", "artifacts": [{"groupId": "x", "artifactId": "y", "version": "1", "fileName": "a.jar", "sha256": "sha256:${"a".repeat(64)}", "sizeBytes": 1, "extension": "jar"}]}
+        """.trimIndent())
+        assertThatThrownBy { ReleaseBundleEvidenceLoader.load(path) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("release-bundle-evidence-unsupported-schema-version")
+    }
+
+    // ── Missing artifacts ───────────────────────────────────────────────────
+
+    @Test
+    fun `missing artifacts field throws missing-artifacts`() {
+        val path = writeManifest("""
+            {"schemaVersion": 1, "buildTool": "Gradle", "javaVersion": "25", "gradleVersion": "8"}
+        """.trimIndent())
+        assertThatThrownBy { ReleaseBundleEvidenceLoader.load(path) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("release-bundle-evidence-missing-artifacts")
+    }
+
+    // ── Empty artifacts ─────────────────────────────────────────────────────
+
+    @Test
+    fun `empty artifacts throws empty-artifacts`() {
+        val path = writeManifest("""
+            {"schemaVersion": 1, "buildTool": "Gradle", "javaVersion": "25", "gradleVersion": "8", "artifacts": []}
+        """.trimIndent())
+        assertThatThrownBy { ReleaseBundleEvidenceLoader.load(path) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("release-bundle-evidence-empty-artifacts")
+    }
+
+    // ── Missing field in artifact entry ─────────────────────────────────────
+
+    @Test
+    fun `missing required field throws invalid-artifact-entry`() {
+        val path = writeManifest("""
+            {"schemaVersion": 1, "buildTool": "Gradle", "javaVersion": "25", "gradleVersion": "8", "artifacts": [{"groupId": "x", "artifactId": "y"}]}
+        """.trimIndent())
+        assertThatThrownBy { ReleaseBundleEvidenceLoader.load(path) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("release-bundle-evidence-invalid-artifact-entry")
+    }
+
+    // ── Non-string classifier ───────────────────────────────────────────────
+
+    @Test
+    fun `non-string non-null classifier throws invalid-artifact-entry`() {
+        val path = writeManifest("""
+            {"schemaVersion": 1, "buildTool": "Gradle", "javaVersion": "25", "gradleVersion": "8", "artifacts": [{"groupId": "x", "artifactId": "y", "version": "1", "classifier": 42, "extension": "jar", "fileName": "a.jar", "sha256": "sha256:${"a".repeat(64)}", "sizeBytes": 1}]}
+        """.trimIndent())
+        assertThatThrownBy { ReleaseBundleEvidenceLoader.load(path) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("release-bundle-evidence-invalid-artifact-entry")
+    }
+
+    // ── Blank filename ──────────────────────────────────────────────────────
+
+    @Test
+    fun `blank filename throws unsafe-file-name`() {
+        val path = writeManifest("""
+            {"schemaVersion": 1, "buildTool": "Gradle", "javaVersion": "25", "gradleVersion": "8", "artifacts": [{"groupId": "x", "artifactId": "y", "version": "1", "extension": "jar", "fileName": "  ", "sha256": "sha256:${"a".repeat(64)}", "sizeBytes": 1}]}
+        """.trimIndent())
+        assertThatThrownBy { ReleaseBundleEvidenceLoader.load(path) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("release-bundle-evidence-unsafe-file-name")
+    }
+
+    // ── Filename with path traversal ────────────────────────────────────────
+
+    @Test
+    fun `filename with slash throws unsafe-file-name`() {
+        val path = writeManifest("""
+            {"schemaVersion": 1, "buildTool": "Gradle", "javaVersion": "25", "gradleVersion": "8", "artifacts": [{"groupId": "x", "artifactId": "y", "version": "1", "extension": "jar", "fileName": "../evil.jar", "sha256": "sha256:${"a".repeat(64)}", "sizeBytes": 1}]}
+        """.trimIndent())
+        assertThatThrownBy { ReleaseBundleEvidenceLoader.load(path) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("release-bundle-evidence-unsafe-file-name")
+    }
+
+    // ── Invalid digest ──────────────────────────────────────────────────────
+
+    @Test
+    fun `invalid digest format throws invalid-digest-format`() {
+        val path = writeManifest("""
+            {"schemaVersion": 1, "buildTool": "Gradle", "javaVersion": "25", "gradleVersion": "8", "artifacts": [{"groupId": "x", "artifactId": "y", "version": "1", "extension": "jar", "fileName": "a.jar", "sha256": "sha256:xyz", "sizeBytes": 1}]}
+        """.trimIndent())
+        assertThatThrownBy { ReleaseBundleEvidenceLoader.load(path) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("release-bundle-evidence-invalid-digest-format")
+    }
+
+    // ── Uppercase digest ────────────────────────────────────────────────────
+
+    @Test
+    fun `uppercase hex digest is accepted`() {
+        val upperHex = "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789"
+        val path = writeManifest("""
+            {"schemaVersion": 1, "buildTool": "Gradle", "javaVersion": "25", "gradleVersion": "8", "artifacts": [{"groupId": "x", "artifactId": "y", "version": "1", "extension": "jar", "fileName": "a.jar", "sha256": "sha256:$upperHex", "sizeBytes": 1}]}
+        """.trimIndent())
+        val result = ReleaseBundleEvidenceLoader.load(path)
+        assertThat(result.artifacts[0].sha256).isEqualTo("sha256:$upperHex")
+    }
+
+    // ── Negative size ───────────────────────────────────────────────────────
+
+    @Test
+    fun `negative size throws invalid-size`() {
+        val path = writeManifest("""
+            {"schemaVersion": 1, "buildTool": "Gradle", "javaVersion": "25", "gradleVersion": "8", "artifacts": [{"groupId": "x", "artifactId": "y", "version": "1", "extension": "jar", "fileName": "a.jar", "sha256": "sha256:${"a".repeat(64)}", "sizeBytes": -1}]}
+        """.trimIndent())
+        assertThatThrownBy { ReleaseBundleEvidenceLoader.load(path) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("release-bundle-evidence-invalid-size")
+    }
+
+    // ── Zero size ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `zero size throws invalid-size`() {
+        val path = writeManifest("""
+            {"schemaVersion": 1, "buildTool": "Gradle", "javaVersion": "25", "gradleVersion": "8", "artifacts": [{"groupId": "x", "artifactId": "y", "version": "1", "extension": "jar", "fileName": "a.jar", "sha256": "sha256:${"a".repeat(64)}", "sizeBytes": 0}]}
+        """.trimIndent())
+        assertThatThrownBy { ReleaseBundleEvidenceLoader.load(path) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("release-bundle-evidence-invalid-size")
+    }
+
+    // ── Unsupported extension ───────────────────────────────────────────────
+
+    @Test
+    fun `unsupported extension throws unsupported-extension`() {
+        val path = writeManifest("""
+            {"schemaVersion": 1, "buildTool": "Gradle", "javaVersion": "25", "gradleVersion": "8", "artifacts": [{"groupId": "x", "artifactId": "y", "version": "1", "extension": "zip", "fileName": "a.zip", "sha256": "sha256:${"a".repeat(64)}", "sizeBytes": 1}]}
+        """.trimIndent())
+        assertThatThrownBy { ReleaseBundleEvidenceLoader.load(path) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("release-bundle-evidence-unsupported-extension")
+    }
+
+    // ── Duplicate filename ──────────────────────────────────────────────────
+
+    @Test
+    fun `duplicate filename throws duplicate-file-name`() {
+        val path = writeManifest("""
+            {"schemaVersion": 1, "buildTool": "Gradle", "javaVersion": "25", "gradleVersion": "8", "artifacts": [{"groupId": "x", "artifactId": "y", "version": "1", "extension": "jar", "fileName": "same.jar", "sha256": "sha256:${"a".repeat(64)}", "sizeBytes": 1}, {"groupId": "x", "artifactId": "z", "version": "1", "extension": "jar", "fileName": "same.jar", "sha256": "sha256:${"b".repeat(64)}", "sizeBytes": 1}]}
+        """.trimIndent())
+        assertThatThrownBy { ReleaseBundleEvidenceLoader.load(path) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("release-bundle-evidence-duplicate-file-name")
+    }
+
+    // ── Duplicate coordinate ────────────────────────────────────────────────
+
+    @Test
+    fun `duplicate coordinate throws duplicate-coordinate`() {
+        val path = writeManifest("""
+            {"schemaVersion": 1, "buildTool": "Gradle", "javaVersion": "25", "gradleVersion": "8", "artifacts": [{"groupId": "g", "artifactId": "a", "version": "1", "classifier": null, "extension": "jar", "fileName": "a-v1.jar", "sha256": "sha256:${"a".repeat(64)}", "sizeBytes": 1}, {"groupId": "g", "artifactId": "a", "version": "1", "classifier": null, "extension": "jar", "fileName": "a-v1-dup.jar", "sha256": "sha256:${"b".repeat(64)}", "sizeBytes": 1}]}
+        """.trimIndent())
+        assertThatThrownBy { ReleaseBundleEvidenceLoader.load(path) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("release-bundle-evidence-duplicate-coordinate")
+    }
+}

--- a/tramai-sovereign/src/test/kotlin/dev/tramai/sovereign/evidence/ReleaseBundleEvidenceLoaderTest.kt
+++ b/tramai-sovereign/src/test/kotlin/dev/tramai/sovereign/evidence/ReleaseBundleEvidenceLoaderTest.kt
@@ -275,4 +275,30 @@ class ReleaseBundleEvidenceLoaderTest {
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("release-bundle-evidence-duplicate-coordinate")
     }
+
+    // ── Trailing content ────────────────────────────────────────────────────
+
+    @Test
+    fun `trailing garbage after valid json throws invalid-json`() {
+        val path = writeManifest(validManifest + " trailing-garbage")
+        assertThatThrownBy { ReleaseBundleEvidenceLoader.load(path) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("release-bundle-evidence-invalid-json")
+    }
+
+    @Test
+    fun `second JSON object after valid json throws invalid-json`() {
+        val path = writeManifest(validManifest + "\n{}")
+        assertThatThrownBy { ReleaseBundleEvidenceLoader.load(path) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("release-bundle-evidence-invalid-json")
+    }
+
+    @Test
+    fun `allows trailing whitespace after valid json`() {
+        val path = writeManifest(validManifest + "   \n  \t  ")
+        val result = ReleaseBundleEvidenceLoader.load(path)
+        assertThat(result.schemaVersion).isEqualTo(1)
+        assertThat(result.artifacts).hasSize(2)
+    }
 }


### PR DESCRIPTION
## Summary

Automatically loads the verified release artifact manifest into the sovereign evidence pack.

Connects the release evidence chain end-to-end:

```
release-artifacts-v1.json
→ verifySovereignReleaseManifest (PR #37)
→ ReleaseBundleEvidenceLoader
→ ReleaseBundleEvidenceV1
→ sovereign-evidence-pack-v1.json
→ sovereign-evidence-bundle
```

## Changes

### 1. ReleaseBundleEvidenceLoader
New file in `tramai-sovereign`. Uses a manual recursive-descent JSON parser (matching the project's existing `SovereignEvidencePackWriter` approach — no heavy JSON dependency). Validates manifest shape with 12 deterministic error codes.

### 2. OfflineVerificationMain
Accepts `--release-bundle-manifest=` CLI arg, loads via the loader, passes `releaseBundle` to both `evidencePack()` generations.

### 3. verify-zero-egress.sh
Reads `TRAMAI_RELEASE_BUNDLE_MANIFEST` env var, mounts the file into Docker, passes `--release-bundle-manifest=`.

### 4. prepareSovereignEvidenceBundle is now PURE
Removed implicit `dependsOn` on `prepareCycloneDxBom` and `prepareSovereignReleaseArtifacts`. CI sequences all tasks explicitly — prevents release manifest drift after the evidence pack has already embedded the bundle.

### 5. New verifySovereignEvidencePackContainsReleaseBundle
Verifies `sovereign-evidence-pack-v1.json` contains non-null `releaseBundle`. Error: `sovereign-evidence-pack-missing-release-bundle`.

### 6. CI updated
Zero-egress job now: prepare release artifacts → verify → zero-egress harness (with TRAMAI_RELEASE_BUNDLE_MANIFEST) → verify evidence pack → assemble bundle → verify bundled manifest.

### 7. Tests
18 loader unit tests + existing integration test. All 134 tasks pass.

## Validation

```
✓ ./gradlew test --rerun-tasks  (134 tasks, all pass)
✓ ./gradlew prepareCycloneDxBom
✓ ./gradlew prepareSovereignReleaseArtifacts
✓ ./gradlew verifySovereignReleaseManifest
✓ ./gradlew :tramai-sovereign:test --tests "*ReleaseBundleEvidenceLoader*"
```

## Non-goals (explicitly excluded)

- Maven Central publishing
- GPG signing
- Cosign/SLSA
- Evidence schema v2
- GitHub attestation verification
- JAR hash recomputation in loader (PR #37 owns that)