### PR TITLE
feat(spring): add sovereign Spring Boot starter (#40)

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,7 @@ include(
     "tramai-ollama",
     "tramai-platform",
     "tramai-spring",
+    "tramai-spring-boot-starter-sovereign",
     "tramai-scheduler",
     "tramai-security",
     "tramai-sovereign",

--- a/tramai-spring-boot-starter-sovereign/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
 
     annotationProcessor(libs.spring.boot.configuration.processor)
 
+    testImplementation(project(":tramai-spring"))
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.assertj.core)
     testImplementation(libs.coroutines.core)

--- a/tramai-spring-boot-starter-sovereign/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign/build.gradle.kts
@@ -1,0 +1,41 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    `java-library`
+    alias(libs.plugins.kotlin.jvm)
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+    withSourcesJar()
+}
+
+kotlin {
+    jvmToolchain(21)
+    compilerOptions {
+        jvmTarget.set(JvmTarget.fromTarget("21"))
+    }
+}
+
+dependencies {
+    api(project(":tramai-core"))
+    api(project(":tramai-security"))
+    api(project(":tramai-sovereign"))
+
+    implementation(libs.spring.boot.autoconfigure)
+
+    annotationProcessor(libs.spring.boot.configuration.processor)
+
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.coroutines.core)
+    testImplementation(libs.kotlin.test.junit5)
+    testImplementation(libs.spring.boot.starter.test)
+    testImplementation("org.junit.jupiter:junit-jupiter")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/tramai-spring-boot-starter-sovereign/src/main/kotlin/dev/tramai/spring/sovereign/SovereignTramaiAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign/src/main/kotlin/dev/tramai/spring/sovereign/SovereignTramaiAutoConfiguration.kt
@@ -2,9 +2,11 @@ package dev.tramai.spring.sovereign
 
 import dev.tramai.core.approval.ApprovalContinuationStore
 import dev.tramai.core.approval.ApprovalGateCoordinator
+import dev.tramai.core.approval.ApprovalStore
 import dev.tramai.core.approval.ApprovalTokenDigester
 import dev.tramai.core.approval.ToolArgumentsDigester
 import dev.tramai.core.model.ModelRegistry
+import dev.tramai.core.model.RegisteredModel
 import dev.tramai.core.provider.ModelProvider
 import dev.tramai.security.approval.DefaultApprovalGateCoordinator
 import dev.tramai.security.approval.InMemoryApprovalContinuationStore
@@ -33,7 +35,7 @@ import org.springframework.context.annotation.Bean
  *
  * Creates beans for:
  * - [SovereignProfileConfiguration] from [SovereignTramaiProperties]
- * - [ModelRegistry] (defaults to empty [InMemoryModelRegistry])
+ * - [ModelRegistry] derived from `tramai.sovereign.models` (or user-provided)
  * - [AuditStore] (defaults to [InMemoryAuditStore])
  * - Approval stores, gate coordinator, digesters
  * - [SovereignTramai] and [SovereignTramaiRuntime]
@@ -50,6 +52,10 @@ import org.springframework.context.annotation.Bean
     matchIfMissing = true,
 )
 class SovereignTramaiAutoConfiguration {
+
+    companion object {
+        private const val DEFAULT_REVISION = "0.0.1"
+    }
 
     // ── Sovereign profile configuration ──────────────────────────────────
 
@@ -68,12 +74,26 @@ class SovereignTramaiAutoConfiguration {
         )
     }
 
-    // ── Model registry ───────────────────────────────────────────────────
+    // ── Model registry (derived from properties.models) ───────────────────
 
     @Bean
     @ConditionalOnMissingBean
-    fun modelRegistry(): ModelRegistry =
-        InMemoryModelRegistry.builder().build()
+    fun modelRegistry(
+        properties: SovereignTramaiProperties,
+    ): ModelRegistry {
+        val builder = InMemoryModelRegistry.builder()
+        for ((modelName, providerName) in properties.models) {
+            builder.register(
+                RegisteredModel(
+                    registryEntryId = modelName,
+                    providerId = providerName,
+                    modelName = modelName,
+                    revision = DEFAULT_REVISION,
+                ),
+            )
+        }
+        return builder.build()
+    }
 
     // ── Audit store ──────────────────────────────────────────────────────
 
@@ -86,7 +106,7 @@ class SovereignTramaiAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    fun approvalStore(clock: Clock): InMemoryApprovalStore =
+    fun approvalStore(clock: Clock): ApprovalStore =
         InMemoryApprovalStore(clock = clock)
 
     @Bean
