### PR TITLE
chore(release): add sovereign runtime signed publication bundle dry-run

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -529,6 +529,262 @@ tasks.register("verifySovereignRuntimePublication") {
     }
 }
 
+tasks.register("verifySovereignRuntimeSignedBundle") {
+    group = "verification"
+    description = "Validates local signed publication bundle for the sovereign runtime release boundary. Publishes to a file-based Maven repository, validates artifact structure (POMs, JARs, .module metadata), and optionally verifies .asc signatures when signing properties are provided. Generates bundle-manifest.json. Does NOT publish remotely, tag, bump versions, or freeze APIs."
+    notCompatibleWithConfigurationCache("Sovereign runtime signed bundle verification inspects published artifacts and generates a manifest at execution time.")
+
+    // Always publish to mavenLocal for baseline artifact validation
+    dependsOn(
+        sovereignRuntimePublishableModules.map { ":${it}:publishToMavenLocal" },
+        ":tramai-bom:publishToMavenLocal",
+    )
+
+    // When signing properties and a file-based repo URL are provided,
+    // also publish to that repo (with .asc signatures)
+    val signingKey = providers.gradleProperty("signingKey").orNull
+    val signingPassword = providers.gradleProperty("signingPassword").orNull
+    val repoUrl = providers.gradleProperty("tramaiPublishReleaseUrl").orNull
+    val wantsSigning = !signingKey.isNullOrBlank() && !signingPassword.isNullOrBlank()
+    val wantsFileRepo = !repoUrl.isNullOrBlank()
+
+    if (wantsSigning || wantsFileRepo) {
+        dependsOn(
+            sovereignRuntimePublishableModules.map { ":${it}:publish" },
+            ":tramai-bom:publish",
+        )
+    }
+
+    doFirst {
+        if (wantsSigning && !wantsFileRepo) {
+            throw GradleException(
+                "Signing requires -PtramaiPublishReleaseUrl=file://<path> for local file-based repository. " +
+                "Signed verification cannot run against mavenLocal() alone."
+            )
+        }
+        if (wantsFileRepo && !repoUrl!!.startsWith("file:")) {
+            throw GradleException(
+                "verifySovereignRuntimeSignedBundle only supports file:// repositories for local verification. " +
+                "Got: $repoUrl"
+            )
+        }
+    }
+
+    doLast {
+        val groupPath = tramaiGroup.get().replace('.', '/')
+        val expectedVersion = tramaiVersion.get()
+        val userHome = System.getProperty("user.home")
+        val m2Repo = File(userHome, ".m2/repository").resolve(groupPath)
+        val buildDir = rootProject.layout.buildDirectory.get().asFile
+        val bundleDir = buildDir.resolve("sovereign-runtime-release")
+        val bundleManifestJson = bundleDir.resolve("bundle-manifest.json")
+        val allModules = sovereignRuntimePublishableModules + "tramai-bom"
+
+        // ── 1. Validate mavenLocal baseline ──────────────────────────────
+        logger.lifecycle("Validating mavenLocal baseline artifacts...")
+        allModules.forEach { moduleName ->
+            val moduleDir = m2Repo.resolve("$moduleName/$expectedVersion")
+            require(moduleDir.isDirectory) {
+                "Missing mavenLocal module directory for $moduleName at ${moduleDir.absolutePath}"
+            }
+            val baseName = "$moduleName-$expectedVersion"
+            val requiredFiles = mutableListOf(
+                "$baseName.pom",
+                "$baseName.module",
+            )
+            if (moduleName != "tramai-bom") {
+                requiredFiles += listOf(
+                    "$baseName.jar",
+                    "$baseName-sources.jar",
+                    "$baseName-javadoc.jar",
+                )
+            }
+            requiredFiles.forEach { fileName ->
+                val artifact = moduleDir.resolve(fileName)
+                require(artifact.isFile) {
+                    "Missing mavenLocal artifact for $moduleName: ${artifact.absolutePath}"
+                }
+                require(artifact.length() > 0) {
+                    "Empty mavenLocal artifact for $moduleName: ${artifact.absolutePath}"
+                }
+            }
+        }
+        logger.lifecycle("  All mavenLocal artifacts present and non-empty.")
+
+        // ── 2. Validate file-based repository (if configured) ──────────
+        val fileRepoDir: File? = if (wantsFileRepo && repoUrl != null) {
+            File(URI(repoUrl))
+        } else {
+            null
+        }
+
+        if (fileRepoDir != null) {
+            logger.lifecycle("Validating file-based repository at ${fileRepoDir.absolutePath}...")
+            require(fileRepoDir.isDirectory) {
+                "Missing file-based repository root at ${fileRepoDir.absolutePath}"
+            }
+            allModules.forEach { moduleName ->
+                val moduleDir = fileRepoDir.resolve("$groupPath/$moduleName/$expectedVersion")
+                require(moduleDir.isDirectory) {
+                    "Missing file-repo module directory for $moduleName at ${moduleDir.absolutePath}"
+                }
+                val publishedFiles = moduleDir.listFiles()?.filter(File::isFile).orEmpty()
+
+                fun requireArtifact(description: String, predicate: (String) -> Boolean) {
+                    val matching = publishedFiles.filter { predicate(it.name) }
+                    require(matching.isNotEmpty()) {
+                        "Missing $description for $moduleName in ${moduleDir.absolutePath}"
+                    }
+                    require(matching.all { it.length() > 0 }) {
+                        "Empty $description for $moduleName in ${moduleDir.absolutePath}"
+                    }
+                }
+
+                requireArtifact("POM") { it.endsWith(".pom") && !it.endsWith(".pom.asc") }
+                requireArtifact("Gradle module metadata") { it.endsWith(".module") && !it.endsWith(".module.asc") }
+
+                if (moduleName != "tramai-bom") {
+                    requireArtifact("binary jar") {
+                        it.endsWith(".jar") &&
+                        !it.endsWith("-sources.jar") &&
+                        !it.endsWith("-javadoc.jar") &&
+                        !it.endsWith(".jar.asc")
+                    }
+                    requireArtifact("sources jar") { it.endsWith("-sources.jar") && !it.endsWith("-sources.jar.asc") }
+                    requireArtifact("javadoc jar") { it.endsWith("-javadoc.jar") && !it.endsWith("-javadoc.jar.asc") }
+                }
+
+                // Optional signing validation
+                if (wantsSigning) {
+                    requireArtifact("POM signature") { it.endsWith(".pom.asc") }
+                    requireArtifact("Gradle module metadata signature") { it.endsWith(".module.asc") }
+                    if (moduleName != "tramai-bom") {
+                        requireArtifact("binary jar signature") {
+                            it.endsWith(".jar.asc") &&
+                            !it.endsWith("-sources.jar.asc") &&
+                            !it.endsWith("-javadoc.jar.asc")
+                        }
+                        requireArtifact("sources jar signature") { it.endsWith("-sources.jar.asc") }
+                        requireArtifact("javadoc jar signature") { it.endsWith("-javadoc.jar.asc") }
+                    }
+                    logger.lifecycle("  Signatures validated for $moduleName.")
+                }
+            }
+            logger.lifecycle("  File-based repository validation complete.")
+        }
+
+        // ── 3. Generate bundle-manifest.json ───────────────────────────
+        logger.lifecycle("Generating bundle manifest...")
+        bundleDir.mkdirs()
+
+        fun jsonEscape(value: String): String {
+            val sb = StringBuilder()
+            for (ch in value) {
+                when (ch) {
+                    '"' -> sb.append("\\\"")
+                    '\\' -> sb.append("\\\\")
+                    '\n' -> sb.append("\\n")
+                    '\r' -> sb.append("\\r")
+                    '\t' -> sb.append("\\t")
+                    else -> {
+                        if (ch.code < 0x20) {
+                            sb.append("\\u%04x".format(ch.code))
+                        } else {
+                            sb.append(ch)
+                        }
+                    }
+                }
+            }
+            return sb.toString()
+        }
+
+        fun sha256Hex(file: File): String {
+            val digest = java.security.MessageDigest.getInstance("SHA-256")
+            return digest.digest(file.readBytes())
+                .joinToString("") { "%02x".format(it) }
+        }
+
+        val moduleEntries = mutableListOf<String>()
+
+        allModules.forEach { moduleName ->
+            val sourceDir = if (fileRepoDir != null) {
+                fileRepoDir.resolve("$groupPath/$moduleName/$expectedVersion")
+            } else {
+                m2Repo.resolve("$moduleName/$expectedVersion")
+            }
+            if (!sourceDir.isDirectory) return@forEach
+
+            val baseName = "$moduleName-$expectedVersion"
+            val artifactFiles = sourceDir.listFiles { f -> f.isFile }.orEmpty().sortedBy { it.name }
+            val artifactPaths = mutableListOf<String>()
+            val signatures = mutableListOf<String>()
+            val checksums = mutableMapOf<String, String>()
+
+            for (file in artifactFiles) {
+                val relPath = fileRepoDir?.let {
+                    file.absolutePath.removePrefix(it.absolutePath).trimStart('/')
+                } ?: file.name
+
+                if (file.name.endsWith(".asc")) {
+                    signatures.add(relPath)
+                } else {
+                    artifactPaths.add(relPath)
+                    checksums[relPath] = "sha256:${sha256Hex(file)}"
+                }
+            }
+
+            val moduleEntry = buildString {
+                append("      {")
+                append("\"groupId\": \"${jsonEscape(tramaiGroup.get())}\", ")
+                append("\"artifactId\": \"${jsonEscape(moduleName)}\", ")
+                append("\"version\": \"${jsonEscape(expectedVersion)}\", ")
+                append("\"baseName\": \"${jsonEscape(baseName)}\", ")
+                append("\"artifactPaths\": [${artifactPaths.joinToString(", ") { "\"${jsonEscape(it)}\"" }}], ")
+                if (signatures.isNotEmpty()) {
+                    append("\"signatures\": [${signatures.joinToString(", ") { "\"${jsonEscape(it)}\"" }}], ")
+                }
+                append("\"checksums\": {${checksums.entries.joinToString(", ") { "\"${jsonEscape(it.key)}\": \"${jsonEscape(it.value)}\"" }}}")
+                append("}")
+            }
+            moduleEntries.add(moduleEntry)
+        }
+
+        val now = java.time.Instant.now().toString()
+        val jsonSink = buildString {
+            appendLine("{")
+            appendLine("  \"schemaVersion\": 1,")
+            appendLine("  \"generatedAt\": \"${jsonEscape(now)}\",")
+            appendLine("  \"version\": \"${jsonEscape(expectedVersion)}\",")
+            val repoPath = fileRepoDir?.absolutePath ?: "mavenLocal"
+            appendLine("  \"repository\": \"${jsonEscape(repoPath)}\",")
+            appendLine("  \"remotePublish\": false,")
+            appendLine("  \"tagCreated\": false,")
+            appendLine("  \"signaturesPresent\": $wantsSigning,")
+            appendLine("  \"modules\": [")
+            for ((i, entry) in moduleEntries.withIndex()) {
+                append(entry)
+                if (i < moduleEntries.lastIndex) append(",")
+                appendLine()
+            }
+            appendLine("  ]")
+            append("}")
+            appendLine()
+        }
+
+        bundleManifestJson.writeText(jsonSink)
+        logger.lifecycle("Bundle manifest generated: ${bundleManifestJson.absolutePath}")
+
+        // ── Summary ──────────────────────────────────────────────────────
+        logger.lifecycle("")
+        logger.lifecycle("verifySovereignRuntimeSignedBundle — PASSED")
+        logger.lifecycle("  Modules validated: ${allModules.size} (${allModules.joinToString(", ")})")
+        logger.lifecycle("  Signatures: ${if (wantsSigning) "validated" else "not configured (skipped)"}")
+        logger.lifecycle("  Remote publish: false")
+        logger.lifecycle("  Tag created: false")
+        logger.lifecycle("  Manifest: ${bundleManifestJson.absolutePath}")
+    }
+}
+
 // ── CycloneDX SBOM ────────────────────────────────────────────────────────
 
 // Plugin is applied above via: alias(libs.plugins.cyclonedx.bom)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,6 +82,27 @@ val publishableProjectNames = listOf(
 )
 val jarPublishingProjectNames = publishableProjectNames - "tramai-bom"
 
