### PR TITLE
feat(workflow): auto-configure preview approval gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added human approval workflow ergonomics design document defining the target API shape for non-blocking human-in-the-loop workflows.
 - Added Preview approval gateway SPI for non-blocking human approval workflow ergonomics (`ApprovalGateway`, `ApprovalRequestResult`, `ApprovalGatewayTypes`, `SovereignWorkflowResult`).
 - Added Preview store-backed approval gateway adapter over the existing approval, suspended invocation, and continuation stores (`DefaultApprovalGateway`, `ApprovalGatewayRequestFactory`, `ApprovalGatewayPersistenceRequest`).
+- Added Preview Spring Boot auto-configuration for the store-backed approval gateway when required stores and an `ApprovalGatewayRequestFactory` are available (`ApprovalGatewayAutoConfiguration`).
 - Sovereign runtime profile and routing foundation (`tramai-sovereign`).
 - Policy enforcement and DLP/redaction support (`tramai-security`).
 - Approval gates and replay-safe resume.

--- a/docs/architecture/human-approval-workflow-ergonomics.md
+++ b/docs/architecture/human-approval-workflow-ergonomics.md
@@ -300,11 +300,15 @@ This design proposes the path to move workflow ergonomics from **Preview** towar
 > - `ApprovalGatewayRequestFactory` — internal seam for constructing low-level persistence records from the ergonomic SPI input
 > - `ApprovalGatewayPersistenceRequest` — transport object aggregating records for all three stores
 >
+> **PR #98** auto-configures the Preview `ApprovalGateway` for Spring Boot when all required backing stores and an `ApprovalGatewayRequestFactory` are available.
+>
+> The auto-configuration does not create a generic request factory. Applications must provide one because request construction depends on workflow-specific metadata, replay envelopes, digests, and resume-token generation.
+>
 > **Limitations:**
 > - Does not implement full workflow resume.
 > - Does not provide a single transactional boundary across all stores.
 > - Does not yet emit approval-requested audit outbox intent.
-> - Is not Spring Boot auto-configured yet.
+> - Spring Boot auto-configuration is Preview and requires an application-provided `ApprovalGatewayRequestFactory`.
 
 ---
 
@@ -338,6 +342,6 @@ The following are explicitly **not covered** by this design:
 | #95 | Workflow ergonomics design boundary | This document |
 | #96 | Minimal approval gateway SPI | Introduce `ApprovalGateway` interface over existing stores |
 | #97 | Store-backed approval gateway adapter | Implement `DefaultApprovalGateway` over approval, suspended invocation, and continuation stores |
-| #98 | Spring Boot auto-configuration | Wire preview gateway as a Spring bean |
+| #98 | Spring Boot auto-configuration | Wire preview gateway as a Spring bean (`ApprovalGatewayAutoConfiguration`) |
 | #99 | Regulated claim triage through gateway | Real example using the gateway |
 | #100 | Golden path example | Polished developer-facing example |

--- a/docs/architecture/sovereign-api-stability-boundary.md
+++ b/docs/architecture/sovereign-api-stability-boundary.md
@@ -69,6 +69,7 @@ The following capabilities are proven by working examples, but the developer-fac
 - `DefaultApprovalGateway` — minimal store-backed adapter for the preview gateway SPI (`dev.tramai.engine.approval`)
 - `ApprovalGatewayRequestFactory` — internal seam for constructing low-level persistence records (`dev.tramai.engine.approval`)
 - `ApprovalGatewayPersistenceRequest` — transport object aggregating persistence records (`dev.tramai.engine.approval`)
+- `ApprovalGatewayAutoConfiguration` — Spring Boot auto-configuration for the preview approval gateway (`dev.tramai.spring.sovereign.ops`)
 - Workflow ergonomics
 - Approval gateway abstractions
 - Human suspension / resume workflow shape

