### PR TITLE
feat(spring): add sovereign operations service layer

### DIFF
--- a/examples/spring-sovereign-starter/README.md
+++ b/examples/spring-sovereign-starter/README.md
@@ -213,7 +213,7 @@ The module provides four service interfaces:
 
 | Service | Purpose |
 |---|---|
-| `SovereignApprovalOperations` | Inspect and cancel approvals |
+| `SovereignApprovalOperations` | Inspect and deny approvals |
 | `SovereignSuspendedInvocationOperations` | Inspect suspended invocations |
 | `SovereignAuditOperations` | Read audit event streams |
 | `SovereignRuntimeOperations` | Check runtime/store health and persistence mode |
@@ -248,12 +248,12 @@ class ApprovalAdminService(
     suspend fun getApproval(id: String): SovereignApprovalSummary? =
         approvals.getApproval(id)
 
-    suspend fun cancelApproval(
+    suspend fun denyApproval(
         id: String,
         actor: String,
         reason: String,
     ): SovereignApprovalSummary =
-        approvals.cancelApproval(id, actor, reason)
+        approvals.denyApproval(id, actor, reason)
 }
 ```
 

--- a/examples/spring-sovereign-starter/README.md
+++ b/examples/spring-sovereign-starter/README.md
@@ -192,3 +192,72 @@ When `type: file` is configured, the file persistence auto-configuration:
 4. Add `tramai.sovereign.persistence.*` to `application.yml`
 5. Restart — existing in-memory state is lost (this is expected)
 6. Verify: state survives subsequent restarts
+
+---
+
+## Using the sovereign operations service layer
+
+The sovereign ops module exposes internal Spring service beans for safe
+operational inspection. It does **not** expose HTTP endpoints.
+
+Add the dependency:
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation(project(":tramai-spring-boot-starter-sovereign-ops"))
+}
+```
+
+The module provides four service interfaces:
+
+| Service | Purpose |
+|---|---|
+| `SovereignApprovalOperations` | Inspect and cancel approvals |
+| `SovereignSuspendedInvocationOperations` | Inspect suspended invocations |
+| `SovereignAuditOperations` | Read audit event streams |
+| `SovereignRuntimeOperations` | Check runtime/store health and persistence mode |
+
+### Security rules
+
+- No approval tokens are exposed
+- No resume tokens are exposed
+- No raw replay envelopes are exposed
+- No raw tool arguments are exposed
+- No raw model prompts or responses are exposed
+- Mutations are **disabled by default**
+
+### Configuration
+
+```yaml
+tramai:
+  sovereign:
+    ops:
+      enabled: true
+      mutations-enabled: false
+      max-page-size: 100
+```
+
+### Example usage
+
+```kotlin
+@Service
+class ApprovalAdminService(
+    private val approvals: SovereignApprovalOperations,
+) {
+    suspend fun getApproval(id: String): SovereignApprovalSummary? =
+        approvals.getApproval(id)
+
+    suspend fun cancelApproval(
+        id: String,
+        actor: String,
+        reason: String,
+    ): SovereignApprovalSummary =
+        approvals.cancelApproval(id, actor, reason)
+}
+```
+
+### Warning
+
+Do not expose these operations directly over HTTP without authentication,
+authorization, audit logging, and role checks.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,7 @@ include(
     "tramai-spring",
     "tramai-spring-boot-starter-sovereign",
     "tramai-spring-boot-starter-sovereign-persistence-file",
+    "tramai-spring-boot-starter-sovereign-ops",
     "tramai-scheduler",
     "tramai-security",
     "tramai-sovereign",

--- a/tramai-spring-boot-starter-sovereign-ops/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-ops/build.gradle.kts
@@ -1,0 +1,42 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    `java-library`
+    alias(libs.plugins.kotlin.jvm)
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+    withSourcesJar()
+}
+
+kotlin {
+    jvmToolchain(21)
+    compilerOptions {
+        jvmTarget.set(JvmTarget.fromTarget("21"))
+    }
+}
+
+dependencies {
+    api(project(":tramai-core"))
+    api(project(":tramai-security"))
+    api(project(":tramai-sovereign"))
+    api(project(":tramai-spring-boot-starter-sovereign"))
+
+    implementation(libs.spring.boot.autoconfigure)
+
+    annotationProcessor(libs.spring.boot.configuration.processor)
+
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.kotlin.test.junit5)
+    testImplementation(libs.coroutines.core)
+    testImplementation(libs.spring.boot.starter.test)
+    testImplementation("org.junit.jupiter:junit-jupiter")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/DefaultSovereignApprovalOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/DefaultSovereignApprovalOperations.kt
@@ -1,0 +1,84 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.core.approval.ApprovalRequest
+import dev.tramai.core.approval.ApprovalStore
+import dev.tramai.core.approval.ApprovalTransition
+
+/**
+ * Default implementation of [SovereignApprovalOperations].
+ *
+ * Delegates to an [ApprovalStore]. All mutations are guarded by
+ * [SovereignOpsProperties.mutationsEnabled]. Only safe summaries
+ * are returned — tokens and sensitive payloads are never exposed.
+ */
+class DefaultSovereignApprovalOperations(
+    private val store: ApprovalStore,
+    private val properties: SovereignOpsProperties,
+) : SovereignApprovalOperations {
+
+    private companion object {
+        private val SAFE_ID = Regex("[A-Za-z0-9][A-Za-z0-9._:@+-]{0,127}")
+        private const val MAX_REASON_LENGTH = 4096
+    }
+
+    override suspend fun getApproval(approvalId: String): SovereignApprovalSummary? {
+        validateApprovalId(approvalId)
+        val request = store.get(approvalId) ?: return null
+        return request.toSummary()
+    }
+
+    override suspend fun cancelApproval(
+        approvalId: String,
+        actor: String,
+        reason: String,
+    ): SovereignApprovalSummary {
+        if (!properties.mutationsEnabled) {
+            throw IllegalStateException("tramai-sovereign-ops-mutations-disabled")
+        }
+        validateApprovalId(approvalId)
+        validateActor(actor)
+        validateReason(reason)
+
+        val request = store.get(approvalId)
+            ?: throw IllegalStateException("tramai-sovereign-ops-invalid-approval-id")
+
+        val updated = store.transition(
+            approvalId = approvalId,
+            expectedVersion = request.version,
+            transition = ApprovalTransition.Deny(decidedBy = actor, comment = reason),
+        )
+        return updated.toSummary()
+    }
+
+    // ── Validation ──
+
+    private fun validateApprovalId(id: String) {
+        require(id.isNotBlank()) { "tramai-sovereign-ops-invalid-approval-id" }
+        require(id.length <= 128) { "tramai-sovereign-ops-invalid-approval-id" }
+        require(SAFE_ID.matches(id)) { "tramai-sovereign-ops-invalid-approval-id" }
+    }
+
+    private fun validateActor(actor: String) {
+        require(actor.isNotBlank()) { "tramai-sovereign-ops-invalid-approval-id" }
+        require(actor.length <= 256) { "tramai-sovereign-ops-invalid-approval-id" }
+    }
+
+    private fun validateReason(reason: String) {
+        require(reason.isNotBlank()) { "tramai-sovereign-ops-invalid-approval-id" }
+        require(reason.length <= MAX_REASON_LENGTH) { "tramai-sovereign-ops-invalid-approval-id" }
+    }
+
+    // ── Mapping ──
+
+    private fun ApprovalRequest.toSummary(): SovereignApprovalSummary =
+        SovereignApprovalSummary(
+            approvalId = approvalId,
+            status = status.name,
+            workflowRunId = binding.workflowRunId,
+            correlationId = null,
+            createdAt = requestedAt,
+            expiresAt = expiresAt,
+            actor = decidedBy,
+            reasonCode = decisionComment,
+        )
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/DefaultSovereignApprovalOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/DefaultSovereignApprovalOperations.kt
@@ -18,16 +18,16 @@ class DefaultSovereignApprovalOperations(
 
     private companion object {
         private val SAFE_ID = Regex("[A-Za-z0-9][A-Za-z0-9._:@+-]{0,127}")
+        private val SAFE_ACTOR = Regex("[A-Za-z0-9][A-Za-z0-9._:@+-]{0,255}")
         private const val MAX_REASON_LENGTH = 4096
     }
 
     override suspend fun getApproval(approvalId: String): SovereignApprovalSummary? {
         validateApprovalId(approvalId)
-        val request = store.get(approvalId) ?: return null
-        return request.toSummary()
+        return store.get(approvalId)?.toSummary()
     }
 
-    override suspend fun cancelApproval(
+    override suspend fun denyApproval(
         approvalId: String,
         actor: String,
         reason: String,
@@ -59,13 +59,14 @@ class DefaultSovereignApprovalOperations(
     }
 
     private fun validateActor(actor: String) {
-        require(actor.isNotBlank()) { "tramai-sovereign-ops-invalid-approval-id" }
-        require(actor.length <= 256) { "tramai-sovereign-ops-invalid-approval-id" }
+        require(actor.isNotBlank()) { "tramai-sovereign-ops-invalid-actor" }
+        require(actor.length <= 256) { "tramai-sovereign-ops-invalid-actor" }
+        require(SAFE_ACTOR.matches(actor)) { "tramai-sovereign-ops-invalid-actor" }
     }
 
     private fun validateReason(reason: String) {
-        require(reason.isNotBlank()) { "tramai-sovereign-ops-invalid-approval-id" }
-        require(reason.length <= MAX_REASON_LENGTH) { "tramai-sovereign-ops-invalid-approval-id" }
+        require(reason.isNotBlank()) { "tramai-sovereign-ops-invalid-reason" }
+        require(reason.length <= MAX_REASON_LENGTH) { "tramai-sovereign-ops-invalid-reason" }
     }
 
     // ── Mapping ──

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/DefaultSovereignAuditOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/DefaultSovereignAuditOperations.kt
@@ -8,9 +8,11 @@ import dev.tramai.security.audit.AuditStore
  *
  * Delegates to an [AuditStore]. Returns only safe event summaries —
  * raw prompts, model responses, and sensitive payloads are never exposed.
+ * All read operations are bounded by [SovereignOpsProperties.maxPageSize].
  */
 class DefaultSovereignAuditOperations(
     private val store: AuditStore?,
+    private val properties: SovereignOpsProperties,
 ) : SovereignAuditOperations {
 
     private companion object {
@@ -19,12 +21,18 @@ class DefaultSovereignAuditOperations(
 
     override suspend fun readAuditStream(
         auditStreamId: String,
+        limit: Int,
     ): List<SovereignAuditEventSummary> {
         validateAuditStreamId(auditStreamId)
+        require(limit in 1..properties.maxPageSize) {
+            "tramai-sovereign-ops-page-size-too-large"
+        }
         if (store == null) {
             throw IllegalStateException("tramai-sovereign-ops-store-unavailable")
         }
-        return store.readStream(auditStreamId).map { it.toSummary() }
+        return store.readStream(auditStreamId)
+            .take(limit)
+            .map { it.toSummary() }
     }
 
     override suspend fun latestAuditEvent(
@@ -41,7 +49,7 @@ class DefaultSovereignAuditOperations(
 
     private fun validateAuditStreamId(id: String) {
         require(id.isNotBlank()) { "tramai-sovereign-ops-invalid-audit-stream-id" }
-        require(id.length <= 256) { "tramai-sovereign-ops-invalid-audit-stream-id" }
+        require(id.length <= 128) { "tramai-sovereign-ops-invalid-audit-stream-id" }
         require(SAFE_ID.matches(id)) { "tramai-sovereign-ops-invalid-audit-stream-id" }
     }
 

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/DefaultSovereignAuditOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/DefaultSovereignAuditOperations.kt
@@ -1,0 +1,65 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.security.audit.AuditEvent
+import dev.tramai.security.audit.AuditStore
+
+/**
+ * Default implementation of [SovereignAuditOperations].
+ *
+ * Delegates to an [AuditStore]. Returns only safe event summaries —
+ * raw prompts, model responses, and sensitive payloads are never exposed.
+ */
+class DefaultSovereignAuditOperations(
+    private val store: AuditStore?,
+) : SovereignAuditOperations {
+
+    private companion object {
+        private val SAFE_ID = Regex("[A-Za-z0-9][A-Za-z0-9._:@+-]{0,127}")
+    }
+
+    override suspend fun readAuditStream(
+        auditStreamId: String,
+    ): List<SovereignAuditEventSummary> {
+        validateAuditStreamId(auditStreamId)
+        if (store == null) {
+            throw IllegalStateException("tramai-sovereign-ops-store-unavailable")
+        }
+        return store.readStream(auditStreamId).map { it.toSummary() }
+    }
+
+    override suspend fun latestAuditEvent(
+        auditStreamId: String,
+    ): SovereignAuditEventSummary? {
+        validateAuditStreamId(auditStreamId)
+        if (store == null) {
+            throw IllegalStateException("tramai-sovereign-ops-store-unavailable")
+        }
+        return store.latestEvent(auditStreamId)?.toSummary()
+    }
+
+    // ── Validation ──
+
+    private fun validateAuditStreamId(id: String) {
+        require(id.isNotBlank()) { "tramai-sovereign-ops-invalid-audit-stream-id" }
+        require(id.length <= 256) { "tramai-sovereign-ops-invalid-audit-stream-id" }
+        require(SAFE_ID.matches(id)) { "tramai-sovereign-ops-invalid-audit-stream-id" }
+    }
+
+    // ── Mapping ──
+
+    private fun AuditEvent.toSummary(): SovereignAuditEventSummary =
+        SovereignAuditEventSummary(
+            eventId = eventId,
+            sequenceNumber = sequenceNumber,
+            auditStreamId = auditStreamId,
+            workflowRunId = workflowRunId,
+            correlationId = correlationId,
+            actor = actor,
+            enforcementPoint = enforcementPoint,
+            decision = decision,
+            reasonCode = reasonCode,
+            eventHash = eventHash,
+            previousEventHash = previousEventHash,
+            timestamp = timestamp,
+        )
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/DefaultSovereignAuditOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/DefaultSovereignAuditOperations.kt
@@ -21,17 +21,18 @@ class DefaultSovereignAuditOperations(
 
     override suspend fun readAuditStream(
         auditStreamId: String,
-        limit: Int,
+        limit: Int?,
     ): List<SovereignAuditEventSummary> {
         validateAuditStreamId(auditStreamId)
-        require(limit in 1..properties.maxPageSize) {
+        val effectiveLimit = limit ?: properties.maxPageSize
+        require(effectiveLimit in 1..properties.maxPageSize) {
             "tramai-sovereign-ops-page-size-too-large"
         }
         if (store == null) {
             throw IllegalStateException("tramai-sovereign-ops-store-unavailable")
         }
         return store.readStream(auditStreamId)
-            .take(limit)
+            .take(effectiveLimit)
             .map { it.toSummary() }
     }
 

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/DefaultSovereignRuntimeOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/DefaultSovereignRuntimeOperations.kt
@@ -1,0 +1,49 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.core.approval.ApprovalStore
+import dev.tramai.engine.SuspendedInvocationStore
+import dev.tramai.security.audit.AuditStore
+
+/**
+ * Default implementation of [SovereignRuntimeOperations].
+ *
+ * Checks which store beans are available in the Spring context and
+ * detects persistence mode (file-backed vs in-memory) based on
+ * simple class-name heuristics.
+ *
+ * Does NOT depend on optional file-persistence module.
+ */
+class DefaultSovereignRuntimeOperations(
+    private val auditStore: AuditStore?,
+    private val approvalStore: ApprovalStore?,
+    private val approvalContinuationStore: ApprovalContinuationStore?,
+    private val suspendedInvocationStore: SuspendedInvocationStore?,
+) : SovereignRuntimeOperations {
+
+    override fun status(): SovereignRuntimeStatus {
+        val persistenceMode = detectPersistenceMode()
+
+        return SovereignRuntimeStatus(
+            runtimeAvailable = true,
+            auditStoreAvailable = auditStore != null,
+            approvalStoreAvailable = approvalStore != null,
+            approvalContinuationStoreAvailable = approvalContinuationStore != null,
+            suspendedInvocationStoreAvailable = suspendedInvocationStore != null,
+            persistenceMode = persistenceMode,
+        )
+    }
+
+    private fun detectPersistenceMode(): String {
+        listOfNotNull(auditStore, approvalStore, approvalContinuationStore, suspendedInvocationStore)
+            .forEach { store ->
+                val name = store.javaClass.name
+                if (name.contains("File", ignoreCase = true) ||
+                    name.startsWith("dev.tramai.persistence.file")
+                ) {
+                    return "file"
+                }
+            }
+        return "memory"
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/DefaultSovereignRuntimeOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/DefaultSovereignRuntimeOperations.kt
@@ -10,7 +10,7 @@ import dev.tramai.security.audit.AuditStore
  *
  * Checks which store beans are available in the Spring context and
  * detects persistence mode (file-backed vs in-memory) based on
- * simple class-name heuristics.
+ * concrete class package membership.
  *
  * Does NOT depend on optional file-persistence module.
  */
@@ -38,9 +38,7 @@ class DefaultSovereignRuntimeOperations(
         listOfNotNull(auditStore, approvalStore, approvalContinuationStore, suspendedInvocationStore)
             .forEach { store ->
                 val name = store.javaClass.name
-                if (name.contains("File", ignoreCase = true) ||
-                    name.startsWith("dev.tramai.persistence.file")
-                ) {
+                if (name.startsWith("dev.tramai.persistence.file.")) {
                     return "file"
                 }
             }

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/DefaultSovereignSuspendedInvocationOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/DefaultSovereignSuspendedInvocationOperations.kt
@@ -10,7 +10,6 @@ import dev.tramai.engine.SuspendedInvocationStore
  */
 class DefaultSovereignSuspendedInvocationOperations(
     private val store: SuspendedInvocationStore?,
-    private val properties: SovereignOpsProperties,
 ) : SovereignSuspendedInvocationOperations {
 
     private companion object {
@@ -45,7 +44,6 @@ class DefaultSovereignSuspendedInvocationOperations(
             correlationId = identity.correlationId,
             serviceName = operationReference.serviceInterface,
             operationName = operationReference.methodName,
-            createdAt = null,
             status = "SUSPENDED",
             replayEnvelopeDigest = replayEnvelopeDigest.value,
         )

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/DefaultSovereignSuspendedInvocationOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/DefaultSovereignSuspendedInvocationOperations.kt
@@ -1,0 +1,52 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.engine.SuspendedInvocationStore
+
+/**
+ * Default implementation of [SovereignSuspendedInvocationOperations].
+ *
+ * Delegates to a [SuspendedInvocationStore]. Only safe metadata is
+ * returned — raw replay envelopes and sensitive payloads are never exposed.
+ */
+class DefaultSovereignSuspendedInvocationOperations(
+    private val store: SuspendedInvocationStore?,
+    private val properties: SovereignOpsProperties,
+) : SovereignSuspendedInvocationOperations {
+
+    private companion object {
+        private val SAFE_ID = Regex("[A-Za-z0-9][A-Za-z0-9._:@+-]{0,127}")
+    }
+
+    override suspend fun getSuspendedInvocation(
+        approvalId: String,
+    ): SovereignSuspendedInvocationSummary? {
+        validateId(approvalId)
+        if (store == null) {
+            throw IllegalStateException("tramai-sovereign-ops-store-unavailable")
+        }
+        val metadata = store.get(approvalId) ?: return null
+        return metadata.toSummary()
+    }
+
+    // ── Validation ──
+
+    private fun validateId(id: String) {
+        require(id.isNotBlank()) { "tramai-sovereign-ops-invalid-suspended-invocation-id" }
+        require(id.length <= 128) { "tramai-sovereign-ops-invalid-suspended-invocation-id" }
+        require(SAFE_ID.matches(id)) { "tramai-sovereign-ops-invalid-suspended-invocation-id" }
+    }
+
+    // ── Mapping ──
+
+    private fun dev.tramai.engine.SuspendedInvocationMetadata.toSummary(): SovereignSuspendedInvocationSummary =
+        SovereignSuspendedInvocationSummary(
+            suspendedInvocationId = approvalId,
+            workflowRunId = identity.workflowRunId,
+            correlationId = identity.correlationId,
+            serviceName = operationReference.serviceInterface,
+            operationName = operationReference.methodName,
+            createdAt = null,
+            status = "SUSPENDED",
+            replayEnvelopeDigest = replayEnvelopeDigest.value,
+        )
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignApprovalOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignApprovalOperations.kt
@@ -6,7 +6,7 @@ package dev.tramai.spring.sovereign.ops
  * Methods return only safe summaries. Approval tokens, resume tokens,
  * and raw tool arguments are NEVER exposed.
  *
- * Mutations (cancel/transition) are guarded by [SovereignOpsProperties.mutationsEnabled].
+ * Mutations (deny) are guarded by [SovereignOpsProperties.mutationsEnabled].
  */
 interface SovereignApprovalOperations {
 
@@ -17,17 +17,21 @@ interface SovereignApprovalOperations {
     suspend fun getApproval(approvalId: String): SovereignApprovalSummary?
 
     /**
-     * Cancel a pending approval.
+     * Administratively deny a pending approval by applying a Deny transition.
+     *
+     * This is the mutation path for rejecting pending approvals through the
+     * operations layer. In the underlying store the result is a DENIED status
+     * (operationally "cancelled" or "rejected").
      *
      * Requires [SovereignOpsProperties.mutationsEnabled] to be true.
      *
-     * @param approvalId The approval to cancel.
-     * @param actor The identity of the actor performing the cancellation.
-     * @param reason A human-readable reason for the cancellation.
+     * @param approvalId The approval to deny.
+     * @param actor The identity of the actor performing the denial.
+     * @param reason A human-readable reason for the denial.
      * @return The updated approval summary.
      * @throws IllegalStateException if mutations are disabled or validation fails.
      */
-    suspend fun cancelApproval(
+    suspend fun denyApproval(
         approvalId: String,
         actor: String,
         reason: String,

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignApprovalOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignApprovalOperations.kt
@@ -1,0 +1,35 @@
+package dev.tramai.spring.sovereign.ops
+
+/**
+ * Operations for inspecting and managing approval requests.
+ *
+ * Methods return only safe summaries. Approval tokens, resume tokens,
+ * and raw tool arguments are NEVER exposed.
+ *
+ * Mutations (cancel/transition) are guarded by [SovereignOpsProperties.mutationsEnabled].
+ */
+interface SovereignApprovalOperations {
+
+    /**
+     * Retrieve a single approval by ID.
+     * @return A safe summary, or null if not found.
+     */
+    suspend fun getApproval(approvalId: String): SovereignApprovalSummary?
+
+    /**
+     * Cancel a pending approval.
+     *
+     * Requires [SovereignOpsProperties.mutationsEnabled] to be true.
+     *
+     * @param approvalId The approval to cancel.
+     * @param actor The identity of the actor performing the cancellation.
+     * @param reason A human-readable reason for the cancellation.
+     * @return The updated approval summary.
+     * @throws IllegalStateException if mutations are disabled or validation fails.
+     */
+    suspend fun cancelApproval(
+        approvalId: String,
+        actor: String,
+        reason: String,
+    ): SovereignApprovalSummary
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignAuditOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignAuditOperations.kt
@@ -12,12 +12,12 @@ interface SovereignAuditOperations {
     /**
      * Read events in an audit stream, bounded by [limit].
      * @param auditStreamId The audit stream identifier.
-     * @param limit Maximum number of events to return (capped by [SovereignOpsProperties.maxPageSize]).
-     * @return A list of safe audit event summaries (empty if stream not found).
+     * @param limit Maximum number of events to return (defaults to [SovereignOpsProperties.maxPageSize]).
+     * @return A list of safe event summaries (empty if stream not found).
      */
     suspend fun readAuditStream(
         auditStreamId: String,
-        limit: Int = 100,
+        limit: Int? = null,
     ): List<SovereignAuditEventSummary>
 
     /**

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignAuditOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignAuditOperations.kt
@@ -1,0 +1,25 @@
+package dev.tramai.spring.sovereign.ops
+
+/**
+ * Operations for reading sovereign audit event streams.
+ *
+ * Delegates to the underlying [AuditStore]. Only safe summaries
+ * are returned — raw prompts, model responses, and sensitive
+ * payloads are NEVER exposed.
+ */
+interface SovereignAuditOperations {
+
+    /**
+     * Read all events in an audit stream.
+     * @param auditStreamId The audit stream identifier.
+     * @return A list of safe audit event summaries (empty if stream not found).
+     */
+    suspend fun readAuditStream(auditStreamId: String): List<SovereignAuditEventSummary>
+
+    /**
+     * Get the latest event in an audit stream.
+     * @param auditStreamId The audit stream identifier.
+     * @return The latest event summary, or null if the stream has no events.
+     */
+    suspend fun latestAuditEvent(auditStreamId: String): SovereignAuditEventSummary?
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignAuditOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignAuditOperations.kt
@@ -10,11 +10,15 @@ package dev.tramai.spring.sovereign.ops
 interface SovereignAuditOperations {
 
     /**
-     * Read all events in an audit stream.
+     * Read events in an audit stream, bounded by [limit].
      * @param auditStreamId The audit stream identifier.
+     * @param limit Maximum number of events to return (capped by [SovereignOpsProperties.maxPageSize]).
      * @return A list of safe audit event summaries (empty if stream not found).
      */
-    suspend fun readAuditStream(auditStreamId: String): List<SovereignAuditEventSummary>
+    suspend fun readAuditStream(
+        auditStreamId: String,
+        limit: Int = 100,
+    ): List<SovereignAuditEventSummary>
 
     /**
      * Get the latest event in an audit stream.

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOperationDtos.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOperationDtos.kt
@@ -37,7 +37,6 @@ data class SovereignSuspendedInvocationSummary(
     val correlationId: String?,
     val serviceName: String?,
     val operationName: String?,
-    val createdAt: Instant?,
     val status: String,
     val replayEnvelopeDigest: String?,
 )

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOperationDtos.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOperationDtos.kt
@@ -1,0 +1,82 @@
+package dev.tramai.spring.sovereign.ops
+
+import java.time.Instant
+
+/**
+ * Safe summary of an approval request.
+ *
+ * Does NOT expose:
+ * - approval tokens
+ * - resume tokens
+ * - raw tool arguments
+ * - sensitive payloads
+ */
+data class SovereignApprovalSummary(
+    val approvalId: String,
+    val status: String,
+    val workflowRunId: String?,
+    val correlationId: String?,
+    val createdAt: Instant?,
+    val expiresAt: Instant?,
+    val actor: String?,
+    val reasonCode: String?,
+)
+
+/**
+ * Safe summary of a suspended invocation.
+ *
+ * Does NOT expose:
+ * - raw replay envelopes
+ * - raw tool arguments
+ * - sensitive payloads
+ * - raw messages
+ */
+data class SovereignSuspendedInvocationSummary(
+    val suspendedInvocationId: String,
+    val workflowRunId: String?,
+    val correlationId: String?,
+    val serviceName: String?,
+    val operationName: String?,
+    val createdAt: Instant?,
+    val status: String,
+    val replayEnvelopeDigest: String?,
+)
+
+/**
+ * Safe summary of an audit event.
+ *
+ * Does NOT expose:
+ * - raw prompts
+ * - raw model responses
+ * - sensitive payloads
+ * - document content
+ */
+data class SovereignAuditEventSummary(
+    val eventId: String,
+    val sequenceNumber: Long,
+    val auditStreamId: String,
+    val workflowRunId: String?,
+    val correlationId: String?,
+    val actor: String?,
+    val enforcementPoint: String?,
+    val decision: String?,
+    val reasonCode: String?,
+    val eventHash: String,
+    val previousEventHash: String?,
+    val timestamp: Instant,
+)
+
+/**
+ * Runtime health/state check.
+ *
+ * Reports which store beans are available and the persistence mode
+ * (file-backed or in-memory) based on detected bean types.
+ */
+data class SovereignRuntimeStatus(
+    val runtimeAvailable: Boolean,
+    val auditStoreAvailable: Boolean,
+    val approvalStoreAvailable: Boolean,
+    val approvalContinuationStoreAvailable: Boolean,
+    val suspendedInvocationStoreAvailable: Boolean,
+    val persistenceMode: String,
+)

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
@@ -1,0 +1,97 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.core.approval.ApprovalStore
+import dev.tramai.engine.SuspendedInvocationStore
+import dev.tramai.security.audit.AuditStore
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+
+/**
+ * Spring Boot auto-configuration for TramAI sovereign operations services.
+ *
+ * Activates when `tramai.sovereign.ops.enabled=true` (default).
+ * Adds internal service beans for safe operational inspection of:
+ * - Approvals
+ * - Suspended invocations
+ * - Audit streams
+ * - Runtime/store status
+ *
+ * This module exposes **service beans only** — no HTTP endpoints.
+ * Applications must put these operations behind their own authentication
+ * and authorization layer.
+ *
+ * ## Configuration
+ *
+ * ```yaml
+ * tramai:
+ *   sovereign:
+ *     ops:
+ *       enabled: true
+ *       mutations-enabled: false
+ *       max-page-size: 100
+ * ```
+ *
+ * Read-capable, mutation-disabled by default.
+ */
+@AutoConfiguration(after = [dev.tramai.spring.sovereign.SovereignTramaiAutoConfiguration::class])
+@EnableConfigurationProperties(SovereignOpsProperties::class)
+@ConditionalOnProperty(
+    prefix = "tramai.sovereign.ops",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
+class SovereignOpsAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun sovereignApprovalOperations(
+        approvalStore: ObjectProvider<ApprovalStore>,
+        properties: SovereignOpsProperties,
+    ): SovereignApprovalOperations =
+        DefaultSovereignApprovalOperations(
+            store = approvalStore.ifAvailable
+                ?: throw IllegalStateException("tramai-sovereign-ops-store-unavailable"),
+            properties = properties,
+        )
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun sovereignSuspendedInvocationOperations(
+        suspendedInvocationStore: ObjectProvider<SuspendedInvocationStore>,
+        properties: SovereignOpsProperties,
+    ): SovereignSuspendedInvocationOperations =
+        DefaultSovereignSuspendedInvocationOperations(
+            store = suspendedInvocationStore.ifAvailable,
+            properties = properties,
+        )
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun sovereignAuditOperations(
+        auditStore: ObjectProvider<AuditStore>,
+    ): SovereignAuditOperations =
+        DefaultSovereignAuditOperations(
+            store = auditStore.ifAvailable,
+        )
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun sovereignRuntimeOperations(
+        auditStore: ObjectProvider<AuditStore>,
+        approvalStore: ObjectProvider<ApprovalStore>,
+        approvalContinuationStore: ObjectProvider<ApprovalContinuationStore>,
+        suspendedInvocationStore: ObjectProvider<SuspendedInvocationStore>,
+    ): SovereignRuntimeOperations =
+        DefaultSovereignRuntimeOperations(
+            auditStore = auditStore.ifAvailable,
+            approvalStore = approvalStore.ifAvailable,
+            approvalContinuationStore = approvalContinuationStore.ifAvailable,
+            suspendedInvocationStore = suspendedInvocationStore.ifAvailable,
+        )
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
@@ -6,6 +6,7 @@ import dev.tramai.engine.SuspendedInvocationStore
 import dev.tramai.security.audit.AuditStore
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -50,13 +51,13 @@ class SovereignOpsAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnBean(ApprovalStore::class)
     fun sovereignApprovalOperations(
-        approvalStore: ObjectProvider<ApprovalStore>,
+        approvalStore: ApprovalStore,
         properties: SovereignOpsProperties,
     ): SovereignApprovalOperations =
         DefaultSovereignApprovalOperations(
-            store = approvalStore.ifAvailable
-                ?: throw IllegalStateException("tramai-sovereign-ops-store-unavailable"),
+            store = approvalStore,
             properties = properties,
         )
 
@@ -64,20 +65,20 @@ class SovereignOpsAutoConfiguration {
     @ConditionalOnMissingBean
     fun sovereignSuspendedInvocationOperations(
         suspendedInvocationStore: ObjectProvider<SuspendedInvocationStore>,
-        properties: SovereignOpsProperties,
     ): SovereignSuspendedInvocationOperations =
         DefaultSovereignSuspendedInvocationOperations(
             store = suspendedInvocationStore.ifAvailable,
-            properties = properties,
         )
 
     @Bean
     @ConditionalOnMissingBean
     fun sovereignAuditOperations(
         auditStore: ObjectProvider<AuditStore>,
+        properties: SovereignOpsProperties,
     ): SovereignAuditOperations =
         DefaultSovereignAuditOperations(
             store = auditStore.ifAvailable,
+            properties = properties,
         )
 
     @Bean

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsProperties.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsProperties.kt
@@ -16,16 +16,20 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * ```
  *
  * Read-capable, mutation-disabled by default — inspection is safer than
- * state mutation. Set `mutations-enabled: true` to allow cancel/force-recover.
+ * state mutation. Set `mutations-enabled: true` to allow administrative
+ * denial of approvals.
  */
 @ConfigurationProperties(prefix = "tramai.sovereign.ops")
 data class SovereignOpsProperties(
     /** Enables operations service beans. When false, no ops beans are created. */
     var enabled: Boolean = true,
 
-    /** When false, state-changing operations (cancel, force-recover) are blocked. */
+    /**
+     * When false, mutation operations (denyApproval) are blocked.
+     * When true, administrative denial of approvals is allowed.
+     */
     var mutationsEnabled: Boolean = false,
 
-    /** Maximum number of items returned by list/query operations. */
+    /** Maximum number of audit events returned by readAuditStream. */
     var maxPageSize: Int = 100,
 )

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsProperties.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsProperties.kt
@@ -1,0 +1,31 @@
+package dev.tramai.spring.sovereign.ops
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Externalized configuration for TramAI sovereign operations.
+ *
+ * Usage:
+ * ```yaml
+ * tramai:
+ *   sovereign:
+ *     ops:
+ *       enabled: true
+ *       mutations-enabled: false
+ *       max-page-size: 100
+ * ```
+ *
+ * Read-capable, mutation-disabled by default — inspection is safer than
+ * state mutation. Set `mutations-enabled: true` to allow cancel/force-recover.
+ */
+@ConfigurationProperties(prefix = "tramai.sovereign.ops")
+data class SovereignOpsProperties(
+    /** Enables operations service beans. When false, no ops beans are created. */
+    var enabled: Boolean = true,
+
+    /** When false, state-changing operations (cancel, force-recover) are blocked. */
+    var mutationsEnabled: Boolean = false,
+
+    /** Maximum number of items returned by list/query operations. */
+    var maxPageSize: Int = 100,
+)

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignRuntimeOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignRuntimeOperations.kt
@@ -1,0 +1,16 @@
+package dev.tramai.spring.sovereign.ops
+
+/**
+ * Operations for checking sovereign runtime health and persistence state.
+ *
+ * Reports which store beans are available in the Spring context and
+ * whether stores appear to be file-backed or in-memory.
+ */
+interface SovereignRuntimeOperations {
+
+    /**
+     * Returns the current runtime status, including store availability
+     * and detected persistence mode.
+     */
+    fun status(): SovereignRuntimeStatus
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignSuspendedInvocationOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignSuspendedInvocationOperations.kt
@@ -1,0 +1,16 @@
+package dev.tramai.spring.sovereign.ops
+
+/**
+ * Operations for inspecting suspended invocations.
+ *
+ * Returns only safe metadata. Raw replay envelopes, tool arguments,
+ * and sensitive payloads are NEVER exposed.
+ */
+interface SovereignSuspendedInvocationOperations {
+
+    /**
+     * Retrieve a single suspended invocation by its approval ID.
+     * @return A safe summary, or null if not found.
+     */
+    suspend fun getSuspendedInvocation(approvalId: String): SovereignSuspendedInvocationSummary?
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.tramai.spring.sovereign.ops.SovereignOpsAutoConfiguration

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfigurationTest.kt
@@ -237,6 +237,20 @@ class SovereignOpsAutoConfigurationTest {
             }
     }
 
+    @Test
+    fun `default audit stream limit uses configured max page size`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .withPropertyValues("tramai.sovereign.ops.max-page-size=50")
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignAuditOperations::class.java)
+                val events = runBlocking {
+                    ops.readAuditStream("test-stream")
+                }
+                assertThat(events).isNotNull
+            }
+    }
+
     // ── Custom bean is not overridden ──────────────────────────────────
 
     @Test
@@ -423,7 +437,7 @@ class CustomApprovalOperations : SovereignApprovalOperations {
 class CustomAuditOperations : SovereignAuditOperations {
     override suspend fun readAuditStream(
         auditStreamId: String,
-        limit: Int,
+        limit: Int?,
     ): List<SovereignAuditEventSummary> = emptyList()
     override suspend fun latestAuditEvent(
         auditStreamId: String,

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfigurationTest.kt
@@ -1,0 +1,560 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.core.approval.ApprovalRequest
+import dev.tramai.core.approval.ApprovalStatus
+import dev.tramai.core.approval.ApprovalStore
+import dev.tramai.core.approval.ApprovalTransition
+import dev.tramai.engine.SuspendedInvocationStore
+import dev.tramai.security.audit.AuditEvent
+import dev.tramai.security.audit.AuditStore
+import java.time.Instant
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import kotlin.reflect.full.memberProperties
+
+class SovereignOpsAutoConfigurationTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(SovereignOpsAutoConfiguration::class.java),
+        )
+
+    // ── Happy path: beans exist ─────────────────────────────────────────
+
+    @Test
+    fun `creates approval operations bean`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SovereignApprovalOperations::class.java)
+            }
+    }
+
+    @Test
+    fun `creates suspended invocation operations bean`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(
+                    SovereignSuspendedInvocationOperations::class.java,
+                )
+            }
+    }
+
+    @Test
+    fun `creates audit operations bean`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SovereignAuditOperations::class.java)
+            }
+    }
+
+    @Test
+    fun `creates runtime operations bean`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SovereignRuntimeOperations::class.java)
+            }
+    }
+
+    // ── enabled=false disables ops beans ────────────────────────────────
+
+    @Test
+    fun `ops disabled when enabled is false`() {
+        contextRunner
+            .withPropertyValues("tramai.sovereign.ops.enabled=false")
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                assertThat(ctx).doesNotHaveBean(SovereignApprovalOperations::class.java)
+                assertThat(ctx).doesNotHaveBean(
+                    SovereignSuspendedInvocationOperations::class.java,
+                )
+                assertThat(ctx).doesNotHaveBean(SovereignAuditOperations::class.java)
+                assertThat(ctx).doesNotHaveBean(SovereignRuntimeOperations::class.java)
+            }
+    }
+
+    // ── mutationsEnabled=false blocks cancel ────────────────────────────
+
+    @Test
+    fun `mutations disabled blocks cancel approval`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignApprovalOperations::class.java)
+                val ex = runCatching {
+                    runBlocking {
+                        ops.cancelApproval("test-id", "actor", "reason")
+                    }
+                }.exceptionOrNull()
+                assertThat(ex)
+                    .isInstanceOf(IllegalStateException::class.java)
+                    .hasMessageContaining("tramai-sovereign-ops-mutations-disabled")
+            }
+    }
+
+    // ── ID validation ──────────────────────────────────────────────────
+
+    @Test
+    fun `blank approval id is rejected`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignApprovalOperations::class.java)
+                val ex = runCatching {
+                    runBlocking { ops.getApproval("") }
+                }.exceptionOrNull()
+                assertThat(ex)
+                    .hasMessageContaining("tramai-sovereign-ops-invalid-approval-id")
+            }
+    }
+
+    @Test
+    fun `blank suspended invocation id is rejected`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                val ops = ctx.getBean(
+                    SovereignSuspendedInvocationOperations::class.java,
+                )
+                val ex = runCatching {
+                    runBlocking { ops.getSuspendedInvocation("") }
+                }.exceptionOrNull()
+                assertThat(ex)
+                    .hasMessageContaining(
+                        "tramai-sovereign-ops-invalid-suspended-invocation-id",
+                    )
+            }
+    }
+
+    @Test
+    fun `blank audit stream id is rejected`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignAuditOperations::class.java)
+                val ex = runCatching {
+                    runBlocking { ops.readAuditStream("") }
+                }.exceptionOrNull()
+                assertThat(ex)
+                    .hasMessageContaining("tramai-sovereign-ops-invalid-audit-stream-id")
+            }
+    }
+
+    // ── Custom bean is not overridden ──────────────────────────────────
+
+    @Test
+    fun `custom approval operations bean is not overridden`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                CustomApprovalOpsConfig::class.java,
+            )
+            .run { ctx ->
+                assertThat(ctx.getBeansOfType(SovereignApprovalOperations::class.java))
+                    .hasSize(1)
+                val ops = ctx.getBean(SovereignApprovalOperations::class.java)
+                assertThat(ops).isInstanceOf(CustomApprovalOperations::class.java)
+            }
+    }
+
+    @Test
+    fun `custom audit operations bean is not overridden`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                CustomAuditOpsConfig::class.java,
+            )
+            .run { ctx ->
+                assertThat(ctx.getBeansOfType(SovereignAuditOperations::class.java))
+                    .hasSize(1)
+                val ops = ctx.getBean(SovereignAuditOperations::class.java)
+                assertThat(ops).isInstanceOf(CustomAuditOperations::class.java)
+            }
+    }
+
+    // ── Approval summary does not expose tokens ────────────────────────
+
+    @Test
+    fun `approval summary does not expose approval token`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignApprovalOperations::class.java)
+                val summary = runBlocking {
+                    ops.getApproval("test-approval")
+                }
+                assertThat(summary).isNotNull
+                // Verify no token-like fields exist on the DTO
+                val props = SovereignApprovalSummary::class.memberProperties
+                    .map { it.name }
+                assertThat(props).doesNotContain("approvalToken")
+                assertThat(props).doesNotContain("approvalTokenDigest")
+                assertThat(props).doesNotContain("resumeToken")
+                assertThat(props).doesNotContain("token")
+            }
+    }
+
+    @Test
+    fun `suspended summary does not expose replay envelope`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                val ops = ctx.getBean(
+                    SovereignSuspendedInvocationOperations::class.java,
+                )
+                val summary = runBlocking {
+                    ops.getSuspendedInvocation("test-suspended")
+                }
+                assertThat(summary).isNotNull
+                val props = SovereignSuspendedInvocationSummary::class.memberProperties
+                    .map { it.name }
+                assertThat(props).doesNotContain("replayEnvelope")
+                assertThat(props).doesNotContain("rawEnvelope")
+                assertThat(props).doesNotContain("arguments")
+                assertThat(props).doesNotContain("toolArguments")
+            }
+    }
+
+    // ── Audit event summary does not map raw payload ────────────────────
+
+    @Test
+    fun `audit events are mapped to safe summaries`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignAuditOperations::class.java)
+                val events = runBlocking {
+                    ops.readAuditStream("test-stream")
+                }
+                assertThat(events).isNotEmpty
+                val props = SovereignAuditEventSummary::class.memberProperties
+                    .map { it.name }
+                assertThat(props).doesNotContain("metadata")
+                assertThat(props).doesNotContain("prompt")
+                assertThat(props).doesNotContain("response")
+                assertThat(props).doesNotContain("rawContent")
+                assertThat(props).doesNotContain("documentContent")
+            }
+    }
+
+    // ── Runtime status ─────────────────────────────────────────────────
+
+    @Test
+    fun `runtime status detects memory backed stores`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignRuntimeOperations::class.java)
+                val status = ops.status()
+                assertThat(status.runtimeAvailable).isTrue
+                assertThat(status.auditStoreAvailable).isTrue
+                assertThat(status.approvalStoreAvailable).isTrue
+                assertThat(status.approvalContinuationStoreAvailable).isTrue
+                assertThat(status.suspendedInvocationStoreAvailable).isTrue
+                assertThat(status.persistenceMode).isEqualTo("memory")
+            }
+    }
+}
+
+// ── Test services ─────────────────────────────────────────────────────
+
+class TestApprovalContinuationStore :
+    dev.tramai.core.approval.ApprovalContinuationStore {
+    override suspend fun create(
+        continuation: dev.tramai.core.approval.ApprovalContinuation,
+        arguments: dev.tramai.core.approval.SensitiveToolArguments,
+    ): dev.tramai.core.approval.ApprovalContinuation = continuation
+
+    override suspend fun get(approvalId: String): dev.tramai.core.approval.ApprovalContinuation? =
+        null
+
+    override suspend fun claimForExecution(
+        approvalId: String,
+        expectedVersion: Long,
+        claimedBy: String,
+    ): dev.tramai.core.approval.ClaimedApprovalContinuation =
+        throw UnsupportedOperationException("stub")
+
+    override suspend fun complete(
+        approvalId: String,
+        expectedVersion: Long,
+        completedBy: String,
+    ): dev.tramai.core.approval.ApprovalContinuation =
+        throw UnsupportedOperationException("stub")
+
+    override suspend fun expire(
+        approvalId: String,
+        expectedVersion: Long,
+    ): dev.tramai.core.approval.ApprovalContinuation =
+        throw UnsupportedOperationException("stub")
+
+    override suspend fun cancel(
+        approvalId: String,
+        expectedVersion: Long,
+    ): dev.tramai.core.approval.ApprovalContinuation =
+        throw UnsupportedOperationException("stub")
+
+    override suspend fun findStaleClaimed(
+        claimedBefore: Instant,
+        limit: Int,
+    ): List<dev.tramai.core.approval.ApprovalContinuation> = emptyList()
+
+    override suspend fun forceCancelClaimed(
+        approvalId: String,
+        expectedVersion: Long,
+        cancelledBy: String,
+        reasonCode: String,
+    ): dev.tramai.core.approval.ApprovalContinuation =
+        throw UnsupportedOperationException("stub")
+
+    override suspend fun sweepExpired(): Int = 0
+}
+
+class CustomApprovalOperations : SovereignApprovalOperations {
+    override suspend fun getApproval(
+        approvalId: String,
+    ): SovereignApprovalSummary? = null
+    override suspend fun cancelApproval(
+        approvalId: String,
+        actor: String,
+        reason: String,
+    ): SovereignApprovalSummary =
+        throw UnsupportedOperationException("custom stub")
+}
+
+class CustomAuditOperations : SovereignAuditOperations {
+    override suspend fun readAuditStream(
+        auditStreamId: String,
+    ): List<SovereignAuditEventSummary> = emptyList()
+    override suspend fun latestAuditEvent(
+        auditStreamId: String,
+    ): SovereignAuditEventSummary? = null
+}
+
+// ── Test configuration classes ────────────────────────────────────────
+
+open class MinimalStoreConfig {
+    @Bean
+    open fun testAuditStore(): AuditStore = TestAuditStore()
+
+    @Bean
+    open fun testApprovalStore(): ApprovalStore = TestApprovalStore()
+
+    @Bean
+    open fun testApprovalContinuationStore(): dev.tramai.core.approval.ApprovalContinuationStore =
+        TestApprovalContinuationStore()
+
+    @Bean
+    open fun testSuspendedInvocationStore(): SuspendedInvocationStore =
+        TestSuspendedInvocationStore()
+}
+
+open class CustomApprovalOpsConfig {
+    @Bean
+    @Primary
+    open fun customApprovalOps(): SovereignApprovalOperations =
+        CustomApprovalOperations()
+}
+
+open class CustomAuditOpsConfig {
+    @Bean
+    @Primary
+    open fun customAuditOps(): SovereignAuditOperations =
+        CustomAuditOperations()
+}
+
+// ── Test store stubs ──────────────────────────────────────────────────
+
+class TestApprovalStore : ApprovalStore {
+    private val store = mutableMapOf<String, ApprovalRequest>()
+
+    init {
+        // Pre-populate with a test approval
+        store["test-approval"] = ApprovalRequest(
+            approvalId = "test-approval",
+            binding = dev.tramai.core.approval.ApprovalBinding(
+                workflowRunId = "wf-1",
+                toolName = "test-tool",
+                argumentsDigest = dev.tramai.core.approval.Sha256Digest.of(
+                    "sha256:${"a".repeat(64)}",
+                ),
+                policyVersion = "1.0",
+                workflowDigest = dev.tramai.core.approval.Sha256Digest.of(
+                    "sha256:${"b".repeat(64)}",
+                ),
+                approvalTokenDigest = dev.tramai.core.approval.Sha256Digest.of(
+                    "sha256:${"c".repeat(64)}",
+                ),
+            ),
+            status = ApprovalStatus.PENDING,
+            requestedBy = "requester",
+            requestedAt = Instant.parse("2026-06-01T00:00:00Z"),
+            expiresAt = Instant.parse("2026-06-01T00:15:00Z"),
+            decidedBy = null,
+            decidedAt = null,
+            decisionComment = null,
+            consumedBy = null,
+            consumedAt = null,
+            version = 0,
+        )
+    }
+
+    override suspend fun create(
+        request: ApprovalRequest,
+    ): ApprovalRequest {
+        store[request.approvalId] = request
+        return request
+    }
+
+    override suspend fun get(approvalId: String): ApprovalRequest? =
+        store[approvalId]
+
+    override suspend fun transition(
+        approvalId: String,
+        expectedVersion: Long,
+        transition: ApprovalTransition,
+    ): ApprovalRequest {
+        val current = store[approvalId] ?: throw IllegalArgumentException(
+            "not found",
+        )
+        val updated = current.copy(
+            status = ApprovalStatus.DENIED,
+            decidedBy = when (transition) {
+                is ApprovalTransition.Deny -> transition.decidedBy
+                else -> null
+            },
+            decisionComment = when (transition) {
+                is ApprovalTransition.Deny -> transition.comment
+                else -> null
+            },
+            version = current.version + 1,
+        )
+        store[approvalId] = updated
+        return updated
+    }
+
+    override suspend fun consumeApprovedOrReplay(
+        approvalId: String,
+        expectedVersion: Long,
+        presentedTokenDigest: dev.tramai.core.approval.Sha256Digest,
+        consumedBy: String,
+    ) = throw UnsupportedOperationException("stub")
+}
+
+class TestAuditStore : AuditStore {
+    private val streams = mutableMapOf<String, MutableList<AuditEvent>>()
+
+    init {
+        val event = AuditEvent(
+            schemaVersion = 1,
+            hashAlgorithm = dev.tramai.security.audit.AuditHashAlgorithm.SHA_256,
+            auditStreamId = "test-stream",
+            eventId = "evt-1",
+            sequenceNumber = 1,
+            workflowRunId = "wf-1",
+            correlationId = "corr-1",
+            actor = "tester",
+            enforcementPoint = "approval-gate",
+            decision = "permit",
+            policyVersion = null,
+            workflowDigest = null,
+            previousEventHash = null,
+            eventHash = "a".repeat(64),
+            timestamp = Instant.parse("2026-06-01T00:00:00Z"),
+            reasonCode = null,
+        )
+        streams["test-stream"] = mutableListOf(event)
+    }
+
+    override suspend fun appendNext(
+        auditStreamId: String,
+        eventFactory: (AuditEvent?) -> AuditEvent,
+    ): AuditEvent {
+        val latest = streams[auditStreamId]?.lastOrNull()
+        val event = eventFactory(latest)
+        streams.getOrPut(auditStreamId) { mutableListOf() }.add(event)
+        return event
+    }
+
+    override suspend fun readStream(auditStreamId: String): List<AuditEvent> =
+        streams[auditStreamId] ?: emptyList()
+
+    override suspend fun latestEvent(auditStreamId: String): AuditEvent? =
+        streams[auditStreamId]?.lastOrNull()
+}
+
+class TestSuspendedInvocationStore : SuspendedInvocationStore {
+    private val store = mutableMapOf<String, dev.tramai.engine.SuspendedInvocationMetadata>()
+
+    init {
+        val metadata = dev.tramai.engine.SuspendedInvocationMetadata(
+            approvalId = "test-suspended",
+            toolCallId = "tc-1",
+            toolName = "test-tool",
+            toolCallIndex = 0,
+            correlationId = "corr-suspended",
+            identity = dev.tramai.engine.EngineExecutionIdentity(
+                workflowRunId = "wf-suspended",
+                correlationId = "corr-suspended",
+                workflowDigest = dev.tramai.core.approval.Sha256Digest.of(
+                    "sha256:${"a".repeat(64)}",
+                ),
+                policyVersion = "1.0",
+                actorId = "system",
+            ),
+            securityContext = dev.tramai.engine.ExecutionSecurityContext(
+                dataClassification = null,
+                classificationSource = null,
+            ),
+            operationReference = dev.tramai.engine.ResumeOperationReference(
+                serviceInterface = "com.example.TestService",
+                methodName = "process",
+                jvmMethodDescriptor = "(Ljava/lang/String;)V",
+                resumeDefinitionDigest = dev.tramai.core.approval.Sha256Digest.of(
+                    "sha256:${"d".repeat(64)}",
+                ),
+            ),
+            replayEnvelopeDigest = dev.tramai.core.approval.Sha256Digest.of(
+                "sha256:${"e".repeat(64)}",
+            ),
+            conversationId = null,
+            historySize = 5,
+            tokenBudgetSnapshot = null,
+            toolReference = dev.tramai.engine.ResumeToolReference(
+                toolName = "test-tool",
+                declarationDigest = dev.tramai.core.approval.Sha256Digest.of(
+                    "sha256:${"f".repeat(64)}",
+                ),
+            ),
+            toolSecurity = null,
+        )
+        store["test-suspended"] = metadata
+    }
+
+    override suspend fun create(
+        metadata: dev.tramai.engine.SuspendedInvocationMetadata,
+        replayEnvelope: dev.tramai.engine.SensitiveReplayEnvelope,
+    ) {
+        store[metadata.approvalId] = metadata
+    }
+
+    override suspend fun get(
+        approvalId: String,
+    ): dev.tramai.engine.SuspendedInvocationMetadata? = store[approvalId]
+
+    override suspend fun revealReplayEnvelope(
+        approvalId: String,
+    ): dev.tramai.engine.SensitiveReplayEnvelope? = null
+
+    override suspend fun remove(
+        approvalId: String,
+    ): dev.tramai.engine.SuspendedInvocationMetadata? = store.remove(approvalId)
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfigurationTest.kt
@@ -64,6 +64,29 @@ class SovereignOpsAutoConfigurationTest {
             }
     }
 
+    // ── P1: Startup safety when ApprovalStore is absent ────────────────
+
+    @Test
+    fun `does not fail startup when approval store is absent`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfigWithoutApproval::class.java,
+            )
+            .run { ctx ->
+                // Approval operations bean should not be created
+                assertThat(ctx).doesNotHaveBean(
+                    SovereignApprovalOperations::class.java,
+                )
+                // Other ops beans should still exist
+                assertThat(ctx).hasSingleBean(
+                    SovereignAuditOperations::class.java,
+                )
+                assertThat(ctx).hasSingleBean(
+                    SovereignRuntimeOperations::class.java,
+                )
+            }
+    }
+
     // ── enabled=false disables ops beans ────────────────────────────────
 
     @Test
@@ -81,17 +104,17 @@ class SovereignOpsAutoConfigurationTest {
             }
     }
 
-    // ── mutationsEnabled=false blocks cancel ────────────────────────────
+    // ── mutationsEnabled=false blocks deny ─────────────────────────────
 
     @Test
-    fun `mutations disabled blocks cancel approval`() {
+    fun `mutations disabled blocks deny approval`() {
         contextRunner
             .withUserConfiguration(MinimalStoreConfig::class.java)
             .run { ctx ->
                 val ops = ctx.getBean(SovereignApprovalOperations::class.java)
                 val ex = runCatching {
                     runBlocking {
-                        ops.cancelApproval("test-id", "actor", "reason")
+                        ops.denyApproval("test-approval", "actor", "reason")
                     }
                 }.exceptionOrNull()
                 assertThat(ex)
@@ -113,6 +136,40 @@ class SovereignOpsAutoConfigurationTest {
                 }.exceptionOrNull()
                 assertThat(ex)
                     .hasMessageContaining("tramai-sovereign-ops-invalid-approval-id")
+            }
+    }
+
+    @Test
+    fun `invalid actor is rejected with correct error code`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .withPropertyValues("tramai.sovereign.ops.mutations-enabled=true")
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignApprovalOperations::class.java)
+                val ex = runCatching {
+                    runBlocking {
+                        ops.denyApproval("test-approval", " ", "reason")
+                    }
+                }.exceptionOrNull()
+                assertThat(ex)
+                    .hasMessageContaining("tramai-sovereign-ops-invalid-actor")
+            }
+    }
+
+    @Test
+    fun `blank reason is rejected with correct error code`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .withPropertyValues("tramai.sovereign.ops.mutations-enabled=true")
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignApprovalOperations::class.java)
+                val ex = runCatching {
+                    runBlocking {
+                        ops.denyApproval("test-approval", "admin", "")
+                    }
+                }.exceptionOrNull()
+                assertThat(ex)
+                    .hasMessageContaining("tramai-sovereign-ops-invalid-reason")
             }
     }
 
@@ -145,6 +202,38 @@ class SovereignOpsAutoConfigurationTest {
                 }.exceptionOrNull()
                 assertThat(ex)
                     .hasMessageContaining("tramai-sovereign-ops-invalid-audit-stream-id")
+            }
+    }
+
+    @Test
+    fun `audit stream id over 128 chars is rejected`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignAuditOperations::class.java)
+                val longId = "a".repeat(129)
+                val ex = runCatching {
+                    runBlocking { ops.readAuditStream(longId) }
+                }.exceptionOrNull()
+                assertThat(ex)
+                    .hasMessageContaining("tramai-sovereign-ops-invalid-audit-stream-id")
+            }
+    }
+
+    // ── Page size enforcement ──────────────────────────────────────────
+
+    @Test
+    fun `page size beyond max is rejected`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .withPropertyValues("tramai.sovereign.ops.max-page-size=10")
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignAuditOperations::class.java)
+                val ex = runCatching {
+                    runBlocking { ops.readAuditStream("test-stream", limit = 50) }
+                }.exceptionOrNull()
+                assertThat(ex)
+                    .hasMessageContaining("tramai-sovereign-ops-page-size-too-large")
             }
     }
 
@@ -192,7 +281,6 @@ class SovereignOpsAutoConfigurationTest {
                     ops.getApproval("test-approval")
                 }
                 assertThat(summary).isNotNull
-                // Verify no token-like fields exist on the DTO
                 val props = SovereignApprovalSummary::class.memberProperties
                     .map { it.name }
                 assertThat(props).doesNotContain("approvalToken")
@@ -220,6 +308,7 @@ class SovereignOpsAutoConfigurationTest {
                 assertThat(props).doesNotContain("rawEnvelope")
                 assertThat(props).doesNotContain("arguments")
                 assertThat(props).doesNotContain("toolArguments")
+                assertThat(props).doesNotContain("createdAt")
             }
     }
 
@@ -273,8 +362,9 @@ class TestApprovalContinuationStore :
         arguments: dev.tramai.core.approval.SensitiveToolArguments,
     ): dev.tramai.core.approval.ApprovalContinuation = continuation
 
-    override suspend fun get(approvalId: String): dev.tramai.core.approval.ApprovalContinuation? =
-        null
+    override suspend fun get(
+        approvalId: String,
+    ): dev.tramai.core.approval.ApprovalContinuation? = null
 
     override suspend fun claimForExecution(
         approvalId: String,
@@ -322,7 +412,7 @@ class CustomApprovalOperations : SovereignApprovalOperations {
     override suspend fun getApproval(
         approvalId: String,
     ): SovereignApprovalSummary? = null
-    override suspend fun cancelApproval(
+    override suspend fun denyApproval(
         approvalId: String,
         actor: String,
         reason: String,
@@ -333,6 +423,7 @@ class CustomApprovalOperations : SovereignApprovalOperations {
 class CustomAuditOperations : SovereignAuditOperations {
     override suspend fun readAuditStream(
         auditStreamId: String,
+        limit: Int,
     ): List<SovereignAuditEventSummary> = emptyList()
     override suspend fun latestAuditEvent(
         auditStreamId: String,
@@ -342,31 +433,33 @@ class CustomAuditOperations : SovereignAuditOperations {
 // ── Test configuration classes ────────────────────────────────────────
 
 open class MinimalStoreConfig {
-    @Bean
-    open fun testAuditStore(): AuditStore = TestAuditStore()
+    @Bean open fun testAuditStore(): AuditStore = TestAuditStore()
 
-    @Bean
-    open fun testApprovalStore(): ApprovalStore = TestApprovalStore()
+    @Bean open fun testApprovalStore(): ApprovalStore = TestApprovalStore()
 
-    @Bean
-    open fun testApprovalContinuationStore(): dev.tramai.core.approval.ApprovalContinuationStore =
+    @Bean open fun testApprovalContinuationStore():
+        dev.tramai.core.approval.ApprovalContinuationStore =
         TestApprovalContinuationStore()
 
-    @Bean
-    open fun testSuspendedInvocationStore(): SuspendedInvocationStore =
+    @Bean open fun testSuspendedInvocationStore(): SuspendedInvocationStore =
+        TestSuspendedInvocationStore()
+}
+
+open class MinimalStoreConfigWithoutApproval {
+    @Bean open fun testAuditStore(): AuditStore = TestAuditStore()
+
+    @Bean open fun testSuspendedInvocationStore(): SuspendedInvocationStore =
         TestSuspendedInvocationStore()
 }
 
 open class CustomApprovalOpsConfig {
-    @Bean
-    @Primary
+    @Bean @Primary
     open fun customApprovalOps(): SovereignApprovalOperations =
         CustomApprovalOperations()
 }
 
 open class CustomAuditOpsConfig {
-    @Bean
-    @Primary
+    @Bean @Primary
     open fun customAuditOps(): SovereignAuditOperations =
         CustomAuditOperations()
 }
@@ -377,7 +470,6 @@ class TestApprovalStore : ApprovalStore {
     private val store = mutableMapOf<String, ApprovalRequest>()
 
     init {
-        // Pre-populate with a test approval
         store["test-approval"] = ApprovalRequest(
             approvalId = "test-approval",
             binding = dev.tramai.core.approval.ApprovalBinding(
@@ -407,9 +499,7 @@ class TestApprovalStore : ApprovalStore {
         )
     }
 
-    override suspend fun create(
-        request: ApprovalRequest,
-    ): ApprovalRequest {
+    override suspend fun create(request: ApprovalRequest): ApprovalRequest {
         store[request.approvalId] = request
         return request
     }
@@ -422,9 +512,8 @@ class TestApprovalStore : ApprovalStore {
         expectedVersion: Long,
         transition: ApprovalTransition,
     ): ApprovalRequest {
-        val current = store[approvalId] ?: throw IllegalArgumentException(
-            "not found",
-        )
+        val current = store[approvalId]
+            ?: throw IllegalArgumentException("not found")
         val updated = current.copy(
             status = ApprovalStatus.DENIED,
             decidedBy = when (transition) {


### PR DESCRIPTION
## Summary

Adds a Spring Boot sovereign operations service layer.

New module: `tramai-spring-boot-starter-sovereign-ops`

The module exposes internal Spring service beans for safe operational inspection of approvals, suspended invocations, audit streams, and runtime/store status. It does **not** expose HTTP endpoints.

### Services

| Service | Capabilities |
|---|---|
| `SovereignApprovalOperations` | getApproval, cancelApproval |
| `SovereignSuspendedInvocationOperations` | getSuspendedInvocation |
| `SovereignAuditOperations` | readAuditStream, latestAuditEvent |
| `SovereignRuntimeOperations` | status (store health, persistence mode) |

### Security posture

- No approval tokens exposed
- No resume tokens exposed
- No raw replay envelopes exposed
- No raw tool arguments exposed
- No raw model prompts/responses exposed
- Mutations disabled by default (`mutationsEnabled: false`)

### Configuration

```yaml
tramai:
  sovereign:
    ops:
      enabled: true
      mutations-enabled: false
      max-page-size: 100
```

### Validation

```bash
./gradlew test --rerun-tasks        # 154 tasks, all green
./gradlew :tramai-spring-boot-starter-sovereign-ops:test  # 15 tests, all green
```

### Non-goals

- No REST controllers
- No Actuator endpoints
- No Spring Security integration
- No admin UI
- No raw payload export
- No list APIs for approvals/suspended invocations (deferred to follow-up)