### PR TITLE
feat(sovereign-ops): add optional Actuator endpoint for worker status

### DIFF
--- a/docs/releases/sovereign-runtime-release-readiness.md
+++ b/docs/releases/sovereign-runtime-release-readiness.md
@@ -25,6 +25,7 @@ Candidate release: 0.4.0 or the next unreleased version. No tag, no Maven Centra
 | Background worker (recovery + dispatch) | Implemented / evolving | tramai-spring-boot-starter-sovereign-ops | Unit + integration tests |
 | Worker observer SPI | Implemented | tramai-spring-boot-starter-sovereign-ops | Unit tests |
 | OpenTelemetry worker metrics | Implemented | tramai-spring-boot-starter-sovereign-ops-observability | Unit tests |
+| Optional read-only Actuator worker status endpoint | Implemented / opt-in | tramai-spring-boot-starter-sovereign-ops-actuator | Unit tests |
 | Evidence generation | Implemented / evolving | Release artifacts, examples | Smoke tests |
 | Sovereign document intelligence example | Implemented | examples:sovereign-document-intelligence | Smoke test |
 
@@ -34,7 +35,7 @@ These capabilities are NOT claimed as complete, stable, or production-ready:
 
 - Stable 1.0 public API
 - Maven Central release of sovereign runtime modules (not verified)
