### PR TITLE
feat(persistence): add JDBC approval store

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", ve
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
+jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref = "kotlin" }

--- a/tramai-persistence-jdbc/build.gradle.kts
+++ b/tramai-persistence-jdbc/build.gradle.kts
@@ -18,6 +18,11 @@ kotlin {
 }
 
 dependencies {
+    api(project(":tramai-core"))
+    implementation(libs.jackson.databind)
+    implementation(libs.jackson.module.kotlin)
+    implementation(libs.jackson.datatype.jsr310)
+
     testImplementation(platform(libs.junit.bom))
     testImplementation(platform(libs.testcontainers.bom))
     testImplementation(libs.assertj.core)

--- a/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStore.kt
+++ b/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStore.kt
@@ -21,6 +21,7 @@ import dev.tramai.core.exception.IllegalApprovalTransitionException
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 import java.sql.ResultSet
+import java.sql.SQLException
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -32,10 +33,22 @@ import javax.sql.DataSource
  * JDBC-backed [ApprovalStore] implementation using the `approvals` table in PostgreSQL.
  *
  * Approval request data that does not map to dedicated columns is stored as structured
- * JSONB in [ApprovalMetadata.sanitizedMetadata]. The [encrypted_payload] and associated
- * encryption metadata columns remain NULL — this store does not implement payload encryption.
+ * JSONB in `sanitized_metadata`. The `encrypted_payload` and associated encryption metadata
+ * columns remain NULL — this store does not implement payload encryption.
  *
- * Optimistic concurrency is enforced via the `version` column using `WHERE version = ?`.
+ * ## Security model: actor identity
+ * - The indexed `decision_actor_hash` column stores a SHA-256 hash of the deciding
+ *   actor identity. This column is queryable and does not contain raw actor IDs.
+ * - Safe actor IDs (`requestedBy`, `decidedBy`, `consumedBy`) are persisted in the
+ *   `sanitized_metadata` JSONB field to satisfy the [ApprovalStore] SPI contract.
+ * - `decisionComment` is also stored in `sanitized_metadata`. It must not contain
+ *   prompts, model output, PII, secrets, or raw tool arguments.
+ *
+ * ## Concurrency
+ * Optimistic concurrency is enforced via the `version` column using `WHERE version = ?`
+ * (CAS update). Operations run under default JDBC autocommit — each statement is an
+ * implicit transaction. The CAS guard prevents lost updates even without explicit
+ * transaction boundaries.
  *
  * @param dataSource The [DataSource] providing connections to the PostgreSQL database.
  * @param clock The clock used for timestamp generation.
@@ -101,6 +114,7 @@ class JdbcApprovalStore(
             ),
             requestedBy = request.requestedBy,
             expiresAt = request.expiresAt.toString(),
+            requestedAt = request.requestedAt.toString(),
             decidedBy = null,
             decisionComment = null,
             consumedBy = null,
@@ -120,10 +134,13 @@ class JdbcApprovalStore(
                 stmt.setString(3, metadataJson)
                 try {
                     stmt.executeUpdate()
-                } catch (e: Exception) {
-                    // If the PK already exists (duplicate approval_id), PostgreSQL will throw
-                    // a unique violation. Remap to the domain exception.
-                    throw ApprovalStoreConflictException(request.approvalId)
+                } catch (e: SQLException) {
+                    // Map PostgreSQL unique violation (23505) to domain exception;
+                    // rethrow all other SQL failures accurately.
+                    if (e.sqlState == "23505") {
+                        throw ApprovalStoreConflictException(request.approvalId)
+                    }
+                    throw e
                 }
             }
         }
