### PR TITLE
feat(sovereign-ops): add Micrometer metrics observer for worker status

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ TramAI is organized into focused Gradle modules:
 | `tramai-persistence-file` | Encrypted file-backed stores for approvals, continuations, audit, and outbox |
 | `tramai-spring-boot-starter-sovereign` | Sovereign runtime Spring Boot auto-configuration |
 | `tramai-spring-boot-starter-sovereign-ops` | Operational APIs for audit, approval, recovery, and outbox workflows |
+| `tramai-spring-boot-starter-sovereign-ops-micrometer` | Micrometer metrics for sovereign ops audit outbox worker |
 | `tramai-spring-boot-starter-sovereign-ops-observability` | OpenTelemetry metrics for sovereign ops audit outbox worker |
 | `tramai-spring-boot-starter-sovereign-persistence-file` | File-backed persistence auto-configuration |
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ TramAI is organized into focused Gradle modules:
 | `tramai-sovereign` | Trust zones, sovereign routing, local/cloud enforcement primitives |
 | `tramai-persistence-file` | Encrypted file-backed stores for approvals, continuations, audit, and outbox |
 | `tramai-spring-boot-starter-sovereign` | Sovereign runtime Spring Boot auto-configuration |
-| `tramai-spring-boot-starter-sovereign-ops` | Operational APIs for audit, approval, recovery, and outbox workflows |
+| `tramai-spring-boot-starter-sovereign-ops` | Operational APIs: audit outbox, recovery, dispatch, background worker, observer SPI |
+| `tramai-spring-boot-starter-sovereign-ops-actuator` | Optional Actuator endpoint for worker status (read-only, opt-in) |
 | `tramai-spring-boot-starter-sovereign-ops-micrometer` | Micrometer metrics for sovereign ops audit outbox worker |
 | `tramai-spring-boot-starter-sovereign-ops-observability` | OpenTelemetry metrics for sovereign ops audit outbox worker |
 | `tramai-spring-boot-starter-sovereign-persistence-file` | File-backed persistence auto-configuration |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,6 +79,7 @@ val publishableProjectNames = listOf(
     "tramai-spring-boot-starter-sovereign",
     "tramai-spring-boot-starter-sovereign-persistence-file",
     "tramai-spring-boot-starter-sovereign-ops",
+    "tramai-spring-boot-starter-sovereign-ops-actuator",
     "tramai-spring-boot-starter-sovereign-ops-micrometer",
     "tramai-spring-boot-starter-sovereign-ops-observability",
 )
@@ -100,6 +101,7 @@ val sovereignBundleModuleNames = listOf(
     "tramai-spring-boot-starter-sovereign",
     "tramai-spring-boot-starter-sovereign-persistence-file",
     "tramai-spring-boot-starter-sovereign-ops",
+    "tramai-spring-boot-starter-sovereign-ops-actuator",
     "tramai-spring-boot-starter-sovereign-ops-micrometer",
     "tramai-spring-boot-starter-sovereign-ops-observability",
 )
@@ -676,6 +678,7 @@ val sovereignRuntimePublishableModules = listOf(
     "tramai-spring-boot-starter-sovereign",
     "tramai-spring-boot-starter-sovereign-persistence-file",
     "tramai-spring-boot-starter-sovereign-ops",
+    "tramai-spring-boot-starter-sovereign-ops-actuator",
     "tramai-spring-boot-starter-sovereign-ops-micrometer",
     "tramai-spring-boot-starter-sovereign-ops-observability",
 )
@@ -1018,6 +1021,7 @@ val sovereignReleaseModules = listOf(
     ":tramai-spring-boot-starter-sovereign",
     ":tramai-spring-boot-starter-sovereign-persistence-file",
     ":tramai-spring-boot-starter-sovereign-ops",
+    ":tramai-spring-boot-starter-sovereign-ops-actuator",
     ":tramai-spring-boot-starter-sovereign-ops-micrometer",
     ":tramai-spring-boot-starter-sovereign-ops-observability",
 )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,6 +79,7 @@ val publishableProjectNames = listOf(
     "tramai-spring-boot-starter-sovereign",
     "tramai-spring-boot-starter-sovereign-persistence-file",
     "tramai-spring-boot-starter-sovereign-ops",
+    "tramai-spring-boot-starter-sovereign-ops-micrometer",
     "tramai-spring-boot-starter-sovereign-ops-observability",
 )
 val jarPublishingProjectNames = publishableProjectNames - "tramai-bom"
@@ -99,6 +100,7 @@ val sovereignBundleModuleNames = listOf(
     "tramai-spring-boot-starter-sovereign",
     "tramai-spring-boot-starter-sovereign-persistence-file",
     "tramai-spring-boot-starter-sovereign-ops",
+    "tramai-spring-boot-starter-sovereign-ops-micrometer",
     "tramai-spring-boot-starter-sovereign-ops-observability",
 )
 
@@ -674,6 +676,7 @@ val sovereignRuntimePublishableModules = listOf(
     "tramai-spring-boot-starter-sovereign",
     "tramai-spring-boot-starter-sovereign-persistence-file",
     "tramai-spring-boot-starter-sovereign-ops",
+    "tramai-spring-boot-starter-sovereign-ops-micrometer",
     "tramai-spring-boot-starter-sovereign-ops-observability",
 )
 
