### PR TITLE
docs(sovereign): define JDBC persistence production-hardening design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ For the current release-readiness boundary, see [docs/releases/sovereign-runtime
 - Added Sovereign Runtime Release Candidate boundary declaration and linked it to the canonical verification task.
 - Added Sovereign Runtime Quickstart for first-time RC evaluation and integration.
 - Added a regulated claim triage reference scenario for Sovereign Runtime RC evaluation.
+- Added Sovereign JDBC persistence design as the first production-hardening target after the Sovereign Runtime RC boundary.
 
 ## 0.3.1 — 2026-05-24
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,10 @@ For a domain-level walkthrough, see:
 
 - [Regulated Claim Triage Reference Scenario](docs/scenarios/regulated-claim-triage.md)
 
+For the production-hardening direction toward JDBC / database-backed persistence, see:
+
+- [Sovereign JDBC Persistence Design](docs/architecture/sovereign-jdbc-persistence-design.md)
+
 ## Development Commands
 
 ```bash

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -112,6 +112,8 @@ For first-time integration, see [Sovereign Runtime Quickstart](./guides/sovereig
 
 For a regulated workflow reference scenario, see [Regulated Claim Triage Reference Scenario](./scenarios/regulated-claim-triage.md).
 
+For the production-hardening direction toward database-backed persistence, see [Sovereign JDBC Persistence Design](./architecture/sovereign-jdbc-persistence-design.md).
+
 These documents cover included capability areas, representative modules, validation commands, explicit non-goals, and known release risks.
 
 ## Historical Context

--- a/docs/architecture/sovereign-jdbc-persistence-design.md
+++ b/docs/architecture/sovereign-jdbc-persistence-design.md
@@ -1,0 +1,315 @@
+# Sovereign JDBC Persistence Design
+
+## Purpose
+
+This document defines the production-hardening direction for database-backed Sovereign Runtime persistence.
+
+The current Sovereign Runtime RC uses encrypted file-backed persistence suitable for local evaluation and single-node scenarios. Enterprise deployments will require JDBC / database-backed persistence for approvals, suspended invocations, audit streams, and outbox recovery.
+
+This document is a **design target**. It does **not** claim that JDBC persistence is implemented yet.
+
+## Current State
+
+The Sovereign Runtime RC currently provides:
+
+- encrypted file-backed persistence
+- approval persistence
+- suspended invocation persistence
+- audit chain persistence
+- audit outbox persistence
+- worker recovery and dispatch
+- local verification through `verifySovereignRuntimeReleaseCandidate`
+
+Current limitations:
+
+- local-node persistence only
+- no JDBC / Postgres-backed store
+- no schema migrations
+- no multi-node worker coordination
+- no database transaction boundary
+- no production deployment certification
+
+## Target Capabilities
+
+The production-hardening target is to support:
+
+- JDBC-backed approval store
+- JDBC-backed suspended invocation store
+- JDBC-backed audit stream store
+- JDBC-backed audit outbox store
+- durable recovery after process restart
+- transactional writes where required
+- duplicate dispatch protection
+- schema migration support
+- Testcontainers-based integration tests
+- future distributed worker coordination
+
+## Persistence Areas
+
+| Area | Purpose | Production Requirement |
+|------|---------|------------------------|
+| Approvals | Store approval requests and decisions | Durable, queryable, auditable |
+| Suspended invocations | Store replay-safe continuations | Encrypted, tamper-resistant, resumable |
+| Audit stream | Store ordered audit events | Append-only, hash-chain verifiable |
+| Audit outbox | Store dispatchable operational events | Durable retry, duplicate protection |
+| Worker status | Store sanitized worker state | Optional, operational visibility |
+
+## Design Principles
+
+1. **Fail closed** for governed workflows when critical persistence is unavailable.
+2. Keep sensitive payloads **encrypted at rest**.
+3. **Do not expose** prompts, model responses, replay envelopes, raw exception messages, or PII through operational surfaces.
+4. Preserve **replay safety** for suspended invocations.
+5. Preserve **audit hash-chain verification**.
+6. Preserve **idempotency and duplicate protection**.
+7. Keep JDBC implementation **compatible with future distributed worker coordination**.
+8. **Avoid coupling** persistence to a specific application domain.
+
+## Minimum Constraints
+
+The first JDBC implementation should define at least:
+
+- `approvals`: primary key on `approval_id`; optimistic update on `version`
+- `suspended_invocations`: primary key on `invocation_id`; unique `replay_envelope_digest`
+- `audit_events`: primary key on (`stream_id`, `sequence_number`); unique `event_id`
+- `audit_outbox`: primary key on `outbox_id`; unique `event_key`
+- `worker_leases`: primary key on `lease_name`
+
+These constraints give the implementation agent a precise contract for the first PR.
+
+## Database Scope
+
+Initial target database:
+
+- **PostgreSQL-compatible JDBC**
+
+Future-compatible but not required initially:
+
+- generic JDBC portability
+- vendor-specific optimizations
+- managed cloud database certification
+
+## Proposed Tables
+
+### approvals
+
+Purpose: store approval requests and decisions.
+
+Required fields (conceptual):
+
+- `approval_id`
+- `status`
+- `required_role`
+- `created_at`
+- `decided_at`
+- `decision_actor_hash`
+- `decision_type`
+- `sanitized_metadata`
+- `encryption_key_id`
+- `encryption_algorithm`
+- `encryption_nonce`
+- `encrypted_payload`
+- `payload_digest`
+- `version`
+
+### suspended_invocations
+
+Purpose: store replay-safe suspended workflow continuations.
+
+Required fields (conceptual):
+
+- `invocation_id`
+- `service_key`
+- `operation_key`
+- `descriptor_hash`
+- `status`
+- `created_at`
+- `resumed_at`
+- `replay_envelope_digest`
+- `encryption_key_id`
+- `encryption_algorithm`
+- `encryption_nonce`
+- `encrypted_replay_envelope`
+- `version`
+
+### audit_events
+
+Purpose: store tamper-evident audit events.
+
+Required fields (conceptual):
+
+- `stream_id`
+- `sequence_number`
+- `event_id`
+- `event_type`
+- `event_hash`
+- `previous_event_hash`
+- `occurred_at`
+- `sanitized_actor`
+- `encryption_key_id`
+- `encryption_algorithm`
+- `encryption_nonce`
+- `encrypted_payload`
+- `payload_digest`
+- `schema_version`
+
+### audit_outbox
+
+Purpose: store dispatchable audit / outbox records.
+
+Required fields (conceptual):
+
+- `outbox_id`
+- `event_key`
+- `status`
+- `correlation_key_hash`
+- `created_at`
+- `claimed_at`
+- `dispatched_at`
+- `attempt_count`
+- `last_failure_type`
+- `next_attempt_at`
+- `encryption_key_id`
+- `encryption_algorithm`
+- `encryption_nonce`
+- `encrypted_payload`
+- `payload_digest`
+- `version`
+
+### worker_leases
+
+Purpose: future multi-node coordination.
+
+This is **not** required for the first JDBC implementation, but the design should reserve space for it.
+
+Required fields (conceptual):
+
+- `lease_name`
+- `owner_id`
+- `acquired_at`
+- `expires_at`
+- `heartbeat_at`
+- `version`
+
+## Transaction Boundaries
+
+Documented expected transaction behaviour:
+
+- Approval request creation should be **atomic**.
+- Approval decision update should be **atomic and idempotent**.
+- Suspended invocation creation should be **atomic**.
+- Resume should **atomically mark** invocation consumed / resumed.
+- Audit event append must preserve **sequence and hash-chain integrity**. Append must use either a per-stream lock row (`SELECT ... FOR UPDATE`) or optimistic insert with unique (`stream_id`, `sequence_number`) and retry on conflict. Concurrent writers must not be able to create two valid events with the same `previous_event_hash`.
+- When audit event append and outbox record creation use the same JDBC `DataSource`, they must occur in the **same database transaction**. If the application uses different persistence backends, TramAI must document that atomicity is not guaranteed and must fail closed or expose an explicit degraded mode.
+- Outbox dispatch should use **claim / lease semantics** to avoid duplicate dispatch.
+
+## Idempotency and Duplicate Protection
+
+The JDBC design must protect against:
+
+- duplicate approval decisions
+- duplicate resume attempts
+- duplicate audit events
+- duplicate outbox dispatch
+- worker restart replay
+- concurrent dispatch workers
+
+Suggested mechanisms:
+
+- unique constraints
+- version columns
+- compare-and-set updates
+- event keys
+- replay envelope digests
+- claim tokens / leases
+
+## Encryption
+
+The JDBC implementation must preserve the same security posture as file persistence:
+
+- sensitive payloads encrypted **before** storage
+- no plaintext prompts
+- no plaintext model responses
+- no plaintext replay envelopes
+- no plaintext tool arguments
+- no raw exception messages in persisted operational metadata
+
+Key rotation is **not** part of the first implementation, but the schema should not make future rotation impossible.
+
+## Migration Strategy
+
+The JDBC implementation should eventually provide schema migrations.
+
+Possible options:
+
+- plain SQL migration files
+- Flyway-compatible scripts
+- Liquibase-compatible scripts
+
+Initial recommendation:
+
+- provide **plain SQL migration scripts** first
+- document Flyway / Liquibase integration later
+
+## Testing Strategy
+
+The JDBC persistence track should include:
+
+- reusable persistence contract tests
+- Postgres Testcontainers integration tests
+- restart / reopen tests
+- duplicate detection tests
+- concurrent claim tests
+- audit hash-chain verification tests
+- corruption / tamper detection tests where applicable
+- migration smoke tests
+
+## Observability
+
+Database-backed persistence must preserve sanitized observability.
+
+**Allowed:**
+
+- worker state
+- counters
+- timestamps
+- sanitized failure type
+- retry counts
+
+**Forbidden:**
+
+- prompts
+- model responses
+- replay envelopes
+- raw exception messages
+- PII
+- medical / financial data
+- claim IDs as metric labels
+- approval IDs as metric labels
+
+## Rollout Plan
+
+Suggested implementation sequence:
+
+1. Add `tramai-persistence-jdbc` module skeleton.
+2. Add JDBC schema and migration layout.
+3. Add approval JDBC store.
+4. Add suspended invocation JDBC store.
+5. Add audit stream JDBC store.
+6. Add audit outbox JDBC store.
+7. Add Testcontainers-based integration tests.
+8. Add optional worker lease support.
+9. Add production deployment documentation.
+
+## Non-Goals
+
+This design does **not** claim:
+
+- JDBC persistence is already implemented
+- Production readiness
+- Distributed worker coordination
+- Key rotation
+- Cloud database certification
+- Cross-database distributed transactions / XA coordination
+- Stable 1.0 API
+- Maven Central availability

--- a/docs/releases/sovereign-runtime-rc-boundary.md
+++ b/docs/releases/sovereign-runtime-rc-boundary.md
@@ -76,3 +76,5 @@ After this RC boundary, the next roadmap area is production hardening:
 4. Production deployment guide
 5. End-to-end regulated workflow examples
 6. API stabilization based on integration feedback
+
+The first production-hardening design target is database-backed persistence. See [Sovereign JDBC Persistence Design](../architecture/sovereign-jdbc-persistence-design.md).

--- a/docs/scenarios/regulated-claim-triage.md
+++ b/docs/scenarios/regulated-claim-triage.md
@@ -194,6 +194,8 @@ Then read:
 - [Sovereign Runtime RC Boundary](../releases/sovereign-runtime-rc-boundary.md)
 - [Worker Observability Runbook](../operations/sovereign-ops-worker-observability-runbook.md)
 
+For the planned database-backed persistence direction, see [Sovereign JDBC Persistence Design](../architecture/sovereign-jdbc-persistence-design.md).
+
 ## Non-Goals
 
 This scenario does **not** claim:


### PR DESCRIPTION
Starts the Sovereign Runtime production-hardening track by defining the design target for JDBC / database-backed persistence. This is the first step beyond the RC boundary into enterprise-ready persistence.

This is a **design / architecture PR**, not an implementation PR — documentation only, no code changes.

## Changes

| File | Change |
|------|--------|
| `docs/architecture/sovereign-jdbc-persistence-design.md` | **New** (~285 loc) — Full production-hardening design: current state / limitations, target capabilities, 5 persistence areas, 8 design principles, database scope, 5 proposed table designs, transaction boundaries, idempotency mechanisms, encryption expectations, migration strategy, testing strategy, observability guardrails, 9-step rollout plan, and explicit non-goals |
| `README.md` | Added JDBC persistence design link under Sovereign Runtime docs |
| `docs/STATUS.md` | Added JDBC persistence design link in Release Readiness section |
| `docs/releases/sovereign-runtime-rc-boundary.md` | Added JDBC persistence design link under Post-RC Roadmap |
| `docs/scenarios/regulated-claim-triage.md` | Added JDBC persistence design link in How to Evaluate section |
| `CHANGELOG.md` | Added Unreleased documentation entry |

## Acceptance Criteria

- Design document exists — clearly states JDBC persistence is a future target, not implemented
- Documents current file-backed limitations
- Defines target persistence areas and conceptual table designs
- Explains transaction boundaries, idempotency, encryption, migration, and testing
- Links from STATUS, RC boundary doc, regulated scenario, and README
- No runtime code, Gradle tasks, or workflow changes
- No production-ready, DB-implemented, distributed-worker, or stable 1.0 claims

## Verification

```bash
./gradlew verifyReleaseReadiness --no-configuration-cache
./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks
```