### PR TITLE
test(example): refactor regulated claim triage through approval gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added Preview approval gateway SPI for non-blocking human approval workflow ergonomics (`ApprovalGateway`, `ApprovalRequestResult`, `ApprovalGatewayTypes`, `SovereignWorkflowResult`).
 - Added Preview store-backed approval gateway adapter over the existing approval, suspended invocation, and continuation stores (`DefaultApprovalGateway`, `ApprovalGatewayRequestFactory`, `ApprovalGatewayPersistenceRequest`).
 - Added Preview Spring Boot auto-configuration for the store-backed approval gateway when required stores and an `ApprovalGatewayRequestFactory` are available (`ApprovalGatewayAutoConfiguration`).
+- Refactored the regulated claim triage E2E proof to request human approval through the Preview ApprovalGateway (`PR #99`). The workflow now calls `approvalGateway.requestApproval(...)` instead of manually creating low-level store records. An `RegulatedClaimTriageApprovalGatewayRequestFactory` provides the persistence records, and Spring auto-configuration creates the `DefaultApprovalGateway` bean.
 - Sovereign runtime profile and routing foundation (`tramai-sovereign`).
 - Policy enforcement and DLP/redaction support (`tramai-security`).
 - Approval gates and replay-safe resume.

--- a/docs/architecture/human-approval-workflow-ergonomics.md
+++ b/docs/architecture/human-approval-workflow-ergonomics.md
@@ -304,6 +304,10 @@ This design proposes the path to move workflow ergonomics from **Preview** towar
 >
 > The auto-configuration does not create a generic request factory. Applications must provide one because request construction depends on workflow-specific metadata, replay envelopes, digests, and resume-token generation.
 >
+> **PR #99** proves the Preview gateway can drive the regulated claim triage E2E scenario while preserving restart safety, durable approval state, continuation persistence, audit chain validation, and outbox dispatch.
+>
+> The example provides an [RegulatedClaimTriageApprovalGatewayRequestFactory] that translates ergonomic gateway calls into low-level persistence records. Spring Auto-configuration creates [DefaultApprovalGateway] when the factory bean is present alongside the JDBC stores.
+>
 > **Limitations:**
 > - Does not implement full workflow resume.
 > - Does not provide a single transactional boundary across all stores.

--- a/docs/scenarios/regulated-claim-triage.md
+++ b/docs/scenarios/regulated-claim-triage.md
@@ -206,7 +206,7 @@ This scenario is now covered by a JDBC-backed E2E test in:
 `examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageJdbcE2ETest.kt`
 
 The test proves:
-- High-risk recommendations require approval and persist to PostgreSQL
+- High-risk recommendations are suspended through the Preview ApprovalGateway API instead of manual store creation
 - Approval denial and audit intent are committed transactionally in one database transaction
 - Audit outbox records are durable and dispatchable after context restart
 - Restricted medical data is denied before cloud model invocation (policy enforcement)

