### PR TITLE
feat(workflow): add preview approval resume control plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added Preview `SovereignOpsApprovalRequestMutationStore` with a JDBC transactional boundary for atomic approval request creation across `ApprovalStore`, `SuspendedInvocationStore`, `ApprovalContinuationStore`, and optional audit outbox intent (`PR #101`). `SovereignOpsTransactionalApprovalGateway` now replaces the sequential `DefaultApprovalGateway` write path when the request mutation store is available.
 - Added Preview `ApprovalGatewayAuditIntentFactory` SPI and wiring — `SovereignOpsTransactionalApprovalGateway` now emits approval-requested audit outbox intent atomically when an audit intent factory is present (`PR #102`). The regulated claim triage E2E test proves a `PENDING` approval-requested outbox record exists after gateway request creation.
 - Added Preview `ApprovalDecisionControlPlane` service for approving or denying pending approvals through the transactional mutation/outbox boundary (`PR #103`).
+- Added Preview `ApprovalResumeControlPlane` service for resuming approved, suspended workflow executions through the engine resume runtime (`PR #104`).
 - Sovereign runtime profile and routing foundation (`tramai-sovereign`).
 - Policy enforcement and DLP/redaction support (`tramai-security`).
 - Approval gates and replay-safe resume.

--- a/docs/architecture/human-approval-workflow-ergonomics.md
+++ b/docs/architecture/human-approval-workflow-ergonomics.md
@@ -336,8 +336,13 @@ This design proposes the path to move workflow ergonomics from **Preview** towar
 > - Spring Boot auto-configuration now wires the control plane when approval mutations are enabled
 > - The regulated claim triage E2E now proves denial through the control plane persists both the approval decision and the denial audit outbox intent
 >
+> **PR #104** adds a preview approval resume control plane:
+> - `ApprovalResumeControlPlane` — application-facing resume boundary
+> - `SovereignOpsApprovalResumeControlPlane` — composes engine `ResumeApprovalCommand` and `TramaiRuntime.resumeApproval`
+> - Spring Boot auto-configuration wires the resume control plane when `resume-enabled=true`
+> - The regulated claim triage E2E now proves request → approve → resume → complete
+>
 > **Limitations remaining:**
-> - Does not implement full workflow resume.
 > - Generic fallback gateway (`DefaultApprovalGateway`) still has no cross-store transaction boundary and does not emit audit intent.
 
 ---
@@ -378,3 +383,4 @@ The following are explicitly **not covered** by this design:
 | #101 | Transactional request creation boundary | Add JDBC-backed atomic approval-request creation and prefer the transactional gateway when available |
 | #102 | Approval-requested audit intent from gateway | Emit approval-requested audit outbox intent atomically from the transactional gateway when an `ApprovalGatewayAuditIntentFactory` is present |
 | #103 | Preview approval decision control plane | Add application-facing approve/deny service over the transactional mutation and outbox boundary |
+| #104 | Preview approval resume control plane | Add application-facing resume API over the engine resume runtime |

--- a/docs/guides/approval-gateway-golden-path.md
+++ b/docs/guides/approval-gateway-golden-path.md
@@ -168,7 +168,7 @@ The Preview approval gateway has the following limitations:
 
 | Area | Status |
 |------|--------|
-| Full workflow resume runtime | Not implemented yet |
+| Full workflow resume runtime | Service-level `ApprovalResumeControlPlane` available |
 | Reviewer UI | Not implemented yet |
 | REST control plane for approvals | Not implemented yet; service-level `ApprovalDecisionControlPlane` available |
 | Generic workflow DSL | Not implemented yet |

--- a/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageJdbcE2ETest.kt
+++ b/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageJdbcE2ETest.kt
@@ -1,15 +1,36 @@
 package dev.tramai.examples.spring
 
 import com.zaxxer.hikari.HikariDataSource
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.annotations.User
 import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.core.approval.ApprovalContinuationStatus
 import dev.tramai.core.approval.ApprovalStatus
 import dev.tramai.core.approval.ApprovalStore
 import dev.tramai.core.approval.gateway.ApprovalGateway
+import dev.tramai.core.approval.gateway.ApprovalId
 import dev.tramai.core.approval.gateway.ApprovalRecommendation
 import dev.tramai.core.approval.gateway.ApprovalRequestResult
+import dev.tramai.core.approval.gateway.ResumeToken
 import dev.tramai.core.approval.gateway.ApprovalSubject
 import dev.tramai.core.approval.gateway.ApproverRole
 import dev.tramai.core.approval.gateway.WorkflowRunId
+import dev.tramai.core.exception.ApprovalSuspendedException
+import dev.tramai.core.model.FinishReason
+import dev.tramai.core.model.ModelRegistry
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.model.SideEffectLevel
+import dev.tramai.core.model.ToolCall
+import dev.tramai.core.model.ToolExecutionContext
+import dev.tramai.core.model.TramaiTool
+import dev.tramai.core.policy.ApprovalMode
+import dev.tramai.core.policy.AuditDetail
+import dev.tramai.core.policy.ManagedNetworkEgress
+import dev.tramai.core.policy.RiskLevel
+import dev.tramai.core.policy.ToolSecurityMetadata
+import dev.tramai.core.provider.ModelProvider
 import dev.tramai.engine.SuspendedInvocationStore
 import dev.tramai.security.audit.AuditEvent
 import dev.tramai.security.audit.AuditHashAlgorithm
@@ -19,11 +40,18 @@ import dev.tramai.spring.sovereign.ops.ApprovalDecisionCommand
 import dev.tramai.spring.sovereign.ops.ApprovalDecisionControlPlane
 import dev.tramai.spring.sovereign.ops.ApprovalDecisionControlPlaneAutoConfiguration
 import dev.tramai.spring.sovereign.ops.ApprovalDecisionResult
+import dev.tramai.spring.sovereign.ops.ApprovalResumeCommand
+import dev.tramai.spring.sovereign.ops.ApprovalResumeControlPlane
+import dev.tramai.spring.sovereign.ops.ApprovalResumeControlPlaneAutoConfiguration
+import dev.tramai.spring.sovereign.ops.ApprovalResumeResult
 import dev.tramai.engine.approval.ApprovalGatewayRequestFactory
 import dev.tramai.spring.sovereign.SovereignTramaiAutoConfiguration
 import dev.tramai.spring.sovereign.ops.ApprovalGatewayAuditIntentFactory
 import dev.tramai.spring.sovereign.ops.ApprovalGatewayAutoConfiguration
 import dev.tramai.spring.sovereign.ops.SovereignOpsTransactionalApprovalGateway
+import dev.tramai.sovereign.SovereignProfileConfiguration
+import dev.tramai.sovereign.SovereignTramai
+import dev.tramai.sovereign.SovereignTramaiRuntime
 import dev.tramai.spring.sovereign.persistence.jdbc.SovereignJdbcPersistenceAutoConfiguration
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalMutationResult
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsApprovalMutationStore
@@ -32,9 +60,11 @@ import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStatus
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
 import java.nio.file.Path
 import java.security.MessageDigest
