### PR TITLE
feat(workflow): add approved resume queue status snapshot

### DIFF
--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedContinuationResumeWorkerHealthIndicator.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedContinuationResumeWorkerHealthIndicator.kt
@@ -1,11 +1,16 @@
 package dev.tramai.spring.sovereign.ops.actuator
 
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeQueueStatusStore
 import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeWorkerStatusStore
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.springframework.boot.actuate.health.Health
 import org.springframework.boot.actuate.health.HealthIndicator
 
 class ApprovedContinuationResumeWorkerHealthIndicator(
     private val statusStore: ApprovedContinuationResumeWorkerStatusStore,
+    private val queueStatusStore: ApprovedContinuationResumeQueueStatusStore? = null,
 ) : HealthIndicator {
 
     override fun health(): Health {
@@ -19,7 +24,7 @@ class ApprovedContinuationResumeWorkerHealthIndicator(
             else -> Health.up()
         }
 
-        return builder
+        val healthBuilder = builder
             .withDetail("enabled", snapshot.enabled)
             .withDetail("lifecycleEnabled", snapshot.lifecycleEnabled)
             .withDetail("running", snapshot.running)
@@ -33,7 +38,28 @@ class ApprovedContinuationResumeWorkerHealthIndicator(
             .withDetailIfPresent("lastFailureAt", snapshot.lastFailureAt?.toString())
             .withDetail("totalCyclesCompleted", snapshot.totalCyclesCompleted)
             .withDetail("totalCyclesFailed", snapshot.totalCyclesFailed)
-            .build()
+
+        if (queueStatusStore != null) {
+            try {
+                val queueSnapshot = runBlocking {
+                    withTimeout(5_000) {
+                        queueStatusStore.snapshot()
+                    }
+                }
+                healthBuilder
+                    .withDetail("eligibleNow", queueSnapshot.eligibleNow)
+                    .withDetail("delayedRetry", queueSnapshot.delayedRetry)
+                    .withDetail("activeLeases", queueSnapshot.activeLeases)
+                    .withDetail("expiredLeases", queueSnapshot.expiredLeases)
+                    .withDetail("terminalFailures", queueSnapshot.terminalFailures)
+                    .withDetailIfPresent("oldestEligibleAgeSeconds", queueSnapshot.oldestEligibleAgeSeconds)
+                    .withDetailIfPresent("oldestRetryDueInSeconds", queueSnapshot.oldestRetryDueInSeconds)
+            } catch (_: Exception) {
+                healthBuilder.withDetail("queueStatusError", "snapshot-failed")
+            }
+        }
+
+        return healthBuilder.build()
     }
 
     private fun Health.Builder.withDetailIfPresent(

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsActuatorAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsActuatorAutoConfiguration.kt
@@ -1,8 +1,10 @@
 package dev.tramai.spring.sovereign.ops.actuator
 
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeQueueStatusStore
 import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeWorkerStatusStore
 import dev.tramai.spring.sovereign.ops.SovereignOpsAutoConfiguration
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerStatusStore
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint
 import org.springframework.boot.actuate.health.HealthIndicator
 import org.springframework.boot.autoconfigure.AutoConfiguration
@@ -74,6 +76,10 @@ class SovereignOpsActuatorAutoConfiguration {
     )
     fun approvedContinuationResumeWorkerHealthIndicator(
         statusStore: ApprovedContinuationResumeWorkerStatusStore,
+        queueStatusStore: ObjectProvider<ApprovedContinuationResumeQueueStatusStore>,
     ): ApprovedContinuationResumeWorkerHealthIndicator =
-        ApprovedContinuationResumeWorkerHealthIndicator(statusStore)
+        ApprovedContinuationResumeWorkerHealthIndicator(
+            statusStore = statusStore,
+            queueStatusStore = queueStatusStore.ifAvailable,
+        )
 }

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedContinuationResumeWorkerHealthIndicatorTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedContinuationResumeWorkerHealthIndicatorTest.kt
@@ -1,5 +1,7 @@
 package dev.tramai.spring.sovereign.ops.actuator
 
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeQueueSnapshot
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeQueueStatusStore
 import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeWorkerResult
 import dev.tramai.spring.sovereign.ops.InMemoryApprovedContinuationResumeWorkerStatusStore
 import dev.tramai.spring.sovereign.ops.SovereignOpsApprovedResumeWorkerProperties
@@ -119,6 +121,64 @@ class ApprovedContinuationResumeWorkerHealthIndicatorTest {
         )
     }
 
+    @Test
+    fun `health includes queue counts when queue status store is provided`() {
+        val store = statusStore(lifecycleEnabled = true)
+        store.markLifecycleStarted()
+        store.recordCycleCompleted(
+            workerId = "worker-a",
+            result = successfulSummary(),
+            duration = Duration.ofMillis(20),
+        )
+        val queueStore = FakeApprovedContinuationResumeQueueStatusStore(
+            ApprovedContinuationResumeQueueSnapshot(
+                eligibleNow = 3,
+                delayedRetry = 1,
+                activeLeases = 0,
+                expiredLeases = 0,
+                terminalFailures = 0,
+                oldestEligibleAgeSeconds = 42,
+                oldestRetryDueInSeconds = null,
+                lastErrorCodeCounts = mapOf("IllegalStateException" to 2L),
+            ),
+        )
+
+        val health = ApprovedContinuationResumeWorkerHealthIndicator(
+            statusStore = store,
+            queueStatusStore = queueStore,
+        ).health()
+
+        assertThat(health.status).isEqualTo(Status.UP)
+        assertThat(health.details["eligibleNow"]).isEqualTo(3L)
+        assertThat(health.details["oldestEligibleAgeSeconds"]).isEqualTo(42L)
+        assertThat(health.details).doesNotContainKeys("lastErrorCodeCounts")
+    }
+
+    @Test
+    fun `health does not include last error code counts from queue snapshot`() {
+        val store = statusStore(lifecycleEnabled = true)
+        store.markLifecycleStarted()
+        val queueStore = FakeApprovedContinuationResumeQueueStatusStore(
+            ApprovedContinuationResumeQueueSnapshot(
+                eligibleNow = 1,
+                delayedRetry = 0,
+                activeLeases = 0,
+                expiredLeases = 0,
+                terminalFailures = 1,
+                oldestEligibleAgeSeconds = null,
+                oldestRetryDueInSeconds = null,
+                lastErrorCodeCounts = mapOf("TimeoutException" to 1L),
+            ),
+        )
+
+        val health = ApprovedContinuationResumeWorkerHealthIndicator(
+            statusStore = store,
+            queueStatusStore = queueStore,
+        ).health()
+
+        assertThat(health.details).doesNotContainKey("lastErrorCodeCounts")
+    }
+
     private fun statusStore(lifecycleEnabled: Boolean): InMemoryApprovedContinuationResumeWorkerStatusStore =
         InMemoryApprovedContinuationResumeWorkerStatusStore(
             SovereignOpsApprovedResumeWorkerProperties(
@@ -128,4 +188,13 @@ class ApprovedContinuationResumeWorkerHealthIndicatorTest {
                 interval = Duration.ofSeconds(7),
             ),
         )
+
+    private fun successfulSummary(): ApprovedContinuationResumeWorkerResult =
+        ApprovedContinuationResumeWorkerResult(4, 2, 1, 1)
+
+    private class FakeApprovedContinuationResumeQueueStatusStore(
+        private val snapshot: ApprovedContinuationResumeQueueSnapshot,
+    ) : ApprovedContinuationResumeQueueStatusStore {
+        override suspend fun snapshot(now: java.time.Instant): ApprovedContinuationResumeQueueSnapshot = snapshot
+    }
 }

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovedContinuationResumeQueueSnapshot.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovedContinuationResumeQueueSnapshot.kt
@@ -1,0 +1,32 @@
+package dev.tramai.spring.sovereign.ops
+
+/**
+ * Sanitised aggregated snapshot of the approved-continuation resume queue.
+ *
+ * Contains only counts and safe scalar values — no approval IDs,
+ * workflow run IDs, resume tokens, metadata, or raw error messages.
+ *
+ * Field semantics mirror the eligibility rules in
+ * [dev.tramai.spring.sovereign.persistence.jdbc.JdbcApprovedContinuationResumeQueue.claimApprovedPending] —
+ * approved approval + pending continuation + valid credential +
+ * non-expired + lease/reclaim eligibility + retry due.
+ *
+ * @property eligibleNow items that can be claimed right now.
+ * @property delayedRetry items waiting for retry backoff.
+ * @property activeLeases items claimed with non-expired lease.
+ * @property expiredLeases items claimed with expired lease (reclaimable).
+ * @property terminalFailures continuations cancelled with a resume error code.
+ * @property oldestEligibleAgeSeconds age in seconds of the oldest eligible item, or null if none.
+ * @property oldestRetryDueInSeconds seconds until the oldest retry is due, or null if none.
+ * @property lastErrorCodeCounts safe reason code → count (class names only, no messages).
+ */
+data class ApprovedContinuationResumeQueueSnapshot(
+    val eligibleNow: Long,
+    val delayedRetry: Long,
+    val activeLeases: Long,
+    val expiredLeases: Long,
+    val terminalFailures: Long,
+    val oldestEligibleAgeSeconds: Long?,
+    val oldestRetryDueInSeconds: Long?,
+    val lastErrorCodeCounts: Map<String, Long>,
+)

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovedContinuationResumeQueueStatusStore.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovedContinuationResumeQueueStatusStore.kt
@@ -1,0 +1,17 @@
+package dev.tramai.spring.sovereign.ops
+
+import java.time.Instant
+
+/**
+ * Read-only SPI for inspecting the approved continuation resume backlog.
+ *
+ * Provides aggregated counts and safe diagnostic data without exposing
+ * approval IDs, workflow run IDs, resume tokens, or raw error messages.
+ */
+interface ApprovedContinuationResumeQueueStatusStore {
+
+    /**
+     * Return a snapshot of the resume queue state at [now].
+     */
+    suspend fun snapshot(now: Instant = Instant.now()): ApprovedContinuationResumeQueueSnapshot
+}

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcApprovedContinuationResumeQueueStatusStore.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcApprovedContinuationResumeQueueStatusStore.kt
@@ -1,0 +1,227 @@
+package dev.tramai.spring.sovereign.persistence.jdbc
+
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeQueueSnapshot
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeQueueStatusStore
+import java.sql.Connection
+import java.time.Instant
+import java.time.ZoneOffset
+import javax.sql.DataSource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class JdbcApprovedContinuationResumeQueueStatusStore(
+    private val dataSource: DataSource,
+) : ApprovedContinuationResumeQueueStatusStore {
+
+    override suspend fun snapshot(now: Instant): ApprovedContinuationResumeQueueSnapshot =
+        withContext(Dispatchers.IO) {
+            dataSource.connection.use { conn ->
+                val snapshotNow = now.atOffset(ZoneOffset.UTC)
+                val eligibleNow = countEligibleNow(conn, snapshotNow)
+                val delayedRetry = countDelayedRetry(conn, snapshotNow)
+                val activeLeases = countActiveLeases(conn, snapshotNow)
+                val expiredLeases = countExpiredLeases(conn, snapshotNow)
+                val terminalFailures = countTerminalFailures(conn)
+                val oldestEligibleAgeSeconds = oldestEligibleAgeSeconds(conn, snapshotNow)
+                val oldestRetryDueInSeconds = oldestRetryDueInSeconds(conn, snapshotNow)
+                val lastErrorCodeCounts = lastErrorCodeCounts(conn)
+
+                ApprovedContinuationResumeQueueSnapshot(
+                    eligibleNow = eligibleNow,
+                    delayedRetry = delayedRetry,
+                    activeLeases = activeLeases,
+                    expiredLeases = expiredLeases,
+                    terminalFailures = terminalFailures,
+                    oldestEligibleAgeSeconds = oldestEligibleAgeSeconds,
+                    oldestRetryDueInSeconds = oldestRetryDueInSeconds,
+                    lastErrorCodeCounts = lastErrorCodeCounts,
+                )
+            }
+        }
+
+    private fun countEligibleNow(conn: Connection, now: java.time.OffsetDateTime): Long {
+        val sql = """
+            SELECT COUNT(*)
+            FROM approvals a
+            JOIN approval_continuations c ON c.approval_id = a.approval_id
+            JOIN tramai_approval_resume_credentials rc
+                ON rc.approval_id = a.approval_id
+                AND rc.workflow_run_id = c.workflow_run_id
+            WHERE a.status = 'APPROVED'
+              AND c.status = 'PENDING'
+              AND c.approval_expires_at > ?
+              AND rc.expires_at > ?
+              AND (
+                  c.claimed_by IS NULL
+                  OR c.claimed_at < ?
+              )
+              AND (
+                  c.resume_next_attempt_at IS NULL
+                  OR c.resume_next_attempt_at <= ?
+              )
+        """.trimIndent()
+        return conn.prepareStatement(sql).use { stmt ->
+            stmt.setObject(1, now)
+            stmt.setObject(2, now)
+            stmt.setObject(3, now)
+            stmt.setObject(4, now)
+            stmt.executeQuery().use { rs ->
+                check(rs.next())
+                rs.getLong(1)
+            }
+        }
+    }
+
+    private fun countDelayedRetry(conn: Connection, now: java.time.OffsetDateTime): Long {
+        val sql = """
+            SELECT COUNT(*)
+            FROM approval_continuations c
+            JOIN approvals a ON a.approval_id = c.approval_id
+            WHERE a.status = 'APPROVED'
+              AND c.status = 'PENDING'
+              AND c.resume_next_attempt_at IS NOT NULL
+              AND c.resume_next_attempt_at > ?
+        """.trimIndent()
+        return conn.prepareStatement(sql).use { stmt ->
+            stmt.setObject(1, now)
+            stmt.executeQuery().use { rs ->
+                check(rs.next())
+                rs.getLong(1)
+            }
+        }
+    }
+
+    private fun countActiveLeases(conn: Connection, now: java.time.OffsetDateTime): Long {
+        val sql = """
+            SELECT COUNT(*)
+            FROM approval_continuations c
+            JOIN approvals a ON a.approval_id = c.approval_id
+            WHERE a.status = 'APPROVED'
+              AND c.status = 'PENDING'
+              AND c.claimed_by IS NOT NULL
+              AND c.claimed_at >= ?
+        """.trimIndent()
+        return conn.prepareStatement(sql).use { stmt ->
+            stmt.setObject(1, now)
+            stmt.executeQuery().use { rs ->
+                check(rs.next())
+                rs.getLong(1)
+            }
+        }
+    }
+
+    private fun countExpiredLeases(conn: Connection, now: java.time.OffsetDateTime): Long {
+        val sql = """
+            SELECT COUNT(*)
+            FROM approval_continuations c
+            JOIN approvals a ON a.approval_id = c.approval_id
+            WHERE a.status = 'APPROVED'
+              AND c.status = 'PENDING'
+              AND c.claimed_by IS NOT NULL
+              AND c.claimed_at < ?
+        """.trimIndent()
+        return conn.prepareStatement(sql).use { stmt ->
+            stmt.setObject(1, now)
+            stmt.executeQuery().use { rs ->
+                check(rs.next())
+                rs.getLong(1)
+            }
+        }
+    }
+
+    private fun countTerminalFailures(conn: Connection): Long {
+        val sql = """
+            SELECT COUNT(*)
+            FROM approval_continuations
+            WHERE status = 'CANCELLED'
+              AND resume_last_error_code IS NOT NULL
+        """.trimIndent()
+        return conn.prepareStatement(sql).use { stmt ->
+            stmt.executeQuery().use { rs ->
+                check(rs.next())
+                rs.getLong(1)
+            }
+        }
+    }
+
+    private fun oldestEligibleAgeSeconds(
+        conn: Connection,
+        now: java.time.OffsetDateTime,
+    ): Long? {
+        val sql = """
+            SELECT EXTRACT(EPOCH FROM (? - c.created_at))::BIGINT
+            FROM approvals a
+            JOIN approval_continuations c ON c.approval_id = a.approval_id
+            JOIN tramai_approval_resume_credentials rc
+                ON rc.approval_id = a.approval_id
+                AND rc.workflow_run_id = c.workflow_run_id
+            WHERE a.status = 'APPROVED'
+              AND c.status = 'PENDING'
+              AND c.approval_expires_at > ?
+              AND rc.expires_at > ?
+              AND (
+                  c.claimed_by IS NULL
+                  OR c.claimed_at < ?
+              )
+              AND (
+                  c.resume_next_attempt_at IS NULL
+                  OR c.resume_next_attempt_at <= ?
+              )
+            ORDER BY c.created_at ASC
+            LIMIT 1
+        """.trimIndent()
+        return conn.prepareStatement(sql).use { stmt ->
+            stmt.setObject(1, now)
+            stmt.setObject(2, now)
+            stmt.setObject(3, now)
+            stmt.setObject(4, now)
+            stmt.setObject(5, now)
+            stmt.executeQuery().use { rs ->
+                if (rs.next()) rs.getLong(1) else null
+            }
+        }
+    }
+
+    private fun oldestRetryDueInSeconds(
+        conn: Connection,
+        now: java.time.OffsetDateTime,
+    ): Long? {
+        val sql = """
+            SELECT EXTRACT(EPOCH FROM (c.resume_next_attempt_at - ?))::BIGINT
+            FROM approval_continuations c
+            JOIN approvals a ON a.approval_id = c.approval_id
+            WHERE a.status = 'APPROVED'
+              AND c.status = 'PENDING'
+              AND c.resume_next_attempt_at IS NOT NULL
+              AND c.resume_next_attempt_at > ?
+            ORDER BY c.resume_next_attempt_at ASC
+            LIMIT 1
+        """.trimIndent()
+        return conn.prepareStatement(sql).use { stmt ->
+            stmt.setObject(1, now)
+            stmt.setObject(2, now)
+            stmt.executeQuery().use { rs ->
+                if (rs.next()) rs.getLong(1) else null
+            }
+        }
+    }
+
+    private fun lastErrorCodeCounts(conn: Connection): Map<String, Long> {
+        val sql = """
+            SELECT resume_last_error_code, COUNT(*) AS cnt
+            FROM approval_continuations
+            WHERE status = 'CANCELLED'
+              AND resume_last_error_code IS NOT NULL
+            GROUP BY resume_last_error_code
+        """.trimIndent()
+        return conn.prepareStatement(sql).use { stmt ->
+            stmt.executeQuery().use { rs ->
+                buildMap {
+                    while (rs.next()) {
+                        put(rs.getString("resume_last_error_code"), rs.getLong("cnt"))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/SovereignJdbcPersistenceAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/SovereignJdbcPersistenceAutoConfiguration.kt
@@ -5,6 +5,7 @@ import dev.tramai.core.approval.ApprovalStore
 import dev.tramai.core.approval.gateway.ApprovalResumeCredentialStore
 import dev.tramai.engine.SuspendedInvocationStore
 import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeQueue
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeQueueStatusStore
 import dev.tramai.persistence.jdbc.JdbcApprovalContinuationStore
 import dev.tramai.persistence.jdbc.JdbcApprovalStore
 import dev.tramai.persistence.jdbc.JdbcAuditPayloadCodec
@@ -273,4 +274,12 @@ class SovereignJdbcPersistenceAutoConfiguration {
         dataSource: DataSource,
     ): ApprovedContinuationResumeQueue =
         JdbcApprovedContinuationResumeQueue(dataSource)
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean(DataSource::class)
+    fun approvedContinuationResumeQueueStatusStore(
+        dataSource: DataSource,
+    ): ApprovedContinuationResumeQueueStatusStore =
+        JdbcApprovedContinuationResumeQueueStatusStore(dataSource)
 }

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcApprovedContinuationResumeQueueStatusStoreTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcApprovedContinuationResumeQueueStatusStoreTest.kt
@@ -1,0 +1,385 @@
+package dev.tramai.spring.sovereign.persistence.jdbc
+
+import java.time.Instant
+import java.time.ZoneOffset
+import javax.sql.DataSource
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.postgresql.ds.PGSimpleDataSource
+import org.testcontainers.containers.PostgreSQLContainer
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JdbcApprovedContinuationResumeQueueStatusStoreTest {
+
+    companion object {
+        private const val POSTGRES_IMAGE = "postgres:17-alpine"
+        private val postgres = PostgreSQLContainer(POSTGRES_IMAGE)
+            .withDatabaseName("resume_queue_status_store_test")
+            .withUsername("test")
+            .withPassword("test")
+
+        private fun createDataSource() = PGSimpleDataSource().apply {
+            setUrl(postgres.jdbcUrl)
+            user = postgres.username
+            password = postgres.password
+        }
+    }
+
+    private lateinit var dataSource: DataSource
+    private lateinit var queueStatusStore: JdbcApprovedContinuationResumeQueueStatusStore
+    private val baseNow: Instant = Instant.parse("2026-06-01T12:00:00Z")
+
+    @BeforeAll
+    fun startPostgres() {
+        postgres.start()
+        dataSource = createDataSource()
+        runMigrations()
+    }
+
+    @AfterAll
+    fun stopPostgres() {
+        postgres.stop()
+    }
+
+    @BeforeEach
+    fun setUp() {
+        truncateTables()
+        queueStatusStore = JdbcApprovedContinuationResumeQueueStatusStore(dataSource)
+    }
+
+    @Test
+    fun `empty queue returns zero snapshot`() {
+        runBlocking {
+            val snapshot = queueStatusStore.snapshot(baseNow)
+
+            assertThat(snapshot.eligibleNow).isZero()
+            assertThat(snapshot.delayedRetry).isZero()
+            assertThat(snapshot.activeLeases).isZero()
+            assertThat(snapshot.expiredLeases).isZero()
+            assertThat(snapshot.terminalFailures).isZero()
+            assertThat(snapshot.oldestEligibleAgeSeconds).isNull()
+            assertThat(snapshot.oldestRetryDueInSeconds).isNull()
+            assertThat(snapshot.lastErrorCodeCounts).isEmpty()
+        }
+    }
+
+    @Test
+    fun `eligible approved continuation is counted`() {
+        runBlocking {
+            insertApprovedPending("eligible-001", createdAt = baseNow.minusSeconds(60), approvalExpiresAt = baseNow.plusSeconds(300))
+            insertCredential("eligible-001", workflowRunId = "wf-eligible-001", expiresAt = baseNow.plusSeconds(300))
+
+            val snapshot = queueStatusStore.snapshot(baseNow)
+
+            assertThat(snapshot.eligibleNow).isEqualTo(1L)
+        }
+    }
+
+    @Test
+    fun `pending approval is not counted as eligible`() {
+        runBlocking {
+            insertApproval("pending-001", "PENDING")
+            insertContinuation(
+                approvalId = "pending-001",
+                workflowRunId = "wf-pending-001",
+                createdAt = baseNow.minusSeconds(60),
+                approvalExpiresAt = baseNow.plusSeconds(300),
+            )
+            insertCredential("pending-001", workflowRunId = "wf-pending-001", expiresAt = baseNow.plusSeconds(300))
+
+            val snapshot = queueStatusStore.snapshot(baseNow)
+
+            assertThat(snapshot.eligibleNow).isZero()
+        }
+    }
+
+    @Test
+    fun `missing credential is not counted as eligible`() {
+        runBlocking {
+            insertApprovedPending("no-credential-001", createdAt = baseNow.minusSeconds(60), approvalExpiresAt = baseNow.plusSeconds(300))
+
+            val snapshot = queueStatusStore.snapshot(baseNow)
+
+            assertThat(snapshot.eligibleNow).isZero()
+        }
+    }
+
+    @Test
+    fun `wrong workflow run credential is not counted as eligible`() {
+        runBlocking {
+            insertApprovedPending("wrong-workflow-001", createdAt = baseNow.minusSeconds(60), approvalExpiresAt = baseNow.plusSeconds(300))
+            insertCredential("wrong-workflow-001", workflowRunId = "wf-other", expiresAt = baseNow.plusSeconds(300))
+
+            val snapshot = queueStatusStore.snapshot(baseNow)
+
+            assertThat(snapshot.eligibleNow).isZero()
+        }
+    }
+
+    @Test
+    fun `delayed retry is counted`() {
+        runBlocking {
+            insertApprovedPending(
+                "delayed-001",
+                createdAt = baseNow.minusSeconds(60),
+                approvalExpiresAt = baseNow.plusSeconds(300),
+                resumeNextAttemptAt = baseNow.plusSeconds(90),
+            )
+            insertCredential("delayed-001", workflowRunId = "wf-delayed-001", expiresAt = baseNow.plusSeconds(300))
+
+            val snapshot = queueStatusStore.snapshot(baseNow)
+
+            assertThat(snapshot.delayedRetry).isEqualTo(1L)
+            assertThat(snapshot.oldestRetryDueInSeconds).isEqualTo(90L)
+        }
+    }
+
+    @Test
+    fun `active lease is counted`() {
+        runBlocking {
+            insertApprovedPending(
+                "active-lease-001",
+                createdAt = baseNow.minusSeconds(60),
+                approvalExpiresAt = baseNow.plusSeconds(300),
+                claimedBy = "worker-a",
+                claimedAt = baseNow.plusSeconds(120),
+            )
+            insertCredential("active-lease-001", workflowRunId = "wf-active-lease-001", expiresAt = baseNow.plusSeconds(300))
+
+            val snapshot = queueStatusStore.snapshot(baseNow)
+
+            assertThat(snapshot.activeLeases).isEqualTo(1L)
+        }
+    }
+
+    @Test
+    fun `expired lease is counted`() {
+        runBlocking {
+            insertApprovedPending(
+                "expired-lease-001",
+                createdAt = baseNow.minusSeconds(60),
+                approvalExpiresAt = baseNow.plusSeconds(300),
+                claimedBy = "worker-a",
+                claimedAt = baseNow.minusSeconds(10),
+            )
+            insertCredential("expired-lease-001", workflowRunId = "wf-expired-lease-001", expiresAt = baseNow.plusSeconds(300))
+
+            val snapshot = queueStatusStore.snapshot(baseNow)
+
+            assertThat(snapshot.expiredLeases).isEqualTo(1L)
+        }
+    }
+
+    @Test
+    fun `terminal cancelled with reason is counted`() {
+        runBlocking {
+            insertApproval("terminal-001", "APPROVED")
+            insertContinuation(
+                approvalId = "terminal-001",
+                workflowRunId = "wf-terminal-001",
+                status = "CANCELLED",
+                createdAt = baseNow.minusSeconds(60),
+                approvalExpiresAt = baseNow.plusSeconds(300),
+                resumeLastErrorCode = "IllegalStateException",
+            )
+
+            val snapshot = queueStatusStore.snapshot(baseNow)
+
+            assertThat(snapshot.terminalFailures).isEqualTo(1L)
+        }
+    }
+
+    @Test
+    fun `oldest eligible age is computed as positive seconds`() {
+        runBlocking {
+            insertApprovedPending("older-001", createdAt = baseNow.minusSeconds(120), approvalExpiresAt = baseNow.plusSeconds(60))
+            insertCredential("older-001", workflowRunId = "wf-older-001", expiresAt = baseNow.plusSeconds(300))
+            insertApprovedPending("newer-001", createdAt = baseNow.minusSeconds(30), approvalExpiresAt = baseNow.plusSeconds(120))
+            insertCredential("newer-001", workflowRunId = "wf-newer-001", expiresAt = baseNow.plusSeconds(300))
+
+            val snapshot = queueStatusStore.snapshot(baseNow)
+
+            assertThat(snapshot.oldestEligibleAgeSeconds).isEqualTo(120L)
+        }
+    }
+
+    @Test
+    fun `error code counts are grouped safely`() {
+        runBlocking {
+            insertApproval("terminal-a", "APPROVED")
+            insertContinuation(
+                approvalId = "terminal-a",
+                workflowRunId = "wf-terminal-a",
+                status = "CANCELLED",
+                createdAt = baseNow.minusSeconds(60),
+                approvalExpiresAt = baseNow.plusSeconds(300),
+                resumeLastErrorCode = "IllegalStateException",
+            )
+            insertApproval("terminal-b", "APPROVED")
+            insertContinuation(
+                approvalId = "terminal-b",
+                workflowRunId = "wf-terminal-b",
+                status = "CANCELLED",
+                createdAt = baseNow.minusSeconds(60),
+                approvalExpiresAt = baseNow.plusSeconds(300),
+                resumeLastErrorCode = "IllegalStateException",
+            )
+            insertApproval("terminal-c", "APPROVED")
+            insertContinuation(
+                approvalId = "terminal-c",
+                workflowRunId = "wf-terminal-c",
+                status = "CANCELLED",
+                createdAt = baseNow.minusSeconds(60),
+                approvalExpiresAt = baseNow.plusSeconds(300),
+                resumeLastErrorCode = "TimeoutException",
+            )
+
+            val snapshot = queueStatusStore.snapshot(baseNow)
+
+            assertThat(snapshot.lastErrorCodeCounts).containsExactlyInAnyOrderEntriesOf(
+                mapOf(
+                    "IllegalStateException" to 2L,
+                    "TimeoutException" to 1L,
+                ),
+            )
+        }
+    }
+
+    private fun insertApprovedPending(
+        approvalId: String,
+        createdAt: Instant,
+        approvalExpiresAt: Instant,
+        claimedBy: String? = null,
+        claimedAt: Instant? = null,
+        resumeNextAttemptAt: Instant? = null,
+    ) {
+        insertApproval(approvalId, "APPROVED")
+        insertContinuation(
+            approvalId = approvalId,
+            workflowRunId = "wf-$approvalId",
+            createdAt = createdAt,
+            approvalExpiresAt = approvalExpiresAt,
+            claimedBy = claimedBy,
+            claimedAt = claimedAt,
+            resumeNextAttemptAt = resumeNextAttemptAt,
+        )
+    }
+
+    private fun insertApproval(approvalId: String, status: String) {
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(
+                """
+                INSERT INTO approvals (approval_id, status, created_at, sanitized_metadata, version)
+                VALUES (?, ?, ?, '{}'::jsonb, 0)
+                """.trimIndent(),
+            ).use { stmt ->
+                stmt.setString(1, approvalId)
+                stmt.setString(2, status)
+                stmt.setObject(3, baseNow.atOffset(ZoneOffset.UTC))
+                stmt.executeUpdate()
+            }
+        }
+    }
+
+    private fun insertContinuation(
+        approvalId: String,
+        workflowRunId: String,
+        status: String = "PENDING",
+        createdAt: Instant,
+        approvalExpiresAt: Instant,
+        claimedBy: String? = null,
+        claimedAt: Instant? = null,
+        resumeNextAttemptAt: Instant? = null,
+        resumeLastErrorCode: String? = null,
+    ) {
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(
+                """
+                INSERT INTO approval_continuations
+                    (approval_id, status, workflow_run_id, correlation_id, tool_call_id, tool_name,
+                     arguments_digest, policy_version, workflow_digest, created_at, approval_expires_at,
+                     claimed_by, claimed_at, resume_next_attempt_at, resume_last_error_code, version)
+                VALUES (?, ?, ?, ?, ?, ?,
+                        'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                        'v1', 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+                        ?, ?, ?, ?, ?, ?, 0)
+                """.trimIndent(),
+            ).use { stmt ->
+                stmt.setString(1, approvalId)
+                stmt.setString(2, status)
+                stmt.setString(3, workflowRunId)
+                stmt.setString(4, "corr-$approvalId")
+                stmt.setString(5, "tc-$approvalId")
+                stmt.setString(6, "tool-$approvalId")
+                stmt.setObject(7, createdAt.atOffset(ZoneOffset.UTC))
+                stmt.setObject(8, approvalExpiresAt.atOffset(ZoneOffset.UTC))
+                stmt.setString(9, claimedBy)
+                stmt.setObject(10, claimedAt?.atOffset(ZoneOffset.UTC))
+                stmt.setObject(11, resumeNextAttemptAt?.atOffset(ZoneOffset.UTC))
+                stmt.setString(12, resumeLastErrorCode)
+                stmt.executeUpdate()
+            }
+        }
+    }
+
+    private fun insertCredential(
+        approvalId: String,
+        workflowRunId: String,
+        expiresAt: Instant,
+    ) {
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(
+                """
+                INSERT INTO tramai_approval_resume_credentials
+                    (approval_id, workflow_run_id, encrypted_resume_token,
+                     encryption_key_id, encryption_algorithm, encryption_nonce,
+                     payload_digest, created_at, expires_at, version)
+                VALUES (?, ?,
+                        decode('74657374', 'hex'),
+                        'test-key', 'AES-256-GCM', decode('000000000000000000000000', 'hex'),
+                        'sha256:0000000000000000000000000000000000000000000000000000000000000000',
+                        ?, ?, 0)
+                """.trimIndent(),
+            ).use { stmt ->
+                stmt.setString(1, approvalId)
+                stmt.setString(2, workflowRunId)
+                stmt.setObject(3, baseNow.atOffset(ZoneOffset.UTC))
+                stmt.setObject(4, expiresAt.atOffset(ZoneOffset.UTC))
+                stmt.executeUpdate()
+            }
+        }
+    }
+
+    private fun truncateTables() {
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.execute("TRUNCATE TABLE approval_continuations, approvals, tramai_approval_resume_credentials CASCADE")
+            }
+        }
+    }
+
+    private fun runMigrations() {
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                listOf(
+                    "tramai/persistence/jdbc/postgres/V1__sovereign_persistence.sql",
+                    "tramai/persistence/jdbc/postgres/V2__approval_continuations.sql",
+                    "tramai/persistence/jdbc/postgres/V6__approval_resume_credential_custody.sql",
+                    "tramai/persistence/jdbc/postgres/V7__approval_continuations_resume_retry.sql",
+                ).forEach { resource ->
+                    val sql = javaClass.classLoader
+                        .getResourceAsStream(resource)
+                        ?.bufferedReader()
+                        ?.readText()
+                        ?: error("Migration not found: $resource")
+                    stmt.execute(sql)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add read-only aggregated queue diagnostics so operators can answer "are approved continuations stuck?" without SQL.

## What changed

### SPI (ops module)
- `ApprovedContinuationResumeQueueStatusStore` — `suspend fun snapshot(now: Instant): ApprovedContinuationResumeQueueSnapshot`
- `ApprovedContinuationResumeQueueSnapshot` — sanitised data class: `eligibleNow`, `delayedRetry`, `activeLeases`, `expiredLeases`, `terminalFailures`, `oldestEligibleAgeSeconds`, `oldestRetryDueInSeconds`, `lastErrorCodeCounts`

### JDBC implementation
- `JdbcApprovedContinuationResumeQueueStatusStore` — 8 aggregated SQL queries mirroring `JdbcApprovedContinuationResumeQueue.claimApprovedPending()` eligibility semantics exactly
- Uses `withContext(Dispatchers.IO)` for coroutine-safe blocking I/O

### Health indicator extension
- Queue snapshot details added when `ApprovedContinuationResumeQueueStatusStore` is available
- Protected by `withTimeout(5_000)` to prevent health thread hangs
- No `lastErrorCodeCounts` in health details

### Auto-configuration
- JDBC persistence starter creates the bean when `type=jdbc` and `DataSource` is present
- Actuator auto-config wires it into the health indicator via `ObjectProvider`

### Security constraints
- No approval IDs, workflow run IDs, resume tokens, or metadata in snapshot
- `lastErrorCodeCounts` uses class-name error codes only (no messages)
- `lastErrorCodeCounts` excluded from health indicator

## Configuration
```yaml
tramai:
  sovereign:
    ops:
      actuator:
        approved-resume-worker-health:
          enabled: true  # queue counts appear automatically
```

No new properties needed — queue snapshot is available whenever JDBC is active.

## Files changed (8 files, 774 insertions, 3 deletions)
```
A  .../ApprovedContinuationResumeQueueStatusStore.kt
A  .../ApprovedContinuationResumeQueueSnapshot.kt
A  .../JdbcApprovedContinuationResumeQueueStatusStore.kt
A  .../JdbcApprovedContinuationResumeQueueStatusStoreTest.kt
M  .../ApprovedContinuationResumeWorkerHealthIndicator.kt
M  .../SovereignOpsActuatorAutoConfiguration.kt
M  .../ApprovedContinuationResumeWorkerHealthIndicatorTest.kt
M  .../SovereignJdbcPersistenceAutoConfiguration.kt
```

## Review findings addressed
- P1.1: Removed unused `clock` field from JDBC store
- P1.2: Added `withTimeout(5_000)` around `runBlocking` in health indicator
- P1.3: Added `withContext(Dispatchers.IO)` for coroutine-safe blocking JDBC
- P2.2: Credential/approval expiry join consistency documented
- P2.3: Snapshot exception test added to health indicator tests