### PR TITLE
docs(sovereign-ops): add worker observability runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ TramAI is organized into focused Gradle modules:
 | `tramai-spring-boot-starter-sovereign-ops-actuator` | Optional Actuator endpoint for worker status (read-only, opt-in) |
 | `tramai-spring-boot-starter-sovereign-ops-micrometer` | Micrometer metrics for sovereign ops audit outbox worker |
 | `tramai-spring-boot-starter-sovereign-ops-observability` | OpenTelemetry metrics for sovereign ops audit outbox worker |
+| [Worker observability runbook](docs/operations/sovereign-ops-worker-observability-runbook.md) | Operator-facing documentation for all three observability surfaces |
 | `tramai-spring-boot-starter-sovereign-persistence-file` | File-backed persistence auto-configuration |
 
 ### Optional Higher-Level Modules

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -22,6 +22,7 @@ This document describes the state of the repository, not a formal release contra
 | Audit chain (tamper-evident sequencing) | Implemented / evolving |
 | Audit outbox (atomic mutation + audit intent, claim-based dispatch) | Implemented / evolving |
 | Audit outbox background worker (recovery + dispatch loop) | Implemented / evolving |
+| Sovereign ops worker observability runbook | Implemented |
 | Sovereign ops audit outbox OpenTelemetry metrics | Implemented |
 | Evidence generation (bundles, release artifacts) | Implemented / evolving |
 | Sovereign document intelligence example | Implemented |

--- a/docs/modules/sovereign-runtime-module-matrix.md
+++ b/docs/modules/sovereign-runtime-module-matrix.md
@@ -1,8 +1,12 @@
 # Sovereign Runtime Module Matrix
 
-One-stop reference for the sovereign runtime modules on master. Updated 2026-06-18.
+One-stop reference for the sovereign runtime modules on master. Updated 2026-06-20.
 
-## Module Overview
+### Sovereign Runtime
+
+See the [worker observability runbook](../operations/sovereign-ops-worker-observability-runbook.md) for operator-facing
+documentation covering the Actuator status endpoint, Micrometer metrics,
+OpenTelemetry metrics, PromQL examples, and troubleshooting flows.
 
 | Module | Purpose | Runtime Role | Release Status |
 |---|---|---|---|
@@ -48,6 +52,7 @@ All modules are opt-in. The sovereign runtime does not activate unless explicitl
 
 ## Finding More
 
+- [Worker observability runbook](../operations/sovereign-ops-worker-observability-runbook.md)
 - [Sovereign Runtime Release Readiness](../releases/sovereign-runtime-release-readiness.md)
 - [TramAI Architecture](../ARCHITECTURE.md)
 - [Project Status](../STATUS.md)

--- a/docs/operations/prometheus/sovereign-ops-worker-alerts.example.yml
+++ b/docs/operations/prometheus/sovereign-ops-worker-alerts.example.yml
@@ -1,0 +1,69 @@
+# Sovereign Ops Worker — Example Prometheus Alert Rules
+#
+# WARNING: These are examples — NOT production defaults.
+#
+# Thresholds must be tuned based on:
+# - Workload volume and patterns
+# - Retry policy and batch size
+# - Expected cycle interval
+# - Historical baseline behavior
+# - Team on-call capacity
+#
+# Always validate alert sensitivity against historical data before
+# deploying to production.
+
+groups:
+  - name: tramai-sovereign-ops-worker
+    rules:
+      # Elevated cycle failure rate
+      - alert: TramaiSovereignOpsWorkerCycleFailures
+        expr: |
+          sum(rate(tramai_sovereign_ops_outbox_worker_cycles_total{outcome="failure"}[10m]))
+          /
+          clamp_min(sum(rate(tramai_sovereign_ops_outbox_worker_cycles_total[10m])), 1)
+          > 0.10
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "TramAI sovereign ops worker has elevated cycle failures"
+          description: "More than 10% of worker cycles failed over the last 10 minutes. Current failure ratio: {{ $value | humanizePercentage }}."
+
+      # Permanent failures detected
+      - alert: TramaiSovereignOpsWorkerPermanentFailures
+        expr: |
+          sum(rate(tramai_sovereign_ops_outbox_worker_recovered_records_total{result="failed_permanent"}[10m]))
+          +
+          sum(rate(tramai_sovereign_ops_outbox_worker_dispatched_records_total{result="failed_permanent"}[10m]))
+          > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "TramAI sovereign ops worker is producing permanent failures"
+          description: "Permanent failures were observed in recovery or dispatch. Records cannot be recovered automatically."
+
+      # Worker metrics absent (possible worker down)
+      - alert: TramaiSovereignOpsWorkerAbsent
+        expr: |
+          absent(tramai_sovereign_ops_outbox_worker_cycles_total) == 1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "TramAI sovereign ops worker metrics absent"
+          description: "No sovereign ops worker cycle metrics have been received for at least 5 minutes. The worker may not be running."
+
+      # High cycle duration (slow worker)
+      - alert: TramaiSovereignOpsWorkerSlowCycles
+        expr: |
+          rate(tramai_sovereign_ops_outbox_worker_duration_seconds_sum[10m])
+          /
+          rate(tramai_sovereign_ops_outbox_worker_duration_seconds_count[10m])
+          > 30
+        for: 15m
+        labels:
+          severity: info
+        annotations:
+          summary: "TramAI sovereign ops worker cycles are slow"
+          description: "Average cycle duration exceeded 30s over the last 10 minutes. Current average: {{ $value | humanizeDuration }}."

