### PR TITLE
feat(workflow): implement approval gateway suspension adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added Sovereign Runtime API stability boundary documenting RC+ stable, preview, internal, and deferred surfaces.
 - Added human approval workflow ergonomics design document defining the target API shape for non-blocking human-in-the-loop workflows.
 - Added Preview approval gateway SPI for non-blocking human approval workflow ergonomics (`ApprovalGateway`, `ApprovalRequestResult`, `ApprovalGatewayTypes`, `SovereignWorkflowResult`).
+- Added Preview store-backed approval gateway adapter over the existing approval, suspended invocation, and continuation stores (`DefaultApprovalGateway`, `ApprovalGatewayRequestFactory`, `ApprovalGatewayPersistenceRequest`).
 - Sovereign runtime profile and routing foundation (`tramai-sovereign`).
 - Policy enforcement and DLP/redaction support (`tramai-security`).
 - Approval gates and replay-safe resume.

--- a/docs/architecture/human-approval-workflow-ergonomics.md
+++ b/docs/architecture/human-approval-workflow-ergonomics.md
@@ -292,9 +292,19 @@ This design proposes the path to move workflow ergonomics from **Preview** towar
 > **Current implementation status:** The minimal SPI described here is now represented by concrete Preview APIs in:
 > - `dev.tramai.core.approval.gateway.ApprovalGateway`
 > - `dev.tramai.core.approval.gateway.ApprovalRequestResult`
+> - `dev.tramai.core.approval.gateway.ApprovalGatewayTypes`
 > - `dev.tramai.core.workflow.SovereignWorkflowResult`
 >
-> The implementation remains intentionally minimal. Persistence wiring, resume runtime, and example refactoring are handled by later PRs.
+> **PR #97** adds a minimal store-backed adapter:
+> - `DefaultApprovalGateway` — Preview implementation of `ApprovalGateway` that delegates to `ApprovalStore`, `SuspendedInvocationStore`, and `ApprovalContinuationStore`
+> - `ApprovalGatewayRequestFactory` — internal seam for constructing low-level persistence records from the ergonomic SPI input
+> - `ApprovalGatewayPersistenceRequest` — transport object aggregating records for all three stores
+>
+> **Limitations:**
+> - Does not implement full workflow resume.
+> - Does not provide a single transactional boundary across all stores.
+> - Does not yet emit approval-requested audit outbox intent.
+> - Is not Spring Boot auto-configured yet.
 
 ---
 
@@ -327,5 +337,7 @@ The following are explicitly **not covered** by this design:
 |---|---|---|
 | #95 | Workflow ergonomics design boundary | This document |
 | #96 | Minimal approval gateway SPI | Introduce `ApprovalGateway` interface over existing stores |
-| #97 | Refactor regulated claim triage through gateway | Real example using the gateway |
-| #98 | Golden path example | Polished developer-facing example |
+| #97 | Store-backed approval gateway adapter | Implement `DefaultApprovalGateway` over approval, suspended invocation, and continuation stores |
+| #98 | Spring Boot auto-configuration | Wire preview gateway as a Spring bean |
+| #99 | Regulated claim triage through gateway | Real example using the gateway |
+| #100 | Golden path example | Polished developer-facing example |

--- a/docs/architecture/sovereign-api-stability-boundary.md
+++ b/docs/architecture/sovereign-api-stability-boundary.md
@@ -66,6 +66,9 @@ The following capabilities are proven by working examples, but the developer-fac
 - `ApprovalGateway` — front-door contract for non-blocking human approval (`dev.tramai.core.approval.gateway`)
 - `ApprovalRequestResult` — sealed type for approval request outcomes (`dev.tramai.core.approval.gateway`)
 - `SovereignWorkflowResult` — sealed type for workflow-level outcomes (`dev.tramai.core.workflow`)
+- `DefaultApprovalGateway` — minimal store-backed adapter for the preview gateway SPI (`dev.tramai.engine.approval`)
+- `ApprovalGatewayRequestFactory` — internal seam for constructing low-level persistence records (`dev.tramai.engine.approval`)
+- `ApprovalGatewayPersistenceRequest` — transport object aggregating persistence records (`dev.tramai.engine.approval`)
 - Workflow ergonomics
 - Approval gateway abstractions
 - Human suspension / resume workflow shape

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/approval/ApprovalGatewayPersistenceRequest.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/approval/ApprovalGatewayPersistenceRequest.kt
@@ -3,6 +3,7 @@ package dev.tramai.engine.approval
 import dev.tramai.core.approval.ApprovalContinuation
 import dev.tramai.core.approval.ApprovalRequest
 import dev.tramai.core.approval.SensitiveToolArguments
+import dev.tramai.core.approval.gateway.ResumeToken
 import dev.tramai.engine.SensitiveReplayEnvelope
 import dev.tramai.engine.SuspendedInvocationMetadata
 
@@ -13,6 +14,11 @@ import dev.tramai.engine.SuspendedInvocationMetadata
  * - [approvalRequest] → [dev.tramai.core.approval.ApprovalStore]
  * - [continuation] + [sensitiveArguments] → [dev.tramai.core.approval.ApprovalContinuationStore]
  * - [suspendedInvocationMetadata] + [replayEnvelope] → [dev.tramai.engine.SuspendedInvocationStore]
