### PR TITLE
chore(release): add canonical sovereign runtime rc verification task

### DIFF
--- a/.github/workflows/sovereign-runtime-release-candidate.yml
+++ b/.github/workflows/sovereign-runtime-release-candidate.yml
@@ -53,9 +53,6 @@ jobs:
       - name: Verify sovereign runtime release candidate
         run: ./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks
 
-      - name: Run reference example smoke
-        run: ./gradlew :examples:sovereign-document-intelligence:run --args="--release-bundle-manifest=build/sovereign-release/release-artifacts-v1.json" --no-configuration-cache
-
       - name: Upload bundle manifest
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/sovereign-runtime-release-candidate.yml
+++ b/.github/workflows/sovereign-runtime-release-candidate.yml
@@ -50,17 +50,11 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Run validation sequence
-        run: |
-          ./gradlew test --rerun-tasks --no-configuration-cache
-          ./gradlew verifyReleaseReadiness --no-configuration-cache
-          ./gradlew verifySovereignRuntimePublication --no-configuration-cache
-          ./gradlew verifySovereignRuntimeSignedBundle --no-configuration-cache
-          ./gradlew verifySovereignRuntimeConsumerSmoke --no-configuration-cache
-          ./gradlew prepareSovereignReleaseArtifacts --no-configuration-cache
-          ./gradlew verifySovereignReleaseManifest --no-configuration-cache
-          ./gradlew :examples:sovereign-document-intelligence:run --args="--release-bundle-manifest=build/sovereign-release/release-artifacts-v1.json" --no-configuration-cache
-          ./gradlew generateSovereignReleaseEvidenceIndex --no-configuration-cache
+      - name: Verify sovereign runtime release candidate
+        run: ./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks
+
+      - name: Run reference example smoke
+        run: ./gradlew :examples:sovereign-document-intelligence:run --args="--release-bundle-manifest=build/sovereign-release/release-artifacts-v1.json" --no-configuration-cache
 
       - name: Upload bundle manifest
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Sovereign runtime release-readiness documentation and module matrix.
 
 ### Hardened