+import java.time.Clock
 import java.time.Instant
 import java.util.Base64
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 import javax.sql.DataSource
 import kotlinx.coroutines.runBlocking
@@ -105,18 +135,23 @@ class RegulatedClaimTriageJdbcE2ETest {
                     SovereignTramaiAutoConfiguration::class.java,
                     ApprovalGatewayAutoConfiguration::class.java,
                     ApprovalDecisionControlPlaneAutoConfiguration::class.java,
+                    ApprovalResumeControlPlaneAutoConfiguration::class.java,
                 ),
             )
             .withUserConfiguration(
                 JdbcE2eDataSourceConfig::class.java,
                 DemoProviderConfiguration::class.java,
                 RegulatedClaimTriageGatewayConfig::class.java,
+                ApprovalResumeRuntimeConfig::class.java,
             )
             .withPropertyValues(
                 "tramai.sovereign.enabled=true",
                 "tramai.sovereign.ops.mutations-enabled=true",
+                "tramai.sovereign.ops.resume-enabled=true",
                 "tramai.sovereign.allowed-models[0]=local-invoice-model",
                 "tramai.sovereign.allowed-providers[0]=deterministic-local-provider",
+                "tramai.sovereign.allowed-tools[0]=claim-payout",
+                "tramai.sovereign.allowed-permissions[0]=claim.payout",
                 "tramai.sovereign.provider-zones.deterministic-local-provider=LOCAL",
                 "tramai.sovereign.models.local-invoice-model=deterministic-local-provider",
                 "tramai.sovereign.persistence.type=jdbc",
@@ -338,6 +373,61 @@ class RegulatedClaimTriageJdbcE2ETest {
             }
     }
 
+    @Test
+    fun `regulated claim triage approval through control plane resumes workflow`() {
+        val claimId = "claim-resume-${UUID.randomUUID()}"
+
+        createJdbcRunner().run { ctx ->
+            val workflow = ctx.workflow()
+            runBlocking {
+                val suspension = try {
+                    val service = workflow.runtime.create(RegulatedClaimApprovalResumeService::class)
+                    service.triageAndExecutePayout(claimId)
+                    error("Expected approval suspension")
+                } catch (e: ApprovalSuspendedException) {
+                    e
+                }
+
+                assertThat(suspension.approvalId).isNotNull
+                assertThat(workflow.suspendedInvocationStore.get(suspension.approvalId)).isNotNull
+
+                val approvalResult = workflow.decisionControlPlane.approve(
+                    ApprovalDecisionCommand(
+                        approvalId = ApprovalId(suspension.approvalId),
+                        actorId = "medical-ops-reviewer",
+                        actorRole = ApproverRole("medical-reviewer"),
+                        comment = "Approved for regulated claim payout",
+                        correlationId = claimId,
+                    ),
+                )
+
+                assertThat(approvalResult).isInstanceOf(ApprovalDecisionResult.Approved::class.java)
+
+                val approved = workflow.approvalStore.get(suspension.approvalId)
+                assertThat(approved).isNotNull
+                assertThat(approved!!.status).isEqualTo(ApprovalStatus.APPROVED)
+
+                val resumeResult = workflow.resumeControlPlane.resume(
+                    ApprovalResumeCommand(
+                        approvalId = ApprovalId(suspension.approvalId),
+                        resumeToken = ResumeToken(suspension.challenge.token.reveal()),
+                        resumedBy = "medical-ops-reviewer",
+                        expectedApprovalVersion = approved.version,
+                        expectedContinuationVersion = suspension.continuationVersion,
+                    ),
+                )
+
+                assertThat(resumeResult).isInstanceOf(ApprovalResumeResult.Resumed::class.java)
+                val resumed = resumeResult as ApprovalResumeResult.Resumed
+                assertThat(resumed.result).isInstanceOf(String::class.java)
+
+                val continuation = workflow.approvalContinuationStore.get(suspension.approvalId)
+                assertThat(continuation).isNotNull
+                assertThat(continuation!!.status).isEqualTo(ApprovalContinuationStatus.COMPLETED)
+            }
+        }
+    }
+
     // ══════════════════════════════════════════════════════════════════
     // Test 2 — Fail-closed cloud routing
     // ══════════════════════════════════════════════════════════════════
@@ -458,6 +548,38 @@ class RegulatedClaimTriageJdbcE2ETest {
         fun regulatedClaimTriageApprovalDecisionControlPlaneAuthorizer(): RegulatedClaimTriageApprovalDecisionControlPlaneAuthorizer =
             RegulatedClaimTriageApprovalDecisionControlPlaneAuthorizer()
     }
+
+    @Configuration
+    class ApprovalResumeRuntimeConfig {
+        @Bean
+        fun claimPayoutLedger(): ClaimPayoutLedger = ClaimPayoutLedger()
+
+        @Bean
+        fun sovereignTramai(
+            profile: SovereignProfileConfiguration,
+            modelRegistry: ModelRegistry,
+            auditStore: AuditStore,
+            infrastructure: SovereignTramaiAutoConfiguration.SovereignTramaiInfrastructure,
+            clock: Clock,
+            claimPayoutLedger: ClaimPayoutLedger,
+        ): SovereignTramai {
+            val builder = SovereignTramai.builder()
+                .profile(profile)
+                .modelRegistry(modelRegistry)
+                .auditStore(auditStore)
+                .provider(ResumeAwareDemoProvider(), name = "deterministic-local-provider", default = true)
+                .model("local-invoice-model", "deterministic-local-provider")
+                .tools(ClaimPayoutTool(claimPayoutLedger))
+                .approvalContinuationStore(infrastructure.approvalContinuationStore)
+                .approvalGateCoordinator(infrastructure.approvalGateCoordinator)
+                .clock(clock)
+
+            infrastructure.suspendedInvocationStore?.let { builder.suspendedInvocationStore(it) }
+            infrastructure.toolArgumentsDigester?.let { builder.toolArgumentsDigester(it) }
+
+            return builder.build()
+        }
+    }
 }
 
 // ══════════════════════════════════════════════════════════════════════
@@ -528,6 +650,112 @@ class RecordingCloudClaimModel {
     }
 }
 
