### PR TITLE
test(sovereign-ops): verify worker health endpoint integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -772,6 +772,12 @@ tasks.register("verifySovereignOpsObservabilityDocs") {
             "Alert examples must state that thresholds must be tuned"
         }
 
+        // ── J. Health indicator documentation guard
+        requireContains("tramai.sovereign.ops.actuator.worker-health.enabled=true")
+        requireContains("tramaiSovereignOpsWorkerHealthIndicator")
+        requireContains("tramaiSovereignOpsWorker")
+        requireContains("Health component name")
+
         // ── I. Starter README link guard
         val actuatorReadme = rootDir.resolve("tramai-spring-boot-starter-sovereign-ops-actuator/README.md")
         val micrometerReadme = rootDir.resolve("tramai-spring-boot-starter-sovereign-ops-micrometer/README.md")

--- a/docs/operations/sovereign-ops-worker-observability-runbook.md
+++ b/docs/operations/sovereign-ops-worker-observability-runbook.md
@@ -250,6 +250,16 @@ not enable the custom worker status endpoint. Enabling
 `tramai.sovereign.ops.actuator.worker-status.enabled=true` does not enable
 the health indicator.
 
+**Health component name:** `tramaiSovereignOpsWorker` (Spring Boot derives
+this from the `tramaiSovereignOpsWorkerHealthIndicator` bean name by
+removing the `HealthIndicator` suffix).
+
+The custom status endpoint (id: `tramaiSovereignOpsWorker`) and the health
+component share the same logical name but are exposed through different
+Actuator surfaces — the custom endpoint at
+`/actuator/tramaiSovereignOpsWorker` and the health component as part of
+`/actuator/health`. They can coexist without conflicts.
+
 ---
 
 ## Safe exposure model

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testi
 opentelemetry-sdk-trace = { module = "io.opentelemetry:opentelemetry-sdk-trace", version.ref = "opentelemetry" }
 spring-boot-autoconfigure = { module = "org.springframework.boot:spring-boot-autoconfigure", version.ref = "spring-boot" }
 spring-boot-actuator = { module = "org.springframework.boot:spring-boot-actuator", version.ref = "spring-boot" }
+spring-boot-actuator-autoconfigure = { module = "org.springframework.boot:spring-boot-actuator-autoconfigure", version.ref = "spring-boot" }
 micrometer-core = { module = "io.micrometer:micrometer-core", version.ref = "micrometer" }
 micrometer-registry-prometheus = { module = "io.micrometer:micrometer-registry-prometheus", version.ref = "micrometer" }
 spring-boot-configuration-processor = { module = "org.springframework.boot:spring-boot-configuration-processor", version.ref = "spring-boot" }

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/README.md
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/README.md
@@ -77,10 +77,36 @@ paths, stack traces, exception messages, or reason text.
 ## Health component
 
 - **Bean name:** `tramaiSovereignOpsWorkerHealthIndicator`
-- **Health component name:** derived by Spring Boot from the bean name
+- **Health component name:** `tramaiSovereignOpsWorker`
 - **Status mapping:** disabled worker is `UNKNOWN`; enabled but not running is
   `DOWN`; running with failures before the first success is `DOWN`; running
   after at least one completed cycle is `UP`.
