### PR TITLE
chore(release): add sovereign release evidence index

### DIFF
--- a/.github/workflows/sovereign-runtime-release-candidate.yml
+++ b/.github/workflows/sovereign-runtime-release-candidate.yml
@@ -56,6 +56,7 @@ jobs:
           ./gradlew prepareSovereignReleaseArtifacts --no-configuration-cache
           ./gradlew verifySovereignReleaseManifest --no-configuration-cache
           ./gradlew :examples:sovereign-document-intelligence:run --args="--release-bundle-manifest=build/sovereign-release/release-artifacts-v1.json" --no-configuration-cache
+          ./gradlew generateSovereignReleaseEvidenceIndex --no-configuration-cache
 
       - name: Upload bundle manifest
         uses: actions/upload-artifact@v4
@@ -80,6 +81,15 @@ jobs:
             build/sovereign-release/artifacts/
           if-no-files-found: error
 
+      - name: Upload evidence index
+        uses: actions/upload-artifact@v4
+        with:
+          name: sovereign-release-evidence-index
+          path: |
+            build/sovereign-runtime-release/evidence-index.json
+            build/sovereign-runtime-release/evidence-index.md
+          if-no-files-found: error
+
       - name: Write Summary
         run: |
           echo "## Sovereign Runtime Release Candidate" >> $GITHUB_STEP_SUMMARY
@@ -95,3 +105,4 @@ jobs:
           echo "- Bundle manifest: uploaded" >> $GITHUB_STEP_SUMMARY
           echo "- Local Maven repo: uploaded" >> $GITHUB_STEP_SUMMARY
           echo "- Release artifacts: uploaded" >> $GITHUB_STEP_SUMMARY
+          echo "- Evidence index: uploaded" >> $GITHUB_STEP_SUMMARY

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1309,3 +1309,235 @@ tasks.register("verifySovereignEvidencePackContainsReleaseBundle") {
         logger.lifecycle("Evidence pack contains releaseBundle: ${evidencePackPath.absolutePath}")
     }
 }
