### PR TITLE
feat(sovereign-ops): compose worker observers

### DIFF
--- a/docs/releases/sovereign-runtime-release-readiness.md
+++ b/docs/releases/sovereign-runtime-release-readiness.md
@@ -104,7 +104,7 @@ No timelines are committed for these items.
 - [x] No Maven Central claim for sovereign runtime modules unless verified
 - [x] CHANGELOG.md has Unreleased section
 
-Checklist last verified: 2026-06-19 after PR #63. Full release-candidate evidence chain verified by CI.
+Checklist last verified: 2026-06-20 after PR #68 wiring review. Full release-candidate evidence chain remains documented.
 
 ## Sovereign Runtime Release-Candidate CI Gate
 

--- a/tramai-spring-boot-starter-sovereign-ops-micrometer/README.md
+++ b/tramai-spring-boot-starter-sovereign-ops-micrometer/README.md
@@ -40,17 +40,15 @@ never contain:
 - prompt, model, or tool data
 - raw outbox record content
 
-## Observer precedence
+## Observer composition
 
-When this module is on the classpath and a `MeterRegistry` bean exists,
-the Micrometer observer replaces the default recording observer.
-Status snapshot recording (for the Actuator endpoint) does not update
-when Micrometer metrics are active.
+When used with the sovereign ops starter, Micrometer metrics are composed
+with the default status-recording observer. The Actuator worker status
+snapshot continues to update while metrics are emitted.
 
-To use both metrics and status recording, wait for PR #68 (composite
-observer support) or manually wire a
-`RecordingSovereignOpsAuditOutboxWorkerObserver` with the Micrometer
-observer as its delegate.
+No manual wiring is required -- the base sovereign ops starter automatically
+collects observer contributions from Micrometer and OpenTelemetry modules
+and composes them behind the status-recording observer.
 
 ## Enable
 

--- a/tramai-spring-boot-starter-sovereign-ops-micrometer/src/main/kotlin/dev/tramai/spring/sovereign/ops/micrometer/SovereignOpsOutboxMicrometerAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-micrometer/src/main/kotlin/dev/tramai/spring/sovereign/ops/micrometer/SovereignOpsOutboxMicrometerAutoConfiguration.kt
@@ -1,8 +1,7 @@
 package dev.tramai.spring.sovereign.ops.micrometer
 
 import dev.tramai.spring.sovereign.ops.SovereignOpsAutoConfiguration
-import dev.tramai.spring.sovereign.ops.outbox.RecordingSovereignOpsAuditOutboxWorkerObserver
-import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserverContribution
 import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.AutoConfigureBefore
@@ -12,27 +11,19 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 
 /**
- * Auto-configuration for the Micrometer-backed sovereign ops audit outbox worker observer.
+ * Auto-configuration for the Micrometer-backed sovereign ops audit outbox worker observer contribution.
  *
- * Runs before [SovereignOpsAutoConfiguration] so this observer is available
- * before the fallback recording observer is registered. Follows the same
- * pattern as `SovereignOpsOutboxObservabilityAutoConfiguration`.
+ * Runs before [SovereignOpsAutoConfiguration] so this contribution is
+ * available when the base starter builds the final observer chain.
  *
- * The observer is only created when:
+ * The contribution is only created when:
  * - Micrometer is on the classpath (`MeterRegistry`)
  * - A [MeterRegistry] bean exists
- * - No custom [SovereignOpsAuditOutboxWorkerObserver] has been registered
+ * - No Micrometer observer contribution has already been registered
  *
- * ## Observer precedence
- *
- * When this module is on the classpath and a [MeterRegistry] bean exists,
- * the Micrometer observer replaces the default recording observer.
- * This means status snapshot recording does not update when Micrometer
- * metrics are active.
- *
- * To compose both metrics and status recording, manually wire a
- * [RecordingSovereignOpsAuditOutboxWorkerObserver] with the Micrometer
- * observer as its delegate.
+ * The base sovereign ops starter composes contributions behind the
+ * recording observer, so status snapshots update while Micrometer metrics
+ * are emitted.
  */
 @AutoConfiguration
 @AutoConfigureBefore(SovereignOpsAutoConfiguration::class)