+// Sovereign bundle modules for the dedicated publication dry-run repository.
+// Used by the verifySovereignRuntimeSignedBundle task to publish only to a local
+// file-based Maven repository — never to a remote — preventing accidental remote
+// publication during dry-run validation.
+val sovereignBundleModuleNames = listOf(
+    "tramai-bom",
+    "tramai-security",
+    "tramai-sovereign",
+    "tramai-persistence-file",
+    "tramai-spring-boot-starter-sovereign",
+    "tramai-spring-boot-starter-sovereign-persistence-file",
+    "tramai-spring-boot-starter-sovereign-ops",
+    "tramai-spring-boot-starter-sovereign-ops-observability",
+)
+
+// Lazy default URL for the sovereign bundle local repository.
+// Override with -PtramaiPublishReleaseUrl=file://<path> for custom local paths.
+val sovereignBundleRepoUrl: Provider<String> = providers.gradleProperty("tramaiPublishReleaseUrl")
+    .orElse(rootProject.layout.buildDirectory.dir("sovereign-runtime-release-verification-repo")
+        .map { "file://${it.asFile.absolutePath}" })
+
 subprojects {
     group = tramaiGroup.get()
     version = tramaiVersion.get()
@@ -115,6 +136,14 @@ subprojects {
             developerName = tramaiDeveloperName.get(),
             developerEmail = tramaiDeveloperEmail.get(),
         )
+
+        // Dedicated local-only Maven repository for the sovereign signed bundle dry-run.
+        // Added inside the plugin block so maven-publish has already registered
+        // PublishingExtension. This repo is always file:// (build-local by default)
+        // and is never configured with remote credentials.
+        if (project.name in sovereignBundleModuleNames) {
+            configureSovereignBundleLocalRepo()
+        }
     }
 
     plugins.withId("java-platform") {
@@ -134,6 +163,14 @@ subprojects {
             developerName = tramaiDeveloperName.get(),
             developerEmail = tramaiDeveloperEmail.get(),
         )
+
+        // Dedicated local-only Maven repository for the sovereign signed bundle dry-run.
+        // Added inside the plugin block so maven-publish has already registered
+        // PublishingExtension. This repo is always file:// (build-local by default)
+        // and is never configured with remote credentials.
+        if (project.name in sovereignBundleModuleNames) {
+            configureSovereignBundleLocalRepo()
+        }
     }
 }
 
