### PR TITLE
feat(ops): reconcile prepared audit outbox records

### DIFF
--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
@@ -9,11 +9,13 @@ import dev.tramai.spring.sovereign.ops.outbox.DefaultSovereignOpsAuditDigestServ
 import dev.tramai.spring.sovereign.ops.outbox.DefaultSovereignOpsAuditOutboxOperations
 import dev.tramai.spring.sovereign.ops.outbox.InMemorySovereignOpsApprovalMutationStore
 import dev.tramai.spring.sovereign.ops.outbox.InMemorySovereignOpsAuditOutboxStore
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalRecoveryResolver
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalMutationStore
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditDigestService
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxDispatcher
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxOperations
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
+import dev.tramai.spring.sovereign.ops.outbox.UnknownSovereignOpsApprovalRecoveryResolver
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
@@ -128,14 +130,21 @@ class SovereignOpsAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    fun sovereignOpsApprovalRecoveryResolver(): SovereignOpsApprovalRecoveryResolver =
+        UnknownSovereignOpsApprovalRecoveryResolver
+
+    @Bean
+    @ConditionalOnMissingBean
     fun sovereignOpsAuditOutboxOperations(
         outboxStore: SovereignOpsAuditOutboxStore,
         outboxDispatcher: ObjectProvider<SovereignOpsAuditOutboxDispatcher>,
+        recoveryResolver: SovereignOpsApprovalRecoveryResolver,
         properties: SovereignOpsProperties,
     ): SovereignOpsAuditOutboxOperations =
         DefaultSovereignOpsAuditOutboxOperations(
             outboxStore = outboxStore,
             outboxDispatcher = outboxDispatcher.ifAvailable,
+            recoveryResolver = recoveryResolver,
             properties = properties,
         )
 

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/DefaultSovereignOpsAuditOutboxOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/DefaultSovereignOpsAuditOutboxOperations.kt
@@ -26,6 +26,7 @@ class DefaultSovereignOpsAuditOutboxOperations(
     private val outboxStore: SovereignOpsAuditOutboxStore,
     private val outboxDispatcher: SovereignOpsAuditOutboxDispatcher?,
     private val properties: SovereignOpsProperties,
+    private val recoveryResolver: SovereignOpsApprovalRecoveryResolver,
 ) : SovereignOpsAuditOutboxOperations {
 
     private companion object {
@@ -89,6 +90,60 @@ class DefaultSovereignOpsAuditOutboxOperations(
             errorCode = "operator-marked-prepared-failed",
             retryable = false,
         ).toSummary()
+    }
+
+    override suspend fun recoverPrepared(limit: Int?): SovereignOpsAuditOutboxRecoverySummary {
+        if (!properties.mutationsEnabled) {
+            throw IllegalStateException("tramai-sovereign-ops-mutations-disabled")
+        }
+
+        val boundedLimit = validateLimit(limit)
+        val prepared = outboxStore.listByStatus(SovereignOpsAuditOutboxStatus.PREPARED, boundedLimit)
+
+        var movedToPending = 0
+        var markedFailedPermanent = 0
+        var skippedUnresolved = 0
+        var resolverFailures = 0
+
+        for (record in prepared) {
+            try {
+                when (recoveryResolver.resolvePreparedOutboxRecord(record)) {
+                    SovereignOpsPreparedRecoveryDecision.COMMITTED_DENIED -> {
+                        outboxStore.markReadyForDispatch(
+                            outboxId = record.outboxId,
+                            expectedStatus = SovereignOpsAuditOutboxStatus.PREPARED,
+                        )
+                        movedToPending++
+                    }
+
+                    SovereignOpsPreparedRecoveryDecision.NOT_COMMITTED -> {
+                        outboxStore.markFailed(
+                            outboxId = record.outboxId,
+                            expectedStatus = SovereignOpsAuditOutboxStatus.PREPARED,
+                            errorCode = "prepared-recovery-not-committed",
+                            retryable = false,
+                        )
+                        markedFailedPermanent++
+                    }
+
+                    SovereignOpsPreparedRecoveryDecision.UNKNOWN -> {
+                        skippedUnresolved++
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: RuntimeException) {
+                resolverFailures++
+            }
+        }
+
+        return SovereignOpsAuditOutboxRecoverySummary(
+            inspected = prepared.size,
+            movedToPending = movedToPending,
+            markedFailedPermanent = markedFailedPermanent,
+            skippedUnresolved = skippedUnresolved,
+            resolverFailures = resolverFailures,
+        )
     }
 
     private suspend fun listAcrossStatuses(limit: Int): List<SovereignOpsAuditOutboxRecord> {

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsApprovalRecoveryResolver.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsApprovalRecoveryResolver.kt
@@ -1,0 +1,46 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+/**
+ * Resolver that determines whether a stuck PREPARED outbox record
+ * corresponds to a committed approval denial that can be safely
+ * moved to PENDING for dispatch.
+ *
+ * ## Contract
+ * Return [SovereignOpsPreparedRecoveryDecision.COMMITTED_DENIED] only
+ * when you can prove the approval transition committed. Never dispatch
+ * a PREPARED record without positive proof.
+ *
+ * ## Security invariants
+ * - Resolver implementations must not expose raw approval IDs, raw reason
+ *   text, or operator comments.
+ * - Implementations must not log or persist the encryption key.
+ * - Implementations must not throw on the first failure -- resolver
+ *   errors are caught and counted in the recovery summary.
+ */
+fun interface SovereignOpsApprovalRecoveryResolver {
+
+    /**
+     * Resolve a stuck PREPARED outbox record.
+     *
+     * @param record The PREPARED outbox record to resolve.
+     * @return [SovereignOpsPreparedRecoveryDecision] indicating the resolution outcome.
+     * @throws kotlinx.coroutines.CancellationException Always propagated.
+     */
+    suspend fun resolvePreparedOutboxRecord(
+        record: SovereignOpsAuditOutboxRecord,
+    ): SovereignOpsPreparedRecoveryDecision
+}
+
+/**
+ * Decision returned by [SovereignOpsApprovalRecoveryResolver.resolvePreparedOutboxRecord].
+ */
+enum class SovereignOpsPreparedRecoveryDecision {
+    /** Approval denial is confirmed committed -- safe to move PREPARED -> PENDING. */
+    COMMITTED_DENIED,
+
+    /** Approval denial did not complete -- safe to mark FAILED_PERMANENT. */
+    NOT_COMMITTED,
+
+    /** Cannot determine -- skip this record. */
+    UNKNOWN,
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxOperations.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxOperations.kt
@@ -4,7 +4,8 @@ package dev.tramai.spring.sovereign.ops.outbox
  * Operational interface for inspecting and managing the audit outbox.
  *
  * Provides visibility into all outbox states, retry of dispatchable records,
- * and manual terminal marking for stuck PREPARED records.
+ * automatic reconciliation, and manual terminal marking for stuck PREPARED
+ * records.
  *
  * ## Security invariants
  * All returned summaries use safe DTOs that expose only digested identifiers
@@ -14,10 +15,10 @@ package dev.tramai.spring.sovereign.ops.outbox
  * ## Capabilities
  * - **Visibility**: List records by status or across all statuses
  * - **Retry**: Re-dispatch PENDING and FAILED_RETRYABLE records
+ * - **Recovery**: Reconcile stuck PREPARED records using a configured resolver
  * - **Manual terminal marking**: Close orphan PREPARED records as FAILED_PERMANENT
  *
  * ## Non-goals (in this interface)
- * - Automatic PREPARED reconciliation (planned for a future PR)
  * - Background retry scheduling
  * - REST/Actuator endpoints
  */
@@ -75,4 +76,24 @@ interface SovereignOpsAuditOutboxOperations {
         outboxId: String,
         reason: String,
     ): SovereignOpsAuditOutboxSummary
+
+    /**
+     * Reconcile stuck PREPARED outbox records using the configured
+     * [SovereignOpsApprovalRecoveryResolver].
+     *
+     * For each PREPARED record:
+     * - [SovereignOpsPreparedRecoveryDecision.COMMITTED_DENIED] -> markReadyForDispatch
+     * - [SovereignOpsPreparedRecoveryDecision.NOT_COMMITTED] -> markFailed with fixed error code
+     * - [SovereignOpsPreparedRecoveryDecision.UNKNOWN] -> skip
+     * - Resolver exception -> skip, count in resolverFailures
+     *
+     * Does NOT require a dispatcher -- recovery only moves PREPARED to PENDING
+     * (or FAILED_PERMANENT). Actual dispatch happens via [retryPending].
+     *
+     * @param limit Max records to inspect. Defaults to 100, max 500.
+     * @return Summary of the recovery operation.
+     * @throws IllegalStateException if mutations are disabled.
+     * @throws kotlinx.coroutines.CancellationException if the coroutine is cancelled.
+     */
+    suspend fun recoverPrepared(limit: Int?): SovereignOpsAuditOutboxRecoverySummary
 }

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxRecoverySummary.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxRecoverySummary.kt
@@ -3,18 +3,16 @@ package dev.tramai.spring.sovereign.ops.outbox
 /**
  * Summary of a PREPARED recovery operation.
  *
- * Defined in this PR as a future contract for automatic PREPARED
- * reconciliation (PR #48). Not yet used — kept as a forward contract
- * so the DTO shape is agreed before implementation.
- *
  * @property inspected Number of PREPARED records examined.
- * @property movedToPending Number of records recovered to PENDING.
- * @property markedFailedPermanent Number of records marked terminal.
- * @property skipped Number of records left as-is (unresolvable).
+ * @property movedToPending Number of records recovered to PENDING (resolver returned COMMITTED_DENIED).
+ * @property markedFailedPermanent Number of records marked FAILED_PERMANENT (resolver returned NOT_COMMITTED).
+ * @property skippedUnresolved Number of records left as-is (resolver returned UNKNOWN).
+ * @property resolverFailures Number of records skipped due to resolver exception.
  */
 data class SovereignOpsAuditOutboxRecoverySummary(
     val inspected: Int,
-    val movedToPending: Int?,
-    val markedFailedPermanent: Int?,
-    val skipped: Int,
+    val movedToPending: Int = 0,
+    val markedFailedPermanent: Int = 0,
+    val skippedUnresolved: Int = 0,
+    val resolverFailures: Int = 0,
 )

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/UnknownSovereignOpsApprovalRecoveryResolver.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/UnknownSovereignOpsApprovalRecoveryResolver.kt
@@ -1,0 +1,16 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+/**
+ * Default recovery resolver that always returns [SovereignOpsPreparedRecoveryDecision.UNKNOWN].
+ *
+ * This ensures the safest default: PREPARED records are never automatically
+ * moved to PENDING without a resolver that can prove the approval denial
+ * committed. Custom resolvers are expected for production use.
+ */
+object UnknownSovereignOpsApprovalRecoveryResolver : SovereignOpsApprovalRecoveryResolver {
+
+    override suspend fun resolvePreparedOutboxRecord(
+        record: SovereignOpsAuditOutboxRecord,
+    ): SovereignOpsPreparedRecoveryDecision =
+        SovereignOpsPreparedRecoveryDecision.UNKNOWN
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxOperationsTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxOperationsTest.kt
@@ -7,6 +7,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
 import java.time.Instant
 
 class SovereignOpsAuditOutboxOperationsTest {
@@ -264,6 +266,312 @@ class SovereignOpsAuditOutboxOperationsTest {
             }
     }
 
+    // -- recoverPrepared tests ------------------------------------------------
+
+    @Test
+    fun `recoverPrepared requires mutations enabled`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                DurableOutboxStoreConfig::class.java,
+            )
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignOpsAuditOutboxOperations::class.java)
+
+                val ex = runCatching {
+                    runBlocking { ops.recoverPrepared(limit = 10) }
+                }.exceptionOrNull()
+
+                assertThat(ex).hasMessageContaining("tramai-sovereign-ops-mutations-disabled")
+            }
+    }
+
+    @Test
+    fun `recoverPrepared with default resolver skips prepared records as unresolved`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                DurableOutboxStoreConfig::class.java,
+            )
+            .withPropertyValues("tramai.sovereign.ops.mutations-enabled=true")
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignOpsAuditOutboxOperations::class.java)
+                val outboxStore = ctx.getBean(SovereignOpsAuditOutboxStore::class.java)
+
+                runBlocking {
+                    outboxStore.append(record("prepared-1", SovereignOpsAuditOutboxStatus.PREPARED))
+                    outboxStore.append(record("prepared-2", SovereignOpsAuditOutboxStatus.PREPARED))
+                }
+
+                val summary = runBlocking { ops.recoverPrepared(limit = 10) }
+
+                assertThat(summary.inspected).isEqualTo(2)
+                assertThat(summary.movedToPending).isEqualTo(0)
+                assertThat(summary.markedFailedPermanent).isEqualTo(0)
+                assertThat(summary.skippedUnresolved).isEqualTo(2)
+                assertThat(summary.resolverFailures).isEqualTo(0)
+            }
+    }
+
+    @Test
+    fun `recoverPrepared moves committed denied records to pending`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                DurableOutboxStoreConfig::class.java,
+                CommittedDeniedResolverConfig::class.java,
+            )
+            .withPropertyValues("tramai.sovereign.ops.mutations-enabled=true")
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignOpsAuditOutboxOperations::class.java)
+                val outboxStore = ctx.getBean(SovereignOpsAuditOutboxStore::class.java)
+
+                runBlocking {
+                    outboxStore.append(record("prepared-1", SovereignOpsAuditOutboxStatus.PREPARED))
+                }
+
+                val summary = runBlocking { ops.recoverPrepared(limit = 10) }
+                val stored = runBlocking { outboxStore.get("prepared-1") }
+
+                assertThat(summary.inspected).isEqualTo(1)
+                assertThat(summary.movedToPending).isEqualTo(1)
+                assertThat(stored!!.status).isEqualTo(SovereignOpsAuditOutboxStatus.PENDING)
+            }
+    }
+
+    @Test
+    fun `recoverPrepared marks not committed records as permanently failed with fixed error code`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                DurableOutboxStoreConfig::class.java,
+                NotCommittedResolverConfig::class.java,
+            )
+            .withPropertyValues("tramai.sovereign.ops.mutations-enabled=true")
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignOpsAuditOutboxOperations::class.java)
+                val outboxStore = ctx.getBean(SovereignOpsAuditOutboxStore::class.java)
+
+                runBlocking {
+                    outboxStore.append(record("prepared-1", SovereignOpsAuditOutboxStatus.PREPARED))
+                }
+
+                val summary = runBlocking { ops.recoverPrepared(limit = 10) }
+                val stored = runBlocking { outboxStore.get("prepared-1") }
+
+                assertThat(summary.inspected).isEqualTo(1)
+                assertThat(summary.markedFailedPermanent).isEqualTo(1)
+                assertThat(stored!!.status).isEqualTo(SovereignOpsAuditOutboxStatus.FAILED_PERMANENT)
+                assertThat(stored.lastErrorCode).isEqualTo("prepared-recovery-not-committed")
+            }
+    }
+
+    @Test
+    fun `recoverPrepared not committed uses fixed safe error code without sensitive text`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                DurableOutboxStoreConfig::class.java,
+                NotCommittedResolverConfig::class.java,
+            )
+            .withPropertyValues("tramai.sovereign.ops.mutations-enabled=true")
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignOpsAuditOutboxOperations::class.java)
+                val outboxStore = ctx.getBean(SovereignOpsAuditOutboxStore::class.java)
+
+                runBlocking {
+                    outboxStore.append(record("prepared-1", SovereignOpsAuditOutboxStatus.PREPARED))
+                }
+
+                runBlocking { ops.recoverPrepared(limit = 10) }
+                val stored = runBlocking { outboxStore.get("prepared-1") }
+
+                assertThat(stored!!.lastErrorCode).doesNotContain("/private/path")
+                assertThat(stored.lastErrorCode).doesNotContain("user@example.com")
+                assertThat(stored.lastErrorCode).isEqualTo("prepared-recovery-not-committed")
+            }
+    }
+
+    @Test
+    fun `recoverPrepared does not touch pending records`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                DurableOutboxStoreConfig::class.java,
+                CommittedDeniedResolverConfig::class.java,
+            )
+            .withPropertyValues("tramai.sovereign.ops.mutations-enabled=true")
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignOpsAuditOutboxOperations::class.java)
+                val outboxStore = ctx.getBean(SovereignOpsAuditOutboxStore::class.java)
+
+                runBlocking {
+                    outboxStore.append(record("pending", SovereignOpsAuditOutboxStatus.PREPARED))
+                    outboxStore.markReadyForDispatch("pending", SovereignOpsAuditOutboxStatus.PREPARED)
+                }
+
+                val summary = runBlocking { ops.recoverPrepared(limit = 10) }
+                val stored = runBlocking { outboxStore.get("pending") }
+
+                assertThat(summary.inspected).isEqualTo(0)
+                assertThat(stored!!.status).isEqualTo(SovereignOpsAuditOutboxStatus.PENDING)
+            }
+    }
+
+    @Test
+    fun `recoverPrepared does not touch emitted records`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                DurableOutboxStoreConfig::class.java,
+                CommittedDeniedResolverConfig::class.java,
+            )
+            .withPropertyValues("tramai.sovereign.ops.mutations-enabled=true")
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignOpsAuditOutboxOperations::class.java)
+                val outboxStore = ctx.getBean(SovereignOpsAuditOutboxStore::class.java)
+
+                runBlocking {
+                    outboxStore.append(record("emitted", SovereignOpsAuditOutboxStatus.PREPARED))
+                    outboxStore.markReadyForDispatch("emitted", SovereignOpsAuditOutboxStatus.PREPARED)
+                    val claimed = outboxStore.claimPending("test", 10, Instant.now())
+                    for (c in claimed) {
+                        outboxStore.markEmitted(c.outboxId, SovereignOpsAuditOutboxStatus.EMITTING, Instant.now())
+                    }
+                }
+
+                val summary = runBlocking { ops.recoverPrepared(limit = 10) }
+
+                assertThat(summary.inspected).isEqualTo(0)
+            }
+    }
+
+    @Test
+    fun `recoverPrepared respects limit`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                DurableOutboxStoreConfig::class.java,
+                CommittedDeniedResolverConfig::class.java,
+            )
+            .withPropertyValues("tramai.sovereign.ops.mutations-enabled=true")
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignOpsAuditOutboxOperations::class.java)
+                val outboxStore = ctx.getBean(SovereignOpsAuditOutboxStore::class.java)
+
+                runBlocking {
+                    outboxStore.append(record("p1", SovereignOpsAuditOutboxStatus.PREPARED))
+                    outboxStore.append(record("p2", SovereignOpsAuditOutboxStatus.PREPARED))
+                    outboxStore.append(record("p3", SovereignOpsAuditOutboxStatus.PREPARED))
+                }
+
+                val summary = runBlocking { ops.recoverPrepared(limit = 2) }
+
+                assertThat(summary.inspected).isEqualTo(2)
+                assertThat(summary.movedToPending).isEqualTo(2)
+            }
+    }
+
+    @Test
+    fun `recoverPrepared rejects invalid limit`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                DurableOutboxStoreConfig::class.java,
+            )
+            .withPropertyValues("tramai.sovereign.ops.mutations-enabled=true")
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignOpsAuditOutboxOperations::class.java)
+
+                val ex = runCatching {
+                    runBlocking { ops.recoverPrepared(limit = 0) }
+                }.exceptionOrNull()
+
+                assertThat(ex).hasMessageContaining("tramai-sovereign-ops-invalid-limit")
+            }
+    }
+
+    @Test
+    fun `recoverPrepared summary counts are correct for mixed decisions`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                DurableOutboxStoreConfig::class.java,
+                MixedDecisionResolverConfig::class.java,
+            )
+            .withPropertyValues("tramai.sovereign.ops.mutations-enabled=true")
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignOpsAuditOutboxOperations::class.java)
+                val outboxStore = ctx.getBean(SovereignOpsAuditOutboxStore::class.java)
+
+                runBlocking {
+                    outboxStore.append(record("p1", SovereignOpsAuditOutboxStatus.PREPARED))
+                    outboxStore.append(record("p2", SovereignOpsAuditOutboxStatus.PREPARED))
+                    outboxStore.append(record("p3", SovereignOpsAuditOutboxStatus.PREPARED))
+                }
+
+                val summary = runBlocking { ops.recoverPrepared(limit = 10) }
+
+                assertThat(summary.inspected).isEqualTo(3)
+                assertThat(summary.movedToPending).isEqualTo(1)
+                assertThat(summary.markedFailedPermanent).isEqualTo(1)
+                assertThat(summary.skippedUnresolved).isEqualTo(1)
+                assertThat(summary.resolverFailures).isEqualTo(0)
+            }
+    }
+
+    @Test
+    fun `recoverPrepared handles resolver RuntimeException without leaking exception message`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                DurableOutboxStoreConfig::class.java,
+                ThrowingResolverConfig::class.java,
+            )
+            .withPropertyValues("tramai.sovereign.ops.mutations-enabled=true")
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignOpsAuditOutboxOperations::class.java)
+                val outboxStore = ctx.getBean(SovereignOpsAuditOutboxStore::class.java)
+
+                runBlocking {
+                    outboxStore.append(record("prepared-1", SovereignOpsAuditOutboxStatus.PREPARED))
+                }
+
+                val summary = runBlocking { ops.recoverPrepared(limit = 10) }
+                val stored = runBlocking { outboxStore.get("prepared-1") }
+
+                assertThat(summary.inspected).isEqualTo(1)
+                assertThat(summary.movedToPending).isEqualTo(0)
+                assertThat(summary.resolverFailures).isEqualTo(1)
+                assertThat(stored!!.status).isEqualTo(SovereignOpsAuditOutboxStatus.PREPARED)
+                assertThat(stored.lastErrorCode).isNull()
+            }
+    }
+
+    @Test
+    fun `recoverPrepared custom resolver bean is not overridden`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                DurableOutboxStoreConfig::class.java,
+                CustomRecoveryResolverConfig::class.java,
+            )
+            .withPropertyValues("tramai.sovereign.ops.mutations-enabled=true")
+            .run { ctx ->
+                val ops = ctx.getBean(SovereignOpsAuditOutboxOperations::class.java)
+                val outboxStore = ctx.getBean(SovereignOpsAuditOutboxStore::class.java)
+
+                runBlocking {
+                    outboxStore.append(record("prepared-1", SovereignOpsAuditOutboxStatus.PREPARED))
+                }
+
+                val summary = runBlocking { ops.recoverPrepared(limit = 10) }
+
+                assertThat(summary.inspected).isEqualTo(1)
+                assertThat(summary.movedToPending).isEqualTo(1)
+            }
+    }
+
     private fun record(
         outboxId: String,
         status: SovereignOpsAuditOutboxStatus,
@@ -282,4 +590,54 @@ class SovereignOpsAuditOutboxOperationsTest {
             createdAt = Instant.parse("2026-06-01T00:00:00Z"),
             status = status,
         )
+}
+
+// -- Recovery resolver test configs -----------------------------------------
+
+class CommittedDeniedResolverConfig {
+    @Bean
+    open fun committedDeniedResolver(): SovereignOpsApprovalRecoveryResolver =
+        SovereignOpsApprovalRecoveryResolver { _ ->
+            SovereignOpsPreparedRecoveryDecision.COMMITTED_DENIED
+        }
+}
+
+class NotCommittedResolverConfig {
+    @Bean
+    open fun notCommittedResolver(): SovereignOpsApprovalRecoveryResolver =
+        SovereignOpsApprovalRecoveryResolver { _ ->
+            SovereignOpsPreparedRecoveryDecision.NOT_COMMITTED
+        }
+}
+
+class MixedDecisionResolverConfig {
+    private var counter = 0
+
+    @Bean
+    open fun mixedDecisionResolver(): SovereignOpsApprovalRecoveryResolver =
+        SovereignOpsApprovalRecoveryResolver { _ ->
+            val current = counter++
+            when {
+                current == 0 -> SovereignOpsPreparedRecoveryDecision.COMMITTED_DENIED
+                current == 1 -> SovereignOpsPreparedRecoveryDecision.NOT_COMMITTED
+                else -> SovereignOpsPreparedRecoveryDecision.UNKNOWN
+            }
+        }
+}
+
+class ThrowingResolverConfig {
+    @Bean
+    open fun throwingResolver(): SovereignOpsApprovalRecoveryResolver =
+        SovereignOpsApprovalRecoveryResolver { _ ->
+            throw RuntimeException("test-resolver-error /private/path user@example.com")
+        }
+}
+
+class CustomRecoveryResolverConfig {
+    @Bean
+    @Primary
+    open fun customRecoveryResolver(): SovereignOpsApprovalRecoveryResolver =
+        SovereignOpsApprovalRecoveryResolver { _ ->
+            SovereignOpsPreparedRecoveryDecision.COMMITTED_DENIED
+        }
 }