@@ -40,10 +31,12 @@ import org.springframework.context.annotation.Bean
 open class SovereignOpsOutboxMicrometerAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean(SovereignOpsAuditOutboxWorkerObserver::class)
     @ConditionalOnBean(MeterRegistry::class)
-    open fun micrometerSovereignOpsAuditOutboxWorkerObserver(
+    @ConditionalOnMissingBean(name = ["micrometerSovereignOpsAuditOutboxWorkerObserverContribution"])
+    open fun micrometerSovereignOpsAuditOutboxWorkerObserverContribution(
         meterRegistry: MeterRegistry,
-    ): SovereignOpsAuditOutboxWorkerObserver =
-        MicrometerSovereignOpsAuditOutboxWorkerObserver(meterRegistry)
+    ): SovereignOpsAuditOutboxWorkerObserverContribution =
+        SovereignOpsAuditOutboxWorkerObserverContribution(
+            MicrometerSovereignOpsAuditOutboxWorkerObserver(meterRegistry),
+        )
 }

--- a/tramai-spring-boot-starter-sovereign-ops-micrometer/src/test/kotlin/dev/tramai/spring/sovereign/ops/micrometer/SovereignOpsOutboxMicrometerAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-micrometer/src/test/kotlin/dev/tramai/spring/sovereign/ops/micrometer/SovereignOpsOutboxMicrometerAutoConfigurationTest.kt
@@ -3,7 +3,9 @@ package dev.tramai.spring.sovereign.ops.micrometer
 import dev.tramai.spring.sovereign.ops.SovereignOpsAutoConfiguration
 import dev.tramai.spring.sovereign.ops.outbox.RecordingSovereignOpsAuditOutboxWorkerObserver
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserverContribution
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerRunSummary
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerStatusStore
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.assertj.core.api.Assertions.assertThat
@@ -12,6 +14,8 @@ import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import java.time.Duration
+import java.time.Instant
 
 class SovereignOpsOutboxMicrometerAutoConfigurationTest {
 
@@ -33,28 +37,62 @@ class SovereignOpsOutboxMicrometerAutoConfigurationTest {
                 assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
                 val observer = ctx.getBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
                 assertThat(observer).isInstanceOf(RecordingSovereignOpsAuditOutboxWorkerObserver::class.java)
+                assertThat(ctx).doesNotHaveBean(SovereignOpsAuditOutboxWorkerObserverContribution::class.java)
             }
     }
 
     @Test
-    fun `observer is created when MeterRegistry exists`() {
+    fun `micrometer contribution is created when MeterRegistry exists`() {
         contextRunner
             .withUserConfiguration(MeterRegistryConfig::class.java)
             .run { ctx ->
                 assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
                 val observer = ctx.getBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
-                assertThat(observer).isInstanceOf(MicrometerSovereignOpsAuditOutboxWorkerObserver::class.java)
+                assertThat(observer).isInstanceOf(RecordingSovereignOpsAuditOutboxWorkerObserver::class.java)
+
+                assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxWorkerObserverContribution::class.java)
+                val contribution = ctx.getBean(SovereignOpsAuditOutboxWorkerObserverContribution::class.java)
+                assertThat(contribution.observer).isInstanceOf(MicrometerSovereignOpsAuditOutboxWorkerObserver::class.java)
             }
     }
 
     @Test
