### PR TITLE
chore(release): prepare sovereign runtime release readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Sovereign runtime profile and routing foundation (`tramai-sovereign`).
+- Policy enforcement and DLP/redaction support (`tramai-security`).
+- Approval gates and replay-safe resume.
+- Encrypted file-backed persistence (`tramai-persistence-file`).
+- File-backed audit outbox and recovery workflow (`tramai-spring-boot-starter-sovereign-ops`).
+- Background worker for audit outbox recovery and dispatch.
+- Observer SPI for sovereign ops audit outbox worker cycles and failures.
+- OpenTelemetry observer for sovereign ops audit outbox worker metrics (`tramai-spring-boot-starter-sovereign-ops-observability`).
+- Sovereign document intelligence reference workflow (`examples:sovereign-document-intelligence`).
+- Evidence and release-bundle generation support.
+- Sovereign runtime release-readiness documentation and module matrix.
+
+### Changed
+
+- README and architecture documentation realigned around governed AI workflows.
+- Status documentation updated to distinguish implemented, evolving, and not-complete areas.
+
+### Not included yet
+
+- Stable 1.0 API.
+- Maven Central release of sovereign runtime modules.
+- REST/Actuator operational endpoints.
+- Micrometer / Prometheus / dashboard integration.
+- Database-backed persistence or outbox.
+- Distributed worker leader election.
+- Key rotation.
+- Full production deployment guide.
+
+For the current release-readiness boundary, see [docs/releases/sovereign-runtime-release-readiness.md](docs/releases/sovereign-runtime-release-readiness.md).
+
 ## 0.3.1 — 2026-05-24
 
 Patch release focused on streaming stability, memory persistence, and proxy-aware tool scanning.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ TramAI is organized into focused Gradle modules:
 | `tramai-persistence-file` | Encrypted file-backed stores for approvals, continuations, audit, and outbox |
 | `tramai-spring-boot-starter-sovereign` | Sovereign runtime Spring Boot auto-configuration |
 | `tramai-spring-boot-starter-sovereign-ops` | Operational APIs for audit, approval, recovery, and outbox workflows |
+| `tramai-spring-boot-starter-sovereign-ops-observability` | OpenTelemetry metrics for sovereign ops audit outbox worker |
 | `tramai-spring-boot-starter-sovereign-persistence-file` | File-backed persistence auto-configuration |
 
 ### Optional Higher-Level Modules
@@ -208,12 +209,18 @@ The following are intentionally not claimed as complete:
 
 - stable 1.0 API
 - REST/Actuator operational endpoints
-- sovereign ops / audit outbox metrics
 - database-backed outbox or persistence
 - distributed worker leader election
 - key rotation
 - full production deployment guide
 - complete API reference documentation
+
+## Sovereign Runtime Release Readiness
+
+The sovereign runtime capabilities on `master` are actively evolving and not yet a stable 1.0 API. For the current release-readiness boundary, included modules, validation commands, and known non-goals, see:
+
+- [docs/releases/sovereign-runtime-release-readiness.md](docs/releases/sovereign-runtime-release-readiness.md)
+- [docs/modules/sovereign-runtime-module-matrix.md](docs/modules/sovereign-runtime-module-matrix.md)
 
 ## Development Commands
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -84,6 +84,15 @@ The CI pipeline runs the full test suite on every push:
 
 All sovereign-runtime tests (policy, approval, audit, outbox, replay, persistence) pass against the current `master` branch. No tests are skipped or marked as flaky.
 
+## Release Readiness
+
+The current sovereign runtime release-readiness checklist and module matrix are tracked in:
+
+- [docs/releases/sovereign-runtime-release-readiness.md](./releases/sovereign-runtime-release-readiness.md)
+- [docs/modules/sovereign-runtime-module-matrix.md](./modules/sovereign-runtime-module-matrix.md)
+
+These documents cover included capability areas, representative modules, validation commands, explicit non-goals, and known release risks.
+
 ## Historical Context
 
 Prior to June 2026, TramAI was primarily positioned as a typed AI integration library. The pivot to a governed AI workflow runtime began with the sovereign-runtime modules. The ROADMAP.md at the repository root documents the full enterprise vision and phased plan.

