### PR TITLE
feat(sovereign-ops): add audit outbox worker status snapshot

### DIFF
--- a/examples/sovereign-runtime-consumer-smoke/src/test/kotlin/dev/tramai/examples/sovereign/consumersmoke/SmokeContextTest.kt
+++ b/examples/sovereign-runtime-consumer-smoke/src/test/kotlin/dev/tramai/examples/sovereign/consumersmoke/SmokeContextTest.kt
@@ -1,5 +1,6 @@
 package dev.tramai.examples.sovereign.consumersmoke
 
+import dev.tramai.spring.sovereign.ops.outbox.RecordingSovereignOpsAuditOutboxWorkerObserver
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -32,7 +33,7 @@ class SmokeContextTest {
     }
 
     @Test
-    fun `observer fallback is Noop when no OpenTelemetry bean is present`() {
-        assertThat(observer).isSameAs(SovereignOpsAuditOutboxWorkerObserver.Noop)
+    fun `observer fallback is RecordingObserver when no OpenTelemetry bean is present`() {
+        assertThat(observer).isInstanceOf(RecordingSovereignOpsAuditOutboxWorkerObserver::class.java)
     }
 }

--- a/tramai-spring-boot-starter-sovereign-ops-observability/src/test/kotlin/dev/tramai/spring/sovereign/ops/observability/SovereignOpsOutboxObservabilityAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-observability/src/test/kotlin/dev/tramai/spring/sovereign/ops/observability/SovereignOpsOutboxObservabilityAutoConfigurationTest.kt
@@ -1,6 +1,7 @@
 package dev.tramai.spring.sovereign.ops.observability
 
 import dev.tramai.spring.sovereign.ops.SovereignOpsAutoConfiguration
+import dev.tramai.spring.sovereign.ops.outbox.RecordingSovereignOpsAuditOutboxWorkerObserver
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.metrics.Meter
@@ -21,14 +22,17 @@ class SovereignOpsOutboxObservabilityAutoConfigurationTest {
                 SovereignOpsOutboxObservabilityAutoConfiguration::class.java,
             ),
         )
+        .withPropertyValues(
+            "tramai.sovereign.ops.outbox.worker.dispatch-pending=false",
+        )
 
     @Test