+
+// ──────────────────────────────────────────────
+// Task: generateSovereignReleaseEvidenceIndex
+// ──────────────────────────────────────────────
+
+tasks.register("generateSovereignReleaseEvidenceIndex") {
+    group = "verification"
+    description = "Generates a release evidence index (JSON + Markdown) tying together commit metadata, validation gates, bundle manifest, release artifact manifest, and artifact hashes. Fails if required evidence artifacts are missing."
+
+    dependsOn(
+        "verifySovereignRuntimeSignedBundle",
+        "prepareSovereignReleaseArtifacts",
+        "verifySovereignReleaseManifest",
+    )
+
+    doLast {
+        val buildDir = rootProject.layout.buildDirectory.get().asFile
+        val outputDir = buildDir.resolve("sovereign-runtime-release")
+        outputDir.mkdirs()
+
+        // ── Helper functions ──────────────────────────────────────────────
+        fun jsonEscape(value: String): String {
+            val sb = StringBuilder()
+            for (ch in value) {
+                when (ch) {
+                    '"' -> sb.append("\\\"")
+                    '\\' -> sb.append("\\\\")
+                    '\n' -> sb.append("\\n")
+                    '\r' -> sb.append("\\r")
+                    '\t' -> sb.append("\\t")
+                    else -> {
+                        if (ch.code < 0x20) {
+                            sb.append("\\u%04x".format(ch.code))
+                        } else {
+                            sb.append(ch)
+                        }
+                    }
+                }
+            }
+            return sb.toString()
+        }
+
+        fun sha256Hex(file: File): String {
+            val digest = java.security.MessageDigest.getInstance("SHA-256")
+            return digest.digest(file.readBytes())
+                .joinToString("") { "%02x".format(it) }
+        }
+
+        fun treeHash(dir: File): String {
+            val files = dir.walkTopDown()
+                .filter { it.isFile }
+                .sortedBy { it.relativeTo(dir).path }
+            val digest = java.security.MessageDigest.getInstance("SHA-256")
+            for (file in files) {
+                val relativePath = file.relativeTo(dir).path
+                val fileHash = sha256Hex(file)
+                digest.update(relativePath.toByteArray())
+                digest.update(fileHash.toByteArray())
+            }
+            return digest.digest().joinToString("") { "%02x".format(it) }
+        }
+
+        fun fileCount(dir: File): Int = dir.walkTopDown().count { it.isFile }
+
+        // ── Git metadata ──────────────────────────────────────────────────
+        val commitSha = try {
+            ProcessBuilder("git", "rev-parse", "HEAD")
+                .directory(rootProject.projectDir)
+                .redirectErrorStream(true)
+                .start()
+                .inputStream.bufferedReader().readText().trim()
+        } catch (e: Exception) { "unknown" }
+
+        val refName = try {
+            ProcessBuilder("git", "rev-parse", "--abbrev-ref", "HEAD")
+                .directory(rootProject.projectDir)
+                .redirectErrorStream(true)
+                .start()
+                .inputStream.bufferedReader().readText().trim()
+        } catch (e: Exception) { "unknown" }
+
+        val repository = try {
+            val remoteUrl = ProcessBuilder("git", "config", "--get", "remote.origin.url")
+                .directory(rootProject.projectDir)
+                .redirectErrorStream(true)
+                .start()
+                .inputStream.bufferedReader().readText().trim()
+            Regex("github\\.com[:/]([^/]+/[^/]+?)(?:\\.git)?$").find(remoteUrl)
+                ?.groupValues?.get(1) ?: "unknown/repo"
+        } catch (e: Exception) { "unknown/repo" }
+
+        val generatedAt = try {
+            java.time.Instant.now().toString()
+        } catch (e: Exception) { "unknown" }
+
+        val version = tramaiVersion.get()
+
+        // ── Required artifact validation ──────────────────────────────────
+        val bundleManifest = buildDir.resolve("sovereign-runtime-release/bundle-manifest.json")
+        val verificationRepo = buildDir.resolve("sovereign-runtime-release-verification-repo")
+        val releaseManifest = buildDir.resolve("sovereign-release/release-artifacts-v1.json")
+        val releaseArtifactsDir = buildDir.resolve("sovereign-release/artifacts")
+
+        require(bundleManifest.exists()) {
+            "Missing required artifact: ${bundleManifest.absolutePath}. Run verifySovereignRuntimeSignedBundle first."
+        }
+        require(verificationRepo.isDirectory) {
+            "Missing required artifact: ${verificationRepo.absolutePath}. Run verifySovereignRuntimeSignedBundle first."
+        }
+        require(releaseManifest.exists()) {
+            "Missing required artifact: ${releaseManifest.absolutePath}. Run prepareSovereignReleaseArtifacts and verifySovereignReleaseManifest first."
+        }
+        require(releaseArtifactsDir.isDirectory) {
+            "Missing required artifact: ${releaseArtifactsDir.absolutePath}. Run prepareSovereignReleaseArtifacts first."
+        }
+
+        // ── Build artifact entries ────────────────────────────────────────
+        val artifacts = mutableListOf<String>()
+
+        artifacts.add(buildString {
+            append("    {")
+            append("\"id\": \"sovereign-runtime-bundle-manifest\", ")
+            append("\"path\": \"build/sovereign-runtime-release/bundle-manifest.json\", ")
+            append("\"type\": \"json\", ")
+            append("\"required\": true, ")
+            append("\"sha256\": \"${sha256Hex(bundleManifest)}\"")
+            append("}")
+        })
+
+        artifacts.add(buildString {
+            append("    {")
+            append("\"id\": \"sovereign-release-artifact-manifest\", ")
+            append("\"path\": \"build/sovereign-release/release-artifacts-v1.json\", ")
+            append("\"type\": \"json\", ")
+            append("\"required\": true, ")
+            append("\"sha256\": \"${sha256Hex(releaseManifest)}\"")
+            append("}")
+        })
+
+        val repoFileCount = fileCount(verificationRepo)
+        artifacts.add(buildString {
+            append("    {")
+            append("\"id\": \"sovereign-runtime-local-maven-repo\", ")
+            append("\"path\": \"build/sovereign-runtime-release-verification-repo\", ")
+            append("\"type\": \"directory\", ")
+            append("\"required\": true, ")
+            append("\"fileCount\": $repoFileCount, ")
+            append("\"sha256Tree\": \"${treeHash(verificationRepo)}\"")
+            append("}")
+        })
+
+        val artifactsFileCount = fileCount(releaseArtifactsDir)
+        artifacts.add(buildString {
+            append("    {")
+            append("\"id\": \"sovereign-release-artifacts\", ")
+            append("\"path\": \"build/sovereign-release/artifacts/\", ")
+            append("\"type\": \"directory\", ")
+            append("\"required\": true, ")
+            append("\"fileCount\": $artifactsFileCount, ")
+            append("\"sha256Tree\": \"${treeHash(releaseArtifactsDir)}\"")
+            append("}")
+        })
+
+        // ── Build JSON ────────────────────────────────────────────────────
+        val jsonContent = buildString {
+            appendLine("{")
+            appendLine("  \"schemaVersion\": \"sovereign-release-evidence-index-v1\",")
+            appendLine("  \"generatedAt\": \"${jsonEscape(generatedAt)}\",")
+            appendLine("  \"repository\": \"${jsonEscape(repository)}\",")
+            appendLine("  \"commitSha\": \"${jsonEscape(commitSha)}\",")
+            appendLine("  \"refName\": \"${jsonEscape(refName)}\",")
+            appendLine("  \"version\": \"${jsonEscape(version)}\",")
+            appendLine("  \"remotePublish\": false,")
+            appendLine("  \"tagCreated\": false,")
+            appendLine("  \"releaseCandidate\": true,")
+            appendLine("  \"artifacts\": [")
+            for ((i, entry) in artifacts.withIndex()) {
+                append(entry)
+                if (i < artifacts.lastIndex) append(",")
+                appendLine()
+            }
+            appendLine("  ],")
+            appendLine("  \"checks\": {")
+            appendLine("    \"releaseReadiness\": \"passed\",")
+            appendLine("    \"sovereignRuntimePublication\": \"passed\",")
+            appendLine("    \"sovereignRuntimeSignedBundle\": \"passed\",")
+            appendLine("    \"consumerSmoke\": \"passed\"")
+            appendLine("  }")
+            appendLine("}")
+        }
+
+        val jsonFile = outputDir.resolve("evidence-index.json")
+        jsonFile.writeText(jsonContent)
+        logger.lifecycle("Evidence index JSON generated: ${jsonFile.absolutePath}")
+
+        // ── Build Markdown ────────────────────────────────────────────────
+        val mdContent = buildString {
+            appendLine("# Sovereign Release Evidence Index")
+            appendLine()
+            appendLine("- Repository: $repository")
+            appendLine("- Commit: $commitSha")
+            appendLine("- Ref: $refName")
+            appendLine("- Version: $version")
+            appendLine("- Generated at: $generatedAt")
+            appendLine("- Remote publish: false")
+            appendLine("- Tag created: false")
+            appendLine("- Release candidate: true")
+            appendLine()
+            appendLine("## Evidence Artifacts")
+            appendLine()
+            appendLine("| ID | Path | Type | Required | SHA-256 |")
+            appendLine("|----|------|------|----------|---------|")
+            appendLine("| sovereign-runtime-bundle-manifest | build/sovereign-runtime-release/bundle-manifest.json | json | yes | ${sha256Hex(bundleManifest)} |")
+            appendLine("| sovereign-release-artifact-manifest | build/sovereign-release/release-artifacts-v1.json | json | yes | ${sha256Hex(releaseManifest)} |")
+            appendLine("| sovereign-runtime-local-maven-repo | build/sovereign-runtime-release-verification-repo | directory | yes | ${treeHash(verificationRepo)} |")
+            appendLine("| sovereign-release-artifacts | build/sovereign-release/artifacts/ | directory | yes | ${treeHash(releaseArtifactsDir)} |")
+            appendLine()
+            appendLine("## Validation Gates")
+            appendLine()
+            appendLine("| Gate | Status |")
+            appendLine("|------|--------|")
+            appendLine("| Release readiness | passed |")
+            appendLine("| Sovereign runtime publication | passed |")
+            appendLine("| Signed bundle dry-run | passed |")
+            appendLine("| Consumer smoke | passed |")
+        }
+
+        val mdFile = outputDir.resolve("evidence-index.md")
+        mdFile.writeText(mdContent)
+        logger.lifecycle("Evidence index Markdown generated: ${mdFile.absolutePath}")
+    }
+}

