### PR TITLE
feat(workflow): add preview approval decision control plane service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added Approval Gateway Golden Path developer-facing guide (`PR #100`). The guide explains how to request human approval through the Preview ApprovalGateway API, how Spring Boot auto-configuration wires it, what persistence records are created, and what the current Preview limitations are.
 - Added Preview `SovereignOpsApprovalRequestMutationStore` with a JDBC transactional boundary for atomic approval request creation across `ApprovalStore`, `SuspendedInvocationStore`, `ApprovalContinuationStore`, and optional audit outbox intent (`PR #101`). `SovereignOpsTransactionalApprovalGateway` now replaces the sequential `DefaultApprovalGateway` write path when the request mutation store is available.
 - Added Preview `ApprovalGatewayAuditIntentFactory` SPI and wiring — `SovereignOpsTransactionalApprovalGateway` now emits approval-requested audit outbox intent atomically when an audit intent factory is present (`PR #102`). The regulated claim triage E2E test proves a `PENDING` approval-requested outbox record exists after gateway request creation.
+- Added Preview `ApprovalDecisionControlPlane` service for approving or denying pending approvals through the transactional mutation/outbox boundary (`PR #103`).
 - Sovereign runtime profile and routing foundation (`tramai-sovereign`).
 - Policy enforcement and DLP/redaction support (`tramai-security`).
 - Approval gates and replay-safe resume.

--- a/docs/architecture/human-approval-workflow-ergonomics.md
+++ b/docs/architecture/human-approval-workflow-ergonomics.md
@@ -329,6 +329,13 @@ This design proposes the path to move workflow ergonomics from **Preview** towar
 > - `RegulatedClaimTriageApprovalGatewayAuditIntentFactory` — example factory that creates `regulated-claim-triage.approval-requested` outbox records
 > - The E2E test now asserts the gateway-created approval-requested outbox record exists
 >
+> **PR #103** adds a preview approval decision control plane service:
+> - `ApprovalDecisionControlPlane` — application-facing service boundary for approving or denying pending approvals
+> - `ApprovalDecisionAuthorizer` — Preview authorization seam for decision actors
+> - `SovereignOpsApprovalDecisionControlPlane` — transactional implementation backed by `ApprovalStore` and `SovereignOpsApprovalMutationStore`
+> - Spring Boot auto-configuration now wires the control plane when approval mutations are enabled
+> - The regulated claim triage E2E now proves denial through the control plane persists both the approval decision and the denial audit outbox intent
+>
 > **Limitations remaining:**
 > - Does not implement full workflow resume.
 > - Generic fallback gateway (`DefaultApprovalGateway`) still has no cross-store transaction boundary and does not emit audit intent.
@@ -370,3 +377,4 @@ The following are explicitly **not covered** by this design:
 | #100 | Golden path example | Polished developer-facing example |
 | #101 | Transactional request creation boundary | Add JDBC-backed atomic approval-request creation and prefer the transactional gateway when available |
 | #102 | Approval-requested audit intent from gateway | Emit approval-requested audit outbox intent atomically from the transactional gateway when an `ApprovalGatewayAuditIntentFactory` is present |
+| #103 | Preview approval decision control plane | Add application-facing approve/deny service over the transactional mutation and outbox boundary |

--- a/docs/guides/approval-gateway-golden-path.md
+++ b/docs/guides/approval-gateway-golden-path.md
@@ -170,7 +170,7 @@ The Preview approval gateway has the following limitations:
 |------|--------|
 | Full workflow resume runtime | Not implemented yet |
 | Reviewer UI | Not implemented yet |
-| REST control plane for approvals | Not implemented yet |
+| REST control plane for approvals | Not implemented yet; service-level `ApprovalDecisionControlPlane` available |
 | Generic workflow DSL | Not implemented yet |
 | Cross-store transaction boundary at creation | ✅ Implemented for JDBC-backed stores via `SovereignOpsApprovalRequestMutationStore` |
 | Approval-requested audit outbox mutation boundary | ✅ Implemented for JDBC-backed stores when an `ApprovalGatewayAuditIntentFactory` bean is provided |

--- a/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageApprovalDecisionControlPlaneAuthorizer.kt
+++ b/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageApprovalDecisionControlPlaneAuthorizer.kt
@@ -1,0 +1,20 @@
+package dev.tramai.examples.spring
+
+import dev.tramai.core.approval.ApprovalRequest
+import dev.tramai.core.approval.gateway.ApproverRole
+import dev.tramai.spring.sovereign.ops.ApprovalDecisionAuthorizer
+import dev.tramai.spring.sovereign.ops.ApprovalDecisionType
+
+/**
+ * Example authorizer for the regulated claim triage scenario.
+ * Allows decisions from known reviewer actors.
+ * For Preview: permits all decisions (permissive default).
+ */
+class RegulatedClaimTriageApprovalDecisionControlPlaneAuthorizer : ApprovalDecisionAuthorizer {
+    override fun canDecide(
+        approval: ApprovalRequest,
+        actorId: String,
+        actorRole: ApproverRole,
+        decisionType: ApprovalDecisionType,
+    ): Boolean = true
+}

