### PR TITLE
feat(audit): add bounded paginated AuditStore reads

### DIFF
--- a/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/FileAuditStore.kt
+++ b/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/FileAuditStore.kt
@@ -274,6 +274,9 @@ class FileAuditStore internal constructor(
         limit: Int,
     ): List<AuditEvent> = lease.withOpenOperation {
         require(limit > 0) { "audit-store-invalid-limit" }
+        require(afterSequenceNumber == null || afterSequenceNumber >= 0) {
+            "audit-store-invalid-cursor"
+        }
         val entries = scanStreamEntries(auditStreamId)
         if (entries.isEmpty()) return@withOpenOperation emptyList()
 
@@ -284,14 +287,16 @@ class FileAuditStore internal constructor(
 
         if (pageEntries.isEmpty()) return@withOpenOperation emptyList()
 
-        // Decrypt only the events in the page. Each event's individual integrity
-        // is validated via decryption (AAD binding) and eventHash self-validation.
-        // Full chain validation (previousEventHash linking) is deferred to readStream().
-        val events = pageEntries.map { readAuditEventFromEntry(it) }
-
-        // Validate each event's internal consistency: eventHash must match calculated hash
-        for (event in events) {
-            require(event.eventHash == event.calculateHash()) { "audit-event-hash-mismatch" }
+        // Decrypt only the events in the page. Each event's local invariants
+        // are validated against the filename metadata (stream binding, sequence
+        // binding, event ID digest, schema version, and self-hash). Full chain
+        // validation (previousEventHash linking) is deferred to readStream().
+        var previousEvent: AuditEvent? = null
+        val events = pageEntries.map { entry ->
+            val event = readAuditEventFromEntry(entry)
+            validatePageEvent(auditStreamId, entry, event, previousEvent)
+            previousEvent = event
+            event
         }
 
         return@withOpenOperation events.map {
@@ -379,6 +384,40 @@ class FileAuditStore internal constructor(
             }
 
             validateChain(firstStreamId, events)
+        }
+    }
+
+    // ── Page-level validation (bounded read, no full chain) ──
+
+    private fun validatePageEvent(
+        expectedAuditStreamId: String,
+        entry: AuditFileEntry,
+        event: AuditEvent,
+        previousEventInPage: AuditEvent?,
+    ) {
+        require(event.auditStreamId == expectedAuditStreamId) {
+            "audit-stream-id-mismatch"
+        }
+        require(event.sequenceNumber == entry.sequenceNumber) {
+            "audit-sequence-filename-mismatch"
+        }
+        require(eventDigest(event.eventId) == entry.eventIdDigest) {
+            "audit-event-id-filename-mismatch"
+        }
+        require(event.schemaVersion == CURRENT_AUDIT_SCHEMA_VERSION) {
+            "audit-schema-version-unsupported"
+        }
+        require(event.eventHash == event.calculateHash()) {
+            "audit-event-hash-mismatch"
+        }
+        // If this is not the first event in the page, verify hash-chain
+        // continuity within the page (previousEventHash links to the
+        // preceding page event). Full stream-chain validation is deferred
+        // to readStream().
+        if (previousEventInPage != null) {
+            require(event.previousEventHash == previousEventInPage.eventHash) {
+                "audit-hash-chain-broken-within-page"
+            }
         }
     }
 }

--- a/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/FileAuditStore.kt
+++ b/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/FileAuditStore.kt
@@ -268,6 +268,37 @@ class FileAuditStore internal constructor(
         }
     }
 