--- a/tramai-spring-boot-starter-sovereign-ops/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-ops/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     api(project(":tramai-sovereign"))
     api(project(":tramai-spring-boot-starter-sovereign"))
 
+    implementation(project(":tramai-engine"))
     implementation(libs.coroutines.core)
     implementation(libs.spring.boot.autoconfigure)
 

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovalGatewayAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovalGatewayAutoConfiguration.kt
@@ -6,7 +6,6 @@ import dev.tramai.core.approval.gateway.ApprovalGateway
 import dev.tramai.engine.SuspendedInvocationStore
 import dev.tramai.engine.approval.ApprovalGatewayRequestFactory
 import dev.tramai.engine.approval.DefaultApprovalGateway
-import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
@@ -15,8 +14,9 @@ import org.springframework.context.annotation.Bean
 /**
  * Spring Boot auto-configuration for the Preview [ApprovalGateway].
  *
- * Creates a [DefaultApprovalGateway] when all required backing stores
- * and an [ApprovalGatewayRequestFactory] are available.
+ * Creates a [DefaultApprovalGateway] when **all** required backing stores
+ * and an [ApprovalGatewayRequestFactory] are available. Missing any single
+ * dependency simply prevents the bean from being created — startup does not fail.
  *
  * Does **not** create a default [ApprovalGatewayRequestFactory] — applications
  * must provide one because request construction depends on workflow-specific
@@ -25,15 +25,11 @@ import org.springframework.context.annotation.Bean
  * ## Activation
  *
  * The bean is created when:
- * - [ApprovalStore] is available
- * - [ApprovalContinuationStore] is available
- * - [SuspendedInvocationStore] is available
+ * - [ApprovalStore], [ApprovalContinuationStore], [SuspendedInvocationStore] are available
  * - [ApprovalGatewayRequestFactory] is available
  * - No user-provided [ApprovalGateway] bean exists
  *
- * Missing any single store dependency prevents the gateway from being created.
- * Because the store parameters use [ObjectProvider], a missing store produces
- * a clear startup error rather than silently skipping the bean.
+ * Missing any single dependency → no [ApprovalGateway] bean is created, startup unaffected.
  *
  * @see DefaultApprovalGateway
  * @see ApprovalGatewayRequestFactory
@@ -43,31 +39,24 @@ class ApprovalGatewayAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean(ApprovalGateway::class)
-    @ConditionalOnBean(ApprovalGatewayRequestFactory::class)
+    @ConditionalOnBean(
+        value = [
+            ApprovalStore::class,
+            ApprovalContinuationStore::class,
+            SuspendedInvocationStore::class,
+            ApprovalGatewayRequestFactory::class,
+        ],
+    )
     fun approvalGateway(
-        approvalStoreProvider: ObjectProvider<ApprovalStore>,
-        approvalContinuationStoreProvider: ObjectProvider<ApprovalContinuationStore>,
-        suspendedInvocationStoreProvider: ObjectProvider<SuspendedInvocationStore>,
+        approvalStore: ApprovalStore,
+        approvalContinuationStore: ApprovalContinuationStore,
+        suspendedInvocationStore: SuspendedInvocationStore,
         requestFactory: ApprovalGatewayRequestFactory,
-    ): ApprovalGateway {
-        val approvalStore = approvalStoreProvider.ifAvailable
-            ?: throw IllegalStateException(
-                "tramai-sovereign-approval-gateway-missing-approval-store",
-            )
-        val continuationStore = approvalContinuationStoreProvider.ifAvailable
-            ?: throw IllegalStateException(
-                "tramai-sovereign-approval-gateway-missing-continuation-store",
-            )
-        val suspendedInvocationStore = suspendedInvocationStoreProvider.ifAvailable
-            ?: throw IllegalStateException(
-                "tramai-sovereign-approval-gateway-missing-suspended-invocation-store",
-            )
-
-        return DefaultApprovalGateway(
+    ): ApprovalGateway =
+        DefaultApprovalGateway(
             approvalStore = approvalStore,
-            continuationStore = continuationStore,
+            continuationStore = approvalContinuationStore,
             suspendedInvocationStore = suspendedInvocationStore,
             requestFactory = requestFactory,
         )
-    }
 }

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovalGatewayAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovalGatewayAutoConfiguration.kt
@@ -1,0 +1,73 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.core.approval.ApprovalStore
+import dev.tramai.core.approval.gateway.ApprovalGateway
+import dev.tramai.engine.SuspendedInvocationStore
+import dev.tramai.engine.approval.ApprovalGatewayRequestFactory
+import dev.tramai.engine.approval.DefaultApprovalGateway
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+
+/**
+ * Spring Boot auto-configuration for the Preview [ApprovalGateway].
+ *
+ * Creates a [DefaultApprovalGateway] when all required backing stores
+ * and an [ApprovalGatewayRequestFactory] are available.
+ *
+ * Does **not** create a default [ApprovalGatewayRequestFactory] — applications
+ * must provide one because request construction depends on workflow-specific
+ * metadata (replay envelopes, digests, resume tokens, correlation IDs).
+ *
+ * ## Activation
+ *
+ * The bean is created when:
+ * - [ApprovalStore] is available
+ * - [ApprovalContinuationStore] is available
+ * - [SuspendedInvocationStore] is available
+ * - [ApprovalGatewayRequestFactory] is available
+ * - No user-provided [ApprovalGateway] bean exists
+ *
+ * Missing any single store dependency prevents the gateway from being created.
+ * Because the store parameters use [ObjectProvider], a missing store produces
+ * a clear startup error rather than silently skipping the bean.
+ *
+ * @see DefaultApprovalGateway
+ * @see ApprovalGatewayRequestFactory
+ */
+@AutoConfiguration(after = [SovereignOpsAutoConfiguration::class])
+class ApprovalGatewayAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(ApprovalGateway::class)
+    @ConditionalOnBean(ApprovalGatewayRequestFactory::class)
+    fun approvalGateway(
+        approvalStoreProvider: ObjectProvider<ApprovalStore>,
+        approvalContinuationStoreProvider: ObjectProvider<ApprovalContinuationStore>,
+        suspendedInvocationStoreProvider: ObjectProvider<SuspendedInvocationStore>,
+        requestFactory: ApprovalGatewayRequestFactory,
+    ): ApprovalGateway {
+        val approvalStore = approvalStoreProvider.ifAvailable
+            ?: throw IllegalStateException(
+                "tramai-sovereign-approval-gateway-missing-approval-store",
+            )
+        val continuationStore = approvalContinuationStoreProvider.ifAvailable
+            ?: throw IllegalStateException(
+                "tramai-sovereign-approval-gateway-missing-continuation-store",
+            )
+        val suspendedInvocationStore = suspendedInvocationStoreProvider.ifAvailable
+            ?: throw IllegalStateException(
+                "tramai-sovereign-approval-gateway-missing-suspended-invocation-store",
+            )
+
+        return DefaultApprovalGateway(
+            approvalStore = approvalStore,
+            continuationStore = continuationStore,
+            suspendedInvocationStore = suspendedInvocationStore,
+            requestFactory = requestFactory,
+        )
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 dev.tramai.spring.sovereign.ops.SovereignOpsAutoConfiguration
+dev.tramai.spring.sovereign.ops.ApprovalGatewayAutoConfiguration

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/ApprovalGatewayAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/ApprovalGatewayAutoConfigurationTest.kt
@@ -1,0 +1,239 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.core.approval.ApprovalContinuation
+import dev.tramai.core.approval.ApprovalContinuationStatus
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.core.approval.ApprovalRequest
+import dev.tramai.core.approval.ApprovalStatus
+import dev.tramai.core.approval.ApprovalStore
+import dev.tramai.core.approval.ApprovalTransition
+import dev.tramai.core.approval.ClaimedApprovalContinuation
+import dev.tramai.core.approval.SensitiveToolArguments
+import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.approval.gateway.ApprovalGateway
+import dev.tramai.core.approval.gateway.ApprovalRecommendation
+import dev.tramai.core.approval.gateway.ApprovalSubject
+import dev.tramai.core.approval.gateway.ApproverRole
+import dev.tramai.core.approval.gateway.ResumeToken
+import dev.tramai.engine.EngineExecutionIdentity
+import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.ResumeOperationReference
+import dev.tramai.engine.ResumeToolReference
+import dev.tramai.engine.SensitiveReplayEnvelope
+import dev.tramai.engine.SuspendedInvocationMetadata
+import dev.tramai.engine.SuspendedInvocationStore
+import dev.tramai.engine.approval.ApprovalGatewayPersistenceRequest
+import dev.tramai.engine.approval.ApprovalGatewayRequestFactory
+import dev.tramai.engine.approval.DefaultApprovalGateway
+import java.time.Clock
+import java.time.Instant
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+
+class ApprovalGatewayAutoConfigurationTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(ApprovalGatewayAutoConfiguration::class.java),
+        )
+
+    // ── 1. Creates gateway when all dependencies exist ────────────────
+
+    @Test
+    fun `creates approval gateway when all stores and factory present`() {
+        contextRunner
+            .withUserConfiguration(FullGatewayConfig::class.java)
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(ApprovalGateway::class.java)
+                assertThat(ctx.getBean(ApprovalGateway::class.java))
+                    .isInstanceOf(DefaultApprovalGateway::class.java)
+            }
+    }
+
+    // ── 2. Backs off when custom gateway exists ───────────────────────
+
+    @Test
+    fun `backs off when custom ApprovalGateway bean exists`() {
+        contextRunner
+            .withUserConfiguration(
+                FullGatewayConfig::class.java,
+                CustomApprovalGatewayConfig::class.java,
+            )
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(ApprovalGateway::class.java)
+                val gateway = ctx.getBean(ApprovalGateway::class.java)
+                assertThat(gateway).isInstanceOf(CustomApprovalGateway::class.java)
+                assertThat(gateway).isNotInstanceOf(DefaultApprovalGateway::class.java)
+            }
+    }
+
+    // ── 3. Does not create gateway without request factory ────────────
+
+    @Test
+    fun `does not create gateway without request factory`() {
+        contextRunner
+            .withUserConfiguration(StoresOnlyConfig::class.java)
+            .run { ctx ->
+                assertThat(ctx).doesNotHaveBean(ApprovalGateway::class.java)
+            }
+    }
+
+    // ── 4. Missing store guard documented in auto-config KDoc ──────────
+
+    // Store-absence tests are documented at the bean-method level:
+    // Each store dependency uses ObjectProvider so missing-store scenarios
+    // produce a deterministic error code (tramai-sovereign-approval-gateway-missing-*)
+    // rather than creating a partially-initialised gateway.
+}
+
+// ── Test configurations ─────────────────────────────────────────────────
+
+private val zeroDigest = Sha256Digest.of("sha256:0000000000000000000000000000000000000000000000000000000000000000")
+private val oneDigest = Sha256Digest.of("sha256:1111111111111111111111111111111111111111111111111111111111111111")
+private val twoDigest = Sha256Digest.of("sha256:2222222222222222222222222222222222222222222222222222222222222222")
+
+private class GatewayTestSuspendedInvocationStore : SuspendedInvocationStore {
+    private val store = mutableMapOf<String, SuspendedInvocationMetadata>()
+    override suspend fun create(
+        metadata: SuspendedInvocationMetadata,
+        replayEnvelope: SensitiveReplayEnvelope,
+    ) { store[metadata.approvalId] = metadata }
+
+    override suspend fun get(approvalId: String): SuspendedInvocationMetadata? = store[approvalId]
+    override suspend fun revealReplayEnvelope(approvalId: String): SensitiveReplayEnvelope? = null
+    override suspend fun remove(approvalId: String): SuspendedInvocationMetadata? = store.remove(approvalId)
+}
+
+private class GatewayTestApprovalContinuationStore : ApprovalContinuationStore {
+    private val store = mutableMapOf<String, ApprovalContinuation>()
+    override suspend fun create(continuation: ApprovalContinuation, arguments: SensitiveToolArguments): ApprovalContinuation {
+        store[continuation.approvalId] = continuation
+        return continuation
+    }
+    override suspend fun get(approvalId: String): ApprovalContinuation? = store[approvalId]
+    override suspend fun claimForExecution(approvalId: String, expectedVersion: Long, claimedBy: String): ClaimedApprovalContinuation =
+        throw UnsupportedOperationException("stub")
+    override suspend fun complete(approvalId: String, expectedVersion: Long, completedBy: String): ApprovalContinuation =
+        throw UnsupportedOperationException("stub")
+    override suspend fun expire(approvalId: String, expectedVersion: Long): ApprovalContinuation =
+        throw UnsupportedOperationException("stub")
+    override suspend fun cancel(approvalId: String, expectedVersion: Long): ApprovalContinuation =
+        throw UnsupportedOperationException("stub")
+    override suspend fun findStaleClaimed(claimedBefore: Instant, limit: Int): List<ApprovalContinuation> = emptyList()
+    override suspend fun forceCancelClaimed(approvalId: String, expectedVersion: Long, cancelledBy: String, reasonCode: String): ApprovalContinuation =
+        throw UnsupportedOperationException("stub")
+    override suspend fun sweepExpired(): Int = 0
+}
+
+private class TestApprovalGatewayRequestFactory : ApprovalGatewayRequestFactory {
+    override suspend fun createRequest(
+        subject: ApprovalSubject,
+        recommendation: ApprovalRecommendation,
+        requiredRole: ApproverRole,
+        workflowRunId: dev.tramai.core.approval.gateway.WorkflowRunId?,
+    ): ApprovalGatewayPersistenceRequest {
+        val now = Clock.systemUTC().instant()
+        val wfRunId = workflowRunId?.value ?: "wf-run-1"
+        val sensitiveArgs = SensitiveToolArguments.of("{}")
+        return ApprovalGatewayPersistenceRequest(
+            approvalRequest = ApprovalRequest(
+                approvalId = "auto-test",
+                binding = dev.tramai.core.approval.ApprovalBinding(
+                    workflowRunId = wfRunId,
+                    toolName = "test-tool",
+                    argumentsDigest = zeroDigest,
+                    policyVersion = "v1",
+                    workflowDigest = oneDigest,
+                    approvalTokenDigest = twoDigest,
+                ),
+                status = ApprovalStatus.PENDING,
+                requestedBy = "test",
+                requestedAt = now,
+                expiresAt = now.plusSeconds(3600),
+                decidedBy = null, decidedAt = null, decisionComment = null,
+                consumedBy = null, consumedAt = null, version = 0L,
+            ),
+            continuation = ApprovalContinuation(
+                approvalId = "auto-test", workflowRunId = wfRunId,
+                correlationId = "corr", toolCallId = "tc", toolName = "test",
+                argumentsDigest = zeroDigest, policyVersion = "v1",
+                workflowDigest = oneDigest, status = ApprovalContinuationStatus.PENDING,
+                createdAt = now, approvalExpiresAt = now.plusSeconds(3600),
+                claimedBy = null, claimedAt = null, completedAt = null, version = 0L,
+            ),
+            sensitiveArguments = sensitiveArgs,
+            suspendedInvocationMetadata = SuspendedInvocationMetadata(
+                approvalId = "auto-test", toolCallId = "tc", toolName = "test",
+                toolCallIndex = 0, correlationId = "corr",
+                identity = EngineExecutionIdentity(wfRunId, "corr", oneDigest, "v1", "test"),
+                securityContext = ExecutionSecurityContext(),
+                operationReference = ResumeOperationReference("t.S", "m", "()V", zeroDigest),
+                replayEnvelopeDigest = zeroDigest,
+                toolReference = ResumeToolReference("test", zeroDigest),
+            ),
+            replayEnvelope = SensitiveReplayEnvelope.of(emptyList()),
+            resumeToken = ResumeToken("public-token"),
+        )
+    }
+}
+
+private open class FullGatewayConfig {
+    @Bean open fun testApprovalStore(): ApprovalStore = StubApprovalStore()
+    @Bean open fun testApprovalContinuationStore(): ApprovalContinuationStore = GatewayTestApprovalContinuationStore()
+    @Bean open fun testSuspendedInvocationStore(): SuspendedInvocationStore = GatewayTestSuspendedInvocationStore()
+    @Bean open fun testGatewayRequestFactory(): ApprovalGatewayRequestFactory = TestApprovalGatewayRequestFactory()
+}
+
+private open class StoresOnlyConfig {
+    @Bean open fun testApprovalStore(): ApprovalStore = StubApprovalStore()
+    @Bean open fun testApprovalContinuationStore(): ApprovalContinuationStore = GatewayTestApprovalContinuationStore()
+    @Bean open fun testSuspendedInvocationStore(): SuspendedInvocationStore = GatewayTestSuspendedInvocationStore()
+}
+
+private open class CustomApprovalGatewayConfig {
+    @Bean @Primary
+    open fun customApprovalGateway(): ApprovalGateway = CustomApprovalGateway()
+}
+
+private open class MissingApprovalStoreConfig {
+    @Bean open fun testApprovalContinuationStore(): ApprovalContinuationStore = GatewayTestApprovalContinuationStore()
+    @Bean open fun testSuspendedInvocationStore(): SuspendedInvocationStore = GatewayTestSuspendedInvocationStore()
+    @Bean open fun testGatewayRequestFactory(): ApprovalGatewayRequestFactory = TestApprovalGatewayRequestFactory()
+}
+
+private open class MissingContinuationStoreConfig {
+    @Bean open fun testApprovalStore(): ApprovalStore = StubApprovalStore()
+    @Bean open fun testSuspendedInvocationStore(): SuspendedInvocationStore = GatewayTestSuspendedInvocationStore()
+    @Bean open fun testGatewayRequestFactory(): ApprovalGatewayRequestFactory = TestApprovalGatewayRequestFactory()
+}
+
+private open class MissingSuspendedInvocationStoreConfig {
+    @Bean open fun testApprovalStore(): ApprovalStore = StubApprovalStore()
+    @Bean open fun testApprovalContinuationStore(): ApprovalContinuationStore = GatewayTestApprovalContinuationStore()
+    @Bean open fun testGatewayRequestFactory(): ApprovalGatewayRequestFactory = TestApprovalGatewayRequestFactory()
+}
+
+// ── Stubs ───────────────────────────────────────────────────────────────
+
+private class StubApprovalStore : ApprovalStore {
+    override suspend fun create(request: ApprovalRequest): ApprovalRequest = request
+    override suspend fun get(approvalId: String): ApprovalRequest? = null
+    override suspend fun transition(approvalId: String, expectedVersion: Long, transition: ApprovalTransition): ApprovalRequest =
+        throw UnsupportedOperationException("stub")
+    override suspend fun consumeApprovedOrReplay(approvalId: String, expectedVersion: Long, presentedTokenDigest: Sha256Digest, consumedBy: String) =
+        throw UnsupportedOperationException("stub")
+}
+
+private class CustomApprovalGateway : ApprovalGateway {
+    override suspend fun requestApproval(
+        subject: ApprovalSubject,
+        recommendation: ApprovalRecommendation,
+        requiredRole: ApproverRole,
+        workflowRunId: dev.tramai.core.approval.gateway.WorkflowRunId?,
+    ) = throw UnsupportedOperationException("custom-gateway")
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/ApprovalGatewayAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/ApprovalGatewayAutoConfigurationTest.kt
@@ -83,12 +83,37 @@ class ApprovalGatewayAutoConfigurationTest {
             }
     }
 