--- a/docs/operations/prometheus/sovereign-ops-worker-promql.md
+++ b/docs/operations/prometheus/sovereign-ops-worker-promql.md
@@ -1,0 +1,186 @@
+# Sovereign Ops Worker — PromQL Query Reference
+
+PromQL queries for the sovereign ops audit outbox worker Micrometer
+metrics. All metric names assume the Prometheus naming convention
+(dots → underscores, counters suffixed with `_total`).
+
+## Metric reference
+
+### Worker cycles
+
+Prometheus name: `tamai_sovereign_ops_outbox_worker_cycles_total`
+
+Tags: `outcome`, `failure_action`, `error_type`
+
+### Worker cycle duration (timer)
+
+Prometheus names:
+
+- `tamai_sovereign_ops_outbox_worker_duration_seconds_count`
+- `tamai_sovereign_ops_outbox_worker_duration_seconds_sum`
+- `tamai_sovereign_ops_outbox_worker_duration_seconds_max`
+
+Tags: `outcome`, `failure_action`, `error_type`
+
+Histogram buckets (`_bucket`) are absent by default — emitted only
+when percentile histograms are explicitly enabled.
+
+### Worker failures
+
+Prometheus name: `tamai_sovereign_ops_outbox_worker_failures_total`
+
+Tags: `failure_action`, `error_type`
+
+### Recovery records
+
+Prometheus name: `tamai_sovereign_ops_outbox_worker_recovered_records_total`
+
+Tags: `result` (`inspected`, `moved_to_pending`, `failed_permanent`,
+`resolver_failure`)
+
+### Dispatch records
+
+Prometheus name: `tamai_sovereign_ops_outbox_worker_dispatched_records_total`
+
+Tags: `result` (`claimed`, `emitted`, `failed_retryable`,
+`failed_permanent`)
+
+---
+
+## Queries
+
+### Worker cycle rate
+
+Rate of completed worker cycles (all outcomes).
+
+```promql
+rate(tramai_sovereign_ops_outbox_worker_cycles_total[5m])
+```
+
+### Failed cycle rate
+
+Rate of worker cycles that completed with a failure outcome.
+
+```promql
+rate(tramai_sovereign_ops_outbox_worker_cycles_total{outcome="failure"}[5m])
+```
+
+### Failure ratio
+
+Proportion of worker cycles that ended in failure.
+
+```promql
+sum(rate(tramai_sovereign_ops_outbox_worker_cycles_total{outcome="failure"}[5m]))
+/
+sum(rate(tramai_sovereign_ops_outbox_worker_cycles_total[5m]))
+```
+
+If no cycles are observed, the denominator is zero and the query
+returns `NaN`. Use `clamp_min(coalesce(..., 0), 1)` in alert rules
+to avoid division by zero.
+
+### Average cycle duration
+
+Average wall-clock duration of worker cycles.
+
+```promql
+rate(tramai_sovereign_ops_outbox_worker_duration_seconds_sum[5m])
+/
+rate(tramai_sovereign_ops_outbox_worker_duration_seconds_count[5m])
+```
+
+### Maximum cycle duration (latest rolling window)
+
+```promql
+tramai_sovereign_ops_outbox_worker_duration_seconds_max
+```
+
+### Recovery throughput by result
+
+Per-result-type rate of records processed by the recovery phase.
+
+```promql
+sum by (result) (
+  rate(tramai_sovereign_ops_outbox_worker_recovered_records_total[5m])
+)
+```
+
+### Dispatch throughput by result
+
+Per-result-type rate of records processed by the dispatch phase.
+
+```promql
+sum by (result) (
+  rate(tramai_sovereign_ops_outbox_worker_dispatched_records_total[5m])
+)
+```
+
+### Permanent failure signal
+
+Rate of records that were permanently failed (not retryable) in either
+the recovery or dispatch phase.
+
+```promql
+rate(tramai_sovereign_ops_outbox_worker_recovered_records_total{result="failed_permanent"}[5m])
++
+rate(tramai_sovereign_ops_outbox_worker_dispatched_records_total{result="failed_permanent"}[5m])
+```
+
+Any sustained non-zero value for this query indicates records that
+cannot be processed and require operator attention.
+
+### Worker not running (absent signal)
+
+Alert when the worker is expected to be running but no cycle metrics
+appear.
+
+```promql
+absent(tramai_sovereign_ops_outbox_worker_cycles_total) == 1
+```
+
+Note: This fires a single alert when the metric is absent. Use
+`for: 5m` to avoid flapping during restarts.
+
+### Failure rate by failure_action
+
+Break down failure rates by the action that failed.
+
+```promql
+sum by (failure_action) (
+  rate(tramai_sovereign_ops_outbox_worker_failures_total[5m])
+)
+```
+
+### Error type distribution
+
+Identify which error types contribute to failures.
+
+```promql
+sum by (error_type) (
+  rate(tramai_sovereign_ops_outbox_worker_failures_total[5m])
+)
+```
+
+---
+
+## Query guidance
+
+- **Use rates, not raw counters.** Counter values reset on restart and
+  are meaningless as absolute values. Always use `rate()` or
+  `increase()` over a time window.
+- **Match duration window to cycle interval.** A 5m rate window works
+  for workers with polling intervals up to 60 seconds. For slower
+  intervals (e.g., 5 minutes), use a correspondingly longer window
+  (15m+).
+- **Division by zero.** When computing ratios (failure ratio, average
+  duration), the denominator may be zero if no cycles have completed.
+  Wrap denominators in `clamp_min(..., 1)` for alert rules.
+- **Timer buckets are opt-in.** If you need latency SLOs with
+  percentile histograms, enable them in Micrometer configuration:
+  ```yaml
+  management:
+    metrics:
+      distribution:
+        percentiles-histogram:
+          tramai.sovereign.ops.outbox.worker.duration: true
+  ```

--- a/docs/operations/prometheus/sovereign-ops-worker-promql.md
+++ b/docs/operations/prometheus/sovereign-ops-worker-promql.md
@@ -8,7 +8,7 @@ metrics. All metric names assume the Prometheus naming convention
 
 ### Worker cycles
 
