### PR TITLE
feat(workflow): add minimal approval gateway SPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `verifySovereignRuntimeClosure`, a canonical verification task for the Sovereign Runtime RC+ / enterprise proof closure boundary.
 - Added Sovereign Runtime API stability boundary documenting RC+ stable, preview, internal, and deferred surfaces.
 - Added human approval workflow ergonomics design document defining the target API shape for non-blocking human-in-the-loop workflows.
+- Added Preview approval gateway SPI for non-blocking human approval workflow ergonomics (`ApprovalGateway`, `ApprovalRequestResult`, `ApprovalGatewayTypes`, `SovereignWorkflowResult`).
 - Sovereign runtime profile and routing foundation (`tramai-sovereign`).
 - Policy enforcement and DLP/redaction support (`tramai-security`).
 - Approval gates and replay-safe resume.

--- a/docs/architecture/human-approval-workflow-ergonomics.md
+++ b/docs/architecture/human-approval-workflow-ergonomics.md
@@ -289,6 +289,13 @@ Per the [Sovereign Runtime API Stability Boundary](../architecture/sovereign-api
 
 This design proposes the path to move workflow ergonomics from **Preview** toward **RC+ Stable**.
 
+> **Current implementation status:** The minimal SPI described here is now represented by concrete Preview APIs in:
+> - `dev.tramai.core.approval.gateway.ApprovalGateway`
+> - `dev.tramai.core.approval.gateway.ApprovalRequestResult`
+> - `dev.tramai.core.workflow.SovereignWorkflowResult`
+>
+> The implementation remains intentionally minimal. Persistence wiring, resume runtime, and example refactoring are handled by later PRs.
+
 ---
 
 ## 8. Out of Scope

--- a/docs/architecture/sovereign-api-stability-boundary.md
+++ b/docs/architecture/sovereign-api-stability-boundary.md
@@ -63,6 +63,9 @@ These are the APIs that form the Sovereign Runtime contract surface for the clos
 
 The following capabilities are proven by working examples, but the developer-facing API is **not** final.
 
+- `ApprovalGateway` — front-door contract for non-blocking human approval (`dev.tramai.core.approval.gateway`)
+- `ApprovalRequestResult` — sealed type for approval request outcomes (`dev.tramai.core.approval.gateway`)
+- `SovereignWorkflowResult` — sealed type for workflow-level outcomes (`dev.tramai.core.workflow`)
 - Workflow ergonomics
 - Approval gateway abstractions
 - Human suspension / resume workflow shape

--- a/tramai-core/build.gradle.kts
+++ b/tramai-core/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.assertj.core)
     testImplementation(libs.kotlin.test.junit5)