-- REST/Actuator operational endpoints
+- Broad REST/Actuator operational control endpoints
 - Micrometer / Prometheus / dashboard integration
 - Database-backed persistence or outbox
 - Distributed worker leader election

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ opentelemetry-sdk-metrics = { module = "io.opentelemetry:opentelemetry-sdk-metri
 opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testing", version.ref = "opentelemetry" }
 opentelemetry-sdk-trace = { module = "io.opentelemetry:opentelemetry-sdk-trace", version.ref = "opentelemetry" }
 spring-boot-autoconfigure = { module = "org.springframework.boot:spring-boot-autoconfigure", version.ref = "spring-boot" }
+spring-boot-actuator = { module = "org.springframework.boot:spring-boot-actuator", version.ref = "spring-boot" }
 spring-boot-configuration-processor = { module = "org.springframework.boot:spring-boot-configuration-processor", version.ref = "spring-boot" }
 spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web", version.ref = "spring-boot" }
 spring-boot-starter-validation = { module = "org.springframework.boot:spring-boot-starter-validation", version.ref = "spring-boot" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ include(
     "tramai-spring-boot-starter-sovereign",
     "tramai-spring-boot-starter-sovereign-persistence-file",
     "tramai-spring-boot-starter-sovereign-ops",
+    "tramai-spring-boot-starter-sovereign-ops-actuator",
     "tramai-spring-boot-starter-sovereign-ops-observability",
     "tramai-scheduler",
     "tramai-security",

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/README.md
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/README.md
@@ -1,0 +1,56 @@
+# TramAI Sovereign Ops Actuator
+
+Optional Spring Boot Actuator integration for sovereign ops worker status.
+
+This module exposes a read-only Actuator endpoint that returns the sanitized
+audit outbox worker status snapshot from the sovereign ops starter.
+
+It does NOT expose:
+- Raw outbox records or outbox IDs
+- Approval IDs, reason text, tokens, or replay envelopes
+- Prompts, model responses, or tool arguments
+- Exception messages, file paths, or stack traces
+
+## Enable
+
+Add the dependency:
+
+```xml
+<dependency>
+    <groupId>dev.tramai</groupId>
+    <artifactId>tramai-spring-boot-starter-sovereign-ops-actuator</artifactId>
+</dependency>
+```
+
+Enable the endpoint in your application:
+
+```yaml
+tramai:
+  sovereign:
+    ops:
+      actuator:
+        worker-status:
+          enabled: true
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: tramaiSovereignOpsWorker
+```
+
+The TramAI property creates the endpoint bean. Spring Boot Actuator exposure
+must be configured separately -- the endpoint is disabled by default.
+
+## Endpoint
+
+- **ID:** `tramaiSovereignOpsWorker`
+- **URL:** `/actuator/tramaiSovereignOpsWorker`
+- **Method:** GET
+- **Response:** `SovereignOpsAuditOutboxWorkerStatusSnapshot`
+
+## Security
+
+This endpoint returns only sanitized operational state. Applications that
+expose the endpoint over HTTP should add their own authentication and
+authorization layer (e.g., Spring Security).

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/build.gradle.kts
@@ -1,0 +1,39 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    `java-library`
+    alias(libs.plugins.kotlin.jvm)
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+    withSourcesJar()
+}
+
+kotlin {
+    jvmToolchain(21)
+    compilerOptions {
+        jvmTarget.set(JvmTarget.fromTarget("21"))
+    }
+}
+
+dependencies {
+    api(project(":tramai-spring-boot-starter-sovereign-ops"))
+
+    implementation(libs.spring.boot.autoconfigure)
+    implementation(libs.spring.boot.actuator)
+
+    annotationProcessor(libs.spring.boot.configuration.processor)
+
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.kotlin.test.junit5)
+    testImplementation(libs.spring.boot.starter.test)
+    testImplementation("org.junit.jupiter:junit-jupiter")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsActuatorAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsActuatorAutoConfiguration.kt
@@ -1,0 +1,44 @@
+package dev.tramai.spring.sovereign.ops.actuator
+
+import dev.tramai.spring.sovereign.ops.SovereignOpsAutoConfiguration
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerStatusStore
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+
+/**
+ * Auto-configuration for the sovereign ops worker status Actuator endpoint.
+ *
+ * Runs after [SovereignOpsAutoConfiguration] so the status store bean is available.
+ * The endpoint is only created when:
+ * - Actuator is on the classpath (`@ConditionalOnClass(Endpoint::class)`)
+ * - A [SovereignOpsAuditOutboxWorkerStatusStore] bean exists
+ * - `tramai.sovereign.ops.actuator.worker-status.enabled=true`
+ * - No custom [SovereignOpsWorkerStatusEndpoint] bean has been registered
+ *
+ * The endpoint is disabled by default.
+ */
+@AutoConfiguration(after = [SovereignOpsAutoConfiguration::class])
+@ConditionalOnClass(Endpoint::class)
+@EnableConfigurationProperties(SovereignOpsWorkerStatusEndpointProperties::class)
+class SovereignOpsActuatorAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean(SovereignOpsAuditOutboxWorkerStatusStore::class)
+    @ConditionalOnProperty(
+        prefix = "tramai.sovereign.ops.actuator.worker-status",
+        name = ["enabled"],
+        havingValue = "true",
+        matchIfMissing = false,
+    )
+    fun sovereignOpsWorkerStatusEndpoint(
+        statusStore: SovereignOpsAuditOutboxWorkerStatusStore,
+    ): SovereignOpsWorkerStatusEndpoint =
+        SovereignOpsWorkerStatusEndpoint(statusStore)
+}

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsWorkerStatusEndpoint.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsWorkerStatusEndpoint.kt
@@ -1,0 +1,40 @@
+package dev.tramai.spring.sovereign.ops.actuator
+
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerStatusSnapshot
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerStatusStore
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation
+
+/**
+ * Read-only Actuator endpoint exposing the sanitized sovereign ops audit outbox worker status.
+ *
+ * Returns [SovereignOpsAuditOutboxWorkerStatusSnapshot] which contains only:
+ * - configuration state (enabled, running, dispatch settings)
+ * - last cycle timestamps and sanitized summaries
+ * - completed/failed cycle counters
+ *
+ * Does NOT expose:
+ * - raw outbox records
+ * - approval IDs, reason text, tokens, replay envelopes
+ * - prompts, model responses, tool arguments
+ * - exception messages, file paths, or stack traces
+ *
+ * Disabled by default. Enable with:
+ * ```
+ * tramai.sovereign.ops.actuator.worker-status.enabled=true
+ * ```
+ *
+ * Note: The TramAI property only creates the endpoint bean. Spring Boot
+ * Actuator exposure must also be configured by the application:
+ * ```
+ * management.endpoints.web.exposure.include=tramaiSovereignOpsWorker
+ * ```
+ */
+@Endpoint(id = "tramaiSovereignOpsWorker")
+class SovereignOpsWorkerStatusEndpoint(
+    private val statusStore: SovereignOpsAuditOutboxWorkerStatusStore,
+) {
+    @ReadOperation
+    fun status(): SovereignOpsAuditOutboxWorkerStatusSnapshot =
+        statusStore.snapshot()
+}

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsWorkerStatusEndpointProperties.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsWorkerStatusEndpointProperties.kt
@@ -1,0 +1,8 @@
+package dev.tramai.spring.sovereign.ops.actuator
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "tramai.sovereign.ops.actuator.worker-status")
+data class SovereignOpsWorkerStatusEndpointProperties(
+    val enabled: Boolean = false,
+)

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.tramai.spring.sovereign.ops.actuator.SovereignOpsActuatorAutoConfiguration

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsActuatorAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsActuatorAutoConfigurationTest.kt
@@ -1,0 +1,130 @@
+package dev.tramai.spring.sovereign.ops.actuator
+
+import dev.tramai.spring.sovereign.ops.SovereignOpsAutoConfiguration
+import dev.tramai.spring.sovereign.ops.SovereignOpsOutboxWorkerProperties
+import dev.tramai.spring.sovereign.ops.outbox.InMemorySovereignOpsAuditOutboxWorkerStatusStore
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerStatusSnapshot
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerStatusStore
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Duration
+
+class SovereignOpsActuatorAutoConfigurationTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                SovereignOpsAutoConfiguration::class.java,
+                SovereignOpsActuatorAutoConfiguration::class.java,
+            ),
+        )
+        .withPropertyValues(
+            "tramai.sovereign.ops.outbox.worker.dispatch-pending=false",
+        )
+
+    @Test
+    fun `endpoint is not created by default`() {
+        contextRunner
+            .run { ctx ->
+                assertThat(ctx).doesNotHaveBean(SovereignOpsWorkerStatusEndpoint::class.java)
+            }
+    }
+
+    @Test
+    fun `endpoint is created when worker status actuator endpoint is enabled`() {
+        contextRunner
+            .withUserConfiguration(StatusStoreConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.worker-status.enabled=true",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SovereignOpsWorkerStatusEndpoint::class.java)
+                val endpoint = ctx.getBean(SovereignOpsWorkerStatusEndpoint::class.java)
+                val snapshot = endpoint.status()
+                assertThat(snapshot).isNotNull
+            }
+    }
+
+    @Test
+    fun `read operation returns sanitized worker status snapshot`() {
+        contextRunner
+            .withUserConfiguration(StatusStoreConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.worker-status.enabled=true",
+            )
+            .run { ctx ->
+                val endpoint = ctx.getBean(SovereignOpsWorkerStatusEndpoint::class.java)
+                val snapshot = endpoint.status()
+
+                assertThat(snapshot.enabled).isFalse()
+                assertThat(snapshot.running).isFalse()
+                assertThat(snapshot.recoverPreparedEnabled).isTrue()
+                assertThat(snapshot.dispatchPendingEnabled).isFalse()
+                assertThat(snapshot.batchSize).isEqualTo(42)
+                assertThat(snapshot.initialDelayMillis).isEqualTo(Duration.ofSeconds(5).toMillis())
+                assertThat(snapshot.intervalMillis).isEqualTo(Duration.ofMinutes(1).toMillis())
+                assertThat(snapshot.totalCyclesCompleted).isZero()
+                assertThat(snapshot.totalCyclesFailed).isZero()
+                assertThat(snapshot.lastCycleStartedAt).isNull()
+                assertThat(snapshot.lastCycleCompletedAt).isNull()
+                assertThat(snapshot.lastCycleDurationMillis).isNull()
+                assertThat(snapshot.lastRecovered).isNull()
+                assertThat(snapshot.lastDispatched).isNull()
+                assertThat(snapshot.lastFailure).isNull()
+                assertThat(snapshot.lastFailureAt).isNull()
+            }
+    }
+
+    @Test
+    fun `endpoint is not created without status store`() {
+        ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(SovereignOpsActuatorAutoConfiguration::class.java),
+            )
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.worker-status.enabled=true",
+            )
+            .run { ctx ->
+                assertThat(ctx).doesNotHaveBean(SovereignOpsWorkerStatusEndpoint::class.java)
+            }
+    }
+
+    @Test
+    fun `endpoint exposes read operation only`() {
+        val statusMethod = SovereignOpsWorkerStatusEndpoint::class.java.getDeclaredMethod("status")
+        assertThat(statusMethod.returnType).isEqualTo(SovereignOpsAuditOutboxWorkerStatusSnapshot::class.java)
+        assertThat(statusMethod.getDeclaredAnnotation(org.springframework.boot.actuate.endpoint.annotation.ReadOperation::class.java))
+            .isNotNull()
+
+        val methods = SovereignOpsWorkerStatusEndpoint::class.java.declaredMethods
+            .filter {
+                it.getDeclaredAnnotation(org.springframework.boot.actuate.endpoint.annotation.ReadOperation::class.java) != null
+            }
+        assertThat(methods).containsExactly(statusMethod)
+
+        val writeOps = SovereignOpsWorkerStatusEndpoint::class.java.declaredMethods
+            .filter {
+                it.getDeclaredAnnotation(org.springframework.boot.actuate.endpoint.annotation.WriteOperation::class.java) != null
+            }
+        assertThat(writeOps).isEmpty()
+    }
+}
+
+@Configuration
+open class StatusStoreConfig {
+    @Bean
+    open fun statusStore(): SovereignOpsAuditOutboxWorkerStatusStore =
+        InMemorySovereignOpsAuditOutboxWorkerStatusStore(
+            SovereignOpsOutboxWorkerProperties(
+                recoverPrepared = true,
+                dispatchPending = false,
+                batchSize = 42,
+                initialDelay = Duration.ofSeconds(5),
+                interval = Duration.ofMinutes(1),
+            ),
+        )
+}