@@ -1015,6 +1018,7 @@ val sovereignReleaseModules = listOf(
     ":tramai-spring-boot-starter-sovereign",
     ":tramai-spring-boot-starter-sovereign-persistence-file",
     ":tramai-spring-boot-starter-sovereign-ops",
+    ":tramai-spring-boot-starter-sovereign-ops-micrometer",
     ":tramai-spring-boot-starter-sovereign-ops-observability",
 )
 

--- a/docs/modules/sovereign-runtime-module-matrix.md
+++ b/docs/modules/sovereign-runtime-module-matrix.md
@@ -12,6 +12,7 @@ One-stop reference for the sovereign runtime modules on master. Updated 2026-06-
 | tramai-spring-boot-starter-sovereign | Spring Boot auto-configuration for sovereign runtime | Spring integration | Implemented / evolving |
 | tramai-spring-boot-starter-sovereign-persistence-file | Spring auto-configuration for file-backed persistence | Spring persistence integration | Implemented / evolving |
 | tramai-spring-boot-starter-sovereign-ops | Operational APIs: audit outbox, recovery, dispatch, background worker, observer SPI | Operational recovery | Implemented / evolving |
+| tramai-spring-boot-starter-sovereign-ops-micrometer | Micrometer metrics for ops audit outbox worker | Operational observability | Implemented / opt-in |
 | tramai-spring-boot-starter-sovereign-ops-observability | OpenTelemetry metrics for ops audit outbox worker | Operational observability | Implemented |
 | examples:sovereign-document-intelligence | End-to-end reference sovereign workflow | Demo / evidence pack | Implemented |
 
@@ -29,6 +30,10 @@ application
 application
   -> tramai-spring-boot-starter-sovereign-ops
      -> audit outbox worker / recovery / dispatch
+
+application
+  -> tramai-spring-boot-starter-sovereign-ops-micrometer
+     -> Micrometer metrics only (requires MeterRegistry bean)
 
 application
   -> tramai-spring-boot-starter-sovereign-ops-observability

--- a/docs/modules/sovereign-runtime-module-matrix.md
+++ b/docs/modules/sovereign-runtime-module-matrix.md
@@ -12,6 +12,7 @@ One-stop reference for the sovereign runtime modules on master. Updated 2026-06-
 | tramai-spring-boot-starter-sovereign | Spring Boot auto-configuration for sovereign runtime | Spring integration | Implemented / evolving |
 | tramai-spring-boot-starter-sovereign-persistence-file | Spring auto-configuration for file-backed persistence | Spring persistence integration | Implemented / evolving |
 | tramai-spring-boot-starter-sovereign-ops | Operational APIs: audit outbox, recovery, dispatch, background worker, observer SPI | Operational recovery | Implemented / evolving |
+| tramai-spring-boot-starter-sovereign-ops-actuator | Optional read-only Actuator endpoint for worker status | Operational visibility | Implemented / opt-in |
 | tramai-spring-boot-starter-sovereign-ops-micrometer | Micrometer metrics for ops audit outbox worker | Operational observability | Implemented / opt-in |
 | tramai-spring-boot-starter-sovereign-ops-observability | OpenTelemetry metrics for ops audit outbox worker | Operational observability | Implemented |
 | examples:sovereign-document-intelligence | End-to-end reference sovereign workflow | Demo / evidence pack | Implemented |
@@ -29,7 +30,11 @@ application
 
 application
   -> tramai-spring-boot-starter-sovereign-ops
-     -> audit outbox worker / recovery / dispatch
+     -> Operational auto-configuration (audit outbox, recovery, dispatch)
+
+application
+  -> tramai-spring-boot-starter-sovereign-ops-actuator
+     -> Read-only Actuator endpoint (requires spring-boot-actuator)
 
 application
   -> tramai-spring-boot-starter-sovereign-ops-micrometer

--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -156,6 +156,7 @@ This publishes the following to mavenLocal() and runs their test suites:
 - `tramai-spring-boot-starter-sovereign`
 - `tramai-spring-boot-starter-sovereign-persistence-file`
 - `tramai-spring-boot-starter-sovereign-ops`
+- `tramai-spring-boot-starter-sovereign-ops-micrometer`
 - `tramai-spring-boot-starter-sovereign-ops-observability`
 
 After publishing, a consumer-resolution smoke test proves an external app can resolve them

--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -156,6 +156,7 @@ This publishes the following to mavenLocal() and runs their test suites:
 - `tramai-spring-boot-starter-sovereign`
 - `tramai-spring-boot-starter-sovereign-persistence-file`
 - `tramai-spring-boot-starter-sovereign-ops`
+- `tramai-spring-boot-starter-sovereign-ops-actuator`
 - `tramai-spring-boot-starter-sovereign-ops-micrometer`
 - `tramai-spring-boot-starter-sovereign-ops-observability`
 