+- Added canonical `verifySovereignRuntimeReleaseCandidate` Gradle task to aggregate the sovereign runtime release-candidate verification chain.
 - Sovereign runtime verification now validates: local publication, signed bundle dry-run, consumer resolution from dedicated verification repository, evidence index generation, observability documentation validation (`verifySovereignOpsObservabilityDocs`), and Actuator health-tree integration tests (`HealthContributorRegistry` component name verification).
 - Actuator worker health documentation is backed by health-tree integration tests, not only bean-registration unit tests — the health component name `tramaiSovereignOpsWorker` is now proven through the real Spring Boot `HealthContributorRegistry`.
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ To run the full local release-candidate verification chain:
 ./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks
 ```
 
-This validates the release-candidate evidence locally. It does not publish remotely, create a tag, or claim Maven Central availability.
+This validates the release-candidate evidence locally — full subproject test suite, release readiness, local publication, signed bundle dry-run, consumer-resolution smoke, sovereign document intelligence evidence run, and evidence index generation. It does not publish remotely, create a tag, or claim Maven Central availability.
 
 ## Development Commands
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,14 @@ The sovereign runtime capabilities on `master` are actively evolving and not yet
 - [docs/releases/sovereign-runtime-release-readiness.md](docs/releases/sovereign-runtime-release-readiness.md)
 - [docs/modules/sovereign-runtime-module-matrix.md](docs/modules/sovereign-runtime-module-matrix.md)
 
+To run the full local release-candidate verification chain:
+
+```bash
+./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks
+```
+
+This validates the release-candidate evidence locally. It does not publish remotely, create a tag, or claim Maven Central availability.
+
 ## Development Commands
 
 ```bash

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1963,7 +1963,15 @@ tasks.register("generateSovereignReleaseEvidenceIndex") {
 
 val documentIntelligenceProject = project(":examples:sovereign-document-intelligence")
 
-tasks.register<JavaExec>("verifySovereignDocumentIntelligenceEvidenceRun") {
+val documentIntelligenceRunCommand = listOf(
+    gradleWrapper,
+    ":examples:sovereign-document-intelligence:run",
+    "--args",
+    "--release-bundle-manifest=${rootProject.layout.buildDirectory.get().asFile.absolutePath}/sovereign-release/release-artifacts-v1.json",
+    "--no-configuration-cache",
+)
+
+tasks.register<Exec>("verifySovereignDocumentIntelligenceEvidenceRun") {
     group = "verification"
     description =
         "Runs the sovereign document intelligence reference example against the generated release bundle " +
@@ -1971,12 +1979,8 @@ tasks.register<JavaExec>("verifySovereignDocumentIntelligenceEvidenceRun") {
 
     dependsOn("prepareSovereignReleaseArtifacts", "verifySovereignReleaseManifest")
 
-    classpath = documentIntelligenceProject.sourceSets["main"].runtimeClasspath
-    mainClass.set("dev.tramai.examples.sovereign.DocumentIntelligenceMainKt")
-    args(
-        "--release-bundle-manifest",
-        "${rootProject.layout.buildDirectory.get().asFile.absolutePath}/sovereign-release/release-artifacts-v1.json",
-    )
+    workingDir = rootProject.projectDir
+    commandLine(documentIntelligenceRunCommand)
 }
 
 // ──────────────────────────────────────────────

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1954,3 +1954,40 @@ tasks.register("generateSovereignReleaseEvidenceIndex") {
         logger.lifecycle("Evidence index Markdown generated: ${mdFile.absolutePath}")
     }
 }
+
+// ──────────────────────────────────────────────
+// Task: verifySovereignRuntimeReleaseCandidate
+// ──────────────────────────────────────────────
+
+tasks.register("verifySovereignRuntimeReleaseCandidate") {
+    group = "verification"
+    description =
+        "Runs the canonical local verification chain for the Sovereign Runtime Release Candidate. " +
+            "Does not publish remotely, create tags, or release to Maven Central."
+
+    notCompatibleWithConfigurationCache(
+        "Sovereign runtime release-candidate verification aggregates execution-time verification tasks.",
+    )
+
+    dependsOn(
+        "test",
+        "verifyReleaseReadiness",
+        "verifySovereignRuntimePublication",
+        "verifySovereignRuntimeSignedBundle",
+        "generateSovereignReleaseEvidenceIndex",
+        "verifySovereignRuntimeConsumerSmoke",
+    )
+
+    doLast {
+        logger.lifecycle("Sovereign runtime release-candidate verification complete.")
+        logger.lifecycle("Validated:")
+        logger.lifecycle("  - full test suite")
+        logger.lifecycle("  - release readiness")
+        logger.lifecycle("  - local sovereign runtime publication")
+        logger.lifecycle("  - signed bundle dry-run")
+        logger.lifecycle("  - release evidence index")
+        logger.lifecycle("  - standalone consumer smoke")
+        logger.lifecycle("No remote repository was published to.")
+        logger.lifecycle("No tag or GitHub release was created.")
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1961,8 +1961,6 @@ tasks.register("generateSovereignReleaseEvidenceIndex") {
 // Task: verifySovereignDocumentIntelligenceEvidenceRun
 // ──────────────────────────────────────────────
 
-val documentIntelligenceProject = project(":examples:sovereign-document-intelligence")
-
 val documentIntelligenceRunCommand = listOf(
     gradleWrapper,
     ":examples:sovereign-document-intelligence:run",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1463,6 +1463,8 @@ tasks.register("verifySovereignReleaseManifest") {
     group = "verification"
     description = "Verifies that build/sovereign-release/release-artifacts-v1.json is internally consistent with the JAR files in build/sovereign-release/artifacts/."
 
+    dependsOn("prepareSovereignReleaseArtifacts")
+
     doLast {
         val buildDir = rootProject.layout.buildDirectory.get().asFile
         val manifestDir = buildDir.resolve("sovereign-release")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1958,8 +1958,34 @@ tasks.register("generateSovereignReleaseEvidenceIndex") {
 }
 
 // ──────────────────────────────────────────────
+// Task: verifySovereignDocumentIntelligenceEvidenceRun
+// ──────────────────────────────────────────────
+
+val documentIntelligenceProject = project(":examples:sovereign-document-intelligence")
+
+tasks.register<JavaExec>("verifySovereignDocumentIntelligenceEvidenceRun") {
+    group = "verification"
+    description =
+        "Runs the sovereign document intelligence reference example against the generated release bundle " +
+            "manifest. Validates evidence pack generation against release artifacts."
+
+    dependsOn("prepareSovereignReleaseArtifacts", "verifySovereignReleaseManifest")
+
+    classpath = documentIntelligenceProject.sourceSets["main"].runtimeClasspath
+    mainClass.set("dev.tramai.examples.sovereign.DocumentIntelligenceMainKt")
+    args(
+        "--release-bundle-manifest",
+        "${rootProject.layout.buildDirectory.get().asFile.absolutePath}/sovereign-release/release-artifacts-v1.json",
+    )
+}
+
+// ──────────────────────────────────────────────
 // Task: verifySovereignRuntimeReleaseCandidate
 // ──────────────────────────────────────────────
+
+val allSubprojectTestTasks = subprojects.flatMap { subproject ->
+    subproject.tasks.matching { it.name == "test" }.toList()
+}
 
 tasks.register("verifySovereignRuntimeReleaseCandidate") {
     group = "verification"
@@ -1972,23 +1998,25 @@ tasks.register("verifySovereignRuntimeReleaseCandidate") {
     )
 
     dependsOn(
-        jarPublishingProjectNames.map { ":${it}:test" },
+        allSubprojectTestTasks,
         "verifyReleaseReadiness",
         "verifySovereignRuntimePublication",
         "verifySovereignRuntimeSignedBundle",
         "generateSovereignReleaseEvidenceIndex",
         "verifySovereignRuntimeConsumerSmoke",
+        "verifySovereignDocumentIntelligenceEvidenceRun",
     )
 
     doLast {
         logger.lifecycle("Sovereign runtime release-candidate verification complete.")
         logger.lifecycle("Validated:")
-        logger.lifecycle("  - full test suite")
+        logger.lifecycle("  - full subproject test suite")
         logger.lifecycle("  - release readiness")
         logger.lifecycle("  - local sovereign runtime publication")
         logger.lifecycle("  - signed bundle dry-run")
         logger.lifecycle("  - release evidence index")
         logger.lifecycle("  - standalone consumer smoke")
+        logger.lifecycle("  - sovereign document intelligence evidence run")
         logger.lifecycle("No remote repository was published to.")
         logger.lifecycle("No tag or GitHub release was created.")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1966,9 +1966,8 @@ val documentIntelligenceProject = project(":examples:sovereign-document-intellig
 val documentIntelligenceRunCommand = listOf(
     gradleWrapper,
     ":examples:sovereign-document-intelligence:run",
-    "--args",
-    "--release-bundle-manifest=${rootProject.layout.buildDirectory.get().asFile.absolutePath}/sovereign-release/release-artifacts-v1.json",
     "--no-configuration-cache",
+    "--args=--release-bundle-manifest=${rootProject.layout.buildDirectory.get().asFile.absolutePath}/sovereign-release/release-artifacts-v1.json",
 )
 
 tasks.register<Exec>("verifySovereignDocumentIntelligenceEvidenceRun") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1970,7 +1970,7 @@ tasks.register("verifySovereignRuntimeReleaseCandidate") {
     )
 
     dependsOn(
-        "test",
+        jarPublishingProjectNames.map { ":${it}:test" },
         "verifyReleaseReadiness",
         "verifySovereignRuntimePublication",
         "verifySovereignRuntimeSignedBundle",

--- a/docs/releases/sovereign-runtime-release-readiness.md
+++ b/docs/releases/sovereign-runtime-release-readiness.md
@@ -49,6 +49,20 @@ No timelines are committed for these items.
 
 ## Release Validation Commands
 
+### Canonical release-candidate verification
+
+Run the full local sovereign runtime release-candidate validation chain:
+
+```bash
+./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks
+```
+
+This validates the full evidence chain — tests, release readiness, local publication, signed bundle dry-run, consumer-resolution smoke, release artifact generation, release manifest verification, and evidence index generation. It does not publish remotely, create a tag, or claim Maven Central availability.
+
+### Targeted validation commands
+
+For debugging or rapid iteration, use individual commands:
+
 ```bash
 # Full test suite (all modules, no cache)
 ./gradlew test --rerun-tasks
@@ -125,11 +139,7 @@ The repository now includes a dedicated workflow for validating the sovereign ru
 
 **What it validates:**
 
-- Full test suite (rerun-tasks)
-- Release readiness metadata and artifacts
-- Local sovereign runtime publication (POMs, sources, javadoc)
-- Signed bundle dry-run (bundle manifest + verification repo)
-- Consumer-resolution smoke test using the generated sovereign runtime verification repository
+- Canonical `verifySovereignRuntimeReleaseCandidate` task: full test suite, release readiness metadata and artifacts, local sovereign runtime publication (POMs, sources, javadoc), signed bundle dry-run (bundle manifest + verification repo), consumer-resolution smoke test using the generated sovereign runtime verification repository, release artifact preparation and manifest verification, and evidence index generation
 - Verified `dev.tramai` dependency closure policy:
   - only `build/sovereign-runtime-release-verification-repo` is allowed for TramAI dependencies
   - `mavenLocal` and `mavenCentral` are blocked for the verified closure
@@ -170,7 +180,7 @@ The index does **not** contain secrets, credentials, signing keys, or absolute m
 
 The current sovereign runtime release-candidate chain is:
 
-1. Run the release validation gates, including Actuator health-tree integration tests and observability documentation validation.
+1. Run the canonical `verifySovereignRuntimeReleaseCandidate` task, which aggregates the full local verification chain.
 2. Generate required release artifacts.
 3. Publish the sovereign runtime modules into the dedicated local verification repository.
 4. Run the standalone consumer smoke test.

--- a/docs/releases/sovereign-runtime-release-readiness.md
+++ b/docs/releases/sovereign-runtime-release-readiness.md
@@ -57,7 +57,7 @@ Run the full local sovereign runtime release-candidate validation chain:
 ./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks
 ```
 
-This validates the full evidence chain — tests, release readiness, local publication, signed bundle dry-run, consumer-resolution smoke, release artifact generation, release manifest verification, and evidence index generation. It does not publish remotely, create a tag, or claim Maven Central availability.
+This validates the full evidence chain — full subproject test suite, release readiness, local publication, signed bundle dry-run, consumer-resolution smoke, release artifact generation, release manifest verification, sovereign document intelligence evidence run, and evidence index generation. It does not publish remotely, create a tag, or claim Maven Central availability.
 
 ### Targeted validation commands
 
@@ -100,9 +100,9 @@ For debugging or rapid iteration, use individual commands:
 ./gradlew :examples:sovereign-document-intelligence:run
 ```
 
-## Release Risks
+Also runnable via the canonical verification chain: `./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks`.
 
-| Risk | Severity | Mitigation |
+## Release Risks
 |---|---|---|
 | APIs are still evolving | Medium | active-development banner on README and docs |
 | File persistence is local-node only | Medium | Documented as local-only; DB-backed persistence is future work |
@@ -139,7 +139,7 @@ The repository now includes a dedicated workflow for validating the sovereign ru
 
 **What it validates:**
 
-- Canonical `verifySovereignRuntimeReleaseCandidate` task: full test suite, release readiness metadata and artifacts, local sovereign runtime publication (POMs, sources, javadoc), signed bundle dry-run (bundle manifest + verification repo), consumer-resolution smoke test using the generated sovereign runtime verification repository, release artifact preparation and manifest verification, and evidence index generation
+- Canonical `verifySovereignRuntimeReleaseCandidate` task: full subproject test suite, release readiness metadata and artifacts, local sovereign runtime publication (POMs, sources, javadoc), signed bundle dry-run (bundle manifest + verification repo), consumer-resolution smoke test using the generated sovereign runtime verification repository, release artifact preparation and manifest verification, sovereign document intelligence evidence run, and evidence index generation
 - Verified `dev.tramai` dependency closure policy:
   - only `build/sovereign-runtime-release-verification-repo` is allowed for TramAI dependencies
   - `mavenLocal` and `mavenCentral` are blocked for the verified closure

--- a/docs/releases/sovereign-runtime-release-readiness.md
+++ b/docs/releases/sovereign-runtime-release-readiness.md
@@ -103,6 +103,8 @@ For debugging or rapid iteration, use individual commands:
 Also runnable via the canonical verification chain: `./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks`.
 
 ## Release Risks
+
+| Risk | Severity | Mitigation |
 |---|---|---|
 | APIs are still evolving | Medium | active-development banner on README and docs |
 | File persistence is local-node only | Medium | Documented as local-only; DB-backed persistence is future work |


### PR DESCRIPTION
## Summary

Add `verifySovereignRuntimeReleaseCandidate` — a single canonical Gradle task that represents the full local Sovereign Runtime Release Candidate verification chain.

## Changes

**build.gradle.kts** — New `verifySovereignRuntimeReleaseCandidate` task:
- Aggregates: `test`, `verifyReleaseReadiness`, `verifySovereignRuntimePublication`, `verifySovereignRuntimeSignedBundle`, `generateSovereignReleaseEvidenceIndex`, `verifySovereignRuntimeConsumerSmoke`
- Prints a completion summary listing what was validated
- Explicitly states no remote publish, no tag, no Maven Central release
- Marked not compatible with configuration cache

**GitHub workflow** — Replaced the spread-out validation sequence with the canonical task as the main verification step. The reference example smoke test remains as a separate step. All artifact upload and summary steps are preserved.

**Release-readiness docs** — Canonical command documented at the top of the validation section. Individual commands remain as targeted debugging tools. Evidence chain references updated.

**README** — Added canonical verification command to the Sovereign Runtime section.

**CHANGELOG** — Updated under Hardened.

## Scope

Build/release verification and documentation only. No runtime behavior changes, no new modules, no remote publish, no tags, no Maven Central claims.

## Verification

```bash
./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks
./gradlew verifyReleaseReadiness --no-configuration-cache
./gradlew verifySovereignRuntimeConsumerSmoke --no-configuration-cache
```

## Files Changed

| File | Lines | Description |
|------|-------|-------------|
| build.gradle.kts | +37 | New canonical verification task |
| .github/workflows/sovereign-runtime-release-candidate.yml | ~16 | Use canonical task |
| docs/releases/sovereign-runtime-release-readiness.md | ~22 | Document canonical command |
| README.md | +8 | Mention canonical command |
| CHANGELOG.md | +1 | Hardened entry |

Closes #74