### PR TITLE
feat(sovereign-ops): add optional worker health indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ TramAI is organized into focused Gradle modules:
 | `tramai-persistence-file` | Encrypted file-backed stores for approvals, continuations, audit, and outbox |
 | `tramai-spring-boot-starter-sovereign` | Sovereign runtime Spring Boot auto-configuration |
 | `tramai-spring-boot-starter-sovereign-ops` | Operational APIs: audit outbox, recovery, dispatch, background worker, observer SPI |
-| `tramai-spring-boot-starter-sovereign-ops-actuator` | Optional Actuator endpoint for worker status (read-only, opt-in) |
+| `tramai-spring-boot-starter-sovereign-ops-actuator` | Optional Actuator endpoint and health indicator for worker status (read-only, opt-in) |
 | `tramai-spring-boot-starter-sovereign-ops-micrometer` | Micrometer metrics for sovereign ops audit outbox worker |
 | `tramai-spring-boot-starter-sovereign-ops-observability` | OpenTelemetry metrics for sovereign ops audit outbox worker |
-| [Worker observability runbook](docs/operations/sovereign-ops-worker-observability-runbook.md) | Operator-facing documentation for all three observability surfaces |
+| [Worker observability runbook](docs/operations/sovereign-ops-worker-observability-runbook.md) | Operator-facing documentation for worker status, health, and metrics surfaces |
 | `tramai-spring-boot-starter-sovereign-persistence-file` | File-backed persistence auto-configuration |
 
 ### Optional Higher-Level Modules

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Until the next tagged release, APIs in these areas may change.
 The following are intentionally not claimed as complete:
 
 - stable 1.0 API
-- REST/Actuator operational endpoints
+- write/control-plane operational endpoints
 - database-backed outbox or persistence
 - distributed worker leader election
 - key rotation

--- a/docs/modules/sovereign-runtime-module-matrix.md
+++ b/docs/modules/sovereign-runtime-module-matrix.md
@@ -5,8 +5,9 @@ One-stop reference for the sovereign runtime modules on master. Updated 2026-06-
 ### Sovereign Runtime
 
 See the [worker observability runbook](../operations/sovereign-ops-worker-observability-runbook.md) for operator-facing
-documentation covering the Actuator status endpoint, Micrometer metrics,
-OpenTelemetry metrics, PromQL examples, and troubleshooting flows.
+documentation covering the Actuator status endpoint, Actuator health component,
+Micrometer metrics, OpenTelemetry metrics, PromQL examples, and
+troubleshooting flows.
 
 | Module | Purpose | Runtime Role | Release Status |
 |---|---|---|---|
@@ -16,7 +17,7 @@ OpenTelemetry metrics, PromQL examples, and troubleshooting flows.
 | tramai-spring-boot-starter-sovereign | Spring Boot auto-configuration for sovereign runtime | Spring integration | Implemented / evolving |
 | tramai-spring-boot-starter-sovereign-persistence-file | Spring auto-configuration for file-backed persistence | Spring persistence integration | Implemented / evolving |
 | tramai-spring-boot-starter-sovereign-ops | Operational APIs: audit outbox, recovery, dispatch, background worker, observer SPI | Operational recovery | Implemented / evolving |
-| tramai-spring-boot-starter-sovereign-ops-actuator | Optional read-only Actuator endpoint for worker status | Operational visibility | Implemented / opt-in |
+| tramai-spring-boot-starter-sovereign-ops-actuator | Optional read-only Actuator endpoint and health indicator for worker status | Operational visibility | Implemented / opt-in |
 | tramai-spring-boot-starter-sovereign-ops-micrometer | Micrometer metrics for ops audit outbox worker | Operational observability | Implemented / opt-in |
 | tramai-spring-boot-starter-sovereign-ops-observability | OpenTelemetry metrics for ops audit outbox worker | Operational observability | Implemented |
 | examples:sovereign-document-intelligence | End-to-end reference sovereign workflow | Demo / evidence pack | Implemented |
@@ -38,7 +39,7 @@ application
 
 application
   -> tramai-spring-boot-starter-sovereign-ops-actuator
