### PR TITLE
docs(release): declare sovereign runtime release-candidate boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@
 
 For the current release-readiness boundary, see [docs/releases/sovereign-runtime-release-readiness.md](docs/releases/sovereign-runtime-release-readiness.md).
 
+### Documentation
+- Added Sovereign Runtime Release Candidate boundary declaration and linked it to the canonical verification task.
+
 ## 0.3.1 — 2026-05-24
 
 Patch release focused on streaming stability, memory persistence, and proxy-aware tool scanning.

--- a/README.md
+++ b/README.md
@@ -218,6 +218,23 @@ The following are intentionally not claimed as complete:
 - full production deployment guide
 - complete API reference documentation
 
+### Sovereign Runtime Release Candidate
+
+The current `master` branch contains a Sovereign Runtime Release Candidate boundary.
+
+See:
+
+- [Sovereign Runtime RC Boundary](docs/releases/sovereign-runtime-rc-boundary.md)
+- [Sovereign Runtime Release Readiness](docs/releases/sovereign-runtime-release-readiness.md)
+
+Run the full local verification chain with:
+
+```bash
+./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks
+```
+
+This is **not** a stable 1.0 API declaration, **not** a Maven Central release, and **not** a production deployment certification.
+
 ## Sovereign Runtime Release Readiness
 
 The sovereign runtime capabilities on `master` are actively evolving and not yet a stable 1.0 API. For the current release-readiness boundary, included modules, validation commands, and known non-goals, see:

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -60,6 +60,22 @@ Unreleased capabilities include:
 
 APIs in these areas may change before the next release.
 
+## Sovereign Runtime
+
+**Status: Release Candidate boundary declared / active development**
+
+The Sovereign Runtime RC boundary is now documented and locally verifiable through:
+
+```bash
+./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks
+```
+
+This includes governed runtime execution, sovereign routing, DLP, replay-safe approvals, encrypted file-backed persistence, audit/outbox recovery, worker observability, and release evidence generation.
+
+For the full RC boundary declaration, see [docs/releases/sovereign-runtime-rc-boundary.md](./releases/sovereign-runtime-rc-boundary.md).
+
+Not yet included: stable 1.0 API, Maven Central release, database-backed persistence, distributed worker coordination, key rotation, and production deployment certification.
+
 ## Planned / Not Complete
 
 The following are intentionally not claimed as complete. Some are planned, some are deferred, and some represent infrastructure that does not yet exist:

--- a/docs/releases/sovereign-runtime-rc-boundary.md
+++ b/docs/releases/sovereign-runtime-rc-boundary.md
@@ -1,0 +1,72 @@
+# Sovereign Runtime Release Candidate Boundary
+
+## Purpose
+
+This document declares the current Sovereign Runtime Release Candidate boundary on `master`.
+
+It is **not** a stable 1.0 API declaration.
+It is **not** a Maven Central release announcement.
+It is **not** a production deployment certification.
+
+## Release Candidate Definition
+
+The Sovereign Runtime RC is the set of TramAI capabilities that allow a JVM application to run governed AI workflows with policy enforcement, DLP, sovereign routing, replay-safe approval flows, local encrypted persistence, audit/outbox recovery, and operator-facing observability.
+
+## Included
+
+- Policy enforcement
+- DLP and redaction
+- Sovereign routing and trust zones
+- Approval gates
+- Replay-safe resume
+- Encrypted file-backed persistence
+- Audit chain
+- Audit outbox persistence and dispatch
+- Background worker recovery and dispatch
+- Worker observer SPI
+- Composite observer pipeline
+- Optional Actuator worker status endpoint
+- Optional Actuator worker health component
+- Micrometer worker metrics
+- OpenTelemetry worker metrics
+- Worker observability runbook
+- PromQL examples and alert examples
+- Sovereign document intelligence reference workflow
+- Release evidence index
+- Consumer-resolution smoke test
+- Canonical release-candidate verification task
+
+## Verification
+
+The full local release-candidate verification chain is:
+
+```bash
+./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks
+```
+
+This validates the release-candidate evidence locally. It does **not** publish remotely, create a tag, or claim Maven Central availability.
+
+## Explicit Non-Goals
+
+The following are intentionally **not included** in this RC:
+
+- Stable 1.0 public API
+- Maven Central release
+- Production deployment certification
+- Database-backed persistence or outbox
+- Distributed worker leader election
+- Key rotation
+- Broad REST/Actuator control-plane endpoints
+- Production dashboard
+- Complete API reference documentation
+
+## Post-RC Roadmap
+
+After this RC boundary, the next roadmap area is production hardening:
+
+1. JDBC/database-backed persistence and outbox
+2. Distributed worker coordination
+3. Key rotation
+4. Production deployment guide
+5. End-to-end regulated workflow examples
+6. API stabilization based on integration feedback

--- a/docs/releases/sovereign-runtime-release-readiness.md
+++ b/docs/releases/sovereign-runtime-release-readiness.md
@@ -2,9 +2,11 @@
 
 ## Purpose
 
-This document tracks the readiness of the current sovereign runtime capabilities on master.
+This document tracks readiness evidence for the declared Sovereign Runtime Release Candidate boundary on `master`.
 
 It is NOT a formal release announcement and does NOT promise API stability. It exists so that reviewers, integrators, and the project itself have an honest, auditable snapshot of what is implemented, what is evolving, and what is intentionally not done.
+
+For the declared RC boundary, see [Sovereign Runtime RC Boundary](sovereign-runtime-rc-boundary.md).
 
 ## Target Release Boundary
 


### PR DESCRIPTION
Closes the Sovereign Runtime RC roadmap by declaring, in documentation, the exact release-candidate boundary: what is included, what is verified, what is intentionally not included, what command proves the boundary, and what future work starts after the RC.

This is a **closure PR**, not a feature PR — documentation only, no code changes.

## Changes

| File | Change |
|------|--------|
| `docs/releases/sovereign-runtime-rc-boundary.md` | **New** — Full RC boundary declaration: Purpose, RC definition, included capabilities, verification command, explicit non-goals, and post-RC roadmap |
| `README.md` | Added Sovereign Runtime Release Candidate section linking to the boundary doc, release-readiness doc, and canonical verification command |
| `docs/STATUS.md` | Added Sovereign Runtime section with status Release Candidate boundary declared / active development |
| `docs/releases/sovereign-runtime-release-readiness.md` | Updated purpose to reference declared RC boundary, added link to boundary doc |
| `CHANGELOG.md` | Added Unreleased documentation entry for the RC boundary declaration |

## Acceptance Criteria

- RC boundary document exists
- README links to it
- STATUS.md reflects RC boundary declared / active development
- Release-readiness doc links to the boundary doc
- CHANGELOG mentions the boundary declaration
- Canonical command is documented
- Non-goals are explicit
- No production-ready, stable 1.0, or Maven Central claims
- Documentation only — no code changes