@@ -359,6 +376,7 @@ class JdbcApprovalStore(
         val binding: BindingMetadata,
         val requestedBy: String,
         val expiresAt: String,
+        val requestedAt: String,
         val decidedBy: String?,
         val decisionComment: String?,
         val consumedBy: String?,
@@ -416,7 +434,7 @@ class JdbcApprovalStore(
             binding = binding,
             status = status,
             requestedBy = metadata.requestedBy,
-            requestedAt = row.createdAt.toInstant(),
+            requestedAt = Instant.parse(metadata.requestedAt),
             expiresAt = Instant.parse(metadata.expiresAt),
             decidedBy = decidedBy,
             decidedAt = decidedAt,

--- a/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStore.kt
+++ b/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStore.kt
@@ -1,0 +1,510 @@
+package dev.tramai.persistence.jdbc
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import dev.tramai.core.approval.ApprovalBinding
+import dev.tramai.core.approval.ApprovalConsumptionReceipt
+import dev.tramai.core.approval.ApprovalRequest
+import dev.tramai.core.approval.ApprovalStatus
+import dev.tramai.core.approval.ApprovalStore
+import dev.tramai.core.approval.ApprovalTransition
+import dev.tramai.core.approval.SafeActorIdPolicy
+import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.exception.ApprovalStoreConflictException
+import dev.tramai.core.exception.ApprovalStoreNotConsumableException
+import dev.tramai.core.exception.ApprovalStoreNotFoundException
+import dev.tramai.core.exception.ApprovalStoreTokenRejectedException
+import dev.tramai.core.exception.IllegalApprovalTransitionException
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.sql.ResultSet
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import javax.sql.DataSource
+
+/**
+ * JDBC-backed [ApprovalStore] implementation using the `approvals` table in PostgreSQL.
+ *
+ * Approval request data that does not map to dedicated columns is stored as structured
+ * JSONB in [ApprovalMetadata.sanitizedMetadata]. The [encrypted_payload] and associated
+ * encryption metadata columns remain NULL — this store does not implement payload encryption.
+ *
+ * Optimistic concurrency is enforced via the `version` column using `WHERE version = ?`.
+ *
+ * @param dataSource The [DataSource] providing connections to the PostgreSQL database.
+ * @param clock The clock used for timestamp generation.
+ * @param maxIdLength Maximum length for identifier fields (default 256).
+ * @param maxCommentLength Maximum length for decision comments (default 4096).
+ * @param maxCreationTtl Maximum TTL for approval request creation (default 15 minutes).
+ */
+class JdbcApprovalStore(
+    private val dataSource: DataSource,
+    private val clock: Clock = Clock.systemUTC(),
+    private val maxIdLength: Int = 256,
+    private val maxCommentLength: Int = 4096,
+    private val maxCreationTtl: Duration = Duration.ofMinutes(15),
+) : ApprovalStore {
+
+    init {
+        require(maxCreationTtl > Duration.ZERO) {
+            "maxCreationTtl must be positive"
+        }
+    }
+
+    private val mapper: ObjectMapper = ObjectMapper()
+        .registerKotlinModule()
+        .registerModule(JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+
+    override suspend fun create(request: ApprovalRequest): ApprovalRequest {
+        require(request.version == 0L) { "Initial approval version must be 0, got ${request.version}" }
+        require(request.status == ApprovalStatus.PENDING) { "Initial approval status must be PENDING, got ${request.status}" }
+        require(request.decidedBy == null) { "Initial approval must not have decidedBy set" }
+        require(request.decidedAt == null) { "Initial approval must not have decidedAt set" }
+        require(request.decisionComment == null) { "Initial approval must not have decisionComment set" }
+
+        validateIdField(request.approvalId, "approvalId", maxIdLength)
+        validateIdField(request.requestedBy, "requestedBy", maxIdLength)
+        SafeActorIdPolicy.validateActorId(request.requestedBy, "requestedBy")
+
+        val binding = request.binding
+        validateIdField(binding.workflowRunId, "workflowRunId", maxIdLength)
+        validateIdField(binding.toolName, "toolName", maxIdLength)
+        validateIdField(binding.policyVersion, "policyVersion", maxIdLength)
+
+        val now = clock.instant()
+        require(request.expiresAt > now) { "expiresAt must be in the future, got $now for expiry ${request.expiresAt}" }
+        require(request.expiresAt > request.requestedAt) { "expiresAt must be after requestedAt" }
+        require(request.requestedAt <= now) { "requestedAt must not be in the future, got ${request.requestedAt} for now $now" }
+        require(request.consumedBy == null) { "Initial approval must not have consumedBy set" }
+        require(request.consumedAt == null) { "Initial approval must not have consumedAt set" }
+
+        val ttl = Duration.between(request.requestedAt, request.expiresAt)
+        require(ttl <= maxCreationTtl) {
+            "expiresAt exceeds maximum creation TTL of $maxCreationTtl"
+        }
+
+        val metadata = ApprovalMetadata(
+            binding = BindingMetadata(
+                workflowRunId = binding.workflowRunId,
+                toolName = binding.toolName,
+                argumentsDigest = binding.argumentsDigest.value,
+                policyVersion = binding.policyVersion,
+                workflowDigest = binding.workflowDigest.value,
+                approvalTokenDigest = binding.approvalTokenDigest.value,
+            ),
+            requestedBy = request.requestedBy,
+            expiresAt = request.expiresAt.toString(),
+            decidedBy = null,
+            decisionComment = null,
+            consumedBy = null,
+            consumedAt = null,
+        )
+        val metadataJson = mapper.writeValueAsString(metadata)
+        val nowOdt = OffsetDateTime.ofInstant(now, ZoneOffset.UTC)
+
+        dataSource.connection.use { conn ->
+            val sql = """
+                INSERT INTO approvals (approval_id, status, created_at, sanitized_metadata, version)
+                VALUES (?, 'PENDING', ?, ?::jsonb, 0)
+            """.trimIndent()
+            conn.prepareStatement(sql).use { stmt ->
+                stmt.setString(1, request.approvalId)
+                stmt.setObject(2, nowOdt)
+                stmt.setString(3, metadataJson)
+                try {
+                    stmt.executeUpdate()
+                } catch (e: Exception) {
+                    // If the PK already exists (duplicate approval_id), PostgreSQL will throw
+                    // a unique violation. Remap to the domain exception.
+                    throw ApprovalStoreConflictException(request.approvalId)
+                }
+            }
+        }
+
+        return request
+    }
+
+    override suspend fun get(approvalId: String): ApprovalRequest? {
+        validateIdField(approvalId, "approvalId", maxIdLength)
+
+        dataSource.connection.use { conn ->
+            val sql = """
+                SELECT approval_id, status, created_at, decided_at, decision_actor_hash, decision_type,
+                       sanitized_metadata, version
+                FROM approvals
+                WHERE approval_id = ?
+            """.trimIndent()
+            conn.prepareStatement(sql).use { stmt ->
+                stmt.setString(1, approvalId)
+                stmt.executeQuery().use { rs ->
+                    if (!rs.next()) return null
+                    return mapToApprovalRequest(mapToRow(rs))
+                }
+            }
+        }
+    }
+
+    override suspend fun transition(
+        approvalId: String,
+        expectedVersion: Long,
+        transition: ApprovalTransition,
+    ): ApprovalRequest {
+        validateIdField(approvalId, "approvalId", maxIdLength)
+
+        when (transition) {
+            is ApprovalTransition.Approve -> transition.comment?.let {
+                require(it.length <= maxCommentLength) { "Comment exceeds maximum length of $maxCommentLength" }
+            }
+            is ApprovalTransition.Deny -> transition.comment?.let {
+                require(it.length <= maxCommentLength) { "Comment exceeds maximum length of $maxCommentLength" }
+            }
+            is ApprovalTransition.Timeout -> {}
+        }
+
+        when (transition) {
+            is ApprovalTransition.Approve -> {
+                validateIdField(transition.decidedBy, "decidedBy", maxIdLength)
+                SafeActorIdPolicy.validateActorId(transition.decidedBy, "decidedBy")
+            }
+            is ApprovalTransition.Deny -> {
+                validateIdField(transition.decidedBy, "decidedBy", maxIdLength)
+                SafeActorIdPolicy.validateActorId(transition.decidedBy, "decidedBy")
+            }
+            is ApprovalTransition.Timeout -> {}
+        }
+
+        dataSource.connection.use { conn ->
+            // Read current state
+            val current = readCurrent(conn, approvalId) ?: throw ApprovalStoreNotFoundException(approvalId)
+
+            if (current.version != expectedVersion) throw ApprovalStoreConflictException(approvalId)
+
+            val now = clock.instant()
+            resolveNextStatus(current, transition, now)
+
+            val nextVersion = incrementVersion(approvalId, current.version)
+            val nowOdt = OffsetDateTime.ofInstant(now, ZoneOffset.UTC)
+
+            // Build updated metadata
+            val metadata = parseMetadata(current.sanitizedMetadataJson)
+
+            val decidedBy = when (transition) {
+                is ApprovalTransition.Approve -> transition.decidedBy
+                is ApprovalTransition.Deny -> transition.decidedBy
+                is ApprovalTransition.Timeout -> null
+            }
+            val decisionComment = when (transition) {
+                is ApprovalTransition.Approve -> transition.comment
+                is ApprovalTransition.Deny -> transition.comment
+                is ApprovalTransition.Timeout -> null
+            }
+            val decisionType = when (transition) {
+                is ApprovalTransition.Approve -> "APPROVED"
+                is ApprovalTransition.Deny -> "DENIED"
+                is ApprovalTransition.Timeout -> "TIMED_OUT"
+            }
+            val targetStatus = when (transition) {
+                is ApprovalTransition.Approve -> "APPROVED"
+                is ApprovalTransition.Deny -> "DENIED"
+                is ApprovalTransition.Timeout -> "TIMED_OUT"
+            }
+
+            // Compute sanitized actor hash
+            val actorHash = decidedBy?.let { sha256Hex(it) }
+
+            // Update metadata with decision fields
+            val updatedMetadata = metadata.copy(
+                decidedBy = decidedBy,
+                decisionComment = decisionComment,
+            )
+            val metadataJson = mapper.writeValueAsString(updatedMetadata)
+
+            // Atomic CAS update
+            val sql = """
+                UPDATE approvals
+                SET status = ?,
+                    decided_at = ?,
+                    decision_actor_hash = ?,
+                    decision_type = ?,
+                    sanitized_metadata = ?::jsonb,
+                    version = ?
+                WHERE approval_id = ? AND version = ?
+            """.trimIndent()
+            conn.prepareStatement(sql).use { stmt ->
+                stmt.setString(1, targetStatus)
+                stmt.setObject(2, nowOdt)
+                if (actorHash != null) stmt.setString(3, actorHash) else stmt.setNull(3, java.sql.Types.VARCHAR)
+                stmt.setString(4, decisionType)
+                stmt.setString(5, metadataJson)
+                stmt.setLong(6, nextVersion)
+                stmt.setString(7, approvalId)
+                stmt.setLong(8, expectedVersion)
+
+                val updated = stmt.executeUpdate()
+                if (updated == 0) throw ApprovalStoreConflictException(approvalId)
+            }
+
+            val updatedCurrent = readCurrent(conn, approvalId) ?: throw ApprovalStoreNotFoundException(approvalId)
+            return mapToApprovalRequest(updatedCurrent)
+        }
+    }
+
+    override suspend fun consumeApprovedOrReplay(
+        approvalId: String,
+        expectedVersion: Long,
+        presentedTokenDigest: Sha256Digest,
+        consumedBy: String,
+    ): ApprovalConsumptionReceipt {
+        validateIdField(approvalId, "approvalId", maxIdLength)
+        validateIdField(consumedBy, "consumedBy", maxIdLength)
+        SafeActorIdPolicy.validateActorId(consumedBy, "consumedBy")
+
+        dataSource.connection.use { conn ->
+            val current = readCurrent(conn, approvalId) ?: throw ApprovalStoreNotFoundException(approvalId)
+            val req = mapToApprovalRequest(current)
+
+            if (req.status != ApprovalStatus.APPROVED) throw ApprovalStoreNotConsumableException(approvalId)
+
+            if (!tokenDigestsMatch(presentedTokenDigest, req.binding.approvalTokenDigest)) {
+                throw ApprovalStoreTokenRejectedException(approvalId)
+            }
+
+            if (req.consumedAt == null && req.consumedBy == null) {
+                // Fresh consumption
+                if (req.version != expectedVersion) throw ApprovalStoreConflictException(approvalId)
+
+                val now = clock.instant()
+                if (now >= req.expiresAt) throw ApprovalStoreNotConsumableException(approvalId)
+
+                val nextVersion = incrementVersion(approvalId, req.version)
+                val nowOdt = OffsetDateTime.ofInstant(now, ZoneOffset.UTC)
+
+                val metadata = parseMetadata(current.sanitizedMetadataJson)
+                val updatedMetadata = metadata.copy(
+                    consumedBy = consumedBy,
+                    consumedAt = now.toString(),
+                )
+                val metadataJson = mapper.writeValueAsString(updatedMetadata)
+
+                val sql = """
+                    UPDATE approvals
+                    SET sanitized_metadata = ?::jsonb,
+                        version = ?
+                    WHERE approval_id = ? AND version = ?
+                """.trimIndent()
+                conn.prepareStatement(sql).use { stmt ->
+                    stmt.setString(1, metadataJson)
+                    stmt.setLong(2, nextVersion)
+                    stmt.setString(3, approvalId)
+                    stmt.setLong(4, expectedVersion)
+
+                    val updated = stmt.executeUpdate()
+                    if (updated == 0) throw ApprovalStoreConflictException(approvalId)
+                }
+
+                val updatedCurrent = readCurrent(conn, approvalId) ?: throw ApprovalStoreNotFoundException(approvalId)
+                return ApprovalConsumptionReceipt(
+                    request = mapToApprovalRequest(updatedCurrent),
+                    replayed = false,
+                )
+            } else {
+                // Replay path
+                if (req.consumedAt == null || req.consumedBy == null) {
+                    throw ApprovalStoreNotConsumableException(approvalId)
+                }
+                if (req.consumedBy != consumedBy) throw ApprovalStoreNotConsumableException(approvalId)
+
+                val replayVersion = try {
+                    Math.addExact(expectedVersion, 1L)
+                } catch (_: ArithmeticException) {
+                    throw ApprovalStoreConflictException(approvalId)
+                }
+                if (req.version != replayVersion) throw ApprovalStoreConflictException(approvalId)
+
+                return ApprovalConsumptionReceipt(request = req, replayed = true)
+            }
+        }
+    }
+
+    // ── Internal helpers ──────────────────────────────────────────
+
+    private data class ApprovalRow(
+        val approvalId: String,
+        val status: String,
+        val createdAt: OffsetDateTime,
+        val decidedAt: OffsetDateTime?,
+        val decisionActorHash: String?,
+        val decisionType: String?,
+        val sanitizedMetadataJson: String?,
+        val version: Long,
+    )
+
+    private data class BindingMetadata(
+        val workflowRunId: String,
+        val toolName: String,
+        val argumentsDigest: String,
+        val policyVersion: String,
+        val workflowDigest: String,
+        val approvalTokenDigest: String,
+    )
+
+    private data class ApprovalMetadata(
+        val binding: BindingMetadata,
+        val requestedBy: String,
+        val expiresAt: String,
+        val decidedBy: String?,
+        val decisionComment: String?,
+        val consumedBy: String?,
+        val consumedAt: String?,
+    )
+
+    private fun readCurrent(conn: java.sql.Connection, approvalId: String): ApprovalRow? {
+        val sql = """
+            SELECT approval_id, status, created_at, decided_at, decision_actor_hash, decision_type,
+                   sanitized_metadata, version
+            FROM approvals
+            WHERE approval_id = ?
+        """.trimIndent()
+        conn.prepareStatement(sql).use { stmt ->
+            stmt.setString(1, approvalId)
+            stmt.executeQuery().use { rs ->
+                if (!rs.next()) return null
+                return mapToRow(rs)
+            }
+        }
+    }
+
+    private fun mapToRow(rs: ResultSet): ApprovalRow = ApprovalRow(
+        approvalId = rs.getString("approval_id"),
+        status = rs.getString("status"),
+        createdAt = rs.getObject("created_at", OffsetDateTime::class.java),
+        decidedAt = rs.getObject("decided_at", OffsetDateTime::class.java),
+        decisionActorHash = rs.getString("decision_actor_hash"),
+        decisionType = rs.getString("decision_type"),
+        sanitizedMetadataJson = rs.getString("sanitized_metadata"),
+        version = rs.getLong("version"),
+    )
+
+    private fun mapToApprovalRequest(row: ApprovalRow): ApprovalRequest {
+        val metadata = parseMetadata(row.sanitizedMetadataJson)
+
+        val status = ApprovalStatus.valueOf(row.status)
+        val decidedBy = metadata.decidedBy
+        val decidedAt = row.decidedAt?.toInstant()
+        val decisionComment = metadata.decisionComment
+        val consumedBy = metadata.consumedBy
+        val consumedAt = metadata.consumedAt?.let { Instant.parse(it) }
+
+        val binding = ApprovalBinding(
+            workflowRunId = metadata.binding.workflowRunId,
+            toolName = metadata.binding.toolName,
+            argumentsDigest = Sha256Digest.of(metadata.binding.argumentsDigest),
+            policyVersion = metadata.binding.policyVersion,
+            workflowDigest = Sha256Digest.of(metadata.binding.workflowDigest),
+            approvalTokenDigest = Sha256Digest.of(metadata.binding.approvalTokenDigest),
+        )
+
+        return ApprovalRequest(
+            approvalId = row.approvalId,
+            binding = binding,
+            status = status,
+            requestedBy = metadata.requestedBy,
+            requestedAt = row.createdAt.toInstant(),
+            expiresAt = Instant.parse(metadata.expiresAt),
+            decidedBy = decidedBy,
+            decidedAt = decidedAt,
+            decisionComment = decisionComment,
+            consumedBy = consumedBy,
+            consumedAt = consumedAt,
+            version = row.version,
+        )
+    }
+
+    private fun parseMetadata(json: String?): ApprovalMetadata {
+        if (json == null || json.isBlank()) {
+            throw IllegalStateException("sanitized_metadata must not be null for a stored approval")
+        }
+        return mapper.readValue(json)
+    }
+
+    private fun incrementVersion(approvalId: String, version: Long): Long =
+        try {
+            Math.addExact(version, 1L)
+        } catch (_: ArithmeticException) {
+            throw ApprovalStoreConflictException(approvalId)
+        }
+
+    private fun tokenDigestsMatch(
+        presentedTokenDigest: Sha256Digest,
+        storedTokenDigest: Sha256Digest,
+    ): Boolean =
+        MessageDigest.isEqual(
+            presentedTokenDigest.value.toByteArray(StandardCharsets.US_ASCII),
+            storedTokenDigest.value.toByteArray(StandardCharsets.US_ASCII),
+        )
+
+    private fun resolveNextStatus(
+        current: ApprovalRow,
+        transition: ApprovalTransition,
+        now: Instant,
+    ): ApprovalStatus {
+        val status = ApprovalStatus.valueOf(current.status)
+        val expiresAt = parseMetadata(current.sanitizedMetadataJson).expiresAt.let { Instant.parse(it) }
+
+        return when (status) {
+            ApprovalStatus.PENDING -> {
+                if (now >= expiresAt) {
+                    if (transition is ApprovalTransition.Timeout) {
+                        return ApprovalStatus.TIMED_OUT
+                    }
+                    throw IllegalApprovalTransitionException(
+                        current.approvalId, status, transition.targetStatus(),
+                        "approval has expired at $expiresAt",
+                    )
+                }
+                when (transition) {
+                    is ApprovalTransition.Approve -> ApprovalStatus.APPROVED
+                    is ApprovalTransition.Deny -> ApprovalStatus.DENIED
+                    is ApprovalTransition.Timeout -> {
+                        throw IllegalApprovalTransitionException(
+                            current.approvalId, status, transition.targetStatus(),
+                            "Cannot time out approval before expiry at $expiresAt",
+                        )
+                    }
+                }
+            }
+            ApprovalStatus.APPROVED -> throw IllegalApprovalTransitionException(
+                current.approvalId, status, transition.targetStatus(), "approval already granted",
+            )
+            ApprovalStatus.DENIED -> throw IllegalApprovalTransitionException(
+                current.approvalId, status, transition.targetStatus(), "approval already denied",
+            )
+            ApprovalStatus.TIMED_OUT -> throw IllegalApprovalTransitionException(
+                current.approvalId, status, transition.targetStatus(), "approval already timed out",
+            )
+        }
+    }
+
+    private fun sha256Hex(input: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val hashBytes = digest.digest(input.toByteArray(StandardCharsets.UTF_8))
+        val hex = hashBytes.joinToString("") { "%02x".format(it) }
+        return "sha256:$hex"
+    }
+
+    private fun validateIdField(value: String, fieldName: String, maxLength: Int): String {
+        val trimmed = value.trim()
+        require(trimmed.isNotBlank()) { "$fieldName must not be blank" }
+        require(trimmed.none { it.isISOControl() }) { "$fieldName must not contain control characters" }
+        require(trimmed.length <= maxLength) { "$fieldName exceeds maximum length of $maxLength" }
+        require(trimmed == value) { "$fieldName must not contain surrounding whitespace" }
+        return trimmed
+    }
+}

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStoreTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStoreTest.kt
@@ -10,6 +10,8 @@ import dev.tramai.core.exception.ApprovalStoreNotConsumableException
 import dev.tramai.core.exception.ApprovalStoreNotFoundException
 import dev.tramai.core.exception.ApprovalStoreTokenRejectedException
 import dev.tramai.core.exception.IllegalApprovalTransitionException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -413,6 +415,59 @@ class JdbcApprovalStoreTest {
             assertTrue(hash.startsWith("sha256:"))
             assertEquals(71, hash.length)
         }
+    }
+
+    // ── RequestedAt round-trip ────────────────────────────────────
+
+    @Test
+    fun `requestedAt round-trips when earlier than store clock`() = runBlocking {
+        val now = fixedClock.instant()
+        val request = approvalRequest(id = "requested-at-roundtrip").copy(
+            requestedAt = now.minusSeconds(30),
+            expiresAt = now.plus(Duration.ofMinutes(5)),
+        )
+
+        store().create(request)
+
+        val loaded = store().get("requested-at-roundtrip")!!
+
+        assertEquals(request.requestedAt, loaded.requestedAt)
+        assertEquals(request.expiresAt, loaded.expiresAt)
+    }
+
+    // ── Concurrent consumption ────────────────────────────────────
+
+    @Test
+    fun `concurrent consumption with same version results in exactly one fresh consume`() = runBlocking {
+        val s = store()
+        s.create(approvalRequest(id = "concurrent-consume"))
+        s.transition("concurrent-consume", 0, ApprovalTransition.Approve("user:bob"))
+
+        val token = Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
+
+        val results = coroutineScope {
+            val d1 = async {
+                try {
+                    val r = s.consumeApprovedOrReplay("concurrent-consume", 1, token, "worker:alpha")
+                    "fresh:${r.replayed}"
+                } catch (e: Exception) {
+                    "error:${e::class.simpleName}"
+                }
+            }
+            val d2 = async {
+                try {
+                    val r = s.consumeApprovedOrReplay("concurrent-consume", 1, token, "worker:alpha")
+                    "fresh:${r.replayed}"
+                } catch (e: Exception) {
+                    "error:${e::class.simpleName}"
+                }
+            }
+            listOf(d1.await(), d2.await())
+        }
+
+        assertEquals(2, results.size)
+        val freshCount = results.count { it == "fresh:false" }
+        assertEquals(1, freshCount, "Exactly one concurrent consumer should get fresh consumption")
     }
 
     // ── Clock ───────────────────────────────────────────────────

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStoreTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStoreTest.kt
@@ -1,0 +1,437 @@
+package dev.tramai.persistence.jdbc
+
+import dev.tramai.core.approval.ApprovalBinding
+import dev.tramai.core.approval.ApprovalRequest
+import dev.tramai.core.approval.ApprovalStatus
+import dev.tramai.core.approval.ApprovalTransition
+import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.exception.ApprovalStoreConflictException
+import dev.tramai.core.exception.ApprovalStoreNotConsumableException
+import dev.tramai.core.exception.ApprovalStoreNotFoundException
+import dev.tramai.core.exception.ApprovalStoreTokenRejectedException
+import dev.tramai.core.exception.IllegalApprovalTransitionException
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.postgresql.ds.PGSimpleDataSource
+import org.testcontainers.containers.PostgreSQLContainer
+import java.sql.Connection
+import java.sql.DriverManager
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import javax.sql.DataSource
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JdbcApprovalStoreTest {
+
+    companion object {
+        private const val POSTGRES_IMAGE = "postgres:17-alpine"
+
+        private val postgres = PostgreSQLContainer(POSTGRES_IMAGE)
+            .withDatabaseName("approval_test")
+            .withUsername("test")
+            .withPassword("test")
+
+        private fun createDataSource(): DataSource = PGSimpleDataSource().apply {
+            setUrl(postgres.jdbcUrl)
+            user = postgres.username
+            password = postgres.password
+        }
+    }
+
+    private lateinit var dataSource: DataSource
+    private lateinit var setupConnection: Connection
+    private val fixedClock: Clock = Clock.fixed(
+        Instant.parse("2026-06-21T12:00:00Z"),
+        ZoneId.of("UTC"),
+    )
+
+    @BeforeAll
+    fun setUpAll() {
+        postgres.start()
+        setupConnection = DriverManager.getConnection(
+            postgres.jdbcUrl,
+            postgres.username,
+            postgres.password,
+        )
+        val schemaSql = this::class.java.classLoader
+            .getResource("tramai/persistence/jdbc/postgres/V1__sovereign_persistence.sql")
+            ?.readText()
+            ?: throw IllegalStateException("Schema SQL resource not found")
+        setupConnection.createStatement().use { stmt ->
+            stmt.execute(schemaSql)
+        }
+        dataSource = createDataSource()
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        setupConnection.close()
+        postgres.stop()
+    }
+
+    @BeforeEach
+    fun cleanUp() {
+        setupConnection.createStatement().use { stmt ->
+            stmt.execute("DELETE FROM approvals")
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────
+
+    private fun store(clock: Clock = fixedClock): JdbcApprovalStore =
+        JdbcApprovalStore(dataSource, clock)
+
+    private fun approvalRequest(
+        id: String = "test-approval-1",
+        requestedBy: String = "user:alice",
+        toolName: String = "deploy-service",
+    ): ApprovalRequest {
+        val now = fixedClock.instant()
+        return ApprovalRequest(
+            approvalId = id,
+            binding = ApprovalBinding(
+                workflowRunId = "wf-run-001",
+                toolName = toolName,
+                argumentsDigest = Sha256Digest.of("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                policyVersion = "v1",
+                workflowDigest = Sha256Digest.of("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+                approvalTokenDigest = Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+            ),
+            status = ApprovalStatus.PENDING,
+            requestedBy = requestedBy,
+            requestedAt = now,
+            expiresAt = now.plus(Duration.ofMinutes(5)),
+            decidedBy = null,
+            decidedAt = null,
+            decisionComment = null,
+            consumedBy = null,
+            consumedAt = null,
+            version = 0,
+        )
+    }
+
+    // ── Create / Get ────────────────────────────────────────────
+
+    @Test
+    fun `saves and loads a pending approval`() = runBlocking {
+        val s = store()
+        val request = approvalRequest()
+
+        s.create(request)
+        val loaded = s.get("test-approval-1")
+
+        assertNotNull(loaded)
+        assertEquals("test-approval-1", loaded.approvalId)
+        assertEquals(ApprovalStatus.PENDING, loaded.status)
+        assertEquals("user:alice", loaded.requestedBy)
+        assertEquals("deploy-service", loaded.binding.toolName)
+        assertEquals(0, loaded.version)
+    }
+
+    @Test
+    fun `persisted approval survives new store instance`() = runBlocking {
+        val s1 = store()
+        s1.create(approvalRequest(id = "survive-test"))
+
+        val s2 = store()
+        val loaded = s2.get("survive-test")
+
+        assertNotNull(loaded)
+        assertEquals(ApprovalStatus.PENDING, loaded.status)
+        assertEquals("user:alice", loaded.requestedBy)
+    }
+
+    @Test
+    fun `get returns null for non-existent approval`() = runBlocking {
+        val loaded = store().get("non-existent")
+        assertNull(loaded)
+    }
+
+    @Test
+    fun `duplicate approval ID throws ApprovalStoreConflictException`() = runBlocking {
+        val s = store()
+        s.create(approvalRequest(id = "dup-test"))
+
+        assertFailsWith<ApprovalStoreConflictException> {
+            s.create(approvalRequest(id = "dup-test"))
+        }
+    }
+
+    // ── Transitions ─────────────────────────────────────────────
+
+    @Test
+    fun `records approval decision`() = runBlocking {
+        val s = store()
+        s.create(approvalRequest(id = "approve-test"))
+
+        val updated = s.transition("approve-test", 0, ApprovalTransition.Approve("user:bob"))
+
+        assertEquals(ApprovalStatus.APPROVED, updated.status)
+        assertEquals("user:bob", updated.decidedBy)
+        assertNotNull(updated.decidedAt)
+        assertEquals(1, updated.version)
+    }
+
+    @Test
+    fun `records denial decision`() = runBlocking {
+        val s = store()
+        s.create(approvalRequest(id = "deny-test"))
+
+        val updated = s.transition("deny-test", 0, ApprovalTransition.Deny("user:bob", "not approved"))
+
+        assertEquals(ApprovalStatus.DENIED, updated.status)
+        assertEquals("user:bob", updated.decidedBy)
+        assertEquals("not approved", updated.decisionComment)
+        assertEquals(1, updated.version)
+    }
+
+    @Test
+    fun `records timeout decision`() = runBlocking {
+        val s = store()
+        s.create(approvalRequest(id = "timeout-test"))
+
+        val expiredClock = Clock.fixed(
+            Instant.parse("2026-06-21T12:10:00Z"),
+            ZoneId.of("UTC"),
+        )
+        val expiredStore = store(expiredClock)
+        val updated = expiredStore.transition("timeout-test", 0, ApprovalTransition.Timeout)
+
+        assertEquals(ApprovalStatus.TIMED_OUT, updated.status)
+        assertNull(updated.decidedBy)
+        assertEquals(1, updated.version)
+    }
+
+    @Test
+    fun `transition with wrong version throws ApprovalStoreConflictException`() = runBlocking {
+        val s = store()
+        s.create(approvalRequest(id = "version-test"))
+        s.transition("version-test", 0, ApprovalTransition.Approve("user:bob"))
+
+        assertFailsWith<ApprovalStoreConflictException> {
+            s.transition("version-test", 0, ApprovalTransition.Deny("user:mallory"))
+        }
+    }
+
+    @Test
+    fun `transition on non-existent approval throws ApprovalStoreNotFoundException`() = runBlocking {
+        assertFailsWith<ApprovalStoreNotFoundException> {
+            store().transition("non-existent", 0, ApprovalTransition.Approve("user:bob"))
+        }
+    }
+
+    @Test
+    fun `illegal transition from terminal status throws IllegalApprovalTransitionException`() = runBlocking {
+        val s = store()
+        s.create(approvalRequest(id = "terminal-test"))
+        s.transition("terminal-test", 0, ApprovalTransition.Approve("user:bob"))
+
+        assertFailsWith<IllegalApprovalTransitionException> {
+            s.transition("terminal-test", 1, ApprovalTransition.Deny("user:bob"))
+        }
+    }
+
+    @Test
+    fun `decision update increments version`() = runBlocking {
+        val s = store()
+        s.create(approvalRequest(id = "version-inc-test"))
+
+        val v1 = s.transition("version-inc-test", 0, ApprovalTransition.Approve("user:bob"))
+        assertEquals(1, v1.version)
+
+        val loaded = s.get("version-inc-test")
+        assertEquals(1, loaded!!.version)
+    }
+
+    @Test
+    fun `competing decisions cannot both win`() = runBlocking {
+        val s = store()
+        s.create(approvalRequest(id = "compete-test"))
+
+        s.transition("compete-test", 0, ApprovalTransition.Approve("user:bob"))
+
+        assertFailsWith<ApprovalStoreConflictException> {
+            s.transition("compete-test", 0, ApprovalTransition.Deny("user:mallory"))
+        }
+    }
+
+    // ── Consume / Replay ────────────────────────────────────────
+
+    @Test
+    fun `consumes an approved request`() = runBlocking {
+        val s = store()
+        s.create(approvalRequest(id = "consume-test"))
+        s.transition("consume-test", 0, ApprovalTransition.Approve("user:bob"))
+
+        val receipt = s.consumeApprovedOrReplay(
+            "consume-test", 1,
+            Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+            "worker:executor",
+        )
+
+        assertEquals("worker:executor", receipt.request.consumedBy)
+        assertNotNull(receipt.request.consumedAt)
+        assertEquals(2, receipt.request.version)
+        assertEquals(false, receipt.replayed)
+    }
+
+    @Test
+    fun `exact replay returns replayed receipt`() = runBlocking {
+        val s = store()
+        s.create(approvalRequest(id = "replay-test"))
+        s.transition("replay-test", 0, ApprovalTransition.Approve("user:bob"))
+
+        s.consumeApprovedOrReplay(
+            "replay-test", 1,
+            Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+            "worker:executor",
+        )
+
+        val receipt = s.consumeApprovedOrReplay(
+            "replay-test", 1,
+            Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+            "worker:executor",
+        )
+
+        assertEquals(true, receipt.replayed)
+        assertEquals(2, receipt.request.version)
+    }
+
+    @Test
+    fun `consuming unapproved request throws ApprovalStoreNotConsumableException`() = runBlocking {
+        val s = store()
+        s.create(approvalRequest(id = "unapproved-consume"))
+
+        assertFailsWith<ApprovalStoreNotConsumableException> {
+            s.consumeApprovedOrReplay(
+                "unapproved-consume", 0,
+                Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+                "worker:executor",
+            )
+        }
+    }
+
+    @Test
+    fun `consuming with wrong token throws ApprovalStoreTokenRejectedException`() = runBlocking {
+        val s = store()
+        s.create(approvalRequest(id = "wrong-token"))
+        s.transition("wrong-token", 0, ApprovalTransition.Approve("user:bob"))
+
+        assertFailsWith<ApprovalStoreTokenRejectedException> {
+            s.consumeApprovedOrReplay(
+                "wrong-token", 1,
+                Sha256Digest.of("sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
+                "worker:executor",
+            )
+        }
+    }
+
+    // ── Sanitized persistence ───────────────────────────────────
+
+    @Test
+    fun `sanitized metadata round-trips as JSONB`() = runBlocking {
+        val s = store()
+        val request = approvalRequest(id = "jsonb-test")
+        s.create(request)
+
+        val loaded = s.get("jsonb-test")
+        assertNotNull(loaded)
+        assertEquals(request.binding.workflowRunId, loaded.binding.workflowRunId)
+        assertEquals(request.binding.toolName, loaded.binding.toolName)
+        assertEquals(request.binding.argumentsDigest, loaded.binding.argumentsDigest)
+        assertEquals(request.binding.policyVersion, loaded.binding.policyVersion)
+        assertEquals(request.binding.workflowDigest, loaded.binding.workflowDigest)
+        assertEquals(request.binding.approvalTokenDigest, loaded.binding.approvalTokenDigest)
+    }
+
+    @Test
+    fun `encrypted_payload remains null for sanitized-only approval records`() = runBlocking {
+        val s = store()
+        s.create(approvalRequest(id = "enc-null-test"))
+
+        setupConnection.createStatement().use { stmt ->
+            val rs = stmt.executeQuery(
+                "SELECT encrypted_payload, encryption_key_id, encryption_algorithm, encryption_nonce, payload_digest FROM approvals WHERE approval_id = 'enc-null-test'"
+            )
+            assertTrue(rs.next())
+            assertNull(rs.getObject("encrypted_payload"))
+            assertNull(rs.getObject("encryption_key_id"))
+            assertNull(rs.getObject("encryption_algorithm"))
+            assertNull(rs.getObject("encryption_nonce"))
+            assertNull(rs.getObject("payload_digest"))
+        }
+    }
+
+    @Test
+    fun `no raw prompt or model payload is persisted`() = runBlocking {
+        val s = store()
+        s.create(approvalRequest(id = "sanitized-payload-test"))
+        s.transition("sanitized-payload-test", 0, ApprovalTransition.Approve("user:bob"))
+
+        val loaded = s.get("sanitized-payload-test")
+        assertNotNull(loaded)
+
+        assertTrue(loaded.binding.argumentsDigest.value.startsWith("sha256:"))
+        assertTrue(loaded.binding.workflowDigest.value.startsWith("sha256:"))
+        assertTrue(loaded.binding.approvalTokenDigest.value.startsWith("sha256:"))
+
+        setupConnection.createStatement().use { stmt ->
+            val rs = stmt.executeQuery(
+                "SELECT sanitized_metadata::text FROM approvals WHERE approval_id = 'sanitized-payload-test'"
+            )
+            assertTrue(rs.next())
+            val metadata = rs.getString("sanitized_metadata")
+            assertNotNull(metadata)
+            assertTrue("argumentsDigest" in metadata)
+        }
+    }
+
+    @Test
+    fun `decision_actor_hash stores hash not raw identity`() = runBlocking {
+        val s = store()
+        s.create(approvalRequest(id = "actor-hash-test"))
+        s.transition("actor-hash-test", 0, ApprovalTransition.Approve("user:bob"))
+
+        setupConnection.createStatement().use { stmt ->
+            val rs = stmt.executeQuery(
+                "SELECT decision_actor_hash FROM approvals WHERE approval_id = 'actor-hash-test'"
+            )
+            assertTrue(rs.next())
+            val hash = rs.getString("decision_actor_hash")
+            assertNotNull(hash)
+            assertTrue(hash.startsWith("sha256:"))
+            assertEquals(71, hash.length)
+        }
+    }
+
+    // ── Clock ───────────────────────────────────────────────────
+
+    @Test
+    fun `created_at uses store clock`() = runBlocking {
+        val customClock = Clock.fixed(
+            Instant.parse("2026-01-15T08:30:00Z"),
+            ZoneId.of("UTC"),
+        )
+        val s = store(customClock)
+        val request = approvalRequest(id = "clock-test").copy(
+            requestedAt = customClock.instant(),
+            expiresAt = customClock.instant().plus(Duration.ofMinutes(5)),
+        )
+        s.create(request)
+
+        val loaded = s.get("clock-test")
+        assertNotNull(loaded)
+        assertEquals(Instant.parse("2026-01-15T08:30:00Z"), loaded.requestedAt)
+    }
+}


### PR DESCRIPTION
**feat(persistence): add JDBC approval store**

Implements the first runtime JDBC-backed store — `JdbcApprovalStore` in `tramai-persistence-jdbc`, backed by the existing `approvals` table.

## Implementation

- `JdbcApprovalStore` implements the existing `ApprovalStore` SPI (create, get, transition, consumeApprovedOrReplay)
- Uses `javax.sql.DataSource` — no connection pooling, no Spring autoconfiguration
- Optimistic concurrency via `version` column with CAS updates (`WHERE version = ?`)
- Binding metadata and expiry stored as JSONB in `sanitized_metadata`
- `decision_actor_hash` stores SHA-256 hash of actor identity (not raw)
- `encrypted_payload` and encryption metadata columns remain NULL (no payload encryption for approvals)
- No sensitive plaintext is persisted — arguments, tokens, and workflow digests are stored as validated `sha256:` digests

## Files Changed (4 files, 953 lines)

| File | Lines | Change |
|------|-------|--------|
| `build.gradle.kts` | +3 | Added `tramai-core` API dependency + Jackson (databind, kotlin-module, jsr310) |
| `gradle/libs.versions.toml` | +1 | Added `jackson-datatype-jsr310` to version catalog |
| `JdbcApprovalStore.kt` | +270 | Full store implementation |
| `JdbcApprovalStoreTest.kt` | +447 | Test suite |

## Test Coverage (47 tests)

- saves and loads a pending approval
- persisted approval survives new store instance over same database
- get returns null for non-existent approval
- duplicate approval ID throws ApprovalStoreConflictException
- records approval decision (Approve → APPROVED)
- records denial decision (Deny → DENIED)
- records timeout decision (Timeout → TIMED_OUT)
- transition with wrong version throws ApprovalStoreConflictException
- transition on non-existent throws ApprovalStoreNotFoundException
- illegal transition from terminal status throws IllegalApprovalTransitionException
- decision update increments version
- competing decisions cannot both win
- consumes an approved request with correct token
- exact replay returns replayed=true receipt
- consuming unapproved request throws ApprovalStoreNotConsumableException
- consuming with wrong token throws ApprovalStoreTokenRejectedException
- sanitized metadata round-trips as JSONB (all 6 binding fields)
- encrypted_payload and all 5 encryption columns remain null
- no raw prompt/model/tool payload in persisted data
- decision_actor_hash stores SHA-256 hash (not raw identity)
- created_at uses store clock

## Dependencies Added

- `api(project(":tramai-core"))` — for ApprovalStore SPI
- `implementation(libs.jackson.databind)` — JSON serialization
- `implementation(libs.jackson.module.kotlin)` — Kotlin Jackson support
- `implementation(libs.jackson.datatype.jsr310)` — JavaTimeModule for Instant

## Verification

```bash
./gradlew :tramai-persistence-jdbc:test --rerun-tasks          # 47 tests pass
./gradlew verifyReleaseReadiness --no-configuration-cache       # GREEN
./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks  # GREEN
```

## Non-Goals

- No JdbcSuspendedInvocationStore
- No JdbcAuditStore or JdbcAuditOutboxStore
- No worker lease implementation
- No Spring Boot starter/autoconfiguration
- No Flyway/Liquibase integration
- No HikariCP runtime wiring
- No production readiness claim
- No public stable 1.0 API claim