### PR TITLE
docs(sovereign): define Sovereign Runtime closure boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,8 @@
 For the current release-readiness boundary, see [docs/releases/sovereign-runtime-release-readiness.md](docs/releases/sovereign-runtime-release-readiness.md).
 
 ### Documentation
-- Added Sovereign Runtime Release Candidate boundary declaration and linked it to the canonical verification task.
+- Added Sovereign Runtime release-candidate boundary declaration and linked it to the canonical verification task.
+- Added Sovereign Runtime closure boundary defining the completed RC+ / enterprise proof scope, closure evidence, explicit non-goals, and deferred GA items.
 - Added Sovereign Runtime Quickstart for first-time RC evaluation and integration.
 - Added a regulated claim triage reference scenario for Sovereign Runtime RC evaluation.
 - Added Sovereign JDBC persistence design as the first production-hardening target after the Sovereign Runtime RC boundary.

--- a/README.md
+++ b/README.md
@@ -214,28 +214,24 @@ The following are intentionally not claimed as complete:
 
 - stable 1.0 API
 - write/control-plane operational endpoints
-- database-backed outbox or persistence
-- distributed worker leader election
 - key rotation
-- full production deployment guide
 - complete API reference documentation
 
-### Sovereign Runtime Release Candidate
+### Sovereign Runtime
 
-The current `master` branch contains a Sovereign Runtime Release Candidate boundary.
+The Sovereign Runtime roadmap is **functionally complete as an RC+ / enterprise proof milestone**.
 
 See:
 
-- [Sovereign Runtime RC Boundary](docs/releases/sovereign-runtime-rc-boundary.md)
-- [Sovereign Runtime Release Readiness](docs/releases/sovereign-runtime-release-readiness.md)
+- [Sovereign Runtime Closure Boundary](docs/releases/sovereign-runtime-closure-boundary.md)
+- [Regulated Claim Triage Scenario](docs/scenarios/regulated-claim-triage.md)
+- [Sovereign JDBC Production Deployment Runbook](docs/runbooks/sovereign-jdbc-production-deployment.md)
 
-Run the full local verification chain with:
+Run the full closure verification chain with:
 
 ```bash
 ./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks
 ```
-
-This is **not** a stable 1.0 API declaration, **not** a Maven Central release, and **not** a production deployment certification.
 
 ## Sovereign Runtime Release Readiness
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -4,6 +4,30 @@ TramAI is under **active development**.
 
 This document describes the state of the repository, not a formal release contract. It tracks what is implemented and evolving on `master`, and what is intentionally not yet complete.
 
+## Sovereign Runtime Closure Status
+
+The Sovereign Runtime roadmap is **functionally complete as an RC+ / enterprise proof milestone**.
+
+Closure boundary:
+- [Sovereign Runtime Closure Boundary](releases/sovereign-runtime-closure-boundary.md)
+
+### Included Proof Points
+- JDBC-backed runtime persistence (approval, audit, outbox stores)
+- Transactional approval mutation + audit outbox boundary
+- Worker lease coordination for multi-node deployments
+- Production deployment runbook (JDBC stack)
+- Regulated claim triage JDBC E2E proof
+- CI-backed E2E execution
+
+### Deferred from Closure
+- Key rotation
+- Production certification
+- Reviewer UI
+- Full REST control plane
+- Maven Central release
+
+The next roadmap after this closure is API stabilization and workflow ergonomics.
+
 ## Implemented / Evolving
 
 | Area | Status |