--- a/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageApprovalGatewayRequestFactory.kt
+++ b/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageApprovalGatewayRequestFactory.kt
@@ -1,0 +1,146 @@
+package dev.tramai.examples.spring
+
+import dev.tramai.core.approval.ApprovalBinding
+import dev.tramai.core.approval.ApprovalContinuation
+import dev.tramai.core.approval.ApprovalContinuationStatus
+import dev.tramai.core.approval.ApprovalRequest
+import dev.tramai.core.approval.ApprovalStatus
+import dev.tramai.core.approval.SensitiveToolArguments
+import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.approval.gateway.ApprovalRecommendation
+import dev.tramai.core.approval.gateway.ApprovalSubject
+import dev.tramai.core.approval.gateway.ApproverRole
+import dev.tramai.core.approval.gateway.ResumeToken
+import dev.tramai.core.approval.gateway.WorkflowRunId
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
+import dev.tramai.core.model.ToolCall
+import dev.tramai.engine.EngineExecutionIdentity
+import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.ReplayEnvelopeDigestHelper
+import dev.tramai.engine.ResumeOperationReference
+import dev.tramai.engine.ResumeToolReference
+import dev.tramai.engine.SensitiveReplayEnvelope
+import dev.tramai.engine.SuspendedInvocationMetadata
+import dev.tramai.engine.approval.ApprovalGatewayPersistenceRequest
+import dev.tramai.engine.approval.ApprovalGatewayRequestFactory
+import java.time.Clock
+import java.time.Duration
+
+class RegulatedClaimTriageApprovalGatewayRequestFactory(
+    private val clock: Clock = Clock.systemUTC(),
+) : ApprovalGatewayRequestFactory {
+
+    override suspend fun createRequest(
+        subject: ApprovalSubject,
+        recommendation: ApprovalRecommendation,
+        requiredRole: ApproverRole,
+        workflowRunId: WorkflowRunId?,
+    ): ApprovalGatewayPersistenceRequest {
+        val now = clock.instant()
+        val claimId = subject.value
+        val workflowRun = requireNotNull(workflowRunId) { "regulated-claim-triage-workflow-run-id-required" }
+        val approvalId = "approval-gateway-$claimId"
+        val correlationId = "corr-$claimId"
+        val resumeToken = ResumeToken("resume-token-$claimId")
+        val toolCallId = "tool-call-$claimId"
+        val toolName = "claim-triage-model"
+        val expiresAt = now.plus(Duration.ofMinutes(5))
+        val sensitiveArgumentsJson = """{"claimId":"$claimId","recommendationType":"${recommendation.summary}","summary":"${recommendation.summary}"}"""
+
+        val operationReference = ResumeOperationReference(
+            serviceInterface = "dev.tramai.examples.spring.ClaimTriageWorkflow",
+            methodName = "triage",
+            jvmMethodDescriptor = "(Ldev/tramai/examples/spring/ClaimTriageInput;Ldev/tramai/examples/spring/RequestedRoute;)Ldev/tramai/examples/spring/ClaimTriageResult;",
+            resumeDefinitionDigest = ZERO_DIGEST,
+        )
+
+        val messages = listOf(
+            Message(
+                role = MessageRole.ASSISTANT,
+                content = "",
+                toolCalls = listOf(
+                    ToolCall(
+                        id = toolCallId,
+                        name = toolName,
+                        argumentsJson = sensitiveArgumentsJson,
+                    ),
+                ),
+            ),
+        )
+
+        val computedDigest = ReplayEnvelopeDigestHelper.compute(operationReference, messages)
+
+        return ApprovalGatewayPersistenceRequest(
+            approvalRequest = ApprovalRequest(
+                approvalId = approvalId,
+                binding = ApprovalBinding(
+                    workflowRunId = workflowRun.value,
+                    toolName = toolName,
+                    argumentsDigest = ARGUMENTS_DIGEST,
+                    policyVersion = "1.0",
+                    workflowDigest = WORKFLOW_DIGEST,
+                    approvalTokenDigest = APPROVAL_TOKEN_DIGEST,
+                ),
+                status = ApprovalStatus.PENDING,
+                requestedBy = "triage-system",
+                requestedAt = now,
+                expiresAt = expiresAt,
+                decidedBy = null,
+                decidedAt = null,
+                decisionComment = null,
+                consumedBy = null,
+                consumedAt = null,
+                version = 0L,
+            ),
+            continuation = ApprovalContinuation(
+                approvalId = approvalId,
+                workflowRunId = workflowRun.value,
+                correlationId = correlationId,
+                toolCallId = toolCallId,
+                toolName = toolName,
+                argumentsDigest = ARGUMENTS_DIGEST,
+                policyVersion = "1.0",
+                workflowDigest = WORKFLOW_DIGEST,
+                status = ApprovalContinuationStatus.PENDING,
+                createdAt = now,
+                approvalExpiresAt = expiresAt,
+                claimedBy = null,
+                claimedAt = null,
+                completedAt = null,
+                version = 0L,
+            ),
+            sensitiveArguments = SensitiveToolArguments.of(sensitiveArgumentsJson),
+            suspendedInvocationMetadata = SuspendedInvocationMetadata(
+                approvalId = approvalId,
+                toolCallId = toolCallId,
+                toolName = toolName,
+                toolCallIndex = 0,
+                correlationId = correlationId,
+                identity = EngineExecutionIdentity(
+                    workflowRunId = workflowRun.value,
+                    correlationId = correlationId,
+                    workflowDigest = WORKFLOW_DIGEST,
+                    policyVersion = "1.0",
+                    actorId = "triage-system",
+                ),
+                securityContext = ExecutionSecurityContext(),
+                operationReference = operationReference,
+                replayEnvelopeDigest = computedDigest,
+                toolReference = ResumeToolReference(
+                    toolName = toolName,
+                    declarationDigest = ZERO_DIGEST,
+                ),
+            ),
+            replayEnvelope = SensitiveReplayEnvelope.of(messages),
+            resumeToken = resumeToken,
+        )
+    }
+
+    private companion object {
+        private val ZERO_DIGEST = Sha256Digest.of("sha256:${"0".repeat(64)}")
+        private val WORKFLOW_DIGEST = Sha256Digest.of("sha256:${"1".repeat(64)}")
+        private val ARGUMENTS_DIGEST = Sha256Digest.of("sha256:${"2".repeat(64)}")
+        private val APPROVAL_TOKEN_DIGEST = Sha256Digest.of("sha256:${"3".repeat(64)}")
+    }
+}