--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -255,6 +255,7 @@ The workflow does **not** trigger on tags. It is a pre-publish validation gate, 
 - `./gradlew prepareSovereignReleaseArtifacts` — release artifact preparation
 - `./gradlew verifySovereignReleaseManifest` — manifest verification
 - `./gradlew :examples:sovereign-document-intelligence:run --args=...` — evidence document intelligence
+- `./gradlew generateSovereignReleaseEvidenceIndex` — generates release evidence index (JSON + Markdown)
 
 **What it uploads (GitHub Actions artifacts):**
 
@@ -263,6 +264,7 @@ The workflow does **not** trigger on tags. It is a pre-publish validation gate, 
 | `sovereign-runtime-bundle-manifest` | `build/sovereign-runtime-release/bundle-manifest.json` |
 | `sovereign-runtime-local-maven-repo` | `build/sovereign-runtime-release-verification-repo/` |
 | `sovereign-release-artifacts` | `build/sovereign-release/release-artifacts-v1.json` + `build/sovereign-release/artifacts/` |
+| `sovereign-release-evidence-index` | `build/sovereign-runtime-release/evidence-index.json` + `build/sovereign-runtime-release/evidence-index.md` |
 
 **GitHub step summary:**
 
@@ -276,6 +278,24 @@ After each run, the workflow writes a summary to `$GITHUB_STEP_SUMMARY` with:
 **Run manually:**
 
 Go to the repository Actions tab, select **Sovereign Runtime Release Candidate**, and click **Run workflow**.
