### PR TITLE
feat(workflow): add approved continuation resume worker

### DIFF
--- a/docs/specs/spec-112-approved-continuation-resume-worker.md
+++ b/docs/specs/spec-112-approved-continuation-resume-worker.md
@@ -1,0 +1,106 @@
+# SPEC-112: Approved Continuation Resume Worker
+
+## 1. Executive Summary
+
+Add a runtime-owned background worker that finds approved + pending continuations, loads the internal sealed resume credential, calls `ApprovalResumeControlPlane.resume(...)`, deletes the credential after success, and records safe audit evidence. Never exposes resume tokens.
+
+## 2. Design
+
+### 2.1 Worker API
+
+```kotlin
+interface ApprovedContinuationResumeWorker {
+    suspend fun runOnce(limit: Int = 50): ApprovedContinuationResumeWorkerResult
+}
+
+data class ApprovedContinuationResumeWorkerResult(
+    val scanned: Int,
+    val resumed: Int,
+    val skipped: Int,
+    val failed: Int,
+)
+```
+
+### 2.2 Claim SPI
+
+```kotlin
+interface ApprovedContinuationResumeQueue {
+    suspend fun claimApprovedPending(
+        workerId: String,
+        limit: Int,
+        leaseUntil: Instant,
+    ): List<ApprovedContinuationResumeWorkItem>
+
+    suspend fun markResumeSucceeded(approvalId: ApprovalId, workerId: String)
+    suspend fun markResumeFailed(approvalId: ApprovalId, workerId: String, reasonCode: String, retryAt: Instant? = null)
+}
+
+data class ApprovedContinuationResumeWorkItem(
+    val approvalId: ApprovalId,
+    val approvalVersion: Long,
+    val continuationVersion: Long,
+    val workflowRunId: String,
+)
+```
+
+### 2.3 Worker implementation
+
+The worker:
+1. Calls `queue.claimApprovedPending(...)` to get work items
+2. For each item, loads the sealed credential via `ApprovalResumeCredentialStore.get(...)`
+3. If credential missing → `markResumeFailed(..., "credential-not-found")` and continue
+4. Calls `ApprovalResumeControlPlane.resume(ApprovalResumeCommand(...))`
+5. On `Resumed` or `AlreadyCompleted` → `markResumeSucceeded(...)` + `delete(approvalId)`
+6. On `NotApproved` or `NotFound` → `markResumeFailed(...)` terminal, keep credential
+7. On `Conflict("approval-continuation-expired")` → `markResumeFailed(...)` terminal, delete credential
+8. On `Failed` or `Conflict` other → `markResumeFailed(...)` retryable, keep credential
+
+### 2.4 Configuration
+
+```yaml
+tramai:
+  sovereign:
+    ops:
+      approved-resume-worker:
+        enabled: false
+        worker-id: tramai-approved-resume-worker
+        batch-size: 50
+        lease-duration: 2m
+        lease-heartbeat-interval: 30s
+```
+
+## 3. Persistence
+
+JDBC queue implementation:
+
+```sql
+SELECT a.approval_id, a.version, c.version
+FROM approvals a
+JOIN approval_continuations c ON c.approval_id = a.approval_id
+JOIN tramai_approval_resume_credentials rc ON rc.approval_id = a.approval_id
+WHERE a.status = 'APPROVED'
+  AND c.status = 'PENDING'
+  AND c.approval_expires_at > now()
+  AND rc.expires_at > now()
+ORDER BY c.approval_expires_at ASC
+LIMIT ?
+FOR UPDATE SKIP LOCKED
+```
+
+## 4. Tests
+
+### 4.1 Worker tests
+- approved pending continuation resumes once
+- denied approval is skipped
+- missing credential fails closed
+- resume success deletes credential
+- already completed reconciles credential
+- resume failed keeps credential for retry
+
+### 4.2 JDBC queue tests
+- two workers claim same item → exactly one resumes
+- batch limit respected
+- oldest expiry first ordering
+
+### 4.3 E2E
+- Extend regulated claim triage flow with auto-resume

--- a/tramai-persistence-jdbc/src/main/resources/tramai/persistence/jdbc/postgres/V7__approval_continuations_resume_retry.sql
+++ b/tramai-persistence-jdbc/src/main/resources/tramai/persistence/jdbc/postgres/V7__approval_continuations_resume_retry.sql
@@ -1,0 +1,34 @@
+-- ────────────────────────────────────────────────────────────────────
+-- V7: approval_continuations resume retry tracking
+-- ────────────────────────────────────────────────────────────────────
+-- Adds retry-state columns to approval_continuations so the approved
+-- continuation resume worker can persist reason codes, backoff timers,
+-- and attempt counts for transient failures.
+--
+-- These columns are used exclusively by the runtime-owned resume worker
+-- (PR #112). They are never exposed through inbox, REST, audit, or UI.
+-- ────────────────────────────────────────────────────────────────────
+
+DO $$ BEGIN
+    ALTER TABLE approval_continuations
+        ADD COLUMN IF NOT EXISTS resume_last_error_code TEXT;
+EXCEPTION WHEN duplicate_column THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    ALTER TABLE approval_continuations
+        ADD COLUMN IF NOT EXISTS resume_next_attempt_at TIMESTAMPTZ;
+EXCEPTION WHEN duplicate_column THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    ALTER TABLE approval_continuations
+        ADD COLUMN IF NOT EXISTS resume_attempt_count BIGINT NOT NULL DEFAULT 0;
+EXCEPTION WHEN duplicate_column THEN NULL;
+END $$;
+
+-- Index for finding retry-eligible rows
+CREATE INDEX IF NOT EXISTS idx_approval_continuations_resume_attempt
+    ON approval_continuations (resume_next_attempt_at)
+    WHERE resume_next_attempt_at IS NOT NULL
+      AND status = 'PENDING';

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovedContinuationResumeQueue.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovedContinuationResumeQueue.kt
@@ -1,0 +1,54 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.core.approval.gateway.ApprovalId
+import java.time.Instant
+
+/**
+ * SPI for claiming and managing approved + pending continuations eligible for auto-resume.
+ *
+ * Implementations must use `SELECT ... FOR UPDATE SKIP LOCKED` to avoid
+ * duplicate resume under concurrent workers.
+ */
+interface ApprovedContinuationResumeQueue {
+
+    /**
+     * Claim up to [limit] approved + pending continuations that are eligible
+     * for resume. The lease expires at [leaseUntil] — the worker must complete
+     * processing and call [markResumeSucceeded] or [markResumeFailed] before then.
+     *
+     * Each item is claimed with [workerId] so that another worker running in
+     * parallel does not pick up the same item.
+     */
+    suspend fun claimApprovedPending(
+        workerId: String,
+        limit: Int,
+        leaseUntil: Instant,
+    ): List<ApprovedContinuationResumeWorkItem>
+
+    /**
+     * Mark a claimed item as successfully resumed.
+     */
+    suspend fun markResumeSucceeded(approvalId: ApprovalId, workerId: String)
+
+    /**
+     * Mark a claimed item as failed.
+     *
+     * @param retryAt when to make this item available for retry, or null for terminal failure.
+     */
+    suspend fun markResumeFailed(
+        approvalId: ApprovalId,
+        workerId: String,
+        reasonCode: String,
+        retryAt: Instant? = null,
+    )
+}
+
+/**
+ * A work item claimed by the resume worker.
+ */
+data class ApprovedContinuationResumeWorkItem(
+    val approvalId: ApprovalId,
+    val approvalVersion: Long,
+    val continuationVersion: Long,
+    val workflowRunId: String,
+)

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovedContinuationResumeWorker.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovedContinuationResumeWorker.kt
@@ -1,0 +1,34 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.core.approval.gateway.ApprovalId
+
+/**
+ * Runtime-owned worker that finds approved + pending continuations and resumes
+ * them using the internal encrypted credential store.
+ *
+ * This worker calls [ApprovalResumeControlPlane.resume] with sealed credentials
+ * from [ApprovalResumeCredentialStore] — it never exposes resume tokens to
+ * human-facing surfaces.
+ *
+ * @see SovereignOpsApprovedContinuationResumeWorker for the implementation.
+ */
+interface ApprovedContinuationResumeWorker {
+
+    /**
+     * Run one cycle: claim resumable items, resume them, and record outcomes.
+     *
+     * @param limit max items to process in this cycle.
+     * @return summary of the cycle.
+     */
+    suspend fun runOnce(limit: Int = 50): ApprovedContinuationResumeWorkerResult
+}
+
+/**
+ * Summary of one [ApprovedContinuationResumeWorker.runOnce] cycle.
+ */
+data class ApprovedContinuationResumeWorkerResult(
+    val scanned: Int,
+    val resumed: Int,
+    val skipped: Int,
+    val failed: Int,
+)

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovedContinuationResumeWorkerAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovedContinuationResumeWorkerAutoConfiguration.kt
@@ -1,0 +1,53 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.core.approval.gateway.ApprovalResumeCredentialStore
+import java.time.Clock
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+
+/**
+ * Spring Boot auto-configuration for the [ApprovedContinuationResumeWorker].
+ *
+ * Activated when:
+ * - `tramai.sovereign.ops.approved-resume-worker.enabled=true`
+ * - [ApprovedContinuationResumeQueue] is available
+ * - [ApprovalResumeCredentialStore] is available
+ * - [ApprovalResumeControlPlane] is available
+ *
+ * Disabled by default — the auto-resume worker must be explicitly enabled.
+ *
+ * @see SovereignOpsApprovedContinuationResumeWorker
+ */
+@AutoConfiguration(after = [ApprovalResumeControlPlaneAutoConfiguration::class])
+@ConditionalOnProperty(
+    prefix = "tramai.sovereign.ops.approved-resume-worker",
+    name = ["enabled"],
+    havingValue = "true",
+)
+class ApprovedContinuationResumeWorkerAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(ApprovedContinuationResumeWorker::class)
+    @ConditionalOnBean(
+        value = [
+            ApprovedContinuationResumeQueue::class,
+            ApprovalResumeCredentialStore::class,
+            ApprovalResumeControlPlane::class,
+        ],
+    )
+    fun approvedContinuationResumeWorker(
+        queue: ApprovedContinuationResumeQueue,
+        credentialStore: ApprovalResumeCredentialStore,
+        resumeControlPlane: ApprovalResumeControlPlane,
+        clock: Clock,
+    ): ApprovedContinuationResumeWorker =
+        SovereignOpsApprovedContinuationResumeWorker(
+            queue = queue,
+            credentialStore = credentialStore,
+            resumeControlPlane = resumeControlPlane,
+            clock = clock,
+        )
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovedContinuationResumeWorkerAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovedContinuationResumeWorkerAutoConfiguration.kt
@@ -2,6 +2,7 @@ package dev.tramai.spring.sovereign.ops
 
 import dev.tramai.core.approval.gateway.ApprovalResumeCredentialStore
 import java.time.Clock
+import java.time.Duration
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
@@ -42,12 +43,17 @@ class ApprovedContinuationResumeWorkerAutoConfiguration {
         queue: ApprovedContinuationResumeQueue,
         credentialStore: ApprovalResumeCredentialStore,
         resumeControlPlane: ApprovalResumeControlPlane,
+        properties: SovereignOpsProperties,
         clock: Clock,
     ): ApprovedContinuationResumeWorker =
         SovereignOpsApprovedContinuationResumeWorker(
             queue = queue,
             credentialStore = credentialStore,
             resumeControlPlane = resumeControlPlane,
+            workerId = properties.approvedResumeWorker.workerId,
+            leaseDuration = properties.approvedResumeWorker.leaseDuration,
+            retryDelay = Duration.ofSeconds(30),
+            conflictRetryDelay = Duration.ofSeconds(60),
             clock = clock,
         )
 }

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovedContinuationResumeWorkerAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovedContinuationResumeWorkerAutoConfiguration.kt
@@ -2,7 +2,6 @@ package dev.tramai.spring.sovereign.ops
 
 import dev.tramai.core.approval.gateway.ApprovalResumeCredentialStore
 import java.time.Clock
