### PR TITLE
feat(spring): add file-backed sovereign persistence auto-configuration

### DIFF
--- a/examples/spring-sovereign-starter/README.md
+++ b/examples/spring-sovereign-starter/README.md
@@ -96,7 +96,7 @@ The test verifies:
 - Spring context starts with `SovereignTramaiRuntime`
 - `analyzeInvoice` returns a deterministic result through the sovereign runtime
 - `riskLevel` is `MEDIUM`
-| `detectedRisks` is non-empty
+- `detectedRisks` is non-empty
 
 ---
 
@@ -158,7 +158,6 @@ When `type: file` is configured, the file persistence auto-configuration:
 | Key file missing | `tramai-sovereign-file-persistence-key-file-missing` |
 | Invalid key (bad base64 / wrong size) | `tramai-sovereign-file-persistence-invalid-key` |
 | Base dir cannot be created | `tramai-sovereign-file-persistence-base-dir-unavailable` |
-| Base dir path unsafe | `tramai-sovereign-file-persistence-unsafe-base-dir` |
 
 ### Expected directory layout
 

--- a/examples/spring-sovereign-starter/README.md
+++ b/examples/spring-sovereign-starter/README.md
@@ -96,4 +96,100 @@ The test verifies:
 - Spring context starts with `SovereignTramaiRuntime`
 - `analyzeInvoice` returns a deterministic result through the sovereign runtime
 - `riskLevel` is `MEDIUM`