@@ -101,14 +121,15 @@ class SovereignTramaiAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     fun approvalGateCoordinator(
-        approvalStore: InMemoryApprovalStore,
+        approvalStore: ApprovalStore,
+        approvalTokenDigester: ApprovalTokenDigester,
         clock: Clock,
     ): ApprovalGateCoordinator =
         DefaultApprovalGateCoordinator(
             store = approvalStore,
             approvalIdGenerator = UuidApprovalIdGenerator(),
             approvalTokenGenerator = SecureRandomApprovalTokenGenerator(),
-            approvalTokenDigester = Sha256ApprovalTokenDigester(),
+            approvalTokenDigester = approvalTokenDigester,
             clock = clock,
         )
 
@@ -166,11 +187,6 @@ class SovereignTramaiAutoConfiguration {
         for ((modelName, providerName) in properties.models) {
             builder.model(modelName, providerName)
         }
-
-        // Register allowed tools from properties.
-        // Users must also provide actual TramaiTool beans for tools to function.
-        // The SovereignTramai builder accepts tool beans via its .tools() method,
-        // but tool auto-discovery is intentionally out of scope for the starter MVP.
 
         return builder.build()
     }

--- a/tramai-spring-boot-starter-sovereign/src/main/kotlin/dev/tramai/spring/sovereign/SovereignTramaiAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign/src/main/kotlin/dev/tramai/spring/sovereign/SovereignTramaiAutoConfiguration.kt
@@ -1,0 +1,184 @@
+package dev.tramai.spring.sovereign
+
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.core.approval.ApprovalGateCoordinator
+import dev.tramai.core.approval.ApprovalTokenDigester
+import dev.tramai.core.approval.ToolArgumentsDigester
+import dev.tramai.core.model.ModelRegistry
+import dev.tramai.core.provider.ModelProvider
+import dev.tramai.security.approval.DefaultApprovalGateCoordinator
+import dev.tramai.security.approval.InMemoryApprovalContinuationStore
+import dev.tramai.security.approval.InMemoryApprovalStore
+import dev.tramai.security.approval.SecureRandomApprovalTokenGenerator
+import dev.tramai.security.approval.Sha256ApprovalTokenDigester
+import dev.tramai.security.approval.Sha256ToolArgumentsDigester
+import dev.tramai.security.approval.UuidApprovalIdGenerator
+import dev.tramai.security.audit.AuditStore
+import dev.tramai.security.audit.InMemoryAuditStore
+import dev.tramai.security.model.InMemoryModelRegistry
+import dev.tramai.sovereign.SovereignProfileConfiguration
+import dev.tramai.sovereign.SovereignTramai
+import dev.tramai.sovereign.SovereignTramaiRuntime
+import java.time.Clock
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+
+/**
+ * Spring Boot auto-configuration for TramAI sovereign runtime.
+ *
+ * Creates beans for:
+ * - [SovereignProfileConfiguration] from [SovereignTramaiProperties]
+ * - [ModelRegistry] (defaults to empty [InMemoryModelRegistry])
+ * - [AuditStore] (defaults to [InMemoryAuditStore])
+ * - Approval stores, gate coordinator, digesters
+ * - [SovereignTramai] and [SovereignTramaiRuntime]
+ *
+ * All beans are [ConditionalOnMissingBean] so users can override any default.
+ * Set `tramai.sovereign.enabled=false` to disable all sovereign auto-configuration.
+ */
+@AutoConfiguration
+@EnableConfigurationProperties(SovereignTramaiProperties::class)
+@ConditionalOnProperty(
+    prefix = "tramai.sovereign",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
+class SovereignTramaiAutoConfiguration {
+
+    // ── Sovereign profile configuration ──────────────────────────────────
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun sovereignProfileConfiguration(
+        properties: SovereignTramaiProperties,
+    ): SovereignProfileConfiguration {
+        val zones = properties.resolveProviderTrustZones()
+        return SovereignProfileConfiguration(
+            allowedModels = properties.allowedModels,
+            allowedProviders = properties.allowedProviders,
+            allowedTools = properties.allowedTools,
+            allowedPermissions = properties.allowedPermissions,
+            providerZones = zones,
+        )
+    }
+
+    // ── Model registry ───────────────────────────────────────────────────
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun modelRegistry(): ModelRegistry =
+        InMemoryModelRegistry.builder().build()
+
+    // ── Audit store ──────────────────────────────────────────────────────
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun auditStore(): AuditStore =
+        InMemoryAuditStore()
+
+    // ── Approval stores ──────────────────────────────────────────────────
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun approvalStore(clock: Clock): InMemoryApprovalStore =
+        InMemoryApprovalStore(clock = clock)
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun approvalContinuationStore(
+        clock: Clock,
+    ): ApprovalContinuationStore =
+        InMemoryApprovalContinuationStore(clock = clock)
+
+    // ── Approval gate coordinator ────────────────────────────────────────
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun approvalGateCoordinator(
+        approvalStore: InMemoryApprovalStore,
+        clock: Clock,
+    ): ApprovalGateCoordinator =
+        DefaultApprovalGateCoordinator(
+            store = approvalStore,
+            approvalIdGenerator = UuidApprovalIdGenerator(),
+            approvalTokenGenerator = SecureRandomApprovalTokenGenerator(),
+            approvalTokenDigester = Sha256ApprovalTokenDigester(),
+            clock = clock,
+        )
+
+    // ── Digesters ────────────────────────────────────────────────────────
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun toolArgumentsDigester(): ToolArgumentsDigester =
+        Sha256ToolArgumentsDigester()
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun approvalTokenDigester(): ApprovalTokenDigester =
+        Sha256ApprovalTokenDigester()
+
+    // ── Clock ────────────────────────────────────────────────────────────
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun sovereignClock(): Clock = Clock.systemUTC()
+
+    // ── Sovereign runtime ────────────────────────────────────────────────
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean(ModelProvider::class)
+    fun sovereignTramai(
+        profile: SovereignProfileConfiguration,
+        modelRegistry: ModelRegistry,
+        auditStore: AuditStore,
+        modelProviders: ObjectProvider<ModelProvider>,
+        approvalGateCoordinator: ApprovalGateCoordinator,
+        approvalContinuationStore: ApprovalContinuationStore,
+        toolArgumentsDigester: ToolArgumentsDigester?,
+        clock: Clock,
+        properties: SovereignTramaiProperties,
+    ): SovereignTramai {
+        val builder = SovereignTramai.builder()
+            .profile(profile)
+            .modelRegistry(modelRegistry)
+            .auditStore(auditStore)
+            .approvalGateCoordinator(approvalGateCoordinator)
+            .approvalContinuationStore(approvalContinuationStore)
+            .clock(clock)
+
+        toolArgumentsDigester?.let { builder.toolArgumentsDigester(it) }
+
+        // Register provider beans from the application context.
+        // Users provide ModelProvider beans and the starter wires them in.
+        modelProviders.orderedStream().forEach { provider ->
+            builder.provider(provider, name = provider.providerId())
+        }
+
+        // Register model routes from properties.
+        for ((modelName, providerName) in properties.models) {
+            builder.model(modelName, providerName)
+        }
+
+        // Register allowed tools from properties.
+        // Users must also provide actual TramaiTool beans for tools to function.
+        // The SovereignTramai builder accepts tool beans via its .tools() method,
+        // but tool auto-discovery is intentionally out of scope for the starter MVP.
+
+        return builder.build()
+    }
+
+    @Bean(destroyMethod = "close")
+    @ConditionalOnMissingBean
+    @ConditionalOnBean(SovereignTramai::class)
+    fun sovereignTramaiRuntime(
+        sovereignTramai: SovereignTramai,
+    ): SovereignTramaiRuntime = sovereignTramai.runtime()
+}

--- a/tramai-spring-boot-starter-sovereign/src/main/kotlin/dev/tramai/spring/sovereign/SovereignTramaiProperties.kt
+++ b/tramai-spring-boot-starter-sovereign/src/main/kotlin/dev/tramai/spring/sovereign/SovereignTramaiProperties.kt
@@ -1,0 +1,143 @@
+package dev.tramai.spring.sovereign
+
+import dev.tramai.security.ProviderTrustZone
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Externalized configuration for TramAI sovereign runtime.
+ *
+ * Usage:
+ * ```
+ * tramai:
+ *   sovereign:
+ *     enabled: true
+ *     allowed-models:
+ *       - local-invoice-model
+ *     allowed-providers:
+ *       - local-provider
+ *     allowed-tools:
+ *       - schedule-payment
+ *     allowed-permissions:
+ *       - payment.schedule
+ *     provider-zones:
+ *       local-provider: LOCAL
+ *     models:
+ *       local-invoice-model: local-provider
+ * ```
+ */
+@ConfigurationProperties(prefix = "tramai.sovereign")
+data class SovereignTramaiProperties(
+    /**
+     * Enables sovereign profile auto-configuration. When false, no sovereign
+     * beans are created (respects [ConditionalOnProperty] semantics).
+     */
+    var enabled: Boolean = true,
+
+    /**
+     * Models whose invocation is permitted. Must be non-empty when enabled.
+     * Each entry must appear as a key in [models].
+     */
+    var allowedModels: Set<String> = emptySet(),
+
+    /**
+     * Providers that may be used. Must be non-empty when enabled.
+     * Each entry must have a corresponding [providerZones] mapping.
+     */
+    var allowedProviders: Set<String> = emptySet(),
+
+    /**
+     * Tools whose execution is permitted.
+     */
+    var allowedTools: Set<String> = emptySet(),
+
+    /**
+     * Tool permissions that are granted.
+     */
+    var allowedPermissions: Set<String> = emptySet(),
+
+    /**
+     * Explicit trust-zone mapping for every allowed provider.
+     * Keys must be a subset of [allowedProviders].
+     */
+    var providerZones: Map<String, String> = emptyMap(),
+
+    /**
+     * Maps each logical model name to its provider.
+     * Keys must be a subset of [allowedModels].
+     */
+    var models: Map<String, String> = emptyMap(),
+) {
+    /** Validates this configuration and returns a resolved [ProviderTrustZone] map. */
+    internal fun resolveProviderTrustZones(): Map<String, ProviderTrustZone> {
+        val zones = providerZones.mapValues { (_, zone) ->
+            try {
+                ProviderTrustZone.valueOf(zone.uppercase())
+            } catch (_: IllegalArgumentException) {
+                throw IllegalStateException(
+                    "tramai-sovereign-spring-invalid-provider-zone: '$zone' is not a valid ProviderTrustZone " +
+                        "(expected one of: ${ProviderTrustZone.entries.joinToString(", ")})",
+                )
+            }
+        }
+
+        // enabled=true but no allowed models
+        if (allowedModels.isEmpty()) {
+            throw IllegalStateException("tramai-sovereign-spring-missing-allowed-models")
+        }
+
+        // enabled=true but no allowed providers
+        if (allowedProviders.isEmpty()) {
+            throw IllegalStateException("tramai-sovereign-spring-missing-allowed-providers")
+        }
+
+        // Every allowed provider must have an explicit provider zone
+        for (provider in allowedProviders) {
+            if (provider !in zones) {
+                throw IllegalStateException(
+                    "tramai-sovereign-spring-provider-zone-missing: provider '$provider' has no configured trust zone"
+                )
+            }
+        }
+
+        // Every provider zone must reference an allowed provider
+        for (provider in zones.keys) {
+            if (provider !in allowedProviders) {
+                throw IllegalStateException(
+                    "tramai-sovereign-spring-provider-zone-unknown-provider: zone configured for " +
+                        "provider '$provider' which is not in allowedProviders"
+                )
+            }
+        }
+
+        // Every model in models map must be in allowedModels
+        for (modelName in models.keys) {
+            if (modelName !in allowedModels) {
+                throw IllegalStateException(
+                    "tramai-sovereign-spring-model-route-unknown-model: model '$modelName' has a route " +
+                        "but is not in allowedModels"
+                )
+            }
+        }
+
+        // Every allowed model must have a route
+        for (modelName in allowedModels) {
+            if (modelName !in models) {
+                throw IllegalStateException(
+                    "tramai-sovereign-spring-missing-model-route: allowed model '$modelName' has no configured provider route"
+                )
+            }
+        }
+
+        // Every model route must target an allowed provider
+        for ((modelName, providerName) in models) {
+            if (providerName !in allowedProviders) {
+                throw IllegalStateException(
+                    "tramai-sovereign-spring-model-route-unknown-provider: model '$modelName' routes to " +
+                        "provider '$providerName' which is not in allowedProviders"
+                )
+            }
+        }
+
+        return zones
+    }
+}

--- a/tramai-spring-boot-starter-sovereign/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/tramai-spring-boot-starter-sovereign/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.tramai.spring.sovereign.SovereignTramaiAutoConfiguration

--- a/tramai-spring-boot-starter-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/SovereignTramaiAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/SovereignTramaiAutoConfigurationTest.kt
@@ -1,0 +1,266 @@
+package dev.tramai.spring.sovereign
+
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.model.ModelRegistry
+import dev.tramai.core.provider.ModelProvider
+import dev.tramai.security.audit.AuditStore
+import dev.tramai.security.audit.AuditEvent
+import dev.tramai.security.model.InMemoryModelRegistry
+import dev.tramai.sovereign.SovereignProfileConfiguration
+import dev.tramai.sovereign.SovereignTramai
+import dev.tramai.sovereign.SovereignTramaiRuntime
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import org.assertj.core.api.Assertions.assertThat
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import kotlin.test.Test
+
+class SovereignTramaiAutoConfigurationTest {
+
+    private val minimalProperties = mapOf(
+        "tramai.sovereign.allowed-models[0]" to "local-invoice-model",
+        "tramai.sovereign.allowed-providers[0]" to "local-provider",
+        "tramai.sovereign.provider-zones.local-provider" to "LOCAL",
+        "tramai.sovereign.models.local-invoice-model" to "local-provider",
+    )
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(SovereignTramaiAutoConfiguration::class.java),
+        )
+
+    // ── Happy path ───────────────────────────────────────────────────────
+
+    @Test
+    fun `creates SovereignProfileConfiguration from valid properties`() {
+        contextRunner
+            .withPropertyValues(*minimalProperties.entries.map { "${it.key}=${it.value}" }.toTypedArray())
+            .run { context ->
+                assertThat(context).hasSingleBean(SovereignProfileConfiguration::class.java)
+                val profile = context.getBean(SovereignProfileConfiguration::class.java)
+                assertThat(profile.allowedModels).containsExactly("local-invoice-model")
+                assertThat(profile.allowedProviders).containsExactly("local-provider")
+                assertThat(profile.providerZones).containsKey("local-provider")
+            }
+    }
+
+    @Test
+    fun `creates SovereignTramai and SovereignTramaiRuntime when providers are available`() {
+        contextRunner
+            .withUserConfiguration(MinimalProviderConfiguration::class.java)
+            .withPropertyValues(*minimalProperties.entries.map { "${it.key}=${it.value}" }.toTypedArray())
+            .run { context ->
+                assertThat(context).hasSingleBean(SovereignTramai::class.java)
+                assertThat(context).hasSingleBean(SovereignTramaiRuntime::class.java)
+            }
+    }
+
+    // ── enabled=false ────────────────────────────────────────────────────
+
+    @Test
+    fun `sovereign profile beans are not created when enabled is false`() {
+        contextRunner
+            .withPropertyValues("tramai.sovereign.enabled=false")
+            .run { context ->
+                assertThat(context).doesNotHaveBean(SovereignProfileConfiguration::class.java)
+                assertThat(context).doesNotHaveBean(SovereignTramai::class.java)
+                assertThat(context).doesNotHaveBean(SovereignTramaiRuntime::class.java)
+            }
+    }
+
+    // ── User beans are respected ─────────────────────────────────────────
+
+    @Test
+    fun `user-provided ModelRegistry bean is respected`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalProviderConfiguration::class.java,
+                CustomModelRegistryConfiguration::class.java,
+            )
+            .withPropertyValues(*minimalProperties.entries.map { "${it.key}=${it.value}" }.toTypedArray())
+            .run { context ->
+                val registry = context.getBean(ModelRegistry::class.java)
+                assertThat(registry).isInstanceOf(InMemoryModelRegistry::class.java)
+            }
+    }
+
+    @Test
+    fun `user-provided AuditStore bean is respected`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalProviderConfiguration::class.java,
+                CustomAuditStoreConfiguration::class.java,
+            )
+            .withPropertyValues(*minimalProperties.entries.map { "${it.key}=${it.value}" }.toTypedArray())
+            .run { context ->
+                val store = context.getBean(AuditStore::class.java)
+                assertThat(store).isInstanceOf(CustomAuditStore::class.java)
+            }
+    }
+
+    @Test
+    fun `user-provided Clock bean is respected`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalProviderConfiguration::class.java,
+                CustomClockConfiguration::class.java,
+            )
+            .withPropertyValues(*minimalProperties.entries.map { "${it.key}=${it.value}" }.toTypedArray())
+            .run { context ->
+                val clock = context.getBean(Clock::class.java)
+                assertThat(clock.instant()).isEqualTo(Instant.parse("2026-06-01T00:00:00Z"))
+            }
+    }
+
+    // ── Validation: missing allowed models ───────────────────────────────
+
+    @Test
+    fun `missing allowed models fails`() {
+        contextRunner
+            .withPropertyValues(
+                "tramai.sovereign.allowed-providers[0]=local-provider",
+                "tramai.sovereign.provider-zones.local-provider=LOCAL",
+            )
+            .run { context ->
+                assertThat(context).hasFailed()
+                val failure = requireNotNull(context.startupFailure)
+                assertThat(failure).hasMessageContaining("tramai-sovereign-spring-missing-allowed-models")
+            }
+    }
+
+    // ── Validation: missing allowed providers ───────────────────────────
+
+    @Test
+    fun `missing allowed providers fails`() {
+        contextRunner
+            .withPropertyValues("tramai.sovereign.allowed-models[0]=local-invoice-model")
+            .run { context ->
+                assertThat(context).hasFailed()
+                val failure = requireNotNull(context.startupFailure)
+                assertThat(failure).hasMessageContaining("tramai-sovereign-spring-missing-allowed-providers")
+            }
+    }
+
+    // ── Validation: missing provider zone ────────────────────────────────
+
+    @Test
+    fun `missing provider zone fails`() {
+        contextRunner
+            .withPropertyValues(
+                "tramai.sovereign.allowed-models[0]=local-invoice-model",
+                "tramai.sovereign.allowed-providers[0]=local-provider",
+            )
+            .run { context ->
+                assertThat(context).hasFailed()
+                val failure = requireNotNull(context.startupFailure)
+                assertThat(failure)
+                    .hasMessageContaining("tramai-sovereign-spring-provider-zone-missing")
+                    .hasMessageContaining("local-provider")
+            }
+    }
+
+    // ── Validation: unknown provider zone ────────────────────────────────
+
+    @Test
+    fun `unknown provider zone fails`() {
+        contextRunner
+            .withPropertyValues(
+                "tramai.sovereign.allowed-models[0]=local-invoice-model",
+                "tramai.sovereign.allowed-providers[0]=local-provider",
+                "tramai.sovereign.provider-zones.local-provider=LOCAL",
+                "tramai.sovereign.provider-zones.extra-provider=LOCAL",
+                "tramai.sovereign.models.local-invoice-model=local-provider",
+            )
+            .run { context ->
+                assertThat(context).hasFailed()
+                val failure = requireNotNull(context.startupFailure)
+                assertThat(failure)
+                    .hasMessageContaining("tramai-sovereign-spring-provider-zone-unknown-provider")
+            }
+    }
+
+    // ── Validation: invalid provider zone value ──────────────────────────
+
+    @Test
+    fun `invalid provider zone value fails`() {
+        contextRunner
+            .withPropertyValues(
+                "tramai.sovereign.allowed-models[0]=local-invoice-model",
+                "tramai.sovereign.allowed-providers[0]=local-provider",
+                "tramai.sovereign.provider-zones.local-provider=NOT_A_ZONE",
+            )
+            .run { context ->
+                assertThat(context).hasFailed()
+                val failure = requireNotNull(context.startupFailure)
+                assertThat(failure)
+                    .hasMessageContaining("tramai-sovereign-spring-invalid-provider-zone")
+            }
+    }
+}
+
+// ── User Configuration classes (top-level) ───────────────────────────────
+
+open class MinimalProviderConfiguration {
+    @Bean
+    open fun stubModelProvider(): ModelProvider = StubModelProvider()
+}
+
+open class CustomModelRegistryConfiguration {
+    @Bean
+    @Primary
+    open fun customModelRegistry(): InMemoryModelRegistry =
+        InMemoryModelRegistry.builder().build()
+}
+
+open class CustomAuditStoreConfiguration {
+    @Bean
+    open fun customAuditStore(): AuditStore = CustomAuditStore()
+}
+
+open class CustomClockConfiguration {
+    @Bean
+    open fun sovereignClock(): Clock =
+        Clock.fixed(Instant.parse("2026-06-01T00:00:00Z"), ZoneId.of("UTC"))
+}
+
+// ── Stub implementations ─────────────────────────────────────────────────
+
+class StubModelProvider : ModelProvider {
+    override fun providerId(): String = "local-provider"
+    override suspend fun complete(request: ModelRequest): ModelResponse =
+        ModelResponse(content = "stub response")
+}
+
+class CustomAuditStore : AuditStore {
+    override suspend fun appendNext(
+        auditStreamId: String,
+        eventFactory: (AuditEvent?) -> AuditEvent,
+    ): AuditEvent = eventFactory(
+        AuditEvent(
+            schemaVersion = 1,
+            hashAlgorithm = dev.tramai.security.audit.AuditHashAlgorithm.SHA_256,
+            auditStreamId = auditStreamId,
+            eventId = "test-event",
+            sequenceNumber = 1,
+            workflowRunId = null,
+            correlationId = null,
+            actor = "test",
+            enforcementPoint = "test",
+            decision = "permit",
+            policyVersion = null,
+            workflowDigest = null,
+            previousEventHash = null,
+            eventHash = "a".repeat(64),
+            timestamp = Instant.now(),
+            reasonCode = null,
+        )
+    )
+
+    override suspend fun readStream(auditStreamId: String): List<AuditEvent> = emptyList()
+    override suspend fun latestEvent(auditStreamId: String): AuditEvent? = null
+}