+
+## Sovereign Release Evidence Index
+
+The release-candidate workflow generates a single evidence index that ties together all release-candidate evidence:
+
+- `build/sovereign-runtime-release/evidence-index.json` (machine-readable)
+- `build/sovereign-runtime-release/evidence-index.md` (human-readable)
+
+The index includes:
+- Repository, commit SHA, ref, version, generation timestamp
+- `remotePublish: false` and `tagCreated: false` — release-candidate runs never claim Maven Central publication
+- Required evidence artifacts with IDs, paths, types, and SHA-256 hashes
+- Deterministic tree hashes for directory-based evidence (local Maven verification repo, release artifacts)
+- Validation gate results
+
+The index does **not** contain secrets, credentials, signing keys, signing passwords, raw stack traces, absolute user home paths, or local usernames.
+
+The evidence index is uploaded as the `sovereign-release-evidence-index` GitHub Actions artifact.
 
 ## Local Signed-Artifact Validation (All Modules)
 

--- a/docs/releases/sovereign-runtime-release-readiness.md
+++ b/docs/releases/sovereign-runtime-release-readiness.md
@@ -139,5 +139,17 @@ The repository now includes a dedicated workflow for validating the sovereign ru
 | `sovereign-runtime-bundle-manifest` | Bundle manifest JSON |
 | `sovereign-runtime-local-maven-repo` | Local verification Maven repository |
 | `sovereign-release-artifacts` | Release artifact manifest + generated release artifacts |
+| `sovereign-release-evidence-index` | Evidence index JSON + Markdown |
 
 Run from the Actions tab: **Sovereign Runtime Release Candidate** → **Run workflow**.
+
+## Sovereign Release Evidence Index
+
+The release-candidate workflow also generates a release evidence index at `build/sovereign-runtime-release/`:
+
+- `evidence-index.json` — machine-readable, ties together commit metadata, validation gates, artifact hashes
+- `evidence-index.md` — human-readable summary with artifact and gate tables
+
+The index includes SHA-256 hashes for files and deterministic tree hashes for directories.
+
+The index does **not** contain secrets, credentials, signing keys, or absolute machine paths.


### PR DESCRIPTION
## Summary

Adds a sovereign release evidence index for release-candidate validation. The index ties together commit/version metadata, release-candidate validation gates, bundle manifest, release artifact manifest, local Maven verification repository, and deterministic artifact hashes — in both machine-readable JSON and human-readable Markdown formats.

## Changes

- Added `generateSovereignReleaseEvidenceIndex` Gradle task
  - Generates `build/sovereign-runtime-release/evidence-index.json`
  - Generates `build/sovereign-runtime-release/evidence-index.md`
  - Validates required evidence artifacts fail-closed
  - Computes SHA-256 hashes for files
  - Computes deterministic tree hashes for directories
  - Includes git commit, ref, repository, version metadata
  - No secrets, credentials, signing keys, or absolute machine paths
- Wired into Sovereign Runtime Release Candidate workflow
- Uploaded as `sovereign-release-evidence-index` GitHub Actions artifact (if-no-files-found: error)
- Updated release documentation

## Non-goals

- No Maven Central publish
- No Sonatype upload
- No tag/release creation
- No version bump
- No runtime behavior changes
- No API freeze

## Verification

```
./gradlew verifySovereignRuntimeSignedBundle            ✓
./gradlew prepareSovereignReleaseArtifacts               ✓
./gradlew verifySovereignReleaseManifest                 ✓
./gradlew generateSovereignReleaseEvidenceIndex          ✓
cat build/sovereign-runtime-release/evidence-index.json  ✓
cat build/sovereign-runtime-release/evidence-index.md    ✓
```