+    testImplementation(libs.coroutines.test)
 }
 
 tasks.test {

--- a/tramai-core/src/main/kotlin/dev/tramai/core/approval/gateway/ApprovalGateway.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/approval/gateway/ApprovalGateway.kt
@@ -1,0 +1,29 @@
+package dev.tramai.core.approval.gateway
+
+/**
+ * Front-door contract for non-blocking human approval in sovereign workflows.
+ *
+ * Implementations persist durable suspension state and return immediately;
+ * they must not block a thread waiting for a human decision.
+ *
+ * This SPI is [Preview] — the API shape is usable but may evolve.
+ * See [docs/architecture/sovereign-api-stability-boundary.md](../../../../../../docs/architecture/sovereign-api-stability-boundary.md).
+ */
+interface ApprovalGateway {
+
+    /**
+     * Request human approval for a workflow step.
+     *
+     * @param subject  the business object requiring approval (e.g. claim ID)
+     * @param recommendation  the recommendation to be reviewed
+     * @param requiredRole  the role permitted to approve or deny
+     * @param workflowRunId  optional workflow run identifier for idempotency
+     * @return  [ApprovalRequestResult] indicating suspension or pre-existing decision
+     */
+    suspend fun requestApproval(
+        subject: ApprovalSubject,
+        recommendation: ApprovalRecommendation,
+        requiredRole: ApproverRole,
+        workflowRunId: WorkflowRunId? = null,
+    ): ApprovalRequestResult
+}

--- a/tramai-core/src/main/kotlin/dev/tramai/core/approval/gateway/ApprovalGateway.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/approval/gateway/ApprovalGateway.kt
@@ -6,8 +6,7 @@ package dev.tramai.core.approval.gateway
  * Implementations persist durable suspension state and return immediately;
  * they must not block a thread waiting for a human decision.
  *
- * This SPI is [Preview] — the API shape is usable but may evolve.
- * See [docs/architecture/sovereign-api-stability-boundary.md](../../../../../../docs/architecture/sovereign-api-stability-boundary.md).
+ * Preview API. See docs/architecture/sovereign-api-stability-boundary.md.
  */
 interface ApprovalGateway {
 

--- a/tramai-core/src/main/kotlin/dev/tramai/core/approval/gateway/ApprovalGatewayTypes.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/approval/gateway/ApprovalGatewayTypes.kt
@@ -72,15 +72,24 @@ sealed interface HumanApprovalDecision {
         override val decidedBy: String,
         override val decidedAt: Instant,
         override val comment: String? = null,
-    ) : HumanApprovalDecision
+    ) : HumanApprovalDecision {
+        init {
+            require(decidedBy.isNotBlank()) { "human-approval-decision-decided-by-blank" }
+        }
+    }
 
     data class Denied(
         override val approvalId: ApprovalId,
         override val decidedBy: String,
         override val decidedAt: Instant,
-        override val comment: String? = null,
         val reason: String,
-    ) : HumanApprovalDecision
+        override val comment: String? = null,
+    ) : HumanApprovalDecision {
+        init {
+            require(decidedBy.isNotBlank()) { "human-approval-decision-decided-by-blank" }
+            require(reason.isNotBlank()) { "human-approval-denial-reason-blank" }
+        }
+    }
 }
 
 // ── Approval request result ──