-     -> Read-only Actuator endpoint (requires spring-boot-actuator)
+     -> Read-only Actuator endpoint and health indicator (requires spring-boot-actuator)
 
 application
   -> tramai-spring-boot-starter-sovereign-ops-micrometer

--- a/docs/operations/sovereign-ops-worker-observability-runbook.md
+++ b/docs/operations/sovereign-ops-worker-observability-runbook.md
@@ -4,8 +4,8 @@
 
 This runbook describes how to observe, monitor, and troubleshoot the
 TramAI sovereign ops audit outbox worker at runtime. It covers the
-three operational surfaces — Actuator status endpoint, Micrometer
-metrics (Prometheus), and OpenTelemetry metrics — along with
+four operational surfaces — Actuator status endpoint, Actuator health
+component, Micrometer metrics (Prometheus), and OpenTelemetry metrics — along with
 PromQL queries, alert examples, and troubleshooting flows.
 
 The audience is operators who deploy applications using the sovereign
@@ -15,6 +15,7 @@ looks like, how to detect problems, and what is safe to expose.
 ## What this runbook covers
 
 - Actuator worker status endpoint (`/actuator/tramaiSovereignOpsWorker`)
+- Actuator worker health component
 - Micrometer/Prometheus metric surface (five metric families)
 - OpenTelemetry metric surface
 - PromQL query examples for all metric families
@@ -196,6 +197,58 @@ sensitive data in instrument names, attributes, or values.
 context. The module depends only on `opentelemetry-api` and does not
 bring an SDK or exporter. Applications that want to export OT metrics
 must provide their own OpenTelemetry SDK and exporter configuration.
+
+---
+
+### 4. Actuator health component
+
+**Purpose:** Provides a coarse Spring Boot health signal for the audit
+outbox worker without exposing the full worker status snapshot.
+
+**Activation:**
+
+```yaml
+tramai:
+  sovereign:
+    ops:
+      actuator:
+        worker-health:
+          enabled: true
+```
+
+The health indicator is disabled by default. It is created only when a
+`SovereignOpsAuditOutboxWorkerStatusStore` bean exists and no bean named
+`tramaiSovereignOpsWorkerHealthIndicator` has already been registered.
+
+#### Health status mapping
+
+| Worker state | Health status | Meaning |
+|--------------|---------------|---------|
+| `enabled=false` | `UNKNOWN` | Worker is intentionally disabled, not failed |
+| `enabled=true`, `running=false` | `DOWN` | Worker is expected but not running |
+| `enabled=true`, `running=true`, `totalCyclesCompleted=0`, `totalCyclesFailed>0` | `DOWN` | Worker is failing before its first successful cycle |
+| `enabled=true`, `running=true`, `totalCyclesCompleted=0`, `totalCyclesFailed=0` | `UP` | Worker has started and has not failed yet |
+| `enabled=true`, `running=true`, `totalCyclesCompleted>0` | `UP` | Worker has completed at least one cycle; later transient failures may be normal |
+
+The health details include only flat operational values such as
+`enabled`, `running`, cycle counters, scheduling configuration, and
+boolean presence flags (`hasLastRecovered`, `hasLastDispatched`,
+`hasLastFailure`). Nested recovery, dispatch, and failure objects are not
+returned directly.
+
+#### Relationship to other surfaces
+
+- **Health component:** coarse status for platform health checks and
+  alert routing. It answers whether the worker appears operational.
+- **Custom status endpoint:** full sanitized snapshot for operators
+  investigating current state and recent cycle summaries.
+- **Metrics:** time-series signals for trend analysis, dashboards,
+  PromQL alerts, and failure ratios.
+
+Enabling `tramai.sovereign.ops.actuator.worker-health.enabled=true` does
+not enable the custom worker status endpoint. Enabling
+`tramai.sovereign.ops.actuator.worker-status.enabled=true` does not enable
+the health indicator.
 
 ---
 