--- a/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageApprovalGatewayRequestFactory.kt
+++ b/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageApprovalGatewayRequestFactory.kt
@@ -24,6 +24,7 @@ import dev.tramai.engine.SensitiveReplayEnvelope
 import dev.tramai.engine.SuspendedInvocationMetadata
 import dev.tramai.engine.approval.ApprovalGatewayPersistenceRequest
 import dev.tramai.engine.approval.ApprovalGatewayRequestFactory
+import dev.tramai.security.approval.Sha256ToolArgumentsDigester
 import java.time.Clock
 import java.time.Duration
 
@@ -47,6 +48,9 @@ class RegulatedClaimTriageApprovalGatewayRequestFactory(
         val toolName = "claim-triage-model"
         val expiresAt = now.plus(Duration.ofMinutes(5))
         val sensitiveArgumentsJson = """{"claimId":"$claimId","recommendationType":"${recommendation.summary}","summary":"${recommendation.summary}"}"""
+
+        val sensitiveArguments = SensitiveToolArguments.of(sensitiveArgumentsJson)
+        val computedArgumentsDigest = Sha256ToolArgumentsDigester().digest(sensitiveArguments)
 
         val operationReference = ResumeOperationReference(
             serviceInterface = "dev.tramai.examples.spring.ClaimTriageWorkflow",
@@ -77,7 +81,7 @@ class RegulatedClaimTriageApprovalGatewayRequestFactory(
                 binding = ApprovalBinding(
                     workflowRunId = workflowRun.value,
                     toolName = toolName,
-                    argumentsDigest = ARGUMENTS_DIGEST,
+                    argumentsDigest = computedArgumentsDigest,
                     policyVersion = "1.0",
                     workflowDigest = WORKFLOW_DIGEST,
                     approvalTokenDigest = APPROVAL_TOKEN_DIGEST,
@@ -99,7 +103,7 @@ class RegulatedClaimTriageApprovalGatewayRequestFactory(
                 correlationId = correlationId,
                 toolCallId = toolCallId,
                 toolName = toolName,
-                argumentsDigest = ARGUMENTS_DIGEST,
+                argumentsDigest = computedArgumentsDigest,
                 policyVersion = "1.0",
                 workflowDigest = WORKFLOW_DIGEST,
                 status = ApprovalContinuationStatus.PENDING,
@@ -110,7 +114,7 @@ class RegulatedClaimTriageApprovalGatewayRequestFactory(
                 completedAt = null,
                 version = 0L,
             ),
-            sensitiveArguments = SensitiveToolArguments.of(sensitiveArgumentsJson),
+            sensitiveArguments = sensitiveArguments,
             suspendedInvocationMetadata = SuspendedInvocationMetadata(
                 approvalId = approvalId,
                 toolCallId = toolCallId,
@@ -140,7 +144,6 @@ class RegulatedClaimTriageApprovalGatewayRequestFactory(
     private companion object {
         private val ZERO_DIGEST = Sha256Digest.of("sha256:${"0".repeat(64)}")
         private val WORKFLOW_DIGEST = Sha256Digest.of("sha256:${"1".repeat(64)}")
-        private val ARGUMENTS_DIGEST = Sha256Digest.of("sha256:${"2".repeat(64)}")
         private val APPROVAL_TOKEN_DIGEST = Sha256Digest.of("sha256:${"3".repeat(64)}")
     }
 }

--- a/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageJdbcE2ETest.kt
+++ b/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageJdbcE2ETest.kt
@@ -1,16 +1,22 @@
 package dev.tramai.examples.spring
 
 import com.zaxxer.hikari.HikariDataSource
-import dev.tramai.core.approval.ApprovalBinding
-import dev.tramai.core.approval.ApprovalRequest
 import dev.tramai.core.approval.ApprovalStatus
 import dev.tramai.core.approval.ApprovalStore
-import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.approval.gateway.ApprovalGateway
+import dev.tramai.core.approval.gateway.ApprovalRecommendation
+import dev.tramai.core.approval.gateway.ApprovalRequestResult
+import dev.tramai.core.approval.gateway.ApprovalSubject
+import dev.tramai.core.approval.gateway.ApproverRole
+import dev.tramai.core.approval.gateway.WorkflowRunId
 import dev.tramai.security.audit.AuditEvent
 import dev.tramai.security.audit.AuditHashAlgorithm
 import dev.tramai.security.audit.AuditStore
 import dev.tramai.security.audit.calculateHash
+import dev.tramai.engine.approval.ApprovalGatewayRequestFactory
+import dev.tramai.engine.approval.DefaultApprovalGateway
 import dev.tramai.spring.sovereign.SovereignTramaiAutoConfiguration
+import dev.tramai.spring.sovereign.ops.ApprovalGatewayAutoConfiguration
 import dev.tramai.spring.sovereign.persistence.jdbc.SovereignJdbcPersistenceAutoConfiguration
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalMutationResult
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalMutationStore
@@ -19,7 +25,6 @@ import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStatus
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
 import java.nio.file.Path
 import java.security.MessageDigest
-import java.time.Duration
 import java.time.Instant
 import java.util.Base64
 import java.util.UUID
@@ -91,11 +96,13 @@ class RegulatedClaimTriageJdbcE2ETest {
                 AutoConfigurations.of(
                     SovereignJdbcPersistenceAutoConfiguration::class.java,
                     SovereignTramaiAutoConfiguration::class.java,
+                    ApprovalGatewayAutoConfiguration::class.java,
                 ),
             )
             .withUserConfiguration(
                 JdbcE2eDataSourceConfig::class.java,
                 DemoProviderConfiguration::class.java,
+                RegulatedClaimTriageGatewayConfig::class.java,
             )
             .withPropertyValues(
                 "tramai.sovereign.enabled=true",
@@ -112,7 +119,7 @@ class RegulatedClaimTriageJdbcE2ETest {
     // ══════════════════════════════════════════════════════════════════
 
     @Test
-    fun `high risk claim is classified routed locally approved denied transactionally and survives restart`() {
+    fun `high risk claim suspends through approval gateway and survives restart`() {
         val claimId = "claim-hr-${UUID.randomUUID()}"
         val workflowRunId = "wf-$claimId"
         val input = ClaimTriageInput(
@@ -139,6 +146,10 @@ class RegulatedClaimTriageJdbcE2ETest {
                 assertThat(result.requiredApproval).isTrue()
                 assertThat(result.policyDecision).isEqualTo("ALLOW_LOCAL")
                 assertThat(result.classification).isEqualTo("RESTRICTED")
+
+                val pendingApproval = workflow.approvalStore.get(result.approvalId!!)
+                assertThat(pendingApproval).isNotNull
+                assertThat(pendingApproval!!.status).isEqualTo(ApprovalStatus.PENDING)
 
                 // Audit: policy decision (allow-local) + recommendation + approval-requested → 3 events
                 val events = workflow.auditStore.readStream(result.auditStreamId)
@@ -219,6 +230,15 @@ class RegulatedClaimTriageJdbcE2ETest {
                 val dispatched = workflow.outboxStore.get(denialOutboxId)
                 assertThat(dispatched!!.status).isEqualTo(SovereignOpsAuditOutboxStatus.EMITTED)
             }
+        }
+    }
+
+    @Test
+    fun `spring auto-configures DefaultApprovalGateway when factory is present`() {
+        createJdbcRunner().run { ctx ->
+            assertThat(ctx).hasSingleBean(ApprovalGateway::class.java)
+            assertThat(ctx.getBean(ApprovalGateway::class.java))
+                .isInstanceOf(DefaultApprovalGateway::class.java)
         }
     }
 
@@ -327,6 +347,13 @@ class RegulatedClaimTriageJdbcE2ETest {
             return ds
         }
     }
+
+    @Configuration
+    class RegulatedClaimTriageGatewayConfig {
+        @Bean
+        fun regulatedClaimTriageApprovalGatewayRequestFactory(): ApprovalGatewayRequestFactory =
+            RegulatedClaimTriageApprovalGatewayRequestFactory()
+    }
 }
 
 // ══════════════════════════════════════════════════════════════════════
@@ -412,6 +439,7 @@ class ClaimTriageWorkflow(
     val auditStore: AuditStore,
     val mutationStore: SovereignOpsApprovalMutationStore,
     val outboxStore: SovereignOpsAuditOutboxStore,
+    private val approvalGateway: ApprovalGateway,
     private val dataSource: DataSource,
     private val dlp: FakeDlpClassifier = FakeDlpClassifier(),
     private val policy: FakePolicyEvaluator = FakePolicyEvaluator(),
@@ -497,31 +525,27 @@ class ClaimTriageWorkflow(
 
         // 8. Approval gate: high-risk requires approval
         if (recommendation.requiredApproval) {
-            val approvalId = "approval-${UUID.randomUUID()}"
-            val binding = ApprovalBinding(
-                workflowRunId = workflowRunId,
-                toolName = "claim-triage-model",
-                argumentsDigest = Sha256Digest.of(sha256Hex(input.claimId)),
-                policyVersion = "1.0",
-                workflowDigest = Sha256Digest.of(sha256Hex("claim-triage-workflow")),
-                approvalTokenDigest = Sha256Digest.of(sha256Hex(approvalId)),
-            )
-            approvalStore.create(
-                ApprovalRequest(
-                    approvalId = approvalId,
-                    binding = binding,
-                    status = ApprovalStatus.PENDING,
-                    requestedBy = "triage-system",
-                    requestedAt = Instant.now(),
-                    expiresAt = Instant.now().plus(Duration.ofMinutes(5)),
-                    decidedBy = null,
-                    decidedAt = null,
-                    decisionComment = null,
-                    consumedBy = null,
-                    consumedAt = null,
-                    version = 0,
+            val approvalResult = approvalGateway.requestApproval(
+                subject = ApprovalSubject(input.claimId),
+                recommendation = ApprovalRecommendation(
+                    type = "regulated-claim-triage",
+                    summary = recommendation.recommendationType,
+                    payload = mapOf(
+                        "riskLevel" to recommendation.riskLevel,
+                        "requiredApprover" to if (recommendation.riskLevel == "HIGH") "medical-reviewer" else "reviewer",
+                    ),
                 ),
+                requiredRole = ApproverRole(
+                    if (recommendation.riskLevel == "HIGH") "medical-reviewer" else "reviewer",
+                ),
+                workflowRunId = WorkflowRunId(workflowRunId),
             )
+            val approvalId = when (approvalResult) {
+                is ApprovalRequestResult.Suspended -> approvalResult.approvalId.value
+                is ApprovalRequestResult.AlreadyApproved -> approvalResult.decision.approvalId.value
+                is ApprovalRequestResult.AlreadyDenied -> approvalResult.decision.approvalId.value
+                is ApprovalRequestResult.Expired -> approvalResult.approvalId.value
+            }
 
             // Audit: approval requested
             emitAuditEvent(
@@ -619,6 +643,7 @@ private fun org.springframework.context.ApplicationContext.workflow(
     auditStore = getBean(AuditStore::class.java),
     mutationStore = getBean(SovereignOpsApprovalMutationStore::class.java),
     outboxStore = getBean(SovereignOpsAuditOutboxStore::class.java),
+    approvalGateway = getBean(ApprovalGateway::class.java),
     dataSource = getBean(DataSource::class.java),
     cloudModel = cloudModel,
 )

--- a/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageJdbcE2ETest.kt
+++ b/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageJdbcE2ETest.kt
@@ -1,6 +1,7 @@
 package dev.tramai.examples.spring
 
 import com.zaxxer.hikari.HikariDataSource
+import dev.tramai.core.approval.ApprovalContinuationStore
 import dev.tramai.core.approval.ApprovalStatus
 import dev.tramai.core.approval.ApprovalStore
 import dev.tramai.core.approval.gateway.ApprovalGateway
@@ -9,6 +10,7 @@ import dev.tramai.core.approval.gateway.ApprovalRequestResult
 import dev.tramai.core.approval.gateway.ApprovalSubject
 import dev.tramai.core.approval.gateway.ApproverRole
 import dev.tramai.core.approval.gateway.WorkflowRunId
+import dev.tramai.engine.SuspendedInvocationStore
 import dev.tramai.security.audit.AuditEvent
 import dev.tramai.security.audit.AuditHashAlgorithm
 import dev.tramai.security.audit.AuditStore
@@ -151,6 +153,16 @@ class RegulatedClaimTriageJdbcE2ETest {
                 assertThat(pendingApproval).isNotNull
                 assertThat(pendingApproval!!.status).isEqualTo(ApprovalStatus.PENDING)
 
+                // Gateway also persisted suspended invocation and continuation
+                val suspended = workflow.suspendedInvocationStore.get(result.approvalId!!)
+                assertThat(suspended).isNotNull
+                assertThat(suspended!!.approvalId).isEqualTo(result.approvalId)
+                val continuation = workflow.approvalContinuationStore.get(result.approvalId!!)
+                assertThat(continuation).isNotNull
+                assertThat(continuation!!.workflowRunId).isEqualTo(workflowRunId)
+                assertThat(continuation.argumentsDigest)
+                    .isEqualTo(pendingApproval.binding.argumentsDigest)
+
                 // Audit: policy decision (allow-local) + recommendation + approval-requested → 3 events
                 val events = workflow.auditStore.readStream(result.auditStreamId)
                 assertThat(events).hasSize(3)
@@ -208,6 +220,15 @@ class RegulatedClaimTriageJdbcE2ETest {
                 assertThat(approval).isNotNull
                 assertThat(approval!!.status).isEqualTo(ApprovalStatus.DENIED)
                 assertThat(approval.version).isEqualTo(1)
+
+                // Suspended invocation survives restart
+                val suspendedAfterRestart = workflow.suspendedInvocationStore.get(persistedApprovalId)
+                assertThat(suspendedAfterRestart).isNotNull
+
+                // Continuation survives restart
+                val continuationAfterRestart = workflow.approvalContinuationStore.get(persistedApprovalId)
+                assertThat(continuationAfterRestart).isNotNull
+                assertThat(continuationAfterRestart!!.workflowRunId).isEqualTo(workflowRunId)
 
                 // Audit chain intact across restart
                 val events = workflow.auditStore.readStream(persistedAuditStreamId)
@@ -439,6 +460,8 @@ class ClaimTriageWorkflow(
     val auditStore: AuditStore,
     val mutationStore: SovereignOpsApprovalMutationStore,
     val outboxStore: SovereignOpsAuditOutboxStore,
+    val suspendedInvocationStore: SuspendedInvocationStore,
+    val approvalContinuationStore: ApprovalContinuationStore,
     private val approvalGateway: ApprovalGateway,
     private val dataSource: DataSource,
     private val dlp: FakeDlpClassifier = FakeDlpClassifier(),
@@ -546,13 +569,19 @@ class ClaimTriageWorkflow(
                 is ApprovalRequestResult.AlreadyDenied -> approvalResult.decision.approvalId.value
                 is ApprovalRequestResult.Expired -> approvalResult.approvalId.value
             }
+            val approvalAuditDecision = when (approvalResult) {
+                is ApprovalRequestResult.Suspended -> "approval-requested-high-risk"
+                is ApprovalRequestResult.AlreadyApproved -> "approval-already-approved"
+                is ApprovalRequestResult.AlreadyDenied -> "approval-already-denied"
+                is ApprovalRequestResult.Expired -> "approval-expired"
+            }
 
             // Audit: approval requested
             emitAuditEvent(
                 auditStreamId, workflowRunId, input.claimId,
                 actor = "triage-system",
                 enforcementPoint = "approval-gate",
-                decision = "approval-requested-high-risk",
+                decision = approvalAuditDecision,
                 reasonCode = null,
             )
 
@@ -643,6 +672,8 @@ private fun org.springframework.context.ApplicationContext.workflow(
     auditStore = getBean(AuditStore::class.java),
     mutationStore = getBean(SovereignOpsApprovalMutationStore::class.java),
     outboxStore = getBean(SovereignOpsAuditOutboxStore::class.java),
+    suspendedInvocationStore = getBean(SuspendedInvocationStore::class.java),
+    approvalContinuationStore = getBean(ApprovalContinuationStore::class.java),
     approvalGateway = getBean(ApprovalGateway::class.java),
     dataSource = getBean(DataSource::class.java),
     cloudModel = cloudModel,


### PR DESCRIPTION
## Summary

Refactor the regulated claim triage executable E2E example so the workflow requests human approval through the Preview ApprovalGateway API instead of manually creating low-level approval, suspended invocation, and continuation records.

## Changes

### New files

- `examples/.../RegulatedClaimTriageApprovalGatewayRequestFactory.kt` — example-scoped factory translating ergonomic gateway calls into low-level persistence records (ApprovalRequest, ApprovalContinuation, SuspendedInvocationMetadata, SensitiveReplayEnvelope). Computes argumentsDigest from actual SensitiveToolArguments via Sha256ToolArgumentsDigester.

### Modified files

- `examples/.../RegulatedClaimTriageJdbcE2ETest.kt`:
  - Refactored ClaimTriageWorkflow to use `approvalGateway.requestApproval(...)` instead of manual `ApprovalStore.create(...)`
  - Added RegulatedClaimTriageGatewayConfig `@Configuration` class with factory bean
  - Added ApprovalGatewayAutoConfiguration to the test context
  - Added `spring auto-configures DefaultApprovalGateway when factory is present` test
  - **Added suspended invocation + continuation durability assertions** in Context A and Context B, proving the gateway created all three durable records
  - **Added argumentsDigest consistency assertion** between ApprovalBinding and ApprovalContinuation
  - **Mapped audit decision based on ApprovalRequestResult type** instead of hard-coded value
  - Updated test names and imports
- `docs/scenarios/regulated-claim-triage.md`
- `docs/architecture/human-approval-workflow-ergonomics.md`
- `CHANGELOG.md`

## Fixes from review round 1

| Finding | Fix |
|---------|-----|
| P1/P2 — No suspended invocation + continuation assertions | Exposed both stores in workflow harness; assert existence and ID match in Context A + Context B |
| P2 — Hard-coded ARGUMENTS_DIGEST doesn't match actual arguments | Use Sha256ToolArgumentsDigester to compute digest from actual SensitiveToolArguments; pass same object to persistence request |
| P2/P3 — Audit always says "approval-requested- high-risk" | Branch audit decision based on ApprovalRequestResult type (Suspended/AlreadyApproved/AlreadyDenied/Expired) |

## Verification

- `./gradlew :examples:spring-sovereign-starter:e2eTest` ✅ (10/10 tests pass)
- `./gradlew check` ✅
- `./gradlew verifySovereignRuntimeClosure` ✅

## Constraints

- Does not implement full workflow resume runtime
- Does not add reviewer UI or REST control plane
- Does not add workflow DSL
- Does not add cross-store transaction hardening
- Does not add audit-requested outbox mutation boundary
- Does not create a generic global ApprovalGatewayRequestFactory
- All items stay Preview, not RC+ Stable or GA