+
+Spring Boot derives the health component name from the bean name by removing
+the `HealthIndicator` suffix. When exposed through the Actuator health
+endpoint, the component appears as:
+
+```json
+{
+  "components": {
+    "tramaiSovereignOpsWorker": {
+      "status": "UP",
+      "details": {
+        "enabled": true,
+        "running": true,
+        "totalCyclesCompleted": 42,
+        "totalCyclesFailed": 0
+      }
+    }
+  }
+}
+```
+
+The custom `tramaiSovereignOpsWorker` status endpoint (id:
+`tramaiSovereignOpsWorker`) and the health component share the same logical
+name but are exposed through different Actuator surfaces — the custom
+endpoint at `/actuator/tramaiSovereignOpsWorker` and the health component
+as part of `/actuator/health`. They can coexist without conflicts.
 
 ## Security
 

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     testImplementation(libs.assertj.core)
     testImplementation(libs.kotlin.test.junit5)
     testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.spring.boot.actuator.autoconfigure)
     testImplementation("org.junit.jupiter:junit-jupiter")
 }
 

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsWorkerHealthEndpointIntegrationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsWorkerHealthEndpointIntegrationTest.kt
@@ -1,0 +1,149 @@
+package dev.tramai.spring.sovereign.ops.actuator
+
+import dev.tramai.spring.sovereign.ops.SovereignOpsOutboxWorkerProperties
+import dev.tramai.spring.sovereign.ops.outbox.InMemorySovereignOpsAuditOutboxWorkerStatusStore
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerStatusStore
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.boot.actuate.health.Status
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Duration
+
+class SovereignOpsWorkerHealthEndpointIntegrationTest {
+
+    @Test
+    fun `health indicator bean is registered under the expected named bean`() {
+        ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(SovereignOpsActuatorAutoConfiguration::class.java),
+            )
+            .withUserConfiguration(StatusStoreConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.worker-health.enabled=true",
+            )
+            .run { ctx ->
+                val beanNames = ctx.getBeanNamesForType(HealthIndicator::class.java)
+
+                assertThat(beanNames)
+                    .describedAs(
+                        "Expected a health indicator bean named " +
+                            "tramaiSovereignOpsWorkerHealthIndicator",
+                    )
+                    .contains("tramaiSovereignOpsWorkerHealthIndicator")
+
+                // Verify the bean is the correct type
+                val indicator = ctx.getBean(
+                    "tramaiSovereignOpsWorkerHealthIndicator",
+                    HealthIndicator::class.java,
+                )
+                assertThat(indicator).isInstanceOf(SovereignOpsWorkerHealthIndicator::class.java)
+            }
+    }
+
+    @Test
+    fun `health indicator bean has expected status through the bean API`() {
+        ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(SovereignOpsActuatorAutoConfiguration::class.java),
+            )
+            .withUserConfiguration(RunningStatusStoreConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.worker-health.enabled=true",
+            )
+            .run { ctx ->
+                val indicator = ctx.getBean(
+                    "tramaiSovereignOpsWorkerHealthIndicator",
+                    HealthIndicator::class.java,
+                )
+                assertThat(indicator.health().status).isEqualTo(Status.UP)
+            }
+    }
+
+    @Test
+    fun `health indicator is absent when health is disabled`() {
+        ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(SovereignOpsActuatorAutoConfiguration::class.java),
+            )
+            .withUserConfiguration(StatusStoreConfig::class.java)
+            .run { ctx ->
+                val beanNames = ctx.getBeanNamesForType(HealthIndicator::class.java)
+                assertThat(beanNames)
+                    .describedAs(
+                        "No HealthIndicator beans should exist " +
+                            "when worker-health is disabled",
+                    )
+                    .doesNotContain("tramaiSovereignOpsWorkerHealthIndicator")
+            }
+    }
+
+    @Test
+    fun `custom named health indicator registered under same bean name`() {
+        ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(SovereignOpsActuatorAutoConfiguration::class.java),
+            )
+            .withUserConfiguration(
+                StatusStoreConfig::class.java,
+                CustomHealthIndicatorConfig::class.java,
+            )
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.worker-health.enabled=true",
+            )
+            .run { ctx ->
+                assertThat(ctx).doesNotHaveBean(SovereignOpsWorkerHealthIndicator::class.java)
+
+                val indicator = ctx.getBean(
+                    "tramaiSovereignOpsWorkerHealthIndicator",
+                    HealthIndicator::class.java,
+                )
+                assertThat(indicator.health().details["custom"]).isEqualTo(true)
+            }
+    }
+
+    @Test
+    fun `worker status endpoint and health indicator bean can coexist`() {
+        ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(SovereignOpsActuatorAutoConfiguration::class.java),
+            )
+            .withUserConfiguration(StatusStoreConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.worker-status.enabled=true",
+                "tramai.sovereign.ops.actuator.worker-health.enabled=true",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SovereignOpsWorkerStatusEndpoint::class.java)
+                assertThat(ctx).hasSingleBean(SovereignOpsWorkerHealthIndicator::class.java)
+
+                val indicator = ctx.getBean(
+                    "tramaiSovereignOpsWorkerHealthIndicator",
+                    HealthIndicator::class.java,
+                )
+                assertThat(indicator.health().status).isEqualTo(Status.UNKNOWN)
+            }
+    }
+}
+
+@Configuration
+open class RunningStatusStoreConfig {
+    @Bean
+    open fun runningStatusStore(): SovereignOpsAuditOutboxWorkerStatusStore {
+        val store = InMemorySovereignOpsAuditOutboxWorkerStatusStore(
+            SovereignOpsOutboxWorkerProperties(
+                enabled = true,
+                recoverPrepared = true,
+                dispatchPending = true,
+                batchSize = 10,
+                initialDelay = Duration.ofSeconds(5),
+                interval = Duration.ofSeconds(30),
+            ),
+        )
+        store.markLifecycleStarted()
+        return store
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsWorkerHealthEndpointIntegrationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsWorkerHealthEndpointIntegrationTest.kt
@@ -5,6 +5,9 @@ import dev.tramai.spring.sovereign.ops.outbox.InMemorySovereignOpsAuditOutboxWor
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerStatusStore
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.boot.actuate.autoconfigure.health.HealthContributorAutoConfiguration
+import org.springframework.boot.actuate.autoconfigure.health.HealthEndpointAutoConfiguration
+import org.springframework.boot.actuate.health.HealthContributorRegistry
 import org.springframework.boot.actuate.health.HealthIndicator
 import org.springframework.boot.actuate.health.Status
 import org.springframework.boot.autoconfigure.AutoConfigurations
@@ -13,7 +16,22 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.time.Duration
 
+/**
+ * Integration tests for the sovereign ops worker health indicator.
+ *
+ * These tests verify two levels of registration:
+ * - Level 1 (bean registration): the auto-configuration creates a bean named
+ *   [tramaiSovereignOpsWorkerHealthIndicator] when [tramai.sovereign.ops.actuator.worker-health.enabled]
+ *   is set to true.
+ * - Level 2 (Actuator health-tree integration): Spring Boot's [HealthContributorAutoConfiguration]
+ *   registers the health indicator in the [HealthContributorRegistry] under the expected
+ *   component name [tramaiSovereignOpsWorker] — not the raw bean name.
+ */
 class SovereignOpsWorkerHealthEndpointIntegrationTest {
+
+    // -----------------------------------------------------------------------
+    // Level 1 — Bean-registration tests
+    // -----------------------------------------------------------------------
 
     @Test
     fun `health indicator bean is registered under the expected named bean`() {
@@ -125,6 +143,168 @@ class SovereignOpsWorkerHealthEndpointIntegrationTest {
                     HealthIndicator::class.java,
                 )
                 assertThat(indicator.health().status).isEqualTo(Status.UNKNOWN)
+            }
+    }
+
+    // -----------------------------------------------------------------------
+    // Level 2 — Actuator health-tree integration tests (HealthContributorRegistry)
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `health component is registered in HealthContributorRegistry under expected name`() {
+        ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(
+                    HealthEndpointAutoConfiguration::class.java,
+                    HealthContributorAutoConfiguration::class.java,
+                    SovereignOpsActuatorAutoConfiguration::class.java,
+                ),
+            )
+            .withUserConfiguration(StatusStoreConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.worker-health.enabled=true",
+            )
+            .run { ctx ->
+                val registry = ctx.getBean(HealthContributorRegistry::class.java)
+
+                val contributor = registry.getContributor("tramaiSovereignOpsWorker")
+                assertThat(contributor)
+                    .describedAs(
+                        "Expected a health contributor named tramaiSovereignOpsWorker " +
+                            "in the registry, not the raw bean name " +
+                            "tramaiSovereignOpsWorkerHealthIndicator",
+                    )
+                    .isNotNull()
+
+                // The raw bean name must NOT appear as a component name
+                assertThat(registry.getContributor("tramaiSovereignOpsWorkerHealthIndicator"))
+                    .describedAs(
+                        "The raw bean name tramaiSovereignOpsWorkerHealthIndicator " +
+                            "must not appear as a health component name — only " +
+                            "tramaiSovereignOpsWorker is the expected component name",
+                    )
+                    .isNull()
+            }
+    }
+
+    @Test
+    fun `health component is a HealthIndicator and reports correct status`() {
+        ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(
+                    HealthEndpointAutoConfiguration::class.java,
+                    HealthContributorAutoConfiguration::class.java,
+                    SovereignOpsActuatorAutoConfiguration::class.java,
+                ),
+            )
+            .withUserConfiguration(RunningStatusStoreConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.worker-health.enabled=true",
+            )
+            .run { ctx ->
+                val registry = ctx.getBean(HealthContributorRegistry::class.java)
+                val contributor =
+                    registry.getContributor("tramaiSovereignOpsWorker")
+                        ?: throw AssertionError(
+                            "Expected contributor tramaiSovereignOpsWorker to be present",
+                        )
+
+                assertThat(contributor)
+                    .isInstanceOf(HealthIndicator::class.java)
+
+                val health = (contributor as HealthIndicator).health()
+                assertThat(health.status).isEqualTo(Status.UP)
+            }
+    }
+
+    @Test
+    fun `no health component in registry when health is disabled`() {
+        ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(
+                    HealthEndpointAutoConfiguration::class.java,
+                    HealthContributorAutoConfiguration::class.java,
+                    SovereignOpsActuatorAutoConfiguration::class.java,
+                ),
+            )
+            .withUserConfiguration(StatusStoreConfig::class.java)
+            .run { ctx ->
+                val registry = ctx.getBean(HealthContributorRegistry::class.java)
+
+                assertThat(registry.getContributor("tramaiSovereignOpsWorker"))
+                    .describedAs(
+                        "No health contributor should be registered " +
+                            "when worker-health is disabled",
+                    )
+                    .isNull()
+            }
+    }
+
+    @Test
+    fun `custom named bean maps to same health component in registry`() {
+        ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(
+                    HealthEndpointAutoConfiguration::class.java,
+                    HealthContributorAutoConfiguration::class.java,
+                    SovereignOpsActuatorAutoConfiguration::class.java,
+                ),
+            )
+            .withUserConfiguration(
+                StatusStoreConfig::class.java,
+                CustomHealthIndicatorConfig::class.java,
+            )
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.worker-health.enabled=true",
+            )
+            .run { ctx ->
+                val registry = ctx.getBean(HealthContributorRegistry::class.java)
+                val contributor =
+                    registry.getContributor("tramaiSovereignOpsWorker")
+                        ?: throw AssertionError(
+                            "Expected contributor tramaiSovereignOpsWorker to be present " +
+                                "with custom bean backoff",
+                        )
+
+                assertThat(contributor).isInstanceOf(HealthIndicator::class.java)
+
+                val health = (contributor as HealthIndicator).health()
+                assertThat(health.status).isEqualTo(Status.UP)
+                assertThat(health.details["custom"]).isEqualTo(true)
+            }
+    }
+
+    @Test
+    fun `status endpoint and health component coexist in health tree`() {
+        ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(
+                    HealthEndpointAutoConfiguration::class.java,
+                    HealthContributorAutoConfiguration::class.java,
+                    SovereignOpsActuatorAutoConfiguration::class.java,
+                ),
+            )
+            .withUserConfiguration(StatusStoreConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.worker-status.enabled=true",
+                "tramai.sovereign.ops.actuator.worker-health.enabled=true",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SovereignOpsWorkerStatusEndpoint::class.java)
+                assertThat(ctx).hasSingleBean(SovereignOpsWorkerHealthIndicator::class.java)
+
+                val registry = ctx.getBean(HealthContributorRegistry::class.java)
+                val contributor =
+                    registry.getContributor("tramaiSovereignOpsWorker")
+                        ?: throw AssertionError(
+                            "Expected contributor tramaiSovereignOpsWorker to be present " +
+                                "when both worker-status and worker-health are enabled",
+                        )
+
+                assertThat(contributor).isInstanceOf(HealthIndicator::class.java)
+
+                val health = (contributor as HealthIndicator).health()
+                assertThat(health.status).isEqualTo(Status.UNKNOWN)
             }
     }
 }


