### PR TITLE
feat(jdbc): add worker leases for sovereign ops coordination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - File-backed audit outbox and recovery workflow (`tramai-spring-boot-starter-sovereign-ops`).
 - JDBC-backed sovereign persistence with Spring Boot auto-configuration (`tramai-spring-boot-starter-sovereign-persistence-jdbc`). Activated via `tramai.sovereign.persistence.type=jdbc`.
 - JDBC E2E restart proof: Spring Boot example with Testcontainers PostgreSQL, five E2E tests proving sovereign state survives context restart, outbox dispatch recovery, and audit stream hash-chain validation.
+- JDBC worker lease support for multi-node audit outbox worker coordination via the `worker_leases` table, with atomic lease acquisition (`SELECT ... FOR UPDATE`), heartbeat extension, release, and lease-aware worker wrapper.
 - Background worker for audit outbox recovery and dispatch.
 - Observer SPI and composite observer pipeline for sovereign ops audit outbox worker cycles and failures.
 - OpenTelemetry worker metrics (`tramai-spring-boot-starter-sovereign-ops-observability`).
@@ -36,7 +37,6 @@
 - Broad REST/Actuator operational control endpoints beyond worker status and health.
 - Full dashboard integration and production monitoring runbook.
 - Database-backed persistence or outbox.
-- Distributed worker leader election.
 - Key rotation.
 - Full production deployment guide.
 - Complete API reference documentation.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -25,6 +25,7 @@ This document describes the state of the repository, not a formal release contra
 | JDBC sovereign persistence (PostgreSQL-backed approval, audit, outbox stores) | Implemented / evolving |
 | Spring Boot auto-configuration for JDBC persistence | Implemented |
 | JDBC E2E restart proof (Testcontainers, audit/outbox recovery) | Implemented |
+| JDBC worker lease coordination (multi-node audit outbox worker coordination) | Implemented |
 | Sovereign ops worker observability runbook | Implemented |
 | Sovereign ops audit outbox OpenTelemetry metrics | Implemented |
 | Evidence generation (bundles, release artifacts) | Implemented / evolving |

--- a/docs/architecture/sovereign-jdbc-persistence-design.md
+++ b/docs/architecture/sovereign-jdbc-persistence-design.md
@@ -223,13 +223,16 @@ Required fields (conceptual):
 
 ### worker_leases
 
-Purpose: future multi-node coordination.
+Purpose: multi-node worker coordination via lease-based leader election.
 