--- a/docs/modules/sovereign-runtime-module-matrix.md
+++ b/docs/modules/sovereign-runtime-module-matrix.md
@@ -1,0 +1,44 @@
+# Sovereign Runtime Module Matrix
+
+One-stop reference for the sovereign runtime modules on master. Updated 2026-06-18.
+
+## Module Overview
+
+| Module | Purpose | Runtime Role | Release Status |
+|---|---|---|---|
+| tramai-security | Policy enforcement, DLP, redaction, replay envelope safety | Governance core | Implemented / evolving |
+| tramai-sovereign | Trust zones, sovereign routing, local/cloud enforcement primitives | Runtime composition | Implemented / evolving |
+| tramai-persistence-file | Encrypted file-backed stores for approvals, continuations, audit, and outbox | Durable local persistence | Implemented / evolving |
+| tramai-spring-boot-starter-sovereign | Spring Boot auto-configuration for sovereign runtime | Spring integration | Implemented / evolving |
+| tramai-spring-boot-starter-sovereign-persistence-file | Spring auto-configuration for file-backed persistence | Spring persistence integration | Implemented / evolving |
+| tramai-spring-boot-starter-sovereign-ops | Operational APIs: audit outbox, recovery, dispatch, background worker, observer SPI | Operational recovery | Implemented / evolving |
+| tramai-spring-boot-starter-sovereign-ops-observability | OpenTelemetry metrics for ops audit outbox worker | Operational observability | Implemented |
+| examples:sovereign-document-intelligence | End-to-end reference sovereign workflow | Demo / evidence pack | Implemented |
+
+## Dependency Direction
+
+application
+  -> tramai-spring-boot-starter-sovereign
+     -> tramai-sovereign
+     -> tramai-security
+
+application
+  -> tramai-spring-boot-starter-sovereign-persistence-file
+     -> tramai-persistence-file
+
+application
+  -> tramai-spring-boot-starter-sovereign-ops
+     -> audit outbox worker / recovery / dispatch
+
+application
+  -> tramai-spring-boot-starter-sovereign-ops-observability
+     -> OpenTelemetry metrics only (no SDK, no exporter)
+
+All modules are opt-in. The sovereign runtime does not activate unless explicitly configured.
+
+## Finding More
+
+- [Sovereign Runtime Release Readiness](../releases/sovereign-runtime-release-readiness.md)
+- [TramAI Architecture](../ARCHITECTURE.md)
+- [Project Status](../STATUS.md)
+- [CHANGELOG](../../CHANGELOG.md)