-    fun `observer is not created when custom observer already exists`() {
+    fun `custom observer is not overridden by auto-configuration`() {
         contextRunner
             .withUserConfiguration(MeterRegistryConfig::class.java, CustomObserverConfig::class.java)
             .run { ctx ->
                 assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
                 val observer = ctx.getBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
                 assertThat(observer).isInstanceOf(CustomSovereignOpsAuditOutboxWorkerObserver::class.java)
+            }
+    }
+
+    @Test
+    fun `status recording and micrometer metrics work together`() {
+        contextRunner
+            .withUserConfiguration(MeterRegistryConfig::class.java)
+            .run { ctx ->
+                val statusStore = ctx.getBean(SovereignOpsAuditOutboxWorkerStatusStore::class.java)
+                val meterRegistry = ctx.getBean(MeterRegistry::class.java)
+
+                val observer = ctx.getBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
+                val now = Instant.now()
+                val summary = SovereignOpsAuditOutboxWorkerRunSummary(
+                    recovered = null,
+                    dispatched = null,
+                    startedAt = now,
+                    completedAt = now.plus(Duration.ofMillis(500)),
+                )
+
+                observer.onCycleCompleted(summary)
+
+                val snapshot = statusStore.snapshot()
+                assertThat(snapshot.totalCyclesCompleted).isEqualTo(1)
+
+                val cycleCounter = meterRegistry
+                    .get("tramai.sovereign.ops.outbox.worker.cycles")
+                    .counter()
+                assertThat(cycleCounter.count()).isEqualTo(1.0)
             }
     }
 }

--- a/tramai-spring-boot-starter-sovereign-ops-observability/README.md
+++ b/tramai-spring-boot-starter-sovereign-ops-observability/README.md
@@ -16,11 +16,15 @@ implementation(project(":tramai-spring-boot-starter-sovereign-ops-observability"
 
 ### 2. Provide an OpenTelemetry bean
 
-The observer activates **automatically** when:
+The observer contribution activates **automatically** when:
 - An `io.opentelemetry.api.OpenTelemetry` bean is in the Spring context
-- No custom `SovereignOpsAuditOutboxWorkerObserver` bean is registered
 
-Without an `OpenTelemetry` bean, the sovereign ops starter's `Noop` observer remains active.
+The base sovereign ops starter composes OT metrics with the status-recording
+observer. Without an `OpenTelemetry` bean, no OT contribution is created.
+
+To override the entire observer chain, provide a custom
+`SovereignOpsAuditOutboxWorkerObserver` bean — the auto-configuration
+respects `@ConditionalOnMissingBean` in the base module.
 
 ### 3. Enable the worker
 

--- a/tramai-spring-boot-starter-sovereign-ops-observability/src/main/kotlin/dev/tramai/spring/sovereign/ops/observability/SovereignOpsOutboxObservabilityAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-observability/src/main/kotlin/dev/tramai/spring/sovereign/ops/observability/SovereignOpsOutboxObservabilityAutoConfiguration.kt
@@ -1,7 +1,7 @@
 package dev.tramai.spring.sovereign.ops.observability
 
 import dev.tramai.spring.sovereign.ops.SovereignOpsAutoConfiguration
-import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserverContribution
 import io.opentelemetry.api.OpenTelemetry
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.AutoConfigureBefore
@@ -10,26 +10,28 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 
 /**
- * Auto-configures [OpenTelemetrySovereignOpsAuditOutboxWorkerObserver]
- * when:
+ * Auto-configures an [SovereignOpsAuditOutboxWorkerObserverContribution]
+ * wrapping [OpenTelemetrySovereignOpsAuditOutboxWorkerObserver] when:
  *
  * 1. An [OpenTelemetry] bean is present in the context, AND
- * 2. No custom [SovereignOpsAuditOutboxWorkerObserver] has been registered.
+ * 2. No OT contribution has been registered yet.
  *
- * Runs before [SovereignOpsAutoConfiguration] so the OT observer is created
- * before the Noop fallback. Without an [OpenTelemetry] bean the standard
- * [SovereignOpsAuditOutboxWorkerObserver.Noop] (registered by
- * [SovereignOpsAutoConfiguration]) remains active.
+ * Runs before [SovereignOpsAutoConfiguration] so the OT observer
+ * contribution is available when the base auto-config builds the final
+ * composite observer chain. The recording observer wraps the composite,
+ * so status snapshots update and OT metrics fire simultaneously.
  */
 @AutoConfiguration
 @AutoConfigureBefore(SovereignOpsAutoConfiguration::class)
 open class SovereignOpsOutboxObservabilityAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean(SovereignOpsAuditOutboxWorkerObserver::class)
     @ConditionalOnBean(OpenTelemetry::class)
-    open fun openTelemetrySovereignOpsAuditOutboxWorkerObserver(
+    @ConditionalOnMissingBean(name = ["openTelemetrySovereignOpsAuditOutboxWorkerObserverContribution"])
+    open fun openTelemetrySovereignOpsAuditOutboxWorkerObserverContribution(
         openTelemetry: OpenTelemetry,
-    ): SovereignOpsAuditOutboxWorkerObserver =
-        OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry)
+    ): SovereignOpsAuditOutboxWorkerObserverContribution =
+        SovereignOpsAuditOutboxWorkerObserverContribution(
+            OpenTelemetrySovereignOpsAuditOutboxWorkerObserver(openTelemetry),
+        )
 }