--- a/tramai-spring-boot-starter-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/SovereignTramaiAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/SovereignTramaiAutoConfigurationTest.kt
@@ -1,19 +1,24 @@
 package dev.tramai.spring.sovereign
 
-import dev.tramai.core.model.ModelRequest
-import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.approval.ApprovalStore
 import dev.tramai.core.model.ModelRegistry
 import dev.tramai.core.provider.ModelProvider
-import dev.tramai.security.audit.AuditStore
+import dev.tramai.security.approval.InMemoryApprovalContinuationStore
 import dev.tramai.security.audit.AuditEvent
+import dev.tramai.security.audit.AuditStore
 import dev.tramai.security.model.InMemoryModelRegistry
 import dev.tramai.sovereign.SovereignProfileConfiguration
 import dev.tramai.sovereign.SovereignTramai
 import dev.tramai.sovereign.SovereignTramaiRuntime
+import dev.tramai.spring.AiServiceBeanDefinitionRegistrar
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.annotation.Bean
@@ -50,6 +55,17 @@ class SovereignTramaiAutoConfigurationTest {
     }
 
     @Test
+    fun `model registry is derived from properties dot models`() {
+        contextRunner
+            .withPropertyValues(*minimalProperties.entries.map { "${it.key}=${it.value}" }.toTypedArray())
+            .run { context ->
+                assertThat(context).hasSingleBean(ModelRegistry::class.java)
+                val registry = context.getBean(ModelRegistry::class.java)
+                assertThat(registry).isInstanceOf(InMemoryModelRegistry::class.java)
+            }
+    }
+
+    @Test
     fun `creates SovereignTramai and SovereignTramaiRuntime when providers are available`() {
         contextRunner
             .withUserConfiguration(MinimalProviderConfiguration::class.java)
@@ -57,6 +73,23 @@ class SovereignTramaiAutoConfigurationTest {
             .run { context ->
                 assertThat(context).hasSingleBean(SovereignTramai::class.java)
                 assertThat(context).hasSingleBean(SovereignTramaiRuntime::class.java)
+            }
+    }
+
+    @Test
+    fun `sovereign runtime creates an AiService and invokes it`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalProviderConfiguration::class.java,
+                AiServiceRegistrarConfiguration::class.java,
+            )
+            .withPropertyValues(*minimalProperties.entries.map { "${it.key}=${it.value}" }.toTypedArray())
+            .run { context ->
+                assertThat(context).hasSingleBean(SovereignTramaiRuntime::class.java)
+                val runtime = context.getBean(SovereignTramaiRuntime::class.java)
+                val service = runtime.create(TestInvoiceAi::class)
+                val result = runBlocking { service.analyze("invoice-001") }
+                assertThat(result).isEqualTo("stub response")
             }
     }
 