### PR DESCRIPTION
## Summary

Add automatic reconciliation for PREPARED sovereign ops audit outbox records, closing the remaining crash-safety gap from PR #46.

**The problem:** An approval denial commits (approval store transition succeeds), but the process crashes before `markReadyForDispatch` moves the outbox record from PREPARED → PENDING. The outbox is safe (not falsely dispatchable) but stuck until manual operator intervention.

**The fix:** A `SovereignOpsApprovalRecoveryResolver` SPI that determines the disposition of each stuck PREPARED record, backed by a safe default (UNKNOWN = skip) and a new `recoverPrepared(limit)` operation.

## Core design

- **SovereignOpsApprovalRecoveryResolver** — `fun interface` with three possible decisions:
  - `COMMITTED_DENIED` → `markReadyForDispatch` (PREPARED → PENDING)
  - `NOT_COMMITTED` → `markFailed` with fixed error code `prepared-recovery-not-committed`
  - `UNKNOWN` → skip the record
- **UnknownSovereignOpsApprovalRecoveryResolver** — safe default that always returns UNKNOWN. Custom resolvers expected for production.
- **Recovery behavior:** resolver `RuntimeException` → skip record, count in `resolverFailures`. `CancellationException` rethrown.
- **No dispatcher required:** recovery only moves PREPARED to PENDING (or FAILED_PERMANENT). Actual dispatch happens via `retryPending`.