-import java.time.Duration
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
@@ -52,8 +51,8 @@ class ApprovedContinuationResumeWorkerAutoConfiguration {
             resumeControlPlane = resumeControlPlane,
             workerId = properties.approvedResumeWorker.workerId,
             leaseDuration = properties.approvedResumeWorker.leaseDuration,
-            retryDelay = Duration.ofSeconds(30),
-            conflictRetryDelay = Duration.ofSeconds(60),
+            retryDelay = properties.approvedResumeWorker.retryDelay,
+            conflictRetryDelay = properties.approvedResumeWorker.conflictRetryDelay,
             clock = clock,
         )
 }

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovedContinuationResumeWorker.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovedContinuationResumeWorker.kt
@@ -1,0 +1,187 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.core.approval.gateway.ApprovalId
+import dev.tramai.core.approval.gateway.ApprovalResumeCredentialStore
+import java.time.Clock
+import java.time.Instant
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Runtime-owned implementation of [ApprovedContinuationResumeWorker].
+ *
+ * Flow per cycle:
+ * 1. Claim approved + pending continuations via [ApprovedContinuationResumeQueue].
+ * 2. For each item, load the sealed resume credential.
+ * 3. If credential missing → mark failed (terminal) and continue.
+ * 4. Call [ApprovalResumeControlPlane.resume] with the revealed token.
+ * 5. On success → mark succeeded, delete credential.
+ * 6. On already-completed → mark succeeded (reconciliation), delete stale credential.
+ * 7. On expired conflict → mark failed (terminal), delete credential.
+ * 8. On other failure → mark failed (retryable), keep credential.
+ *
+ * Never exposes resume tokens to logs, REST, or human-facing surfaces.
+ *
+ * @param queue claim store for approved continuations.
+ * @param credentialStore internal encrypted credential store (PR #111).
+ * @param resumeControlPlane the approval resume control plane.
+ * @param clock clock for temporal checks.
+ */
+class SovereignOpsApprovedContinuationResumeWorker(
+    private val queue: ApprovedContinuationResumeQueue,
+    private val credentialStore: ApprovalResumeCredentialStore,
+    private val resumeControlPlane: ApprovalResumeControlPlane,
+    private val clock: Clock = Clock.systemUTC(),
+) : ApprovedContinuationResumeWorker {
+
+    override suspend fun runOnce(limit: Int): ApprovedContinuationResumeWorkerResult {
+        val now = clock.instant()
+        val leaseUntil = now.plusSeconds(120)
+        val items = queue.claimApprovedPending(
+            workerId = WORKER_ID,
+            limit = limit,
+            leaseUntil = leaseUntil,
+        )
+
+        if (items.isEmpty()) {
+            return ApprovedContinuationResumeWorkerResult(
+                scanned = 0,
+                resumed = 0,
+                skipped = 0,
+                failed = 0,
+            )
+        }
+
+        var resumed = 0
+        var skipped = 0
+        var failed = 0
+
+        for (item in items) {
+            val outcome = processItem(item)
+            when (outcome) {
+                Outcome.RESUMED -> resumed++
+                Outcome.SKIPPED -> skipped++
+                Outcome.FAILED -> failed++
+            }
+        }
+
+        return ApprovedContinuationResumeWorkerResult(
+            scanned = items.size,
+            resumed = resumed,
+            skipped = skipped,
+            failed = failed,
+        )
+    }
+
+    private suspend fun processItem(item: ApprovedContinuationResumeWorkItem): Outcome {
+        // 1. Load sealed credential
+        val credential = try {
+            credentialStore.get(item.approvalId)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            queue.markResumeFailed(
+                item.approvalId,
+                WORKER_ID,
+                "credential-store-error:${e::class.simpleName}",
+                retryAt = clock.instant().plusSeconds(30),
+            )
+            return Outcome.FAILED
+        }
+
+        if (credential == null) {
+            queue.markResumeFailed(
+                item.approvalId,
+                WORKER_ID,
+                "credential-not-found",
+                retryAt = null,
+            )
+            return Outcome.SKIPPED
+        }
+
+        // 2. Reveal the token and resume
+        val resumeToken = credential.resumeToken.revealForInternalResume()
+        val command = ApprovalResumeCommand(
+            approvalId = item.approvalId,
+            resumeToken = resumeToken,
+            resumedBy = WORKER_ID,
+            expectedApprovalVersion = item.approvalVersion,
+            expectedContinuationVersion = item.continuationVersion,
+        )
+
+        val result = try {
+            resumeControlPlane.resume(command)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            queue.markResumeFailed(
+                item.approvalId,
+                WORKER_ID,
+                "resume-error:${e::class.simpleName}",
+                retryAt = clock.instant().plusSeconds(30),
+            )
+            return Outcome.FAILED
+        }
+
+        return when (result) {
+            is ApprovalResumeResult.Resumed -> {
+                queue.markResumeSucceeded(item.approvalId, WORKER_ID)
+                credentialStore.delete(item.approvalId)
+                Outcome.RESUMED
+            }
+
+            is ApprovalResumeResult.AlreadyCompleted -> {
+                queue.markResumeSucceeded(item.approvalId, WORKER_ID)
+                credentialStore.delete(item.approvalId)
+                Outcome.RESUMED
+            }
+
+            is ApprovalResumeResult.NotFound,
+            is ApprovalResumeResult.NotApproved -> {
+                queue.markResumeFailed(
+                    item.approvalId,
+                    WORKER_ID,
+                    "resume-${result::class.simpleName}",
+                    retryAt = null,
+                )
+                Outcome.SKIPPED
+            }
+
+            is ApprovalResumeResult.Conflict -> {
+                if (result.reason == "approval-continuation-expired") {
+                    queue.markResumeFailed(
+                        item.approvalId,
+                        WORKER_ID,
+                        "continuation-expired",
+                        retryAt = null,
+                    )
+                    credentialStore.delete(item.approvalId)
+                    Outcome.SKIPPED
+                } else {
+                    queue.markResumeFailed(
+                        item.approvalId,
+                        WORKER_ID,
+                        "resume-conflict:${result.reason}",
+                        retryAt = clock.instant().plusSeconds(60),
+                    )
+                    Outcome.FAILED
+                }
+            }
+
+            is ApprovalResumeResult.Failed -> {
+                queue.markResumeFailed(
+                    item.approvalId,
+                    WORKER_ID,
+                    "resume-failed:${result.reason}",
+                    retryAt = clock.instant().plusSeconds(30),
+                )
+                Outcome.FAILED
+            }
+        }
+    }
+
+    private enum class Outcome { RESUMED, SKIPPED, FAILED }
+
+    companion object {
+        const val WORKER_ID: String = "tramai-sovereign-approved-resume-worker"
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovedContinuationResumeWorker.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovedContinuationResumeWorker.kt
@@ -1,8 +1,8 @@
 package dev.tramai.spring.sovereign.ops
 
-import dev.tramai.core.approval.gateway.ApprovalId
 import dev.tramai.core.approval.gateway.ApprovalResumeCredentialStore
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import kotlinx.coroutines.CancellationException
 
@@ -24,20 +24,28 @@ import kotlinx.coroutines.CancellationException
  * @param queue claim store for approved continuations.
  * @param credentialStore internal encrypted credential store (PR #111).
  * @param resumeControlPlane the approval resume control plane.
+ * @param workerId identity used for claiming and resuming.
+ * @param leaseDuration how long each claimed item's lease lives.
+ * @param retryDelay delay before retrying a transient failure.
+ * @param conflictRetryDelay delay before retrying a conflict.
  * @param clock clock for temporal checks.
  */
 class SovereignOpsApprovedContinuationResumeWorker(
     private val queue: ApprovedContinuationResumeQueue,
     private val credentialStore: ApprovalResumeCredentialStore,
     private val resumeControlPlane: ApprovalResumeControlPlane,
+    private val workerId: String,
+    private val leaseDuration: Duration,
+    private val retryDelay: Duration,
+    private val conflictRetryDelay: Duration,
     private val clock: Clock = Clock.systemUTC(),
 ) : ApprovedContinuationResumeWorker {
 
     override suspend fun runOnce(limit: Int): ApprovedContinuationResumeWorkerResult {
         val now = clock.instant()
-        val leaseUntil = now.plusSeconds(120)
+        val leaseUntil = now.plus(leaseDuration)
         val items = queue.claimApprovedPending(
-            workerId = WORKER_ID,
+            workerId = workerId,
             limit = limit,
             leaseUntil = leaseUntil,
         )
@@ -81,9 +89,9 @@ class SovereignOpsApprovedContinuationResumeWorker(
         } catch (e: Exception) {
             queue.markResumeFailed(
                 item.approvalId,
-                WORKER_ID,
+                workerId,
                 "credential-store-error:${e::class.simpleName}",
-                retryAt = clock.instant().plusSeconds(30),
+                retryAt = clock.instant().plus(retryDelay),
             )
             return Outcome.FAILED
         }
@@ -91,7 +99,7 @@ class SovereignOpsApprovedContinuationResumeWorker(
         if (credential == null) {
             queue.markResumeFailed(
                 item.approvalId,
-                WORKER_ID,
+                workerId,
                 "credential-not-found",
                 retryAt = null,
             )
@@ -103,9 +111,12 @@ class SovereignOpsApprovedContinuationResumeWorker(
         val command = ApprovalResumeCommand(
             approvalId = item.approvalId,
             resumeToken = resumeToken,
-            resumedBy = WORKER_ID,
-            expectedApprovalVersion = item.approvalVersion,
-            expectedContinuationVersion = item.continuationVersion,
+            resumedBy = workerId,
+            // Do not pass expected versions — let the engine auto-detect
+            // from the store. The queue does NOT increment continuation
+            // version during claim, so the engine sees the canonical version.
+            expectedApprovalVersion = null,
+            expectedContinuationVersion = null,
         )
 
         val result = try {
@@ -115,22 +126,22 @@ class SovereignOpsApprovedContinuationResumeWorker(
         } catch (e: Exception) {
             queue.markResumeFailed(
                 item.approvalId,
-                WORKER_ID,
+                workerId,
                 "resume-error:${e::class.simpleName}",
-                retryAt = clock.instant().plusSeconds(30),
+                retryAt = clock.instant().plus(retryDelay),
             )
             return Outcome.FAILED
         }
 
         return when (result) {
             is ApprovalResumeResult.Resumed -> {
-                queue.markResumeSucceeded(item.approvalId, WORKER_ID)
+                queue.markResumeSucceeded(item.approvalId, workerId)
                 credentialStore.delete(item.approvalId)
                 Outcome.RESUMED
             }
 
             is ApprovalResumeResult.AlreadyCompleted -> {
-                queue.markResumeSucceeded(item.approvalId, WORKER_ID)
+                queue.markResumeSucceeded(item.approvalId, workerId)
                 credentialStore.delete(item.approvalId)
                 Outcome.RESUMED
             }
@@ -139,7 +150,7 @@ class SovereignOpsApprovedContinuationResumeWorker(
             is ApprovalResumeResult.NotApproved -> {
                 queue.markResumeFailed(
                     item.approvalId,
-                    WORKER_ID,
+                    workerId,
                     "resume-${result::class.simpleName}",
                     retryAt = null,
                 )
@@ -150,7 +161,7 @@ class SovereignOpsApprovedContinuationResumeWorker(
                 if (result.reason == "approval-continuation-expired") {
                     queue.markResumeFailed(
                         item.approvalId,
-                        WORKER_ID,
+                        workerId,
                         "continuation-expired",
                         retryAt = null,
                     )
@@ -159,9 +170,9 @@ class SovereignOpsApprovedContinuationResumeWorker(
                 } else {
                     queue.markResumeFailed(
                         item.approvalId,
-                        WORKER_ID,
+                        workerId,
                         "resume-conflict:${result.reason}",
-                        retryAt = clock.instant().plusSeconds(60),
+                        retryAt = clock.instant().plus(conflictRetryDelay),
                     )
                     Outcome.FAILED
                 }
@@ -170,9 +181,9 @@ class SovereignOpsApprovedContinuationResumeWorker(
             is ApprovalResumeResult.Failed -> {
                 queue.markResumeFailed(
                     item.approvalId,
-                    WORKER_ID,
+                    workerId,
                     "resume-failed:${result.reason}",
-                    retryAt = clock.instant().plusSeconds(30),
+                    retryAt = clock.instant().plus(retryDelay),
                 )
                 Outcome.FAILED
             }
@@ -180,8 +191,4 @@ class SovereignOpsApprovedContinuationResumeWorker(
     }
 
     private enum class Outcome { RESUMED, SKIPPED, FAILED }
-
-    companion object {
-        const val WORKER_ID: String = "tramai-sovereign-approved-resume-worker"
-    }
 }

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsProperties.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsProperties.kt
@@ -40,6 +40,9 @@ data class SovereignOpsProperties(
 
     /** Configuration for sovereign ops audit outbox behavior. */
     var outbox: SovereignOpsOutboxProperties = SovereignOpsOutboxProperties(),
+
+    /** Configuration for the approved-continuation auto-resume worker. */
+    var approvedResumeWorker: SovereignOpsApprovedResumeWorkerProperties = SovereignOpsApprovedResumeWorkerProperties(),
 )
 
 data class SovereignOpsOutboxProperties(
@@ -68,3 +71,11 @@ data class SovereignOpsOutboxWorkerProperties(
  */
 fun defaultWorkerId(): String =
     System.getenv("HOSTNAME") ?: UUID.randomUUID().toString()
+
+data class SovereignOpsApprovedResumeWorkerProperties(
+    val enabled: Boolean = false,
+    var workerId: String = defaultWorkerId(),
+    val batchSize: Int = 50,
+    val leaseDuration: Duration = Duration.ofMinutes(2),
+    val leaseHeartbeatInterval: Duration = Duration.ofSeconds(30),
+)

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsProperties.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsProperties.kt
@@ -78,4 +78,6 @@ data class SovereignOpsApprovedResumeWorkerProperties(
     val batchSize: Int = 50,
     val leaseDuration: Duration = Duration.ofMinutes(2),
     val leaseHeartbeatInterval: Duration = Duration.ofSeconds(30),
+    val retryDelay: Duration = Duration.ofSeconds(30),
+    val conflictRetryDelay: Duration = Duration.ofSeconds(60),
 )

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -2,3 +2,4 @@ dev.tramai.spring.sovereign.ops.SovereignOpsAutoConfiguration
 dev.tramai.spring.sovereign.ops.ApprovalGatewayAutoConfiguration
 dev.tramai.spring.sovereign.ops.ApprovalDecisionControlPlaneAutoConfiguration
 dev.tramai.spring.sovereign.ops.ApprovalResumeControlPlaneAutoConfiguration
+dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeWorkerAutoConfiguration

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/ApprovedContinuationResumeWorkerAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/ApprovedContinuationResumeWorkerAutoConfigurationTest.kt
@@ -1,0 +1,143 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.core.approval.gateway.ApprovalResumeCredentialStore
+import java.time.Clock
+import java.time.Instant
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Tests that [ApprovedContinuationResumeWorkerAutoConfiguration] correctly
+ * creates the worker bean when enabled and all dependencies are present,
+ * and does NOT create it when disabled.
+ *
+ * Relies on the auto-config being registered in AutoConfiguration.imports.
+ */
+class ApprovedContinuationResumeWorkerAutoConfigurationTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                SovereignOpsAutoConfiguration::class.java,
+                ApprovedContinuationResumeWorkerAutoConfiguration::class.java,
+            ),
+        )
+
+    @Test
+    fun `worker bean is not created when disabled by default`() {
+        contextRunner
+            .withUserConfiguration(MinimalDependenciesConfig::class.java)
+            .run { ctx ->
+                assertThat(ctx).doesNotHaveBean(ApprovedContinuationResumeWorker::class.java)
+            }
+    }
+
+    @Test
+    fun `worker bean is created when enabled`() {
+        contextRunner
+            .withUserConfiguration(MinimalDependenciesConfig::class.java)
+            .withPropertyValues("tramai.sovereign.ops.approved-resume-worker.enabled=true")
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(ApprovedContinuationResumeWorker::class.java)
+            }
+    }
+
+    @Test
+    fun `worker bean is not created when queue is missing`() {
+        contextRunner
+            .withUserConfiguration(MinimalDependenciesWithoutQueueConfig::class.java)
+            .withPropertyValues("tramai.sovereign.ops.approved-resume-worker.enabled=true")
+            .run { ctx ->
+                assertThat(ctx).doesNotHaveBean(ApprovedContinuationResumeWorker::class.java)
+            }
+    }
+
+    @Test
+    fun `worker bean uses configured retry delays from properties`() {
+        contextRunner
+            .withUserConfiguration(MinimalDependenciesConfig::class.java)
+            .withPropertyValues("tramai.sovereign.ops.approved-resume-worker.enabled=true")
+            .run { ctx ->
+                val worker = ctx.getBean(ApprovedContinuationResumeWorker::class.java)
+                assertThat(worker).isInstanceOf(SovereignOpsApprovedContinuationResumeWorker::class.java)
+            }
+    }
+}
+
+/** Provides all three dependencies needed for the worker auto-config. */
+@Configuration
+open class MinimalDependenciesConfig {
+
+    @Bean
+    open fun clock(): Clock = Clock.systemUTC()
+
+    @Bean
+    open fun approvedContinuationResumeQueue(): ApprovedContinuationResumeQueue = NoopQueue()
+
+    @Bean
+    open fun approvalResumeCredentialStore(): ApprovalResumeCredentialStore = NoopCredentialStore()
+
+    @Bean
+    open fun approvalResumeControlPlane(): ApprovalResumeControlPlane = NoopControlPlane()
+}
+
+/** Provides only credential store and control plane — missing the queue. */
+@Configuration
+open class MinimalDependenciesWithoutQueueConfig {
+
+    @Bean
+    open fun clock(): Clock = Clock.systemUTC()
+
+    @Bean
+    open fun approvalResumeCredentialStore(): ApprovalResumeCredentialStore = NoopCredentialStore()
+
+    @Bean
+    open fun approvalResumeControlPlane(): ApprovalResumeControlPlane = NoopControlPlane()
+}
+
+private class NoopQueue : ApprovedContinuationResumeQueue {
+    override suspend fun claimApprovedPending(
+        workerId: String,
+        limit: Int,
+        leaseUntil: Instant,
+    ): List<ApprovedContinuationResumeWorkItem> = emptyList()
+
+    override suspend fun markResumeSucceeded(
+        approvalId: dev.tramai.core.approval.gateway.ApprovalId,
+        workerId: String,
+    ) = Unit
+
+    override suspend fun markResumeFailed(
+        approvalId: dev.tramai.core.approval.gateway.ApprovalId,
+        workerId: String,
+        reasonCode: String,
+        retryAt: Instant?,
+    ) = Unit
+}
+
+private class NoopCredentialStore : ApprovalResumeCredentialStore {
+    override suspend fun create(
+        record: dev.tramai.core.approval.gateway.ApprovalResumeCredentialRecord,
+    ) = Unit
+
+    override suspend fun get(
+        approvalId: dev.tramai.core.approval.gateway.ApprovalId,
+    ): dev.tramai.core.approval.gateway.ApprovalResumeCredentialRecord? = null
+
+    override suspend fun delete(
+        approvalId: dev.tramai.core.approval.gateway.ApprovalId,
+    ) = Unit
+}
+
+private class NoopControlPlane : ApprovalResumeControlPlane {
+    override suspend fun resume(command: ApprovalResumeCommand): ApprovalResumeResult =
+        ApprovalResumeResult.Resumed(
+            approvalId = command.approvalId,
+            resumedBy = command.resumedBy,
+            result = null,
+        )
+}

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovedContinuationResumeWorkerTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovedContinuationResumeWorkerTest.kt
@@ -7,6 +7,8 @@ import dev.tramai.core.approval.gateway.ApprovalResumeCredentialStore
 import dev.tramai.core.approval.gateway.ResumeToken
 import dev.tramai.core.approval.gateway.SealedResumeToken
 import dev.tramai.core.approval.gateway.WorkflowRunId
+import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
@@ -35,6 +37,11 @@ class SovereignOpsApprovedContinuationResumeWorkerTest {
             queue = queue,
             credentialStore = credentialStore,
             resumeControlPlane = controlPlane,
+            workerId = "test-worker",
+            leaseDuration = Duration.ofMinutes(2),
+            retryDelay = Duration.ofSeconds(30),
+            conflictRetryDelay = Duration.ofSeconds(60),
+            clock = Clock.systemUTC(),
         )
     }
 

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovedContinuationResumeWorkerTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovedContinuationResumeWorkerTest.kt
@@ -1,0 +1,271 @@
+package dev.tramai.spring.sovereign.ops
+
+import dev.tramai.core.approval.ApprovalStatus
+import dev.tramai.core.approval.gateway.ApprovalId
+import dev.tramai.core.approval.gateway.ApprovalResumeCredentialRecord
+import dev.tramai.core.approval.gateway.ApprovalResumeCredentialStore
+import dev.tramai.core.approval.gateway.ResumeToken
+import dev.tramai.core.approval.gateway.SealedResumeToken
+import dev.tramai.core.approval.gateway.WorkflowRunId
+import java.time.Instant
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Contract tests for [SovereignOpsApprovedContinuationResumeWorker].
+ *
+ * Uses in-memory fakes for the queue, credential store, and control plane
+ * to verify the worker's decision logic without a database.
+ */
+class SovereignOpsApprovedContinuationResumeWorkerTest {
+
+    private lateinit var queue: FakeApprovedContinuationResumeQueue
+    private lateinit var credentialStore: FakeApprovalResumeCredentialStore
+    private lateinit var controlPlane: FakeApprovalResumeControlPlane
+    private lateinit var worker: SovereignOpsApprovedContinuationResumeWorker
+
+    @BeforeEach
+    fun setUp() {
+        queue = FakeApprovedContinuationResumeQueue()
+        credentialStore = FakeApprovalResumeCredentialStore()
+        controlPlane = FakeApprovalResumeControlPlane()
+        worker = SovereignOpsApprovedContinuationResumeWorker(
+            queue = queue,
+            credentialStore = credentialStore,
+            resumeControlPlane = controlPlane,
+        )
+    }
+
+    @Test
+    fun `no items to process returns zero counts`() {
+        runBlocking {
+            val result = worker.runOnce(limit = 10)
+            assertThat(result.scanned).isZero()
+            assertThat(result.resumed).isZero()
+            assertThat(result.skipped).isZero()
+            assertThat(result.failed).isZero()
+        }
+    }
+
+    @Test
+    fun `approved pending continuation resumes once`() {
+        runBlocking {
+            val approvalId = ApprovalId("test-001")
+            queue.addItem(approvalId, approvalVersion = 1, continuationVersion = 1)
+            credentialStore.add(credential(approvalId, ResumeToken("tok-001")))
+            controlPlane.result = ApprovalResumeResult.Resumed(
+                approvalId = approvalId,
+                resumedBy = "tramai-sovereign-approved-resume-worker",
+                result = "workflow-result",
+            )
+
+            val result = worker.runOnce(limit = 10)
+
+            assertThat(result.scanned).isEqualTo(1)
+            assertThat(result.resumed).isEqualTo(1)
+            assertThat(result.skipped).isZero()
+            assertThat(result.failed).isZero()
+            assertThat(credentialStore.deleted).contains(approvalId)
+            assertThat(queue.markedSucceeded).contains(approvalId)
+        }
+    }
+
+    @Test
+    fun `missing credential skips the item`() {
+        runBlocking {
+            val approvalId = ApprovalId("test-002")
+            queue.addItem(approvalId, approvalVersion = 1, continuationVersion = 1)
+            // No credential in store
+
+            val result = worker.runOnce(limit = 10)
+
+            assertThat(result.scanned).isEqualTo(1)
+            assertThat(result.resumed).isZero()
+            assertThat(result.skipped).isEqualTo(1)
+            assertThat(result.failed).isZero()
+            assertThat(queue.markedFailed).containsKey(approvalId)
+            assertThat(queue.markedFailed[approvalId]).isEqualTo("credential-not-found")
+        }
+    }
+
+    @Test
+    fun `already completed reconciles and deletes credential`() {
+        runBlocking {
+            val approvalId = ApprovalId("test-003")
+            queue.addItem(approvalId, approvalVersion = 1, continuationVersion = 1)
+            credentialStore.add(credential(approvalId, ResumeToken("tok-003")))
+            controlPlane.result = ApprovalResumeResult.AlreadyCompleted(approvalId)
+
+            val result = worker.runOnce(limit = 10)
+
+            assertThat(result.resumed).isEqualTo(1)
+            assertThat(credentialStore.deleted).contains(approvalId)
+            assertThat(queue.markedSucceeded).contains(approvalId)
+        }
+    }
+
+    @Test
+    fun `not approved skips item and keeps credential`() {
+        runBlocking {
+            val approvalId = ApprovalId("test-004")
+            queue.addItem(approvalId, approvalVersion = 1, continuationVersion = 1)
+            credentialStore.add(credential(approvalId, ResumeToken("tok-004")))
+            controlPlane.result = ApprovalResumeResult.NotApproved(
+                approvalId = approvalId,
+                status = ApprovalStatus.DENIED,
+            )
+
+            val result = worker.runOnce(limit = 10)
+
+            assertThat(result.skipped).isEqualTo(1)
+            assertThat(result.resumed).isZero()
+            assertThat(credentialStore.deleted).doesNotContain(approvalId)
+        }
+    }
+
+    @Test
+    fun `resume success deletes credential`() {
+        runBlocking {
+            val approvalId = ApprovalId("test-005")
+            queue.addItem(approvalId, approvalVersion = 1, continuationVersion = 1)
+            credentialStore.add(credential(approvalId, ResumeToken("tok-005")))
+            controlPlane.result = ApprovalResumeResult.Resumed(
+                approvalId = approvalId,
+                resumedBy = "tramai-sovereign-approved-resume-worker",
+                result = "done",
+            )
+
+            val result = worker.runOnce(limit = 10)
+
+            assertThat(result.resumed).isEqualTo(1)
+            assertThat(credentialStore.deleted).contains(approvalId)
+        }
+    }
+
+    @Test
+    fun `continuation expired deletes credential`() {
+        runBlocking {
+            val approvalId = ApprovalId("test-006")
+            queue.addItem(approvalId, approvalVersion = 1, continuationVersion = 1)
+            credentialStore.add(credential(approvalId, ResumeToken("tok-006")))
+            controlPlane.result = ApprovalResumeResult.Conflict(
+                approvalId = approvalId,
+                reason = "approval-continuation-expired",
+            )
+
+            val result = worker.runOnce(limit = 10)
+
+            assertThat(result.skipped).isEqualTo(1)
+            assertThat(result.resumed).isZero()
+            assertThat(result.failed).isZero()
+            assertThat(credentialStore.deleted).contains(approvalId)
+        }
+    }
+
+    @Test
+    fun `resume failed keeps credential for retry`() {
+        runBlocking {
+            val approvalId = ApprovalId("test-007")
+            queue.addItem(approvalId, approvalVersion = 1, continuationVersion = 1)
+            credentialStore.add(credential(approvalId, ResumeToken("tok-007")))
+            controlPlane.result = ApprovalResumeResult.Failed(
+                approvalId = approvalId,
+                reason = "engine-timeout",
+            )
+
+            val result = worker.runOnce(limit = 10)
+
+            assertThat(result.failed).isEqualTo(1)
+            assertThat(result.resumed).isZero()
+            assertThat(credentialStore.deleted).doesNotContain(approvalId)
+            assertThat(queue.markedFailed).containsKey(approvalId)
+        }
+    }
+
+    // ── Fakes ───────────────────────────────────────────────────────
+
+    private fun credential(approvalId: ApprovalId, token: ResumeToken): ApprovalResumeCredentialRecord {
+        val now = Instant.parse("2026-06-01T12:00:00Z")
+        return ApprovalResumeCredentialRecord(
+            approvalId = approvalId,
+            workflowRunId = WorkflowRunId("wf-${approvalId.value}"),
+            resumeToken = SealedResumeToken.seal(token),
+            createdAt = now,
+            expiresAt = now.plusSeconds(300),
+            version = 1L,
+        )
+    }
+
+    private class FakeApprovedContinuationResumeQueue : ApprovedContinuationResumeQueue {
+        val items = mutableListOf<ApprovedContinuationResumeWorkItem>()
+        val markedSucceeded = mutableListOf<ApprovalId>()
+        val markedFailed = mutableMapOf<ApprovalId, String>()
+
+        fun addItem(approvalId: ApprovalId, approvalVersion: Long, continuationVersion: Long) {
+            items.add(
+                ApprovedContinuationResumeWorkItem(
+                    approvalId = approvalId,
+                    approvalVersion = approvalVersion,
+                    continuationVersion = continuationVersion,
+                    workflowRunId = "wf-${approvalId.value}",
+                ),
+            )
+        }
+
+        override suspend fun claimApprovedPending(
+            workerId: String,
+            limit: Int,
+            leaseUntil: Instant,
+        ): List<ApprovedContinuationResumeWorkItem> {
+            val result = items.take(limit).toList()
+            items.clear()
+            return result
+        }
+
+        override suspend fun markResumeSucceeded(approvalId: ApprovalId, workerId: String) {
+            markedSucceeded.add(approvalId)
+        }
+
+        override suspend fun markResumeFailed(
+            approvalId: ApprovalId,
+            workerId: String,
+            reasonCode: String,
+            retryAt: Instant?,
+        ) {
+            markedFailed[approvalId] = reasonCode
+        }
+    }
+
+    private class FakeApprovalResumeCredentialStore : ApprovalResumeCredentialStore {
+        val records = mutableMapOf<ApprovalId, ApprovalResumeCredentialRecord>()
+        val deleted = mutableListOf<ApprovalId>()
+
+        fun add(record: ApprovalResumeCredentialRecord) {
+            records[record.approvalId] = record
+        }
+
+        override suspend fun create(record: ApprovalResumeCredentialRecord) {
+            records[record.approvalId] = record
+        }
+
+        override suspend fun get(approvalId: ApprovalId): ApprovalResumeCredentialRecord? =
+            records[approvalId]
+
+        override suspend fun delete(approvalId: ApprovalId) {
+            records.remove(approvalId)
+            deleted.add(approvalId)
+        }
+    }
+
+    private class FakeApprovalResumeControlPlane : ApprovalResumeControlPlane {
+        var result: ApprovalResumeResult = ApprovalResumeResult.Resumed(
+            approvalId = ApprovalId("default"),
+            resumedBy = "test",
+            result = null,
+        )
+
+        override suspend fun resume(command: ApprovalResumeCommand): ApprovalResumeResult = result
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcApprovedContinuationResumeQueue.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcApprovedContinuationResumeQueue.kt
@@ -3,7 +3,6 @@ package dev.tramai.spring.sovereign.persistence.jdbc
 import dev.tramai.core.approval.gateway.ApprovalId
 import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeQueue
 import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeWorkItem
-import java.sql.Connection
 import java.time.Clock
 import java.time.Instant
 import java.time.OffsetDateTime
@@ -15,10 +14,27 @@ import javax.sql.DataSource
  * `SELECT ... FOR UPDATE SKIP LOCKED` to safely claim resumable items
  * under concurrent workers.
  *
- * The claim writes `claimed_by`, `claimed_at` into the continuation row.
- * If the continuation already has a claim (claimed_by is not null), it is
- * skipped — the worker first acquired the database-level lock and then
- * verified the claim is still available.
+ * ## Claim semantics
+ * 1. Select candidates with SKIP LOCKED — only rows that are not locked
+ *    by another transaction are considered.
+ * 2. Items must be APPROVED, continuation PENDING, not expired, and have
+ *    a valid encrypted credential.
+ * 3. Unclaimed rows (`claimed_by IS NULL`) are eligible.
+ * 4. Previously claimed rows with expired leases (`claimed_at < now()`)
+ *    are eligible for reclamation.
+ * 5. Claim writes `claimed_by` = worker ID, `claimed_at` = lease expiry.
+ *    Continuation version is NOT touched — the engine resume owns version
+ *    management.
+ *
+ * ## Retry state
+ * On retryable failure, `resume_last_error_code`, `resume_next_attempt_at`,
+ * and `resume_attempt_count` are updated. The claim is released so the
+ * row can be reclaimed after the backoff window.
+ *
+ * ## Terminal failure
+ * On terminal failure (retryAt = null), the continuation is set to
+ * `CANCELLED` — not COMPLETED — so the state is distinguishable from
+ * successful resume.
  *
  * @param dataSource PostgreSQL DataSource.
  * @param clock clock for temporal checks.
@@ -34,20 +50,29 @@ class JdbcApprovedContinuationResumeQueue(
         leaseUntil: Instant,
     ): List<ApprovedContinuationResumeWorkItem> =
         dataSource.connection.use { conn ->
-            val leaseUntilOdt = leaseUntil.atOffset(ZoneOffset.UTC)
             val nowOdt = clock.instant().atOffset(ZoneOffset.UTC)
+            val leaseUntilOdt = leaseUntil.atOffset(ZoneOffset.UTC)
+
             val selectSql = """
                 SELECT a.approval_id, a.version AS approval_version,
                        c.version AS continuation_version, c.workflow_run_id
                 FROM approvals a
                 JOIN approval_continuations c ON c.approval_id = a.approval_id
-                JOIN tramai_approval_resume_credentials rc ON rc.approval_id = a.approval_id
+                JOIN tramai_approval_resume_credentials rc
+                    ON rc.approval_id = a.approval_id
+                    AND rc.workflow_run_id = c.workflow_run_id
                 WHERE a.status = 'APPROVED'
                   AND c.status = 'PENDING'
-                  AND c.claimed_by IS NULL
-                  AND c.claimed_at IS NULL
                   AND c.approval_expires_at > ?
                   AND rc.expires_at > ?
+                  AND (
+                      c.claimed_by IS NULL
+                      OR c.claimed_at < ?
+                  )
+                  AND (
+                      c.resume_next_attempt_at IS NULL
+                      OR c.resume_next_attempt_at <= ?
+                  )
                 ORDER BY c.approval_expires_at ASC
                 LIMIT ?
                 FOR UPDATE SKIP LOCKED
@@ -57,7 +82,9 @@ class JdbcApprovedContinuationResumeQueue(
             conn.prepareStatement(selectSql).use { stmt ->
                 stmt.setObject(1, nowOdt)
                 stmt.setObject(2, nowOdt)
-                stmt.setInt(3, limit)
+                stmt.setObject(3, nowOdt)
+                stmt.setObject(4, nowOdt)
+                stmt.setInt(5, limit)
                 stmt.executeQuery().use { rs ->
                     while (rs.next()) {
                         items += ApprovedContinuationResumeWorkItem(
@@ -72,14 +99,20 @@ class JdbcApprovedContinuationResumeQueue(
 
             if (items.isEmpty()) return@use emptyList()
 
-            // Claim each item by updating claimed_by + claimed_at
+            // Claim each item. Version is NOT incremented — engine resume
+            // owns version management.
             val updateSql = """
                 UPDATE approval_continuations
-                SET claimed_by = ?, claimed_at = ?, version = version + 1
+                SET claimed_by = ?,
+                    claimed_at = ?,
+                    resume_attempt_count = resume_attempt_count + 1,
+                    resume_next_attempt_at = NULL
                 WHERE approval_id = ?
                   AND status = 'PENDING'
-                  AND claimed_by IS NULL
-                  AND claimed_at IS NULL
+                  AND (
+                      claimed_by IS NULL
+                      OR claimed_at < ?
+                  )
             """.trimIndent()
 
             val claimed = mutableListOf<ApprovedContinuationResumeWorkItem>()
@@ -88,6 +121,7 @@ class JdbcApprovedContinuationResumeQueue(
                     stmt.setString(1, workerId)
                     stmt.setObject(2, leaseUntilOdt)
                     stmt.setString(3, item.approvalId.value)
+                    stmt.setObject(4, nowOdt)
                     if (stmt.executeUpdate() == 1) {
                         claimed += item
                     }
@@ -101,7 +135,14 @@ class JdbcApprovedContinuationResumeQueue(
         dataSource.connection.use { conn ->
             val updateSql = """
                 UPDATE approval_continuations
-                SET status = 'COMPLETED', completed_at = ?, version = version + 1
+                SET status = 'COMPLETED',
+                    completed_at = ?,
+                    version = version + 1,
+                    claimed_by = NULL,
+                    claimed_at = NULL,
+                    resume_next_attempt_at = NULL,
+                    resume_last_error_code = NULL,
+                    resume_attempt_count = 0
                 WHERE approval_id = ?
                   AND claimed_by = ?
                   AND status = 'PENDING'
@@ -122,31 +163,47 @@ class JdbcApprovedContinuationResumeQueue(
         retryAt: Instant?,
     ) {
         dataSource.connection.use { conn ->
+            val nowOdt = OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC)
+
             if (retryAt != null) {
-                // Release claim but mark for retry — keep status PENDING
-                val releaseSql = """
+                // Release claim but schedule retry — keep status PENDING
+                val retrySql = """
                     UPDATE approval_continuations
-                    SET claimed_by = NULL, claimed_at = NULL, version = version + 1
+                    SET claimed_by = NULL,
+                        claimed_at = NULL,
+                        resume_last_error_code = ?,
+                        resume_next_attempt_at = ?,
+                        version = version + 1
                     WHERE approval_id = ?
                       AND claimed_by = ?
                 """.trimIndent()
-                conn.prepareStatement(releaseSql).use { stmt ->
-                    stmt.setString(1, approvalId.value)
-                    stmt.setString(2, workerId)
+                conn.prepareStatement(retrySql).use { stmt ->
+                    stmt.setString(1, reasonCode)
+                    stmt.setObject(2, retryAt.atOffset(ZoneOffset.UTC))
+                    stmt.setString(3, approvalId.value)
+                    stmt.setString(4, workerId)
                     stmt.executeUpdate()
                 }
             } else {
-                // Terminal failure — mark as completed (terminal state)
+                // Terminal failure — set CANCELLED (not COMPLETED)
                 val terminalSql = """
                     UPDATE approval_continuations
-                    SET status = 'COMPLETED', completed_at = ?, version = version + 1
+                    SET status = 'CANCELLED',
+                        completed_at = ?,
+                        version = version + 1,
+                        claimed_by = NULL,
+                        claimed_at = NULL,
+                        resume_last_error_code = ?,
+                        resume_next_attempt_at = NULL,
+                        resume_attempt_count = 0
                     WHERE approval_id = ?
                       AND claimed_by = ?
                 """.trimIndent()
                 conn.prepareStatement(terminalSql).use { stmt ->
-                    stmt.setObject(1, OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC))
-                    stmt.setString(2, approvalId.value)
-                    stmt.setString(3, workerId)
+                    stmt.setObject(1, nowOdt)
+                    stmt.setString(2, reasonCode)
+                    stmt.setString(3, approvalId.value)
+                    stmt.setString(4, workerId)
                     stmt.executeUpdate()
                 }
             }

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcApprovedContinuationResumeQueue.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcApprovedContinuationResumeQueue.kt
@@ -1,0 +1,155 @@
+package dev.tramai.spring.sovereign.persistence.jdbc
+
+import dev.tramai.core.approval.gateway.ApprovalId
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeQueue
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeWorkItem
+import java.sql.Connection
+import java.time.Clock
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import javax.sql.DataSource
+
+/**
+ * JDBC-backed [ApprovedContinuationResumeQueue] that uses
+ * `SELECT ... FOR UPDATE SKIP LOCKED` to safely claim resumable items
+ * under concurrent workers.
+ *
+ * The claim writes `claimed_by`, `claimed_at` into the continuation row.
+ * If the continuation already has a claim (claimed_by is not null), it is
+ * skipped — the worker first acquired the database-level lock and then
+ * verified the claim is still available.
+ *
+ * @param dataSource PostgreSQL DataSource.
+ * @param clock clock for temporal checks.
+ */
+class JdbcApprovedContinuationResumeQueue(
+    private val dataSource: DataSource,
+    private val clock: Clock = Clock.systemUTC(),
+) : ApprovedContinuationResumeQueue {
+
+    override suspend fun claimApprovedPending(
+        workerId: String,
+        limit: Int,
+        leaseUntil: Instant,
+    ): List<ApprovedContinuationResumeWorkItem> =
+        dataSource.connection.use { conn ->
+            val leaseUntilOdt = leaseUntil.atOffset(ZoneOffset.UTC)
+            val nowOdt = clock.instant().atOffset(ZoneOffset.UTC)
+            val selectSql = """
+                SELECT a.approval_id, a.version AS approval_version,
+                       c.version AS continuation_version, c.workflow_run_id
+                FROM approvals a
+                JOIN approval_continuations c ON c.approval_id = a.approval_id
+                JOIN tramai_approval_resume_credentials rc ON rc.approval_id = a.approval_id
+                WHERE a.status = 'APPROVED'
+                  AND c.status = 'PENDING'
+                  AND c.claimed_by IS NULL
+                  AND c.claimed_at IS NULL
+                  AND c.approval_expires_at > ?
+                  AND rc.expires_at > ?
+                ORDER BY c.approval_expires_at ASC
+                LIMIT ?
+                FOR UPDATE SKIP LOCKED
+            """.trimIndent()
+
+            val items = mutableListOf<ApprovedContinuationResumeWorkItem>()
+            conn.prepareStatement(selectSql).use { stmt ->
+                stmt.setObject(1, nowOdt)
+                stmt.setObject(2, nowOdt)
+                stmt.setInt(3, limit)
+                stmt.executeQuery().use { rs ->
+                    while (rs.next()) {
+                        items += ApprovedContinuationResumeWorkItem(
+                            approvalId = ApprovalId(rs.getString("approval_id")),
+                            approvalVersion = rs.getLong("approval_version"),
+                            continuationVersion = rs.getLong("continuation_version"),
+                            workflowRunId = rs.getString("workflow_run_id"),
+                        )
+                    }
+                }
+            }
+
+            if (items.isEmpty()) return@use emptyList()
+
+            // Claim each item by updating claimed_by + claimed_at
+            val updateSql = """
+                UPDATE approval_continuations
+                SET claimed_by = ?, claimed_at = ?, version = version + 1
+                WHERE approval_id = ?
+                  AND status = 'PENDING'
+                  AND claimed_by IS NULL
+                  AND claimed_at IS NULL
+            """.trimIndent()
+
+            val claimed = mutableListOf<ApprovedContinuationResumeWorkItem>()
+            conn.prepareStatement(updateSql).use { stmt ->
+                for (item in items) {
+                    stmt.setString(1, workerId)
+                    stmt.setObject(2, leaseUntilOdt)
+                    stmt.setString(3, item.approvalId.value)
+                    if (stmt.executeUpdate() == 1) {
+                        claimed += item
+                    }
+                }
+            }
+
+            claimed
+        }
+
+    override suspend fun markResumeSucceeded(approvalId: ApprovalId, workerId: String) {
+        dataSource.connection.use { conn ->
+            val updateSql = """
+                UPDATE approval_continuations
+                SET status = 'COMPLETED', completed_at = ?, version = version + 1
+                WHERE approval_id = ?
+                  AND claimed_by = ?
+                  AND status = 'PENDING'
+            """.trimIndent()
+            conn.prepareStatement(updateSql).use { stmt ->
+                stmt.setObject(1, OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC))
+                stmt.setString(2, approvalId.value)
+                stmt.setString(3, workerId)
+                stmt.executeUpdate()
+            }
+        }
+    }
+
+    override suspend fun markResumeFailed(
+        approvalId: ApprovalId,
+        workerId: String,
+        reasonCode: String,
+        retryAt: Instant?,
+    ) {
+        dataSource.connection.use { conn ->
+            if (retryAt != null) {
+                // Release claim but mark for retry — keep status PENDING
+                val releaseSql = """
+                    UPDATE approval_continuations
+                    SET claimed_by = NULL, claimed_at = NULL, version = version + 1
+                    WHERE approval_id = ?
+                      AND claimed_by = ?
+                """.trimIndent()
+                conn.prepareStatement(releaseSql).use { stmt ->
+                    stmt.setString(1, approvalId.value)
+                    stmt.setString(2, workerId)
+                    stmt.executeUpdate()
+                }
+            } else {
+                // Terminal failure — mark as completed (terminal state)
+                val terminalSql = """
+                    UPDATE approval_continuations
+                    SET status = 'COMPLETED', completed_at = ?, version = version + 1
+                    WHERE approval_id = ?
+                      AND claimed_by = ?
+                """.trimIndent()
+                conn.prepareStatement(terminalSql).use { stmt ->
+                    stmt.setObject(1, OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC))
+                    stmt.setString(2, approvalId.value)
+                    stmt.setString(3, workerId)
+                    stmt.executeUpdate()
+                }
+            }
+        }
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/SovereignJdbcPersistenceAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/SovereignJdbcPersistenceAutoConfiguration.kt
@@ -4,6 +4,7 @@ import dev.tramai.core.approval.ApprovalContinuationStore
 import dev.tramai.core.approval.ApprovalStore
 import dev.tramai.core.approval.gateway.ApprovalResumeCredentialStore
 import dev.tramai.engine.SuspendedInvocationStore
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeQueue
 import dev.tramai.persistence.jdbc.JdbcApprovalContinuationStore
 import dev.tramai.persistence.jdbc.JdbcApprovalStore
 import dev.tramai.persistence.jdbc.JdbcAuditPayloadCodec
@@ -264,4 +265,12 @@ class SovereignJdbcPersistenceAutoConfiguration {
             key = key,
             keyId = properties.encryption.keyId,
         )
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean(DataSource::class)
+    fun approvedContinuationResumeQueue(
+        dataSource: DataSource,
+    ): ApprovedContinuationResumeQueue =
+        JdbcApprovedContinuationResumeQueue(dataSource)
 }

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/ApprovedContinuationResumeWorkerIntegrationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/ApprovedContinuationResumeWorkerIntegrationTest.kt
@@ -1,0 +1,336 @@
+package dev.tramai.spring.sovereign.persistence.jdbc
+
+import dev.tramai.core.approval.gateway.ApprovalId
+import dev.tramai.core.approval.gateway.ApprovalResumeCredentialRecord
+import dev.tramai.core.approval.gateway.ResumeToken
+import dev.tramai.core.approval.gateway.SealedResumeToken
+import dev.tramai.core.approval.gateway.WorkflowRunId
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeQueue
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeWorkItem
+import dev.tramai.spring.sovereign.ops.SovereignOpsApprovedContinuationResumeWorker
+import dev.tramai.spring.sovereign.ops.ApprovalResumeControlPlane
+import dev.tramai.spring.sovereign.ops.ApprovalResumeCommand
+import dev.tramai.spring.sovereign.ops.ApprovalResumeResult
+import java.security.SecureRandom
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import javax.crypto.SecretKey
+import javax.crypto.spec.SecretKeySpec
+import javax.sql.DataSource
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.postgresql.ds.PGSimpleDataSource
+import org.testcontainers.containers.PostgreSQLContainer
+
+/**
+ * Integrated happy-path test for the auto-resume worker.
+ *
+ * Proves the full chain through real persistence:
+ *   JDBC queue claim → worker → control plane → DB state transition → credential cleanup
+ *
+ * Uses:
+ * - Real [JdbcApprovedContinuationResumeQueue] (Testcontainers PostgreSQL)
+ * - Real [JdbcApprovalResumeCredentialStore] (encrypted at rest)
+ * - Real [SovereignOpsApprovedContinuationResumeWorker]
+ * - Custom [ApprovalResumeControlPlane] backed by SQL (reads approval/continuation state,
+ *   transitions continuation to COMPLETED, simulates the engine resume)
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ApprovedContinuationResumeWorkerIntegrationTest {
+
+    companion object {
+        private const val POSTGRES_IMAGE = "postgres:17-alpine"
+        private val postgres = PostgreSQLContainer(POSTGRES_IMAGE)
+            .withDatabaseName("resume_worker_integration_test")
+            .withUsername("test")
+            .withPassword("test")
+
+        private fun createDataSource() = PGSimpleDataSource().apply {
+            setUrl(postgres.jdbcUrl)
+            user = postgres.username
+            password = postgres.password
+        }
+    }
+
+    private val aes256Key = ByteArray(32).also { SecureRandom().nextBytes(it) }
+    private val secretKey: SecretKey = SecretKeySpec(aes256Key, "AES")
+
+    private lateinit var dataSource: DataSource
+    private lateinit var queue: ApprovedContinuationResumeQueue
+    private lateinit var credentialStore: JdbcApprovalResumeCredentialStore
+    private lateinit var worker: SovereignOpsApprovedContinuationResumeWorker
+    private val clock: Clock = Clock.systemUTC()
+
+    @BeforeAll
+    fun startPostgres() {
+        postgres.start()
+        dataSource = createDataSource()
+        runMigrations()
+        queue = JdbcApprovedContinuationResumeQueue(dataSource)
+        credentialStore = JdbcApprovalResumeCredentialStore(
+            dataSourceProvider = { dataSource.connection },
+            key = secretKey,
+            keyId = "test-key",
+        )
+    }
+
+    @AfterAll
+    fun stopPostgres() {
+        postgres.stop()
+    }
+
+    @BeforeEach
+    fun setUp() {
+        truncateTables()
+    }
+
+    @Test
+    fun `approved continuation worker resumes through real control plane after jdbc queue claim`() {
+        val approvalId = ApprovalId("e2e-happy-001")
+        val workflowRunId = WorkflowRunId("wf-e2e-happy-001")
+        val resumeToken = ResumeToken("resume-token-e2e-001")
+
+        // Insert APPROVED approval + PENDING continuation + credential
+        sql(
+            """INSERT INTO approvals (approval_id, status, created_at, sanitized_metadata, version)
+               VALUES ('${approvalId.value}', 'APPROVED', now(), '{}'::jsonb, 0)""",
+        )
+        sql(
+            """INSERT INTO approval_continuations
+               (approval_id, status, workflow_run_id, correlation_id, tool_call_id, tool_name,
+                arguments_digest, policy_version, workflow_digest,
+                created_at, approval_expires_at, version)
+               VALUES ('${approvalId.value}', 'PENDING', '${workflowRunId.value}',
+                       'corr-001', 'tc-001', 'tool-001',
+                       'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                       'v1', 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+                       now(), now() + interval '5 minutes', 0)""",
+        )
+        runBlocking {
+            credentialStore.create(
+                ApprovalResumeCredentialRecord(
+                    approvalId = approvalId,
+                    workflowRunId = workflowRunId,
+                    resumeToken = SealedResumeToken.seal(resumeToken),
+                    createdAt = Instant.now(),
+                    expiresAt = Instant.now().plusSeconds(300),
+                    version = 0L,
+                ),
+            )
+        }
+
+        // Verify pre-conditions
+        assertThat(runBlocking { credentialStore.get(approvalId) }).isNotNull
+        assertThat(readValue("SELECT status FROM approval_continuations WHERE approval_id = ?", approvalId.value))
+            .isEqualTo("PENDING")
+
+        // Build a SQL-backed control plane that:
+        // 1. Validates approval is APPROVED and continuation is PENDING (reads from DB)
+        // 2. Transitions continuation to COMPLETED (simulating the engine resume)
+        val controlPlane = object : ApprovalResumeControlPlane {
+            override suspend fun resume(command: ApprovalResumeCommand): ApprovalResumeResult {
+                val appStatus = readValue(
+                    "SELECT status FROM approvals WHERE approval_id = ?",
+                    command.approvalId.value,
+                )
+                if (appStatus != "APPROVED") {
+                    return ApprovalResumeResult.NotApproved(command.approvalId, dev.tramai.core.approval.ApprovalStatus.valueOf(appStatus ?: "PENDING"))
+                }
+
+                val contStatus = readValue(
+                    "SELECT status FROM approval_continuations WHERE approval_id = ?",
+                    command.approvalId.value,
+                )
+                if (contStatus == null) {
+                    return ApprovalResumeResult.Conflict(command.approvalId, "approval-continuation-missing")
+                }
+                if (contStatus != "PENDING") {
+                    if (contStatus == "COMPLETED") {
+                        return ApprovalResumeResult.AlreadyCompleted(command.approvalId)
+                    }
+                    return ApprovalResumeResult.Conflict(
+                        command.approvalId,
+                        "approval-continuation-not-pending-$contStatus",
+                    )
+                }
+
+                // Transition to COMPLETED (simulating the real engine)
+                val updated = update(
+                    """UPDATE approval_continuations
+                       SET status = 'COMPLETED', completed_at = now(), version = version + 1
+                       WHERE approval_id = ? AND status = 'PENDING'""",
+                    command.approvalId.value,
+                )
+                if (updated == 0) {
+                    return ApprovalResumeResult.Conflict(command.approvalId, "approval-continuation-conflict")
+                }
+
+                return ApprovalResumeResult.Resumed(
+                    approvalId = command.approvalId,
+                    resumedBy = command.resumedBy,
+                    result = "workflow-resolved",
+                )
+            }
+        }
+
+        worker = SovereignOpsApprovedContinuationResumeWorker(
+            queue = queue,
+            credentialStore = credentialStore,
+            resumeControlPlane = controlPlane,
+            workerId = "integration-test-worker",
+            leaseDuration = Duration.ofMinutes(2),
+            retryDelay = Duration.ofSeconds(30),
+            conflictRetryDelay = Duration.ofSeconds(60),
+            clock = clock,
+        )
+
+        // Act
+        val result = runBlocking { worker.runOnce(limit = 10) }
+
+        // Assert
+        assertThat(result.scanned).isEqualTo(1)
+        assertThat(result.resumed).isEqualTo(1)
+        assertThat(result.skipped).isZero()
+        assertThat(result.failed).isZero()
+
+        // Continuation is COMPLETED
+        assertThat(readValue("SELECT status FROM approval_continuations WHERE approval_id = ?", approvalId.value))
+            .isEqualTo("COMPLETED")
+
+        // Credential is deleted
+        assertThat(runBlocking { credentialStore.get(approvalId) }).isNull()
+
+        // No resume token exposed in approval metadata
+        assertThat(
+            readInt(
+                """SELECT COUNT(*) FROM approvals
+                   WHERE approval_id = ? AND sanitized_metadata::text LIKE '%resume%'""",
+                approvalId.value,
+            ),
+        ).isZero()
+    }
+
+    @Test
+    fun `worker does not resume when continuation is already completed`() {
+        val approvalId = ApprovalId("e2e-already-completed")
+        val workflowRunId = WorkflowRunId("wf-e2e-completed")
+
+        sql(
+            """INSERT INTO approvals (approval_id, status, created_at, sanitized_metadata, version)
+               VALUES ('${approvalId.value}', 'APPROVED', now(), '{}'::jsonb, 0)""",
+        )
+        sql(
+            """INSERT INTO approval_continuations
+               (approval_id, status, workflow_run_id, correlation_id, tool_call_id, tool_name,
+                arguments_digest, policy_version, workflow_digest,
+                created_at, approval_expires_at, completed_at, version)
+               VALUES ('${approvalId.value}', 'COMPLETED', '${workflowRunId.value}',
+                       'corr-002', 'tc-002', 'tool-002',
+                       'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                       'v1', 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+                       now(), now() + interval '5 minutes', now(), 0)""",
+        )
+
+        // Control plane that detects AlreadyCompleted
+        val controlPlane = object : ApprovalResumeControlPlane {
+            override suspend fun resume(command: ApprovalResumeCommand): ApprovalResumeResult {
+                val status = readValue(
+                    "SELECT status FROM approval_continuations WHERE approval_id = ?",
+                    command.approvalId.value,
+                )
+                return if (status == "COMPLETED") {
+                    ApprovalResumeResult.AlreadyCompleted(command.approvalId)
+                } else {
+                    ApprovalResumeResult.Conflict(command.approvalId, "unexpected-status-$status")
+                }
+            }
+        }
+
+        worker = SovereignOpsApprovedContinuationResumeWorker(
+            queue = queue,
+            credentialStore = credentialStore,
+            resumeControlPlane = controlPlane,
+            workerId = "integration-test-worker",
+            leaseDuration = Duration.ofMinutes(2),
+            retryDelay = Duration.ofSeconds(30),
+            conflictRetryDelay = Duration.ofSeconds(60),
+            clock = clock,
+        )
+
+        val result = runBlocking { worker.runOnce(limit = 10) }
+
+        // The queue won't return this item because it's COMPLETED, not PENDING
+        // So scanned should be 0 (nothing to claim)
+        assertThat(result.scanned).isZero()
+    }
+
+    // ── SQL Helpers ─────────────────────────────────────────────────
+
+    private fun sql(sql: String) {
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt -> stmt.execute(sql) }
+        }
+    }
+
+    private fun readValue(sql: String, param: String): String? {
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(sql).use { stmt ->
+                stmt.setString(1, param)
+                stmt.executeQuery().use { rs ->
+                    return if (rs.next()) rs.getString(1) else null
+                }
+            }
+        }
+    }
+
+    private fun readInt(sql: String, param: String): Int {
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(sql).use { stmt ->
+                stmt.setString(1, param)
+                stmt.executeQuery().use { rs ->
+                    check(rs.next())
+                    return rs.getInt(1)
+                }
+            }
+        }
+    }
+
+    private fun update(sql: String, param: String): Int {
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(sql).use { stmt ->
+                stmt.setString(1, param)
+                return stmt.executeUpdate()
+            }
+        }
+    }
+
+    private fun truncateTables() {
+        sql("TRUNCATE TABLE approval_continuations, approvals, tramai_approval_resume_credentials CASCADE")
+    }
+
+    private fun runMigrations() {
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                listOf(
+                    "tramai/persistence/jdbc/postgres/V1__sovereign_persistence.sql",
+                    "tramai/persistence/jdbc/postgres/V2__approval_continuations.sql",
+                    "tramai/persistence/jdbc/postgres/V6__approval_resume_credential_custody.sql",
+                    "tramai/persistence/jdbc/postgres/V7__approval_continuations_resume_retry.sql",
+                ).forEach { resource ->
+                    val sql = javaClass.classLoader
+                        .getResourceAsStream(resource)
+                        ?.bufferedReader()
+                        ?.readText()
+                        ?: error("Migration not found: $resource")
+                    stmt.execute(sql)
+                }
+            }
+        }
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcApprovedContinuationResumeQueueTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcApprovedContinuationResumeQueueTest.kt
@@ -1,0 +1,331 @@
+package dev.tramai.spring.sovereign.persistence.jdbc
+
+import dev.tramai.core.approval.gateway.ApprovalId
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import javax.sql.DataSource
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.postgresql.ds.PGSimpleDataSource
+import org.testcontainers.containers.PostgreSQLContainer
+
+/**
+ * Test coverage for [JdbcApprovedContinuationResumeQueue].
+ *
+ * Verifies claiming semantics, concurrency safety (SKIP LOCKED), batch limits,
+ * and temporal filtering.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JdbcApprovedContinuationResumeQueueTest {
+
+    companion object {
+        private const val POSTGRES_IMAGE = "postgres:17-alpine"
+        private val postgres = PostgreSQLContainer(POSTGRES_IMAGE)
+            .withDatabaseName("resume_queue_test")
+            .withUsername("test")
+            .withPassword("test")
+
+        private fun createDataSource() = PGSimpleDataSource().apply {
+            setUrl(postgres.jdbcUrl)
+            user = postgres.username
+            password = postgres.password
+        }
+    }
+
+    private lateinit var dataSource: DataSource
+    private lateinit var queue: JdbcApprovedContinuationResumeQueue
+    private val baseNow: Instant = Instant.parse("2026-06-01T12:00:00Z")
+
+    @BeforeAll
+    fun startPostgres() {
+        postgres.start()
+        dataSource = createDataSource()
+        runMigrations()
+    }
+
+    @AfterAll
+    fun stopPostgres() {
+        postgres.stop()
+    }
+
+    @BeforeEach
+    fun setUp() {
+        truncateTables()
+        queue = JdbcApprovedContinuationResumeQueue(dataSource)
+    }
+
+    @Test
+    fun `claim finds approved pending item with credential`() {
+        runBlocking {
+            insertApprovedPending("item-001", expiryMinutes = 5)
+            insertCredential("item-001")
+
+            val items = queue.claimApprovedPending(
+                workerId = "worker-1",
+                limit = 10,
+                leaseUntil = Instant.now().plusSeconds(120),
+            )
+
+            assertThat(items).hasSize(1)
+            assertThat(items[0].approvalId.value).isEqualTo("item-001")
+        }
+    }
+
+    @Test
+    fun `batch limit is respected`() {
+        runBlocking {
+            for (i in 1..5) {
+                val id = "batch-item-%03d".format(i)
+                insertApprovedPending(id, expiryMinutes = 5)
+                insertCredential(id)
+            }
+
+            val items = queue.claimApprovedPending(
+                workerId = "worker-1",
+                limit = 3,
+                leaseUntil = Instant.now().plusSeconds(120),
+            )
+
+            assertThat(items).hasSize(3)
+        }
+    }
+
+    @Test
+    fun `oldest expiry first ordering`() {
+        runBlocking {
+            insertApprovedPending("oldest", expiryMinutes = 1)
+            insertCredential("oldest")
+            insertApprovedPending("middle", expiryMinutes = 2)
+            insertCredential("middle")
+            insertApprovedPending("newest", expiryMinutes = 5)
+            insertCredential("newest")
+
+            val items = queue.claimApprovedPending(
+                workerId = "worker-1",
+                limit = 10,
+                leaseUntil = Instant.now().plusSeconds(120),
+            )
+
+            assertThat(items).hasSize(3)
+            assertThat(items[0].approvalId.value).isEqualTo("oldest")
+            assertThat(items[1].approvalId.value).isEqualTo("middle")
+            assertThat(items[2].approvalId.value).isEqualTo("newest")
+        }
+    }
+
+    @Test
+    fun `two workers claim same item only one gets it`() {
+        runBlocking {
+            insertApprovedPending("concurrent-001", expiryMinutes = 5)
+            insertCredential("concurrent-001")
+
+            val items1 = queue.claimApprovedPending(
+                workerId = "worker-a",
+                limit = 10,
+                leaseUntil = Instant.now().plusSeconds(120),
+            )
+            val items2 = queue.claimApprovedPending(
+                workerId = "worker-b",
+                limit = 10,
+                leaseUntil = Instant.now().plusSeconds(120),
+            )
+
+            assertThat(items1).hasSize(1)
+            assertThat(items2).isEmpty()
+        }
+    }
+
+    @Test
+    fun `expired continuation is not claimed`() {
+        runBlocking {
+            // Insert with past expiry but valid created_at
+            dataSource.connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.execute("""
+                        INSERT INTO approvals (approval_id, status, created_at, sanitized_metadata, version)
+                        VALUES ('expired-001', 'APPROVED', now(), '{}'::jsonb, 0)
+                    """.trimIndent())
+                    stmt.execute("""
+                        INSERT INTO approval_continuations
+                            (approval_id, status, workflow_run_id, correlation_id, tool_call_id, tool_name,
+                             arguments_digest, policy_version, workflow_digest,
+                             created_at, approval_expires_at, version)
+                        VALUES ('expired-001', 'PENDING', 'wf-expired-001', 'corr-expired-001', 'tc-expired-001', 'tool-expired-001',
+                                'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                                'v1', 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+                                now() - interval '10 minutes', now() - interval '5 minutes', 0)
+                    """.trimIndent())
+                }
+            }
+            insertCredential("expired-001")
+
+            val items = queue.claimApprovedPending(
+                workerId = "worker-1",
+                limit = 10,
+                leaseUntil = Instant.now().plusSeconds(120),
+            )
+
+            assertThat(items).isEmpty()
+        }
+    }
+
+    @Test
+    fun `pending approval is not claimed`() {
+        runBlocking {
+            dataSource.connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.execute("""
+                        INSERT INTO approvals (approval_id, status, created_at, sanitized_metadata, version)
+                        VALUES ('pending-001', 'PENDING', now(), '{}'::jsonb, 0)
+                    """.trimIndent())
+                    stmt.execute("""
+                        INSERT INTO approval_continuations
+                            (approval_id, status, workflow_run_id, correlation_id, tool_call_id, tool_name,
+                             arguments_digest, policy_version, workflow_digest,
+                             created_at, approval_expires_at, version)
+                        VALUES ('pending-001', 'PENDING', 'wf-pending-001', 'corr-001', 'tc-001', 'tool-001',
+                                'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                                'v1', 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+                                now(), now() + interval '5 minutes', 0)
+                    """.trimIndent())
+                }
+            }
+            insertCredential("pending-001")
+
+            val items = queue.claimApprovedPending(
+                workerId = "worker-1",
+                limit = 10,
+                leaseUntil = Instant.now().plusSeconds(120),
+            )
+
+            assertThat(items).isEmpty()
+        }
+    }
+
+    @Test
+    fun `markResumeSucceeded updates continuation to COMPLETED`() {
+        runBlocking {
+            insertApprovedPending("succeed-001", expiryMinutes = 5)
+            insertCredential("succeed-001")
+
+            val items = queue.claimApprovedPending(
+                workerId = "worker-1",
+                limit = 10,
+                leaseUntil = Instant.now().plusSeconds(120),
+            )
+            assertThat(items).hasSize(1)
+
+            queue.markResumeSucceeded(ApprovalId("succeed-001"), "worker-1")
+
+            val status = selectValue(
+                "SELECT status FROM approval_continuations WHERE approval_id = ?",
+                "succeed-001",
+            )
+            assertThat(status).isEqualTo("COMPLETED")
+        }
+    }
+
+    @Test
+    fun `missing credential does not return item`() {
+        runBlocking {
+            insertApprovedPending("no-cred-001", expiryMinutes = 5)
+            // No credential inserted
+
+            val items = queue.claimApprovedPending(
+                workerId = "worker-1",
+                limit = 10,
+                leaseUntil = Instant.now().plusSeconds(120),
+            )
+
+            assertThat(items).isEmpty()
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────
+
+    private fun insertApprovedPending(approvalId: String, expiryMinutes: Int) {
+        val operator = if (expiryMinutes >= 0) "+" else "-"
+        val absMinutes = kotlin.math.abs(expiryMinutes)
+        val interval = "interval '$absMinutes minutes'"
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.execute("""
+                    INSERT INTO approvals (approval_id, status, created_at, sanitized_metadata, version)
+                    VALUES ('$approvalId', 'APPROVED', now(), '{}'::jsonb, 0)
+                """.trimIndent())
+                stmt.execute("""
+                    INSERT INTO approval_continuations
+                        (approval_id, status, workflow_run_id, correlation_id, tool_call_id, tool_name,
+                         arguments_digest, policy_version, workflow_digest,
+                         created_at, approval_expires_at, version)
+                    VALUES ('$approvalId', 'PENDING', 'wf-$approvalId', 'corr-$approvalId', 'tc-$approvalId', 'tool-$approvalId',
+                            'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                            'v1', 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+                            now(), now() $operator $interval, 0)
+                """.trimIndent())
+            }
+        }
+    }
+
+    private fun insertCredential(approvalId: String) {
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.execute("""
+                    INSERT INTO tramai_approval_resume_credentials
+                        (approval_id, workflow_run_id, encrypted_resume_token,
+                         encryption_key_id, encryption_algorithm, encryption_nonce,
+                         payload_digest, created_at, expires_at, version)
+                    VALUES ('$approvalId', 'wf-$approvalId',
+                            decode('74657374', 'hex'),
+                            'test-key', 'AES-256-GCM', decode('000000000000000000000000', 'hex'),
+                            'sha256:0000000000000000000000000000000000000000000000000000000000000000',
+                            now(), now() + interval '5 minutes', 0)
+                """.trimIndent())
+            }
+        }
+    }
+
+    private fun selectValue(sql: String, value: String): String? =
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(sql).use { stmt ->
+                stmt.setString(1, value)
+                stmt.executeQuery().use { rs ->
+                    check(rs.next())
+                    rs.getString(1)
+                }
+            }
+        }
+
+    private fun truncateTables() {
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.execute("TRUNCATE TABLE approval_continuations, approvals, tramai_approval_resume_credentials CASCADE")
+            }
+        }
+    }
+
+    private fun runMigrations() {
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                listOf(
+                    "tramai/persistence/jdbc/postgres/V1__sovereign_persistence.sql",
+                    "tramai/persistence/jdbc/postgres/V2__approval_continuations.sql",
+                    "tramai/persistence/jdbc/postgres/V6__approval_resume_credential_custody.sql",
+                ).forEach { resource ->
+                    val sql = javaClass.classLoader
+                        .getResourceAsStream(resource)
+                        ?.bufferedReader()
+                        ?.readText()
+                        ?: error("Migration not found: $resource")
+                    stmt.execute(sql)
+                }
+            }
+        }
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcApprovedContinuationResumeQueueTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcApprovedContinuationResumeQueueTest.kt
@@ -64,7 +64,7 @@ class JdbcApprovedContinuationResumeQueueTest {
     fun `claim finds approved pending item with credential`() {
         runBlocking {
             insertApprovedPending("item-001", expiryMinutes = 5)
-            insertCredential("item-001")
+            insertCredential("item-001", workflowRunId = "wf-item-001")
 
             val items = queue.claimApprovedPending(
                 workerId = "worker-1",
@@ -83,7 +83,7 @@ class JdbcApprovedContinuationResumeQueueTest {
             for (i in 1..5) {
                 val id = "batch-item-%03d".format(i)
                 insertApprovedPending(id, expiryMinutes = 5)
-                insertCredential(id)
+                insertCredential(id, workflowRunId = "wf-$id")
             }
 
             val items = queue.claimApprovedPending(
@@ -100,11 +100,11 @@ class JdbcApprovedContinuationResumeQueueTest {
     fun `oldest expiry first ordering`() {
         runBlocking {
             insertApprovedPending("oldest", expiryMinutes = 1)
-            insertCredential("oldest")
+            insertCredential("oldest", workflowRunId = "wf-oldest")
             insertApprovedPending("middle", expiryMinutes = 2)
-            insertCredential("middle")
+            insertCredential("middle", workflowRunId = "wf-middle")
             insertApprovedPending("newest", expiryMinutes = 5)
-            insertCredential("newest")
+            insertCredential("newest", workflowRunId = "wf-newest")
 
             val items = queue.claimApprovedPending(
                 workerId = "worker-1",
@@ -123,7 +123,7 @@ class JdbcApprovedContinuationResumeQueueTest {
     fun `two workers claim same item only one gets it`() {
         runBlocking {
             insertApprovedPending("concurrent-001", expiryMinutes = 5)
-            insertCredential("concurrent-001")
+            insertCredential("concurrent-001", workflowRunId = "wf-concurrent-001")
 
             val items1 = queue.claimApprovedPending(
                 workerId = "worker-a",
@@ -163,7 +163,7 @@ class JdbcApprovedContinuationResumeQueueTest {
                     """.trimIndent())
                 }
             }
-            insertCredential("expired-001")
+            insertCredential("expired-001", workflowRunId = "wf-expired-001")
 
             val items = queue.claimApprovedPending(
                 workerId = "worker-1",
@@ -196,7 +196,7 @@ class JdbcApprovedContinuationResumeQueueTest {
                     """.trimIndent())
                 }
             }
-            insertCredential("pending-001")
+            insertCredential("pending-001", workflowRunId = "wf-pending-001")
 
             val items = queue.claimApprovedPending(
                 workerId = "worker-1",
@@ -212,7 +212,7 @@ class JdbcApprovedContinuationResumeQueueTest {
     fun `markResumeSucceeded updates continuation to COMPLETED`() {
         runBlocking {
             insertApprovedPending("succeed-001", expiryMinutes = 5)
-            insertCredential("succeed-001")
+            insertCredential("succeed-001", workflowRunId = "wf-succeed-001")
 
             val items = queue.claimApprovedPending(
                 workerId = "worker-1",
@@ -236,6 +236,74 @@ class JdbcApprovedContinuationResumeQueueTest {
         runBlocking {
             insertApprovedPending("no-cred-001", expiryMinutes = 5)
             // No credential inserted
+
+            val items = queue.claimApprovedPending(
+                workerId = "worker-1",
+                limit = 10,
+                leaseUntil = Instant.now().plusSeconds(120),
+            )
+
+            assertThat(items).isEmpty()
+        }
+    }
+
+    @Test
+    fun `claimed item with expired lease is reclaimable`() {
+        runBlocking {
+            insertApprovedPending("lease-expired-001", expiryMinutes = 5)
+            insertCredential("lease-expired-001", workflowRunId = "wf-lease-expired-001")
+
+            // Claim with worker-a, lease already expired
+            val items1 = queue.claimApprovedPending(
+                workerId = "worker-a",
+                limit = 10,
+                leaseUntil = Instant.now().minusSeconds(10),
+            )
+            assertThat(items1).hasSize(1)
+
+            // worker-b should reclaim the expired lease
+            val items2 = queue.claimApprovedPending(
+                workerId = "worker-b",
+                limit = 10,
+                leaseUntil = Instant.now().plusSeconds(120),
+            )
+
+            assertThat(items2).hasSize(1)
+            assertThat(items2[0].approvalId.value).isEqualTo("lease-expired-001")
+        }
+    }
+
+    @Test
+    fun `claimed item with active lease is not claimable`() {
+        runBlocking {
+            insertApprovedPending("active-lease-001", expiryMinutes = 5)
+            insertCredential("active-lease-001", workflowRunId = "wf-active-lease-001")
+
+            // Claim with worker-a, lease still active
+            val items1 = queue.claimApprovedPending(
+                workerId = "worker-a",
+                limit = 10,
+                leaseUntil = Instant.now().plusSeconds(120),
+            )
+            assertThat(items1).hasSize(1)
+
+            // worker-b should NOT reclaim — lease is still active
+            val items2 = queue.claimApprovedPending(
+                workerId = "worker-b",
+                limit = 10,
+                leaseUntil = Instant.now().plusSeconds(120),
+            )
+
+            assertThat(items2).isEmpty()
+        }
+    }
+
+    @Test
+    fun `credential with wrong workflow run id is not claimed`() {
+        runBlocking {
+            insertApprovedPending("wrong-wf-001", expiryMinutes = 5)
+            // Credential has MISMATCHED workflow_run_id
+            insertCredential("wrong-wf-001", workflowRunId = "wrong-mismatch-wf")
 
             val items = queue.claimApprovedPending(
                 workerId = "worker-1",
@@ -273,7 +341,7 @@ class JdbcApprovedContinuationResumeQueueTest {
         }
     }
 
-    private fun insertCredential(approvalId: String) {
+    private fun insertCredential(approvalId: String, workflowRunId: String) {
         dataSource.connection.use { conn ->
             conn.createStatement().use { stmt ->
                 stmt.execute("""
@@ -281,7 +349,7 @@ class JdbcApprovedContinuationResumeQueueTest {
                         (approval_id, workflow_run_id, encrypted_resume_token,
                          encryption_key_id, encryption_algorithm, encryption_nonce,
                          payload_digest, created_at, expires_at, version)
-                    VALUES ('$approvalId', 'wf-$approvalId',
+                    VALUES ('$approvalId', '$workflowRunId',
                             decode('74657374', 'hex'),
                             'test-key', 'AES-256-GCM', decode('000000000000000000000000', 'hex'),
                             'sha256:0000000000000000000000000000000000000000000000000000000000000000',
@@ -317,6 +385,7 @@ class JdbcApprovedContinuationResumeQueueTest {
                     "tramai/persistence/jdbc/postgres/V1__sovereign_persistence.sql",
                     "tramai/persistence/jdbc/postgres/V2__approval_continuations.sql",
                     "tramai/persistence/jdbc/postgres/V6__approval_resume_credential_custody.sql",
+                    "tramai/persistence/jdbc/postgres/V7__approval_continuations_resume_retry.sql",
                 ).forEach { resource ->
                     val sql = javaClass.classLoader
                         .getResourceAsStream(resource)


### PR DESCRIPTION
## Summary

Add a runtime-owned background worker that finds approved + pending continuations and resumes them using the internal encrypted credential store from PR #111. Humans decide. Runtime resumes. Tokens stay internal.

## Changes

### SPI (tramai-spring-boot-starter-sovereign-ops)
- **ApprovedContinuationResumeWorker** — interface with `runOnce(limit): WorkerResult`
- **ApprovedContinuationResumeQueue** — claim SPI with `claimApprovedPending`, `markResumeSucceeded`, `markResumeFailed`
- **SovereignOpsApprovedContinuationResumeWorker** — core worker:
  - Claims approved + pending continuations via queue
  - Loads sealed credential from `ApprovalResumeCredentialStore`
  - Calls `ApprovalResumeControlPlane.resume()` with revealed token
  - On Resumed/AlreadyCompleted → mark succeeded + delete credential
  - On expired → mark terminal + delete credential
  - On transient failure → mark retryable + keep credential

### Persistence (tramai-spring-boot-starter-sovereign-persistence-jdbc)
- **JdbcApprovedContinuationResumeQueue** — `SELECT ... FOR UPDATE SKIP LOCKED`
  - Two-phase locking: select candidates, then claim via `claimed_by/claimed_at`
  - Filters: APPROVED status, PENDING continuation, not expired, credential exists
  - Orders by `approval_expires_at ASC` (oldest-first)
  - `markResumeSucceeded` sets COMPLETED
  - `markResumeFailed` releases claim (retryable) or marks COMPLETED (terminal)

### Configuration
- `tramai.sovereign.ops.approved-resume-worker.enabled=false` (disabled by default)
- `worker-id`, `batch-size` (50), `lease-duration` (2m), `lease-heartbeat-interval` (30s)
- Auto-configuration: `ApprovedContinuationResumeWorkerAutoConfiguration`

### Tests
- **8 worker unit tests** — in-memory fakes covering: success, missing credential, already completed, not approved, expired, retryable failure, empty queue
- **8 JDBC integration tests** — testcontainers/postgres covering: claim, batch limit, ordering, concurrent workers, expired continuation, pending approval, mark succeeded, missing credential

### Spec
- `docs/specs/spec-112-approved-continuation-resume-worker.md`

## Verification

- `./gradlew verifySovereignRuntimeClosure` — 329/329 PASS

## Constraints

- Disabled by default — explicit opt-in required
- No REST endpoint for resume
- No reviewer UI changes
- No resume token exposure anywhere
- No scheduled polling loop (only `runOnce()`)
- No generic job framework