@@ -80,7 +113,7 @@ class SovereignTramaiAutoConfigurationTest {
         contextRunner
             .withUserConfiguration(
                 MinimalProviderConfiguration::class.java,
-                CustomModelRegistryConfiguration::class.java,
+                ModelRegistrySupplierConfiguration::class.java,
             )
             .withPropertyValues(*minimalProperties.entries.map { "${it.key}=${it.value}" }.toTypedArray())
             .run { context ->
@@ -100,6 +133,20 @@ class SovereignTramaiAutoConfigurationTest {
             .run { context ->
                 val store = context.getBean(AuditStore::class.java)
                 assertThat(store).isInstanceOf(CustomAuditStore::class.java)
+            }
+    }
+
+    @Test
+    fun `user-provided ApprovalStore bean is respected`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalProviderConfiguration::class.java,
+                CustomApprovalStoreConfiguration::class.java,
+            )
+            .withPropertyValues(*minimalProperties.entries.map { "${it.key}=${it.value}" }.toTypedArray())
+            .run { context ->
+                val store = context.getBean(ApprovalStore::class.java)
+                assertThat(store).isInstanceOf(CustomApprovalStore::class.java)
             }
     }
 
@@ -203,18 +250,41 @@ class SovereignTramaiAutoConfigurationTest {
     }
 }
 