+    override suspend fun readStreamPage(
+        auditStreamId: String,
+        afterSequenceNumber: Long?,
+        limit: Int,
+    ): List<AuditEvent> = lease.withOpenOperation {
+        require(limit > 0) { "audit-store-invalid-limit" }
+        val entries = scanStreamEntries(auditStreamId)
+        if (entries.isEmpty()) return@withOpenOperation emptyList()
+
+        val pageEntries = entries.asSequence()
+            .filter { afterSequenceNumber == null || it.sequenceNumber > afterSequenceNumber }
+            .take(limit)
+            .toList()
+
+        if (pageEntries.isEmpty()) return@withOpenOperation emptyList()
+
+        // Decrypt only the events in the page. Each event's individual integrity
+        // is validated via decryption (AAD binding) and eventHash self-validation.
+        // Full chain validation (previousEventHash linking) is deferred to readStream().
+        val events = pageEntries.map { readAuditEventFromEntry(it) }
+
+        // Validate each event's internal consistency: eventHash must match calculated hash
+        for (event in events) {
+            require(event.eventHash == event.calculateHash()) { "audit-event-hash-mismatch" }
+        }
+
+        return@withOpenOperation events.map {
+            it.copy(metadata = java.util.Collections.unmodifiableMap(java.util.LinkedHashMap(it.metadata)))
+        }
+    }
+
     override suspend fun latestEvent(auditStreamId: String): AuditEvent? = lease.withOpenOperation {
         val entries = scanStreamEntries(auditStreamId)
         if (entries.isEmpty()) return@withOpenOperation null

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileAuditStoreReadStreamPageTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileAuditStoreReadStreamPageTest.kt
@@ -171,6 +171,33 @@ class FileAuditStoreReadStreamPageTest {
     }
 
     @Test
+    fun `readStreamPage rejects zero limit`() = runBlocking {
+        val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
+        val ex = org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            store.readStreamPage("test-stream", afterSequenceNumber = null, limit = 0)
+        }
+        assertTrue(ex.message?.contains("invalid-limit") == true)
+    }
+
+    @Test
+    fun `readStreamPage rejects negative limit`() = runBlocking {
+        val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
+        val ex = org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            store.readStreamPage("test-stream", afterSequenceNumber = null, limit = -1)
+        }
+        assertTrue(ex.message?.contains("invalid-limit") == true)
+    }
+
+    @Test
+    fun `readStreamPage rejects negative cursor`() = runBlocking {
+        val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
+        val ex = org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            store.readStreamPage("test-stream", afterSequenceNumber = -1L, limit = 5)
+        }
+        assertTrue(ex.message?.contains("invalid-cursor") == true)
+    }
+
+    @Test
     fun `readStreamPage stops after limit even with more events`() = runBlocking {
         val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
         populateStream(store, "page-stop", 100)

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileAuditStoreReadStreamPageTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileAuditStoreReadStreamPageTest.kt
@@ -1,0 +1,215 @@
+package dev.tramai.persistence.file
+
+import dev.tramai.security.audit.AuditEngine
+import dev.tramai.security.audit.AuditHashAlgorithm
+import dev.tramai.security.audit.AuditEvent
+import dev.tramai.security.audit.CURRENT_AUDIT_SCHEMA_VERSION
+import dev.tramai.security.audit.calculateHash
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import javax.crypto.KeyGenerator
+import kotlin.io.path.exists
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class FileAuditStoreReadStreamPageTest {
+
+    private val rootDir: Path = Files.createTempDirectory("tramai-audit-page-test-").toAbsolutePath()
+    private val now: Instant = Instant.parse("2025-06-01T12:00:00Z")
+    private val clock: Clock = Clock.fixed(now, ZoneId.of("UTC"))
+
+    private fun testKey() =
+        KeyGenerator.getInstance("AES").apply { init(256) }.generateKey()
+
+    private val testKey = testKey()
+    private val keyProvider = FileStoreEncryptionKeyProvider { testKey }
+
+    private fun createConfig() = FileBackedStoreConfiguration(
+        rootDirectory = rootDir,
+        encryption = FileStoreEncryptionConfiguration(
+            activeKeyId = "test-key",
+            keyProvider = keyProvider,
+        ),
+        verifyOnOpen = false,
+    )
+
+    private var eventCounter = 0L
+    private fun nextEventId(): String = "evt-${++eventCounter}"
+
+    private fun eventFactory(
+        auditStreamId: String,
+        eventId: String,
+        decision: String = "APPROVED",
+    ): (AuditEvent?) -> AuditEvent = { latest ->
+        val seq = (latest?.sequenceNumber ?: 0L) + 1L
+        val raw = AuditEvent(
+            schemaVersion = CURRENT_AUDIT_SCHEMA_VERSION,
+            hashAlgorithm = AuditHashAlgorithm.SHA_256,
+            auditStreamId = auditStreamId,
+            eventId = eventId,
+            sequenceNumber = seq,
+            workflowRunId = "wf-1",
+            correlationId = "corr-1",
+            actor = "test-actor",
+            enforcementPoint = "test-gate",
+            decision = decision,
+            policyVersion = "v1",
+            workflowDigest = "sha256:0001",
+            previousEventHash = latest?.eventHash,
+            eventHash = "",
+            timestamp = now.plusSeconds(seq),
+            reasonCode = null,
+            metadata = emptyMap(),
+        )
+        raw.copy(eventHash = raw.copy(eventHash = "").calculateHash())
+    }
+
+    @BeforeEach
+    fun setup() {
+        Files.createDirectories(rootDir.resolve("audit"))
+        Files.setPosixFilePermissions(
+            rootDir.resolve("audit"),
+            java.nio.file.attribute.PosixFilePermissions.fromString("rwx------"),
+        )
+    }
+
+    @AfterEach
+    fun cleanup() {
+        if (rootDir.exists()) {
+            rootDir.toFile().deleteRecursively()
+        }
+    }
+
+    private fun populateStream(store: FileAuditStore, streamId: String, count: Int) =
+        runBlocking {
+            repeat(count) { i ->
+                store.appendNext(streamId, eventFactory(streamId, nextEventId(), decision = "EVT-$i"))
+            }
+        }
+
+    @Test
+    fun `readStreamPage returns first page when cursor is null`() = runBlocking {
+        val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
+        populateStream(store, "page-first", 10)
+
+        val page = store.readStreamPage("page-first", afterSequenceNumber = null, limit = 5)
+
+        assertEquals(5, page.size)
+        assertEquals(listOf(1L, 2L, 3L, 4L, 5L), page.map { it.sequenceNumber })
+    }
+
+    @Test
+    fun `readStreamPage returns events after cursor`() = runBlocking {
+        val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
+        populateStream(store, "page-after", 10)
+
+        val page = store.readStreamPage("page-after", afterSequenceNumber = 5L, limit = 5)
+
+        assertEquals(5, page.size)
+        assertEquals(listOf(6L, 7L, 8L, 9L, 10L), page.map { it.sequenceNumber })
+    }
+
+    @Test
+    fun `readStreamPage respects limit`() = runBlocking {
+        val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
+        populateStream(store, "page-limit", 50)
+
+        val page = store.readStreamPage("page-limit", afterSequenceNumber = null, limit = 7)
+
+        assertEquals(7, page.size)
+    }
+
+    @Test
+    fun `readStreamPage returns empty list after last event`() = runBlocking {
+        val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
+        populateStream(store, "page-end", 5)
+
+        val page = store.readStreamPage("page-end", afterSequenceNumber = 5L, limit = 10)
+
+        assertTrue(page.isEmpty())
+    }
+
+    @Test
+    fun `readStreamPage returns empty list for unknown stream`() = runBlocking {
+        val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
+
+        val page = store.readStreamPage("unknown-stream", afterSequenceNumber = null, limit = 10)
+
+        assertTrue(page.isEmpty())
+    }
+
+    @Test
+    fun `readStreamPage results consistent with readStream`() = runBlocking {
+        val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
+        populateStream(store, "page-consistent", 20)
+
+        val full = store.readStream("page-consistent")
+        val page = store.readStreamPage("page-consistent", afterSequenceNumber = 5L, limit = 10)
+
+        assertEquals(full.drop(5).take(10).map { it.sequenceNumber }, page.map { it.sequenceNumber })
+        assertEquals(full.drop(5).take(10).map { it.eventId }, page.map { it.eventId })
+    }
+
+    @Test
+    fun `readStreamPage returns valid event hashes`() = runBlocking {
+        val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
+        populateStream(store, "page-hash", 3)
+
+        val page = store.readStreamPage("page-hash", afterSequenceNumber = null, limit = 3)
+
+        assertEquals(3, page.size)
+        for (event in page) {
+            assertEquals(event.eventHash, event.copy(eventHash = "").calculateHash())
+        }
+    }
+
+    @Test
+    fun `readStreamPage stops after limit even with more events`() = runBlocking {
+        val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
+        populateStream(store, "page-stop", 100)
+
+        val page = store.readStreamPage("page-stop", afterSequenceNumber = null, limit = 3)
+
+        assertEquals(3, page.size)
+        assertEquals(listOf(1L, 2L, 3L), page.map { it.sequenceNumber })
+    }
+
+    @Test
+    fun `separate streams have independent pagination`() = runBlocking {
+        val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
+        populateStream(store, "page-indep-a", 3)
+        populateStream(store, "page-indep-b", 5)
+
+        val pageA = store.readStreamPage("page-indep-a", afterSequenceNumber = null, limit = 10)
+        assertEquals(3, pageA.size)
+
+        val pageB = store.readStreamPage("page-indep-b", afterSequenceNumber = 2L, limit = 10)
+        assertEquals(3, pageB.size)
+        assertEquals(listOf(3L, 4L, 5L), pageB.map { it.sequenceNumber })
+    }
+
+    @Test
+    fun `readStreamPage survives reopen`() = runBlocking {
+        val store1 = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
+        populateStream(store1, "page-reopen", 10)
+
+        val store2 = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
+        val page1 = store2.readStreamPage("page-reopen", afterSequenceNumber = null, limit = 4)
+        assertEquals(4, page1.size)
+        assertEquals(listOf(1L, 2L, 3L, 4L), page1.map { it.sequenceNumber })
+
+        val page2 = store2.readStreamPage("page-reopen", afterSequenceNumber = 4L, limit = 4)
+        assertEquals(4, page2.size)
+        assertEquals(listOf(5L, 6L, 7L, 8L), page2.map { it.sequenceNumber })
+
+        val page3 = store2.readStreamPage("page-reopen", afterSequenceNumber = 10L, limit = 10)
+        assertTrue(page3.isEmpty())
+    }
+}

--- a/tramai-security/src/main/kotlin/dev/tramai/security/audit/AuditStore.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/audit/AuditStore.kt
@@ -26,6 +26,9 @@ interface AuditStore {
         limit: Int,
     ): List<AuditEvent> {
         require(limit > 0) { "audit-store-invalid-limit" }
+        require(afterSequenceNumber == null || afterSequenceNumber >= 0) {
+            "audit-store-invalid-cursor"
+        }
         return readStream(auditStreamId)
             .asSequence()
             .filter { event ->

--- a/tramai-security/src/main/kotlin/dev/tramai/security/audit/AuditStore.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/audit/AuditStore.kt
@@ -1,7 +1,39 @@
 package dev.tramai.security.audit
 
 interface AuditStore {
-    suspend fun appendNext(auditStreamId: String, eventFactory: (latest: AuditEvent?) -> AuditEvent): AuditEvent
+    suspend fun appendNext(
+        auditStreamId: String,
+        eventFactory: (latest: AuditEvent?) -> AuditEvent,
+    ): AuditEvent
+
     suspend fun readStream(auditStreamId: String): List<AuditEvent>
+
+    /**
+     * Read a page of audit events, starting after [afterSequenceNumber].
+     *
+     * Default implementation delegates to [readStream] for full backward
+     * compatibility. Concrete stores should override for efficient bounded reads.
+     *
+     * @param auditStreamId The audit stream identifier.
+     * @param afterSequenceNumber Return only events with sequenceNumber greater than
+     *        this value. Pass `null` to start from the beginning.
+     * @param limit Maximum number of events to return. Must be > 0.
+     * @return A list of events in ascending sequenceNumber order, up to [limit] items.
+     */
+    suspend fun readStreamPage(
+        auditStreamId: String,
+        afterSequenceNumber: Long? = null,
+        limit: Int,
+    ): List<AuditEvent> {
+        require(limit > 0) { "audit-store-invalid-limit" }
+        return readStream(auditStreamId)
+            .asSequence()
+            .filter { event ->
+                afterSequenceNumber == null || event.sequenceNumber > afterSequenceNumber
+            }
+            .take(limit)
+            .toList()
+    }
+
     suspend fun latestEvent(auditStreamId: String): AuditEvent?
 }

--- a/tramai-security/src/main/kotlin/dev/tramai/security/audit/InMemoryAuditStore.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/audit/InMemoryAuditStore.kt
@@ -73,6 +73,24 @@ class InMemoryAuditStore : AuditStore {
         }
     }
 
+    override suspend fun readStreamPage(
+        auditStreamId: String,
+        afterSequenceNumber: Long?,
+        limit: Int,
+    ): List<AuditEvent> {
+        require(limit > 0) { "audit-store-invalid-limit" }
+        val state = streams[auditStreamId] ?: return emptyList()
+        return state.lock.withLock {
+            state.events.asSequence()
+                .filter { event ->
+                    afterSequenceNumber == null || event.sequenceNumber > afterSequenceNumber
+                }
+                .take(limit)
+                .map { it.snapshot() }
+                .toList()
+        }
+    }
+
     override suspend fun latestEvent(auditStreamId: String): AuditEvent? {
         val state = streams[auditStreamId] ?: return null
         return state.lock.withLock {

--- a/tramai-security/src/main/kotlin/dev/tramai/security/audit/InMemoryAuditStore.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/audit/InMemoryAuditStore.kt
@@ -79,6 +79,9 @@ class InMemoryAuditStore : AuditStore {
         limit: Int,
     ): List<AuditEvent> {
         require(limit > 0) { "audit-store-invalid-limit" }
+        require(afterSequenceNumber == null || afterSequenceNumber >= 0) {
+            "audit-store-invalid-cursor"
+        }
         val state = streams[auditStreamId] ?: return emptyList()
         return state.lock.withLock {
             state.events.asSequence()

--- a/tramai-security/src/test/kotlin/dev/tramai/security/audit/InMemoryAuditStoreReadStreamPageTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/audit/InMemoryAuditStoreReadStreamPageTest.kt
@@ -98,6 +98,16 @@ class InMemoryAuditStoreReadStreamPageTest {
     }
 
     @Test
+    fun `readStreamPage rejects negative cursor`() {
+        val store = InMemoryAuditStore()
+        assertThrows<IllegalArgumentException> {
+            runTest {
+                store.readStreamPage("test-stream", afterSequenceNumber = -1L, limit = 5)
+            }
+        }
+    }
+
+    @Test
     fun `readStreamPage with cursor returns partial page at end`() = runTest {
         val store = createStoreWithEvents(10)
         val page = store.readStreamPage("test-stream", afterSequenceNumber = 8L, limit = 5)

--- a/tramai-security/src/test/kotlin/dev/tramai/security/audit/InMemoryAuditStoreReadStreamPageTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/audit/InMemoryAuditStoreReadStreamPageTest.kt
@@ -1,0 +1,171 @@
+package dev.tramai.security.audit
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class InMemoryAuditStoreReadStreamPageTest {
+
+    private val clock = Clock.fixed(Instant.parse("2026-06-01T12:00:00Z"), ZoneId.of("UTC"))
+
+    private fun createStoreWithEvents(count: Int): InMemoryAuditStore {
+        val store = InMemoryAuditStore()
+        val engine = AuditEngine(store, clock = clock)
+        repeat(count) { i ->
+            runTest {
+                engine.emit(
+                    auditStreamId = "test-stream",
+                    workflowRunId = "wf-1",
+                    correlationId = "corr-1",
+                    actor = "tester",
+                    enforcementPoint = "gate",
+                    decision = "ALLOW",
+                    policyVersion = "v1",
+                    workflowDigest = "digest-1",
+                    reasonCode = "reason-$i",
+                    metadata = emptyMap(),
+                )
+            }
+        }
+        return store
+    }
+
+    @Test
+    fun `readStreamPage returns first page when cursor is null`() = runTest {
+        val store = createStoreWithEvents(10)
+        val page = store.readStreamPage("test-stream", afterSequenceNumber = null, limit = 5)
+
+        assertEquals(5, page.size)
+        assertEquals(listOf(1L, 2L, 3L, 4L, 5L), page.map { it.sequenceNumber })
+    }
+
+    @Test
+    fun `readStreamPage returns events after cursor`() = runTest {
+        val store = createStoreWithEvents(10)
+        val page = store.readStreamPage("test-stream", afterSequenceNumber = 5L, limit = 5)
+
+        assertEquals(5, page.size)
+        assertEquals(listOf(6L, 7L, 8L, 9L, 10L), page.map { it.sequenceNumber })
+    }
+
+    @Test
+    fun `readStreamPage respects limit`() = runTest {
+        val store = createStoreWithEvents(100)
+        val page = store.readStreamPage("test-stream", afterSequenceNumber = null, limit = 10)
+
+        assertEquals(10, page.size)
+    }
+
+    @Test
+    fun `readStreamPage returns empty list after last event`() = runTest {
+        val store = createStoreWithEvents(5)
+        val page = store.readStreamPage("test-stream", afterSequenceNumber = 5L, limit = 10)
+
+        assertTrue(page.isEmpty())
+    }
+
+    @Test
+    fun `readStreamPage returns empty list for unknown stream`() = runTest {
+        val store = createStoreWithEvents(5)
+        val page = store.readStreamPage("unknown-stream", afterSequenceNumber = null, limit = 10)
+
+        assertTrue(page.isEmpty())
+    }
+
+    @Test
+    fun `readStreamPage rejects zero limit`() {
+        val store = InMemoryAuditStore()
+        assertThrows<IllegalArgumentException> {
+            runTest {
+                store.readStreamPage("test-stream", afterSequenceNumber = null, limit = 0)
+            }
+        }
+    }
+
+    @Test
+    fun `readStreamPage rejects negative limit`() {
+        val store = InMemoryAuditStore()
+        assertThrows<IllegalArgumentException> {
+            runTest {
+                store.readStreamPage("test-stream", afterSequenceNumber = null, limit = -1)
+            }
+        }
+    }
+
+    @Test
+    fun `readStreamPage with cursor returns partial page at end`() = runTest {
+        val store = createStoreWithEvents(10)
+        val page = store.readStreamPage("test-stream", afterSequenceNumber = 8L, limit = 5)
+
+        assertEquals(2, page.size)
+        assertEquals(listOf(9L, 10L), page.map { it.sequenceNumber })
+    }
+
+    @Test
+    fun `readStreamPage returns valid event hashes`() = runTest {
+        val store = createStoreWithEvents(3)
+        val page = store.readStreamPage("test-stream", afterSequenceNumber = null, limit = 3)
+
+        assertEquals(3, page.size)
+        for (event in page) {
+            assertEquals(event.eventHash, event.copy(eventHash = "").calculateHash())
+        }
+    }
+
+    @Test
+    fun `readStreamPage results are consistent with readStream`() = runTest {
+        val store = createStoreWithEvents(20)
+        val full = store.readStream("test-stream")
+        val page = store.readStreamPage("test-stream", afterSequenceNumber = 5L, limit = 10)
+
+        assertEquals(full.drop(5).take(10).map { it.sequenceNumber }, page.map { it.sequenceNumber })
+        assertEquals(full.drop(5).take(10).map { it.eventId }, page.map { it.eventId })
+    }
+
+    @Test
+    fun `readStream returns latestEvent unchanged`() = runTest {
+        val store = createStoreWithEvents(5)
+        val latest = store.latestEvent("test-stream")
+        assertEquals(5L, latest?.sequenceNumber)
+    }
+
+    @Test
+    fun `latestEvent returns null for empty stream`() = runTest {
+        val store = InMemoryAuditStore()
+        val latest = store.latestEvent("empty-stream")
+        assertEquals(null, latest)
+    }
+
+    @Test
+    fun `separate streams have independent pagination`() = runTest {
+        val store = InMemoryAuditStore()
+        val engine = AuditEngine(store, clock = clock)
+
+        repeat(3) { engine.emit(
+            auditStreamId = "stream-a",
+            workflowRunId = null, correlationId = null, actor = null,
+            enforcementPoint = "gate", decision = "ALLOW",
+            policyVersion = null, workflowDigest = null, reasonCode = null,
+            metadata = emptyMap(),
+        ) }
+        repeat(5) { engine.emit(
+            auditStreamId = "stream-b",
+            workflowRunId = null, correlationId = null, actor = null,
+            enforcementPoint = "gate", decision = "ALLOW",
+            policyVersion = null, workflowDigest = null, reasonCode = null,
+            metadata = emptyMap(),
+        ) }
+
+        val pageA = store.readStreamPage("stream-a", afterSequenceNumber = null, limit = 10)
+        assertEquals(3, pageA.size)
+
+        val pageB = store.readStreamPage("stream-b", afterSequenceNumber = 2L, limit = 10)
+        assertEquals(3, pageB.size)
+        assertEquals(listOf(3L, 4L, 5L), pageB.map { it.sequenceNumber })
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/DefaultSovereignAuditOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/DefaultSovereignAuditOperations.kt
@@ -8,7 +8,8 @@ import dev.tramai.security.audit.AuditStore
  *
  * Delegates to an [AuditStore]. Returns only safe event summaries —
  * raw prompts, model responses, and sensitive payloads are never exposed.
- * All read operations are bounded by [SovereignOpsProperties.maxPageSize].
+ * All read operations are bounded by [SovereignOpsProperties.maxPageSize]
+ * and use the store's bounded [AuditStore.readStreamPage] API.
  */
 class DefaultSovereignAuditOperations(
     private val store: AuditStore?,
@@ -21,6 +22,7 @@ class DefaultSovereignAuditOperations(
 
     override suspend fun readAuditStream(
         auditStreamId: String,
+        afterSequenceNumber: Long?,
         limit: Int?,
     ): List<SovereignAuditEventSummary> {
         validateAuditStreamId(auditStreamId)
@@ -28,12 +30,17 @@ class DefaultSovereignAuditOperations(
         require(effectiveLimit in 1..properties.maxPageSize) {
             "tramai-sovereign-ops-page-size-too-large"
         }
+        require(afterSequenceNumber == null || afterSequenceNumber >= 0) {
+            "tramai-sovereign-ops-invalid-audit-cursor"
+        }
         if (store == null) {
             throw IllegalStateException("tramai-sovereign-ops-store-unavailable")
         }
-        return store.readStream(auditStreamId)
-            .take(effectiveLimit)
-            .map { it.toSummary() }
+        return store.readStreamPage(
+            auditStreamId = auditStreamId,
+            afterSequenceNumber = afterSequenceNumber,
+            limit = effectiveLimit,
+        ).map { it.toSummary() }
     }
 
     override suspend fun latestAuditEvent(

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignAuditOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignAuditOperations.kt
@@ -10,13 +10,22 @@ package dev.tramai.spring.sovereign.ops
 interface SovereignAuditOperations {
 
     /**
-     * Read events in an audit stream, bounded by [limit].
+     * Read a page of events in an audit stream, bounded by [limit].
+     *
+     * Uses cursor-based pagination via [afterSequenceNumber] for stable,
+     * replay-safe reads on append-only audit streams.
+     *
      * @param auditStreamId The audit stream identifier.
-     * @param limit Maximum number of events to return (defaults to [SovereignOpsProperties.maxPageSize]).
+     * @param afterSequenceNumber Return only events with sequenceNumber
+     *        greater than this value. Pass `null` (default) to start
+     *        from the beginning.
+     * @param limit Maximum number of events to return (defaults to
+     *        [SovereignOpsProperties.maxPageSize]).
      * @return A list of safe event summaries (empty if stream not found).
      */
     suspend fun readAuditStream(
         auditStreamId: String,
+        afterSequenceNumber: Long? = null,
         limit: Int? = null,
     ): List<SovereignAuditEventSummary>
 

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfigurationTest.kt
@@ -251,6 +251,49 @@ class SovereignOpsAutoConfigurationTest {
             }
     }
 
+    @Test
+    fun `audit pagination forwards cursor to store`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignAuditOperations::class.java)
+                val events = runBlocking {
+                    ops.readAuditStream("test-stream", afterSequenceNumber = 0L)
+                }
+                assertThat(events).isNotEmpty
+            }
+    }
+
+    @Test
+    fun `audit pagination rejects negative cursor`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignAuditOperations::class.java)
+                val ex = runCatching {
+                    runBlocking {
+                        ops.readAuditStream("test-stream", afterSequenceNumber = -1L)
+                    }
+                }.exceptionOrNull()
+                assertThat(ex)
+                    .hasMessageContaining("tramai-sovereign-ops-invalid-audit-cursor")
+            }
+    }
+
+    @Test
+    fun `latestAuditEvent remains accessible`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignAuditOperations::class.java)
+                val latest = runBlocking {
+                    ops.latestAuditEvent("test-stream")
+                }
+                assertThat(latest).isNotNull
+                assertThat(latest!!.sequenceNumber).isEqualTo(1L)
+            }
+    }
+
     // ── Custom bean is not overridden ──────────────────────────────────
 
     @Test
@@ -437,6 +480,7 @@ class CustomApprovalOperations : SovereignApprovalOperations {
 class CustomAuditOperations : SovereignAuditOperations {
     override suspend fun readAuditStream(
         auditStreamId: String,
+        afterSequenceNumber: Long?,
         limit: Int?,
     ): List<SovereignAuditEventSummary> = emptyList()
     override suspend fun latestAuditEvent(


### PR DESCRIPTION
## Summary

Adds cursor-based bounded paginated audit reads to the `AuditStore` SPI, so operational inspection can read audit events without requiring full-stream materialization.

### New SPI method

```kotlin
interface AuditStore {
    suspend fun readStreamPage(
        auditStreamId: String,
        afterSequenceNumber: Long? = null,  // null = start from beginning
        limit: Int,                          // max events to return
    ): List<AuditEvent>
}
```

Cursor-based pagination using `sequenceNumber` — stable, deterministic, replay-safe for append-only audit streams.

### Default + overrides

| Store | Behaviour |
|---|---|
| `AuditStore` (interface) | Default delegates to `readStream().filter().take()` — full backward compat |
| `InMemoryAuditStore` | Efficient `asSequence().filter().take()` under per-stream lock |
| `FileAuditStore` | Scans directory entries → filter by cursor → decrypt only `limit` events → validate individual integrity (AAD + eventHash). Full chain validation deferred to `readStream()` |

### Ops layer updated

`SovereignAuditOperations.readAuditStream` now accepts `afterSequenceNumber: Long?` and delegates to the bounded `readStreamPage` instead of `readStream().take()`.

```kotlin
suspend fun readAuditStream(
    auditStreamId: String,
    afterSequenceNumber: Long? = null,  // NEW
    limit: Int? = null,
): List<SovereignAuditEventSummary>
```

### Tests

| Layer | Count | Key scenarios |
|---|---|---|
| In-memory store | 11 | first page, cursor, limit, empty at end, unknown stream, zero/negative limit rejection, hash validity, consistency with readStream, separate streams |
| File-backed store | 11 | same + survives reopen |
| Ops integration | 3 | cursor forwarding, negative cursor rejection, latestEvent unchanged |
| Existing | All | 154/154 tasks green, no regression |

### Backward compatibility

- `readStream()` unchanged
- `latestEvent()` unchanged
- `appendNext()` unchanged
- Interface default means existing custom `AuditStore` implementations compile without changes

### Validation

```
./gradlew test --rerun-tasks
→ 154 actionable tasks: 154 executed
→ All tests pass
```

### Non-goals (deferred)

- Audit filtering by actor/decision/enforcementPoint
- Audit search
- Date range filtering
- HTTP endpoints
- Actuator endpoints
- Audit compaction / retention policy
- Cross-stream queries