### PR DESCRIPTION
## Summary

Add integration-level coverage proving the optional sovereign ops worker HealthIndicator (PR #71) is registered under the expected Spring Boot Actuator health infrastructure name `tramaiSovereignOpsWorker`.

## Changes

**4 files — 192 insertions, 1 deletion**

### New

- **SovereignOpsWorkerHealthEndpointIntegrationTest.kt** — 5 tests:
  1. Health indicator bean is registered as `tramaiSovereignOpsWorkerHealthIndicator`
  2. Bean reports expected `UP` status through the bean API when worker is running
  3. Health indicator is absent when `worker-health.enabled` is not set
  4. Custom named bean backoff works (custom `tramaiSovereignOpsWorkerHealthIndicator` replaces default)
  5. `worker-status.enabled=true` and `worker-health.enabled=true` can coexist

### Updated

- **Actuator README** — Documents exact health component name (`tramaiSovereignOpsWorker`) with JSON example, derivation explanation (`HealthIndicator` suffix stripped), and coexistence doc
- **Runbook** — Adds exact component name `tramaiSovereignOpsWorker` and explains that the custom status endpoint and health component share the same logical name but different Actuator surfaces
- **build.gradle.kts** (`verifySovereignOpsObservabilityDocs`) — Adds section J requiring:
  - `tramai.sovereign.ops.actuator.worker-health.enabled=true`
  - `tramaiSovereignOpsWorkerHealthIndicator`
  - `tramaiSovereignOpsWorker`
  - `Health component name`

### Health component name derivation

Spring Boot derives the health component name by stripping the `HealthIndicator` suffix from the bean name:

| Bean name | Health component name |
|---|---|
| `tramaiSovereignOpsWorkerHealthIndicator` | `tramaiSovereignOpsWorker` |

The custom status endpoint (id: `tramaiSovereignOpsWorker`) and the health component share the same logical name but are different Actuator surfaces — they can coexist without conflicts.

## Verification

```
./gradlew :tramai-spring-boot-starter-sovereign-ops-actuator:test --rerun-tasks   → 23 tasks, BUILD SUCCESSFUL
./gradlew verifySovereignOpsObservabilityDocs --no-configuration-cache             → all checks passed
./gradlew test --no-configuration-cache                                            → 169 tasks, BUILD SUCCESSFUL
./gradlew generateSovereignReleaseEvidenceIndex --no-configuration-cache           → evidence validated
./gradlew verifySovereignRuntimeConsumerSmoke --no-configuration-cache             → consumer smoke green
```