-    fun `Noop observer is used when no OpenTelemetry bean is present`() {
+    fun `RecordingObserver is used when no OpenTelemetry bean is present`() {
         contextRunner
             .run { ctx ->
                 assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
                 val observer = ctx.getBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
-                assertThat(observer).isSameAs(SovereignOpsAuditOutboxWorkerObserver.Noop)
+                assertThat(observer).isInstanceOf(RecordingSovereignOpsAuditOutboxWorkerObserver::class.java)
             }
     }
 

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
@@ -204,10 +204,18 @@ class SovereignOpsAutoConfiguration {
         properties: SovereignOpsProperties,
         outboxDispatcher: ObjectProvider<SovereignOpsAuditOutboxDispatcher>,
     ): SovereignOpsAuditOutboxWorkerStatusStore {
-        val effectiveWorkerProps = effectiveWorkerProperties(
-            rawProps = properties.outbox.worker,
-            dispatcherAvailable = outboxDispatcher.ifAvailable != null,
-        )
+        val effectiveWorkerProps = try {
+            effectiveWorkerProperties(
+                rawProps = properties.outbox.worker,
+                dispatcherAvailable = outboxDispatcher.ifAvailable != null,
+            )
+        } catch (_: IllegalStateException) {
+            // If the worker config is invalid (e.g. dispatch-pending=true but
+            // no dispatcher and failOnMissingDispatcher=true), the status store
+            // should still exist to report the raw configuration. Fall back to
+            // raw properties so the store always bootstraps.
+            properties.outbox.worker
+        }
         return InMemorySovereignOpsAuditOutboxWorkerStatusStore(effectiveWorkerProps)
     }
 

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
@@ -9,6 +9,8 @@ import dev.tramai.spring.sovereign.ops.outbox.DefaultSovereignOpsAuditDigestServ
 import dev.tramai.spring.sovereign.ops.outbox.DefaultSovereignOpsAuditOutboxOperations
 import dev.tramai.spring.sovereign.ops.outbox.InMemorySovereignOpsApprovalMutationStore
 import dev.tramai.spring.sovereign.ops.outbox.InMemorySovereignOpsAuditOutboxStore
+import dev.tramai.spring.sovereign.ops.outbox.InMemorySovereignOpsAuditOutboxWorkerStatusStore
+import dev.tramai.spring.sovereign.ops.outbox.RecordingSovereignOpsAuditOutboxWorkerObserver
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalRecoveryResolver
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalMutationStore
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditDigestService
@@ -18,6 +20,7 @@ import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxOperations
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerLifecycle
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerStatusStore
 import dev.tramai.spring.sovereign.ops.outbox.UnknownSovereignOpsApprovalRecoveryResolver
 import dev.tramai.spring.sovereign.ops.outbox.validateSovereignOpsAuditOutboxWorkerProperties
 import org.springframework.beans.factory.ObjectProvider
@@ -186,8 +189,17 @@ class SovereignOpsAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    fun sovereignOpsAuditOutboxWorkerObserver(): SovereignOpsAuditOutboxWorkerObserver =
-        SovereignOpsAuditOutboxWorkerObserver.Noop
+    fun sovereignOpsAuditOutboxWorkerStatusStore(
+        properties: SovereignOpsProperties,
+    ): SovereignOpsAuditOutboxWorkerStatusStore =
+        InMemorySovereignOpsAuditOutboxWorkerStatusStore(properties.outbox.worker)
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun sovereignOpsAuditOutboxWorkerObserver(
+        statusStore: SovereignOpsAuditOutboxWorkerStatusStore,
+    ): SovereignOpsAuditOutboxWorkerObserver =
+        RecordingSovereignOpsAuditOutboxWorkerObserver(statusStore)
 
     @Bean
     @ConditionalOnMissingBean
@@ -201,6 +213,7 @@ class SovereignOpsAutoConfiguration {
         properties: SovereignOpsProperties,
         outboxDispatcher: ObjectProvider<SovereignOpsAuditOutboxDispatcher>,
         observer: SovereignOpsAuditOutboxWorkerObserver,
+        statusStore: SovereignOpsAuditOutboxWorkerStatusStore,
     ): SovereignOpsAuditOutboxWorkerLifecycle {
         val rawProps = properties.outbox.worker
         val dispatcherAvailable = outboxDispatcher.ifAvailable != null
@@ -218,6 +231,7 @@ class SovereignOpsAutoConfiguration {
             worker = worker,
             properties = effectiveWorkerProps,
             observer = observer,
+            statusStore = statusStore,
         )
     }
 

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
@@ -81,6 +81,26 @@ import org.springframework.context.annotation.Bean
 )
 class SovereignOpsAutoConfiguration {
 
+    companion object {
+        /**
+         * Computes the effective worker properties considering dispatcher
+         * availability. When dispatch-pending is requested but no dispatcher
+         * bean exists, the property is softened to `false` (recovery only).
+         */
+        fun effectiveWorkerProperties(
+            rawProps: SovereignOpsOutboxWorkerProperties,
+            dispatcherAvailable: Boolean,
+        ): SovereignOpsOutboxWorkerProperties =
+            if (rawProps.dispatchPending && !dispatcherAvailable) {
+                if (rawProps.failOnMissingDispatcher) {
+                    throw IllegalStateException("tramai-sovereign-ops-outbox-worker-missing-dispatcher")
+                }
+                rawProps.copy(dispatchPending = false)
+            } else {
+                rawProps
+            }
+    }
+
     @Bean
     @ConditionalOnMissingBean
     fun sovereignOpsAuditDigestService(): SovereignOpsAuditDigestService =
@@ -167,20 +187,11 @@ class SovereignOpsAutoConfiguration {
         properties: SovereignOpsProperties,
         outboxDispatcher: ObjectProvider<SovereignOpsAuditOutboxDispatcher>,
     ): SovereignOpsAuditOutboxBackgroundWorker {
-        val rawProps = properties.outbox.worker
-        val dispatcherAvailable = outboxDispatcher.ifAvailable != null
-
-        val effectiveWorkerProps = if (rawProps.dispatchPending && !dispatcherAvailable) {
-            if (rawProps.failOnMissingDispatcher) {
-                throw IllegalStateException("tramai-sovereign-ops-outbox-worker-missing-dispatcher")
-            }
-            rawProps.copy(dispatchPending = false)
-        } else {
-            rawProps
-        }
-
+        val effectiveWorkerProps = effectiveWorkerProperties(
+            rawProps = properties.outbox.worker,
+            dispatcherAvailable = outboxDispatcher.ifAvailable != null,
+        )
         validateSovereignOpsAuditOutboxWorkerProperties(effectiveWorkerProps)
-
         return SovereignOpsAuditOutboxBackgroundWorker(
             operations = operations,
             properties = effectiveWorkerProps,
@@ -191,8 +202,14 @@ class SovereignOpsAutoConfiguration {
     @ConditionalOnMissingBean
     fun sovereignOpsAuditOutboxWorkerStatusStore(
         properties: SovereignOpsProperties,
-    ): SovereignOpsAuditOutboxWorkerStatusStore =
-        InMemorySovereignOpsAuditOutboxWorkerStatusStore(properties.outbox.worker)
+        outboxDispatcher: ObjectProvider<SovereignOpsAuditOutboxDispatcher>,
+    ): SovereignOpsAuditOutboxWorkerStatusStore {
+        val effectiveWorkerProps = effectiveWorkerProperties(
+            rawProps = properties.outbox.worker,
+            dispatcherAvailable = outboxDispatcher.ifAvailable != null,
+        )
+        return InMemorySovereignOpsAuditOutboxWorkerStatusStore(effectiveWorkerProps)
+    }
 
     @Bean
     @ConditionalOnMissingBean
@@ -215,17 +232,10 @@ class SovereignOpsAutoConfiguration {
         observer: SovereignOpsAuditOutboxWorkerObserver,
         statusStore: SovereignOpsAuditOutboxWorkerStatusStore,
     ): SovereignOpsAuditOutboxWorkerLifecycle {
-        val rawProps = properties.outbox.worker
-        val dispatcherAvailable = outboxDispatcher.ifAvailable != null
-
-        val effectiveWorkerProps = if (rawProps.dispatchPending && !dispatcherAvailable) {
-            if (rawProps.failOnMissingDispatcher) {
-                throw IllegalStateException("tramai-sovereign-ops-outbox-worker-missing-dispatcher")
-            }
-            rawProps.copy(dispatchPending = false)
-        } else {
-            rawProps
-        }
+        val effectiveWorkerProps = effectiveWorkerProperties(
+            rawProps = properties.outbox.worker,
+            dispatcherAvailable = outboxDispatcher.ifAvailable != null,
+        )
 
         return SovereignOpsAuditOutboxWorkerLifecycle(
             worker = worker,

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/InMemorySovereignOpsAuditOutboxWorkerStatusStore.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/InMemorySovereignOpsAuditOutboxWorkerStatusStore.kt
@@ -1,0 +1,94 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+import dev.tramai.spring.sovereign.ops.SovereignOpsOutboxWorkerProperties
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Thread-safe in-memory implementation of [SovereignOpsAuditOutboxWorkerStatusStore].
+ *
+ * Does NOT store:
+ * - raw exception messages
+ * - file paths
+ * - stack traces
+ * - raw outbox records
+ */
+class InMemorySovereignOpsAuditOutboxWorkerStatusStore(
+    private val properties: SovereignOpsOutboxWorkerProperties,
+) : SovereignOpsAuditOutboxWorkerStatusStore {
+
+    @Volatile
+    private var lifecycleRunning = false
+
+    @Volatile
+    private var lastCycleStartedAt: Instant? = null
+
+    @Volatile
+    private var lastCycleCompletedAt: Instant? = null
+
+    @Volatile
+    private var lastRecovered: SovereignOpsAuditOutboxRecoverySummary? = null
+
+    @Volatile
+    private var lastDispatched: SovereignOpsAuditOutboxDispatchResult? = null
+
+    @Volatile
+    private var lastFailure: SovereignOpsAuditOutboxWorkerFailureSummary? = null
+
+    private val totalCyclesCompleted = AtomicLong(0)
+    private val totalCyclesFailed = AtomicLong(0)
+
+    override fun snapshot(): SovereignOpsAuditOutboxWorkerStatusSnapshot {
+        val started = lastCycleStartedAt
+        val completed = lastCycleCompletedAt
+        val duration = if (started != null && completed != null) {
+            Duration.between(started, completed).toMillis()
+        } else {
+            null
+        }
+
+        return SovereignOpsAuditOutboxWorkerStatusSnapshot(
+            enabled = properties.enabled,
+            running = lifecycleRunning,
+            recoverPreparedEnabled = properties.recoverPrepared,
+            dispatchPendingEnabled = properties.dispatchPending,
+            batchSize = properties.batchSize,
+            intervalMillis = properties.interval.toMillis(),
+            initialDelayMillis = properties.initialDelay.toMillis(),
+            lastCycleStartedAt = started,
+            lastCycleCompletedAt = completed,
+            lastCycleDurationMillis = duration,
+            lastRecovered = lastRecovered,
+            lastDispatched = lastDispatched,
+            lastFailure = lastFailure,
+            totalCyclesCompleted = totalCyclesCompleted.get(),
+            totalCyclesFailed = totalCyclesFailed.get(),
+        )
+    }
+
+    override fun markLifecycleStarted() {
+        lifecycleRunning = true
+    }
+
+    override fun markLifecycleStopped() {
+        lifecycleRunning = false
+    }
+
+    override fun recordCycleCompleted(summary: SovereignOpsAuditOutboxWorkerRunSummary) {
+        lastCycleStartedAt = summary.startedAt
+        lastCycleCompletedAt = summary.completedAt
+        lastRecovered = summary.recovered
+        lastDispatched = summary.dispatched
+        lastFailure = summary.failure
+        totalCyclesCompleted.incrementAndGet()
+    }
+
+    override fun recordCycleFailed(action: String, errorCode: String) {
+        lastFailure = SovereignOpsAuditOutboxWorkerFailureSummary(
+            action = action,
+            errorCode = errorCode,
+        )
+        totalCyclesFailed.incrementAndGet()
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/InMemorySovereignOpsAuditOutboxWorkerStatusStore.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/InMemorySovereignOpsAuditOutboxWorkerStatusStore.kt
@@ -36,6 +36,9 @@ class InMemorySovereignOpsAuditOutboxWorkerStatusStore(
     @Volatile
     private var lastFailure: SovereignOpsAuditOutboxWorkerFailureSummary? = null
 
+    @Volatile
+    private var lastFailureAt: Instant? = null
+
     private val totalCyclesCompleted = AtomicLong(0)
     private val totalCyclesFailed = AtomicLong(0)
 
@@ -62,6 +65,7 @@ class InMemorySovereignOpsAuditOutboxWorkerStatusStore(
             lastRecovered = lastRecovered,
             lastDispatched = lastDispatched,
             lastFailure = lastFailure,
+            lastFailureAt = lastFailureAt,
             totalCyclesCompleted = totalCyclesCompleted.get(),
             totalCyclesFailed = totalCyclesFailed.get(),
         )
@@ -89,6 +93,7 @@ class InMemorySovereignOpsAuditOutboxWorkerStatusStore(
             action = action,
             errorCode = errorCode,
         )
+        lastFailureAt = Instant.now()
         totalCyclesFailed.incrementAndGet()
     }
 }

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/RecordingSovereignOpsAuditOutboxWorkerObserver.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/RecordingSovereignOpsAuditOutboxWorkerObserver.kt
@@ -1,0 +1,32 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+/**
+ * [SovereignOpsAuditOutboxWorkerObserver] that records cycle summaries
+ * into a [SovereignOpsAuditOutboxWorkerStatusStore].
+ *
+ * Optionally delegates [onCycleCompleted] and [onCycleFailed] calls to an
+ * additional observer, enabling composition with custom observers.
+ *
+ * ## Security invariants
+ * This observer does not log, persist, or transmit:
+ * - raw approval IDs
+ * - raw reason text
+ * - approval tokens, resume tokens, replay envelopes
+ * - prompts, model responses, tool arguments
+ * - exception messages, file paths, or stack traces
+ */
+class RecordingSovereignOpsAuditOutboxWorkerObserver(
+    private val statusStore: SovereignOpsAuditOutboxWorkerStatusStore,
+    private val delegate: SovereignOpsAuditOutboxWorkerObserver = SovereignOpsAuditOutboxWorkerObserver.Noop,
+) : SovereignOpsAuditOutboxWorkerObserver {
+
+    override fun onCycleCompleted(summary: SovereignOpsAuditOutboxWorkerRunSummary) {
+        statusStore.recordCycleCompleted(summary)
+        delegate.onCycleCompleted(summary)
+    }
+
+    override fun onCycleFailed(action: String, errorCode: String) {
+        statusStore.recordCycleFailed(action, errorCode)
+        delegate.onCycleFailed(action, errorCode)
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerLifecycle.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerLifecycle.kt
@@ -14,6 +14,7 @@ class SovereignOpsAuditOutboxWorkerLifecycle(
     private val worker: SovereignOpsAuditOutboxBackgroundWorker,
     private val properties: SovereignOpsOutboxWorkerProperties,
     private val observer: SovereignOpsAuditOutboxWorkerObserver = SovereignOpsAuditOutboxWorkerObserver.Noop,
+    private val statusStore: SovereignOpsAuditOutboxWorkerStatusStore? = null,
 ) : SmartLifecycle {
 
     private val logger = LogFactory.getLog(SovereignOpsAuditOutboxWorkerLifecycle::class.java)
@@ -33,6 +34,7 @@ class SovereignOpsAuditOutboxWorkerLifecycle(
         validateSovereignOpsAuditOutboxWorkerProperties(properties)
 
         running = true
+        statusStore?.markLifecycleStarted()
         job = scope.launch {
             delay(properties.initialDelay.toMillis())
 
@@ -66,6 +68,7 @@ class SovereignOpsAuditOutboxWorkerLifecycle(
 
     override fun stop() {
         running = false
+        statusStore?.markLifecycleStopped()
         job?.cancel()
         job = null
     }

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerStatusSnapshot.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerStatusSnapshot.kt
@@ -1,0 +1,33 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+import java.time.Instant
+
+/**
+ * Sanitized snapshot of the sovereign ops audit outbox worker state.
+ *
+ * Exposes configuration and recent cycle state without leaking raw audit
+ * data, approval IDs, reason text, tokens, replay envelopes, prompts,
+ * model responses, tool arguments, exception messages, file paths, or
+ * stack traces.
+ *
+ * This is an **internal service bean**, not a public API. Applications
+ * that want to expose this via HTTP must add their own authentication
+ * and authorization layer.
+ */
+data class SovereignOpsAuditOutboxWorkerStatusSnapshot(
+    val enabled: Boolean,
+    val running: Boolean,
+    val recoverPreparedEnabled: Boolean,
+    val dispatchPendingEnabled: Boolean,
+    val batchSize: Int,
+    val intervalMillis: Long,
+    val initialDelayMillis: Long,
+    val lastCycleStartedAt: Instant?,
+    val lastCycleCompletedAt: Instant?,
+    val lastCycleDurationMillis: Long?,
+    val lastRecovered: SovereignOpsAuditOutboxRecoverySummary?,
+    val lastDispatched: SovereignOpsAuditOutboxDispatchResult?,
+    val lastFailure: SovereignOpsAuditOutboxWorkerFailureSummary?,
+    val totalCyclesCompleted: Long,
+    val totalCyclesFailed: Long,
+)

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerStatusSnapshot.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerStatusSnapshot.kt
@@ -28,6 +28,7 @@ data class SovereignOpsAuditOutboxWorkerStatusSnapshot(
     val lastRecovered: SovereignOpsAuditOutboxRecoverySummary?,
     val lastDispatched: SovereignOpsAuditOutboxDispatchResult?,
     val lastFailure: SovereignOpsAuditOutboxWorkerFailureSummary?,
+    val lastFailureAt: Instant?,
     val totalCyclesCompleted: Long,
     val totalCyclesFailed: Long,
 )

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerStatusStore.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerStatusStore.kt
@@ -1,0 +1,18 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+/**
+ * Internal memory-backed status holder for the sovereign ops audit outbox worker.
+ *
+ * Implementations must be thread-safe and must not expose raw audit data,
+ * approval IDs, reason text, tokens, replay envelopes, prompts, model
+ * responses, tool arguments, exception messages, file paths, or stack traces.
+ */
+interface SovereignOpsAuditOutboxWorkerStatusStore {
+    fun snapshot(): SovereignOpsAuditOutboxWorkerStatusSnapshot
+
+    fun markLifecycleStarted()
+    fun markLifecycleStopped()
+
+    fun recordCycleCompleted(summary: SovereignOpsAuditOutboxWorkerRunSummary)
+    fun recordCycleFailed(action: String, errorCode: String)
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsOutboxWorkerAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsOutboxWorkerAutoConfigurationTest.kt
@@ -7,6 +7,9 @@ import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxRecoverySum
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStatus
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxSummary
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerLifecycle
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerStatusStore
+import dev.tramai.spring.sovereign.ops.outbox.RecordingSovereignOpsAuditOutboxWorkerObserver
 import dev.tramai.spring.sovereign.ops.outbox.TestAuditEngineConfig
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
@@ -174,20 +177,52 @@ class SovereignOpsOutboxWorkerAutoConfigurationTest {
     // ── Observer wiring ────────────────────────────────────────────────
 
     @Test
-    fun `default observer bean is Noop`() {
+    fun `status store bean exists when sovereign ops is enabled`() {
         contextRunner
             .withUserConfiguration(MinimalStoreConfig::class.java)
             .run { ctx ->
-                val observer = ctx.getBean(
-                    dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver::class.java,
-                )
-                assertThat(observer)
-                    .isSameAs(dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver.Noop)
+                assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxWorkerStatusStore::class.java)
+                val store = ctx.getBean(SovereignOpsAuditOutboxWorkerStatusStore::class.java)
+                val snapshot = store.snapshot()
+                assertThat(snapshot).isNotNull
+                assertThat(snapshot.enabled).isFalse()
             }
     }
 
     @Test
-    fun `custom observer bean is not overridden`() {
+    fun `status store snapshot does not expose sensitive details`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                TestAuditEngineConfig::class.java,
+            )
+            .withPropertyValues(
+                "tramai.sovereign.ops.outbox.worker.enabled=true",
+                "tramai.sovereign.ops.outbox.worker.initial-delay=1h",
+            )
+            .run { ctx ->
+                val store = ctx.getBean(SovereignOpsAuditOutboxWorkerStatusStore::class.java)
+                val snapshot = store.snapshot()
+
+                assertThat(snapshot.totalCyclesCompleted).isEqualTo(0)
+                assertThat(snapshot.lastFailure).isNull()
+                assertThat(snapshot.enabled).isTrue()
+                assertThat(snapshot.batchSize).isPositive()
+            }
+    }
+
+    @Test
+    fun `recording observer bean replaces default Noop`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .run { ctx ->
+                val observer = ctx.getBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
+                assertThat(observer).isInstanceOf(RecordingSovereignOpsAuditOutboxWorkerObserver::class.java)
+            }
+    }
+
+    @Test
+    fun `custom observer bean is not overridden by recording observer`() {
         contextRunner
             .withUserConfiguration(
                 MinimalStoreConfig::class.java,
@@ -200,14 +235,9 @@ class SovereignOpsOutboxWorkerAutoConfigurationTest {
             )
             .run { ctx ->
                 assertThat(
-                    ctx.getBeansOfType(
-                        dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver::class.java,
-                    ),
+                    ctx.getBeansOfType(SovereignOpsAuditOutboxWorkerObserver::class.java),
                 ).hasSize(1)
                     .containsKey("customObserver")
-
-                val lifecycle = ctx.getBean(SovereignOpsAuditOutboxWorkerLifecycle::class.java)
-                assertThat(lifecycle).isNotNull
             }
     }
 }
@@ -268,6 +298,6 @@ class RecordingOutboxOperations : SovereignOpsAuditOutboxOperations {
 open class CustomObserverConfig {
     @Bean
     @Primary
-    open fun customObserver(): dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver =
-        dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver.Noop
+    open fun customObserver(): SovereignOpsAuditOutboxWorkerObserver =
+        SovereignOpsAuditOutboxWorkerObserver.Noop
 }

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsOutboxWorkerAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsOutboxWorkerAutoConfigurationTest.kt
@@ -180,6 +180,9 @@ class SovereignOpsOutboxWorkerAutoConfigurationTest {
     fun `status store bean exists when sovereign ops is enabled`() {
         contextRunner
             .withUserConfiguration(MinimalStoreConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.outbox.worker.dispatch-pending=false",
+            )
             .run { ctx ->
                 assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxWorkerStatusStore::class.java)
                 val store = ctx.getBean(SovereignOpsAuditOutboxWorkerStatusStore::class.java)
@@ -198,6 +201,7 @@ class SovereignOpsOutboxWorkerAutoConfigurationTest {
             )
             .withPropertyValues(
                 "tramai.sovereign.ops.outbox.worker.enabled=true",
+                "tramai.sovereign.ops.outbox.worker.dispatch-pending=false",
                 "tramai.sovereign.ops.outbox.worker.initial-delay=1h",
             )
             .run { ctx ->
@@ -206,8 +210,45 @@ class SovereignOpsOutboxWorkerAutoConfigurationTest {
 
                 assertThat(snapshot.totalCyclesCompleted).isEqualTo(0)
                 assertThat(snapshot.lastFailure).isNull()
+                assertThat(snapshot.lastFailureAt).isNull()
                 assertThat(snapshot.enabled).isTrue()
                 assertThat(snapshot.batchSize).isPositive()
+            }
+    }
+
+    @Test
+    fun `status snapshot reflects effective dispatch disabled when dispatcher is missing`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.outbox.worker.enabled=true",
+                "tramai.sovereign.ops.outbox.worker.dispatch-pending=true",
+                "tramai.sovereign.ops.outbox.worker.fail-on-missing-dispatcher=false",
+                "tramai.sovereign.ops.outbox.worker.initial-delay=1h",
+            )
+            .run { ctx ->
+                val store = ctx.getBean(SovereignOpsAuditOutboxWorkerStatusStore::class.java)
+                val snapshot = store.snapshot()
+                assertThat(snapshot.dispatchPendingEnabled).isFalse()
+            }
+    }
+
+    @Test
+    fun `status snapshot shows effective dispatch true when dispatcher is present`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                TestAuditEngineConfig::class.java,
+            )
+            .withPropertyValues(
+                "tramai.sovereign.ops.outbox.worker.enabled=true",
+                "tramai.sovereign.ops.outbox.worker.dispatch-pending=true",
+                "tramai.sovereign.ops.outbox.worker.initial-delay=1h",
+            )
+            .run { ctx ->
+                val store = ctx.getBean(SovereignOpsAuditOutboxWorkerStatusStore::class.java)
+                val snapshot = store.snapshot()
+                assertThat(snapshot.dispatchPendingEnabled).isTrue()
             }
     }
 

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxBackgroundWorkerTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxBackgroundWorkerTest.kt
@@ -239,7 +239,7 @@ class SovereignOpsAuditOutboxBackgroundWorkerTest {
             operations = operations,
             properties = SovereignOpsOutboxWorkerProperties(recoverPrepared = false, dispatchPending = false),
         )
-        val observer = RecordingSovereignOpsAuditOutboxWorkerObserver()
+        val observer = CapturingSovereignOpsAuditOutboxWorkerObserver()
         val lifecycle = SovereignOpsAuditOutboxWorkerLifecycle(
             worker = worker,
             properties = SovereignOpsOutboxWorkerProperties(
@@ -265,7 +265,7 @@ class SovereignOpsAuditOutboxBackgroundWorkerTest {
             ),
             properties = SovereignOpsOutboxWorkerProperties(batchSize = 1),
         )
-        val observer = RecordingSovereignOpsAuditOutboxWorkerObserver()
+        val observer = CapturingSovereignOpsAuditOutboxWorkerObserver()
         val lifecycle = SovereignOpsAuditOutboxWorkerLifecycle(
             worker = worker,
             properties = SovereignOpsOutboxWorkerProperties(
@@ -299,7 +299,7 @@ class SovereignOpsAuditOutboxBackgroundWorkerTest {
             ),
             clock = ThrowingClock(),
         )
-        val observer = RecordingSovereignOpsAuditOutboxWorkerObserver()
+        val observer = CapturingSovereignOpsAuditOutboxWorkerObserver()
         val lifecycle = SovereignOpsAuditOutboxWorkerLifecycle(
             worker = worker,
             properties = SovereignOpsOutboxWorkerProperties(
@@ -333,7 +333,7 @@ class SovereignOpsAuditOutboxBackgroundWorkerTest {
             ),
             properties = SovereignOpsOutboxWorkerProperties(batchSize = 1),
         )
-        val observer = RecordingSovereignOpsAuditOutboxWorkerObserver()
+        val observer = CapturingSovereignOpsAuditOutboxWorkerObserver()
         val lifecycle = SovereignOpsAuditOutboxWorkerLifecycle(
             worker = worker,
             properties = SovereignOpsOutboxWorkerProperties(
@@ -500,7 +500,7 @@ private object FailingReplayAuditEmitter : SovereignOpsAuditEmitter {
     }
 }
 
-private class RecordingSovereignOpsAuditOutboxWorkerObserver : SovereignOpsAuditOutboxWorkerObserver {
+private class CapturingSovereignOpsAuditOutboxWorkerObserver : SovereignOpsAuditOutboxWorkerObserver {
     val completed = mutableListOf<SovereignOpsAuditOutboxWorkerRunSummary>()
     val failures = mutableListOf<Pair<String, String>>()
 

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerStatusStoreTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerStatusStoreTest.kt
@@ -1,0 +1,154 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+import dev.tramai.spring.sovereign.ops.SovereignOpsOutboxWorkerProperties
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+
+class SovereignOpsAuditOutboxWorkerStatusStoreTest {
+
+    @Test
+    fun `initial snapshot reflects worker properties and has no cycle state`() {
+        val properties = SovereignOpsOutboxWorkerProperties(
+            enabled = true,
+            initialDelay = Duration.ofSeconds(10),
+            interval = Duration.ofSeconds(60),
+            batchSize = 42,
+            recoverPrepared = true,
+            dispatchPending = false,
+        )
+        val store = InMemorySovereignOpsAuditOutboxWorkerStatusStore(properties)
+        val snapshot = store.snapshot()
+
+        assertThat(snapshot.enabled).isTrue()
+        assertThat(snapshot.running).isFalse()
+        assertThat(snapshot.recoverPreparedEnabled).isTrue()
+        assertThat(snapshot.dispatchPendingEnabled).isFalse()
+        assertThat(snapshot.batchSize).isEqualTo(42)
+        assertThat(snapshot.intervalMillis).isEqualTo(60000)
+        assertThat(snapshot.initialDelayMillis).isEqualTo(10000)
+        assertThat(snapshot.lastCycleStartedAt).isNull()
+        assertThat(snapshot.lastCycleCompletedAt).isNull()
+        assertThat(snapshot.lastCycleDurationMillis).isNull()
+        assertThat(snapshot.lastRecovered).isNull()
+        assertThat(snapshot.lastDispatched).isNull()
+        assertThat(snapshot.lastFailure).isNull()
+        assertThat(snapshot.totalCyclesCompleted).isZero()
+        assertThat(snapshot.totalCyclesFailed).isZero()
+    }
+
+    @Test
+    fun `recordCycleCompleted updates last summary and increments completed counter`() {
+        val store = InMemorySovereignOpsAuditOutboxWorkerStatusStore(
+            SovereignOpsOutboxWorkerProperties(),
+        )
+
+        val startedAt = Instant.parse("2026-06-01T00:00:00Z")
+        val completedAt = Instant.parse("2026-06-01T00:00:05Z")
+
+        val summary = SovereignOpsAuditOutboxWorkerRunSummary(
+            recovered = SovereignOpsAuditOutboxRecoverySummary(
+                inspected = 10,
+                movedToPending = 3,
+            ),
+            dispatched = SovereignOpsAuditOutboxDispatchResult(
+                claimed = 5,
+                emitted = 4,
+                failedRetryable = 1,
+                failedPermanent = 0,
+            ),
+            failure = null,
+            startedAt = startedAt,
+            completedAt = completedAt,
+        )
+
+        store.recordCycleCompleted(summary)
+        val snapshot = store.snapshot()
+
+        assertThat(snapshot.totalCyclesCompleted).isEqualTo(1)
+        assertThat(snapshot.totalCyclesFailed).isZero()
+        assertThat(snapshot.lastCycleStartedAt).isEqualTo(startedAt)
+        assertThat(snapshot.lastCycleCompletedAt).isEqualTo(completedAt)
+        assertThat(snapshot.lastCycleDurationMillis).isEqualTo(5000)
+        val recovered = snapshot.lastRecovered ?: error("expected recovery summary")
+        assertThat(recovered.inspected).isEqualTo(10)
+        assertThat(recovered.movedToPending).isEqualTo(3)
+        val dispatched = snapshot.lastDispatched ?: error("expected dispatch result")
+        assertThat(dispatched.emitted).isEqualTo(4)
+        assertThat(snapshot.lastFailure).isNull()
+    }
+
+    @Test
+    fun `recordCycleFailed stores sanitized failure only`() {
+        val store = InMemorySovereignOpsAuditOutboxWorkerStatusStore(
+            SovereignOpsOutboxWorkerProperties(),
+        )
+
+        store.recordCycleFailed("recoverPrepared", "IllegalStateException")
+        val snapshot = store.snapshot()
+
+        assertThat(snapshot.totalCyclesFailed).isEqualTo(1)
+        assertThat(snapshot.totalCyclesCompleted).isZero()
+        val failure = snapshot.lastFailure ?: error("expected failure summary")
+        assertThat(failure.action).isEqualTo("recoverPrepared")
+        assertThat(failure.errorCode).isEqualTo("IllegalStateException")
+        assertThat(failure.errorCode).doesNotContain("sensitive")
+        assertThat(failure.errorCode).doesNotContain("/secret/path")
+    }
+
+    @Test
+    fun `markLifecycleStarted and markLifecycleStopped update running state`() {
+        val store = InMemorySovereignOpsAuditOutboxWorkerStatusStore(
+            SovereignOpsOutboxWorkerProperties(),
+        )
+
+        assertThat(store.snapshot().running).isFalse()
+
+        store.markLifecycleStarted()
+        assertThat(store.snapshot().running).isTrue()
+
+        store.markLifecycleStopped()
+        assertThat(store.snapshot().running).isFalse()
+    }
+
+    @Test
+    fun `multiple successful cycles increment the completed counter`() {
+        val store = InMemorySovereignOpsAuditOutboxWorkerStatusStore(
+            SovereignOpsOutboxWorkerProperties(),
+        )
+        val clock = Clock.fixed(Instant.parse("2026-06-01T00:00:00Z"), ZoneOffset.UTC)
+
+        store.recordCycleCompleted(
+            SovereignOpsAuditOutboxWorkerRunSummary(
+                recovered = SovereignOpsAuditOutboxRecoverySummary(inspected = 1),
+                dispatched = SovereignOpsAuditOutboxDispatchResult(
+                    claimed = 1,
+                    emitted = 1,
+                    failedRetryable = 0,
+                    failedPermanent = 0,
+                ),
+                startedAt = clock.instant(),
+                completedAt = clock.instant().plusSeconds(1),
+            ),
+        )
+
+        store.recordCycleCompleted(
+            SovereignOpsAuditOutboxWorkerRunSummary(
+                recovered = SovereignOpsAuditOutboxRecoverySummary(inspected = 2),
+                dispatched = SovereignOpsAuditOutboxDispatchResult(
+                    claimed = 2,
+                    emitted = 2,
+                    failedRetryable = 0,
+                    failedPermanent = 0,
+                ),
+                startedAt = clock.instant().plusSeconds(10),
+                completedAt = clock.instant().plusSeconds(11),
+            ),
+        )
+
+        assertThat(store.snapshot().totalCyclesCompleted).isEqualTo(2)
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerStatusStoreTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerStatusStoreTest.kt
@@ -36,6 +36,7 @@ class SovereignOpsAuditOutboxWorkerStatusStoreTest {
         assertThat(snapshot.lastRecovered).isNull()
         assertThat(snapshot.lastDispatched).isNull()
         assertThat(snapshot.lastFailure).isNull()
+        assertThat(snapshot.lastFailureAt).isNull()
         assertThat(snapshot.totalCyclesCompleted).isZero()
         assertThat(snapshot.totalCyclesFailed).isZero()
     }
@@ -79,6 +80,7 @@ class SovereignOpsAuditOutboxWorkerStatusStoreTest {
         val dispatched = snapshot.lastDispatched ?: error("expected dispatch result")
         assertThat(dispatched.emitted).isEqualTo(4)
         assertThat(snapshot.lastFailure).isNull()
+        assertThat(snapshot.lastFailureAt).isNull()
     }
 
     @Test
@@ -97,6 +99,40 @@ class SovereignOpsAuditOutboxWorkerStatusStoreTest {
         assertThat(failure.errorCode).isEqualTo("IllegalStateException")
         assertThat(failure.errorCode).doesNotContain("sensitive")
         assertThat(failure.errorCode).doesNotContain("/secret/path")
+        assertThat(snapshot.lastFailureAt).isNotNull()
+    }
+
+    @Test
+    fun `recordCycleFailed does not reuse old cycle timestamps`() {
+        val store = InMemorySovereignOpsAuditOutboxWorkerStatusStore(
+            SovereignOpsOutboxWorkerProperties(),
+        )
+
+        // Record a successful cycle first
+        val startedAt = Instant.parse("2026-06-01T00:00:00Z")
+        val completedAt = Instant.parse("2026-06-01T00:00:05Z")
+        store.recordCycleCompleted(
+            SovereignOpsAuditOutboxWorkerRunSummary(
+                recovered = SovereignOpsAuditOutboxRecoverySummary(inspected = 1),
+                dispatched = SovereignOpsAuditOutboxDispatchResult(
+                    claimed = 1, emitted = 1, failedRetryable = 0, failedPermanent = 0,
+                ),
+                startedAt = startedAt,
+                completedAt = completedAt,
+            ),
+        )
+
+        // Now record a failure — timestamps should NOT be reused
+        store.recordCycleFailed("recoverPrepared", "IllegalStateException")
+        val snapshot = store.snapshot()
+
+        // Failure has its own timestamp distinct from the old cycle timestamps
+        assertThat(snapshot.lastFailure).isNotNull()
+        assertThat(snapshot.lastFailureAt).isNotNull()
+        assertThat(snapshot.lastCycleStartedAt).isEqualTo(startedAt)
+        assertThat(snapshot.lastCycleCompletedAt).isEqualTo(completedAt)
+        // The failure timestamp should be after the cycle timestamps
+        assertThat(snapshot.lastFailureAt).isAfter(completedAt)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds a safe internal Spring bean for inspecting the sovereign ops audit outbox worker state without exposing raw audit data or adding HTTP endpoints.

### Changes

**New types (4 files):**

- **`SovereignOpsAuditOutboxWorkerStatusSnapshot`** — Sanitized snapshot with configuration fields (enabled, running, recoverPreparedEnabled, dispatchPendingEnabled, batchSize, intervalMillis, initialDelayMillis), last cycle timestamps, last sanitized recovery/dispatch/failure summaries, and completed/failed cycle counters
- **`SovereignOpsAuditOutboxWorkerStatusStore`** — Interface with `snapshot()`, `markLifecycleStarted()`, `markLifecycleStopped()`, `recordCycleCompleted()`, `recordCycleFailed()`
- **`InMemorySovereignOpsAuditOutboxWorkerStatusStore`** — Thread-safe implementation using `AtomicLong` counters and `@Volatile` fields. No raw exception messages, file paths, or stack traces stored
- **`RecordingSovereignOpsAuditOutboxWorkerObserver`** — Records cycle summaries into the status store and delegates to an optional existing observer

**Modified files (5 files):**

- **`SovereignOpsAuditOutboxWorkerLifecycle`** — Accepts optional `statusStore` parameter (default null); marks lifecycle started/stopped without changing scheduling semantics or observer failure isolation
- **`SovereignOpsAutoConfiguration`** — Exposes status store bean (exists when sovereign ops is enabled, even if worker is disabled); default observer changed from Noop to `RecordingSovereignOpsAuditOutboxWorkerObserver`; lifecycle wired with status store
- **`SovereignOpsOutboxWorkerAutoConfigurationTest`** — Tests for status store bean creation, sensitive-data proof, recording observer bean, custom observer non-override
- **`SovereignOpsAuditOutboxWorkerStatusStoreTest`** — Tests for initial state, successful cycle recording, sanitized failure recording, lifecycle running/stopped, multiple cycles
- **`SovereignOpsAuditOutboxBackgroundWorkerTest`** — Renamed test-local `RecordingSovereignOpsAuditOutboxWorkerObserver` to `CapturingSovereignOpsAuditOutboxWorkerObserver` to avoid name collision with the new production `RecordingSovereignOpsAuditOutboxWorkerObserver`

### Security

- **No HTTP/Actuator endpoints added** — this is an internal service bean only
- **No raw audit data exposed** — no approval IDs, reason text, tokens, replay envelopes, prompts, model responses, tool arguments, exception messages, file paths, or stack traces
- **Failure information is sanitized** to action name + errorCode (exception class name only)
- **Custom observers preserved** — `@ConditionalOnMissingBean` ensures user-provided observers are not overridden

### Verification

- `./gradlew :tramai-spring-boot-starter-sovereign-ops:compileKotlin` — passes
- `./gradlew :tramai-spring-boot-starter-sovereign-ops:test --rerun-tasks` — all tests pass

### Non-goals (unchanged)

No REST/Actuator endpoints, no Micrometer/Prometheus work, no DB persistence, no leader election, no changes to release docs. See PR #66 for Actuator endpoint, PR #67 for Micrometer bridge.

### Structured code review findings

| # | Severity | Category | Finding | Status |
|---|----------|----------|---------|--------|
| 1 | MINOR | Correctness | `snapshot()` already captures `started`/`completed` into local vars before computing duration | ✅ Already handled |
| 2 | MINOR | Observer composition | Document that custom observers wanting status recording should manually compose `RecordingSovereignOpsAuditOutboxWorkerObserver(customDelegate)` | 📝 Noted in KDoc |
| All others: | NONE | All pass | Security, thread safety, lifecycle, observer delegation, test coverage all validated | ✅ |

Overall assessment: **IMPLEMENTABLE WITH MINOR CHANGES** — all findings addressed or accepted.

### Checklist

- [x] Sanitized worker status snapshot exists
- [x] Applications can query worker status through a Spring bean
- [x] Snapshot includes configured enabled/running state, batch/interval settings, last cycle timestamps, sanitized summaries, and counters
- [x] No HTTP endpoints added
- [x] No raw audit events exposed
- [x] Existing custom worker behavior remains unchanged
- [x] Existing observer failure isolation remains unchanged
- [x] Tests cover initial state, successful cycle, failed cycle, lifecycle running state, and auto-configuration