--- a/docs/releases/sovereign-runtime-release-readiness.md
+++ b/docs/releases/sovereign-runtime-release-readiness.md
@@ -89,7 +89,7 @@ No timelines are committed for these items.
 |---|---|---|
 | APIs are still evolving | Medium | active-development banner on README and docs |
 | File persistence is local-node only | Medium | Documented as local-only; DB-backed persistence is future work |
-|| No production monitoring dashboard or runbook | Low | Runbook exists (see [runbook](../operations/sovereign-ops-worker-observability-runbook.md)); dashboard remains a non-goal |
+| No production monitoring dashboard | Low | Worker observability runbook exists (see [runbook](../operations/sovereign-ops-worker-observability-runbook.md)); production dashboard and environment-specific alert thresholds remain non-goals |
 | No DB-backed outbox | Medium | Explicitly listed as future work |
 | No distributed leader election | Medium | Worker assumes single-node operation; documented |
 | Sovereign ops worker is opt-in, disabled by default | Low | Production users must explicitly enable |
@@ -105,7 +105,7 @@ No timelines are committed for these items.
 - [x] No Maven Central claim for sovereign runtime modules unless verified
 - [x] CHANGELOG.md has Unreleased section
 
-Checklist last verified: 2026-06-20 after PR #68 wiring review. Full release-candidate evidence chain remains documented.
+Checklist last verified: 2026-06-20 after PR #71 health indicator review. Full release-candidate evidence chain remains documented.
 
 ## Sovereign Runtime Release-Candidate CI Gate
 

--- a/docs/releases/sovereign-runtime-release-readiness.md
+++ b/docs/releases/sovereign-runtime-release-readiness.md
@@ -25,7 +25,7 @@ Candidate release: 0.4.0 or the next unreleased version. No tag, no Maven Centra
 | Background worker (recovery + dispatch) | Implemented / evolving | tramai-spring-boot-starter-sovereign-ops | Unit + integration tests |
 | Worker observer SPI | Implemented | tramai-spring-boot-starter-sovereign-ops | Unit tests |
 | OpenTelemetry worker metrics | Implemented | tramai-spring-boot-starter-sovereign-ops-observability | Unit tests |
-| Optional read-only Actuator worker status endpoint | Implemented / opt-in | tramai-spring-boot-starter-sovereign-ops-actuator | Unit tests |
+| Optional read-only Actuator worker status endpoint and health component | Implemented / opt-in | tramai-spring-boot-starter-sovereign-ops-actuator | Unit tests |
 | Micrometer worker metrics bridge | Implemented / opt-in | tramai-spring-boot-starter-sovereign-ops-micrometer | Unit tests |
 | Worker observability runbook | Implemented | docs/operations/sovereign-ops-worker-observability-runbook.md | Documentation review |
 | Evidence generation | Implemented / evolving | Release artifacts, examples | Smoke tests |

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/README.md
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/README.md
@@ -1,9 +1,10 @@
 # TramAI Sovereign Ops Actuator
 
-Optional Spring Boot Actuator integration for sovereign ops worker status.
+Optional Spring Boot Actuator integration for sovereign ops worker status and health.
 
 This module exposes a read-only Actuator endpoint that returns the sanitized
-audit outbox worker status snapshot from the sovereign ops starter.
+audit outbox worker status snapshot from the sovereign ops starter. It can
+also expose an optional Spring Boot health component for the same worker.
 
 It does NOT expose:
 - Raw outbox records or outbox IDs
@@ -42,12 +43,44 @@ management:
 The TramAI property creates the endpoint bean. Spring Boot Actuator exposure
 must be configured separately -- the endpoint is disabled by default.
 
+## Optional worker health indicator
+
+The module can also create a sanitized Spring Boot `HealthIndicator` for the
+audit outbox worker:
+
+```yaml
+tramai:
+  sovereign:
+    ops:
+      actuator:
+        worker-health:
+          enabled: true
+```
+
+The health indicator is disabled by default and is independent from the
+`worker-status` endpoint property. Enabling `worker-health` does not create
+the custom status endpoint, and enabling `worker-status` does not create the
+health indicator.
+
+The health details contain only flat operational fields and booleans for
+nested state. They do not expose raw records, approval IDs, outbox IDs,
+tokens, replay envelopes, prompts, model responses, tool arguments, file
+paths, stack traces, exception messages, or reason text.
+
 ## Endpoint
 
 - **ID:** `tramaiSovereignOpsWorker`
 - **URL:** `/actuator/tramaiSovereignOpsWorker`
 - **Method:** GET
 - **Response:** `SovereignOpsAuditOutboxWorkerStatusSnapshot`