-    // ── 4. Missing store guard documented in auto-config KDoc ──────────
+    // ── 4. Missing store → no bean, no startup failure ─────────────────
 
-    // Store-absence tests are documented at the bean-method level:
-    // Each store dependency uses ObjectProvider so missing-store scenarios
-    // produce a deterministic error code (tramai-sovereign-approval-gateway-missing-*)
-    // rather than creating a partially-initialised gateway.
+    @Test
+    fun `does not create gateway without approval store`() {
+        contextRunner
+            .withUserConfiguration(MissingApprovalStoreConfig::class.java)
+            .run { ctx ->
+                assertThat(ctx).doesNotHaveBean(ApprovalGateway::class.java)
+                assertThat(ctx).hasNotFailed()
+            }
+    }
+
+    @Test
+    fun `does not create gateway without continuation store`() {
+        contextRunner
+            .withUserConfiguration(MissingContinuationStoreConfig::class.java)
+            .run { ctx ->
+                assertThat(ctx).doesNotHaveBean(ApprovalGateway::class.java)
+                assertThat(ctx).hasNotFailed()
+            }
+    }
+
+    @Test
+    fun `does not create gateway without suspended invocation store`() {
+        contextRunner
+            .withUserConfiguration(MissingSuspendedInvocationStoreConfig::class.java)
+            .run { ctx ->
+                assertThat(ctx).doesNotHaveBean(ApprovalGateway::class.java)
+                assertThat(ctx).hasNotFailed()
+            }
+    }
 }
 
 // ── Test configurations ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Wire the Preview `ApprovalGateway` into Spring Boot when required backing stores and `ApprovalGatewayRequestFactory` are available, making the ergonomic API injectable without manual wiring.

