### PR TITLE
feat(example): add Spring Boot sovereign starter reference app (#41)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Run sovereign document intelligence example
         run: ./gradlew :examples:sovereign-document-intelligence:run --args="--release-bundle-manifest=build/sovereign-release/release-artifacts-v1.json"
 
+      - name: Run Spring sovereign starter example tests
+        run: ./gradlew :examples:spring-sovereign-starter:test
+
       - name: Upload SBOM
         uses: actions/upload-artifact@v4
         with:

--- a/examples/spring-sovereign-starter/README.md
+++ b/examples/spring-sovereign-starter/README.md
@@ -1,0 +1,99 @@
+# Spring Boot Sovereign Starter Example
+
+A minimal Spring Boot application that demonstrates how to use the TramAI
+Sovereign runtime starter in a standard enterprise project.
+
+## What this example proves
+
+A Spring Boot developer can use TramAI Sovereign by:
+
+1. **Adding the starter dependency** to `build.gradle.kts`
+2. **Configuring sovereign policy** in `application.yml`
+3. **Providing a `ModelProvider` bean** (here: a deterministic local provider)
+4. **Injecting `SovereignTramaiRuntime`** (auto-configured by the starter)
+5. **Creating a typed `@AiService` interface** with `@Operation(model = "…")`
+6. **Executing the service** through the runtime
+
+## Configuration
+
+```yaml
+tramai:
+  sovereign:
+    enabled: true
+    allowed-models:
+      - local-invoice-model
+    allowed-providers:
+      - deterministic-local-provider
+    provider-zones:
+      deterministic-local-provider: LOCAL
+    models:
+      local-invoice-model: deterministic-local-provider
+```
+
+### Why this is sovereign
+
+| Property | What it enforces |
+|---|---|
+| `allowed-models` | Only `local-invoice-model` may be invoked |
+| `allowed-providers` | Only `deterministic-local-provider` is trusted |
+| `provider-zones` | The provider is explicitly marked `LOCAL` — no cloud routing |
+| `models` | Routes the logical model name to the registered provider |
+
+If any of these are misconfigured or missing, the runtime fails closed with a
+descriptive error code (e.g. `tramai-sovereign-spring-missing-allowed-models`).
+
+### No cloud call is made
+
+- The only registered provider is `DemoModelProvider`, which returns a
+  hard-coded JSON response.
+- No HTTP client, API key, or network dependency is configured.
+- The sovereign runtime enforces that only the configured provider and model
+  are accessible.
+
+## How to run
+
+```bash
+# From the repository root
+./gradlew :examples:spring-sovereign-starter:bootRun
+```
+
+Because the application has no web dependency and uses a `CommandLineRunner`,
+it starts, runs the analysis, prints the result, and exits cleanly.
+
+### Expected output
+
+```
+Sovereign invoice analysis result:
+InvoiceAnalysisResult(
+    summary=Invoice requires review before payment.,
+    riskLevel=MEDIUM,
+    detectedRisks=[Restricted customer reference present, High-value invoice, Short payment window],
+    recommendedAction=Route to finance approval workflow
+)
+```
+
+## How the starter wires the runtime
+
+1. `SovereignTramaiAutoConfiguration` reads `tramai.sovereign.*` properties.
+2. It creates `SovereignProfileConfiguration` with validated allowlists.
+3. It creates an `InMemoryModelRegistry` with the model from `models` entries.
+4. It creates default in-memory stores for audit, approval, and continuation.
+5. When a `ModelProvider` bean is found (our `DemoModelProvider`), it builds
+   `SovereignTramai` and exposes `SovereignTramaiRuntime`.
+6. The application injects `SovereignTramaiRuntime` and calls
+   `runtime.create(InvoiceAiService::class)`.
+
+All beans use `@ConditionalOnMissingBean`, so users can override any default.
+
+## Test
+
+```bash
+# From the repository root
+./gradlew :examples:spring-sovereign-starter:test
+```
+
+The test verifies:
+- Spring context starts with `SovereignTramaiRuntime`
+- `analyzeInvoice` returns a deterministic result through the sovereign runtime
+- `riskLevel` is `MEDIUM`
+- `detectedRisks` is non-empty

--- a/examples/spring-sovereign-starter/build.gradle.kts
+++ b/examples/spring-sovereign-starter/build.gradle.kts
@@ -1,0 +1,48 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    id("org.springframework.boot") version "3.4.5"
+    id("io.spring.dependency-management") version "1.1.7"
+    kotlin("jvm") version "2.3.0"
+    kotlin("plugin.spring") version "2.3.0"
+}
+
+springBoot {
+    mainClass.set("dev.tramai.examples.spring.SpringSovereignStarterApplicationKt")
+}
+
+group = "dev.tramai.examples"
+version = "0.3.1"
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+kotlin {
+    jvmToolchain(21)
+    compilerOptions {
+        jvmTarget.set(JvmTarget.fromTarget("21"))
+    }
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation(project(":tramai-spring-boot-starter-sovereign"))
+    implementation(project(":tramai-spring"))
+    implementation("org.springframework.boot:spring-boot-starter")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/examples/spring-sovereign-starter/src/main/kotlin/dev/tramai/examples/spring/DemoModelProvider.kt
+++ b/examples/spring-sovereign-starter/src/main/kotlin/dev/tramai/examples/spring/DemoModelProvider.kt
@@ -1,0 +1,48 @@
+package dev.tramai.examples.spring
+
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.provider.ModelProvider
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * A deterministic local model provider that returns a fixed JSON response
+ * for invoice analysis requests.
+ *
+ * This provider proves the sovereign runtime works without any cloud
+ * provider dependency. It identifies as `deterministic-local-provider`,
+ * matching the `allowed-providers` and `models` entries in `application.yml`.
+ */
+class DemoModelProvider : ModelProvider {
+
+    override fun providerId(): String = "deterministic-local-provider"
+
+    override suspend fun complete(request: ModelRequest): ModelResponse {
+        return ModelResponse(
+            content = """
+                {
+                  "summary": "Invoice requires review before payment.",
+                  "riskLevel": "MEDIUM",
+                  "detectedRisks": [
+                    "Restricted customer reference present",
+                    "High-value invoice",
+                    "Short payment window"
+                  ],
+                  "recommendedAction": "Route to finance approval workflow"
+                }
+            """.trimIndent(),
+        )
+    }
+}
+
+/**
+ * Registers the [DemoModelProvider] as a Spring bean so the Sovereign
+ * starter can discover and wire it into [dev.tramai.sovereign.SovereignTramai].
+ */
+@Configuration
+class DemoProviderConfiguration {
+    @Bean
+    fun deterministicLocalProvider(): ModelProvider =
+        DemoModelProvider()
+}

--- a/examples/spring-sovereign-starter/src/main/kotlin/dev/tramai/examples/spring/InvoiceAiService.kt
+++ b/examples/spring-sovereign-starter/src/main/kotlin/dev/tramai/examples/spring/InvoiceAiService.kt
@@ -1,0 +1,16 @@
+package dev.tramai.examples.spring
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+
+/**
+ * Typed AI service for sovereign invoice analysis.
+ *
+ * The `model` references the logical model name defined in `application.yml`
+ * under `tramai.sovereign.models`, which routes to the deterministic local provider.
+ */
+@AiService
+interface InvoiceAiService {
+    @Operation(model = "local-invoice-model")
+    suspend fun analyzeInvoice(invoiceText: String): InvoiceAnalysisResult
+}

--- a/examples/spring-sovereign-starter/src/main/kotlin/dev/tramai/examples/spring/InvoiceAnalysisResult.kt
+++ b/examples/spring-sovereign-starter/src/main/kotlin/dev/tramai/examples/spring/InvoiceAnalysisResult.kt
@@ -1,0 +1,15 @@
+package dev.tramai.examples.spring
+
+/**
+ * Deterministic structured result from the sovereign invoice analysis.
+ *
+ * Returned by [InvoiceAiService.analyzeInvoice] as a typed data class.
+ * The structured output module deserialises the provider's JSON response
+ * into this type automatically.
+ */
+data class InvoiceAnalysisResult(
+    val summary: String,
+    val riskLevel: String,
+    val detectedRisks: List<String>,
+    val recommendedAction: String,
+)

--- a/examples/spring-sovereign-starter/src/main/kotlin/dev/tramai/examples/spring/InvoiceAnalysisRunner.kt
+++ b/examples/spring-sovereign-starter/src/main/kotlin/dev/tramai/examples/spring/InvoiceAnalysisRunner.kt
@@ -1,0 +1,35 @@
+package dev.tramai.examples.spring
+
+import dev.tramai.sovereign.SovereignTramaiRuntime
+import kotlinx.coroutines.runBlocking
+import org.springframework.boot.CommandLineRunner
+import org.springframework.stereotype.Component
+
+/**
+ * Runs the sovereign invoice analysis when the application starts.
+ *
+ * Injects [SovereignTramaiRuntime] (auto-configured by the starter),
+ * creates the typed [InvoiceAiService] proxy, and executes it.
+ */
+@Component
+class InvoiceAnalysisRunner(
+    private val runtime: SovereignTramaiRuntime,
+) : CommandLineRunner {
+
+    override fun run(vararg args: String) {
+        runBlocking {
+            val service = runtime.create(InvoiceAiService::class)
+
+            val result = service.analyzeInvoice(
+                """
+                Invoice INV-2026-001 for €12,500 from Vendor Alpha.
+                Contains customer reference NL-RESTRICTED-8842.
+                Payment requested within 7 days.
+                """.trimIndent(),
+            )
+
+            println("Sovereign invoice analysis result:")
+            println(result)
+        }
+    }
+}

--- a/examples/spring-sovereign-starter/src/main/kotlin/dev/tramai/examples/spring/SpringSovereignStarterApplication.kt
+++ b/examples/spring-sovereign-starter/src/main/kotlin/dev/tramai/examples/spring/SpringSovereignStarterApplication.kt
@@ -1,0 +1,18 @@
+package dev.tramai.examples.spring
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+/**
+ * Minimal Spring Boot application demonstrating the TramAI Sovereign starter.
+ *
+ * The application simply configures TramAI's sovereign runtime via
+ * `application.yml`, provides a deterministic local model provider, and
+ * runs an invoice analysis when started.
+ */
+@SpringBootApplication
+class SpringSovereignStarterApplication
+
+fun main(args: Array<String>) {
+    runApplication<SpringSovereignStarterApplication>(*args)
+}

--- a/examples/spring-sovereign-starter/src/main/resources/application.yml
+++ b/examples/spring-sovereign-starter/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+tramai:
+  sovereign:
+    enabled: true
+    allowed-models:
+      - local-invoice-model
+    allowed-providers:
+      - deterministic-local-provider
+    provider-zones:
+      deterministic-local-provider: LOCAL
+    models:
+      local-invoice-model: deterministic-local-provider

--- a/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/SpringSovereignStarterExampleTest.kt
+++ b/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/SpringSovereignStarterExampleTest.kt
@@ -1,0 +1,49 @@
+package dev.tramai.examples.spring
+
+import dev.tramai.sovereign.SovereignTramaiRuntime
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+/**
+ * Verifies that the sovereign Spring Boot starter example works end to end.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class SpringSovereignStarterExampleTest {
+
+    @Autowired
+    private lateinit var runtime: SovereignTramaiRuntime
+
+    @Test
+    fun `context loads with SovereignTramaiRuntime`() {
+        assertThat(runtime).isNotNull
+    }
+
+    @Test
+    fun `analyzeInvoice returns deterministic result through sovereign runtime`() {
+        val service = runtime.create(InvoiceAiService::class)
+
+        val result = runBlocking {
+            service.analyzeInvoice("""
+                Invoice INV-2026-001 for €12,500 from Vendor Alpha.
+                Contains customer reference NL-RESTRICTED-8842.
+                Payment requested within 7 days.
+            """.trimIndent())
+        }
+
+        assertThat(result.summary)
+            .isEqualTo("Invoice requires review before payment.")
+        assertThat(result.riskLevel)
+            .isEqualTo("MEDIUM")
+        assertThat(result.detectedRisks)
+            .containsExactly(
+                "Restricted customer reference present",
+                "High-value invoice",
+                "Short payment window",
+            )
+        assertThat(result.recommendedAction)
+            .isEqualTo("Route to finance approval workflow")
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,4 +36,5 @@ include(
     "examples:support-agent",
     "examples:sovereign-document-intelligence",
     "examples:sovereign-offline-verification",
+    "examples:spring-sovereign-starter",
 )


### PR DESCRIPTION
## Summary

Adds a runnable Spring Boot example for the TramAI Sovereign starter.

The example demonstrates how a normal Spring Boot application can:

- configure sovereign model/provider policy through application.yml
- provide a local ModelProvider bean
- inject SovereignTramaiRuntime
- create a typed @AiService
- execute deterministic structured output without cloud access

### New module
**examples/spring-sovereign-starter** — 9 files, +337 lines

### Example configuration
```yaml
tramai:
  sovereign:
    enabled: true
    allowed-models:
      - local-invoice-model
    allowed-providers:
      - deterministic-local-provider
    provider-zones:
      deterministic-local-provider: LOCAL
    models:
      local-invoice-model: deterministic-local-provider
```

### Files
| File | Purpose |
|------|---------|
| `build.gradle.kts` | Spring Boot + TramAI sovereign starter |
| `SpringSovereignStarterApplication.kt` | @SpringBootApplication entry |
| `DemoModelProvider.kt` | Deterministic local provider + @Configuration |
| `InvoiceAiService.kt` | @AiService interface |
| `InvoiceAnalysisResult.kt` | Typed structured result |
| `InvoiceAnalysisRunner.kt` | CommandLineRunner demonstrating injection |
| `application.yml` | Sovereign policy config |
| `SpringSovereignStarterExampleTest.kt` | SpringBootTest with runtime verification |
| `README.md` | Usage and architecture documentation |

### Validation
```
./gradlew test --rerun-tasks    → 144 tasks ✅
./gradlew :examples:spring-sovereign-starter:test    → passes ✅
./gradlew :examples:spring-sovereign-starter:bootRun    → exits cleanly ✅
```

### Why this is sovereign
- Only configured model is allowed
- Only configured provider is allowed
- Provider is explicitly marked LOCAL
- No cloud provider registered, no network access required
- Runtime fails closed on missing/misconfigured policy

### Non-goals
- No Spring Web / REST controller
- No Spring Security integration
- No actuator endpoints
- No real cloud/local provider dependency
- No evidence generation in Spring