+
+## Health component
+
+- **Bean name:** `tramaiSovereignOpsWorkerHealthIndicator`
+- **Health component name:** derived by Spring Boot from the bean name
+- **Status mapping:** disabled worker is `UNKNOWN`; enabled but not running is
+  `DOWN`; running with failures before the first success is `DOWN`; running
+  after at least one completed cycle is `UP`.
 
 ## Security
 
@@ -58,6 +91,6 @@ authorization layer (e.g., Spring Security).
 ## See also
 
 - [Worker observability runbook](../../docs/operations/sovereign-ops-worker-observability-runbook.md) —
-  operator-facing documentation covering all three observability surfaces
-  (Actuator, Micrometer, OpenTelemetry), PromQL queries, and
+  operator-facing documentation covering the Actuator endpoint, Actuator
+  health component, Micrometer metrics, OpenTelemetry metrics, PromQL queries, and
   troubleshooting flows.

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsActuatorAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsActuatorAutoConfiguration.kt
@@ -3,6 +3,7 @@ package dev.tramai.spring.sovereign.ops.actuator
 import dev.tramai.spring.sovereign.ops.SovereignOpsAutoConfiguration
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerStatusStore
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint
+import org.springframework.boot.actuate.health.HealthIndicator
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
@@ -12,19 +13,24 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 
 /**
- * Auto-configuration for the sovereign ops worker status Actuator endpoint.
+ * Auto-configuration for the sovereign ops worker status Actuator endpoint
+ * and optional health indicator.
  *
  * Runs after [SovereignOpsAutoConfiguration] so the status store bean is available.
- * The endpoint is only created when:
- * - Actuator is on the classpath (`@ConditionalOnClass(Endpoint::class)`)
+ *
+ * Endpoint conditions (disabled by default):
+ * - Actuator is on the classpath (`@ConditionalOnClass(Endpoint::class, HealthIndicator::class)`)
  * - A [SovereignOpsAuditOutboxWorkerStatusStore] bean exists
  * - `tramai.sovereign.ops.actuator.worker-status.enabled=true`
  * - No custom [SovereignOpsWorkerStatusEndpoint] bean has been registered
  *
- * The endpoint is disabled by default.
+ * Health indicator conditions (disabled by default, independent property):
+ * - Same classpath and store conditions
+ * - `tramai.sovereign.ops.actuator.worker-health.enabled=true`
+ * - No custom bean named `tramaiSovereignOpsWorkerHealthIndicator` exists
  */
 @AutoConfiguration(after = [SovereignOpsAutoConfiguration::class])
