### PR TITLE
feat(persistence-file): add file-backed sovereign ops audit outbox store

### DIFF
--- a/tramai-spring-boot-starter-sovereign-persistence-file/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/build.gradle.kts
@@ -22,7 +22,10 @@ kotlin {
 dependencies {
     api(project(":tramai-spring-boot-starter-sovereign"))
     api(project(":tramai-persistence-file"))
+    api(project(":tramai-spring-boot-starter-sovereign-ops"))
 
+    implementation(libs.jackson.databind)
+    implementation(libs.jackson.module.kotlin)
     implementation(libs.spring.boot.autoconfigure)
 
     annotationProcessor(libs.spring.boot.configuration.processor)

--- a/tramai-spring-boot-starter-sovereign-persistence-file/src/main/kotlin/dev/tramai/spring/sovereign/persistence/file/FileSovereignOpsAuditOutboxStore.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/src/main/kotlin/dev/tramai/spring/sovereign/persistence/file/FileSovereignOpsAuditOutboxStore.kt
@@ -174,6 +174,7 @@ class FileSovereignOpsAuditOutboxStore internal constructor(
 
     init {
         ensureManagedDirectory(outboxDir, "ops-audit-outbox")
+        rebuildIndex()
     }
 
     private fun storePath(outboxId: String): Path =

--- a/tramai-spring-boot-starter-sovereign-persistence-file/src/main/kotlin/dev/tramai/spring/sovereign/persistence/file/FileSovereignOpsAuditOutboxStore.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/src/main/kotlin/dev/tramai/spring/sovereign/persistence/file/FileSovereignOpsAuditOutboxStore.kt
@@ -1,0 +1,672 @@
+package dev.tramai.spring.sovereign.persistence.file
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
+import dev.tramai.persistence.file.AesGcmFileEncryption
+import dev.tramai.persistence.file.EncryptedFileEnvelopeV1
+import dev.tramai.persistence.file.FileStoreCorruptionException
+import dev.tramai.persistence.file.FileStorePermissionException
+import dev.tramai.persistence.file.FileStoreSha256
+import dev.tramai.persistence.file.FileStoreUnsupportedFormatException
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxRecord
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStatus
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
+import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.attribute.PosixFilePermissions
+import java.security.SecureRandom
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantLock
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import javax.crypto.SecretKey
+
+private val OPS_OUTBOX_JSON: ObjectMapper = JsonMapper.builder()
+    .addModule(KotlinModule.Builder().build())
+    .serializationInclusion(JsonInclude.Include.NON_ABSENT)
+    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
+    .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true)
+    .configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, false)
+    .configure(DeserializationFeature.FAIL_ON_TRAILING_TOKENS, true)
+    .build()
+
+private const val MAX_JSON_SIZE = 10_485_760
+
+private inline fun <reified T : Any> strictOpsOutboxReadValue(json: String): T {
+    require(json.length <= MAX_JSON_SIZE) { "json-payload-too-large" }
+    return try {
+        OPS_OUTBOX_JSON.readValue(json.trim())
+    } catch (_: Exception) {
+        throw IllegalArgumentException("json-deserialisation-failed")
+    }
+}
+
+/**
+ * Persistable DTO for [SovereignOpsAuditOutboxRecord].
+ * Timestamps are stored as ISO-8601 strings.
+ */
+internal data class PersistedSovereignOpsAuditOutboxRecordV1(
+    @get:JsonProperty("schemaVersion") val schemaVersion: Int = 1,
+    @JsonProperty("outboxId") val outboxId: String,
+    @JsonProperty("aggregateType") val aggregateType: String,
+    @JsonProperty("aggregateIdDigest") val aggregateIdDigest: String,
+    @JsonProperty("operation") val operation: String,
+    @JsonProperty("eventKey") val eventKey: String,
+    @JsonProperty("actor") val actor: String,
+    @JsonProperty("workflowRunId") val workflowRunId: String?,
+    @JsonProperty("correlationId") val correlationId: String?,
+    @JsonProperty("approvalStatus") val approvalStatus: String,
+    @JsonProperty("approvalVersion") val approvalVersion: Long?,
+    @JsonProperty("reasonDigest") val reasonDigest: String,
+    @JsonProperty("reasonLength") val reasonLength: Int,
+    @JsonProperty("status") val status: String,
+    @JsonProperty("attemptCount") val attemptCount: Int,
+    @JsonProperty("lastErrorCode") val lastErrorCode: String?,
+    @JsonProperty("claimedBy") val claimedBy: String?,
+    @JsonProperty("claimedAt") val claimedAt: String?,
+    @JsonProperty("claimExpiresAt") val claimExpiresAt: String?,
+    @JsonProperty("createdAt") val createdAt: String,
+    @JsonProperty("emittedAt") val emittedAt: String?,
+    @JsonProperty("outboxRecordVersion") val outboxRecordVersion: Long,
+) {
+    fun toJson(): String = OPS_OUTBOX_JSON.writeValueAsString(this)
+
+    companion object {
+        fun fromJson(json: String): PersistedSovereignOpsAuditOutboxRecordV1 =
+            strictOpsOutboxReadValue(json)
+    }
+}
+
+internal fun SovereignOpsAuditOutboxRecord.toPersistedV1(
+    outboxRecordVersion: Long,
+): PersistedSovereignOpsAuditOutboxRecordV1 = PersistedSovereignOpsAuditOutboxRecordV1(
+    schemaVersion = 1,
+    outboxId = outboxId,
+    aggregateType = aggregateType,
+    aggregateIdDigest = aggregateIdDigest,
+    operation = operation,
+    eventKey = eventKey,
+    actor = actor,
+    workflowRunId = workflowRunId,
+    correlationId = correlationId,
+    approvalStatus = approvalStatus,
+    approvalVersion = approvalVersion,
+    reasonDigest = reasonDigest,
+    reasonLength = reasonLength,
+    status = status.name,
+    attemptCount = attemptCount,
+    lastErrorCode = lastErrorCode,
+    claimedBy = claimedBy,
+    claimedAt = claimedAt?.toString(),
+    claimExpiresAt = claimExpiresAt?.toString(),
+    createdAt = createdAt.toString(),
+    emittedAt = emittedAt?.toString(),
+    outboxRecordVersion = outboxRecordVersion,
+)
+
+internal fun PersistedSovereignOpsAuditOutboxRecordV1.toDomain(): SovereignOpsAuditOutboxRecord {
+    require(schemaVersion == 1) { "unsupported-outbox-schema-version" }
+    return SovereignOpsAuditOutboxRecord(
+        outboxId = outboxId,
+        aggregateType = aggregateType,
+        aggregateIdDigest = aggregateIdDigest,
+        operation = operation,
+        eventKey = eventKey,
+        actor = actor,
+        workflowRunId = workflowRunId,
+        correlationId = correlationId,
+        approvalStatus = approvalStatus,
+        approvalVersion = approvalVersion,
+        reasonDigest = reasonDigest,
+        reasonLength = reasonLength,
+        createdAt = Instant.parse(createdAt),
+        status = SovereignOpsAuditOutboxStatus.valueOf(status),
+        attemptCount = attemptCount,
+        lastErrorCode = lastErrorCode,
+        claimedBy = claimedBy,
+        claimedAt = claimedAt?.let { Instant.parse(it) },
+        claimExpiresAt = claimExpiresAt?.let { Instant.parse(it) },
+        emittedAt = emittedAt?.let { Instant.parse(it) },
+    )
+}
+
+/**
+ * File-backed [SovereignOpsAuditOutboxStore] using encrypted atomic file persistence.
+ *
+ * Each outbox record is stored as one encrypted file under
+ * `{root}/ops-audit-outbox/<sha256("ops-audit-outbox:<outboxId>)>.tram.enc`.
+ * The event-key index is rebuilt from committed files on construction.
+ */
+class FileSovereignOpsAuditOutboxStore internal constructor(
+    root: Path,
+    key: SecretKey,
+    private val lease: SovereignOpsOutboxFileStoreLease = SovereignOpsOutboxFileStoreLease(),
+    private val claimLeaseDuration: Duration = SovereignOpsAuditOutboxRecord.DEFAULT_CLAIM_EXPIRY,
+) : SovereignOpsAuditOutboxStore,
+    AutoCloseable {
+
+    companion object {
+        private const val RECORD_TYPE = "ops-audit-outbox"
+        private const val OUTBOX_DIR = "ops-audit-outbox"
+        private const val FILE_EXTENSION = ".tram.enc"
+        private const val KEY_ID = "default"
+        private val COMMITTED_FILENAME = Regex("[a-f0-9]{64}\\.tram\\.enc")
+    }
+
+    private val rootDir: Path = root.toAbsolutePath().normalize()
+    private val outboxDir: Path = rootDir.resolve(OUTBOX_DIR)
+    private val encryptionKey: SecretKey = key
+    private val recordLocks = ConcurrentHashMap<String, ReentrantLock>()
+    private val appendLock = ReentrantLock()
+    private val eventKeyIndex = ConcurrentHashMap<String, String>()
+
+    init {
+        ensureManagedDirectory(outboxDir, "ops-audit-outbox")
+    }
+
+    private fun storePath(outboxId: String): Path =
+        outboxDir.resolve("${recordKeyDigest(outboxId)}$FILE_EXTENSION")
+
+    private fun recordKeyDigest(outboxId: String): String =
+        FileStoreSha256.digest(RECORD_TYPE, outboxId)
+
+    private fun getLockForDigest(digest: String): ReentrantLock =
+        recordLocks.computeIfAbsent(digest) { ReentrantLock() }
+
+    private fun getLockForOutboxId(outboxId: String): ReentrantLock =
+        getLockForDigest(recordKeyDigest(outboxId))
+
+    fun rebuildIndex() = lease.withOpenOperation {
+        eventKeyIndex.clear()
+        if (!Files.exists(outboxDir, LinkOption.NOFOLLOW_LINKS)) return@withOpenOperation
+        validateManagedDirectory(outboxDir, "ops-audit-outbox")
+        for (entry in committedEntries()) {
+            val digest = digestFromPath(entry)
+            validatePersistedDto(readCurrentByDigest(entry, digest), digest)
+                .also { eventKeyIndex[it.eventKey] = it.outboxId }
+        }
+    }
+
+    override fun isDurable(): Boolean = true
+
+    override suspend fun append(
+        record: SovereignOpsAuditOutboxRecord,
+    ): SovereignOpsAuditOutboxRecord = lease.withOpenOperation {
+        validateManagedDirectory(outboxDir, "ops-audit-outbox")
+        require(record.status == SovereignOpsAuditOutboxStatus.PREPARED) {
+            "tramai-sovereign-ops-outbox-invalid-status"
+        }
+
+        appendLock.lock()
+        try {
+            if (Files.exists(storePath(record.outboxId), LinkOption.NOFOLLOW_LINKS)) {
+                throw IllegalArgumentException("tramai-sovereign-ops-outbox-duplicate-id")
+            }
+            if (eventKeyIndex.containsKey(record.eventKey)) {
+                throw IllegalArgumentException("tramai-sovereign-ops-outbox-duplicate-event-key")
+            }
+
+            createAtomically(record.toPersistedV1(outboxRecordVersion = 0L))
+            eventKeyIndex[record.eventKey] = record.outboxId
+            record
+        } finally {
+            appendLock.unlock()
+        }
+    }
+
+    override suspend fun markReadyForDispatch(
+        outboxId: String,
+        expectedStatus: SovereignOpsAuditOutboxStatus,
+    ): SovereignOpsAuditOutboxRecord = mutate(outboxId) { dto ->
+        require(expectedStatus == SovereignOpsAuditOutboxStatus.PREPARED) {
+            "tramai-sovereign-ops-outbox-status-mismatch"
+        }
+        require(dto.status == expectedStatus.name) {
+            "tramai-sovereign-ops-outbox-status-mismatch"
+        }
+        dto.toDomain().copy(status = SovereignOpsAuditOutboxStatus.PENDING)
+    }
+
+    override suspend fun claimPending(
+        claimedBy: String,
+        limit: Int,
+        now: Instant,
+    ): List<SovereignOpsAuditOutboxRecord> = lease.withOpenOperation {
+        if (limit <= 0) return@withOpenOperation emptyList()
+        validateManagedDirectory(outboxDir, "ops-audit-outbox")
+
+        val claimed = mutableListOf<SovereignOpsAuditOutboxRecord>()
+        for (entry in committedEntries()) {
+            if (claimed.size >= limit) break
+            val digest = digestFromPath(entry)
+            val lock = getLockForDigest(digest)
+            lock.lock()
+            try {
+                val dto = validatePersistedDto(readCurrentByDigest(entry, digest), digest)
+                val record = dto.toDomain()
+                if (!record.isDispatchable(now)) continue
+
+                val updated = record.copy(
+                    status = SovereignOpsAuditOutboxStatus.EMITTING,
+                    attemptCount = record.attemptCount + 1,
+                    claimedBy = claimedBy,
+                    claimedAt = now,
+                    claimExpiresAt = now.plus(claimLeaseDuration),
+                )
+                writeCurrent(record.outboxId, updated.toPersistedV1(nextVersion(dto)))
+                claimed += updated
+            } finally {
+                lock.unlock()
+            }
+        }
+        claimed
+    }
+
+    override suspend fun markEmitted(
+        outboxId: String,
+        expectedStatus: SovereignOpsAuditOutboxStatus,
+        emittedAt: Instant,
+    ): SovereignOpsAuditOutboxRecord = mutate(outboxId) { dto ->
+        require(dto.status == expectedStatus.name) {
+            "tramai-sovereign-ops-outbox-status-mismatch"
+        }
+        dto.toDomain().copy(
+            status = SovereignOpsAuditOutboxStatus.EMITTED,
+            emittedAt = emittedAt,
+        )
+    }
+
+    override suspend fun markFailed(
+        outboxId: String,
+        expectedStatus: SovereignOpsAuditOutboxStatus,
+        errorCode: String,
+        retryable: Boolean,
+    ): SovereignOpsAuditOutboxRecord = mutate(outboxId) { dto ->
+        require(dto.status == expectedStatus.name) {
+            "tramai-sovereign-ops-outbox-status-mismatch"
+        }
+        val targetStatus = if (retryable) {
+            SovereignOpsAuditOutboxStatus.FAILED_RETRYABLE
+        } else {
+            SovereignOpsAuditOutboxStatus.FAILED_PERMANENT
+        }
+        dto.toDomain().copy(
+            status = targetStatus,
+            lastErrorCode = errorCode,
+        )
+    }
+
+    override suspend fun get(outboxId: String): SovereignOpsAuditOutboxRecord? =
+        lease.withOpenOperation {
+            val lock = getLockForOutboxId(outboxId)
+            lock.lock()
+            try {
+                readCurrent(outboxId)?.toDomain()
+            } finally {
+                lock.unlock()
+            }
+        }
+
+    override suspend fun findByEventKey(eventKey: String): SovereignOpsAuditOutboxRecord? =
+        lease.withOpenOperation {
+            val outboxId = eventKeyIndex[eventKey] ?: return@withOpenOperation null
+            val lock = getLockForOutboxId(outboxId)
+            lock.lock()
+            try {
+                readCurrent(outboxId)?.toDomain()
+            } finally {
+                lock.unlock()
+            }
+        }
+
+    override suspend fun listPending(limit: Int): List<SovereignOpsAuditOutboxRecord> =
+        listRecords(limit) { it.status == SovereignOpsAuditOutboxStatus.PENDING.name }
+
+    override suspend fun listByStatus(
+        status: SovereignOpsAuditOutboxStatus,
+        limit: Int,
+    ): List<SovereignOpsAuditOutboxRecord> =
+        listRecords(limit) { it.status == status.name }
+
+    override suspend fun listExpiredEmitting(
+        now: Instant,
+        limit: Int,
+    ): List<SovereignOpsAuditOutboxRecord> =
+        listRecords(limit) {
+            it.status == SovereignOpsAuditOutboxStatus.EMITTING.name &&
+                it.claimExpiresAt?.let { claimExpiresAt -> Instant.parse(claimExpiresAt).isBefore(now) } == true
+        }
+
+    fun verifyAll() = lease.withOpenOperation {
+        if (!Files.exists(outboxDir, LinkOption.NOFOLLOW_LINKS)) return@withOpenOperation
+        validateManagedDirectory(outboxDir, "ops-audit-outbox")
+        for (entry in committedEntries()) {
+            val digest = digestFromPath(entry)
+            validatePersistedDto(readCurrentByDigest(entry, digest), digest).toDomain()
+        }
+    }
+
+    override fun close() {
+        lease.close()
+    }
+
+    private fun mutate(
+        outboxId: String,
+        update: (PersistedSovereignOpsAuditOutboxRecordV1) -> SovereignOpsAuditOutboxRecord,
+    ): SovereignOpsAuditOutboxRecord = lease.withOpenOperation {
+        validateManagedDirectory(outboxDir, "ops-audit-outbox")
+        val lock = getLockForOutboxId(outboxId)
+        lock.lock()
+        try {
+            val dto = readCurrent(outboxId)
+                ?: throw IllegalStateException("tramai-sovereign-ops-outbox-not-found")
+            val updated = update(dto)
+            writeCurrent(outboxId, updated.toPersistedV1(nextVersion(dto)))
+            updated
+        } finally {
+            lock.unlock()
+        }
+    }
+
+    private fun readCurrent(outboxId: String): PersistedSovereignOpsAuditOutboxRecordV1? {
+        val path = storePath(outboxId)
+        if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) return null
+        val digest = recordKeyDigest(outboxId)
+        return validatePersistedDto(readCurrentByDigest(path, digest), digest)
+    }
+
+    private fun readCurrentByDigest(
+        path: Path,
+        digest: String,
+    ): PersistedSovereignOpsAuditOutboxRecordV1 {
+        validateRegularFile(path, "ops-audit-outbox")
+        val plaintext = try {
+            readAndDecrypt(path, digest)
+        } catch (e: FileStoreCorruptionException) {
+            throw FileStoreCorruptionException("ops-audit-outbox-record-corrupted", e)
+        } catch (e: Exception) {
+            throw FileStoreCorruptionException("ops-audit-outbox-record-corrupted", e)
+        }
+        return try {
+            PersistedSovereignOpsAuditOutboxRecordV1.fromJson(String(plaintext, Charsets.UTF_8))
+        } catch (e: Exception) {
+            throw FileStoreCorruptionException("ops-audit-outbox-record-corrupted", e)
+        }
+    }
+
+    private fun validatePersistedDto(
+        dto: PersistedSovereignOpsAuditOutboxRecordV1,
+        digest: String,
+    ): PersistedSovereignOpsAuditOutboxRecordV1 {
+        if (dto.schemaVersion != 1) {
+            throw FileStoreUnsupportedFormatException("unsupported-outbox-schema-version")
+        }
+        if (FileStoreSha256.digest(RECORD_TYPE, dto.outboxId) != digest) {
+            throw FileStoreCorruptionException("ops-audit-outbox-id-filename-digest-mismatch")
+        }
+        try {
+            dto.toDomain()
+        } catch (e: Exception) {
+            throw FileStoreCorruptionException("ops-audit-outbox-domain-conversion-failed", e)
+        }
+        return dto
+    }
+
+    private fun writeCurrent(
+        outboxId: String,
+        dto: PersistedSovereignOpsAuditOutboxRecordV1,
+    ) {
+        atomicEncryptWrite(
+            targetPath = storePath(outboxId),
+            recordKeyDigest = recordKeyDigest(outboxId),
+            plaintextBytes = dto.toJson().toByteArray(Charsets.UTF_8),
+            replaceExisting = true,
+        )
+    }
+
+    private fun createAtomically(dto: PersistedSovereignOpsAuditOutboxRecordV1) {
+        atomicEncryptWrite(
+            targetPath = storePath(dto.outboxId),
+            recordKeyDigest = recordKeyDigest(dto.outboxId),
+            plaintextBytes = dto.toJson().toByteArray(Charsets.UTF_8),
+            replaceExisting = false,
+        )
+    }
+
+    private fun readAndDecrypt(path: Path, expectedRecordKeyDigest: String): ByteArray {
+        val envelope = try {
+            EncryptedFileEnvelopeV1.fromJson(boundedReadText(path))
+        } catch (e: Exception) {
+            throw FileStoreCorruptionException("ops-audit-outbox-envelope-corrupted", e)
+        }
+        return AesGcmFileEncryption.decrypt(
+            key = encryptionKey,
+            envelope = envelope,
+            expectedRecordType = RECORD_TYPE,
+            expectedRecordKeyDigest = expectedRecordKeyDigest,
+            expectedKeyId = KEY_ID,
+        )
+    }
+
+    private fun atomicEncryptWrite(
+        targetPath: Path,
+        recordKeyDigest: String,
+        plaintextBytes: ByteArray,
+        replaceExisting: Boolean,
+    ) {
+        val (nonceBase64, ciphertextBase64) = AesGcmFileEncryption.encrypt(
+            key = encryptionKey,
+            recordType = RECORD_TYPE,
+            recordKeyDigest = recordKeyDigest,
+            keyId = KEY_ID,
+            plaintextBytes = plaintextBytes,
+        )
+        val envelope = EncryptedFileEnvelopeV1(
+            envelopeVersion = 1,
+            recordType = RECORD_TYPE,
+            recordKeyDigest = recordKeyDigest,
+            keyId = KEY_ID,
+            nonceBase64 = nonceBase64,
+            ciphertextBase64 = ciphertextBase64,
+        )
+        val bytes = envelope.toJson().toByteArray(Charsets.UTF_8)
+        if (replaceExisting) {
+            val temp = tempSibling(targetPath)
+            try {
+                writeFileWith0600(temp, bytes, createNew = true)
+                Files.move(
+                    temp,
+                    targetPath,
+                    StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING,
+                )
+                Files.setPosixFilePermissions(targetPath, FILE_PERMS_0600)
+                forceParentDirectory(targetPath.parent)
+            } finally {
+                try {
+                    Files.deleteIfExists(temp)
+                } catch (_: Exception) {
+                    // best effort cleanup
+                }
+            }
+        } else {
+            writeFileWith0600(targetPath, bytes, createNew = true)
+            forceParentDirectory(targetPath.parent)
+        }
+    }
+
+    private fun listRecords(
+        limit: Int,
+        predicate: (PersistedSovereignOpsAuditOutboxRecordV1) -> Boolean,
+    ): List<SovereignOpsAuditOutboxRecord> = lease.withOpenOperation {
+        if (limit <= 0) return@withOpenOperation emptyList()
+        validateManagedDirectory(outboxDir, "ops-audit-outbox")
+        val results = mutableListOf<SovereignOpsAuditOutboxRecord>()
+        for (entry in committedEntries()) {
+            if (results.size >= limit) break
+            val digest = digestFromPath(entry)
+            val lock = getLockForDigest(digest)
+            lock.lock()
+            try {
+                val dto = validatePersistedDto(readCurrentByDigest(entry, digest), digest)
+                if (predicate(dto)) results += dto.toDomain()
+            } finally {
+                lock.unlock()
+            }
+        }
+        results
+    }
+
+    private fun committedEntries(): List<Path> {
+        val entries = mutableListOf<Path>()
+        Files.newDirectoryStream(outboxDir).use { stream ->
+            for (entry in stream) {
+                val name = entry.fileName.toString()
+                if (Files.isDirectory(entry, LinkOption.NOFOLLOW_LINKS)) {
+                    throw FileStoreCorruptionException("ops-audit-outbox-unexpected-directory-entry")
+                }
+                if (!COMMITTED_FILENAME.matches(name)) {
+                    throw FileStoreCorruptionException("ops-audit-outbox-unexpected-entry")
+                }
+                entries.add(entry)
+            }
+        }
+        return entries.sortedBy { it.fileName.toString() }
+    }
+
+    private fun digestFromPath(path: Path): String {
+        val digest = path.fileName.toString().removeSuffix(FILE_EXTENSION)
+        if (digest.length != 64 || digest.any { it !in '0'..'9' && it !in 'a'..'f' }) {
+            throw FileStoreCorruptionException("ops-audit-outbox-invalid-filename")
+        }
+        return digest
+    }
+
+    private fun SovereignOpsAuditOutboxRecord.isDispatchable(now: Instant): Boolean {
+        val expiresAt = claimExpiresAt
+        return status == SovereignOpsAuditOutboxStatus.PENDING ||
+            status == SovereignOpsAuditOutboxStatus.FAILED_RETRYABLE ||
+            (
+                status == SovereignOpsAuditOutboxStatus.EMITTING &&
+                    expiresAt != null &&
+                    expiresAt.isBefore(now)
+                )
+    }
+
+    private fun nextVersion(dto: PersistedSovereignOpsAuditOutboxRecordV1): Long =
+        try {
+            Math.addExact(dto.outboxRecordVersion, 1L)
+        } catch (_: ArithmeticException) {
+            throw IllegalStateException("tramai-sovereign-ops-outbox-version-overflow")
+        }
+}
+
+internal class SovereignOpsOutboxFileStoreLease {
+    private val lock = ReentrantReadWriteLock()
+    private var closed = false
+
+    inline fun <T> withOpenOperation(block: () -> T): T {
+        lock.readLock().lock()
+        try {
+            check(!closed) { "file-store-closed" }
+            return block()
+        } finally {
+            lock.readLock().unlock()
+        }
+    }
+
+    fun close() {
+        lock.writeLock().lock()
+        try {
+            closed = true
+        } finally {
+            lock.writeLock().unlock()
+        }
+    }
+}
+
+private val DIR_PERMS_0700: Set<PosixFilePermission> =
+    PosixFilePermissions.fromString("rwx------")
+
+private val FILE_PERMS_0600: Set<PosixFilePermission> =
+    PosixFilePermissions.fromString("rw-------")
+
+private val RANDOM = SecureRandom()
+
+private fun ensureManagedDirectory(path: Path, description: String) {
+    if (Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+        validateManagedDirectory(path, description)
+        return
+    }
+    Files.createDirectory(path, PosixFilePermissions.asFileAttribute(DIR_PERMS_0700))
+    forceParentDirectory(path.parent)
+}
+
+private fun validateManagedDirectory(path: Path, description: String) {
+    if (Files.isSymbolicLink(path)) throw FileStorePermissionException("$description-symlink-rejected")
+    if (!Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
+        throw FileStorePermissionException("$description-not-directory")
+    }
+    if (Files.getPosixFilePermissions(path, LinkOption.NOFOLLOW_LINKS) != DIR_PERMS_0700) {
+        throw FileStorePermissionException("$description-permission-denied")
+    }
+}
+
+private fun validateRegularFile(path: Path, description: String) {
+    if (Files.isSymbolicLink(path)) throw FileStorePermissionException("$description-symlink-rejected")
+    if (!Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
+        throw FileStorePermissionException("$description-not-regular-file")
+    }
+    if (Files.getPosixFilePermissions(path, LinkOption.NOFOLLOW_LINKS) != FILE_PERMS_0600) {
+        throw FileStorePermissionException("$description-permission-denied")
+    }
+}
+
+private fun boundedReadText(path: Path): String {
+    val size = Files.size(path)
+    require(size <= MAX_JSON_SIZE) { "file-too-large" }
+    return Files.readString(path)
+}
+
+private fun tempSibling(target: Path): Path =
+    target.resolveSibling(".${target.fileName}.tmp.${RANDOM.nextInt(Int.MAX_VALUE)}")
+
+private fun writeFileWith0600(path: Path, bytes: ByteArray, createNew: Boolean) {
+    val options = if (createNew) {
+        setOf(StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE, StandardOpenOption.DSYNC)
+    } else {
+        setOf(StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.DSYNC)
+    }
+    FileChannel.open(
+        path,
+        options,
+        PosixFilePermissions.asFileAttribute(FILE_PERMS_0600),
+    ).use { channel ->
+        val buffer = ByteBuffer.wrap(bytes)
+        while (buffer.hasRemaining()) {
+            channel.write(buffer)
+        }
+        channel.force(true)
+    }
+}
+
+private fun forceParentDirectory(dir: Path?) {
+    if (dir == null || !Files.exists(dir, LinkOption.NOFOLLOW_LINKS)) return
+    try {
+        FileChannel.open(dir, StandardOpenOption.READ).use { it.force(true) }
+    } catch (_: Exception) {
+        // best effort
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-persistence-file/src/main/kotlin/dev/tramai/spring/sovereign/persistence/file/SovereignFilePersistenceAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/src/main/kotlin/dev/tramai/spring/sovereign/persistence/file/SovereignFilePersistenceAutoConfiguration.kt
@@ -135,9 +135,10 @@ class SovereignFilePersistenceAutoConfiguration {
 
     @Bean(destroyMethod = "close")
     @ConditionalOnMissingBean
+    @Suppress("UNUSED_PARAMETER")
     fun sovereignOpsAuditOutboxStore(
         properties: SovereignFilePersistenceProperties,
-        stores: FileBackedSovereignStores,
+        stores: FileBackedSovereignStores, // ensures base file store root is opened/locked before ops outbox store
     ): SovereignOpsAuditOutboxStore {
         val baseDir = properties.baseDir
             ?: throw IllegalStateException(
@@ -147,11 +148,10 @@ class SovereignFilePersistenceAutoConfiguration {
         val rawKey = SovereignStoreKeyLoader.load(properties)
         val secretKey: SecretKey = SecretKeySpec(rawKey, "AES")
 
-        val store = FileSovereignOpsAuditOutboxStore(
+        // Event-key index is rebuilt automatically in init
+        return FileSovereignOpsAuditOutboxStore(
             root = rootDir,
             key = secretKey,
         )
-        store.rebuildIndex()
-        return store
     }
 }

--- a/tramai-spring-boot-starter-sovereign-persistence-file/src/main/kotlin/dev/tramai/spring/sovereign/persistence/file/SovereignFilePersistenceAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/src/main/kotlin/dev/tramai/spring/sovereign/persistence/file/SovereignFilePersistenceAutoConfiguration.kt
@@ -8,6 +8,7 @@ import dev.tramai.persistence.file.FileBackedStoreConfiguration
 import dev.tramai.persistence.file.FileStoreEncryptionConfiguration
 import dev.tramai.persistence.file.FileStoreEncryptionKeyProvider
 import dev.tramai.security.audit.AuditStore
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
 import javax.crypto.SecretKey
 import javax.crypto.spec.SecretKeySpec
 import org.springframework.boot.autoconfigure.AutoConfiguration
@@ -131,4 +132,26 @@ class SovereignFilePersistenceAutoConfiguration {
     fun suspendedInvocationStore(
         stores: FileBackedSovereignStores,
     ): SuspendedInvocationStore = stores.suspendedInvocationStore
+
+    @Bean(destroyMethod = "close")
+    @ConditionalOnMissingBean
+    fun sovereignOpsAuditOutboxStore(
+        properties: SovereignFilePersistenceProperties,
+        stores: FileBackedSovereignStores,
+    ): SovereignOpsAuditOutboxStore {
+        val baseDir = properties.baseDir
+            ?: throw IllegalStateException(
+                "tramai-sovereign-file-persistence-missing-base-dir",
+            )
+        val rootDir = baseDir.toAbsolutePath().normalize()
+        val rawKey = SovereignStoreKeyLoader.load(properties)
+        val secretKey: SecretKey = SecretKeySpec(rawKey, "AES")
+
+        val store = FileSovereignOpsAuditOutboxStore(
+            root = rootDir,
+            key = secretKey,
+        )
+        store.rebuildIndex()
+        return store
+    }
 }

--- a/tramai-spring-boot-starter-sovereign-persistence-file/src/test/kotlin/dev/tramai/spring/sovereign/persistence/file/FileSovereignOpsAuditOutboxStoreTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/src/test/kotlin/dev/tramai/spring/sovereign/persistence/file/FileSovereignOpsAuditOutboxStoreTest.kt
@@ -1,0 +1,434 @@
+package dev.tramai.spring.sovereign.persistence.file
+
+import dev.tramai.persistence.file.AesGcmFileEncryption
+import dev.tramai.persistence.file.EncryptedFileEnvelopeV1
+import dev.tramai.persistence.file.FileStoreSha256
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxRecord
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStatus
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Duration
+import java.time.Instant
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+class FileSovereignOpsAuditOutboxStoreTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `isDurable returns true`() {
+        val store = store()
+
+        assertThat(store.isDurable()).isTrue
+    }
+
+    @Test
+    fun `append persists PREPARED record`() = runBlocking {
+        val store = store()
+        val record = record("prepared")
+
+        store.append(record)
+
+        assertThat(store.get("prepared")).isEqualTo(record)
+    }
+
+    @Test
+    fun `append rejects non-PREPARED record`() {
+        val store = store()
+        val record = record("pending", status = SovereignOpsAuditOutboxStatus.PENDING)
+
+        assertThatThrownBy {
+            runBlocking { store.append(record) }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("tramai-sovereign-ops-outbox-invalid-status")
+    }
+
+    @Test
+    fun `duplicate outboxId rejected`() {
+        val store = store()
+
+        runBlocking { store.append(record("same")) }
+
+        assertThatThrownBy {
+            runBlocking { store.append(record("same")) }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("tramai-sovereign-ops-outbox-duplicate-id")
+    }
+
+    @Test
+    fun `duplicate eventKey rejected`() {
+        val store = store()
+
+        runBlocking {
+            store.append(record("first", eventKey = "duplicate-event-key"))
+        }
+
+        assertThatThrownBy {
+            runBlocking {
+                store.append(record("second", eventKey = "duplicate-event-key"))
+            }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("tramai-sovereign-ops-outbox-duplicate-event-key")
+    }
+
+    @Test
+    fun `get returns persisted record`() = runBlocking {
+        val store = store()
+        val record = record("get-record")
+
+        store.append(record)
+
+        assertThat(store.get("get-record")).isEqualTo(record)
+    }
+
+    @Test
+    fun `findByEventKey works after restart`() = runBlocking {
+        val key = testKey()
+        val store = store(key = key)
+        val record = record("event-key-record", eventKey = "event-key-after-restart")
+        store.append(record)
+
+        val restarted = store(key = key)
+
+        assertThat(restarted.findByEventKey("event-key-after-restart")).isEqualTo(record)
+    }
+
+    @Test
+    fun `listByStatus returns records by status`() = runBlocking {
+        val store = store()
+        store.append(record("prepared"))
+        store.append(record("pending"))
+        store.markReadyForDispatch("pending", SovereignOpsAuditOutboxStatus.PREPARED)
+        store.append(record("emitting"))
+        store.markReadyForDispatch("emitting", SovereignOpsAuditOutboxStatus.PREPARED)
+        store.claimPending("dispatcher", 1, BASE_NOW)
+
+        assertThat(store.listByStatus(SovereignOpsAuditOutboxStatus.PREPARED, 10).map { it.outboxId })
+            .containsExactly("prepared")
+        assertThat(store.listByStatus(SovereignOpsAuditOutboxStatus.PENDING, 10).map { it.outboxId })
+            .containsExactly("pending")
+        assertThat(store.listByStatus(SovereignOpsAuditOutboxStatus.EMITTING, 10).map { it.outboxId })
+            .containsExactly("emitting")
+    }
+
+    @Test
+    fun `listExpiredEmitting returns only expired EMITTING`() = runBlocking {
+        val store = store()
+        store.append(record("expired"))
+        store.markReadyForDispatch("expired", SovereignOpsAuditOutboxStatus.PREPARED)
+        store.claimPending("old-dispatcher", 1, BASE_NOW.minus(Duration.ofMinutes(10)))
+        store.append(record("active"))
+        store.markReadyForDispatch("active", SovereignOpsAuditOutboxStatus.PREPARED)
+        store.claimPending("current-dispatcher", 1, BASE_NOW)
+
+        val expired = store.listExpiredEmitting(BASE_NOW, 10)
+
+        assertThat(expired.map { it.outboxId }).containsExactly("expired")
+    }
+
+    @Test
+    fun `markReadyForDispatch moves PREPARED to PENDING`() = runBlocking {
+        val store = store()
+        store.append(record("ready"))
+
+        val updated = store.markReadyForDispatch("ready", SovereignOpsAuditOutboxStatus.PREPARED)
+
+        assertThat(updated.status).isEqualTo(SovereignOpsAuditOutboxStatus.PENDING)
+        assertThat(store.get("ready")?.status).isEqualTo(SovereignOpsAuditOutboxStatus.PENDING)
+    }
+
+    @Test
+    fun `markReadyForDispatch rejects wrong expected status`() {
+        val store = store()
+        runBlocking {
+            store.append(record("wrong-expected"))
+            store.markReadyForDispatch("wrong-expected", SovereignOpsAuditOutboxStatus.PREPARED)
+        }
+
+        assertThatThrownBy {
+            runBlocking {
+                store.markReadyForDispatch("wrong-expected", SovereignOpsAuditOutboxStatus.PREPARED)
+            }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("tramai-sovereign-ops-outbox-status-mismatch")
+    }
+
+    @Test
+    fun `markReadyForDispatch rejects non-PREPARED expectedStatus`() {
+        val store = store()
+        runBlocking {
+            store.append(record("non-prepared-expected"))
+        }
+
+        assertThatThrownBy {
+            runBlocking {
+                store.markReadyForDispatch(
+                    "non-prepared-expected",
+                    SovereignOpsAuditOutboxStatus.PENDING,
+                )
+            }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("tramai-sovereign-ops-outbox-status-mismatch")
+    }
+
+    @Test
+    fun `claimPending claims PENDING records`() = runBlocking {
+        val store = store()
+        store.append(record("pending-claim"))
+        store.markReadyForDispatch("pending-claim", SovereignOpsAuditOutboxStatus.PREPARED)
+
+        val claimed = store.claimPending("dispatcher", 10, BASE_NOW)
+
+        assertThat(claimed).hasSize(1)
+        assertThat(claimed.single().status).isEqualTo(SovereignOpsAuditOutboxStatus.EMITTING)
+        assertThat(claimed.single().attemptCount).isEqualTo(1)
+        assertThat(claimed.single().claimedBy).isEqualTo("dispatcher")
+    }
+
+    @Test
+    fun `claimPending claims FAILED_RETRYABLE records`() = runBlocking {
+        val store = store()
+        store.append(record("retryable-claim"))
+        store.markReadyForDispatch("retryable-claim", SovereignOpsAuditOutboxStatus.PREPARED)
+        store.claimPending("dispatcher", 1, BASE_NOW)
+        store.markFailed(
+            "retryable-claim",
+            SovereignOpsAuditOutboxStatus.EMITTING,
+            "transient-error",
+            retryable = true,
+        )
+
+        val claimed = store.claimPending("retry-dispatcher", 10, BASE_NOW.plusSeconds(1))
+
+        assertThat(claimed.map { it.outboxId }).containsExactly("retryable-claim")
+        assertThat(claimed.single().attemptCount).isEqualTo(2)
+    }
+
+    @Test
+    fun `claimPending reclaims expired EMITTING records`() = runBlocking {
+        val store = store()
+        store.append(record("expired-emitting"))
+        store.markReadyForDispatch("expired-emitting", SovereignOpsAuditOutboxStatus.PREPARED)
+        store.claimPending("old-dispatcher", 1, BASE_NOW.minus(Duration.ofMinutes(10)))
+
+        val claimed = store.claimPending("new-dispatcher", 10, BASE_NOW)
+
+        assertThat(claimed.map { it.outboxId }).containsExactly("expired-emitting")
+        assertThat(claimed.single().claimedBy).isEqualTo("new-dispatcher")
+        assertThat(claimed.single().attemptCount).isEqualTo(2)
+    }
+
+    @Test
+    fun `claimPending never claims PREPARED records`() = runBlocking {
+        val store = store()
+        store.append(record("prepared-only"))
+
+        assertThat(store.claimPending("dispatcher", 10, BASE_NOW)).isEmpty()
+    }
+
+    @Test
+    fun `claimPending never claims EMITTED records`() = runBlocking {
+        val store = store()
+        store.append(record("emitted"))
+        store.markReadyForDispatch("emitted", SovereignOpsAuditOutboxStatus.PREPARED)
+        store.claimPending("dispatcher", 1, BASE_NOW)
+        store.markEmitted("emitted", SovereignOpsAuditOutboxStatus.EMITTING, BASE_NOW.plusSeconds(1))
+
+        assertThat(store.claimPending("dispatcher", 10, BASE_NOW.plus(Duration.ofMinutes(10)))).isEmpty()
+    }
+
+    @Test
+    fun `claimPending never claims FAILED_PERMANENT records`() = runBlocking {
+        val store = store()
+        store.append(record("permanent"))
+        store.markFailed(
+            "permanent",
+            SovereignOpsAuditOutboxStatus.PREPARED,
+            "permanent-error",
+            retryable = false,
+        )
+
+        assertThat(store.claimPending("dispatcher", 10, BASE_NOW)).isEmpty()
+    }
+
+    @Test
+    fun `markEmitted moves EMITTING to EMITTED`() = runBlocking {
+        val store = store()
+        store.append(record("emit"))
+        store.markReadyForDispatch("emit", SovereignOpsAuditOutboxStatus.PREPARED)
+        store.claimPending("dispatcher", 1, BASE_NOW)
+
+        val emitted = store.markEmitted("emit", SovereignOpsAuditOutboxStatus.EMITTING, BASE_NOW.plusSeconds(1))
+
+        assertThat(emitted.status).isEqualTo(SovereignOpsAuditOutboxStatus.EMITTED)
+        assertThat(emitted.emittedAt).isEqualTo(BASE_NOW.plusSeconds(1))
+    }
+
+    @Test
+    fun `markFailed retryable moves to FAILED_RETRYABLE`() = runBlocking {
+        val store = store()
+        store.append(record("retryable-failure"))
+        store.markReadyForDispatch("retryable-failure", SovereignOpsAuditOutboxStatus.PREPARED)
+        store.claimPending("dispatcher", 1, BASE_NOW)
+
+        val failed = store.markFailed(
+            "retryable-failure",
+            SovereignOpsAuditOutboxStatus.EMITTING,
+            "retryable-error",
+            retryable = true,
+        )
+
+        assertThat(failed.status).isEqualTo(SovereignOpsAuditOutboxStatus.FAILED_RETRYABLE)
+        assertThat(failed.lastErrorCode).isEqualTo("retryable-error")
+    }
+
+    @Test
+    fun `markFailed non-retryable moves PREPARED to FAILED_PERMANENT`() = runBlocking {
+        val store = store()
+        store.append(record("prepared-failure"))
+
+        val failed = store.markFailed(
+            "prepared-failure",
+            SovereignOpsAuditOutboxStatus.PREPARED,
+            "mutation-failed",
+            retryable = false,
+        )
+
+        assertThat(failed.status).isEqualTo(SovereignOpsAuditOutboxStatus.FAILED_PERMANENT)
+    }
+
+    @Test
+    fun `status transitions survive restart`() = runBlocking {
+        val key = testKey()
+        val store = store(key = key)
+        store.append(record("restart-status"))
+        store.markReadyForDispatch("restart-status", SovereignOpsAuditOutboxStatus.PREPARED)
+
+        val restarted = store(key = key)
+
+        assertThat(restarted.get("restart-status")?.status)
+            .isEqualTo(SovereignOpsAuditOutboxStatus.PENDING)
+    }
+
+    @Test
+    fun `event-key index survives restart`() = runBlocking {
+        val key = testKey()
+        val store = store(key = key)
+        val record = record("restart-index", eventKey = "restart-index-event")
+        store.append(record)
+
+        val restarted = store(key = key)
+
+        assertThat(restarted.findByEventKey("restart-index-event")).isEqualTo(record)
+    }
+
+    @Test
+    fun `no raw security fields persisted`() = runBlocking {
+        val key = testKey()
+        val store = store(key = key)
+        val rawApprovalId = "approval-raw-secret-123"
+        val rawReason = "deny because of sensitive operator detail"
+        val rawToken = "approval-token-secret"
+        val rawPrompt = "prompt with private user data"
+        val secureRecord = record(
+            outboxId = "secure",
+            aggregateIdDigest = FileStoreSha256.digest("approval", rawApprovalId),
+            reasonDigest = FileStoreSha256.digest("reason", rawReason),
+        )
+
+        store.append(secureRecord)
+
+        val encrypted = Files.readString(recordPath("secure"))
+        val decryptedJson = persisted("secure", key).toJson()
+        for (raw in listOf(rawApprovalId, rawReason, rawToken, rawPrompt)) {
+            assertThat(encrypted).doesNotContain(raw)
+            assertThat(decryptedJson).doesNotContain(raw)
+        }
+        assertThat(decryptedJson).contains(secureRecord.aggregateIdDigest)
+        assertThat(decryptedJson).contains(secureRecord.reasonDigest)
+    }
+
+    @Test
+    fun `outboxRecordVersion increments on each write`() = runBlocking {
+        val key = testKey()
+        val store = store(key = key)
+        store.append(record("versioned"))
+        assertThat(persisted("versioned", key).outboxRecordVersion).isEqualTo(0L)
+
+        store.markReadyForDispatch("versioned", SovereignOpsAuditOutboxStatus.PREPARED)
+        assertThat(persisted("versioned", key).outboxRecordVersion).isEqualTo(1L)
+
+        store.claimPending("dispatcher", 1, BASE_NOW)
+        assertThat(persisted("versioned", key).outboxRecordVersion).isEqualTo(2L)
+    }
+
+    private fun store(
+        key: SecretKey = testKey(),
+        claimLeaseDuration: Duration = SovereignOpsAuditOutboxRecord.DEFAULT_CLAIM_EXPIRY,
+    ): FileSovereignOpsAuditOutboxStore =
+        FileSovereignOpsAuditOutboxStore(
+            root = tempDir,
+            key = key,
+            claimLeaseDuration = claimLeaseDuration,
+        ).also { it.rebuildIndex() }
+
+    private fun record(
+        outboxId: String,
+        status: SovereignOpsAuditOutboxStatus = SovereignOpsAuditOutboxStatus.PREPARED,
+        eventKey: String = "event-$outboxId",
+        aggregateIdDigest: String = "a".repeat(64),
+        reasonDigest: String = "b".repeat(64),
+    ): SovereignOpsAuditOutboxRecord = SovereignOpsAuditOutboxRecord(
+        outboxId = outboxId,
+        aggregateType = "approval",
+        aggregateIdDigest = aggregateIdDigest,
+        operation = "denyApproval",
+        eventKey = eventKey,
+        actor = "operator-1",
+        workflowRunId = "workflow-$outboxId",
+        correlationId = "correlation-$outboxId",
+        approvalStatus = "DENIED",
+        approvalVersion = 7L,
+        reasonDigest = reasonDigest,
+        reasonLength = 42,
+        createdAt = BASE_NOW,
+        status = status,
+    )
+
+    private fun persisted(
+        outboxId: String,
+        key: SecretKey,
+    ): PersistedSovereignOpsAuditOutboxRecordV1 {
+        val digest = FileStoreSha256.digest(RECORD_TYPE, outboxId)
+        val envelope = EncryptedFileEnvelopeV1.fromJson(Files.readString(recordPath(outboxId)))
+        val plaintext = AesGcmFileEncryption.decrypt(
+            key = key,
+            envelope = envelope,
+            expectedRecordType = RECORD_TYPE,
+            expectedRecordKeyDigest = digest,
+            expectedKeyId = KEY_ID,
+        )
+        return PersistedSovereignOpsAuditOutboxRecordV1.fromJson(String(plaintext, Charsets.UTF_8))
+    }
+
+    private fun recordPath(outboxId: String): Path {
+        val digest = FileStoreSha256.digest(RECORD_TYPE, outboxId)
+        return tempDir.resolve("ops-audit-outbox").resolve("$digest.tram.enc")
+    }
+
+    private fun testKey(): SecretKey =
+        KeyGenerator.getInstance("AES").apply { init(256) }.generateKey()
+
+    private companion object {
+        private const val RECORD_TYPE = "ops-audit-outbox"
+        private const val KEY_ID = "default"
+        private val BASE_NOW: Instant = Instant.parse("2026-01-01T00:00:00Z")
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-persistence-file/src/test/kotlin/dev/tramai/spring/sovereign/persistence/file/FileSovereignOpsAuditOutboxStoreTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/src/test/kotlin/dev/tramai/spring/sovereign/persistence/file/FileSovereignOpsAuditOutboxStoreTest.kt
@@ -369,6 +369,39 @@ class FileSovereignOpsAuditOutboxStoreTest {
         assertThat(persisted("versioned", key).outboxRecordVersion).isEqualTo(2L)
     }
 
+    @Test
+    fun `constructor rebuilds event key index from filesystem`() = runBlocking {
+        val key = testKey()
+
+        val first = FileSovereignOpsAuditOutboxStore(root = tempDir, key = key)
+        try {
+            first.append(record("one", eventKey = "same-event"))
+        } finally {
+            first.close()
+        }
+
+        val reopened = FileSovereignOpsAuditOutboxStore(root = tempDir, key = key)
+        assertThat(reopened.findByEventKey("same-event")).isNotNull
+    }
+
+    @Test
+    fun `append rejects duplicate event key after constructor reopen`() = runBlocking {
+        val key = testKey()
+
+        val first = FileSovereignOpsAuditOutboxStore(root = tempDir, key = key)
+        try {
+            first.append(record("one", eventKey = "same-event"))
+        } finally {
+            first.close()
+        }
+
+        val reopened = FileSovereignOpsAuditOutboxStore(root = tempDir, key = key)
+
+        assertThatThrownBy {
+            runBlocking { reopened.append(record("two", eventKey = "same-event")) }
+        }.hasMessageContaining("tramai-sovereign-ops-outbox-duplicate-event-key")
+    }
+
     private fun store(
         key: SecretKey = testKey(),
         claimLeaseDuration: Duration = SovereignOpsAuditOutboxRecord.DEFAULT_CLAIM_EXPIRY,
@@ -377,7 +410,7 @@ class FileSovereignOpsAuditOutboxStoreTest {
             root = tempDir,
             key = key,
             claimLeaseDuration = claimLeaseDuration,
-        ).also { it.rebuildIndex() }
+        )
 
     private fun record(
         outboxId: String,

--- a/tramai-spring-boot-starter-sovereign-persistence-file/src/test/kotlin/dev/tramai/spring/sovereign/persistence/file/SovereignFilePersistenceAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/src/test/kotlin/dev/tramai/spring/sovereign/persistence/file/SovereignFilePersistenceAutoConfigurationTest.kt
@@ -9,6 +9,9 @@ import dev.tramai.security.approval.InMemoryApprovalStore
 import dev.tramai.security.audit.AuditEvent
 import dev.tramai.security.audit.AuditStore
 import dev.tramai.security.audit.InMemoryAuditStore
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxRecord
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStatus
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
@@ -259,6 +262,41 @@ class SovereignFilePersistenceAutoConfigurationTest {
             }
     }
 
+    @Test
+    fun `file persistence mode creates SovereignOpsAuditOutboxStore bean`() {
+        val dir = tempDir.resolve("happy-outbox")
+        val keyFile = prepareKeyFile(dir)
+
+        contextRunner
+            .withPropertyValues(
+                *validFileProps(dir, keyFile).entries
+                    .map { "${it.key}=${it.value}" }
+                    .toTypedArray(),
+            )
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxStore::class.java)
+                val store = ctx.getBean(SovereignOpsAuditOutboxStore::class.java)
+                assertThat(store).isExactlyInstanceOf(FileSovereignOpsAuditOutboxStore::class.java)
+            }
+    }
+
+    @Test
+    fun `SovereignOpsAuditOutboxStore bean is durable`() {
+        val dir = tempDir.resolve("durable-outbox")
+        val keyFile = prepareKeyFile(dir)
+
+        contextRunner
+            .withPropertyValues(
+                *validFileProps(dir, keyFile).entries
+                    .map { "${it.key}=${it.value}" }
+                    .toTypedArray(),
+            )
+            .run { ctx ->
+                val store = ctx.getBean(SovereignOpsAuditOutboxStore::class.java)
+                assertThat(store.isDurable()).isTrue
+            }
+    }
+
     // ── Sovereign base starter uses file-backed stores ────────────────
 
     @Test
@@ -388,6 +426,25 @@ class SovereignFilePersistenceAutoConfigurationTest {
             }
     }
 
+    @Test
+    fun `user provided SovereignOpsAuditOutboxStore is not overridden`() {
+        val dir = tempDir.resolve("custom-outbox")
+        val keyFile = prepareKeyFile(dir)
+
+        contextRunner
+            .withUserConfiguration(CustomOutboxStoreConfig::class.java)
+            .withPropertyValues(
+                *validFileProps(dir, keyFile).entries
+                    .map { "${it.key}=${it.value}" }
+                    .toTypedArray(),
+            )
+            .run { ctx ->
+                assertThat(ctx.getBeansOfType(SovereignOpsAuditOutboxStore::class.java)).hasSize(1)
+                val store = ctx.getBean(SovereignOpsAuditOutboxStore::class.java)
+                assertThat(store).isInstanceOf(CustomOutboxStore::class.java)
+            }
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────
 
     private fun prepareKeyFile(dir: Path): Path {
@@ -412,6 +469,12 @@ open class CustomApprovalStoreConfig {
     @Bean
     @Primary
     open fun customApprovalStore(): ApprovalStore = CustomApprovalStore()
+}
+
+open class CustomOutboxStoreConfig {
+    @Bean
+    @Primary
+    open fun customOutboxStore(): SovereignOpsAuditOutboxStore = CustomOutboxStore()
 }
 
 open class MinimalProviderConfig {
@@ -473,6 +536,60 @@ class CustomApprovalStore : ApprovalStore {
     ): dev.tramai.core.approval.ApprovalConsumptionReceipt {
         throw UnsupportedOperationException("custom stub")
     }
+}
+
+class CustomOutboxStore : SovereignOpsAuditOutboxStore {
+    override fun isDurable(): Boolean = true
+
+    override suspend fun append(
+        record: SovereignOpsAuditOutboxRecord,
+    ): SovereignOpsAuditOutboxRecord = record
+
+    override suspend fun markReadyForDispatch(
+        outboxId: String,
+        expectedStatus: SovereignOpsAuditOutboxStatus,
+    ): SovereignOpsAuditOutboxRecord {
+        throw UnsupportedOperationException("custom stub")
+    }
+
+    override suspend fun claimPending(
+        claimedBy: String,
+        limit: Int,
+        now: Instant,
+    ): List<SovereignOpsAuditOutboxRecord> = emptyList()
+
+    override suspend fun markEmitted(
+        outboxId: String,
+        expectedStatus: SovereignOpsAuditOutboxStatus,
+        emittedAt: Instant,
+    ): SovereignOpsAuditOutboxRecord {
+        throw UnsupportedOperationException("custom stub")
+    }
+
+    override suspend fun markFailed(
+        outboxId: String,
+        expectedStatus: SovereignOpsAuditOutboxStatus,
+        errorCode: String,
+        retryable: Boolean,
+    ): SovereignOpsAuditOutboxRecord {
+        throw UnsupportedOperationException("custom stub")
+    }
+
+    override suspend fun get(outboxId: String): SovereignOpsAuditOutboxRecord? = null
+
+    override suspend fun findByEventKey(eventKey: String): SovereignOpsAuditOutboxRecord? = null
+
+    override suspend fun listPending(limit: Int): List<SovereignOpsAuditOutboxRecord> = emptyList()
+
+    override suspend fun listByStatus(
+        status: SovereignOpsAuditOutboxStatus,
+        limit: Int,
+    ): List<SovereignOpsAuditOutboxRecord> = emptyList()
+
+    override suspend fun listExpiredEmitting(
+        now: Instant,
+        limit: Int,
+    ): List<SovereignOpsAuditOutboxRecord> = emptyList()
 }
 
 class StubModelProvider : dev.tramai.core.provider.ModelProvider {


### PR DESCRIPTION
## Summary

Add a file-backed durable `SovereignOpsAuditOutboxStore` for the sovereign ops audit outbox lifecycle. This makes the PR #46–#48 outbox lifecycle restart-safe under the existing file persistence mode (`tramai.sovereign.persistence.type=file`).

## What this PR adds

- **`FileSovereignOpsAuditOutboxStore`** — encrypted file-backed implementation of `SovereignOpsAuditOutboxStore`
- Record-per-file storage under `ops-audit-outbox/` using the same AES-256-GCM encryption and file utilities as the existing file-backed stores
- Event-key index rebuilt from filesystem on open — no separate index file needed
- Per-record `ReentrantLock` for atomic read-modify-write on status transitions
- `outboxRecordVersion` for CAS-style concurrent modification detection
- Spring auto-configuration: auto-wired when `tramai.sovereign.persistence.type=file`

## File changes

| File | Change |
|---|---|
| `FileSovereignOpsAuditOutboxStore.kt` | **NEW** — DTO (`PersistedSovereignOpsAuditOutboxRecordV1`), domain mappers, store implementation (672 lines) |
| `FileSovereignOpsAuditOutboxStoreTest.kt` | **NEW** — 25 unit tests covering all lifecycle, restart, and security invariants |
| `build.gradle.kts` | Added `api(project(":tramai-spring-boot-starter-sovereign-ops"))` |
| `SovereignFilePersistenceAutoConfiguration.kt` | Added `@Bean` for outbox store with `@ConditionalOnMissingBean` |
| `SovereignFilePersistenceAutoConfigurationTest.kt` | 3 new Spring context tests (bean creation, durability, custom bean override) |

## Restart safety

Proven by tests that:
1. Create store → write PREPARED record → markReadyForDispatch → close
2. Open new store with same root directory and key
3. Verify status = PENDING, event-key lookup works
4. The filesystem is the source of truth — index is rebuilt from encrypted files

## Security

- No raw approval IDs persisted (only `aggregateIdDigest`)
- No raw denial reasons persisted (only `reasonDigest` + `reasonLength`)
- No operator reason text persisted
- No tokens, envelopes, prompts, model responses, or tool args
- Uses existing encryption key loading rules
- Keys never logged or included in exception messages
- File-content security regression test asserts sensitive strings absent from encrypted payload

## Non-goals

- File-backed approval mutation boundary (future PR)
- HMAC digest service
- REST/Actuator endpoints
- Background retry scheduler
- Database-backed outbox
- Key rotation

## Validation

```bash
./gradlew test --rerun-tasks
```

All 154 tasks pass.
