### PR TITLE
chore(release): harden sovereign release evidence index

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1319,7 +1319,13 @@ tasks.register("generateSovereignReleaseEvidenceIndex") {
     description = "Generates a release evidence index (JSON + Markdown) tying together commit metadata, validation gates, bundle manifest, release artifact manifest, and artifact hashes. Fails if required evidence artifacts are missing."
 
     dependsOn(
+        "verifyReleaseReadiness",
+        "verifySovereignRuntimePublication",
         "verifySovereignRuntimeSignedBundle",
+        // Note: consumerSmoke (:examples:sovereign-runtime-consumer-smoke:test) is a
+        // standalone Gradle build, not a subproject of this build. It runs separately
+        // via `./gradlew -p examples/sovereign-runtime-consumer-smoke test`.
+        // The evidence index documents its task path in the checks section.
         "prepareSovereignReleaseArtifacts",
         "verifySovereignReleaseManifest",
     )
@@ -1353,52 +1359,73 @@ tasks.register("generateSovereignReleaseEvidenceIndex") {
 
         fun sha256Hex(file: File): String {
             val digest = java.security.MessageDigest.getInstance("SHA-256")
-            return digest.digest(file.readBytes())
-                .joinToString("") { "%02x".format(it) }
+            file.inputStream().use { input ->
+                val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                while (true) {
+                    val read = input.read(buffer)
+                    if (read < 0) break
+                    digest.update(buffer, 0, read)
+                }
+            }
+            return digest.digest().joinToString("") { "%02x".format(it) }
         }
 
         fun treeHash(dir: File): String {
             val files = dir.walkTopDown()
                 .filter { it.isFile }
-                .sortedBy { it.relativeTo(dir).path }
+                .sortedBy { it.relativeTo(dir).invariantSeparatorsPath }
             val digest = java.security.MessageDigest.getInstance("SHA-256")
             for (file in files) {
-                val relativePath = file.relativeTo(dir).path
+                val relativePath = file.relativeTo(dir).invariantSeparatorsPath
                 val fileHash = sha256Hex(file)
-                digest.update(relativePath.toByteArray())
-                digest.update(fileHash.toByteArray())
+                digest.update(relativePath.toByteArray(Charsets.UTF_8))
+                digest.update(0)
+                digest.update(fileHash.toByteArray(Charsets.UTF_8))
+                digest.update(0)
             }
             return digest.digest().joinToString("") { "%02x".format(it) }
         }
 
         fun fileCount(dir: File): Int = dir.walkTopDown().count { it.isFile }
 
-        // ── Git metadata ──────────────────────────────────────────────────
-        val commitSha = try {
-            ProcessBuilder("git", "rev-parse", "HEAD")
+        // ── Git metadata (fail-closed) ─────────────────────────────────────
+        val commitSha = run {
+            val out = ProcessBuilder("git", "rev-parse", "HEAD")
                 .directory(rootProject.projectDir)
                 .redirectErrorStream(true)
                 .start()
                 .inputStream.bufferedReader().readText().trim()
-        } catch (e: Exception) { "unknown" }
+            require(out.matches(Regex("[a-f0-9]{40}"))) {
+                "Cannot generate release evidence index without a valid git commit SHA."
+            }
+            out
+        }
 
-        val refName = try {
-            ProcessBuilder("git", "rev-parse", "--abbrev-ref", "HEAD")
+        val refName = run {
+            val out = ProcessBuilder("git", "rev-parse", "--abbrev-ref", "HEAD")
                 .directory(rootProject.projectDir)
                 .redirectErrorStream(true)
                 .start()
                 .inputStream.bufferedReader().readText().trim()
-        } catch (e: Exception) { "unknown" }
+            require(out.isNotBlank() && out != "unknown") {
+                "Cannot generate release evidence index without git ref metadata."
+            }
+            out
+        }
 
-        val repository = try {
+        val repository = run {
             val remoteUrl = ProcessBuilder("git", "config", "--get", "remote.origin.url")
                 .directory(rootProject.projectDir)
                 .redirectErrorStream(true)
                 .start()
                 .inputStream.bufferedReader().readText().trim()
-            Regex("github\\.com[:/]([^/]+/[^/]+?)(?:\\.git)?$").find(remoteUrl)
-                ?.groupValues?.get(1) ?: "unknown/repo"
-        } catch (e: Exception) { "unknown/repo" }
+            val repo = Regex("github\\.com[:/]([^/]+/[^/]+?)(?:\\.git)?$").find(remoteUrl)
+                ?.groupValues?.get(1) ?: error("Cannot generate release evidence index without repository metadata.")
+            require(repo != "unknown/repo") {
+                "Cannot generate release evidence index without repository metadata."
+            }
+            repo
+        }
 
         val generatedAt = try {
             java.time.Instant.now().toString()
@@ -1413,16 +1440,16 @@ tasks.register("generateSovereignReleaseEvidenceIndex") {
         val releaseArtifactsDir = buildDir.resolve("sovereign-release/artifacts")
 
         require(bundleManifest.exists()) {
-            "Missing required artifact: ${bundleManifest.absolutePath}. Run verifySovereignRuntimeSignedBundle first."
+            "Missing required artifact: build/sovereign-runtime-release/bundle-manifest.json. Run verifySovereignRuntimeSignedBundle first."
         }
         require(verificationRepo.isDirectory) {
-            "Missing required artifact: ${verificationRepo.absolutePath}. Run verifySovereignRuntimeSignedBundle first."
+            "Missing required artifact: build/sovereign-runtime-release-verification-repo/. Run verifySovereignRuntimeSignedBundle first."
         }
         require(releaseManifest.exists()) {
-            "Missing required artifact: ${releaseManifest.absolutePath}. Run prepareSovereignReleaseArtifacts and verifySovereignReleaseManifest first."
+            "Missing required artifact: build/sovereign-release/release-artifacts-v1.json. Run prepareSovereignReleaseArtifacts and verifySovereignReleaseManifest first."
         }
         require(releaseArtifactsDir.isDirectory) {
-            "Missing required artifact: ${releaseArtifactsDir.absolutePath}. Run prepareSovereignReleaseArtifacts first."
+            "Missing required artifact: build/sovereign-release/artifacts/. Run prepareSovereignReleaseArtifacts first."
         }
 
         // ── Build artifact entries ────────────────────────────────────────
@@ -1492,10 +1519,22 @@ tasks.register("generateSovereignReleaseEvidenceIndex") {
             }
             appendLine("  ],")
             appendLine("  \"checks\": {")
-            appendLine("    \"releaseReadiness\": \"passed\",")
-            appendLine("    \"sovereignRuntimePublication\": \"passed\",")
-            appendLine("    \"sovereignRuntimeSignedBundle\": \"passed\",")
-            appendLine("    \"consumerSmoke\": \"passed\"")
+            appendLine("    \"releaseReadiness\": {")
+            appendLine("      \"status\": \"passed\",")
+            appendLine("      \"taskPath\": \":verifyReleaseReadiness\"")
+            appendLine("    },")
+            appendLine("    \"sovereignRuntimePublication\": {")
+            appendLine("      \"status\": \"passed\",")
+            appendLine("      \"taskPath\": \":verifySovereignRuntimePublication\"")
+            appendLine("    },")
+            appendLine("    \"sovereignRuntimeSignedBundle\": {")
+            appendLine("      \"status\": \"passed\",")
+            appendLine("      \"taskPath\": \":verifySovereignRuntimeSignedBundle\"")
+            appendLine("    },")
+            appendLine("    \"consumerSmoke\": {")
+            appendLine("      \"status\": \"passed\",")
+            appendLine("      \"taskPath\": \":examples:sovereign-runtime-consumer-smoke:test\"")
+            appendLine("    }")
             appendLine("  }")
             appendLine("}")
         }
@@ -1503,6 +1542,21 @@ tasks.register("generateSovereignReleaseEvidenceIndex") {
         val jsonFile = outputDir.resolve("evidence-index.json")
         jsonFile.writeText(jsonContent)
         logger.lifecycle("Evidence index JSON generated: ${jsonFile.absolutePath}")
+
+        // ── Post-write structural validation ───────────────────────────────
+        require(jsonFile.isFile) {
+            "Evidence index JSON was not generated."
+        }
+        val jsonText = jsonFile.readText()
+        require(jsonText.contains("\"schemaVersion\"")) {
+            "Evidence index JSON is missing schemaVersion."
+        }
+        require(jsonText.contains("\"artifacts\"")) {
+            "Evidence index JSON is missing artifacts."
+        }
+        require(jsonText.contains("\"checks\"")) {
+            "Evidence index JSON is missing checks."
+        }
 
         // ── Build Markdown ────────────────────────────────────────────────
         val mdContent = buildString {
@@ -1528,12 +1582,12 @@ tasks.register("generateSovereignReleaseEvidenceIndex") {
             appendLine()
             appendLine("## Validation Gates")
             appendLine()
-            appendLine("| Gate | Status |")
-            appendLine("|------|--------|")
-            appendLine("| Release readiness | passed |")
-            appendLine("| Sovereign runtime publication | passed |")
-            appendLine("| Signed bundle dry-run | passed |")
-            appendLine("| Consumer smoke | passed |")
+            appendLine("| Gate | Status | Task |")
+            appendLine("|------|--------|------|")
+            appendLine("| Release readiness | passed | :verifyReleaseReadiness |")
+            appendLine("| Sovereign runtime publication | passed | :verifySovereignRuntimePublication |")
+            appendLine("| Signed bundle dry-run | passed | :verifySovereignRuntimeSignedBundle |")
+            appendLine("| Consumer smoke | passed | :examples:sovereign-runtime-consumer-smoke:test |")
         }
 
         val mdFile = outputDir.resolve("evidence-index.md")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1311,6 +1311,30 @@ tasks.register("verifySovereignEvidencePackContainsReleaseBundle") {
 }
 
 // ──────────────────────────────────────────────
+// Task: verifySovereignRuntimeConsumerSmoke
+// ──────────────────────────────────────────────
+
+val gradleWrapper = if (System.getProperty("os.name").lowercase().contains("windows")) {
+    "gradlew.bat"
+} else {
+    "./gradlew"
+}
+
+tasks.register<Exec>("verifySovereignRuntimeConsumerSmoke") {
+    group = "verification"
+    description = "Runs the standalone sovereign runtime consumer smoke test."
+
+    workingDir = rootProject.projectDir
+    commandLine(
+        gradleWrapper,
+        "-p",
+        "examples/sovereign-runtime-consumer-smoke",
+        "test",
+        "--no-configuration-cache",
+    )
+}
+
+// ──────────────────────────────────────────────
 // Task: generateSovereignReleaseEvidenceIndex
 // ──────────────────────────────────────────────
 
@@ -1322,10 +1346,7 @@ tasks.register("generateSovereignReleaseEvidenceIndex") {
         "verifyReleaseReadiness",
         "verifySovereignRuntimePublication",
         "verifySovereignRuntimeSignedBundle",
-        // Note: consumerSmoke (:examples:sovereign-runtime-consumer-smoke:test) is a
-        // standalone Gradle build, not a subproject of this build. It runs separately
-        // via `./gradlew -p examples/sovereign-runtime-consumer-smoke test`.
-        // The evidence index documents its task path in the checks section.
+        "verifySovereignRuntimeConsumerSmoke",
         "prepareSovereignReleaseArtifacts",
         "verifySovereignReleaseManifest",
     )
@@ -1533,7 +1554,8 @@ tasks.register("generateSovereignReleaseEvidenceIndex") {
             appendLine("    },")
             appendLine("    \"consumerSmoke\": {")
             appendLine("      \"status\": \"passed\",")
-            appendLine("      \"taskPath\": \":examples:sovereign-runtime-consumer-smoke:test\"")
+            appendLine("      \"taskPath\": \":verifySovereignRuntimeConsumerSmoke\",")
+            appendLine("      \"executes\": \"./gradlew -p examples/sovereign-runtime-consumer-smoke test --no-configuration-cache\"")
             appendLine("    }")
             appendLine("  }")
             appendLine("}")
@@ -1587,7 +1609,7 @@ tasks.register("generateSovereignReleaseEvidenceIndex") {
             appendLine("| Release readiness | passed | :verifyReleaseReadiness |")
             appendLine("| Sovereign runtime publication | passed | :verifySovereignRuntimePublication |")
             appendLine("| Signed bundle dry-run | passed | :verifySovereignRuntimeSignedBundle |")
-            appendLine("| Consumer smoke | passed | :examples:sovereign-runtime-consumer-smoke:test |")
+            appendLine("| Consumer smoke | passed | :verifySovereignRuntimeConsumerSmoke |")
         }
 
         val mdFile = outputDir.resolve("evidence-index.md")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1320,18 +1320,23 @@ val gradleWrapper = if (System.getProperty("os.name").lowercase().contains("wind
     "./gradlew"
 }
 
+val consumerSmokeVersion = tramaiVersion.get()
+val consumerSmokeArgs = listOf(
+    "-p", "examples/sovereign-runtime-consumer-smoke",
+    "test",
+    "-PtramaiVersion=$consumerSmokeVersion",
+    "--no-configuration-cache",
+)
+val consumerSmokeCommand = "$gradleWrapper ${consumerSmokeArgs.joinToString(" ")}"
+
 tasks.register<Exec>("verifySovereignRuntimeConsumerSmoke") {
     group = "verification"
     description = "Runs the standalone sovereign runtime consumer smoke test."
 
+    dependsOn("verifySovereignRuntimePublication")
+
     workingDir = rootProject.projectDir
-    commandLine(
-        gradleWrapper,
-        "-p",
-        "examples/sovereign-runtime-consumer-smoke",
-        "test",
-        "--no-configuration-cache",
-    )
+    commandLine(gradleWrapper, *consumerSmokeArgs.toTypedArray())
 }
 
 // ──────────────────────────────────────────────
@@ -1555,7 +1560,7 @@ tasks.register("generateSovereignReleaseEvidenceIndex") {
             appendLine("    \"consumerSmoke\": {")
             appendLine("      \"status\": \"passed\",")
             appendLine("      \"taskPath\": \":verifySovereignRuntimeConsumerSmoke\",")
-            appendLine("      \"executes\": \"./gradlew -p examples/sovereign-runtime-consumer-smoke test --no-configuration-cache\"")
+            appendLine("      \"executes\": \"${jsonEscape(consumerSmokeCommand)}\"")
             appendLine("    }")
             appendLine("  }")
             appendLine("}")
@@ -1569,15 +1574,26 @@ tasks.register("generateSovereignReleaseEvidenceIndex") {
         require(jsonFile.isFile) {
             "Evidence index JSON was not generated."
         }
-        val jsonText = jsonFile.readText()
-        require(jsonText.contains("\"schemaVersion\"")) {
-            "Evidence index JSON is missing schemaVersion."
+        @Suppress("UNCHECKED_CAST")
+        val parsed = JsonSlurper().parse(jsonFile) as Map<String, Any>
+        require(parsed["schemaVersion"] == "sovereign-release-evidence-index-v1") {
+            "Evidence index JSON has invalid schemaVersion: expected sovereign-release-evidence-index-v1, got ${parsed["schemaVersion"]}"
         }
-        require(jsonText.contains("\"artifacts\"")) {
-            "Evidence index JSON is missing artifacts."
+        require(parsed["artifacts"] is List<*>) {
+            "Evidence index JSON artifacts must be an array."
         }
-        require(jsonText.contains("\"checks\"")) {
-            "Evidence index JSON is missing checks."
+        require(parsed["checks"] is Map<*, *>) {
+            "Evidence index JSON checks must be an object."
+        }
+        // Verify every check entry has status and taskPath
+        val checks = parsed["checks"] as Map<String, Map<String, Any>>
+        for ((name, check) in checks) {
+            require(check["status"] == "passed") {
+                "Evidence index check '$name' has unexpected status: ${check["status"]}"
+            }
+            require(check.containsKey("taskPath")) {
+                "Evidence index check '$name' is missing taskPath."
+            }
         }
 
         // ── Build Markdown ────────────────────────────────────────────────

--- a/examples/sovereign-runtime-consumer-smoke/build.gradle.kts
+++ b/examples/sovereign-runtime-consumer-smoke/build.gradle.kts
@@ -1,5 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
+val tramaiVersion = providers.gradleProperty("tramaiVersion").orElse("0.3.1")
+
 plugins {
     id("org.springframework.boot") version "3.4.5"
     id("io.spring.dependency-management") version "1.1.7"
@@ -12,7 +14,7 @@ springBoot {
 }
 
 group = "dev.tramai.examples"
-version = "0.3.1"
+version = tramaiVersion.get()
 
 java {
     toolchain {
@@ -28,17 +30,24 @@ kotlin {
 }
 
 repositories {
-    mavenLocal()
+    // dev.tramai modules must resolve from mavenLocal — the point is verifying
+    // that locally published artifacts are consumer-valid. Block remote resolution
+    // so stale Maven Central or other remote artifacts cannot make the test pass
+    // accidentally.
+    exclusiveContent {
+        forRepository { mavenLocal() }
+        filter { includeGroup("dev.tramai") }
+    }
     mavenCentral()
 }
 
 dependencies {
     // Resolve sovereign runtime modules from mavenLocal to prove they are publishable.
     // These must NOT use project() dependencies — the point is to verify consumer resolution.
-    implementation("dev.tramai:tramai-spring-boot-starter-sovereign:0.3.1")
-    implementation("dev.tramai:tramai-spring-boot-starter-sovereign-persistence-file:0.3.1")
-    implementation("dev.tramai:tramai-spring-boot-starter-sovereign-ops:0.3.1")
-    implementation("dev.tramai:tramai-spring-boot-starter-sovereign-ops-observability:0.3.1")
+    implementation("dev.tramai:tramai-spring-boot-starter-sovereign:${tramaiVersion.get()}")
+    implementation("dev.tramai:tramai-spring-boot-starter-sovereign-persistence-file:${tramaiVersion.get()}")
+    implementation("dev.tramai:tramai-spring-boot-starter-sovereign-ops:${tramaiVersion.get()}")
+    implementation("dev.tramai:tramai-spring-boot-starter-sovereign-ops-observability:${tramaiVersion.get()}")
 
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.jetbrains.kotlin:kotlin-reflect")


### PR DESCRIPTION
## Summary

Hardens `generateSovereignReleaseEvidenceIndex` so it produces trustworthy evidence even when run standalone via Gradle — not only when executed inside the GitHub Actions release-candidate workflow.

## Changes

### 1. Gate claims now match task dependencies

Every gate claim in the evidence index is backed by a real Gradle task dependency:

| Gate | Depends on |
|------|------------|
| releaseReadiness | `verifyReleaseReadiness` |
| sovereignRuntimePublication | `verifySovereignRuntimePublication` |
| sovereignRuntimeSignedBundle | `verifySovereignRuntimeSignedBundle` |
| consumerSmoke | `verifySovereignRuntimeConsumerSmoke` (new Exec task) |
| | `prepareSovereignReleaseArtifacts` |
| | `verifySovereignReleaseManifest` |

The consumer smoke test is a standalone Gradle build with its own `settings.gradle.kts`. It's wrapped in a root `Exec` task that:
- Explicitly depends on `verifySovereignRuntimePublication` (ensures mavenLocal is populated before smoke runs)
- Passes `-PtramaiVersion` from the root build to the nested build (evidence version matches consumed version)

### 2. Consumer smoke build is now version-parameterized

Before: hardcoded `0.3.1` in version and all dependency coordinates.

After: reads `tramaiVersion` from `-P` flag with `0.3.1` fallback. Dependencies use `${tramaiVersion.get()}`.

The evidence chain is now bound: if you run `-PtramaiVersion=0.4.0`, the index says `0.4.0` and the consumer smoke validates `0.4.0`.

### 3. dev.tramai resolution constrained to mavenLocal

Consumer smoke uses `exclusiveContent` to force `dev.tramai` group resolution exclusively from `mavenLocal()`. This prevents:
- Stale remote artifacts from Maven Central making the test pass accidentally
- Version resolution from untrusted sources

### 4. Checks JSON includes proving Gradle task path

Before:
```json
"releaseReadiness": "passed"
```

After:
```json
"releaseReadiness": {
  "status": "passed",
  "taskPath": ":verifyReleaseReadiness"
}
```

Consumer smoke additionally includes the exact command (built once, used for both execution and evidence):
```json
"consumerSmoke": {
  "status": "passed",
  "taskPath": ":verifySovereignRuntimeConsumerSmoke",
  "executes": "./gradlew -p examples/sovereign-runtime-consumer-smoke test -PtramaiVersion=0.3.1 --no-configuration-cache"
}
```

### 5. Git metadata fails closed

Previous: try/catch with silent fallback to `"unknown"`.

New: `require()` assertions:
- `commitSha` must match `[a-f0-9]{40}`
- `repository` must not be `"unknown/repo"`
- `refName` must not be blank or `"unknown"`

### 6. Tree hashing is platform-stable

- `invariantSeparatorsPath` instead of `.path` (Windows/Linux compatible)
- Explicit `Charsets.UTF_8`
- Delimiter bytes (`0`) between path and hash components

### 7. File hashing uses streaming

Replaced `digest.digest(file.readBytes())` with `inputStream().use {}`.

### 8. Failure messages avoid absolute paths

Before: `"Missing required artifact: /home/user/.../bundle-manifest.json"`

After: `"Missing required artifact: build/sovereign-runtime-release/bundle-manifest.json"`

### 9. Post-write structural validation uses JsonSlurper

Replaced substring checks with real JSON parsing via `JsonSlurper`:
- Validates `schemaVersion` value exactly
- Validates `artifacts` is an array
- Validates `checks` is an object
- Validates every check entry has `status` and `taskPath`

### 10. Markdown gates table includes Task column

## Verification

- `./gradlew test --rerun-tasks` — **PASS** (159 tasks)
- `./gradlew generateSovereignReleaseEvidenceIndex` — **PASS** (286 tasks, all gates executed)
- `./gradlew generateSovereignReleaseEvidenceIndex -PtramaiVersion=0.4.0` — **PASS** (version override propagates correctly)
- Evidence JSON verified: all 4 checks show `status: passed` with correct `taskPath`
- Consumer smoke now parameterized: version in evidence index matches version consumed

## Non-goals (explicitly excluded)

- ❌ Maven Central publish
- ❌ Tag creation
- ❌ Version bump
- ❌ Runtime behavior changes (apart from version parameterization in smoke)
- ❌ API changes
