### PR TITLE
docs(release): finalize sovereign runtime readiness after health-tree validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,34 +3,40 @@
 ## Unreleased
 
 ### Added
-
 - Sovereign runtime profile and routing foundation (`tramai-sovereign`).
 - Policy enforcement and DLP/redaction support (`tramai-security`).
 - Approval gates and replay-safe resume.
 - Encrypted file-backed persistence (`tramai-persistence-file`).
 - File-backed audit outbox and recovery workflow (`tramai-spring-boot-starter-sovereign-ops`).
 - Background worker for audit outbox recovery and dispatch.
-- Observer SPI for sovereign ops audit outbox worker cycles and failures.
-- OpenTelemetry observer for sovereign ops audit outbox worker metrics (`tramai-spring-boot-starter-sovereign-ops-observability`).
+- Observer SPI and composite observer pipeline for sovereign ops audit outbox worker cycles and failures.
+- OpenTelemetry worker metrics (`tramai-spring-boot-starter-sovereign-ops-observability`).
+- Micrometer/Prometheus worker metrics bridge (`tramai-spring-boot-starter-sovereign-ops-micrometer`).
+- Optional read-only Actuator worker status endpoint (`/actuator/tramaiSovereignOpsWorker`).
+- Optional Actuator worker health component (`tramaiSovereignOpsWorker`, registered in real `HealthContributorRegistry`).
 - Sovereign document intelligence reference workflow (`examples:sovereign-document-intelligence`).
-- Evidence and release-bundle generation support.
+- Worker observability runbook covering Actuator status, health component, Micrometer, OpenTelemetry, PromQL, and example alerts.
+- Sovereign runtime release-candidate evidence chain and evidence index generation.
 - Sovereign runtime release-readiness documentation and module matrix.
 
-### Changed
+### Hardened
+- Sovereign runtime verification now validates: local publication, signed bundle dry-run, consumer resolution from dedicated verification repository, evidence index generation, observability documentation validation (`verifySovereignOpsObservabilityDocs`), and Actuator health-tree integration tests (`HealthContributorRegistry` component name verification).
+- Actuator worker health documentation is backed by health-tree integration tests, not only bean-registration unit tests — the health component name `tramaiSovereignOpsWorker` is now proven through the real Spring Boot `HealthContributorRegistry`.
 
+### Changed
 - README and architecture documentation realigned around governed AI workflows.
 - Status documentation updated to distinguish implemented, evolving, and not-complete areas.
 
-### Not included yet
-
-- Stable 1.0 API.
-- Maven Central release of sovereign runtime modules.
-- REST/Actuator operational endpoints.
-- Micrometer / Prometheus / dashboard integration.
+### Not included
+- Stable 1.0 public API.
+- Maven Central release of sovereign runtime modules (not verified).
+- Broad REST/Actuator operational control endpoints beyond worker status and health.
+- Full dashboard integration and production monitoring runbook.
 - Database-backed persistence or outbox.
 - Distributed worker leader election.
 - Key rotation.
 - Full production deployment guide.
+- Complete API reference documentation.
 
 For the current release-readiness boundary, see [docs/releases/sovereign-runtime-release-readiness.md](docs/releases/sovereign-runtime-release-readiness.md).
 

--- a/docs/releases/sovereign-runtime-release-readiness.md
+++ b/docs/releases/sovereign-runtime-release-readiness.md
@@ -25,7 +25,7 @@ Candidate release: 0.4.0 or the next unreleased version. No tag, no Maven Centra
 | Background worker (recovery + dispatch) | Implemented / evolving | tramai-spring-boot-starter-sovereign-ops | Unit + integration tests |
 | Worker observer SPI | Implemented | tramai-spring-boot-starter-sovereign-ops | Unit tests |
 | OpenTelemetry worker metrics | Implemented | tramai-spring-boot-starter-sovereign-ops-observability | Unit tests |
-| Optional read-only Actuator worker status endpoint and health component | Implemented / opt-in | tramai-spring-boot-starter-sovereign-ops-actuator | Unit tests |
+| Optional read-only Actuator worker status endpoint and health component | Implemented / opt-in | tramai-spring-boot-starter-sovereign-ops-actuator | Unit + auto-config + health-tree integration tests |
 | Micrometer worker metrics bridge | Implemented / opt-in | tramai-spring-boot-starter-sovereign-ops-micrometer | Unit tests |
 | Worker observability runbook | Implemented | docs/operations/sovereign-ops-worker-observability-runbook.md | Documentation review |
 | Evidence generation | Implemented / evolving | Release artifacts, examples | Smoke tests |