### PR DESCRIPTION
## Summary

Adds an optional, disabled-by-default Spring Boot Actuator endpoint that exposes the sanitized sovereign ops audit outbox worker status snapshot (from PR #65).

### Design

New dedicated module: `tramai-spring-boot-starter-sovereign-ops-actuator`
- Separate from the base ops starter — no Actuator dependency added there
- Follows the same pattern as the existing `tramai-spring-boot-starter-sovereign-ops-observability` module

### Files changed

**New files (7):**

| File | Purpose |
|------|---------|
| `tramai-spring-boot-starter-sovereign-ops-actuator/build.gradle.kts` | Module build file |
| `tramai-spring-boot-starter-sovereign-ops-actuator/README.md` | Enablement and security docs |
| `.../actuator/SovereignOpsActuatorAutoConfiguration.kt` | Auto-configuration with conditional guards |
| `.../actuator/SovereignOpsWorkerStatusEndpoint.kt` | Read-only `@Endpoint(id = "tramaiSovereignOpsWorker")` |
| `.../actuator/SovereignOpsWorkerStatusEndpointProperties.kt` | `@ConfigurationProperties(prefix = "tramai.sovereign.ops.actuator.worker-status")` |
| `.../AutoConfiguration.imports` | Spring Boot 3 auto-config registration |
| `.../SovereignOpsActuatorAutoConfigurationTest.kt` | 5 test scenarios |

**Modified files (3):**

| File | Change |
|------|--------|
| `settings.gradle.kts` | Added module include |
| `gradle/libs.versions.toml` | Added `spring-boot-actuator` library alias |
| `docs/releases/sovereign-runtime-release-readiness.md` | Added actuator capability row, updated non-goal wording |

### Security

- **Disabled by default:** The endpoint bean is only created when `tramai.sovereign.ops.actuator.worker-status.enabled=true` AND Actuator is on the classpath AND a status store bean exists
- **Read-only:** Single `@ReadOperation`, no `@WriteOperation` or `@DeleteOperation`
- **No sensitive data exposure:** Returns only `SovereignOpsAuditOutboxWorkerStatusSnapshot` — configuration booleans, timestamps, counters, sanitized failure summaries. No raw outbox records, approval IDs, tokens, prompts, or stack traces
- **Double-gated:** Both the TramAI property AND standard Spring Boot Actuator exposure (`management.endpoints.web.exposure.include=tramaiSovereignOpsWorker`) must be configured

### Verification

```
./gradlew :tramai-spring-boot-starter-sovereign-ops-actuator:test --rerun-tasks      ✅
./gradlew :tramai-spring-boot-starter-sovereign-ops:test --rerun-tasks              ✅
./gradlew test --no-configuration-cache                                              ✅
```