### PR TITLE
feat(sovereign-ops): add background audit outbox worker

### DIFF
--- a/tramai-spring-boot-starter-sovereign-ops/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-ops/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     api(project(":tramai-sovereign"))
     api(project(":tramai-spring-boot-starter-sovereign"))
 
+    implementation(libs.coroutines.core)
     implementation(libs.spring.boot.autoconfigure)
 
     annotationProcessor(libs.spring.boot.configuration.processor)

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
@@ -12,9 +12,11 @@ import dev.tramai.spring.sovereign.ops.outbox.InMemorySovereignOpsAuditOutboxSto
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalRecoveryResolver
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalMutationStore
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditDigestService
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxBackgroundWorker
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxDispatcher
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxOperations
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerLifecycle
 import dev.tramai.spring.sovereign.ops.outbox.UnknownSovereignOpsApprovalRecoveryResolver
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.autoconfigure.AutoConfiguration
@@ -146,6 +148,46 @@ class SovereignOpsAutoConfiguration {
             outboxDispatcher = outboxDispatcher.ifAvailable,
             recoveryResolver = recoveryResolver,
             properties = properties,
+        )
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnProperty(
+        prefix = "tramai.sovereign.ops.outbox.worker",
+        name = ["enabled"],
+        havingValue = "true",
+    )
+    fun sovereignOpsAuditOutboxBackgroundWorker(
+        operations: SovereignOpsAuditOutboxOperations,
+        properties: SovereignOpsProperties,
+        outboxDispatcher: ObjectProvider<SovereignOpsAuditOutboxDispatcher>,
+    ): SovereignOpsAuditOutboxBackgroundWorker {
+        val workerProps = properties.outbox.worker
+        if (workerProps.dispatchPending && workerProps.failOnMissingDispatcher) {
+            if (outboxDispatcher.ifAvailable == null) {
+                throw IllegalStateException("tramai-sovereign-ops-outbox-worker-missing-dispatcher")
+            }
+        }
+        return SovereignOpsAuditOutboxBackgroundWorker(
+            operations = operations,
+            properties = workerProps,
+        )
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnProperty(
+        prefix = "tramai.sovereign.ops.outbox.worker",
+        name = ["enabled"],
+        havingValue = "true",
+    )
+    fun sovereignOpsAuditOutboxWorkerLifecycle(
+        worker: SovereignOpsAuditOutboxBackgroundWorker,
+        properties: SovereignOpsProperties,
+    ): SovereignOpsAuditOutboxWorkerLifecycle =
+        SovereignOpsAuditOutboxWorkerLifecycle(
+            worker = worker,
+            properties = properties.outbox.worker,
         )
 
     @Bean

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
@@ -18,6 +18,7 @@ import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxOperations
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerLifecycle
 import dev.tramai.spring.sovereign.ops.outbox.UnknownSovereignOpsApprovalRecoveryResolver
+import dev.tramai.spring.sovereign.ops.outbox.validateSovereignOpsAuditOutboxWorkerProperties
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
@@ -162,15 +163,23 @@ class SovereignOpsAutoConfiguration {
         properties: SovereignOpsProperties,
         outboxDispatcher: ObjectProvider<SovereignOpsAuditOutboxDispatcher>,
     ): SovereignOpsAuditOutboxBackgroundWorker {
-        val workerProps = properties.outbox.worker
-        if (workerProps.dispatchPending && workerProps.failOnMissingDispatcher) {
-            if (outboxDispatcher.ifAvailable == null) {
+        val rawProps = properties.outbox.worker
+        val dispatcherAvailable = outboxDispatcher.ifAvailable != null
+
+        val effectiveWorkerProps = if (rawProps.dispatchPending && !dispatcherAvailable) {
+            if (rawProps.failOnMissingDispatcher) {
                 throw IllegalStateException("tramai-sovereign-ops-outbox-worker-missing-dispatcher")
             }
+            rawProps.copy(dispatchPending = false)
+        } else {
+            rawProps
         }
+
+        validateSovereignOpsAuditOutboxWorkerProperties(effectiveWorkerProps)
+
         return SovereignOpsAuditOutboxBackgroundWorker(
             operations = operations,
-            properties = workerProps,
+            properties = effectiveWorkerProps,
         )
     }
 
@@ -184,11 +193,25 @@ class SovereignOpsAutoConfiguration {
     fun sovereignOpsAuditOutboxWorkerLifecycle(
         worker: SovereignOpsAuditOutboxBackgroundWorker,
         properties: SovereignOpsProperties,
-    ): SovereignOpsAuditOutboxWorkerLifecycle =
-        SovereignOpsAuditOutboxWorkerLifecycle(
+        outboxDispatcher: ObjectProvider<SovereignOpsAuditOutboxDispatcher>,
+    ): SovereignOpsAuditOutboxWorkerLifecycle {
+        val rawProps = properties.outbox.worker
+        val dispatcherAvailable = outboxDispatcher.ifAvailable != null
+
+        val effectiveWorkerProps = if (rawProps.dispatchPending && !dispatcherAvailable) {
+            if (rawProps.failOnMissingDispatcher) {
+                throw IllegalStateException("tramai-sovereign-ops-outbox-worker-missing-dispatcher")
+            }
+            rawProps.copy(dispatchPending = false)
+        } else {
+            rawProps
+        }
+
+        return SovereignOpsAuditOutboxWorkerLifecycle(
             worker = worker,
-            properties = properties.outbox.worker,
+            properties = effectiveWorkerProps,
         )
+    }
 
     @Bean
     @ConditionalOnMissingBean

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsProperties.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsProperties.kt
@@ -1,6 +1,7 @@
 package dev.tramai.spring.sovereign.ops
 
 import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.Duration
 
 /**
  * Externalized configuration for TramAI sovereign operations.
@@ -13,6 +14,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  *       enabled: true
  *       mutations-enabled: false
  *       max-page-size: 100
+ *       outbox:
+ *         worker:
+ *           enabled: false
  * ```
  *
  * Read-capable, mutation-disabled by default — inspection is safer than
@@ -32,4 +36,21 @@ data class SovereignOpsProperties(
 
     /** Maximum number of audit events returned by readAuditStream. */
     var maxPageSize: Int = 100,
+
+    /** Configuration for sovereign ops audit outbox behavior. */
+    var outbox: SovereignOpsOutboxProperties = SovereignOpsOutboxProperties(),
+)
+
+data class SovereignOpsOutboxProperties(
+    val worker: SovereignOpsOutboxWorkerProperties = SovereignOpsOutboxWorkerProperties(),
+)
+
+data class SovereignOpsOutboxWorkerProperties(
+    val enabled: Boolean = false,
+    val initialDelay: Duration = Duration.ofSeconds(5),
+    val interval: Duration = Duration.ofSeconds(30),
+    val batchSize: Int = 100,
+    val recoverPrepared: Boolean = true,
+    val dispatchPending: Boolean = true,
+    val failOnMissingDispatcher: Boolean = true,
 )

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxBackgroundWorker.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxBackgroundWorker.kt
@@ -36,6 +36,8 @@ class SovereignOpsAuditOutboxBackgroundWorker(
                 throw e
             } catch (e: RuntimeException) {
                 failure = e.toFailureSummary(action = "recoverPrepared")
+            } catch (e: Exception) {
+                failure = e.toFailureSummary(action = "recoverPrepared")
             }
         }
 
@@ -45,6 +47,8 @@ class SovereignOpsAuditOutboxBackgroundWorker(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: RuntimeException) {
+                failure = e.toFailureSummary(action = "dispatchPending")
+            } catch (e: Exception) {
                 failure = e.toFailureSummary(action = "dispatchPending")
             }
         }
@@ -58,12 +62,12 @@ class SovereignOpsAuditOutboxBackgroundWorker(
         )
     }
 
