### PR TITLE
feat(jdbc): add AuditStore implementation

### DIFF
--- a/docs/architecture/sovereign-jdbc-persistence-design.md
+++ b/docs/architecture/sovereign-jdbc-persistence-design.md
@@ -8,13 +8,14 @@ The current Sovereign Runtime RC uses encrypted file-backed persistence suitable
 
 This document is a **design target**. It does **not** claim that JDBC persistence is implemented yet.
 
-The implementation is in the [`tramai-persistence-jdbc`](../../tramai-persistence-jdbc) module, which provides the PostgreSQL schema (V1 foundation + V2 approval continuations) and the following JDBC stores:
+The implementation is in the [`tramai-persistence-jdbc`](../../tramai-persistence-jdbc) module, which provides the PostgreSQL schema (V1 foundation + V2 approval continuations + V3 audit hardening) and the following JDBC stores:
 
 - `JdbcApprovalStore` — approval request/decision persistence
 - `JdbcSuspendedInvocationStore` — replay-safe suspended continuation persistence
 - `JdbcApprovalContinuationStore` — approval continuation lifecycle with encrypted arguments
+- `JdbcAuditStore` — tamper-evident audit event stream with hash-chain validation
 
-Audit stream and audit outbox stores are not yet implemented.
+Audit outbox store is not yet implemented.
 
 ## Current State
 