@@ -94,11 +103,11 @@ sealed interface ApprovalRequestResult {
     ) : ApprovalRequestResult
 
     data class AlreadyApproved(
-        val decision: HumanApprovalDecision,
+        val decision: HumanApprovalDecision.Approved,
     ) : ApprovalRequestResult
 
     data class AlreadyDenied(
-        val decision: HumanApprovalDecision,
+        val decision: HumanApprovalDecision.Denied,
     ) : ApprovalRequestResult
 
     data class Expired(

--- a/tramai-core/src/main/kotlin/dev/tramai/core/approval/gateway/ApprovalGatewayTypes.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/approval/gateway/ApprovalGatewayTypes.kt
@@ -1,0 +1,109 @@
+package dev.tramai.core.approval.gateway
+
+import java.time.Instant
+
+// ── Value types ──
+
+@JvmInline
+value class ApprovalSubject(val value: String) {
+    init {
+        require(value.isNotBlank()) { "approval-subject-blank" }
+    }
+}
+
+@JvmInline
+value class ApproverRole(val value: String) {
+    init {
+        require(value.isNotBlank()) { "approver-role-blank" }
+    }
+}
+
+@JvmInline
+value class ApprovalId(val value: String) {
+    init {
+        require(value.isNotBlank()) { "approval-id-blank" }
+    }
+}
+
+@JvmInline
+value class WorkflowRunId(val value: String) {
+    init {
+        require(value.isNotBlank()) { "workflow-run-id-blank" }
+    }
+}
+
+@JvmInline
+value class AuditStreamId(val value: String) {
+    init {
+        require(value.isNotBlank()) { "audit-stream-id-blank" }
+    }
+}
+
+@JvmInline
+value class ResumeToken(val value: String) {
+    init {
+        require(value.isNotBlank()) { "resume-token-blank" }
+    }
+}
+
+// ── Recommendation ──
+
+data class ApprovalRecommendation(
+    val type: String,
+    val summary: String,
+    val payload: Map<String, String> = emptyMap(),
+) {
+    init {
+        require(type.isNotBlank()) { "approval-recommendation-type-blank" }
+        require(summary.isNotBlank()) { "approval-recommendation-summary-blank" }
+    }
+}
+
+// ── Human decision ──
+
+sealed interface HumanApprovalDecision {
+    val approvalId: ApprovalId
+    val decidedBy: String
+    val decidedAt: Instant
+    val comment: String?
+
+    data class Approved(
+        override val approvalId: ApprovalId,
+        override val decidedBy: String,
+        override val decidedAt: Instant,
+        override val comment: String? = null,
+    ) : HumanApprovalDecision
+
+    data class Denied(
+        override val approvalId: ApprovalId,
+        override val decidedBy: String,
+        override val decidedAt: Instant,
+        override val comment: String? = null,
+        val reason: String,
+    ) : HumanApprovalDecision
+}
+
+// ── Approval request result ──
+
+sealed interface ApprovalRequestResult {
+    data class Suspended(
+        val approvalId: ApprovalId,
+        val workflowRunId: WorkflowRunId,
+        val auditStreamId: AuditStreamId,
+        val resumeToken: ResumeToken,
+    ) : ApprovalRequestResult
+
+    data class AlreadyApproved(
+        val decision: HumanApprovalDecision,
+    ) : ApprovalRequestResult
+
+    data class AlreadyDenied(
+        val decision: HumanApprovalDecision,
+    ) : ApprovalRequestResult
+
+    data class Expired(
+        val approvalId: ApprovalId,
+        val expiredAt: Instant,
+        val reason: String,
+    ) : ApprovalRequestResult
+}

--- a/tramai-core/src/main/kotlin/dev/tramai/core/workflow/SovereignWorkflowResult.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/workflow/SovereignWorkflowResult.kt
@@ -1,0 +1,34 @@
+package dev.tramai.core.workflow
+
+import dev.tramai.core.approval.gateway.ApprovalId
+import dev.tramai.core.approval.gateway.AuditStreamId
+import dev.tramai.core.approval.gateway.ResumeToken
+import dev.tramai.core.approval.gateway.WorkflowRunId
+
+/**
+ * Top-level result type for sovereign workflows that may suspend for human approval.
+ *
+ * This SPI is [Preview] — the API shape is usable but may evolve.
+ * See [docs/architecture/sovereign-api-stability-boundary.md](../../../../../docs/architecture/sovereign-api-stability-boundary.md).
+ */
+sealed interface SovereignWorkflowResult<out T> {
+
+    data class Completed<T>(
+        val value: T,
+    ) : SovereignWorkflowResult<T>
+
+    data class SuspendedForApproval(
+        val approvalId: ApprovalId,
+        val workflowRunId: WorkflowRunId,
+        val auditStreamId: AuditStreamId,
+        val resumeToken: ResumeToken,
+    ) : SovereignWorkflowResult<Nothing>
+
+    data class Rejected(
+        val reason: String,
+    ) : SovereignWorkflowResult<Nothing>
+
+    data class Expired(
+        val reason: String,
+    ) : SovereignWorkflowResult<Nothing>
+}

--- a/tramai-core/src/main/kotlin/dev/tramai/core/workflow/SovereignWorkflowResult.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/workflow/SovereignWorkflowResult.kt
@@ -8,8 +8,7 @@ import dev.tramai.core.approval.gateway.WorkflowRunId
 /**
  * Top-level result type for sovereign workflows that may suspend for human approval.
  *
- * This SPI is [Preview] — the API shape is usable but may evolve.
- * See [docs/architecture/sovereign-api-stability-boundary.md](../../../../../docs/architecture/sovereign-api-stability-boundary.md).
+ * Preview API. See docs/architecture/sovereign-api-stability-boundary.md.
  */
 sealed interface SovereignWorkflowResult<out T> {
 

--- a/tramai-core/src/test/kotlin/dev/tramai/core/approval/gateway/ApprovalGatewayContractTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/approval/gateway/ApprovalGatewayContractTest.kt
@@ -139,7 +139,7 @@ class ApprovalGatewayContractTest {
 
         val result = ApprovalRequestResult.AlreadyDenied(decision)
 
-        assertThat((result.decision as HumanApprovalDecision.Denied).reason).isEqualTo("requires-legal-review")
+        assertThat(result.decision.reason).isEqualTo("requires-legal-review")
     }
 
     // ── Gateway contract returns without blocking ──

--- a/tramai-core/src/test/kotlin/dev/tramai/core/approval/gateway/ApprovalGatewayContractTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/approval/gateway/ApprovalGatewayContractTest.kt
@@ -1,0 +1,240 @@
+package dev.tramai.core.approval.gateway
+
+import dev.tramai.core.workflow.SovereignWorkflowResult
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class ApprovalGatewayContractTest {
+
+    // ── Value class validation ──
+
+    @Test
+    fun `ApprovalSubject rejects blank value`() {
+        assertThatIllegalArgumentException()
+            .isThrownBy { ApprovalSubject(" ") }
+            .withMessage("approval-subject-blank")
+    }
+
+    @Test
+    fun `ApproverRole rejects blank value`() {
+        assertThatIllegalArgumentException()
+            .isThrownBy { ApproverRole(" ") }
+            .withMessage("approver-role-blank")
+    }
+
+    @Test
+    fun `ApprovalId rejects blank value`() {
+        assertThatIllegalArgumentException()
+            .isThrownBy { ApprovalId(" ") }
+            .withMessage("approval-id-blank")
+    }
+
+    @Test
+    fun `WorkflowRunId rejects blank value`() {
+        assertThatIllegalArgumentException()
+            .isThrownBy { WorkflowRunId(" ") }
+            .withMessage("workflow-run-id-blank")
+    }
+
+    @Test
+    fun `AuditStreamId rejects blank value`() {
+        assertThatIllegalArgumentException()
+            .isThrownBy { AuditStreamId(" ") }
+            .withMessage("audit-stream-id-blank")
+    }
+
+    @Test
+    fun `ResumeToken rejects blank value`() {
+        assertThatIllegalArgumentException()
+            .isThrownBy { ResumeToken(" ") }
+            .withMessage("resume-token-blank")
+    }
+
+    @Test
+    fun `ApprovalRecommendation rejects blank type`() {
+        assertThatIllegalArgumentException()
+            .isThrownBy {
+                ApprovalRecommendation(
+                    type = " ",
+                    summary = "valid summary",
+                )
+            }
+            .withMessage("approval-recommendation-type-blank")
+    }
+
+    @Test
+    fun `ApprovalRecommendation rejects blank summary`() {
+        assertThatIllegalArgumentException()
+            .isThrownBy {
+                ApprovalRecommendation(
+                    type = "claim-triage",
+                    summary = " ",
+                )
+            }
+            .withMessage("approval-recommendation-summary-blank")
+    }
+
+    // ── Suspended result ──
+
+    @Test
+    fun `Suspended result exposes durable resume identifiers`() {
+        val result = ApprovalRequestResult.Suspended(
+            approvalId = ApprovalId("approval-1"),
+            workflowRunId = WorkflowRunId("workflow-1"),
+            auditStreamId = AuditStreamId("audit-1"),
+            resumeToken = ResumeToken("resume-1"),
+        )
+
+        assertThat(result.approvalId).isEqualTo(ApprovalId("approval-1"))
+        assertThat(result.workflowRunId).isEqualTo(WorkflowRunId("workflow-1"))
+        assertThat(result.auditStreamId).isEqualTo(AuditStreamId("audit-1"))
+        assertThat(result.resumeToken).isEqualTo(ResumeToken("resume-1"))
+    }
+
+    // ── Expired result ──
+
+    @Test
+    fun `Expired result is explicit terminal approval state`() {
+        val expiredAt = Instant.parse("2026-06-25T10:00:00Z")
+
+        val result = ApprovalRequestResult.Expired(
+            approvalId = ApprovalId("approval-1"),
+            expiredAt = expiredAt,
+            reason = "approval-expired",
+        )
+
+        assertThat(result.expiredAt).isEqualTo(expiredAt)
+        assertThat(result.reason).isEqualTo("approval-expired")
+    }
+
+    // ── Already approved / denied ──
+
+    @Test
+    fun `AlreadyApproved preserves decision`() {
+        val decision = HumanApprovalDecision.Approved(
+            approvalId = ApprovalId("approval-1"),
+            decidedBy = "reviewer-1",
+            decidedAt = Instant.parse("2026-06-25T10:00:00Z"),
+            comment = "Looks correct",
+        )
+
+        val result = ApprovalRequestResult.AlreadyApproved(decision)
+
+        assertThat(result.decision.approvalId).isEqualTo(ApprovalId("approval-1"))
+        assertThat(result.decision.decidedBy).isEqualTo("reviewer-1")
+    }
+
+    @Test
+    fun `AlreadyDenied preserves decision with reason`() {
+        val decision = HumanApprovalDecision.Denied(
+            approvalId = ApprovalId("approval-1"),
+            decidedBy = "reviewer-1",
+            decidedAt = Instant.parse("2026-06-25T10:00:00Z"),
+            reason = "requires-legal-review",
+            comment = "Needs legal team input first",
+        )
+
+        val result = ApprovalRequestResult.AlreadyDenied(decision)
+
+        assertThat((result.decision as HumanApprovalDecision.Denied).reason).isEqualTo("requires-legal-review")
+    }
+
+    // ── Gateway contract returns without blocking ──
+
+    private class RecordingApprovalGateway : ApprovalGateway {
+        var calls = 0
+
+        override suspend fun requestApproval(
+            subject: ApprovalSubject,
+            recommendation: ApprovalRecommendation,
+            requiredRole: ApproverRole,
+            workflowRunId: WorkflowRunId?,
+        ): ApprovalRequestResult {
+            calls++
+            return ApprovalRequestResult.Suspended(
+                approvalId = ApprovalId("approval-1"),
+                workflowRunId = workflowRunId ?: WorkflowRunId("workflow-1"),
+                auditStreamId = AuditStreamId("audit-1"),
+                resumeToken = ResumeToken("resume-1"),
+            )
+        }
+    }
+
+    @Test
+    fun `gateway request approval returns Suspended result without blocking`() = runTest {
+        val gateway = RecordingApprovalGateway()
+
+        val result = gateway.requestApproval(
+            subject = ApprovalSubject("claim-1"),
+            recommendation = ApprovalRecommendation(
+                type = "claim-triage",
+                summary = "requires medical review",
+            ),
+            requiredRole = ApproverRole("medical-reviewer"),
+            workflowRunId = WorkflowRunId("workflow-1"),
+        )
+
+        assertThat(result).isInstanceOf(ApprovalRequestResult.Suspended::class.java)
+        assertThat(gateway.calls).isOne()
+    }
+
+    @Test
+    fun `gateway request approval defaults workflowRunId to null`() = runTest {
+        val gateway = RecordingApprovalGateway()
+
+        val result = gateway.requestApproval(
+            subject = ApprovalSubject("claim-1"),
+            recommendation = ApprovalRecommendation(
+                type = "claim-triage",
+                summary = "requires medical review",
+            ),
+            requiredRole = ApproverRole("medical-reviewer"),
+        )
+
+        assertThat(result).isInstanceOf(ApprovalRequestResult.Suspended::class.java)
+        val suspended = result as ApprovalRequestResult.Suspended
+        assertThat(suspended.workflowRunId).isEqualTo(WorkflowRunId("workflow-1"))
+        assertThat(gateway.calls).isOne()
+    }
+
+    // ── SovereignWorkflowResult ──
+
+    @Test
+    fun `SovereignWorkflowResult Completed preserves value`() {
+        val result: SovereignWorkflowResult<String> =
+            SovereignWorkflowResult.Completed("done")
+
+        assertThat(result).isInstanceOf(SovereignWorkflowResult.Completed::class.java)
+        assertThat((result as SovereignWorkflowResult.Completed).value).isEqualTo("done")
+    }
+
+    @Test
+    fun `SovereignWorkflowResult SuspendedForApproval exposes identifiers`() {
+        val result = SovereignWorkflowResult.SuspendedForApproval(
+            approvalId = ApprovalId("approval-1"),
+            workflowRunId = WorkflowRunId("workflow-1"),
+            auditStreamId = AuditStreamId("audit-1"),
+            resumeToken = ResumeToken("resume-1"),
+        )
+
+        assertThat(result.approvalId).isEqualTo(ApprovalId("approval-1"))
+        assertThat(result.workflowRunId).isEqualTo(WorkflowRunId("workflow-1"))
+    }
+
+    @Test
+    fun `SovereignWorkflowResult Rejected preserves reason`() {
+        val result = SovereignWorkflowResult.Rejected("policy-violation")
+
+        assertThat(result.reason).isEqualTo("policy-violation")
+    }
+
+    @Test
+    fun `SovereignWorkflowResult Expired preserves reason`() {
+        val result = SovereignWorkflowResult.Expired("approval-expired")
+
+        assertThat(result.reason).isEqualTo("approval-expired")
+    }
+}


### PR DESCRIPTION
# Minimal Approval Gateway SPI

## Summary

Introduces the minimal concrete SPI for human approval workflow ergonomics, based on the design boundary from PR #95. **No persistence wiring, no resume runtime, no workflow DSL.**

## Changes

### New Source Files

| File | Content |
|------|---------|
| `tramai-core/.../approval/gateway/ApprovalGatewayTypes.kt` | Value classes (`ApprovalSubject`, `ApproverRole`, `ApprovalId`, `WorkflowRunId`, `AuditStreamId`, `ResumeToken`), `ApprovalRecommendation`, `HumanApprovalDecision`, `ApprovalRequestResult` |
| `tramai-core/.../approval/gateway/ApprovalGateway.kt` | `ApprovalGateway` interface with `suspend fun requestApproval(...)` |
| `tramai-core/.../workflow/SovereignWorkflowResult.kt` | `SovereignWorkflowResult<T>` sealed type |
| `tramai-core/.../approval/gateway/ApprovalGatewayContractTest.kt` | 15 unit tests covering blank validation, result shapes, fake gateway contract |

### Modified Files

| File | Change |
|------|--------|
| `tramai-core/build.gradle.kts` | Added `testImplementation(libs.coroutines.test)` |
| `docs/architecture/sovereign-api-stability-boundary.md` | Lists new types as **Preview** |
| `docs/architecture/human-approval-workflow-ergonomics.md` | References concrete Preview API surface |
| `CHANGELOG.md` | Added entry |

## Design Decisions

- `workflowRunId` is optional (`WorkflowRunId? = null`) — enables idempotency by subject + run ID
- `ApprovalRecommendation` is a data class, not a value class — domain-specific payload
- Mapping extension (`toWorkflowResult`) deferred to PR #97 when the regulated triage refactor reveals the right shape
- No `DefaultApprovalGateway` — wiring to stores comes in PR #97

## Non-Goals

- No `DefaultApprovalGateway` implementation
- No persistence wiring to `ApprovalStore`, `SuspendedInvocationStore`, or `ApprovalContinuationStore`
- No Spring Boot auto-configuration
- No resume runtime implementation
- No regulated triage refactor
- No workflow DSL
- No reviewer UI

## Verification

```
./gradlew verifySovereignRuntimeClosure ✅
```