+// ── Test interfaces ─────────────────────────────────────────────────────
+
+@AiService
+interface TestInvoiceAi {
+    @Operation(
+        prompt = "Analyze the invoice",
+        model = "local-invoice-model",
+    )
+    suspend fun analyze(invoiceId: String): String
+}
+
 // ── User Configuration classes (top-level) ───────────────────────────────
 
 open class MinimalProviderConfiguration {
     @Bean
-    open fun stubModelProvider(): ModelProvider = StubModelProvider()
+    open fun stubModelProvider(): StubModelProvider = StubModelProvider()
 }
 
-open class CustomModelRegistryConfiguration {
+open class ModelRegistrySupplierConfiguration {
     @Bean
     @Primary
     open fun customModelRegistry(): InMemoryModelRegistry =
         InMemoryModelRegistry.builder().build()
+}
+
+open class AiServiceRegistrarConfiguration {
+    @Bean
+    open fun aiServiceBeanDefinitionRegistrar(
+        beanFactory: ConfigurableListableBeanFactory,
+    ): AiServiceBeanDefinitionRegistrar = AiServiceBeanDefinitionRegistrar(beanFactory)
+}
+
+open class CustomApprovalStoreConfiguration {
+    @Bean
+    open fun customApprovalStore(): ApprovalStore = CustomApprovalStore()
 }
 
 open class CustomAuditStoreConfiguration {
@@ -232,8 +302,8 @@ open class CustomClockConfiguration {
 
 class StubModelProvider : ModelProvider {
     override fun providerId(): String = "local-provider"
-    override suspend fun complete(request: ModelRequest): ModelResponse =
-        ModelResponse(content = "stub response")
+    override suspend fun complete(request: dev.tramai.core.model.ModelRequest): dev.tramai.core.model.ModelResponse =
+        dev.tramai.core.model.ModelResponse(content = "stub response")
 }
 
 class CustomAuditStore : AuditStore {
@@ -263,4 +333,32 @@ class CustomAuditStore : AuditStore {
 
     override suspend fun readStream(auditStreamId: String): List<AuditEvent> = emptyList()
     override suspend fun latestEvent(auditStreamId: String): AuditEvent? = null
+}
+
+class CustomApprovalStore : ApprovalStore {
+    private var created = false
+
+    override suspend fun create(request: dev.tramai.core.approval.ApprovalRequest): dev.tramai.core.approval.ApprovalRequest {
+        created = true
+        return request
+    }
+
+    override suspend fun get(approvalId: String): dev.tramai.core.approval.ApprovalRequest? = null
+
+    override suspend fun transition(
+        approvalId: String,
+        expectedVersion: Long,
+        transition: dev.tramai.core.approval.ApprovalTransition,
+    ): dev.tramai.core.approval.ApprovalRequest {
+        throw UnsupportedOperationException("custom stub")
+    }
+
+    override suspend fun consumeApprovedOrReplay(
+        approvalId: String,
+        expectedVersion: Long,
+        presentedTokenDigest: dev.tramai.core.approval.Sha256Digest,
+        consumedBy: String,
+    ): dev.tramai.core.approval.ApprovalConsumptionReceipt {
+        throw UnsupportedOperationException("custom stub")
+    }
 }


### PR DESCRIPTION
## Summary

Adds a Spring Boot starter for TramAI Sovereign runtime auto-configuration.

This makes TramAI easier to adopt in standard Spring Boot services by exposing configured beans for:

- SovereignProfileConfiguration
- SovereignTramai
- SovereignTramaiRuntime
- ModelRegistry (InMemoryModelRegistry default)
- AuditStore (InMemoryAuditStore default)
- ApprovalStore (InMemoryApprovalStore)
- ApprovalContinuationStore (InMemoryApprovalContinuationStore)
- ApprovalGateCoordinator (DefaultApprovalGateCoordinator)
- ToolArgumentsDigester (Sha256ToolArgumentsDigester)
- ApprovalTokenDigester (Sha256ApprovalTokenDigester)
- Clock (system UTC)

### New module
**tramai-spring-boot-starter-sovereign** — 6 files, +636 lines

### Why
After the sovereign evidence chain and reference workflow, the next adoption blocker is framework integration. A Spring team should be able to add the starter, configure sovereign policy through properties, and inject SovereignTramaiRuntime.

### Fail-closed validation
- Missing allowed models: `tramai-sovereign-spring-missing-allowed-models`
- Missing allowed providers: `tramai-sovereign-spring-missing-allowed-providers`
- Missing provider zone: `tramai-sovereign-spring-provider-zone-missing`
- Unknown provider zone: `tramai-sovereign-spring-provider-zone-unknown-provider`
- Invalid zone value: `tramai-sovereign-spring-invalid-provider-zone`

### Architecture
- All beans use `@ConditionalOnMissingBean` — users override any default
- `SovereignTramai`/`SovereignTramaiRuntime` only created when `@ConditionalOnBean(ModelProvider)` is satisfied
- `tramai.sovereign.enabled=false` disables all sovereign auto-configuration
- Spring Boot 3 style via `AutoConfiguration.imports`

### Non-goals
- No Spring Web integration
- No Spring Security integration
- No actuator endpoints
- No provider-specific autoconfiguration (users provide ModelProvider beans)
- No YAML-based model/tool registry (future PR)
- No Maven publishing

### Validation
```bash
./gradlew test --rerun-tasks    # 139 tasks ✅
```