@@ -194,9 +195,9 @@ This publishes the sovereign runtime modules **and their full transitive dev.tra
 The published module set includes:
 
 - 4 transitive framework modules: `tramai-core`, `tramai-standalone`, `tramai-engine`, `tramai-structured`
-- 8 sovereign modules: `tramai-bom`, `tramai-security`, `tramai-sovereign`, `tramai-persistence-file`, and the 4 Spring Boot starters
+- 10 sovereign modules: `tramai-bom`, `tramai-security`, `tramai-sovereign`, `tramai-persistence-file`, and the 6 Spring Boot starters
 
-After the bundle dry-run, the consumer smoke test resolves all 12 modules exclusively from the verification repo — no `mavenLocal` fallback.
+After the bundle dry-run, the consumer smoke test resolves all 14 modules exclusively from the verification repo — no `mavenLocal` fallback.
 
 The task always publishes to both `mavenLocal()` and the dedicated build-local repository. The dedicated repo uses a separate `sovereignBundleLocal` Maven repository configuration — never the shared `tramaiRemote` repository — so it cannot accidentally push to a remote publish target.
 

--- a/docs/releases/sovereign-runtime-release-readiness.md
+++ b/docs/releases/sovereign-runtime-release-readiness.md
@@ -26,6 +26,7 @@ Candidate release: 0.4.0 or the next unreleased version. No tag, no Maven Centra
 | Worker observer SPI | Implemented | tramai-spring-boot-starter-sovereign-ops | Unit tests |
 | OpenTelemetry worker metrics | Implemented | tramai-spring-boot-starter-sovereign-ops-observability | Unit tests |
 | Optional read-only Actuator worker status endpoint | Implemented / opt-in | tramai-spring-boot-starter-sovereign-ops-actuator | Unit tests |
+| Micrometer worker metrics bridge | Implemented / opt-in | tramai-spring-boot-starter-sovereign-ops-micrometer | Unit tests |
 | Evidence generation | Implemented / evolving | Release artifacts, examples | Smoke tests |
 | Sovereign document intelligence example | Implemented | examples:sovereign-document-intelligence | Smoke test |
 
@@ -36,7 +37,7 @@ These capabilities are NOT claimed as complete, stable, or production-ready:
 - Stable 1.0 public API
 - Maven Central release of sovereign runtime modules (not verified)
 - Broad REST/Actuator operational control endpoints
-- Micrometer / Prometheus / dashboard integration
+- Full dashboard integration and production monitoring runbook
 - Database-backed persistence or outbox
 - Distributed worker leader election
 - Key rotation
@@ -74,6 +75,9 @@ No timelines are committed for these items.
 # Observability module tests
 ./gradlew :tramai-spring-boot-starter-sovereign-ops-observability:test --rerun-tasks
 
