### PR TITLE
docs(jdbc): add sovereign production deployment runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Encrypted file-backed persistence (`tramai-persistence-file`).
 - File-backed audit outbox and recovery workflow (`tramai-spring-boot-starter-sovereign-ops`).
 - JDBC-backed sovereign persistence with Spring Boot auto-configuration (`tramai-spring-boot-starter-sovereign-persistence-jdbc`). Activated via `tramai.sovereign.persistence.type=jdbc`.
+- JDBC transactional approval mutation outbox boundary via `JdbcSovereignOpsApprovalMutationStore`, committing approval denial and audit intent in one PostgreSQL transaction.
 - JDBC E2E restart proof: Spring Boot example with Testcontainers PostgreSQL, five E2E tests proving sovereign state survives context restart, outbox dispatch recovery, and audit stream hash-chain validation.
 - JDBC worker lease support for multi-node audit outbox worker coordination via the `worker_leases` table, with atomic lease acquisition (`SELECT ... FOR UPDATE`), heartbeat extension, release, and lease-aware worker wrapper.
 - Background worker for audit outbox recovery and dispatch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Optional Actuator worker health component (`tramaiSovereignOpsWorker`, registered in real `HealthContributorRegistry`).
 - Sovereign document intelligence reference workflow (`examples:sovereign-document-intelligence`).
 - Worker observability runbook covering Actuator status, health component, Micrometer, OpenTelemetry, PromQL, and example alerts.
+- Sovereign JDBC production deployment runbook: deployment topology, configuration reference, encryption key requirements, migration order, worker lease setup, health checks, failure modes, rollback strategy, and verification checklist.
 - Sovereign runtime release-candidate evidence chain and evidence index generation.
 - Sovereign runtime release-readiness documentation and module matrix.
 
@@ -37,9 +38,7 @@
 - Maven Central release of sovereign runtime modules (not verified).
 - Broad REST/Actuator operational control endpoints beyond worker status and health.
 - Full dashboard integration and production monitoring runbook.
-- Database-backed persistence or outbox.
 - Key rotation.
-- Full production deployment guide.
 - Complete API reference documentation.
 
 For the current release-readiness boundary, see [docs/releases/sovereign-runtime-release-readiness.md](docs/releases/sovereign-runtime-release-readiness.md).