-    private fun RuntimeException.toFailureSummary(
+    private fun Throwable.toFailureSummary(
         action: String,
     ): SovereignOpsAuditOutboxWorkerFailureSummary =
         SovereignOpsAuditOutboxWorkerFailureSummary(
             action = action,
-            errorCode = this::class.simpleName ?: "RuntimeException",
+            errorCode = this::class.simpleName ?: "Exception",
         )
 }
 

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxBackgroundWorker.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxBackgroundWorker.kt
@@ -1,0 +1,81 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+import dev.tramai.spring.sovereign.ops.SovereignOpsOutboxWorkerProperties
+import kotlinx.coroutines.CancellationException
+import java.time.Clock
+import java.time.Instant
+
+/**
+ * Background worker that periodically recovers prepared outbox records
+ * and dispatches pending audit outbox records.
+ *
+ * Exposes [runOnce] for deterministic testing. The scheduled loop
+ * calls [runOnce], not the business logic directly.
+ *
+ * ## Security invariants
+ * - No raw approval IDs, raw reason text, tokens, envelopes, prompts,
+ *   or tool arguments are logged or exposed in summaries.
+ * - [CancellationException] is never swallowed by this worker.
+ * - Runtime failures do not kill the worker loop.
+ */
+class SovereignOpsAuditOutboxBackgroundWorker(
+    private val operations: SovereignOpsAuditOutboxOperations,
+    private val properties: SovereignOpsOutboxWorkerProperties,
+    private val clock: Clock = Clock.systemUTC(),
+) {
+    suspend fun runOnce(): SovereignOpsAuditOutboxWorkerRunSummary {
+        val startedAt = clock.instant()
+        var recovered: SovereignOpsAuditOutboxRecoverySummary? = null
+        var dispatched: SovereignOpsAuditOutboxDispatchResult? = null
+        var failure: SovereignOpsAuditOutboxWorkerFailureSummary? = null
+
+        if (properties.recoverPrepared) {
+            try {
+                recovered = operations.recoverPrepared(properties.batchSize)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: RuntimeException) {
+                failure = e.toFailureSummary(action = "recoverPrepared")
+            }
+        }
+
+        if (failure == null && properties.dispatchPending) {
+            try {
+                dispatched = operations.retryPending(properties.batchSize)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: RuntimeException) {
+                failure = e.toFailureSummary(action = "dispatchPending")
+            }
+        }
+
+        return SovereignOpsAuditOutboxWorkerRunSummary(
+            recovered = recovered,
+            dispatched = dispatched,
+            failure = failure,
+            startedAt = startedAt,
+            completedAt = clock.instant(),
+        )
+    }
+
+    private fun RuntimeException.toFailureSummary(
+        action: String,
+    ): SovereignOpsAuditOutboxWorkerFailureSummary =
+        SovereignOpsAuditOutboxWorkerFailureSummary(
+            action = action,
+            errorCode = this::class.simpleName ?: "RuntimeException",
+        )
+}
+
+data class SovereignOpsAuditOutboxWorkerRunSummary(
+    val recovered: SovereignOpsAuditOutboxRecoverySummary?,
+    val dispatched: SovereignOpsAuditOutboxDispatchResult?,
+    val failure: SovereignOpsAuditOutboxWorkerFailureSummary? = null,
+    val startedAt: Instant,
+    val completedAt: Instant,
+)
+
+data class SovereignOpsAuditOutboxWorkerFailureSummary(
+    val action: String,
+    val errorCode: String,
+)

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerLifecycle.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerLifecycle.kt
@@ -37,11 +37,19 @@ class SovereignOpsAuditOutboxWorkerLifecycle(
 
             while (running) {
                 try {
-                    worker.runOnce()
+                    val summary = worker.runOnce()
+                    summary.failure?.let {
+                        logger.warn(
+                            "Sovereign ops audit outbox worker cycle failed: action=${it.action}, errorCode=${it.errorCode}",
+                        )
+                    }
                 } catch (e: CancellationException) {
                     throw e
-                } catch (_: Exception) {
-                    // Runtime failures must not kill the background loop.
+                } catch (e: Exception) {
+                    logger.warn(
+                        "Sovereign ops audit outbox worker cycle failed unexpectedly: " +
+                            "errorCode=${e::class.simpleName ?: "Exception"}",
+                    )
                 }
 
                 if (running) {
@@ -62,7 +70,7 @@ class SovereignOpsAuditOutboxWorkerLifecycle(
     override fun getPhase(): Int = 0
 }
 
-internal fun validateSovereignOpsAuditOutboxWorkerProperties(
+fun validateSovereignOpsAuditOutboxWorkerProperties(
     properties: SovereignOpsOutboxWorkerProperties,
 ) {
     require(!properties.interval.isZero && !properties.interval.isNegative) {

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerLifecycle.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerLifecycle.kt
@@ -1,0 +1,80 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+import dev.tramai.spring.sovereign.ops.SovereignOpsOutboxWorkerProperties
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.apache.commons.logging.LogFactory
+import org.springframework.context.SmartLifecycle
+
+class SovereignOpsAuditOutboxWorkerLifecycle(
+    private val worker: SovereignOpsAuditOutboxBackgroundWorker,
+    private val properties: SovereignOpsOutboxWorkerProperties,
+) : SmartLifecycle {
+
+    private val logger = LogFactory.getLog(SovereignOpsAuditOutboxWorkerLifecycle::class.java)
+    private val scope = CoroutineScope(Dispatchers.Default)
+    private var job: Job? = null
+
+    @Volatile
+    private var running = false
+
+    override fun start() {
+        if (!properties.enabled) {
+            logger.debug("Sovereign ops audit outbox worker is disabled - not starting")
+            return
+        }
+        if (running) return
+
+        validateSovereignOpsAuditOutboxWorkerProperties(properties)
+
+        running = true
+        job = scope.launch {
+            delay(properties.initialDelay.toMillis())
+
+            while (running) {
+                try {
+                    worker.runOnce()
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (_: Exception) {
+                    // Runtime failures must not kill the background loop.
+                }
+
+                if (running) {
+                    delay(properties.interval.toMillis())
+                }
+            }
+        }
+    }
+
+    override fun stop() {
+        running = false
+        job?.cancel()
+        job = null
+    }
+
+    override fun isRunning(): Boolean = running
+
+    override fun getPhase(): Int = 0
+}
+
+internal fun validateSovereignOpsAuditOutboxWorkerProperties(
+    properties: SovereignOpsOutboxWorkerProperties,
+) {
+    require(!properties.interval.isZero && !properties.interval.isNegative) {
+        "tramai-sovereign-ops-outbox-worker-invalid-interval"
+    }
+    require(!properties.initialDelay.isNegative) {
+        "tramai-sovereign-ops-outbox-worker-invalid-initial-delay"
+    }
+    require(properties.batchSize in 1..500) {
+        "tramai-sovereign-ops-outbox-worker-invalid-batch-size"
+    }
+    require(properties.recoverPrepared || properties.dispatchPending) {
+        "tramai-sovereign-ops-outbox-worker-invalid-actions: at least one of recoverPrepared or dispatchPending must be true when worker is enabled"
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsOutboxWorkerAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsOutboxWorkerAutoConfigurationTest.kt
@@ -1,0 +1,181 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxBackgroundWorker
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxDispatchResult
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxOperations
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxRecoverySummary
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStatus
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxSummary
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerLifecycle
+import dev.tramai.spring.sovereign.ops.outbox.TestAuditEngineConfig
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+
+class SovereignOpsOutboxWorkerAutoConfigurationTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(SovereignOpsAutoConfiguration::class.java),
+        )
+
+    @Test
+    fun `worker bean is not created by default`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                assertThat(ctx).doesNotHaveBean(SovereignOpsAuditOutboxBackgroundWorker::class.java)
+                assertThat(ctx).doesNotHaveBean(SovereignOpsAuditOutboxWorkerLifecycle::class.java)
+            }
+    }
+
+    @Test
+    fun `worker bean is created when enabled`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                TestAuditEngineConfig::class.java,
+            )
+            .withPropertyValues(
+                "tramai.sovereign.ops.outbox.worker.enabled=true",
+                "tramai.sovereign.ops.outbox.worker.initial-delay=1h",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxBackgroundWorker::class.java)
+                assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxWorkerLifecycle::class.java)
+            }
+    }
+
+    @Test
+    fun `custom worker bean overrides default`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                CustomOutboxBackgroundWorkerConfig::class.java,
+            )
+            .withPropertyValues(
+                "tramai.sovereign.ops.outbox.worker.enabled=true",
+                "tramai.sovereign.ops.outbox.worker.initial-delay=1h",
+            )
+            .run { ctx ->
+                assertThat(ctx.getBeansOfType(SovereignOpsAuditOutboxBackgroundWorker::class.java))
+                    .hasSize(1)
+                    .containsKey("customOutboxBackgroundWorker")
+                assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxWorkerLifecycle::class.java)
+            }
+    }
+
+    @Test
+    fun `enabled dispatch worker fails without dispatcher when failOnMissingDispatcher true`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.outbox.worker.enabled=true",
+                "tramai.sovereign.ops.outbox.worker.initial-delay=1h",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasFailed()
+                assertThat(ctx.startupFailure)
+                    .hasMessageContaining("tramai-sovereign-ops-outbox-worker-missing-dispatcher")
+            }
+    }
+
+    @Test
+    fun `enabled recovery-only worker does not require dispatcher`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.outbox.worker.enabled=true",
+                "tramai.sovereign.ops.outbox.worker.initial-delay=1h",
+                "tramai.sovereign.ops.outbox.worker.dispatch-pending=false",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasNotFailed()
+                assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxBackgroundWorker::class.java)
+            }
+    }
+
+    @Test
+    fun `worker uses configured interval and batch size`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                RecordingOutboxOperationsConfig::class.java,
+            )
+            .withPropertyValues(
+                "tramai.sovereign.ops.outbox.worker.enabled=true",
+                "tramai.sovereign.ops.outbox.worker.initial-delay=1h",
+                "tramai.sovereign.ops.outbox.worker.interval=42s",
+                "tramai.sovereign.ops.outbox.worker.batch-size=17",
+                "tramai.sovereign.ops.outbox.worker.dispatch-pending=false",
+            )
+            .run { ctx ->
+                val properties = ctx.getBean(SovereignOpsProperties::class.java)
+                val worker = ctx.getBean(SovereignOpsAuditOutboxBackgroundWorker::class.java)
+                val operations = ctx.getBean(RecordingOutboxOperations::class.java)
+
+                runBlocking { worker.runOnce() }
+
+                assertThat(properties.outbox.worker.interval).isEqualTo(java.time.Duration.ofSeconds(42))
+                assertThat(properties.outbox.worker.batchSize).isEqualTo(17)
+                assertThat(operations.recoverLimits).containsExactly(17)
+            }
+    }
+}
+
+open class CustomOutboxBackgroundWorkerConfig {
+    @Bean
+    @Primary
+    open fun customOutboxBackgroundWorker(): SovereignOpsAuditOutboxBackgroundWorker =
+        SovereignOpsAuditOutboxBackgroundWorker(
+            operations = RecordingOutboxOperations(),
+            properties = SovereignOpsOutboxWorkerProperties(
+                enabled = true,
+                initialDelay = java.time.Duration.ofHours(1),
+                dispatchPending = false,
+            ),
+        )
+}
+
+open class RecordingOutboxOperationsConfig {
+    @Bean
+    @Primary
+    open fun recordingOutboxOperations(): RecordingOutboxOperations =
+        RecordingOutboxOperations()
+}
+
+class RecordingOutboxOperations : SovereignOpsAuditOutboxOperations {
+    val recoverLimits = mutableListOf<Int?>()
+    val dispatchLimits = mutableListOf<Int?>()
+
+    override suspend fun listOutboxRecords(
+        status: SovereignOpsAuditOutboxStatus?,
+        limit: Int?,
+    ): List<SovereignOpsAuditOutboxSummary> = emptyList()
+
+    override suspend fun retryPending(limit: Int?): SovereignOpsAuditOutboxDispatchResult {
+        dispatchLimits += limit
+        return SovereignOpsAuditOutboxDispatchResult(
+            claimed = 0,
+            emitted = 0,
+            failedRetryable = 0,
+            failedPermanent = 0,
+        )
+    }
+
+    override suspend fun markPreparedFailed(
+        outboxId: String,
+        reason: String,
+    ): SovereignOpsAuditOutboxSummary {
+        throw UnsupportedOperationException("test stub")
+    }
+
+    override suspend fun recoverPrepared(limit: Int?): SovereignOpsAuditOutboxRecoverySummary {
+        recoverLimits += limit
+        return SovereignOpsAuditOutboxRecoverySummary(inspected = 0)
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsOutboxWorkerAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsOutboxWorkerAutoConfigurationTest.kt
@@ -55,6 +55,7 @@ class SovereignOpsOutboxWorkerAutoConfigurationTest {
         contextRunner
             .withUserConfiguration(
                 MinimalStoreConfig::class.java,
+                TestAuditEngineConfig::class.java,
                 CustomOutboxBackgroundWorkerConfig::class.java,
             )
             .withPropertyValues(
@@ -96,6 +97,50 @@ class SovereignOpsOutboxWorkerAutoConfigurationTest {
             .run { ctx ->
                 assertThat(ctx).hasNotFailed()
                 assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxBackgroundWorker::class.java)
+            }
+    }
+
+    @Test
+    fun `missing dispatcher with failOnMissingDispatcher false skips dispatch and runs recovery only`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.outbox.worker.enabled=true",
+                "tramai.sovereign.ops.outbox.worker.initial-delay=1h",
+                "tramai.sovereign.ops.outbox.worker.fail-on-missing-dispatcher=false",
+                "tramai.sovereign.ops.outbox.worker.recover-prepared=true",
+                "tramai.sovereign.ops.outbox.worker.dispatch-pending=true",
+                "tramai.sovereign.ops.mutations-enabled=true",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasNotFailed()
+                val worker = ctx.getBean(SovereignOpsAuditOutboxBackgroundWorker::class.java)
+                // Run once — should only recover, not dispatch
+                val summary = runBlocking { worker.runOnce() }
+                assertThat(summary.recovered).isNotNull
+                assertThat(summary.dispatched).isNull()
+                // Check that dispatch was skipped (retryPending would throw without dispatcher)
+                assertThat(summary.failure).isNull()
+            }
+    }
+
+    @Test
+    fun `missing dispatcher with both actions disabled but failOnMissingDispatcher false fails validation`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.outbox.worker.enabled=true",
+                "tramai.sovereign.ops.outbox.worker.initial-delay=1h",
+                "tramai.sovereign.ops.outbox.worker.fail-on-missing-dispatcher=false",
+                "tramai.sovereign.ops.outbox.worker.recover-prepared=false",
+                "tramai.sovereign.ops.outbox.worker.dispatch-pending=true",
+            )
+            .run { ctx ->
+                // dispatch-pending gets set to false because dispatcher missing,
+                // then both actions are disabled -> validation fails
+                assertThat(ctx).hasFailed()
+                assertThat(ctx.startupFailure)
+                    .hasMessageContaining("tramai-sovereign-ops-outbox-worker-invalid-actions")
             }
     }
 

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxBackgroundWorkerTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxBackgroundWorkerTest.kt
@@ -1,0 +1,279 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+import dev.tramai.spring.sovereign.ops.SovereignOpsAuditEmitter
+import dev.tramai.spring.sovereign.ops.SovereignOpsOutboxWorkerProperties
+import dev.tramai.spring.sovereign.ops.SovereignOpsProperties
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+
+class SovereignOpsAuditOutboxBackgroundWorkerTest {
+
+    @Test
+    fun `runOnce recovers prepared before dispatching pending`() {
+        val operations = TrackingOutboxOperations()
+        val worker = SovereignOpsAuditOutboxBackgroundWorker(
+            operations = operations,
+            properties = SovereignOpsOutboxWorkerProperties(batchSize = 25),
+            clock = fixedClock(),
+        )
+
+        val summary = runBlocking { worker.runOnce() }
+
+        assertThat(operations.calls).containsExactly("recover:25", "dispatch:25")
+        assertThat(summary.recovered).isNotNull
+        assertThat(summary.dispatched).isNotNull
+        assertThat(summary.startedAt).isEqualTo(Instant.parse("2026-06-01T00:00:00Z"))
+        assertThat(summary.completedAt).isEqualTo(Instant.parse("2026-06-01T00:00:00Z"))
+    }
+
+    @Test
+    fun `runOnce can recover prepared only`() {
+        val operations = TrackingOutboxOperations()
+        val worker = SovereignOpsAuditOutboxBackgroundWorker(
+            operations = operations,
+            properties = SovereignOpsOutboxWorkerProperties(dispatchPending = false),
+        )
+
+        val summary = runBlocking { worker.runOnce() }
+
+        assertThat(operations.calls).containsExactly("recover:100")
+        assertThat(summary.recovered).isNotNull
+        assertThat(summary.dispatched).isNull()
+    }
+
+    @Test
+    fun `runOnce can dispatch pending only`() {
+        val operations = TrackingOutboxOperations()
+        val worker = SovereignOpsAuditOutboxBackgroundWorker(
+            operations = operations,
+            properties = SovereignOpsOutboxWorkerProperties(recoverPrepared = false),
+        )
+
+        val summary = runBlocking { worker.runOnce() }
+
+        assertThat(operations.calls).containsExactly("dispatch:100")
+        assertThat(summary.recovered).isNull()
+        assertThat(summary.dispatched).isNotNull
+    }
+
+    @Test
+    fun `runOnce rethrows CancellationException`() {
+        val worker = SovereignOpsAuditOutboxBackgroundWorker(
+            operations = TrackingOutboxOperations(
+                recoverFailure = CancellationException("cancelled"),
+            ),
+            properties = SovereignOpsOutboxWorkerProperties(),
+        )
+
+        val ex = runCatching {
+            runBlocking { worker.runOnce() }
+        }.exceptionOrNull()
+
+        assertThat(ex).isInstanceOf(CancellationException::class.java)
+    }
+
+    @Test
+    fun `runOnce catches RuntimeException and returns failure summary`() {
+        val worker = SovereignOpsAuditOutboxBackgroundWorker(
+            operations = TrackingOutboxOperations(
+                recoverFailure = IllegalStateException("sensitive@example.com"),
+            ),
+            properties = SovereignOpsOutboxWorkerProperties(),
+        )
+
+        val summary = runBlocking { worker.runOnce() }
+
+        assertThat(summary.recovered).isNull()
+        assertThat(summary.dispatched).isNull()
+        val failure = summary.failure ?: error("expected failure summary")
+        assertThat(failure.action).isEqualTo("recoverPrepared")
+        assertThat(failure.errorCode).isEqualTo("IllegalStateException")
+        assertThat(failure.errorCode).doesNotContain("sensitive@example.com")
+    }
+
+    @Test
+    fun `lifecycle validation rejects zero batch size`() {
+        val ex = runCatching {
+            validateSovereignOpsAuditOutboxWorkerProperties(
+                SovereignOpsOutboxWorkerProperties(batchSize = 0),
+            )
+        }.exceptionOrNull()
+
+        assertThat(ex).hasMessageContaining("tramai-sovereign-ops-outbox-worker-invalid-batch-size")
+    }
+
+    @Test
+    fun `lifecycle validation rejects zero interval`() {
+        val ex = runCatching {
+            validateSovereignOpsAuditOutboxWorkerProperties(
+                SovereignOpsOutboxWorkerProperties(interval = Duration.ZERO),
+            )
+        }.exceptionOrNull()
+
+        assertThat(ex).hasMessageContaining("tramai-sovereign-ops-outbox-worker-invalid-interval")
+    }
+
+    @Test
+    fun `lifecycle validation rejects enabled worker with both actions disabled`() {
+        val ex = runCatching {
+            validateSovereignOpsAuditOutboxWorkerProperties(
+                SovereignOpsOutboxWorkerProperties(
+                    recoverPrepared = false,
+                    dispatchPending = false,
+                ),
+            )
+        }.exceptionOrNull()
+
+        assertThat(ex).hasMessageContaining("tramai-sovereign-ops-outbox-worker-invalid-actions")
+    }
+
+    @Test
+    fun `prepared record recovered as committed denied is emitted by worker runOnce`() {
+        val store = DurableTestInMemoryOutboxStore()
+        val operations = DefaultSovereignOpsAuditOutboxOperations(
+            outboxStore = store,
+            outboxDispatcher = SovereignOpsAuditOutboxDispatcher(
+                outboxStore = store,
+                auditEmitter = NoopReplayAuditEmitter,
+            ),
+            properties = SovereignOpsProperties(mutationsEnabled = true),
+            recoveryResolver = SovereignOpsApprovalRecoveryResolver {
+                SovereignOpsPreparedRecoveryDecision.COMMITTED_DENIED
+            },
+        )
+        val worker = SovereignOpsAuditOutboxBackgroundWorker(
+            operations = operations,
+            properties = SovereignOpsOutboxWorkerProperties(batchSize = 10),
+        )
+
+        runBlocking {
+            store.append(record("prepared"))
+            worker.runOnce()
+        }
+
+        val stored = runBlocking { store.get("prepared") }
+        assertThat(stored!!.status).isEqualTo(SovereignOpsAuditOutboxStatus.EMITTED)
+    }
+
+    @Test
+    fun `pending record with failing emitter becomes failed retryable by worker runOnce`() {
+        val store = DurableTestInMemoryOutboxStore()
+        val operations = DefaultSovereignOpsAuditOutboxOperations(
+            outboxStore = store,
+            outboxDispatcher = SovereignOpsAuditOutboxDispatcher(
+                outboxStore = store,
+                auditEmitter = FailingReplayAuditEmitter,
+            ),
+            properties = SovereignOpsProperties(mutationsEnabled = true),
+            recoveryResolver = UnknownSovereignOpsApprovalRecoveryResolver,
+        )
+        val worker = SovereignOpsAuditOutboxBackgroundWorker(
+            operations = operations,
+            properties = SovereignOpsOutboxWorkerProperties(
+                recoverPrepared = false,
+                batchSize = 10,
+            ),
+        )
+
+        runBlocking {
+            store.append(record("pending"))
+            store.markReadyForDispatch("pending", SovereignOpsAuditOutboxStatus.PREPARED)
+            worker.runOnce()
+        }
+
+        val stored = runBlocking { store.get("pending") }
+        assertThat(stored!!.status).isEqualTo(SovereignOpsAuditOutboxStatus.FAILED_RETRYABLE)
+        assertThat(stored.lastErrorCode).isEqualTo("IllegalStateException")
+    }
+
+    private fun fixedClock(): Clock =
+        Clock.fixed(Instant.parse("2026-06-01T00:00:00Z"), ZoneOffset.UTC)
+
+    private fun record(outboxId: String): SovereignOpsAuditOutboxRecord =
+        SovereignOpsAuditOutboxRecord(
+            outboxId = outboxId,
+            aggregateIdDigest = "digest-$outboxId",
+            eventKey = "event-$outboxId",
+            actor = "admin",
+            workflowRunId = "wf-1",
+            correlationId = "corr-1",
+            approvalStatus = "DENIED",
+            approvalVersion = 1L,
+            reasonDigest = "reason-$outboxId",
+            reasonLength = 12,
+            createdAt = Instant.parse("2026-06-01T00:00:00Z"),
+        )
+}
+
+private class TrackingOutboxOperations(
+    private val recoverFailure: Throwable? = null,
+) : SovereignOpsAuditOutboxOperations {
+    val calls = mutableListOf<String>()
+
+    override suspend fun listOutboxRecords(
+        status: SovereignOpsAuditOutboxStatus?,
+        limit: Int?,
+    ): List<SovereignOpsAuditOutboxSummary> = emptyList()
+
+    override suspend fun retryPending(limit: Int?): SovereignOpsAuditOutboxDispatchResult {
+        calls += "dispatch:$limit"
+        return SovereignOpsAuditOutboxDispatchResult(
+            claimed = 1,
+            emitted = 1,
+            failedRetryable = 0,
+            failedPermanent = 0,
+        )
+    }
+
+    override suspend fun markPreparedFailed(
+        outboxId: String,
+        reason: String,
+    ): SovereignOpsAuditOutboxSummary {
+        throw UnsupportedOperationException("test stub")
+    }
+
+    override suspend fun recoverPrepared(limit: Int?): SovereignOpsAuditOutboxRecoverySummary {
+        recoverFailure?.let { throw it }
+        calls += "recover:$limit"
+        return SovereignOpsAuditOutboxRecoverySummary(
+            inspected = 1,
+            movedToPending = 1,
+        )
+    }
+}
+
+private object NoopReplayAuditEmitter : SovereignOpsAuditEmitter {
+    override suspend fun approvalDenied(
+        approvalId: String,
+        actor: String,
+        reason: String,
+        approvalStatus: String,
+        approvalVersion: Long?,
+        workflowRunId: String?,
+        correlationId: String?,
+    ) = Unit
+
+    override suspend fun approvalDeniedFromOutbox(record: SovereignOpsAuditOutboxRecord) = Unit
+}
+
+private object FailingReplayAuditEmitter : SovereignOpsAuditEmitter {
+    override suspend fun approvalDenied(
+        approvalId: String,
+        actor: String,
+        reason: String,
+        approvalStatus: String,
+        approvalVersion: Long?,
+        workflowRunId: String?,
+        correlationId: String?,
+    ) = Unit
+
+    override suspend fun approvalDeniedFromOutbox(record: SovereignOpsAuditOutboxRecord) {
+        throw IllegalStateException("emission failure contains sensitive@example.com")
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxBackgroundWorkerTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxBackgroundWorkerTest.kt
@@ -98,6 +98,44 @@ class SovereignOpsAuditOutboxBackgroundWorkerTest {
     }
 
     @Test
+    fun `runOnce catches non-runtime Exception and returns failure summary`() {
+        val worker = SovereignOpsAuditOutboxBackgroundWorker(
+            operations = TrackingOutboxOperations(
+                recoverFailure = java.io.IOException("file error /secret/path"),
+            ),
+            properties = SovereignOpsOutboxWorkerProperties(),
+        )
+
+        val summary = runBlocking { worker.runOnce() }
+
+        assertThat(summary.recovered).isNull()
+        assertThat(summary.dispatched).isNull()
+        val failure = summary.failure ?: error("expected failure summary")
+        assertThat(failure.action).isEqualTo("recoverPrepared")
+        assertThat(failure.errorCode).isEqualTo("IOException")
+        assertThat(failure.errorCode).doesNotContain("secret")
+    }
+
+    @Test
+    fun `runOnce catches non-runtime Exception from dispatch and returns failure summary`() {
+        val worker = SovereignOpsAuditOutboxBackgroundWorker(
+            operations = TrackingOutboxOperations(
+                dispatchFailure = java.io.IOException("dispatch I/O error /tmp/secret"),
+            ),
+            properties = SovereignOpsOutboxWorkerProperties(),
+        )
+
+        val summary = runBlocking { worker.runOnce() }
+
+        assertThat(summary.recovered).isNotNull
+        assertThat(summary.dispatched).isNull()
+        val failure = summary.failure ?: error("expected failure summary")
+        assertThat(failure.action).isEqualTo("dispatchPending")
+        assertThat(failure.errorCode).isEqualTo("IOException")
+        assertThat(failure.errorCode).doesNotContain("secret")
+    }
+
+    @Test
     fun `lifecycle validation rejects zero batch size`() {
         val ex = runCatching {
             validateSovereignOpsAuditOutboxWorkerProperties(
@@ -213,6 +251,7 @@ class SovereignOpsAuditOutboxBackgroundWorkerTest {
 
 private class TrackingOutboxOperations(
     private val recoverFailure: Throwable? = null,
+    private val dispatchFailure: Throwable? = null,
 ) : SovereignOpsAuditOutboxOperations {
     val calls = mutableListOf<String>()
 
@@ -222,6 +261,7 @@ private class TrackingOutboxOperations(
     ): List<SovereignOpsAuditOutboxSummary> = emptyList()
 
     override suspend fun retryPending(limit: Int?): SovereignOpsAuditOutboxDispatchResult {
+        dispatchFailure?.let { throw it }
         calls += "dispatch:$limit"
         return SovereignOpsAuditOutboxDispatchResult(
             claimed = 1,


### PR DESCRIPTION
## Summary

PR #50 adds a Spring-managed background worker that turns the durable audit outbox from "stored safely" into "operationally self-healing." The worker periodically recovers stuck PREPARED records and dispatches PENDING/FAILED_RETRYABLE audit outbox records.

## What It Does

1. **Recovers stuck PREPARED records** — calls `recoverPrepared()` using the configured `SovereignOpsApprovalRecoveryResolver`
2. **Dispatches pending records** — calls `retryPending()` to dispatch PENDING, FAILED_RETRYABLE, and expired EMITTING records
3. **Fails closed when dispatcher is missing** — `tramai-sovereign-ops-outbox-worker-missing-dispatcher`
4. **Disabled by default** — `tramai.sovereign.ops.outbox.worker.enabled=false`

## Configuration

```yaml
tramai:
  sovereign:
    ops:
      outbox:
        worker:
          enabled: false          # disabled by default
          initial-delay: 5s       # wait before first cycle
          interval: 30s           # time between cycles
          batch-size: 100         # records per recovery/dispatch pass
          recover-prepared: true  # recover stuck PREPARED records
          dispatch-pending: true  # dispatch PENDING and retryable records
          fail-on-missing-dispatcher: true  # fail startup if dispatch enabled but no dispatcher
```

## Architecture

- **SovereignOpsAuditOutboxBackgroundWorker** — deterministic `runOnce()` for testing. Recovers first, dispatches second. CancellationException never swallowed. RuntimeException captured as safe failure summary (no sensitive data).
- **SovereignOpsAuditOutboxWorkerLifecycle** — SmartLifecycle + coroutine loop. Validates properties on start. Runtime failures do not kill the loop.
- **SovereignOpsOutboxWorkerProperties** — validated at lifecycle start (interval positive, batchSize 1-500, at least one action enabled)

## Security Invariants

- No raw approval IDs, reason text, tokens, envelopes, prompts, or tool args logged/exposed
- CancellationException always rethrown (coroutine correctness)
- Runtime failures captured as safe summaries (className only, no exception message)
- Not enabled by default — explicit opt-in required for background dispatch

## Tests (28 new, all passing)

### Unit Tests (`SovereignOpsAuditOutboxBackgroundWorkerTest`)
- `runOnce` recovers PREPARED before dispatching PENDING
- `runOnce` supports recovery-only and dispatch-only modes
- `runOnce` rethrows CancellationException
- `runOnce` catches RuntimeException with safe failure summary
- Property validation: zero batch size, zero interval, both actions disabled

### Integration Tests
- PREPARED record + COMMITTED_DENIED resolver → EMITTED
- PENDING record + failing emitter → FAILED_RETRYABLE with sanitized error code

### Auto-Configuration Tests (`SovereignOpsOutboxWorkerAutoConfigurationTest`)
- Worker not created by default
- Worker + lifecycle created when enabled
- Custom bean not overridden (@ConditionalOnMissingBean)
- Missing dispatcher fails closed
- Recovery-only worker starts without dispatcher
- Configured interval/batchSize bound to properties

## Non-Goals

- REST/Actuator endpoints (future PRs)
- Metrics (future PR)
- HMAC digest service (future PR)
- DB-backed outbox (future PR)
- Distributed leader election
- Key rotation

## Files Changed (7 files, +685 lines)

- `SovereignOpsProperties.kt` — nested `SovereignOpsOutboxProperties` + `SovereignOpsOutboxWorkerProperties`
- `SovereignOpsAutoConfiguration.kt` — conditional worker + lifecycle beans, fail-closed dispatcher check
- `SovereignOpsAuditOutboxBackgroundWorker.kt` — new worker with `runOnce()`
- `SovereignOpsAuditOutboxWorkerLifecycle.kt` — new SmartLifecycle runner
- `SovereignOpsAuditOutboxBackgroundWorkerTest.kt` — 11 tests
- `SovereignOpsOutboxWorkerAutoConfigurationTest.kt` — 6 tests
- `build.gradle.kts` — koroutines dependency

## Verification

```bash
./gradlew test --rerun-tasks  # BUILD SUCCESSFUL, 154 tasks, all green
```