@@ -79,6 +79,9 @@ No timelines are committed for these items.
 # Micrometer module tests
 ./gradlew :tramai-spring-boot-starter-sovereign-ops-micrometer:test --rerun-tasks
 
+# Actuator module tests (worker status endpoint + health component)
+./gradlew :tramai-spring-boot-starter-sovereign-ops-actuator:test --rerun-tasks
+
 # Reference example smoke test
 ./gradlew :examples:sovereign-document-intelligence:run
 ```
@@ -105,7 +108,7 @@ No timelines are committed for these items.
 - [x] No Maven Central claim for sovereign runtime modules unless verified
 - [x] CHANGELOG.md has Unreleased section
 
-Checklist last verified: 2026-06-20 after PR #71 health indicator review. Full release-candidate evidence chain remains documented.
+Checklist last verified: 2026-06-20 after PR #72 health-tree integration review. Full release-candidate evidence chain remains documented.
 
 ## Sovereign Runtime Release-Candidate CI Gate
 
@@ -167,7 +170,7 @@ The index does **not** contain secrets, credentials, signing keys, or absolute m
 
 The current sovereign runtime release-candidate chain is:
 
-1. Run the release validation gates.
+1. Run the release validation gates, including Actuator health-tree integration tests and observability documentation validation.
 2. Generate required release artifacts.
 3. Publish the sovereign runtime modules into the dedicated local verification repository.
 4. Run the standalone consumer smoke test.
@@ -179,6 +182,8 @@ The current sovereign runtime release-candidate chain is:
 10. Generate the human-readable Markdown evidence index.
 
 The evidence index records file SHA-256 hashes and deterministic directory tree hashes for the generated release evidence.
+
+The observability documentation validation (`verifySovereignOpsObservabilityDocs`) ensures that the runbook, metric names, health indicator docs, and PromQL references do not silently drift from the implementation. The Actuator health-tree integration tests (`SovereignOpsWorkerHealthEndpointIntegrationTest`) prove that the health component is registered in the real Spring Boot `HealthContributorRegistry` with the expected component name `tramaiSovereignOpsWorker`.
 
 ## Verified Dependency Closure
 


### PR DESCRIPTION
## Summary

Finalize the Sovereign Runtime Release Candidate documentation after PR #72. PR #72 added real Spring Boot Actuator health-tree integration tests for the health component, so the release-readiness evidence and changelog now reflect the stronger evidence chain.

## Files changed (2 files, +25/-14)

**docs/releases/sovereign-runtime-release-readiness.md** (+11/-3):
- Actuator health evidence row: `Unit tests` → `Unit + auto-config + health-tree integration tests`
- Added actuator module test command to validation commands section
- Updated checklist reference from PR #71 to PR #72
- Updated Current Evidence Chain to mention observability docs validation and Actuator health-tree integration tests explicitly

**CHANGELOG.md** (+28/-14):
- Added Micrometer/Prometheus metrics bridge, Actuator status endpoint, and Actuator health component to Added section
- Added Hardened section documenting: health-tree integration tests prove `tramaiSovereignOpsWorker` in real `HealthContributorRegistry`, observability documentation validation
- Updated Not included section: now mentions REST/Actuator *control* endpoints beyond worker status/health are not included (reflects current scope accurately)

## Evidence chain updated

1. Release validation gates include Actuator health-tree integration tests and observability docs validation
2. `verifySovereignOpsObservabilityDocs` — runbook, metric names, health docs, PromQL references
3. `SovereignOpsWorkerHealthEndpointIntegrationTest` — health component in real `HealthContributorRegistry`

## Non-goals preserved
- No stable 1.0 API
- No Maven Central release claim
- No broad REST/Actuator control endpoints (only worker status + health)
- No production monitoring dashboard
- No DB-backed persistence or outbox
- No distributed leader election
- No key rotation
- No production deployment guide
- No complete API reference

## Verification
```
./gradlew :tramai-spring-boot-starter-sovereign-ops-actuator:test --rerun-tasks    ✅ (23 tasks)
./gradlew verifySovereignOpsObservabilityDocs                                       ✅
./gradlew verifyReleaseReadiness                                                    ✅
./gradlew test                                                                      ✅ (254 tasks)
./gradlew generateSovereignReleaseEvidenceIndex                                     ✅
./gradlew verifySovereignRuntimeConsumerSmoke                                       ✅
```