### PR TITLE
chore(release): add sovereign runtime release-candidate CI gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to publish or validate. Leave empty for 0.2.0-SNAPSHOT, or set a release like 0.2.0."
+        description: "Version to publish or validate. Leave empty to use the project default snapshot, or set a release like 0.3.1."
         required: false
         type: string
   push:
@@ -51,7 +51,7 @@ jobs:
           elif [[ -n "${{ github.event.inputs.version }}" ]]; then
             echo "TRAMAI_VERSION=${{ github.event.inputs.version }}" >> "$GITHUB_ENV"
           else
-            echo "TRAMAI_VERSION=0.2.0-SNAPSHOT" >> "$GITHUB_ENV"
+            echo "TRAMAI_VERSION=0.3.1" >> "$GITHUB_ENV"
           fi
 
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to publish or validate. Leave empty to use the project default snapshot, or set a release like 0.3.1."
+        description: "Version to publish or validate. Leave empty to use the project default version, or set a release like 0.3.1."
         required: false
         type: string
   push:

--- a/.github/workflows/sovereign-runtime-release-candidate.yml
+++ b/.github/workflows/sovereign-runtime-release-candidate.yml
@@ -1,0 +1,90 @@
+name: Sovereign Runtime Release Candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to validate. Leave empty to use gradle.properties."
+        required: false
+        type: string
+  pull_request:
+    paths:
+      - "build.gradle.kts"
+      - "gradle.properties"
+      - "tramai-bom/**"
+      - "tramai-security/**"
+      - "tramai-sovereign/**"
+      - "tramai-persistence-file/**"
+      - "tramai-spring-boot-starter-sovereign/**"
+      - "tramai-spring-boot-starter-sovereign-persistence-file/**"
+      - "tramai-spring-boot-starter-sovereign-ops/**"
+      - "tramai-spring-boot-starter-sovereign-ops-observability/**"
+      - "examples/sovereign-runtime-consumer-smoke/**"
+      - "docs/releases/**"
+      - "docs/reference/releasing.md"
+      - ".github/workflows/sovereign-runtime-release-candidate.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      TRAMAI_VERSION: ${{ github.event.inputs.version || '0.3.1-SNAPSHOT' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: \"25\"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run validation sequence
+        run: |
+          ./gradlew test --rerun-tasks --no-configuration-cache
+          ./gradlew verifyReleaseReadiness --no-configuration-cache
+          ./gradlew verifySovereignRuntimePublication --no-configuration-cache
+          ./gradlew verifySovereignRuntimeSignedBundle --no-configuration-cache
+          ./gradlew -p examples/sovereign-runtime-consumer-smoke test --no-configuration-cache
+          ./gradlew prepareSovereignReleaseArtifacts --no-configuration-cache
+          ./gradlew verifySovereignReleaseManifest --no-configuration-cache
+          ./gradlew :examples:sovereign-document-intelligence:run --args="--release-bundle-manifest=build/sovereign-release/release-artifacts-v1.json" --no-configuration-cache
+
+      - name: Upload bundle manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: sovereign-runtime-bundle-manifest
+          path: build/sovereign-runtime-release/bundle-manifest.json
+
+      - name: Upload local Maven repo bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: sovereign-runtime-local-maven-repo
+          path: build/sovereign-runtime-release-verification-repo/
+
+      - name: Upload sovereign release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sovereign-release-artifacts
+          path: |
+            build/sovereign-release/release-artifacts-v1.json
+            build/sovereign-release/artifacts/
+
+      - name: Write Summary
+        run: |
+          echo "## Sovereign Runtime Release Candidate" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- Remote publish: false" >> $GITHUB_STEP_SUMMARY
+          echo "- Tag created: false" >> $GITHUB_STEP_SUMMARY
+          echo "- Version: $TRAMAI_VERSION" >> $GITHUB_STEP_SUMMARY
+          echo "- Full tests: passed" >> $GITHUB_STEP_SUMMARY
+          echo "- Release readiness: passed" >> $GITHUB_STEP_SUMMARY
+          echo "- Local publication: passed" >> $GITHUB_STEP_SUMMARY
+          echo "- Signed bundle dry-run: passed" >> $GITHUB_STEP_SUMMARY
+          echo "- Consumer smoke: passed" >> $GITHUB_STEP_SUMMARY
+          echo "- Bundle manifest: uploaded" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/sovereign-runtime-release-candidate.yml
+++ b/.github/workflows/sovereign-runtime-release-candidate.yml
@@ -30,7 +30,9 @@ jobs:
     permissions:
       contents: read
     env:
-      TRAMAI_VERSION: ${{ github.event.inputs.version || '0.3.1-SNAPSHOT' }}
+      TRAMAI_VERSION: ${{ github.event.inputs.version || '0.3.1' }}
+      # Override project version when workflow_dispatch provides one
+      ORG_GRADLE_PROJECT_tramaiVersion: ${{ github.event.inputs.version || '0.3.1' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,7 +41,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: \"25\"
+          java-version: "25"
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -60,12 +62,14 @@ jobs:
         with:
           name: sovereign-runtime-bundle-manifest
           path: build/sovereign-runtime-release/bundle-manifest.json
+          if-no-files-found: error
 
       - name: Upload local Maven repo bundle
         uses: actions/upload-artifact@v4
         with:
           name: sovereign-runtime-local-maven-repo
           path: build/sovereign-runtime-release-verification-repo/
+          if-no-files-found: error
 
       - name: Upload sovereign release artifacts
         uses: actions/upload-artifact@v4
@@ -74,6 +78,7 @@ jobs:
           path: |
             build/sovereign-release/release-artifacts-v1.json
             build/sovereign-release/artifacts/
+          if-no-files-found: error
 
       - name: Write Summary
         run: |
@@ -88,3 +93,5 @@ jobs:
           echo "- Signed bundle dry-run: passed" >> $GITHUB_STEP_SUMMARY
           echo "- Consumer smoke: passed" >> $GITHUB_STEP_SUMMARY
           echo "- Bundle manifest: uploaded" >> $GITHUB_STEP_SUMMARY
+          echo "- Local Maven repo: uploaded" >> $GITHUB_STEP_SUMMARY
+          echo "- Release artifacts: uploaded" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/sovereign-runtime-release-candidate.yml
+++ b/.github/workflows/sovereign-runtime-release-candidate.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to validate. Leave empty to use gradle.properties."
+        description: "Version to validate. Leave empty to use the current project default version."
         required: false
         type: string
   pull_request:

--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -188,6 +188,53 @@ The task generates `build/sovereign-runtime-release/bundle-manifest.json`:
 | `signaturesPresent` | Whether .asc signatures were validated |
 | `modules[]` | List of validated modules with artifact paths, signatures, and checksums |
 
+## Sovereign Runtime Release-Candidate CI Gate
+
+The repository contains a dedicated workflow for validating the sovereign runtime release boundary:
+
+`.github/workflows/sovereign-runtime-release-candidate.yml`
+
+**Name:** Sovereign Runtime Release Candidate
+
+**Triggers:**
+
+- `workflow_dispatch` (manual) — no tag, no remote publish, no version bump
+- `pull_request` targeting release-critical paths (build config, sovereign modules, BOM, release docs, consumer smoke example)
+
+The workflow does **not** trigger on tags. It is a pre-publish validation gate, not the real publish workflow.
+
+**What it runs:**
+
+- `./gradlew test --rerun-tasks` — full test suite
+- `./gradlew verifyReleaseReadiness` — release metadata and artifact validation
+- `./gradlew verifySovereignRuntimePublication` — local sovereign runtime publishability
+- `./gradlew verifySovereignRuntimeSignedBundle` — signed bundle dry-run
+- `./gradlew -p examples/sovereign-runtime-consumer-smoke test` — consumer-resolution smoke
+- `./gradlew prepareSovereignReleaseArtifacts` — release artifact preparation
+- `./gradlew verifySovereignReleaseManifest` — manifest verification
+- `./gradlew :examples:sovereign-document-intelligence:run --args=...` — evidence document intelligence
+
+**What it uploads (GitHub Actions artifacts):**
+
+| Artifact | Source Path |
+|----------|-------------|
+| `sovereign-runtime-bundle-manifest` | `build/sovereign-runtime-release/bundle-manifest.json` |
+| `sovereign-runtime-local-maven-repo` | `build/sovereign-runtime-release-verification-repo/` |
+| `sovereign-release-artifacts` | `build/sovereign-release/release-artifacts-v1.json` + `build/sovereign-release/artifacts/` |
+
+**GitHub step summary:**
+
+After each run, the workflow writes a summary to `$GITHUB_STEP_SUMMARY` with:
+- Remote publish: false
+- Tag created: false
+- Version validated
+- Status of each gate
+- Uploaded artifact names
+
+**Run manually:**
+
+Go to the repository Actions tab, select **Sovereign Runtime Release Candidate**, and click **Run workflow**.
+
 ## Local Signed-Artifact Validation (All Modules)
 
 When you want to validate signing for ALL publishable modules locally without touching a real remote repository, publish to a file-based Maven repository and verify signatures there:

--- a/docs/releases/sovereign-runtime-release-readiness.md
+++ b/docs/releases/sovereign-runtime-release-readiness.md
@@ -138,6 +138,6 @@ The repository now includes a dedicated workflow for validating the sovereign ru
 |----------|----------|
 | `sovereign-runtime-bundle-manifest` | Bundle manifest JSON |
 | `sovereign-runtime-local-maven-repo` | Local verification Maven repository |
-| `sovereign-release-artifacts` | Release artifact manifest + signed artifacts |
+| `sovereign-release-artifacts` | Release artifact manifest + generated release artifacts |
 
 Run from the Actions tab: **Sovereign Runtime Release Candidate** → **Run workflow**.

--- a/docs/releases/sovereign-runtime-release-readiness.md
+++ b/docs/releases/sovereign-runtime-release-readiness.md
@@ -100,3 +100,44 @@ No timelines are committed for these items.
 - [x] CHANGELOG.md has Unreleased section
 
 Checklist last verified: 2026-06-18. Full test suite: 159 tasks, all green.
+
+## Sovereign Runtime Release-Candidate CI Gate
+
+The repository now includes a dedicated workflow for validating the sovereign runtime release boundary:
+
+`.github/workflows/sovereign-runtime-release-candidate.yml`
+
+**Name:** Sovereign Runtime Release Candidate
+
+**Triggers:**
+
+- `workflow_dispatch` — run manually without tagging or publishing
+- `pull_request` targeting release-critical paths
+
+**What it validates:**
+
+- Full test suite (rerun-tasks)
+- Release readiness metadata and artifacts
+- Local sovereign runtime publication (POMs, sources, javadoc)
+- Signed bundle dry-run (bundle manifest + verification repo)
+- Consumer-resolution smoke test from mavenLocal()
+- Release artifact preparation and manifest verification
+- Sovereign document intelligence evidence run
+
+**What it does NOT do:**
+
+- Publish to Maven Central or Sonatype
+- Create a tag or GitHub release
+- Bump the version
+- Require signing keys
+- Freeze APIs
+
+**Artifacts uploaded:**
+
+| Artifact | Contents |
+|----------|----------|
+| `sovereign-runtime-bundle-manifest` | Bundle manifest JSON |
+| `sovereign-runtime-local-maven-repo` | Local verification Maven repository |
+| `sovereign-release-artifacts` | Release artifact manifest + signed artifacts |
+
+Run from the Actions tab: **Sovereign Runtime Release Candidate** → **Run workflow**.

--- a/examples/sovereign-runtime-consumer-smoke/settings.gradle.kts
+++ b/examples/sovereign-runtime-consumer-smoke/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "sovereign-runtime-consumer-smoke"

--- a/examples/sovereign-runtime-consumer-smoke/src/test/resources/application.yml
+++ b/examples/sovereign-runtime-consumer-smoke/src/test/resources/application.yml
@@ -1,0 +1,15 @@
+tramai:
+  sovereign:
+    enabled: true
+    allowed-models:
+      - local-invoice-model
+    allowed-providers:
+      - local-provider
+    allowed-tools:
+      - schedule-payment
+    allowed-permissions:
+      - payment.schedule
+    provider-zones:
+      local-provider: LOCAL
+    models:
+      local-invoice-model: local-provider


### PR DESCRIPTION
## Summary

Adds a dedicated sovereign runtime release-candidate CI workflow.

The workflow runs the local release gates and uploads release-candidate evidence artifacts without publishing remotely, tagging, bumping versions, or freezing APIs.

## Changes

- Added **Sovereign Runtime Release Candidate** workflow
- Runs full tests, release readiness, local publication validation, signed bundle dry-run, and consumer-resolution smoke
- Also runs prepareSovereignReleaseArtifacts, verifySovereignReleaseManifest, and sovereign document intelligence evidence
- Uploads bundle manifest, local Maven repo bundle, and sovereign release artifacts
- Adds GitHub step summary for release-candidate validation (all 3 artifacts listed)
- Adds `if-no-files-found: error` guard to all artifact upload steps
- Adds `ORG_GRADLE_PROJECT_tramaiVersion` env wiring so `workflow_dispatch` version input propagates to Gradle
- Updates release documentation (releasing.md, sovereign-runtime-release-readiness.md)
- Corrects stale publish workflow version wording/default (0.2.0-SNAPSHOT → 0.3.1)
- Fixes missing settings.gradle.kts and application.yml in consumer-smoke project

## Review fixes applied

After Codex, agy, and Giona review:
- Fixed escaped backslash-quotes on `java-version` that would break every workflow run
- Fixed fallback version `0.3.1-SNAPSHOT` → `0.3.1` to match gradle.properties
- Added `if-no-files-found: error` to all artifact upload steps
- Updated summary to list all 3 uploaded artifacts (was only 1)
- Updated publish.yml description from "snapshot" → "version"
- Fixed docs: "signed artifacts" → "generated release artifacts"
- Fixed workflow input description: "use gradle.properties" → "use the current project default version"

## Non-goals

- No Maven Central publishing
- No Sonatype upload
- No tag/release
- No version bump
- No signing key requirement
- No remote credentials
- No runtime behavior changes
- No new feature work

## Verification

```
./gradlew test --rerun-tasks        ✓
./gradlew verifyReleaseReadiness         ✓
./gradlew verifySovereignRuntimePublication   ✓
./gradlew verifySovereignRuntimeSignedBundle   ✓
./gradlew -p examples/sovereign-runtime-consumer-smoke test  ✓
```