--- a/docs/releases/sovereign-runtime-closure-boundary.md
+++ b/docs/releases/sovereign-runtime-closure-boundary.md
@@ -1,0 +1,130 @@
+# Sovereign Runtime Closure Boundary
+
+> This document defines the formal closure boundary for the Sovereignty roadmap.
+> The Sovereign Runtime is considered functionally complete as an RC+ / enterprise proof milestone.
+> It is **not** a GA-certified production release.
+
+---
+
+## Status
+
+Sovereign Runtime is **functionally complete as an enterprise proof / RC+ milestone**.
+
+It is not yet a GA-certified production release. The next roadmap focuses on API stabilization and workflow ergonomics.
+
+---
+
+## Included Capabilities
+
+The following capabilities are included in the closure boundary:
+
+- Policy enforcement (allow / deny / suspend)
+- Data classification and DLP-aware routing
+- Sovereign routing and trust zones (local-only, EU/trusted, approved cloud, denied)
+- Human approval request persistence (`ApprovalStore`)
+- Suspended invocation persistence (`SuspendedInvocationStore`)
+- Approval continuation persistence (`ApprovalContinuationStore`)
+- Tamper-evident audit chain (`AuditStore`)
+- Durable audit outbox (`SovereignOpsAuditOutboxStore`)
+- Transactional approval mutation + audit outbox boundary (`SovereignOpsApprovalMutationStore`)
+- JDBC-backed PostgreSQL persistence for all sovereign stores
+- Encrypted file-backed persistence for all sovereign stores
+- Background worker dispatch loop for audit outbox recovery and dispatch
+- Worker lease coordination for multi-node deployments
+- Worker observer SPI and composite observer pipeline
+- Spring Boot auto-configuration for JDBC persistence (`type=jdbc`)
+- Spring Boot auto-configuration for file-backed persistence (`type=file`)
+- Optional Actuator worker status endpoint (`/actuator/tramaiSovereignOpsWorker`)
+- Optional Actuator worker health component
+- Micrometer / Prometheus metrics bridge
+- OpenTelemetry worker metrics
+- Worker observability runbook with PromQL examples and alert definitions
+- Sovereign document intelligence reference workflow (file-backed example)
+- Regulated claim triage executable JDBC E2E proof
+- CI-backed E2E verification
+- Production deployment runbook (JDBC persistence stack)
+- Release-candidate evidence index generation
+- Consumer-resolution smoke test
+- Canonical `verifySovereignRuntimeReleaseCandidate` verification task
+- Release readiness documentation and module matrix
+
+---
+
+## Closure Evidence
+
+The Sovereignty roadmap is considered **closed** when the following verification commands pass:
+
+```bash
+# Full test suite
+./gradlew check
+
+# Release-candidate verification chain
+./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks
+
+# JDBC E2E restart proof
+./gradlew :examples:spring-sovereign-starter:e2eTest
+```
+
+These gates prove that all included capabilities are functional, the release evidence chain is intact, and the regulated JDBC scenario works end-to-end.
+
+---
+
+## Explicit Non-Goals
+
+The closure boundary explicitly does **not** include:
+
+- Production reviewer UI
+- Production certification (HIPAA, GDPR, or any regulatory certification)
+- Maven Central release of sovereign runtime modules
+- Key rotation
+- Full REST control plane (write / admin endpoints)
+- Broad workflow DSL
+- Enterprise identity / IAM integration
+- Customer-specific policy packs
+- Stable 1.0 API across all TramAI modules
+- Complete API reference documentation
+
+---
+
+## Deferred Work
+
+### Deferred: Key Rotation
+
+Key rotation is explicitly deferred to the future Sovereign Runtime GA / production-certification roadmap.
+
+Rationale:
+- The current Sovereignty milestone goal is RC+ / enterprise proof, not production-certified security.
+- Minimal key rotation (key ID in records, multiple active keys, re-encryption) would add 3–5 PRs.
+- Deferring keeps the closure timeline achievable and prevents scope creep into another long roadmap.
+
+All other items listed under the original post-RC roadmap are now complete:
+- JDBC/database-backed persistence and outbox ✅
+- Distributed worker coordination (worker leases) ✅
+- Production deployment guide (runbook) ✅
+- End-to-end regulated workflow examples (JDBC E2E) ✅
+
+---
+
+## What Comes Next
+
+After this closure boundary, the next roadmap is **API stabilization and workflow ergonomics**.
+
+Potential directions (decided separately):
+
+| Option | Focus |
+|--------|-------|
+| Workflow Runtime | Workflow DSL, suspension/resume ergonomics, approval gateway abstraction |
+| Enterprise Integration | REST control plane, reviewer UI hooks, audit export, admin APIs |
+| Sovereign Runtime GA | Key rotation, API compatibility, Maven Central release, security review |
+
+See the full enterprise vision in [`ROADMAP.md`](../../ROADMAP.md).
+
+---
+
+## References
+
+- [Sovereign Runtime RC Boundary (historical)](./sovereign-runtime-rc-boundary.md)
+- [Regulated Claim Triage Scenario](../scenarios/regulated-claim-triage.md)
+- [Sovereign JDBC Production Deployment Runbook](../runbooks/sovereign-jdbc-production-deployment.md)
+- [Project Status](../STATUS.md)
+- [Enterprise Roadmap](../../ROADMAP.md)