@@ -211,6 +248,25 @@ fun Project.configureTramaiPublishing(
         if (!signingKey.isNullOrBlank() && !signingPassword.isNullOrBlank()) {
             useInMemoryPgpKeys(signingKey, signingPassword)
             sign(extensions.getByType(PublishingExtension::class.java).publications)
+        }
+    }
+}
+
+/**
+ * Adds the dedicated sovereignBundleLocal Maven repository to this project's
+ * PublishingExtension. This repo is always file:// (build-local by default,
+ * or overridden via -PtramaiPublishReleaseUrl=file://...) and is never
+ * configured with remote credentials. The verifySovereignRuntimeSignedBundle
+ * task publishes exclusively to this repo using the generated
+ * *ToSovereignBundleLocalRepository tasks, never to tramaiRemote or :publish.
+ */
+fun Project.configureSovereignBundleLocalRepo() {
+    extensions.configure<PublishingExtension> {
+        repositories {
+            maven {
+                name = "sovereignBundleLocal"
+                url = URI(sovereignBundleRepoUrl.get())
+            }
         }
     }
 }
@@ -531,42 +587,63 @@ tasks.register("verifySovereignRuntimePublication") {
 
 tasks.register("verifySovereignRuntimeSignedBundle") {
     group = "verification"
-    description = "Validates local signed publication bundle for the sovereign runtime release boundary. Publishes to a file-based Maven repository, validates artifact structure (POMs, JARs, .module metadata), and optionally verifies .asc signatures when signing properties are provided. Generates bundle-manifest.json. Does NOT publish remotely, tag, bump versions, or freeze APIs."
+    description = "Validates local signed publication bundle for the sovereign runtime release boundary. " +
+        "Publishes to a dedicated local-only file-based Maven repository (" +
+        "build/sovereign-runtime-release-verification-repo by default), validates artifact " +
+        "structure (POMs, JARs, .module metadata), and optionally verifies .asc signatures " +
+        "when signing properties are provided. Generates bundle-manifest.json. " +
+        "Does NOT publish remotely, tag, bump versions, or freeze APIs."
     notCompatibleWithConfigurationCache("Sovereign runtime signed bundle verification inspects published artifacts and generates a manifest at execution time.")
 
-    // Always publish to mavenLocal for baseline artifact validation
+    // ── Configuration-time URL validation ────────────────────────────────
+    // Reject non-file URLs before any publish task can run. The sovereign bundle
+    // dry-run uses a dedicated soverignBundleLocal repository that is always file://
+    // (build-local by default). If someone passes -PtramaiPublishReleaseUrl pointing
+    // to a remote server, the dependent publish tasks must never be triggered.
+    val userProvidedUrl = providers.gradleProperty("tramaiPublishReleaseUrl").orNull
+    if (userProvidedUrl != null && !userProvidedUrl.startsWith("file:")) {
+        throw GradleException(
+            "verifySovereignRuntimeSignedBundle only supports file:// repositories for local " +
+            "verification. Got: $userProvidedUrl. The sovereign bundle dry-run publishes " +
+            "to a dedicated local-only repository and must never contact a remote server."
+        )
+    }
+
+    // Resolve the dedicated bundle repo URL (default or user-provided file://)
+    val bundleRepoUrl = sovereignBundleRepoUrl.get()
+
+    // Signing key properties — evaluated at configuration time by the signing extension
+    // in configureTramaiPublishing, so .asc files are produced automatically during publish.
+    val signingKey = providers.gradleProperty("signingKey").orNull
+    val signingPassword = providers.gradleProperty("signingPassword").orNull
+    val wantsSigning = !signingKey.isNullOrBlank() && !signingPassword.isNullOrBlank()
+
+    // ── Dependencies ─────────────────────────────────────────────────────
+    // Baseline: publish to mavenLocal for artifact structure checks
     dependsOn(
         sovereignRuntimePublishableModules.map { ":${it}:publishToMavenLocal" },
         ":tramai-bom:publishToMavenLocal",
     )
 
-    // When signing properties and a file-based repo URL are provided,
-    // also publish to that repo (with .asc signatures)
-    val signingKey = providers.gradleProperty("signingKey").orNull
-    val signingPassword = providers.gradleProperty("signingPassword").orNull
-    val repoUrl = providers.gradleProperty("tramaiPublishReleaseUrl").orNull
-    val wantsSigning = !signingKey.isNullOrBlank() && !signingPassword.isNullOrBlank()
-    val wantsFileRepo = !repoUrl.isNullOrBlank()
+    // Always publish to the dedicated sovereignBundleLocal repository.
+    // This repo is unconditionally file:// (build-local by default, or overridden with
+    // -PtramaiPublishReleaseUrl=file://...) and is configured separately from the
+    // tramaiRemote repository used by other publish tasks.
+    // We use the specific *ToSovereignBundleLocalRepository task — never generic :publish.
+    dependsOn(
+        sovereignRuntimePublishableModules.map { ":${it}:publishMavenPublicationToSovereignBundleLocalRepository" },
+        ":tramai-bom:publishMavenPublicationToSovereignBundleLocalRepository",
+    )
 
-    if (wantsSigning || wantsFileRepo) {
-        dependsOn(
-            sovereignRuntimePublishableModules.map { ":${it}:publish" },
-            ":tramai-bom:publish",
-        )
-    }
+    // Skip tests in the signed bundle dry-run — the verifySovereignRuntimePublication task
+    // handles test execution separately. This task focuses purely on artifact structure,
+    // signing (optional), and manifest generation.
 
     doFirst {
-        if (wantsSigning && !wantsFileRepo) {
-            throw GradleException(
-                "Signing requires -PtramaiPublishReleaseUrl=file://<path> for local file-based repository. " +
-                "Signed verification cannot run against mavenLocal() alone."
-            )
-        }
-        if (wantsFileRepo && !repoUrl!!.startsWith("file:")) {
-            throw GradleException(
-                "verifySovereignRuntimeSignedBundle only supports file:// repositories for local verification. " +
-                "Got: $repoUrl"
-            )
+        if (wantsSigning) {
+            logger.lifecycle("Signing key provided — will validate .asc signatures.")
+        } else {
+            logger.lifecycle("No signing key provided — skipping .asc signature validation.")
         }
     }
 
@@ -579,6 +656,10 @@ tasks.register("verifySovereignRuntimeSignedBundle") {
         val bundleDir = buildDir.resolve("sovereign-runtime-release")
         val bundleManifestJson = bundleDir.resolve("bundle-manifest.json")
         val allModules = sovereignRuntimePublishableModules + "tramai-bom"
+
+        // Dedicated bundle repo directory
+        val bundleRepoDir = File(URI(bundleRepoUrl))
+        logger.lifecycle("Bundle repository: ${bundleRepoDir.absolutePath}")
 
         // ── 1. Validate mavenLocal baseline ──────────────────────────────
         logger.lifecycle("Validating mavenLocal baseline artifacts...")
@@ -611,69 +692,63 @@ tasks.register("verifySovereignRuntimeSignedBundle") {
         }
         logger.lifecycle("  All mavenLocal artifacts present and non-empty.")
 
-        // ── 2. Validate file-based repository (if configured) ──────────
-        val fileRepoDir: File? = if (wantsFileRepo && repoUrl != null) {
-            File(URI(repoUrl))
-        } else {
-            null
+        // ── 2. Validate the dedicated file-based bundle repository ─────────
+        logger.lifecycle("Validating bundle repository at ${bundleRepoDir.absolutePath}...")
+        require(bundleRepoDir.isDirectory) {
+            "Missing bundle repository root at ${bundleRepoDir.absolutePath}." +
+            "The sovereignBundleLocal repository should have been populated during publish."
         }
 
-        if (fileRepoDir != null) {
-            logger.lifecycle("Validating file-based repository at ${fileRepoDir.absolutePath}...")
-            require(fileRepoDir.isDirectory) {
-                "Missing file-based repository root at ${fileRepoDir.absolutePath}"
+        allModules.forEach { moduleName ->
+            val moduleDir = bundleRepoDir.resolve("$groupPath/$moduleName/$expectedVersion")
+            require(moduleDir.isDirectory) {
+                "Missing bundle-repo module directory for $moduleName at ${moduleDir.absolutePath}"
             }
-            allModules.forEach { moduleName ->
-                val moduleDir = fileRepoDir.resolve("$groupPath/$moduleName/$expectedVersion")
-                require(moduleDir.isDirectory) {
-                    "Missing file-repo module directory for $moduleName at ${moduleDir.absolutePath}"
+            val publishedFiles = moduleDir.listFiles()?.filter(File::isFile).orEmpty()
+
+            fun requireArtifact(description: String, predicate: (String) -> Boolean) {
+                val matching = publishedFiles.filter { predicate(it.name) }
+                require(matching.isNotEmpty()) {
+                    "Missing $description for $moduleName in ${moduleDir.absolutePath}"
                 }
-                val publishedFiles = moduleDir.listFiles()?.filter(File::isFile).orEmpty()
-
-                fun requireArtifact(description: String, predicate: (String) -> Boolean) {
-                    val matching = publishedFiles.filter { predicate(it.name) }
-                    require(matching.isNotEmpty()) {
-                        "Missing $description for $moduleName in ${moduleDir.absolutePath}"
-                    }
-                    require(matching.all { it.length() > 0 }) {
-                        "Empty $description for $moduleName in ${moduleDir.absolutePath}"
-                    }
+                require(matching.all { it.length() > 0 }) {
+                    "Empty $description for $moduleName in ${moduleDir.absolutePath}"
                 }
+            }
 
-                requireArtifact("POM") { it.endsWith(".pom") && !it.endsWith(".pom.asc") }
-                requireArtifact("Gradle module metadata") { it.endsWith(".module") && !it.endsWith(".module.asc") }
+            requireArtifact("POM") { it.endsWith(".pom") && !it.endsWith(".pom.asc") }
+            requireArtifact("Gradle module metadata") { it.endsWith(".module") && !it.endsWith(".module.asc") }
 
+            if (moduleName != "tramai-bom") {
+                requireArtifact("binary jar") {
+                    it.endsWith(".jar") &&
+                    !it.endsWith("-sources.jar") &&
+                    !it.endsWith("-javadoc.jar") &&
+                    !it.endsWith(".jar.asc")
+                }
+                requireArtifact("sources jar") { it.endsWith("-sources.jar") && !it.endsWith("-sources.jar.asc") }
+                requireArtifact("javadoc jar") { it.endsWith("-javadoc.jar") && !it.endsWith("-javadoc.jar.asc") }
+            }
+
+            // Optional signing validation
+            if (wantsSigning) {
+                requireArtifact("POM signature") { it.endsWith(".pom.asc") }
+                requireArtifact("Gradle module metadata signature") { it.endsWith(".module.asc") }
                 if (moduleName != "tramai-bom") {
-                    requireArtifact("binary jar") {
-                        it.endsWith(".jar") &&
-                        !it.endsWith("-sources.jar") &&
-                        !it.endsWith("-javadoc.jar") &&
-                        !it.endsWith(".jar.asc")
+                    requireArtifact("binary jar signature") {
+                        it.endsWith(".jar.asc") &&
+                        !it.endsWith("-sources.jar.asc") &&
+                        !it.endsWith("-javadoc.jar.asc")
                     }
-                    requireArtifact("sources jar") { it.endsWith("-sources.jar") && !it.endsWith("-sources.jar.asc") }
-                    requireArtifact("javadoc jar") { it.endsWith("-javadoc.jar") && !it.endsWith("-javadoc.jar.asc") }
+                    requireArtifact("sources jar signature") { it.endsWith("-sources.jar.asc") }
+                    requireArtifact("javadoc jar signature") { it.endsWith("-javadoc.jar.asc") }
                 }
-
-                // Optional signing validation
-                if (wantsSigning) {
-                    requireArtifact("POM signature") { it.endsWith(".pom.asc") }
-                    requireArtifact("Gradle module metadata signature") { it.endsWith(".module.asc") }
-                    if (moduleName != "tramai-bom") {
-                        requireArtifact("binary jar signature") {
-                            it.endsWith(".jar.asc") &&
-                            !it.endsWith("-sources.jar.asc") &&
-                            !it.endsWith("-javadoc.jar.asc")
-                        }
-                        requireArtifact("sources jar signature") { it.endsWith("-sources.jar.asc") }
-                        requireArtifact("javadoc jar signature") { it.endsWith("-javadoc.jar.asc") }
-                    }
-                    logger.lifecycle("  Signatures validated for $moduleName.")
-                }
+                logger.lifecycle("  Signatures validated for $moduleName.")
             }
-            logger.lifecycle("  File-based repository validation complete.")
         }
+        logger.lifecycle("  Bundle repository validation complete.")
 
-        // ── 3. Generate bundle-manifest.json ───────────────────────────
+        // ── 3. Generate bundle-manifest.json (fail-closed) ───────────────
         logger.lifecycle("Generating bundle manifest...")
         bundleDir.mkdirs()
 
@@ -707,12 +782,13 @@ tasks.register("verifySovereignRuntimeSignedBundle") {
         val moduleEntries = mutableListOf<String>()
 
         allModules.forEach { moduleName ->
-            val sourceDir = if (fileRepoDir != null) {
-                fileRepoDir.resolve("$groupPath/$moduleName/$expectedVersion")
-            } else {
-                m2Repo.resolve("$moduleName/$expectedVersion")
+            val sourceDir = bundleRepoDir.resolve("$groupPath/$moduleName/$expectedVersion")
+            // Fail closed: every module must have published artifact directory
+            require(sourceDir.isDirectory) {
+                "Cannot generate bundle manifest: missing artifact directory for $moduleName " +
+                "at ${sourceDir.absolutePath}. All sovereign bundle modules must produce " +
+                "published artifacts."
             }
-            if (!sourceDir.isDirectory) return@forEach
 
             val baseName = "$moduleName-$expectedVersion"
             val artifactFiles = sourceDir.listFiles { f -> f.isFile }.orEmpty().sortedBy { it.name }
@@ -721,9 +797,7 @@ tasks.register("verifySovereignRuntimeSignedBundle") {
             val checksums = mutableMapOf<String, String>()
 
             for (file in artifactFiles) {
-                val relPath = fileRepoDir?.let {
-                    file.absolutePath.removePrefix(it.absolutePath).trimStart('/')
-                } ?: file.name
+                val relPath = file.absolutePath.removePrefix(bundleRepoDir.absolutePath).trimStart('/')
 
                 if (file.name.endsWith(".asc")) {
                     signatures.add(relPath)
@@ -749,14 +823,21 @@ tasks.register("verifySovereignRuntimeSignedBundle") {
             moduleEntries.add(moduleEntry)
         }
 
+        // Fail closed: all expected modules must have entries in the manifest
+        require(moduleEntries.size == allModules.size) {
+            "Bundle manifest expected $allModules modules but only " +
+            "${moduleEntries.size} modules have artifact directories. " +
+            "Expected: ${allModules.joinToString(", ")}. " +
+            "Found: ${moduleEntries.map { it.substringAfter("\"artifactId\": \"").substringBefore("\"") }}."
+        }
+
         val now = java.time.Instant.now().toString()
         val jsonSink = buildString {
             appendLine("{")
-            appendLine("  \"schemaVersion\": 1,")
+            appendLine("  \"schemaVersion\": \"sovereign-runtime-release-bundle-v1\",")
             appendLine("  \"generatedAt\": \"${jsonEscape(now)}\",")
             appendLine("  \"version\": \"${jsonEscape(expectedVersion)}\",")
-            val repoPath = fileRepoDir?.absolutePath ?: "mavenLocal"
-            appendLine("  \"repository\": \"${jsonEscape(repoPath)}\",")
+            appendLine("  \"repository\": \"${jsonEscape(bundleRepoDir.absolutePath)}\",")
             appendLine("  \"remotePublish\": false,")
             appendLine("  \"tagCreated\": false,")
             appendLine("  \"signaturesPresent\": $wantsSigning,")
@@ -778,6 +859,7 @@ tasks.register("verifySovereignRuntimeSignedBundle") {
         logger.lifecycle("")
         logger.lifecycle("verifySovereignRuntimeSignedBundle — PASSED")
         logger.lifecycle("  Modules validated: ${allModules.size} (${allModules.joinToString(", ")})")
+        logger.lifecycle("  Repository: ${bundleRepoDir.absolutePath}")
         logger.lifecycle("  Signatures: ${if (wantsSigning) "validated" else "not configured (skipped)"}")
         logger.lifecycle("  Remote publish: false")
         logger.lifecycle("  Tag created: false")

--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -130,9 +130,69 @@ This validation does **not**:
 - Create a tag or GitHub release
 - Bump the version
 
-## Local Signed-Artifact Validation
+## Sovereign Runtime Signed Bundle Dry-Run
 
-When you want to validate signing locally without touching a real remote repository, publish to a file-based Maven repository and verify signatures there:
+The sovereign runtime release boundary can be validated as a local signed publication bundle without touching a remote repository, creating a tag, bumping versions, or freezing APIs:
+
+```bash
+./gradlew verifySovereignRuntimeSignedBundle
+```
+
+This validates the sovereign runtime modules and BOM in a file-based repository:
+
+- `tramai-bom`
+- `tramai-security`
+- `tramai-sovereign`
+- `tramai-persistence-file`
+- `tramai-spring-boot-starter-sovereign`
+- `tramai-spring-boot-starter-sovereign-persistence-file`
+- `tramai-spring-boot-starter-sovereign-ops`
+- `tramai-spring-boot-starter-sovereign-ops-observability`
+
+The default path validates:
+
+- POM files
+- binary JARs where expected
+- sources JARs where expected
+- javadoc JARs where expected
+- dependency graph / publication metadata
+- local file-based repository output (mavenLocal)
+- Generates `build/sovereign-runtime-release/bundle-manifest.json`
+
+When signing properties are provided, the task additionally validates `.asc` signatures:
+
+```bash
+./gradlew verifySovereignRuntimeSignedBundle \
+  -PtramaiPublishReleaseUrl=file://$PWD/build/sovereign-runtime-release-verification-repo \
+  -PsigningKey="$SIGNING_KEY" \
+  -PsigningPassword="$SIGNING_PASSWORD"
+```
+
+This validation does **not**:
+- Publish to Maven Central or Sonatype
+- Create a tag or GitHub release
+- Bump the version
+- Require signing keys for the default CI path
+- Claim API stability
+
+### Bundle Manifest
+
+The task generates `build/sovereign-runtime-release/bundle-manifest.json`:
+
+| Field | Description |
+|-------|-------------|
+| `schemaVersion` | Manifest format version (currently 1) |
+| `generatedAt` | ISO-8601 timestamp of generation |
+| `version` | The TramAI version validated |
+| `repository` | Repository path (mavenLocal or file:// path) |
+| `remotePublish` | Always `false` — local validation only |
+| `tagCreated` | Always `false` — no tag is created |
+| `signaturesPresent` | Whether .asc signatures were validated |
+| `modules[]` | List of validated modules with artifact paths, signatures, and checksums |
+
+## Local Signed-Artifact Validation (All Modules)
+
+When you want to validate signing for ALL publishable modules locally without touching a real remote repository, publish to a file-based Maven repository and verify signatures there:
 
 ```bash
 ./gradlew verifySignedPublicationBundle \

--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -138,32 +138,30 @@ The sovereign runtime release boundary can be validated as a local signed public
 ./gradlew verifySovereignRuntimeSignedBundle
 ```
 
-This validates the sovereign runtime modules and BOM in a file-based repository:
-
-- `tramai-bom`
-- `tramai-security`
-- `tramai-sovereign`
-- `tramai-persistence-file`
-- `tramai-spring-boot-starter-sovereign`
-- `tramai-spring-boot-starter-sovereign-persistence-file`
-- `tramai-spring-boot-starter-sovereign-ops`
-- `tramai-spring-boot-starter-sovereign-ops-observability`
-
-The default path validates:
+This publishes the sovereign runtime modules and BOM to a dedicated local-only Maven repository at `build/sovereign-runtime-release-verification-repo/` and validates:
 
 - POM files
 - binary JARs where expected
 - sources JARs where expected
 - javadoc JARs where expected
 - dependency graph / publication metadata
-- local file-based repository output (mavenLocal)
 - Generates `build/sovereign-runtime-release/bundle-manifest.json`
+
+The task always publishes to both `mavenLocal()` and the dedicated build-local repository. The dedicated repo uses a separate `sovereignBundleLocal` Maven repository configuration — never the shared `tramaiRemote` repository — so it cannot accidentally push to a remote publish target.
 
 When signing properties are provided, the task additionally validates `.asc` signatures:
 
 ```bash
 ./gradlew verifySovereignRuntimeSignedBundle \
-  -PtramaiPublishReleaseUrl=file://$PWD/build/sovereign-runtime-release-verification-repo \
+  -PsigningKey="$SIGNING_KEY" \
+  -PsigningPassword="$SIGNING_PASSWORD"
+```
+
+To use a custom local path instead of the build directory default:
+
+```bash
+./gradlew verifySovereignRuntimeSignedBundle \
+  -PtramaiPublishReleaseUrl=file:///path/to/custom-repo \
   -PsigningKey="$SIGNING_KEY" \
   -PsigningPassword="$SIGNING_PASSWORD"
 ```
@@ -181,10 +179,10 @@ The task generates `build/sovereign-runtime-release/bundle-manifest.json`:
 
 | Field | Description |
 |-------|-------------|
-| `schemaVersion` | Manifest format version (currently 1) |
+| `schemaVersion` | `"sovereign-runtime-release-bundle-v1"` — named schema for release evidence clarity |
 | `generatedAt` | ISO-8601 timestamp of generation |
 | `version` | The TramAI version validated |
-| `repository` | Repository path (mavenLocal or file:// path) |
+| `repository` | Absolute path to the file-based repository |
 | `remotePublish` | Always `false` — local validation only |
 | `tagCreated` | Always `false` — no tag is created |
 | `signaturesPresent` | Whether .asc signatures were validated |

--- a/docs/releases/sovereign-runtime-release-readiness.md
+++ b/docs/releases/sovereign-runtime-release-readiness.md
@@ -61,7 +61,6 @@ No timelines are committed for these items.
 
 # Sovereign runtime signed bundle dry-run (with optional signing)
 ./gradlew verifySovereignRuntimeSignedBundle \
-  -PtramaiPublishReleaseUrl=file://$PWD/build/sovereign-runtime-release-verification-repo \
   -PsigningKey="$SIGNING_KEY" \
   -PsigningPassword="$SIGNING_PASSWORD"
 

--- a/docs/releases/sovereign-runtime-release-readiness.md
+++ b/docs/releases/sovereign-runtime-release-readiness.md
@@ -50,8 +50,20 @@ No timelines are committed for these items.
 # Full test suite (all modules, no cache)
 ./gradlew test --rerun-tasks
 
+# Release metadata and artifact validation
+./gradlew verifyReleaseReadiness
+
 # Sovereign runtime local publishability
 ./gradlew verifySovereignRuntimePublication
+
+# Sovereign runtime signed bundle dry-run (default — no signing)
+./gradlew verifySovereignRuntimeSignedBundle
+
+# Sovereign runtime signed bundle dry-run (with optional signing)
+./gradlew verifySovereignRuntimeSignedBundle \
+  -PtramaiPublishReleaseUrl=file://$PWD/build/sovereign-runtime-release-verification-repo \
+  -PsigningKey="$SIGNING_KEY" \
+  -PsigningPassword="$SIGNING_PASSWORD"
 
 # Sovereign runtime consumer-resolution smoke
 ./gradlew -p examples/sovereign-runtime-consumer-smoke test


### PR DESCRIPTION
## Summary

Adds a sovereign runtime signed publication bundle dry-run.

This validates local release artifact structure and optional signatures without publishing remotely, tagging, bumping versions, or freezing APIs.

## Changes

- Added `verifySovereignRuntimeSignedBundle` Gradle task
- Validates sovereign runtime modules and BOM in a dedicated local-only Maven repository:
  - `tramai-bom`, `tramai-security`, `tramai-sovereign`, `tramai-persistence-file`
  - `tramai-spring-boot-starter-sovereign`
  - `tramai-spring-boot-starter-sovereign-persistence-file`
  - `tramai-spring-boot-starter-sovereign-ops`
  - `tramai-spring-boot-starter-sovereign-ops-observability`
- Publishes to a dedicated `sovereignBundleLocal` repository (always file://, build-local by default) — never to the shared `tramaiRemote` repo
- Validates POM files, binary JARs, sources JARs, javadoc JARs, and .module metadata
- Optionally validates `.asc` signatures when `-PsigningKey` and `-PsigningPassword` are provided (no URL needed)
- Generates `build/sovereign-runtime-release/bundle-manifest.json` with:
  - `schemaVersion: "sovereign-runtime-release-bundle-v1"`
  - Module list with artifact paths, optional signatures, checksums
  - `remotePublish=false`, `tagCreated=false`
- **Configuration-time URL guard**: rejects non-`file://` `tramaiPublishReleaseUrl` before any publish task can run
- **Fail-closed manifest generation**: missing module directories or incomplete entries cause the build to fail
- Updated release documentation:
  - `docs/reference/releasing.md` — new signed bundle dry-run section with manifest field reference
  - `docs/releases/sovereign-runtime-release-readiness.md` — new validation commands

## Non-goals

- No Maven Central publishing
- No Sonatype upload
- No tag/release
- No version bump
- No API freeze
- No runtime behavior changes
- No new feature work
- No signing keys required for default CI path
- No remote repository contact of any kind — the dry-run uses a dedicated local-only repo

## Verification

```bash
./gradlew test --rerun-tasks
./gradlew verifyReleaseReadiness
./gradlew verifySovereignRuntimePublication
./gradlew verifySovereignRuntimeSignedBundle
```

Signed local validation (no URL needed — defaults to build-local repo):
```bash
./gradlew verifySovereignRuntimeSignedBundle \
  -PsigningKey="$SIGNING_KEY" \
  -PsigningPassword="$SIGNING_PASSWORD"
```

Custom repo path:
```bash
./gradlew verifySovereignRuntimeSignedBundle \
  -PtramaiPublishReleaseUrl=file:///path/to/custom-repo \
  -PsigningKey="$SIGNING_KEY" \
  -PsigningPassword="$SIGNING_PASSWORD"
```

Rejected (configuration-time guard):
```bash
./gradlew verifySovereignRuntimeSignedBundle \
  -PtramaiPublishReleaseUrl=https://example.com/repo
# Fails with: only supports file:// repositories
```