### PR TITLE
feat(ops): add durable audit outbox recovery operations

### DIFF
--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
@@ -6,11 +6,13 @@ import dev.tramai.engine.SuspendedInvocationStore
 import dev.tramai.security.audit.AuditEngine
 import dev.tramai.security.audit.AuditStore
 import dev.tramai.spring.sovereign.ops.outbox.DefaultSovereignOpsAuditDigestService
+import dev.tramai.spring.sovereign.ops.outbox.DefaultSovereignOpsAuditOutboxOperations
 import dev.tramai.spring.sovereign.ops.outbox.InMemorySovereignOpsApprovalMutationStore
 import dev.tramai.spring.sovereign.ops.outbox.InMemorySovereignOpsAuditOutboxStore
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalMutationStore
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditDigestService
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxDispatcher
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxOperations
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.autoconfigure.AutoConfiguration
@@ -122,6 +124,19 @@ class SovereignOpsAutoConfiguration {
             outboxDispatcher = outboxDispatcher.ifAvailable,
             outboxStore = outboxStore,
             digestService = digestService,
+        )
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun sovereignOpsAuditOutboxOperations(
+        outboxStore: SovereignOpsAuditOutboxStore,
+        outboxDispatcher: ObjectProvider<SovereignOpsAuditOutboxDispatcher>,
+        properties: SovereignOpsProperties,
+    ): SovereignOpsAuditOutboxOperations =
+        DefaultSovereignOpsAuditOutboxOperations(
+            outboxStore = outboxStore,
+            outboxDispatcher = outboxDispatcher.ifAvailable,
+            properties = properties,
         )
 
     @Bean

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/DefaultSovereignOpsAuditOutboxOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/DefaultSovereignOpsAuditOutboxOperations.kt
@@ -86,7 +86,7 @@ class DefaultSovereignOpsAuditOutboxOperations(
         return outboxStore.markFailed(
             outboxId = outboxId,
             expectedStatus = SovereignOpsAuditOutboxStatus.PREPARED,
-            errorCode = reason,
+            errorCode = "operator-marked-prepared-failed",
             retryable = false,
         ).toSummary()
     }

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/DefaultSovereignOpsAuditOutboxOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/DefaultSovereignOpsAuditOutboxOperations.kt
@@ -1,0 +1,149 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+import dev.tramai.spring.sovereign.ops.SovereignOpsProperties
+import kotlinx.coroutines.CancellationException
+import java.time.Instant
+
+/**
+ * Default implementation of [SovereignOpsAuditOutboxOperations].
+ *
+ * Delegates read operations to [SovereignOpsAuditOutboxStore] and
+ * mutation operations (retry, mark terminal) to the dispatcher
+ * and store respectively.
+ *
+ * ## Validation
+ * - Limits are bounded to [MAX_LIMIT] (500), defaulting to [DEFAULT_LIMIT] (100)
+ * - outboxId must be non-blank, ≤ 128 chars, matching SAFE_ID pattern
+ * - reason must be non-blank, ≤ [MAX_REASON_LENGTH] (4096) chars
+ * - Mutations require `mutations-enabled=true` and dispatcher presence
+ *
+ * ## Security
+ * - All summaries are created via [SovereignOpsAuditOutboxRecord.toSummary]
+ *   which sanitises error codes using a whitelist regex
+ * - No raw reason, raw approval ID, tokens, or envelopes in summaries
+ */
+class DefaultSovereignOpsAuditOutboxOperations(
+    private val outboxStore: SovereignOpsAuditOutboxStore,
+    private val outboxDispatcher: SovereignOpsAuditOutboxDispatcher?,
+    private val properties: SovereignOpsProperties,
+) : SovereignOpsAuditOutboxOperations {
+
+    private companion object {
+        private const val DEFAULT_LIMIT = 100
+        private const val MAX_LIMIT = 500
+        private const val MAX_REASON_LENGTH = 4096
+        private val SAFE_OUTBOX_ID = Regex("[A-Za-z0-9][A-Za-z0-9._:@+-]{0,127}")
+        private val SAFE_ERROR_CODE = Regex("[A-Za-z0-9][A-Za-z0-9._:@+-]{0,127}")
+        private val STATUS_ORDER = listOf(
+            SovereignOpsAuditOutboxStatus.PREPARED,
+            SovereignOpsAuditOutboxStatus.PENDING,
+            SovereignOpsAuditOutboxStatus.EMITTING,
+            SovereignOpsAuditOutboxStatus.EMITTED,
+            SovereignOpsAuditOutboxStatus.FAILED_RETRYABLE,
+            SovereignOpsAuditOutboxStatus.FAILED_PERMANENT,
+        )
+    }
+
+    override suspend fun listOutboxRecords(
+        status: SovereignOpsAuditOutboxStatus?,
+        limit: Int?,
+    ): List<SovereignOpsAuditOutboxSummary> {
+        val boundedLimit = validateLimit(limit)
+        val records = if (status != null) {
+            outboxStore.listByStatus(status, boundedLimit)
+        } else {
+            listAcrossStatuses(boundedLimit)
+        }
+        return records.map { it.toSummary() }
+    }
+
+    override suspend fun retryPending(limit: Int?): SovereignOpsAuditOutboxDispatchResult {
+        val boundedLimit = validateLimit(limit)
+        val dispatcher = outboxDispatcher
+            ?: throw IllegalStateException("tramai-sovereign-ops-audit-unavailable")
+        return try {
+            dispatcher.dispatchPending(boundedLimit)
+        } catch (e: CancellationException) {
+            throw e
+        }
+    }
+
+    override suspend fun markPreparedFailed(
+        outboxId: String,
+        reason: String,
+    ): SovereignOpsAuditOutboxSummary {
+        if (!properties.mutationsEnabled) {
+            throw IllegalStateException("tramai-sovereign-ops-mutations-disabled")
+        }
+        validateOutboxId(outboxId)
+        validateReason(reason)
+
+        val record = outboxStore.get(outboxId)
+            ?: throw IllegalStateException("tramai-sovereign-ops-invalid-outbox-id")
+        require(record.status == SovereignOpsAuditOutboxStatus.PREPARED) {
+            "tramai-sovereign-ops-outbox-status-mismatch"
+        }
+        return outboxStore.markFailed(
+            outboxId = outboxId,
+            expectedStatus = SovereignOpsAuditOutboxStatus.PREPARED,
+            errorCode = reason,
+            retryable = false,
+        ).toSummary()
+    }
+
+    private suspend fun listAcrossStatuses(limit: Int): List<SovereignOpsAuditOutboxRecord> {
+        val results = ArrayList<SovereignOpsAuditOutboxRecord>(limit)
+        for (status in STATUS_ORDER) {
+            if (results.size >= limit) break
+            val remaining = limit - results.size
+            results += outboxStore.listByStatus(status, remaining)
+        }
+        return results
+    }
+
+    private fun validateLimit(limit: Int?): Int {
+        val resolved = limit ?: DEFAULT_LIMIT
+        require(resolved > 0) { "tramai-sovereign-ops-invalid-limit" }
+        require(resolved <= MAX_LIMIT) { "tramai-sovereign-ops-invalid-limit" }
+        return resolved
+    }
+
+    private fun validateOutboxId(outboxId: String) {
+        require(outboxId.isNotBlank()) { "tramai-sovereign-ops-invalid-outbox-id" }
+        require(outboxId.length <= 128) { "tramai-sovereign-ops-invalid-outbox-id" }
+        require(SAFE_OUTBOX_ID.matches(outboxId)) { "tramai-sovereign-ops-invalid-outbox-id" }
+    }
+
+    private fun validateReason(reason: String) {
+        require(reason.isNotBlank()) { "tramai-sovereign-ops-invalid-reason" }
+        require(reason.length <= MAX_REASON_LENGTH) { "tramai-sovereign-ops-invalid-reason" }
+    }
+
+    private fun SovereignOpsAuditOutboxRecord.toSummary(): SovereignOpsAuditOutboxSummary =
+        SovereignOpsAuditOutboxSummary(
+            outboxId = outboxId,
+            aggregateType = aggregateType,
+            aggregateIdDigest = aggregateIdDigest,
+            operation = operation,
+            eventKey = eventKey,
+            actor = actor,
+            workflowRunId = workflowRunId,
+            correlationId = correlationId,
+            approvalStatus = approvalStatus,
+            approvalVersion = approvalVersion,
+            reasonLength = reasonLength,
+            status = status,
+            attemptCount = attemptCount,
+            lastErrorCode = sanitizeErrorCode(lastErrorCode),
+            claimedBy = claimedBy,
+            claimedAt = claimedAt,
+            claimExpiresAt = claimExpiresAt,
+            createdAt = createdAt,
+            emittedAt = emittedAt,
+        )
+
+    private fun sanitizeErrorCode(errorCode: String?): String? {
+        if (errorCode == null) return null
+        return errorCode.takeIf { SAFE_ERROR_CODE.matches(it) }
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/InMemorySovereignOpsAuditOutboxStore.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/InMemorySovereignOpsAuditOutboxStore.kt
@@ -147,4 +147,21 @@ class InMemorySovereignOpsAuditOutboxStore : SovereignOpsAuditOutboxStore {
         store.values
             .filter { it.status == SovereignOpsAuditOutboxStatus.PENDING }
             .take(limit)
+
+    override suspend fun listByStatus(
+        status: SovereignOpsAuditOutboxStatus,
+        limit: Int,
+    ): List<SovereignOpsAuditOutboxRecord> =
+        store.values
+            .filter { it.status == status }
+            .take(limit)
+
+    override suspend fun listExpiredEmitting(
+        now: Instant,
+        limit: Int,
+    ): List<SovereignOpsAuditOutboxRecord> =
+        store.values
+            .filter { it.status == SovereignOpsAuditOutboxStatus.EMITTING }
+            .filter { it.claimExpiresAt != null && it.claimExpiresAt.isBefore(now) }
+            .take(limit)
 }

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxOperations.kt
@@ -1,0 +1,78 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+/**
+ * Operational interface for inspecting and managing the audit outbox.
+ *
+ * Provides visibility into all outbox states, retry of dispatchable records,
+ * and manual terminal marking for stuck PREPARED records.
+ *
+ * ## Security invariants
+ * All returned summaries use safe DTOs that expose only digested identifiers
+ * and sanitised error codes — never raw approval IDs, raw reason text,
+ * approval tokens, resume tokens, replay envelopes, prompts, or tool args.
+ *
+ * ## Capabilities
+ * - **Visibility**: List records by status or across all statuses
+ * - **Retry**: Re-dispatch PENDING and FAILED_RETRYABLE records
+ * - **Manual terminal marking**: Close orphan PREPARED records as FAILED_PERMANENT
+ *
+ * ## Non-goals (in this interface)
+ * - Automatic PREPARED reconciliation (planned for a future PR)
+ * - Background retry scheduling
+ * - REST/Actuator endpoints
+ */
+interface SovereignOpsAuditOutboxOperations {
+
+    /**
+     * List outbox records, optionally filtered by [status].
+     *
+     * When [status] is null, returns records across all statuses in
+     * enum order (PREPARED → PENDING → EMITTING → EMITTED →
+     * FAILED_RETRYABLE → FAILED_PERMANENT), up to [limit].
+     *
+     * @param status Optional status filter. When null, returns a bounded
+     *               sample across all statuses.
+     * @param limit Max records to return. Defaults to 100, max 500.
+     * @return Safe summaries (no raw sensitive data).
+     * @throws IllegalArgumentException if [limit] is <= 0 or > 500.
+     */
+    suspend fun listOutboxRecords(
+        status: SovereignOpsAuditOutboxStatus?,
+        limit: Int?,
+    ): List<SovereignOpsAuditOutboxSummary>
+
+    /**
+     * Retry dispatch of pending and retryable outbox records.
+     *
+     * Delegates to [SovereignOpsAuditOutboxDispatcher.dispatchPending],
+     * which claims PENDING, FAILED_RETRYABLE, and expired EMITTING records
+     * and emits audit events via [SovereignOpsAuditEmitter.approvalDeniedFromOutbox].
+     *
+     * @param limit Max records to process. Defaults to 100, max 500.
+     * @return Summary of the dispatch run (claimed, emitted, failed counts).
+     * @throws IllegalStateException if no dispatcher is available
+     *         (tramai-sovereign-ops-audit-unavailable).
+     * @throws kotlinx.coroutines.CancellationException if the coroutine is cancelled.
+     */
+    suspend fun retryPending(limit: Int?): SovereignOpsAuditOutboxDispatchResult
+
+    /**
+     * Mark a stuck PREPARED outbox record as FAILED_PERMANENT.
+     *
+     * Used for manual recovery when an operator has verified that the
+     * associated approval transition did not complete, or the outbox
+     * intent should be discarded.
+     *
+     * @param outboxId The PREPARED record to close.
+     * @param reason A human-readable reason for the closure.
+     * @return Summary of the updated record.
+     * @throws IllegalStateException if mutations are disabled.
+     * @throws IllegalArgumentException if [outboxId] is invalid.
+     * @throws IllegalArgumentException if [reason] is blank or too long.
+     * @throws IllegalStateException if the record is not in PREPARED status.
+     */
+    suspend fun markPreparedFailed(
+        outboxId: String,
+        reason: String,
+    ): SovereignOpsAuditOutboxSummary
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxRecoverySummary.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxRecoverySummary.kt
@@ -1,0 +1,20 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+/**
+ * Summary of a PREPARED recovery operation.
+ *
+ * Defined in this PR as a future contract for automatic PREPARED
+ * reconciliation (PR #48). Not yet used — kept as a forward contract
+ * so the DTO shape is agreed before implementation.
+ *
+ * @property inspected Number of PREPARED records examined.
+ * @property movedToPending Number of records recovered to PENDING.
+ * @property markedFailedPermanent Number of records marked terminal.
+ * @property skipped Number of records left as-is (unresolvable).
+ */
+data class SovereignOpsAuditOutboxRecoverySummary(
+    val inspected: Int,
+    val movedToPending: Int?,
+    val markedFailedPermanent: Int?,
+    val skipped: Int,
+)

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxStore.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxStore.kt
@@ -98,4 +98,16 @@ interface SovereignOpsAuditOutboxStore {
 
     /** List pending records (for diagnostics). */
     suspend fun listPending(limit: Int): List<SovereignOpsAuditOutboxRecord>
+
+    /** List records by exact status (for diagnostics and recovery). */
+    suspend fun listByStatus(
+        status: SovereignOpsAuditOutboxStatus,
+        limit: Int,
+    ): List<SovereignOpsAuditOutboxRecord>
+
+    /** List EMITTING records whose claim has expired. */
+    suspend fun listExpiredEmitting(
+        now: Instant,
+        limit: Int,
+    ): List<SovereignOpsAuditOutboxRecord>
 }

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxSummary.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxSummary.kt
@@ -1,0 +1,55 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+import java.time.Instant
+
+/**
+ * Safe summary of an outbox record returned by [SovereignOpsAuditOutboxOperations].
+ *
+ * Does NOT expose:
+ * - Raw approval ID (only [aggregateIdDigest])
+ * - Raw reason text (only [reasonLength])
+ * - Approval tokens, resume tokens, or replay envelopes
+ * - Prompts, model responses, or tool arguments
+ * - Raw payloads
+ *
+ * @property outboxId Unique identifier for this outbox record.
+ * @property aggregateType The domain aggregate type (e.g. "approval").
+ * @property aggregateIdDigest Safe digest of the aggregate identifier.
+ * @property operation The operation name (e.g. "denyApproval").
+ * @property eventKey Deterministic key for idempotent replay.
+ * @property actor The identity who performed the operation.
+ * @property workflowRunId The workflow run ID, if available.
+ * @property correlationId The correlation ID, if available.
+ * @property approvalStatus The resulting approval status (e.g. "DENIED").
+ * @property approvalVersion The version of the approval after the transition.
+ * @property reasonLength Length of the reason string (not the content).
+ * @property status Current outbox processing status.
+ * @property attemptCount Number of emission attempts.
+ * @property lastErrorCode Last error code, if any (sanitised for safe display).
+ * @property claimedBy The identity that claimed this record, if any.
+ * @property claimedAt When this record was claimed, if any.
+ * @property claimExpiresAt When the claim expires and another dispatcher may re-claim.
+ * @property createdAt When this outbox record was created.
+ * @property emittedAt When the audit event was successfully emitted, if ever.
+ */
+data class SovereignOpsAuditOutboxSummary(
+    val outboxId: String,
+    val aggregateType: String,
+    val aggregateIdDigest: String,
+    val operation: String,
+    val eventKey: String,
+    val actor: String,
+    val workflowRunId: String?,
+    val correlationId: String?,
+    val approvalStatus: String,
+    val approvalVersion: Long?,
+    val reasonLength: Int,
+    val status: SovereignOpsAuditOutboxStatus,
+    val attemptCount: Int,
+    val lastErrorCode: String?,
+    val claimedBy: String?,
+    val claimedAt: Instant?,
+    val claimExpiresAt: Instant?,
+    val createdAt: Instant,
+    val emittedAt: Instant?,
+)

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfigurationTest.kt
@@ -7,6 +7,7 @@ import dev.tramai.core.approval.ApprovalTransition
 import dev.tramai.engine.SuspendedInvocationStore
 import dev.tramai.security.audit.AuditEvent
 import dev.tramai.security.audit.AuditStore
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxOperations
 import java.time.Instant
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
@@ -61,6 +62,15 @@ class SovereignOpsAutoConfigurationTest {
             .withUserConfiguration(MinimalStoreConfig::class.java)
             .run { ctx ->
                 assertThat(ctx).hasSingleBean(SovereignRuntimeOperations::class.java)
+            }
+    }
+
+    @Test
+    fun `creates outbox operations bean`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxOperations::class.java)
             }
     }
 

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxOperationsTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxOperationsTest.kt
@@ -1,0 +1,254 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+import dev.tramai.spring.sovereign.ops.MinimalStoreConfig
+import dev.tramai.spring.sovereign.ops.SovereignOpsAutoConfiguration
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import java.time.Instant
+
+class SovereignOpsAuditOutboxOperationsTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(SovereignOpsAutoConfiguration::class.java),
+        )
+
+    @Test
+    fun `listOutboxRecords uses bounded cross-status default`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                DurableOutboxStoreConfig::class.java,
+            )
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignOpsAuditOutboxOperations::class.java)
+                val outboxStore = ctx.getBean(SovereignOpsAuditOutboxStore::class.java)
+
+                runBlocking {
+                    outboxStore.append(record("prepared", SovereignOpsAuditOutboxStatus.PREPARED))
+                    outboxStore.append(record("pending", SovereignOpsAuditOutboxStatus.PREPARED))
+                    outboxStore.markReadyForDispatch("pending", SovereignOpsAuditOutboxStatus.PREPARED)
+                    outboxStore.append(record("retryable", SovereignOpsAuditOutboxStatus.PREPARED))
+                    outboxStore.markReadyForDispatch("retryable", SovereignOpsAuditOutboxStatus.PREPARED)
+                    outboxStore.markFailed(
+                        outboxId = "retryable",
+                        expectedStatus = SovereignOpsAuditOutboxStatus.PENDING,
+                        errorCode = "DispatchFailure",
+                        retryable = true,
+                    )
+                }
+
+                val summaries = runBlocking { ops.listOutboxRecords(status = null, limit = null) }
+
+                assertThat(summaries).hasSize(3)
+                assertThat(summaries.map { it.status }).containsExactly(
+                    SovereignOpsAuditOutboxStatus.PREPARED,
+                    SovereignOpsAuditOutboxStatus.PENDING,
+                    SovereignOpsAuditOutboxStatus.FAILED_RETRYABLE,
+                )
+            }
+    }
+
+    @Test
+    fun `listOutboxRecords filters by status`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                DurableOutboxStoreConfig::class.java,
+            )
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignOpsAuditOutboxOperations::class.java)
+                val outboxStore = ctx.getBean(SovereignOpsAuditOutboxStore::class.java)
+
+                runBlocking {
+                    outboxStore.append(record("prepared", SovereignOpsAuditOutboxStatus.PREPARED))
+                    outboxStore.append(record("pending", SovereignOpsAuditOutboxStatus.PREPARED))
+                    outboxStore.markReadyForDispatch("pending", SovereignOpsAuditOutboxStatus.PREPARED)
+                }
+
+                val summaries = runBlocking {
+                    ops.listOutboxRecords(
+                        status = SovereignOpsAuditOutboxStatus.PENDING,
+                        limit = 10,
+                    )
+                }
+
+                val summary = summaries.single()
+                assertThat(summary.outboxId).isEqualTo("pending")
+                assertThat(summary.status).isEqualTo(SovereignOpsAuditOutboxStatus.PENDING)
+            }
+    }
+
+    @Test
+    fun `listOutboxRecords rejects invalid limit`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignOpsAuditOutboxOperations::class.java)
+
+                val ex = runCatching {
+                    runBlocking { ops.listOutboxRecords(status = null, limit = 0) }
+                }.exceptionOrNull()
+
+                assertThat(ex).hasMessageContaining("tramai-sovereign-ops-invalid-limit")
+            }
+    }
+
+    @Test
+    fun `retryPending rejects missing dispatcher`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignOpsAuditOutboxOperations::class.java)
+
+                val ex = runCatching {
+                    runBlocking { ops.retryPending(limit = 1) }
+                }.exceptionOrNull()
+
+                assertThat(ex).hasMessageContaining("tramai-sovereign-ops-audit-unavailable")
+            }
+    }
+
+    @Test
+    fun `retryPending dispatches retryable records`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                DurableOutboxStoreConfig::class.java,
+                TestAuditEngineConfig::class.java,
+            )
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignOpsAuditOutboxOperations::class.java)
+                val outboxStore = ctx.getBean(SovereignOpsAuditOutboxStore::class.java)
+
+                runBlocking {
+                    outboxStore.append(record("retryable", SovereignOpsAuditOutboxStatus.PREPARED))
+                    outboxStore.markReadyForDispatch("retryable", SovereignOpsAuditOutboxStatus.PREPARED)
+                    outboxStore.markFailed(
+                        outboxId = "retryable",
+                        expectedStatus = SovereignOpsAuditOutboxStatus.PENDING,
+                        errorCode = "DispatchFailure",
+                        retryable = true,
+                    )
+                }
+
+                val summary = runBlocking { ops.retryPending(limit = 10) }
+                val stored = runBlocking { outboxStore.get("retryable") }
+
+                assertThat(summary.claimed).isEqualTo(1)
+                assertThat(summary.emitted).isEqualTo(1)
+                assertThat(stored!!.status).isEqualTo(SovereignOpsAuditOutboxStatus.EMITTED)
+            }
+    }
+
+    @Test
+    fun `markPreparedFailed requires mutations enabled`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                DurableOutboxStoreConfig::class.java,
+            )
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignOpsAuditOutboxOperations::class.java)
+
+                val ex = runCatching {
+                    runBlocking { ops.markPreparedFailed("prepared", "operator-close") }
+                }.exceptionOrNull()
+
+                assertThat(ex).hasMessageContaining("tramai-sovereign-ops-mutations-disabled")
+            }
+    }
+
+    @Test
+    fun `markPreparedFailed marks prepared record permanently failed and sanitizes summary`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                DurableOutboxStoreConfig::class.java,
+            )
+            .withPropertyValues("tramai.sovereign.ops.mutations-enabled=true")
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignOpsAuditOutboxOperations::class.java)
+                val outboxStore = ctx.getBean(SovereignOpsAuditOutboxStore::class.java)
+
+                runBlocking {
+                    outboxStore.append(record("prepared", SovereignOpsAuditOutboxStatus.PREPARED))
+                }
+
+                val summary = runBlocking {
+                    ops.markPreparedFailed("prepared", "operator closed after crash")
+                }
+                val stored = runBlocking { outboxStore.get("prepared") }
+
+                assertThat(summary.status).isEqualTo(SovereignOpsAuditOutboxStatus.FAILED_PERMANENT)
+                assertThat(summary.lastErrorCode).isNull()
+                assertThat(stored!!.lastErrorCode).isEqualTo("operator closed after crash")
+            }
+    }
+
+    @Test
+    fun `markPreparedFailed rejects non prepared record`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                DurableOutboxStoreConfig::class.java,
+            )
+            .withPropertyValues("tramai.sovereign.ops.mutations-enabled=true")
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignOpsAuditOutboxOperations::class.java)
+                val outboxStore = ctx.getBean(SovereignOpsAuditOutboxStore::class.java)
+
+                runBlocking {
+                    outboxStore.append(record("pending", SovereignOpsAuditOutboxStatus.PREPARED))
+                    outboxStore.markReadyForDispatch("pending", SovereignOpsAuditOutboxStatus.PREPARED)
+                }
+
+                val ex = runCatching {
+                    runBlocking { ops.markPreparedFailed("pending", "operator-close") }
+                }.exceptionOrNull()
+
+                assertThat(ex).hasMessageContaining("tramai-sovereign-ops-outbox-status-mismatch")
+            }
+    }
+
+    @Test
+    fun `markPreparedFailed rejects blank reason`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                DurableOutboxStoreConfig::class.java,
+            )
+            .withPropertyValues("tramai.sovereign.ops.mutations-enabled=true")
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignOpsAuditOutboxOperations::class.java)
+
+                val ex = runCatching {
+                    runBlocking { ops.markPreparedFailed("prepared", " ") }
+                }.exceptionOrNull()
+
+                assertThat(ex).hasMessageContaining("tramai-sovereign-ops-invalid-reason")
+            }
+    }
+
+    private fun record(
+        outboxId: String,
+        status: SovereignOpsAuditOutboxStatus,
+    ): SovereignOpsAuditOutboxRecord =
+        SovereignOpsAuditOutboxRecord(
+            outboxId = outboxId,
+            aggregateIdDigest = "digest-$outboxId",
+            eventKey = "event-$outboxId",
+            actor = "admin",
+            workflowRunId = "wf-1",
+            correlationId = "corr-1",
+            approvalStatus = "DENIED",
+            approvalVersion = 1L,
+            reasonDigest = "reason-$outboxId",
+            reasonLength = 12,
+            createdAt = Instant.parse("2026-06-01T00:00:00Z"),
+            status = status,
+        )
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxOperationsTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxOperationsTest.kt
@@ -163,7 +163,7 @@ class SovereignOpsAuditOutboxOperationsTest {
     }
 
     @Test