@@ -49,6 +48,7 @@ For the current release-readiness boundary, see [docs/releases/sovereign-runtime
 - Added Sovereign Runtime Quickstart for first-time RC evaluation and integration.
 - Added a regulated claim triage reference scenario for Sovereign Runtime RC evaluation.
 - Added Sovereign JDBC persistence design as the first production-hardening target after the Sovereign Runtime RC boundary.
+- Added Sovereign JDBC production deployment runbook covering topology, configuration, encryption, migrations, worker leases, health checks, failure modes, and verification checklist.
 
 ### Added
 - Added `tramai-persistence-jdbc` module with PostgreSQL schema skeleton and schema contract tests for the five sovereign persistence areas.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -79,7 +79,7 @@ This includes governed runtime execution, sovereign routing, DLP, replay-safe ap
 
 For the full RC boundary declaration, see [docs/releases/sovereign-runtime-rc-boundary.md](./releases/sovereign-runtime-rc-boundary.md).
 
-Not yet included: stable 1.0 API, Maven Central release, database-backed persistence, distributed worker coordination, key rotation, and production deployment certification.
+Not yet included: stable 1.0 API, Maven Central release, key rotation, and cloud-provider production certification.
 
 ## Planned / Not Complete
 
@@ -88,10 +88,9 @@ The following are intentionally not claimed as complete. Some are planned, some 
 - stable 1.0 public API
 - Maven Central release of sovereign-runtime modules
 - REST/Actuator operational endpoints
-- database-backed outbox worker E2E scheduling or transaction-boundary hardening
-- distributed worker leader election
 - key rotation
 - complete API reference documentation
+- production dashboards
 
 No timelines are committed for these items.
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -91,7 +91,6 @@ The following are intentionally not claimed as complete. Some are planned, some 
 - database-backed outbox worker E2E scheduling or transaction-boundary hardening
 - distributed worker leader election
 - key rotation
-- full production deployment guide
 - complete API reference documentation
 
 No timelines are committed for these items.
@@ -118,6 +117,8 @@ For first-time integration, see [Sovereign Runtime Quickstart](./guides/sovereig
 For a regulated workflow reference scenario, see [Regulated Claim Triage Reference Scenario](./scenarios/regulated-claim-triage.md).
 
 For the production-hardening direction toward database-backed persistence, see [Sovereign JDBC Persistence Design](./architecture/sovereign-jdbc-persistence-design.md).
+
+For production deployment guidance, see [Sovereign JDBC Production Deployment Runbook](./runbooks/sovereign-jdbc-production-deployment.md).
 
 These documents cover included capability areas, representative modules, validation commands, explicit non-goals, and known release risks.
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -23,6 +23,7 @@ This document describes the state of the repository, not a formal release contra
 | Audit outbox (atomic mutation + audit intent, claim-based dispatch) | Implemented / evolving |
 | Audit outbox background worker (recovery + dispatch loop) | Implemented / evolving |
 | JDBC sovereign persistence (PostgreSQL-backed approval, audit, outbox stores) | Implemented / evolving |
+| JDBC transactional approval mutation outbox boundary | Implemented / evolving |
 | Spring Boot auto-configuration for JDBC persistence | Implemented |
 | JDBC E2E restart proof (Testcontainers, audit/outbox recovery) | Implemented |
 | JDBC worker lease coordination (multi-node audit outbox worker coordination) | Implemented |

--- a/docs/architecture/sovereign-jdbc-persistence-design.md
+++ b/docs/architecture/sovereign-jdbc-persistence-design.md
@@ -251,6 +251,10 @@ Documented expected transaction behaviour:
 - When audit event append and outbox record creation use the same JDBC `DataSource`, they must occur in the **same database transaction**. If the application uses different persistence backends, TramAI must document that atomicity is not guaranteed and must fail closed or expose an explicit degraded mode.
 - Outbox dispatch should use **claim / lease semantics** to avoid duplicate dispatch.
 
+Status: **Implemented** (PR #89) for sovereign approval denial via
+`JdbcSovereignOpsApprovalMutationStore`, which commits the approval denial and
+audit outbox intent inside one PostgreSQL transaction on one JDBC `Connection`.
+
 ## Idempotency and Duplicate Protection
 
 The JDBC design must protect against:

--- a/docs/architecture/sovereign-jdbc-persistence-design.md
+++ b/docs/architecture/sovereign-jdbc-persistence-design.md
@@ -353,7 +353,7 @@ Suggested implementation sequence:
 8. Add Testcontainers-based integration tests. ✅ (per-store coverage)
 9. Add Spring Boot auto-configuration for JDBC persistence. ✅ `SovereignJdbcPersistenceAutoConfiguration` (PR #86)
 10. Add optional worker lease support.
-11. Add production deployment documentation.
+11. Add production deployment documentation. ✅ [Sovereign JDBC Production Deployment Runbook](../runbooks/sovereign-jdbc-production-deployment.md) (PR #90)
 
 ## Spring Boot Auto-Configuration (PR #86)
 

--- a/docs/architecture/sovereign-jdbc-persistence-design.md
+++ b/docs/architecture/sovereign-jdbc-persistence-design.md
@@ -39,8 +39,6 @@ Current JDBC stores (implemented):
 
 Current limitations:
 
-- no multi-node worker coordination
-- no database transaction boundary
 - no production deployment certification
 
 ## Target Capabilities
@@ -390,6 +388,8 @@ tramai:
 | `SuspendedInvocationStore` | `JdbcSuspendedInvocationStore` | `@ConditionalOnMissingBean` |
 | `AuditStore` | `JdbcAuditStore` | `@ConditionalOnMissingBean` |
 | `SovereignOpsAuditOutboxStore` | `JdbcSovereignOpsAuditOutboxStore` | `@ConditionalOnMissingBean` |
+| `SovereignOpsApprovalMutationStore` | `JdbcSovereignOpsApprovalMutationStore` | `@ConditionalOnMissingBean` |
+| `SovereignOpsWorkerLeaseStore` | `JdbcSovereignOpsWorkerLeaseStore` | `@ConditionalOnMissingBean` |
 
 All store beans are `@ConditionalOnMissingBean` — user-provided stores always take precedence.
 
@@ -435,11 +435,9 @@ The application database must have the TramAI JDBC schema migrations applied bef
 
 This design does **not** claim:
 
-- JDBC persistence is already implemented
-- Production readiness
-- Distributed worker coordination
 - Key rotation
 - Cloud database certification
 - Cross-database distributed transactions / XA coordination
+- Kubernetes/cloud-provider deployment templates
 - Stable 1.0 API
 - Maven Central availability

--- a/docs/guides/sovereign-runtime-quickstart.md
+++ b/docs/guides/sovereign-runtime-quickstart.md
@@ -212,7 +212,7 @@ It does **not** publish remotely, create a tag, or claim Maven Central availabil
 
 For a regulated-domain walkthrough, see [Regulated Claim Triage Reference Scenario](../scenarios/regulated-claim-triage.md).
 
-- Production deployment and operational runbooks
+- [Production deployment and operational runbooks](../runbooks/sovereign-jdbc-production-deployment.md) (now available)
 - Key rotation and secrets lifecycle
 - Maven Central release or public artifact publication
 - Stable 1.0 API — interfaces are still evolving

--- a/docs/releases/sovereign-runtime-rc-boundary.md
+++ b/docs/releases/sovereign-runtime-rc-boundary.md
@@ -66,14 +66,16 @@ The following are intentionally **not included** in this RC:
 - Production dashboard
 - Complete API reference documentation
 
+> **Note:** The production deployment runbook now exists for the JDBC persistence stack ([Sovereign JDBC Production Deployment Runbook](../runbooks/sovereign-jdbc-production-deployment.md)). This RC boundary document has not been updated to reflect the now-complete JDBC stack — it represents the original encrypted file-backed RC baseline.
+
 ## Post-RC Roadmap
 
 After this RC boundary, the next roadmap area is production hardening:
 
-1. JDBC/database-backed persistence and outbox
-2. Distributed worker coordination
+1. JDBC/database-backed persistence and outbox ✅ (PRs #80–#89)
+2. Distributed worker coordination ✅ (PR #88, worker leases)
 3. Key rotation
-4. Production deployment guide
+4. Production deployment guide ✅ (PR #90, [runbook](../runbooks/sovereign-jdbc-production-deployment.md))
 5. End-to-end regulated workflow examples
 6. API stabilization based on integration feedback
 

--- a/docs/releases/sovereign-runtime-rc-boundary.md
+++ b/docs/releases/sovereign-runtime-rc-boundary.md
@@ -59,8 +59,6 @@ The following are intentionally **not included** in this RC:
 - Stable 1.0 public API
 - Maven Central release
 - Production deployment certification
-- Database-backed persistence or outbox
-- Distributed worker leader election
 - Key rotation
 - Broad REST/Actuator control-plane endpoints
 - Production dashboard

--- a/docs/runbooks/sovereign-jdbc-production-deployment.md
+++ b/docs/runbooks/sovereign-jdbc-production-deployment.md
@@ -104,7 +104,6 @@ tramai:
           enabled: true
           dispatch-pending: true
           recover-prepared: true
-          recover-expired-emitting: true
           lease-enabled: true
           lease-name: sovereign-audit-outbox
           worker-id: ${HOSTNAME}
@@ -218,13 +217,15 @@ tramai:
 
 ## Audit outbox dispatch model
 
-The audit outbox worker runs a continuous loop:
+The audit outbox worker runs a continuous loop with two runtime toggles:
 
 ```
 runOnce()
-  ├── recoverPrepared()    — recover stale PREPARED records
-  └── retryPending()       — claim and dispatch PENDING records
+  ├── recoverPrepared()    — recover stale PREPARED records (toggle: recover-prepared)
+  └── retryPending()       — claim and dispatch PENDING records (toggle: dispatch-pending)
 ```
+
+Retryable or expired EMITTING records are handled by the outbox claim/retry logic (SKIP LOCKED + attempt count + next_attempt_at), not by a separate worker configuration property.
 
 **Dispatch is claim-based:** each dispatch uses `SELECT ... FOR UPDATE SKIP LOCKED` on the `audit_outbox` table. Multiple workers (with lease disabled) cannot claim the same row — PostgreSQL row-level locking prevents that. The lease prevents multiple workers from *running the recovery/dispatch cycle* simultaneously, which is the higher-level coordination concern.
 

--- a/docs/runbooks/sovereign-jdbc-production-deployment.md
+++ b/docs/runbooks/sovereign-jdbc-production-deployment.md
@@ -1,0 +1,398 @@
+# Sovereign JDBC Production Deployment Runbook
+
+## Purpose
+
+This runbook describes how to safely deploy TramAI Sovereign Runtime with PostgreSQL-backed persistence in a production or production-like environment.
+
+It covers topology, required configuration, encryption keys, worker leases, migrations, health checks, failure modes, and operational verification.
+
+This document is **not** a stable 1.0 API declaration. It is a production-readiness boundary for the current `master` branch.
+
+## Deployment topology
+
+### Single-node
+
+```
+Spring Boot app
+  └── PostgreSQL
+        ├── approvals
+        ├── suspended_invocations
+        ├── approval_continuations
+        ├── audit_events
+        ├── audit_outbox
+        └── worker_leases
+```
+
+Use case: local enterprise app, regulated prototype, controlled demo, one worker loop.
+
+### Multi-node
+
+```
+Spring Boot node A ──┐
+Spring Boot node B ──┼── PostgreSQL
+Spring Boot node C ──┘       ├── approvals
+                              ├── suspended_invocations
+                              ├── approval_continuations
+                              ├── audit_events
+                              ├── audit_outbox
+                              └── worker_leases
+```
+
+Key rule: **only one audit outbox worker actively runs per lease name**. Worker lease coordination prevents duplicate dispatch cycles across nodes. Set `lease-enabled: true` and configure unique `worker-id` per node.
+
+## Required dependencies
+
+```kotlin
+implementation("dev.tramai:tramai-spring-boot-starter-sovereign-persistence-jdbc:<version>")
+runtimeOnly("org.postgresql:postgresql")
+```
+
+Also required (typically already present):
+
+```kotlin
+implementation("dev.tramai:tramai-spring-boot-starter-sovereign:<version>")
+implementation("dev.tramai:tramai-spring-boot-starter-sovereign-ops:<version>")
+```
+
+## Required database migrations
+
+The following migrations exist and **must be applied in order** before the application starts:
+
+| Migration | Purpose |
+|-----------|---------|
+| V1 | Foundation schema (approvals, suspended_invocations, audit_events, audit_outbox, worker_leases) |
+| V2 | Approval continuations table |
+| V3 | Audit event hardening constraints |
+| V4 | Audit outbox hardening constraints |
+| V5 | Worker lease hardening constraints |
+
+Migration SQL files live under:
+```
+tramai-persistence-jdbc/src/main/resources/tramai/persistence/jdbc/postgres/
+```
+
+**Rules:**
+- Apply migrations in order. Do not skip.
+- Do not partially apply a migration. If a migration fails, roll it back before retrying.
+- Do not run the worker before all required tables exist.
+- Do not run multi-node workers without lease support enabled.
+- **Do not manually edit encrypted payload columns.**
+
+TramAI does not currently bundle a migration runner (Flyway, Liquibase). You must apply migrations with your own tooling, or place the SQL files in your Flyway/Liquibase migration directory.
+
+## Required configuration
+
+### Minimal production YAML
+
+```yaml
+tramai:
+  sovereign:
+    enabled: true
+    persistence:
+      type: jdbc
+      jdbc:
+        claim-lease-duration: 5m
+        max-claim-limit: 500
+      encryption:
+        key-env: TRAMAI_SOVEREIGN_STORE_KEY
+
+    ops:
+      enabled: true
+      mutations-enabled: false
+      outbox:
+        worker:
+          enabled: true
+          dispatch-pending: true
+          recover-prepared: true
+          recover-expired-emitting: true
+          lease-enabled: true
+          lease-name: sovereign-audit-outbox
+          worker-id: ${HOSTNAME}
+          lease-duration: 30s
+          lease-heartbeat-interval: 10s
+
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/tramai
+    username: tramai
+    password: ${TRAMAI_DB_PASSWORD}
+```
+
+### Configuration reference
+
+| Property | Required | Default | Notes |
+|----------|----------|---------|-------|
+| `tramai.sovereign.persistence.type` | Yes | — | Must be `jdbc` for JDBC persistence |
+| `tramai.sovereign.persistence.encryption.key-env` | Yes | — | Environment variable holding the AES key |
+| `tramai.sovereign.ops.outbox.worker.enabled` | No | `false` | Enable the audit outbox background worker |
+| `tramai.sovereign.ops.outbox.worker.lease-enabled` | No | `false` | Enable multi-node lease coordination |
+| `tramai.sovereign.ops.outbox.worker.lease-name` | No | `sovereign-ops-audit-outbox-worker` | Must be identical across all nodes |
+| `tramai.sovereign.ops.outbox.worker.worker-id` | No | Random UUID | Must be unique per node. Use `${HOSTNAME}`. |
+| `tramai.sovereign.ops.outbox.worker.lease-duration` | No | `2m` | How long a lease is valid before expiry |
+| `tramai.sovereign.ops.outbox.worker.lease-heartbeat-interval` | No | `30s` | How often the worker heartbeats (must be < `lease-duration`) |
+
+### Configuration validation
+
+On startup, if `lease-enabled: true`, the application validates:
+
+- `lease-duration > 0`
+- `lease-heartbeat-interval > 0`
+- `lease-heartbeat-interval < lease-duration`
+
+Violations cause **startup failure** (fail closed).
+
+## Encryption key requirements
+
+**Environment variable:** `TRAMAI_SOVEREIGN_STORE_KEY`
+
+**Format:** Base64-encoded 256-bit AES key.
+
+**Decoded value must be exactly 32 bytes.**
+
+Generate a key:
+```bash
+openssl rand -base64 32
+```
+
+**Forbidden:**
+- Plaintext keys in YAML or properties files
+- Keys shorter than 32 bytes
+- Keys in version control
+- Keys in logs, metrics, or exception messages
+
+**Key must be set in the process environment:**
+```bash
+export TRAMAI_SOVEREIGN_STORE_KEY="$(openssl rand -base64 32)"
+```
+
+The application reads the key from the environment variable named by `encryption.key-env`. If the key is missing or invalid, startup **fails closed** — no stores are created, no traffic is accepted.
+
+**Key rotation** is not yet supported. Plan for key rotation out of band (migrate data, then rotate).
+
+## Worker lease configuration
+
+### Single-node (default)
+
+```yaml
+tramai:
+  sovereign:
+    ops:
+      outbox:
+        worker:
+          enabled: true
+          lease-enabled: false
+```
+
+Lease is disabled. The worker runs recovery and dispatch without coordination. Safe for single-node deployments.
+
+### Multi-node
+
+```yaml
+tramai:
+  sovereign:
+    ops:
+      outbox:
+        worker:
+          enabled: true
+          lease-enabled: true
+          lease-name: sovereign-audit-outbox
+          worker-id: ${HOSTNAME}
+          lease-duration: 30s
+          lease-heartbeat-interval: 10s
+```
+
+**Requirements for multi-node:**
+
+1. All nodes must share the same PostgreSQL database.
+2. All nodes must use the same `lease-name`.
+3. Each node must have a unique `worker-id` (use `${HOSTNAME}` or a pod name).
+4. `lease-heartbeat-interval` must be less than `lease-duration`.
+5. The `worker_leases` table must exist (created by V1 migration).
+
+**Runtime behavior:**
+- On each `runOnce()` cycle, the worker tries to acquire the lease.
+- If the lease is held by another active node, the cycle is skipped (`lease-held-by-other`).
+- If the lease is expired, the current node takes it.
+- During execution, the worker heartbeats at `lease-heartbeat-interval`.
+- If the heartbeat fails (another node stole the lease, or the lease disappeared), the current worker cycle is cancelled (`SovereignOpsWorkerLeaseLostException`).
+
+## Audit outbox dispatch model
+
+The audit outbox worker runs a continuous loop:
+
+```
+runOnce()
+  ├── recoverPrepared()    — recover stale PREPARED records
+  └── retryPending()       — claim and dispatch PENDING records
+```
+
+**Dispatch is claim-based:** each dispatch uses `SELECT ... FOR UPDATE SKIP LOCKED` on the `audit_outbox` table. Multiple workers (with lease disabled) cannot claim the same row — PostgreSQL row-level locking prevents that. The lease prevents multiple workers from *running the recovery/dispatch cycle* simultaneously, which is the higher-level coordination concern.
+
+**Status lifecycle:**
+```
+PREPARED → PENDING → DISPATCHED
+                       ├── FAILED (retryable)
+                       └── DEAD (terminal)
+```
+
+## Health and readiness checks
+
+### Actuator endpoints (optional)
+
+If `tramai-spring-boot-starter-sovereign-ops-actuator` is on the classpath:
+
+```yaml
+tramai:
+  sovereign:
+    ops:
+      actuator:
+        worker-status:
+          enabled: true
+        worker-health:
+          enabled: true
+```
+
+**Worker status endpoint:**
+```
+GET /actuator/tramaiSovereignOpsWorker
+```
+
+Returns cycle statistics: success count, failure count, last run timestamp, current state.
+
+**Worker health component:**
+```
+GET /actuator/health
+```
+
+Includes `tramaiSovereignOpsWorker` health indicator (UP / DOWN / DEGRADED).
+
+### Database health
+
+Ensure your Spring Boot application has a DataSource health indicator:
+
+```yaml
+management:
+  health:
+    db:
+      enabled: true
+```
+
+**What these endpoints expose:**
+- Worker cycle statistics
+- Worker health status
+- Database connectivity status
+
+**What they intentionally do NOT expose:**
+- Prompts sent to models
+- Model responses
+- Raw exception messages or stack traces
+- Sensitive identifiers or PII
+- Tool arguments or intermediate workflow data
+
+## Operational verification checklist
+
+Before enabling production traffic, verify:
+
+- [ ] PostgreSQL is reachable from the application.
+- [ ] All migrations (V1–V5) are applied in order.
+- [ ] `tramai.sovereign.persistence.type=jdbc` is set.
+- [ ] `TRAMAI_SOVEREIGN_STORE_KEY` is set and loads successfully.
+- [ ] Application does **not** fall back to in-memory stores.
+- [ ] `AuditStore` is JDBC-backed (`JdbcAuditStore`).
+- [ ] `ApprovalStore` is JDBC-backed (`JdbcApprovalStore`).
+- [ ] `SuspendedInvocationStore` is JDBC-backed (`JdbcSuspendedInvocationStore`).
+- [ ] `ApprovalContinuationStore` is JDBC-backed (`JdbcApprovalContinuationStore`).
+- [ ] `SovereignOpsAuditOutboxStore` is JDBC-backed (`JdbcSovereignOpsAuditOutboxStore`).
+- [ ] `SovereignOpsApprovalMutationStore` is JDBC-backed (`JdbcSovereignOpsApprovalMutationStore`).
+- [ ] `SovereignOpsWorkerLeaseStore` is available (if `lease-enabled: true`).
+- [ ] Outbox worker starts only when configured.
+- [ ] Health/readiness endpoint reports expected state.
+- [ ] No prompts, model outputs, replay envelopes, or PII appear in metrics/logs.
+- [ ] Application logs do not contain plaintext encryption keys.
+
+## Failure modes and expected behavior
+
+| Failure | Expected behavior |
+|---------|-------------------|
+| Missing `DataSource` with `type=jdbc` | Startup fails closed |
+| Missing encryption key | Startup fails closed |
+| Invalid encryption key size (not 32 bytes) | Startup fails closed |
+| Outbox worker lease missing while `lease-enabled: true` | Startup fails closed |
+| `lease-heartbeat-interval >= lease-duration` with leasing enabled | Startup fails closed |
+| Audit dispatcher unavailable | Mutations fail closed |
+| Outbox dispatch fails after mutation commit | Mutation remains committed; outbox retries on next cycle |
+| Approval mutation fails before commit | Approval and outbox rollback together |
+| Worker loses lease during run | Current worker cycle cancelled |
+| Expired approval denial attempted | Denied transition rejected (`IllegalApprovalTransitionException`) |
+| Outbox insert conflict (duplicate `event_key`) | Transaction rolls back; approval unchanged |
+| Approval version conflict | Transaction rolls back; no orphan outbox record |
+| Malformed approval metadata (missing fields) | Transaction rolls back; approval unchanged |
+| Payload codec failure | Transaction rolls back; approval unchanged |
+
+## Rollback strategy
+
+### Rolling back an application deployment
+
+1. Stop the new version.
+2. Deploy the previous version.
+3. Verify database connectivity and store health.
+4. Verify the worker acquires its lease (if multi-node).
+5. Verify no stale outbox records from the aborted deployment.
+
+Schema migrations are **additive-only** — rolling back an application version does not require rolling back migrations. If a future migration is destructive, a separate rollback migration must be documented.
+
+### Recovering from a failed deployment
+
+1. Check that PostgreSQL is healthy.
+2. Check that all required environment variables are set.
+3. Check the application startup log for `tramai-sovereign-*` error codes.
+4. Verify migrations are applied:
+   ```sql
+   SELECT table_name FROM information_schema.tables
+   WHERE table_schema = 'public' AND table_name IN (
+     'approvals', 'suspended_invocations', 'approval_continuations',
+     'audit_events', 'audit_outbox', 'worker_leases'
+   );
+   ```
+   All six tables must exist.
+
+## Security and observability boundaries
+
+### Allowed in operational surfaces
+
+- Worker state (cycle count, last run)
+- Counters and timestamps
+- Sanitized failure types
+- Retry counts
+- Lease acquisition status
+
+### Forbidden in operational surfaces
+
+- Prompts
+- Model responses
+- Replay envelopes
+- Raw exception messages
+- PII
+- Medical or financial data
+- Approval IDs as metric labels
+- Encryption keys
+- SHA-256 hashes that can be reversed to plaintext
+
+## Non-goals
+
+This runbook does **not** cover:
+
+- Flyway/Liquibase integration (migrations are plain SQL; integrate with your own tooling)
+- Kubernetes manifests or cloud-provider-specific deployment templates
+- Key rotation implementation
+- Cross-database distributed transactions (XA)
+- Production migration executor
+- Stable 1.0 API
+- Maven Central availability
+
+## See also
+
+- [Sovereign JDBC Persistence Design](../architecture/sovereign-jdbc-persistence-design.md) — architecture and rollout plan
+- [Sovereign Runtime Quickstart](../guides/sovereign-runtime-quickstart.md) — evaluation and integration
+- [Sovereign Runtime RC Boundary](../releases/sovereign-runtime-rc-boundary.md) — what the RC includes
+- [Worker Observability Runbook](../operations/sovereign-ops-worker-observability-runbook.md) — monitoring and alerts

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsApprovalMutationStore.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsApprovalMutationStore.kt
@@ -1,15 +1,15 @@
 package dev.tramai.spring.sovereign.persistence.jdbc
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import dev.tramai.core.approval.ApprovalBinding
 import dev.tramai.core.approval.ApprovalRequest
 import dev.tramai.core.approval.ApprovalStatus
+import dev.tramai.core.approval.SafeActorIdPolicy
 import dev.tramai.core.approval.Sha256Digest
-import dev.tramai.core.exception.ApprovalStoreConflictException
 import dev.tramai.core.exception.ApprovalStoreNotFoundException
 import dev.tramai.core.exception.IllegalApprovalTransitionException
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalMutationResult
@@ -23,7 +23,6 @@ import java.sql.ResultSet
 import java.sql.SQLException
 import java.sql.Timestamp
 import java.time.Clock
-import java.time.Duration
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -33,6 +32,8 @@ class JdbcSovereignOpsApprovalMutationStore(
     private val dataSource: DataSource,
     private val payloadCodec: JdbcOpsAuditOutboxPayloadCodec,
     private val clock: Clock = Clock.systemUTC(),
+    private val maxIdLength: Int = 256,
+    private val maxCommentLength: Int = 4096,
 ) : SovereignOpsApprovalMutationStore {
 
     private val mapper: ObjectMapper = ObjectMapper()
@@ -47,17 +48,34 @@ class JdbcSovereignOpsApprovalMutationStore(
         reason: String,
         auditIntent: SovereignOpsAuditOutboxRecord,
     ): SovereignOpsApprovalMutationResult {
+        // ── Input validation ──────────────────────────────────────────
+        validateIdField(approvalId, "approvalId")
+        validateIdField(actor, "decidedBy")
+        SafeActorIdPolicy.validateActorId(actor, "decidedBy")
+
+        require(reason.length <= maxCommentLength) {
+            "Comment exceeds maximum length of $maxCommentLength"
+        }
+
+        require(auditIntent.outboxId.isNotBlank()) {
+            "Outbox ID must not be blank"
+        }
+        require(auditIntent.eventKey.isNotBlank()) {
+            "Event key must not be blank"
+        }
         require(auditIntent.status == SovereignOpsAuditOutboxStatus.PREPARED) {
             "tramai-sovereign-ops-outbox-invalid-status: only PREPARED records can be appended"
         }
 
+        // ── Transactional mutation ────────────────────────────────────
         return dataSource.connection.use { conn ->
             val previousAutoCommit = conn.autoCommit
             conn.autoCommit = false
             try {
                 val current = selectApprovalForUpdate(conn, approvalId)
-                    ?: throw IllegalStateException("tramai-sovereign-ops-invalid-approval-id")
+                    ?: throw ApprovalStoreNotFoundException(approvalId)
 
+                // Guard: status
                 if (current.status != ApprovalStatus.PENDING.name) {
                     throw IllegalApprovalTransitionException(
                         approvalId = approvalId,
@@ -67,18 +85,37 @@ class JdbcSovereignOpsApprovalMutationStore(
                     )
                 }
 
+                // Guard: version
                 if (current.version != expectedVersion) {
                     throw IllegalStateException("tramai-sovereign-ops-approval-version-conflict")
                 }
 
+                // Guard: expiry (match JdbcApprovalStore.transition behavior)
+                val metadata = parseMetadata(current.sanitizedMetadataJson)
+                val expiresAt = Instant.parse(metadata.expiresAt)
+                val now = clock.instant()
+                if (!now.isBefore(expiresAt)) {
+                    throw IllegalApprovalTransitionException(
+                        approvalId = approvalId,
+                        from = ApprovalStatus.PENDING,
+                        to = ApprovalStatus.DENIED,
+                        reason = "approval has expired at $expiresAt",
+                    )
+                }
+
+                // Insert outbox as PREPARED
                 val preparedPayload = mapper.writeValueAsBytes(auditIntent.toPersistedOutbox())
                 val preparedEncrypted = payloadCodec.encode(preparedPayload)
                 insertPreparedOutbox(conn, auditIntent, preparedEncrypted)
 
-                val now = clock.instant()
+                // Update approval to DENIED
                 val decidedAt = Timestamp.from(now)
                 val nextVersion = incrementVersion(approvalId, expectedVersion)
-                val metadataJson = updatedMetadataJson(current.sanitizedMetadataJson, actor, reason, current.createdAt)
+                val updatedMetadata = metadata.copy(
+                    decidedBy = actor,
+                    decisionComment = reason,
+                )
+                val metadataJson = mapper.writeValueAsString(updatedMetadata)
 
                 updateApprovalRow(
                     conn = conn,
@@ -89,6 +126,7 @@ class JdbcSovereignOpsApprovalMutationStore(
                     metadataJson = metadataJson,
                 )
 
+                // Mark outbox PENDING
                 val pendingAuditIntent = auditIntent.copy(
                     approvalStatus = ApprovalStatus.DENIED.name,
                     approvalVersion = nextVersion,
@@ -99,9 +137,10 @@ class JdbcSovereignOpsApprovalMutationStore(
 
                 markPreparedOutboxPending(conn, pendingAuditIntent, pendingEncrypted)
 
+                // Re-read for return value
                 val updated = selectApproval(conn, approvalId)
-                    ?: throw IllegalStateException("tramai-sovereign-ops-invalid-approval-id")
-                val approval = updated.toDomain()
+                    ?: throw ApprovalStoreNotFoundException(approvalId)
+                val approval = mapToApprovalRequest(updated)
 
                 conn.commit()
                 SovereignOpsApprovalMutationResult(
@@ -119,6 +158,8 @@ class JdbcSovereignOpsApprovalMutationStore(
             }
         }
     }
+
+    // ── SQL helpers ──────────────────────────────────────────────────
 
     private fun selectApprovalForUpdate(conn: Connection, approvalId: String): ApprovalRow? {
         val sql = """
@@ -161,35 +202,6 @@ class JdbcSovereignOpsApprovalMutationStore(
         sanitizedMetadataJson = rs.getString("sanitized_metadata"),
         version = rs.getLong("version"),
     )
-
-    private fun updatedMetadataJson(
-        currentJson: String?,
-        actor: String,
-        reason: String,
-        createdAt: OffsetDateTime,
-    ): String {
-        val node = parseMetadataNode(currentJson)
-        val mutable = if (node != null && node.isObject) {
-            node.deepCopy<com.fasterxml.jackson.databind.node.ObjectNode>()
-        } else {
-            mapper.createObjectNode()
-        }
-        mutable.put("decidedBy", actor)
-        mutable.put("decisionComment", reason)
-        if (!mutable.has("requestedAt")) {
-            mutable.put("requestedAt", createdAt.toInstant().toString())
-        }
-        if (!mutable.has("expiresAt")) {
-            mutable.put(
-                "expiresAt",
-                createdAt.toInstant().plus(DEFAULT_FALLBACK_EXPIRY).toString(),
-            )
-        }
-        if (!mutable.has("requestedBy")) {
-            mutable.put("requestedBy", DEFAULT_REQUESTED_BY)
-        }
-        return mapper.writeValueAsString(mutable)
-    }
 
     private fun insertPreparedOutbox(
         conn: Connection,
@@ -247,8 +259,6 @@ class JdbcSovereignOpsApprovalMutationStore(
             stmt.setLong(5, expectedVersion)
             val updated = stmt.executeUpdate()
             if (updated != 1) {
-                // Version or status mismatch. Application-level guards above
-                // check both, so this is belt-and-suspenders.
                 throw IllegalStateException("tramai-sovereign-ops-approval-update-failed")
             }
         }
@@ -283,55 +293,50 @@ class JdbcSovereignOpsApprovalMutationStore(
         }
     }
 
-    private fun ApprovalRow.toDomain(): ApprovalRequest {
-        val node = parseMetadataNode(sanitizedMetadataJson)
-        val binding = bindingFrom(node)
+    // ── Domain mapping ───────────────────────────────────────────────
+
+    private fun mapToApprovalRequest(row: ApprovalRow): ApprovalRequest {
+        val metadata = parseMetadata(row.sanitizedMetadataJson)
 
         return ApprovalRequest(
-            approvalId = approvalId,
-            binding = binding,
-            status = ApprovalStatus.valueOf(status),
-            requestedBy = node.textValue("requestedBy") ?: DEFAULT_REQUESTED_BY,
-            requestedAt = node.instantValue("requestedAt") ?: createdAt.toInstant(),
-            expiresAt = node.instantValue("expiresAt")
-                ?: createdAt.toInstant().plus(DEFAULT_FALLBACK_EXPIRY),
-            decidedBy = node.textValue("decidedBy"),
-            decidedAt = decidedAt?.toInstant(),
-            decisionComment = node.textValue("decisionComment"),
-            consumedBy = node.textValue("consumedBy"),
-            consumedAt = node.instantValue("consumedAt"),
-            version = version,
+            approvalId = row.approvalId,
+            binding = ApprovalBinding(
+                workflowRunId = metadata.binding.workflowRunId,
+                toolName = metadata.binding.toolName,
+                argumentsDigest = Sha256Digest.of(metadata.binding.argumentsDigest),
+                policyVersion = metadata.binding.policyVersion,
+                workflowDigest = Sha256Digest.of(metadata.binding.workflowDigest),
+                approvalTokenDigest = Sha256Digest.of(metadata.binding.approvalTokenDigest),
+            ),
+            status = ApprovalStatus.valueOf(row.status),
+            requestedBy = metadata.requestedBy,
+            requestedAt = Instant.parse(metadata.requestedAt),
+            expiresAt = Instant.parse(metadata.expiresAt),
+            decidedBy = metadata.decidedBy,
+            decidedAt = row.decidedAt?.toInstant(),
+            decisionComment = metadata.decisionComment,
+            consumedBy = metadata.consumedBy,
+            consumedAt = metadata.consumedAt?.let { Instant.parse(it) },
+            version = row.version,
         )
     }
 
-    private fun bindingFrom(node: JsonNode?): ApprovalBinding {
-        val bindingNode = node?.get("binding")
-        return ApprovalBinding(
-            workflowRunId = bindingNode.textValue("workflowRunId") ?: DEFAULT_WORKFLOW_RUN_ID,
-            toolName = bindingNode.textValue("toolName") ?: DEFAULT_TOOL_NAME,
-            argumentsDigest = Sha256Digest.of(
-                bindingNode.textValue("argumentsDigest") ?: DEFAULT_DIGEST,
-            ),
-            policyVersion = bindingNode.textValue("policyVersion") ?: DEFAULT_POLICY_VERSION,
-            workflowDigest = Sha256Digest.of(
-                bindingNode.textValue("workflowDigest") ?: DEFAULT_DIGEST,
-            ),
-            approvalTokenDigest = Sha256Digest.of(
-                bindingNode.textValue("approvalTokenDigest") ?: DEFAULT_DIGEST,
-            ),
-        )
+    private fun parseMetadata(json: String?): ApprovalMetadata {
+        check(!json.isNullOrBlank()) {
+            "sanitized_metadata must not be null for a stored approval"
+        }
+        return mapper.readValue(json)
     }
 
-    private fun parseMetadataNode(json: String?): JsonNode? {
-        if (json.isNullOrBlank()) return null
-        return mapper.readTree(json)
+    // ── Validation ───────────────────────────────────────────────────
+
+    private fun validateIdField(value: String, fieldName: String) {
+        val trimmed = value.trim()
+        require(trimmed.isNotBlank()) { "$fieldName must not be blank" }
+        require(trimmed.none { it.isISOControl() }) { "$fieldName must not contain control characters" }
+        require(trimmed.length <= maxIdLength) { "$fieldName exceeds maximum length of $maxIdLength" }
+        require(trimmed == value) { "$fieldName must not contain surrounding whitespace" }
     }
-
-    private fun JsonNode?.textValue(field: String): String? =
-        this?.get(field)?.takeUnless { it.isNull }?.asText()
-
-    private fun JsonNode?.instantValue(field: String): Instant? =
-        textValue(field)?.let(Instant::parse)
 
     private fun incrementVersion(approvalId: String, version: Long): Long =
         try {
@@ -360,6 +365,8 @@ class JdbcSovereignOpsApprovalMutationStore(
         return "sha256:${hashBytes.joinToString("") { "%02x".format(it) }}"
     }
 
+    // ── Data classes ─────────────────────────────────────────────────
+
     private data class ApprovalRow(
         val approvalId: String,
         val status: String,
@@ -371,13 +378,27 @@ class JdbcSovereignOpsApprovalMutationStore(
         val version: Long,
     )
 
-    private companion object {
-        val DEFAULT_FALLBACK_EXPIRY: Duration = Duration.ofMinutes(15)
-        const val DEFAULT_REQUESTED_BY: String = "unknown-requestor"
-        const val DEFAULT_WORKFLOW_RUN_ID: String = "unknown-workflow-run"
-        const val DEFAULT_TOOL_NAME: String = "unknown-tool"
-        const val DEFAULT_POLICY_VERSION: String = "unknown-policy"
-        const val DEFAULT_DIGEST: String =
-            "sha256:0000000000000000000000000000000000000000000000000000000000000000"
-    }
+    /**
+     * Typed metadata model matching [JdbcApprovalStore.ApprovalMetadata].
+     * Absence of any required field is a fail-closed condition — no fallbacks.
+     */
+    private data class BindingMetadata(
+        val workflowRunId: String,
+        val toolName: String,
+        val argumentsDigest: String,
+        val policyVersion: String,
+        val workflowDigest: String,
+        val approvalTokenDigest: String,
+    )
+
+    private data class ApprovalMetadata(
+        val binding: BindingMetadata,
+        val requestedBy: String,
+        val expiresAt: String,
+        val requestedAt: String,
+        val decidedBy: String? = null,
+        val decisionComment: String? = null,
+        val consumedBy: String? = null,
+        val consumedAt: String? = null,
+    )
 }

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsApprovalMutationStore.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsApprovalMutationStore.kt
@@ -1,0 +1,383 @@
+package dev.tramai.spring.sovereign.persistence.jdbc
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import dev.tramai.core.approval.ApprovalBinding
+import dev.tramai.core.approval.ApprovalRequest
+import dev.tramai.core.approval.ApprovalStatus
+import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.exception.ApprovalStoreConflictException
+import dev.tramai.core.exception.ApprovalStoreNotFoundException
+import dev.tramai.core.exception.IllegalApprovalTransitionException
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalMutationResult
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalMutationStore
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxRecord
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStatus
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.sql.Connection
+import java.sql.ResultSet
+import java.sql.SQLException
+import java.sql.Timestamp
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import javax.sql.DataSource
+
+class JdbcSovereignOpsApprovalMutationStore(
+    private val dataSource: DataSource,
+    private val payloadCodec: JdbcOpsAuditOutboxPayloadCodec,
+    private val clock: Clock = Clock.systemUTC(),
+) : SovereignOpsApprovalMutationStore {
+
+    private val mapper: ObjectMapper = ObjectMapper()
+        .registerKotlinModule()
+        .registerModule(JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+
+    override suspend fun denyApprovalWithAuditIntent(
+        approvalId: String,
+        expectedVersion: Long,
+        actor: String,
+        reason: String,
+        auditIntent: SovereignOpsAuditOutboxRecord,
+    ): SovereignOpsApprovalMutationResult {
+        require(auditIntent.status == SovereignOpsAuditOutboxStatus.PREPARED) {
+            "tramai-sovereign-ops-outbox-invalid-status: only PREPARED records can be appended"
+        }
+
+        return dataSource.connection.use { conn ->
+            val previousAutoCommit = conn.autoCommit
+            conn.autoCommit = false
+            try {
+                val current = selectApprovalForUpdate(conn, approvalId)
+                    ?: throw IllegalStateException("tramai-sovereign-ops-invalid-approval-id")
+
+                if (current.status != ApprovalStatus.PENDING.name) {
+                    throw IllegalApprovalTransitionException(
+                        approvalId = approvalId,
+                        from = ApprovalStatus.valueOf(current.status),
+                        to = ApprovalStatus.DENIED,
+                        reason = "approval already ${current.status.lowercase()}",
+                    )
+                }
+
+                if (current.version != expectedVersion) {
+                    throw IllegalStateException("tramai-sovereign-ops-approval-version-conflict")
+                }
+
+                val preparedPayload = mapper.writeValueAsBytes(auditIntent.toPersistedOutbox())
+                val preparedEncrypted = payloadCodec.encode(preparedPayload)
+                insertPreparedOutbox(conn, auditIntent, preparedEncrypted)
+
+                val now = clock.instant()
+                val decidedAt = Timestamp.from(now)
+                val nextVersion = incrementVersion(approvalId, expectedVersion)
+                val metadataJson = updatedMetadataJson(current.sanitizedMetadataJson, actor, reason, current.createdAt)
+
+                updateApprovalRow(
+                    conn = conn,
+                    approvalId = approvalId,
+                    expectedVersion = expectedVersion,
+                    decidedAt = decidedAt,
+                    actorHash = sha256Hex(actor),
+                    metadataJson = metadataJson,
+                )
+
+                val pendingAuditIntent = auditIntent.copy(
+                    approvalStatus = ApprovalStatus.DENIED.name,
+                    approvalVersion = nextVersion,
+                    status = SovereignOpsAuditOutboxStatus.PENDING,
+                )
+                val pendingPayload = mapper.writeValueAsBytes(pendingAuditIntent.toPersistedOutbox())
+                val pendingEncrypted = payloadCodec.encode(pendingPayload)
+
+                markPreparedOutboxPending(conn, pendingAuditIntent, pendingEncrypted)
+
+                val updated = selectApproval(conn, approvalId)
+                    ?: throw IllegalStateException("tramai-sovereign-ops-invalid-approval-id")
+                val approval = updated.toDomain()
+
+                conn.commit()
+                SovereignOpsApprovalMutationResult(
+                    approval = approval,
+                    auditOutboxRecord = pendingAuditIntent,
+                )
+            } catch (e: SQLException) {
+                conn.rollback()
+                throw mapDatabaseException(e, auditIntent)
+            } catch (e: Exception) {
+                conn.rollback()
+                throw e
+            } finally {
+                conn.autoCommit = previousAutoCommit
+            }
+        }
+    }
+
+    private fun selectApprovalForUpdate(conn: Connection, approvalId: String): ApprovalRow? {
+        val sql = """
+            SELECT approval_id, status, created_at, decided_at, decision_actor_hash, decision_type,
+                   sanitized_metadata, version
+            FROM approvals
+            WHERE approval_id = ?
+            FOR UPDATE
+        """.trimIndent()
+        return conn.prepareStatement(sql).use { stmt ->
+            stmt.setString(1, approvalId)
+            stmt.executeQuery().use { rs ->
+                if (rs.next()) mapApprovalRow(rs) else null
+            }
+        }
+    }
+
+    private fun selectApproval(conn: Connection, approvalId: String): ApprovalRow? {
+        val sql = """
+            SELECT approval_id, status, created_at, decided_at, decision_actor_hash, decision_type,
+                   sanitized_metadata, version
+            FROM approvals
+            WHERE approval_id = ?
+        """.trimIndent()
+        return conn.prepareStatement(sql).use { stmt ->
+            stmt.setString(1, approvalId)
+            stmt.executeQuery().use { rs ->
+                if (rs.next()) mapApprovalRow(rs) else null
+            }
+        }
+    }
+
+    private fun mapApprovalRow(rs: ResultSet): ApprovalRow = ApprovalRow(
+        approvalId = rs.getString("approval_id"),
+        status = rs.getString("status"),
+        createdAt = rs.getObject("created_at", OffsetDateTime::class.java),
+        decidedAt = rs.getObject("decided_at", OffsetDateTime::class.java),
+        decisionActorHash = rs.getString("decision_actor_hash"),
+        decisionType = rs.getString("decision_type"),
+        sanitizedMetadataJson = rs.getString("sanitized_metadata"),
+        version = rs.getLong("version"),
+    )
+
+    private fun updatedMetadataJson(
+        currentJson: String?,
+        actor: String,
+        reason: String,
+        createdAt: OffsetDateTime,
+    ): String {
+        val node = parseMetadataNode(currentJson)
+        val mutable = if (node != null && node.isObject) {
+            node.deepCopy<com.fasterxml.jackson.databind.node.ObjectNode>()
+        } else {
+            mapper.createObjectNode()
+        }
+        mutable.put("decidedBy", actor)
+        mutable.put("decisionComment", reason)
+        if (!mutable.has("requestedAt")) {
+            mutable.put("requestedAt", createdAt.toInstant().toString())
+        }
+        if (!mutable.has("expiresAt")) {
+            mutable.put(
+                "expiresAt",
+                createdAt.toInstant().plus(DEFAULT_FALLBACK_EXPIRY).toString(),
+            )
+        }
+        if (!mutable.has("requestedBy")) {
+            mutable.put("requestedBy", DEFAULT_REQUESTED_BY)
+        }
+        return mapper.writeValueAsString(mutable)
+    }
+
+    private fun insertPreparedOutbox(
+        conn: Connection,
+        record: SovereignOpsAuditOutboxRecord,
+        encrypted: JdbcEncryptedAuditOutboxPayload,
+    ) {
+        val sql = """
+            INSERT INTO audit_outbox (
+                outbox_id, event_key, status, correlation_key_hash,
+                created_at, attempt_count,
+                encrypted_payload, encryption_key_id, encryption_algorithm,
+                encryption_nonce, payload_digest, version
+            ) VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, 1)
+        """.trimIndent()
+
+        conn.prepareStatement(sql).use { stmt ->
+            stmt.setString(1, record.outboxId)
+            stmt.setString(2, record.eventKey)
+            stmt.setString(3, record.status.name)
+            stmt.setString(4, record.aggregateIdDigest)
+            stmt.setTimestamp(5, Timestamp.from(record.createdAt))
+            stmt.setBytes(6, encrypted.ciphertext)
+            stmt.setString(7, encrypted.keyId)
+            stmt.setString(8, encrypted.algorithm)
+            stmt.setBytes(9, encrypted.nonce)
+            stmt.setString(10, encrypted.payloadDigest)
+            stmt.executeUpdate()
+        }
+    }
+
+    private fun updateApprovalRow(
+        conn: Connection,
+        approvalId: String,
+        expectedVersion: Long,
+        decidedAt: Timestamp,
+        actorHash: String,
+        metadataJson: String,
+    ) {
+        val sql = """
+            UPDATE approvals
+            SET status = 'DENIED',
+                decided_at = ?,
+                decision_actor_hash = ?,
+                decision_type = 'DENIED',
+                sanitized_metadata = ?::jsonb,
+                version = version + 1
+            WHERE approval_id = ? AND version = ? AND status = 'PENDING'
+        """.trimIndent()
+
+        conn.prepareStatement(sql).use { stmt ->
+            stmt.setTimestamp(1, decidedAt)
+            stmt.setString(2, actorHash)
+            stmt.setString(3, metadataJson)
+            stmt.setString(4, approvalId)
+            stmt.setLong(5, expectedVersion)
+            val updated = stmt.executeUpdate()
+            if (updated != 1) {
+                // Version or status mismatch. Application-level guards above
+                // check both, so this is belt-and-suspenders.
+                throw IllegalStateException("tramai-sovereign-ops-approval-update-failed")
+            }
+        }
+    }
+
+    private fun markPreparedOutboxPending(
+        conn: Connection,
+        record: SovereignOpsAuditOutboxRecord,
+        encrypted: JdbcEncryptedAuditOutboxPayload,
+    ) {
+        val sql = """
+            UPDATE audit_outbox
+            SET status = 'PENDING',
+                encrypted_payload = ?,
+                encryption_key_id = ?,
+                encryption_algorithm = ?,
+                encryption_nonce = ?,
+                payload_digest = ?,
+                version = version + 1
+            WHERE outbox_id = ? AND status = 'PREPARED'
+        """.trimIndent()
+
+        conn.prepareStatement(sql).use { stmt ->
+            stmt.setBytes(1, encrypted.ciphertext)
+            stmt.setString(2, encrypted.keyId)
+            stmt.setString(3, encrypted.algorithm)
+            stmt.setBytes(4, encrypted.nonce)
+            stmt.setString(5, encrypted.payloadDigest)
+            stmt.setString(6, record.outboxId)
+            val updated = stmt.executeUpdate()
+            check(updated == 1) { "tramai-sovereign-ops-outbox-concurrent-update" }
+        }
+    }
+
+    private fun ApprovalRow.toDomain(): ApprovalRequest {
+        val node = parseMetadataNode(sanitizedMetadataJson)
+        val binding = bindingFrom(node)
+
+        return ApprovalRequest(
+            approvalId = approvalId,
+            binding = binding,
+            status = ApprovalStatus.valueOf(status),
+            requestedBy = node.textValue("requestedBy") ?: DEFAULT_REQUESTED_BY,
+            requestedAt = node.instantValue("requestedAt") ?: createdAt.toInstant(),
+            expiresAt = node.instantValue("expiresAt")
+                ?: createdAt.toInstant().plus(DEFAULT_FALLBACK_EXPIRY),
+            decidedBy = node.textValue("decidedBy"),
+            decidedAt = decidedAt?.toInstant(),
+            decisionComment = node.textValue("decisionComment"),
+            consumedBy = node.textValue("consumedBy"),
+            consumedAt = node.instantValue("consumedAt"),
+            version = version,
+        )
+    }
+
+    private fun bindingFrom(node: JsonNode?): ApprovalBinding {
+        val bindingNode = node?.get("binding")
+        return ApprovalBinding(
+            workflowRunId = bindingNode.textValue("workflowRunId") ?: DEFAULT_WORKFLOW_RUN_ID,
+            toolName = bindingNode.textValue("toolName") ?: DEFAULT_TOOL_NAME,
+            argumentsDigest = Sha256Digest.of(
+                bindingNode.textValue("argumentsDigest") ?: DEFAULT_DIGEST,
+            ),
+            policyVersion = bindingNode.textValue("policyVersion") ?: DEFAULT_POLICY_VERSION,
+            workflowDigest = Sha256Digest.of(
+                bindingNode.textValue("workflowDigest") ?: DEFAULT_DIGEST,
+            ),
+            approvalTokenDigest = Sha256Digest.of(
+                bindingNode.textValue("approvalTokenDigest") ?: DEFAULT_DIGEST,
+            ),
+        )
+    }
+
+    private fun parseMetadataNode(json: String?): JsonNode? {
+        if (json.isNullOrBlank()) return null
+        return mapper.readTree(json)
+    }
+
+    private fun JsonNode?.textValue(field: String): String? =
+        this?.get(field)?.takeUnless { it.isNull }?.asText()
+
+    private fun JsonNode?.instantValue(field: String): Instant? =
+        textValue(field)?.let(Instant::parse)
+
+    private fun incrementVersion(approvalId: String, version: Long): Long =
+        try {
+            Math.addExact(version, 1L)
+        } catch (_: ArithmeticException) {
+            throw IllegalStateException("tramai-sovereign-ops-approval-version-overflow")
+        }
+
+    private fun mapDatabaseException(
+        e: SQLException,
+        record: SovereignOpsAuditOutboxRecord,
+    ): RuntimeException {
+        val message = e.message ?: ""
+        return when {
+            message.contains("uq_audit_outbox_event_key") || message.contains("audit_outbox_event_key_key") ->
+                IllegalStateException("tramai-sovereign-ops-outbox-duplicate-event-key: ${record.eventKey}")
+            message.contains("audit_outbox_pkey") ->
+                IllegalStateException("tramai-sovereign-ops-outbox-duplicate-id: ${record.outboxId}")
+            else -> IllegalStateException("tramai-sovereign-ops-approval-mutation-database-failure", e)
+        }
+    }
+
+    private fun sha256Hex(input: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val hashBytes = digest.digest(input.toByteArray(StandardCharsets.UTF_8))
+        return "sha256:${hashBytes.joinToString("") { "%02x".format(it) }}"
+    }
+
+    private data class ApprovalRow(
+        val approvalId: String,
+        val status: String,
+        val createdAt: OffsetDateTime,
+        val decidedAt: OffsetDateTime?,
+        val decisionActorHash: String?,
+        val decisionType: String?,
+        val sanitizedMetadataJson: String?,
+        val version: Long,
+    )
+
+    private companion object {
+        val DEFAULT_FALLBACK_EXPIRY: Duration = Duration.ofMinutes(15)
+        const val DEFAULT_REQUESTED_BY: String = "unknown-requestor"
+        const val DEFAULT_WORKFLOW_RUN_ID: String = "unknown-workflow-run"
+        const val DEFAULT_TOOL_NAME: String = "unknown-tool"
+        const val DEFAULT_POLICY_VERSION: String = "unknown-policy"
+        const val DEFAULT_DIGEST: String =
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/SovereignJdbcPersistenceAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/SovereignJdbcPersistenceAutoConfiguration.kt
@@ -12,6 +12,7 @@ import dev.tramai.persistence.jdbc.JdbcReplayEnvelopeCodec
 import dev.tramai.persistence.jdbc.JdbcSuspendedInvocationStore
 import dev.tramai.security.audit.AuditStore
 import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseStore
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalMutationStore
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
 import javax.crypto.SecretKey
 import javax.crypto.spec.SecretKeySpec
@@ -40,6 +41,7 @@ import org.springframework.context.annotation.Bean
  * - [SuspendedInvocationStore] → [JdbcSuspendedInvocationStore]
  * - [AuditStore] → [JdbcAuditStore]
  * - [SovereignOpsAuditOutboxStore] → [JdbcSovereignOpsAuditOutboxStore]
+ * - [SovereignOpsApprovalMutationStore] → [JdbcSovereignOpsApprovalMutationStore]
  *
  * All store beans are `@ConditionalOnMissingBean` — user-provided stores
  * always take precedence.
@@ -209,6 +211,15 @@ class SovereignJdbcPersistenceAutoConfiguration {
             maxClaimLimit = jdbcConfig.maxClaimLimit,
         )
     }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean(DataSource::class)
+    fun sovereignOpsApprovalMutationStore(
+        dataSource: DataSource,
+        outboxPayloadCodec: JdbcOpsAuditOutboxPayloadCodec,
+    ): SovereignOpsApprovalMutationStore =
+        JdbcSovereignOpsApprovalMutationStore(dataSource, outboxPayloadCodec)
 
     @Bean
     @ConditionalOnMissingBean

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsApprovalMutationStoreTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsApprovalMutationStoreTest.kt
@@ -82,10 +82,13 @@ class JdbcSovereignOpsApprovalMutationStoreTest {
         )
     }
 
+    // ── Happy path ───────────────────────────────────────────────────
+
     @Test
     fun `deny approval commits approval denial and pending outbox record atomically`() = runBlocking {
         val approvalId = "approval-a"
-        insertApproval(approvalId)
+        val expiresAt = BASE_NOW.plusSeconds(600) // far in the future
+        insertApproval(approvalId, expiresAt = expiresAt)
         val auditIntent = auditIntent(approvalId, "test-key-a")
 
         val result = store.denyApprovalWithAuditIntent(
@@ -110,11 +113,14 @@ class JdbcSovereignOpsApprovalMutationStoreTest {
         assertThat(countOutboxRowsForEventKey(auditIntent.eventKey)).isEqualTo(1)
     }
 
+    // ── Rollback guards ──────────────────────────────────────────────
+
     @Test
     fun `outbox conflict prevents approval denial`() = runBlocking {
         val approvalId = "approval-b"
         val eventKey = "test-key-b"
-        insertApproval(approvalId)
+        val expiresAt = BASE_NOW.plusSeconds(600)
+        insertApproval(approvalId, expiresAt = expiresAt)
         insertOutboxRecord(auditIntent(approvalId, eventKey))
 
         assertThatThrownBy {
@@ -139,7 +145,8 @@ class JdbcSovereignOpsApprovalMutationStoreTest {
     fun `approval version conflict rolls back outbox insert`() = runBlocking {
         val approvalId = "approval-c"
         val auditIntent = auditIntent(approvalId, "test-key-c")
-        insertApproval(approvalId)
+        val expiresAt = BASE_NOW.plusSeconds(600)
+        insertApproval(approvalId, expiresAt = expiresAt)
 
         assertThatThrownBy {
             runBlocking {
@@ -163,7 +170,8 @@ class JdbcSovereignOpsApprovalMutationStoreTest {
     fun `non pending approval denial is rejected`() = runBlocking {
         val approvalId = "approval-d"
         val auditIntent = auditIntent(approvalId, "test-key-d")
-        insertApproval(approvalId, status = "APPROVED")
+        val expiresAt = BASE_NOW.plusSeconds(600)
+        insertApproval(approvalId, status = "APPROVED", expiresAt = expiresAt)
 
         assertThatThrownBy {
             runBlocking {
@@ -186,7 +194,8 @@ class JdbcSovereignOpsApprovalMutationStoreTest {
     fun `payload codec failure rolls back approval mutation`() = runBlocking {
         val approvalId = "approval-e"
         val auditIntent = auditIntent(approvalId, "test-key-e")
-        insertApproval(approvalId)
+        val expiresAt = BASE_NOW.plusSeconds(600)
+        insertApproval(approvalId, expiresAt = expiresAt)
         val failingStore = JdbcSovereignOpsApprovalMutationStore(
             dataSource = dataSource,
             payloadCodec = object : JdbcOpsAuditOutboxPayloadCodec {
@@ -216,6 +225,116 @@ class JdbcSovereignOpsApprovalMutationStoreTest {
         assertThat(selectApprovalVersion(approvalId)).isEqualTo(1L)
         assertThat(countOutboxRowsForEventKey(auditIntent.eventKey)).isZero()
     }
+
+    // ── Expiry guard (P1) ────────────────────────────────────────────
+
+    @Test
+    fun `expired pending approval denial is rejected and no outbox is inserted`() = runBlocking {
+        val approvalId = "approval-f"
+        val auditIntent = auditIntent(approvalId, "test-key-f")
+        // expiresAt is in the past relative to clock (BASE_NOW + 30s)
+        val expiresAt = BASE_NOW.plusSeconds(10) // expired 20s ago
+        insertApproval(approvalId, expiresAt = expiresAt)
+
+        assertThatThrownBy {
+            runBlocking {
+                store.denyApprovalWithAuditIntent(
+                    approvalId = approvalId,
+                    expectedVersion = 1,
+                    actor = "admin",
+                    reason = "reason",
+                    auditIntent = auditIntent,
+                )
+            }
+        }.isInstanceOf(IllegalApprovalTransitionException::class.java)
+            .hasMessageContaining("expired")
+
+        assertThat(selectApprovalStatus(approvalId)).isEqualTo("PENDING")
+        assertThat(selectApprovalVersion(approvalId)).isEqualTo(1L)
+        assertThat(countOutboxRowsForEventKey(auditIntent.eventKey)).isZero()
+    }
+
+    // ── Metadata integrity (P2) ──────────────────────────────────────
+
+    @Test
+    fun `malformed approval metadata fails closed and rolls back outbox insert`() = runBlocking {
+        val approvalId = "approval-g"
+        val auditIntent = auditIntent(approvalId, "test-key-g")
+        // Insert with '{}'::jsonb — missing binding, requestedBy, expiresAt, requestedAt
+        insertApprovalWithJsonMetadata(approvalId, """{}""")
+
+        assertThatThrownBy {
+            runBlocking {
+                store.denyApprovalWithAuditIntent(
+                    approvalId = approvalId,
+                    expectedVersion = 1,
+                    actor = "admin",
+                    reason = "reason",
+                    auditIntent = auditIntent,
+                )
+            }
+        }.isInstanceOf(IllegalStateException::class.java)
+
+        assertThat(selectApprovalStatus(approvalId)).isEqualTo("PENDING")
+        assertThat(selectApprovalVersion(approvalId)).isEqualTo(1L)
+        assertThat(countOutboxRowsForEventKey(auditIntent.eventKey)).isZero()
+    }
+
+    // ── Actor/reason validation (P2) ─────────────────────────────────
+
+    @Test
+    fun `invalid actor is rejected before mutation and no outbox is inserted`() = runBlocking {
+        val approvalId = "approval-h"
+        val auditIntent = auditIntent(approvalId, "test-key-h")
+        val expiresAt = BASE_NOW.plusSeconds(600)
+        insertApproval(approvalId, expiresAt = expiresAt)
+
+        // Space is not allowed by SafeActorIdPolicy
+        assertThatThrownBy {
+            runBlocking {
+                store.denyApprovalWithAuditIntent(
+                    approvalId = approvalId,
+                    expectedVersion = 1,
+                    actor = "bad actor",
+                    reason = "reason",
+                    auditIntent = auditIntent,
+                )
+            }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+
+        assertThat(selectApprovalStatus(approvalId)).isEqualTo("PENDING")
+        assertThat(selectApprovalVersion(approvalId)).isEqualTo(1L)
+        assertThat(countOutboxRowsForEventKey(auditIntent.eventKey)).isZero()
+    }
+
+    @Test
+    fun `oversized reason is rejected before mutation and no outbox is inserted`() = runBlocking {
+        val approvalId = "approval-i"
+        val auditIntent = auditIntent(approvalId, "test-key-i")
+        val expiresAt = BASE_NOW.plusSeconds(600)
+        insertApproval(approvalId, expiresAt = expiresAt)
+
+        val hugeReason = "x".repeat(5000)
+
+        assertThatThrownBy {
+            runBlocking {
+                store.denyApprovalWithAuditIntent(
+                    approvalId = approvalId,
+                    expectedVersion = 1,
+                    actor = "admin",
+                    reason = hugeReason,
+                    auditIntent = auditIntent,
+                )
+            }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Comment exceeds maximum length")
+
+        assertThat(selectApprovalStatus(approvalId)).isEqualTo("PENDING")
+        assertThat(selectApprovalVersion(approvalId)).isEqualTo(1L)
+        assertThat(countOutboxRowsForEventKey(auditIntent.eventKey)).isZero()
+    }
+
+    // ── Test infrastructure ──────────────────────────────────────────
 
     private fun testCodec(): JdbcOpsAuditOutboxPayloadCodec =
         object : JdbcOpsAuditOutboxPayloadCodec {
@@ -250,23 +369,56 @@ class JdbcSovereignOpsApprovalMutationStoreTest {
             }
         }
 
+    /**
+     * Insert an approval with valid metadata matching [JdbcApprovalStore]'s
+     * [ApprovalMetadata] shape.
+     */
     private fun insertApproval(
         approvalId: String,
+        status: String = "PENDING",
+        expiresAt: Instant = BASE_NOW.plusSeconds(600),
+    ) {
+        val metadata = validApprovalMetadata(expiresAt)
+        insertApprovalWithJsonMetadata(approvalId, mapper.writeValueAsString(metadata), status)
+    }
+
+    private fun insertApprovalWithJsonMetadata(
+        approvalId: String,
+        metadataJson: String,
         status: String = "PENDING",
     ) {
         dataSource.connection.use { conn ->
             val sql = """
                 INSERT INTO approvals (approval_id, status, created_at, sanitized_metadata, version)
-                VALUES (?, ?, ?, '{}'::jsonb, 1)
+                VALUES (?, ?, ?, ?::jsonb, 1)
             """.trimIndent()
             conn.prepareStatement(sql).use { stmt ->
                 stmt.setString(1, approvalId)
                 stmt.setString(2, status)
                 stmt.setTimestamp(3, Timestamp.from(BASE_NOW))
+                stmt.setString(4, metadataJson)
                 stmt.executeUpdate()
             }
         }
     }
+
+    /**
+     * Produces metadata matching the shape JdbcApprovalStore writes:
+     * { binding: {...}, requestedBy, expiresAt, requestedAt }
+     */
+    private fun validApprovalMetadata(expiresAt: Instant): Map<String, Any?> = mapOf(
+        "binding" to mapOf(
+            "workflowRunId" to "run-1",
+            "toolName" to "test-tool",
+            "argumentsDigest" to "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "policyVersion" to "1.0.0",
+            "workflowDigest" to "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "approvalTokenDigest" to "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        ),
+        "requestedBy" to "test-user",
+        "expiresAt" to expiresAt.toString(),
+        "requestedAt" to BASE_NOW.toString(),
+    )
 
     private fun insertOutboxRecord(record: SovereignOpsAuditOutboxRecord) {
         val encrypted = codec.encode(mapper.writeValueAsBytes(record.toPersistedOutbox()))

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsApprovalMutationStoreTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsApprovalMutationStoreTest.kt
@@ -1,0 +1,417 @@
+package dev.tramai.spring.sovereign.persistence.jdbc
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import dev.tramai.core.approval.ApprovalStatus
+import dev.tramai.core.exception.IllegalApprovalTransitionException
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxRecord
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStatus
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.postgresql.ds.PGSimpleDataSource
+import org.testcontainers.containers.PostgreSQLContainer
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.sql.Timestamp
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+import javax.sql.DataSource
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JdbcSovereignOpsApprovalMutationStoreTest {
+
+    companion object {
+        private const val POSTGRES_IMAGE = "postgres:17-alpine"
+        private val postgres = PostgreSQLContainer(POSTGRES_IMAGE)
+            .withDatabaseName("sovereign_ops_mutation_test")
+            .withUsername("test")
+            .withPassword("test")
+
+        private fun createDataSource(): DataSource = PGSimpleDataSource().apply {
+            setUrl(postgres.jdbcUrl)
+            user = postgres.username
+            password = postgres.password
+        }
+
+        private val BASE_NOW: Instant = Instant.parse("2026-01-01T00:00:00Z")
+    }
+
+    private val testAesKey = ByteArray(16).also { SecureRandom().nextBytes(it) }
+    private val mapper: ObjectMapper = ObjectMapper()
+        .registerKotlinModule()
+        .registerModule(JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    private lateinit var dataSource: DataSource
+    private lateinit var codec: JdbcOpsAuditOutboxPayloadCodec
+    private lateinit var store: JdbcSovereignOpsApprovalMutationStore
+
+    @BeforeAll
+    fun startPostgres() {
+        postgres.start()
+        dataSource = createDataSource()
+        runMigrations()
+    }
+
+    @AfterAll
+    fun stopPostgres() {
+        postgres.stop()
+    }
+
+    @BeforeEach
+    fun setUp() {
+        truncateTables()
+        codec = testCodec()
+        store = JdbcSovereignOpsApprovalMutationStore(
+            dataSource = dataSource,
+            payloadCodec = codec,
+            clock = Clock.fixed(BASE_NOW.plusSeconds(30), ZoneOffset.UTC),
+        )
+    }
+
+    @Test
+    fun `deny approval commits approval denial and pending outbox record atomically`() = runBlocking {
+        val approvalId = "approval-a"
+        insertApproval(approvalId)
+        val auditIntent = auditIntent(approvalId, "test-key-a")
+
+        val result = store.denyApprovalWithAuditIntent(
+            approvalId = approvalId,
+            expectedVersion = 1,
+            actor = "admin",
+            reason = "reason",
+            auditIntent = auditIntent,
+        )
+
+        assertThat(result.approval.status).isEqualTo(ApprovalStatus.DENIED)
+        assertThat(result.approval.version).isEqualTo(2)
+        assertThat(result.auditOutboxRecord.status).isEqualTo(SovereignOpsAuditOutboxStatus.PENDING)
+        assertThat(result.auditOutboxRecord.approvalStatus).isEqualTo("DENIED")
+        assertThat(result.auditOutboxRecord.approvalVersion).isEqualTo(2)
+
+        assertThat(selectApprovalStatus(approvalId)).isEqualTo("DENIED")
+        assertThat(selectApprovalVersion(approvalId)).isEqualTo(2L)
+        assertThat(selectApprovalDecisionType(approvalId)).isEqualTo("DENIED")
+        assertThat(selectApprovalDecisionActorHash(approvalId)).isEqualTo(sha256Hex("admin"))
+        assertThat(selectOutboxStatus(auditIntent.outboxId)).isEqualTo("PENDING")
+        assertThat(countOutboxRowsForEventKey(auditIntent.eventKey)).isEqualTo(1)
+    }
+
+    @Test
+    fun `outbox conflict prevents approval denial`() = runBlocking {
+        val approvalId = "approval-b"
+        val eventKey = "test-key-b"
+        insertApproval(approvalId)
+        insertOutboxRecord(auditIntent(approvalId, eventKey))
+
+        assertThatThrownBy {
+            runBlocking {
+                store.denyApprovalWithAuditIntent(
+                    approvalId = approvalId,
+                    expectedVersion = 1,
+                    actor = "admin",
+                    reason = "reason",
+                    auditIntent = auditIntent(approvalId, eventKey),
+                )
+            }
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("duplicate-event-key")
+
+        assertThat(selectApprovalStatus(approvalId)).isEqualTo("PENDING")
+        assertThat(selectApprovalVersion(approvalId)).isEqualTo(1L)
+        assertThat(countOutboxRowsForEventKey(eventKey)).isEqualTo(1)
+    }
+
+    @Test
+    fun `approval version conflict rolls back outbox insert`() = runBlocking {
+        val approvalId = "approval-c"
+        val auditIntent = auditIntent(approvalId, "test-key-c")
+        insertApproval(approvalId)
+
+        assertThatThrownBy {
+            runBlocking {
+                store.denyApprovalWithAuditIntent(
+                    approvalId = approvalId,
+                    expectedVersion = 0,
+                    actor = "admin",
+                    reason = "reason",
+                    auditIntent = auditIntent,
+                )
+            }
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("tramai-sovereign-ops-approval-version-conflict")
+
+        assertThat(selectApprovalStatus(approvalId)).isEqualTo("PENDING")
+        assertThat(selectApprovalVersion(approvalId)).isEqualTo(1L)
+        assertThat(countOutboxRowsForEventKey(auditIntent.eventKey)).isZero()
+    }
+
+    @Test
+    fun `non pending approval denial is rejected`() = runBlocking {
+        val approvalId = "approval-d"
+        val auditIntent = auditIntent(approvalId, "test-key-d")
+        insertApproval(approvalId, status = "APPROVED")
+
+        assertThatThrownBy {
+            runBlocking {
+                store.denyApprovalWithAuditIntent(
+                    approvalId = approvalId,
+                    expectedVersion = 1,
+                    actor = "admin",
+                    reason = "reason",
+                    auditIntent = auditIntent,
+                )
+            }
+        }.isInstanceOf(IllegalApprovalTransitionException::class.java)
+
+        assertThat(selectApprovalStatus(approvalId)).isEqualTo("APPROVED")
+        assertThat(selectApprovalVersion(approvalId)).isEqualTo(1L)
+        assertThat(countOutboxRowsForEventKey(auditIntent.eventKey)).isZero()
+    }
+
+    @Test
+    fun `payload codec failure rolls back approval mutation`() = runBlocking {
+        val approvalId = "approval-e"
+        val auditIntent = auditIntent(approvalId, "test-key-e")
+        insertApproval(approvalId)
+        val failingStore = JdbcSovereignOpsApprovalMutationStore(
+            dataSource = dataSource,
+            payloadCodec = object : JdbcOpsAuditOutboxPayloadCodec {
+                override fun encode(plaintext: ByteArray): JdbcEncryptedAuditOutboxPayload {
+                    throw IllegalStateException("encode failure")
+                }
+
+                override fun decode(envelope: JdbcEncryptedAuditOutboxPayload): ByteArray = envelope.ciphertext
+            },
+            clock = Clock.fixed(BASE_NOW.plusSeconds(30), ZoneOffset.UTC),
+        )
+
+        assertThatThrownBy {
+            runBlocking {
+                failingStore.denyApprovalWithAuditIntent(
+                    approvalId = approvalId,
+                    expectedVersion = 1,
+                    actor = "admin",
+                    reason = "reason",
+                    auditIntent = auditIntent,
+                )
+            }
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("encode failure")
+
+        assertThat(selectApprovalStatus(approvalId)).isEqualTo("PENDING")
+        assertThat(selectApprovalVersion(approvalId)).isEqualTo(1L)
+        assertThat(countOutboxRowsForEventKey(auditIntent.eventKey)).isZero()
+    }
+
+    private fun testCodec(): JdbcOpsAuditOutboxPayloadCodec =
+        object : JdbcOpsAuditOutboxPayloadCodec {
+            private val algorithm = "AES/GCM/NoPadding"
+            private val tagLength = 128
+
+            override fun encode(plaintext: ByteArray): JdbcEncryptedAuditOutboxPayload {
+                val cipher = Cipher.getInstance(algorithm)
+                val nonce = ByteArray(12).also { SecureRandom().nextBytes(it) }
+                val keySpec = SecretKeySpec(testAesKey, "AES")
+                val spec = GCMParameterSpec(tagLength, nonce)
+                cipher.init(Cipher.ENCRYPT_MODE, keySpec, spec)
+                val ciphertext = cipher.doFinal(plaintext)
+                val digest = MessageDigest.getInstance("SHA-256")
+                    .digest(plaintext)
+                    .joinToString("") { "%02x".format(it) }
+                return JdbcEncryptedAuditOutboxPayload(
+                    ciphertext = ciphertext,
+                    keyId = "test-key-1",
+                    algorithm = algorithm,
+                    nonce = nonce,
+                    payloadDigest = "sha256:$digest",
+                )
+            }
+
+            override fun decode(envelope: JdbcEncryptedAuditOutboxPayload): ByteArray {
+                val cipher = Cipher.getInstance(algorithm)
+                val keySpec = SecretKeySpec(testAesKey, "AES")
+                val spec = GCMParameterSpec(tagLength, envelope.nonce)
+                cipher.init(Cipher.DECRYPT_MODE, keySpec, spec)
+                return cipher.doFinal(envelope.ciphertext)
+            }
+        }
+
+    private fun insertApproval(
+        approvalId: String,
+        status: String = "PENDING",
+    ) {
+        dataSource.connection.use { conn ->
+            val sql = """
+                INSERT INTO approvals (approval_id, status, created_at, sanitized_metadata, version)
+                VALUES (?, ?, ?, '{}'::jsonb, 1)
+            """.trimIndent()
+            conn.prepareStatement(sql).use { stmt ->
+                stmt.setString(1, approvalId)
+                stmt.setString(2, status)
+                stmt.setTimestamp(3, Timestamp.from(BASE_NOW))
+                stmt.executeUpdate()
+            }
+        }
+    }
+
+    private fun insertOutboxRecord(record: SovereignOpsAuditOutboxRecord) {
+        val encrypted = codec.encode(mapper.writeValueAsBytes(record.toPersistedOutbox()))
+        dataSource.connection.use { conn ->
+            val sql = """
+                INSERT INTO audit_outbox (
+                    outbox_id, event_key, status, correlation_key_hash,
+                    created_at, attempt_count,
+                    encrypted_payload, encryption_key_id, encryption_algorithm,
+                    encryption_nonce, payload_digest, version
+                ) VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, 1)
+            """.trimIndent()
+            conn.prepareStatement(sql).use { stmt ->
+                stmt.setString(1, record.outboxId)
+                stmt.setString(2, record.eventKey)
+                stmt.setString(3, record.status.name)
+                stmt.setString(4, record.aggregateIdDigest)
+                stmt.setTimestamp(5, Timestamp.from(record.createdAt))
+                stmt.setBytes(6, encrypted.ciphertext)
+                stmt.setString(7, encrypted.keyId)
+                stmt.setString(8, encrypted.algorithm)
+                stmt.setBytes(9, encrypted.nonce)
+                stmt.setString(10, encrypted.payloadDigest)
+                stmt.executeUpdate()
+            }
+        }
+    }
+
+    private fun auditIntent(
+        approvalId: String,
+        eventKey: String,
+    ): SovereignOpsAuditOutboxRecord = SovereignOpsAuditOutboxRecord(
+        outboxId = UUID.randomUUID().toString(),
+        eventKey = eventKey,
+        aggregateIdDigest = sha256Hex(approvalId),
+        actor = "admin",
+        workflowRunId = null,
+        correlationId = null,
+        approvalStatus = "PENDING",
+        approvalVersion = 1,
+        reasonDigest = sha256Hex("reason"),
+        reasonLength = 6,
+        createdAt = BASE_NOW,
+    )
+
+    private fun selectApprovalStatus(approvalId: String): String =
+        selectSingleValue(
+            "SELECT status FROM approvals WHERE approval_id = ?",
+            approvalId,
+        )
+
+    private fun selectApprovalVersion(approvalId: String): Long =
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(
+                "SELECT version FROM approvals WHERE approval_id = ?"
+            ).use { stmt ->
+                stmt.setString(1, approvalId)
+                stmt.executeQuery().use { rs ->
+                    check(rs.next())
+                    rs.getLong(1)
+                }
+            }
+        }
+
+    private fun selectApprovalDecisionType(approvalId: String): String? =
+        selectNullableValue(
+            "SELECT decision_type FROM approvals WHERE approval_id = ?",
+            approvalId,
+        )
+
+    private fun selectApprovalDecisionActorHash(approvalId: String): String? =
+        selectNullableValue(
+            "SELECT decision_actor_hash FROM approvals WHERE approval_id = ?",
+            approvalId,
+        )
+
+    private fun selectOutboxStatus(outboxId: String): String =
+        selectSingleValue(
+            "SELECT status FROM audit_outbox WHERE outbox_id = ?",
+            outboxId,
+        )
+
+    private fun countOutboxRowsForEventKey(eventKey: String): Int =
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(
+                "SELECT count(*) FROM audit_outbox WHERE event_key = ?"
+            ).use { stmt ->
+                stmt.setString(1, eventKey)
+                stmt.executeQuery().use { rs ->
+                    check(rs.next())
+                    rs.getInt(1)
+                }
+            }
+        }
+
+    private fun selectSingleValue(sql: String, value: String): String =
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(sql).use { stmt ->
+                stmt.setString(1, value)
+                stmt.executeQuery().use { rs ->
+                    check(rs.next())
+                    rs.getString(1)
+                }
+            }
+        }
+
+    private fun selectNullableValue(sql: String, value: String): String? =
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(sql).use { stmt ->
+                stmt.setString(1, value)
+                stmt.executeQuery().use { rs ->
+                    check(rs.next())
+                    rs.getString(1)
+                }
+            }
+        }
+
+    private fun truncateTables() {
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.execute("TRUNCATE TABLE audit_outbox, approvals CASCADE")
+            }
+        }
+    }
+
+    private fun runMigrations() {
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                val v1 = javaClass.classLoader
+                    .getResourceAsStream("tramai/persistence/jdbc/postgres/V1__sovereign_persistence.sql")
+                    ?.bufferedReader()?.readText()
+                    ?: error("V1 migration not found")
+                stmt.execute(v1)
+                val v4 = javaClass.classLoader
+                    .getResourceAsStream("tramai/persistence/jdbc/postgres/V4__audit_outbox_hardening.sql")
+                    ?.bufferedReader()?.readText()
+                    ?: error("V4 migration not found")
+                runCatching { stmt.execute(v4) }
+            }
+        }
+    }
+
+    private fun sha256Hex(input: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val hash = digest.digest(input.toByteArray(StandardCharsets.UTF_8))
+        return "sha256:${hash.joinToString("") { "%02x".format(it) }}"
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/SovereignJdbcPersistenceAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/SovereignJdbcPersistenceAutoConfigurationTest.kt
@@ -16,6 +16,7 @@ import dev.tramai.security.approval.InMemoryApprovalStore
 import dev.tramai.security.audit.AuditEvent
 import dev.tramai.security.audit.AuditStore
 import dev.tramai.security.audit.InMemoryAuditStore
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalMutationStore
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxRecord
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStatus
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
@@ -330,7 +331,7 @@ class SovereignJdbcPersistenceAutoConfigurationTest {
     // ── all beans created with valid config ───────────────────────────
 
     @Test
-    fun `valid config creates all five store beans`() {
+    fun `valid config creates all six store beans`() {
         val keyFile = prepareKeyFile()
 
         contextRunner
@@ -345,6 +346,7 @@ class SovereignJdbcPersistenceAutoConfigurationTest {
                 assertThat(ctx).hasSingleBean(ApprovalContinuationStore::class.java)
                 assertThat(ctx).hasSingleBean(AuditStore::class.java)
                 assertThat(ctx).hasSingleBean(SovereignOpsAuditOutboxStore::class.java)
+                assertThat(ctx).hasSingleBean(SovereignOpsApprovalMutationStore::class.java)
             }
     }
 
@@ -563,6 +565,23 @@ class SovereignJdbcPersistenceAutoConfigurationTest {
                 assertThat(ctx).hasSingleBean(SovereignOpsWorkerLeaseStore::class.java)
                 val store = ctx.getBean(SovereignOpsWorkerLeaseStore::class.java)
                 assertThat(store).isExactlyInstanceOf(JdbcSovereignOpsWorkerLeaseStore::class.java)
+            }
+    }
+
+    @Test
+    fun `type=jdbc + DataSource creates SovereignOpsApprovalMutationStore`() {
+        val keyFile = prepareKeyFile()
+
+        contextRunner
+            .withPropertyValues(
+                *validJdbcProps(keyFile).entries
+                    .map { "${it.key}=${it.value}" }
+                    .toTypedArray(),
+            )
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(SovereignOpsApprovalMutationStore::class.java)
+                val store = ctx.getBean(SovereignOpsApprovalMutationStore::class.java)
+                assertThat(store).isExactlyInstanceOf(JdbcSovereignOpsApprovalMutationStore::class.java)
             }
     }
 


### PR DESCRIPTION
## Summary

Adds a production deployment runbook for JDBC-backed TramAI Sovereign Runtime. Documents safe deployment with PostgreSQL-backed persistence, encrypted stores, audit outbox dispatch, worker leases, health checks, and fail-closed configuration.

**Post-review fixes (rev 2):**
- Removed non-existent `recover-expired-emitting` from production YAML — worker toggles are `recover-prepared` + `dispatch-pending` only
- Updated dispatch model description to clarify retryable/expired EMITTING records are handled by claim/retry logic
- Removed stale "database-backed persistence not included" and "distributed coordination not complete" claims from STATUS.md
- Removed stale non-goals from RC boundary (DB persistence, distributed worker leader election — now implemented)
- Added missing `SovereignOpsApprovalMutationStore` and `SovereignOpsWorkerLeaseStore` to design doc store table
- Removed stale "JDBC persistence not implemented", "no distributed coordination", "no transaction boundary" from design doc

## Build

```
./gradlew check -x :examples:spring-sovereign-starter:e2eTest → 179 tasks, BUILD SUCCESSFUL
```