+ *
+ * @property resumeToken The public resume token returned in [ApprovalRequestResult.Suspended].
+ *   This is the **credential** presented by the requestor at resume time — NOT the stored
+ *   approval token digest. The factory is responsible for providing it; the gateway must never
+ *   derive it from [ApprovalRequest.binding.approvalTokenDigest].
  */
 data class ApprovalGatewayPersistenceRequest(
     val approvalRequest: ApprovalRequest,
@@ -20,4 +26,5 @@ data class ApprovalGatewayPersistenceRequest(
     val sensitiveArguments: SensitiveToolArguments,
     val suspendedInvocationMetadata: SuspendedInvocationMetadata,
     val replayEnvelope: SensitiveReplayEnvelope,
+    val resumeToken: ResumeToken,
 )

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/approval/ApprovalGatewayPersistenceRequest.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/approval/ApprovalGatewayPersistenceRequest.kt
@@ -1,0 +1,23 @@
+package dev.tramai.engine.approval
+
+import dev.tramai.core.approval.ApprovalContinuation
+import dev.tramai.core.approval.ApprovalRequest
+import dev.tramai.core.approval.SensitiveToolArguments
+import dev.tramai.engine.SensitiveReplayEnvelope
+import dev.tramai.engine.SuspendedInvocationMetadata
+
+/**
+ * Aggregated low-level persistence records produced by [ApprovalGatewayRequestFactory].
+ *
+ * Mirrors the existing store split in a single transport object:
+ * - [approvalRequest] → [dev.tramai.core.approval.ApprovalStore]
+ * - [continuation] + [sensitiveArguments] → [dev.tramai.core.approval.ApprovalContinuationStore]
+ * - [suspendedInvocationMetadata] + [replayEnvelope] → [dev.tramai.engine.SuspendedInvocationStore]
+ */
+data class ApprovalGatewayPersistenceRequest(
+    val approvalRequest: ApprovalRequest,
+    val continuation: ApprovalContinuation,
+    val sensitiveArguments: SensitiveToolArguments,
+    val suspendedInvocationMetadata: SuspendedInvocationMetadata,
+    val replayEnvelope: SensitiveReplayEnvelope,
+)

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/approval/ApprovalGatewayRequestFactory.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/approval/ApprovalGatewayRequestFactory.kt
@@ -1,0 +1,26 @@
+package dev.tramai.engine.approval
+
+import dev.tramai.core.approval.gateway.ApprovalRecommendation
+import dev.tramai.core.approval.gateway.ApprovalSubject
+import dev.tramai.core.approval.gateway.ApproverRole
+import dev.tramai.core.approval.gateway.WorkflowRunId
+
+/**
+ * Internal seam between the ergonomic [dev.tramai.core.approval.gateway.ApprovalGateway] SPI
+ * and the existing low-level persistence records.
+ *
+ * The public SPI receives high-level domain types ([ApprovalSubject], [ApprovalRecommendation],
+ * [ApproverRole]) but the three backing stores require richer runtime metadata: workflow digest,
+ * tool identity, argument digests, approval token digests, replay envelopes, and continuation
+ * metadata. This factory encapsulates that translation.
+ *
+ * Preview API — may change as runtime bridge requirements stabilize.
+ */
+interface ApprovalGatewayRequestFactory {
+    suspend fun createRequest(
+        subject: ApprovalSubject,
+        recommendation: ApprovalRecommendation,
+        requiredRole: ApproverRole,
+        workflowRunId: WorkflowRunId?,
+    ): ApprovalGatewayPersistenceRequest
+}

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/approval/DefaultApprovalGateway.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/approval/DefaultApprovalGateway.kt
@@ -1,0 +1,141 @@
+package dev.tramai.engine.approval
+
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.core.approval.ApprovalStatus
+import dev.tramai.core.approval.ApprovalStore
+import dev.tramai.core.approval.gateway.ApprovalGateway
+import dev.tramai.core.approval.gateway.ApprovalId
+import dev.tramai.core.approval.gateway.ApprovalRecommendation
+import dev.tramai.core.approval.gateway.ApprovalRequestResult
+import dev.tramai.core.approval.gateway.ApprovalSubject
+import dev.tramai.core.approval.gateway.ApproverRole
+import dev.tramai.core.approval.gateway.AuditStreamId
+import dev.tramai.core.approval.gateway.HumanApprovalDecision
+import dev.tramai.core.approval.gateway.ResumeToken
+import dev.tramai.core.approval.gateway.WorkflowRunId
+import dev.tramai.engine.SuspendedInvocationStore
+import java.time.Clock
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Minimal Preview adapter for [ApprovalGateway].
+ *
+ * Writes the existing approval, suspended invocation, and continuation stores
+ * in order. Intended for ergonomic integration tests and Preview usage.
+ *
+ * **Limitations:**
+ * - Does not provide a single transactional boundary across all three stores.
+ *   If step 2 or 3 fails after step 1 succeeds, the stores are left in an
+ *   inconsistent state. A future PR should harden the transaction boundary.
+ * - Does not emit audit-requested outbox intent.
+ * - Does not implement workflow resume.
+ *
+ * @param approvalStore         The store for approval request lifecycle.
+ * @param continuationStore     The store for approval continuation records.
+ * @param suspendedInvocationStore The store for suspended invocation metadata and replay envelope.
+ * @param requestFactory        Internal seam that translates high-level SPI input into low-level
+ *                              persistence records.
+ * @param clock                 Clock for time-based checks. Defaults to system UTC.
+ */
+class DefaultApprovalGateway(
+    private val approvalStore: ApprovalStore,
+    private val continuationStore: ApprovalContinuationStore,
+    private val suspendedInvocationStore: SuspendedInvocationStore,
+    private val requestFactory: ApprovalGatewayRequestFactory,
+    private val clock: Clock = Clock.systemUTC(),
+) : ApprovalGateway {
+
+    override suspend fun requestApproval(
+        subject: ApprovalSubject,
+        recommendation: ApprovalRecommendation,
+        requiredRole: ApproverRole,
+        workflowRunId: WorkflowRunId?,
+    ): ApprovalRequestResult {
+        val request = requestFactory.createRequest(
+            subject = subject,
+            recommendation = recommendation,
+            requiredRole = requiredRole,
+            workflowRunId = workflowRunId,
+        )
+
+        return try {
+            val existing = approvalStore.get(request.approvalRequest.approvalId)
+            if (existing != null) {
+                return existing.toGatewayResult(clock)
+            }
+
+            approvalStore.create(request.approvalRequest)
+
+            suspendedInvocationStore.create(
+                metadata = request.suspendedInvocationMetadata,
+                replayEnvelope = request.replayEnvelope,
+            )
+
+            continuationStore.create(
+                continuation = request.continuation,
+                arguments = request.sensitiveArguments,
+            )
+
+            ApprovalRequestResult.Suspended(
+                approvalId = ApprovalId(request.approvalRequest.approvalId),
+                workflowRunId = WorkflowRunId(request.approvalRequest.binding.workflowRunId),
+                auditStreamId = AuditStreamId(request.suspendedInvocationMetadata.correlationId),
+                resumeToken = ResumeToken(request.approvalRequest.binding.approvalTokenDigest.value),
+            )
+        } catch (e: CancellationException) {
+            throw e
+        }
+    }
+
+    /**
+     * Maps an existing [dev.tramai.core.approval.ApprovalRequest] to a gateway result.
+     */
+    private fun dev.tramai.core.approval.ApprovalRequest.toGatewayResult(
+        clock: Clock,
+    ): ApprovalRequestResult {
+        val approvalId = ApprovalId(approvalId)
+        val now = clock.instant()
+
+        return when {
+            status == ApprovalStatus.APPROVED -> ApprovalRequestResult.AlreadyApproved(
+                decision = HumanApprovalDecision.Approved(
+                    approvalId = approvalId,
+                    decidedBy = requireNotNull(decidedBy) {
+                        "approved request must have a decider"
+                    },
+                    decidedAt = requireNotNull(decidedAt) {
+                        "approved request must have a decision timestamp"
+                    },
+                    comment = decisionComment,
+                ),
+            )
+
+            status == ApprovalStatus.DENIED -> ApprovalRequestResult.AlreadyDenied(
+                decision = HumanApprovalDecision.Denied(
+                    approvalId = approvalId,
+                    decidedBy = requireNotNull(decidedBy) {
+                        "denied request must have a decider"
+                    },
+                    decidedAt = requireNotNull(decidedAt) {
+                        "denied request must have a decision timestamp"
+                    },
+                    reason = decisionComment ?: "approval-denied",
+                ),
+            )
+
+            status == ApprovalStatus.TIMED_OUT || !expiresAt.isAfter(now) ->
+                ApprovalRequestResult.Expired(
+                    approvalId = approvalId,
+                    expiredAt = expiresAt,
+                    reason = "approval-expired",
+                )
+
+            else -> ApprovalRequestResult.Suspended(
+                approvalId = approvalId,
+                workflowRunId = WorkflowRunId(binding.workflowRunId),
+                auditStreamId = AuditStreamId(binding.workflowRunId),
+                resumeToken = ResumeToken(binding.approvalTokenDigest.value),
+            )
+        }
+    }
+}

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/approval/DefaultApprovalGateway.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/approval/DefaultApprovalGateway.kt
@@ -29,12 +29,17 @@ import kotlinx.coroutines.CancellationException
  *   inconsistent state. A future PR should harden the transaction boundary.
  * - Does not emit audit-requested outbox intent.
  * - Does not implement workflow resume.
+ * - Existing pending requests cannot recover the original suspended invocation
+ *   correlation ID from [ApprovalStore] alone, so the adapter currently uses
+ *   the workflow run ID as a temporary audit stream identifier until the
+ *   resume/gateway state model is hardened.
  *
  * @param approvalStore         The store for approval request lifecycle.
  * @param continuationStore     The store for approval continuation records.
  * @param suspendedInvocationStore The store for suspended invocation metadata and replay envelope.
  * @param requestFactory        Internal seam that translates high-level SPI input into low-level
- *                              persistence records.
+ *                              persistence records. Must provide a stable [ResumeToken] — the
+ *                              gateway never derives it from [dev.tramai.core.approval.ApprovalBinding.approvalTokenDigest].
  * @param clock                 Clock for time-based checks. Defaults to system UTC.
  */
 class DefaultApprovalGateway(
@@ -61,7 +66,7 @@ class DefaultApprovalGateway(
         return try {
             val existing = approvalStore.get(request.approvalRequest.approvalId)
             if (existing != null) {
-                return existing.toGatewayResult(clock)
+                return existing.toGatewayResult(request, clock)
             }
 
             approvalStore.create(request.approvalRequest)
@@ -80,7 +85,7 @@ class DefaultApprovalGateway(
                 approvalId = ApprovalId(request.approvalRequest.approvalId),
                 workflowRunId = WorkflowRunId(request.approvalRequest.binding.workflowRunId),
                 auditStreamId = AuditStreamId(request.suspendedInvocationMetadata.correlationId),
-                resumeToken = ResumeToken(request.approvalRequest.binding.approvalTokenDigest.value),
+                resumeToken = request.resumeToken,
             )
         } catch (e: CancellationException) {
             throw e
@@ -89,8 +94,14 @@ class DefaultApprovalGateway(
 
     /**
      * Maps an existing [dev.tramai.core.approval.ApprovalRequest] to a gateway result.
+     *
+     * For the existing-PENDING case, the factory's [resumeToken] is used because the stored
+     * approval binding only contains the digest of the nonce, not the credential itself.
+     * The factory is expected to provide a deterministic token for idempotent calls.
      */
+    @Suppress("unused")
     private fun dev.tramai.core.approval.ApprovalRequest.toGatewayResult(
+        request: ApprovalGatewayPersistenceRequest,
         clock: Clock,
     ): ApprovalRequestResult {
         val approvalId = ApprovalId(approvalId)
@@ -133,8 +144,11 @@ class DefaultApprovalGateway(
             else -> ApprovalRequestResult.Suspended(
                 approvalId = approvalId,
                 workflowRunId = WorkflowRunId(binding.workflowRunId),
+                // Existing pending cannot recover the original correlation ID from
+                // ApprovalStore alone, so workflowRunId serves as a temporary audit
+                // stream identifier until the resume/gateway state model is hardened.
                 auditStreamId = AuditStreamId(binding.workflowRunId),
-                resumeToken = ResumeToken(binding.approvalTokenDigest.value),
+                resumeToken = request.resumeToken,
             )
         }
     }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/approval/DefaultApprovalGatewayTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/approval/DefaultApprovalGatewayTest.kt
@@ -1,0 +1,613 @@
+package dev.tramai.engine.approval
+
+import dev.tramai.core.approval.ApprovalBinding
+import dev.tramai.core.approval.ApprovalContinuation
+import dev.tramai.core.approval.ApprovalContinuationStatus
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.core.approval.ApprovalRequest
+import dev.tramai.core.approval.ApprovalStatus
+import dev.tramai.core.approval.ApprovalStore
+import dev.tramai.core.approval.ApprovalTransition
+import dev.tramai.core.approval.SensitiveToolArguments
+import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.approval.gateway.ApprovalGateway
+import dev.tramai.core.approval.gateway.ApprovalId
+import dev.tramai.core.approval.gateway.ApprovalRecommendation
+import dev.tramai.core.approval.gateway.ApprovalRequestResult
+import dev.tramai.core.approval.gateway.ApprovalSubject
+import dev.tramai.core.approval.gateway.ApproverRole
+import dev.tramai.core.approval.gateway.AuditStreamId
+import dev.tramai.core.approval.gateway.ResumeToken
+import dev.tramai.core.approval.gateway.WorkflowRunId
+import dev.tramai.engine.EngineExecutionIdentity
+import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.ResumeOperationReference
+import dev.tramai.engine.ResumeToolReference
+import dev.tramai.engine.SensitiveReplayEnvelope
+import dev.tramai.engine.SuspendedInvocationMetadata
+import dev.tramai.engine.SuspendedInvocationStore
+import dev.tramai.engine.inMemorySuspendedInvocationStore
+import dev.tramai.security.approval.InMemoryApprovalContinuationStore
+import dev.tramai.security.approval.InMemoryApprovalStore
+import dev.tramai.security.approval.Sha256ToolArgumentsDigester
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class DefaultApprovalGatewayTest {
+
+    private val fixedClock: Clock = Clock.fixed(
+        Instant.parse("2026-06-25T10:00:00Z"),
+        ZoneId.of("UTC"),
+    )
+    private val digester = Sha256ToolArgumentsDigester()
+
+    private lateinit var approvalStore: InMemoryApprovalStore
+    private lateinit var continuationStore: InMemoryApprovalContinuationStore
+    private lateinit var suspendedInvocationStore: SuspendedInvocationStore
+    private lateinit var factory: FakeApprovalGatewayRequestFactory
+
+    // The gateway under test
+    private fun createGateway(): DefaultApprovalGateway = DefaultApprovalGateway(
+        approvalStore = approvalStore,
+        continuationStore = continuationStore,
+        suspendedInvocationStore = suspendedInvocationStore,
+        requestFactory = factory,
+        clock = fixedClock,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        approvalStore = InMemoryApprovalStore(
+            clock = fixedClock,
+            maxCreationTtl = Duration.ofHours(2),
+        )
+        continuationStore = InMemoryApprovalContinuationStore(
+            clock = fixedClock,
+            maxContinuationTtl = Duration.ofHours(2),
+        )
+        suspendedInvocationStore = inMemorySuspendedInvocationStore()
+        factory = FakeApprovalGatewayRequestFactory(
+            fixedClock = fixedClock,
+            defaultApprovalId = "gateway-test-1",
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // 1. New request persists all three records and returns Suspended
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `new request persists approval, suspended invocation, and continuation`(): Unit = runBlocking {
+        val gateway = createGateway()
+        val approvalId = "fresh-request"
+        factory.defaultApprovalId = approvalId
+
+        val result = gateway.requestApproval(
+            subject = ApprovalSubject("claim-42"),
+            recommendation = ApprovalRecommendation("review", "Medical review required"),
+            requiredRole = ApproverRole("medical-reviewer"),
+        )
+
+        // Assert all three stores contain the records
+        val storedApproval = approvalStore.get(approvalId)
+        assertThat(storedApproval).isNotNull
+        assertThat(storedApproval!!.status).isEqualTo(ApprovalStatus.PENDING)
+
+        val storedMetadata = suspendedInvocationStore.get(approvalId)
+        assertThat(storedMetadata).isNotNull
+
+        val storedContinuation = continuationStore.get(approvalId)
+        assertThat(storedContinuation).isNotNull
+
+        // Assert result type
+        assertThat(result).isInstanceOf(ApprovalRequestResult.Suspended::class.java)
+        val suspended = result as ApprovalRequestResult.Suspended
+        assertThat(suspended.approvalId.value).isEqualTo(approvalId)
+        assertThat(suspended.workflowRunId.value).isEqualTo("wf-run-1")
+        assertThat(suspended.auditStreamId.value).isNotEmpty()
+        assertThat(suspended.resumeToken.value).isNotEmpty()
+    }
+
+    // -----------------------------------------------------------------------
+    // 2. Does not block waiting for human (returns Suspended immediately)
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `new request returns immediately without blocking`(): Unit = runBlocking {
+        val gateway = createGateway()
+
+        val result = gateway.requestApproval(
+            subject = ApprovalSubject("claim-42"),
+            recommendation = ApprovalRecommendation("review", "Quick review"),
+            requiredRole = ApproverRole("reviewer"),
+        )
+
+        assertThat(result).isInstanceOf(ApprovalRequestResult.Suspended::class.java)
+    }
+
+    // -----------------------------------------------------------------------
+    // 3. Existing pending request returns Suspended without duplicate create
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `existing pending approval returns Suspended without duplicate create`(): Unit = runBlocking {
+        val approvalId = "duplicate-pending"
+        factory.defaultApprovalId = approvalId
+        val gateway = createGateway()
+
+        // First call creates the request
+        val firstResult = gateway.requestApproval(
+            subject = ApprovalSubject("claim-42"),
+            recommendation = ApprovalRecommendation("review", "Review"),
+            requiredRole = ApproverRole("medical-reviewer"),
+        )
+        assertThat(firstResult).isInstanceOf(ApprovalRequestResult.Suspended::class.java)
+        val firstSuspended = firstResult as ApprovalRequestResult.Suspended
+
+        // Create separate store reference to track create operations
+        val initialApprovalVersion = approvalStore.get(approvalId)!!.version
+
+        // Second call with same data should return Suspended without changing stores
+        val secondResult = gateway.requestApproval(
+            subject = ApprovalSubject("claim-42"),
+            recommendation = ApprovalRecommendation("review", "Review"),
+            requiredRole = ApproverRole("medical-reviewer"),
+        )
+
+        assertThat(secondResult).isInstanceOf(ApprovalRequestResult.Suspended::class.java)
+        val secondSuspended = secondResult as ApprovalRequestResult.Suspended
+        assertThat(secondSuspended.approvalId).isEqualTo(firstSuspended.approvalId)
+
+        // Version should not have changed — create was not called again
+        val approvalAfterSecondCall = approvalStore.get(approvalId)!!
+        assertThat(approvalAfterSecondCall.version).isEqualTo(initialApprovalVersion)
+    }
+
+    // -----------------------------------------------------------------------
+    // 4. Existing approved request returns AlreadyApproved
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `existing approved approval returns AlreadyApproved`(): Unit = runBlocking {
+        val approvalId = "already-approved"
+        val requestingActor = "test-actor"
+        val decidingActor = "human-1"
+        val factory = FakeApprovalGatewayRequestFactory(
+            fixedClock = fixedClock,
+            defaultApprovalId = approvalId,
+            defaultRequestedBy = requestingActor,
+        )
+        val gateway = DefaultApprovalGateway(
+            approvalStore = approvalStore,
+            continuationStore = continuationStore,
+            suspendedInvocationStore = suspendedInvocationStore,
+            requestFactory = factory,
+            clock = fixedClock,
+        )
+
+        // Pre-create an approved request directly
+        val pendingRequest = createPendingApprovalRequest(approvalId, workflowRunId = "wf-approved", requestedBy = requestingActor)
+        approvalStore.create(pendingRequest)
+        approvalStore.transition(
+            approvalId = approvalId,
+            expectedVersion = 0L,
+            transition = ApprovalTransition.Approve(decidedBy = decidingActor, comment = "Looks good"),
+        )
+
+        val result = gateway.requestApproval(
+            subject = ApprovalSubject("claim-42"),
+            recommendation = ApprovalRecommendation("review", "Review"),
+            requiredRole = ApproverRole("medical-reviewer"),
+        )
+
+        assertThat(result).isInstanceOf(ApprovalRequestResult.AlreadyApproved::class.java)
+        val approved = result as ApprovalRequestResult.AlreadyApproved
+        assertThat(approved.decision.decidedBy).isEqualTo(decidingActor)
+        assertThat(approved.decision.comment).isEqualTo("Looks good")
+    }
+
+    // -----------------------------------------------------------------------
+    // 5. Existing denied request returns AlreadyDenied
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `existing denied approval returns AlreadyDenied`(): Unit = runBlocking {
+        val approvalId = "already-denied"
+        val requestingActor = "test-actor"
+        val decidingActor = "human-2"
+        val factory = FakeApprovalGatewayRequestFactory(
+            fixedClock = fixedClock,
+            defaultApprovalId = approvalId,
+            defaultRequestedBy = requestingActor,
+        )
+        val gateway = DefaultApprovalGateway(
+            approvalStore = approvalStore,
+            continuationStore = continuationStore,
+            suspendedInvocationStore = suspendedInvocationStore,
+            requestFactory = factory,
+            clock = fixedClock,
+        )
+
+        // Pre-create a denied request directly
+        val pendingRequest = createPendingApprovalRequest(approvalId, workflowRunId = "wf-denied", requestedBy = requestingActor)
+        approvalStore.create(pendingRequest)
+        approvalStore.transition(
+            approvalId = approvalId,
+            expectedVersion = 0L,
+            transition = ApprovalTransition.Deny(decidedBy = decidingActor, comment = "Not appropriate"),
+        )
+
+        val result = gateway.requestApproval(
+            subject = ApprovalSubject("claim-42"),
+            recommendation = ApprovalRecommendation("review", "Review"),
+            requiredRole = ApproverRole("medical-reviewer"),
+        )
+
+        assertThat(result).isInstanceOf(ApprovalRequestResult.AlreadyDenied::class.java)
+        val denied = result as ApprovalRequestResult.AlreadyDenied
+        assertThat(denied.decision.decidedBy).isEqualTo(decidingActor)
+        assertThat(denied.decision.reason).isEqualTo("Not appropriate")
+    }
+
+    // -----------------------------------------------------------------------
+    // 6. Existing expired/timed-out request returns Expired
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `existing timed-out approval returns Expired`(): Unit = runBlocking {
+        val approvalId = "already-timed-out"
+        val requestingActor = "test-actor"
+        val mutableClock = MutableTestClock(fixedClock.instant())
+        val expiry = mutableClock.instant().plusSeconds(60) // short 60s TTL
+
+        val timeoutingStore = InMemoryApprovalStore(
+            clock = mutableClock,
+            maxCreationTtl = Duration.ofHours(2),
+        )
+        val timeoutingContinuationStore = InMemoryApprovalContinuationStore(
+            clock = mutableClock,
+            maxContinuationTtl = Duration.ofHours(2),
+        )
+        val factory = FakeApprovalGatewayRequestFactory(
+            fixedClock = mutableClock,
+            defaultApprovalId = approvalId,
+            defaultRequestedBy = requestingActor,
+        )
+        val gateway = DefaultApprovalGateway(
+            approvalStore = timeoutingStore,
+            continuationStore = timeoutingContinuationStore,
+            suspendedInvocationStore = inMemorySuspendedInvocationStore(),
+            requestFactory = factory,
+            clock = mutableClock,
+        )
+
+        // Create a PENDING request with a short TTL
+        val pendingRequest = createPendingApprovalRequest(
+            approvalId = approvalId,
+            workflowRunId = "wf-expired",
+            requestedBy = requestingActor,
+            requestedAt = mutableClock.instant(),
+            expiresAt = expiry,
+        )
+        timeoutingStore.create(pendingRequest)
+
+        // Advance clock past expiry, then time out
+        mutableClock.advance(Duration.ofMinutes(5))
+
+        timeoutingStore.transition(
+            approvalId = approvalId,
+            expectedVersion = 0L,
+            transition = ApprovalTransition.Timeout,
+        )
+
+        val result = gateway.requestApproval(
+            subject = ApprovalSubject("claim-42"),
+            recommendation = ApprovalRecommendation("review", "Review"),
+            requiredRole = ApproverRole("medical-reviewer"),
+        )
+
+        assertThat(result).isInstanceOf(ApprovalRequestResult.Expired::class.java)
+        val expired = result as ApprovalRequestResult.Expired
+        assertThat(expired.approvalId.value).isEqualTo(approvalId)
+        assertThat(expired.reason).isEqualTo("approval-expired")
+    }
+
+    @Test
+    fun `expired-by-clock approval returns Expired`(): Unit = runBlocking {
+        val approvalId = "clock-expired"
+        val requestingActor = "test-actor"
+        val mutableClock = MutableTestClock(fixedClock.instant())
+        val pastExpiry = mutableClock.instant().plusSeconds(60) // short 60s TTL
+
+        // Create approval store with the mutable clock
+        val expiringStore = InMemoryApprovalStore(
+            clock = mutableClock,
+            maxCreationTtl = Duration.ofHours(2),
+        )
+        val expiringContinuationStore = InMemoryApprovalContinuationStore(
+            clock = mutableClock,
+            maxContinuationTtl = Duration.ofHours(2),
+        )
+        val factory = FakeApprovalGatewayRequestFactory(
+            fixedClock = mutableClock,
+            defaultApprovalId = approvalId,
+            defaultRequestedBy = requestingActor,
+        )
+        val gateway = DefaultApprovalGateway(
+            approvalStore = expiringStore,
+            continuationStore = expiringContinuationStore,
+            suspendedInvocationStore = inMemorySuspendedInvocationStore(),
+            requestFactory = factory,
+            clock = mutableClock,
+        )
+
+        // Pre-create a PENDING request with short TTL
+        val pendingRequest = createPendingApprovalRequest(
+            approvalId = approvalId,
+            workflowRunId = "wf-expired-clock",
+            requestedBy = requestingActor,
+            requestedAt = mutableClock.instant(),
+            expiresAt = pastExpiry,
+        )
+        expiringStore.create(pendingRequest)
+
+        // Advance clock past expiry — request is now stale but still PENDING
+        mutableClock.advance(Duration.ofMinutes(5))
+
+        val result = gateway.requestApproval(
+            subject = ApprovalSubject("claim-42"),
+            recommendation = ApprovalRecommendation("review", "Review"),
+            requiredRole = ApproverRole("medical-reviewer"),
+        )
+
+        assertThat(result).isInstanceOf(ApprovalRequestResult.Expired::class.java)
+        val expired = result as ApprovalRequestResult.Expired
+        assertThat(expired.approvalId.value).isEqualTo(approvalId)
+        assertThat(expired.reason).isEqualTo("approval-expired")
+    }
+
+    // -----------------------------------------------------------------------
+    // 7. CancellationException is rethrown
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `cancellation exception from store is rethrown`(): Unit = runBlocking {
+        val failingStore = object : ApprovalStore by approvalStore {
+            override suspend fun create(request: ApprovalRequest): ApprovalRequest {
+                throw CancellationException("simulated-cancel")
+            }
+        }
+        val gateway = DefaultApprovalGateway(
+            approvalStore = failingStore,
+            continuationStore = continuationStore,
+            suspendedInvocationStore = suspendedInvocationStore,
+            requestFactory = factory,
+            clock = fixedClock,
+        )
+
+        val thrown = try {
+            gateway.requestApproval(
+                subject = ApprovalSubject("claim-42"),
+                recommendation = ApprovalRecommendation("review", "Cancel test"),
+                requiredRole = ApproverRole("reviewer"),
+            )
+            null
+        } catch (e: CancellationException) {
+            e
+        }
+
+        assertThat(thrown).isNotNull
+        assertThat(thrown!!.message).isEqualTo("simulated-cancel")
+    }
+
+    // -----------------------------------------------------------------------
+    // 8. Factory failure fails closed without creating approval
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `factory failure does not write stores`(): Unit = runBlocking {
+        val failingFactory = object : ApprovalGatewayRequestFactory {
+            override suspend fun createRequest(
+                subject: ApprovalSubject,
+                recommendation: ApprovalRecommendation,
+                requiredRole: ApproverRole,
+                workflowRunId: WorkflowRunId?,
+            ): ApprovalGatewayPersistenceRequest {
+                throw RuntimeException("factory-exploded")
+            }
+        }
+        val gateway = DefaultApprovalGateway(
+            approvalStore = approvalStore,
+            continuationStore = continuationStore,
+            suspendedInvocationStore = suspendedInvocationStore,
+            requestFactory = failingFactory,
+            clock = fixedClock,
+        )
+
+        val thrown = try {
+            gateway.requestApproval(
+                subject = ApprovalSubject("claim-42"),
+                recommendation = ApprovalRecommendation("review", "Factory failure"),
+                requiredRole = ApproverRole("reviewer"),
+            )
+            null
+        } catch (e: RuntimeException) {
+            e
+        }
+
+        assertThat(thrown).isNotNull
+        assertThat(thrown!!.message).isEqualTo("factory-exploded")
+
+        // No stores were written
+        assertThat(approvalStore.get("any-id")).isNull()
+        assertThat(continuationStore.get("any-id")).isNull()
+        assertThat(suspendedInvocationStore.get("any-id")).isNull()
+    }
+
+    // -----------------------------------------------------------------------
+    // Test helpers
+    // -----------------------------------------------------------------------
+
+    private val zeroDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000000")
+    private val oneDigest = Sha256Digest.of("sha256:1111111111111111111111111111111111111111111111111111111111111111")
+    private val twoDigest = Sha256Digest.of("sha256:2222222222222222222222222222222222222222222222222222222222222222")
+
+    private fun createPendingApprovalRequest(
+        approvalId: String,
+        workflowRunId: String = "wf-run-${approvalId}",
+        requestedBy: String = "test-actor",
+        requestedAt: Instant = fixedClock.instant(),
+        expiresAt: Instant = fixedClock.instant().plusSeconds(3600),
+        status: ApprovalStatus = ApprovalStatus.PENDING,
+        version: Long = 0L,
+    ) = ApprovalRequest(
+        approvalId = approvalId,
+        binding = ApprovalBinding(
+            workflowRunId = workflowRunId,
+            toolName = "test-tool",
+            argumentsDigest = zeroDigest,
+            policyVersion = "v1",
+            workflowDigest = oneDigest,
+            approvalTokenDigest = twoDigest,
+        ),
+        status = status,
+        requestedBy = requestedBy,
+        requestedAt = requestedAt,
+        expiresAt = expiresAt,
+        decidedBy = null,
+        decidedAt = null,
+        decisionComment = null,
+        consumedBy = null,
+        consumedAt = null,
+        version = version,
+    )
+}
+
+/**
+ * A fake [ApprovalGatewayRequestFactory] that returns deterministic persistence requests.
+ */
+internal class FakeApprovalGatewayRequestFactory(
+    private val fixedClock: Clock,
+    var defaultApprovalId: String = "gateway-test-1",
+    var defaultRequestedBy: String = "test-actor",
+    private val digester: Sha256ToolArgumentsDigester = Sha256ToolArgumentsDigester(),
+) : ApprovalGatewayRequestFactory {
+
+    private val zeroDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000000")
+    private val oneDigest = Sha256Digest.of("sha256:1111111111111111111111111111111111111111111111111111111111111111")
+    private val twoDigest = Sha256Digest.of("sha256:2222222222222222222222222222222222222222222222222222222222222222")
+
+    override suspend fun createRequest(
+        subject: ApprovalSubject,
+        recommendation: ApprovalRecommendation,
+        requiredRole: ApproverRole,
+        workflowRunId: WorkflowRunId?,
+    ): ApprovalGatewayPersistenceRequest {
+        val now = fixedClock.instant()
+        val wfRunId = workflowRunId?.value ?: "wf-run-1"
+        val argumentJson = "{\"subject\":\"${subject.value}\"}"
+        val sensitiveArgs = SensitiveToolArguments.of(argumentJson)
+        val argsDigest = digester.digest(sensitiveArgs)
+
+        val approvalRequest = ApprovalRequest(
+            approvalId = defaultApprovalId,
+            binding = ApprovalBinding(
+                workflowRunId = wfRunId,
+                toolName = "test-tool",
+                argumentsDigest = argsDigest,
+                policyVersion = "v1",
+                workflowDigest = oneDigest,
+                approvalTokenDigest = twoDigest,
+            ),
+            status = ApprovalStatus.PENDING,
+            requestedBy = defaultRequestedBy,
+            requestedAt = now,
+            expiresAt = now.plusSeconds(3600),
+            decidedBy = null,
+            decidedAt = null,
+            decisionComment = null,
+            consumedBy = null,
+            consumedAt = null,
+            version = 0L,
+        )
+
+        val continuation = ApprovalContinuation(
+            approvalId = defaultApprovalId,
+            workflowRunId = wfRunId,
+            correlationId = "corr-${defaultApprovalId}",
+            toolCallId = "tc-1",
+            toolName = "test-tool",
+            argumentsDigest = argsDigest,
+            policyVersion = "v1",
+            workflowDigest = oneDigest,
+            status = ApprovalContinuationStatus.PENDING,
+            createdAt = now,
+            approvalExpiresAt = now.plusSeconds(3600),
+            claimedBy = null,
+            claimedAt = null,
+            completedAt = null,
+            version = 0L,
+        )
+
+        val suspendedInvocationMetadata = SuspendedInvocationMetadata(
+            approvalId = defaultApprovalId,
+            toolCallId = "tc-1",
+            toolName = "test-tool",
+            toolCallIndex = 0,
+            correlationId = "corr-${defaultApprovalId}",
+            identity = EngineExecutionIdentity(
+                workflowRunId = wfRunId,
+                correlationId = "corr-${defaultApprovalId}",
+                workflowDigest = oneDigest,
+                policyVersion = "v1",
+                actorId = defaultRequestedBy,
+            ),
+            securityContext = ExecutionSecurityContext(),
+            operationReference = ResumeOperationReference(
+                serviceInterface = "dev.tramai.test.TestService",
+                methodName = "testMethod",
+                jvmMethodDescriptor = "(Ltest/Input;)Ltest/Output;",
+                resumeDefinitionDigest = zeroDigest,
+            ),
+            replayEnvelopeDigest = zeroDigest,
+            toolReference = ResumeToolReference(
+                toolName = "test-tool",
+                declarationDigest = zeroDigest,
+            ),
+        )
+
+        // Create a minimal SensitiveReplayEnvelope
+        val replayEnvelope = SensitiveReplayEnvelope.of(emptyList())
+
+        return ApprovalGatewayPersistenceRequest(
+            approvalRequest = approvalRequest,
+            continuation = continuation,
+            sensitiveArguments = sensitiveArgs,
+            suspendedInvocationMetadata = suspendedInvocationMetadata,
+            replayEnvelope = replayEnvelope,
+        )
+    }
+}
+
+/**
+ * A mutable [Clock] that can be advanced programmatically for time-dependent testing.
+ */
+internal class MutableTestClock(
+    private var now: Instant,
+    private val zone: ZoneId = ZoneId.of("UTC"),
+) : Clock() {
+    override fun instant(): Instant = now
+    override fun withZone(zone: ZoneId): Clock = MutableTestClock(now, zone)
+    override fun getZone(): ZoneId = zone
+
+    fun advance(amount: Duration) {
+        now = now.plus(amount)
+    }
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/approval/DefaultApprovalGatewayTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/approval/DefaultApprovalGatewayTest.kt
@@ -46,14 +46,12 @@ class DefaultApprovalGatewayTest {
         Instant.parse("2026-06-25T10:00:00Z"),
         ZoneId.of("UTC"),
     )
-    private val digester = Sha256ToolArgumentsDigester()
 
     private lateinit var approvalStore: InMemoryApprovalStore
     private lateinit var continuationStore: InMemoryApprovalContinuationStore
     private lateinit var suspendedInvocationStore: SuspendedInvocationStore
     private lateinit var factory: FakeApprovalGatewayRequestFactory
 
-    // The gateway under test
     private fun createGateway(): DefaultApprovalGateway = DefaultApprovalGateway(
         approvalStore = approvalStore,
         continuationStore = continuationStore,
@@ -95,7 +93,6 @@ class DefaultApprovalGatewayTest {
             requiredRole = ApproverRole("medical-reviewer"),
         )
 
-        // Assert all three stores contain the records
         val storedApproval = approvalStore.get(approvalId)
         assertThat(storedApproval).isNotNull
         assertThat(storedApproval!!.status).isEqualTo(ApprovalStatus.PENDING)
@@ -106,7 +103,6 @@ class DefaultApprovalGatewayTest {
         val storedContinuation = continuationStore.get(approvalId)
         assertThat(storedContinuation).isNotNull
 
-        // Assert result type
         assertThat(result).isInstanceOf(ApprovalRequestResult.Suspended::class.java)
         val suspended = result as ApprovalRequestResult.Suspended
         assertThat(suspended.approvalId.value).isEqualTo(approvalId)
@@ -133,7 +129,7 @@ class DefaultApprovalGatewayTest {
     }
 
     // -----------------------------------------------------------------------
-    // 3. Existing pending request returns Suspended without duplicate create
+    // 3. Existing pending — duplicate does not create, no duplicate store writes
     // -----------------------------------------------------------------------
 
     @Test
@@ -141,6 +137,8 @@ class DefaultApprovalGatewayTest {
         val approvalId = "duplicate-pending"
         factory.defaultApprovalId = approvalId
         val gateway = createGateway()
+        val publicToken = ResumeToken("public-pending-token")
+        factory.defaultResumeToken = publicToken
 
         // First call creates the request
         val firstResult = gateway.requestApproval(
@@ -151,10 +149,12 @@ class DefaultApprovalGatewayTest {
         assertThat(firstResult).isInstanceOf(ApprovalRequestResult.Suspended::class.java)
         val firstSuspended = firstResult as ApprovalRequestResult.Suspended
 
-        // Create separate store reference to track create operations
+        // Capture state after first call
         val initialApprovalVersion = approvalStore.get(approvalId)!!.version
+        assertThat(suspendedInvocationStore.get(approvalId)).isNotNull()
+        assertThat(continuationStore.get(approvalId)).isNotNull()
 
-        // Second call with same data should return Suspended without changing stores
+        // Second call with same data — should not duplicate store writes
         val secondResult = gateway.requestApproval(
             subject = ApprovalSubject("claim-42"),
             recommendation = ApprovalRecommendation("review", "Review"),
@@ -165,9 +165,17 @@ class DefaultApprovalGatewayTest {
         val secondSuspended = secondResult as ApprovalRequestResult.Suspended
         assertThat(secondSuspended.approvalId).isEqualTo(firstSuspended.approvalId)
 
-        // Version should not have changed — create was not called again
+        // Approval version unchanged — create was not called again
         val approvalAfterSecondCall = approvalStore.get(approvalId)!!
         assertThat(approvalAfterSecondCall.version).isEqualTo(initialApprovalVersion)
+
+        // Suspended invocation and continuation still exist and were not duplicated
+        assertThat(suspendedInvocationStore.get(approvalId)).isNotNull()
+        assertThat(continuationStore.get(approvalId)).isNotNull()
+
+        // Resume token from factory, not from stored digest
+        assertThat(secondSuspended.resumeToken).isEqualTo(publicToken)
+        assertThat(secondSuspended.resumeToken.value).isNotEqualTo(twoDigest.value)
     }
 
     // -----------------------------------------------------------------------
@@ -192,7 +200,6 @@ class DefaultApprovalGatewayTest {
             clock = fixedClock,
         )
 
-        // Pre-create an approved request directly
         val pendingRequest = createPendingApprovalRequest(approvalId, workflowRunId = "wf-approved", requestedBy = requestingActor)
         approvalStore.create(pendingRequest)
         approvalStore.transition(
@@ -235,7 +242,6 @@ class DefaultApprovalGatewayTest {
             clock = fixedClock,
         )
 
-        // Pre-create a denied request directly
         val pendingRequest = createPendingApprovalRequest(approvalId, workflowRunId = "wf-denied", requestedBy = requestingActor)
         approvalStore.create(pendingRequest)
         approvalStore.transition(
@@ -265,7 +271,7 @@ class DefaultApprovalGatewayTest {
         val approvalId = "already-timed-out"
         val requestingActor = "test-actor"
         val mutableClock = MutableTestClock(fixedClock.instant())
-        val expiry = mutableClock.instant().plusSeconds(60) // short 60s TTL
+        val expiry = mutableClock.instant().plusSeconds(60)
 
         val timeoutingStore = InMemoryApprovalStore(
             clock = mutableClock,
@@ -288,7 +294,6 @@ class DefaultApprovalGatewayTest {
             clock = mutableClock,
         )
 
-        // Create a PENDING request with a short TTL
         val pendingRequest = createPendingApprovalRequest(
             approvalId = approvalId,
             workflowRunId = "wf-expired",
@@ -298,7 +303,6 @@ class DefaultApprovalGatewayTest {
         )
         timeoutingStore.create(pendingRequest)
 
-        // Advance clock past expiry, then time out
         mutableClock.advance(Duration.ofMinutes(5))
 
         timeoutingStore.transition(
@@ -324,9 +328,8 @@ class DefaultApprovalGatewayTest {
         val approvalId = "clock-expired"
         val requestingActor = "test-actor"
         val mutableClock = MutableTestClock(fixedClock.instant())
-        val pastExpiry = mutableClock.instant().plusSeconds(60) // short 60s TTL
+        val pastExpiry = mutableClock.instant().plusSeconds(60)
 
-        // Create approval store with the mutable clock
         val expiringStore = InMemoryApprovalStore(
             clock = mutableClock,
             maxCreationTtl = Duration.ofHours(2),
@@ -348,7 +351,6 @@ class DefaultApprovalGatewayTest {
             clock = mutableClock,
         )
 
-        // Pre-create a PENDING request with short TTL
         val pendingRequest = createPendingApprovalRequest(
             approvalId = approvalId,
             workflowRunId = "wf-expired-clock",
@@ -358,7 +360,6 @@ class DefaultApprovalGatewayTest {
         )
         expiringStore.create(pendingRequest)
 
-        // Advance clock past expiry — request is now stale but still PENDING
         mutableClock.advance(Duration.ofMinutes(5))
 
         val result = gateway.requestApproval(
@@ -445,10 +446,58 @@ class DefaultApprovalGatewayTest {
         assertThat(thrown).isNotNull
         assertThat(thrown!!.message).isEqualTo("factory-exploded")
 
-        // No stores were written
         assertThat(approvalStore.get("any-id")).isNull()
         assertThat(continuationStore.get("any-id")).isNull()
         assertThat(suspendedInvocationStore.get("any-id")).isNull()
+    }
+
+    // -----------------------------------------------------------------------
+    // 9. ResumeToken is the public credential, not the approval token digest
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `suspended result uses public resume token from factory not approval token digest`(): Unit = runBlocking {
+        val approvalId = "token-test"
+        factory.defaultApprovalId = approvalId
+        val publicToken = ResumeToken("public-resume-token")
+        factory.defaultResumeToken = publicToken
+
+        val result = createGateway().requestApproval(
+            subject = ApprovalSubject("claim-42"),
+            recommendation = ApprovalRecommendation("review", "Review"),
+            requiredRole = ApproverRole("medical-reviewer"),
+        )
+
+        val suspended = result as ApprovalRequestResult.Suspended
+        assertThat(suspended.resumeToken).isEqualTo(publicToken)
+        assertThat(suspended.resumeToken.value).isNotEqualTo(twoDigest.value)
+    }
+
+    @Test
+    fun `existing pending result uses factory resume token not stored digest`(): Unit = runBlocking {
+        val approvalId = "duplicate-token"
+        factory.defaultApprovalId = approvalId
+        val publicToken = ResumeToken("public-existing-pending-token")
+        factory.defaultResumeToken = publicToken
+        val gateway = createGateway()
+
+        // First call creates
+        gateway.requestApproval(
+            subject = ApprovalSubject("claim-42"),
+            recommendation = ApprovalRecommendation("review", "Review"),
+            requiredRole = ApproverRole("medical-reviewer"),
+        )
+
+        // Second call returns existing pending
+        val result = gateway.requestApproval(
+            subject = ApprovalSubject("claim-42"),
+            recommendation = ApprovalRecommendation("review", "Review"),
+            requiredRole = ApproverRole("medical-reviewer"),
+        )
+
+        val suspended = result as ApprovalRequestResult.Suspended
+        assertThat(suspended.resumeToken).isEqualTo(publicToken)
+        assertThat(suspended.resumeToken.value).isNotEqualTo(twoDigest.value)
     }
 
     // -----------------------------------------------------------------------
@@ -457,7 +506,7 @@ class DefaultApprovalGatewayTest {
 
     private val zeroDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000000")
     private val oneDigest = Sha256Digest.of("sha256:1111111111111111111111111111111111111111111111111111111111111111")
-    private val twoDigest = Sha256Digest.of("sha256:2222222222222222222222222222222222222222222222222222222222222222")
+    internal val twoDigest = Sha256Digest.of("sha256:2222222222222222222222222222222222222222222222222222222222222222")
 
     private fun createPendingApprovalRequest(
         approvalId: String,
@@ -497,6 +546,7 @@ internal class FakeApprovalGatewayRequestFactory(
     private val fixedClock: Clock,
     var defaultApprovalId: String = "gateway-test-1",
     var defaultRequestedBy: String = "test-actor",
+    var defaultResumeToken: ResumeToken = ResumeToken("public-resume-token"),
     private val digester: Sha256ToolArgumentsDigester = Sha256ToolArgumentsDigester(),
 ) : ApprovalGatewayRequestFactory {
 
@@ -583,7 +633,6 @@ internal class FakeApprovalGatewayRequestFactory(
             ),
         )
 
-        // Create a minimal SensitiveReplayEnvelope
         val replayEnvelope = SensitiveReplayEnvelope.of(emptyList())
 
         return ApprovalGatewayPersistenceRequest(
@@ -592,6 +641,7 @@ internal class FakeApprovalGatewayRequestFactory(
             sensitiveArguments = sensitiveArgs,
             suspendedInvocationMetadata = suspendedInvocationMetadata,
             replayEnvelope = replayEnvelope,
+            resumeToken = defaultResumeToken,
         )
     }
 }


### PR DESCRIPTION
## Summary

Implements the first Preview store-backed adapter for the `ApprovalGateway` SPI introduced in PR #96. Connects `ApprovalGateway.requestApproval(...)` to the existing approval, suspended invocation, and approval continuation stores.

## Implementation

**Module:** `tramai-engine` (package `dev.tramai.engine.approval`)

### Added

- **`ApprovalGatewayPersistenceRequest`** — transport object aggregating records for all three stores
- **`ApprovalGatewayRequestFactory`** — internal seam that translates ergonomic SPI input into low-level persistence records
- **`DefaultApprovalGateway`** — implements `ApprovalGateway` using `ApprovalStore` + `ApprovalContinuationStore` + `SuspendedInvocationStore`
- **`DefaultApprovalGatewayTest`** — 9 tests covering all acceptance criteria

### Behavior

New request → persists all 3 stores, returns Suspended
Existing APPROVED → AlreadyApproved
Existing DENIED → AlreadyDenied
Existing TIMED_OUT or clock-expired → Expired
Existing PENDING → Suspended (no duplicate create)
CancellationException → rethrown unchanged
Factory failure → fails closed, no store writes

### Design Decisions

- **Option A (documented non-atomic writes):** The adapter writes stores in order without a transactional boundary. Documented as Preview with clear limitation.
- **Existing-pending shortcut:** Early return when the approval already exists prevents duplicate store entries.
- **Internal factory seam:** Keeps the public `ApprovalGateway` clean while satisfying the richer metadata requirements of the existing stores.

## Non-Goals (explicitly deferred)

- Spring Boot auto-configuration (→ PR #98)
- `workflowRuntime.resumeApproval(...)`
- Regulated claim triage refactor
- Cross-store transactional boundary
- Audit-requested outbox intent
- Reviewer UI / REST API / workflow DSL

## Verification

- `./gradlew check` ✅
- `./gradlew verifySovereignRuntimeClosure` ✅