+@AiService
+fun interface RegulatedClaimApprovalResumeService {
+    @Operation(
+        model = "local-invoice-model",
+        tools = ["claim-payout"],
+    )
+    @User(
+        """
+        Review the regulated claim and execute payout when the claim is approved.
+        Claim ID: {claimId}
+        """
+    )
+    suspend fun triageAndExecutePayout(claimId: String): String
+}
+
+data class ClaimPayoutInput(
+    val claimId: String,
+)
+
+data class ClaimPayoutResult(
+    val claimId: String,
+    val status: String,
+)
+
+class ClaimPayoutLedger {
+    private val executions = ConcurrentHashMap<String, ClaimPayoutResult>()
+
+    fun executeExactlyOnce(
+        idempotencyKey: String,
+        input: ClaimPayoutInput,
+    ): ClaimPayoutResult =
+        executions.computeIfAbsent(idempotencyKey) {
+            ClaimPayoutResult(
+                claimId = input.claimId,
+                status = "PAYOUT_SCHEDULED",
+            )
+        }
+
+    fun executionCount(): Int = executions.size
+}
+
+class ClaimPayoutTool(
+    private val ledger: ClaimPayoutLedger,
+) : TramaiTool<ClaimPayoutInput, ClaimPayoutResult> {
+    override val name: String = "claim-payout"
+    override val description: String = "Execute a regulated claim payout"
+    override val inputType = ClaimPayoutInput::class
+    override val idempotent: Boolean = true
+    override val sideEffectLevel: SideEffectLevel = SideEffectLevel.WRITE
+    override val security: ToolSecurityMetadata = ToolSecurityMetadata(
+        permission = "claim.payout",
+        risk = RiskLevel.HIGH,
+        approval = ApprovalMode.HUMAN_REQUIRED,
+        managedNetworkEgress = ManagedNetworkEgress.DENY,
+        audit = AuditDetail.FULL,
+    )
+
+    override suspend fun execute(
+        input: ClaimPayoutInput,
+        context: ToolExecutionContext,
+    ): ClaimPayoutResult {
+        val idempotencyKey = requireNotNull(context.idempotencyKey) {
+            "claim-payout requires an idempotencyKey from the engine"
+        }
+        return ledger.executeExactlyOnce(idempotencyKey, input)
+    }
+}
+
+class ResumeAwareDemoProvider : ModelProvider {
+    private val callCount = AtomicInteger(0)
+
+    override fun providerId(): String = "deterministic-local-provider"
+
+    override suspend fun complete(request: ModelRequest): ModelResponse {
+        val attempt = callCount.incrementAndGet()
+        if (attempt == 1) {
+            val claimId = extractClaimId(request)
+            return ModelResponse(
+                content = "The claim payout requires tool execution.",
+                toolCalls = listOf(
+                    ToolCall(
+                        id = "call-claim-payout-001",
+                        name = "claim-payout",
+                        argumentsJson = """{"claimId":"$claimId"}""",
+                    ),
+                ),
+                finishReason = FinishReason.OTHER,
+            )
+        }
+
+        return ModelResponse(
+            content = "CLAIM_PAYOUT_COMPLETED",
+            finishReason = FinishReason.STOP,
+        )
+    }
+
+    private fun extractClaimId(request: ModelRequest): String {
+        val content = request.messages.lastOrNull()?.content.orEmpty()
+        return Regex("Claim ID: ([^\\s]+)")
+            .find(content)
+            ?.groupValues
+            ?.get(1)
+            ?: "claim-unknown"
+    }
+}
+
 data class FakeRecommendation(
     val recommendationType: String,
     val riskLevel: String,
@@ -544,8 +772,11 @@ class ClaimTriageWorkflow(
     val mutationStore: SovereignOpsApprovalMutationStore,
     val outboxStore: SovereignOpsAuditOutboxStore,
     val decisionControlPlane: ApprovalDecisionControlPlane,
+    val resumeControlPlane: ApprovalResumeControlPlane,
     val suspendedInvocationStore: SuspendedInvocationStore,
     val approvalContinuationStore: ApprovalContinuationStore,
+    val runtime: SovereignTramaiRuntime,
+    val claimPayoutLedger: ClaimPayoutLedger,
     private val approvalGateway: ApprovalGateway,
     private val dataSource: DataSource,
     private val dlp: FakeDlpClassifier = FakeDlpClassifier(),
@@ -757,8 +988,11 @@ private fun org.springframework.context.ApplicationContext.workflow(
     mutationStore = getBean(SovereignOpsApprovalMutationStore::class.java),
     outboxStore = getBean(SovereignOpsAuditOutboxStore::class.java),
     decisionControlPlane = getBean(ApprovalDecisionControlPlane::class.java),
+    resumeControlPlane = getBean(ApprovalResumeControlPlane::class.java),
     suspendedInvocationStore = getBean(SuspendedInvocationStore::class.java),
     approvalContinuationStore = getBean(ApprovalContinuationStore::class.java),
+    runtime = getBean(SovereignTramaiRuntime::class.java),
+    claimPayoutLedger = ClaimPayoutLedger(),
     approvalGateway = getBean(ApprovalGateway::class.java),
     dataSource = getBean(DataSource::class.java),
     cloudModel = cloudModel,

--- a/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageJdbcE2ETest.kt
+++ b/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageJdbcE2ETest.kt
@@ -419,7 +419,23 @@ class RegulatedClaimTriageJdbcE2ETest {
 
                 assertThat(resumeResult).isInstanceOf(ApprovalResumeResult.Resumed::class.java)
                 val resumed = resumeResult as ApprovalResumeResult.Resumed
-                assertThat(resumed.result).isInstanceOf(String::class.java)
+                assertThat(resumed.result).isEqualTo("CLAIM_PAYOUT_COMPLETED")
+
+                // Side-effect executed exactly once
+                assertThat(workflow.claimPayoutLedger.executionCount()).isEqualTo(1)
+
+                // Subsequent resume is AlreadyCompleted — no duplicate side effect
+                val secondResume = workflow.resumeControlPlane.resume(
+                    ApprovalResumeCommand(
+                        approvalId = ApprovalId(suspension.approvalId),
+                        resumeToken = ResumeToken(suspension.challenge.token.reveal()),
+                        resumedBy = "medical-ops-reviewer",
+                        expectedApprovalVersion = approved.version + 1,
+                        expectedContinuationVersion = suspension.continuationVersion + 1,
+                    ),
+                )
+                assertThat(secondResume).isInstanceOf(ApprovalResumeResult.AlreadyCompleted::class.java)
+                assertThat(workflow.claimPayoutLedger.executionCount()).isEqualTo(1)
 
                 val continuation = workflow.approvalContinuationStore.get(suspension.approvalId)
                 assertThat(continuation).isNotNull
@@ -992,7 +1008,7 @@ private fun org.springframework.context.ApplicationContext.workflow(
     suspendedInvocationStore = getBean(SuspendedInvocationStore::class.java),
     approvalContinuationStore = getBean(ApprovalContinuationStore::class.java),
     runtime = getBean(SovereignTramaiRuntime::class.java),
-    claimPayoutLedger = ClaimPayoutLedger(),
+    claimPayoutLedger = getBean(ClaimPayoutLedger::class.java),
     approvalGateway = getBean(ApprovalGateway::class.java),
     dataSource = getBean(DataSource::class.java),
     cloudModel = cloudModel,

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovalResumeControlPlane.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovalResumeControlPlane.kt
@@ -1,0 +1,81 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.core.approval.ApprovalStatus
+import dev.tramai.core.approval.gateway.ApprovalId
+import dev.tramai.core.approval.gateway.ResumeToken
+
+/**
+ * Preview resume control-plane API for resuming approved, suspended workflow executions.
+ *
+ * This is the application-facing boundary between the approval decision control plane
+ * and the engine-level workflow resume runtime.
+ *
+ * Implementations must compose the existing [dev.tramai.engine.ResumeApprovalCommand]
+ * and [dev.tramai.standalone.TramaiRuntime.resumeApproval] rather than reimplementing resume logic.
+ */
+interface ApprovalResumeControlPlane {
+
+    /**
+     * Resume a suspended workflow execution after its approval was approved.
+     * @return typed [ApprovalResumeResult] indicating outcome.
+     */
+    suspend fun resume(command: ApprovalResumeCommand): ApprovalResumeResult
+}
+
+/**
+ * Command to resume a suspended workflow execution after approval.
+ *
+ * @param approvalId The approval that was approved.
+ * @param resumeToken The resume token returned from [dev.tramai.core.approval.gateway.ApprovalRequestResult.Suspended.resumeToken].
+ * @param resumedBy The identity initiating the resume.
+ * @param expectedApprovalVersion Expected version of the approval for optimistic concurrency (null = auto-detect from store).
+ * @param expectedContinuationVersion Expected version of the continuation for optimistic concurrency (null = auto-detect from store).
+ */
+data class ApprovalResumeCommand(
+    val approvalId: ApprovalId,
+    val resumeToken: ResumeToken,
+    val resumedBy: String,
+    val expectedApprovalVersion: Long? = null,
+    val expectedContinuationVersion: Long? = null,
+)
+
+/**
+ * Typed result from an approval resume operation.
+ */
+sealed interface ApprovalResumeResult {
+
+    /** The workflow was successfully resumed and produced a result. */
+    data class Resumed(
+        val approvalId: ApprovalId,
+        val resumedBy: String,
+        val result: Any?,
+    ) : ApprovalResumeResult
+
+    /** The approval was not found. */
+    data class NotFound(
+        val approvalId: ApprovalId,
+    ) : ApprovalResumeResult
+
+    /** The approval exists but is not in APPROVED status (e.g. PENDING, DENIED, EXPIRED). */
+    data class NotApproved(
+        val approvalId: ApprovalId,
+        val status: ApprovalStatus,
+    ) : ApprovalResumeResult
+
+    /** The continuation was already completed (resume already happened). */
+    data class AlreadyCompleted(
+        val approvalId: ApprovalId,
+    ) : ApprovalResumeResult
+
+    /** Version conflict, invalid token, or state mismatch. */
+    data class Conflict(
+        val approvalId: ApprovalId,
+        val reason: String,
+    ) : ApprovalResumeResult
+
+    /** The engine-level resume failed with an exception. */
+    data class Failed(
+        val approvalId: ApprovalId,
+        val reason: String,
+    ) : ApprovalResumeResult
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovalResumeControlPlaneAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovalResumeControlPlaneAutoConfiguration.kt
@@ -1,0 +1,52 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.core.approval.ApprovalStore
+import dev.tramai.sovereign.SovereignTramaiRuntime
+import java.time.Clock
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+
+/**
+ * Spring Boot auto-configuration for the Preview [ApprovalResumeControlPlane].
+ *
+ * Creates a [SovereignOpsApprovalResumeControlPlane] bean when
+ * [ApprovalStore], [ApprovalContinuationStore], and [SovereignTramaiRuntime] are available.
+ *
+ * Guarded by `tramai.sovereign.ops.resume-enabled=true`.
+ *
+ * @see SovereignOpsApprovalResumeControlPlane
+ */
+@AutoConfiguration(after = [SovereignOpsAutoConfiguration::class])
+@ConditionalOnProperty(
+    prefix = "tramai.sovereign.ops",
+    name = ["resume-enabled"],
+    havingValue = "true",
+)
+class ApprovalResumeControlPlaneAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(ApprovalResumeControlPlane::class)
+    @ConditionalOnBean(
+        value = [
+            ApprovalStore::class,
+            ApprovalContinuationStore::class,
+            SovereignTramaiRuntime::class,
+        ],
+    )
+    fun sovereignOpsApprovalResumeControlPlane(
+        approvalStore: ApprovalStore,
+        approvalContinuationStore: ApprovalContinuationStore,
+        runtime: SovereignTramaiRuntime,
+        clock: Clock,
+    ): ApprovalResumeControlPlane =
+        SovereignOpsApprovalResumeControlPlane(
+            approvalStore = approvalStore,
+            approvalContinuationStore = approvalContinuationStore,
+            resumeApproval = runtime::resumeApproval,
+            clock = clock,
+        )
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovalResumeControlPlaneAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovalResumeControlPlaneAutoConfiguration.kt
@@ -20,7 +20,12 @@ import org.springframework.context.annotation.Bean
  *
  * @see SovereignOpsApprovalResumeControlPlane
  */
-@AutoConfiguration(after = [SovereignOpsAutoConfiguration::class])
+@AutoConfiguration(
+    after = [SovereignOpsAutoConfiguration::class],
+    afterName = [
+        "dev.tramai.spring.sovereign.SovereignTramaiAutoConfiguration",
+    ],
+)
 @ConditionalOnProperty(
     prefix = "tramai.sovereign.ops",
     name = ["resume-enabled"],

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovalResumeControlPlane.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovalResumeControlPlane.kt
@@ -1,0 +1,129 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.core.approval.ApprovalContinuationStatus
+import dev.tramai.core.approval.ApprovalStatus
+import dev.tramai.core.approval.ApprovalStore
+import dev.tramai.core.approval.ApprovalToken
+import dev.tramai.core.exception.ApprovalBindingMismatchException
+import dev.tramai.core.exception.ApprovalNotFoundException
+import dev.tramai.core.exception.ApprovalTokenRejectedException
+import dev.tramai.core.exception.ConfigurationException
+import dev.tramai.engine.ResumeApprovalCommand
+import java.time.Clock
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Preview [ApprovalResumeControlPlane] backed by the existing engine resume runtime.
+ *
+ * Composes [resumeApproval] rather than duplicating resume logic.
+ *
+ * Flow:
+ * 1. Load approval by approvalId.
+ * 2. If missing → NotFound.
+ * 3. If status != APPROVED → NotApproved.
+ * 4. Load continuation by approvalId.
+ * 5. If missing → Conflict("approval-continuation-missing").
+ * 6. If continuation already completed → AlreadyCompleted.
+ * 7. Compose [ResumeApprovalCommand] with validated versions and token.
+ * 8. Call the injected engine/runtime resume function.
+ * 9. Return Resumed with the workflow result.
+ *
+ * @param approvalStore stores approval requests
+ * @param approvalContinuationStore stores continuation records
+ * @param resumeApproval engine-level runtime for workflow resume
+ * @param clock clock for temporal checks
+ */
+class SovereignOpsApprovalResumeControlPlane(
+    private val approvalStore: ApprovalStore,
+    private val approvalContinuationStore: ApprovalContinuationStore,
+    private val resumeApproval: suspend (ResumeApprovalCommand) -> Any?,
+    private val clock: Clock = Clock.systemUTC(),
+) : ApprovalResumeControlPlane {
+
+    override suspend fun resume(command: ApprovalResumeCommand): ApprovalResumeResult {
+        val approval = approvalStore.get(command.approvalId.value)
+            ?: return ApprovalResumeResult.NotFound(command.approvalId)
+
+        if (approval.status != ApprovalStatus.APPROVED) {
+            return ApprovalResumeResult.NotApproved(command.approvalId, approval.status)
+        }
+
+        val continuation = approvalContinuationStore.get(command.approvalId.value)
+            ?: return ApprovalResumeResult.Conflict(
+                command.approvalId,
+                "approval-continuation-missing",
+            )
+
+        if (continuation.status == ApprovalContinuationStatus.COMPLETED) {
+            return ApprovalResumeResult.AlreadyCompleted(command.approvalId)
+        }
+
+        if (continuation.approvalExpiresAt.isBefore(clock.instant())) {
+            return ApprovalResumeResult.Conflict(
+                command.approvalId,
+                "approval-continuation-expired",
+            )
+        }
+
+        val presentedToken = try {
+            ApprovalToken.parsePresented(command.resumeToken.value)
+        } catch (_: IllegalArgumentException) {
+            return ApprovalResumeResult.Conflict(
+                command.approvalId,
+                "approval-resume-token-invalid",
+            )
+        }
+
+        val engineCommand = ResumeApprovalCommand(
+            approvalId = command.approvalId.value,
+            approvalExpectedVersion = command.expectedApprovalVersion ?: approval.version,
+            continuationExpectedVersion = command.expectedContinuationVersion ?: continuation.version,
+            presentedToken = presentedToken,
+            resumedBy = command.resumedBy,
+        )
+
+        return try {
+            val workflowResult = resumeApproval(engineCommand)
+            ApprovalResumeResult.Resumed(
+                approvalId = command.approvalId,
+                resumedBy = command.resumedBy,
+                result = workflowResult,
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: ApprovalNotFoundException) {
+            ApprovalResumeResult.NotFound(command.approvalId)
+        } catch (e: ApprovalTokenRejectedException) {
+            ApprovalResumeResult.Conflict(
+                approvalId = command.approvalId,
+                reason = "approval-token-rejected",
+            )
+        } catch (e: ApprovalBindingMismatchException) {
+            ApprovalResumeResult.Conflict(
+                approvalId = command.approvalId,
+                reason = e.message ?: "approval-binding-mismatch",
+            )
+        } catch (e: ConfigurationException) {
+            ApprovalResumeResult.Conflict(
+                approvalId = command.approvalId,
+                reason = e.message ?: "approval-resume-configuration-conflict",
+            )
+        } catch (e: IllegalArgumentException) {
+            ApprovalResumeResult.Conflict(
+                approvalId = command.approvalId,
+                reason = e.message ?: "approval-resume-conflict",
+            )
+        } catch (e: IllegalStateException) {
+            ApprovalResumeResult.Conflict(
+                approvalId = command.approvalId,
+                reason = e.message ?: "approval-resume-conflict",
+            )
+        } catch (e: Exception) {
+            ApprovalResumeResult.Failed(
+                approvalId = command.approvalId,
+                reason = e.message ?: "approval-resume-failed",
+            )
+        }
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovalResumeControlPlane.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovalResumeControlPlane.kt
@@ -55,8 +55,17 @@ class SovereignOpsApprovalResumeControlPlane(
                 "approval-continuation-missing",
             )
 
-        if (continuation.status == ApprovalContinuationStatus.COMPLETED) {
-            return ApprovalResumeResult.AlreadyCompleted(command.approvalId)
+        when (continuation.status) {
+            ApprovalContinuationStatus.PENDING -> Unit
+
+            ApprovalContinuationStatus.COMPLETED ->
+                return ApprovalResumeResult.AlreadyCompleted(command.approvalId)
+
+            else ->
+                return ApprovalResumeResult.Conflict(
+                    approvalId = command.approvalId,
+                    reason = "approval-continuation-not-pending-${continuation.status.name}",
+                )
         }
 
         if (continuation.approvalExpiresAt.isBefore(clock.instant())) {

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,4 @@
 dev.tramai.spring.sovereign.ops.SovereignOpsAutoConfiguration
 dev.tramai.spring.sovereign.ops.ApprovalGatewayAutoConfiguration
 dev.tramai.spring.sovereign.ops.ApprovalDecisionControlPlaneAutoConfiguration
+dev.tramai.spring.sovereign.ops.ApprovalResumeControlPlaneAutoConfiguration

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovalResumeControlPlaneTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovalResumeControlPlaneTest.kt
@@ -1,0 +1,432 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.core.approval.ApprovalBinding
+import dev.tramai.core.approval.ApprovalConsumptionReceipt
+import dev.tramai.core.approval.ApprovalContinuation
+import dev.tramai.core.approval.ApprovalContinuationStatus
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.core.approval.ApprovalRequest
+import dev.tramai.core.approval.ApprovalStatus
+import dev.tramai.core.approval.ApprovalStore
+import dev.tramai.core.approval.ApprovalToken
+import dev.tramai.core.approval.ApprovalTransition
+import dev.tramai.core.approval.SensitiveToolArguments
+import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.approval.gateway.ApprovalId
+import dev.tramai.core.approval.gateway.ResumeToken
+import dev.tramai.engine.ResumeApprovalCommand
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class SovereignOpsApprovalResumeControlPlaneTest {
+
+    private val now: Instant = Instant.parse("2026-06-25T10:15:30Z")
+    private val clock: Clock = Clock.fixed(now, ZoneOffset.UTC)
+
+    @Test
+    fun `resume approved approval returns Resumed with workflow result`() = runBlocking {
+        val approvalStore = ResumeMutableApprovalStore(
+            mutableMapOf("approval-1" to approvedApproval("approval-1")),
+        )
+        val continuationStore = ResumeMutableApprovalContinuationStore(
+            mutableMapOf("approval-1" to pendingContinuation("approval-1")),
+        )
+        var capturedCommand: ResumeApprovalCommand? = null
+        val controlPlane = SovereignOpsApprovalResumeControlPlane(
+            approvalStore = approvalStore,
+            approvalContinuationStore = continuationStore,
+            resumeApproval = { command ->
+                capturedCommand = command
+                "workflow-result"
+            },
+            clock = clock,
+        )
+
+        val result = controlPlane.resume(resumeCommand("approval-1"))
+
+        assertThat(result).isEqualTo(
+            ApprovalResumeResult.Resumed(
+                approvalId = ApprovalId("approval-1"),
+                resumedBy = "operator-1",
+                result = "workflow-result",
+            ),
+        )
+        assertThat(capturedCommand).isEqualTo(
+            ResumeApprovalCommand(
+                approvalId = "approval-1",
+                approvalExpectedVersion = 1L,
+                continuationExpectedVersion = 0L,
+                presentedToken = ApprovalToken.parsePresented("resume-token-1"),
+                resumedBy = "operator-1",
+            ),
+        )
+    }
+
+    @Test
+    fun `resume missing approval returns NotFound`() = runBlocking {
+        val controlPlane = SovereignOpsApprovalResumeControlPlane(
+            approvalStore = ResumeMutableApprovalStore(),
+            approvalContinuationStore = ResumeMutableApprovalContinuationStore(),
+            resumeApproval = { error("should not run") },
+            clock = clock,
+        )
+
+        val result = controlPlane.resume(resumeCommand("approval-404"))
+
+        assertThat(result).isEqualTo(ApprovalResumeResult.NotFound(ApprovalId("approval-404")))
+    }
+
+    @Test
+    fun `resume pending approval returns NotApproved`() = runBlocking {
+        val approvalStore = ResumeMutableApprovalStore(
+            mutableMapOf("approval-1" to approval("approval-1", ApprovalStatus.PENDING)),
+        )
+        val controlPlane = SovereignOpsApprovalResumeControlPlane(
+            approvalStore = approvalStore,
+            approvalContinuationStore = ResumeMutableApprovalContinuationStore(),
+            resumeApproval = { error("should not run") },
+            clock = clock,
+        )
+
+        val result = controlPlane.resume(resumeCommand("approval-1"))
+
+        assertThat(result).isEqualTo(
+            ApprovalResumeResult.NotApproved(ApprovalId("approval-1"), ApprovalStatus.PENDING),
+        )
+    }
+
+    @Test
+    fun `resume denied approval returns NotApproved`() = runBlocking {
+        val approvalStore = ResumeMutableApprovalStore(
+            mutableMapOf("approval-1" to approval("approval-1", ApprovalStatus.DENIED, version = 1L)),
+        )
+        val controlPlane = SovereignOpsApprovalResumeControlPlane(
+            approvalStore = approvalStore,
+            approvalContinuationStore = ResumeMutableApprovalContinuationStore(),
+            resumeApproval = { error("should not run") },
+            clock = clock,
+        )
+
+        val result = controlPlane.resume(resumeCommand("approval-1"))
+
+        assertThat(result).isEqualTo(
+            ApprovalResumeResult.NotApproved(ApprovalId("approval-1"), ApprovalStatus.DENIED),
+        )
+    }
+
+    @Test
+    fun `resume expired pending approval returns NotApproved while approved expired approval can still resume`() = runBlocking {
+        val pendingApprovalStore = ResumeMutableApprovalStore(
+            mutableMapOf(
+                "pending-expired" to approval(
+                    approvalId = "pending-expired",
+                    status = ApprovalStatus.PENDING,
+                    expiresAt = now.minusSeconds(1),
+                ),
+            ),
+        )
+        val pendingControlPlane = SovereignOpsApprovalResumeControlPlane(
+            approvalStore = pendingApprovalStore,
+            approvalContinuationStore = ResumeMutableApprovalContinuationStore(),
+            resumeApproval = { error("should not run") },
+            clock = clock,
+        )
+
+        val pendingResult = pendingControlPlane.resume(resumeCommand("pending-expired"))
+
+        assertThat(pendingResult).isEqualTo(
+            ApprovalResumeResult.NotApproved(ApprovalId("pending-expired"), ApprovalStatus.PENDING),
+        )
+
+        val approvedApprovalStore = ResumeMutableApprovalStore(
+            mutableMapOf(
+                "approved-expired" to approvedApproval("approved-expired").copy(expiresAt = now.minusSeconds(1)),
+            ),
+        )
+        val continuationStore = ResumeMutableApprovalContinuationStore(
+            mutableMapOf("approved-expired" to pendingContinuation("approved-expired", approvalExpiresAt = now.plusSeconds(60))),
+        )
+        val approvedControlPlane = SovereignOpsApprovalResumeControlPlane(
+            approvalStore = approvedApprovalStore,
+            approvalContinuationStore = continuationStore,
+            resumeApproval = { "resumed-after-approval" },
+            clock = clock,
+        )
+
+        val approvedResult = approvedControlPlane.resume(resumeCommand("approved-expired"))
+
+        assertThat(approvedResult).isEqualTo(
+            ApprovalResumeResult.Resumed(
+                approvalId = ApprovalId("approved-expired"),
+                resumedBy = "operator-1",
+                result = "resumed-after-approval",
+            ),
+        )
+    }
+
+    @Test
+    fun `resume missing continuation returns Conflict`() = runBlocking {
+        val approvalStore = ResumeMutableApprovalStore(
+            mutableMapOf("approval-1" to approvedApproval("approval-1")),
+        )
+        val controlPlane = SovereignOpsApprovalResumeControlPlane(
+            approvalStore = approvalStore,
+            approvalContinuationStore = ResumeMutableApprovalContinuationStore(),
+            resumeApproval = { error("should not run") },
+            clock = clock,
+        )
+
+        val result = controlPlane.resume(resumeCommand("approval-1"))
+
+        assertThat(result).isEqualTo(
+            ApprovalResumeResult.Conflict(
+                approvalId = ApprovalId("approval-1"),
+                reason = "approval-continuation-missing",
+            ),
+        )
+    }
+
+    @Test
+    fun `resume completed continuation returns AlreadyCompleted`() = runBlocking {
+        val approvalStore = ResumeMutableApprovalStore(
+            mutableMapOf("approval-1" to approvedApproval("approval-1")),
+        )
+        val continuationStore = ResumeMutableApprovalContinuationStore(
+            mutableMapOf(
+                "approval-1" to pendingContinuation("approval-1").copy(status = ApprovalContinuationStatus.COMPLETED),
+            ),
+        )
+        val controlPlane = SovereignOpsApprovalResumeControlPlane(
+            approvalStore = approvalStore,
+            approvalContinuationStore = continuationStore,
+            resumeApproval = { error("should not run") },
+            clock = clock,
+        )
+
+        val result = controlPlane.resume(resumeCommand("approval-1"))
+
+        assertThat(result).isEqualTo(ApprovalResumeResult.AlreadyCompleted(ApprovalId("approval-1")))
+    }
+
+    @Test
+    fun `resume with invalid resume token returns Conflict`() = runBlocking {
+        val approvalStore = ResumeMutableApprovalStore(
+            mutableMapOf("approval-1" to approvedApproval("approval-1")),
+        )
+        val continuationStore = ResumeMutableApprovalContinuationStore(
+            mutableMapOf("approval-1" to pendingContinuation("approval-1")),
+        )
+        val controlPlane = SovereignOpsApprovalResumeControlPlane(
+            approvalStore = approvalStore,
+            approvalContinuationStore = continuationStore,
+            resumeApproval = { error("should not run") },
+            clock = clock,
+        )
+
+        val result = controlPlane.resume(
+            resumeCommand("approval-1").copy(resumeToken = ResumeToken("bad token")),
+        )
+
+        assertThat(result).isEqualTo(
+            ApprovalResumeResult.Conflict(
+                approvalId = ApprovalId("approval-1"),
+                reason = "approval-resume-token-invalid",
+            ),
+        )
+    }
+
+    @Test
+    fun `runtime exception returns Failed without deleting continuation`() = runBlocking {
+        val approvalStore = ResumeMutableApprovalStore(
+            mutableMapOf("approval-1" to approvedApproval("approval-1")),
+        )
+        val continuationStore = ResumeMutableApprovalContinuationStore(
+            mutableMapOf("approval-1" to pendingContinuation("approval-1")),
+        )
+        val controlPlane = SovereignOpsApprovalResumeControlPlane(
+            approvalStore = approvalStore,
+            approvalContinuationStore = continuationStore,
+            resumeApproval = { throw RuntimeException("boom") },
+            clock = clock,
+        )
+
+        val result = controlPlane.resume(resumeCommand("approval-1"))
+
+        assertThat(result).isEqualTo(
+            ApprovalResumeResult.Failed(
+                approvalId = ApprovalId("approval-1"),
+                reason = "boom",
+            ),
+        )
+        assertThat(continuationStore.get("approval-1")).isEqualTo(pendingContinuation("approval-1"))
+    }
+
+    @Test
+    fun `cancellation exception is rethrown`() = runBlocking {
+        val approvalStore = ResumeMutableApprovalStore(
+            mutableMapOf("approval-1" to approvedApproval("approval-1")),
+        )
+        val continuationStore = ResumeMutableApprovalContinuationStore(
+            mutableMapOf("approval-1" to pendingContinuation("approval-1")),
+        )
+        val controlPlane = SovereignOpsApprovalResumeControlPlane(
+            approvalStore = approvalStore,
+            approvalContinuationStore = continuationStore,
+            resumeApproval = { throw CancellationException("cancelled") },
+            clock = clock,
+        )
+
+        assertThatThrownBy {
+            runBlocking { controlPlane.resume(resumeCommand("approval-1")) }
+        }.isInstanceOf(CancellationException::class.java)
+    }
+
+    private fun resumeCommand(approvalId: String): ApprovalResumeCommand =
+        ApprovalResumeCommand(
+            approvalId = ApprovalId(approvalId),
+            resumeToken = ResumeToken("resume-token-1"),
+            resumedBy = "operator-1",
+        )
+
+    private fun approval(
+        approvalId: String,
+        status: ApprovalStatus,
+        expiresAt: Instant = now.plusSeconds(600),
+        version: Long = 0L,
+    ): ApprovalRequest = ApprovalRequest(
+        approvalId = approvalId,
+        binding = ApprovalBinding(
+            workflowRunId = "wf-$approvalId",
+            toolName = "claim-payout",
+            argumentsDigest = digest("01"),
+            policyVersion = "v1",
+            workflowDigest = digest("02"),
+            approvalTokenDigest = digest("03"),
+        ),
+        status = status,
+        requestedBy = "triage-system",
+        requestedAt = now.minusSeconds(30),
+        expiresAt = expiresAt,
+        decidedBy = if (status == ApprovalStatus.APPROVED) "reviewer-1" else null,
+        decidedAt = if (status == ApprovalStatus.APPROVED) now.minusSeconds(20) else null,
+        decisionComment = if (status == ApprovalStatus.APPROVED) "approved" else null,
+        consumedBy = null,
+        consumedAt = null,
+        version = version,
+    )
+
+    private fun approvedApproval(approvalId: String): ApprovalRequest =
+        approval(
+            approvalId = approvalId,
+            status = ApprovalStatus.APPROVED,
+            version = 1L,
+        )
+
+    private fun pendingContinuation(
+        approvalId: String,
+        approvalExpiresAt: Instant = now.plusSeconds(600),
+    ): ApprovalContinuation = ApprovalContinuation(
+        approvalId = approvalId,
+        workflowRunId = "wf-$approvalId",
+        correlationId = "corr-$approvalId",
+        toolCallId = "tool-call-$approvalId",
+        toolName = "claim-payout",
+        argumentsDigest = digest("04"),
+        policyVersion = "v1",
+        workflowDigest = digest("05"),
+        status = ApprovalContinuationStatus.PENDING,
+        createdAt = now.minusSeconds(30),
+        approvalExpiresAt = approvalExpiresAt,
+        claimedBy = null,
+        claimedAt = null,
+        completedAt = null,
+        version = 0L,
+    )
+
+    private fun digest(suffix: String): Sha256Digest =
+        Sha256Digest.of("sha256:${suffix.padStart(64, suffix.first())}")
+}
+
+private class ResumeMutableApprovalStore(
+    private val approvals: MutableMap<String, ApprovalRequest> = mutableMapOf(),
+) : ApprovalStore {
+    override suspend fun create(request: ApprovalRequest): ApprovalRequest {
+        approvals[request.approvalId] = request
+        return request
+    }
+
+    override suspend fun get(approvalId: String): ApprovalRequest? = approvals[approvalId]
+
+    override suspend fun transition(
+        approvalId: String,
+        expectedVersion: Long,
+        transition: ApprovalTransition,
+    ): ApprovalRequest {
+        throw UnsupportedOperationException("transition not needed in this test")
+    }
+
+    override suspend fun consumeApprovedOrReplay(
+        approvalId: String,
+        expectedVersion: Long,
+        presentedTokenDigest: Sha256Digest,
+        consumedBy: String,
+    ): ApprovalConsumptionReceipt {
+        throw UnsupportedOperationException("consumeApprovedOrReplay not needed in this test")
+    }
+}
+
+private class ResumeMutableApprovalContinuationStore(
+    private val continuations: MutableMap<String, ApprovalContinuation> = mutableMapOf(),
+) : ApprovalContinuationStore {
+    override suspend fun create(
+        continuation: ApprovalContinuation,
+        arguments: SensitiveToolArguments,
+    ): ApprovalContinuation {
+        continuations[continuation.approvalId] = continuation
+        return continuation
+    }
+
+    override suspend fun get(approvalId: String): ApprovalContinuation? = continuations[approvalId]
+
+    override suspend fun claimForExecution(
+        approvalId: String,
+        expectedVersion: Long,
+        claimedBy: String,
+    ) = throw UnsupportedOperationException("claimForExecution not needed in this test")
+
+    override suspend fun complete(
+        approvalId: String,
+        expectedVersion: Long,
+        completedBy: String,
+    ) = throw UnsupportedOperationException("complete not needed in this test")
+
+    override suspend fun expire(
+        approvalId: String,
+        expectedVersion: Long,
+    ) = throw UnsupportedOperationException("expire not needed in this test")
+
+    override suspend fun cancel(
+        approvalId: String,
+        expectedVersion: Long,
+    ) = throw UnsupportedOperationException("cancel not needed in this test")
+
+    override suspend fun findStaleClaimed(
+        claimedBefore: Instant,
+        limit: Int,
+    ): List<ApprovalContinuation> = emptyList()
+
+    override suspend fun forceCancelClaimed(
+        approvalId: String,
+        expectedVersion: Long,
+        cancelledBy: String,
+        reasonCode: String,
+    ) = throw UnsupportedOperationException("forceCancelClaimed not needed in this test")
+
+    override suspend fun sweepExpired(): Int = 0
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovalResumeControlPlaneTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovalResumeControlPlaneTest.kt
@@ -215,6 +215,95 @@ class SovereignOpsApprovalResumeControlPlaneTest {
     }
 
     @Test
+    fun `resume claimed continuation returns Conflict`() = runBlocking {
+        val approvalStore = ResumeMutableApprovalStore(
+            mutableMapOf("approval-1" to approvedApproval("approval-1")),
+        )
+        val continuationStore = ResumeMutableApprovalContinuationStore(
+            mutableMapOf(
+                "approval-1" to pendingContinuation("approval-1").copy(
+                    status = ApprovalContinuationStatus.CLAIMED,
+                    claimedBy = "worker-1",
+                    claimedAt = now.minusSeconds(10),
+                ),
+            ),
+        )
+        val controlPlane = SovereignOpsApprovalResumeControlPlane(
+            approvalStore = approvalStore,
+            approvalContinuationStore = continuationStore,
+            resumeApproval = { error("should not run") },
+            clock = clock,
+        )
+
+        val result = controlPlane.resume(resumeCommand("approval-1"))
+
+        assertThat(result).isEqualTo(
+            ApprovalResumeResult.Conflict(
+                approvalId = ApprovalId("approval-1"),
+                reason = "approval-continuation-not-pending-CLAIMED",
+            ),
+        )
+    }
+
+    @Test
+    fun `resume expired continuation returns Conflict`() = runBlocking {
+        val approvalStore = ResumeMutableApprovalStore(
+            mutableMapOf("approval-1" to approvedApproval("approval-1")),
+        )
+        val continuationStore = ResumeMutableApprovalContinuationStore(
+            mutableMapOf(
+                "approval-1" to pendingContinuation("approval-1").copy(
+                    status = ApprovalContinuationStatus.EXPIRED,
+                ),
+            ),
+        )
+        val controlPlane = SovereignOpsApprovalResumeControlPlane(
+            approvalStore = approvalStore,
+            approvalContinuationStore = continuationStore,
+            resumeApproval = { error("should not run") },
+            clock = clock,
+        )
+
+        val result = controlPlane.resume(resumeCommand("approval-1"))
+
+        assertThat(result).isEqualTo(
+            ApprovalResumeResult.Conflict(
+                approvalId = ApprovalId("approval-1"),
+                reason = "approval-continuation-not-pending-EXPIRED",
+            ),
+        )
+    }
+
+    @Test
+    fun `resume cancelled continuation returns Conflict`() = runBlocking {
+        val approvalStore = ResumeMutableApprovalStore(
+            mutableMapOf("approval-1" to approvedApproval("approval-1")),
+        )
+        val continuationStore = ResumeMutableApprovalContinuationStore(
+            mutableMapOf(
+                "approval-1" to pendingContinuation("approval-1").copy(
+                    status = ApprovalContinuationStatus.CANCELLED,
+                ),
+            ),
+        )
+        val controlPlane = SovereignOpsApprovalResumeControlPlane(
+            approvalStore = approvalStore,
+            approvalContinuationStore = continuationStore,
+            resumeApproval = { error("should not run") },
+            clock = clock,
+        )
+
+        val result = controlPlane.resume(resumeCommand("approval-1"))
+
+        assertThat(result).isEqualTo(
+            ApprovalResumeResult.Conflict(
+                approvalId = ApprovalId("approval-1"),
+                reason = "approval-continuation-not-pending-CANCELLED",
+            ),
+        )
+    }
+
+    @Test
     fun `resume with invalid resume token returns Conflict`() = runBlocking {
         val approvalStore = ResumeMutableApprovalStore(
             mutableMapOf("approval-1" to approvedApproval("approval-1")),


### PR DESCRIPTION
## Summary

Add a Preview approval resume control-plane service that resumes approved, suspended workflows through the existing engine resume runtime.

This completes the service-level lifecycle after the ApprovalGateway request boundary and ApprovalDecisionControlPlane decision boundary:

request → approve → resume → complete

## Changes

### New
- `ApprovalResumeControlPlane` — Preview interface with `resume()` method + typed `ApprovalResumeResult` sealed interface
- `SovereignOpsApprovalResumeControlPlane` — validates approval status (APPROVED only), loads continuation, composes `ResumeApprovalCommand`, delegates to engine `resumeApproval()`
- `ApprovalResumeControlPlaneAutoConfiguration` — Spring Boot auto-config, guarded by `tramai.sovereign.ops.resume-enabled=true`, ordered after `SovereignTramaiAutoConfiguration`
- `SovereignOpsApprovalResumeControlPlaneTest` — 13 unit tests covering all result types

### Modified
- `RegulatedClaimTriageJdbcE2ETest` — new E2E test proving request → approve → resume → complete through the `@AiService` pattern; asserts exact result value, side-effect execution count (1), duplicate resume prevention
- Golden path doc — "Full workflow resume runtime" updated from "Not implemented yet"
- Ergonomics doc — PR #104 added to implementation sequence
- Auto-configuration imports — `ApprovalResumeControlPlaneAutoConfiguration` registered
- CHANGELOG — PR #104 entry

## Design decisions
- `SovereignOpsApprovalResumeControlPlane` accepts `resumeApproval` as a lambda function (`suspend (ResumeApprovalCommand) -> Any?`) instead of the concrete `TramaiRuntime` class, making it testable from other modules
- Auto-config wires `runtime::resumeApproval` from `SovereignTramaiRuntime` bean
- Only `PENDING` continuation status is resumable; `CLAIMED`, `EXPIRED`, `COMPLETED`, `CANCELLED`, `CANCELLED_UNCERTAIN` all return typed outcomes before engine invocation
- Engine-specific exceptions mapped to `ApprovalResumeResult.Conflict` or `NotFound`

## Review fixes (commit 2c786b2)
| Finding | Fix |
|---------|-----|
| Auto-config ordering | Added `afterName` dependency on `SovereignTramaiAutoConfiguration` |
| Non-PENDING continuations | Reject CLAIMED/EXPIRED/CANCELLED/CANCELLED_UNCERTAIN with `Conflict` before engine call |
| E2E ledger wiring | Use Spring-managed `claimPayoutLedger` bean, not separate instance |
| Missing assertion rigor | Assert exact result `"CLAIM_PAYOUT_COMPLETED"`, side-effect count (1), second resume → AlreadyCompleted (no duplicate) |

## Verification
- `./gradlew verifySovereignRuntimeClosure` ✅ (329 tasks)
- 13/13 resume control plane unit tests pass (10 original + 3 non-PENDING state tests)
- 12/12 E2E tests pass
- `resume-enabled=true` + stores → bean; `resume-enabled=false` → no bean; custom bean → backs off

## Constraints
- Preview API remains Preview
- No REST endpoints yet
- No reviewer UI yet
- No generic workflow DSL yet