-@ConditionalOnClass(Endpoint::class)
+@ConditionalOnClass(Endpoint::class, HealthIndicator::class)
 @EnableConfigurationProperties(SovereignOpsWorkerStatusEndpointProperties::class)
 class SovereignOpsActuatorAutoConfiguration {
 
@@ -41,4 +47,18 @@ class SovereignOpsActuatorAutoConfiguration {
         statusStore: SovereignOpsAuditOutboxWorkerStatusStore,
     ): SovereignOpsWorkerStatusEndpoint =
         SovereignOpsWorkerStatusEndpoint(statusStore)
+
+    @Bean("tramaiSovereignOpsWorkerHealthIndicator")
+    @ConditionalOnMissingBean(name = ["tramaiSovereignOpsWorkerHealthIndicator"])
+    @ConditionalOnBean(SovereignOpsAuditOutboxWorkerStatusStore::class)
+    @ConditionalOnProperty(
+        prefix = "tramai.sovereign.ops.actuator.worker-health",
+        name = ["enabled"],
+        havingValue = "true",
+        matchIfMissing = false,
+    )
+    fun sovereignOpsWorkerHealthIndicator(
+        statusStore: SovereignOpsAuditOutboxWorkerStatusStore,
+    ): SovereignOpsWorkerHealthIndicator =
+        SovereignOpsWorkerHealthIndicator(statusStore)
 }

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsWorkerHealthIndicator.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsWorkerHealthIndicator.kt
@@ -1,0 +1,50 @@
+package dev.tramai.spring.sovereign.ops.actuator
+
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerStatusStore
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.HealthIndicator
+
+class SovereignOpsWorkerHealthIndicator(
+    private val statusStore: SovereignOpsAuditOutboxWorkerStatusStore,
+) : HealthIndicator {
+
+    override fun health(): Health {
+        val snapshot = statusStore.snapshot()
+
+        val builder = when {
+            !snapshot.enabled -> Health.unknown()
+            snapshot.enabled && !snapshot.running -> Health.down()
+            snapshot.running && snapshot.totalCyclesCompleted == 0L && snapshot.totalCyclesFailed > 0L -> Health.down()
+            else -> Health.up()
+        }
+
+        return builder
+            .withDetail("enabled", snapshot.enabled)
+            .withDetail("running", snapshot.running)
+            .withDetail("recoverPreparedEnabled", snapshot.recoverPreparedEnabled)
+            .withDetail("dispatchPendingEnabled", snapshot.dispatchPendingEnabled)
+            .withDetail("batchSize", snapshot.batchSize)
+            .withDetail("intervalMillis", snapshot.intervalMillis)
+            .withDetail("initialDelayMillis", snapshot.initialDelayMillis)
+            .withDetailIfPresent("lastCycleStartedAt", snapshot.lastCycleStartedAt?.toString())
+            .withDetailIfPresent("lastCycleCompletedAt", snapshot.lastCycleCompletedAt?.toString())
+            .withDetailIfPresent("lastCycleDurationMillis", snapshot.lastCycleDurationMillis)
+            .withDetailIfPresent("lastFailureAt", snapshot.lastFailureAt?.toString())
+            .withDetail("totalCyclesCompleted", snapshot.totalCyclesCompleted)
+            .withDetail("totalCyclesFailed", snapshot.totalCyclesFailed)
+            .withDetail("hasLastRecovered", snapshot.lastRecovered != null)
+            .withDetail("hasLastDispatched", snapshot.lastDispatched != null)
+            .withDetail("hasLastFailure", snapshot.lastFailure != null)
+            .build()
+    }
+
+    private fun Health.Builder.withDetailIfPresent(
+        key: String,
+        value: Any?,
+    ): Health.Builder =
+        if (value == null) {
+            this
+        } else {
+            withDetail(key, value)
+        }
+}

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsWorkerHealthAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsWorkerHealthAutoConfigurationTest.kt
@@ -1,0 +1,106 @@
+package dev.tramai.spring.sovereign.ops.actuator
+
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerStatusStore
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+class SovereignOpsWorkerHealthAutoConfigurationTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(SovereignOpsActuatorAutoConfiguration::class.java),
+        )
+
+    @Test
+    fun `health indicator is disabled by default`() {
+        contextRunner
+            .withUserConfiguration(StatusStoreConfig::class.java)
+            .run { ctx ->
+                assertThat(ctx).doesNotHaveBean(SovereignOpsWorkerHealthIndicator::class.java)
+                assertThat(ctx).doesNotHaveBean("tramaiSovereignOpsWorkerHealthIndicator")
+            }
+    }
+
+    @Test
+    fun `health indicator is created when enabled and status store exists`() {
+        contextRunner
+            .withUserConfiguration(StatusStoreConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.worker-health.enabled=true",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SovereignOpsWorkerHealthIndicator::class.java)
+                assertThat(ctx).hasBean("tramaiSovereignOpsWorkerHealthIndicator")
+            }
+    }
+
+    @Test
+    fun `health indicator is not created without status store`() {
+        contextRunner
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.worker-health.enabled=true",
+            )
+            .run { ctx ->
+                assertThat(ctx).doesNotHaveBean(SovereignOpsWorkerHealthIndicator::class.java)
+                assertThat(ctx).doesNotHaveBean("tramaiSovereignOpsWorkerHealthIndicator")
+            }
+    }
+
+    @Test
+    fun `health indicator backs off when custom named health indicator exists`() {
+        contextRunner
+            .withUserConfiguration(StatusStoreConfig::class.java, CustomHealthIndicatorConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.worker-health.enabled=true",
+            )
+            .run { ctx ->
+                assertThat(ctx).doesNotHaveBean(SovereignOpsWorkerHealthIndicator::class.java)
+                val indicator = ctx.getBean("tramaiSovereignOpsWorkerHealthIndicator", HealthIndicator::class.java)
+                assertThat(indicator.health().details["custom"]).isEqualTo(true)
+            }
+    }
+
+    @Test
+    fun `worker status endpoint property does not create health indicator`() {
+        contextRunner
+            .withUserConfiguration(StatusStoreConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.worker-status.enabled=true",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SovereignOpsWorkerStatusEndpoint::class.java)
+                assertThat(ctx).doesNotHaveBean(SovereignOpsWorkerHealthIndicator::class.java)
+                assertThat(ctx).doesNotHaveBean("tramaiSovereignOpsWorkerHealthIndicator")
+            }
+    }
+
+    @Test
+    fun `worker health property does not create worker status endpoint`() {
+        contextRunner
+            .withUserConfiguration(StatusStoreConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.worker-health.enabled=true",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SovereignOpsWorkerHealthIndicator::class.java)
+                assertThat(ctx).doesNotHaveBean(SovereignOpsWorkerStatusEndpoint::class.java)
+            }
+    }
+}
+
+@Configuration
+open class CustomHealthIndicatorConfig {
+    @Bean("tramaiSovereignOpsWorkerHealthIndicator")
+    open fun customHealthIndicator(): HealthIndicator =
+        HealthIndicator {
+            Health.up()
+                .withDetail("custom", true)
+                .build()
+        }
+}

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsWorkerHealthIndicatorTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsWorkerHealthIndicatorTest.kt
@@ -1,0 +1,180 @@
+package dev.tramai.spring.sovereign.ops.actuator
+
+import dev.tramai.spring.sovereign.ops.SovereignOpsOutboxWorkerProperties
+import dev.tramai.spring.sovereign.ops.outbox.InMemorySovereignOpsAuditOutboxWorkerStatusStore
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxDispatchResult
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxRecoverySummary
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerFailureSummary
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerRunSummary
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.actuate.health.Status
+import java.time.Duration
+import java.time.Instant
+
+class SovereignOpsWorkerHealthIndicatorTest {
+
+    @Test
+    fun `disabled worker reports unknown health`() {
+        val health = SovereignOpsWorkerHealthIndicator(statusStore(enabled = false)).health()
+
+        assertThat(health.status).isEqualTo(Status.UNKNOWN)
+    }
+
+    @Test
+    fun `enabled running worker reports up health`() {
+        val store = statusStore(enabled = true)
+        store.markLifecycleStarted()
+
+        val health = SovereignOpsWorkerHealthIndicator(store).health()
+
+        assertThat(health.status).isEqualTo(Status.UP)
+    }
+
+    @Test
+    fun `enabled worker that is not running reports down health`() {
+        val health = SovereignOpsWorkerHealthIndicator(statusStore(enabled = true)).health()
+
+        assertThat(health.status).isEqualTo(Status.DOWN)
+    }
+
+    @Test
+    fun `disabled worker that is somehow still running reports unknown health`() {
+        val store = statusStore(enabled = false)
+        store.markLifecycleStarted()
+
+        val health = SovereignOpsWorkerHealthIndicator(store).health()
+
+        assertThat(health.status).isEqualTo(Status.UNKNOWN)
+    }
+
+    @Test
+    fun `enabled running worker with failed cycles and successful cycles reports up health`() {
+        val store = statusStore(enabled = true)
+        store.markLifecycleStarted()
+        store.recordCycleFailed(action = "dispatchPending", errorCode = "IOException")
+        store.recordCycleCompleted(successfulSummary(failure = failureSummary()))
+
+        val health = SovereignOpsWorkerHealthIndicator(store).health()
+
+        assertThat(health.status).isEqualTo(Status.UP)
+        assertThat(health.details["totalCyclesCompleted"]).isEqualTo(1L)
+        assertThat(health.details["totalCyclesFailed"]).isEqualTo(1L)
+        assertThat(health.details["hasLastFailure"]).isEqualTo(true)
+    }
+
+    @Test
+    fun `enabled running worker with failed cycles and zero completed cycles reports down health`() {
+        val store = statusStore(enabled = true)
+        store.markLifecycleStarted()
+        store.recordCycleFailed(action = "recoverPrepared", errorCode = "IllegalStateException")
+
+        val health = SovereignOpsWorkerHealthIndicator(store).health()
+
+        assertThat(health.status).isEqualTo(Status.DOWN)
+        assertThat(health.details["totalCyclesCompleted"]).isEqualTo(0L)
+        assertThat(health.details["totalCyclesFailed"]).isEqualTo(1L)
+        assertThat(health.details["hasLastFailure"]).isEqualTo(true)
+        assertThat(health.details["lastFailureAt"]).isNotNull
+    }
+
+    @Test
+    fun `health details contain expected operational keys`() {
+        val store = statusStore(enabled = true)
+        store.markLifecycleStarted()
+        store.recordCycleCompleted(successfulSummary())
+
+        val health = SovereignOpsWorkerHealthIndicator(store).health()
+
+        assertThat(health.details.keys).contains(
+            "enabled",
+            "running",
+            "totalCyclesCompleted",
+            "totalCyclesFailed",
+            "hasLastRecovered",
+            "hasLastDispatched",
+            "hasLastFailure",
+        )
+    }
+
+    @Test
+    fun `health details do not contain sensitive or verbose diagnostic keys`() {
+        val store = statusStore(enabled = true)
+        store.markLifecycleStarted()
+        store.recordCycleFailed(action = "dispatchPending", errorCode = "RuntimeException")
+        store.recordCycleCompleted(successfulSummary(failure = failureSummary()))
+
+        val health = SovereignOpsWorkerHealthIndicator(store).health()
+
+        assertThat(health.details.keys).doesNotContain(
+            "approvalId",
+            "outboxId",
+            "recordId",
+            "token",
+            "replayEnvelope",
+            "prompt",
+            "modelResponse",
+            "toolArguments",
+            "filePath",
+            "stackTrace",
+            "exceptionMessage",
+            "reason",
+        )
+    }
+
+    @Test
+    fun `health detail values are safe types only`() {
+        val store = statusStore(enabled = true)
+        store.markLifecycleStarted()
+        store.recordCycleFailed(action = "dispatchPending", errorCode = "RuntimeException")
+        store.recordCycleCompleted(successfulSummary(failure = failureSummary()))
+
+        val health = SovereignOpsWorkerHealthIndicator(store).health()
+
+        // All values must be safe scalars — no nested objects, no complex types
+        val isoInstant = Regex("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z$")
+        health.details.values.forEach { value ->
+            val isSafe = value is Boolean || value is Number ||
+                (value is String && isoInstant.matches(value))
+            assertThat(isSafe)
+                .describedAs("Health detail value has an unexpected type: $value (${value?.javaClass?.name})")
+                .isTrue()
+        }
+    }
+
+    private fun statusStore(enabled: Boolean): InMemorySovereignOpsAuditOutboxWorkerStatusStore =
+        InMemorySovereignOpsAuditOutboxWorkerStatusStore(
+            SovereignOpsOutboxWorkerProperties(
+                enabled = enabled,
+                initialDelay = Duration.ofSeconds(5),
+                interval = Duration.ofSeconds(30),
+                batchSize = 10,
+                recoverPrepared = true,
+                dispatchPending = true,
+            ),
+        )
+
+    private fun successfulSummary(
+        failure: SovereignOpsAuditOutboxWorkerFailureSummary? = null,
+    ): SovereignOpsAuditOutboxWorkerRunSummary {
+        val startedAt = Instant.parse("2026-06-20T10:00:00Z")
+        return SovereignOpsAuditOutboxWorkerRunSummary(
+            recovered = SovereignOpsAuditOutboxRecoverySummary(inspected = 1),
+            dispatched = SovereignOpsAuditOutboxDispatchResult(
+                claimed = 1,
+                emitted = 1,
+                failedRetryable = 0,
+                failedPermanent = 0,
+            ),
+            failure = failure,
+            startedAt = startedAt,
+            completedAt = startedAt.plusMillis(25),
+        )
+    }
+
+    private fun failureSummary(): SovereignOpsAuditOutboxWorkerFailureSummary =
+        SovereignOpsAuditOutboxWorkerFailureSummary(
+            action = "dispatchPending",
+            errorCode = "RuntimeException",
+        )
+}


