### PR TITLE
feat(sovereign-ops): add OpenTelemetry observer for sovereign ops audit outbox worker

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -22,6 +22,7 @@ This document describes the state of the repository, not a formal release contra
 | Audit chain (tamper-evident sequencing) | Implemented / evolving |
 | Audit outbox (atomic mutation + audit intent, claim-based dispatch) | Implemented / evolving |
 | Audit outbox background worker (recovery + dispatch loop) | Implemented / evolving |
+| Sovereign ops audit outbox OpenTelemetry metrics | Implemented |
 | Evidence generation (bundles, release artifacts) | Implemented / evolving |
 | Sovereign document intelligence example | Implemented |
 | OpenTelemetry observability (spans, metrics, opt-in) | Implemented |
@@ -65,7 +66,6 @@ The following are intentionally not claimed as complete. Some are planned, some 
 - stable 1.0 public API
 - Maven Central release of sovereign-runtime modules
 - REST/Actuator operational endpoints
-- sovereign ops / audit outbox metrics (OpenTelemetry observer available in `tramai-spring-boot-starter-sovereign-ops-observability`)
 - database-backed outbox or persistence
 - distributed worker leader election
 - key rotation

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -65,7 +65,7 @@ The following are intentionally not claimed as complete. Some are planned, some 
 - stable 1.0 public API
 - Maven Central release of sovereign-runtime modules
 - REST/Actuator operational endpoints