--- a/docs/releases/sovereign-runtime-release-readiness.md
+++ b/docs/releases/sovereign-runtime-release-readiness.md
@@ -1,0 +1,78 @@
+# Sovereign Runtime Release Readiness
+
+## Purpose
+
+This document tracks the readiness of the current sovereign runtime capabilities on master.
+
+It is NOT a formal release announcement and does NOT promise API stability. It exists so that reviewers, integrators, and the project itself have an honest, auditable snapshot of what is implemented, what is evolving, and what is intentionally not done.
+
+## Target Release Boundary
+
+Candidate release: 0.4.0 or the next unreleased version. No tag, no Maven Central publication, and no API freeze is claimed here.
+
+## Included Capability Areas
+
+| Area | Status | Representative Modules | Evidence |
+|---|---|---|---|
+| Policy enforcement | Implemented / evolving | tramai-security | Unit + integration tests |
+| DLP / redaction | Implemented / evolving | tramai-security | Unit + integration tests |
+| Sovereign routing | Implemented / evolving | tramai-sovereign | Unit tests |
+| Approval gates | Implemented / evolving | tramai-security / tramai-sovereign | Unit + integration tests |
+| Replay-safe resume | Implemented / evolving | tramai-security / engine | Unit + integration tests |
+| Encrypted file persistence | Implemented / evolving | tramai-persistence-file | Unit + integration tests |
+| Audit chain | Implemented / evolving | tramai-security | Unit tests |
+| Audit outbox (persistence + dispatch) | Implemented / evolving | tramai-spring-boot-starter-sovereign-ops | Unit + integration tests |
+| Background worker (recovery + dispatch) | Implemented / evolving | tramai-spring-boot-starter-sovereign-ops | Unit + integration tests |
+| Worker observer SPI | Implemented | tramai-spring-boot-starter-sovereign-ops | Unit tests |
+| OpenTelemetry worker metrics | Implemented | tramai-spring-boot-starter-sovereign-ops-observability | Unit tests |
+| Evidence generation | Implemented / evolving | Release artifacts, examples | Smoke tests |
+| Sovereign document intelligence example | Implemented | examples:sovereign-document-intelligence | Smoke test |
+
+## Not Included — Explicit Non-Goals
+
+These capabilities are NOT claimed as complete, stable, or production-ready:
+
+- Stable 1.0 public API
+- Maven Central release of sovereign runtime modules (not verified)
+- REST/Actuator operational endpoints
+- Micrometer / Prometheus / dashboard integration
+- Database-backed persistence or outbox
+- Distributed worker leader election
+- Key rotation
+- Full production deployment guide
+- Complete API reference documentation
+
+No timelines are committed for these items.
+
+## Release Validation Commands
+
+```bash
+./gradlew test --rerun-tasks
+./gradlew :tramai-spring-boot-starter-sovereign-ops:test --rerun-tasks
+./gradlew :tramai-spring-boot-starter-sovereign-ops-observability:test --rerun-tasks
+./gradlew :examples:sovereign-document-intelligence:run
+```
+
+## Release Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| APIs are still evolving | Medium | active-development banner on README and docs |
+| File persistence is local-node only | Medium | Documented as local-only; DB-backed persistence is future work |
+| No Actuator / Micrometer bridge for OT metrics | Low | Documented clearly; metrics available via OT collector |
+| No DB-backed outbox | Medium | Explicitly listed as future work |
+| No distributed leader election | Medium | Worker assumes single-node operation; documented |
+| Sovereign ops worker is opt-in, disabled by default | Low | Production users must explicitly enable |
+
+## Merge-Readiness Checklist
+
+- [x] Full test suite green
+- [x] Sovereign example smoke run green
+- [x] Status docs aligned with current master
+- [x] README not overclaiming
+- [x] New modules listed in module matrix
+- [x] No production-ready or stable-1.0 claims
+- [x] No Maven Central claim for sovereign runtime modules unless verified
+- [x] CHANGELOG.md has Unreleased section
+
+Checklist last verified: 2026-06-18. Full test suite: 159 tasks, all green.

--- a/docs/releases/sovereign-runtime-release-readiness.md
+++ b/docs/releases/sovereign-runtime-release-readiness.md
@@ -18,7 +18,7 @@ Candidate release: 0.4.0 or the next unreleased version. No tag, no Maven Centra
 | DLP / redaction | Implemented / evolving | tramai-security | Unit + integration tests |
 | Sovereign routing | Implemented / evolving | tramai-sovereign | Unit tests |
 | Approval gates | Implemented / evolving | tramai-security / tramai-sovereign | Unit + integration tests |
-| Replay-safe resume | Implemented / evolving | tramai-security / engine | Unit + integration tests |
+| Replay-safe resume | Implemented / evolving | `tramai-security`, `tramai-engine` | Unit + integration tests |
 | Encrypted file persistence | Implemented / evolving | tramai-persistence-file | Unit + integration tests |
 | Audit chain | Implemented / evolving | tramai-security | Unit tests |
 | Audit outbox (persistence + dispatch) | Implemented / evolving | tramai-spring-boot-starter-sovereign-ops | Unit + integration tests |


### PR DESCRIPTION
## Summary

Release-readiness pass for the current sovereign runtime capabilities on master. Documentation only — no runtime code changes.

Tells reviewers, integrators, and the project itself exactly what exists, what is not done, what is safe to claim, and how to validate it.

## Changes

- **New:** `docs/releases/sovereign-runtime-release-readiness.md` — capability areas, validation commands, explicit non-goals, known risks, merge-readiness checklist
- **New:** `docs/modules/sovereign-runtime-module-matrix.md` — all 8 sovereign runtime modules with purpose, role, status, dependency direction
- **Updated:** `CHANGELOG.md` — Unreleased section (Added, Changed, Not included yet)
- **Updated:** `README.md` — added observability module, removed obsolete outbox metrics from Not Yet Included, added Sovereign Runtime Release Readiness section
- **Updated:** `docs/STATUS.md` — Release Readiness section linking to new docs

## Non-goals

- No production code changes
- No version bump
- No publishing / tag / release
- No stable 1.0 API claims
- No REST/Actuator/Micrometer/Prometheus/dashboard
- No DB-backed persistence
- No leader election

## Verification

```
./gradlew test --rerun-tasks
``
BUILD SUCCESSFUL — 159 tasks, all green.