--- a/tramai-spring-boot-starter-sovereign-ops-observability/src/test/kotlin/dev/tramai/spring/sovereign/ops/observability/SovereignOpsOutboxObservabilityAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-observability/src/test/kotlin/dev/tramai/spring/sovereign/ops/observability/SovereignOpsOutboxObservabilityAutoConfigurationTest.kt
@@ -3,8 +3,9 @@ package dev.tramai.spring.sovereign.ops.observability
 import dev.tramai.spring.sovereign.ops.SovereignOpsAutoConfiguration
 import dev.tramai.spring.sovereign.ops.outbox.RecordingSovereignOpsAuditOutboxWorkerObserver
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserverContribution
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerRunSummary
 import io.opentelemetry.api.OpenTelemetry
-import io.opentelemetry.api.metrics.Meter
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.boot.autoconfigure.AutoConfigurations
@@ -33,22 +34,27 @@ class SovereignOpsOutboxObservabilityAutoConfigurationTest {
                 assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
                 val observer = ctx.getBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
                 assertThat(observer).isInstanceOf(RecordingSovereignOpsAuditOutboxWorkerObserver::class.java)
+                assertThat(ctx).doesNotHaveBean(SovereignOpsAuditOutboxWorkerObserverContribution::class.java)
             }
     }
 
     @Test
-    fun `OpenTelemetry observer is created when OpenTelemetry bean is present`() {
+    fun `OT contribution is created when OpenTelemetry bean is present`() {
         contextRunner
             .withUserConfiguration(OpenTelemetryConfig::class.java)
             .run { ctx ->
                 assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
                 val observer = ctx.getBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
-                assertThat(observer).isInstanceOf(OpenTelemetrySovereignOpsAuditOutboxWorkerObserver::class.java)
+                assertThat(observer).isInstanceOf(RecordingSovereignOpsAuditOutboxWorkerObserver::class.java)
+
+                assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxWorkerObserverContribution::class.java)
+                val contribution = ctx.getBean(SovereignOpsAuditOutboxWorkerObserverContribution::class.java)
+                assertThat(contribution.observer).isInstanceOf(OpenTelemetrySovereignOpsAuditOutboxWorkerObserver::class.java)
             }
     }
 
     @Test
