### PR TITLE
build(sovereign): add Sovereign Runtime closure verification gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Run Spring sovereign starter E2E tests
         run: ./gradlew :examples:spring-sovereign-starter:e2eTest
 
+      - name: Verify Sovereign Runtime closure
+        run: ./gradlew verifySovereignRuntimeClosure
+
       - name: Upload SBOM
         uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- Added `verifySovereignRuntimeClosure`, a canonical verification task for the Sovereign Runtime RC+ / enterprise proof closure boundary.
 - Sovereign runtime profile and routing foundation (`tramai-sovereign`).
 - Policy enforcement and DLP/redaction support (`tramai-security`).
 - Approval gates and replay-safe resume.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2041,7 +2041,7 @@ tasks.register("verifySovereignRuntimeClosureDocs") {
 
         val requiredPhrases = listOf(
             "RC+ / enterprise proof",
-            "GA-certified",
+            "not a GA-certified production release",
             "Key rotation",
             "verifySovereignRuntimeReleaseCandidate",
             ":examples:spring-sovereign-starter:e2eTest",
@@ -2053,6 +2053,27 @@ tasks.register("verifySovereignRuntimeClosureDocs") {
             require(closureText.contains(phrase)) {
                 "Sovereign Runtime closure boundary is missing required phrase: $phrase"
             }
+        }
+
+        // Verify that GA is explicitly not claimed — positive check above already
+        // requires "not a GA-certified production release". These negative guards
+        // prevent accidental overclaiming if the document is later edited.
+        // Note: "stable 1.0 API" appears legitimately in the non-goals section,
+        // so we only guard against affirmative claims.
+        val forbiddenClaims = listOf(
+            "is GA-certified",
+            "production certified",
+        )
+
+        forbiddenClaims.forEach { forbidden ->
+            require(!closureText.contains(forbidden, ignoreCase = true)) {
+                "Sovereign Runtime closure boundary must not claim: $forbidden"
+            }
+        }
+
+        // Key rotation must be explicitly deferred, not merely mentioned
+        require(closureText.contains("deferred", ignoreCase = true)) {
+            "Closure boundary must explicitly defer key rotation (found 'Key rotation' but not 'deferred')."
         }
 
         val rcBoundary = file("docs/releases/sovereign-runtime-rc-boundary.md").readText()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2022,3 +2022,79 @@ tasks.register("verifySovereignRuntimeReleaseCandidate") {
         logger.lifecycle("No tag or GitHub release was created.")
     }
 }
+
+// ──────────────────────────────────────────────
+// Task: verifySovereignRuntimeClosureDocs
+// ──────────────────────────────────────────────
+
+tasks.register("verifySovereignRuntimeClosureDocs") {
+    group = "verification"
+    description = "Verifies Sovereign Runtime closure documentation links and required claims."
+
+    doLast {
+        val closureDoc = file("docs/releases/sovereign-runtime-closure-boundary.md")
+        require(closureDoc.exists()) {
+            "Missing Sovereign Runtime closure boundary document at ${closureDoc.absolutePath}."
+        }
+
+        val closureText = closureDoc.readText()
+
+        val requiredPhrases = listOf(
+            "RC+ / enterprise proof",
+            "GA-certified",
+            "Key rotation",
+            "verifySovereignRuntimeReleaseCandidate",
+            ":examples:spring-sovereign-starter:e2eTest",
+            "Regulated Claim Triage",
+            "Sovereign JDBC Production Deployment Runbook",
+        )
+
+        requiredPhrases.forEach { phrase ->
+            require(closureText.contains(phrase)) {
+                "Sovereign Runtime closure boundary is missing required phrase: $phrase"
+            }
+        }
+
+        val rcBoundary = file("docs/releases/sovereign-runtime-rc-boundary.md").readText()
+        require(rcBoundary.contains("sovereign-runtime-closure-boundary.md")) {
+            "RC boundary must link to the closure boundary."
+        }
+
+        val status = file("docs/STATUS.md").readText()
+        require(status.contains("Sovereign Runtime Closure Status")) {
+            "docs/STATUS.md must include Sovereign Runtime Closure Status section."
+        }
+
+        logger.lifecycle("verifySovereignRuntimeClosureDocs: all documentation consistency checks passed.")
+    }
+}
+
+// ──────────────────────────────────────────────
+// Task: verifySovereignRuntimeClosure
+// ──────────────────────────────────────────────
+
+tasks.register("verifySovereignRuntimeClosure") {
+    group = "verification"
+    description = "Verifies the Sovereign Runtime closure boundary — the canonical gate for the Sovereignty RC+ / enterprise proof milestone."
+
+    notCompatibleWithConfigurationCache(
+        "Sovereign runtime closure verification aggregates execution-time verification tasks.",
+    )
+
+    dependsOn(
+        "check",
+        "verifySovereignRuntimeReleaseCandidate",
+        ":examples:spring-sovereign-starter:e2eTest",
+        "verifySovereignRuntimeClosureDocs",
+    )
+
+    doLast {
+        logger.lifecycle("Sovereign runtime closure verification complete.")
+        logger.lifecycle("Validated:")
+        logger.lifecycle("  - check (full test suite)")
+        logger.lifecycle("  - verifySovereignRuntimeReleaseCandidate")
+        logger.lifecycle("  - :examples:spring-sovereign-starter:e2eTest")
+        logger.lifecycle("  - verifySovereignRuntimeClosureDocs (documentation consistency)")
+        logger.lifecycle("Sovereignty roadmap is closed at the RC+ / enterprise proof level.")
+    }
+}

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -4,6 +4,16 @@ TramAI is under **active development**.
 
 This document describes the state of the repository, not a formal release contract. It tracks what is implemented and evolving on `master`, and what is intentionally not yet complete.
 
+## Sovereign Runtime Closure Verification
+
+The closure boundary can be verified with:
+
+```bash
+./gradlew verifySovereignRuntimeClosure
+```
+
+This is the canonical local verification command for the Sovereign Runtime RC+ / enterprise proof milestone.
+
 ## Sovereign Runtime Closure Status
 
 The Sovereign Runtime roadmap is **functionally complete as an RC+ / enterprise proof milestone**.

--- a/docs/releases/sovereign-runtime-closure-boundary.md
+++ b/docs/releases/sovereign-runtime-closure-boundary.md
@@ -52,20 +52,20 @@ The following capabilities are included in the closure boundary:
 
 ## Closure Evidence
 
-The Sovereignty roadmap is considered **closed** when the following verification commands pass:
+The Sovereign Runtime closure boundary is verified by:
 
 ```bash
-# Full test suite
-./gradlew check
-
-# Release-candidate verification chain
-./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks
-
-# JDBC E2E restart proof
-./gradlew :examples:spring-sovereign-starter:e2eTest
+./gradlew verifySovereignRuntimeClosure
 ```
 
-These gates prove that all included capabilities are functional, the release evidence chain is intact, and the regulated JDBC scenario works end-to-end.
+This task depends on:
+
+- `./gradlew check` — full test suite
+- `./gradlew verifySovereignRuntimeReleaseCandidate` — release-candidate verification chain
+- `./gradlew :examples:spring-sovereign-starter:e2eTest` — JDBC E2E restart proof
+- closure documentation consistency checks
+
+These gates prove that all included capabilities are functional, the release evidence chain is intact, the regulated JDBC scenario works end-to-end, and the closure documentation is internally consistent.
 
 ---
 

--- a/docs/releases/sovereign-runtime-closure-boundary.md
+++ b/docs/releases/sovereign-runtime-closure-boundary.md
@@ -3,6 +3,8 @@
 > This document defines the formal closure boundary for the Sovereignty roadmap.
 > The Sovereign Runtime is considered functionally complete as an RC+ / enterprise proof milestone.
 > It is **not** a GA-certified production release.
+>
+> This is not a GA-certified production release.
 
 ---
 
@@ -10,7 +12,7 @@
 
 Sovereign Runtime is **functionally complete as an enterprise proof / RC+ milestone**.
 
-It is not yet a GA-certified production release. The next roadmap focuses on API stabilization and workflow ergonomics.
+**This is not a GA-certified production release.** The next roadmap focuses on API stabilization and workflow ergonomics.
 
 ---
 


### PR DESCRIPTION
# Sovereign Runtime Closure Verification Gate

## Summary

Adds a canonical Gradle verification task `verifySovereignRuntimeClosure` that proves the Sovereign Runtime closure boundary from a single command.

## Changes

| File | Change |
|------|--------|
| `build.gradle.kts` | Added `verifySovereignRuntimeClosure` (depends on `check`, `verifySovereignRuntimeReleaseCandidate`, `:examples:spring-sovereign-starter:e2eTest`, `verifySovereignRuntimeClosureDocs`) and `verifySovereignRuntimeClosureDocs` (validates closure boundary doc, RC boundary cross-link, STATUS.md section) |
| `docs/releases/sovereign-runtime-closure-boundary.md` | Closure evidence now references `./gradlew verifySovereignRuntimeClosure` as the canonical command |
| `docs/STATUS.md` | Added Sovereign Runtime Closure Verification section |
| `CHANGELOG.md` | Added closure verification gate entry |

## Verification

```
./gradlew verifySovereignRuntimeClosure ✅
```

This single task now proves:
- Full test suite passes
- Release-candidate verification chain passes
- JDBC E2E restart proof passes
- Closure documentation is internally consistent

## Non-Goals

- No runtime APIs added
- No key rotation implemented
- No workflow DSL added
- No production behavior changed