### PR DESCRIPTION
## Summary

Add an optional Spring Boot Actuator HealthIndicator for the sovereign ops audit outbox worker, using the existing sanitized status store. This gives platform teams a standard `/actuator/health` component while keeping the detailed worker status endpoint and metrics separate.

## Changes

**9 files — 3 new, 6 modified — 461 insertions(+), 18 deletions(-)**

### New files

- **SovereignOpsWorkerHealthIndicator.kt** — `HealthIndicator` implementation with conservative status mapping and flat sanitized details
- **SovereignOpsWorkerHealthIndicatorTest.kt** — 9 unit tests covering all health status mappings, detail key/type assertions, and security guardrails
- **SovereignOpsWorkerHealthAutoConfigurationTest.kt** — 6 auto-config tests covering default-disabled, enabled, missing-store, custom-bean-backoff, and property independence

### Modified files

- **SovereignOpsActuatorAutoConfiguration.kt** — Added health indicator bean (named `tramaiSovereignOpsWorkerHealthIndicator`) gated by `@ConditionalOnClass(Endpoint::class, HealthIndicator::class)`, `@ConditionalOnBean(StatusStore)`, `tramai.sovereign.ops.actuator.worker-health.enabled=true`, and `@ConditionalOnMissingBean(name = [...],)`. Updated KDoc.
- **Actuator README** — Added Optional worker health indicator and Health component sections
- **Runbook** — Added section 4: Actuator health component with mapping table and surface comparison
- **Module matrix, Release readiness, Root README** — Cross-reference updates