-This is **not** required for the first JDBC implementation, but the design should reserve space for it.
+Status: **Implemented** (PR #88). The table exists in V1, hardened in V5.
+The `JdbcSovereignOpsWorkerLeaseStore` provides atomic lease acquisition
+with `SELECT ... FOR UPDATE`. The `LeasedSovereignOpsAuditOutboxBackgroundWorker`
+wraps the audit outbox worker with lease coordination.
 
-Required fields (conceptual):
+Required fields:
 
-- `lease_name`
+- `lease_name` (PK)
 - `owner_id`
 - `acquired_at`
 - `expires_at`

--- a/docs/guides/sovereign-runtime-quickstart.md
+++ b/docs/guides/sovereign-runtime-quickstart.md
@@ -91,6 +91,7 @@ This activates:
 - sovereign runtime policy engine and routing
 - encrypted file-backed persistence (approvals, continuations, audit stream, outbox)
 - audit outbox background worker (recovery + dispatch loop)
+- multi-node worker lease coordination (prevents duplicate dispatch cycles)
 - optional read-only Actuator worker status endpoint
 - optional Actuator worker health component
 
@@ -113,7 +114,13 @@ tramai:
       audit-outbox:
         worker:
           enabled: true
+          lease-enabled: true
+          lease-name: sovereign-ops-audit-outbox-worker
+          worker-id: ${HOSTNAME:node-1}
+          lease-duration: 2m
+```
 
+This activates JDBC-backed stores and multi-node worker coordination via the `worker_leases` table. Set `lease-enabled: false` to run without lease coordination (single-node mode).
 spring:
   datasource:
     url: jdbc:postgresql://localhost:5432/tramai
@@ -206,8 +213,6 @@ It does **not** publish remotely, create a tag, or claim Maven Central availabil
 For a regulated-domain walkthrough, see [Regulated Claim Triage Reference Scenario](../scenarios/regulated-claim-triage.md).
 
 - Production deployment and operational runbooks
-- Distributed worker coordination and leader election
-- Database-backed persistence or outbox (JDBC / Postgres)
 - Key rotation and secrets lifecycle
 - Maven Central release or public artifact publication
 - Stable 1.0 API — interfaces are still evolving

--- a/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/JdbcSchemaTestSupport.kt
+++ b/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/JdbcSchemaTestSupport.kt
@@ -21,6 +21,7 @@ object JdbcSchemaTestSupport {
         "/tramai/persistence/jdbc/postgres/V2__approval_continuations.sql",
         "/tramai/persistence/jdbc/postgres/V3__audit_events_hardening.sql",
         "/tramai/persistence/jdbc/postgres/V4__audit_outbox_hardening.sql",
+        "/tramai/persistence/jdbc/postgres/V5__worker_leases_hardening.sql",
     )
 
     /**

--- a/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/JdbcSovereignRuntimeE2ETest.kt
+++ b/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/JdbcSovereignRuntimeE2ETest.kt
@@ -19,9 +19,12 @@ import dev.tramai.spring.sovereign.persistence.jdbc.SovereignJdbcPersistenceAuto
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxRecord
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStatus
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseAcquisition
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseStore
 import com.zaxxer.hikari.HikariDataSource
 import java.nio.file.Path
 import java.security.MessageDigest
+import java.time.Duration
 import java.time.Instant
 import java.util.Base64
 import java.util.UUID
@@ -452,6 +455,58 @@ class JdbcSovereignRuntimeE2ETest {
 
                     // Stream identity
                     assertThat(events).allMatch { it.auditStreamId == streamId }
+                }
+            }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Test 6 — Two-worker lease coordination
+    // ════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun `two JDBC-backed workers coordinate through worker lease`() {
+        ensureMigrationsApplied()
+
+        val leaseName = "test-coordination"
+        val now = Instant.now()
+        val leaseDuration = Duration.ofSeconds(30)
+
+        // ── Context A: worker-a acquires the lease ──────────────────────
+        createJdbcRunner()
+            .run { ctx ->
+                val leaseStore = ctx.getBean(SovereignOpsWorkerLeaseStore::class.java)
+                runBlocking {
+                    val result = leaseStore.tryAcquire(leaseName, "worker-a", now, leaseDuration)
+                    assertThat(result)
+                        .isInstanceOf(SovereignOpsWorkerLeaseAcquisition.Acquired::class.java)
+                    val acquired = result as SovereignOpsWorkerLeaseAcquisition.Acquired
+                    assertThat(acquired.lease.ownerId).isEqualTo("worker-a")
+                    assertThat(acquired.lease.isExpired(now)).isFalse()
+                }
+            }
+
+        // ── Context B: worker-b attempts to acquire → HeldByOther ───────
+        createJdbcRunner()
+            .run { ctx ->
+                val leaseStore = ctx.getBean(SovereignOpsWorkerLeaseStore::class.java)
+                runBlocking {
+                    val result = leaseStore.tryAcquire(leaseName, "worker-b", now, leaseDuration)
+                    assertThat(result)
+                        .isInstanceOf(SovereignOpsWorkerLeaseAcquisition.HeldByOther::class.java)
+                    val held = result as SovereignOpsWorkerLeaseAcquisition.HeldByOther
+                    assertThat(held.lease.ownerId).isEqualTo("worker-a")
+                }
+            }
+
+        // ── Context A re-check: worker-a still owns the lease ───────────
+        createJdbcRunner()
+            .run { ctx ->
+                val leaseStore = ctx.getBean(SovereignOpsWorkerLeaseStore::class.java)
+                runBlocking {
+                    val lease = leaseStore.get(leaseName)
+                    assertThat(lease).isNotNull
+                    assertThat(lease!!.ownerId).isEqualTo("worker-a")
+                    assertThat(lease.isExpired(now)).isFalse()
                 }
             }
     }

--- a/tramai-persistence-jdbc/src/main/resources/tramai/persistence/jdbc/postgres/V5__worker_leases_hardening.sql
+++ b/tramai-persistence-jdbc/src/main/resources/tramai/persistence/jdbc/postgres/V5__worker_leases_hardening.sql
@@ -1,0 +1,52 @@
+-- ────────────────────────────────────────────────────────────────────
+-- V5: worker_leases hardening
+-- ────────────────────────────────────────────────────────────────────
+-- Adds domain constraints to the worker_leases table created in V1.
+-- All constraints are idempotent (ALTER TABLE ... ADD CONSTRAINT IF NOT
+-- EXISTS is not standard SQL, but PostgreSQL's IF NOT EXISTS works for
+-- ALTER TABLE ... ADD CONSTRAINT since PG 17. For earlier PG versions,
+-- DO blocks provide idempotent constraint creation.)
+
+-- 1. Non-blank lease_name
+DO $$ BEGIN
+    ALTER TABLE worker_leases ADD CONSTRAINT ck_worker_leases_lease_name_non_blank
+        CHECK (length(trim(lease_name)) > 0);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- 2. Positive version
+DO $$ BEGIN
+    ALTER TABLE worker_leases ADD CONSTRAINT ck_worker_leases_version_positive
+        CHECK (version > 0);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- 3. Owner consistency: either all owner fields are NULL (unowned) or
+--    all are NOT NULL (owned).
+DO $$ BEGIN
+    ALTER TABLE worker_leases ADD CONSTRAINT ck_worker_leases_owner_consistency
+        CHECK (
+            (owner_id IS NULL AND acquired_at IS NULL AND expires_at IS NULL AND heartbeat_at IS NULL)
+            OR
+            (owner_id IS NOT NULL AND acquired_at IS NOT NULL AND expires_at IS NOT NULL AND heartbeat_at IS NOT NULL)
+        );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- 4. Expiry after acquire (when both are set)
+DO $$ BEGIN
+    ALTER TABLE worker_leases ADD CONSTRAINT ck_worker_leases_expiry_after_acquire
+        CHECK (
+            expires_at IS NULL
+            OR acquired_at IS NULL
+            OR expires_at > acquired_at
+        );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- 5. Owner ID index (optional but useful for diagnostics)
+DO $$ BEGIN
+    CREATE INDEX IF NOT EXISTS idx_worker_leases_owner_id
+        ON worker_leases (owner_id);
+EXCEPTION WHEN duplicate_table THEN NULL;
+END $$;

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsAutoConfiguration.kt
@@ -11,6 +11,8 @@ import dev.tramai.spring.sovereign.ops.outbox.CompositeSovereignOpsAuditOutboxWo
 import dev.tramai.spring.sovereign.ops.outbox.InMemorySovereignOpsApprovalMutationStore
 import dev.tramai.spring.sovereign.ops.outbox.InMemorySovereignOpsAuditOutboxStore
 import dev.tramai.spring.sovereign.ops.outbox.InMemorySovereignOpsAuditOutboxWorkerStatusStore
+import dev.tramai.spring.sovereign.ops.outbox.LeasedSovereignOpsAuditOutboxBackgroundWorker
+import dev.tramai.spring.sovereign.ops.outbox.LeasedSovereignOpsAuditOutboxWorkerLifecycle
 import dev.tramai.spring.sovereign.ops.outbox.RecordingSovereignOpsAuditOutboxWorkerObserver
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalRecoveryResolver
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalMutationStore
@@ -25,9 +27,11 @@ import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerObser
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerStatusStore
 import dev.tramai.spring.sovereign.ops.outbox.UnknownSovereignOpsApprovalRecoveryResolver
 import dev.tramai.spring.sovereign.ops.outbox.validateSovereignOpsAuditOutboxWorkerProperties
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseStore
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -202,6 +206,41 @@ class SovereignOpsAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnExpression(
+        "'\${tramai.sovereign.ops.outbox.worker.enabled:false}' == 'true' " +
+            "&& '\${tramai.sovereign.ops.outbox.worker.lease-enabled:false}' == 'true'",
+    )
+    @ConditionalOnBean(SovereignOpsWorkerLeaseStore::class)
+    fun sovereignOpsAuditOutboxLeasedWorker(
+        delegate: SovereignOpsAuditOutboxBackgroundWorker,
+        leaseStore: SovereignOpsWorkerLeaseStore,
+        properties: SovereignOpsProperties,
+    ): LeasedSovereignOpsAuditOutboxBackgroundWorker =
+        LeasedSovereignOpsAuditOutboxBackgroundWorker(
+            delegate = delegate,
+            leaseStore = leaseStore,
+            properties = properties.outbox.worker,
+        )
+
+    /**
+     * Fails loudly when lease is enabled but no [SovereignOpsWorkerLeaseStore]
+     * bean is available. Do not silently run unleased when the user explicitly
+     * enabled leasing.
+     */
+    @Bean
+    @ConditionalOnExpression(
+        "'\${tramai.sovereign.ops.outbox.worker.enabled:false}' == 'true' " +
+            "&& '\${tramai.sovereign.ops.outbox.worker.lease-enabled:false}' == 'true'",
+    )
+    @ConditionalOnMissingBean(SovereignOpsWorkerLeaseStore::class)
+    fun missingLeaseStoreFailure(): Nothing {
+        throw IllegalStateException(
+            "tramai-sovereign-ops-worker-lease-store-missing",
+        )
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
     fun sovereignOpsAuditOutboxWorkerStatusStore(
         properties: SovereignOpsProperties,
         outboxDispatcher: ObjectProvider<SovereignOpsAuditOutboxDispatcher>,
@@ -212,10 +251,6 @@ class SovereignOpsAutoConfiguration {
                 dispatcherAvailable = outboxDispatcher.ifAvailable != null,
             )
         } catch (_: IllegalStateException) {
-            // If the worker config is invalid (e.g. dispatch-pending=true but
-            // no dispatcher and failOnMissingDispatcher=true), the status store
-            // should still exist to report the raw configuration. Fall back to
-            // raw properties so the store always bootstraps.
             properties.outbox.worker
         }
         return InMemorySovereignOpsAuditOutboxWorkerStatusStore(effectiveWorkerProps)
@@ -245,12 +280,17 @@ class SovereignOpsAutoConfiguration {
         )
     }
 
+    // ── Unleased lifecycle (lease-enabled=false or missing, the default) ──
+
     @Bean
     @ConditionalOnMissingBean
     @ConditionalOnProperty(
         prefix = "tramai.sovereign.ops.outbox.worker",
         name = ["enabled"],
         havingValue = "true",
+    )
+    @ConditionalOnExpression(
+        "'\${tramai.sovereign.ops.outbox.worker.lease-enabled:false}' == 'false'",
     )
     fun sovereignOpsAuditOutboxWorkerLifecycle(
         worker: SovereignOpsAuditOutboxBackgroundWorker,
@@ -266,6 +306,35 @@ class SovereignOpsAutoConfiguration {
 
         return SovereignOpsAuditOutboxWorkerLifecycle(
             worker = worker,
+            properties = effectiveWorkerProps,
+            observer = observer,
+            statusStore = statusStore,
+        )
+    }
+
+    // ── Leased lifecycle (lease-enabled=true + store exists) ──
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression(
+        "'\${tramai.sovereign.ops.outbox.worker.enabled:false}' == 'true' " +
+            "&& '\${tramai.sovereign.ops.outbox.worker.lease-enabled:false}' == 'true'",
+    )
+    @ConditionalOnBean(SovereignOpsWorkerLeaseStore::class)
+    fun sovereignOpsAuditOutboxLeasedWorkerLifecycle(
+        leasedWorker: LeasedSovereignOpsAuditOutboxBackgroundWorker,
+        properties: SovereignOpsProperties,
+        outboxDispatcher: ObjectProvider<SovereignOpsAuditOutboxDispatcher>,
+        observer: SovereignOpsAuditOutboxWorkerObserver,
+        statusStore: SovereignOpsAuditOutboxWorkerStatusStore,
+    ): LeasedSovereignOpsAuditOutboxWorkerLifecycle {
+        val effectiveWorkerProps = effectiveWorkerProperties(
+            rawProps = properties.outbox.worker,
+            dispatcherAvailable = outboxDispatcher.ifAvailable != null,
+        )
+
+        return LeasedSovereignOpsAuditOutboxWorkerLifecycle(
+            worker = leasedWorker,
             properties = effectiveWorkerProps,
             observer = observer,
             statusStore = statusStore,

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsProperties.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsProperties.kt
@@ -2,6 +2,7 @@ package dev.tramai.spring.sovereign.ops
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 import java.time.Duration
+import java.util.UUID
 
 /**
  * Externalized configuration for TramAI sovereign operations.
@@ -53,4 +54,16 @@ data class SovereignOpsOutboxWorkerProperties(
     val recoverPrepared: Boolean = true,
     val dispatchPending: Boolean = true,
     val failOnMissingDispatcher: Boolean = true,
+    val leaseEnabled: Boolean = false,
+    val leaseName: String = "sovereign-ops-audit-outbox-worker",
+    var workerId: String = defaultWorkerId(),
+    val leaseDuration: Duration = Duration.ofMinutes(2),
 )
+
+/**
+ * Computes a default worker ID from the HOSTNAME env var, falling back
+ * to a random UUID. Used as the [SovereignOpsOutboxWorkerProperties.workerId]
+ * default so that each node gets a stable identity without explicit config.
+ */
+fun defaultWorkerId(): String =
+    System.getenv("HOSTNAME") ?: UUID.randomUUID().toString()

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsProperties.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsProperties.kt
@@ -58,6 +58,7 @@ data class SovereignOpsOutboxWorkerProperties(
     val leaseName: String = "sovereign-ops-audit-outbox-worker",
     var workerId: String = defaultWorkerId(),
     val leaseDuration: Duration = Duration.ofMinutes(2),
+    val leaseHeartbeatInterval: Duration = Duration.ofSeconds(30),
 )
 
 /**

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/lease/SovereignOpsWorkerLease.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/lease/SovereignOpsWorkerLease.kt
@@ -1,0 +1,40 @@
+package dev.tramai.spring.sovereign.ops.lease
+
+import java.time.Instant
+
+/**
+ * A named worker lease used for multi-node coordination of sovereign ops
+ * background workers.
+ *
+ * ## Security invariants
+ * - [ownerId] is persisted as-is in the `worker_leases` table — no hashing.
+ * - This is an internal coordination lease, not a user-facing credential.
+ *   [ownerId] values should be machine identities (hostnames, instance IDs),
+ *   not user PII.
+ * - The [version] field acts as an optimistic lock for CAS updates.
+ */
+data class SovereignOpsWorkerLease(
+    val leaseName: String,
+    val ownerId: String?,
+    val acquiredAt: Instant?,
+    val expiresAt: Instant?,
+    val heartbeatAt: Instant?,
+    val version: Long,
+) {
+    /** A lease is expired when no expiry is set or the expiry is in the past. */
+    fun isExpired(now: Instant): Boolean =
+        expiresAt == null || !expiresAt.isAfter(now)
+
+    /** True when [ownerId] is non-null and matches the given ID. */
+    fun isOwnedBy(ownerId: String): Boolean =
+        this.ownerId == ownerId
+
+    init {
+        if (leaseName.isBlank()) {
+            throw IllegalArgumentException("leaseName must not be blank")
+        }
+        if (version <= 0) {
+            throw IllegalArgumentException("version must be positive, got $version")
+        }
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/lease/SovereignOpsWorkerLeaseResult.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/lease/SovereignOpsWorkerLeaseResult.kt
@@ -1,0 +1,33 @@
+package dev.tramai.spring.sovereign.ops.lease
+
+/**
+ * Result of a [SovereignOpsWorkerLeaseStore.tryAcquire] attempt.
+ *
+ * ## Variants
+ * - [Acquired]: the lease was successfully acquired by the caller.
+ * - [AlreadyOwned]: the lease is already owned by the caller (heartbeat extended).
+ * - [HeldByOther]: the lease is actively held by a different owner.
+ */
+sealed interface SovereignOpsWorkerLeaseAcquisition {
+    data class Acquired(val lease: SovereignOpsWorkerLease) : SovereignOpsWorkerLeaseAcquisition
+    data class AlreadyOwned(val lease: SovereignOpsWorkerLease) : SovereignOpsWorkerLeaseAcquisition
+    data class HeldByOther(val lease: SovereignOpsWorkerLease) : SovereignOpsWorkerLeaseAcquisition
+}
+
+/**
+ * Result of a [SovereignOpsWorkerLeaseStore.heartbeat] attempt.
+ */
+sealed interface SovereignOpsWorkerLeaseHeartbeat {
+    data class Extended(val lease: SovereignOpsWorkerLease) : SovereignOpsWorkerLeaseHeartbeat
+    data object NotOwner : SovereignOpsWorkerLeaseHeartbeat
+    data object Missing : SovereignOpsWorkerLeaseHeartbeat
+}
+
+/**
+ * Result of a [SovereignOpsWorkerLeaseStore.release] attempt.
+ */
+sealed interface SovereignOpsWorkerLeaseRelease {
+    data object Released : SovereignOpsWorkerLeaseRelease
+    data object NotOwner : SovereignOpsWorkerLeaseRelease
+    data object Missing : SovereignOpsWorkerLeaseRelease
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/lease/SovereignOpsWorkerLeaseResult.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/lease/SovereignOpsWorkerLeaseResult.kt
@@ -21,6 +21,7 @@ sealed interface SovereignOpsWorkerLeaseHeartbeat {
     data class Extended(val lease: SovereignOpsWorkerLease) : SovereignOpsWorkerLeaseHeartbeat
     data object NotOwner : SovereignOpsWorkerLeaseHeartbeat
     data object Missing : SovereignOpsWorkerLeaseHeartbeat
+    data object Expired : SovereignOpsWorkerLeaseHeartbeat
 }
 
 /**

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/lease/SovereignOpsWorkerLeaseStore.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/lease/SovereignOpsWorkerLeaseStore.kt
@@ -1,0 +1,88 @@
+package dev.tramai.spring.sovereign.ops.lease
+
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Persistence contract for worker lease coordination.
+ *
+ * Implementations coordinate named leases across multiple JVM nodes
+ * using an external store (JDBC, Redis, etc.). A lease allows a worker
+ * to claim exclusive ownership of a background task (e.g., audit outbox
+ * recovery/dispatch) so that only one node runs the cycle at a time.
+ *
+ * ## Design constraints
+ * - All methods accept [now] for test determinism — do not use static clocks.
+ * - [tryAcquire] must be atomic: if two callers race for the same lease name,
+ *   exactly one wins. The other receives [SovereignOpsWorkerLeaseAcquisition.HeldByOther].
+ * - Expired leases can be stolen. A non-expired lease held by a different
+ *   owner must never be stolen.
+ * - [heartbeat] extends the lease expiry. Only the current owner may heartbeat.
+ * - [release] clears ownership. Only the current owner may release.
+ */
+interface SovereignOpsWorkerLeaseStore {
+
+    /**
+     * Attempt to acquire [leaseName] for [ownerId].
+     *
+     * If no lease exists for this name, a new row is inserted with
+     * `expiresAt = now + leaseDuration` and [SovereignOpsWorkerLeaseAcquisition.Acquired]
+     * is returned.
+     *
+     * If a lease exists and is owned by [ownerId], the expiry is extended
+     * and [SovereignOpsWorkerLeaseAcquisition.AlreadyOwned] is returned.
+     *
+     * If a lease exists, is not expired, and is owned by a different owner,
+     * [SovereignOpsWorkerLeaseAcquisition.HeldByOther] is returned.
+     *
+     * If a lease exists, is expired, and is owned by a different owner,
+     * the lease is stolen and [SovereignOpsWorkerLeaseAcquisition.Acquired]
+     * is returned.
+     */
+    suspend fun tryAcquire(
+        leaseName: String,
+        ownerId: String,
+        now: Instant,
+        leaseDuration: Duration,
+    ): SovereignOpsWorkerLeaseAcquisition
+
+    /**
+     * Extend the lease expiry for [leaseName] by [leaseDuration] from [now].
+     *
+     * Returns [SovereignOpsWorkerLeaseHeartbeat.Extended] if the caller is the
+     * current owner and the lease is not expired.
+     *
+     * Returns [SovereignOpsWorkerLeaseHeartbeat.NotOwner] if a different owner
+     * holds the lease.
+     *
+     * Returns [SovereignOpsWorkerLeaseHeartbeat.Missing] if no lease exists
+     * for [leaseName].
+     */
+    suspend fun heartbeat(
+        leaseName: String,
+        ownerId: String,
+        now: Instant,
+        leaseDuration: Duration,
+    ): SovereignOpsWorkerLeaseHeartbeat
+
+    /**
+     * Release a lease held by [ownerId].
+     *
+     * Clears [ownerId], [acquiredAt], [expiresAt], and [heartbeatAt].
+     * The row remains for future acquisition.
+     *
+     * Returns [SovereignOpsWorkerLeaseRelease.Released] on success,
+     * [SovereignOpsWorkerLeaseRelease.NotOwner] if a different owner holds
+     * the lease, or [SovereignOpsWorkerLeaseRelease.Missing] if no row exists.
+     */
+    suspend fun release(
+        leaseName: String,
+        ownerId: String,
+        now: Instant,
+    ): SovereignOpsWorkerLeaseRelease
+
+    /**
+     * Look up a lease by name. Returns null if no row exists.
+     */
+    suspend fun get(leaseName: String): SovereignOpsWorkerLease?
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/LeasedSovereignOpsAuditOutboxBackgroundWorker.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/LeasedSovereignOpsAuditOutboxBackgroundWorker.kt
@@ -1,8 +1,15 @@
 package dev.tramai.spring.sovereign.ops.outbox
 
 import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseAcquisition
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseHeartbeat
 import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseStore
 import dev.tramai.spring.sovereign.ops.SovereignOpsOutboxWorkerProperties
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import java.time.Clock
 import java.time.Instant
 
@@ -13,18 +20,22 @@ import java.time.Instant
  * the configured worker lease. If the lease is held by another owner,
  * the cycle is skipped with a [SovereignOpsAuditOutboxWorkerSkippedSummary].
  *
+ * During the delegate execution, a heartbeat coroutine periodically extends
+ * the lease so that long-running cycles do not lose the lease mid-run.
+ * If the heartbeat fails (lease lost), the cycle is aborted.
+ *
  * ## Design
  * - **Wrapper, not rewrite.** The existing [SovereignOpsAuditOutboxBackgroundWorker]
  *   is unchanged. This class adds the coordination layer on top.
- * - **Heartbeat after run.** When the lease is acquired and the delegate
- *   completes successfully, a heartbeat is issued to extend the lease.
- * - **Cancellation is rethrown.** [kotlinx.coroutines.CancellationException]
- *   must never be swallowed by lease logic.
+ * - **Heartbeat loop during run.** A coroutine heartbeats at
+ *   [SovereignOpsOutboxWorkerProperties.leaseHeartbeatInterval] while the
+ *   delegate runs. If the heartbeat returns anything other than Extended,
+ *   the cycle is aborted with [kotlinx.coroutines.CancellationException].
+ * - **Cancellation is rethrown.** [CancellationException] must never be
+ *   swallowed by lease logic.
  *
  * ## Security
  * - No raw lease metadata is leaked in the skipped summary.
- * - Heartbeat failures are logged at the store level, not reflected
- *   in the worker run summary (the dispatch cycle already completed).
  */
 class LeasedSovereignOpsAuditOutboxBackgroundWorker(
     private val delegate: SovereignOpsAuditOutboxBackgroundWorker,
@@ -34,8 +45,13 @@ class LeasedSovereignOpsAuditOutboxBackgroundWorker(
 ) {
     /**
      * Attempts to acquire the worker lease, then:
-     * - If acquired/owned: delegates to the real worker and heartbeats.
+     * - If acquired/owned: runs the delegate with a heartbeat loop.
      * - If held by another owner: returns a skipped summary.
+     *
+     * The heartbeat loop extends the lease at
+     * [SovereignOpsOutboxWorkerProperties.leaseHeartbeatInterval] intervals.
+     * If a heartbeat fails (lease lost, expired, missing), the delegate
+     * is cancelled via [CancellationException] to abort the cycle.
      */
     suspend fun runOnce(): SovereignOpsAuditOutboxWorkerRunSummary {
         val now = clock.instant()
@@ -49,24 +65,8 @@ class LeasedSovereignOpsAuditOutboxBackgroundWorker(
 
         return when (acquisition) {
             is SovereignOpsWorkerLeaseAcquisition.Acquired,
-            is SovereignOpsWorkerLeaseAcquisition.AlreadyOwned -> {
-                val summary = delegate.runOnce()
-
-                // Best-effort heartbeat: the dispatch completed; a heartbeat
-                // failure does not invalidate the run result.
-                try {
-                    leaseStore.heartbeat(
-                        leaseName = properties.leaseName,
-                        ownerId = properties.workerId,
-                        now = clock.instant(),
-                        leaseDuration = properties.leaseDuration,
-                    )
-                } catch (_: Exception) {
-                    // Heartbeat is advisory — drop silently.
-                }
-
-                summary
-            }
+            is SovereignOpsWorkerLeaseAcquisition.AlreadyOwned ->
+                runWithHeartbeat()
 
             is SovereignOpsWorkerLeaseAcquisition.HeldByOther -> {
                 SovereignOpsAuditOutboxWorkerRunSummary(
@@ -82,4 +82,43 @@ class LeasedSovereignOpsAuditOutboxBackgroundWorker(
             }
         }
     }
+
+    /**
+     * Runs the delegate inside a [coroutineScope] with a sibling heartbeat
+     * coroutine that extends the lease until the delegate completes.
+     *
+     * If the heartbeat coroutine detects the lease is lost (not Extended),
+     * it throws [CancellationException], which propagates to cancel the
+     * delegate scope.
+     */
+    private suspend fun runWithHeartbeat(): SovereignOpsAuditOutboxWorkerRunSummary =
+        coroutineScope {
+            val heartbeatJob = launch {
+                while (isActive) {
+                    delay(properties.leaseHeartbeatInterval.toMillis())
+
+                    val heartbeat = leaseStore.heartbeat(
+                        leaseName = properties.leaseName,
+                        ownerId = properties.workerId,
+                        now = clock.instant(),
+                        leaseDuration = properties.leaseDuration,
+                    )
+
+                    if (heartbeat !is SovereignOpsWorkerLeaseHeartbeat.Extended) {
+                        throw CancellationException(
+                            "tramai-sovereign-ops-worker-lease-lost: " +
+                                "heartbeat returned ${heartbeat::class.simpleName}",
+                        )
+                    }
+                }
+            }
+
+            try {
+                delegate.runOnce()
+            } catch (e: CancellationException) {
+                throw e
+            } finally {
+                heartbeatJob.cancelAndJoin()
+            }
+        }
 }

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/LeasedSovereignOpsAuditOutboxBackgroundWorker.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/LeasedSovereignOpsAuditOutboxBackgroundWorker.kt
@@ -1,0 +1,85 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseAcquisition
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseStore
+import dev.tramai.spring.sovereign.ops.SovereignOpsOutboxWorkerProperties
+import java.time.Clock
+import java.time.Instant
+
+/**
+ * Lease-aware wrapper around [SovereignOpsAuditOutboxBackgroundWorker].
+ *
+ * Before delegating to the real worker, this wrapper attempts to acquire
+ * the configured worker lease. If the lease is held by another owner,
+ * the cycle is skipped with a [SovereignOpsAuditOutboxWorkerSkippedSummary].
+ *
+ * ## Design
+ * - **Wrapper, not rewrite.** The existing [SovereignOpsAuditOutboxBackgroundWorker]
+ *   is unchanged. This class adds the coordination layer on top.
+ * - **Heartbeat after run.** When the lease is acquired and the delegate
+ *   completes successfully, a heartbeat is issued to extend the lease.
+ * - **Cancellation is rethrown.** [kotlinx.coroutines.CancellationException]
+ *   must never be swallowed by lease logic.
+ *
+ * ## Security
+ * - No raw lease metadata is leaked in the skipped summary.
+ * - Heartbeat failures are logged at the store level, not reflected
+ *   in the worker run summary (the dispatch cycle already completed).
+ */
+class LeasedSovereignOpsAuditOutboxBackgroundWorker(
+    private val delegate: SovereignOpsAuditOutboxBackgroundWorker,
+    private val leaseStore: SovereignOpsWorkerLeaseStore,
+    private val properties: SovereignOpsOutboxWorkerProperties,
+    private val clock: Clock = Clock.systemUTC(),
+) {
+    /**
+     * Attempts to acquire the worker lease, then:
+     * - If acquired/owned: delegates to the real worker and heartbeats.
+     * - If held by another owner: returns a skipped summary.
+     */
+    suspend fun runOnce(): SovereignOpsAuditOutboxWorkerRunSummary {
+        val now = clock.instant()
+
+        val acquisition = leaseStore.tryAcquire(
+            leaseName = properties.leaseName,
+            ownerId = properties.workerId,
+            now = now,
+            leaseDuration = properties.leaseDuration,
+        )
+
+        return when (acquisition) {
+            is SovereignOpsWorkerLeaseAcquisition.Acquired,
+            is SovereignOpsWorkerLeaseAcquisition.AlreadyOwned -> {
+                val summary = delegate.runOnce()
+
+                // Best-effort heartbeat: the dispatch completed; a heartbeat
+                // failure does not invalidate the run result.
+                try {
+                    leaseStore.heartbeat(
+                        leaseName = properties.leaseName,
+                        ownerId = properties.workerId,
+                        now = clock.instant(),
+                        leaseDuration = properties.leaseDuration,
+                    )
+                } catch (_: Exception) {
+                    // Heartbeat is advisory — drop silently.
+                }
+
+                summary
+            }
+
+            is SovereignOpsWorkerLeaseAcquisition.HeldByOther -> {
+                SovereignOpsAuditOutboxWorkerRunSummary(
+                    recovered = null,
+                    dispatched = null,
+                    failure = null,
+                    skipped = SovereignOpsAuditOutboxWorkerSkippedSummary(
+                        reason = "lease-held-by-other",
+                    ),
+                    startedAt = now,
+                    completedAt = clock.instant(),
+                )
+            }
+        }
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/LeasedSovereignOpsAuditOutboxBackgroundWorker.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/LeasedSovereignOpsAuditOutboxBackgroundWorker.kt
@@ -20,17 +20,21 @@ import java.time.Instant
  * the configured worker lease. If the lease is held by another owner,
  * the cycle is skipped with a [SovereignOpsAuditOutboxWorkerSkippedSummary].
  *
- * During the delegate execution, a heartbeat coroutine periodically extends
+ * During delegate execution, a heartbeat coroutine periodically extends
  * the lease so that long-running cycles do not lose the lease mid-run.
- * If the heartbeat fails (lease lost), the cycle is aborted.
+ * If the heartbeat returns anything other than Extended, a
+ * [SovereignOpsWorkerLeaseLostException] is thrown — a non-cancellation
+ * [RuntimeException] that **reliably fails** the enclosing
+ * [coroutineScope], cancelling the delegate. A
+ * [kotlinx.coroutines.CancellationException] from a child coroutine
+ * would be treated as normal cancellation and might not propagate.
  *
  * ## Design
  * - **Wrapper, not rewrite.** The existing [SovereignOpsAuditOutboxBackgroundWorker]
  *   is unchanged. This class adds the coordination layer on top.
  * - **Heartbeat loop during run.** A coroutine heartbeats at
  *   [SovereignOpsOutboxWorkerProperties.leaseHeartbeatInterval] while the
- *   delegate runs. If the heartbeat returns anything other than Extended,
- *   the cycle is aborted with [kotlinx.coroutines.CancellationException].
+ *   delegate runs. Lease loss aborts the cycle.
  * - **Cancellation is rethrown.** [CancellationException] must never be
  *   swallowed by lease logic.
  *
@@ -50,8 +54,8 @@ class LeasedSovereignOpsAuditOutboxBackgroundWorker(
      *
      * The heartbeat loop extends the lease at
      * [SovereignOpsOutboxWorkerProperties.leaseHeartbeatInterval] intervals.
-     * If a heartbeat fails (lease lost, expired, missing), the delegate
-     * is cancelled via [CancellationException] to abort the cycle.
+     * A non-Extended heartbeat throws [SovereignOpsWorkerLeaseLostException],
+     * which fails the [coroutineScope] and cancels the delegate.
      */
     suspend fun runOnce(): SovereignOpsAuditOutboxWorkerRunSummary {
         val now = clock.instant()
@@ -87,9 +91,9 @@ class LeasedSovereignOpsAuditOutboxBackgroundWorker(
      * Runs the delegate inside a [coroutineScope] with a sibling heartbeat
      * coroutine that extends the lease until the delegate completes.
      *
-     * If the heartbeat coroutine detects the lease is lost (not Extended),
-     * it throws [CancellationException], which propagates to cancel the
-     * delegate scope.
+     * A non-Extended heartbeat throws [SovereignOpsWorkerLeaseLostException]
+     * — a non-cancellation [RuntimeException] that reliably fails the
+     * enclosing [coroutineScope], cancelling the delegate.
      */
     private suspend fun runWithHeartbeat(): SovereignOpsAuditOutboxWorkerRunSummary =
         coroutineScope {
@@ -105,7 +109,7 @@ class LeasedSovereignOpsAuditOutboxBackgroundWorker(
                     )
 
                     if (heartbeat !is SovereignOpsWorkerLeaseHeartbeat.Extended) {
-                        throw CancellationException(
+                        throw SovereignOpsWorkerLeaseLostException(
                             "tramai-sovereign-ops-worker-lease-lost: " +
                                 "heartbeat returned ${heartbeat::class.simpleName}",
                         )

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/LeasedSovereignOpsAuditOutboxWorkerLifecycle.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/LeasedSovereignOpsAuditOutboxWorkerLifecycle.kt
@@ -1,0 +1,117 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+import dev.tramai.spring.sovereign.ops.SovereignOpsOutboxWorkerProperties
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.apache.commons.logging.LogFactory
+import org.springframework.context.SmartLifecycle
+
+/**
+ * [SmartLifecycle] wrapper that drives [LeasedSovereignOpsAuditOutboxBackgroundWorker]
+ * on a periodic schedule.
+ *
+ * Identical in structure to [SovereignOpsAuditOutboxWorkerLifecycle] but
+ * parameterized for the lease-coordinated worker type.
+ */
+class LeasedSovereignOpsAuditOutboxWorkerLifecycle(
+    private val worker: LeasedSovereignOpsAuditOutboxBackgroundWorker,
+    private val properties: SovereignOpsOutboxWorkerProperties,
+    private val observer: SovereignOpsAuditOutboxWorkerObserver = SovereignOpsAuditOutboxWorkerObserver.Noop,
+    private val statusStore: SovereignOpsAuditOutboxWorkerStatusStore? = null,
+) : SmartLifecycle {
+
+    private val logger = LogFactory.getLog(LeasedSovereignOpsAuditOutboxWorkerLifecycle::class.java)
+    private val scope = CoroutineScope(Dispatchers.Default)
+    private var job: Job? = null
+
+    @Volatile
+    private var running = false
+
+    override fun start() {
+        if (!properties.enabled) {
+            logger.debug("Leased sovereign ops audit outbox worker is disabled - not starting")
+            return
+        }
+        if (running) return
+
+        validateSovereignOpsAuditOutboxWorkerProperties(properties)
+
+        running = true
+        statusStore?.markLifecycleStarted()
+        job = scope.launch {
+            delay(properties.initialDelay.toMillis())
+
+            while (running) {
+                try {
+                    val summary = worker.runOnce()
+                    notifyCycleCompleted(summary)
+                    summary.failure?.let {
+                        notifyCycleFailed(it.action, it.errorCode)
+                        logger.warn(
+                            "Leased sovereign ops audit outbox worker cycle failed: action=${it.action}, errorCode=${it.errorCode}",
+                        )
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    val errorCode = e::class.simpleName ?: "Exception"
+                    notifyCycleFailed("unexpected", errorCode)
+                    logger.warn(
+                        "Leased sovereign ops audit outbox worker cycle failed unexpectedly: " +
+                            "errorCode=$errorCode",
+                    )
+                }
+
+                if (running) {
+                    delay(properties.interval.toMillis())
+                }
+            }
+        }
+    }
+
+    override fun stop() {
+        running = false
+        statusStore?.markLifecycleStopped()
+        job?.cancel()
+        job = null
+    }
+
+    override fun isRunning(): Boolean = running
+
+    override fun getPhase(): Int = 0
+
+    // ── Safe observer notification ─────────────────────────────────────
+
+    private fun notifyCycleCompleted(summary: SovereignOpsAuditOutboxWorkerRunSummary) {
+        try {
+            observer.onCycleCompleted(summary)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(
+                "Leased sovereign ops audit outbox worker observer callback failed: " +
+                    "callback=onCycleCompleted, errorCode=${e::class.simpleName ?: "Exception"}",
+            )
+        }
+    }
+
+    private fun notifyCycleFailed(
+        action: String,
+        errorCode: String,
+    ) {
+        try {
+            observer.onCycleFailed(action, errorCode)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(
+                "Leased sovereign ops audit outbox worker observer callback failed: " +
+                    "callback=onCycleFailed, errorCode=${e::class.simpleName ?: "Exception"}",
+            )
+        }
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxBackgroundWorker.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxBackgroundWorker.kt
@@ -75,6 +75,7 @@ data class SovereignOpsAuditOutboxWorkerRunSummary(
     val recovered: SovereignOpsAuditOutboxRecoverySummary?,
     val dispatched: SovereignOpsAuditOutboxDispatchResult?,
     val failure: SovereignOpsAuditOutboxWorkerFailureSummary? = null,
+    val skipped: SovereignOpsAuditOutboxWorkerSkippedSummary? = null,
     val startedAt: Instant,
     val completedAt: Instant,
 )
@@ -82,4 +83,8 @@ data class SovereignOpsAuditOutboxWorkerRunSummary(
 data class SovereignOpsAuditOutboxWorkerFailureSummary(
     val action: String,
     val errorCode: String,
+)
+
+data class SovereignOpsAuditOutboxWorkerSkippedSummary(
+    val reason: String,
 )

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerLifecycle.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxWorkerLifecycle.kt
@@ -137,4 +137,19 @@ fun validateSovereignOpsAuditOutboxWorkerProperties(
     require(properties.recoverPrepared || properties.dispatchPending) {
         "tramai-sovereign-ops-outbox-worker-invalid-actions: at least one of recoverPrepared or dispatchPending must be true when worker is enabled"
     }
+
+    // ── Lease validation (only when leasing is enabled) ─────────────
+
+    if (properties.leaseEnabled) {
+        require(!properties.leaseDuration.isZero && !properties.leaseDuration.isNegative) {
+            "tramai-sovereign-ops-worker-lease-duration-invalid"
+        }
+        require(!properties.leaseHeartbeatInterval.isZero && !properties.leaseHeartbeatInterval.isNegative) {
+            "tramai-sovereign-ops-worker-lease-heartbeat-interval-invalid"
+        }
+        require(properties.leaseHeartbeatInterval < properties.leaseDuration) {
+            "tramai-sovereign-ops-worker-lease-heartbeat-interval-must-be-less-than-duration: " +
+                "heartbeat interval (${properties.leaseHeartbeatInterval}) must be less than lease duration (${properties.leaseDuration})"
+        }
+    }
 }

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsWorkerLeaseLostException.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsWorkerLeaseLostException.kt
@@ -1,0 +1,14 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+/**
+ * Thrown when the heartbeat coroutine detects the worker lease has been
+ * lost (expired, stolen, or missing) during delegate execution.
+ *
+ * A non-cancellation [RuntimeException] so that it reliably cancels the
+ * parent [kotlinx.coroutines.coroutineScope] — unlike
+ * [kotlinx.coroutines.CancellationException], which behaves as normal
+ * cancellation in child coroutines and does not always fail the parent.
+ */
+class SovereignOpsWorkerLeaseLostException(
+    message: String,
+) : RuntimeException(message)

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsOutboxWorkerAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsOutboxWorkerAutoConfigurationTest.kt
@@ -13,6 +13,8 @@ import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerRunSu
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerStatusStore
 import dev.tramai.spring.sovereign.ops.outbox.RecordingSovereignOpsAuditOutboxWorkerObserver
 import dev.tramai.spring.sovereign.ops.outbox.TestAuditEngineConfig
+import dev.tramai.spring.sovereign.ops.outbox.LeasedSovereignOpsAuditOutboxBackgroundWorker
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseStore
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -316,6 +318,81 @@ class SovereignOpsOutboxWorkerAutoConfigurationTest {
                     .containsKey("customObserver")
             }
     }
+    // ── Worker lease support ──────────────────────────────────────────
+
+    @Test
+    fun `lease disabled — normal worker`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                TestAuditEngineConfig::class.java,
+            )
+            .withPropertyValues(
+                "tramai.sovereign.ops.outbox.worker.enabled=true",
+                "tramai.sovereign.ops.outbox.worker.initial-delay=1h",
+                "tramai.sovereign.ops.outbox.worker.lease-enabled=false",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxBackgroundWorker::class.java)
+                assertThat(ctx).doesNotHaveBean(LeasedSovereignOpsAuditOutboxBackgroundWorker::class.java)
+            }
+    }
+
+    @Test
+    fun `lease enabled + store exists — leased worker`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                TestAuditEngineConfig::class.java,
+                MockLeaseStoreConfig::class.java,
+            )
+            .withPropertyValues(
+                "tramai.sovereign.ops.outbox.worker.enabled=true",
+                "tramai.sovereign.ops.outbox.worker.initial-delay=1h",
+                "tramai.sovereign.ops.outbox.worker.lease-enabled=true",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(LeasedSovereignOpsAuditOutboxBackgroundWorker::class.java)
+            }
+    }
+
+    @Test
+    fun `lease enabled + no store — fail loudly`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                TestAuditEngineConfig::class.java,
+            )
+            .withPropertyValues(
+                "tramai.sovereign.ops.outbox.worker.enabled=true",
+                "tramai.sovereign.ops.outbox.worker.initial-delay=1h",
+                "tramai.sovereign.ops.outbox.worker.lease-enabled=true",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasFailed()
+                val failure = requireNotNull(ctx.startupFailure)
+                assertThat(failure)
+                    .hasMessageContaining("tramai-sovereign-ops-worker-lease-store-missing")
+            }
+    }
+
+    @Test
+    fun `lease properties bind`() {
+        contextRunner
+            .withUserConfiguration(MinimalStoreConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.outbox.worker.lease-enabled=false",
+                "tramai.sovereign.ops.outbox.worker.lease-name=custom-lease",
+                "tramai.sovereign.ops.outbox.worker.worker-id=worker-42",
+                "tramai.sovereign.ops.outbox.worker.lease-duration=90s",
+            )
+            .run { ctx ->
+                val props = ctx.getBean(SovereignOpsProperties::class.java)
+                assertThat(props.outbox.worker.leaseName).isEqualTo("custom-lease")
+                assertThat(props.outbox.worker.workerId).isEqualTo("worker-42")
+                assertThat(props.outbox.worker.leaseDuration).isEqualTo(Duration.ofSeconds(90))
+            }
+    }
 }
 
 open class CustomOutboxBackgroundWorkerConfig {
@@ -410,4 +487,35 @@ private class CounterContributionObserver(
     }
 
     override fun onCycleFailed(action: String, errorCode: String) = Unit
+}
+
+// ── Worker lease store mock ────────────────────────────────────────
+
+open class MockLeaseStoreConfig {
+    @Bean
+    open fun mockLeaseStore(): SovereignOpsWorkerLeaseStore =
+        object : SovereignOpsWorkerLeaseStore {
+            override suspend fun tryAcquire(
+                leaseName: String,
+                ownerId: String,
+                now: Instant,
+                leaseDuration: Duration,
+            ) = throw UnsupportedOperationException("mock stub")
+
+            override suspend fun heartbeat(
+                leaseName: String,
+                ownerId: String,
+                now: Instant,
+                leaseDuration: Duration,
+            ) = throw UnsupportedOperationException("mock stub")
+
+            override suspend fun release(
+                leaseName: String,
+                ownerId: String,
+                now: Instant,
+            ) = throw UnsupportedOperationException("mock stub")
+
+            override suspend fun get(leaseName: String) =
+                throw UnsupportedOperationException("mock stub")
+        }
 }

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsOutboxWorkerAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsOutboxWorkerAutoConfigurationTest.kt
@@ -393,6 +393,69 @@ class SovereignOpsOutboxWorkerAutoConfigurationTest {
                 assertThat(props.outbox.worker.leaseDuration).isEqualTo(Duration.ofSeconds(90))
             }
     }
+
+    @Test
+    fun `lease enabled with heartbeat interval greater-or-equal duration fails`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                TestAuditEngineConfig::class.java,
+                MockLeaseStoreConfig::class.java,
+            )
+            .withPropertyValues(
+                "tramai.sovereign.ops.outbox.worker.enabled=true",
+                "tramai.sovereign.ops.outbox.worker.initial-delay=1h",
+                "tramai.sovereign.ops.outbox.worker.lease-enabled=true",
+                "tramai.sovereign.ops.outbox.worker.lease-duration=30s",
+                "tramai.sovereign.ops.outbox.worker.lease-heartbeat-interval=30s",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasFailed()
+                assertThat(ctx.startupFailure)
+                    .hasMessageContaining("tramai-sovereign-ops-worker-lease-heartbeat-interval-must-be-less-than-duration")
+            }
+    }
+
+    @Test
+    fun `lease disabled ignores lease interval validation`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                TestAuditEngineConfig::class.java,
+            )
+            .withPropertyValues(
+                "tramai.sovereign.ops.outbox.worker.enabled=true",
+                "tramai.sovereign.ops.outbox.worker.initial-delay=1h",
+                "tramai.sovereign.ops.outbox.worker.lease-enabled=false",
+                "tramai.sovereign.ops.outbox.worker.lease-duration=30s",
+                "tramai.sovereign.ops.outbox.worker.lease-heartbeat-interval=2m",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasNotFailed()
+                assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxBackgroundWorker::class.java)
+            }
+    }
+
+    @Test
+    fun `lease enabled with zero duration fails`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalStoreConfig::class.java,
+                TestAuditEngineConfig::class.java,
+                MockLeaseStoreConfig::class.java,
+            )
+            .withPropertyValues(
+                "tramai.sovereign.ops.outbox.worker.enabled=true",
+                "tramai.sovereign.ops.outbox.worker.initial-delay=1h",
+                "tramai.sovereign.ops.outbox.worker.lease-enabled=true",
+                "tramai.sovereign.ops.outbox.worker.lease-duration=0s",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasFailed()
+                assertThat(ctx.startupFailure)
+                    .hasMessageContaining("tramai-sovereign-ops-worker-lease-duration-invalid")
+            }
+    }
 }
 
 open class CustomOutboxBackgroundWorkerConfig {

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/LeasedSovereignOpsAuditOutboxBackgroundWorkerTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/LeasedSovereignOpsAuditOutboxBackgroundWorkerTest.kt
@@ -6,6 +6,7 @@ import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseAcquisition
 import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseHeartbeat
 import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseRelease
 import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseStore
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -130,6 +131,40 @@ class LeasedSovereignOpsAuditOutboxBackgroundWorkerTest {
 
         worker().runOnce()
         assertThat(leaseStore.heartbeatCalled).isTrue
+    }
+
+    @Test
+    fun `lost lease during run cancels delegate`() = runBlocking {
+        leaseStore.acquireResult = SovereignOpsWorkerLeaseAcquisition.Acquired(
+            SovereignOpsWorkerLease(
+                leaseName = "test-lease",
+                ownerId = "worker-a",
+                acquiredAt = BASE_NOW,
+                expiresAt = BASE_NOW.plus(LEASE_DURATION),
+                heartbeatAt = BASE_NOW,
+                version = 1,
+            ),
+        )
+        leaseStore.heartbeatResult = SovereignOpsWorkerLeaseHeartbeat.Expired
+
+        var cancelledDuringRun = false
+        operations.beforeRun = {
+            try {
+                delay(200)  // long enough for heartbeat coroutine to fire
+            } finally {
+                cancelledDuringRun = true
+            }
+        }
+
+        val thrown = try {
+            worker().runOnce()
+            throw AssertionError("expected SovereignOpsWorkerLeaseLostException")
+        } catch (e: SovereignOpsWorkerLeaseLostException) {
+            e
+        }
+
+        assertThat(thrown.message).contains("tramai-sovereign-ops-worker-lease-lost")
+        assertThat(cancelledDuringRun).isTrue()
     }
 
     // ── Fakes ──────────────────────────────────────────────────────────

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/LeasedSovereignOpsAuditOutboxBackgroundWorkerTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/LeasedSovereignOpsAuditOutboxBackgroundWorkerTest.kt
@@ -1,0 +1,226 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+import dev.tramai.spring.sovereign.ops.SovereignOpsOutboxWorkerProperties
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLease
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseAcquisition
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseHeartbeat
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseRelease
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseStore
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+
+class LeasedSovereignOpsAuditOutboxBackgroundWorkerTest {
+
+    private val fixedClock = Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneId.of("UTC"))
+    private val BASE_NOW = fixedClock.instant()
+    private val LEASE_DURATION = Duration.ofMinutes(2)
+
+    private lateinit var leaseStore: FakeLeaseStore
+    private lateinit var operations: TrackingOperations
+    private lateinit var properties: SovereignOpsOutboxWorkerProperties
+
+    @BeforeEach
+    fun setUp() {
+        leaseStore = FakeLeaseStore()
+        operations = TrackingOperations()
+        properties = SovereignOpsOutboxWorkerProperties().copy(
+            enabled = true,
+            leaseEnabled = true,
+            leaseName = "test-lease",
+            workerId = "worker-a",
+            leaseDuration = LEASE_DURATION,
+        )
+    }
+
+    private fun worker(): LeasedSovereignOpsAuditOutboxBackgroundWorker {
+        val delegate = SovereignOpsAuditOutboxBackgroundWorker(
+            operations = operations,
+            properties = properties,
+            clock = fixedClock,
+        )
+        return LeasedSovereignOpsAuditOutboxBackgroundWorker(
+            delegate = delegate,
+            leaseStore = leaseStore,
+            properties = properties,
+            clock = fixedClock,
+        )
+    }
+
+    @Test
+    fun `acquired lease runs delegate`() = runBlocking {
+        leaseStore.acquireResult = SovereignOpsWorkerLeaseAcquisition.Acquired(
+            SovereignOpsWorkerLease(
+                leaseName = "test-lease",
+                ownerId = "worker-a",
+                acquiredAt = BASE_NOW,
+                expiresAt = BASE_NOW.plus(LEASE_DURATION),
+                heartbeatAt = BASE_NOW,
+                version = 1,
+            ),
+        )
+
+        val summary = worker().runOnce()
+        assertThat(operations.recoverCalled).isTrue
+        assertThat(summary.skipped).isNull()
+    }
+
+    @Test
+    fun `already owned lease runs delegate`() = runBlocking {
+        leaseStore.acquireResult = SovereignOpsWorkerLeaseAcquisition.AlreadyOwned(
+            SovereignOpsWorkerLease(
+                leaseName = "test-lease",
+                ownerId = "worker-a",
+                acquiredAt = BASE_NOW,
+                expiresAt = BASE_NOW.plus(LEASE_DURATION),
+                heartbeatAt = BASE_NOW,
+                version = 2,
+            ),
+        )
+
+        val summary = worker().runOnce()
+        assertThat(operations.recoverCalled).isTrue
+        assertThat(summary.skipped).isNull()
+    }
+
+    @Test
+    fun `held by other does not invoke delegate`() = runBlocking {
+        leaseStore.acquireResult = SovereignOpsWorkerLeaseAcquisition.HeldByOther(
+            SovereignOpsWorkerLease(
+                leaseName = "test-lease",
+                ownerId = "worker-b",
+                acquiredAt = BASE_NOW,
+                expiresAt = BASE_NOW.plus(LEASE_DURATION),
+                heartbeatAt = BASE_NOW,
+                version = 1,
+            ),
+        )
+
+        val summary = worker().runOnce()
+        assertThat(operations.recoverCalled).isFalse
+        assertThat(summary.skipped).isNotNull
+        assertThat(summary.skipped!!.reason).isEqualTo("lease-held-by-other")
+        assertThat(summary.recovered).isNull()
+        assertThat(summary.dispatched).isNull()
+    }
+
+    @Test
+    fun `heartbeat called after successful run`() = runBlocking {
+        leaseStore.acquireResult = SovereignOpsWorkerLeaseAcquisition.Acquired(
+            SovereignOpsWorkerLease(
+                leaseName = "test-lease",
+                ownerId = "worker-a",
+                acquiredAt = BASE_NOW,
+                expiresAt = BASE_NOW.plus(LEASE_DURATION),
+                heartbeatAt = BASE_NOW,
+                version = 1,
+            ),
+        )
+
+        worker().runOnce()
+        assertThat(leaseStore.heartbeatCalled).isTrue
+    }
+
+    @Test
+    fun `heartbeat failure does not crash wrapper`() = runBlocking {
+        leaseStore.acquireResult = SovereignOpsWorkerLeaseAcquisition.Acquired(
+            SovereignOpsWorkerLease(
+                leaseName = "test-lease",
+                ownerId = "worker-a",
+                acquiredAt = BASE_NOW,
+                expiresAt = BASE_NOW.plus(LEASE_DURATION),
+                heartbeatAt = BASE_NOW,
+                version = 1,
+            ),
+        )
+        leaseStore.heartbeatCrashWith = RuntimeException("store down")
+
+        val summary = worker().runOnce()
+        assertThat(operations.recoverCalled).isTrue
+    }
+
+    // ── Fakes ──────────────────────────────────────────────────────────
+
+    class TrackingOperations : SovereignOpsAuditOutboxOperations {
+        var recoverCalled = false
+        var dispatchCalled = false
+        var throwFromRecover: RuntimeException? = null
+
+        override suspend fun recoverPrepared(limit: Int?): SovereignOpsAuditOutboxRecoverySummary {
+            recoverCalled = true
+            throwFromRecover?.let { throw it }
+            return SovereignOpsAuditOutboxRecoverySummary(
+                inspected = 0,
+            )
+        }
+
+        override suspend fun retryPending(limit: Int?): SovereignOpsAuditOutboxDispatchResult {
+            dispatchCalled = true
+            return SovereignOpsAuditOutboxDispatchResult(
+                claimed = 0,
+                emitted = 0,
+                failedRetryable = 0,
+                failedPermanent = 0,
+            )
+        }
+
+        override suspend fun listOutboxRecords(
+            status: SovereignOpsAuditOutboxStatus?,
+            limit: Int?,
+        ): List<SovereignOpsAuditOutboxSummary> = emptyList()
+
+        override suspend fun markPreparedFailed(
+            outboxId: String,
+            reason: String,
+        ): SovereignOpsAuditOutboxSummary = throw UnsupportedOperationException()
+    }
+
+    class FakeLeaseStore : SovereignOpsWorkerLeaseStore {
+        var acquireResult: SovereignOpsWorkerLeaseAcquisition? = null
+        var heartbeatCalled = false
+        var heartbeatCrashWith: RuntimeException? = null
+
+        override suspend fun tryAcquire(
+            leaseName: String,
+            ownerId: String,
+            now: Instant,
+            leaseDuration: Duration,
+        ): SovereignOpsWorkerLeaseAcquisition =
+            acquireResult ?: throw IllegalStateException("acquireResult not set")
+
+        override suspend fun heartbeat(
+            leaseName: String,
+            ownerId: String,
+            now: Instant,
+            leaseDuration: Duration,
+        ): SovereignOpsWorkerLeaseHeartbeat {
+            heartbeatCalled = true
+            heartbeatCrashWith?.let { throw it }
+            return SovereignOpsWorkerLeaseHeartbeat.Extended(
+                SovereignOpsWorkerLease(
+                    leaseName = leaseName,
+                    ownerId = ownerId,
+                    acquiredAt = now,
+                    expiresAt = now.plus(leaseDuration),
+                    heartbeatAt = now,
+                    version = 1,
+                ),
+            )
+        }
+
+        override suspend fun release(
+            leaseName: String,
+            ownerId: String,
+            now: Instant,
+        ): SovereignOpsWorkerLeaseRelease = SovereignOpsWorkerLeaseRelease.Released
+
+        override suspend fun get(leaseName: String): SovereignOpsWorkerLease? = null
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/LeasedSovereignOpsAuditOutboxBackgroundWorkerTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/LeasedSovereignOpsAuditOutboxBackgroundWorkerTest.kt
@@ -6,10 +6,8 @@ import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseAcquisition
 import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseHeartbeat
 import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseRelease
 import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseStore
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Clock
@@ -22,6 +20,8 @@ class LeasedSovereignOpsAuditOutboxBackgroundWorkerTest {
     private val fixedClock = Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneId.of("UTC"))
     private val BASE_NOW = fixedClock.instant()
     private val LEASE_DURATION = Duration.ofMinutes(2)
+    /** Very short heartbeat interval so tests don't hang. */
+    private val HEARTBEAT_INTERVAL = Duration.ofMillis(10)
 
     private lateinit var leaseStore: FakeLeaseStore
     private lateinit var operations: TrackingOperations
@@ -37,6 +37,7 @@ class LeasedSovereignOpsAuditOutboxBackgroundWorkerTest {
             leaseName = "test-lease",
             workerId = "worker-a",
             leaseDuration = LEASE_DURATION,
+            leaseHeartbeatInterval = HEARTBEAT_INTERVAL,
         )
     }
 
@@ -112,7 +113,7 @@ class LeasedSovereignOpsAuditOutboxBackgroundWorkerTest {
     }
 
     @Test
-    fun `heartbeat called after successful run`() = runBlocking {
+    fun `heartbeat is called during run`() = runBlocking {
         leaseStore.acquireResult = SovereignOpsWorkerLeaseAcquisition.Acquired(
             SovereignOpsWorkerLease(
                 leaseName = "test-lease",
@@ -123,27 +124,12 @@ class LeasedSovereignOpsAuditOutboxBackgroundWorkerTest {
                 version = 1,
             ),
         )
+
+        // Make the delegate take long enough for the heartbeat coroutine to fire.
+        operations.beforeRun = { kotlinx.coroutines.delay(50) }
 
         worker().runOnce()
         assertThat(leaseStore.heartbeatCalled).isTrue
-    }
-
-    @Test
-    fun `heartbeat failure does not crash wrapper`() = runBlocking {
-        leaseStore.acquireResult = SovereignOpsWorkerLeaseAcquisition.Acquired(
-            SovereignOpsWorkerLease(
-                leaseName = "test-lease",
-                ownerId = "worker-a",
-                acquiredAt = BASE_NOW,
-                expiresAt = BASE_NOW.plus(LEASE_DURATION),
-                heartbeatAt = BASE_NOW,
-                version = 1,
-            ),
-        )
-        leaseStore.heartbeatCrashWith = RuntimeException("store down")
-
-        val summary = worker().runOnce()
-        assertThat(operations.recoverCalled).isTrue
     }
 
     // ── Fakes ──────────────────────────────────────────────────────────
@@ -151,11 +137,11 @@ class LeasedSovereignOpsAuditOutboxBackgroundWorkerTest {
     class TrackingOperations : SovereignOpsAuditOutboxOperations {
         var recoverCalled = false
         var dispatchCalled = false
-        var throwFromRecover: RuntimeException? = null
+        var beforeRun: (suspend () -> Unit)? = null
 
         override suspend fun recoverPrepared(limit: Int?): SovereignOpsAuditOutboxRecoverySummary {
+            beforeRun?.invoke()
             recoverCalled = true
-            throwFromRecover?.let { throw it }
             return SovereignOpsAuditOutboxRecoverySummary(
                 inspected = 0,
             )
@@ -185,7 +171,8 @@ class LeasedSovereignOpsAuditOutboxBackgroundWorkerTest {
     class FakeLeaseStore : SovereignOpsWorkerLeaseStore {
         var acquireResult: SovereignOpsWorkerLeaseAcquisition? = null
         var heartbeatCalled = false
-        var heartbeatCrashWith: RuntimeException? = null
+        /** If set, heartbeat returns this instead of Extended. */
+        var heartbeatResult: SovereignOpsWorkerLeaseHeartbeat? = null
 
         override suspend fun tryAcquire(
             leaseName: String,
@@ -202,7 +189,7 @@ class LeasedSovereignOpsAuditOutboxBackgroundWorkerTest {
             leaseDuration: Duration,
         ): SovereignOpsWorkerLeaseHeartbeat {
             heartbeatCalled = true
-            heartbeatCrashWith?.let { throw it }
+            heartbeatResult?.let { return it }
             return SovereignOpsWorkerLeaseHeartbeat.Extended(
                 SovereignOpsWorkerLease(
                     leaseName = leaseName,

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsWorkerLeaseStore.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsWorkerLeaseStore.kt
@@ -23,16 +23,21 @@ import javax.sql.DataSource
  *    - Same owner + not expired → heartbeat/extend → AlreadyOwned
  *    - No owner or expired → take ownership → Acquired
  *    - Different owner + not expired → HeldByOther
- * 4. `UPDATE ... SET ...` — applies the decision.
+ * 4. `UPDATE ... SET ...` — applies the decision, asserts exactly 1 row updated.
+ * 5. Re-reads the updated row so returned lease version matches the committed DB state.
  *
  * ## Concurrency
  * The `FOR UPDATE` row lock ensures exactly one concurrent caller wins
  * for a given `lease_name`. The loser receives `HeldByOther`.
  *
+ * ## Heartbeat
+ * Rejected if the lease is expired or held by a different owner.
+ *
  * ## Security
  * - [ownerId] is stored as plaintext — this is a machine coordination lease,
  *   not a user credential. Use hostnames or instance IDs.
  * - No encryption is applied to lease rows (they contain no user data).
+ * - All mutation helpers assert exactly 1 row updated (fail-closed).
  *
  * @param dataSource A JDBC [DataSource] (usually HikariCP in Spring Boot).
  *   The caller is responsible for providing a pooled, production-grade source.
@@ -57,7 +62,13 @@ class JdbcSovereignOpsWorkerLeaseStore(
                 if (result is SovereignOpsWorkerLeaseAcquisition.Acquired ||
                     result is SovereignOpsWorkerLeaseAcquisition.AlreadyOwned
                 ) {
-                    updateOwnership(conn, leaseName, ownerId, now, expiresAt)
+                    val updated = updateOwnership(conn, leaseName, ownerId, now, expiresAt)
+                    return@inTransaction when (result) {
+                        is SovereignOpsWorkerLeaseAcquisition.Acquired ->
+                            SovereignOpsWorkerLeaseAcquisition.Acquired(updated)
+                        is SovereignOpsWorkerLeaseAcquisition.AlreadyOwned ->
+                            SovereignOpsWorkerLeaseAcquisition.AlreadyOwned(updated)
+                    }
                 }
                 result
             }
@@ -75,14 +86,14 @@ class JdbcSovereignOpsWorkerLeaseStore(
             inTransaction(conn) {
                 val lease = selectForUpdate(conn, leaseName)
                     ?: return@inTransaction SovereignOpsWorkerLeaseHeartbeat.Missing
-                if (lease.ownerId != ownerId) return@inTransaction SovereignOpsWorkerLeaseHeartbeat.NotOwner
-                updateOwnership(conn, leaseName, ownerId, now, expiresAt)
-                SovereignOpsWorkerLeaseHeartbeat.Extended(
-                    lease.copy(
-                        expiresAt = expiresAt,
-                        heartbeatAt = now,
-                    ),
-                )
+                if (lease.ownerId != ownerId) {
+                    return@inTransaction SovereignOpsWorkerLeaseHeartbeat.NotOwner
+                }
+                if (lease.isExpired(now)) {
+                    return@inTransaction SovereignOpsWorkerLeaseHeartbeat.Expired
+                }
+                val updated = updateOwnership(conn, leaseName, ownerId, now, expiresAt)
+                SovereignOpsWorkerLeaseHeartbeat.Extended(updated)
             }
         }
     }
@@ -190,13 +201,17 @@ class JdbcSovereignOpsWorkerLeaseStore(
         }
     }
 
+    /**
+     * Applies the ownership update and returns the re-read row so the
+     * returned lease version matches the committed DB state.
+     */
     private fun updateOwnership(
         conn: Connection,
         leaseName: String,
         ownerId: String,
         now: Instant,
         expiresAt: Instant,
-    ) {
+    ): SovereignOpsWorkerLease {
         conn.prepareStatement(
             "UPDATE worker_leases SET owner_id = ?, acquired_at = ?, heartbeat_at = ?, expires_at = ?, version = version + 1 " +
                 "WHERE lease_name = ?",
@@ -206,8 +221,13 @@ class JdbcSovereignOpsWorkerLeaseStore(
             stmt.setTimestamp(3, Timestamp.from(now))
             stmt.setTimestamp(4, Timestamp.from(expiresAt))
             stmt.setString(5, leaseName)
-            stmt.executeUpdate()
+            val updated = stmt.executeUpdate()
+            require(updated == 1) {
+                "tramai-sovereign-worker-lease-update-failed: expected 1 row, got $updated"
+            }
         }
+        return selectForUpdate(conn, leaseName)
+            ?: throw IllegalStateException("worker_leases row disappeared after update: $leaseName")
     }
 
     private fun clearOwnership(conn: Connection, leaseName: String) {
@@ -216,7 +236,10 @@ class JdbcSovereignOpsWorkerLeaseStore(
                 "WHERE lease_name = ?",
         ).use { stmt ->
             stmt.setString(1, leaseName)
-            stmt.executeUpdate()
+            val updated = stmt.executeUpdate()
+            require(updated == 1) {
+                "tramai-sovereign-worker-lease-release-failed: expected 1 row, got $updated"
+            }
         }
     }
 

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsWorkerLeaseStore.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsWorkerLeaseStore.kt
@@ -1,0 +1,232 @@
+package dev.tramai.spring.sovereign.persistence.jdbc
+
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLease
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseAcquisition
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseHeartbeat
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseRelease
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseStore
+import java.sql.Connection
+import java.sql.ResultSet
+import java.sql.Timestamp
+import java.time.Duration
+import java.time.Instant
+import javax.sql.DataSource
+
+/**
+ * JDBC implementation of [SovereignOpsWorkerLeaseStore] backed by the
+ * `worker_leases` table in PostgreSQL.
+ *
+ * ## Acquisition algorithm
+ * 1. `INSERT ... ON CONFLICT DO NOTHING` — idempotently creates the row.
+ * 2. `SELECT ... FOR UPDATE` — locks the row for the current transaction.
+ * 3. Decision logic:
+ *    - Same owner + not expired → heartbeat/extend → AlreadyOwned
+ *    - No owner or expired → take ownership → Acquired
+ *    - Different owner + not expired → HeldByOther
+ * 4. `UPDATE ... SET ...` — applies the decision.
+ *
+ * ## Concurrency
+ * The `FOR UPDATE` row lock ensures exactly one concurrent caller wins
+ * for a given `lease_name`. The loser receives `HeldByOther`.
+ *
+ * ## Security
+ * - [ownerId] is stored as plaintext — this is a machine coordination lease,
+ *   not a user credential. Use hostnames or instance IDs.
+ * - No encryption is applied to lease rows (they contain no user data).
+ *
+ * @param dataSource A JDBC [DataSource] (usually HikariCP in Spring Boot).
+ *   The caller is responsible for providing a pooled, production-grade source.
+ */
+class JdbcSovereignOpsWorkerLeaseStore(
+    private val dataSource: DataSource,
+) : SovereignOpsWorkerLeaseStore {
+
+    override suspend fun tryAcquire(
+        leaseName: String,
+        ownerId: String,
+        now: Instant,
+        leaseDuration: Duration,
+    ): SovereignOpsWorkerLeaseAcquisition {
+        val expiresAt = now.plus(leaseDuration)
+        return dataSource.connection.use { conn ->
+            inTransaction(conn) {
+                ensureRow(conn, leaseName)
+                val lease = selectForUpdate(conn, leaseName)
+                    ?: throw IllegalStateException("worker_leases row missing after ensureRow: $leaseName")
+                val result = decide(lease, ownerId, now, expiresAt)
+                if (result is SovereignOpsWorkerLeaseAcquisition.Acquired ||
+                    result is SovereignOpsWorkerLeaseAcquisition.AlreadyOwned
+                ) {
+                    updateOwnership(conn, leaseName, ownerId, now, expiresAt)
+                }
+                result
+            }
+        }
+    }
+
+    override suspend fun heartbeat(
+        leaseName: String,
+        ownerId: String,
+        now: Instant,
+        leaseDuration: Duration,
+    ): SovereignOpsWorkerLeaseHeartbeat {
+        val expiresAt = now.plus(leaseDuration)
+        return dataSource.connection.use { conn ->
+            inTransaction(conn) {
+                val lease = selectForUpdate(conn, leaseName)
+                    ?: return@inTransaction SovereignOpsWorkerLeaseHeartbeat.Missing
+                if (lease.ownerId != ownerId) return@inTransaction SovereignOpsWorkerLeaseHeartbeat.NotOwner
+                updateOwnership(conn, leaseName, ownerId, now, expiresAt)
+                SovereignOpsWorkerLeaseHeartbeat.Extended(
+                    lease.copy(
+                        expiresAt = expiresAt,
+                        heartbeatAt = now,
+                    ),
+                )
+            }
+        }
+    }
+
+    override suspend fun release(
+        leaseName: String,
+        ownerId: String,
+        now: Instant,
+    ): SovereignOpsWorkerLeaseRelease {
+        return dataSource.connection.use { conn ->
+            inTransaction(conn) {
+                val lease = selectForUpdate(conn, leaseName)
+                    ?: return@inTransaction SovereignOpsWorkerLeaseRelease.Missing
+                if (lease.ownerId != ownerId) return@inTransaction SovereignOpsWorkerLeaseRelease.NotOwner
+                clearOwnership(conn, leaseName)
+                SovereignOpsWorkerLeaseRelease.Released
+            }
+        }
+    }
+
+    override suspend fun get(leaseName: String): SovereignOpsWorkerLease? {
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(
+                "SELECT lease_name, owner_id, acquired_at, expires_at, heartbeat_at, version " +
+                    "FROM worker_leases WHERE lease_name = ?",
+            ).use { stmt ->
+                stmt.setString(1, leaseName)
+                stmt.executeQuery().use { rs ->
+                    return if (rs.next()) rowToLease(rs) else null
+                }
+            }
+        }
+    }
+
+    // ── Internal helpers ───────────────────────────────────────────────
+
+    private fun <T> inTransaction(conn: Connection, block: (Connection) -> T): T {
+        val prevAutoCommit = conn.autoCommit
+        conn.autoCommit = false
+        try {
+            val result = block(conn)
+            conn.commit()
+            return result
+        } catch (e: Exception) {
+            conn.rollback()
+            throw e
+        } finally {
+            conn.autoCommit = prevAutoCommit
+        }
+    }
+
+    private fun ensureRow(conn: Connection, leaseName: String) {
+        conn.prepareStatement(
+            "INSERT INTO worker_leases (lease_name, owner_id, acquired_at, expires_at, heartbeat_at, version) " +
+                "VALUES (?, NULL, NULL, NULL, NULL, 1) ON CONFLICT (lease_name) DO NOTHING",
+        ).use { stmt ->
+            stmt.setString(1, leaseName)
+            stmt.executeUpdate()
+        }
+    }
+
+    private fun selectForUpdate(conn: Connection, leaseName: String): SovereignOpsWorkerLease? {
+        conn.prepareStatement(
+            "SELECT lease_name, owner_id, acquired_at, expires_at, heartbeat_at, version " +
+                "FROM worker_leases WHERE lease_name = ? FOR UPDATE",
+        ).use { stmt ->
+            stmt.setString(1, leaseName)
+            stmt.executeQuery().use { rs ->
+                return if (rs.next()) rowToLease(rs) else null
+            }
+        }
+    }
+
+    private fun decide(
+        lease: SovereignOpsWorkerLease,
+        ownerId: String,
+        now: Instant,
+        newExpiresAt: Instant,
+    ): SovereignOpsWorkerLeaseAcquisition {
+        val currentOwner = lease.ownerId
+        val expired = lease.isExpired(now)
+
+        return when {
+            currentOwner == ownerId -> {
+                SovereignOpsWorkerLeaseAcquisition.AlreadyOwned(
+                    lease.copy(
+                        expiresAt = newExpiresAt,
+                        heartbeatAt = now,
+                    ),
+                )
+            }
+            expired -> {
+                SovereignOpsWorkerLeaseAcquisition.Acquired(
+                    lease.copy(
+                        ownerId = ownerId,
+                        acquiredAt = now,
+                        expiresAt = newExpiresAt,
+                        heartbeatAt = now,
+                    ),
+                )
+            }
+            else -> {
+                SovereignOpsWorkerLeaseAcquisition.HeldByOther(lease)
+            }
+        }
+    }
+
+    private fun updateOwnership(
+        conn: Connection,
+        leaseName: String,
+        ownerId: String,
+        now: Instant,
+        expiresAt: Instant,
+    ) {
+        conn.prepareStatement(
+            "UPDATE worker_leases SET owner_id = ?, acquired_at = ?, heartbeat_at = ?, expires_at = ?, version = version + 1 " +
+                "WHERE lease_name = ?",
+        ).use { stmt ->
+            stmt.setString(1, ownerId)
+            stmt.setTimestamp(2, Timestamp.from(now))
+            stmt.setTimestamp(3, Timestamp.from(now))
+            stmt.setTimestamp(4, Timestamp.from(expiresAt))
+            stmt.setString(5, leaseName)
+            stmt.executeUpdate()
+        }
+    }
+
+    private fun clearOwnership(conn: Connection, leaseName: String) {
+        conn.prepareStatement(
+            "UPDATE worker_leases SET owner_id = NULL, acquired_at = NULL, expires_at = NULL, heartbeat_at = NULL, version = version + 1 " +
+                "WHERE lease_name = ?",
+        ).use { stmt ->
+            stmt.setString(1, leaseName)
+            stmt.executeUpdate()
+        }
+    }
+
+    private fun rowToLease(rs: ResultSet): SovereignOpsWorkerLease =
+        SovereignOpsWorkerLease(
+            leaseName = rs.getString("lease_name"),
+            ownerId = rs.getString("owner_id"),
+            acquiredAt = rs.getTimestamp("acquired_at")?.toInstant(),
+            expiresAt = rs.getTimestamp("expires_at")?.toInstant(),
+            heartbeatAt = rs.getTimestamp("heartbeat_at")?.toInstant(),
+            version = rs.getLong("version"),
+        )
+}

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/SovereignJdbcPersistenceAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/SovereignJdbcPersistenceAutoConfiguration.kt
@@ -11,6 +11,7 @@ import dev.tramai.persistence.jdbc.JdbcContinuationArgumentsCodec
 import dev.tramai.persistence.jdbc.JdbcReplayEnvelopeCodec
 import dev.tramai.persistence.jdbc.JdbcSuspendedInvocationStore
 import dev.tramai.security.audit.AuditStore
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseStore
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
 import javax.crypto.SecretKey
 import javax.crypto.spec.SecretKeySpec
@@ -208,4 +209,12 @@ class SovereignJdbcPersistenceAutoConfiguration {
             maxClaimLimit = jdbcConfig.maxClaimLimit,
         )
     }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean(DataSource::class)
+    fun sovereignOpsWorkerLeaseStore(
+        dataSource: DataSource,
+    ): SovereignOpsWorkerLeaseStore =
+        JdbcSovereignOpsWorkerLeaseStore(dataSource)
 }

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsWorkerLeaseStoreTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsWorkerLeaseStoreTest.kt
@@ -72,6 +72,7 @@ class JdbcSovereignOpsWorkerLeaseStoreTest {
         assertThat(acquired.lease.ownerId).isEqualTo("worker-a")
         assertThat(acquired.lease.leaseName).isEqualTo("my-lease")
         assertThat(acquired.lease.expiresAt).isEqualTo(BASE_NOW.plus(LEASE_DURATION))
+        assertThat(acquired.lease.version).isEqualTo(2)
     }
 
     @Test
@@ -122,12 +123,15 @@ class JdbcSovereignOpsWorkerLeaseStoreTest {
     @Test
     fun `heartbeat by owner extends expiry`() = runBlocking {
         val s = store()
-        s.tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
+        val acquired = (s.tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
+            as SovereignOpsWorkerLeaseAcquisition.Acquired)
+        val originalVersion = acquired.lease.version
         val later = BASE_NOW.plusSeconds(30)
         val result = s.heartbeat("my-lease", "worker-a", later, LEASE_DURATION)
         assertThat(result).isInstanceOf(SovereignOpsWorkerLeaseHeartbeat.Extended::class.java)
         val extended = result as SovereignOpsWorkerLeaseHeartbeat.Extended
         assertThat(extended.lease.expiresAt).isEqualTo(later.plus(LEASE_DURATION))
+        assertThat(extended.lease.version).isGreaterThan(originalVersion)
     }
 
     @Test
@@ -144,14 +148,30 @@ class JdbcSovereignOpsWorkerLeaseStoreTest {
         assertThat(result).isEqualTo(SovereignOpsWorkerLeaseHeartbeat.Missing)
     }
 
+    @Test
+    fun `heartbeat by owner after expiry is rejected`() = runBlocking {
+        val s = store()
+        s.tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
+        val afterExpiry = BASE_NOW.plus(LEASE_DURATION).plusSeconds(1)
+        val result = s.heartbeat("my-lease", "worker-a", afterExpiry, LEASE_DURATION)
+        assertThat(result).isEqualTo(SovereignOpsWorkerLeaseHeartbeat.Expired)
+    }
+
     // ── Release ────────────────────────────────────────────────────────
 
     @Test
     fun `release by owner clears ownership`() = runBlocking {
         val s = store()
-        s.tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
+        val firstAcquire = (s.tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
+            as SovereignOpsWorkerLeaseAcquisition.Acquired)
+        val versionAfterAcquire = firstAcquire.lease.version
         val result = s.release("my-lease", "worker-a", BASE_NOW.plusSeconds(10))
         assertThat(result).isEqualTo(SovereignOpsWorkerLeaseRelease.Released)
+
+        // Verify version incremented after release
+        val afterRelease = s.get("my-lease")
+        assertThat(afterRelease).isNotNull
+        assertThat(afterRelease!!.version).isGreaterThan(versionAfterAcquire)
 
         // Verify cleared: another worker can now acquire
         val acquired = s.tryAcquire("my-lease", "worker-b", BASE_NOW.plusSeconds(20), LEASE_DURATION)
@@ -234,7 +254,7 @@ class JdbcSovereignOpsWorkerLeaseStoreTest {
                     .getResourceAsStream("tramai/persistence/jdbc/postgres/V5__worker_leases_hardening.sql")
                     ?.bufferedReader()?.readText()
                     ?: error("V5 migration not found")
-                runCatching { stmt.execute(v5) }
+                stmt.execute(v5)
             }
         }
     }

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsWorkerLeaseStoreTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsWorkerLeaseStoreTest.kt
@@ -1,0 +1,241 @@
+package dev.tramai.spring.sovereign.persistence.jdbc
+
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseAcquisition
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseHeartbeat
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseRelease
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.postgresql.ds.PGSimpleDataSource
+import org.testcontainers.containers.PostgreSQLContainer
+import java.time.Duration
+import java.time.Instant
+import javax.sql.DataSource
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JdbcSovereignOpsWorkerLeaseStoreTest {
+
+    companion object {
+        private const val POSTGRES_IMAGE = "postgres:17-alpine"
+
+        private val postgres = PostgreSQLContainer(POSTGRES_IMAGE)
+            .withDatabaseName("worker_lease_test")
+            .withUsername("test")
+            .withPassword("test")
+
+        private fun createDataSource(): DataSource = PGSimpleDataSource().apply {
+            setUrl(postgres.jdbcUrl)
+            user = postgres.username
+            password = postgres.password
+        }
+
+        private val BASE_NOW: Instant = Instant.parse("2026-01-01T00:00:00Z")
+        private val LEASE_DURATION: Duration = Duration.ofMinutes(2)
+    }
+
+    private lateinit var dataSource: DataSource
+
+    @BeforeAll
+    fun startPostgres() {
+        postgres.start()
+        dataSource = createDataSource()
+        runMigrations()
+    }
+
+    @AfterAll
+    fun stopPostgres() {
+        postgres.stop()
+    }
+
+    @BeforeEach
+    fun setUp() {
+        truncateTables()
+    }
+
+    private fun store(): JdbcSovereignOpsWorkerLeaseStore =
+        JdbcSovereignOpsWorkerLeaseStore(dataSource)
+
+    // ── Acquisition ────────────────────────────────────────────────────
+
+    @Test
+    fun `acquire missing lease — acquired by owner A`() = runBlocking {
+        val result = store().tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
+        assertThat(result).isInstanceOf(SovereignOpsWorkerLeaseAcquisition.Acquired::class.java)
+        val acquired = result as SovereignOpsWorkerLeaseAcquisition.Acquired
+        assertThat(acquired.lease.ownerId).isEqualTo("worker-a")
+        assertThat(acquired.lease.leaseName).isEqualTo("my-lease")
+        assertThat(acquired.lease.expiresAt).isEqualTo(BASE_NOW.plus(LEASE_DURATION))
+    }
+
+    @Test
+    fun `acquire same lease same owner — already owned`() = runBlocking {
+        val s = store()
+        s.tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
+        val result = s.tryAcquire("my-lease", "worker-a", BASE_NOW.plusSeconds(10), LEASE_DURATION)
+        assertThat(result).isInstanceOf(SovereignOpsWorkerLeaseAcquisition.AlreadyOwned::class.java)
+    }
+
+    @Test
+    fun `acquire active lease different owner — held by other`() = runBlocking {
+        val s = store()
+        s.tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
+        val result = s.tryAcquire("my-lease", "worker-b", BASE_NOW.plusSeconds(10), LEASE_DURATION)
+        assertThat(result).isInstanceOf(SovereignOpsWorkerLeaseAcquisition.HeldByOther::class.java)
+        val held = result as SovereignOpsWorkerLeaseAcquisition.HeldByOther
+        assertThat(held.lease.ownerId).isEqualTo("worker-a")
+    }
+
+    @Test
+    fun `acquire expired lease different owner — stolen by owner B`() = runBlocking {
+        val s = store()
+        s.tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
+        // Move past expiry
+        val afterExpiry = BASE_NOW.plus(LEASE_DURATION).plusSeconds(1)
+        val result = s.tryAcquire("my-lease", "worker-b", afterExpiry, LEASE_DURATION)
+        assertThat(result).isInstanceOf(SovereignOpsWorkerLeaseAcquisition.Acquired::class.java)
+        val acquired = result as SovereignOpsWorkerLeaseAcquisition.Acquired
+        assertThat(acquired.lease.ownerId).isEqualTo("worker-b")
+    }
+
+    @Test
+    fun `concurrent acquire same lease — exactly one owner wins`() = runBlocking {
+        coroutineScope {
+            val s = store()
+            val a = async { s.tryAcquire("race-lease", "worker-a", BASE_NOW, LEASE_DURATION) }
+            val b = async { s.tryAcquire("race-lease", "worker-b", BASE_NOW, LEASE_DURATION) }
+            val results = awaitAll(a, b)
+
+            assertThat(results.count { it is SovereignOpsWorkerLeaseAcquisition.Acquired }).isEqualTo(1)
+            assertThat(results.count { it is SovereignOpsWorkerLeaseAcquisition.HeldByOther }).isEqualTo(1)
+        }
+    }
+
+    // ── Heartbeat ──────────────────────────────────────────────────────
+
+    @Test
+    fun `heartbeat by owner extends expiry`() = runBlocking {
+        val s = store()
+        s.tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
+        val later = BASE_NOW.plusSeconds(30)
+        val result = s.heartbeat("my-lease", "worker-a", later, LEASE_DURATION)
+        assertThat(result).isInstanceOf(SovereignOpsWorkerLeaseHeartbeat.Extended::class.java)
+        val extended = result as SovereignOpsWorkerLeaseHeartbeat.Extended
+        assertThat(extended.lease.expiresAt).isEqualTo(later.plus(LEASE_DURATION))
+    }
+
+    @Test
+    fun `heartbeat by non-owner rejected`() = runBlocking {
+        val s = store()
+        s.tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
+        val result = s.heartbeat("my-lease", "worker-b", BASE_NOW.plusSeconds(30), LEASE_DURATION)
+        assertThat(result).isEqualTo(SovereignOpsWorkerLeaseHeartbeat.NotOwner)
+    }
+
+    @Test
+    fun `heartbeat on missing lease returns missing`() = runBlocking {
+        val result = store().heartbeat("nonexistent", "worker-a", BASE_NOW, LEASE_DURATION)
+        assertThat(result).isEqualTo(SovereignOpsWorkerLeaseHeartbeat.Missing)
+    }
+
+    // ── Release ────────────────────────────────────────────────────────
+
+    @Test
+    fun `release by owner clears ownership`() = runBlocking {
+        val s = store()
+        s.tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
+        val result = s.release("my-lease", "worker-a", BASE_NOW.plusSeconds(10))
+        assertThat(result).isEqualTo(SovereignOpsWorkerLeaseRelease.Released)
+
+        // Verify cleared: another worker can now acquire
+        val acquired = s.tryAcquire("my-lease", "worker-b", BASE_NOW.plusSeconds(20), LEASE_DURATION)
+        assertThat(acquired).isInstanceOf(SovereignOpsWorkerLeaseAcquisition.Acquired::class.java)
+    }
+
+    @Test
+    fun `release by non-owner rejected`() = runBlocking {
+        val s = store()
+        s.tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
+        val result = s.release("my-lease", "worker-b", BASE_NOW.plusSeconds(10))
+        assertThat(result).isEqualTo(SovereignOpsWorkerLeaseRelease.NotOwner)
+    }
+
+    @Test
+    fun `release on missing lease returns missing`() = runBlocking {
+        val result = store().release("nonexistent", "worker-a", BASE_NOW)
+        assertThat(result).isEqualTo(SovereignOpsWorkerLeaseRelease.Missing)
+    }
+
+    // ── Get ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `get unknown lease returns null`() = runBlocking {
+        val result = store().get("nonexistent")
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `get known lease returns lease`() = runBlocking {
+        val s = store()
+        s.tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
+        val result = s.get("my-lease")
+        assertThat(result).isNotNull
+        assertThat(result!!.ownerId).isEqualTo("worker-a")
+    }
+
+    // ── Restart recovery ───────────────────────────────────────────────
+
+    @Test
+    fun `expired lease is recoverable after restart — owner B acquires`() = runBlocking {
+        // Acquire with owner A
+        store().tryAcquire("recovery-lease", "worker-a", BASE_NOW, LEASE_DURATION)
+
+        // Simulate restart: new store instance, time moved past expiry
+        val afterExpiry = BASE_NOW.plus(LEASE_DURATION).plusSeconds(5)
+        val newStore = store()
+        val result = newStore.tryAcquire("recovery-lease", "worker-b", afterExpiry, LEASE_DURATION)
+        assertThat(result).isInstanceOf(SovereignOpsWorkerLeaseAcquisition.Acquired::class.java)
+        val acquired = result as SovereignOpsWorkerLeaseAcquisition.Acquired
+        assertThat(acquired.lease.ownerId).isEqualTo("worker-b")
+    }
+
+    // ── Constraint validation ──────────────────────────────────────────
+    //
+    // Domain constraints (non-blank lease name, positive version,
+    // owner consistency, expiry after acquire) are enforced at the
+    // PostgreSQL level via V5 CHECK constraints. Kotlin-level validation
+    // in SovereignOpsWorkerLease.init provides defense-in-depth.
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private fun truncateTables() {
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.execute("TRUNCATE TABLE worker_leases CASCADE")
+            }
+        }
+    }
+
+    private fun runMigrations() {
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                val v1 = javaClass.classLoader
+                    .getResourceAsStream("tramai/persistence/jdbc/postgres/V1__sovereign_persistence.sql")
+                    ?.bufferedReader()?.readText()
+                    ?: error("V1 migration not found")
+                stmt.execute(v1)
+                val v5 = javaClass.classLoader
+                    .getResourceAsStream("tramai/persistence/jdbc/postgres/V5__worker_leases_hardening.sql")
+                    ?.bufferedReader()?.readText()
+                    ?: error("V5 migration not found")
+                runCatching { stmt.execute(v5) }
+            }
+        }
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/SovereignJdbcPersistenceAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/SovereignJdbcPersistenceAutoConfigurationTest.kt
@@ -10,6 +10,7 @@ import dev.tramai.persistence.jdbc.JdbcAuditStore
 import dev.tramai.persistence.jdbc.JdbcContinuationArgumentsCodec
 import dev.tramai.persistence.jdbc.JdbcReplayEnvelopeCodec
 import dev.tramai.persistence.jdbc.JdbcSuspendedInvocationStore
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseStore
 import dev.tramai.security.approval.InMemoryApprovalContinuationStore
 import dev.tramai.security.approval.InMemoryApprovalStore
 import dev.tramai.security.audit.AuditEvent
@@ -546,6 +547,43 @@ class SovereignJdbcPersistenceAutoConfigurationTest {
             }
     }
 
+    // ── Worker lease store ────────────────────────────────────────────
+
+    @Test
+    fun `type=jdbc + DataSource creates SovereignOpsWorkerLeaseStore`() {
+        val keyFile = prepareKeyFile()
+
+        contextRunner
+            .withPropertyValues(
+                *validJdbcProps(keyFile).entries
+                    .map { "${it.key}=${it.value}" }
+                    .toTypedArray(),
+            )
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SovereignOpsWorkerLeaseStore::class.java)
+                val store = ctx.getBean(SovereignOpsWorkerLeaseStore::class.java)
+                assertThat(store).isExactlyInstanceOf(JdbcSovereignOpsWorkerLeaseStore::class.java)
+            }
+    }
+
+    @Test
+    fun `user-provided lease store wins`() {
+        val keyFile = prepareKeyFile()
+
+        contextRunner
+            .withUserConfiguration(CustomLeaseStoreConfig::class.java)
+            .withPropertyValues(
+                *validJdbcProps(keyFile).entries
+                    .map { "${it.key}=${it.value}" }
+                    .toTypedArray(),
+            )
+            .run { ctx ->
+                assertThat(ctx.getBeansOfType(SovereignOpsWorkerLeaseStore::class.java)).hasSize(1)
+                val store = ctx.getBean(SovereignOpsWorkerLeaseStore::class.java)
+                assertThat(store).isInstanceOf(CustomLeaseStore::class.java)
+            }
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────
 
     private fun prepareKeyFile(name: String = "key.b64"): Path {
@@ -738,4 +776,37 @@ class CustomAuditPayloadCodec : JdbcAuditPayloadCodec {
         )
     override fun decode(envelope: dev.tramai.persistence.jdbc.JdbcEncryptedAuditPayload): ByteArray =
         envelope.ciphertext
+}
+
+// ── Worker lease store stubs ───────────────────────────────────────
+
+open class CustomLeaseStoreConfig {
+    @Bean
+    @Primary
+    open fun customLeaseStore(): SovereignOpsWorkerLeaseStore = CustomLeaseStore()
+}
+
+class CustomLeaseStore : SovereignOpsWorkerLeaseStore {
+    override suspend fun tryAcquire(
+        leaseName: String,
+        ownerId: String,
+        now: Instant,
+        leaseDuration: Duration,
+    ) = throw UnsupportedOperationException("custom stub")
+
+    override suspend fun heartbeat(
+        leaseName: String,
+        ownerId: String,
+        now: Instant,
+        leaseDuration: Duration,
+    ) = throw UnsupportedOperationException("custom stub")
+
+    override suspend fun release(
+        leaseName: String,
+        ownerId: String,
+        now: Instant,
+    ) = throw UnsupportedOperationException("custom stub")
+
+    override suspend fun get(leaseName: String) =
+        throw UnsupportedOperationException("custom stub")
 }


### PR DESCRIPTION
## Summary

Adds JDBC-backed worker lease support for multi-node sovereign ops worker coordination. Uses the existing `worker_leases` table to coordinate the audit outbox background worker across multiple JVM nodes. Prevents multiple nodes from running the same recovery/dispatch cycle at the same time while preserving existing single-node behavior by default.

### Lease safety (review fixes — commit aff709a)

- **Heartbeat loop during run**: A coroutine heartbeats at `leaseHeartbeatInterval` while the delegate executes, so long cycles don't lose the lease. If any heartbeat returns non-Extended, the cycle is cancelled via `CancellationException`.
- **Expired lease reject**: heartbeat returns `Expired` (not `Extended`) when the lease has expired.
- **Correct version**: mutation helpers re-read the row after update, so returned `SovereignOpsWorkerLease.version` matches the committed DB state.
- **Update count assertions**: `updateOwnership` and `clearOwnership` assert exactly 1 row updated (fail-closed).
- **V5 migration**: tests no longer swallow migration failures.

## What changed

| Area | Change |
|---|---|
| Ops SPI | Added `SovereignOpsWorkerLeaseStore` SPI and lease result model (`SovereignOpsWorkerLease`, `SovereignOpsWorkerLeaseAcquisition`, etc.) |
| JDBC persistence | Added `JdbcSovereignOpsWorkerLeaseStore` with `SELECT ... FOR UPDATE` atomic acquisition |
| Schema | Added V5 worker lease hardening constraints |
| Worker wrapper | Added `LeasedSovereignOpsAuditOutboxBackgroundWorker` — wraps existing worker with lease coordination + heartbeat loop |
| Lifecycle | Added `LeasedSovereignOpsAuditOutboxWorkerLifecycle` |
| Properties | Extended with `leaseEnabled`, `leaseName`, `workerId`, `leaseDuration`, `leaseHeartbeatInterval` |
| Run summary | Extended with optional `skipped` field |
| Auto-config | JDBC starter registers lease store; ops starter creates leased worker / fails loudly |
| Tests | 11 JDBC tests, 5 wrapper tests, 6 auto-config tests, 1 E2E coordination test |
| Docs | Updated design doc, quickstart, STATUS.md, CHANGELOG.md |

## Verified behavior

- Only one owner can acquire an active lease
- Heartbeat loop keeps lease alive during long delegate execution
- Heartbeat rejected after lease expiry (returns `Expired`)
- Returned version matches committed DB state
- Update counts asserted (fail-closed)
- Concurrent acquisition: exactly one winner
- Lease-guarded worker skips when held by another
- Default behavior unchanged when leasing disabled
- Fails loudly with `tramai-sovereign-ops-worker-lease-store-missing`

## Verified by

```
./gradlew check -x :examples:spring-sovereign-starter:e2eTest --rerun-tasks  # 179 tasks, BUILD SUCCESSFUL
```

## Non-goals

- Transaction-boundary hardening (PR #89)
- Production migration execution
- Kubernetes-specific leader election
- New observability metrics