--- a/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageApprovalGatewayAuditIntentFactory.kt
+++ b/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageApprovalGatewayAuditIntentFactory.kt
@@ -35,7 +35,7 @@ class RegulatedClaimTriageApprovalGatewayAuditIntentFactory(
             aggregateType = "approval",
             operation = "approvalRequested",
             aggregateIdDigest = sha256Hex(claimId),
-            eventKey = "regulated-claim-triage.approval-requested",
+            eventKey = "regulated-claim-triage.approval-requested.${request.approvalRequest.approvalId}",
             actor = "triage-system",
             workflowRunId = request.approvalRequest.binding.workflowRunId,
             correlationId = request.suspendedInvocationMetadata.correlationId,

--- a/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageJdbcE2ETest.kt
+++ b/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageJdbcE2ETest.kt
@@ -322,7 +322,7 @@ class RegulatedClaimTriageJdbcE2ETest {
                     assertThat(approval).isNotNull
                     assertThat(approval!!.status).isEqualTo(ApprovalStatus.DENIED)
 
-                    val denialOutbox = workflow.outboxStore.findByEventKey("approval-denied")
+                    val denialOutbox = workflow.outboxStore.findByEventKey("approval-denied.${result.approvalId!!}")
                     assertThat(denialOutbox).isNotNull
                     assertThat(denialOutbox!!.status).isEqualTo(SovereignOpsAuditOutboxStatus.PENDING)
                     assertThat(denialOutbox.approvalStatus).isEqualTo(ApprovalStatus.DENIED.name)

--- a/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageJdbcE2ETest.kt
+++ b/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageJdbcE2ETest.kt
@@ -15,6 +15,10 @@ import dev.tramai.security.audit.AuditEvent
 import dev.tramai.security.audit.AuditHashAlgorithm
 import dev.tramai.security.audit.AuditStore
 import dev.tramai.security.audit.calculateHash
+import dev.tramai.spring.sovereign.ops.ApprovalDecisionCommand
+import dev.tramai.spring.sovereign.ops.ApprovalDecisionControlPlane
+import dev.tramai.spring.sovereign.ops.ApprovalDecisionControlPlaneAutoConfiguration
+import dev.tramai.spring.sovereign.ops.ApprovalDecisionResult
 import dev.tramai.engine.approval.ApprovalGatewayRequestFactory
 import dev.tramai.spring.sovereign.SovereignTramaiAutoConfiguration
 import dev.tramai.spring.sovereign.ops.ApprovalGatewayAuditIntentFactory
@@ -100,6 +104,7 @@ class RegulatedClaimTriageJdbcE2ETest {
                     SovereignJdbcPersistenceAutoConfiguration::class.java,
                     SovereignTramaiAutoConfiguration::class.java,
                     ApprovalGatewayAutoConfiguration::class.java,
+                    ApprovalDecisionControlPlaneAutoConfiguration::class.java,
                 ),
             )
             .withUserConfiguration(
@@ -109,6 +114,7 @@ class RegulatedClaimTriageJdbcE2ETest {
             )
             .withPropertyValues(
                 "tramai.sovereign.enabled=true",
+                "tramai.sovereign.ops.mutations-enabled=true",
                 "tramai.sovereign.allowed-models[0]=local-invoice-model",
                 "tramai.sovereign.allowed-providers[0]=deterministic-local-provider",
                 "tramai.sovereign.provider-zones.deterministic-local-provider=LOCAL",
@@ -166,7 +172,7 @@ class RegulatedClaimTriageJdbcE2ETest {
 
                 // Gateway also created approval-requested audit outbox intent atomically
                 val approvalRequestedOutbox = workflow.outboxStore.findByEventKey(
-                    "regulated-claim-triage.approval-requested",
+                    "regulated-claim-triage.approval-requested.${result.approvalId!!}",
                 )
                 assertThat(approvalRequestedOutbox).isNotNull
                 assertThat(approvalRequestedOutbox!!.status)
@@ -276,6 +282,60 @@ class RegulatedClaimTriageJdbcE2ETest {
             // prefers SovereignOpsTransactionalApprovalGateway over DefaultApprovalGateway.
             assertThat(gateway).isInstanceOf(SovereignOpsTransactionalApprovalGateway::class.java)
         }
+    }
+
+    @Test
+    fun `regulated claim triage denial through control plane persists decision and outbox intent`() {
+        val claimId = "claim-cp-${UUID.randomUUID()}"
+        val input = ClaimTriageInput(
+            claimId = claimId,
+            claimantName = "Delta",
+            diagnosisText = "lumbar radiculopathy",
+            invoiceAmount = 4100,
+            paymentReference = "PAY-REF-CP-001",
+        )
+
+        createJdbcRunner().run { ctx ->
+                val workflow = ctx.workflow()
+                runBlocking {
+                    val result = workflow.triage(input, RequestedRoute.LOCAL_ONLY)
+
+                    assertThat(result.requiredApproval).isTrue()
+                    assertThat(result.approvalId).isNotNull()
+
+                    val decisionResult = workflow.decisionControlPlane.deny(
+                        ApprovalDecisionCommand(
+                            approvalId = dev.tramai.core.approval.gateway.ApprovalId(result.approvalId!!),
+                            actorId = "medical-ops-reviewer",
+                            actorRole = ApproverRole("medical-reviewer"),
+                            comment = "Medical necessity not established",
+                            correlationId = claimId,
+                        ),
+                    )
+
+                    assertThat(decisionResult).isInstanceOf(ApprovalDecisionResult.Denied::class.java)
+                    val denied = decisionResult as ApprovalDecisionResult.Denied
+                    assertThat(denied.approvalId.value).isEqualTo(result.approvalId)
+                    assertThat(denied.decidedBy).isEqualTo("medical-ops-reviewer")
+
+                    val approval = workflow.approvalStore.get(result.approvalId!!)
+                    assertThat(approval).isNotNull
+                    assertThat(approval!!.status).isEqualTo(ApprovalStatus.DENIED)
+
+                    val denialOutbox = workflow.outboxStore.findByEventKey("approval-denied")
+                    assertThat(denialOutbox).isNotNull
+                    assertThat(denialOutbox!!.status).isEqualTo(SovereignOpsAuditOutboxStatus.PENDING)
+                    assertThat(denialOutbox.approvalStatus).isEqualTo(ApprovalStatus.DENIED.name)
+                    assertThat(denialOutbox.actor).isEqualTo("medical-ops-reviewer")
+
+                    val approvalRequestedOutbox = workflow.outboxStore.findByEventKey(
+                        "regulated-claim-triage.approval-requested.${result.approvalId!!}",
+                    )
+                    assertThat(approvalRequestedOutbox).isNotNull
+                    assertThat(approvalRequestedOutbox!!.status)
+                        .isEqualTo(SovereignOpsAuditOutboxStatus.PENDING)
+                }
+            }
     }
 
     // ══════════════════════════════════════════════════════════════════
@@ -393,6 +453,10 @@ class RegulatedClaimTriageJdbcE2ETest {
         @Bean
         fun regulatedClaimTriageApprovalGatewayAuditIntentFactory(): ApprovalGatewayAuditIntentFactory =
             RegulatedClaimTriageApprovalGatewayAuditIntentFactory()
+
+        @Bean
+        fun regulatedClaimTriageApprovalDecisionControlPlaneAuthorizer(): RegulatedClaimTriageApprovalDecisionControlPlaneAuthorizer =
+            RegulatedClaimTriageApprovalDecisionControlPlaneAuthorizer()
     }
 }
 
@@ -479,6 +543,7 @@ class ClaimTriageWorkflow(
     val auditStore: AuditStore,
     val mutationStore: SovereignOpsApprovalMutationStore,
     val outboxStore: SovereignOpsAuditOutboxStore,
+    val decisionControlPlane: ApprovalDecisionControlPlane,
     val suspendedInvocationStore: SuspendedInvocationStore,
     val approvalContinuationStore: ApprovalContinuationStore,
     private val approvalGateway: ApprovalGateway,
@@ -691,6 +756,7 @@ private fun org.springframework.context.ApplicationContext.workflow(
     auditStore = getBean(AuditStore::class.java),
     mutationStore = getBean(SovereignOpsApprovalMutationStore::class.java),
     outboxStore = getBean(SovereignOpsAuditOutboxStore::class.java),
+    decisionControlPlane = getBean(ApprovalDecisionControlPlane::class.java),
     suspendedInvocationStore = getBean(SuspendedInvocationStore::class.java),
     approvalContinuationStore = getBean(ApprovalContinuationStore::class.java),
     approvalGateway = getBean(ApprovalGateway::class.java),

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovalDecisionAuthorizer.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovalDecisionAuthorizer.kt
@@ -1,0 +1,42 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.core.approval.ApprovalRequest
+import dev.tramai.core.approval.gateway.ApproverRole
+
+/**
+ * Policy interface for authorizing approval decisions.
+ *
+ * Implementations decide whether a given actor is allowed to approve or deny
+ * a specific approval request.
+ */
+fun interface ApprovalDecisionAuthorizer {
+
+    /**
+     * Check whether [actorId] with [actorRole] may perform [decisionType]
+     * on the given [approval].
+     *
+     * @return `true` if the decision is allowed, `false` to reject.
+     */
+    fun canDecide(
+        approval: ApprovalRequest,
+        actorId: String,
+        actorRole: ApproverRole,
+        decisionType: ApprovalDecisionType,
+    ): Boolean
+}
+
+/** Type of approval decision for authorization. */
+enum class ApprovalDecisionType { APPROVE, DENY }
+
+/**
+ * Permissive default authorizer — allows any actor to decide any approval.
+ * Intended for Preview; replace with real authorization for production.
+ */
+object AllowAllApprovalDecisionAuthorizer : ApprovalDecisionAuthorizer {
+    override fun canDecide(
+        approval: ApprovalRequest,
+        actorId: String,
+        actorRole: ApproverRole,
+        decisionType: ApprovalDecisionType,
+    ): Boolean = true
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovalDecisionControlPlane.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovalDecisionControlPlane.kt
@@ -1,0 +1,102 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.core.approval.gateway.ApprovalId
+import dev.tramai.core.approval.gateway.ApproverRole
+import java.time.Instant
+
+/**
+ * Preview decision control-plane API for approving or denying pending approvals.
+ *
+ * This is the application-facing boundary for human/system decision making.
+ * It sits between the [dev.tramai.core.approval.gateway.ApprovalGateway]
+ * request API and the future workflow resume runtime.
+ *
+ * Implementations must use the existing transactional approval mutation/outbox
+ * boundary to ensure decisions are durably audited.
+ */
+interface ApprovalDecisionControlPlane {
+
+    /**
+     * Approve a pending approval request.
+     * @return typed [ApprovalDecisionResult] indicating outcome.
+     */
+    suspend fun approve(command: ApprovalDecisionCommand): ApprovalDecisionResult
+
+    /**
+     * Deny a pending approval request.
+     * @return typed [ApprovalDecisionResult] indicating outcome.
+     */
+    suspend fun deny(command: ApprovalDecisionCommand): ApprovalDecisionResult
+}
+
+/**
+ * Command to approve or deny a pending approval request.
+ *
+ * @param approvalId The approval to decide on.
+ * @param actorId The identity of the actor making the decision.
+ * @param actorRole The role of the actor making the decision.
+ * @param comment Optional human-readable comment (never stored raw — only digested in outbox).
+ * @param expectedVersion Expected approval version for optimistic concurrency (null = auto-detect).
+ * @param correlationId Optional correlation ID for the decision audit trail.
+ */
+data class ApprovalDecisionCommand(
+    val approvalId: ApprovalId,
+    val actorId: String,
+    val actorRole: ApproverRole,
+    val comment: String? = null,
+    val expectedVersion: Long? = null,
+    val correlationId: String? = null,
+)
+
+/**
+ * Typed result from an approval decision operation.
+ */
+sealed interface ApprovalDecisionResult {
+
+    /** The approval was successfully approved. */
+    data class Approved(
+        val approvalId: ApprovalId,
+        val decidedBy: String,
+        val decidedAt: Instant,
+        val version: Long,
+    ) : ApprovalDecisionResult
+
+    /** The approval was successfully denied. */
+    data class Denied(
+        val approvalId: ApprovalId,
+        val decidedBy: String,
+        val decidedAt: Instant,
+        val version: Long,
+    ) : ApprovalDecisionResult
+
+    /** The approval was already approved. */
+    data class AlreadyApproved(
+        val approvalId: ApprovalId,
+        val decidedBy: String,
+        val decidedAt: Instant,
+    ) : ApprovalDecisionResult
+
+    /** The approval was already denied. */
+    data class AlreadyDenied(
+        val approvalId: ApprovalId,
+        val decidedBy: String,
+        val decidedAt: Instant,
+    ) : ApprovalDecisionResult
+
+    /** The approval has expired and cannot be decided. */
+    data class Expired(
+        val approvalId: ApprovalId,
+        val expiredAt: Instant,
+    ) : ApprovalDecisionResult
+
+    /** The approval was not found. */
+    data class NotFound(
+        val approvalId: ApprovalId,
+    ) : ApprovalDecisionResult
+
+    /** Version conflict or invalid state transition. */
+    data class Conflict(
+        val approvalId: ApprovalId,
+        val reason: String,
+    ) : ApprovalDecisionResult
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovalDecisionControlPlane.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovalDecisionControlPlane.kt
@@ -35,7 +35,10 @@ interface ApprovalDecisionControlPlane {
  * @param approvalId The approval to decide on.
  * @param actorId The identity of the actor making the decision.
  * @param actorRole The role of the actor making the decision.
- * @param comment Optional human-readable comment (never stored raw — only digested in outbox).
+ * @param comment Optional human-readable decision comment.
+ * The comment may be persisted in approval metadata.
+ * Do not include secrets, raw medical details, credentials, or unnecessary PII.
+ * The audit outbox stores only digest/length metadata.
  * @param expectedVersion Expected approval version for optimistic concurrency (null = auto-detect).
  * @param correlationId Optional correlation ID for the decision audit trail.
  */

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovalDecisionControlPlaneAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovalDecisionControlPlaneAutoConfiguration.kt
@@ -1,0 +1,50 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.core.approval.ApprovalStore
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalMutationStore
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+
+/**
+ * Spring Boot auto-configuration for the Preview [ApprovalDecisionControlPlane].
+ *
+ * Creates a [SovereignOpsApprovalDecisionControlPlane] bean when
+ * [SovereignOpsApprovalMutationStore] and [ApprovalStore] are available.
+ *
+ * An optional [ApprovalDecisionAuthorizer] bean can be provided to customise
+ * decision authorization; otherwise [AllowAllApprovalDecisionAuthorizer] is used.
+ *
+ * @see SovereignOpsApprovalDecisionControlPlane
+ * @see ApprovalDecisionAuthorizer
+ */
+@AutoConfiguration(after = [SovereignOpsAutoConfiguration::class])
+@ConditionalOnProperty(
+    prefix = "tramai.sovereign.ops",
+    name = ["mutations-enabled"],
+    havingValue = "true",
+)
+class ApprovalDecisionControlPlaneAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(ApprovalDecisionControlPlane::class)
+    @ConditionalOnBean(
+        value = [
+            SovereignOpsApprovalMutationStore::class,
+            ApprovalStore::class,
+        ],
+    )
+    fun sovereignOpsApprovalDecisionControlPlane(
+        approvalStore: ApprovalStore,
+        mutationStore: SovereignOpsApprovalMutationStore,
+        authorizer: ObjectProvider<ApprovalDecisionAuthorizer>,
+    ): ApprovalDecisionControlPlane =
+        SovereignOpsApprovalDecisionControlPlane(
+            approvalStore = approvalStore,
+            mutationStore = mutationStore,
+            authorizer = authorizer.ifAvailable ?: AllowAllApprovalDecisionAuthorizer,
+        )
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovalDecisionControlPlane.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovalDecisionControlPlane.kt
@@ -46,10 +46,6 @@ class SovereignOpsApprovalDecisionControlPlane(
 
         val now = clock.instant()
 
-        if (!approval.expiresAt.isAfter(now)) {
-            return ApprovalDecisionResult.Expired(command.approvalId, approval.expiresAt)
-        }
-
         if (approval.status == ApprovalStatus.APPROVED) {
             return ApprovalDecisionResult.AlreadyApproved(
                 approvalId = ApprovalId(approval.approvalId),
@@ -70,6 +66,9 @@ class SovereignOpsApprovalDecisionControlPlane(
                 reason = "approval-invalid-status-${approval.status.name}",
             )
         }
+        if (!approval.expiresAt.isAfter(now)) {
+            return ApprovalDecisionResult.Expired(command.approvalId, approval.expiresAt)
+        }
 
         if (!authorizer.canDecide(approval, command.actorId, command.actorRole, decisionType)) {
             return ApprovalDecisionResult.Conflict(
@@ -79,8 +78,8 @@ class SovereignOpsApprovalDecisionControlPlane(
         }
 
         val eventKey = when (decisionType) {
-            ApprovalDecisionType.APPROVE -> "approval-approved"
-            ApprovalDecisionType.DENY -> "approval-denied"
+            ApprovalDecisionType.APPROVE -> "approval-approved.${command.approvalId.value}"
+            ApprovalDecisionType.DENY -> "approval-denied.${command.approvalId.value}"
         }
         val auditIntent = SovereignOpsAuditOutboxRecord(
             outboxId = UUID.randomUUID().toString(),

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovalDecisionControlPlane.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovalDecisionControlPlane.kt
@@ -1,0 +1,163 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.core.approval.ApprovalStatus
+import dev.tramai.core.approval.ApprovalStore
+import dev.tramai.core.approval.gateway.ApprovalId
+import dev.tramai.core.exception.ApprovalStoreNotFoundException
+import dev.tramai.core.exception.IllegalApprovalTransitionException
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalMutationStore
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxRecord
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStatus
+import java.security.MessageDigest
+import java.time.Clock
+import java.util.UUID
+
+/**
+ * Transactional [ApprovalDecisionControlPlane] backed by the existing
+ * [SovereignOpsApprovalMutationStore] and [ApprovalStore].
+ *
+ * Each decision creates an audit outbox intent (PREPARED), transitions the
+ * approval via the mutation store, and returns a typed result.
+ *
+ * @param approvalStore stores approval requests
+ * @param mutationStore transactional approval mutation store
+ * @param authorizer optional decision authorization policy
+ * @param clock clock for temporal decisions
+ */
+class SovereignOpsApprovalDecisionControlPlane(
+    private val approvalStore: ApprovalStore,
+    private val mutationStore: SovereignOpsApprovalMutationStore,
+    private val authorizer: ApprovalDecisionAuthorizer = AllowAllApprovalDecisionAuthorizer,
+    private val clock: Clock = Clock.systemUTC(),
+) : ApprovalDecisionControlPlane {
+
+    override suspend fun approve(command: ApprovalDecisionCommand): ApprovalDecisionResult =
+        decide(command, ApprovalDecisionType.APPROVE)
+
+    override suspend fun deny(command: ApprovalDecisionCommand): ApprovalDecisionResult =
+        decide(command, ApprovalDecisionType.DENY)
+
+    private suspend fun decide(
+        command: ApprovalDecisionCommand,
+        decisionType: ApprovalDecisionType,
+    ): ApprovalDecisionResult {
+        val approval = approvalStore.get(command.approvalId.value)
+            ?: return ApprovalDecisionResult.NotFound(command.approvalId)
+
+        val now = clock.instant()
+
+        if (!approval.expiresAt.isAfter(now)) {
+            return ApprovalDecisionResult.Expired(command.approvalId, approval.expiresAt)
+        }
+
+        if (approval.status == ApprovalStatus.APPROVED) {
+            return ApprovalDecisionResult.AlreadyApproved(
+                approvalId = ApprovalId(approval.approvalId),
+                decidedBy = requireNotNull(approval.decidedBy) { "already approved but no decider" },
+                decidedAt = requireNotNull(approval.decidedAt) { "already approved but no timestamp" },
+            )
+        }
+        if (approval.status == ApprovalStatus.DENIED) {
+            return ApprovalDecisionResult.AlreadyDenied(
+                approvalId = ApprovalId(approval.approvalId),
+                decidedBy = requireNotNull(approval.decidedBy) { "already denied but no decider" },
+                decidedAt = requireNotNull(approval.decidedAt) { "already denied but no timestamp" },
+            )
+        }
+        if (approval.status != ApprovalStatus.PENDING) {
+            return ApprovalDecisionResult.Conflict(
+                approvalId = ApprovalId(approval.approvalId),
+                reason = "approval-invalid-status-${approval.status.name}",
+            )
+        }
+
+        if (!authorizer.canDecide(approval, command.actorId, command.actorRole, decisionType)) {
+            return ApprovalDecisionResult.Conflict(
+                approvalId = ApprovalId(approval.approvalId),
+                reason = "approval-unauthorized-decision",
+            )
+        }
+
+        val eventKey = when (decisionType) {
+            ApprovalDecisionType.APPROVE -> "approval-approved"
+            ApprovalDecisionType.DENY -> "approval-denied"
+        }
+        val auditIntent = SovereignOpsAuditOutboxRecord(
+            outboxId = UUID.randomUUID().toString(),
+            aggregateType = "approval",
+            operation = eventKey,
+            aggregateIdDigest = sha256Hex(command.approvalId.value),
+            eventKey = eventKey,
+            actor = command.actorId,
+            workflowRunId = approval.binding.workflowRunId,
+            correlationId = command.correlationId,
+            approvalStatus = when (decisionType) {
+                ApprovalDecisionType.APPROVE -> ApprovalStatus.APPROVED.name
+                ApprovalDecisionType.DENY -> ApprovalStatus.DENIED.name
+            },
+            approvalVersion = approval.version + 1,
+            reasonDigest = command.comment?.let { sha256Hex(it) } ?: sha256Hex(eventKey),
+            reasonLength = command.comment?.length ?: eventKey.length,
+            createdAt = now,
+            status = SovereignOpsAuditOutboxStatus.PREPARED,
+        )
+
+        return try {
+            val result = when (decisionType) {
+                ApprovalDecisionType.APPROVE ->
+                    mutationStore.approveApprovalWithAuditIntent(
+                        approvalId = approval.approvalId,
+                        expectedVersion = command.expectedVersion ?: approval.version,
+                        actor = command.actorId,
+                        reason = command.comment ?: eventKey,
+                        auditIntent = auditIntent,
+                    )
+
+                ApprovalDecisionType.DENY ->
+                    mutationStore.denyApprovalWithAuditIntent(
+                        approvalId = approval.approvalId,
+                        expectedVersion = command.expectedVersion ?: approval.version,
+                        actor = command.actorId,
+                        reason = command.comment ?: eventKey,
+                        auditIntent = auditIntent,
+                    )
+            }
+
+            when (decisionType) {
+                ApprovalDecisionType.APPROVE ->
+                    ApprovalDecisionResult.Approved(
+                        approvalId = ApprovalId(result.approval.approvalId),
+                        decidedBy = result.approval.decidedBy ?: command.actorId,
+                        decidedAt = result.approval.decidedAt ?: clock.instant(),
+                        version = result.approval.version,
+                    )
+
+                ApprovalDecisionType.DENY ->
+                    ApprovalDecisionResult.Denied(
+                        approvalId = ApprovalId(result.approval.approvalId),
+                        decidedBy = result.approval.decidedBy ?: command.actorId,
+                        decidedAt = result.approval.decidedAt ?: clock.instant(),
+                        version = result.approval.version,
+                    )
+            }
+        } catch (e: IllegalApprovalTransitionException) {
+            ApprovalDecisionResult.Conflict(
+                approvalId = ApprovalId(approval.approvalId),
+                reason = e.message ?: "approval-illegal-transition",
+            )
+        } catch (_: ApprovalStoreNotFoundException) {
+            ApprovalDecisionResult.NotFound(ApprovalId(approval.approvalId))
+        } catch (e: IllegalStateException) {
+            ApprovalDecisionResult.Conflict(
+                approvalId = ApprovalId(approval.approvalId),
+                reason = e.message ?: "approval-mutation-failure",
+            )
+        }
+    }
+
+    private fun sha256Hex(input: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val hash = digest.digest(input.toByteArray(Charsets.UTF_8))
+        return "sha256:${hash.joinToString("") { "%02x".format(it) }}"
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/InMemorySovereignOpsApprovalMutationStore.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/InMemorySovereignOpsApprovalMutationStore.kt
@@ -41,6 +41,35 @@ class InMemorySovereignOpsApprovalMutationStore(
         reason: String,
         auditIntent: SovereignOpsAuditOutboxRecord,
     ): SovereignOpsApprovalMutationResult {
+        return mutateApprovalWithAuditIntent(
+            approvalId = approvalId,
+            expectedVersion = expectedVersion,
+            auditIntent = auditIntent,
+            transition = ApprovalTransition.Deny(decidedBy = actor, comment = reason),
+        )
+    }
+
+    override suspend fun approveApprovalWithAuditIntent(
+        approvalId: String,
+        expectedVersion: Long,
+        actor: String,
+        reason: String,
+        auditIntent: SovereignOpsAuditOutboxRecord,
+    ): SovereignOpsApprovalMutationResult {
+        return mutateApprovalWithAuditIntent(
+            approvalId = approvalId,
+            expectedVersion = expectedVersion,
+            auditIntent = auditIntent,
+            transition = ApprovalTransition.Approve(decidedBy = actor, comment = reason),
+        )
+    }
+
+    private suspend fun mutateApprovalWithAuditIntent(
+        approvalId: String,
+        expectedVersion: Long,
+        auditIntent: SovereignOpsAuditOutboxRecord,
+        transition: ApprovalTransition,
+    ): SovereignOpsApprovalMutationResult {
         val lock = approvalLocks.computeIfAbsent(approvalId) { ReentrantLock() }
         lock.lock()
         try {
@@ -62,7 +91,7 @@ class InMemorySovereignOpsApprovalMutationStore(
                 val updated = approvalStore.transition(
                     approvalId = approvalId,
                     expectedVersion = expectedVersion,
-                    transition = ApprovalTransition.Deny(decidedBy = actor, comment = reason),
+                    transition = transition,
                 )
                 // 4. Mark the outbox as PENDING — now dispatchable
                 outboxStore.markReadyForDispatch(

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsApprovalMutationStore.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsApprovalMutationStore.kt
@@ -19,7 +19,10 @@ interface SovereignOpsApprovalMutationStore {
      * @param approvalId The approval to deny.
      * @param expectedVersion The version expected for optimistic concurrency.
      * @param actor The identity of the actor performing the denial.
-     * @param reason The human-readable reason (never stored raw — only digested).
+     * @param reason Optional human-readable reason for the decision.
+     * The reason may be persisted in the approval metadata as decisionComment.
+     * Do not include secrets, raw medical details, credentials, or unnecessary PII.
+     * The audit outbox stores only digest/length metadata.
      * @param auditIntent The outbox record to append atomically with the transition.
      * @return The updated approval and the persisted outbox record.
      * @throws IllegalStateException if the approval does not exist or version mismatches.
@@ -39,7 +42,10 @@ interface SovereignOpsApprovalMutationStore {
      * @param approvalId The approval to approve.
      * @param expectedVersion The version expected for optimistic concurrency.
      * @param actor The identity of the actor performing the approval.
-     * @param reason The human-readable reason (never stored raw — only digested).
+     * @param reason Optional human-readable reason for the decision.
+     * The reason may be persisted in the approval metadata as decisionComment.
+     * Do not include secrets, raw medical details, credentials, or unnecessary PII.
+     * The audit outbox stores only digest/length metadata.
      * @param auditIntent The outbox record to append atomically with the transition.
      * @return The updated approval and the persisted outbox record.
      * @throws IllegalStateException if the approval does not exist or version mismatches.

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsApprovalMutationStore.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsApprovalMutationStore.kt
@@ -32,4 +32,24 @@ interface SovereignOpsApprovalMutationStore {
         reason: String,
         auditIntent: SovereignOpsAuditOutboxRecord,
     ): SovereignOpsApprovalMutationResult
+
+    /**
+     * Atomically approve an approval and persist the audit outbox record.
+     *
+     * @param approvalId The approval to approve.
+     * @param expectedVersion The version expected for optimistic concurrency.
+     * @param actor The identity of the actor performing the approval.
+     * @param reason The human-readable reason (never stored raw — only digested).
+     * @param auditIntent The outbox record to append atomically with the transition.
+     * @return The updated approval and the persisted outbox record.
+     * @throws IllegalStateException if the approval does not exist or version mismatches.
+     * @throws IllegalStateException if the outbox append fails (approval remains unchanged).
+     */
+    suspend fun approveApprovalWithAuditIntent(
+        approvalId: String,
+        expectedVersion: Long,
+        actor: String,
+        reason: String,
+        auditIntent: SovereignOpsAuditOutboxRecord,
+    ): SovereignOpsApprovalMutationResult
 }

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
 dev.tramai.spring.sovereign.ops.SovereignOpsAutoConfiguration
 dev.tramai.spring.sovereign.ops.ApprovalGatewayAutoConfiguration
+dev.tramai.spring.sovereign.ops.ApprovalDecisionControlPlaneAutoConfiguration

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovalDecisionControlPlaneTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovalDecisionControlPlaneTest.kt
@@ -130,6 +130,58 @@ class SovereignOpsApprovalDecisionControlPlaneTest {
     }
 
     @Test
+    fun `already approved expired approval returns AlreadyApproved`() = runBlocking {
+        val store = MutableApprovalStore(
+            mutableMapOf("approval-1" to approvedApproval(
+                approvalId = "approval-1",
+                decidedBy = "existing-reviewer",
+                decidedAt = now.minusSeconds(60),
+            ).copy(expiresAt = now)),
+        )
+        val controlPlane = SovereignOpsApprovalDecisionControlPlane(
+            approvalStore = store,
+            mutationStore = StubApprovalMutationStore(store),
+            clock = clock,
+        )
+
+        val result = controlPlane.deny(decisionCommand("approval-1"))
+
+        assertThat(result).isEqualTo(
+            ApprovalDecisionResult.AlreadyApproved(
+                approvalId = ApprovalId("approval-1"),
+                decidedBy = "existing-reviewer",
+                decidedAt = now.minusSeconds(60),
+            ),
+        )
+    }
+
+    @Test
+    fun `already denied expired approval returns AlreadyDenied`() = runBlocking {
+        val store = MutableApprovalStore(
+            mutableMapOf("approval-1" to deniedApproval(
+                approvalId = "approval-1",
+                decidedBy = "existing-reviewer",
+                decidedAt = now.minusSeconds(60),
+            ).copy(expiresAt = now)),
+        )
+        val controlPlane = SovereignOpsApprovalDecisionControlPlane(
+            approvalStore = store,
+            mutationStore = StubApprovalMutationStore(store),
+            clock = clock,
+        )
+
+        val result = controlPlane.approve(decisionCommand("approval-1"))
+
+        assertThat(result).isEqualTo(
+            ApprovalDecisionResult.AlreadyDenied(
+                approvalId = ApprovalId("approval-1"),
+                decidedBy = "existing-reviewer",
+                decidedAt = now.minusSeconds(60),
+            ),
+        )
+    }
+
+    @Test
     fun `missing approval returns NotFound`() = runBlocking {
         val store = MutableApprovalStore()
         val controlPlane = SovereignOpsApprovalDecisionControlPlane(

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovalDecisionControlPlaneTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovalDecisionControlPlaneTest.kt
@@ -1,0 +1,401 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.core.approval.ApprovalBinding
+import dev.tramai.core.approval.ApprovalConsumptionReceipt
+import dev.tramai.core.approval.ApprovalRequest
+import dev.tramai.core.approval.ApprovalStatus
+import dev.tramai.core.approval.ApprovalStore
+import dev.tramai.core.approval.ApprovalTransition
+import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.approval.gateway.ApprovalId
+import dev.tramai.core.approval.gateway.ApproverRole
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalMutationResult
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalMutationStore
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxRecord
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SovereignOpsApprovalDecisionControlPlaneTest {
+
+    private val now: Instant = Instant.parse("2026-06-25T10:15:30Z")
+    private val clock: Clock = Clock.fixed(now, ZoneOffset.UTC)
+
+    @Test
+    fun `approve pending approval returns Approved`() = runBlocking {
+        val store = MutableApprovalStore(mutableMapOf("approval-1" to pendingApproval("approval-1")))
+        val mutationStore = StubApprovalMutationStore(store)
+        val controlPlane = SovereignOpsApprovalDecisionControlPlane(
+            approvalStore = store,
+            mutationStore = mutationStore,
+            clock = clock,
+        )
+
+        val result = controlPlane.approve(decisionCommand("approval-1"))
+
+        assertThat(result).isInstanceOf(ApprovalDecisionResult.Approved::class.java)
+        val approved = result as ApprovalDecisionResult.Approved
+        assertThat(approved.approvalId.value).isEqualTo("approval-1")
+        assertThat(approved.decidedBy).isEqualTo("reviewer-1")
+        assertThat(approved.decidedAt).isEqualTo(now)
+        assertThat(approved.version).isEqualTo(1L)
+    }
+
+    @Test
+    fun `deny pending approval returns Denied`() = runBlocking {
+        val store = MutableApprovalStore(mutableMapOf("approval-1" to pendingApproval("approval-1")))
+        val mutationStore = StubApprovalMutationStore(store)
+        val controlPlane = SovereignOpsApprovalDecisionControlPlane(
+            approvalStore = store,
+            mutationStore = mutationStore,
+            clock = clock,
+        )
+
+        val result = controlPlane.deny(decisionCommand("approval-1"))
+
+        assertThat(result).isInstanceOf(ApprovalDecisionResult.Denied::class.java)
+        val denied = result as ApprovalDecisionResult.Denied
+        assertThat(denied.approvalId.value).isEqualTo("approval-1")
+        assertThat(denied.decidedBy).isEqualTo("reviewer-1")
+        assertThat(denied.decidedAt).isEqualTo(now)
+        assertThat(denied.version).isEqualTo(1L)
+    }
+
+    @Test
+    fun `already approved returns AlreadyApproved`() = runBlocking {
+        val store = MutableApprovalStore(
+            mutableMapOf("approval-1" to approvedApproval("approval-1", "existing-reviewer", now.minusSeconds(60))),
+        )
+        val controlPlane = SovereignOpsApprovalDecisionControlPlane(
+            approvalStore = store,
+            mutationStore = StubApprovalMutationStore(store),
+            clock = clock,
+        )
+
+        val result = controlPlane.approve(decisionCommand("approval-1"))
+
+        assertThat(result).isEqualTo(
+            ApprovalDecisionResult.AlreadyApproved(
+                approvalId = ApprovalId("approval-1"),
+                decidedBy = "existing-reviewer",
+                decidedAt = now.minusSeconds(60),
+            ),
+        )
+    }
+
+    @Test
+    fun `already denied returns AlreadyDenied`() = runBlocking {
+        val store = MutableApprovalStore(
+            mutableMapOf("approval-1" to deniedApproval("approval-1", "existing-reviewer", now.minusSeconds(60))),
+        )
+        val controlPlane = SovereignOpsApprovalDecisionControlPlane(
+            approvalStore = store,
+            mutationStore = StubApprovalMutationStore(store),
+            clock = clock,
+        )
+
+        val result = controlPlane.deny(decisionCommand("approval-1"))
+
+        assertThat(result).isEqualTo(
+            ApprovalDecisionResult.AlreadyDenied(
+                approvalId = ApprovalId("approval-1"),
+                decidedBy = "existing-reviewer",
+                decidedAt = now.minusSeconds(60),
+            ),
+        )
+    }
+
+    @Test
+    fun `expired approval returns Expired`() = runBlocking {
+        val store = MutableApprovalStore(
+            mutableMapOf("approval-1" to pendingApproval("approval-1", expiresAt = now)),
+        )
+        val controlPlane = SovereignOpsApprovalDecisionControlPlane(
+            approvalStore = store,
+            mutationStore = StubApprovalMutationStore(store),
+            clock = clock,
+        )
+
+        val result = controlPlane.deny(decisionCommand("approval-1"))
+
+        assertThat(result).isEqualTo(
+            ApprovalDecisionResult.Expired(
+                approvalId = ApprovalId("approval-1"),
+                expiredAt = now,
+            ),
+        )
+    }
+
+    @Test
+    fun `missing approval returns NotFound`() = runBlocking {
+        val store = MutableApprovalStore()
+        val controlPlane = SovereignOpsApprovalDecisionControlPlane(
+            approvalStore = store,
+            mutationStore = StubApprovalMutationStore(store),
+            clock = clock,
+        )
+
+        val result = controlPlane.deny(decisionCommand("approval-404"))
+
+        assertThat(result).isEqualTo(ApprovalDecisionResult.NotFound(ApprovalId("approval-404")))
+    }
+
+    @Test
+    fun `unauthorized actor returns Conflict`() = runBlocking {
+        val store = MutableApprovalStore(mutableMapOf("approval-1" to pendingApproval("approval-1")))
+        val controlPlane = SovereignOpsApprovalDecisionControlPlane(
+            approvalStore = store,
+            mutationStore = StubApprovalMutationStore(store),
+            authorizer = ApprovalDecisionAuthorizer { _, _, _, _ -> false },
+            clock = clock,
+        )
+
+        val result = controlPlane.approve(decisionCommand("approval-1"))
+
+        assertThat(result).isEqualTo(
+            ApprovalDecisionResult.Conflict(
+                approvalId = ApprovalId("approval-1"),
+                reason = "approval-unauthorized-decision",
+            ),
+        )
+    }
+
+    @Test
+    fun `approve on denied returns AlreadyDenied`() = runBlocking {
+        val store = MutableApprovalStore(
+            mutableMapOf("approval-1" to deniedApproval("approval-1", "existing-reviewer", now.minusSeconds(60))),
+        )
+        val controlPlane = SovereignOpsApprovalDecisionControlPlane(
+            approvalStore = store,
+            mutationStore = StubApprovalMutationStore(store),
+            clock = clock,
+        )
+
+        val result = controlPlane.approve(decisionCommand("approval-1"))
+
+        assertThat(result).isEqualTo(
+            ApprovalDecisionResult.AlreadyDenied(
+                approvalId = ApprovalId("approval-1"),
+                decidedBy = "existing-reviewer",
+                decidedAt = now.minusSeconds(60),
+            ),
+        )
+    }
+
+    @Test
+    fun `deny on approved returns AlreadyApproved`() = runBlocking {
+        val store = MutableApprovalStore(
+            mutableMapOf("approval-1" to approvedApproval("approval-1", "existing-reviewer", now.minusSeconds(60))),
+        )
+        val controlPlane = SovereignOpsApprovalDecisionControlPlane(
+            approvalStore = store,
+            mutationStore = StubApprovalMutationStore(store),
+            clock = clock,
+        )
+
+        val result = controlPlane.deny(decisionCommand("approval-1"))
+
+        assertThat(result).isEqualTo(
+            ApprovalDecisionResult.AlreadyApproved(
+                approvalId = ApprovalId("approval-1"),
+                decidedBy = "existing-reviewer",
+                decidedAt = now.minusSeconds(60),
+            ),
+        )
+    }
+
+    @Test
+    fun `version conflict at mutation store returns Conflict`() = runBlocking {
+        val store = MutableApprovalStore(mutableMapOf("approval-1" to pendingApproval("approval-1")))
+        val mutationStore = StubApprovalMutationStore(store)
+        val controlPlane = SovereignOpsApprovalDecisionControlPlane(
+            approvalStore = store,
+            mutationStore = mutationStore,
+            clock = clock,
+        )
+
+        val result = controlPlane.approve(
+            decisionCommand("approval-1").copy(expectedVersion = 99L),
+        )
+
+        assertThat(result).isEqualTo(
+            ApprovalDecisionResult.Conflict(
+                approvalId = ApprovalId("approval-1"),
+                reason = "tramai-sovereign-ops-approval-version-conflict",
+            ),
+        )
+    }
+
+    private fun decisionCommand(approvalId: String): ApprovalDecisionCommand =
+        ApprovalDecisionCommand(
+            approvalId = ApprovalId(approvalId),
+            actorId = "reviewer-1",
+            actorRole = ApproverRole("medical-reviewer"),
+            comment = "review complete",
+            correlationId = "corr-1",
+        )
+
+    private fun pendingApproval(
+        approvalId: String,
+        expiresAt: Instant = now.plusSeconds(600),
+    ): ApprovalRequest = approval(
+        approvalId = approvalId,
+        status = ApprovalStatus.PENDING,
+        expiresAt = expiresAt,
+    )
+
+    private fun approvedApproval(
+        approvalId: String,
+        decidedBy: String,
+        decidedAt: Instant,
+    ): ApprovalRequest = approval(
+        approvalId = approvalId,
+        status = ApprovalStatus.APPROVED,
+        decidedBy = decidedBy,
+        decidedAt = decidedAt,
+        decisionComment = "approved",
+        version = 1L,
+    )
+
+    private fun deniedApproval(
+        approvalId: String,
+        decidedBy: String,
+        decidedAt: Instant,
+    ): ApprovalRequest = approval(
+        approvalId = approvalId,
+        status = ApprovalStatus.DENIED,
+        decidedBy = decidedBy,
+        decidedAt = decidedAt,
+        decisionComment = "denied",
+        version = 1L,
+    )
+
+    private fun approval(
+        approvalId: String,
+        status: ApprovalStatus,
+        expiresAt: Instant = now.plusSeconds(600),
+        decidedBy: String? = null,
+        decidedAt: Instant? = null,
+        decisionComment: String? = null,
+        version: Long = 0L,
+    ): ApprovalRequest = ApprovalRequest(
+        approvalId = approvalId,
+        binding = ApprovalBinding(
+            workflowRunId = "wf-$approvalId",
+            toolName = "claim-triage",
+            argumentsDigest = digest("01"),
+            policyVersion = "v1",
+            workflowDigest = digest("02"),
+            approvalTokenDigest = digest("03"),
+        ),
+        status = status,
+        requestedBy = "triage-system",
+        requestedAt = now.minusSeconds(30),
+        expiresAt = expiresAt,
+        decidedBy = decidedBy,
+        decidedAt = decidedAt,
+        decisionComment = decisionComment,
+        consumedBy = null,
+        consumedAt = null,
+        version = version,
+    )
+
+    private fun digest(suffix: String): Sha256Digest =
+        Sha256Digest.of("sha256:${suffix.padStart(64, suffix.first())}")
+}
+
+private class MutableApprovalStore(
+    private val approvals: MutableMap<String, ApprovalRequest> = mutableMapOf(),
+) : ApprovalStore {
+    override suspend fun create(request: ApprovalRequest): ApprovalRequest {
+        approvals[request.approvalId] = request
+        return request
+    }
+
+    override suspend fun get(approvalId: String): ApprovalRequest? = approvals[approvalId]
+
+    override suspend fun transition(
+        approvalId: String,
+        expectedVersion: Long,
+        transition: ApprovalTransition,
+    ): ApprovalRequest {
+        throw UnsupportedOperationException("transition should not be called directly in this test")
+    }
+
+    override suspend fun consumeApprovedOrReplay(
+        approvalId: String,
+        expectedVersion: Long,
+        presentedTokenDigest: Sha256Digest,
+        consumedBy: String,
+    ): ApprovalConsumptionReceipt {
+        throw UnsupportedOperationException("stub")
+    }
+
+    fun put(request: ApprovalRequest) {
+        approvals[request.approvalId] = request
+    }
+}
+
+private class StubApprovalMutationStore(
+    private val approvalStore: MutableApprovalStore,
+) : SovereignOpsApprovalMutationStore {
+    override suspend fun denyApprovalWithAuditIntent(
+        approvalId: String,
+        expectedVersion: Long,
+        actor: String,
+        reason: String,
+        auditIntent: SovereignOpsAuditOutboxRecord,
+    ): SovereignOpsApprovalMutationResult =
+        mutate(
+            approvalId = approvalId,
+            expectedVersion = expectedVersion,
+            actor = actor,
+            reason = reason,
+            targetStatus = ApprovalStatus.DENIED,
+            auditIntent = auditIntent,
+        )
+
+    override suspend fun approveApprovalWithAuditIntent(
+        approvalId: String,
+        expectedVersion: Long,
+        actor: String,
+        reason: String,
+        auditIntent: SovereignOpsAuditOutboxRecord,
+    ): SovereignOpsApprovalMutationResult =
+        mutate(
+            approvalId = approvalId,
+            expectedVersion = expectedVersion,
+            actor = actor,
+            reason = reason,
+            targetStatus = ApprovalStatus.APPROVED,
+            auditIntent = auditIntent,
+        )
+
+    private suspend fun mutate(
+        approvalId: String,
+        expectedVersion: Long,
+        actor: String,
+        reason: String,
+        targetStatus: ApprovalStatus,
+        auditIntent: SovereignOpsAuditOutboxRecord,
+    ): SovereignOpsApprovalMutationResult {
+        val current = requireNotNull(approvalStore.get(approvalId)) { "missing approval" }
+        check(current.version == expectedVersion) { "tramai-sovereign-ops-approval-version-conflict" }
+        val decidedAt = Instant.parse("2026-06-25T10:15:30Z")
+        val updated = current.copy(
+            status = targetStatus,
+            decidedBy = actor,
+            decidedAt = decidedAt,
+            decisionComment = reason,
+            version = current.version + 1,
+        )
+        approvalStore.put(updated)
+        return SovereignOpsApprovalMutationResult(
+            approval = updated,
+            auditOutboxRecord = auditIntent,
+        )
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsApprovalMutationStore.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsApprovalMutationStore.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import dev.tramai.core.approval.ApprovalBinding
 import dev.tramai.core.approval.ApprovalRequest
 import dev.tramai.core.approval.ApprovalStatus
+import dev.tramai.core.approval.ApprovalTransition
 import dev.tramai.core.approval.SafeActorIdPolicy
 import dev.tramai.core.approval.Sha256Digest
 import dev.tramai.core.exception.ApprovalStoreNotFoundException
@@ -48,6 +49,41 @@ class JdbcSovereignOpsApprovalMutationStore(
         reason: String,
         auditIntent: SovereignOpsAuditOutboxRecord,
     ): SovereignOpsApprovalMutationResult {
+        return mutateApprovalWithAuditIntent(
+            approvalId = approvalId,
+            expectedVersion = expectedVersion,
+            actor = actor,
+            reason = reason,
+            auditIntent = auditIntent,
+            transition = ApprovalTransition.Deny(decidedBy = actor, comment = reason),
+        )
+    }
+
+    override suspend fun approveApprovalWithAuditIntent(
+        approvalId: String,
+        expectedVersion: Long,
+        actor: String,
+        reason: String,
+        auditIntent: SovereignOpsAuditOutboxRecord,
+    ): SovereignOpsApprovalMutationResult {
+        return mutateApprovalWithAuditIntent(
+            approvalId = approvalId,
+            expectedVersion = expectedVersion,
+            actor = actor,
+            reason = reason,
+            auditIntent = auditIntent,
+            transition = ApprovalTransition.Approve(decidedBy = actor, comment = reason),
+        )
+    }
+
+    private suspend fun mutateApprovalWithAuditIntent(
+        approvalId: String,
+        expectedVersion: Long,
+        actor: String,
+        reason: String,
+        auditIntent: SovereignOpsAuditOutboxRecord,
+        transition: ApprovalTransition,
+    ): SovereignOpsApprovalMutationResult {
         // ── Input validation ──────────────────────────────────────────
         validateIdField(approvalId, "approvalId")
         validateIdField(actor, "decidedBy")
@@ -77,10 +113,11 @@ class JdbcSovereignOpsApprovalMutationStore(
 
                 // Guard: status
                 if (current.status != ApprovalStatus.PENDING.name) {
+                    val targetStatus = transition.targetStatus()
                     throw IllegalApprovalTransitionException(
                         approvalId = approvalId,
                         from = ApprovalStatus.valueOf(current.status),
-                        to = ApprovalStatus.DENIED,
+                        to = targetStatus,
                         reason = "approval already ${current.status.lowercase()}",
                     )
                 }
@@ -95,10 +132,11 @@ class JdbcSovereignOpsApprovalMutationStore(
                 val expiresAt = Instant.parse(metadata.expiresAt)
                 val now = clock.instant()
                 if (!now.isBefore(expiresAt)) {
+                    val targetStatus = transition.targetStatus()
                     throw IllegalApprovalTransitionException(
                         approvalId = approvalId,
                         from = ApprovalStatus.PENDING,
-                        to = ApprovalStatus.DENIED,
+                        to = targetStatus,
                         reason = "approval has expired at $expiresAt",
                     )
                 }
@@ -108,7 +146,7 @@ class JdbcSovereignOpsApprovalMutationStore(
                 val preparedEncrypted = payloadCodec.encode(preparedPayload)
                 insertPreparedOutbox(conn, auditIntent, preparedEncrypted)
 
-                // Update approval to DENIED
+                // Update approval
                 val decidedAt = Timestamp.from(now)
                 val nextVersion = incrementVersion(approvalId, expectedVersion)
                 val updatedMetadata = metadata.copy(
@@ -116,6 +154,7 @@ class JdbcSovereignOpsApprovalMutationStore(
                     decisionComment = reason,
                 )
                 val metadataJson = mapper.writeValueAsString(updatedMetadata)
+                val targetStatus = transition.targetStatus()
 
                 updateApprovalRow(
                     conn = conn,
@@ -124,11 +163,12 @@ class JdbcSovereignOpsApprovalMutationStore(
                     decidedAt = decidedAt,
                     actorHash = sha256Hex(actor),
                     metadataJson = metadataJson,
+                    targetStatus = targetStatus,
                 )
 
                 // Mark outbox PENDING
                 val pendingAuditIntent = auditIntent.copy(
-                    approvalStatus = ApprovalStatus.DENIED.name,
+                    approvalStatus = targetStatus.name,
                     approvalVersion = nextVersion,
                     status = SovereignOpsAuditOutboxStatus.PENDING,
                 )
@@ -239,24 +279,27 @@ class JdbcSovereignOpsApprovalMutationStore(
         decidedAt: Timestamp,
         actorHash: String,
         metadataJson: String,
+        targetStatus: ApprovalStatus,
     ) {
         val sql = """
             UPDATE approvals
-            SET status = 'DENIED',
+            SET status = ?,
                 decided_at = ?,
                 decision_actor_hash = ?,
-                decision_type = 'DENIED',
+                decision_type = ?,
                 sanitized_metadata = ?::jsonb,
                 version = version + 1
             WHERE approval_id = ? AND version = ? AND status = 'PENDING'
         """.trimIndent()
 
         conn.prepareStatement(sql).use { stmt ->
-            stmt.setTimestamp(1, decidedAt)
-            stmt.setString(2, actorHash)
-            stmt.setString(3, metadataJson)
-            stmt.setString(4, approvalId)
-            stmt.setLong(5, expectedVersion)
+            stmt.setString(1, targetStatus.name)
+            stmt.setTimestamp(2, decidedAt)
+            stmt.setString(3, actorHash)
+            stmt.setString(4, targetStatus.name)
+            stmt.setString(5, metadataJson)
+            stmt.setString(6, approvalId)
+            stmt.setLong(7, expectedVersion)
             val updated = stmt.executeUpdate()
             if (updated != 1) {
                 throw IllegalStateException("tramai-sovereign-ops-approval-update-failed")

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsApprovalDecisionControlPlaneTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsApprovalDecisionControlPlaneTest.kt
@@ -1,0 +1,344 @@
+package dev.tramai.spring.sovereign.persistence.jdbc
+
+import dev.tramai.core.approval.ApprovalBinding
+import dev.tramai.core.approval.ApprovalContinuation
+import dev.tramai.core.approval.ApprovalContinuationStatus
+import dev.tramai.core.approval.ApprovalRequest
+import dev.tramai.core.approval.ApprovalStatus
+import dev.tramai.core.approval.SensitiveToolArguments
+import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.approval.gateway.ApprovalGateway
+import dev.tramai.core.approval.gateway.ApprovalRecommendation
+import dev.tramai.core.approval.gateway.ApprovalRequestResult
+import dev.tramai.core.approval.gateway.ApprovalSubject
+import dev.tramai.core.approval.gateway.ApproverRole
+import dev.tramai.core.approval.gateway.ResumeToken
+import dev.tramai.core.approval.gateway.WorkflowRunId
+import dev.tramai.engine.EngineExecutionIdentity
+import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.ResumeOperationReference
+import dev.tramai.engine.ResumeToolReference
+import dev.tramai.engine.SensitiveReplayEnvelope
+import dev.tramai.engine.SuspendedInvocationMetadata
+import dev.tramai.engine.approval.ApprovalGatewayPersistenceRequest
+import dev.tramai.engine.approval.ApprovalGatewayRequestFactory
+import dev.tramai.spring.sovereign.ops.AllowAllApprovalDecisionAuthorizer
+import dev.tramai.spring.sovereign.ops.ApprovalDecisionCommand
+import dev.tramai.spring.sovereign.ops.ApprovalDecisionControlPlane
+import dev.tramai.spring.sovereign.ops.ApprovalDecisionControlPlaneAutoConfiguration
+import dev.tramai.spring.sovereign.ops.ApprovalDecisionResult
+import dev.tramai.spring.sovereign.ops.ApprovalGatewayAutoConfiguration
+import dev.tramai.spring.sovereign.ops.SovereignOpsApprovalDecisionControlPlane
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalMutationStore
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStatus
+import java.nio.file.Files
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.SpringBootConfiguration
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+
+/**
+ * JDBC-level test proving approve/deny control-plane behavior at the store boundary.
+ *
+ * Verifies that approving or denying pending approvals through the control plane
+ * creates PENDING audit outbox records with correct status, version, and unique event keys.
+ */
+@SpringBootTest(
+    classes = [JdbcSovereignOpsTestConfig::class],
+)
+@JdbcTestTag
+@Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JdbcSovereignOpsApprovalDecisionControlPlaneTest {
+
+    @Autowired
+    private lateinit var approvalStore: dev.tramai.core.approval.ApprovalStore
+
+    @Autowired
+    private lateinit var mutationStore: SovereignOpsApprovalMutationStore
+
+    @Autowired
+    private lateinit var outboxStore: dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
+
+    @Autowired
+    private lateinit var gateway: ApprovalGateway
+
+    @Autowired
+    private lateinit var jdbcTemplate: JdbcTemplate
+
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-06-25T10:15:30Z"), ZoneOffset.UTC)
+
+    @BeforeAll
+    fun runMigrations() {
+        listOf(
+            "tramai/persistence/jdbc/postgres/V1__sovereign_persistence.sql",
+            "tramai/persistence/jdbc/postgres/V2__approval_continuations.sql",
+            "tramai/persistence/jdbc/postgres/V4__audit_outbox_hardening.sql",
+        ).forEach { resource ->
+            val sql = javaClass.classLoader
+                .getResourceAsStream(resource)
+                ?.bufferedReader()
+                ?.readText()
+                ?: error("Migration not found: $resource")
+            runCatching { jdbcTemplate.execute(sql) }
+        }
+    }
+
+    @BeforeEach
+    fun cleanUp() {
+        jdbcTemplate.execute("TRUNCATE TABLE approval_continuations, suspended_invocations, audit_outbox, approvals CASCADE")
+    }
+
+    @Test
+    fun `approve approval creates pending approval-approved outbox record atomically`() = runBlocking {
+        val requiredRole = ApproverRole("medical-reviewer")
+        val requestResult = gateway.requestApproval(
+            subject = ApprovalSubject("test-approve-1"),
+            recommendation = ApprovalRecommendation(
+                type = "claim-review",
+                summary = "high-value claim",
+                payload = mapOf("amount" to "5000"),
+            ),
+            requiredRole = requiredRole,
+            workflowRunId = WorkflowRunId("wf-test-approve-1"),
+        )
+        val approvalId = (requestResult as ApprovalRequestResult.Suspended).approvalId
+
+        val controlPlane: ApprovalDecisionControlPlane = SovereignOpsApprovalDecisionControlPlane(
+            approvalStore = approvalStore,
+            mutationStore = mutationStore,
+            authorizer = AllowAllApprovalDecisionAuthorizer,
+            clock = clock,
+        )
+
+        val result = controlPlane.approve(
+            ApprovalDecisionCommand(
+                approvalId = approvalId,
+                actorId = "medical-ops-reviewer",
+                actorRole = requiredRole,
+                comment = "Medical necessity established",
+                correlationId = "corr-approve-test-1",
+            ),
+        )
+
+        assertThat(result).isInstanceOf(ApprovalDecisionResult.Approved::class.java)
+        val approved = result as ApprovalDecisionResult.Approved
+        assertThat(approved.approvalId.value).isEqualTo(approvalId.value)
+        assertThat(approved.decidedBy).isEqualTo("medical-ops-reviewer")
+
+        val approval = approvalStore.get(approvalId.value)
+        assertThat(approval).isNotNull
+        assertThat(approval!!.status).isEqualTo(ApprovalStatus.APPROVED)
+        assertThat(approval.version).isEqualTo(1L)
+
+        val approvalOutbox = outboxStore.findByEventKey("approval-approved.${approvalId.value}")
+        assertThat(approvalOutbox).isNotNull
+        assertThat(approvalOutbox!!.status).isEqualTo(SovereignOpsAuditOutboxStatus.PENDING)
+        assertThat(approvalOutbox.approvalStatus).isEqualTo(ApprovalStatus.APPROVED.name)
+        assertThat(approvalOutbox.actor).isEqualTo("medical-ops-reviewer")
+    }
+
+    @Test
+    fun `can deny two different approvals without audit outbox event key conflict`() = runBlocking {
+        val requiredRole = ApproverRole("medical-reviewer")
+
+        val result1 = gateway.requestApproval(
+            subject = ApprovalSubject("claim-deny-conflict-1"),
+            recommendation = ApprovalRecommendation(
+                type = "claim-review",
+                summary = "review required",
+            ),
+            requiredRole = requiredRole,
+            workflowRunId = WorkflowRunId("wf-deny-conflict-1"),
+        )
+        val result2 = gateway.requestApproval(
+            subject = ApprovalSubject("claim-deny-conflict-2"),
+            recommendation = ApprovalRecommendation(
+                type = "claim-review",
+                summary = "review required",
+            ),
+            requiredRole = requiredRole,
+            workflowRunId = WorkflowRunId("wf-deny-conflict-2"),
+        )
+        val id1 = (result1 as ApprovalRequestResult.Suspended).approvalId
+        val id2 = (result2 as ApprovalRequestResult.Suspended).approvalId
+
+        val controlPlane: ApprovalDecisionControlPlane = SovereignOpsApprovalDecisionControlPlane(
+            approvalStore = approvalStore,
+            mutationStore = mutationStore,
+            authorizer = AllowAllApprovalDecisionAuthorizer,
+            clock = clock,
+        )
+
+        val deny1 = controlPlane.deny(
+            ApprovalDecisionCommand(
+                approvalId = id1,
+                actorId = "reviewer",
+                actorRole = requiredRole,
+                correlationId = "c1",
+            ),
+        )
+        val deny2 = controlPlane.deny(
+            ApprovalDecisionCommand(
+                approvalId = id2,
+                actorId = "reviewer",
+                actorRole = requiredRole,
+                correlationId = "c2",
+            ),
+        )
+
+        assertThat(deny1).isInstanceOf(ApprovalDecisionResult.Denied::class.java)
+        assertThat(deny2).isInstanceOf(ApprovalDecisionResult.Denied::class.java)
+
+        val outbox1 = outboxStore.findByEventKey("approval-denied.${id1.value}")
+        val outbox2 = outboxStore.findByEventKey("approval-denied.${id2.value}")
+        assertThat(outbox1).isNotNull
+        assertThat(outbox2).isNotNull
+    }
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:17-alpine")
+            .withDatabaseName("sovereign_ops_decision_test")
+            .withUsername("test")
+            .withPassword("test")
+
+        private val keyFile = Files.createTempFile("tramai-sovereign-jdbc-key", ".b64").apply {
+            toFile().writeText(
+                java.util.Base64.getEncoder().encodeToString(ByteArray(32) { it.toByte() }),
+            )
+            toFile().deleteOnExit()
+        }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun registerProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { postgres.jdbcUrl }
+            registry.add("spring.datasource.username") { postgres.username }
+            registry.add("spring.datasource.password") { postgres.password }
+            registry.add("tramai.sovereign.persistence.type") { "jdbc" }
+            registry.add("tramai.sovereign.persistence.encryption.key-file") { keyFile.toAbsolutePath().toString() }
+            registry.add("tramai.sovereign.ops.mutations-enabled") { "true" }
+        }
+    }
+}
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@Tag("jdbc")
+private annotation class JdbcTestTag
+
+@SpringBootConfiguration
+@EnableAutoConfiguration
+@Import(
+    SovereignJdbcPersistenceAutoConfiguration::class,
+    ApprovalGatewayAutoConfiguration::class,
+    ApprovalDecisionControlPlaneAutoConfiguration::class,
+)
+private open class JdbcSovereignOpsTestConfig {
+
+    @Bean
+    open fun approvalGatewayRequestFactory(): ApprovalGatewayRequestFactory = JdbcTestApprovalGatewayRequestFactory()
+}
+
+private class JdbcTestApprovalGatewayRequestFactory : ApprovalGatewayRequestFactory {
+    override suspend fun createRequest(
+        subject: ApprovalSubject,
+        recommendation: ApprovalRecommendation,
+        requiredRole: ApproverRole,
+        workflowRunId: WorkflowRunId?,
+    ): ApprovalGatewayPersistenceRequest {
+        val now = Instant.parse("2026-06-25T10:00:00Z")
+        val approvalId = subject.value
+        val wfRunId = workflowRunId?.value ?: "wf-$approvalId"
+        val argumentsDigest = Sha256Digest.of("sha256:${"0".repeat(64)}")
+        val workflowDigest = Sha256Digest.of("sha256:${"1".repeat(64)}")
+        val tokenDigest = Sha256Digest.of("sha256:${"2".repeat(64)}")
+
+        return ApprovalGatewayPersistenceRequest(
+            approvalRequest = ApprovalRequest(
+                approvalId = approvalId,
+                binding = ApprovalBinding(
+                    workflowRunId = wfRunId,
+                    toolName = "claim-triage",
+                    argumentsDigest = argumentsDigest,
+                    policyVersion = "v1",
+                    workflowDigest = workflowDigest,
+                    approvalTokenDigest = tokenDigest,
+                ),
+                status = ApprovalStatus.PENDING,
+                requestedBy = "test-requester",
+                requestedAt = now,
+                expiresAt = now.plusSeconds(3600),
+                decidedBy = null,
+                decidedAt = null,
+                decisionComment = null,
+                consumedBy = null,
+                consumedAt = null,
+                version = 0L,
+            ),
+            continuation = ApprovalContinuation(
+                approvalId = approvalId,
+                workflowRunId = wfRunId,
+                correlationId = "corr-$approvalId",
+                toolCallId = "tool-$approvalId",
+                toolName = "claim-triage",
+                argumentsDigest = argumentsDigest,
+                policyVersion = "v1",
+                workflowDigest = workflowDigest,
+                status = ApprovalContinuationStatus.PENDING,
+                createdAt = now,
+                approvalExpiresAt = now.plusSeconds(3600),
+                claimedBy = null,
+                claimedAt = null,
+                completedAt = null,
+                version = 0L,
+            ),
+            sensitiveArguments = SensitiveToolArguments.of("""{"subject":"${subject.value}","summary":"${recommendation.summary}"}"""),
+            suspendedInvocationMetadata = SuspendedInvocationMetadata(
+                approvalId = approvalId,
+                toolCallId = "tool-$approvalId",
+                toolName = "claim-triage",
+                toolCallIndex = 0,
+                correlationId = "corr-$approvalId",
+                identity = EngineExecutionIdentity(
+                    workflowRunId = wfRunId,
+                    correlationId = "corr-$approvalId",
+                    workflowDigest = workflowDigest,
+                    policyVersion = "v1",
+                    actorId = "test-requester",
+                ),
+                securityContext = ExecutionSecurityContext(),
+                operationReference = ResumeOperationReference(
+                    serviceInterface = "dev.tramai.test.Workflow",
+                    methodName = "triage",
+                    jvmMethodDescriptor = "(Ljava/lang/String;)V",
+                    resumeDefinitionDigest = argumentsDigest,
+                ),
+                replayEnvelopeDigest = argumentsDigest,
+                toolReference = ResumeToolReference("claim-triage", argumentsDigest),
+            ),
+            replayEnvelope = SensitiveReplayEnvelope.of(emptyList()),
+            resumeToken = ResumeToken("resume-$approvalId"),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Add a Preview approval decision control-plane service for approving and denying pending approval requests.

This provides the application-facing decision API that sits between the durable ApprovalGateway request boundary and the future workflow resume runtime.

## Changes

### New
- `ApprovalDecisionControlPlane` — interface with `approve()` and `deny()` methods + sealed `ApprovalDecisionResult` types
- `ApprovalDecisionAuthorizer` — `fun interface` for decision authorization policy
- `AllowAllApprovalDecisionAuthorizer` — permissive Preview default
- `SovereignOpsApprovalDecisionControlPlane` — transactional implementation backed by the existing mutation/outbox store
- `ApprovalDecisionControlPlaneAutoConfiguration` — Spring Boot auto-config, guarded by `mutations-enabled=true`
- `RegulatedClaimTriageApprovalDecisionControlPlaneAuthorizer` — example authorizer
- `JdbcSovereignOpsApprovalDecisionControlPlaneTest` — JDBC approve-path + event key uniqueness proof (2 tests, 344 lines)

### Modified
- `SovereignOpsApprovalMutationStore` — added `approveApprovalWithAuditIntent()` method, fixed KDoc safety
- `InMemorySovereignOpsApprovalMutationStore` — approve implementation (lock-based, follows deny pattern)
- `JdbcSovereignOpsApprovalMutationStore` — approve implementation (JDBC transaction); refactored `updateApprovalRow` to parameterize target status with `version = version + 1` and extra `AND status = 'PENDING'` guard
- `RegulatedClaimTriageJdbcE2ETest` — new test proving denial through the control plane persists decision and outbox intent atomically; event key lookup uses unique `approval-denied.<id>` pattern
- `RegulatedClaimTriageApprovalGatewayAuditIntentFactory` — event keys now include approval ID (fixes unique constraint conflicts across tests)
- Golden path doc — limitation updated from "Not implemented yet" to "service-level control plane available"
- Ergonomics doc — PR #103 added to implementation sequence
- CHANGELOG — PR #103 entry

## Design decisions
- Control plane delegates to the existing `SovereignOpsApprovalMutationStore` for transactional safety — no new transaction boundary needed
- Decision authorizer is optional (Preview: `AllowAllApprovalDecisionAuthorizer`); pluggable for production
- Sealed `ApprovalDecisionResult` mirrors the `ApprovalRequestResult` pattern from the gateway SPI
- Unit tests (12 scenarios) use stub stores that avoid needing ApprovalStore.transition()

## Review fixes (commit 80ed2d7)
| Finding | Severity | Fix |
|---------|----------|-----|
| Terminal states checked after expiry | P1 | Moved expiry check after APPROVED/DENIED/PENDING checks |
| Decision outbox event keys not unique | P1 | Made keys approval-specific (`approval-approved.<id>`, `approval-denied.<id>`) |
| Misleading KDoc about comment/reason storage | P2 | Updated to say values may be persisted in metadata, with PII warnings |
| E2E uses constant event key lookup | P2 | Updated to `"approval-denied.${approvalId}"` |
| Missing approve-path JDBC proof | P2 | Added `JdbcSovereignOpsApprovalDecisionControlPlaneTest` |

## Verification
- `./gradlew verifySovereignRuntimeClosure` ✅ (329 tasks)
- 12/12 control plane unit tests pass (10 original + 2 terminal-state ordering tests)
- 2/2 JDBC-level control plane tests pass (approve-path + dual-denial uniqueness)
- E2E proves denial through control plane persists decision + PENDING outbox record

## Constraints
- Preview API remains Preview
- No REST endpoints yet
- No reviewer UI yet
- No workflow resume runtime yet

## Diff stats
16 files, 1366 insertions (+), 16 deletions (-)