## Health status mapping

| Snapshot state | Health status | Reason |
|---|---|---|
| `enabled=false` | UNKNOWN | Worker intentionally disabled; not a failure |
| `enabled=true, running=false` | DOWN | Expected worker not running |
| `enabled=true, running=true, totalCyclesCompleted=0, totalCyclesFailed>0` | DOWN | Worker failing before first success |
| `enabled=true, running=true, failures after success` | UP | Transient failures considered normal after successful operation |

## Security

- All nested objects (`lastRecovered`, `lastDispatched`, `lastFailure`) reduced to boolean presence flags
- No `lastFailure.errorCode` exposed — only `hasLastFailure` boolean and `lastFailureAt` timestamp
- No approval IDs, outbox IDs, record IDs, tokens, replay envelopes, prompts, model responses, tool arguments, file paths, stack traces, exception messages, or reason text
- Type-safety test verifies all detail values are Boolean, Number, or ISO-8601 string only

## Configuration

```yaml
tramai:
  sovereign:
    ops:
      actuator:
        worker-health:
          enabled: true  # default: false
```

Disabled by default. Independent from the `worker-status.enabled` endpoint property.

## Verification

```
./gradlew :tramai-spring-boot-starter-sovereign-ops-actuator:test --rerun-tasks   → 23 tasks, BUILD SUCCESSFUL
./gradlew test --no-configuration-cache                                            → 169 tasks, BUILD SUCCESSFUL
./gradlew verifySovereignOpsObservabilityDocs --no-configuration-cache             → all checks passed
./gradlew generateSovereignReleaseEvidenceIndex --no-configuration-cache           → evidence validated
./gradlew verifySovereignRuntimeConsumerSmoke --no-configuration-cache             → consumer smoke green
```