-    fun `markPreparedFailed marks prepared record permanently failed and sanitizes summary`() {
+    fun `markPreparedFailed marks prepared record permanently failed with fixed error code`() {
         contextRunner
             .withUserConfiguration(
                 MinimalStoreConfig::class.java,
@@ -184,8 +184,39 @@ class SovereignOpsAuditOutboxOperationsTest {
                 val stored = runBlocking { outboxStore.get("prepared") }
 
                 assertThat(summary.status).isEqualTo(SovereignOpsAuditOutboxStatus.FAILED_PERMANENT)
-                assertThat(summary.lastErrorCode).isNull()
-                assertThat(stored!!.lastErrorCode).isEqualTo("operator closed after crash")
+                assertThat(stored!!.lastErrorCode).isEqualTo("operator-marked-prepared-failed")
+                assertThat(summary.lastErrorCode).isEqualTo("operator-marked-prepared-failed")
+            }
+    }
+
+    @Test
+    fun `markPreparedFailed does not persist raw operator reason as lastErrorCode`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                DurableOutboxStoreConfig::class.java,
+            )
+            .withPropertyValues("tramai.sovereign.ops.mutations-enabled=true")
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignOpsAuditOutboxOperations::class.java)
+                val outboxStore = ctx.getBean(SovereignOpsAuditOutboxStore::class.java)
+
+                runBlocking {
+                    outboxStore.append(record("prepared", SovereignOpsAuditOutboxStatus.PREPARED))
+                }
+
+                runBlocking {
+                    ops.markPreparedFailed(
+                        "prepared",
+                        "contains /private/path and user@example.com",
+                    )
+                }
+                val stored = runBlocking { outboxStore.get("prepared") }
+
+                // Raw sensitive text must NOT appear in lastErrorCode
+                assertThat(stored!!.lastErrorCode).doesNotContain("/private/path")
+                assertThat(stored!!.lastErrorCode).doesNotContain("user@example.com")
+                assertThat(stored!!.lastErrorCode).isEqualTo("operator-marked-prepared-failed")
             }
     }
 

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxTest.kt
@@ -829,6 +829,21 @@ class DurableTestInMemoryOutboxStore : SovereignOpsAuditOutboxStore {
     override suspend fun listPending(limit: Int): List<SovereignOpsAuditOutboxRecord> =
         store.values.filter { it.status == SovereignOpsAuditOutboxStatus.PENDING }.take(limit)
 
+    override suspend fun listByStatus(
+        status: SovereignOpsAuditOutboxStatus,
+        limit: Int,
+    ): List<SovereignOpsAuditOutboxRecord> =
+        store.values.filter { it.status == status }.take(limit)
+
+    override suspend fun listExpiredEmitting(
+        now: Instant,
+        limit: Int,
+    ): List<SovereignOpsAuditOutboxRecord> =
+        store.values
+            .filter { it.status == SovereignOpsAuditOutboxStatus.EMITTING }
+            .filter { it.claimExpiresAt != null && it.claimExpiresAt.isBefore(now) }
+            .take(limit)
+
     override suspend fun markReadyForDispatch(
         outboxId: String,
         expectedStatus: SovereignOpsAuditOutboxStatus,
@@ -898,6 +913,18 @@ class CancellationEmittingOutboxStore : SovereignOpsAuditOutboxStore {
 
     override suspend fun listPending(limit: Int): List<SovereignOpsAuditOutboxRecord> =
         delegate.listPending(limit)
+
+    override suspend fun listByStatus(
+        status: SovereignOpsAuditOutboxStatus,
+        limit: Int,
+    ): List<SovereignOpsAuditOutboxRecord> =
+        delegate.listByStatus(status, limit)
+
+    override suspend fun listExpiredEmitting(
+        now: Instant,
+        limit: Int,
+    ): List<SovereignOpsAuditOutboxRecord> =
+        delegate.listExpiredEmitting(now, limit)
 }
 
 class CustomTestOutboxStore : SovereignOpsAuditOutboxStore {
@@ -969,6 +996,21 @@ class CustomTestOutboxStore : SovereignOpsAuditOutboxStore {
     override suspend fun listPending(limit: Int): List<SovereignOpsAuditOutboxRecord> = records.values
         .filter { it.status == SovereignOpsAuditOutboxStatus.PENDING }
         .take(limit)
+
+    override suspend fun listByStatus(
+        status: SovereignOpsAuditOutboxStatus,
+        limit: Int,
+    ): List<SovereignOpsAuditOutboxRecord> =
+        records.values.filter { it.status == status }.take(limit)
+
+    override suspend fun listExpiredEmitting(
+        now: Instant,
+        limit: Int,
+    ): List<SovereignOpsAuditOutboxRecord> =
+        records.values
+            .filter { it.status == SovereignOpsAuditOutboxStatus.EMITTING }
+            .filter { it.claimExpiresAt != null && it.claimExpiresAt.isBefore(now) }
+            .take(limit)
 
     override suspend fun markReadyForDispatch(
         outboxId: String,


### PR DESCRIPTION
## Summary

Add operational APIs for inspecting, retrying, and manually closing audit outbox records, making the outbox lifecycle observable and recoverable without leaking sensitive data.

## Operations interface

```
interface SovereignOpsAuditOutboxOperations {
    suspend fun listOutboxRecords(status: SovereignOpsAuditOutboxStatus?, limit: Int?): List<SovereignOpsAuditOutboxSummary>
    suspend fun retryPending(limit: Int?): SovereignOpsAuditOutboxDispatchResult
    suspend fun markPreparedFailed(outboxId: String, reason: String): SovereignOpsAuditOutboxSummary
}
```

## Capabilities

- **Visibility**: List records by status (PREPARED, PENDING, EMITTING, EMITTED, FAILED_RETRYABLE, FAILED_PERMANENT) or across all statuses — default 100, max 500
- **Retry**: Re-dispatch PENDING, FAILED_RETRYABLE, and expired EMITTING records via the existing dispatcher. Preserves CancellationException propagation. Fails closed without dispatcher.
- **Manual terminal marking**: Close orphan PREPARED records as FAILED_PERMANENT with fixed error code `operator-marked-prepared-failed`. Operator reason text is validated but never persisted in the outbox record.

## Security invariants

- DTOs expose only `aggregateIdDigest` and `reasonLength` — never raw IDs, raw reason, tokens, or envelopes
- `lastErrorCode` uses a fixed safe code (`operator-marked-prepared-failed`) — no raw operator text persisted in durable outbox records
- `CancellationException` propagation preserved

## Store SPI additions

- `listByStatus(status, limit)` — filter records by any status
- `listExpiredEmitting(now, limit)` — find stuck EMITTING records

## Spring wiring

Bean created unconditionally (read-only ops work without dispatcher). `retryPending` fails closed with `tramai-sovereign-ops-audit-unavailable`. `markPreparedFailed` requires `mutations-enabled=true`.

## Tests (10 new)

listOutboxRecords (status filter, cross-status default, limit rejection), retryPending (with/without dispatcher, retryable dispatch), markPreparedFailed (mutations disabled, fixed error code, raw-reason-not-persisted, non-PREPARED rejection, blank reason rejection), store SPI additions in all test stores.

## Non-goals (explicit)

- Automatic PREPARED reconciliation / recoverPrepared (PR #48)
- File-backed outbox store
- HMAC digest
- REST/Actuator endpoints
- Background retry scheduling

## Validation

```
./gradlew test --rerun-tasks
→ 154 actionable tasks, 0 failures
```