-- `detectedRisks` is non-empty
+| `detectedRisks` is non-empty
+
+---
+
+## Using encrypted file-backed stores
+
+By default, the sovereign starter uses in-memory stores for audit, approvals,
+continuations, and suspended invocations. This is fine for demos and local
+development, but state is lost on restart.
+
+For restart-safe workflows, add the file persistence starter:
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation(project(":tramai-spring-boot-starter-sovereign"))
+    implementation(project(":tramai-spring-boot-starter-sovereign-persistence-file"))
+}
+```
+
+Then configure encrypted file persistence:
+
+```yaml
+tramai:
+  sovereign:
+    persistence:
+      type: file
+      base-dir: ./data/tramai-sovereign
+      encryption:
+        key-env: TRAMAI_SOVEREIGN_STORE_KEY
+```
+
+Generate a 256-bit key:
+
+```bash
+openssl rand -base64 32
+```
+
+Set the environment variable before running:
+
+```bash
+export TRAMAI_SOVEREIGN_STORE_KEY="<generated-base64-key>"
+```
+
+When `type: file` is configured, the file persistence auto-configuration:
+- Runs **before** the base starter, so file-backed store beans are registered first
+- The base starter's `@ConditionalOnMissingBean` sees the file-backed beans and backs off
+- All four stores (audit, approvals, continuations, suspended invocations) use
+  encrypted file-backed implementations
+- Stores survive application restarts
+
+### Fail-closed validation
+
+| Condition | Error code |
+|---|---|
+| `type=file` but `base-dir` missing | `tramai-sovereign-file-persistence-missing-base-dir` |
+| Both `key-env` and `key-file` missing | `tramai-sovereign-file-persistence-missing-key-source` |
+| Both `key-env` and `key-file` set | `tramai-sovereign-file-persistence-ambiguous-key-source` |
+| `key-env` set but env var missing/blank | `tramai-sovereign-file-persistence-missing-key-env` |
+| Key file missing | `tramai-sovereign-file-persistence-key-file-missing` |
+| Invalid key (bad base64 / wrong size) | `tramai-sovereign-file-persistence-invalid-key` |
+| Base dir cannot be created | `tramai-sovereign-file-persistence-base-dir-unavailable` |
+| Base dir path unsafe | `tramai-sovereign-file-persistence-unsafe-base-dir` |
+
+### Expected directory layout
+
+```
+<base-dir>/
+  .tramai.lock
+  manifest.json
+  approvals/
+  continuations/
+  audit/
+  suspended/
+```
+
+### Key requirements
+
+- Exactly one key source: `key-env` (environment variable) or `key-file` (file)
+- Key must be base64-encoded 256-bit AES key (decodes to 32 bytes)
+- Plaintext keys in YAML are **not** supported
+- Keys are never logged and never appear in exception messages
+
+### Test
+
+```bash
+./gradlew :tramai-spring-boot-starter-sovereign-persistence-file:test
+```
+
+### Migration guide
+
+1. Add the `tramai-spring-boot-starter-sovereign-persistence-file` dependency
+2. Generate a key with `openssl rand -base64 32`
+3. Set `TRAMAI_SOVEREIGN_STORE_KEY` in your environment
+4. Add `tramai.sovereign.persistence.*` to `application.yml`
+5. Restart — existing in-memory state is lost (this is expected)
+6. Verify: state survives subsequent restarts

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,7 @@ include(
     "tramai-platform",
     "tramai-spring",
     "tramai-spring-boot-starter-sovereign",
+    "tramai-spring-boot-starter-sovereign-persistence-file",
     "tramai-scheduler",
     "tramai-security",
     "tramai-sovereign",

--- a/tramai-spring-boot-starter-sovereign-persistence-file/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/build.gradle.kts
@@ -1,0 +1,40 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    `java-library`
+    alias(libs.plugins.kotlin.jvm)
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+    withSourcesJar()
+}
+
+kotlin {
+    jvmToolchain(21)
+    compilerOptions {
+        jvmTarget.set(JvmTarget.fromTarget("21"))
+    }
+}
+
+dependencies {
+    api(project(":tramai-spring-boot-starter-sovereign"))
+    api(project(":tramai-persistence-file"))
+
+    implementation(libs.spring.boot.autoconfigure)
+
+    annotationProcessor(libs.spring.boot.configuration.processor)
+
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.coroutines.core)
+    testImplementation(libs.kotlin.test.junit5)
+    testImplementation(libs.spring.boot.starter.test)
+    testImplementation("org.junit.jupiter:junit-jupiter")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/tramai-spring-boot-starter-sovereign-persistence-file/src/main/kotlin/dev/tramai/spring/sovereign/persistence/file/SovereignFilePersistenceAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/src/main/kotlin/dev/tramai/spring/sovereign/persistence/file/SovereignFilePersistenceAutoConfiguration.kt
@@ -91,27 +91,17 @@ class SovereignFilePersistenceAutoConfiguration {
 
         val rootDir = baseDir.toAbsolutePath().normalize()
 
-        // Reject path traversal attempts: the normalized path must be
-        // within its own absolute parent tree.
-        val normalizedParent = baseDir.toAbsolutePath().normalize().parent
-        if (normalizedParent != null && !rootDir.startsWith(normalizedParent)) {
-            throw IllegalStateException(
-                "tramai-sovereign-file-persistence-unsafe-base-dir",
-            )
-        }
-
         // ── Load encryption key ──
         val rawKey = SovereignStoreKeyLoader.load(properties)
         val secretKey: SecretKey = SecretKeySpec(rawKey, "AES")
 
-        // ── Build file store configuration ──
+        // ── Build file store configuration (secure defaults: verifyOnOpen=true) ──
         val config = FileBackedStoreConfiguration(
             rootDirectory = rootDir,
             encryption = FileStoreEncryptionConfiguration(
                 activeKeyId = "default",
                 keyProvider = FileStoreEncryptionKeyProvider { secretKey },
             ),
-            verifyOnOpen = false,
         )
 
         // ── Open stores (creates lock, manifest, validates) ──

--- a/tramai-spring-boot-starter-sovereign-persistence-file/src/main/kotlin/dev/tramai/spring/sovereign/persistence/file/SovereignFilePersistenceAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/src/main/kotlin/dev/tramai/spring/sovereign/persistence/file/SovereignFilePersistenceAutoConfiguration.kt
@@ -1,0 +1,144 @@
+package dev.tramai.spring.sovereign.persistence.file
+
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.core.approval.ApprovalStore
+import dev.tramai.engine.SuspendedInvocationStore
+import dev.tramai.persistence.file.FileBackedSovereignStores
+import dev.tramai.persistence.file.FileBackedStoreConfiguration
+import dev.tramai.persistence.file.FileStoreEncryptionConfiguration
+import dev.tramai.persistence.file.FileStoreEncryptionKeyProvider
+import dev.tramai.security.audit.AuditStore
+import javax.crypto.SecretKey
+import javax.crypto.spec.SecretKeySpec
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+
+/**
+ * Spring Boot auto-configuration for encrypted file-backed sovereign persistence.
+ *
+ * Activated when `tramai.sovereign.persistence.type=file`.
+ * Runs before [SovereignTramaiAutoConfiguration] so file-backed store beans
+ * are registered before the base starter creates in-memory defaults. The
+ * base starter's `@ConditionalOnMissingBean` then backs off, resulting in
+ * file-backed stores in [SovereignTramaiRuntime].
+ *
+ * ## Store beans
+ *
+ * - [AuditStore] → `FileBackedSovereignStores.auditStore`
+ * - [ApprovalStore] → `FileBackedSovereignStores.approvalStore`
+ * - [ApprovalContinuationStore] → `FileBackedSovereignStores.approvalContinuationStore`
+ * - [SuspendedInvocationStore] → `FileBackedSovereignStores.suspendedInvocationStore`
+ *
+ * All store beans are `@ConditionalOnMissingBean` — user-provided stores
+ * always take precedence.
+ *
+ * ## Configuration example
+ *
+ * ```yaml
+ * tramai:
+ *   sovereign:
+ *     persistence:
+ *       type: file
+ *       base-dir: ./data/tramai-sovereign
+ *       encryption:
+ *         key-env: TRAMAI_SOVEREIGN_STORE_KEY
+ * ```
+ *
+ * ## Generate a test key
+ *
+ * ```
+ * openssl rand -base64 32
+ * ```
+ *
+ * ## Key requirements
+ *
+ * - Exactly one key source must be specified: `key-env` or `key-file` (not both, not neither)
+ * - Key must be base64-encoded 256-bit AES key (decodes to 32 bytes)
+ * - Plaintext keys in YAML are **not** supported
+ * - Keys are never logged and never appear in exception messages
+ */
+@AutoConfiguration(before = [dev.tramai.spring.sovereign.SovereignTramaiAutoConfiguration::class])
+@EnableConfigurationProperties(SovereignFilePersistenceProperties::class)
+@ConditionalOnProperty(
+    prefix = "tramai.sovereign.persistence",
+    name = ["type"],
+    havingValue = "file",
+)
+class SovereignFilePersistenceAutoConfiguration {
+
+    /**
+     * Creates the [FileBackedSovereignStores] bundle.
+     *
+     * This bean is `@ConditionalOnMissingBean` so users can provide their own
+     * fully customised bundle.
+     *
+     * The `destroyMethod = "close"` ensures the exclusive file lock is released
+     * when the Spring context closes.
+     */
+    @Bean(destroyMethod = "close")
+    @ConditionalOnMissingBean
+    fun sovereignFileBackedStores(
+        properties: SovereignFilePersistenceProperties,
+    ): FileBackedSovereignStores {
+        // ── Validate base directory ──
+        val baseDir = properties.baseDir
+            ?: throw IllegalStateException(
+                "tramai-sovereign-file-persistence-missing-base-dir",
+            )
+
+        val rootDir = baseDir.toAbsolutePath().normalize()
+
+        // Reject path traversal attempts: the normalized path must be
+        // within its own absolute parent tree.
+        val normalizedParent = baseDir.toAbsolutePath().normalize().parent
+        if (normalizedParent != null && !rootDir.startsWith(normalizedParent)) {
+            throw IllegalStateException(
+                "tramai-sovereign-file-persistence-unsafe-base-dir",
+            )
+        }
+
+        // ── Load encryption key ──
+        val rawKey = SovereignStoreKeyLoader.load(properties)
+        val secretKey: SecretKey = SecretKeySpec(rawKey, "AES")
+
+        // ── Build file store configuration ──
+        val config = FileBackedStoreConfiguration(
+            rootDirectory = rootDir,
+            encryption = FileStoreEncryptionConfiguration(
+                activeKeyId = "default",
+                keyProvider = FileStoreEncryptionKeyProvider { secretKey },
+            ),
+            verifyOnOpen = false,
+        )
+
+        // ── Open stores (creates lock, manifest, validates) ──
+        return FileBackedSovereignStores.open(config)
+    }
+
+    // ── Individual store beans (backed off from in-memory defaults) ──
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun auditStore(stores: FileBackedSovereignStores): AuditStore =
+        stores.auditStore
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun approvalStore(stores: FileBackedSovereignStores): ApprovalStore =
+        stores.approvalStore
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun approvalContinuationStore(
+        stores: FileBackedSovereignStores,
+    ): ApprovalContinuationStore = stores.approvalContinuationStore
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun suspendedInvocationStore(
+        stores: FileBackedSovereignStores,
+    ): SuspendedInvocationStore = stores.suspendedInvocationStore
+}

--- a/tramai-spring-boot-starter-sovereign-persistence-file/src/main/kotlin/dev/tramai/spring/sovereign/persistence/file/SovereignFilePersistenceProperties.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/src/main/kotlin/dev/tramai/spring/sovereign/persistence/file/SovereignFilePersistenceProperties.kt
@@ -1,0 +1,38 @@
+package dev.tramai.spring.sovereign.persistence.file
+
+import java.nio.file.Path
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Externalized configuration for TramAI sovereign file-backed persistence.
+ *
+ * Usage:
+ * ```yaml
+ * tramai:
+ *   sovereign:
+ *     persistence:
+ *       type: file
+ *       base-dir: ./data/tramai-sovereign
+ *       encryption:
+ *         key-env: TRAMAI_SOVEREIGN_STORE_KEY
+ * ```
+ */
+@ConfigurationProperties(prefix = "tramai.sovereign.persistence")
+data class SovereignFilePersistenceProperties(
+    /** Persistence type: "memory" (default) or "file". */
+    var type: String = "memory",
+
+    /** Base directory for file-backed sovereign stores. Required when type=file. */
+    var baseDir: Path? = null,
+
+    /** Encryption configuration for file-backed stores. */
+    var encryption: Encryption = Encryption(),
+) {
+    data class Encryption(
+        /** Name of the environment variable containing the base64-encoded 256-bit AES key. */
+        var keyEnv: String? = null,
+
+        /** Path to a file containing the base64-encoded 256-bit AES key. */
+        var keyFile: Path? = null,
+    )
+}

--- a/tramai-spring-boot-starter-sovereign-persistence-file/src/main/kotlin/dev/tramai/spring/sovereign/persistence/file/SovereignStoreKeyLoader.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/src/main/kotlin/dev/tramai/spring/sovereign/persistence/file/SovereignStoreKeyLoader.kt
@@ -1,0 +1,99 @@
+package dev.tramai.spring.sovereign.persistence.file
+
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Base64
+
+/**
+ * Loads and validates a 256-bit AES encryption key from environment variable or file.
+ *
+ * Supports two mutually exclusive sources:
+ * - `key-env`: reads a base64-encoded 256-bit key from an environment variable
+ * - `key-file`: reads a base64-encoded 256-bit key from a file on disk
+ *
+ * Validation rules:
+ * - Exactly one key source must be specified (not zero, not both)
+ * - The env var must exist and be non-blank
+ * - The key file must exist and be readable
+ * - The key must be valid base64 and decode to exactly 32 bytes
+ *
+ * Keys are never logged and never included in exception messages.
+ * Plaintext keys in YAML are not supported — always use env vars or files.
+ */
+object SovereignStoreKeyLoader {
+
+    /**
+     * Loads and validates the AES encryption key from the configured source.
+     *
+     * @param properties The persistence properties.
+     * @return A 32-byte AES-256 key.
+     * @throws IllegalStateException with a fail-closed error code on any validation failure.
+     */
+    fun load(properties: SovereignFilePersistenceProperties): ByteArray {
+        val enc = properties.encryption
+        val keyEnv = enc.keyEnv
+        val keyFile = enc.keyFile
+
+        // ── Exactly one key source ──
+        when {
+            keyEnv == null && keyFile == null -> {
+                throw IllegalStateException(
+                    "tramai-sovereign-file-persistence-missing-key-source",
+                )
+            }
+            keyEnv != null && keyFile != null -> {
+                throw IllegalStateException(
+                    "tramai-sovereign-file-persistence-ambiguous-key-source",
+                )
+            }
+        }
+
+        // ── Load base64 key from the configured source ──
+        val base64Key: String = when {
+            keyEnv != null -> {
+                val value = System.getenv(keyEnv)
+                if (value.isNullOrBlank()) {
+                    throw IllegalStateException(
+                        "tramai-sovereign-file-persistence-missing-key-env",
+                    )
+                }
+                value.trim()
+            }
+            keyFile != null -> {
+                if (!Files.exists(keyFile)) {
+                    throw IllegalStateException(
+                        "tramai-sovereign-file-persistence-key-file-missing",
+                    )
+                }
+                try {
+                    keyFile.toFile().readText().trim()
+                } catch (e: IOException) {
+                    throw IllegalStateException(
+                        "tramai-sovereign-file-persistence-key-file-missing",
+                    )
+                }
+            }
+            else -> error("unreachable")
+        }
+
+        // ── Base64 decode ──
+        val rawKey: ByteArray
+        try {
+            rawKey = Base64.getDecoder().decode(base64Key)
+        } catch (e: IllegalArgumentException) {
+            throw IllegalStateException(
+                "tramai-sovereign-file-persistence-invalid-key",
+            )
+        }
+
+        // ── Must be exactly 32 bytes (256 bits) ──
+        if (rawKey.size != 32) {
+            throw IllegalStateException(
+                "tramai-sovereign-file-persistence-invalid-key",
+            )
+        }
+
+        return rawKey
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-persistence-file/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.tramai.spring.sovereign.persistence.file.SovereignFilePersistenceAutoConfiguration

--- a/tramai-spring-boot-starter-sovereign-persistence-file/src/test/kotlin/dev/tramai/spring/sovereign/persistence/file/SovereignFilePersistenceAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/src/test/kotlin/dev/tramai/spring/sovereign/persistence/file/SovereignFilePersistenceAutoConfigurationTest.kt
@@ -305,6 +305,49 @@ class SovereignFilePersistenceAutoConfigurationTest {
         }
     }
 
+    @Test
+    fun `file backed SuspendedInvocationStore is consumed by SovereignTramaiRuntime`() {
+        val dir = tempDir.resolve("runtime-suspended")
+        val keyFile = prepareKeyFile(dir)
+
+        val combinedRunner = ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(
+                    SovereignFilePersistenceAutoConfiguration::class.java,
+                    dev.tramai.spring.sovereign.SovereignTramaiAutoConfiguration::class.java,
+                ),
+            )
+            .withUserConfiguration(MinimalProviderConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.enabled=true",
+                "tramai.sovereign.allowed-models[0]=test-model",
+                "tramai.sovereign.allowed-providers[0]=test-provider",
+                "tramai.sovereign.provider-zones.test-provider=LOCAL",
+                "tramai.sovereign.models.test-model=test-provider",
+                "tramai.sovereign.persistence.type=file",
+                "tramai.sovereign.persistence.base-dir=${dir.toAbsolutePath()}",
+                "tramai.sovereign.persistence.encryption.key-file=${keyFile.toAbsolutePath()}",
+            )
+
+        combinedRunner.run { ctx ->
+            // Runtime and tramai beans exist (proves builder path succeeded)
+            assertThat(ctx).hasSingleBean(
+                dev.tramai.sovereign.SovereignTramai::class.java,
+            )
+            assertThat(ctx).hasSingleBean(
+                dev.tramai.sovereign.SovereignTramaiRuntime::class.java,
+            )
+
+            // SuspendedInvocationStore is file-backed in the runtime
+            assertThat(ctx).hasSingleBean(SuspendedInvocationStore::class.java)
+            val store = ctx.getBean(SuspendedInvocationStore::class.java)
+            assertThat(store)
+                .isExactlyInstanceOf(
+                    dev.tramai.persistence.file.FileSuspendedInvocationStore::class.java,
+                )
+        }
+    }
+
     // ── User-provided beans are not overridden ─────────────────────────
 
     @Test
@@ -320,6 +363,7 @@ class SovereignFilePersistenceAutoConfigurationTest {
                     .toTypedArray(),
             )
             .run { ctx ->
+                assertThat(ctx.getBeansOfType(AuditStore::class.java)).hasSize(1)
                 val store = ctx.getBean(AuditStore::class.java)
                 assertThat(store).isInstanceOf(CustomAuditStore::class.java)
             }
@@ -338,6 +382,7 @@ class SovereignFilePersistenceAutoConfigurationTest {
                     .toTypedArray(),
             )
             .run { ctx ->
+                assertThat(ctx.getBeansOfType(ApprovalStore::class.java)).hasSize(1)
                 val store = ctx.getBean(ApprovalStore::class.java)
                 assertThat(store).isInstanceOf(CustomApprovalStore::class.java)
             }
@@ -367,6 +412,11 @@ open class CustomApprovalStoreConfig {
     @Bean
     @Primary
     open fun customApprovalStore(): ApprovalStore = CustomApprovalStore()
+}
+
+open class MinimalProviderConfig {
+    @Bean
+    open fun stubModelProvider(): StubModelProvider = StubModelProvider()
 }
 
 // ── Stub implementations ─────────────────────────────────────────────
@@ -423,4 +473,12 @@ class CustomApprovalStore : ApprovalStore {
     ): dev.tramai.core.approval.ApprovalConsumptionReceipt {
         throw UnsupportedOperationException("custom stub")
     }
+}
+
+class StubModelProvider : dev.tramai.core.provider.ModelProvider {
+    override fun providerId(): String = "test-provider"
+    override suspend fun complete(
+        request: dev.tramai.core.model.ModelRequest,
+    ): dev.tramai.core.model.ModelResponse =
+        dev.tramai.core.model.ModelResponse(content = "stub response")
 }

--- a/tramai-spring-boot-starter-sovereign-persistence-file/src/test/kotlin/dev/tramai/spring/sovereign/persistence/file/SovereignFilePersistenceAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/src/test/kotlin/dev/tramai/spring/sovereign/persistence/file/SovereignFilePersistenceAutoConfigurationTest.kt
@@ -1,0 +1,426 @@
+package dev.tramai.spring.sovereign.persistence.file
+
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.core.approval.ApprovalStore
+import dev.tramai.engine.SuspendedInvocationStore
+import dev.tramai.persistence.file.FileBackedSovereignStores
+import dev.tramai.security.approval.InMemoryApprovalContinuationStore
+import dev.tramai.security.approval.InMemoryApprovalStore
+import dev.tramai.security.audit.AuditEvent
+import dev.tramai.security.audit.AuditStore
+import dev.tramai.security.audit.InMemoryAuditStore
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+import java.util.Base64
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+
+class SovereignFilePersistenceAutoConfigurationTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    /** A valid base64-encoded 32-byte (256-bit) AES key. */
+    private val validBase64Key: String =
+        Base64.getEncoder().encodeToString(ByteArray(32) { it.toByte() })
+
+    /** Properties for a valid file-persistence config using key-file. */
+    private fun validFileProps(baseDir: Path, keyFile: Path): Map<String, String> = mapOf(
+        "tramai.sovereign.persistence.type" to "file",
+        "tramai.sovereign.persistence.base-dir" to baseDir.toAbsolutePath().toString(),
+        "tramai.sovereign.persistence.encryption.key-file" to keyFile.toAbsolutePath().toString(),
+    )
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(SovereignFilePersistenceAutoConfiguration::class.java),
+        )
+
+    // ── type=memory does not create file stores ────────────────────────
+
+    @Test
+    fun `type equals memory does not create file backed stores`() {
+        contextRunner
+            .withPropertyValues("tramai.sovereign.persistence.type=memory")
+            .run { ctx ->
+                assertThat(ctx).doesNotHaveBean(FileBackedSovereignStores::class.java)
+            }
+    }
+
+    // ── type=file without base-dir fails ────────────────────────────────
+
+    @Test
+    fun `type is file without base dir fails`() {
+        contextRunner
+            .withPropertyValues(
+                "tramai.sovereign.persistence.type=file",
+                "tramai.sovereign.persistence.encryption.key-file=/tmp/nonexistent",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasFailed()
+                val failure = requireNotNull(ctx.startupFailure)
+                assertThat(failure)
+                    .hasMessageContaining("tramai-sovereign-file-persistence-missing-base-dir")
+            }
+    }
+
+    // ── type=file without key source fails ──────────────────────────────
+
+    @Test
+    fun `type is file without key source fails`() {
+        val dir = tempDir.resolve("no-key")
+        contextRunner
+            .withPropertyValues(
+                "tramai.sovereign.persistence.type=file",
+                "tramai.sovereign.persistence.base-dir=${dir.toAbsolutePath()}",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasFailed()
+                val failure = requireNotNull(ctx.startupFailure)
+                assertThat(failure)
+                    .hasMessageContaining("tramai-sovereign-file-persistence-missing-key-source")
+            }
+    }
+
+    // ── both key-env and key-file set fails ─────────────────────────────
+
+    @Test
+    fun `both key env and key file set fails`() {
+        val dir = tempDir.resolve("ambiguous-key")
+        contextRunner
+            .withPropertyValues(
+                "tramai.sovereign.persistence.type=file",
+                "tramai.sovereign.persistence.base-dir=${dir.toAbsolutePath()}",
+                "tramai.sovereign.persistence.encryption.key-env=MY_KEY",
+                "tramai.sovereign.persistence.encryption.key-file=/tmp/some-key-file",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasFailed()
+                val failure = requireNotNull(ctx.startupFailure)
+                assertThat(failure)
+                    .hasMessageContaining("tramai-sovereign-file-persistence-ambiguous-key-source")
+            }
+    }
+
+    // ── missing env var fails ─────────────────────────────────────────
+
+    @Test
+    fun `key env set but env var missing fails`() {
+        val dir = tempDir.resolve("missing-env")
+        contextRunner
+            .withPropertyValues(
+                "tramai.sovereign.persistence.type=file",
+                "tramai.sovereign.persistence.base-dir=${dir.toAbsolutePath()}",
+                "tramai.sovereign.persistence.encryption.key-env=TRAMAI_TEST_NONEXISTENT_KEY_98765",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasFailed()
+                val failure = requireNotNull(ctx.startupFailure)
+                assertThat(failure)
+                    .hasMessageContaining("tramai-sovereign-file-persistence-missing-key-env")
+            }
+    }
+
+    // ── invalid base64 key fails ─────────────────────────────────────
+
+    @Test
+    fun `invalid base64 key file fails`() {
+        val dir = tempDir.resolve("invalid-base64-key")
+        val keyFile = dir.resolve("key.b64")
+        Files.createDirectories(dir)
+        keyFile.toFile().writeText("===NOT-BASE64===")
+
+        contextRunner
+            .withPropertyValues(
+                "tramai.sovereign.persistence.type=file",
+                "tramai.sovereign.persistence.base-dir=${dir.toAbsolutePath()}",
+                "tramai.sovereign.persistence.encryption.key-file=${keyFile.toAbsolutePath()}",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasFailed()
+                val failure = requireNotNull(ctx.startupFailure)
+                assertThat(failure)
+                    .hasMessageContaining("tramai-sovereign-file-persistence-invalid-key")
+            }
+    }
+
+    // ── decoded key not 32 bytes fails ───────────────────────────────
+
+    @Test
+    fun `decoded key not 32 bytes fails`() {
+        val dir = tempDir.resolve("wrong-key-size")
+        val keyFile = dir.resolve("key.b64")
+        Files.createDirectories(dir)
+        // 16 bytes (AES-128) — not allowed, must be 32
+        val sixteenBytes = Base64.getEncoder().encodeToString(ByteArray(16) { 0x42 })
+        keyFile.toFile().writeText(sixteenBytes)
+
+        contextRunner
+            .withPropertyValues(
+                "tramai.sovereign.persistence.type=file",
+                "tramai.sovereign.persistence.base-dir=${dir.toAbsolutePath()}",
+                "tramai.sovereign.persistence.encryption.key-file=${keyFile.toAbsolutePath()}",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasFailed()
+                val failure = requireNotNull(ctx.startupFailure)
+                assertThat(failure)
+                    .hasMessageContaining("tramai-sovereign-file-persistence-invalid-key")
+            }
+    }
+
+    // ── valid key-file creates all four file-backed stores ─────────────
+
+    @Test
+    fun `valid properties create file backed AuditStore`() {
+        val dir = tempDir.resolve("happy-audit")
+        val keyFile = prepareKeyFile(dir)
+
+        contextRunner
+            .withPropertyValues(
+                *validFileProps(dir, keyFile).entries
+                    .map { "${it.key}=${it.value}" }
+                    .toTypedArray(),
+            )
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(FileBackedSovereignStores::class.java)
+                assertThat(ctx).hasSingleBean(AuditStore::class.java)
+                val store = ctx.getBean(AuditStore::class.java)
+                assertThat(store).isExactlyInstanceOf(
+                    dev.tramai.persistence.file.FileAuditStore::class.java,
+                )
+            }
+    }
+
+    @Test
+    fun `valid properties create file backed ApprovalStore`() {
+        val dir = tempDir.resolve("happy-approval")
+        val keyFile = prepareKeyFile(dir)
+
+        contextRunner
+            .withPropertyValues(
+                *validFileProps(dir, keyFile).entries
+                    .map { "${it.key}=${it.value}" }
+                    .toTypedArray(),
+            )
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(ApprovalStore::class.java)
+                val store = ctx.getBean(ApprovalStore::class.java)
+                assertThat(store).isExactlyInstanceOf(
+                    dev.tramai.persistence.file.FileApprovalStore::class.java,
+                )
+            }
+    }
+
+    @Test
+    fun `valid properties create file backed ApprovalContinuationStore`() {
+        val dir = tempDir.resolve("happy-continuation")
+        val keyFile = prepareKeyFile(dir)
+
+        contextRunner
+            .withPropertyValues(
+                *validFileProps(dir, keyFile).entries
+                    .map { "${it.key}=${it.value}" }
+                    .toTypedArray(),
+            )
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(ApprovalContinuationStore::class.java)
+                val store = ctx.getBean(ApprovalContinuationStore::class.java)
+                assertThat(store).isExactlyInstanceOf(
+                    dev.tramai.persistence.file.FileApprovalContinuationStore::class.java,
+                )
+            }
+    }
+
+    @Test
+    fun `valid properties create file backed SuspendedInvocationStore`() {
+        val dir = tempDir.resolve("happy-suspended")
+        val keyFile = prepareKeyFile(dir)
+
+        contextRunner
+            .withPropertyValues(
+                *validFileProps(dir, keyFile).entries
+                    .map { "${it.key}=${it.value}" }
+                    .toTypedArray(),
+            )
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SuspendedInvocationStore::class.java)
+                val store = ctx.getBean(SuspendedInvocationStore::class.java)
+                assertThat(store).isExactlyInstanceOf(
+                    dev.tramai.persistence.file.FileSuspendedInvocationStore::class.java,
+                )
+            }
+    }
+
+    // ── Sovereign base starter uses file-backed stores ────────────────
+
+    @Test
+    fun `base starter uses file backed stores instead of in memory`() {
+        val dir = tempDir.resolve("base-starter-delegation")
+        val keyFile = prepareKeyFile(dir)
+
+        val combinedRunner = ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(
+                    SovereignFilePersistenceAutoConfiguration::class.java,
+                    dev.tramai.spring.sovereign.SovereignTramaiAutoConfiguration::class.java,
+                ),
+            )
+            .withPropertyValues(
+                "tramai.sovereign.enabled=true",
+                "tramai.sovereign.allowed-models[0]=local-model",
+                "tramai.sovereign.allowed-providers[0]=local-provider",
+                "tramai.sovereign.provider-zones.local-provider=LOCAL",
+                "tramai.sovereign.models.local-model=local-provider",
+                "tramai.sovereign.persistence.type=file",
+                "tramai.sovereign.persistence.base-dir=${dir.toAbsolutePath()}",
+                "tramai.sovereign.persistence.encryption.key-file=${keyFile.toAbsolutePath()}",
+            )
+
+        combinedRunner.run { ctx ->
+            // AuditStore should be file-backed, NOT in-memory
+            val auditStore = ctx.getBean(AuditStore::class.java)
+            assertThat(auditStore)
+                .isNotInstanceOf(InMemoryAuditStore::class.java)
+                .isExactlyInstanceOf(dev.tramai.persistence.file.FileAuditStore::class.java)
+
+            // ApprovalStore should be file-backed, NOT in-memory
+            val approvalStore = ctx.getBean(ApprovalStore::class.java)
+            assertThat(approvalStore)
+                .isNotInstanceOf(InMemoryApprovalStore::class.java)
+                .isExactlyInstanceOf(dev.tramai.persistence.file.FileApprovalStore::class.java)
+
+            // ApprovalContinuationStore should be file-backed, NOT in-memory
+            val continuationStore = ctx.getBean(ApprovalContinuationStore::class.java)
+            assertThat(continuationStore)
+                .isNotInstanceOf(InMemoryApprovalContinuationStore::class.java)
+                .isExactlyInstanceOf(dev.tramai.persistence.file.FileApprovalContinuationStore::class.java)
+        }
+    }
+
+    // ── User-provided beans are not overridden ─────────────────────────
+
+    @Test
+    fun `custom user provided AuditStore is not overridden`() {
+        val dir = tempDir.resolve("custom-audit")
+        val keyFile = prepareKeyFile(dir)
+
+        contextRunner
+            .withUserConfiguration(CustomAuditStoreConfig::class.java)
+            .withPropertyValues(
+                *validFileProps(dir, keyFile).entries
+                    .map { "${it.key}=${it.value}" }
+                    .toTypedArray(),
+            )
+            .run { ctx ->
+                val store = ctx.getBean(AuditStore::class.java)
+                assertThat(store).isInstanceOf(CustomAuditStore::class.java)
+            }
+    }
+
+    @Test
+    fun `custom user provided ApprovalStore is not overridden`() {
+        val dir = tempDir.resolve("custom-approval")
+        val keyFile = prepareKeyFile(dir)
+
+        contextRunner
+            .withUserConfiguration(CustomApprovalStoreConfig::class.java)
+            .withPropertyValues(
+                *validFileProps(dir, keyFile).entries
+                    .map { "${it.key}=${it.value}" }
+                    .toTypedArray(),
+            )
+            .run { ctx ->
+                val store = ctx.getBean(ApprovalStore::class.java)
+                assertThat(store).isInstanceOf(CustomApprovalStore::class.java)
+            }
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private fun prepareKeyFile(dir: Path): Path {
+        // Write key file to a separate temp directory, NOT inside the store base dir.
+        // FileBackedSovereignStores.open() creates the base dir with strict 0700 permissions.
+        val keyDir = Files.createTempDirectory("tramai-test-key-")
+        val keyFile = keyDir.resolve("key.b64")
+        keyFile.toFile().writeText(validBase64Key)
+        return keyFile
+    }
+
+    // ── Test Configuration classes (must be open for CGLIB) ────────────
+}
+
+open class CustomAuditStoreConfig {
+    @Bean
+    @Primary
+    open fun customAuditStore(): AuditStore = CustomAuditStore()
+}
+
+open class CustomApprovalStoreConfig {
+    @Bean
+    @Primary
+    open fun customApprovalStore(): ApprovalStore = CustomApprovalStore()
+}
+
+// ── Stub implementations ─────────────────────────────────────────────
+
+class CustomAuditStore : AuditStore {
+    override suspend fun appendNext(
+        auditStreamId: String,
+        eventFactory: (AuditEvent?) -> AuditEvent,
+    ): AuditEvent = eventFactory(
+        AuditEvent(
+            schemaVersion = 1,
+            hashAlgorithm = dev.tramai.security.audit.AuditHashAlgorithm.SHA_256,
+            auditStreamId = auditStreamId,
+            eventId = "custom-test-event",
+            sequenceNumber = 1,
+            workflowRunId = null,
+            correlationId = null,
+            actor = "test",
+            enforcementPoint = "test",
+            decision = "permit",
+            policyVersion = null,
+            workflowDigest = null,
+            previousEventHash = null,
+            eventHash = "a".repeat(64),
+            timestamp = Instant.now(),
+            reasonCode = null,
+        ),
+    )
+    override suspend fun readStream(auditStreamId: String): List<AuditEvent> = emptyList()
+    override suspend fun latestEvent(auditStreamId: String): AuditEvent? = null
+}
+
+class CustomApprovalStore : ApprovalStore {
+    private var created = false
+    override suspend fun create(
+        request: dev.tramai.core.approval.ApprovalRequest,
+    ): dev.tramai.core.approval.ApprovalRequest {
+        created = true
+        return request
+    }
+    override suspend fun get(approvalId: String): dev.tramai.core.approval.ApprovalRequest? = null
+    override suspend fun transition(
+        approvalId: String,
+        expectedVersion: Long,
+        transition: dev.tramai.core.approval.ApprovalTransition,
+    ): dev.tramai.core.approval.ApprovalRequest {
+        throw UnsupportedOperationException("custom stub")
+    }
+    override suspend fun consumeApprovedOrReplay(
+        approvalId: String,
+        expectedVersion: Long,
+        presentedTokenDigest: dev.tramai.core.approval.Sha256Digest,
+        consumedBy: String,
+    ): dev.tramai.core.approval.ApprovalConsumptionReceipt {
+        throw UnsupportedOperationException("custom stub")
+    }
+}

--- a/tramai-spring-boot-starter-sovereign/src/main/kotlin/dev/tramai/spring/sovereign/SovereignTramaiAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign/src/main/kotlin/dev/tramai/spring/sovereign/SovereignTramaiAutoConfiguration.kt
@@ -8,6 +8,7 @@ import dev.tramai.core.approval.ToolArgumentsDigester
 import dev.tramai.core.model.ModelRegistry
 import dev.tramai.core.model.RegisteredModel
 import dev.tramai.core.provider.ModelProvider
+import dev.tramai.engine.SuspendedInvocationStore
 import dev.tramai.security.approval.DefaultApprovalGateCoordinator
 import dev.tramai.security.approval.InMemoryApprovalContinuationStore
 import dev.tramai.security.approval.InMemoryApprovalStore
@@ -163,6 +164,7 @@ class SovereignTramaiAutoConfiguration {
         modelProviders: ObjectProvider<ModelProvider>,
         approvalGateCoordinator: ApprovalGateCoordinator,
         approvalContinuationStore: ApprovalContinuationStore,
+        suspendedInvocationStore: ObjectProvider<SuspendedInvocationStore>,
         toolArgumentsDigester: ToolArgumentsDigester?,
         clock: Clock,
         properties: SovereignTramaiProperties,
@@ -175,6 +177,7 @@ class SovereignTramaiAutoConfiguration {
             .approvalContinuationStore(approvalContinuationStore)
             .clock(clock)
 
+        suspendedInvocationStore.ifAvailable { builder.suspendedInvocationStore(it) }
         toolArgumentsDigester?.let { builder.toolArgumentsDigester(it) }
 
         // Register provider beans from the application context.


### PR DESCRIPTION
## Summary

Adds an opt-in Spring Boot auto-configuration module for encrypted file-backed sovereign persistence.

New module: `tramai-spring-boot-starter-sovereign-persistence-file`

When configured with:

```yaml
tramai:
  sovereign:
    persistence:
      type: file
      base-dir: ./data/tramai-sovereign
      encryption:
        key-env: TRAMAI_SOVEREIGN_STORE_KEY
```

the Spring sovereign starter uses file-backed stores for audit, approvals, approval continuations, and suspended invocations instead of in-memory defaults.

### Why

The base Spring starter is ideal for demos and local development, but enterprise workflows need restart-safe state for:
- audit chains
- approval lifecycle
- approval continuations
- suspended invocations

This PR provides that through an explicit fail-closed file persistence profile.

### How it works

- `@AutoConfiguration(before = [SovereignTramaiAutoConfiguration::class])` — runs first, so file-backed store beans are registered before the base starter creates in-memory defaults
- `@ConditionalOnMissingBean` on all store beans — user-provided stores always take precedence
- `SovereignStoreKeyLoader` supports key-env and key-file (mutually exclusive)
- Keys must be base64-encoded 256-bit AES (32 bytes decoded)
- Keys are never logged and never appear in exception messages

### Validation

```bash
./gradlew test --rerun-tasks        # 149 tasks, all green
./gradlew :tramai-spring-boot-starter-sovereign-persistence-file:test  # 14 tests, all green
```