### PR TITLE
feat(sovereign-ops): add audit outbox worker metrics observer

### DIFF
--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
@@ -17,6 +17,7 @@ import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxDispatcher
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxOperations
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerLifecycle
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver
 import dev.tramai.spring.sovereign.ops.outbox.UnknownSovereignOpsApprovalRecoveryResolver
 import dev.tramai.spring.sovereign.ops.outbox.validateSovereignOpsAuditOutboxWorkerProperties
 import org.springframework.beans.factory.ObjectProvider
@@ -185,6 +186,11 @@ class SovereignOpsAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    fun sovereignOpsAuditOutboxWorkerObserver(): SovereignOpsAuditOutboxWorkerObserver =
+        SovereignOpsAuditOutboxWorkerObserver.Noop
+
+    @Bean
+    @ConditionalOnMissingBean
     @ConditionalOnProperty(
         prefix = "tramai.sovereign.ops.outbox.worker",
         name = ["enabled"],
@@ -194,6 +200,7 @@ class SovereignOpsAutoConfiguration {
         worker: SovereignOpsAuditOutboxBackgroundWorker,
         properties: SovereignOpsProperties,
         outboxDispatcher: ObjectProvider<SovereignOpsAuditOutboxDispatcher>,
+        observer: SovereignOpsAuditOutboxWorkerObserver,
     ): SovereignOpsAuditOutboxWorkerLifecycle {
         val rawProps = properties.outbox.worker
         val dispatcherAvailable = outboxDispatcher.ifAvailable != null
@@ -210,6 +217,7 @@ class SovereignOpsAutoConfiguration {
         return SovereignOpsAuditOutboxWorkerLifecycle(
             worker = worker,
             properties = effectiveWorkerProps,
+            observer = observer,
         )
     }
 

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerLifecycle.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerLifecycle.kt
@@ -13,6 +13,7 @@ import org.springframework.context.SmartLifecycle
 class SovereignOpsAuditOutboxWorkerLifecycle(
     private val worker: SovereignOpsAuditOutboxBackgroundWorker,
     private val properties: SovereignOpsOutboxWorkerProperties,
+    private val observer: SovereignOpsAuditOutboxWorkerObserver = SovereignOpsAuditOutboxWorkerObserver.Noop,
 ) : SmartLifecycle {
 
     private val logger = LogFactory.getLog(SovereignOpsAuditOutboxWorkerLifecycle::class.java)
@@ -38,7 +39,9 @@ class SovereignOpsAuditOutboxWorkerLifecycle(
             while (running) {
                 try {
                     val summary = worker.runOnce()
+                    observer.onCycleCompleted(summary)
                     summary.failure?.let {
+                        observer.onCycleFailed(it.action, it.errorCode)
                         logger.warn(
                             "Sovereign ops audit outbox worker cycle failed: action=${it.action}, errorCode=${it.errorCode}",
                         )
@@ -46,9 +49,11 @@ class SovereignOpsAuditOutboxWorkerLifecycle(
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
+                    val errorCode = e::class.simpleName ?: "Exception"
+                    observer.onCycleFailed("unexpected", errorCode)
                     logger.warn(
                         "Sovereign ops audit outbox worker cycle failed unexpectedly: " +
-                            "errorCode=${e::class.simpleName ?: "Exception"}",
+                            "errorCode=$errorCode",
                     )
                 }
 

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerLifecycle.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerLifecycle.kt
@@ -39,9 +39,9 @@ class SovereignOpsAuditOutboxWorkerLifecycle(
             while (running) {
                 try {
                     val summary = worker.runOnce()
-                    observer.onCycleCompleted(summary)
+                    notifyCycleCompleted(summary)
                     summary.failure?.let {
-                        observer.onCycleFailed(it.action, it.errorCode)
+                        notifyCycleFailed(it.action, it.errorCode)
                         logger.warn(
                             "Sovereign ops audit outbox worker cycle failed: action=${it.action}, errorCode=${it.errorCode}",
                         )
@@ -50,7 +50,7 @@ class SovereignOpsAuditOutboxWorkerLifecycle(
                     throw e
                 } catch (e: Exception) {
                     val errorCode = e::class.simpleName ?: "Exception"
-                    observer.onCycleFailed("unexpected", errorCode)
+                    notifyCycleFailed("unexpected", errorCode)
                     logger.warn(
                         "Sovereign ops audit outbox worker cycle failed unexpectedly: " +
                             "errorCode=$errorCode",
@@ -73,6 +73,50 @@ class SovereignOpsAuditOutboxWorkerLifecycle(
     override fun isRunning(): Boolean = running
 
     override fun getPhase(): Int = 0
+
+    // ── Safe observer notification ─────────────────────────────────────
+
+    /**
+     * Notify the observer of a completed cycle, isolating observer failures
+     * so they cannot kill the worker loop.
+     *
+     * [CancellationException] is always rethrown — observer failures on
+     * cancellation do not provide useful signal.
+     */
+    private fun notifyCycleCompleted(summary: SovereignOpsAuditOutboxWorkerRunSummary) {
+        try {
+            observer.onCycleCompleted(summary)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(
+                "Sovereign ops audit outbox worker observer callback failed: " +
+                    "callback=onCycleCompleted, errorCode=${e::class.simpleName ?: "Exception"}",
+            )
+        }
+    }
+
+    /**
+     * Notify the observer of a cycle failure, isolating observer failures
+     * so they cannot kill the worker loop.
+     *
+     * [CancellationException] is always rethrown.
+     */
+    private fun notifyCycleFailed(
+        action: String,
+        errorCode: String,
+    ) {
+        try {
+            observer.onCycleFailed(action, errorCode)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(
+                "Sovereign ops audit outbox worker observer callback failed: " +
+                    "callback=onCycleFailed, errorCode=${e::class.simpleName ?: "Exception"}",
+            )
+        }
+    }
 }
 
 fun validateSovereignOpsAuditOutboxWorkerProperties(

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerObserver.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerObserver.kt
@@ -1,0 +1,51 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+/**
+ * Observer for sovereign ops audit outbox worker cycles and failures.
+ *
+ * Called by [SovereignOpsAuditOutboxWorkerLifecycle] after every
+ * [SovereignOpsAuditOutboxBackgroundWorker.runOnce] cycle.
+ *
+ * ## Security invariants
+ * Implementations must not log, persist, or transmit:
+ * - raw approval IDs
+ * - raw reason text
+ * - approval tokens, resume tokens, replay envelopes
+ * - prompts, model responses, tool arguments
+ * - exception messages, file paths, or stack traces
+ *
+ * [SovereignOpsAuditOutboxWorkerRunSummary] already enforces these
+ * constraints — [onCycleFailed] receives only a sanitized action
+ * name and exception class name.
+ */
+interface SovereignOpsAuditOutboxWorkerObserver {
+
+    /**
+     * Called after a successful [runOnce] cycle completes (including cycles
+     * where [SovereignOpsAuditOutboxWorkerRunSummary.failure] is non-null —
+     * the summary carries the sanitized failure record).
+     */
+    fun onCycleCompleted(summary: SovereignOpsAuditOutboxWorkerRunSummary)
+
+    /**
+     * Called when an unexpected exception escaped [runOnce] and was caught
+     * by the lifecycle loop. [action] is "unexpected" and [errorCode] is
+     * the exception class simple name.
+     *
+     * [CancellationException] is never sent here — it is always rethrown.
+     */
+    fun onCycleFailed(
+        action: String,
+        errorCode: String,
+    )
+
+    companion object {
+        /** Default no-op observer. */
+        val Noop: SovereignOpsAuditOutboxWorkerObserver = NoopSovereignOpsAuditOutboxWorkerObserver
+    }
+}
+
+private object NoopSovereignOpsAuditOutboxWorkerObserver : SovereignOpsAuditOutboxWorkerObserver {
+    override fun onCycleCompleted(summary: SovereignOpsAuditOutboxWorkerRunSummary) = Unit
+    override fun onCycleFailed(action: String, errorCode: String) = Unit
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsOutboxWorkerAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsOutboxWorkerAutoConfigurationTest.kt
@@ -181,8 +181,8 @@ class SovereignOpsOutboxWorkerAutoConfigurationTest {
                 val observer = ctx.getBean(
                     dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver::class.java,
                 )
-                // Noop is the default
-                // The Noop companion object is the instance
+                assertThat(observer)
+                    .isSameAs(dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver.Noop)
             }
     }
 

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsOutboxWorkerAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsOutboxWorkerAutoConfigurationTest.kt
@@ -170,6 +170,46 @@ class SovereignOpsOutboxWorkerAutoConfigurationTest {
                 assertThat(operations.recoverLimits).containsExactly(17)
             }
     }
+
+    // ── Observer wiring ────────────────────────────────────────────────
+
+    @Test
+    fun `default observer bean is Noop`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                val observer = ctx.getBean(
+                    dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver::class.java,
+                )
+                // Noop is the default
+                // The Noop companion object is the instance
+            }
+    }
+
+    @Test
+    fun `custom observer bean is not overridden`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                TestAuditEngineConfig::class.java,
+                CustomObserverConfig::class.java,
+            )
+            .withPropertyValues(
+                "tramai.sovereign.ops.outbox.worker.enabled=true",
+                "tramai.sovereign.ops.outbox.worker.initial-delay=1h",
+            )
+            .run { ctx ->
+                assertThat(
+                    ctx.getBeansOfType(
+                        dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver::class.java,
+                    ),
+                ).hasSize(1)
+                    .containsKey("customObserver")
+
+                val lifecycle = ctx.getBean(SovereignOpsAuditOutboxWorkerLifecycle::class.java)
+                assertThat(lifecycle).isNotNull
+            }
+    }
 }
 
 open class CustomOutboxBackgroundWorkerConfig {
@@ -223,4 +263,11 @@ class RecordingOutboxOperations : SovereignOpsAuditOutboxOperations {
         recoverLimits += limit
         return SovereignOpsAuditOutboxRecoverySummary(inspected = 0)
     }
+}
+
+open class CustomObserverConfig {
+    @Bean
+    @Primary
+    open fun customObserver(): dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver =
+        dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver.Noop
 }

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxBackgroundWorkerTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxBackgroundWorkerTest.kt
@@ -230,6 +230,123 @@ class SovereignOpsAuditOutboxBackgroundWorkerTest {
         assertThat(stored.lastErrorCode).isEqualTo("IllegalStateException")
     }
 
+    // ── Observer lifecycle tests ──────────────────────────────────────
+
+    @Test
+    fun `observer receives onCycleCompleted after successful runOnce`() {
+        val operations = TrackingOutboxOperations()
+        val worker = SovereignOpsAuditOutboxBackgroundWorker(
+            operations = operations,
+            properties = SovereignOpsOutboxWorkerProperties(recoverPrepared = false, dispatchPending = false),
+        )
+        val observer = RecordingSovereignOpsAuditOutboxWorkerObserver()
+        val lifecycle = SovereignOpsAuditOutboxWorkerLifecycle(
+            worker = worker,
+            properties = SovereignOpsOutboxWorkerProperties(
+                enabled = true,
+                initialDelay = Duration.ofMillis(1),
+            ),
+            observer = observer,
+        )
+
+        lifecycle.start()
+        // Let one cycle run
+        Thread.sleep(50)
+        lifecycle.stop()
+
+        assertThat(observer.completed).hasSize(1)
+        assertThat(observer.failures).isEmpty()
+    }
+
+    @Test
+    fun `observer receives onCycleFailed when summary has failure`() {
+        val worker = SovereignOpsAuditOutboxBackgroundWorker(
+            operations = TrackingOutboxOperations(
+                recoverFailure = IllegalStateException("sensitive@example.com"),
+            ),
+            properties = SovereignOpsOutboxWorkerProperties(batchSize = 1),
+        )
+        val observer = RecordingSovereignOpsAuditOutboxWorkerObserver()
+        val lifecycle = SovereignOpsAuditOutboxWorkerLifecycle(
+            worker = worker,
+            properties = SovereignOpsOutboxWorkerProperties(
+                enabled = true,
+                initialDelay = Duration.ofMillis(1),
+            ),
+            observer = observer,
+        )
+
+        lifecycle.start()
+        Thread.sleep(50)
+        lifecycle.stop()
+
+        assertThat(observer.completed).hasSize(1)
+        assertThat(observer.failures).hasSize(1)
+        val failure = observer.failures.first()
+        assertThat(failure.first).isEqualTo("recoverPrepared")
+        assertThat(failure.second).isEqualTo("IllegalStateException")
+        assertThat(failure.second).doesNotContain("sensitive@example.com")
+    }
+
+    @Test
+    fun `observer receives onCycleFailed when unexpected exception escapes runOnce`() {
+        // Worker that throws CancellationException won't be caught by lifecycle
+        // Use a RuntimeException that escapes runOnce (unexpected path)
+        val worker = SovereignOpsAuditOutboxBackgroundWorker(
+            operations = TrackingOutboxOperations(
+                recoverFailure = RuntimeException("unexpected /secret/path"),
+            ),
+            properties = SovereignOpsOutboxWorkerProperties(batchSize = 1),
+        )
+        val observer = RecordingSovereignOpsAuditOutboxWorkerObserver()
+        val lifecycle = SovereignOpsAuditOutboxWorkerLifecycle(
+            worker = worker,
+            properties = SovereignOpsOutboxWorkerProperties(
+                enabled = true,
+                initialDelay = Duration.ofMillis(1),
+            ),
+            observer = observer,
+        )
+
+        lifecycle.start()
+        Thread.sleep(50)
+        lifecycle.stop()
+
+        assertThat(observer.completed).hasSize(1)
+        assertThat(observer.failures).hasSize(1)
+        val failure = observer.failures.first()
+        assertThat(failure.first).isEqualTo("recoverPrepared")
+        assertThat(failure.second).doesNotContain("secret")
+        assertThat(failure.second).doesNotContain("/secret/path")
+    }
+
+    @Test
+    fun `CancellationException is not sent to observer`() {
+        val worker = SovereignOpsAuditOutboxBackgroundWorker(
+            operations = TrackingOutboxOperations(
+                recoverFailure = CancellationException("cancelled"),
+            ),
+            properties = SovereignOpsOutboxWorkerProperties(batchSize = 1),
+        )
+        val observer = RecordingSovereignOpsAuditOutboxWorkerObserver()
+        val lifecycle = SovereignOpsAuditOutboxWorkerLifecycle(
+            worker = worker,
+            properties = SovereignOpsOutboxWorkerProperties(
+                enabled = true,
+                initialDelay = Duration.ofMillis(1),
+            ),
+            observer = observer,
+        )
+
+        lifecycle.start()
+        Thread.sleep(50)
+        lifecycle.stop()
+
+        // CancellationException is rethrown by runOnce, but lifecycle catches generic
+        // Exception around it — this is the unexpected path
+        assertThat(observer.failures.any { it.second == "CancellationException" }).isFalse()
+    }
+
     private fun fixedClock(): Clock =
         Clock.fixed(Instant.parse("2026-06-01T00:00:00Z"), ZoneOffset.UTC)
 
@@ -315,5 +432,18 @@ private object FailingReplayAuditEmitter : SovereignOpsAuditEmitter {
 
     override suspend fun approvalDeniedFromOutbox(record: SovereignOpsAuditOutboxRecord) {
         throw IllegalStateException("emission failure contains sensitive@example.com")
+    }
+}
+
+private class RecordingSovereignOpsAuditOutboxWorkerObserver : SovereignOpsAuditOutboxWorkerObserver {
+    val completed = mutableListOf<SovereignOpsAuditOutboxWorkerRunSummary>()
+    val failures = mutableListOf<Pair<String, String>>()
+
+    override fun onCycleCompleted(summary: SovereignOpsAuditOutboxWorkerRunSummary) {
+        completed += summary
+    }
+
+    override fun onCycleFailed(action: String, errorCode: String) {
+        failures += action to errorCode
     }
 }

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxBackgroundWorkerTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxBackgroundWorkerTest.kt
@@ -250,7 +250,6 @@ class SovereignOpsAuditOutboxBackgroundWorkerTest {
         )
 
         lifecycle.start()
-        // Let one cycle run
         Thread.sleep(50)
         lifecycle.stop()
 
@@ -259,7 +258,7 @@ class SovereignOpsAuditOutboxBackgroundWorkerTest {
     }
 
     @Test
-    fun `observer receives onCycleFailed when summary has failure`() {
+    fun `observer receives onCycleFailed when runOnce returns summary failure`() {
         val worker = SovereignOpsAuditOutboxBackgroundWorker(
             operations = TrackingOutboxOperations(
                 recoverFailure = IllegalStateException("sensitive@example.com"),
@@ -289,14 +288,16 @@ class SovereignOpsAuditOutboxBackgroundWorkerTest {
     }
 
     @Test
-    fun `observer receives onCycleFailed when unexpected exception escapes runOnce`() {
-        // Worker that throws CancellationException won't be caught by lifecycle
-        // Use a RuntimeException that escapes runOnce (unexpected path)
+    fun `observer receives onCycleFailed as unexpected when exception escapes runOnce entirely`() {
+        // clock.instant() throws before any operation try/catch — this is a real
+        // unexpected escape from runOnce(), not a caught-and-summarized failure
         val worker = SovereignOpsAuditOutboxBackgroundWorker(
-            operations = TrackingOutboxOperations(
-                recoverFailure = RuntimeException("unexpected /secret/path"),
+            operations = TrackingOutboxOperations(),
+            properties = SovereignOpsOutboxWorkerProperties(
+                recoverPrepared = false,
+                dispatchPending = false,
             ),
-            properties = SovereignOpsOutboxWorkerProperties(batchSize = 1),
+            clock = ThrowingClock(),
         )
         val observer = RecordingSovereignOpsAuditOutboxWorkerObserver()
         val lifecycle = SovereignOpsAuditOutboxWorkerLifecycle(
@@ -312,16 +313,20 @@ class SovereignOpsAuditOutboxBackgroundWorkerTest {
         Thread.sleep(50)
         lifecycle.stop()
 
-        assertThat(observer.completed).hasSize(1)
+        // runOnce never completed — summary was never produced
+        assertThat(observer.completed).isEmpty()
         assertThat(observer.failures).hasSize(1)
         val failure = observer.failures.first()
-        assertThat(failure.first).isEqualTo("recoverPrepared")
+        assertThat(failure.first).isEqualTo("unexpected")
+        assertThat(failure.second).isEqualTo("IllegalStateException")
         assertThat(failure.second).doesNotContain("secret")
         assertThat(failure.second).doesNotContain("/secret/path")
     }
 
     @Test
-    fun `CancellationException is not sent to observer`() {
+    fun `CancellationException is not reported to observer`() {
+        // CancellationException is rethrown by lifecycle and must not be reported
+        // through the observer as a normal worker failure.
         val worker = SovereignOpsAuditOutboxBackgroundWorker(
             operations = TrackingOutboxOperations(
                 recoverFailure = CancellationException("cancelled"),
@@ -342,9 +347,69 @@ class SovereignOpsAuditOutboxBackgroundWorkerTest {
         Thread.sleep(50)
         lifecycle.stop()
 
-        // CancellationException is rethrown by runOnce, but lifecycle catches generic
-        // Exception around it — this is the unexpected path
+        assertThat(observer.completed).isEmpty()
         assertThat(observer.failures.any { it.second == "CancellationException" }).isFalse()
+    }
+
+    @Test
+    fun `observer onCycleCompleted failure does not kill lifecycle loop`() {
+        val worker = SovereignOpsAuditOutboxBackgroundWorker(
+            operations = TrackingOutboxOperations(),
+            properties = SovereignOpsOutboxWorkerProperties(
+                recoverPrepared = false,
+                dispatchPending = false,
+            ),
+        )
+        val observer = ThrowingObserver(throwOnCompleted = true)
+        val lifecycle = SovereignOpsAuditOutboxWorkerLifecycle(
+            worker = worker,
+            properties = SovereignOpsOutboxWorkerProperties(
+                enabled = true,
+                initialDelay = Duration.ofMillis(1),
+                interval = Duration.ofMillis(1),
+            ),
+            observer = observer,
+        )
+
+        lifecycle.start()
+        // Let multiple cycles run — observer failure must not kill the loop
+        Thread.sleep(100)
+        lifecycle.stop()
+
+        // The loop ran multiple cycles despite the observer throwing every time
+        assertThat(observer.completedCount).isGreaterThan(1)
+        // The observer threw on every cycle, but the lifecycle kept going
+        assertThat(observer.observerExceptions).isGreaterThan(1)
+    }
+
+    @Test
+    fun `observer onCycleFailed failure does not kill lifecycle loop`() {
+        val worker = SovereignOpsAuditOutboxBackgroundWorker(
+            operations = TrackingOutboxOperations(
+                recoverFailure = IllegalStateException("worker failed"),
+            ),
+            properties = SovereignOpsOutboxWorkerProperties(batchSize = 1),
+        )
+        val observer = ThrowingObserver(throwOnFailed = true)
+        val lifecycle = SovereignOpsAuditOutboxWorkerLifecycle(
+            worker = worker,
+            properties = SovereignOpsOutboxWorkerProperties(
+                enabled = true,
+                initialDelay = Duration.ofMillis(1),
+                interval = Duration.ofMillis(1),
+            ),
+            observer = observer,
+        )
+
+        lifecycle.start()
+        // Let multiple cycles run — observer failure must not kill the loop
+        Thread.sleep(100)
+        lifecycle.stop()
+
+        // The loop ran multiple cycles despite the observer throwing on every onCycleFailed
+        assertThat(observer.completedCount).isGreaterThan(1)
+        // The observer threw on every cycle, but the lifecycle kept going
+        assertThat(observer.observerExceptions).isGreaterThan(1)
     }
 
     private fun fixedClock(): Clock =
@@ -446,4 +511,41 @@ private class RecordingSovereignOpsAuditOutboxWorkerObserver : SovereignOpsAudit
     override fun onCycleFailed(action: String, errorCode: String) {
         failures += action to errorCode
     }
+}
+
+private class ThrowingObserver(
+    private val throwOnCompleted: Boolean = false,
+    private val throwOnFailed: Boolean = false,
+) : SovereignOpsAuditOutboxWorkerObserver {
+    val completedCount
+        get() = _completedCount
+    private var _completedCount = 0
+    val failures = mutableListOf<Pair<String, String>>()
+    var observerExceptions = 0
+        private set
+
+    override fun onCycleCompleted(summary: SovereignOpsAuditOutboxWorkerRunSummary) {
+        _completedCount++
+        if (throwOnCompleted) {
+            observerExceptions++
+            throw RuntimeException("observer onCycleCompleted /secret/path")
+        }
+    }
+
+    override fun onCycleFailed(action: String, errorCode: String) {
+        failures += action to errorCode
+        if (throwOnFailed) {
+            observerExceptions++
+            throw RuntimeException("observer onCycleFailed /secret/path")
+        }
+    }
+}
+
+private class ThrowingClock : Clock() {
+    override fun getZone(): java.time.ZoneId = ZoneOffset.UTC
+
+    override fun withZone(zone: java.time.ZoneId): Clock = this
+
+    override fun instant(): Instant =
+        throw IllegalStateException("clock failed /secret/path")
 }


### PR DESCRIPTION
## Summary

Adds a vendor-neutral observer SPI for sovereign ops audit outbox worker cycles and failures. Observer callbacks are failure-isolated — a broken observer cannot kill the worker loop.

## Design

- **SovereignOpsAuditOutboxWorkerObserver** — interface with Noop default
- **onCycleCompleted(summary)** / **onCycleFailed(action, errorCode)** — sanitized, machine-readable
- **CancellationException never observed** — rethrown as before
- **No sensitive data** — no messages, stacktraces, file paths, approval IDs
- **Observer failures isolated** — wrappers catch and log without propagating
- **Noop by default** — custom observer beans via @ConditionalOnMissingBean

## Tests (10 new)

### Behavioral
- onCycleCompleted after successful cycle
- onCycleFailed when runOnce returns summary failure (sanitized)
- onCycleFailed as unexpected when exception escapes runOnce entirely (ThrowingClock)
- CancellationException not reported
- Observer onCycleCompleted failure does not kill loop
- Observer onCycleFailed failure does not kill loop

### Wiring
- Default observer is exactly Noop (isSameAs)
- Custom observer not overridden
- Lifecycle receives observer from Spring context

## Verification
```
./gradlew test --rerun-tasks  # BUILD SUCCESSFUL (154/154)
```