-Prometheus name: `tamai_sovereign_ops_outbox_worker_cycles_total`
+Prometheus name: `tramai_sovereign_ops_outbox_worker_cycles_total`
 
 Tags: `outcome`, `failure_action`, `error_type`
 
@@ -16,9 +16,9 @@ Tags: `outcome`, `failure_action`, `error_type`
 
 Prometheus names:
 
-- `tamai_sovereign_ops_outbox_worker_duration_seconds_count`
-- `tamai_sovereign_ops_outbox_worker_duration_seconds_sum`
-- `tamai_sovereign_ops_outbox_worker_duration_seconds_max`
+- `tramai_sovereign_ops_outbox_worker_duration_seconds_count`
+- `tramai_sovereign_ops_outbox_worker_duration_seconds_sum`
+- `tramai_sovereign_ops_outbox_worker_duration_seconds_max`
 
 Tags: `outcome`, `failure_action`, `error_type`
 
@@ -27,20 +27,20 @@ when percentile histograms are explicitly enabled.
 
 ### Worker failures
 
-Prometheus name: `tamai_sovereign_ops_outbox_worker_failures_total`
+Prometheus name: `tramai_sovereign_ops_outbox_worker_failures_total`
 
 Tags: `failure_action`, `error_type`
 
 ### Recovery records
 
-Prometheus name: `tamai_sovereign_ops_outbox_worker_recovered_records_total`
+Prometheus name: `tramai_sovereign_ops_outbox_worker_recovered_records_total`
 
 Tags: `result` (`inspected`, `moved_to_pending`, `failed_permanent`,
 `resolver_failure`)
 
 ### Dispatch records
 
-Prometheus name: `tamai_sovereign_ops_outbox_worker_dispatched_records_total`
+Prometheus name: `tramai_sovereign_ops_outbox_worker_dispatched_records_total`
 
 Tags: `result` (`claimed`, `emitted`, `failed_retryable`,
 `failed_permanent`)