## File changes

| File | Change |
|---|---|
| `SovereignOpsApprovalRecoveryResolver.kt` | **NEW** — SPI + `SovereignOpsPreparedRecoveryDecision` enum |
| `UnknownSovereignOpsApprovalRecoveryResolver.kt` | **NEW** — safe default resolver |
| `SovereignOpsAuditOutboxRecoverySummary.kt` | Updated DTO: non-nullable fields, `skippedUnresolved`, `resolverFailures` |
| `SovereignOpsAuditOutboxOperations.kt` | Added `recoverPrepared(limit)` method |
| `DefaultSovereignOpsAuditOutboxOperations.kt` | Added `recoverPrepared` implementation + resolver injection |
| `SovereignOpsAutoConfiguration.kt` | Added `@ConditionalOnMissingBean` resolver bean + wiring |
| `SovereignOpsAuditOutboxOperationsTest.kt` | 15 new tests for recovery behavior |

## Security

- No raw approval IDs stored
- No raw reason text stored
- No raw resolver/operator text persisted
- Fixed safe error code `prepared-recovery-not-committed` only
- `CancellationException` rethrown; `RuntimeException` caught without leaking message
- Key never logged or included in exception messages

## Non-goals

- File-backed outbox store (PR #49)
- HMAC digest service (PR #51)
- REST/Actuator endpoints
- Background retry scheduler
- Raw approval ID index in outbox records
- Database-backed resolver

## Validation

```bash
./gradlew test --rerun-tasks
```

All 154 tasks pass.