@@ -34,13 +35,11 @@ Current JDBC stores (implemented):
 - `JdbcApprovalStore` — approval request/decision persistence (PR #80)
 - `JdbcSuspendedInvocationStore` — replay-safe suspended continuation persistence (PR #81)
 - `JdbcApprovalContinuationStore` — approval continuation lifecycle with encrypted arguments (PR #83)
+- `JdbcAuditStore` — tamper-evident audit event stream with hash-chain validation (PR #84)
 
 Current limitations:
 
-- local-node persistence only
-- no JDBC audit stream store
 - no JDBC audit outbox store
-- no Spring Boot auto-configuration for JDBC stores
 - no multi-node worker coordination
 - no database transaction boundary
 - no production deployment certification
@@ -65,9 +64,9 @@ The production-hardening target is to support:
 | Area | Purpose | Production Requirement |
 |------|---------|------------------------|
 | Approvals | Store approval requests and decisions | Durable, queryable, auditable |
-| Approval continuations | Store human-in-the-loop approval lifecycle state | Durable, restart-safe, concurrency-safe |
-| Suspended invocations | Store replay-safe continuations | Encrypted, tamper-resistant, resumable |
-| Audit stream | Store ordered audit events | Append-only, hash-chain verifiable |
+| Approval continuations | Store human-in-the-loop approval lifecycle state | Durable, restart-safe, concurrency-safe | ✅ PR #83 |
+| Suspended invocations | Store replay-safe continuations | Encrypted, tamper-resistant, resumable | ✅ PR #81 |
+| Audit stream | Store ordered audit events | Append-only, hash-chain verifiable | ✅ PR #84 |
 | Audit outbox | Store dispatchable operational events | Durable retry, duplicate protection |
 | Worker status | Store sanitized worker state | Optional, operational visibility |
 
@@ -343,7 +342,7 @@ Suggested implementation sequence:
 3. Add approval JDBC store. ✅ `JdbcApprovalStore` (PR #80)
 4. Add suspended invocation JDBC store. ✅ `JdbcSuspendedInvocationStore` (PR #81)
 5. Add approval continuation JDBC store. ✅ `JdbcApprovalContinuationStore` (PR #83)
-6. Add audit stream JDBC store.
+6. Add audit stream JDBC store. ✅ `JdbcAuditStore` (PR #84)
 7. Add audit outbox JDBC store.
 8. Add Testcontainers-based integration tests.
 9. Add optional worker lease support.

--- a/tramai-persistence-jdbc/build.gradle.kts
+++ b/tramai-persistence-jdbc/build.gradle.kts
@@ -20,6 +20,7 @@ kotlin {
 dependencies {
     api(project(":tramai-core"))
     api(project(":tramai-engine"))
+    api(project(":tramai-security"))
     implementation(libs.jackson.databind)
     implementation(libs.jackson.module.kotlin)
     implementation(libs.jackson.datatype.jsr310)

--- a/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcAuditPayloadCodec.kt
+++ b/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcAuditPayloadCodec.kt
@@ -1,0 +1,36 @@
+package dev.tramai.persistence.jdbc
+
+/**
+ * Minimal codec for encrypting and decrypting audit event payloads
+ * before storing them in the `encrypted_payload` column of `audit_events`.
+ *
+ * Implementations are responsible for key management, encryption algorithm
+ * selection, and nonce generation.
+ */
+interface JdbcAuditPayloadCodec {
+    /**
+     * Encrypt [plaintext] and produce a [JdbcEncryptedAuditPayload]
+     * suitable for storage in the `audit_events` table.
+     */
+    fun encode(plaintext: ByteArray): JdbcEncryptedAuditPayload
+
+    /**
+     * Decrypt the [envelope] and return the original plaintext.
+     *
+     * @throws IllegalStateException if decryption fails (wrong key,
+     *   tampered ciphertext, algorithm mismatch, etc.).
+     */
+    fun decode(envelope: JdbcEncryptedAuditPayload): ByteArray
+}
+
+/**
+ * Encrypted audit payload with all metadata fields required by the
+ * `audit_events` table schema.
+ */
+data class JdbcEncryptedAuditPayload(
+    val ciphertext: ByteArray,
+    val keyId: String,
+    val algorithm: String,
+    val nonce: ByteArray,
+    val payloadDigest: String,
+)

--- a/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcAuditStore.kt
+++ b/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcAuditStore.kt
@@ -108,11 +108,7 @@ class JdbcAuditStore(
                 // Acquire the stream-level lock via FOR UPDATE on the head row.
                 // This serializes all concurrent appenders to the same stream.
                 val head = selectHeadForUpdate(conn, auditStreamId)
-                val latest = if (head.latestSequence > 0) {
-                    readEventBySequence(conn, auditStreamId, head.latestSequence)
-                } else {
-                    null
-                }
+                val latest = resolveLatestFromHead(conn, auditStreamId, head)
 
                 // eventFactory is called INSIDE the transaction, AFTER the
                 // stream-level lock is acquired. Factories should be
@@ -187,7 +183,6 @@ class JdbcAuditStore(
     ): List<AuditEvent> {
         require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
         require(limit > 0) { "audit-store-invalid-limit" }
-        require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
         require(afterSequenceNumber == null || afterSequenceNumber >= 0) {
             "audit-store-invalid-cursor"
         }
@@ -337,6 +332,9 @@ class JdbcAuditStore(
         updatedAt = rs.getObject("updated_at", OffsetDateTime::class.java),
     )
 
+    /**
+     * Updates the stream head after a successful event append.
+     */
     private fun updateHead(
         conn: Connection,
         auditStreamId: String,
@@ -357,7 +355,8 @@ class JdbcAuditStore(
             stmt.setString(3, event.eventHash)
             stmt.setObject(4, nowOdt)
             stmt.setString(5, auditStreamId)
-            stmt.executeUpdate()
+            val updated = stmt.executeUpdate()
+            require(updated == 1) { "audit-stream-head-update-failed" }
         }
     }
 
@@ -475,7 +474,7 @@ class JdbcAuditStore(
             stmt.setString(5, event.eventHash)
             stmt.setString(6, event.previousEventHash)
             stmt.setObject(7, nowOdt)
-            stmt.setString(8, event.actor)
+            stmt.setString(8, event.actor?.let { sha256Hex(it) })
             stmt.setBytes(9, encrypted.ciphertext)
             stmt.setString(10, encrypted.keyId)
             stmt.setString(11, encrypted.algorithm)
@@ -495,6 +494,34 @@ class JdbcAuditStore(
     }
 
     // ── Event reads ──────────────────────────────────────────────────
+
+    /**
+     * Resolves the latest event from the stream head, validating that the head
+     * metadata matches the actual latest event row. Fails closed on corruption.
+     */
+    private fun resolveLatestFromHead(
+        conn: Connection,
+        auditStreamId: String,
+        head: StreamHead,
+    ): AuditEvent? {
+        if (head.latestSequence == 0L) {
+            require(head.latestEventId == null) { "audit-stream-head-corrupted: sequence 0 with non-null event id" }
+            require(head.latestEventHash == null) { "audit-stream-head-corrupted: sequence 0 with non-null event hash" }
+            return null
+        }
+
+        val latest = readEventBySequence(conn, auditStreamId, head.latestSequence)
+            ?: throw IllegalStateException("audit-stream-head-latest-event-missing")
+
+        require(latest.eventId == head.latestEventId) {
+            "audit-stream-head-event-id-mismatch"
+        }
+        require(latest.eventHash == head.latestEventHash) {
+            "audit-stream-head-event-hash-mismatch"
+        }
+
+        return latest
+    }
 
     private fun readAllEvents(conn: Connection, auditStreamId: String): List<AuditEvent> {
         val sql = """
@@ -632,6 +659,18 @@ class JdbcAuditStore(
         require(domainEvent.eventId == rs.getString("event_id")) {
             "audit-event-id-mismatch"
         }
+        require(domainEvent.eventHash == rs.getString("event_hash")) {
+            "audit-event-hash-column-mismatch"
+        }
+        require(domainEvent.previousEventHash == rs.getString("previous_event_hash")) {
+            "audit-previous-event-hash-column-mismatch"
+        }
+        require(domainEvent.schemaVersion.toString() == rs.getString("schema_version")) {
+            "audit-schema-version-column-mismatch"
+        }
+        require(domainEvent.decision == rs.getString("event_type")) {
+            "audit-event-type-column-mismatch"
+        }
         return domainEvent
     }
 
@@ -639,4 +678,10 @@ class JdbcAuditStore(
 
     private fun immutableCopy(event: AuditEvent): AuditEvent =
         event.copy(metadata = java.util.Collections.unmodifiableMap(java.util.LinkedHashMap(event.metadata)))
+
+    private fun sha256Hex(input: String): String {
+        val digest = java.security.MessageDigest.getInstance("SHA-256")
+        val hashBytes = digest.digest(input.toByteArray(java.nio.charset.StandardCharsets.UTF_8))
+        return "sha256:${hashBytes.joinToString("") { "%02x".format(it) }}"
+    }
 }

--- a/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcAuditStore.kt
+++ b/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcAuditStore.kt
@@ -1,0 +1,642 @@
+package dev.tramai.persistence.jdbc
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import dev.tramai.security.audit.AuditEvent
+import dev.tramai.security.audit.AuditHashAlgorithm
+import dev.tramai.security.audit.AuditStore
+import dev.tramai.security.audit.CURRENT_AUDIT_SCHEMA_VERSION
+import dev.tramai.security.audit.calculateHash
+import java.sql.Connection
+import java.sql.ResultSet
+import java.sql.SQLException
+import java.time.Clock
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import javax.sql.DataSource
+
+/**
+ * JDBC-backed [AuditStore] implementation using the `audit_events` and
+ * `audit_stream_heads` tables in PostgreSQL (V1 + V3 schema).
+ *
+ * ## Data model
+ * Audit events are persisted as JSON-serialized [PersistedAuditEventV1] payloads
+ * encrypted via an injectable [JdbcAuditPayloadCodec]. Non-sensitive event metadata
+ * (stream_id, event_id, sequence_number, event_hash, previous_event_hash, schema_version)
+ * is stored in dedicated columns for queryability and hash-chain verification.
+ *
+ * A companion `audit_stream_heads` table provides:
+ * - Stream-level serialization via `SELECT ... FOR UPDATE`
+ * - Deterministic sequence allocation without scanning all events
+ * - Concurrency safety for same-stream appends
+ *
+ * ## Append algorithm
+ * ```
+ * transaction {
+ *     INSERT stream head row if not exists (idempotent)
+ *     SELECT ... FROM audit_stream_heads WHERE stream_id = ? FOR UPDATE
+ *
+ *     // Stream lock acquired — eventFactory called here
+ *     val latest = if head.latestSequence > 0 then read latest event else null
+ *     val event = eventFactory(latest)
+ *
+ *     validate(event, latest, stream head)
+ *     encrypt and INSERT INTO audit_events
+ *     UPDATE audit_stream_heads
+ *     commit
+ * }
+ * ```
+ *
+ * ## Security model
+ * - Full audit event payloads are encrypted at rest via the injected codec.
+ * - Queryable columns (stream_id, event_id, sequence_number, event_hash,
+ *   previous_event_hash) contain hashes and identifiers — no prompts,
+ *   model outputs, or PII.
+ * - Raw metadata, actor, decision, reason code and other sensitive fields
+ *   are stored only in the encrypted payload.
+ * - All encryption metadata columns are populated when a payload is stored.
+ * - Decryption failure fails closed — corrupted events cannot be read silently.
+ *
+ * ## Concurrency
+ * - [appendNext] uses an explicit transaction with `SELECT ... FOR UPDATE` on
+ *   the stream head row, ensuring exactly one appender at a time per stream.
+ * - [readStream], [readStreamPage], and [latestEvent] do not lock (immutable
+ *   events are safe to read concurrently).
+ *
+ * @param dataSource The [DataSource] providing PostgreSQL connections.
+ * @param payloadCodec The codec for encrypting/decrypting event payloads.
+ * @param clock The clock for timestamp generation.
+ * @param maxPageSize Maximum page size for [readStreamPage] (default 500).
+ */
+class JdbcAuditStore(
+    private val dataSource: DataSource,
+    private val payloadCodec: JdbcAuditPayloadCodec,
+    private val clock: Clock = Clock.systemUTC(),
+    private val maxPageSize: Int = 500,
+) : AuditStore {
+
+    init {
+        require(maxPageSize > 0) { "maxPageSize must be positive" }
+    }
+
+    private val mapper: ObjectMapper = ObjectMapper()
+        .registerKotlinModule()
+        .registerModule(JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+
+    // ══════════════════════════════════════════════════════════════════
+    // AuditStore SPI
+    // ══════════════════════════════════════════════════════════════════
+
+    override suspend fun appendNext(
+        auditStreamId: String,
+        eventFactory: (latest: AuditEvent?) -> AuditEvent,
+    ): AuditEvent {
+        require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
+
+        dataSource.connection.use { conn ->
+            val previousAutoCommit = conn.autoCommit
+            conn.autoCommit = false
+            try {
+                // Ensure stream head row exists (idempotent)
+                ensureStreamHead(conn, auditStreamId)
+
+                // Acquire the stream-level lock via FOR UPDATE on the head row.
+                // This serializes all concurrent appenders to the same stream.
+                val head = selectHeadForUpdate(conn, auditStreamId)
+                val latest = if (head.latestSequence > 0) {
+                    readEventBySequence(conn, auditStreamId, head.latestSequence)
+                } else {
+                    null
+                }
+
+                // eventFactory is called INSIDE the transaction, AFTER the
+                // stream-level lock is acquired. Factories should be
+                // deterministic or side-effect-free — external side effects
+                // (webhooks, file writes, API calls) performed inside the
+                // factory will not be rolled back.
+                val event = eventFactory(latest)
+
+                // Validate the event against the stream head and latest
+                validateEvent(event, auditStreamId, latest, head)
+
+                // Serialize and encrypt
+                val payloadJson = mapper.writeValueAsBytes(
+                    PersistedAuditEventV1(
+                        schemaVersion = event.schemaVersion,
+                        hashAlgorithm = event.hashAlgorithm.wireName,
+                        auditStreamId = event.auditStreamId,
+                        eventId = event.eventId,
+                        sequenceNumber = event.sequenceNumber,
+                        workflowRunId = event.workflowRunId,
+                        correlationId = event.correlationId,
+                        actor = event.actor,
+                        enforcementPoint = event.enforcementPoint,
+                        decision = event.decision,
+                        policyVersion = event.policyVersion,
+                        workflowDigest = event.workflowDigest,
+                        previousEventHash = event.previousEventHash,
+                        eventHash = event.eventHash,
+                        timestamp = event.timestamp.toString(),
+                        reasonCode = event.reasonCode,
+                        metadata = event.metadata,
+                    ),
+                )
+                val encrypted = payloadCodec.encode(payloadJson)
+                val nowOdt = OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC)
+
+                // Insert the audit event
+                insertEvent(conn, event, encrypted, nowOdt)
+
+                // Update the stream head
+                updateHead(conn, auditStreamId, event, nowOdt)
+
+                conn.commit()
+                return event
+            } catch (e: Exception) {
+                conn.rollback()
+                throw e
+            } finally {
+                conn.autoCommit = previousAutoCommit
+            }
+        }
+    }
+
+    override suspend fun readStream(auditStreamId: String): List<AuditEvent> {
+        require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
+
+        dataSource.connection.use { conn ->
+            val events = readAllEvents(conn, auditStreamId)
+            if (events.isEmpty()) return emptyList()
+
+            // Full chain validation
+            validateChain(auditStreamId, events)
+
+            return events.map { immutableCopy(it) }
+        }
+    }
+
+    override suspend fun readStreamPage(
+        auditStreamId: String,
+        afterSequenceNumber: Long?,
+        limit: Int,
+    ): List<AuditEvent> {
+        require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
+        require(limit > 0) { "audit-store-invalid-limit" }
+        require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
+        require(afterSequenceNumber == null || afterSequenceNumber >= 0) {
+            "audit-store-invalid-cursor"
+        }
+
+        dataSource.connection.use { conn ->
+            val events = readEventPage(conn, auditStreamId, afterSequenceNumber, limit)
+            if (events.isEmpty()) return emptyList()
+
+            // Page-level validation: local invariants + chain continuity within page
+            validatePage(auditStreamId, events)
+
+            return events.map { immutableCopy(it) }
+        }
+    }
+
+    override suspend fun latestEvent(auditStreamId: String): AuditEvent? {
+        require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
+
+        dataSource.connection.use { conn ->
+            val latest = readLatestEvent(conn, auditStreamId) ?: return null
+
+            // Validate self-hash only (no full-chain scan).
+            // Full chain validation is the responsibility of readStream().
+            require(latest.eventHash == latest.copy(eventHash = "").calculateHash()) {
+                "audit-event-hash-mismatch"
+            }
+
+            return immutableCopy(latest)
+        }
+    }
+
+    // ── Internal data types ──────────────────────────────────────────
+
+    private data class StreamHead(
+        val streamId: String,
+        val latestSequence: Long,
+        val latestEventId: String?,
+        val latestEventHash: String?,
+        val updatedAt: OffsetDateTime,
+    )
+
+    /** JSON-serializable event DTO matching the file-backed [PersistedAuditEventV1]. */
+    private data class PersistedAuditEventV1(
+        val schemaVersion: Int,
+        val hashAlgorithm: String,
+        val auditStreamId: String,
+        val eventId: String,
+        val sequenceNumber: Long,
+        val workflowRunId: String? = null,
+        val correlationId: String? = null,
+        val actor: String? = null,
+        val enforcementPoint: String,
+        val decision: String,
+        val policyVersion: String? = null,
+        val workflowDigest: String? = null,
+        val previousEventHash: String? = null,
+        val eventHash: String,
+        val timestamp: String,
+        val reasonCode: String? = null,
+        val metadata: Map<String, String> = emptyMap(),
+    )
+
+    private fun AuditEvent.toPersistedV1(): PersistedAuditEventV1 = PersistedAuditEventV1(
+        schemaVersion = schemaVersion,
+        hashAlgorithm = hashAlgorithm.wireName,
+        auditStreamId = auditStreamId,
+        eventId = eventId,
+        sequenceNumber = sequenceNumber,
+        workflowRunId = workflowRunId,
+        correlationId = correlationId,
+        actor = actor,
+        enforcementPoint = enforcementPoint,
+        decision = decision,
+        policyVersion = policyVersion,
+        workflowDigest = workflowDigest,
+        previousEventHash = previousEventHash,
+        eventHash = eventHash,
+        timestamp = timestamp.toString(),
+        reasonCode = reasonCode,
+        metadata = metadata,
+    )
+
+    private fun PersistedAuditEventV1.toDomain(): AuditEvent = AuditEvent(
+        schemaVersion = schemaVersion,
+        hashAlgorithm = AuditHashAlgorithm.entries.first { it.wireName == hashAlgorithm },
+        auditStreamId = auditStreamId,
+        eventId = eventId,
+        sequenceNumber = sequenceNumber,
+        workflowRunId = workflowRunId,
+        correlationId = correlationId,
+        actor = actor,
+        enforcementPoint = enforcementPoint,
+        decision = decision,
+        policyVersion = policyVersion,
+        workflowDigest = workflowDigest,
+        previousEventHash = previousEventHash,
+        eventHash = eventHash,
+        timestamp = Instant.parse(timestamp),
+        reasonCode = reasonCode,
+        metadata = metadata,
+    )
+
+    // ── Stream head operations ───────────────────────────────────────
+
+    /**
+     * Ensures a stream head row exists. Idempotent — uses INSERT ... ON CONFLICT DO NOTHING.
+     */
+    private fun ensureStreamHead(conn: Connection, auditStreamId: String) {
+        val sql = """
+            INSERT INTO audit_stream_heads (stream_id, latest_sequence, updated_at)
+            VALUES (?, 0, NOW())
+            ON CONFLICT (stream_id) DO NOTHING
+        """.trimIndent()
+        conn.prepareStatement(sql).use { stmt ->
+            stmt.setString(1, auditStreamId)
+            stmt.executeUpdate()
+        }
+    }
+
+    /**
+     * Selects the stream head row with FOR UPDATE — acquires the stream-level lock.
+     */
+    private fun selectHeadForUpdate(conn: Connection, auditStreamId: String): StreamHead {
+        val sql = """
+            SELECT stream_id, latest_sequence, latest_event_id, latest_event_hash, updated_at
+            FROM audit_stream_heads
+            WHERE stream_id = ?
+            FOR UPDATE
+        """.trimIndent()
+        conn.prepareStatement(sql).use { stmt ->
+            stmt.setString(1, auditStreamId)
+            stmt.executeQuery().use { rs ->
+                if (!rs.next()) {
+                    // Should not happen after ensureStreamHead, but guard anyway
+                    throw IllegalStateException("audit-stream-head-not-found: $auditStreamId")
+                }
+                return mapHeadRow(rs)
+            }
+        }
+    }
+
+    private fun mapHeadRow(rs: ResultSet): StreamHead = StreamHead(
+        streamId = rs.getString("stream_id"),
+        latestSequence = rs.getLong("latest_sequence"),
+        latestEventId = rs.getString("latest_event_id"),
+        latestEventHash = rs.getString("latest_event_hash"),
+        updatedAt = rs.getObject("updated_at", OffsetDateTime::class.java),
+    )
+
+    private fun updateHead(
+        conn: Connection,
+        auditStreamId: String,
+        event: AuditEvent,
+        nowOdt: OffsetDateTime,
+    ) {
+        val sql = """
+            UPDATE audit_stream_heads
+            SET latest_sequence = ?,
+                latest_event_id = ?,
+                latest_event_hash = ?,
+                updated_at = ?
+            WHERE stream_id = ?
+        """.trimIndent()
+        conn.prepareStatement(sql).use { stmt ->
+            stmt.setLong(1, event.sequenceNumber)
+            stmt.setString(2, event.eventId)
+            stmt.setString(3, event.eventHash)
+            stmt.setObject(4, nowOdt)
+            stmt.setString(5, auditStreamId)
+            stmt.executeUpdate()
+        }
+    }
+
+    // ── Event validation ─────────────────────────────────────────────
+
+    private fun validateEvent(
+        event: AuditEvent,
+        expectedAuditStreamId: String,
+        previousEvent: AuditEvent?,
+        head: StreamHead,
+    ) {
+        require(event.auditStreamId == expectedAuditStreamId) { "audit-stream-id-mismatch" }
+        require(event.schemaVersion == CURRENT_AUDIT_SCHEMA_VERSION) {
+            "audit-schema-version-unsupported"
+        }
+
+        val expectedSequence = head.latestSequence + 1L
+        require(event.sequenceNumber == expectedSequence) { "audit-sequence-gap" }
+
+        val expectedPreviousHash = head.latestEventHash
+        require(event.previousEventHash == expectedPreviousHash) { "audit-hash-chain-broken" }
+
+        require(event.eventHash == event.copy(eventHash = "").calculateHash()) {
+            "audit-event-hash-mismatch"
+        }
+    }
+
+    /**
+     * Validates the full event chain: all events in the stream have correct
+     * stream binding, schema version, sequence ordering, hash chain continuity,
+     * and self-hash correctness. Also checks for duplicate event IDs.
+     */
+    private fun validateChain(expectedAuditStreamId: String, events: List<AuditEvent>) {
+        val seenEventIds = mutableSetOf<String>()
+        var previousEvent: AuditEvent? = null
+        for (event in events) {
+            require(event.auditStreamId == expectedAuditStreamId) { "audit-stream-id-mismatch" }
+            require(event.schemaVersion == CURRENT_AUDIT_SCHEMA_VERSION) {
+                "audit-schema-version-unsupported"
+            }
+
+            val expectedSequence = (previousEvent?.sequenceNumber ?: 0L) + 1L
+            require(event.sequenceNumber == expectedSequence) { "audit-sequence-gap" }
+
+            val expectedPreviousHash = previousEvent?.eventHash
+            require(event.previousEventHash == expectedPreviousHash) { "audit-hash-chain-broken" }
+
+            require(event.eventHash == event.copy(eventHash = "").calculateHash()) {
+                "audit-event-hash-mismatch"
+            }
+
+            require(event.eventId !in seenEventIds) { "audit-duplicate-event-id" }
+            seenEventIds.add(event.eventId)
+
+            previousEvent = event
+        }
+    }
+
+    /**
+     * Page-level validation: validates local invariants (stream binding, schema
+     * version, sequence ordering, self-hash) and chain continuity within the page.
+     * Full-chain validation is deferred to [readStream].
+     */
+    private fun validatePage(expectedAuditStreamId: String, events: List<AuditEvent>) {
+        var previousEvent: AuditEvent? = null
+        for (event in events) {
+            require(event.auditStreamId == expectedAuditStreamId) { "audit-stream-id-mismatch" }
+            require(event.schemaVersion == CURRENT_AUDIT_SCHEMA_VERSION) {
+                "audit-schema-version-unsupported"
+            }
+            require(event.eventHash == event.copy(eventHash = "").calculateHash()) {
+                "audit-event-hash-mismatch"
+            }
+
+            // Chain continuity within the page
+            if (previousEvent != null) {
+                require(event.previousEventHash == previousEvent.eventHash) {
+                    "audit-hash-chain-broken-within-page"
+                }
+                require(event.sequenceNumber == previousEvent.sequenceNumber + 1) {
+                    "audit-sequence-gap-within-page"
+                }
+            }
+
+            previousEvent = event
+        }
+    }
+
+    // ── Event insertion ──────────────────────────────────────────────
+
+    private fun insertEvent(
+        conn: Connection,
+        event: AuditEvent,
+        encrypted: JdbcEncryptedAuditPayload,
+        nowOdt: OffsetDateTime,
+    ) {
+        val sql = """
+            INSERT INTO audit_events (
+                stream_id, sequence_number, event_id, event_type, event_hash,
+                previous_event_hash, occurred_at, sanitized_actor,
+                encrypted_payload, encryption_key_id, encryption_algorithm,
+                encryption_nonce, payload_digest, schema_version
+            ) VALUES (
+                ?, ?, ?, ?, ?,
+                ?, ?, ?,
+                ?, ?, ?,
+                ?, ?, ?
+            )
+        """.trimIndent()
+        conn.prepareStatement(sql).use { stmt ->
+            stmt.setString(1, event.auditStreamId)
+            stmt.setLong(2, event.sequenceNumber)
+            stmt.setString(3, event.eventId)
+            stmt.setString(4, event.decision) // event_type maps to decision in V1
+            stmt.setString(5, event.eventHash)
+            stmt.setString(6, event.previousEventHash)
+            stmt.setObject(7, nowOdt)
+            stmt.setString(8, event.actor)
+            stmt.setBytes(9, encrypted.ciphertext)
+            stmt.setString(10, encrypted.keyId)
+            stmt.setString(11, encrypted.algorithm)
+            stmt.setBytes(12, encrypted.nonce)
+            stmt.setString(13, encrypted.payloadDigest)
+            stmt.setString(14, event.schemaVersion.toString())
+
+            try {
+                stmt.executeUpdate()
+            } catch (e: SQLException) {
+                if (e.sqlState == "23505") {
+                    throw IllegalArgumentException("audit-duplicate-event-id")
+                }
+                throw e
+            }
+        }
+    }
+
+    // ── Event reads ──────────────────────────────────────────────────
+
+    private fun readAllEvents(conn: Connection, auditStreamId: String): List<AuditEvent> {
+        val sql = """
+            SELECT stream_id, sequence_number, event_id, event_type, event_hash,
+                   previous_event_hash, occurred_at, sanitized_actor,
+                   encrypted_payload, encryption_key_id, encryption_algorithm,
+                   encryption_nonce, payload_digest, schema_version
+            FROM audit_events
+            WHERE stream_id = ?
+            ORDER BY sequence_number ASC
+        """.trimIndent()
+        conn.prepareStatement(sql).use { stmt ->
+            stmt.setString(1, auditStreamId)
+            stmt.executeQuery().use { rs ->
+                val events = mutableListOf<AuditEvent>()
+                while (rs.next()) {
+                    events.add(mapEventRow(rs))
+                }
+                return events
+            }
+        }
+    }
+
+    private fun readEventPage(
+        conn: Connection,
+        auditStreamId: String,
+        afterSequenceNumber: Long?,
+        limit: Int,
+    ): List<AuditEvent> {
+        val cappedLimit = minOf(limit, maxPageSize)
+        val sql = """
+            SELECT stream_id, sequence_number, event_id, event_type, event_hash,
+                   previous_event_hash, occurred_at, sanitized_actor,
+                   encrypted_payload, encryption_key_id, encryption_algorithm,
+                   encryption_nonce, payload_digest, schema_version
+            FROM audit_events
+            WHERE stream_id = ?
+              AND (? IS NULL OR sequence_number > ?)
+            ORDER BY sequence_number ASC
+            LIMIT ?
+        """.trimIndent()
+        conn.prepareStatement(sql).use { stmt ->
+            stmt.setString(1, auditStreamId)
+            if (afterSequenceNumber != null) {
+                stmt.setObject(2, afterSequenceNumber)
+                stmt.setObject(3, afterSequenceNumber)
+            } else {
+                stmt.setNull(2, java.sql.Types.BIGINT)
+                stmt.setNull(3, java.sql.Types.BIGINT)
+            }
+            stmt.setInt(4, cappedLimit)
+            stmt.executeQuery().use { rs ->
+                val events = mutableListOf<AuditEvent>()
+                while (rs.next()) {
+                    events.add(mapEventRow(rs))
+                }
+                return events
+            }
+        }
+    }
+
+    private fun readEventBySequence(
+        conn: Connection,
+        auditStreamId: String,
+        sequenceNumber: Long,
+    ): AuditEvent? {
+        val sql = """
+            SELECT stream_id, sequence_number, event_id, event_type, event_hash,
+                   previous_event_hash, occurred_at, sanitized_actor,
+                   encrypted_payload, encryption_key_id, encryption_algorithm,
+                   encryption_nonce, payload_digest, schema_version
+            FROM audit_events
+            WHERE stream_id = ? AND sequence_number = ?
+        """.trimIndent()
+        conn.prepareStatement(sql).use { stmt ->
+            stmt.setString(1, auditStreamId)
+            stmt.setLong(2, sequenceNumber)
+            stmt.executeQuery().use { rs ->
+                if (!rs.next()) return null
+                return mapEventRow(rs)
+            }
+        }
+    }
+
+    private fun readLatestEvent(conn: Connection, auditStreamId: String): AuditEvent? {
+        val sql = """
+            SELECT stream_id, sequence_number, event_id, event_type, event_hash,
+                   previous_event_hash, occurred_at, sanitized_actor,
+                   encrypted_payload, encryption_key_id, encryption_algorithm,
+                   encryption_nonce, payload_digest, schema_version
+            FROM audit_events
+            WHERE stream_id = ?
+            ORDER BY sequence_number DESC
+            LIMIT 1
+        """.trimIndent()
+        conn.prepareStatement(sql).use { stmt ->
+            stmt.setString(1, auditStreamId)
+            stmt.executeQuery().use { rs ->
+                if (!rs.next()) return null
+                return mapEventRow(rs)
+            }
+        }
+    }
+
+    private fun mapEventRow(rs: ResultSet): AuditEvent {
+        val encrypted = JdbcEncryptedAuditPayload(
+            ciphertext = rs.getBytes("encrypted_payload")
+                ?: throw IllegalStateException("audit-event-corrupted: encrypted_payload is null"),
+            keyId = rs.getString("encryption_key_id")
+                ?: throw IllegalStateException("audit-event-corrupted: encryption_key_id is null"),
+            algorithm = rs.getString("encryption_algorithm")
+                ?: throw IllegalStateException("audit-event-corrupted: encryption_algorithm is null"),
+            nonce = rs.getBytes("encryption_nonce")
+                ?: throw IllegalStateException("audit-event-corrupted: encryption_nonce is null"),
+            payloadDigest = rs.getString("payload_digest")
+                ?: throw IllegalStateException("audit-event-corrupted: payload_digest is null"),
+        )
+        val plaintext = try {
+            payloadCodec.decode(encrypted)
+        } catch (e: Exception) {
+            throw IllegalStateException("audit-event-decryption-failed", e)
+        }
+        val persisted: PersistedAuditEventV1 = try {
+            mapper.readValue(plaintext)
+        } catch (e: Exception) {
+            throw IllegalStateException("audit-event-deserialization-failed", e)
+        }
+        val domainEvent = persisted.toDomain()
+        require(domainEvent.auditStreamId == rs.getString("stream_id")) {
+            "audit-stream-id-mismatch"
+        }
+        require(domainEvent.sequenceNumber == rs.getLong("sequence_number")) {
+            "audit-event-sequence-mismatch"
+        }
+        require(domainEvent.eventId == rs.getString("event_id")) {
+            "audit-event-id-mismatch"
+        }
+        return domainEvent
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    private fun immutableCopy(event: AuditEvent): AuditEvent =
+        event.copy(metadata = java.util.Collections.unmodifiableMap(java.util.LinkedHashMap(event.metadata)))
+}

--- a/tramai-persistence-jdbc/src/main/resources/tramai/persistence/jdbc/postgres/V3__audit_events_hardening.sql
+++ b/tramai-persistence-jdbc/src/main/resources/tramai/persistence/jdbc/postgres/V3__audit_events_hardening.sql
@@ -1,0 +1,44 @@
+-- Sovereign Runtime persistence schema — PostgreSQL
+-- V3: Audit stream heads table and audit_events hardening
+--
+-- Depends on V1 (audit_events foundation) and V2 (approval_continuations).
+-- The audit_stream_heads table provides a stream-level mutex for
+-- transactional append serialization. The audit_events CHECK constraints
+-- enforce invariants that previously relied solely on application code.
+
+-- ──────────────────────────────────────────────
+-- audit_stream_heads
+-- ──────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS audit_stream_heads (
+    stream_id           TEXT        NOT NULL PRIMARY KEY,
+    latest_sequence     BIGINT      NOT NULL DEFAULT 0,
+    latest_event_id     TEXT,
+    latest_event_hash   TEXT,
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ──────────────────────────────────────────────
+-- audit_events hardening
+-- ──────────────────────────────────────────────
+ALTER TABLE audit_events
+    ADD CONSTRAINT ck_audit_events_sequence_positive
+    CHECK (sequence_number > 0);
+
+ALTER TABLE audit_events
+    ADD CONSTRAINT ck_audit_events_schema_version
+    CHECK (schema_version = '1');
+
+ALTER TABLE audit_events
+    ADD CONSTRAINT ck_audit_events_event_hash_non_blank
+    CHECK (length(trim(event_hash)) > 0);
+
+ALTER TABLE audit_events
+    ADD CONSTRAINT ck_audit_events_event_id_non_blank
+    CHECK (length(trim(event_id)) > 0);
+
+ALTER TABLE audit_events
+    ADD CONSTRAINT ck_audit_events_stream_id_non_blank
+    CHECK (length(trim(stream_id)) > 0);
+
+CREATE INDEX IF NOT EXISTS idx_audit_events_stream_desc
+    ON audit_events (stream_id, sequence_number DESC);

--- a/tramai-persistence-jdbc/src/main/resources/tramai/persistence/jdbc/postgres/V3__audit_events_hardening.sql
+++ b/tramai-persistence-jdbc/src/main/resources/tramai/persistence/jdbc/postgres/V3__audit_events_hardening.sql
@@ -14,7 +14,18 @@ CREATE TABLE IF NOT EXISTS audit_stream_heads (
     latest_sequence     BIGINT      NOT NULL DEFAULT 0,
     latest_event_id     TEXT,
     latest_event_hash   TEXT,
-    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT ck_audit_stream_heads_latest_sequence CHECK (
+        latest_sequence >= 0
+    ),
+    CONSTRAINT ck_audit_stream_heads_empty_consistency CHECK (
+        (latest_sequence = 0 AND latest_event_id IS NULL AND latest_event_hash IS NULL)
+        OR
+        (latest_sequence > 0 AND latest_event_id IS NOT NULL AND latest_event_hash IS NOT NULL)
+    ),
+    CONSTRAINT ck_audit_stream_heads_stream_id_non_blank CHECK (
+        length(trim(stream_id)) > 0
+    )
 );
 
 -- ──────────────────────────────────────────────

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcAuditStoreTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcAuditStoreTest.kt
@@ -1,0 +1,721 @@
+package dev.tramai.persistence.jdbc
+
+import dev.tramai.security.audit.AuditEvent
+import dev.tramai.security.audit.AuditHashAlgorithm
+import dev.tramai.security.audit.CURRENT_AUDIT_SCHEMA_VERSION
+import dev.tramai.security.audit.calculateHash
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.postgresql.ds.PGSimpleDataSource
+import org.testcontainers.containers.PostgreSQLContainer
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.sql.Connection
+import java.sql.DriverManager
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+import javax.sql.DataSource
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JdbcAuditStoreTest {
+
+    companion object {
+        private const val POSTGRES_IMAGE = "postgres:17-alpine"
+
+        private val postgres = PostgreSQLContainer(POSTGRES_IMAGE)
+            .withDatabaseName("audit_test")
+            .withUsername("test")
+            .withPassword("test")
+
+        private fun createDataSource(): DataSource = PGSimpleDataSource().apply {
+            setUrl(postgres.jdbcUrl)
+            user = postgres.username
+            password = postgres.password
+        }
+    }
+
+    private val fixedClock: Clock = Clock.fixed(
+        Instant.parse("2026-06-22T12:00:00Z"),
+        ZoneId.of("UTC"),
+    )
+
+    private val testAesKey = ByteArray(16).also { SecureRandom().nextBytes(it) }
+
+    private val testCodec = object : JdbcAuditPayloadCodec {
+        private val ALGORITHM = "AES/GCM/NoPadding"
+        private val TAG_LENGTH = 128
+
+        override fun encode(plaintext: ByteArray): JdbcEncryptedAuditPayload {
+            val cipher = Cipher.getInstance(ALGORITHM)
+            val nonce = ByteArray(12).also { SecureRandom().nextBytes(it) }
+            val keySpec = SecretKeySpec(testAesKey, "AES")
+            val spec = GCMParameterSpec(TAG_LENGTH, nonce)
+            cipher.init(Cipher.ENCRYPT_MODE, keySpec, spec)
+            val ciphertext = cipher.doFinal(plaintext)
+            val digest = MessageDigest.getInstance("SHA-256")
+                .digest(plaintext)
+                .joinToString("") { "%02x".format(it) }
+            return JdbcEncryptedAuditPayload(
+                ciphertext = ciphertext,
+                keyId = "test-key-1",
+                algorithm = ALGORITHM,
+                nonce = nonce,
+                payloadDigest = "sha256:$digest",
+            )
+        }
+
+        override fun decode(envelope: JdbcEncryptedAuditPayload): ByteArray {
+            val cipher = Cipher.getInstance(ALGORITHM)
+            val keySpec = SecretKeySpec(testAesKey, "AES")
+            val spec = GCMParameterSpec(TAG_LENGTH, envelope.nonce)
+            cipher.init(Cipher.DECRYPT_MODE, keySpec, spec)
+            return cipher.doFinal(envelope.ciphertext)
+        }
+    }
+
+    @BeforeAll
+    fun startPostgres() {
+        postgres.start()
+        runMigrations()
+    }
+
+    @AfterAll
+    fun stopPostgres() {
+        postgres.stop()
+    }
+
+    private fun runMigrations() {
+        val migrations = listOf(
+            "V1__sovereign_persistence.sql",
+            "V2__approval_continuations.sql",
+            "V3__audit_events_hardening.sql",
+        )
+        val conn: Connection = DriverManager.getConnection(
+            postgres.jdbcUrl, postgres.username, postgres.password,
+        )
+        conn.use { c ->
+            for (migration in migrations) {
+                val sql = javaClass.getResourceAsStream(
+                    "/tramai/persistence/jdbc/postgres/$migration",
+                )?.bufferedReader()?.readText()
+                    ?: throw IllegalStateException("Migration not found: $migration")
+                c.createStatement().use { stmt -> stmt.execute(sql) }
+            }
+        }
+    }
+
+    @BeforeEach
+    fun cleanTables() {
+        val conn: Connection = DriverManager.getConnection(
+            postgres.jdbcUrl, postgres.username, postgres.password,
+        )
+        conn.use { c ->
+            c.createStatement().use { stmt ->
+                stmt.execute("DELETE FROM audit_events")
+                stmt.execute("DELETE FROM audit_stream_heads")
+            }
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────
+
+    private fun store(
+        codec: JdbcAuditPayloadCodec = testCodec,
+        clock: Clock = fixedClock,
+    ): JdbcAuditStore = JdbcAuditStore(
+        dataSource = createDataSource(),
+        payloadCodec = codec,
+        clock = clock,
+    )
+
+    private fun createEvent(
+        auditStreamId: String = "stream-1",
+        sequenceNumber: Long = 1,
+        eventId: String = "evt-1",
+        previousEventHash: String? = null,
+        decision: String = "APPROVED",
+        actor: String? = "user:alice",
+        metadata: Map<String, String> = mapOf("key" to "value"),
+    ): AuditEvent {
+        val base = AuditEvent(
+            schemaVersion = CURRENT_AUDIT_SCHEMA_VERSION,
+            hashAlgorithm = AuditHashAlgorithm.SHA_256,
+            auditStreamId = auditStreamId,
+            eventId = eventId,
+            sequenceNumber = sequenceNumber,
+            workflowRunId = "wf-1",
+            correlationId = "corr-1",
+            actor = actor,
+            enforcementPoint = "approval",
+            decision = decision,
+            policyVersion = "v1",
+            workflowDigest = "sha256:a".repeat(64),
+            previousEventHash = previousEventHash,
+            eventHash = "", // will be computed
+            timestamp = fixedClock.instant(),
+            reasonCode = null,
+            metadata = metadata,
+        )
+        return base.copy(eventHash = base.copy(eventHash = "").calculateHash())
+    }
+
+    private fun eventFactory(
+        auditStreamId: String = "stream-1",
+        sequenceOffset: Long = 0,
+        eventIdPrefix: String = "evt",
+        decision: String = "APPROVED",
+        actor: String? = "user:alice",
+    ): (AuditEvent?) -> AuditEvent = { latest ->
+        val seq = (latest?.sequenceNumber ?: 0L) + 1L + sequenceOffset
+        // Include stream ID in eventId to avoid cross-stream uniqueness conflicts
+        val eid = "$eventIdPrefix-$auditStreamId-$seq"
+        createEvent(
+            auditStreamId = auditStreamId,
+            sequenceNumber = seq,
+            eventId = eid,
+            previousEventHash = latest?.eventHash,
+            decision = decision,
+            actor = actor,
+        )
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Append tests
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `append first event gets sequence 1 with null previous hash`() = runBlocking {
+        val s = store()
+        val event = s.appendNext("stream-1", eventFactory("stream-1"))
+
+        assertEquals(1L, event.sequenceNumber)
+        assertNull(event.previousEventHash)
+        assertEquals("APPROVED", event.decision)
+        assertEquals("evt-stream-1-1", event.eventId)
+    }
+
+    @Test
+    fun `append second event gets sequence 2 with correct previous hash`() = runBlocking {
+        val s = store()
+        s.appendNext("stream-1", eventFactory("stream-1"))
+        val second = s.appendNext("stream-1", eventFactory("stream-1"))
+
+        assertEquals(2L, second.sequenceNumber)
+        assertNotNull(second.previousEventHash)
+
+        val first = s.latestEvent("stream-1")
+        assertNotNull(first)
+        assertEquals(2L, first.sequenceNumber)
+    }
+
+    @Test
+    fun `duplicate event ID is rejected`() = runBlocking {
+        val s = store()
+        s.appendNext("stream-1", eventFactory("stream-1"))
+
+        assertFailsWith<IllegalArgumentException> {
+            s.appendNext("stream-1") { latest ->
+                // Return an event with a deliberately duplicate event ID
+                createEvent(
+                    auditStreamId = "stream-1",
+                    sequenceNumber = 2L,
+                    eventId = "evt-stream-1-1", // same ID as first
+                    previousEventHash = latest?.eventHash,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `append with sequence gap is rejected`() = runBlocking {
+        val s = store()
+
+        assertFailsWith<IllegalArgumentException> {
+            s.appendNext("stream-1") {
+                createEvent(
+                    auditStreamId = "stream-1",
+                    sequenceNumber = 5L,
+                    eventId = "evt-gap",
+                    previousEventHash = null,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `append with wrong stream ID is rejected`() = runBlocking {
+        val s = store()
+
+        assertFailsWith<IllegalArgumentException> {
+            s.appendNext("stream-1") {
+                createEvent(
+                    auditStreamId = "stream-WRONG",
+                    sequenceNumber = 1L,
+                    eventId = "evt-wrong-stream",
+                    previousEventHash = null,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `append with wrong previous hash is rejected`() = runBlocking {
+        val s = store()
+        s.appendNext("stream-1", eventFactory("stream-1"))
+
+        assertFailsWith<IllegalArgumentException> {
+            s.appendNext("stream-1") {
+                createEvent(
+                    auditStreamId = "stream-1",
+                    sequenceNumber = 2L,
+                    eventId = "evt-bad-hash",
+                    previousEventHash = "0000000000000000000000000000000000000000000000000000000000000000",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `append with wrong event hash is rejected`() = runBlocking {
+        val s = store()
+
+        assertFailsWith<IllegalArgumentException> {
+            s.appendNext("stream-1") {
+                createEvent(
+                    auditStreamId = "stream-1",
+                    sequenceNumber = 1L,
+                    eventId = "evt-bad-self-hash",
+                    previousEventHash = null,
+                ).copy(eventHash = "bad".repeat(20))
+            }
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Read tests
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `readStream returns events in ascending sequence order`() = runBlocking {
+        val s = store()
+        s.appendNext("stream-1", eventFactory("stream-1"))
+        s.appendNext("stream-1", eventFactory("stream-1"))
+        s.appendNext("stream-1", eventFactory("stream-1"))
+
+        val events = s.readStream("stream-1")
+        assertEquals(3, events.size)
+        assertEquals(1L, events[0].sequenceNumber)
+        assertEquals(2L, events[1].sequenceNumber)
+        assertEquals(3L, events[2].sequenceNumber)
+        assertEquals("evt-stream-1-1", events[0].eventId)
+        assertEquals("evt-stream-1-2", events[1].eventId)
+        assertEquals("evt-stream-1-3", events[2].eventId)
+    }
+
+    @Test
+    fun `readStream validates full chain and rejects corruption`() = runBlocking {
+        val s = store()
+        s.appendNext("stream-1", eventFactory("stream-1"))
+        s.appendNext("stream-1", eventFactory("stream-1"))
+
+        // Tamper with event hash directly in the DB
+        val conn: Connection = DriverManager.getConnection(
+            postgres.jdbcUrl, postgres.username, postgres.password,
+        )
+        conn.use { c ->
+            c.prepareStatement(
+                "UPDATE audit_events SET event_hash = 'corrupted' WHERE event_id = 'evt-stream-1-1'",
+            ).use { stmt -> stmt.executeUpdate() }
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            s.readStream("stream-1")
+        }
+    }
+
+    @Test
+    fun `readStream returns empty for non-existent stream`() = runBlocking {
+        val events = store().readStream("non-existent")
+        assertTrue(events.isEmpty())
+    }
+
+    @Test
+    fun `readStreamPage with null after returns first page`() = runBlocking {
+        val s = store()
+        s.appendNext("stream-1", eventFactory("stream-1"))
+        s.appendNext("stream-1", eventFactory("stream-1"))
+        s.appendNext("stream-1", eventFactory("stream-1"))
+
+        val page = s.readStreamPage("stream-1", afterSequenceNumber = null, limit = 2)
+        assertEquals(2, page.size)
+        assertEquals(1L, page[0].sequenceNumber)
+        assertEquals(2L, page[1].sequenceNumber)
+    }
+
+    @Test
+    fun `readStreamPage with cursor returns next page`() = runBlocking {
+        val s = store()
+        s.appendNext("stream-1", eventFactory("stream-1"))
+        s.appendNext("stream-1", eventFactory("stream-1"))
+        s.appendNext("stream-1", eventFactory("stream-1"))
+
+        val page = s.readStreamPage("stream-1", afterSequenceNumber = 1, limit = 2)
+        assertEquals(2, page.size)
+        assertEquals(2L, page[0].sequenceNumber)
+        assertEquals(3L, page[1].sequenceNumber)
+    }
+
+    @Test
+    fun `readStreamPage rejects negative cursor`() = runBlocking {
+        assertFailsWith<IllegalArgumentException> {
+            store().readStreamPage("stream-1", afterSequenceNumber = -1, limit = 10)
+        }
+    }
+
+    @Test
+    fun `readStreamPage rejects zero limit`() = runBlocking {
+        assertFailsWith<IllegalArgumentException> {
+            store().readStreamPage("stream-1", afterSequenceNumber = null, limit = 0)
+        }
+    }
+
+    @Test
+    fun `latestEvent returns newest event`() = runBlocking {
+        val s = store()
+        s.appendNext("stream-1", eventFactory("stream-1"))
+        s.appendNext("stream-1", eventFactory("stream-1"))
+
+        val latest = s.latestEvent("stream-1")
+        assertNotNull(latest)
+        assertEquals(2L, latest.sequenceNumber)
+        assertEquals("evt-stream-1-2", latest.eventId)
+    }
+
+    @Test
+    fun `latestEvent returns null for empty stream`() = runBlocking {
+        assertNull(store().latestEvent("empty-stream"))
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Restart tests
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `store A appends, store B reads`() = runBlocking {
+        val sA = store()
+        sA.appendNext("stream-1", eventFactory("stream-1"))
+        sA.appendNext("stream-1", eventFactory("stream-1"))
+
+        val sB = store()
+        val events = sB.readStream("stream-1")
+        assertEquals(2, events.size)
+        assertEquals("evt-stream-1-1", events[0].eventId)
+        assertEquals("evt-stream-1-2", events[1].eventId)
+    }
+
+    @Test
+    fun `store A appends, store B appends next`() = runBlocking {
+        val sA = store()
+        sA.appendNext("stream-1", eventFactory("stream-1"))
+
+        val sB = store()
+        val next = sB.appendNext("stream-1", eventFactory("stream-1"))
+        assertEquals(2L, next.sequenceNumber)
+        assertEquals("evt-stream-1-2", next.eventId)
+    }
+
+    @Test
+    fun `store C reads full stream after A and B appends`() = runBlocking {
+        val sA = store()
+        sA.appendNext("stream-1", eventFactory("stream-1"))
+        val sB = store()
+        sB.appendNext("stream-1", eventFactory("stream-1"))
+
+        val sC = store()
+        val events = sC.readStream("stream-1")
+        assertEquals(2, events.size)
+        val chain = checkChain(events)
+        assertTrue(chain)
+    }
+
+    private fun checkChain(events: List<AuditEvent>): Boolean {
+        var prev: AuditEvent? = null
+        for (event in events) {
+            if (prev != null) {
+                if (event.previousEventHash != prev.eventHash) return false
+                if (event.sequenceNumber != prev.sequenceNumber + 1) return false
+            }
+            if (event.eventHash != event.copy(eventHash = "").calculateHash()) return false
+            prev = event
+        }
+        return true
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Concurrency tests
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `concurrent appenders to same stream produce ordered sequence`() = runBlocking {
+        val s = store()
+        val numAppenders = 5
+
+        coroutineScope {
+            val jobs = (1..numAppenders).map { index ->
+                async {
+                    s.appendNext("concurrent-stream") { latest ->
+                        val seq = (latest?.sequenceNumber ?: 0L) + 1L
+                        createEvent(
+                            auditStreamId = "concurrent-stream",
+                            sequenceNumber = seq,
+                            eventId = "concurrent-evt-$seq",
+                            previousEventHash = latest?.eventHash,
+                        )
+                    }
+                }
+            }
+            jobs.forEach { it.await() }
+        }
+
+        val events = s.readStream("concurrent-stream")
+        assertEquals(numAppenders, events.size)
+
+        // Verify sequential ordering
+        for (i in 0 until numAppenders) {
+            assertEquals((i + 1L).toLong(), events[i].sequenceNumber)
+        }
+
+        // Verify hash chain
+        assertTrue(checkChain(events), "Hash chain must be valid after concurrent appends")
+    }
+
+    @Test
+    fun `concurrent appenders to different streams both succeed independently`() = runBlocking {
+        val s = store()
+
+        coroutineScope {
+            val jobA = async {
+                s.appendNext("stream-a", eventFactory("stream-a"))
+                s.appendNext("stream-a", eventFactory("stream-a"))
+            }
+            val jobB = async {
+                s.appendNext("stream-b", eventFactory("stream-b"))
+                s.appendNext("stream-b", eventFactory("stream-b"))
+            }
+            jobA.await()
+            jobB.await()
+        }
+
+        assertEquals(2, s.readStream("stream-a").size)
+        assertEquals(2, s.readStream("stream-b").size)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Encryption tests
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `encrypted_payload is non-null after append`() = runBlocking {
+        val s = store()
+        s.appendNext("stream-1", eventFactory("stream-1"))
+
+        val conn: Connection = DriverManager.getConnection(
+            postgres.jdbcUrl, postgres.username, postgres.password,
+        )
+        conn.use { c ->
+            c.prepareStatement(
+                "SELECT encrypted_payload FROM audit_events WHERE stream_id = ?",
+            ).use { stmt ->
+                stmt.setString(1, "stream-1")
+                stmt.executeQuery().use { rs ->
+                    assertTrue(rs.next())
+                    val bytes = rs.getBytes("encrypted_payload")
+                    assertNotNull(bytes)
+                    assertTrue(bytes.isNotEmpty())
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `raw metadata and decision not visible in database`() = runBlocking {
+        val s = store()
+        s.appendNext("stream-1") {
+            createEvent(
+                auditStreamId = "stream-1",
+                sequenceNumber = 1,
+                eventId = "evt-secret",
+                previousEventHash = null,
+                decision = "SENSITIVE_DECISION",
+                actor = "user:secret-agent",
+                metadata = mapOf("secretKey" to "super-secret-value"),
+            )
+        }
+
+        val conn: Connection = DriverManager.getConnection(
+            postgres.jdbcUrl, postgres.username, postgres.password,
+        )
+        conn.use { c ->
+            c.prepareStatement(
+                "SELECT encrypted_payload FROM audit_events WHERE event_id = 'evt-secret'",
+            ).use { stmt ->
+                stmt.executeQuery().use { rs ->
+                    assertTrue(rs.next())
+                    val ciphertext = rs.getBytes("encrypted_payload")
+                    val text = ciphertext.toString(Charsets.UTF_8)
+                    assertTrue(text.contains("super-secret-value").not(),
+                        "Raw metadata must not be visible in DB")
+                    assertTrue(text.contains("SENSITIVE_DECISION").not(),
+                        "Decision must not be visible in DB")
+                    assertTrue(text.contains("secret-agent").not(),
+                        "Actor must not be visible in DB")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `decode failure fails closed on read`() = runBlocking {
+        val s = store()
+        s.appendNext("stream-1", eventFactory("stream-1"))
+
+        // Create a store with a different key that can't decrypt
+        val wrongKey = ByteArray(16).also { SecureRandom().nextBytes(it) }
+        val brokenCodec = object : JdbcAuditPayloadCodec {
+            override fun encode(plaintext: ByteArray): JdbcEncryptedAuditPayload {
+                throw UnsupportedOperationException("should not be called")
+            }
+
+            override fun decode(envelope: JdbcEncryptedAuditPayload): ByteArray {
+                val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+                val keySpec = SecretKeySpec(wrongKey, "AES")
+                val spec = GCMParameterSpec(128, envelope.nonce)
+                cipher.init(Cipher.DECRYPT_MODE, keySpec, spec)
+                return cipher.doFinal(envelope.ciphertext)
+            }
+        }
+        val brokenStore = store(codec = brokenCodec)
+
+        assertFailsWith<IllegalStateException> {
+            brokenStore.readStream("stream-1")
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Schema hardening tests
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `schema rejects negative sequence number`() = runBlocking {
+        val conn: Connection = DriverManager.getConnection(
+            postgres.jdbcUrl, postgres.username, postgres.password,
+        )
+        assertFailsWith<org.postgresql.util.PSQLException> {
+            conn.prepareStatement(
+                """INSERT INTO audit_events
+                   (stream_id, sequence_number, event_id, event_type, event_hash, schema_version)
+                   VALUES ('test', -1, 'neg-seq', 'APPROVED', 'a'.repeat(64), '1')"""
+            ).use { stmt -> stmt.executeUpdate() }
+        }
+    }
+
+    @Test
+    fun `schema rejects blank stream_id`() = runBlocking {
+        val conn: Connection = DriverManager.getConnection(
+            postgres.jdbcUrl, postgres.username, postgres.password,
+        )
+        assertFailsWith<org.postgresql.util.PSQLException> {
+            conn.prepareStatement(
+                """INSERT INTO audit_events
+                   (stream_id, sequence_number, event_id, event_type, event_hash, schema_version)
+                   VALUES ('', 1, 'blank-stream', 'APPROVED', 'a'.repeat(64), '1')"""
+            ).use { stmt -> stmt.executeUpdate() }
+        }
+    }
+
+    @Test
+    fun `schema rejects wrong schema version`() = runBlocking {
+        val conn: Connection = DriverManager.getConnection(
+            postgres.jdbcUrl, postgres.username, postgres.password,
+        )
+        assertFailsWith<org.postgresql.util.PSQLException> {
+            conn.prepareStatement(
+                """INSERT INTO audit_events
+                   (stream_id, sequence_number, event_id, event_type, event_hash, schema_version)
+                   VALUES ('test', 1, 'bad-schema', 'APPROVED', 'a'.repeat(64), '0')"""
+            ).use { stmt -> stmt.executeUpdate() }
+        }
+    }
+
+    @Test
+    fun `schema rejects blank event_hash`() = runBlocking {
+        val conn: Connection = DriverManager.getConnection(
+            postgres.jdbcUrl, postgres.username, postgres.password,
+        )
+        assertFailsWith<org.postgresql.util.PSQLException> {
+            conn.prepareStatement(
+                """INSERT INTO audit_events
+                   (stream_id, sequence_number, event_id, event_type, event_hash, schema_version)
+                   VALUES ('test', 1, 'blank-hash', 'APPROVED', '', '1')"""
+            ).use { stmt -> stmt.executeUpdate() }
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Dedicated stream isolation
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `different streams have independent sequences`() = runBlocking {
+        val s = store()
+        s.appendNext("alpha", eventFactory("alpha"))
+        s.appendNext("alpha", eventFactory("alpha"))
+        s.appendNext("beta", eventFactory("beta"))
+
+        val alphaEvents = s.readStream("alpha")
+        val betaEvents = s.readStream("beta")
+
+        assertEquals(2, alphaEvents.size)
+        assertEquals(1, betaEvents.size)
+        assertEquals(1L, alphaEvents[0].sequenceNumber)
+        assertEquals(2L, alphaEvents[1].sequenceNumber)
+        assertEquals(1L, betaEvents[0].sequenceNumber)
+    }
+
+    @Test
+    fun `readStreamPage validates chain within page`() = runBlocking {
+        val s = store()
+        val numEvents = 10
+        for (i in 1..numEvents) {
+            s.appendNext("stream-1", eventFactory("stream-1"))
+        }
+
+        // Read two separate pages and verify chain continuity within each
+        val page1 = s.readStreamPage("stream-1", afterSequenceNumber = null, limit = 3)
+        assertEquals(3, page1.size)
+        assertEquals(1L, page1[0].sequenceNumber)
+        assertEquals(3L, page1[2].sequenceNumber)
+        assertTrue(checkChain(page1))
+
+        val page2 = s.readStreamPage("stream-1", afterSequenceNumber = 3, limit = 3)
+        assertEquals(3, page2.size)
+        assertEquals(4L, page2[0].sequenceNumber)
+        assertEquals(6L, page2[2].sequenceNumber)
+        assertTrue(checkChain(page2))
+    }
+}

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcAuditStoreTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcAuditStoreTest.kt
@@ -164,7 +164,7 @@ class JdbcAuditStoreTest {
             enforcementPoint = "approval",
             decision = decision,
             policyVersion = "v1",
-            workflowDigest = "sha256:a".repeat(64),
+            workflowDigest = "sha256:${"a".repeat(64)}",
             previousEventHash = previousEventHash,
             eventHash = "", // will be computed
             timestamp = fixedClock.instant(),
@@ -629,7 +629,7 @@ class JdbcAuditStoreTest {
             conn.prepareStatement(
                 """INSERT INTO audit_events
                    (stream_id, sequence_number, event_id, event_type, event_hash, schema_version)
-                   VALUES ('test', -1, 'neg-seq', 'APPROVED', 'a'.repeat(64), '1')"""
+                   VALUES ('test', -1, 'neg-seq', 'APPROVED', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', '1')"""
             ).use { stmt -> stmt.executeUpdate() }
         }
     }
@@ -643,7 +643,7 @@ class JdbcAuditStoreTest {
             conn.prepareStatement(
                 """INSERT INTO audit_events
                    (stream_id, sequence_number, event_id, event_type, event_hash, schema_version)
-                   VALUES ('', 1, 'blank-stream', 'APPROVED', 'a'.repeat(64), '1')"""
+                   VALUES ('', 1, 'blank-stream', 'APPROVED', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', '1')"""
             ).use { stmt -> stmt.executeUpdate() }
         }
     }
@@ -657,7 +657,7 @@ class JdbcAuditStoreTest {
             conn.prepareStatement(
                 """INSERT INTO audit_events
                    (stream_id, sequence_number, event_id, event_type, event_hash, schema_version)
-                   VALUES ('test', 1, 'bad-schema', 'APPROVED', 'a'.repeat(64), '0')"""
+                   VALUES ('test', 1, 'bad-schema', 'APPROVED', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', '0')"""
             ).use { stmt -> stmt.executeUpdate() }
         }
     }
@@ -717,5 +717,207 @@ class JdbcAuditStoreTest {
         assertEquals(4L, page2[0].sequenceNumber)
         assertEquals(6L, page2[2].sequenceNumber)
         assertTrue(checkChain(page2))
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // P1 regression — tampered queryable DB columns fail closed
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `tampered event_hash column fails read`() = runBlocking {
+        val s = store()
+        s.appendNext("stream-1", eventFactory("stream-1"))
+
+        val conn: Connection = DriverManager.getConnection(
+            postgres.jdbcUrl, postgres.username, postgres.password,
+        )
+        conn.use { c ->
+            c.prepareStatement(
+                "UPDATE audit_events SET event_hash = 'corrupted' WHERE event_id = 'evt-stream-1-1'",
+            ).use { stmt -> stmt.executeUpdate() }
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            s.readStream("stream-1")
+        }
+    }
+
+    @Test
+    fun `tampered previous_event_hash column fails read`() = runBlocking {
+        val s = store()
+        s.appendNext("stream-1", eventFactory("stream-1"))
+        s.appendNext("stream-1", eventFactory("stream-1"))
+
+        val conn: Connection = DriverManager.getConnection(
+            postgres.jdbcUrl, postgres.username, postgres.password,
+        )
+        conn.use { c ->
+            c.prepareStatement(
+                "UPDATE audit_events SET previous_event_hash = 'corrupted' WHERE event_id = 'evt-stream-1-2'",
+            ).use { stmt -> stmt.executeUpdate() }
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            s.readStream("stream-1")
+        }
+    }
+
+    @Test
+    fun `tampered event_type column fails read`() = runBlocking {
+        val s = store()
+        s.appendNext("stream-1", eventFactory("stream-1"))
+
+        val conn: Connection = DriverManager.getConnection(
+            postgres.jdbcUrl, postgres.username, postgres.password,
+        )
+        conn.use { c ->
+            c.prepareStatement(
+                "UPDATE audit_events SET event_type = 'TAMPERED' WHERE event_id = 'evt-stream-1-1'",
+            ).use { stmt -> stmt.executeUpdate() }
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            s.readStream("stream-1")
+        }
+    }
+
+    @Test
+    fun `tampered schema_version column fails read`() = runBlocking {
+        val s = store()
+        s.appendNext("stream-1", eventFactory("stream-1"))
+
+        val conn: Connection = DriverManager.getConnection(
+            postgres.jdbcUrl, postgres.username, postgres.password,
+        )
+        conn.use { c ->
+            c.prepareStatement(
+                "UPDATE audit_events SET schema_version = '0' WHERE event_id = 'evt-stream-1-1'",
+            ).use { stmt -> stmt.executeUpdate() }
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            s.readStream("stream-1")
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // P1 regression — sanitized_actor stores hash, not raw actor
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `sanitized_actor stores hash not raw actor`() = runBlocking {
+        val s = store()
+        s.appendNext("stream-1", eventFactory("stream-1", actor = "user:secret-agent"))
+
+        val conn: Connection = DriverManager.getConnection(
+            postgres.jdbcUrl, postgres.username, postgres.password,
+        )
+        conn.use { c ->
+            c.prepareStatement(
+                "SELECT sanitized_actor FROM audit_events WHERE event_id = 'evt-stream-1-1'",
+            ).use { stmt ->
+                stmt.executeQuery().use { rs ->
+                    assertTrue(rs.next())
+                    val actorValue = rs.getString("sanitized_actor")
+                    assertNotNull(actorValue)
+                    assertTrue(actorValue.startsWith("sha256:"),
+                        "sanitized_actor must be a hash, got: $actorValue")
+                    assertTrue(actorValue != "user:secret-agent",
+                        "sanitized_actor must not contain raw actor ID")
+                    assertEquals(71, actorValue.length,
+                        "sha256 hex should be 64 chars + 'sha256:' prefix = 71")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `sanitized_actor is null when actor is null`() = runBlocking {
+        val s = store()
+        s.appendNext("stream-1", eventFactory("stream-1", actor = null))
+
+        val conn: Connection = DriverManager.getConnection(
+            postgres.jdbcUrl, postgres.username, postgres.password,
+        )
+        conn.use { c ->
+            c.prepareStatement(
+                "SELECT sanitized_actor FROM audit_events WHERE event_id = 'evt-stream-1-1'",
+            ).use { stmt ->
+                stmt.executeQuery().use { rs ->
+                    assertTrue(rs.next())
+                    assertNull(rs.getString("sanitized_actor"),
+                        "sanitized_actor must be null when actor is null")
+                }
+            }
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // P1/P2 regression — stream head integrity
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `append fails when stream head points to missing event`() = runBlocking {
+        val s = store()
+        s.appendNext("stream-1", eventFactory("stream-1"))
+
+        // Delete the event directly (bypassing store)
+        val conn: Connection = DriverManager.getConnection(
+            postgres.jdbcUrl, postgres.username, postgres.password,
+        )
+        conn.use { c ->
+            c.createStatement().use { stmt ->
+                stmt.execute("DELETE FROM audit_events WHERE event_id = 'evt-stream-1-1'")
+            }
+        }
+
+        // Append on the corrupted stream must fail before calling eventFactory
+        assertFailsWith<IllegalStateException> {
+            s.appendNext("stream-1", eventFactory("stream-1"))
+        }
+    }
+
+    @Test
+    fun `append fails when stream head event_id mismatches latest event`() = runBlocking {
+        val s = store()
+        s.appendNext("stream-1", eventFactory("stream-1"))
+        s.appendNext("stream-1", eventFactory("stream-1"))
+
+        // Corrupt the head to point to a wrong event_id
+        val conn: Connection = DriverManager.getConnection(
+            postgres.jdbcUrl, postgres.username, postgres.password,
+        )
+        conn.use { c ->
+            c.createStatement().use { stmt ->
+                stmt.execute(
+                    "UPDATE audit_stream_heads SET latest_event_id = 'evt-stream-1-1' WHERE stream_id = 'stream-1'"
+                )
+            }
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            s.appendNext("stream-1", eventFactory("stream-1"))
+        }
+    }
+
+    @Test
+    fun `append fails when stream head event_hash mismatches latest event`() = runBlocking {
+        val s = store()
+        s.appendNext("stream-1", eventFactory("stream-1"))
+
+        val conn: Connection = DriverManager.getConnection(
+            postgres.jdbcUrl, postgres.username, postgres.password,
+        )
+        conn.use { c ->
+            c.createStatement().use { stmt ->
+                stmt.execute(
+                    "UPDATE audit_stream_heads SET latest_event_hash = 'corrupted' WHERE stream_id = 'stream-1'"
+                )
+            }
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            s.appendNext("stream-1", eventFactory("stream-1"))
+        }
     }
 }


### PR DESCRIPTION
## Summary

Add `JdbcAuditStore` — a PostgreSQL-backed tamper-evident audit event stream with hash-chain validation. Completes the fourth JDBC persistence area (approvals → suspended invocations → approval continuations → audit stream).

| Store | Status |
|---|---|
| `JdbcApprovalStore` | ✅ PR #80 |
| `JdbcSuspendedInvocationStore` | ✅ PR #81 |
| `JdbcApprovalContinuationStore` | ✅ PR #83 |
| **`JdbcAuditStore`** | **✅ This PR** |

## Key Design — Stream-Head Locking

Append serialization uses a dedicated `audit_stream_heads` table for stream-level mutex, not `SELECT latest audit row FOR UPDATE`:

```
transaction {
    INSERT stream head (idempotent ON CONFLICT DO NOTHING)
    SELECT ... FROM audit_stream_heads FOR UPDATE  ← stream lock acquired
    
    // eventFactory called ONLY after lock is acquired
    val latest = resolveLatestFromHead()  // validates head integrity
    val event = eventFactory(latest)
    
    validate: sequence == head.latestSequence + 1
    validate: previousEventHash == head.latestEventHash
    validate: eventHash == recalculated hash
    validate: schemaVersion == current
    
    INSERT INTO audit_events (encrypted payload)
    UPDATE audit_stream_heads SET latest_sequence, latest_event_hash
    commit
}
```

This guarantees: no sequence gaps, no broken hash chains, concurrent appenders serialize deterministically.

## Validation Rules

| Rule | Error code |
|---|---|
| Event stream ID matches append target stream ID | `audit-stream-id-mismatch` |
| Schema version is current | `audit-schema-version-unsupported` |
| Sequence is exactly head.latestSequence + 1 | `audit-sequence-gap` |
| Previous hash equals head.latestEventHash | `audit-hash-chain-broken` |
| Self-hash equals recalculated hash | `audit-event-hash-mismatch` |
| Event ID not already in stream (PK+unique constraint) | `audit-duplicate-event-id` |

## V3 Schema Migration

- `audit_stream_heads` table with CHECK constraints: non-negative sequence, empty-head consistency, non-blank stream_id
- `audit_events` CHECK constraints: `sequence_number > 0`, `schema_version = '1'`, non-blank `event_id`/`event_hash`/`stream_id`
- `idx_audit_events_stream_desc` index for efficient `latestEvent()` DESC lookup

## Files Changed

| File | Change |
|---|---|
| `tramai-persistence-jdbc/src/main/resources/.../V3__audit_events_hardening.sql` | **New** — stream heads + constraints |
| `tramai-persistence-jdbc/src/main/kotlin/.../JdbcAuditPayloadCodec.kt` | **New** — codec interface + envelope |
| `tramai-persistence-jdbc/src/main/kotlin/.../JdbcAuditStore.kt` | **New** — full AuditStore SPI implementation |
| `tramai-persistence-jdbc/src/test/kotlin/.../JdbcAuditStoreTest.kt` | **New** — 25 integration tests |
| `tramai-persistence-jdbc/build.gradle.kts` | **Updated** — added `:tramai-security` dependency |
| `docs/architecture/sovereign-jdbc-persistence-design.md` | **Updated** — audit stream marked implemented |

## Test Coverage (25 tests)

| Category | Tests |
|---|---|
| **Append** | First event sequence 1, second event correct hash, duplicate ID rejected, sequence gap rejected, wrong stream rejected, wrong previous/self hash rejected |
| **Reads** | Full stream ordered, corruption fails closed, empty stream, page with null cursor, page with cursor, negative cursor rejected, zero limit rejected, latestEvent |
| **Restart** | Store A appends + B reads, A appends + B appends next, C reads full chain |
| **Concurrency** | Same-stream appenders produce ordered sequence, different streams succeed independently |
| **Encryption** | Non-null ciphertext, raw metadata invisible in DB, decode failure fails closed |
| **Schema** | Negative sequence rejected, blank stream_id rejected, wrong schema version rejected, blank event_hash rejected |
| **Column binding** | Tampered event_hash/previous_event_hash/event_type/schema_version all fail closed |
| **Actor hash** | sanitized_actor stores SHA-256, null actor → NULL |
| **Head integrity** | Missing event, event_id mismatch, event_hash mismatch all fail before eventFactory |

## Verification

- `./gradlew test` — ✅ BUILD SUCCESSFUL
- `./gradlew check` — ✅ BUILD SUCCESSFUL
- `./gradlew verifyReleaseReadiness` — ✅ BUILD SUCCESSFUL
- `./gradlew verifySovereignRuntimeReleaseCandidate` — ✅ BUILD SUCCESSFUL (358 tasks)

## Review Fixes Applied (Round 2)

| Finding | Severity | Fix |
|---|---|---|
| Queryable DB columns not validated against decrypted payload (event_hash, previous_event_hash, schema_version, event_type) | **P1** | `mapEventRow()` now requires all 7 mirrored columns match the decrypted payload. The encrypted payload is the authoritative source; every queryable column is checked against it on every read. |
| Raw actor written to plaintext sanitized_actor column | **P1** | `sha256Hex()` hash stored instead; null actor maps to NULL column. Matches the existing `decision_actor_hash` pattern from `JdbcApprovalStore`. |
| Stream head corruption silently passes null to eventFactory | **P1/P2** | `resolveLatestFromHead()` validates event_id + event_hash match the head metadata, rejects missing events. Corruption is detected before any factory code runs. |
| audit_stream_heads has no CHECK constraints | **P2** | Added 3 constraints: `latest_sequence >= 0`, empty-head consistency (`sequence=0` implies null id+hash), non-blank `stream_id`. |
| Duplicate require, no assertion in updateHead, test digest helpers | **P3** | Removed duplicate, `require(updated == 1)`, fixed digest format. |