--- a/docs/releases/sovereign-runtime-rc-boundary.md
+++ b/docs/releases/sovereign-runtime-rc-boundary.md
@@ -64,17 +64,18 @@ The following are intentionally **not included** in this RC:
 - Production dashboard
 - Complete API reference documentation
 
-> **Note:** The production deployment runbook now exists for the JDBC persistence stack ([Sovereign JDBC Production Deployment Runbook](../runbooks/sovereign-jdbc-production-deployment.md)). This RC boundary document has not been updated to reflect the now-complete JDBC stack — it represents the original encrypted file-backed RC baseline.
+> This document describes the **original** Sovereign Runtime RC boundary established before JDBC persistence, worker coordination, and the regulated JDBC E2E proof were completed.
+>
+> For the **current** completed roadmap boundary, see [Sovereign Runtime Closure Boundary](./sovereign-runtime-closure-boundary.md).
 
-## Post-RC Roadmap
+## Historical Context
 
-After this RC boundary, the next roadmap area is production hardening:
+The original post-RC roadmap listed:
+1. JDBC/database-backed persistence and outbox ✅
+2. Distributed worker coordination ✅
+3. Key rotation *(deferred)*
+4. Production deployment guide ✅
+5. End-to-end regulated workflow examples ✅
+6. API stabilization *(next roadmap)*
 