@@ -76,7 +76,7 @@ sum(rate(tramai_sovereign_ops_outbox_worker_cycles_total[5m]))
 ```
 
 If no cycles are observed, the denominator is zero and the query
-returns `NaN`. Use `clamp_min(coalesce(..., 0), 1)` in alert rules
+returns `NaN`. Use `clamp_min(sum(rate(...)), 1)` in alert rules
 to avoid division by zero.
 
 ### Average cycle duration

--- a/docs/operations/sovereign-ops-worker-observability-runbook.md
+++ b/docs/operations/sovereign-ops-worker-observability-runbook.md
@@ -1,0 +1,503 @@
+# Sovereign Ops Worker Observability Runbook
+
+## Purpose
+
+This runbook describes how to observe, monitor, and troubleshoot the
+TramAI sovereign ops audit outbox worker at runtime. It covers the
+three operational surfaces — Actuator status endpoint, Micrometer
+metrics (Prometheus), and OpenTelemetry metrics — along with
+PromQL queries, alert examples, and troubleshooting flows.
+
+The audience is operators who deploy applications using the sovereign
+ops audit outbox worker and need to understand what healthy operation
+looks like, how to detect problems, and what is safe to expose.
+
+## What this runbook covers
+
+- Actuator worker status endpoint (`/actuator/tramaiSovereignOpsWorker`)
+- Micrometer/Prometheus metric surface (five metric families)
+- OpenTelemetry metric surface
+- PromQL query examples for all metric families
+- Example Prometheus alert rules (mark as examples only)
+- Troubleshooting flows for common operational scenarios
+- Security boundaries and safe-exposure rules
+- Observer composition and custom-override behavior
+
+## What this runbook does not cover
+
+- Production Grafana dashboards or environment-specific alert thresholds
+- SRE-certified alert sensitivities or on-call run procedures
+- Deployment topology, networking, or load balancing
+- Database-backed outbox configuration or migration
+- Distributed worker leader election or multi-node coordination
+- Key rotation or credential management
+- A full production deployment guide
+
+These remain non-goals unless explicitly implemented in a later PR.
+
+---
+
+## Operational surfaces
+
+### 1. Actuator worker status endpoint
+
+**Endpoint:** `GET /actuator/tramaiSovereignOpsWorker`
+
+**Purpose:** Returns a read-only snapshot of the audit outbox worker's
+current operational state: whether the worker is running, the last
+recorded cycle result, the number of cycles since last reset, and
+counts of recovered and dispatched records.
+
+**Properties:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `running` | boolean | Whether the worker schedule is active |
+| `lastCycleResult` | string | `success`, `failure`, or `none` |
+| `cyclesSinceLastReset` | integer | Cycles completed since last reset |
+| `totalCycleDurationMillis` | long | Cumulative cycle wall-clock time |
+| `recoveredCount` | integer | Total records recovered |
+| `dispatchedCount` | integer | Total records dispatched |
+| `failureCount` | integer | Total failures recorded |
+
+**Activation:**
+
+The endpoint is:
+
+- **Read-only** — never writes or mutates state
+- **Disabled by default** — the TramAI bean is created only when
+  `tramai.sovereign.ops.actuator.worker-status.enabled=true`
+- **Sanitized** — never returns outbox IDs, approval IDs, reason text,
+  tokens, replay envelopes, prompts, model responses, or tool arguments
+- **Externally exposed only if the application configures it** through
+  Spring Boot Actuator's `management.endpoints.web.exposure.include`
+
+**Security:**
+
+The TramAI module provides the endpoint bean. It does NOT provide
+authentication. Applications that expose the endpoint over HTTP MUST
+secure it with their own authentication and authorization layer
+(e.g., Spring Security, network policies, or API gateways).
+
+**Example configuration:**
+
+```yaml
+tramai:
+  sovereign:
+    ops:
+      actuator:
+        worker-status:
+          enabled: true
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: tramaiSovereignOpsWorker
+```
+
+---
+
+### 2. Micrometer / Prometheus metrics
+
+The Micrometer bridge exposes five metric families. In Prometheus,
+dot-separated metric names become underscore-separated.
+
+#### Metric families
+
+| Name | Type | Tags |
+|------|------|------|
+| `tramai.sovereign.ops.outbox.worker.cycles` | Counter | outcome, failure_action, error_type |
+| `tramai.sovereign.ops.outbox.worker.duration` | Timer | outcome, failure_action, error_type |
+| `tramai.sovereign.ops.outbox.worker.failures` | Counter | failure_action, error_type |
+| `tramai.sovereign.ops.outbox.worker.recovered.records` | Counter | result |
+| `tramai.sovereign.ops.outbox.worker.dispatched.records` | Counter | result |
+
+#### Prometheus-exported names
+
+| Meter name | Prometheus name |
+|------------|----------------|
+| `tramai.sovereign.ops.outbox.worker.cycles` | `tramai_sovereign_ops_outbox_worker_cycles_total` |
+| `tramai.sovereign.ops.outbox.worker.duration` | `tramai_sovereign_ops_outbox_worker_duration_seconds_count` / `_sum` / `_max` |
+| `tramai.sovereign.ops.outbox.worker.failures` | `tramai_sovereign_ops_outbox_worker_failures_total` |
+| `tramai.sovereign.ops.outbox.worker.recovered.records` | `tramai_sovereign_ops_outbox_worker_recovered_records_total` |
+| `tramai.sovereign.ops.outbox.worker.dispatched.records` | `tramai_sovereign_ops_outbox_worker_dispatched_records_total` |
+
+For the timer (`duration`), Prometheus exports three time series:
+
+- `tramai_sovereign_ops_outbox_worker_duration_seconds_count` — count of
+  recorded observations
+- `tramai_sovereign_ops_outbox_worker_duration_seconds_sum` — sum of
+  durations in seconds
+- `tramai_sovereign_ops_outbox_worker_duration_seconds_max` — maximum
+  duration in seconds over the rolling window
+
+Histogram buckets (`_bucket`) are emitted **only** when percentile
+histograms are explicitly enabled in the Micrometer configuration.
+By default they are absent.
+
+#### Tag values
+
+| Tag | Values |
+|-----|--------|
+| `outcome` | `success`, `failure` |
+| `failure_action` | `none`, `recoverPrepared`, `dispatchPending`, `unexpected` |
+| `error_type` | `none` (on success), sanitized error code (on failure) |
+| `result` | `inspected`, `moved_to_pending`, `failed_permanent`, `resolver_failure`, `claimed`, `emitted`, `failed_retryable` |
+
+Tags are low-cardinality by design. No tenant IDs, user IDs, document
+IDs, approval IDs, workflow IDs, or correlation IDs appear in labels.
+
+#### Enabling Micrometer
+
+```yaml
+dependencies:
+  - tramai-spring-boot-starter-sovereign-ops-micrometer
+  - micrometer-registry-prometheus      # required for Prometheus scrape endpoint
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+```
+
+---
+
+### 3. OpenTelemetry metrics
+
+The OpenTelemetry module registers five instruments under the meter
+`dev.tramai.sovereign.ops.observability`.
+
+| Instrument | Type | Unit | Description |
+|------------|------|------|-------------|
+| `tramai.sovereign.ops.outbox.worker.cycles` | LongCounter | `{cycle}` | Completed worker cycles per action and outcome |
+| `tramai.sovereign.ops.outbox.worker.duration` | DoubleHistogram | `ms` | Cycle wall-clock duration |
+| `tramai.sovereign.ops.outbox.worker.recovered.records` | LongCounter | `{record}` | Recovery result counts per result type |
+| `tramai.sovereign.ops.outbox.worker.dispatched.records` | LongCounter | `{record}` | Dispatch result counts per result type |
+| `tramai.sovereign.ops.outbox.worker.failures` | LongCounter | `{failure}` | Failure notifications emitted by the worker |
+
+**Attributes** follow the same structure as Micrometer tags (see tag
+values table above), prefixed with the meter namespace.
+
+**Sanitization:** Same guarantees as the Micrometer surface — no
+sensitive data in instrument names, attributes, or values.
+
+**Activation:** The OT observer activates automatically when an
+`io.opentelemetry.api.OpenTelemetry` bean is present in the Spring
+context. No SDK or exporter is required — the module depends only on
+`opentelemetry-api`.
+
+---
+
+## Safe exposure model
+
+The observability surface is designed to be safe for operators to read,
+alert on, and include in dashboards without exposing sensitive data.
+
+**The following are NEVER exposed** in metrics, labels, logs, examples,
+or screenshots:
+
+- Approval IDs, denial reasons, or reason text
+- Tokens, session IDs, or replay envelopes
+- Prompts, model responses, or tool arguments
+- Raw outbox records or record IDs
+- File paths, stack traces, or raw exception messages
+- Tenant IDs, user IDs, document IDs, workflow IDs, or correlation IDs
+  as metric labels
+
+**Prometheus labels are low-cardinality.** Do not add high-cardinality
+labels (tenant IDs, user IDs, document IDs, approval IDs, workflow IDs,
+correlation IDs) to any metric in this surface.
+
+---
+
+## Normal operating behavior
+
+Under normal conditions:
+
+- **Worker cycles** execute at the configured polling interval. The
+  `cycles` counter increments with `outcome=success` on each cycle.
+- **Cycle duration** reflects the time taken for recovery and dispatch
+  phases. Duration depends on batch size, outbox volume, and dispatch
+  target latency.
+- **Recovery** (`recovered.records`) shows `inspected` for empty
+  stores or `moved_to_pending` for records promoted from PREPARED to
+  PENDING.
+- **Dispatch** (`dispatched.records`) shows `claimed` and `emitted`
+  for successfully dispatched records.
+- **Failures** are zero or near-zero during normal operation. Occasional
+  transient dispatch errors may produce `failed_retryable` entries,
+  which are expected if the dispatch target is briefly unavailable.
+- **Actuator status** shows `running=true`, with cycle counts and
+  duration updating after each cycle.
+
+---
+
+## Troubleshooting flows
+
+### Worker is not running
+
+**Symptoms:** Actuator returns `running=false`. No metrics updating.
+
+**Checklist:**
+
+1. Verify `tramai.sovereign.ops.outbox.worker.enabled=true` in
+   application configuration.
+2. Check the Actuator status endpoint for `running=false`.
+3. Inspect startup logs for invalid worker configuration errors.
+4. Check whether both `recoverPrepared` and `dispatchPending` are
+   disabled — the worker needs at least one active phase.
+5. If `dispatchPending` requires a dispatcher, verify the dispatcher
+   bean is present and configured.
+
+### Worker cycles are failing
+
+**Symptoms:** `cycles` counter shows `outcome="failure"`. Failure
+ratio exceeds expected threshold.
+
+**Checklist:**
+
+1. Inspect the `failure_action` and `error_type` tags on the failure
+   counter or cycle counter.
+2. Determine whether failures originate in recovery
+   (`failure_action=recoverPrepared`) or dispatch
+   (`failure_action=dispatchPending`).
+3. Check the `failed_retryable` vs `failed_permanent` result tags on
+   the record-level counters to understand whether the worker is
+   recovering from transient errors.
+4. Review worker logs for the error type identified in the metric tags.
+5. If failures are retryable, confirm that the retry policy matches
+   expected behavior.
+
+### Recovery is not moving prepared records
+
+**Symptoms:** `recovered.records` shows only `inspected` but no
+`moved_to_pending`. The PENDING store remains empty.
+
+**Checklist:**
+
+1. Verify the PREPARED store actually contains records.
+2. Check that the resolver is correctly resolving outbox records —
+   `resolver_failure` entries on the recovery counter indicate
+   resolution problems.
+3. Confirm the `recoverPrepared` phase is enabled.
+4. Inspect the outbox store provider configuration (e.g., file path,
+   encryption key presence).
+
+### Dispatch is not emitting records
+
+**Symptoms:** `dispatched.records` shows only `claimed` but no
+`emitted`. Records are being claimed but not completed.
+
+**Checklist:**
+
+1. Check for `failed_retryable` or `failed_permanent` dispatch results.
+2. Verify the dispatch target (e.g., the auditor bean or emitter) is
+   available and responsive.
+3. Check whether the dispatch implementation has retry limits or
+   throttling that is being hit.
+4. Confirm the `dispatchPending` phase is enabled.
+
+### Metrics are present but Actuator status is stale
+
+**Symptoms:** Micrometer/OpenTelemetry metrics are updating with each
+cycle, but the Actuator endpoint returns unchanged values.
+
+**Explanation:** This should be unexpected after PR #68 introduced the
+composite observer pipeline. However, it can still happen if the
+application provides a custom `SovereignOpsAuditOutboxWorkerObserver`
+bean that does not delegate to the composite observer.
+
+**Checklist:**
+
+1. Check whether the application defines a custom observer bean.
+2. If a custom bean exists, confirm it implements the
+   `SovereignOpsAuditOutboxWorkerObserver` interface and does NOT
+   bypass the status-recording observer.
+3. The base module's `@ConditionalOnMissingBean` means a custom bean
+   **replaces** the entire observer chain, including status recording.
+4. To preserve status recording with custom logic, compose your custom
+   observer with the existing one via the composite pattern.
+
+### Actuator status works but Prometheus has no data
+
+**Symptoms:** Actuator endpoint returns valid status. Worker is
+running. Prometheus scrape target is configured but no
+`tramai_sovereign_ops_outbox_worker_*` metrics appear.
+
+**Checklist:**
+
+1. Confirm `tramai-spring-boot-starter-sovereign-ops-micrometer` is on
+   the classpath.
+2. Confirm a `MeterRegistry` bean exists — Spring Boot auto-configures
+   one when a Micrometer implementation is on the classpath.
+3. If using Prometheus, confirm `micrometer-registry-prometheus` is on
+   the classpath.
+4. If using Spring Boot Actuator, confirm the Prometheus endpoint is
+   exposed: `management.endpoints.web.exposure.include=prometheus`.
+5. Confirm the Prometheus scrape target is healthy and pointing to the
+   correct port and path (`/actuator/prometheus`).
+
+---
+
+## PromQL quick reference
+
+See the companion [PromQL reference](./prometheus/sovereign-ops-worker-promql.md)
+for a full set of example queries.
+
+### Worker cycle rate
+
+```promql
+rate(tramai_sovereign_ops_outbox_worker_cycles_total[5m])
+```
+
+### Failed cycle rate
+
+```promql
+rate(tramai_sovereign_ops_outbox_worker_cycles_total{outcome="failure"}[5m])
+```
+
+### Failure ratio
+
+```promql
+sum(rate(tramai_sovereign_ops_outbox_worker_cycles_total{outcome="failure"}[5m]))
+/
+sum(rate(tramai_sovereign_ops_outbox_worker_cycles_total[5m]))
+```
+
+### Average cycle duration
+
+```promql
+rate(tramai_sovereign_ops_outbox_worker_duration_seconds_sum[5m])
+/
+rate(tramai_sovereign_ops_outbox_worker_duration_seconds_count[5m])
+```
+
+### Recovery throughput by result
+
+```promql
+sum by (result) (
+  rate(tramai_sovereign_ops_outbox_worker_recovered_records_total[5m])
+)
+```
+
+### Dispatch throughput by result
+
+```promql
+sum by (result) (
+  rate(tramai_sovereign_ops_outbox_worker_dispatched_records_total[5m])
+)
+```
+
+### Permanent failure signal
+
+```promql
+rate(tramai_sovereign_ops_outbox_worker_recovered_records_total{result="failed_permanent"}[5m])
++
+rate(tramai_sovereign_ops_outbox_worker_dispatched_records_total{result="failed_permanent"}[5m])
+```
+
+---
+
+## Example alert rules
+
+Example Prometheus alert rules are available at
+[prometheus/sovereign-ops-worker-alerts.example.yml](./prometheus/sovereign-ops-worker-alerts.example.yml).
+
+**These are examples — not production defaults.** Thresholds must be
+tuned based on workload, retry policy, batch size, and expected
+traffic. Always validate alert sensitivity against historical data
+before deploying to production.
+
+---
+
+## Security checklist
+
+Before exposing any part of this observability surface in a production
+environment:
+
+- [ ] Actuator endpoint is secured (Spring Security, network policy, or
+      API gateway).
+- [ ] Actuator endpoint is not exposed to untrusted networks.
+- [ ] Prometheus scrape endpoint is restricted to authorized scrapers.
+- [ ] No high-cardinality labels are added to metrics.
+- [ ] Metric examples and dashboards do not contain sensitive samples.
+- [ ] Logging configuration does not expose approval IDs, tokens,
+      prompts, model responses, or tool arguments at non-debug levels.
+- [ ] Custom observer implementations follow the same sanitization
+      guarantees as the built-in observers.
+
+---
+
+## Known limitations
+
+1. **No persistent counters across restarts.** Worker cycle and record
+   counters reset when the application restarts. Use rates rather than
+   absolute counter values in dashboards.
+2. **No distributed state.** The worker is single-node. Metrics reflect
+   only the local instance.
+3. **No percentile histograms by default.** Timer histogram buckets are
+   not emitted unless the application explicitly enables percentile
+   histogram support in Micrometer.
+4. **Custom observer replaces the chain.** Providing a custom
+   `SovereignOpsAuditOutboxWorkerObserver` bean replaces the entire
+   composite pipeline, including status recording. Compose manually if
+   you need both custom logic and built-in surfaces.
+5. **Actuator endpoint enabled but not registered.** Setting
+   `tramai.sovereign.ops.actuator.worker-status.enabled=true` creates
+   the bean, but the endpoint is not reachable until it is also
+   included in `management.endpoints.web.exposure.include`.
+
+---
+
+## Verification commands
+
+```bash
+# Full test suite
+./gradlew test --no-configuration-cache
+
+# Sovereign runtime release evidence generation
+./gradlew generateSovereignReleaseEvidenceIndex --no-configuration-cache
+
+# Sovereign runtime consumer smoke test
+./gradlew verifySovereignRuntimeConsumerSmoke --no-configuration-cache
+```
+
+---
+
+## Custom observer override behavior
+
+The sovereign ops starter uses `@ConditionalOnMissingBean` for the
+`SovereignOpsAuditOutboxWorkerObserver` bean. This means:
+
+- If no custom observer bean is defined, the composite observer chain
+  (status recording + Micrometer + OpenTelemetry) is auto-configured.
+- If a custom `SovereignOpsAuditOutboxWorkerObserver` bean is defined
+  by the application, it **replaces the entire auto-configured chain**,
+  including status recording.
+- To extend rather than replace, compose your custom observer with the
+  composite by injecting and delegating to the existing observers.
+
+Example of composing a custom observer:
+
+```kotlin
+@Bean
+fun myObservingObserver(
+    statusRecorder: SovereignOpsAuditOutboxWorkerObserver,
+    micrometerObserver: SovereignOpsAuditOutboxWorkerObserver?,
+    otelObserver: SovereignOpsAuditOutboxWorkerObserver?
+): SovereignOpsAuditOutboxWorkerObserver {
+    return SovereignOpsAuditOutboxWorkerObserver { status ->
+        // Custom logic here
+        statusRecorder.onStatus(status)
+        micrometerObserver?.onStatus(status)
+        otelObserver?.onStatus(status)
+    }
+}
+```
+
+**Important:** This is an advanced use case. The default composite
+chain is designed to cover the common case. If you override it,
+ensure all desired surfaces (status recording, Micrometer, OTel) are
+still called.

--- a/docs/operations/sovereign-ops-worker-observability-runbook.md
+++ b/docs/operations/sovereign-ops-worker-observability-runbook.md
@@ -48,17 +48,25 @@ current operational state: whether the worker is running, the last
 recorded cycle result, the number of cycles since last reset, and
 counts of recovered and dispatched records.
 
-**Properties:**
+#### Property fields (representative subset)
 
-| Property | Type | Description |
-|----------|------|-------------|
+The snapshot exposes worker configuration and recent cycle state:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `enabled` | boolean | Whether the worker is enabled in configuration |
 | `running` | boolean | Whether the worker schedule is active |
-| `lastCycleResult` | string | `success`, `failure`, or `none` |
-| `cyclesSinceLastReset` | integer | Cycles completed since last reset |
-| `totalCycleDurationMillis` | long | Cumulative cycle wall-clock time |
-| `recoveredCount` | integer | Total records recovered |
-| `dispatchedCount` | integer | Total records dispatched |
-| `failureCount` | integer | Total failures recorded |
+| `recoverPreparedEnabled` | boolean | Whether the PREPARED recovery phase is active |
+| `dispatchPendingEnabled` | boolean | Whether the PENDING dispatch phase is active |
+| `batchSize` | int | Records processed per cycle |
+| `intervalMillis` | long | Polling interval |
+| `totalCyclesCompleted` | long | Cycles completed since last reset |
+| `totalCyclesFailed` | long | Cycles that recorded a failure |
+| `lastCycleDurationMillis` | long? | Duration of the most recent cycle |
+| `lastRecovered` | object? | Most recent recovery summary (inspected, movedToPending, markedFailedPermanent, skippedUnresolved, resolverFailures) |
+| `lastDispatched` | object? | Most recent dispatch result (claimed, emitted, failedRetryable, failedPermanent) |
+| `lastFailure` | object? | Most recent failure summary (action, errorCode) |
+| `lastFailureAt` | instant? | Timestamp of the most recent failure |
 
 **Activation:**
 
@@ -185,8 +193,9 @@ sensitive data in instrument names, attributes, or values.
 
 **Activation:** The OT observer activates automatically when an
 `io.opentelemetry.api.OpenTelemetry` bean is present in the Spring
-context. No SDK or exporter is required — the module depends only on
-`opentelemetry-api`.
+context. The module depends only on `opentelemetry-api` and does not
+bring an SDK or exporter. Applications that want to export OT metrics
+must provide their own OpenTelemetry SDK and exporter configuration.
 
 ---
 
@@ -476,23 +485,38 @@ The sovereign ops starter uses `@ConditionalOnMissingBean` for the
 - If a custom `SovereignOpsAuditOutboxWorkerObserver` bean is defined
   by the application, it **replaces the entire auto-configured chain**,
   including status recording.
-- To extend rather than replace, compose your custom observer with the
-  composite by injecting and delegating to the existing observers.
+- To extend rather than replace, inject the
+  `SovereignOpsAuditOutboxWorkerStatusStore` and any
+  `SovereignOpsAuditOutboxWorkerObserverContribution` beans, then
+  compose your custom observer with the recording observer.
 
 Example of composing a custom observer:
 
 ```kotlin
 @Bean
 fun myObservingObserver(
-    statusRecorder: SovereignOpsAuditOutboxWorkerObserver,
-    micrometerObserver: SovereignOpsAuditOutboxWorkerObserver?,
-    otelObserver: SovereignOpsAuditOutboxWorkerObserver?
+    statusStore: SovereignOpsAuditOutboxWorkerStatusStore,
+    contributions: ObjectProvider<SovereignOpsAuditOutboxWorkerObserverContribution>,
 ): SovereignOpsAuditOutboxWorkerObserver {
-    return SovereignOpsAuditOutboxWorkerObserver { status ->
-        // Custom logic here
-        statusRecorder.onStatus(status)
-        micrometerObserver?.onStatus(status)
-        otelObserver?.onStatus(status)
+    val composite = CompositeSovereignOpsAuditOutboxWorkerObserver(
+        contributions.orderedStream().map { it.observer }.toList()
+    )
+
+    val defaultChain = RecordingSovereignOpsAuditOutboxWorkerObserver(
+        statusStore = statusStore,
+        delegate = composite,
+    )
+
+    return object : SovereignOpsAuditOutboxWorkerObserver {
+        override fun onCycleCompleted(summary: SovereignOpsAuditOutboxWorkerRunSummary) {
+            // Custom sanitized logic here
+            defaultChain.onCycleCompleted(summary)
+        }
+
+        override fun onCycleFailed(action: String, errorCode: String) {
+            // Custom sanitized logic here
+            defaultChain.onCycleFailed(action, errorCode)
+        }
     }
 }
 ```

--- a/docs/releases/sovereign-runtime-release-readiness.md
+++ b/docs/releases/sovereign-runtime-release-readiness.md
@@ -27,6 +27,7 @@ Candidate release: 0.4.0 or the next unreleased version. No tag, no Maven Centra
 | OpenTelemetry worker metrics | Implemented | tramai-spring-boot-starter-sovereign-ops-observability | Unit tests |
 | Optional read-only Actuator worker status endpoint | Implemented / opt-in | tramai-spring-boot-starter-sovereign-ops-actuator | Unit tests |
 | Micrometer worker metrics bridge | Implemented / opt-in | tramai-spring-boot-starter-sovereign-ops-micrometer | Unit tests |
+| Worker observability runbook | Implemented | docs/operations/sovereign-ops-worker-observability-runbook.md | Documentation review |
 | Evidence generation | Implemented / evolving | Release artifacts, examples | Smoke tests |
 | Sovereign document intelligence example | Implemented | examples:sovereign-document-intelligence | Smoke test |
 
@@ -88,7 +89,7 @@ No timelines are committed for these items.
 |---|---|---|
 | APIs are still evolving | Medium | active-development banner on README and docs |
 | File persistence is local-node only | Medium | Documented as local-only; DB-backed persistence is future work |
-| No production monitoring dashboard or runbook | Low | Explicitly listed as a non-goal |
+|| No production monitoring dashboard or runbook | Low | Runbook exists (see [runbook](../operations/sovereign-ops-worker-observability-runbook.md)); dashboard remains a non-goal |
 | No DB-backed outbox | Medium | Explicitly listed as future work |
 | No distributed leader election | Medium | Worker assumes single-node operation; documented |
 | Sovereign ops worker is opt-in, disabled by default | Low | Production users must explicitly enable |

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/README.md
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/README.md
@@ -54,3 +54,10 @@ must be configured separately -- the endpoint is disabled by default.
 This endpoint returns only sanitized operational state. Applications that
 expose the endpoint over HTTP should add their own authentication and
 authorization layer (e.g., Spring Security).
+
+## See also
+
+- [Worker observability runbook](../../docs/operations/sovereign-ops-worker-observability-runbook.md) —
+  operator-facing documentation covering all three observability surfaces
+  (Actuator, Micrometer, OpenTelemetry), PromQL queries, and
+  troubleshooting flows.

--- a/tramai-spring-boot-starter-sovereign-ops-micrometer/README.md
+++ b/tramai-spring-boot-starter-sovereign-ops-micrometer/README.md
@@ -55,3 +55,11 @@ and composes them behind the status-recording observer.
 Add the dependency and ensure a `MeterRegistry` bean exists (Spring Boot
 auto-configures one when `micrometer-core` or
 `micrometer-registry-prometheus` is on the classpath).
+
+## See also
+
+- [Worker observability runbook](../../docs/operations/sovereign-ops-worker-observability-runbook.md) —
+  operator-facing documentation covering Actuator, Micrometer, and
+  OpenTelemetry surfaces, PromQL queries, and troubleshooting flows.
+- [PromQL reference](../../docs/operations/prometheus/sovereign-ops-worker-promql.md) —
+  complete set of Prometheus queries for all five metric families.

--- a/tramai-spring-boot-starter-sovereign-ops-observability/README.md
+++ b/tramai-spring-boot-starter-sovereign-ops-observability/README.md
@@ -109,3 +109,9 @@ fun myObserver(): SovereignOpsAuditOutboxWorkerObserver = MyObserver()
 
 - `tramai-spring-boot-starter-sovereign-ops` — the observer SPI and worker DTOs
 - `io.opentelemetry:opentelemetry-api` — meter creation (no SDK, no exporter)
+
+## See also
+
+- [Worker observability runbook](../../docs/operations/sovereign-ops-worker-observability-runbook.md) —
+  operator-facing documentation covering Actuator, Micrometer, and
+  OpenTelemetry surfaces, PromQL queries, and troubleshooting flows.


### PR DESCRIPTION
## Summary

Add operator-facing documentation for the sovereign ops audit outbox worker observability surface, completing the story after PR #68 (composite observer pipeline).

## Changes

### New files

- **docs/operations/sovereign-ops-worker-observability-runbook.md** — Main runbook covering:
  - Actuator worker status endpoint (configuration, security, example)
  - Micrometer / Prometheus metrics (all 5 families, Prometheus-exported names, tag values)
  - OpenTelemetry metrics (all 5 instruments, attributes)
  - PromQL quick reference (7 query examples)
  - Example alert rules (with warning: "not production defaults")
  - 6 troubleshooting flows (worker not running, cycle failures, recovery stuck, dispatch not emitting, stale Actuator, missing Prometheus)
  - Safe exposure model and security checklist
  - Custom observer override behavior
  - Known limitations and verification commands

- **docs/operations/prometheus/sovereign-ops-worker-promql.md** — Full PromQL reference with 12 queries covering cycle rate, failure ratio, average duration, recovery/dispatch throughput, permanent failure signal, absent worker, and error distribution.

- **docs/operations/prometheus/sovereign-ops-worker-alerts.example.yml** — Example Prometheus alert rules (elevated failures, permanent failures, absent metrics, slow cycles). Clearly marked as examples only.

### Updated files

| File | Change |
|------|--------|
| README.md | Added runbook link to Sovereign Runtime table |
| docs/STATUS.md | Added "Sovereign ops worker observability runbook" row |
| docs/modules/sovereign-runtime-module-matrix.md | Added runbook reference and link |
| docs/releases/sovereign-runtime-release-readiness.md | Added capability row; updated risk entry for runbook |
| tramai-spring-boot-starter-sovereign-ops-actuator/README.md | Added "See also" link to runbook |
| tramai-spring-boot-starter-sovereign-ops-micrometer/README.md | Added "See also" links to runbook + PromQL reference |
| tramai-spring-boot-starter-sovereign-ops-observability/README.md | Added "See also" link to runbook |

## Review fixes (813345d)

Addressed all P2 findings from the review:

1. **Custom observer example** — Replaced invalid example that used a non-existent API with a correct example using `SovereignOpsAuditOutboxWorkerStatusStore`, `ObjectProvider<SovereignOpsAuditOutboxWorkerObserverContribution>`, `CompositeSovereignOpsAuditOutboxWorkerObserver`, and `RecordingSovereignOpsAuditOutboxWorkerObserver`. Now compiles against the real `onCycleCompleted(summary)` / `onCycleFailed(action, errorCode)` interface.

2. **Actuator status field table** — Updated to match the real `SovereignOpsAuditOutboxWorkerStatusSnapshot` data class fields instead of made-up aggregate counters.

3. **tamai_ → tramai_ typos** — Fixed all 5 metric name references in the PromQL reference. Zero remaining.

4. **OpenTelemetry wording** — Corrected to say "does not bring an SDK or exporter; applications must provide their own."

5. **PromQL coalesce guidance** — Replaced `clamp_min(coalesce(..., 0), 1)` with `clamp_min(sum(rate(...)), 1)`.

## Security notes

- All documentation examples follow the safe exposure model — no approval IDs, reason text, tokens, replay envelopes, prompts, model responses, tool arguments, raw outbox records, file paths, or stack traces.
- Prometheus queries and alert examples use only low-cardinality labels.
- A full security checklist is included in the runbook.
- Actuator endpoint security is documented as application-level responsibility.

## Non-goals reaffirmed

- Production Grafana dashboard and environment-specific alert thresholds remain non-goals
- No production monitoring or SRE-certified alert sensitivities claimed
- No runtime code, no new module, no BOM change, no release boundary change

## Verification

```
./gradlew test --no-configuration-cache        -> 169 tasks, BUILD SUCCESSFUL
./gradlew generateSovereignReleaseEvidenceIndex -> evidence index + devTramaiResolutionPolicy validated
./gradlew verifySovereignRuntimeConsumerSmoke   -> consumer smoke green
```

Closes: PR #69