-    fun `custom observer bean is not overridden by auto-configuration`() {
+    fun `custom observer is not overridden by auto-configuration`() {
         contextRunner
             .withUserConfiguration(CustomObserverConfig::class.java)
             .run { ctx ->
@@ -72,8 +78,6 @@ class SovereignOpsOutboxObservabilityAutoConfigurationTest {
             }
     }
 
-    // ── Configurations ──────────────────────────────────────────────
-
     @Configuration
     open class OpenTelemetryConfig {
         @Bean
@@ -90,7 +94,7 @@ class SovereignOpsOutboxObservabilityAutoConfigurationTest {
     }
 
     open class CustomTestObserver : SovereignOpsAuditOutboxWorkerObserver {
-        override fun onCycleCompleted(summary: dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerRunSummary) = Unit
+        override fun onCycleCompleted(summary: SovereignOpsAuditOutboxWorkerRunSummary) = Unit
         override fun onCycleFailed(action: String, errorCode: String) = Unit
     }
 }

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
@@ -7,6 +7,7 @@ import dev.tramai.security.audit.AuditEngine
 import dev.tramai.security.audit.AuditStore
 import dev.tramai.spring.sovereign.ops.outbox.DefaultSovereignOpsAuditDigestService
 import dev.tramai.spring.sovereign.ops.outbox.DefaultSovereignOpsAuditOutboxOperations
+import dev.tramai.spring.sovereign.ops.outbox.CompositeSovereignOpsAuditOutboxWorkerObserver
 import dev.tramai.spring.sovereign.ops.outbox.InMemorySovereignOpsApprovalMutationStore
 import dev.tramai.spring.sovereign.ops.outbox.InMemorySovereignOpsAuditOutboxStore
 import dev.tramai.spring.sovereign.ops.outbox.InMemorySovereignOpsAuditOutboxWorkerStatusStore
@@ -20,6 +21,7 @@ import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxOperations
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerLifecycle
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserverContribution
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerStatusStore
 import dev.tramai.spring.sovereign.ops.outbox.UnknownSovereignOpsApprovalRecoveryResolver
 import dev.tramai.spring.sovereign.ops.outbox.validateSovereignOpsAuditOutboxWorkerProperties
@@ -223,8 +225,21 @@ class SovereignOpsAutoConfiguration {
     @ConditionalOnMissingBean
     fun sovereignOpsAuditOutboxWorkerObserver(
         statusStore: SovereignOpsAuditOutboxWorkerStatusStore,
-    ): SovereignOpsAuditOutboxWorkerObserver =
-        RecordingSovereignOpsAuditOutboxWorkerObserver(statusStore)
+        contributions: ObjectProvider<SovereignOpsAuditOutboxWorkerObserverContribution>,
+    ): SovereignOpsAuditOutboxWorkerObserver {
+        val observerContributions = contributions.orderedStream().toList()
+        val delegate = if (observerContributions.isEmpty()) {
+            SovereignOpsAuditOutboxWorkerObserver.Noop
+        } else {
+            CompositeSovereignOpsAuditOutboxWorkerObserver(
+                observerContributions.map { it.observer },
+            )
+        }
+        return RecordingSovereignOpsAuditOutboxWorkerObserver(
+            statusStore = statusStore,
+            delegate = delegate,
+        )
+    }
 
     @Bean
     @ConditionalOnMissingBean

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/CompositeSovereignOpsAuditOutboxWorkerObserver.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/CompositeSovereignOpsAuditOutboxWorkerObserver.kt
@@ -1,0 +1,40 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+import java.util.concurrent.CancellationException
+
+/**
+ * Composite [SovereignOpsAuditOutboxWorkerObserver] that delegates to a
+ * list of observer instances.
+ *
+ * Each observer is called in order. A [RuntimeException] from one delegate
+ * does not prevent subsequent delegates from being notified.
+ * [CancellationException] is always rethrown.
+ */
+class CompositeSovereignOpsAuditOutboxWorkerObserver(
+    private val observers: List<SovereignOpsAuditOutboxWorkerObserver>,
+) : SovereignOpsAuditOutboxWorkerObserver {
+
+    override fun onCycleCompleted(summary: SovereignOpsAuditOutboxWorkerRunSummary) {
+        observers.forEach { observer ->
+            try {
+                observer.onCycleCompleted(summary)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: RuntimeException) {
+                // Isolate delegate failures. Do not log raw exception details.
+            }
+        }
+    }
+
+    override fun onCycleFailed(action: String, errorCode: String) {
+        observers.forEach { observer ->
+            try {
+                observer.onCycleFailed(action, errorCode)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: RuntimeException) {
+                // Isolate delegate failures. Do not log raw exception details.
+            }
+        }
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerObserverContribution.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerObserverContribution.kt
@@ -1,0 +1,18 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+/**
+ * Contribution wrapper for [SovereignOpsAuditOutboxWorkerObserver] instances.
+ *
+ * Modules like Micrometer and OpenTelemetry contribute their observers
+ * through this type instead of registering a final
+ * [SovereignOpsAuditOutboxWorkerObserver] bean. The base ops auto-config
+ * collects all contributions and composes them into a single delegate chain
+ * behind the recording observer.
+ *
+ * This type intentionally does NOT extend
+ * [SovereignOpsAuditOutboxWorkerObserver] to prevent Spring bean type
+ * collisions.
+ */
+data class SovereignOpsAuditOutboxWorkerObserverContribution(
+    val observer: SovereignOpsAuditOutboxWorkerObserver,
+)

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsOutboxWorkerAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsOutboxWorkerAutoConfigurationTest.kt
@@ -8,6 +8,8 @@ import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStatus
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxSummary
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerLifecycle
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserver
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObserverContribution
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerRunSummary
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerStatusStore
 import dev.tramai.spring.sovereign.ops.outbox.RecordingSovereignOpsAuditOutboxWorkerObserver
 import dev.tramai.spring.sovereign.ops.outbox.TestAuditEngineConfig
@@ -18,6 +20,9 @@ import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
 
 class SovereignOpsOutboxWorkerAutoConfigurationTest {
 
@@ -263,6 +268,36 @@ class SovereignOpsOutboxWorkerAutoConfigurationTest {
     }
 
     @Test
+    fun `recording observer composes observer contributions`() {
+        ContributionObserverCounters.reset()
+
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                ObserverContributionConfig::class.java,
+            )
+            .run { ctx ->
+                val observer = ctx.getBean(SovereignOpsAuditOutboxWorkerObserver::class.java)
+                assertThat(observer).isInstanceOf(RecordingSovereignOpsAuditOutboxWorkerObserver::class.java)
+
+                val now = Instant.now()
+                observer.onCycleCompleted(
+                    SovereignOpsAuditOutboxWorkerRunSummary(
+                        recovered = null,
+                        dispatched = null,
+                        startedAt = now,
+                        completedAt = now.plus(Duration.ofMillis(500)),
+                    ),
+                )
+
+                val statusStore = ctx.getBean(SovereignOpsAuditOutboxWorkerStatusStore::class.java)
+                assertThat(statusStore.snapshot().totalCyclesCompleted).isEqualTo(1)
+                assertThat(ContributionObserverCounters.firstCompleted.get()).isEqualTo(1)
+                assertThat(ContributionObserverCounters.secondCompleted.get()).isEqualTo(1)
+            }
+    }
+
+    @Test
     fun `custom observer bean is not overridden by recording observer`() {
         contextRunner
             .withUserConfiguration(
@@ -341,4 +376,38 @@ open class CustomObserverConfig {
     @Primary
     open fun customObserver(): SovereignOpsAuditOutboxWorkerObserver =
         SovereignOpsAuditOutboxWorkerObserver.Noop
+}
+
+open class ObserverContributionConfig {
+    @Bean
+    open fun firstContribution(): SovereignOpsAuditOutboxWorkerObserverContribution =
+        SovereignOpsAuditOutboxWorkerObserverContribution(
+            CounterContributionObserver(ContributionObserverCounters.firstCompleted),
+        )
+
+    @Bean
+    open fun secondContribution(): SovereignOpsAuditOutboxWorkerObserverContribution =
+        SovereignOpsAuditOutboxWorkerObserverContribution(
+            CounterContributionObserver(ContributionObserverCounters.secondCompleted),
+        )
+}
+
+private object ContributionObserverCounters {
+    val firstCompleted = AtomicInteger()
+    val secondCompleted = AtomicInteger()
+
+    fun reset() {
+        firstCompleted.set(0)
+        secondCompleted.set(0)
+    }
+}
+
+private class CounterContributionObserver(
+    private val completed: AtomicInteger,
+) : SovereignOpsAuditOutboxWorkerObserver {
+    override fun onCycleCompleted(summary: SovereignOpsAuditOutboxWorkerRunSummary) {
+        completed.incrementAndGet()
+    }
+
+    override fun onCycleFailed(action: String, errorCode: String) = Unit
 }

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/CompositeSovereignOpsAuditOutboxWorkerObserverTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/CompositeSovereignOpsAuditOutboxWorkerObserverTest.kt
@@ -1,0 +1,107 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.CancellationException
+
+class CompositeSovereignOpsAuditOutboxWorkerObserverTest {
+
+    private val now = Instant.now()
+    private val summary = SovereignOpsAuditOutboxWorkerRunSummary(
+        recovered = null,
+        dispatched = null,
+        startedAt = now,
+        completedAt = now.plus(Duration.ofMillis(500)),
+    )
+
+    @Test
+    fun `delegates onCycleCompleted to all observers`() {
+        val calls = mutableListOf<String>()
+        val observer1 = RecordingTestObserver(onCompleted = { calls.add("a") })
+        val observer2 = RecordingTestObserver(onCompleted = { calls.add("b") })
+        val composite = CompositeSovereignOpsAuditOutboxWorkerObserver(listOf(observer1, observer2))
+
+        composite.onCycleCompleted(summary)
+
+        assertThat(calls).containsExactly("a", "b")
+    }
+
+    @Test
+    fun `delegates onCycleFailed to all observers`() {
+        val calls = mutableListOf<String>()
+        val observer1 = RecordingTestObserver(onFailed = { calls.add("a") })
+        val observer2 = RecordingTestObserver(onFailed = { calls.add("b") })
+        val composite = CompositeSovereignOpsAuditOutboxWorkerObserver(listOf(observer1, observer2))
+
+        composite.onCycleFailed("unexpected", "test")
+
+        assertThat(calls).containsExactly("a", "b")
+    }
+
+    @Test
+    fun `delegate RuntimeException does not prevent other delegates from receiving cycle callbacks`() {
+        val calls = mutableListOf<String>()
+        val throwing = RecordingTestObserver(onCompleted = { throw RuntimeException("fail") })
+        val working = RecordingTestObserver(onCompleted = { calls.add("b") })
+        val composite = CompositeSovereignOpsAuditOutboxWorkerObserver(listOf(throwing, working))
+
+        composite.onCycleCompleted(summary)
+
+        assertThat(calls).containsExactly("b")
+    }
+
+    @Test
+    fun `delegate RuntimeException does not prevent other delegates from receiving failure callbacks`() {
+        val calls = mutableListOf<String>()
+        val throwing = RecordingTestObserver(onFailed = { throw RuntimeException("fail") })
+        val working = RecordingTestObserver(onFailed = { calls.add("b") })
+        val composite = CompositeSovereignOpsAuditOutboxWorkerObserver(listOf(throwing, working))
+
+        composite.onCycleFailed("unexpected", "test")
+
+        assertThat(calls).containsExactly("b")
+    }
+
+    @Test
+    fun `CancellationException from onCycleCompleted is rethrown`() {
+        val throwing = RecordingTestObserver(onCompleted = { throw CancellationException() })
+        val composite = CompositeSovereignOpsAuditOutboxWorkerObserver(listOf(throwing))
+
+        org.junit.jupiter.api.assertThrows<CancellationException> {
+            composite.onCycleCompleted(summary)
+        }
+    }
+
+    @Test
+    fun `CancellationException from onCycleFailed is rethrown`() {
+        val throwing = RecordingTestObserver(onFailed = { throw CancellationException() })
+        val composite = CompositeSovereignOpsAuditOutboxWorkerObserver(listOf(throwing))
+
+        org.junit.jupiter.api.assertThrows<CancellationException> {
+            composite.onCycleFailed("unexpected", "test")
+        }
+    }
+
+    @Test
+    fun `empty observers list does not throw`() {
+        val composite = CompositeSovereignOpsAuditOutboxWorkerObserver(emptyList())
+
+        composite.onCycleCompleted(summary)
+        composite.onCycleFailed("unexpected", "test")
+    }
+}
+
+private class RecordingTestObserver(
+    private val onCompleted: (() -> Unit)? = null,
+    private val onFailed: (() -> Unit)? = null,
+) : SovereignOpsAuditOutboxWorkerObserver {
+    override fun onCycleCompleted(summary: SovereignOpsAuditOutboxWorkerRunSummary) {
+        onCompleted?.invoke()
+    }
+
+    override fun onCycleFailed(action: String, errorCode: String) {
+        onFailed?.invoke()
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the known observer replacement limitation from PR #67: Micrometer/OpenTelemetry observers no longer replace the status-recording observer. All three work together automatically.

### Design

Introduced two new types in the base ops module:

- **`SovereignOpsAuditOutboxWorkerObserverContribution`** — a `data class` wrapping an observer. Intentionally does NOT extend `SovereignOpsAuditOutboxWorkerObserver` to prevent Spring bean type collisions with the final observer bean.

- **`CompositeSovereignOpsAuditOutboxWorkerObserver`** — implements `SovereignOpsAuditOutboxWorkerObserver` and delegates to a list of observers. Isolates `RuntimeException` per-delegate, rethrows `CancellationException`.

### Auto-config chain

```
RecordingObserver (status store)
  └── CompositeObserver
        ├── Micrometer contribution (if MeterRegistry bean exists)
        ├── OT contribution (if OpenTelemetry bean exists)
        └── ... future contributions
```

### Changes by module

**Base ops starter** (`SovereignOpsAutoConfiguration`):
- Default observer bean now accepts `ObjectProvider<SovereignOpsAuditOutboxWorkerObserverContribution>`
- Builds composite when contributions exist, Noop otherwise
- Recording observer wraps composite as delegate
- `@ConditionalOnMissingBean` preserved — custom observer still wins

**Micrometer module**:
- Changed from `SovereignOpsAuditOutboxWorkerObserver` bean to `SovereignOpsAuditOutboxWorkerObserverContribution` bean
- No longer triggers `@ConditionalOnMissingBean` on the final observer
- Uses `@ConditionalOnMissingBean(name = [...])` for deduplication

**OpenTelemetry module**:
- Same pattern as Micrometer: contribution bean instead of observer bean
- Updated KDoc and README Quickstart

### Files changed

| File | Change |
|------|--------|
| `.../outbox/SovereignOpsAuditOutboxWorkerObserverContribution.kt` | **NEW** — contribution wrapper |
| `.../outbox/CompositeSovereignOpsAuditOutboxWorkerObserver.kt` | **NEW** — composite delegate |
| `.../sovereign/ops/SovereignOpsAutoConfiguration.kt` | Modified — composite wiring |
| `.../micrometer/SovereignOpsOutboxMicrometerAutoConfiguration.kt` | Modified — contribution type |
| `.../observability/SovereignOpsOutboxObservabilityAutoConfiguration.kt` | Modified — contribution type |
| `.../outbox/CompositeSovereignOpsAuditOutboxWorkerObserverTest.kt` | **NEW** — unit tests |
| `.../ops/SovereignOpsOutboxWorkerAutoConfigurationTest.kt` | Modified — contribution composition test |
| `.../micrometer/SovereignOpsOutboxMicrometerAutoConfigurationTest.kt` | Modified — contribution + integration test |
| `.../observability/SovereignOpsOutboxObservabilityAutoConfigurationTest.kt` | Modified — contribution assertions |
| `Micrometer README.md` | Updated — removed limitation, composition docs |
| `OT README.md` | Updated — quickstart for contribution model |

### Compatibility notes

- **Custom final observer**: still supported. Provide a `SovereignOpsAuditOutboxWorkerObserver` bean and the entire auto-config chain is skipped.
- **Backward compatible**: existing applications with only the base ops starter see no behavior change.
- **Backward compatible**: existing applications with Micrometer or OT modules now get status recording **plus** metrics (instead of metrics-only).
- **No new module, no release boundary change, no BOM change needed.**

### Security

No sensitive data is exposed in logs, metrics, tags, or status objects. The composite silently catches delegate `RuntimeException` without logging raw exception messages.

### Verification

```
✅ tramai-spring-boot-starter-sovereign-ops:test (re-run)
✅ tramai-spring-boot-starter-sovereign-ops-micrometer:test (re-run)
✅ tramai-spring-boot-starter-sovereign-ops-observability:test (re-run)
✅ Full test suite (169 tasks)
```