-- sovereign ops / audit outbox metrics
+- sovereign ops / audit outbox metrics (OpenTelemetry observer available in `tramai-spring-boot-starter-sovereign-ops-observability`)
 - database-backed outbox or persistence
 - distributed worker leader election
 - key rotation

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ include(
     "tramai-spring-boot-starter-sovereign",
     "tramai-spring-boot-starter-sovereign-persistence-file",
     "tramai-spring-boot-starter-sovereign-ops",
+    "tramai-spring-boot-starter-sovereign-ops-observability",
     "tramai-scheduler",
     "tramai-security",
     "tramai-sovereign",

--- a/tramai-spring-boot-starter-sovereign-ops-observability/README.md
+++ b/tramai-spring-boot-starter-sovereign-ops-observability/README.md
@@ -1,0 +1,78 @@
+# tramai-spring-boot-starter-sovereign-ops-observability
+
+OpenTelemetry observer for the TramAI sovereign ops audit outbox worker.
+
+Provides [OpenTelemetry metrics](https://opentelemetry.io/docs/specs/semconv/general/metrics/) for the
+[SovereignOpsAuditOutboxBackgroundWorker](https://github.com/nousresearch/tramai) lifecycle — cycle success/failure,
+latency, recovery record counts, and dispatch record counts.
+
+## Quickstart
+
+### 1. Add the dependency
+
+```kotlin
+implementation(project(":tramai-spring-boot-starter-sovereign-ops-observability"))
+```
+
+### 2. Provide an OpenTelemetry bean
+
+The observer activates **automatically** when:
+- An `io.opentelemetry.api.OpenTelemetry` bean is in the Spring context
+- No custom `SovereignOpsAuditOutboxWorkerObserver` bean is registered
+
+Without an `OpenTelemetry` bean, the sovereign ops starter's `Noop` observer remains active.
+
+### 3. Enable the worker
+
+```yaml
+tramai:
+  sovereign:
+    ops:
+      outbox:
+        worker:
+          enabled: true
+```
+
+## Emitted metrics
+
+All instruments are registered under the meter `dev.tramai.sovereign.ops`.
+
+| Instrument | Type | Unit | Description |
+|---|---|---|---|
+| `tramai.sovereign.ops.outbox.worker.cycles` | LongCounter | `{cycle}` | Completed worker cycles, keyed by `action` and `outcome` |
+| `tramai.sovereign.ops.outbox.worker.duration` | DoubleHistogram | `ms` | Cycle wall-clock duration ms |
+| `tramai.sovereign.ops.outbox.worker.recovered.records` | LongCounter | `{record}` | Recovery result counts: inspected, movedToPending, markedFailedPermanent, resolverFailures |
+| `tramai.sovereign.ops.outbox.worker.dispatched.records` | LongCounter | `{record}` | Dispatch result counts: claimed, emitted, failedRetryable, failedPermanent |
+| `tramai.sovereign.ops.outbox.worker.failures` | LongCounter | `{failure}` | Unexpected cycle failures (action="unexpected", error_type=exception simple name) |
+
+### Attributes
+
+All metrics receive these **low-cardinality, sanitized** attributes:
+
+| Attribute | Values | Description |
+|---|---|---|
+| `action` | `recoverPrepared`, `dispatchPending`, `unexpected` | Which operation was in progress |
+| `outcome` | `success`, `failure` | Whether the cycle completed successfully |
+| `error_type` | exception simple class name, `"none"` | Only set on failure counters |
+
+### Sanitization guarantees
+
+The observer **never** emits:
+- Approval IDs, denial reasons, tokens, replay envelopes
+- Prompts, model responses, tool arguments
+- Exception messages, stack traces, file paths
+- Any raw string that could carry sensitive data
+
+## Custom observers
+
+Provide your own `SovereignOpsAuditOutboxWorkerObserver` bean — the auto-configuration respects `@ConditionalOnMissingBean` and never overrides user-provided beans.
+
+```kotlin
+@Bean
+fun myObserver(): SovereignOpsAuditOutboxWorkerObserver = MyObserver()
+```
+
+## Dependencies
+
+- `tramai-spring-boot-starter-sovereign-ops` — the observer SPI and worker DTOs
+- `io.opentelemetry:opentelemetry-api` — meter creation (no SDK, no exporter)

--- a/tramai-spring-boot-starter-sovereign-ops-observability/README.md
+++ b/tramai-spring-boot-starter-sovereign-ops-observability/README.md
@@ -2,8 +2,8 @@
 
 OpenTelemetry observer for the TramAI sovereign ops audit outbox worker.
 
-Provides [OpenTelemetry metrics](https://opentelemetry.io/docs/specs/semconv/general/metrics/) for the
-[SovereignOpsAuditOutboxBackgroundWorker](https://github.com/nousresearch/tramai) lifecycle — cycle success/failure,
+Provides OpenTelemetry metrics for the
+`SovereignOpsAuditOutboxBackgroundWorker` lifecycle — cycle success/failure,
 latency, recovery record counts, and dispatch record counts.
 
 ## Quickstart
@@ -35,25 +35,54 @@ tramai:
 
 ## Emitted metrics
 
-All instruments are registered under the meter `dev.tramai.sovereign.ops`.
+All instruments are registered under the meter `dev.tramai.sovereign.ops.observability`.
 
 | Instrument | Type | Unit | Description |
 |---|---|---|---|
-| `tramai.sovereign.ops.outbox.worker.cycles` | LongCounter | `{cycle}` | Completed worker cycles, keyed by `action` and `outcome` |
-| `tramai.sovereign.ops.outbox.worker.duration` | DoubleHistogram | `ms` | Cycle wall-clock duration ms |
-| `tramai.sovereign.ops.outbox.worker.recovered.records` | LongCounter | `{record}` | Recovery result counts: inspected, movedToPending, markedFailedPermanent, resolverFailures |
-| `tramai.sovereign.ops.outbox.worker.dispatched.records` | LongCounter | `{record}` | Dispatch result counts: claimed, emitted, failedRetryable, failedPermanent |
-| `tramai.sovereign.ops.outbox.worker.failures` | LongCounter | `{failure}` | Unexpected cycle failures (action="unexpected", error_type=exception simple name) |
+| `tramai.sovereign.ops.outbox.worker.cycles` | LongCounter | `{cycle}` | Completed worker cycles per action and outcome |
+| `tramai.sovereign.ops.outbox.worker.duration` | DoubleHistogram | `ms` | Cycle wall-clock duration |
+| `tramai.sovereign.ops.outbox.worker.recovered.records` | LongCounter | `{record}` | Recovery result counts per result type |
+| `tramai.sovereign.ops.outbox.worker.dispatched.records` | LongCounter | `{record}` | Dispatch result counts per result type |
+| `tramai.sovereign.ops.outbox.worker.failures` | LongCounter | `{failure}` | Failure notifications emitted by the worker |
 
-### Attributes
+### Metric: worker.cycles
 
-All metrics receive these **low-cardinality, sanitized** attributes:
+**Attributes:**
 
 | Attribute | Values | Description |
 |---|---|---|
-| `action` | `recoverPrepared`, `dispatchPending`, `unexpected` | Which operation was in progress |
-| `outcome` | `success`, `failure` | Whether the cycle completed successfully |
-| `error_type` | exception simple class name, `"none"` | Only set on failure counters |
+| `tramai.sovereign.ops.outbox.worker.outcome` | `success`, `failure` | Whether the cycle completed successfully |
+| `tramai.sovereign.ops.outbox.worker.failure_action` | `none`, `recoverPrepared`, `dispatchPending` | The action that failed (or `none` on success) |
+| `tramai.sovereign.ops.outbox.worker.error_type` | `none`, simple exception class name | Error type when `outcome=failure` |
+
+### Metric: worker.duration
+
+**Attributes:** same as `worker.cycles`.
+
+### Metric: worker.failures
+
+**Attributes:**
+
+| Attribute | Values | Description |
+|---|---|---|
+| `tramai.sovereign.ops.outbox.worker.failure_action` | `recoverPrepared`, `dispatchPending`, `unexpected` | Which action triggered the failure |
+| `tramai.sovereign.ops.outbox.worker.error_type` | simple exception class name | Error type |
+
+### Metric: worker.recovered.records
+
+**Attributes:**
+
+| Attribute | Values | Description |
+|---|---|---|
+| `tramai.sovereign.ops.outbox.recovery.result` | `inspected`, `moved_to_pending`, `failed_permanent`, `resolver_failure` | Recovery operation result |
+
+### Metric: worker.dispatched.records
+
+**Attributes:**
+
+| Attribute | Values | Description |
+|---|---|---|
+| `tramai.sovereign.ops.outbox.dispatch.result` | `claimed`, `emitted`, `failed_retryable`, `failed_permanent` | Dispatch operation result |
 
 ### Sanitization guarantees
 

--- a/tramai-spring-boot-starter-sovereign-ops-observability/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-ops-observability/build.gradle.kts
@@ -1,0 +1,39 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    `java-library`
+    alias(libs.plugins.kotlin.jvm)
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+    withSourcesJar()
+}
+
+kotlin {
+    jvmToolchain(21)
+    compilerOptions {
+        jvmTarget.set(JvmTarget.fromTarget("21"))
+    }
+}
+
+dependencies {
+    api(project(":tramai-spring-boot-starter-sovereign-ops"))
+
+    implementation(libs.opentelemetry.api)
+    implementation(libs.spring.boot.autoconfigure)
+
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.kotlin.test.junit5)
+    testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.opentelemetry.sdk.testing)
+    testImplementation(libs.opentelemetry.sdk.metrics)
+    testImplementation("org.junit.jupiter:junit-jupiter")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/tramai-spring-boot-starter-sovereign-ops-observability/src/main/kotlin/dev/tramai/spring/sovereign/ops/observability/OpenTelemetrySovereignOpsAuditOutboxWorkerObserver.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-observability/src/main/kotlin/dev/tramai/spring/sovereign/ops/observability/OpenTelemetrySovereignOpsAuditOutboxWorkerObserver.kt
@@ -1,0 +1,128 @@
+package dev.tramai.spring.sovereign.ops.observability
+
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxDispatchResult
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxRecoverySummary
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerRunSummary
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.metrics.DoubleHistogram
+import io.opentelemetry.api.metrics.LongCounter
+import io.opentelemetry.api.metrics.Meter
+import java.time.Duration
+
+private const val INSTRUMENT_NAME = "dev.tramai.sovereign.ops.observability"
+
+private val ATTR_ACTION = AttributeKey.stringKey("action")
+private val ATTR_OUTCOME = AttributeKey.stringKey("outcome")
+private val ATTR_ERROR_TYPE = AttributeKey.stringKey("error_type")
+
+/**
+ * OpenTelemetry-backed observer for the sovereign ops audit outbox worker.
+ *
+ * Emits five metric instruments on every worker cycle. All attributes are
+ * low-cardinality and sanitised — no approval IDs, reason text, tokens,
+ * prompts, model responses, file paths, exception messages, or stack traces
+ * are ever recorded.
+ *
+ * @param meter The OpenTelemetry [Meter] used to create instruments.
+ */
+class OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(
+    meter: Meter,
+) : SovereignOpsAuditOutboxWorkerObserver {
+
+    constructor(
+        openTelemetry: OpenTelemetry,
+        instrumentationName: String = INSTRUMENT_NAME,
+    ) : this(meter = openTelemetry.getMeter(instrumentationName))
+
+    // ── Instruments ─────────────────────────────────────────────────
+
+    private val cycles: LongCounter = meter.counterBuilder("tramai.sovereign.ops.outbox.worker.cycles")
+        .setDescription("Outbox worker cycles completed per action and outcome")
+        .setUnit("{cycle}")
+        .build()
+
+    private val duration: DoubleHistogram = meter.histogramBuilder("tramai.sovereign.ops.outbox.worker.duration")
+        .setDescription("Duration of each outbox worker cycle")
+        .setUnit("ms")
+        .build()
+
+    private val recoveredRecords: LongCounter = meter.counterBuilder("tramai.sovereign.ops.outbox.worker.recovered.records")
+        .setDescription("Records affected by PREPARED recovery")
+        .setUnit("{record}")
+        .build()
+
+    private val dispatchedRecords: LongCounter = meter.counterBuilder("tramai.sovereign.ops.outbox.worker.dispatched.records")
+        .setDescription("Records affected by dispatch")
+        .setUnit("{record}")
+        .build()
+
+    private val cycleFailures: LongCounter = meter.counterBuilder("tramai.sovereign.ops.outbox.worker.failures")
+        .setDescription("Unexpected exceptions escaping runOnce")
+        .setUnit("{failure}")
+        .build()
+
+    // ── SPI ─────────────────────────────────────────────────────────
+
+    override fun onCycleCompleted(summary: SovereignOpsAuditOutboxWorkerRunSummary) {
+        val outcome = if (summary.failure != null) "failure" else "success"
+
+        // Cycle counter (one per action that ran)
+        if (summary.recovered != null) {
+            cycles.add(1, actionAttributes("recoverPrepared", outcome))
+        }
+        if (summary.dispatched != null) {
+            cycles.add(1, actionAttributes("dispatchPending", outcome))
+        }
+
+        // Duration histogram (clamp negative defensively)
+        val ms = Duration.between(summary.startedAt, summary.completedAt).toMillis()
+        val safeMs = if (ms < 0) 0.0 else ms.toDouble()
+        duration.record(safeMs, outcomeAttributes(outcome))
+
+        // Recovery record counters
+        summary.recovered?.let { recordRecovery(it) }
+
+        // Dispatch record counters
+        summary.dispatched?.let { recordDispatch(it) }
+    }
+
+    override fun onCycleFailed(action: String, errorCode: String) {
+        cycles.add(1, Attributes.of(ATTR_ACTION, action, ATTR_OUTCOME, "failure", ATTR_ERROR_TYPE, errorCode))
+        cycleFailures.add(1, Attributes.of(ATTR_ACTION, action, ATTR_ERROR_TYPE, errorCode))
+    }
+
+    // ── Private helpers ─────────────────────────────────────────────
+
+    private fun recordRecovery(r: SovereignOpsAuditOutboxRecoverySummary) {
+        val inspected = Attributes.of(ATTR_ACTION, "recoverPrepared", ATTR_OUTCOME, "inspected")
+        val movedToPending = Attributes.of(ATTR_ACTION, "recoverPrepared", ATTR_OUTCOME, "movedToPending")
+        val failedPermanent = Attributes.of(ATTR_ACTION, "recoverPrepared", ATTR_OUTCOME, "failedPermanent")
+        val resolverFailures = Attributes.of(ATTR_ACTION, "recoverPrepared", ATTR_OUTCOME, "resolverFailures")
+
+        if (r.inspected > 0) recoveredRecords.add(r.inspected.toLong(), inspected)
+        if (r.movedToPending > 0) recoveredRecords.add(r.movedToPending.toLong(), movedToPending)
+        if (r.markedFailedPermanent > 0) recoveredRecords.add(r.markedFailedPermanent.toLong(), failedPermanent)
+        if (r.resolverFailures > 0) recoveredRecords.add(r.resolverFailures.toLong(), resolverFailures)
+    }
+
+    private fun recordDispatch(d: SovereignOpsAuditOutboxDispatchResult) {
+        val claimed = Attributes.of(ATTR_ACTION, "dispatchPending", ATTR_OUTCOME, "claimed")
+        val emitted = Attributes.of(ATTR_ACTION, "dispatchPending", ATTR_OUTCOME, "emitted")
+        val failedRetryable = Attributes.of(ATTR_ACTION, "dispatchPending", ATTR_OUTCOME, "failedRetryable")
+        val failedPermanent = Attributes.of(ATTR_ACTION, "dispatchPending", ATTR_OUTCOME, "failedPermanent")
+
+        if (d.claimed > 0) dispatchedRecords.add(d.claimed.toLong(), claimed)
+        if (d.emitted > 0) dispatchedRecords.add(d.emitted.toLong(), emitted)
+        if (d.failedRetryable > 0) dispatchedRecords.add(d.failedRetryable.toLong(), failedRetryable)
+        if (d.failedPermanent > 0) dispatchedRecords.add(d.failedPermanent.toLong(), failedPermanent)
+    }
+
+    private fun actionAttributes(action: String, outcome: String): Attributes =
+        Attributes.of(ATTR_ACTION, action, ATTR_OUTCOME, outcome, ATTR_ERROR_TYPE, "none")
+
+    private fun outcomeAttributes(outcome: String): Attributes =
+        Attributes.of(ATTR_OUTCOME, outcome, ATTR_ERROR_TYPE, "none")
+}

--- a/tramai-spring-boot-starter-sovereign-ops-observability/src/main/kotlin/dev/tramai/spring/sovereign/ops/observability/OpenTelemetrySovereignOpsAuditOutboxWorkerObserver.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-observability/src/main/kotlin/dev/tramai/spring/sovereign/ops/observability/OpenTelemetrySovereignOpsAuditOutboxWorkerObserver.kt
@@ -12,11 +12,22 @@ import io.opentelemetry.api.metrics.LongCounter
 import io.opentelemetry.api.metrics.Meter
 import java.time.Duration
 
-private const val INSTRUMENT_NAME = "dev.tramai.sovereign.ops.observability"
+private const val INSTRUMENTATION_SCOPE = "dev.tramai.sovereign.ops.observability"
 
-private val ATTR_ACTION = AttributeKey.stringKey("action")
-private val ATTR_OUTCOME = AttributeKey.stringKey("outcome")
-private val ATTR_ERROR_TYPE = AttributeKey.stringKey("error_type")
+// Worker cycle/duration attributes
+private val ATTR_WORKER_OUTCOME = AttributeKey.stringKey("tramai.sovereign.ops.outbox.worker.outcome")
+private val ATTR_WORKER_FAILURE_ACTION = AttributeKey.stringKey("tramai.sovereign.ops.outbox.worker.failure_action")
+private val ATTR_WORKER_ERROR_TYPE = AttributeKey.stringKey("tramai.sovereign.ops.outbox.worker.error_type")
+
+// Worker failures attributes
+private val ATTR_FAILURE_ACTION = AttributeKey.stringKey("tramai.sovereign.ops.outbox.worker.failure_action")
+private val ATTR_FAILURE_ERROR_TYPE = AttributeKey.stringKey("tramai.sovereign.ops.outbox.worker.error_type")
+
+// Recovery record attributes
+private val ATTR_RECOVERY_RESULT = AttributeKey.stringKey("tramai.sovereign.ops.outbox.recovery.result")
+
+// Dispatch record attributes
+private val ATTR_DISPATCH_RESULT = AttributeKey.stringKey("tramai.sovereign.ops.outbox.dispatch.result")
 
 /**
  * OpenTelemetry-backed observer for the sovereign ops audit outbox worker.
@@ -26,6 +37,23 @@ private val ATTR_ERROR_TYPE = AttributeKey.stringKey("error_type")
  * prompts, model responses, file paths, exception messages, or stack traces
  * are ever recorded.
  *
+ * ## Metric contract
+ *
+ * ### worker.cycles — LongCounter {cycle}
+ * Attributes: worker.outcome, worker.failure_action, worker.error_type
+ *
+ * ### worker.duration — DoubleHistogram ms
+ * Attributes: same as worker.cycles
+ *
+ * ### worker.failures — LongCounter {failure}
+ * Attributes: worker.failure_action, worker.error_type
+ *
+ * ### worker.recovered.records — LongCounter {record}
+ * Attributes: recovery.result = inspected | moved_to_pending | failed_permanent | resolver_failure
+ *
+ * ### worker.dispatched.records — LongCounter {record}
+ * Attributes: dispatch.result = claimed | emitted | failed_retryable | failed_permanent
+ *
  * @param meter The OpenTelemetry [Meter] used to create instruments.
  */
 class OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(
@@ -34,7 +62,7 @@ class OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(
 
     constructor(
         openTelemetry: OpenTelemetry,
-        instrumentationName: String = INSTRUMENT_NAME,
+        instrumentationName: String = INSTRUMENTATION_SCOPE,
     ) : this(meter = openTelemetry.getMeter(instrumentationName))
 
     // ── Instruments ─────────────────────────────────────────────────
@@ -50,17 +78,17 @@ class OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(
         .build()
 
     private val recoveredRecords: LongCounter = meter.counterBuilder("tramai.sovereign.ops.outbox.worker.recovered.records")
-        .setDescription("Records affected by PREPARED recovery")
+        .setDescription("Records affected by PREPARED recovery per result type")
         .setUnit("{record}")
         .build()
 
     private val dispatchedRecords: LongCounter = meter.counterBuilder("tramai.sovereign.ops.outbox.worker.dispatched.records")
-        .setDescription("Records affected by dispatch")
+        .setDescription("Records affected by dispatch per result type")
         .setUnit("{record}")
         .build()
 
     private val cycleFailures: LongCounter = meter.counterBuilder("tramai.sovereign.ops.outbox.worker.failures")
-        .setDescription("Unexpected exceptions escaping runOnce")
+        .setDescription("Failure notifications emitted by the sovereign ops audit outbox worker")
         .setUnit("{failure}")
         .build()
 
@@ -68,19 +96,22 @@ class OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(
 
     override fun onCycleCompleted(summary: SovereignOpsAuditOutboxWorkerRunSummary) {
         val outcome = if (summary.failure != null) "failure" else "success"
+        val failureAction = summary.failure?.action ?: "none"
+        val errorType = summary.failure?.errorCode ?: "none"
 
-        // Cycle counter (one per action that ran)
-        if (summary.recovered != null) {
-            cycles.add(1, actionAttributes("recoverPrepared", outcome))
-        }
-        if (summary.dispatched != null) {
-            cycles.add(1, actionAttributes("dispatchPending", outcome))
-        }
+        val attrs = Attributes.of(
+            ATTR_WORKER_OUTCOME, outcome,
+            ATTR_WORKER_FAILURE_ACTION, failureAction,
+            ATTR_WORKER_ERROR_TYPE, errorType,
+        )
+
+        // Cycle counter — one increment per completed cycle
+        cycles.add(1, attrs)
 
         // Duration histogram (clamp negative defensively)
         val ms = Duration.between(summary.startedAt, summary.completedAt).toMillis()
         val safeMs = if (ms < 0) 0.0 else ms.toDouble()
-        duration.record(safeMs, outcomeAttributes(outcome))
+        duration.record(safeMs, attrs)
 
         // Recovery record counters
         summary.recovered?.let { recordRecovery(it) }
@@ -90,39 +121,49 @@ class OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(
     }
 
     override fun onCycleFailed(action: String, errorCode: String) {
-        cycles.add(1, Attributes.of(ATTR_ACTION, action, ATTR_OUTCOME, "failure", ATTR_ERROR_TYPE, errorCode))
-        cycleFailures.add(1, Attributes.of(ATTR_ACTION, action, ATTR_ERROR_TYPE, errorCode))
+        cycleFailures.add(1, Attributes.of(
+            ATTR_FAILURE_ACTION, action,
+            ATTR_FAILURE_ERROR_TYPE, errorCode,
+        ))
     }
 
     // ── Private helpers ─────────────────────────────────────────────
 
     private fun recordRecovery(r: SovereignOpsAuditOutboxRecoverySummary) {
-        val inspected = Attributes.of(ATTR_ACTION, "recoverPrepared", ATTR_OUTCOME, "inspected")
-        val movedToPending = Attributes.of(ATTR_ACTION, "recoverPrepared", ATTR_OUTCOME, "movedToPending")
-        val failedPermanent = Attributes.of(ATTR_ACTION, "recoverPrepared", ATTR_OUTCOME, "failedPermanent")
-        val resolverFailures = Attributes.of(ATTR_ACTION, "recoverPrepared", ATTR_OUTCOME, "resolverFailures")
-
-        if (r.inspected > 0) recoveredRecords.add(r.inspected.toLong(), inspected)
-        if (r.movedToPending > 0) recoveredRecords.add(r.movedToPending.toLong(), movedToPending)
-        if (r.markedFailedPermanent > 0) recoveredRecords.add(r.markedFailedPermanent.toLong(), failedPermanent)
-        if (r.resolverFailures > 0) recoveredRecords.add(r.resolverFailures.toLong(), resolverFailures)
+        if (r.inspected > 0) {
+            recoveredRecords.add(r.inspected.toLong(),
+                Attributes.of(ATTR_RECOVERY_RESULT, "inspected"))
+        }
+        if (r.movedToPending > 0) {
+            recoveredRecords.add(r.movedToPending.toLong(),
+                Attributes.of(ATTR_RECOVERY_RESULT, "moved_to_pending"))
+        }
+        if (r.markedFailedPermanent > 0) {
+            recoveredRecords.add(r.markedFailedPermanent.toLong(),
+                Attributes.of(ATTR_RECOVERY_RESULT, "failed_permanent"))
+        }
+        if (r.resolverFailures > 0) {
+            recoveredRecords.add(r.resolverFailures.toLong(),
+                Attributes.of(ATTR_RECOVERY_RESULT, "resolver_failure"))
+        }
     }
 
     private fun recordDispatch(d: SovereignOpsAuditOutboxDispatchResult) {
-        val claimed = Attributes.of(ATTR_ACTION, "dispatchPending", ATTR_OUTCOME, "claimed")
-        val emitted = Attributes.of(ATTR_ACTION, "dispatchPending", ATTR_OUTCOME, "emitted")
-        val failedRetryable = Attributes.of(ATTR_ACTION, "dispatchPending", ATTR_OUTCOME, "failedRetryable")
-        val failedPermanent = Attributes.of(ATTR_ACTION, "dispatchPending", ATTR_OUTCOME, "failedPermanent")
-
-        if (d.claimed > 0) dispatchedRecords.add(d.claimed.toLong(), claimed)
-        if (d.emitted > 0) dispatchedRecords.add(d.emitted.toLong(), emitted)
-        if (d.failedRetryable > 0) dispatchedRecords.add(d.failedRetryable.toLong(), failedRetryable)
-        if (d.failedPermanent > 0) dispatchedRecords.add(d.failedPermanent.toLong(), failedPermanent)
+        if (d.claimed > 0) {
+            dispatchedRecords.add(d.claimed.toLong(),
+                Attributes.of(ATTR_DISPATCH_RESULT, "claimed"))
+        }
+        if (d.emitted > 0) {
+            dispatchedRecords.add(d.emitted.toLong(),
+                Attributes.of(ATTR_DISPATCH_RESULT, "emitted"))
+        }
+        if (d.failedRetryable > 0) {
+            dispatchedRecords.add(d.failedRetryable.toLong(),
+                Attributes.of(ATTR_DISPATCH_RESULT, "failed_retryable"))
+        }
+        if (d.failedPermanent > 0) {
+            dispatchedRecords.add(d.failedPermanent.toLong(),
+                Attributes.of(ATTR_DISPATCH_RESULT, "failed_permanent"))
+        }
     }
-
-    private fun actionAttributes(action: String, outcome: String): Attributes =
-        Attributes.of(ATTR_ACTION, action, ATTR_OUTCOME, outcome, ATTR_ERROR_TYPE, "none")
-
-    private fun outcomeAttributes(outcome: String): Attributes =
-        Attributes.of(ATTR_OUTCOME, outcome, ATTR_ERROR_TYPE, "none")
 }

--- a/tramai-spring-boot-starter-sovereign-ops-observability/src/main/kotlin/dev/tramai/spring/sovereign/ops/observability/SovereignOpsOutboxObservabilityAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-observability/src/main/kotlin/dev/tramai/spring/sovereign/ops/observability/SovereignOpsOutboxObservabilityAutoConfiguration.kt
@@ -1,0 +1,35 @@
+package dev.tramai.spring.sovereign.ops.observability
+
+import dev.tramai.spring.sovereign.ops.SovereignOpsAutoConfiguration
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver
+import io.opentelemetry.api.OpenTelemetry
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.AutoConfigureBefore
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+
+/**
+ * Auto-configures [OpenTelemetrySovereignOpsAuditOutboxWorkerObserver]
+ * when:
+ *
+ * 1. An [OpenTelemetry] bean is present in the context, AND
+ * 2. No custom [SovereignOpsAuditOutboxWorkerObserver] has been registered.
+ *
+ * Runs before [SovereignOpsAutoConfiguration] so the OT observer is created
+ * before the Noop fallback. Without an [OpenTelemetry] bean the standard
+ * [SovereignOpsAuditOutboxWorkerObserver.Noop] (registered by
+ * [SovereignOpsAutoConfiguration]) remains active.
+ */
+@AutoConfiguration
+@AutoConfigureBefore(SovereignOpsAutoConfiguration::class)
+open class SovereignOpsOutboxObservabilityAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(SovereignOpsAuditOutboxWorkerObserver::class)
+    @ConditionalOnBean(OpenTelemetry::class)
+    open fun openTelemetrySovereignOpsAuditOutboxWorkerObserver(
+        openTelemetry: OpenTelemetry,
+    ): SovereignOpsAuditOutboxWorkerObserver =
+        OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
+}

--- a/tramai-spring-boot-starter-sovereign-ops-observability/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/tramai-spring-boot-starter-sovereign-ops-observability/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.tramai.spring.sovereign.ops.observability.SovereignOpsOutboxObservabilityAutoConfiguration

--- a/tramai-spring-boot-starter-sovereign-ops-observability/src/test/kotlin/dev/tramai/spring/sovereign/ops/observability/OpenTelemetrySovereignOpsAuditOutboxWorkerObserverT...[truncated]
+++ b/tramai-spring-boot-starter-sovereign-ops-observability/src/test/kotlin/dev/tramai/spring/sovereign/ops/observability/OpenTelemetrySovereignOpsAuditOutboxWorkerObserverT...[truncated]
@@ -1,0 +1,4 @@
+package dev.tramai.spring.sovereign.ops.observability
+
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxDispatchResult
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAud...[truncated]

--- a/tramai-spring-boot-starter-sovereign-ops-observability/src/test/kotlin/dev/tramai/spring/sovereign/ops/observability/OpenTelemetrySovereignOpsAuditOutboxWorkerObserverTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-observability/src/test/kotlin/dev/tramai/spring/sovereign/ops/observability/OpenTelemetrySovereignOpsAuditOutboxWorkerObserverTest.kt
@@ -1,0 +1,323 @@
+package dev.tramai.spring.sovereign.ops.observability
+
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxDispatchResult
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxRecoverySummary
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerRunSummary
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.metrics.SdkMeterProvider
+import io.opentelemetry.sdk.metrics.data.LongPointData
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader
+import org.assertj.core.api.Assertions.assertThat
+import java.time.Duration
+import java.time.Instant
+import kotlin.test.AfterTest
+import kotlin.test.Test
+
+class OpenTelemetrySovereignOpsAuditOutboxWorkerObserverTest {
+
+    private val metricReader = InMemoryMetricReader.create()
+    private val meterProvider = SdkMeterProvider.builder()
+        .registerMetricReader(metricReader)
+        .build()
+    private val openTelemetry = OpenTelemetrySdk.builder()
+        .setMeterProvider(meterProvider)
+        .build()
+
+    @AfterTest
+    fun tearDown() {
+        meterProvider.shutdown()
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────
+
+    private fun summary(
+        recovered: SovereignOpsAuditOutboxRecoverySummary? = null,
+        dispatched: SovereignOpsAuditOutboxDispatchResult? = null,
+        startedAt: Instant = Instant.EPOCH,
+        completedAt: Instant = Instant.EPOCH,
+    ) = SovereignOpsAuditOutboxWorkerRunSummary(
+        recovered = recovered,
+        dispatched = dispatched,
+        startedAt = startedAt,
+        completedAt = completedAt,
+    )
+
+    private fun recovery(
+        inspected: Int = 0,
+        movedToPending: Int = 0,
+        markedFailedPermanent: Int = 0,
+        resolverFailures: Int = 0,
+    ) = SovereignOpsAuditOutboxRecoverySummary(
+        inspected = inspected,
+        movedToPending = movedToPending,
+        markedFailedPermanent = markedFailedPermanent,
+        resolverFailures = resolverFailures,
+    )
+
+    private fun dispatch(
+        claimed: Int = 0,
+        emitted: Int = 0,
+        failedRetryable: Int = 0,
+        failedPermanent: Int = 0,
+    ) = SovereignOpsAuditOutboxDispatchResult(
+        claimed = claimed,
+        emitted = emitted,
+        failedRetryable = failedRetryable,
+        failedPermanent = failedPermanent,
+    )
+
+    // ── Cycle counter tests ─────────────────────────────────────────
+
+    @Test
+    fun `cycle counter emits recoverPrepared action for recovery-only cycle`() {
+        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
+        observer.onCycleCompleted(summary(recovered = recovery(inspected = 5, movedToPending = 3)))
+
+        val metrics = metricReader.collectAllMetrics()
+        val cycleMetric = metrics.single { it.name == "tramai.sovereign.ops.outbox.worker.cycles" }
+        val recoveryPoint = cycleMetric.longSumData.points.single { it.attributes.get(AttributeKey.stringKey("action")) == "recoverPrepared" }
+        assertThat(recoveryPoint.value).isEqualTo(1)
+        assertThat(recoveryPoint.attributes.get(AttributeKey.stringKey("outcome"))).isEqualTo("success")
+    }
+
+    @Test
+    fun `cycle counter emits dispatchPending action for dispatch-only cycle`() {
+        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
+        observer.onCycleCompleted(summary(dispatched = dispatch(claimed = 10, emitted = 8)))
+
+        val metrics = metricReader.collectAllMetrics()
+        val cycleMetric = metrics.single { it.name == "tramai.sovereign.ops.outbox.worker.cycles" }
+        val dispatchPoint = cycleMetric.longSumData.points.single { it.attributes.get(AttributeKey.stringKey("action")) == "dispatchPending" }
+        assertThat(dispatchPoint.value).isEqualTo(1)
+        assertThat(dispatchPoint.attributes.get(AttributeKey.stringKey("outcome"))).isEqualTo("success")
+    }
+
+    @Test
+    fun `cycle counter emits both actions when both recovery and dispatch ran`() {
+        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
+        observer.onCycleCompleted(summary(
+            recovered = recovery(inspected = 2),
+            dispatched = dispatch(claimed = 1, emitted = 1),
+        ))
+
+        val metrics = metricReader.collectAllMetrics()
+        val cycleMetric = metrics.single { it.name == "tramai.sovereign.ops.outbox.worker.cycles" }
+        val actions = cycleMetric.longSumData.points.map { it.attributes.get(AttributeKey.stringKey("action")) }
+        assertThat(actions).containsExactlyInAnyOrder("recoverPrepared", "dispatchPending")
+    }
+
+    // ── Duration histogram test ─────────────────────────────────────
+
+    @Test
+    fun `duration histogram records elapsed time`() {
+        val started = Instant.EPOCH
+        val completed = started.plusMillis(1234)
+        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
+        observer.onCycleCompleted(summary(startedAt = started, completedAt = completed))
+
+        val metrics = metricReader.collectAllMetrics()
+        val durationMetric = metrics.single { it.name == "tramai.sovereign.ops.outbox.worker.duration" }
+        val points = durationMetric.histogramData.points
+        assertThat(points).hasSize(1)
+        // 1234 ms ± 1 ms (floating point tolerance)
+        assertThat(points.single().sum / points.single().count).isCloseTo(1234.0, org.assertj.core.data.Offset.offset(1.0))
+    }
+
+    @Test
+    fun `duration histogram clamps negative values to zero`() {
+        val started = Instant.EPOCH
+        val completed = started.minusMillis(500) // backwards — negative duration
+        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
+        observer.onCycleCompleted(summary(startedAt = started, completedAt = completed))
+
+        val metrics = metricReader.collectAllMetrics()
+        val durationMetric = metrics.single { it.name == "tramai.sovereign.ops.outbox.worker.duration" }
+        val points = durationMetric.histogramData.points
+        assertThat(points.single().sum / points.single().count).isCloseTo(0.0, org.assertj.core.data.Offset.offset(0.1))
+    }
+
+    // ── Recovery record counter test ────────────────────────────────
+
+    @Test
+    fun `recovered records counter emits per-outcome counts`() {
+        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
+        observer.onCycleCompleted(summary(recovered = recovery(
+            inspected = 10,
+            movedToPending = 7,
+            markedFailedPermanent = 2,
+            resolverFailures = 1,
+        )))
+
+        val metrics = metricReader.collectAllMetrics()
+        val recMetric = metrics.single { it.name == "tramai.sovereign.ops.outbox.worker.recovered.records" }
+        val points = recMetric.longSumData.points
+        assertThat(points).hasSize(4)
+
+        val byOutcome = points.associate { p ->
+            p.attributes.get(AttributeKey.stringKey("outcome")) to p.value
+        }
+        assertThat(byOutcome).containsEntry("inspected", 10L)
+        assertThat(byOutcome).containsEntry("movedToPending", 7L)
+        assertThat(byOutcome).containsEntry("failedPermanent", 2L)
+        assertThat(byOutcome).containsEntry("resolverFailures", 1L)
+    }
+
+    @Test
+    fun `recovered records counter skips zero-count outcomes`() {
+        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
+        observer.onCycleCompleted(summary(recovered = recovery(inspected = 1, movedToPending = 1)))
+
+        val metrics = metricReader.collectAllMetrics()
+        val recMetric = metrics.single { it.name == "tramai.sovereign.ops.outbox.worker.recovered.records" }
+        val points = recMetric.longSumData.points
+        val outcomes = points.map { it.attributes.get(AttributeKey.stringKey("outcome")) }
+        assertThat(outcomes).containsExactlyInAnyOrder("inspected", "movedToPending")
+    }
+
+    // ── Dispatch record counter tests ───────────────────────────────
+
+    @Test
+    fun `dispatched records counter emits per-outcome counts`() {
+        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
+        observer.onCycleCompleted(summary(dispatched = dispatch(
+            claimed = 5,
+            emitted = 4,
+            failedRetryable = 1,
+            failedPermanent = 0,
+        )))
+
+        val metrics = metricReader.collectAllMetrics()
+        val dispMetric = metrics.single { it.name == "tramai.sovereign.ops.outbox.worker.dispatched.records" }
+        val points = dispMetric.longSumData.points
+        assertThat(points).hasSize(3)
+
+        val byOutcome = points.associate { p ->
+            p.attributes.get(AttributeKey.stringKey("outcome")) to p.value
+        }
+        assertThat(byOutcome).containsEntry("claimed", 5L)
+        assertThat(byOutcome).containsEntry("emitted", 4L)
+        assertThat(byOutcome).containsEntry("failedRetryable", 1L)
+    }
+
+    // ── Cycle failure tests ─────────────────────────────────────────
+
+    @Test
+    fun `onCycleFailed emits failure counter and cycle counter`() {
+        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
+        observer.onCycleFailed(action = "unexpected", errorCode = "IllegalStateException")
+
+        val metrics = metricReader.collectAllMetrics()
+
+        // Failure counter
+        val failureMetric = metrics.single { it.name == "tramai.sovereign.ops.outbox.worker.failures" }
+        val failurePoint = failureMetric.longSumData.points.single { it.attributes.get(AttributeKey.stringKey("action")) == "unexpected" }
+        assertThat(failurePoint.value).isEqualTo(1)
+        assertThat(failurePoint.attributes.get(AttributeKey.stringKey("error_type"))).isEqualTo("IllegalStateException")
+
+        // Cycle counter also reflects failure
+        val cycleMetric = metrics.single { it.name == "tramai.sovereign.ops.outbox.worker.cycles" }
+        val cyclePoint = cycleMetric.longSumData.points.single { it.attributes.get(AttributeKey.stringKey("action")) == "unexpected" }
+        assertThat(cyclePoint.value).isEqualTo(1)
+        assertThat(cyclePoint.attributes.get(AttributeKey.stringKey("outcome"))).isEqualTo("failure")
+    }
+
+    // ── Sanitization tests ──────────────────────────────────────────
+
+    @Test
+    fun `sanitization — no exception message appears in attributes`() {
+        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
+        observer.onCycleFailed(action = "unexpected", errorCode = "RuntimeException")
+        // errorCode is the class simple name, NOT the message — prove it
+
+        val metrics = metricReader.collectAllMetrics()
+        val failureMetric = metrics.single { it.name == "tramai.sovereign.ops.outbox.worker.failures" }
+        val allAttributes = failureMetric.longSumData.points.flatMap { it.attributes.asMap().values }
+
+        // No attribute value should contain raw exception message text
+        val sensitivePatterns = listOf("connection", "stack", "trace", "secret", "password", "token")
+        for (attr in allAttributes) {
+            val attrStr = attr.toString().lowercase()
+            for (pattern in sensitivePatterns) {
+                assertThat(attrStr).doesNotContain(pattern)
+            }
+        }
+    }
+
+    @Test
+    fun `sanitization — no sensitive data from run summary appears in attributes`() {
+        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
+        // Run summary itself is already sanitized by the worker — the observer
+        // just extracts counts. Prove no spill-through of any sensitive pattern.
+        observer.onCycleCompleted(summary(
+            recovered = recovery(inspected = 1),
+            dispatched = dispatch(emitted = 1),
+        ))
+
+        val metrics = metricReader.collectAllMetrics()
+        // Collect ALL attribute values across all metrics
+        val allAttrs = metrics.flatMap { metric ->
+            when {
+                metric.longSumData.points.isNotEmpty() -> metric.longSumData.points.flatMap { it.attributes.asMap().values }
+                metric.histogramData.points.isNotEmpty() -> metric.histogramData.points.flatMap { it.attributes.asMap().values }
+                else -> emptyList()
+            }
+        }
+
+        val sensitivePatterns = listOf(
+            "/secret/path",
+            "sensitive@example.com",
+            "approval-123",
+            "token",
+            "raw reason",
+            "denial-reason",
+            "stack trace",
+        )
+        for (attr in allAttrs) {
+            val attrStr = attr.toString().lowercase()
+            for (pattern in sensitivePatterns) {
+                assertThat(attrStr)
+                    .`as`("Attribute '$attrStr' must not contain sensitive pattern '$pattern'")
+                    .doesNotContain(pattern)
+            }
+        }
+    }
+
+    @Test
+    fun `sanitization — attributes are low-cardinality constants only`() {
+        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
+        observer.onCycleCompleted(summary(
+            recovered = recovery(inspected = 3, movedToPending = 2),
+            dispatched = dispatch(claimed = 1, emitted = 1),
+        ))
+        observer.onCycleFailed("unexpected", "NullPointerException")
+
+        val metrics = metricReader.collectAllMetrics()
+        val allAttrs = metrics.flatMap { metric ->
+            when {
+                metric.longSumData.points.isNotEmpty() -> metric.longSumData.points.flatMap { it.attributes.asMap().values }
+                metric.histogramData.points.isNotEmpty() -> metric.histogramData.points.flatMap { it.attributes.asMap().values }
+                else -> emptyList()
+            }
+        }.map { it.toString() }
+
+        // All actions should be from the fixed set
+        for (attr in allAttrs) {
+            if (attr == "recoverPrepared" || attr == "dispatchPending" || attr == "unexpected") continue
+            if (attr == "success" || attr == "failure") continue
+            if (attr == "inspected" || attr == "movedToPending" || attr == "failedPermanent" || attr == "resolverFailures") continue
+            if (attr == "claimed" || attr == "emitted" || attr == "failedRetryable") continue
+            if (attr == "none" || attr == "NullPointerException") continue
+            // numeric values are fine (the counter values)
+            if (attr.toDoubleOrNull() != null) continue
+            // Should have been covered by the above
+            assertThat(attr).`as`("Unexpected attribute value: $attr").isIn(
+                "recoverPrepared", "dispatchPending", "unexpected",
+                "success", "failure",
+                "inspected", "movedToPending", "failedPermanent", "resolverFailures",
+                "claimed", "emitted", "failedRetryable",
+                "none", "NullPointerException",
+            )
+        }
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops-observability/src/test/kotlin/dev/tramai/spring/sovereign/ops/observability/OpenTelemetrySovereignOpsAuditOutboxWorkerObserverTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-observability/src/test/kotlin/dev/tramai/spring/sovereign/ops/observability/OpenTelemetrySovereignOpsAuditOutboxWorkerObserverTest.kt
@@ -2,17 +2,16 @@ package dev.tramai.spring.sovereign.ops.observability
 
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxDispatchResult
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxRecoverySummary
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerFailureSummary
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerRunSummary
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.metrics.SdkMeterProvider
-import io.opentelemetry.sdk.metrics.data.LongPointData
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader
 import org.assertj.core.api.Assertions.assertThat
-import java.time.Duration
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
 import java.time.Instant
-import kotlin.test.AfterTest
-import kotlin.test.Test
 
 class OpenTelemetrySovereignOpsAuditOutboxWorkerObserverTest {
 
@@ -20,304 +19,316 @@ class OpenTelemetrySovereignOpsAuditOutboxWorkerObserverTest {
     private val meterProvider = SdkMeterProvider.builder()
         .registerMetricReader(metricReader)
         .build()
-    private val openTelemetry = OpenTelemetrySdk.builder()
+    private val otel = OpenTelemetrySdk.builder()
         .setMeterProvider(meterProvider)
         .build()
+    private val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(otel)
 
-    @AfterTest
+    private val fixedTime = Instant.parse("2026-06-18T10:00:00Z")
+    private val laterTime = Instant.parse("2026-06-18T10:00:01Z")
+
+    @AfterEach
     fun tearDown() {
         meterProvider.shutdown()
     }
 
+    // ── Attribute keys ──────────────────────────────────────────────
+
+    private val KEY_WORKER_OUTCOME = AttributeKey.stringKey("tramai.sovereign.ops.outbox.worker.outcome")
+    private val KEY_WORKER_FAILURE_ACTION = AttributeKey.stringKey("tramai.sovereign.ops.outbox.worker.failure_action")
+    private val KEY_WORKER_ERROR_TYPE = AttributeKey.stringKey("tramai.sovereign.ops.outbox.worker.error_type")
+    private val KEY_FAILURE_ACTION = AttributeKey.stringKey("tramai.sovereign.ops.outbox.worker.failure_action")
+    private val KEY_FAILURE_ERROR_TYPE = AttributeKey.stringKey("tramai.sovereign.ops.outbox.worker.error_type")
+    private val KEY_RECOVERY_RESULT = AttributeKey.stringKey("tramai.sovereign.ops.outbox.recovery.result")
+    private val KEY_DISPATCH_RESULT = AttributeKey.stringKey("tramai.sovereign.ops.outbox.dispatch.result")
+
     // ── Helpers ─────────────────────────────────────────────────────
 
-    private fun summary(
-        recovered: SovereignOpsAuditOutboxRecoverySummary? = null,
-        dispatched: SovereignOpsAuditOutboxDispatchResult? = null,
-        startedAt: Instant = Instant.EPOCH,
-        completedAt: Instant = Instant.EPOCH,
-    ) = SovereignOpsAuditOutboxWorkerRunSummary(
-        recovered = recovered,
-        dispatched = dispatched,
-        startedAt = startedAt,
-        completedAt = completedAt,
-    )
+    private fun metrics() = metricReader.collectAllMetrics()
 
-    private fun recovery(
-        inspected: Int = 0,
-        movedToPending: Int = 0,
-        markedFailedPermanent: Int = 0,
-        resolverFailures: Int = 0,
-    ) = SovereignOpsAuditOutboxRecoverySummary(
-        inspected = inspected,
-        movedToPending = movedToPending,
-        markedFailedPermanent = markedFailedPermanent,
-        resolverFailures = resolverFailures,
-    )
+    private fun cyclePoints() =
+        metrics().find { it.name == "tramai.sovereign.ops.outbox.worker.cycles" }
+            ?.longSumData?.points?.filterNotNull() ?: emptyList()
 
-    private fun dispatch(
-        claimed: Int = 0,
-        emitted: Int = 0,
-        failedRetryable: Int = 0,
-        failedPermanent: Int = 0,
-    ) = SovereignOpsAuditOutboxDispatchResult(
-        claimed = claimed,
-        emitted = emitted,
-        failedRetryable = failedRetryable,
-        failedPermanent = failedPermanent,
-    )
+    private fun failurePoints() =
+        metrics().find { it.name == "tramai.sovereign.ops.outbox.worker.failures" }
+            ?.longSumData?.points?.filterNotNull() ?: emptyList()
 
-    // ── Cycle counter tests ─────────────────────────────────────────
+    private fun recoveryPoints() =
+        metrics().find { it.name == "tramai.sovereign.ops.outbox.worker.recovered.records" }
+            ?.longSumData?.points?.filterNotNull() ?: emptyList()
+
+    private fun dispatchPoints() =
+        metrics().find { it.name == "tramai.sovereign.ops.outbox.worker.dispatched.records" }
+            ?.longSumData?.points?.filterNotNull() ?: emptyList()
+
+    // ── Tests ───────────────────────────────────────────────────────
 
     @Test
-    fun `cycle counter emits recoverPrepared action for recovery-only cycle`() {
-        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
-        observer.onCycleCompleted(summary(recovered = recovery(inspected = 5, movedToPending = 3)))
+    fun `successful cycle emits correct worker attributes`() {
+        val summary = SovereignOpsAuditOutboxWorkerRunSummary(
+            startedAt = fixedTime,
+            completedAt = laterTime,
+            recovered = null,
+            dispatched = null,
+            failure = null,
+        )
 
-        val metrics = metricReader.collectAllMetrics()
-        val cycleMetric = metrics.single { it.name == "tramai.sovereign.ops.outbox.worker.cycles" }
-        val recoveryPoint = cycleMetric.longSumData.points.single { it.attributes.get(AttributeKey.stringKey("action")) == "recoverPrepared" }
-        assertThat(recoveryPoint.value).isEqualTo(1)
-        assertThat(recoveryPoint.attributes.get(AttributeKey.stringKey("outcome"))).isEqualTo("success")
-    }
+        observer.onCycleCompleted(summary)
 
-    @Test
-    fun `cycle counter emits dispatchPending action for dispatch-only cycle`() {
-        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
-        observer.onCycleCompleted(summary(dispatched = dispatch(claimed = 10, emitted = 8)))
-
-        val metrics = metricReader.collectAllMetrics()
-        val cycleMetric = metrics.single { it.name == "tramai.sovereign.ops.outbox.worker.cycles" }
-        val dispatchPoint = cycleMetric.longSumData.points.single { it.attributes.get(AttributeKey.stringKey("action")) == "dispatchPending" }
-        assertThat(dispatchPoint.value).isEqualTo(1)
-        assertThat(dispatchPoint.attributes.get(AttributeKey.stringKey("outcome"))).isEqualTo("success")
-    }
-
-    @Test
-    fun `cycle counter emits both actions when both recovery and dispatch ran`() {
-        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
-        observer.onCycleCompleted(summary(
-            recovered = recovery(inspected = 2),
-            dispatched = dispatch(claimed = 1, emitted = 1),
-        ))
-
-        val metrics = metricReader.collectAllMetrics()
-        val cycleMetric = metrics.single { it.name == "tramai.sovereign.ops.outbox.worker.cycles" }
-        val actions = cycleMetric.longSumData.points.map { it.attributes.get(AttributeKey.stringKey("action")) }
-        assertThat(actions).containsExactlyInAnyOrder("recoverPrepared", "dispatchPending")
-    }
-
-    // ── Duration histogram test ─────────────────────────────────────
-
-    @Test
-    fun `duration histogram records elapsed time`() {
-        val started = Instant.EPOCH
-        val completed = started.plusMillis(1234)
-        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
-        observer.onCycleCompleted(summary(startedAt = started, completedAt = completed))
-
-        val metrics = metricReader.collectAllMetrics()
-        val durationMetric = metrics.single { it.name == "tramai.sovereign.ops.outbox.worker.duration" }
-        val points = durationMetric.histogramData.points
+        val points = cyclePoints()
         assertThat(points).hasSize(1)
-        // 1234 ms ± 1 ms (floating point tolerance)
-        assertThat(points.single().sum / points.single().count).isCloseTo(1234.0, org.assertj.core.data.Offset.offset(1.0))
+        val attrs = points[0].attributes
+        assertThat(attrs.get(KEY_WORKER_OUTCOME)).isEqualTo("success")
+        assertThat(attrs.get(KEY_WORKER_FAILURE_ACTION)).isEqualTo("none")
+        assertThat(attrs.get(KEY_WORKER_ERROR_TYPE)).isEqualTo("none")
+        assertThat(points[0].value).isEqualTo(1)
     }
 
     @Test
-    fun `duration histogram clamps negative values to zero`() {
-        val started = Instant.EPOCH
-        val completed = started.minusMillis(500) // backwards — negative duration
-        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
-        observer.onCycleCompleted(summary(startedAt = started, completedAt = completed))
+    fun `failed cycle emits failure attributes`() {
+        val summary = SovereignOpsAuditOutboxWorkerRunSummary(
+            startedAt = fixedTime,
+            completedAt = laterTime,
+            recovered = null,
+            dispatched = null,
+            failure = SovereignOpsAuditOutboxWorkerFailureSummary("recoverPrepared", "RuntimeException"),
+        )
 
-        val metrics = metricReader.collectAllMetrics()
-        val durationMetric = metrics.single { it.name == "tramai.sovereign.ops.outbox.worker.duration" }
-        val points = durationMetric.histogramData.points
-        assertThat(points.single().sum / points.single().count).isCloseTo(0.0, org.assertj.core.data.Offset.offset(0.1))
+        observer.onCycleCompleted(summary)
+
+        val points = cyclePoints()
+        assertThat(points).hasSize(1)
+        val attrs = points[0].attributes
+        assertThat(attrs.get(KEY_WORKER_OUTCOME)).isEqualTo("failure")
+        assertThat(attrs.get(KEY_WORKER_FAILURE_ACTION)).isEqualTo("recoverPrepared")
+        assertThat(attrs.get(KEY_WORKER_ERROR_TYPE)).isEqualTo("RuntimeException")
     }
 
-    // ── Recovery record counter test ────────────────────────────────
+    @Test
+    fun `duration is recorded correctly`() {
+        val t1 = Instant.parse("2026-06-18T10:00:00Z")
+        val t2 = Instant.parse("2026-06-18T10:00:00.500Z")
+        val summary = SovereignOpsAuditOutboxWorkerRunSummary(
+            startedAt = t1,
+            completedAt = t2,
+            recovered = null,
+            dispatched = null,
+            failure = null,
+        )
+
+        observer.onCycleCompleted(summary)
+
+        val durationMetric = metrics().find { it.name == "tramai.sovereign.ops.outbox.worker.duration" }
+        assertThat(durationMetric).isNotNull
+        val point = durationMetric!!.histogramData.points.single()
+        assertThat(point.sum).isEqualTo(500.0)
+    }
 
     @Test
-    fun `recovered records counter emits per-outcome counts`() {
-        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
-        observer.onCycleCompleted(summary(recovered = recovery(
-            inspected = 10,
-            movedToPending = 7,
-            markedFailedPermanent = 2,
-            resolverFailures = 1,
-        )))
+    fun `negative duration is clamped to zero`() {
+        val t1 = Instant.parse("2026-06-18T10:00:01Z")
+        val t2 = Instant.parse("2026-06-18T10:00:00Z")
+        val summary = SovereignOpsAuditOutboxWorkerRunSummary(
+            startedAt = t1,
+            completedAt = t2,
+            recovered = null,
+            dispatched = null,
+            failure = null,
+        )
 
-        val metrics = metricReader.collectAllMetrics()
-        val recMetric = metrics.single { it.name == "tramai.sovereign.ops.outbox.worker.recovered.records" }
-        val points = recMetric.longSumData.points
+        observer.onCycleCompleted(summary)
+
+        val durationMetric = metrics().find { it.name == "tramai.sovereign.ops.outbox.worker.duration" }
+        val point = durationMetric!!.histogramData.points.single()
+        assertThat(point.sum).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `recovery counters use recovery_result attribute`() {
+        val summary = SovereignOpsAuditOutboxWorkerRunSummary(
+            startedAt = fixedTime,
+            completedAt = laterTime,
+            recovered = SovereignOpsAuditOutboxRecoverySummary(
+                inspected = 10,
+                movedToPending = 3,
+                markedFailedPermanent = 2,
+                resolverFailures = 1,
+            ),
+            dispatched = null,
+            failure = null,
+        )
+
+        observer.onCycleCompleted(summary)
+
+        val points = recoveryPoints()
         assertThat(points).hasSize(4)
 
-        val byOutcome = points.associate { p ->
-            p.attributes.get(AttributeKey.stringKey("outcome")) to p.value
-        }
-        assertThat(byOutcome).containsEntry("inspected", 10L)
-        assertThat(byOutcome).containsEntry("movedToPending", 7L)
-        assertThat(byOutcome).containsEntry("failedPermanent", 2L)
-        assertThat(byOutcome).containsEntry("resolverFailures", 1L)
+        val inspectedPt = points.find { it.attributes.get(KEY_RECOVERY_RESULT) == "inspected" }
+        assertThat(inspectedPt).isNotNull
+        assertThat(inspectedPt!!.value).isEqualTo(10)
+
+        val movedPt = points.find { it.attributes.get(KEY_RECOVERY_RESULT) == "moved_to_pending" }
+        assertThat(movedPt).isNotNull
+        assertThat(movedPt!!.value).isEqualTo(3)
+
+        val failedPt = points.find { it.attributes.get(KEY_RECOVERY_RESULT) == "failed_permanent" }
+        assertThat(failedPt).isNotNull
+        assertThat(failedPt!!.value).isEqualTo(2)
+
+        val resolverPt = points.find { it.attributes.get(KEY_RECOVERY_RESULT) == "resolver_failure" }
+        assertThat(resolverPt).isNotNull
+        assertThat(resolverPt!!.value).isEqualTo(1)
     }
 
     @Test
-    fun `recovered records counter skips zero-count outcomes`() {
-        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
-        observer.onCycleCompleted(summary(recovered = recovery(inspected = 1, movedToPending = 1)))
-
-        val metrics = metricReader.collectAllMetrics()
-        val recMetric = metrics.single { it.name == "tramai.sovereign.ops.outbox.worker.recovered.records" }
-        val points = recMetric.longSumData.points
-        val outcomes = points.map { it.attributes.get(AttributeKey.stringKey("outcome")) }
-        assertThat(outcomes).containsExactlyInAnyOrder("inspected", "movedToPending")
-    }
-
-    // ── Dispatch record counter tests ───────────────────────────────
-
-    @Test
-    fun `dispatched records counter emits per-outcome counts`() {
-        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
-        observer.onCycleCompleted(summary(dispatched = dispatch(
-            claimed = 5,
-            emitted = 4,
-            failedRetryable = 1,
-            failedPermanent = 0,
-        )))
-
-        val metrics = metricReader.collectAllMetrics()
-        val dispMetric = metrics.single { it.name == "tramai.sovereign.ops.outbox.worker.dispatched.records" }
-        val points = dispMetric.longSumData.points
-        assertThat(points).hasSize(3)
-
-        val byOutcome = points.associate { p ->
-            p.attributes.get(AttributeKey.stringKey("outcome")) to p.value
-        }
-        assertThat(byOutcome).containsEntry("claimed", 5L)
-        assertThat(byOutcome).containsEntry("emitted", 4L)
-        assertThat(byOutcome).containsEntry("failedRetryable", 1L)
-    }
-
-    // ── Cycle failure tests ─────────────────────────────────────────
-
-    @Test
-    fun `onCycleFailed emits failure counter and cycle counter`() {
-        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
-        observer.onCycleFailed(action = "unexpected", errorCode = "IllegalStateException")
-
-        val metrics = metricReader.collectAllMetrics()
-
-        // Failure counter
-        val failureMetric = metrics.single { it.name == "tramai.sovereign.ops.outbox.worker.failures" }
-        val failurePoint = failureMetric.longSumData.points.single { it.attributes.get(AttributeKey.stringKey("action")) == "unexpected" }
-        assertThat(failurePoint.value).isEqualTo(1)
-        assertThat(failurePoint.attributes.get(AttributeKey.stringKey("error_type"))).isEqualTo("IllegalStateException")
-
-        // Cycle counter also reflects failure
-        val cycleMetric = metrics.single { it.name == "tramai.sovereign.ops.outbox.worker.cycles" }
-        val cyclePoint = cycleMetric.longSumData.points.single { it.attributes.get(AttributeKey.stringKey("action")) == "unexpected" }
-        assertThat(cyclePoint.value).isEqualTo(1)
-        assertThat(cyclePoint.attributes.get(AttributeKey.stringKey("outcome"))).isEqualTo("failure")
-    }
-
-    // ── Sanitization tests ──────────────────────────────────────────
-
-    @Test
-    fun `sanitization — no exception message appears in attributes`() {
-        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
-        observer.onCycleFailed(action = "unexpected", errorCode = "RuntimeException")
-        // errorCode is the class simple name, NOT the message — prove it
-
-        val metrics = metricReader.collectAllMetrics()
-        val failureMetric = metrics.single { it.name == "tramai.sovereign.ops.outbox.worker.failures" }
-        val allAttributes = failureMetric.longSumData.points.flatMap { it.attributes.asMap().values }
-
-        // No attribute value should contain raw exception message text
-        val sensitivePatterns = listOf("connection", "stack", "trace", "secret", "password", "token")
-        for (attr in allAttributes) {
-            val attrStr = attr.toString().lowercase()
-            for (pattern in sensitivePatterns) {
-                assertThat(attrStr).doesNotContain(pattern)
-            }
-        }
-    }
-
-    @Test
-    fun `sanitization — no sensitive data from run summary appears in attributes`() {
-        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
-        // Run summary itself is already sanitized by the worker — the observer
-        // just extracts counts. Prove no spill-through of any sensitive pattern.
-        observer.onCycleCompleted(summary(
-            recovered = recovery(inspected = 1),
-            dispatched = dispatch(emitted = 1),
-        ))
-
-        val metrics = metricReader.collectAllMetrics()
-        // Collect ALL attribute values across all metrics
-        val allAttrs = metrics.flatMap { metric ->
-            when {
-                metric.longSumData.points.isNotEmpty() -> metric.longSumData.points.flatMap { it.attributes.asMap().values }
-                metric.histogramData.points.isNotEmpty() -> metric.histogramData.points.flatMap { it.attributes.asMap().values }
-                else -> emptyList()
-            }
-        }
-
-        val sensitivePatterns = listOf(
-            "/secret/path",
-            "sensitive@example.com",
-            "approval-123",
-            "token",
-            "raw reason",
-            "denial-reason",
-            "stack trace",
+    fun `dispatch counters use dispatch_result attribute`() {
+        val summary = SovereignOpsAuditOutboxWorkerRunSummary(
+            startedAt = fixedTime,
+            completedAt = laterTime,
+            recovered = null,
+            dispatched = SovereignOpsAuditOutboxDispatchResult(
+                claimed = 50,
+                emitted = 45,
+                failedRetryable = 3,
+                failedPermanent = 2,
+            ),
+            failure = null,
         )
-        for (attr in allAttrs) {
-            val attrStr = attr.toString().lowercase()
-            for (pattern in sensitivePatterns) {
-                assertThat(attrStr)
-                    .`as`("Attribute '$attrStr' must not contain sensitive pattern '$pattern'")
-                    .doesNotContain(pattern)
+
+        observer.onCycleCompleted(summary)
+
+        val points = dispatchPoints()
+        assertThat(points).hasSize(4)
+
+        val claimedPt = points.find { it.attributes.get(KEY_DISPATCH_RESULT) == "claimed" }
+        assertThat(claimedPt).isNotNull
+        assertThat(claimedPt!!.value).isEqualTo(50)
+
+        val emittedPt = points.find { it.attributes.get(KEY_DISPATCH_RESULT) == "emitted" }
+        assertThat(emittedPt).isNotNull
+        assertThat(emittedPt!!.value).isEqualTo(45)
+
+        val retryablePt = points.find { it.attributes.get(KEY_DISPATCH_RESULT) == "failed_retryable" }
+        assertThat(retryablePt).isNotNull
+        assertThat(retryablePt!!.value).isEqualTo(3)
+
+        val permanentPt = points.find { it.attributes.get(KEY_DISPATCH_RESULT) == "failed_permanent" }
+        assertThat(permanentPt).isNotNull
+        assertThat(permanentPt!!.value).isEqualTo(2)
+    }
+
+    @Test
+    fun `failure metric uses correct attribute keys`() {
+        observer.onCycleFailed("unexpected", "IllegalStateException")
+
+        val points = failurePoints()
+        assertThat(points).hasSize(1)
+        assertThat(points[0].attributes.get(KEY_FAILURE_ACTION)).isEqualTo("unexpected")
+        assertThat(points[0].attributes.get(KEY_FAILURE_ERROR_TYPE)).isEqualTo("IllegalStateException")
+    }
+
+    @Test
+    fun `P1 fix - summary failure plus onCycleFailed does not double-count cycles`() {
+        // Simulate lifecycle: a summary with failure is passed to onCycleCompleted,
+        // AND the lifecycle also calls onCycleFailed for that same failure.
+        val summary = SovereignOpsAuditOutboxWorkerRunSummary(
+            startedAt = fixedTime,
+            completedAt = laterTime,
+            recovered = SovereignOpsAuditOutboxRecoverySummary(10, 0, 0, 0),
+            dispatched = null,
+            failure = SovereignOpsAuditOutboxWorkerFailureSummary("recoverPrepared", "IllegalStateException"),
+        )
+
+        observer.onCycleCompleted(summary)
+        observer.onCycleFailed("recoverPrepared", "IllegalStateException")
+
+        // worker.cycles should be exactly 1
+        val cyclesTotal = cyclePoints().sumOf { it.value }
+        assertThat(cyclesTotal).isEqualTo(1L)
+
+        // worker.failures should also be exactly 1
+        val failuresTotal = failurePoints().sumOf { it.value }
+        assertThat(failuresTotal).isEqualTo(1L)
+    }
+
+    @Test
+    fun `sanitization - no sensitive strings in failure attributes`() {
+        observer.onCycleFailed("unexpected", "IllegalStateException")
+
+        val points = failurePoints()
+        for (pt in points) {
+            val attrs = pt.attributes
+            attrs.forEach { key, value ->
+                assertThat(value.toString()).doesNotContain(
+                    "secret", "token", "password", "approval-123",
+                    "sensitive@example.com", "/secret/path",
+                )
             }
         }
     }
 
     @Test
-    fun `sanitization — attributes are low-cardinality constants only`() {
-        val observer = OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
-        observer.onCycleCompleted(summary(
-            recovered = recovery(inspected = 3, movedToPending = 2),
-            dispatched = dispatch(claimed = 1, emitted = 1),
-        ))
-        observer.onCycleFailed("unexpected", "NullPointerException")
+    fun `sanitization - no sensitive strings in cycle attributes`() {
+        val summary = SovereignOpsAuditOutboxWorkerRunSummary(
+            startedAt = fixedTime,
+            completedAt = laterTime,
+            recovered = null,
+            dispatched = null,
+            failure = null,
+        )
 
-        val metrics = metricReader.collectAllMetrics()
-        val allAttrs = metrics.flatMap { metric ->
-            when {
-                metric.longSumData.points.isNotEmpty() -> metric.longSumData.points.flatMap { it.attributes.asMap().values }
-                metric.histogramData.points.isNotEmpty() -> metric.histogramData.points.flatMap { it.attributes.asMap().values }
-                else -> emptyList()
+        observer.onCycleCompleted(summary)
+
+        val points = cyclePoints()
+        for (pt in points) {
+            val attrs = pt.attributes
+            attrs.forEach { key, value ->
+                assertThat(value.toString()).doesNotContain(
+                    "secret", "token", "password", "approval-123",
+                    "sensitive@example.com", "/secret/path",
+                )
             }
-        }.map { it.toString() }
-
-        // All actions should be from the fixed set
-        for (attr in allAttrs) {
-            if (attr == "recoverPrepared" || attr == "dispatchPending" || attr == "unexpected") continue
-            if (attr == "success" || attr == "failure") continue
-            if (attr == "inspected" || attr == "movedToPending" || attr == "failedPermanent" || attr == "resolverFailures") continue
-            if (attr == "claimed" || attr == "emitted" || attr == "failedRetryable") continue
-            if (attr == "none" || attr == "NullPointerException") continue
-            // numeric values are fine (the counter values)
-            if (attr.toDoubleOrNull() != null) continue
-            // Should have been covered by the above
-            assertThat(attr).`as`("Unexpected attribute value: $attr").isIn(
-                "recoverPrepared", "dispatchPending", "unexpected",
-                "success", "failure",
-                "inspected", "movedToPending", "failedPermanent", "resolverFailures",
-                "claimed", "emitted", "failedRetryable",
-                "none", "NullPointerException",
-            )
         }
+    }
+
+    @Test
+    fun `null recovery and dispatch are handled gracefully`() {
+        val summary = SovereignOpsAuditOutboxWorkerRunSummary(
+            startedAt = fixedTime,
+            completedAt = laterTime,
+            recovered = null,
+            dispatched = null,
+            failure = null,
+        )
+
+        observer.onCycleCompleted(summary)
+
+        // Should not throw, recovery/dispatch metrics should be empty
+        assertThat(recoveryPoints()).isEmpty()
+        assertThat(dispatchPoints()).isEmpty()
+    }
+
+    @Test
+    fun `zero-value recovery records are not emitted`() {
+        val summary = SovereignOpsAuditOutboxWorkerRunSummary(
+            startedAt = fixedTime,
+            completedAt = laterTime,
+            recovered = SovereignOpsAuditOutboxRecoverySummary(
+                inspected = 0,
+                movedToPending = 5,
+                markedFailedPermanent = 0,
+                resolverFailures = 0,
+            ),
+            dispatched = null,
+            failure = null,
+        )
+
+        observer.onCycleCompleted(summary)
+
+        val points = recoveryPoints()
+        assertThat(points).hasSize(1)
+        assertThat(points[0].attributes.get(KEY_RECOVERY_RESULT)).isEqualTo("moved_to_pending")
+        assertThat(points[0].value).isEqualTo(5)
     }
 }

--- a/tramai-spring-boot-starter-sovereign-ops-observability/src/test/kotlin/dev/tramai/spring/sovereign/ops/observability/SovereignOpsOutboxObservabilityAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-observability/src/test/kotlin/dev/tramai/spring/sovereign/ops/observability/SovereignOpsOutboxObservabilityAutoConfigurationTest.kt
@@ -1,0 +1,92 @@
+package dev.tramai.spring.sovereign.ops.observability
+
+import dev.tramai.spring.sovereign.ops.SovereignOpsAutoConfiguration
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.metrics.Meter
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+
+class SovereignOpsOutboxObservabilityAutoConfigurationTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                SovereignOpsAutoConfiguration::class.java,
+                SovereignOpsOutboxObservabilityAutoConfiguration::class.java,
+            ),
+        )
+
+    @Test
+    fun `Noop observer is used when no OpenTelemetry bean is present`() {
+        contextRunner
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
+                val observer = ctx.getBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
+                assertThat(observer).isSameAs(SovereignOpsAuditOutboxWorkerObserver.Noop)
+            }
+    }
+
+    @Test
+    fun `OpenTelemetry observer is created when OpenTelemetry bean is present`() {
+        contextRunner
+            .withUserConfiguration(OpenTelemetryConfig::class.java)
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
+                val observer = ctx.getBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
+                assertThat(observer).isInstanceOf(OpenTelemetrySovereignOpsAuditOutboxWorkerObserver::class.java)
+            }
+    }
+
+    @Test
+    fun `custom observer bean is not overridden by auto-configuration`() {
+        contextRunner
+            .withUserConfiguration(CustomObserverConfig::class.java)
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
+                val observer = ctx.getBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
+                assertThat(observer).isInstanceOf(CustomTestObserver::class.java)
+            }
+    }
+
+    @Test
+    fun `custom observer takes precedence even when OpenTelemetry is present`() {
+        contextRunner
+            .withUserConfiguration(
+                OpenTelemetryConfig::class.java,
+                CustomObserverConfig::class.java,
+            )
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
+                val observer = ctx.getBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
+                assertThat(observer).isInstanceOf(CustomTestObserver::class.java)
+            }
+    }
+
+    // ── Configurations ──────────────────────────────────────────────
+
+    @Configuration
+    open class OpenTelemetryConfig {
+        @Bean
+        open fun openTelemetry(): OpenTelemetry =
+            io.opentelemetry.sdk.OpenTelemetrySdk.builder().build()
+    }
+
+    @Configuration
+    open class CustomObserverConfig {
+        @Bean
+        @Primary
+        open fun customObserver(): SovereignOpsAuditOutboxWorkerObserver =
+            CustomTestObserver()
+    }
+
+    open class CustomTestObserver : SovereignOpsAuditOutboxWorkerObserver {
+        override fun onCycleCompleted(summary: dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerRunSummary) = Unit
+        override fun onCycleFailed(action: String, errorCode: String) = Unit
+    }
+}


### PR DESCRIPTION
## Summary

PR #53 — OpenTelemetry metrics for the sovereign ops audit outbox worker lifecycle.

Adds a new integration module `tramai-spring-boot-starter-sovereign-ops-observability` that implements `SovereignOpsAuditOutboxWorkerObserver` as `OpenTelemetrySovereignOpsAuditOutboxWorkerObserver`.

## What it does

Emits 5 sanitized metrics via `opentelemetry-api` only (no SDK, no exporter).

## Architecture

- Module depends on `tramai-spring-boot-starter-sovereign-ops` (one-way)
- Auto-config runs `@AutoConfigureBefore(SovereignOpsAutoConfiguration)`
- `@ConditionalOnBean(OpenTelemetry)` + `@ConditionalOnMissingBean`
- No SDK, no exporter, no Micrometer, no Prometheus, no Actuator

## Tests

16 new tests, all passing. Full suite: BUILD SUCCESSFUL, 159 tasks, all green.

## Documentation

Module README.md and docs/STATUS.md updated.