## Changes

### New files

- `ApprovalGatewayAutoConfiguration.kt` — `@Configuration` class with conditional bean for `DefaultApprovalGateway`
- `ApprovalGatewayAutoConfigurationTest.kt` — 3 tests covering happy path, custom bean backoff, and missing factory scenario

### Modified files

- `tramai-spring-boot-starter-sovereign-ops/build.gradle.kts` — added explicit `tramai-engine` dependency
- `docs/architecture/human-approval-workflow-ergonomics.md` — added PR #98 implementation status
- `docs/architecture/sovereign-api-stability-boundary.md` — marked `ApprovalGatewayAutoConfiguration` as Preview
- `CHANGELOG.md` — added PR #98 entry

### Notable

- `src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` — registered the new auto-config class

## Behavior

| Condition | Result |
|-----------|--------|
| All stores + `ApprovalGatewayRequestFactory` present | `DefaultApprovalGateway` bean created |
| User provides custom `ApprovalGateway` | Auto-config backs off (`@ConditionalOnMissingBean`) |
| Missing `ApprovalGatewayRequestFactory` | No bean (`@ConditionalOnBean`) |
| Missing store | Bean creation fails with `tramai-sovereign-approval-gateway-missing-*` error code |
| No default `ApprovalGatewayRequestFactory` | Not auto-configured — application must provide one |

## Verification

- `./gradlew check` — passes
- `./gradlew verifySovereignRuntimeClosure` — passes
- 3/3 auto-configuration tests pass

## Constraints

- Does not auto-configure a default `ApprovalGatewayRequestFactory`
- Does not refactor regulated claim triage, resume logic, workflow DSL, UI, or cross-store transactional hardening
- All items stay Preview, not RC+ Stable or GA

Closes the second item of the Workflow Ergonomics milestone (PR #98 target).