+# Micrometer module tests
+./gradlew :tramai-spring-boot-starter-sovereign-ops-micrometer:test --rerun-tasks
+
 # Reference example smoke test
 ./gradlew :examples:sovereign-document-intelligence:run
 ```
@@ -84,7 +88,7 @@ No timelines are committed for these items.
 |---|---|---|
 | APIs are still evolving | Medium | active-development banner on README and docs |
 | File persistence is local-node only | Medium | Documented as local-only; DB-backed persistence is future work |
-| No Actuator / Micrometer bridge for OT metrics | Low | Documented clearly; metrics available via OT collector |
+| No production monitoring dashboard or runbook | Low | Explicitly listed as a non-goal |
 | No DB-backed outbox | Medium | Explicitly listed as future work |
 | No distributed leader election | Medium | Worker assumes single-node operation; documented |
 | Sovereign ops worker is opt-in, disabled by default | Low | Production users must explicitly enable |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ assertj = "3.27.7"
 jackson = "2.18.3"
 jedis = "6.0.0"
 opentelemetry = "1.49.0"
+micrometer = "1.14.6"
 spring-boot = "3.4.5"
 aws-sdk = "2.31.67"
 flyway = "11.8.0"
@@ -33,6 +34,8 @@ opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testi
 opentelemetry-sdk-trace = { module = "io.opentelemetry:opentelemetry-sdk-trace", version.ref = "opentelemetry" }
 spring-boot-autoconfigure = { module = "org.springframework.boot:spring-boot-autoconfigure", version.ref = "spring-boot" }
 spring-boot-actuator = { module = "org.springframework.boot:spring-boot-actuator", version.ref = "spring-boot" }
+micrometer-core = { module = "io.micrometer:micrometer-core", version.ref = "micrometer" }
+micrometer-registry-prometheus = { module = "io.micrometer:micrometer-registry-prometheus", version.ref = "micrometer" }
 spring-boot-configuration-processor = { module = "org.springframework.boot:spring-boot-configuration-processor", version.ref = "spring-boot" }
 spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web", version.ref = "spring-boot" }
 spring-boot-starter-validation = { module = "org.springframework.boot:spring-boot-starter-validation", version.ref = "spring-boot" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,7 @@ include(
     "tramai-spring-boot-starter-sovereign-persistence-file",
     "tramai-spring-boot-starter-sovereign-ops",
     "tramai-spring-boot-starter-sovereign-ops-actuator",
+    "tramai-spring-boot-starter-sovereign-ops-micrometer",
     "tramai-spring-boot-starter-sovereign-ops-observability",
     "tramai-scheduler",
     "tramai-security",

--- a/tramai-bom/build.gradle.kts
+++ b/tramai-bom/build.gradle.kts
@@ -29,6 +29,8 @@ dependencies {
         api(project(":tramai-spring-boot-starter-sovereign"))
         api(project(":tramai-spring-boot-starter-sovereign-persistence-file"))
         api(project(":tramai-spring-boot-starter-sovereign-ops"))
+        api(project(":tramai-spring-boot-starter-sovereign-ops-actuator"))
+        api(project(":tramai-spring-boot-starter-sovereign-ops-micrometer"))
         api(project(":tramai-spring-boot-starter-sovereign-ops-observability"))
         api(project(":tramai-spring"))
         api(project(":tramai-security"))

--- a/tramai-spring-boot-starter-sovereign-ops-micrometer/README.md
+++ b/tramai-spring-boot-starter-sovereign-ops-micrometer/README.md
@@ -1,0 +1,59 @@
+# TramAI Sovereign Ops Micrometer
+
+Optional Micrometer metrics bridge for the sovereign ops audit outbox worker.
+
+This module exposes five Micrometer metric instruments that mirror the
+existing OpenTelemetry metric contract. All tags are low-cardinality and
+sanitised.
+
+## Metrics
+
+| Name | Type | Tags |
+|------|------|------|
+| `tramai.sovereign.ops.outbox.worker.cycles` | Counter | outcome, failure_action, error_type |
+| `tramai.sovereign.ops.outbox.worker.duration` | Timer | outcome, failure_action, error_type |
+| `tramai.sovereign.ops.outbox.worker.failures` | Counter | failure_action, error_type |
+| `tramai.sovereign.ops.outbox.worker.recovered.records` | Counter | result |
+| `tramai.sovereign.ops.outbox.worker.dispatched.records` | Counter | result |
+
+### Tag values
+
+- `outcome`: `success` | `failure`
+- `failure_action`: `none` | `recoverPrepared` | `dispatchPending` | `unexpected`
+- `error_type`: `none` | sanitized error code
+- `result`: `inspected` | `moved_to_pending` | `failed_permanent` | `resolver_failure` | `claimed` | `emitted` | `failed_retryable`
+
+## Prometheus
+
+If Prometheus is configured for your application, these metrics are
+automatically scraped when `micrometer-registry-prometheus` is on the
+classpath.
+
+## Security
+
+No sensitive data is ever used in metric names or tag values. The metrics
+never contain:
+
+- outbox IDs, approval IDs, aggregate IDs, or workflow run IDs
+- actor names or reason text
+- raw exception messages, file paths, or stack traces
+- prompt, model, or tool data
+- raw outbox record content
+
+## Observer precedence
+
+When this module is on the classpath and a `MeterRegistry` bean exists,
+the Micrometer observer replaces the default recording observer.
+Status snapshot recording (for the Actuator endpoint) does not update
+when Micrometer metrics are active.
+
+To use both metrics and status recording, wait for PR #68 (composite
+observer support) or manually wire a
+`RecordingSovereignOpsAuditOutboxWorkerObserver` with the Micrometer
+observer as its delegate.
+
+## Enable
+
+Add the dependency and ensure a `MeterRegistry` bean exists (Spring Boot
+auto-configures one when `micrometer-core` or
+`micrometer-registry-prometheus` is on the classpath).

--- a/tramai-spring-boot-starter-sovereign-ops-micrometer/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-ops-micrometer/build.gradle.kts
@@ -1,0 +1,41 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    `java-library`
+    alias(libs.plugins.kotlin.jvm)
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+    withSourcesJar()
+}
+
+kotlin {
+    jvmToolchain(21)
+    compilerOptions {
+        jvmTarget.set(JvmTarget.fromTarget("21"))
+    }
+}
+
+dependencies {
+    api(project(":tramai-spring-boot-starter-sovereign-ops"))
+
+    implementation(libs.spring.boot.autoconfigure)
+    implementation(libs.micrometer.core)
+
+    annotationProcessor(libs.spring.boot.configuration.processor)
+
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.kotlin.test.junit5)
+    testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.micrometer.core)
+    testImplementation(libs.micrometer.registry.prometheus)
+    testImplementation("org.junit.jupiter:junit-jupiter")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/tramai-spring-boot-starter-sovereign-ops-micrometer/src/main/kotlin/dev/tramai/spring/sovereign/ops/micrometer/MicrometerSovereignOpsAuditOutboxWorkerObserver.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-micrometer/src/main/kotlin/dev/tramai/spring/sovereign/ops/micrometer/MicrometerSovereignOpsAuditOutboxWorkerObserver.kt
@@ -1,0 +1,128 @@
+package dev.tramai.spring.sovereign.ops.micrometer
+
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxDispatchResult
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxRecoverySummary
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerRunSummary
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Tag
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+/**
+ * Micrometer-backed observer for the sovereign ops audit outbox worker.
+ *
+ * Emits five metric instruments on every worker cycle. All tags are
+ * low-cardinality and sanitised - no approval IDs, reason text, tokens,
+ * prompts, model responses, file paths, exception messages, or stack traces
+ * are ever recorded.
+ *
+ * ## Metric contract
+ *
+ * ### worker.cycles - Counter {cycle}
+ * Tags: outcome, failure_action, error_type
+ *
+ * ### worker.duration - Timer (ms)
+ * Tags: same as worker.cycles
+ *
+ * ### worker.failures - Counter {failure}
+ * Tags: failure_action, error_type
+ *
+ * ### worker.recovered.records - Counter {record}
+ * Tags: result in {inspected, moved_to_pending, failed_permanent, resolver_failure}
+ *
+ * ### worker.dispatched.records - Counter {record}
+ * Tags: result in {claimed, emitted, failed_retryable, failed_permanent}
+ *
+ * @param registry The Micrometer [MeterRegistry] used to create instruments.
+ */
+class MicrometerSovereignOpsAuditOutboxWorkerObserver(
+    private val registry: MeterRegistry,
+) : SovereignOpsAuditOutboxWorkerObserver {
+
+    override fun onCycleCompleted(summary: SovereignOpsAuditOutboxWorkerRunSummary) {
+        val outcome = if (summary.failure != null) "failure" else "success"
+        val failureAction = summary.failure?.action ?: "none"
+        val errorType = summary.failure?.errorCode ?: "none"
+
+        val tags = listOf(
+            Tag.of("outcome", outcome),
+            Tag.of("failure_action", failureAction),
+            Tag.of("error_type", errorType),
+        )
+
+        registry.counter("tramai.sovereign.ops.outbox.worker.cycles", tags).increment()
+
+        val ms = Duration.between(summary.startedAt, summary.completedAt).toMillis()
+        val safeMs = if (ms < 0) 0L else ms
+        registry.timer("tramai.sovereign.ops.outbox.worker.duration", tags)
+            .record(safeMs, TimeUnit.MILLISECONDS)
+
+        summary.recovered?.let { recordRecovery(it) }
+        summary.dispatched?.let { recordDispatch(it) }
+    }
+
+    override fun onCycleFailed(action: String, errorCode: String) {
+        registry.counter(
+            "tramai.sovereign.ops.outbox.worker.failures",
+            listOf(
+                Tag.of("failure_action", action),
+                Tag.of("error_type", errorCode),
+            ),
+        ).increment()
+    }
+
+    private fun recordRecovery(r: SovereignOpsAuditOutboxRecoverySummary) {
+        if (r.inspected > 0) {
+            registry.counter(
+                "tramai.sovereign.ops.outbox.worker.recovered.records",
+                listOf(Tag.of("result", "inspected")),
+            ).increment(r.inspected.toDouble())
+        }
+        if (r.movedToPending > 0) {
+            registry.counter(
+                "tramai.sovereign.ops.outbox.worker.recovered.records",
+                listOf(Tag.of("result", "moved_to_pending")),
+            ).increment(r.movedToPending.toDouble())
+        }
+        if (r.markedFailedPermanent > 0) {
+            registry.counter(
+                "tramai.sovereign.ops.outbox.worker.recovered.records",
+                listOf(Tag.of("result", "failed_permanent")),
+            ).increment(r.markedFailedPermanent.toDouble())
+        }
+        if (r.resolverFailures > 0) {
+            registry.counter(
+                "tramai.sovereign.ops.outbox.worker.recovered.records",
+                listOf(Tag.of("result", "resolver_failure")),
+            ).increment(r.resolverFailures.toDouble())
+        }
+    }
+
+    private fun recordDispatch(d: SovereignOpsAuditOutboxDispatchResult) {
+        if (d.claimed > 0) {
+            registry.counter(
+                "tramai.sovereign.ops.outbox.worker.dispatched.records",
+                listOf(Tag.of("result", "claimed")),
+            ).increment(d.claimed.toDouble())
+        }
+        if (d.emitted > 0) {
+            registry.counter(
+                "tramai.sovereign.ops.outbox.worker.dispatched.records",
+                listOf(Tag.of("result", "emitted")),
+            ).increment(d.emitted.toDouble())
+        }
+        if (d.failedRetryable > 0) {
+            registry.counter(
+                "tramai.sovereign.ops.outbox.worker.dispatched.records",
+                listOf(Tag.of("result", "failed_retryable")),
+            ).increment(d.failedRetryable.toDouble())
+        }
+        if (d.failedPermanent > 0) {
+            registry.counter(
+                "tramai.sovereign.ops.outbox.worker.dispatched.records",
+                listOf(Tag.of("result", "failed_permanent")),
+            ).increment(d.failedPermanent.toDouble())
+        }
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops-micrometer/src/main/kotlin/dev/tramai/spring/sovereign/ops/micrometer/SovereignOpsOutboxMicrometerAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-micrometer/src/main/kotlin/dev/tramai/spring/sovereign/ops/micrometer/SovereignOpsOutboxMicrometerAutoConfiguration.kt
@@ -1,0 +1,49 @@
+package dev.tramai.spring.sovereign.ops.micrometer
+
+import dev.tramai.spring.sovereign.ops.SovereignOpsAutoConfiguration
+import dev.tramai.spring.sovereign.ops.outbox.RecordingSovereignOpsAuditOutboxWorkerObserver
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.AutoConfigureBefore
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+
+/**
+ * Auto-configuration for the Micrometer-backed sovereign ops audit outbox worker observer.
+ *
+ * Runs before [SovereignOpsAutoConfiguration] so this observer is available
+ * before the fallback recording observer is registered. Follows the same
+ * pattern as `SovereignOpsOutboxObservabilityAutoConfiguration`.
+ *
+ * The observer is only created when:
+ * - Micrometer is on the classpath (`MeterRegistry`)
+ * - A [MeterRegistry] bean exists
+ * - No custom [SovereignOpsAuditOutboxWorkerObserver] has been registered
+ *
+ * ## Observer precedence
+ *
+ * When this module is on the classpath and a [MeterRegistry] bean exists,
+ * the Micrometer observer replaces the default recording observer.
+ * This means status snapshot recording does not update when Micrometer
+ * metrics are active.
+ *
+ * To compose both metrics and status recording, manually wire a
+ * [RecordingSovereignOpsAuditOutboxWorkerObserver] with the Micrometer
+ * observer as its delegate.
+ */
+@AutoConfiguration
+@AutoConfigureBefore(SovereignOpsAutoConfiguration::class)
+@ConditionalOnClass(MeterRegistry::class)
+open class SovereignOpsOutboxMicrometerAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(SovereignOpsAuditOutboxWorkerObserver::class)
+    @ConditionalOnBean(MeterRegistry::class)
+    open fun micrometerSovereignOpsAuditOutboxWorkerObserver(
+        meterRegistry: MeterRegistry,
+    ): SovereignOpsAuditOutboxWorkerObserver =
+        MicrometerSovereignOpsAuditOutboxWorkerObserver(meterRegistry)
+}

--- a/tramai-spring-boot-starter-sovereign-ops-micrometer/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/tramai-spring-boot-starter-sovereign-ops-micrometer/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.tramai.spring.sovereign.ops.micrometer.SovereignOpsOutboxMicrometerAutoConfiguration

--- a/tramai-spring-boot-starter-sovereign-ops-micrometer/src/test/kotlin/dev/tramai/spring/sovereign/ops/micrometer/MicrometerSovereignOpsAuditOutboxWorkerObserverTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-micrometer/src/test/kotlin/dev/tramai/spring/sovereign/ops/micrometer/MicrometerSovereignOpsAuditOutboxWorkerObserverTest.kt
@@ -1,0 +1,187 @@
+package dev.tramai.spring.sovereign.ops.micrometer
+
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxDispatchResult
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxRecoverySummary
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerFailureSummary
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerRunSummary
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+
+class MicrometerSovereignOpsAuditOutboxWorkerObserverTest {
+
+    private val registry: MeterRegistry = SimpleMeterRegistry()
+    private val observer = MicrometerSovereignOpsAuditOutboxWorkerObserver(registry)
+
+    @AfterEach
+    fun tearDown() {
+        registry.close()
+    }
+
+    @Test
+    fun `successful cycle records cycle counter and duration timer`() {
+        val now = Instant.now()
+        val summary = SovereignOpsAuditOutboxWorkerRunSummary(
+            recovered = null,
+            dispatched = null,
+            startedAt = now,
+            completedAt = now.plus(Duration.ofMillis(500)),
+        )
+
+        observer.onCycleCompleted(summary)
+
+        val cycleCounter = registry.get("tramai.sovereign.ops.outbox.worker.cycles")
+            .tag("outcome", "success")
+            .tag("failure_action", "none")
+            .tag("error_type", "none")
+            .counter()
+        assertThat(cycleCounter.count()).isEqualTo(1.0)
+
+        val durationTimer = registry.get("tramai.sovereign.ops.outbox.worker.duration")
+            .tag("outcome", "success")
+            .tag("failure_action", "none")
+            .tag("error_type", "none")
+            .timer()
+        assertThat(durationTimer.count()).isEqualTo(1)
+        assertThat(durationTimer.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(500.0)
+    }
+
+    @Test
+    fun `failed cycle records outcome failure with correct tags`() {
+        val now = Instant.now()
+        val summary = SovereignOpsAuditOutboxWorkerRunSummary(
+            recovered = null,
+            dispatched = null,
+            failure = SovereignOpsAuditOutboxWorkerFailureSummary(
+                action = "dispatchPending",
+                errorCode = "dispatch_timeout",
+            ),
+            startedAt = now,
+            completedAt = now.plus(Duration.ofMillis(300)),
+        )
+
+        observer.onCycleCompleted(summary)
+
+        val cycleCounter = registry.get("tramai.sovereign.ops.outbox.worker.cycles")
+            .tag("outcome", "failure")
+            .tag("failure_action", "dispatchPending")
+            .tag("error_type", "dispatch_timeout")
+            .counter()
+        assertThat(cycleCounter.count()).isEqualTo(1.0)
+
+        val durationTimer = registry.get("tramai.sovereign.ops.outbox.worker.duration")
+            .tag("outcome", "failure")
+            .tag("failure_action", "dispatchPending")
+            .tag("error_type", "dispatch_timeout")
+            .timer()
+        assertThat(durationTimer.count()).isEqualTo(1)
+        assertThat(durationTimer.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(300.0)
+    }
+
+    @Test
+    fun `negative duration is clamped to zero`() {
+        val now = Instant.now()
+        val summary = SovereignOpsAuditOutboxWorkerRunSummary(
+            recovered = null,
+            dispatched = null,
+            startedAt = now,
+            completedAt = now.minus(Duration.ofMillis(250)),
+        )
+
+        observer.onCycleCompleted(summary)
+
+        val durationTimer = registry.get("tramai.sovereign.ops.outbox.worker.duration")
+            .tag("outcome", "success")
+            .tag("failure_action", "none")
+            .tag("error_type", "none")
+            .timer()
+        assertThat(durationTimer.count()).isEqualTo(1)
+        assertThat(durationTimer.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `onCycleFailed records worker failure counter`() {
+        observer.onCycleFailed("unexpected", "IllegalStateException")
+
+        val failureCounter = registry.get("tramai.sovereign.ops.outbox.worker.failures")
+            .tag("failure_action", "unexpected")
+            .tag("error_type", "IllegalStateException")
+            .counter()
+        assertThat(failureCounter.count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `recovery summary records recovered record counters by result`() {
+        val now = Instant.now()
+        val summary = SovereignOpsAuditOutboxWorkerRunSummary(
+            recovered = SovereignOpsAuditOutboxRecoverySummary(
+                inspected = 10,
+                movedToPending = 3,
+                markedFailedPermanent = 2,
+                skippedUnresolved = 1,
+                resolverFailures = 1,
+            ),
+            dispatched = null,
+            startedAt = now,
+            completedAt = now.plus(Duration.ofMillis(100)),
+        )
+
+        observer.onCycleCompleted(summary)
+
+        val inspected = registry.get("tramai.sovereign.ops.outbox.worker.recovered.records")
+            .tag("result", "inspected").counter()
+        assertThat(inspected.count()).isEqualTo(10.0)
+
+        val movedToPending = registry.get("tramai.sovereign.ops.outbox.worker.recovered.records")
+            .tag("result", "moved_to_pending").counter()
+        assertThat(movedToPending.count()).isEqualTo(3.0)
+
+        val failedPermanent = registry.get("tramai.sovereign.ops.outbox.worker.recovered.records")
+            .tag("result", "failed_permanent").counter()
+        assertThat(failedPermanent.count()).isEqualTo(2.0)
+
+        val resolverFailure = registry.get("tramai.sovereign.ops.outbox.worker.recovered.records")
+            .tag("result", "resolver_failure").counter()
+        assertThat(resolverFailure.count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `dispatch summary records dispatched record counters by result`() {
+        val now = Instant.now()
+        val summary = SovereignOpsAuditOutboxWorkerRunSummary(
+            recovered = null,
+            dispatched = SovereignOpsAuditOutboxDispatchResult(
+                claimed = 5,
+                emitted = 4,
+                failedRetryable = 1,
+                failedPermanent = 0,
+            ),
+            startedAt = now,
+            completedAt = now.plus(Duration.ofMillis(200)),
+        )
+
+        observer.onCycleCompleted(summary)
+
+        val claimed = registry.get("tramai.sovereign.ops.outbox.worker.dispatched.records")
+            .tag("result", "claimed").counter()
+        assertThat(claimed.count()).isEqualTo(5.0)
+
+        val emitted = registry.get("tramai.sovereign.ops.outbox.worker.dispatched.records")
+            .tag("result", "emitted").counter()
+        assertThat(emitted.count()).isEqualTo(4.0)
+
+        val failedRetryable = registry.get("tramai.sovereign.ops.outbox.worker.dispatched.records")
+            .tag("result", "failed_retryable").counter()
+        assertThat(failedRetryable.count()).isEqualTo(1.0)
+
+        val failedPermanent = registry.find("tramai.sovereign.ops.outbox.worker.dispatched.records")
+            .tag("result", "failed_permanent")
+            .counter()
+        assertThat(failedPermanent).isNull()
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops-micrometer/src/test/kotlin/dev/tramai/spring/sovereign/ops/micrometer/SovereignOpsOutboxMicrometerAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-micrometer/src/test/kotlin/dev/tramai/spring/sovereign/ops/micrometer/SovereignOpsOutboxMicrometerAutoConfigurationTest.kt
@@ -1,0 +1,78 @@
+package dev.tramai.spring.sovereign.ops.micrometer
+
+import dev.tramai.spring.sovereign.ops.SovereignOpsAutoConfiguration
+import dev.tramai.spring.sovereign.ops.outbox.RecordingSovereignOpsAuditOutboxWorkerObserver
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerRunSummary
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+class SovereignOpsOutboxMicrometerAutoConfigurationTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                SovereignOpsAutoConfiguration::class.java,
+                SovereignOpsOutboxMicrometerAutoConfiguration::class.java,
+            ),
+        )
+        .withPropertyValues(
+            "tramai.sovereign.ops.outbox.worker.dispatch-pending=false",
+        )
+
+    @Test
+    fun `recording observer is used when MeterRegistry is absent`() {
+        contextRunner
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
+                val observer = ctx.getBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
+                assertThat(observer).isInstanceOf(RecordingSovereignOpsAuditOutboxWorkerObserver::class.java)
+            }
+    }
+
+    @Test
+    fun `observer is created when MeterRegistry exists`() {
+        contextRunner
+            .withUserConfiguration(MeterRegistryConfig::class.java)
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
+                val observer = ctx.getBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
+                assertThat(observer).isInstanceOf(MicrometerSovereignOpsAuditOutboxWorkerObserver::class.java)
+            }
+    }
+
+    @Test
+    fun `observer is not created when custom observer already exists`() {
+        contextRunner
+            .withUserConfiguration(MeterRegistryConfig::class.java, CustomObserverConfig::class.java)
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
+                val observer = ctx.getBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
+                assertThat(observer).isInstanceOf(CustomSovereignOpsAuditOutboxWorkerObserver::class.java)
+            }
+    }
+}
+
+@Configuration
+open class MeterRegistryConfig {
+    @Bean
+    open fun meterRegistry(): MeterRegistry = SimpleMeterRegistry()
+}
+
+@Configuration
+open class CustomObserverConfig {
+    @Bean
+    open fun customObserver(): SovereignOpsAuditOutboxWorkerObserver =
+        CustomSovereignOpsAuditOutboxWorkerObserver()
+}
+
+private class CustomSovereignOpsAuditOutboxWorkerObserver : SovereignOpsAuditOutboxWorkerObserver {
+    override fun onCycleCompleted(summary: SovereignOpsAuditOutboxWorkerRunSummary) = Unit
+    override fun onCycleFailed(action: String, errorCode: String) = Unit
+}


### PR DESCRIPTION
## Summary

Adds an optional Micrometer/Prometheus-friendly metrics module for the sovereign ops audit outbox worker, mirroring the existing OpenTelemetry metric contract without adding Micrometer to the base ops starter.

### Design

New dedicated module: `tramai-spring-boot-starter-sovereign-ops-micrometer`
- Separate from the base ops starter — no Micrometer dependency added there
- Follows the same pattern as the existing `tramai-spring-boot-starter-sovereign-ops-observability` module
- Implements `SovereignOpsAuditOutboxWorkerObserver` SPI, same as the OT observer

### Metric contract

Five metric instruments mirroring the OT contract:

| Name | Type | Tags |
|------|------|------|
| `tramai.sovereign.ops.outbox.worker.cycles` | Counter | outcome, failure_action, error_type |
| `tramai.sovereign.ops.outbox.worker.duration` | Timer | outcome, failure_action, error_type |
| `tramai.sovereign.ops.outbox.worker.failures` | Counter | failure_action, error_type |
| `tramai.sovereign.ops.outbox.worker.recovered.records` | Counter | result |
| `tramai.sovereign.ops.outbox.worker.dispatched.records` | Counter | result |

All tags are low-cardinality only. No sensitive data (IDs, tokens, prompts, file paths, stack traces).

### Observer precedence

When this module is on the classpath and a `MeterRegistry` bean exists, the Micrometer observer replaces the default recording observer. This means status snapshot recording does not update when Micrometer metrics are active (same tradeoff as the OpenTelemetry module). PR #68 will add composite observer support.

### Files changed

**New files (7):**
- `tramai-spring-boot-starter-sovereign-ops-micrometer/build.gradle.kts`
- `tramai-spring-boot-starter-sovereign-ops-micrometer/README.md`
- `.../micrometer/MicrometerSovereignOpsAuditOutboxWorkerObserver.kt` — 128 lines
- `.../micrometer/SovereignOpsOutboxMicrometerAutoConfiguration.kt` — 49 lines
- `.../META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`
- `.../MicrometerSovereignOpsAuditOutboxWorkerObserverTest.kt` — 6 tests
- `.../SovereignOpsOutboxMicrometerAutoConfigurationTest.kt` — 3 tests

**Modified files (7):**
- `settings.gradle.kts` — module include
- `gradle/libs.versions.toml` — micrometer version + aliases
- `build.gradle.kts` — publishing, bundle, release lists
- `README.md` — module table entry
- `docs/releases/sovereign-runtime-release-readiness.md` — capability row, non-goal wording
- `docs/modules/sovereign-runtime-module-matrix.md` — module matrix row
- `docs/reference/releasing.md` — publish list entry

### Verification

```
./gradlew :tramai-spring-boot-starter-sovereign-ops-micrometer:test --rerun-tasks      ✅ (23 tasks)
./gradlew :tramai-spring-boot-starter-sovereign-ops-observability:test --rerun-tasks  ✅ (23 tasks)
./gradlew :tramai-spring-boot-starter-sovereign-ops:test --rerun-tasks                ✅ (20 tasks)
```