-1. JDBC/database-backed persistence and outbox ✅ (PRs #80–#89)
-2. Distributed worker coordination ✅ (PR #88, worker leases)
-3. Key rotation
-4. Production deployment guide ✅ (PR #90, [runbook](../runbooks/sovereign-jdbc-production-deployment.md))
-5. End-to-end regulated workflow examples ✅ (PR #91, [Regulated Claim Triage JDBC E2E](../scenarios/regulated-claim-triage.md#executable-jdbc-e2e-proof))
-6. API stabilization based on integration feedback
-
-The first production-hardening design target is database-backed persistence. See [Sovereign JDBC Persistence Design](../architecture/sovereign-jdbc-persistence-design.md).
+Items 1, 2, 4, and 5 are now complete. Item 3 (key rotation) is deferred to the future GA roadmap. See the [Sovereign Runtime Closure Boundary](./sovereign-runtime-closure-boundary.md) for the full closure boundary.

--- a/docs/scenarios/regulated-claim-triage.md
+++ b/docs/scenarios/regulated-claim-triage.md
@@ -198,6 +198,9 @@ For the planned database-backed persistence direction, see [Sovereign JDBC Persi
 
 ## Executable JDBC E2E Proof
 
+This scenario is one of the closure evidence items for the Sovereign Runtime roadmap.
+See [Sovereign Runtime Closure Boundary](../releases/sovereign-runtime-closure-boundary.md).
+
 This scenario is now covered by a JDBC-backed E2E test in:
 
 `examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageJdbcE2ETest.kt`

--- a/docs/sovereignty-closure-plan.md
+++ b/docs/sovereignty-closure-plan.md
@@ -1,0 +1,259 @@
+# Sovereignty Milestone — Closure Mini Roadmap
+
+> **Context:** This document is the tactical closure plan for the Sovereignty milestone.
+> The high-level Enterprise Roadmap is at [`ROADMAP.md`](../ROADMAP.md).
+> This plan defines how we close the Sovereignty chapter cleanly, not how we build the next one.
+
+---
+
+## 1. Current State
+
+With [PR #91](https://github.com/dev-tramai/tramai/pull/91) merged, the Sovereignty roadmap is functionally complete.
+
+The repo now has:
+
+| Capability | Status |
+|---|---|
+| File-backed sovereign persistence | ✅ |
+| JDBC/PostgreSQL persistence | ✅ |
+| Approval store | ✅ |
+| Suspended invocation store | ✅ |
+| Approval continuation store | ✅ |
+| Audit store | ✅ |
+| Audit outbox store | ✅ |
+| Transactional approval denial + audit outbox | ✅ |
+| Worker lease coordination | ✅ |
+| Spring Boot JDBC auto-config | ✅ |
+| Production deployment runbook | ✅ |
+| Regulated claim triage executable E2E | ✅ |
+| CI-backed E2E proof | ✅ |
+
+Recent merged PRs show this sequence clearly: JDBC approval store, suspended invocation store, continuation store, audit store, outbox store, auto-config, restart E2E, worker leases, transactional mutation boundary, production runbook, and regulated E2E proof.
+
+---
+
+## 2. The Honest Answer
+
+We are **85–90% done**.
+
+Not because features are missing, but because the roadmap needs closure discipline.
+
+The current RC boundary doc still says the JDBC stack is not fully reflected in the RC boundary and explicitly calls out that the document is stale compared to the current implementation.
+
+Also, the only meaningful roadmap item still not completed:
+
+> **Key rotation**
+
+The post-RC roadmap lists key rotation as the remaining uncompleted item, while JDBC persistence, worker coordination, deployment guide, and regulated workflow examples are already checked off.
+
+---
+
+## 3. Recommended Closing Plan
+
+### PR #92 — Sovereignty Closure Boundary
+
+**Goal:** freeze the meaning of "Sovereign Runtime complete".
+
+This should be a docs + verification PR.
+
+**Changes:**
+
+- Rename/extend the RC boundary into a Sovereign Runtime Closure Boundary.
+- Remove the stale note saying the RC doc does not reflect JDBC.
+- Define what is now included:
+  - policy routing
+  - DLP-aware routing
+  - file persistence
+  - JDBC persistence
+  - approvals
+  - audit chain
+  - audit outbox
+  - worker leases
+  - observability
+  - deployment runbook
+  - executable regulated scenario
+- Define what is explicitly **not** included:
+  - production UI
+  - reviewer dashboard
+  - Maven Central release
+  - full REST control plane
+  - production certification
+  - broad workflow DSL
+  - key rotation, unless you decide to implement it now
+
+**Why this matters:** It prevents the roadmap from becoming infinite.
+
+### PR #93 — Final Sovereign Verification Gate
+
+**Goal:** create one canonical command that says:
+
+```
+./gradlew verifySovereignRuntimeClosure
+```
+
+It should depend on:
+
+- `verifySovereignRuntimeReleaseCandidate`
+- `:examples:spring-sovereign-starter:e2eTest`
+- release evidence index
+- zero-egress evidence
+- regulated claim triage docs link validation
+- production runbook presence
+- status matrix consistency
+
+This is the "no more vibes" PR. After this, closure is machine-verifiable.
+
+### PR #94 — API Stabilization Pass
+
+**Goal:** decide what is public, experimental, internal, and test-only.
+
+This is important because `docs/STATUS.md` still marks many areas as "Implemented / evolving", including JDBC persistence, audit outbox, orchestration, MCP, scheduling, HTTP server, and multi-tenancy.
+
+For Sovereignty closure, you do not need to stabilize all TramAI APIs.
+
+You only need to stabilize the **Sovereign Runtime surface**:
+
+- `ApprovalStore`
+- `SuspendedInvocationStore`
+- `ApprovalContinuationStore`
+- `AuditStore`
+- `SovereignOpsAuditOutboxStore`
+- `SovereignOpsApprovalMutationStore`
+- worker lease SPI/config
+- Spring Boot configuration properties
+- operational status/health contracts
+
+Everything else can remain evolving.
+
+### Optional PR #95 — Key Rotation Decision
+
+This is the fork in the road.
+
+**Option A — Defer key rotation**
+
+Add a clear statement:
+
+> Key rotation is deferred to Sovereign Runtime GA / production certification and is not required for the current Sovereignty roadmap closure.
+
+This is acceptable if the goal is RC / enterprise proof, not production-certified security.
+
+**Option B — Implement minimal key rotation**
+
+- key ID in encrypted records
+- active key for writes
+- old keys allowed for reads
+- no automatic re-encryption yet
+- runbook section for rotation procedure
+
+This is more work and can easily become 3–5 PRs.
+
+**Recommendation:** defer key rotation explicitly. Do not let it drag the roadmap into another rabbit hole.
+
+---
+
+## 4. When Are We Closing It?
+
+### Realistic answer
+
+Close the Sovereignty roadmap after **3 more PRs**:
+
+| PR | Name | Purpose |
+|---|---|---|
+| #92 | Sovereignty closure boundary | Freeze scope |
+| #93 | Final closure verification gate | Machine-check closure |
+| #94 | Sovereign API stabilization pass | Mark stable vs evolving |
+
+Then close it.
+
+### Timeline
+
+Given current pace:
+
+- **Aggressive:** close by Friday, 26 June 2026
+- **Safer:** close by early next week
+- **Do not extend beyond:** PR #95
+
+If key rotation is pulled into scope, the roadmap does not close this week. It becomes another production-security roadmap.
+
+---
+
+## 5. What Comes After Sovereignty
+
+Once closed, the next roadmap should not be called Sovereignty anymore.
+
+It should become one of these:
+
+### Option 1 — TramAI Workflow Runtime
+
+**Focus:**
+- workflow DSL
+- suspension/resume ergonomics
+- state machine expression
+- approval gateway abstraction
+- developer experience
+
+This is the most natural next step because PR #91 proves the workflow is possible, but still through a test harness.
+
+### Option 2 — Enterprise Integration Layer
+
+**Focus:**
+- REST control plane
+- reviewer UI hooks
+- external identity/roles
+- audit export
+- admin APIs
+- deployment templates
+
+This is more product-facing.
+
+### Option 3 — Sovereign Runtime GA
+
+**Focus:**
+- key rotation
+- API compatibility
+- migration guarantees
+- production certification
+- Maven Central release
+- security review
+
+This is more formal and heavier.
+
+---
+
+## 6. Recommendation
+
+Close Sovereignty as:
+
+> **Sovereign Runtime RC+ / Enterprise Proof Complete**
+
+Do not call it GA yet.
+
+Then move to:
+
+> **Post-Sovereignty Roadmap: Workflow Ergonomics + API Stabilization**
+
+### Immediate next task
+
+**[PR #92](https://github.com/dev-tramai/tramai/pull/92)** — `docs(sovereign): define Sovereign Runtime closure boundary`
+
+This PR should say clearly:
+
+- what is complete
+- what is deferred
+- what command proves closure
+- what roadmap comes next
+
+---
+
+## 7. Summary
+
+- PR #91 was the last big feature proof.
+- The remaining work is not feature-building; it is **closure**.
+- Sovereignty should close after **3 small PRs**.
+- Key rotation should be explicitly deferred unless you want another long roadmap.
+- Target closure: **Friday 26 June 2026** if disciplined, otherwise **early next week**.
+- Next task: **PR #92** — Sovereign Runtime closure boundary.
+
+---
+
+*Last updated: 2026-06-24*


### PR DESCRIPTION
# Sovereign Runtime Closure Boundary

## Summary

This PR defines the formal closure boundary for the Sovereignty roadmap after PR #91. It is a **docs-only PR** — zero production code changes.

No claim of GA, production certification, or 1.0 stability is made.

## Changes

| File | Change |
|------|--------|
| `docs/releases/sovereign-runtime-closure-boundary.md` | **NEW** — closure boundary document defining included capabilities, closure evidence commands, explicit non-goals, deferred key rotation, and the next roadmap direction |
| `docs/releases/sovereign-runtime-rc-boundary.md` | Replaced stale "JDBC not reflected" note with historical context + link to new closure boundary |
| `docs/STATUS.md` | Added Sovereign Runtime Closure Status section with proof points and deferred items |
| `README.md` | Removed stale "Not Yet Included" claims (database-backed persistence, worker leader election, deployment guide); added Sovereign Runtime section linking to closure boundary |
| `docs/scenarios/regulated-claim-triage.md` | Marked as closure evidence with link to closure boundary |
| `CHANGELOG.md` | Added closure boundary entry |

## Closure Evidence

All verification gates pass:

```
./gradlew check ✅
./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks ✅
./gradlew :examples:spring-sovereign-starter:e2eTest ✅
```

## What This PR Does Not Do

- Does not implement key rotation
- Does not add new runtime APIs
- Does not add workflow DSL
- Does not claim GA or production certification
- Does not add reviewer UI
- Does not add new examples
- Does not modify Gradle build or publish configuration