### PR TITLE
docs(sovereign): add regulated claim triage reference scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ For the current release-readiness boundary, see [docs/releases/sovereign-runtime
 ### Documentation
 - Added Sovereign Runtime Release Candidate boundary declaration and linked it to the canonical verification task.
 - Added Sovereign Runtime Quickstart for first-time RC evaluation and integration.
+- Added a regulated claim triage reference scenario for Sovereign Runtime RC evaluation.
 
 ## 0.3.1 — 2026-05-24
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,10 @@ For a practical first integration path, see:
 
 - [Sovereign Runtime Quickstart](docs/guides/sovereign-runtime-quickstart.md)
 
+For a domain-level walkthrough, see:
+
+- [Regulated Claim Triage Reference Scenario](docs/scenarios/regulated-claim-triage.md)
+
 ## Development Commands
 
 ```bash

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -110,6 +110,8 @@ The current sovereign runtime release-readiness checklist and module matrix are 
 
 For first-time integration, see [Sovereign Runtime Quickstart](./guides/sovereign-runtime-quickstart.md).
 
+For a regulated workflow reference scenario, see [Regulated Claim Triage Reference Scenario](./scenarios/regulated-claim-triage.md).
+
 These documents cover included capability areas, representative modules, validation commands, explicit non-goals, and known release risks.
 
 ## Historical Context

--- a/docs/guides/sovereign-runtime-quickstart.md
+++ b/docs/guides/sovereign-runtime-quickstart.md
@@ -162,6 +162,8 @@ It does **not** publish remotely, create a tag, or claim Maven Central availabil
 
 ## What this quickstart does not cover
 
+For a regulated-domain walkthrough, see [Regulated Claim Triage Reference Scenario](../scenarios/regulated-claim-triage.md).
+
 - Production deployment and operational runbooks
 - Distributed worker coordination and leader election
 - Database-backed persistence or outbox (JDBC / Postgres)

--- a/docs/releases/sovereign-runtime-rc-boundary.md
+++ b/docs/releases/sovereign-runtime-rc-boundary.md
@@ -50,6 +50,8 @@ This validates the release-candidate evidence locally. It does **not** publish r
 
 For a practical first integration path, see [Sovereign Runtime Quickstart](../guides/sovereign-runtime-quickstart.md).
 
+For a domain-level example of how the RC applies to regulated workflows, see [Regulated Claim Triage Reference Scenario](../scenarios/regulated-claim-triage.md).
+
 ## Explicit Non-Goals
 
 The following are intentionally **not included** in this RC:

--- a/docs/scenarios/regulated-claim-triage.md
+++ b/docs/scenarios/regulated-claim-triage.md
@@ -130,7 +130,7 @@ Operators can inspect worker state **without** exposing sensitive claim data.
 - worker enabled / running state
 - cycle counters (success, failure)
 - last success / failure timestamp
-- sanitized health status (UP / DOWN / DEGRADED)
+- sanitized health status exposed through the Actuator health component
 - metric counters (OpenTelemetry, Micrometer)
 
 **Not allowed:**
@@ -151,7 +151,7 @@ Operators can inspect worker state **without** exposing sensitive claim data.
 | Policy denies route | No model call — fail with explicit denial reason |
 | Model provider unavailable | Retry / fallback according to policy |
 | Approval timeout | Remain suspended or escalate |
-| Outbox dispatch fails | Durable retry with exponential backoff |
+| Outbox dispatch fails | Event remains durable for retry or operator investigation |
 | Worker restarts | Recover pending outbox work |
 | Audit store unavailable | Fail closed for governed workflow |
 

--- a/docs/scenarios/regulated-claim-triage.md
+++ b/docs/scenarios/regulated-claim-triage.md
@@ -1,0 +1,207 @@
+# Regulated Claim Triage Reference Scenario
+
+## Purpose
+
+This scenario shows how the Sovereign Runtime RC can support a regulated healthcare or insurance claim triage workflow.
+
+It is a **reference scenario for architecture and evaluation**. It is **not** a production deployment guide, legal compliance certification, or medical decisioning system.
+
+## Scenario Summary
+
+A healthcare insurer receives a claim that may contain sensitive medical, financial, and personal data.
+
+The organization wants AI assistance for triage, but the workflow must enforce:
+
+- data classification
+- DLP / redaction
+- model routing based on sensitivity
+- human approval for high-risk recommendations
+- tamper-evident audit
+- durable recovery through an outbox
+- sanitized operational observability
+
+## Actors
+
+| Actor | Role |
+|-------|------|
+| Claimant / customer | Submits the claim |
+| Claim intake service | Receives and validates the raw claim |
+| TramAI governed workflow | Orchestrates policy, routing, approval, and audit |
+| DLP classifier | Assigns sensitivity levels to data fields |
+| Policy engine | Decides allow / deny / suspend per data class and route |
+| Local or trusted model provider | Executes the AI triage recommendation |
+| Human reviewer / medical ops specialist | Reviews high-risk recommendations |
+| Audit / outbox worker | Persists and dispatches audit events durably |
+| Compliance reviewer | Audits the audit trail retrospectively |
+| Operator / SRE | Monitors worker health and metrics |
+
+## Data Classes
+
+| Data | Sensitivity | Example |
+|------|-------------|---------|
+| Claim ID | Internal | `claim-123` |
+| Customer identity | Restricted | name, address, customer number |
+| Medical details | Restricted | diagnosis, treatment, medication |
+| Payment details | Confidential | invoice amount, bank / payment details |
+| Claim metadata | Internal | submission date, claim type |
+| AI recommendation | Internal / Restricted | depends on included reasoning |
+
+## Trust Zones
+
+| Zone | Allowed Data | Example Runtime Behavior |
+|------|-------------|--------------------------|
+| Local-only | Restricted medical or identity data | Use local model only |
+| EU / trusted provider | Redacted confidential data | Route only after DLP redaction |
+| Approved cloud | Non-sensitive metadata | Allowed if policy permits |
+| Denied | Unsupported sensitivity / provider combination | Fail before model call |
+
+## Workflow Overview
+
+```
+claim submitted
+  -> input validation
+  -> DLP classification
+  -> policy decision
+  -> redaction if needed
+  -> sovereign routing
+  -> model recommendation
+  -> structured output validation
+  -> approval decision
+  -> audit event
+  -> outbox dispatch
+  -> operator / health / metrics visibility
+```
+
+## Policy Decisions
+
+| Condition | Decision |
+|-----------|----------|
+| Restricted medical data + approved cloud model | Deny |
+| Restricted medical data + local model | Allow |
+| Confidential payment data + redaction available | Allow after redaction |
+| Missing sensitivity classification | Deny by default |
+| High-risk recommendation | Suspend for approval |
+| Low-risk administrative recommendation | Allow without manual approval |
+
+## Example Recommendation Types
+
+| Recommendation | Risk | Approval Needed |
+|----------------|------|-----------------|
+| Request missing document | Low | No |
+| Mark claim for manual review | Medium | Maybe |
+| Suggest rejection | High | Yes |
+| Suggest payout | High | Yes |
+| Detect possible fraud | High | Yes |
+
+## Human Approval Boundary
+
+High-risk recommendations must **not** automatically execute.
+
+The workflow should:
+
+- persist the suspended invocation to the encrypted file store
+- **not** block a thread while waiting for a human decision
+- present a sanitized recommendation to an authorized reviewer (no raw prompts, no model responses, no PII)
+- require a role-based approval decision (approve / deny / escalate)
+- audit every approve / deny / escalate decision with a sequenced audit event
+- resume through a replay-safe envelope when the decision arrives
+
+## Audit and Outbox
+
+The workflow emits audit events for:
+
+- claim received
+- DLP classification completed
+- policy decision made
+- model route selected
+- recommendation generated
+- approval requested
+- approval decision recorded
+- outbox dispatch attempted
+- outbox dispatch completed or failed
+
+The outbox allows recovery after process restart and avoids losing operational events. Each audit event is sequenced for tamper-evident ordering.
+
+## Observability
+
+Operators can inspect worker state **without** exposing sensitive claim data.
+
+**Allowed observability:**
+- worker enabled / running state
+- cycle counters (success, failure)
+- last success / failure timestamp
+- sanitized health status (UP / DOWN / DEGRADED)
+- metric counters (OpenTelemetry, Micrometer)
+
+**Not allowed:**
+- prompts sent to models
+- model responses
+- claimant identity
+- medical text
+- payment details
+- raw exception messages
+- stack traces
+- approval IDs or claim IDs as metric labels
+
+## Failure Modes
+
+| Failure | Expected Behavior |
+|---------|-------------------|
+| DLP classifier unavailable | Fail closed or route to manual review |
+| Policy denies route | No model call — fail with explicit denial reason |
+| Model provider unavailable | Retry / fallback according to policy |
+| Approval timeout | Remain suspended or escalate |
+| Outbox dispatch fails | Durable retry with exponential backoff |
+| Worker restarts | Recover pending outbox work |
+| Audit store unavailable | Fail closed for governed workflow |
+
+## What TramAI Provides in This Scenario
+
+- Typed AI operation boundary (`@AiService`, `@Operation`)
+- Policy enforcement (allow / deny / suspend based on data class and route)
+- DLP-aware routing (redact before sending to model)
+- Sovereign provider selection (local-only, EU / trusted, approved cloud)
+- Replay-safe approval resume (encrypted continuation envelopes)
+- Encrypted file-backed persistence (approvals, continuations, audit stream, outbox)
+- Audit chain (tamper-evident sequencing)
+- Outbox recovery (durable claim-based dispatch)
+- Worker observability (Actuator status / health, Micrometer, OpenTelemetry)
+- Release-candidate verification evidence (`verifySovereignRuntimeReleaseCandidate`)
+
+## What Is Still Application Responsibility
+
+- Legal compliance review (HIPAA, GDPR, sector-specific regulation)
+- Domain-specific medical / insurance rules
+- Final business decisioning
+- User-facing reviewer UI
+- Role / identity management integration
+- Customer communication
+- Production deployment and monitoring
+- Database-backed persistence if required
+- Distributed worker coordination if running multiple nodes
+
+## How to Evaluate This Scenario Locally
+
+Start with the canonical RC verification command:
+
+```bash
+./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks
+```
+
+Then read:
+
+- [Sovereign Runtime Quickstart](../guides/sovereign-runtime-quickstart.md)
+- [Sovereign Runtime RC Boundary](../releases/sovereign-runtime-rc-boundary.md)
+- [Worker Observability Runbook](../operations/sovereign-ops-worker-observability-runbook.md)
+
+## Non-Goals
+
+This scenario does **not** claim:
+
+- Production readiness
+- Regulatory certification (HIPAA, GDPR, or any other)
+- Medical decision automation
+- Stable 1.0 API
+- Maven Central availability
+- Database-backed persistence
+- Distributed worker coordination


### PR DESCRIPTION
Adds a concrete regulated healthcare/insurance claim triage reference scenario showing how the Sovereign Runtime RC applies to a realistic enterprise workflow. Makes TramAI easier to explain to enterprise architects, compliance/security reviewers, developers, and potential partners.

This is an **adoption/positioning PR**, not a feature PR — documentation only, no code changes.

## Changes

| File | Change |
|------|--------|
| `docs/scenarios/regulated-claim-triage.md` | **New** — Full regulated claim triage reference scenario (~207 loc) covering: actors, data classes, trust zones, workflow overview, policy decisions, recommendation types, human approval boundary, audit/outbox, observability sanitization, failure modes, TramAI vs application responsibilities, and how to evaluate locally |
| `README.md` | Added domain-level walkthrough link under Sovereign Runtime section |
| `docs/guides/sovereign-runtime-quickstart.md` | Added regulated-domain walkthrough link |
| `docs/releases/sovereign-runtime-rc-boundary.md` | Added regulated workflow example link under Trying the RC |
| `docs/STATUS.md` | Added regulated workflow reference scenario link |
| `CHANGELOG.md` | Added Unreleased documentation entry |

## Acceptance Criteria

- Scenario exists — domain-level, no fake APIs, no compiling code
- Explains actors, data classes, trust zones, policy decisions, approval boundary, audit/outbox, observability, failure modes, TramAI responsibilities, and application responsibilities
- README, Quickstart, RC boundary doc, and STATUS all link to it
- No production-ready, regulatory certification, medical automation, Maven Central, or stable 1.0 API claims
- Documentation only — no code, no Gradle tasks, no workflows

## Verification

```bash
./gradlew verifyReleaseReadiness --no-configuration-cache
./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks
```