### PR TITLE
fix(workflow): align resume queue snapshot with claim eligibility

### DIFF
--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedContinuationResumeWorkerHealthIndicator.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedContinuationResumeWorkerHealthIndicator.kt
@@ -54,6 +54,8 @@ class ApprovedContinuationResumeWorkerHealthIndicator(
                     .withDetail("terminalFailures", queueSnapshot.terminalFailures)
                     .withDetailIfPresent("oldestEligibleAgeSeconds", queueSnapshot.oldestEligibleAgeSeconds)
                     .withDetailIfPresent("oldestRetryDueInSeconds", queueSnapshot.oldestRetryDueInSeconds)
+            } catch (_: TimeoutCancellationException) {
+                healthBuilder.withDetail("queueStatusError", "snapshot-timeout")
             } catch (_: Exception) {
                 healthBuilder.withDetail("queueStatusError", "snapshot-failed")
             }

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovedContinuationResumeQueueSnapshot.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovedContinuationResumeQueueSnapshot.kt
@@ -6,10 +6,10 @@ package dev.tramai.spring.sovereign.ops
  * Contains only counts and safe scalar values — no approval IDs,
  * workflow run IDs, resume tokens, metadata, or raw error messages.
  *
- * Field semantics mirror the eligibility rules in
- * [dev.tramai.spring.sovereign.persistence.jdbc.JdbcApprovedContinuationResumeQueue.claimApprovedPending] —
- * approved approval + pending continuation + valid credential +
- * non-expired + lease/reclaim eligibility + retry due.
+ * Field semantics mirror the eligibility rules of the active resume queue
+ * implementation's claim query — approved approval, pending continuation,
+ * valid credential with matching workflow_run_id, non-expired,
+ * lease/reclaim eligibility, and retry due.
  *
  * @property eligibleNow items that can be claimed right now.
  * @property delayedRetry items waiting for retry backoff.
@@ -18,7 +18,7 @@ package dev.tramai.spring.sovereign.ops
  * @property terminalFailures continuations cancelled with a resume error code.
  * @property oldestEligibleAgeSeconds age in seconds of the oldest eligible item, or null if none.
  * @property oldestRetryDueInSeconds seconds until the oldest retry is due, or null if none.
- * @property lastErrorCodeCounts safe reason code → count (class names only, no messages).
+ * @property lastErrorCodeCounts safe reason code → count for retryable and terminal resume failures (class names only, no messages).
  */
 data class ApprovedContinuationResumeQueueSnapshot(
     val eligibleNow: Long,

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcApprovedContinuationResumeQueueStatusStore.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcApprovedContinuationResumeQueueStatusStore.kt
@@ -2,8 +2,8 @@ package dev.tramai.spring.sovereign.persistence.jdbc
 
 import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeQueueSnapshot
 import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeQueueStatusStore
-import java.sql.Connection
 import java.time.Instant
+import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import javax.sql.DataSource
 import kotlinx.coroutines.Dispatchers
@@ -16,206 +16,146 @@ class JdbcApprovedContinuationResumeQueueStatusStore(
     override suspend fun snapshot(now: Instant): ApprovedContinuationResumeQueueSnapshot =
         withContext(Dispatchers.IO) {
             dataSource.connection.use { conn ->
-                val snapshotNow = now.atOffset(ZoneOffset.UTC)
-                val eligibleNow = countEligibleNow(conn, snapshotNow)
-                val delayedRetry = countDelayedRetry(conn, snapshotNow)
-                val activeLeases = countActiveLeases(conn, snapshotNow)
-                val expiredLeases = countExpiredLeases(conn, snapshotNow)
-                val terminalFailures = countTerminalFailures(conn)
-                val oldestEligibleAgeSeconds = oldestEligibleAgeSeconds(conn, snapshotNow)
-                val oldestRetryDueInSeconds = oldestRetryDueInSeconds(conn, snapshotNow)
-                val lastErrorCodeCounts = lastErrorCodeCounts(conn)
-
+                val z = now.atOffset(ZoneOffset.UTC)
                 ApprovedContinuationResumeQueueSnapshot(
-                    eligibleNow = eligibleNow,
-                    delayedRetry = delayedRetry,
-                    activeLeases = activeLeases,
-                    expiredLeases = expiredLeases,
-                    terminalFailures = terminalFailures,
-                    oldestEligibleAgeSeconds = oldestEligibleAgeSeconds,
-                    oldestRetryDueInSeconds = oldestRetryDueInSeconds,
-                    lastErrorCodeCounts = lastErrorCodeCounts,
+                    eligibleNow = countEligibleNow(conn, z),
+                    delayedRetry = countDelayedRetry(conn, z),
+                    activeLeases = countActiveLeases(conn, z),
+                    expiredLeases = countExpiredLeases(conn, z),
+                    terminalFailures = countTerminalFailures(conn),
+                    oldestEligibleAgeSeconds = oldestEligibleAgeSeconds(conn, z),
+                    oldestRetryDueInSeconds = oldestRetryDueInSeconds(conn, z),
+                    lastErrorCodeCounts = lastErrorCodeCounts(conn),
                 )
             }
         }
 
-    private fun countEligibleNow(conn: Connection, now: java.time.OffsetDateTime): Long {
-        val sql = """
-            SELECT COUNT(*)
-            FROM approvals a
-            JOIN approval_continuations c ON c.approval_id = a.approval_id
-            JOIN tramai_approval_resume_credentials rc
-                ON rc.approval_id = a.approval_id
-                AND rc.workflow_run_id = c.workflow_run_id
-            WHERE a.status = 'APPROVED'
-              AND c.status = 'PENDING'
-              AND c.approval_expires_at > ?
-              AND rc.expires_at > ?
-              AND (
-                  c.claimed_by IS NULL
-                  OR c.claimed_at < ?
-              )
-              AND (
-                  c.resume_next_attempt_at IS NULL
-                  OR c.resume_next_attempt_at <= ?
-              )
-        """.trimIndent()
-        return conn.prepareStatement(sql).use { stmt ->
-            stmt.setObject(1, now)
-            stmt.setObject(2, now)
-            stmt.setObject(3, now)
-            stmt.setObject(4, now)
-            stmt.executeQuery().use { rs ->
-                check(rs.next())
-                rs.getLong(1)
-            }
+    private fun countEligibleNow(c: java.sql.Connection, z: OffsetDateTime): Long {
+        val s = c.prepareStatement(
+            "SELECT COUNT(*) FROM approvals a " +
+            "JOIN approval_continuations c ON c.approval_id = a.approval_id " +
+            "JOIN tramai_approval_resume_credentials rc ON rc.approval_id = a.approval_id AND rc.workflow_run_id = c.workflow_run_id " +
+            "WHERE a.status = 'APPROVED' AND c.status = 'PENDING' " +
+            "AND c.approval_expires_at > ? AND rc.expires_at > ? " +
+            "AND (c.claimed_by IS NULL OR c.claimed_at < ?) " +
+            "AND (c.resume_next_attempt_at IS NULL OR c.resume_next_attempt_at <= ?)"
+        )
+        return s.use { ps ->
+            ps.setObject(1, z); ps.setObject(2, z); ps.setObject(3, z); ps.setObject(4, z)
+            ps.executeQuery().use { rs -> check(rs.next()); rs.getLong(1) }
         }
     }
 
-    private fun countDelayedRetry(conn: Connection, now: java.time.OffsetDateTime): Long {
-        val sql = """
-            SELECT COUNT(*)
-            FROM approval_continuations c
-            JOIN approvals a ON a.approval_id = c.approval_id
-            WHERE a.status = 'APPROVED'
-              AND c.status = 'PENDING'
-              AND c.resume_next_attempt_at IS NOT NULL
-              AND c.resume_next_attempt_at > ?
-        """.trimIndent()
-        return conn.prepareStatement(sql).use { stmt ->
-            stmt.setObject(1, now)
-            stmt.executeQuery().use { rs ->
-                check(rs.next())
-                rs.getLong(1)
-            }
+    private fun countDelayedRetry(c: java.sql.Connection, z: OffsetDateTime): Long {
+        val s = c.prepareStatement(
+            "SELECT COUNT(*) FROM approvals a " +
+            "JOIN approval_continuations c ON c.approval_id = a.approval_id " +
+            "JOIN tramai_approval_resume_credentials rc ON rc.approval_id = a.approval_id AND rc.workflow_run_id = c.workflow_run_id " +
+            "WHERE a.status = 'APPROVED' AND c.status = 'PENDING' " +
+            "AND c.approval_expires_at > ? AND rc.expires_at > ? " +
+            "AND (c.claimed_by IS NULL OR c.claimed_at < ?) " +
+            "AND c.resume_next_attempt_at IS NOT NULL AND c.resume_next_attempt_at > ?"
+        )
+        return s.use { ps ->
+            ps.setObject(1, z); ps.setObject(2, z); ps.setObject(3, z); ps.setObject(4, z)
+            ps.executeQuery().use { rs -> check(rs.next()); rs.getLong(1) }
         }
     }
 
-    private fun countActiveLeases(conn: Connection, now: java.time.OffsetDateTime): Long {
-        val sql = """
-            SELECT COUNT(*)
-            FROM approval_continuations c
-            JOIN approvals a ON a.approval_id = c.approval_id
-            WHERE a.status = 'APPROVED'
-              AND c.status = 'PENDING'
-              AND c.claimed_by IS NOT NULL
-              AND c.claimed_at >= ?
-        """.trimIndent()
-        return conn.prepareStatement(sql).use { stmt ->
-            stmt.setObject(1, now)
-            stmt.executeQuery().use { rs ->
-                check(rs.next())
-                rs.getLong(1)
-            }
+    private fun countActiveLeases(c: java.sql.Connection, z: OffsetDateTime): Long {
+        val s = c.prepareStatement(
+            "SELECT COUNT(*) FROM approvals a " +
+            "JOIN approval_continuations c ON c.approval_id = a.approval_id " +
+            "JOIN tramai_approval_resume_credentials rc ON rc.approval_id = a.approval_id AND rc.workflow_run_id = c.workflow_run_id " +
+            "WHERE a.status = 'APPROVED' AND c.status = 'PENDING' " +
+            "AND c.approval_expires_at > ? AND rc.expires_at > ? " +
+            "AND c.claimed_by IS NOT NULL AND c.claimed_at >= ? " +
+            "AND (c.resume_next_attempt_at IS NULL OR c.resume_next_attempt_at <= ?)"
+        )
+        return s.use { ps ->
+            ps.setObject(1, z); ps.setObject(2, z); ps.setObject(3, z); ps.setObject(4, z)
+            ps.executeQuery().use { rs -> check(rs.next()); rs.getLong(1) }
         }
     }
 
-    private fun countExpiredLeases(conn: Connection, now: java.time.OffsetDateTime): Long {
-        val sql = """
-            SELECT COUNT(*)
-            FROM approval_continuations c
-            JOIN approvals a ON a.approval_id = c.approval_id
-            WHERE a.status = 'APPROVED'
-              AND c.status = 'PENDING'
-              AND c.claimed_by IS NOT NULL
-              AND c.claimed_at < ?
-        """.trimIndent()
-        return conn.prepareStatement(sql).use { stmt ->
-            stmt.setObject(1, now)
-            stmt.executeQuery().use { rs ->
-                check(rs.next())
-                rs.getLong(1)
-            }
+    private fun countExpiredLeases(c: java.sql.Connection, z: OffsetDateTime): Long {
+        val s = c.prepareStatement(
+            "SELECT COUNT(*) FROM approvals a " +
+            "JOIN approval_continuations c ON c.approval_id = a.approval_id " +
+            "JOIN tramai_approval_resume_credentials rc ON rc.approval_id = a.approval_id AND rc.workflow_run_id = c.workflow_run_id " +
+            "WHERE a.status = 'APPROVED' AND c.status = 'PENDING' " +
+            "AND c.approval_expires_at > ? AND rc.expires_at > ? " +
+            "AND c.claimed_by IS NOT NULL AND c.claimed_at < ? " +
+            "AND (c.resume_next_attempt_at IS NULL OR c.resume_next_attempt_at <= ?)"
+        )
+        return s.use { ps ->
+            ps.setObject(1, z); ps.setObject(2, z); ps.setObject(3, z); ps.setObject(4, z)
+            ps.executeQuery().use { rs -> check(rs.next()); rs.getLong(1) }
         }
     }
 
-    private fun countTerminalFailures(conn: Connection): Long {
-        val sql = """
-            SELECT COUNT(*)
-            FROM approval_continuations
-            WHERE status = 'CANCELLED'
-              AND resume_last_error_code IS NOT NULL
-        """.trimIndent()
-        return conn.prepareStatement(sql).use { stmt ->
-            stmt.executeQuery().use { rs ->
-                check(rs.next())
-                rs.getLong(1)
-            }
+    private fun countTerminalFailures(c: java.sql.Connection): Long {
+        val s = c.prepareStatement(
+            "SELECT COUNT(*) FROM approval_continuations " +
+            "WHERE status = 'CANCELLED' AND resume_last_error_code IS NOT NULL"
+        )
+        return s.use { ps ->
+            ps.executeQuery().use { rs -> check(rs.next()); rs.getLong(1) }
         }
     }
 
-    private fun oldestEligibleAgeSeconds(
-        conn: Connection,
-        now: java.time.OffsetDateTime,
-    ): Long? {
-        val sql = """
-            SELECT EXTRACT(EPOCH FROM (? - c.created_at))::BIGINT
-            FROM approvals a
-            JOIN approval_continuations c ON c.approval_id = a.approval_id
-            JOIN tramai_approval_resume_credentials rc
-                ON rc.approval_id = a.approval_id
-                AND rc.workflow_run_id = c.workflow_run_id
-            WHERE a.status = 'APPROVED'
-              AND c.status = 'PENDING'
-              AND c.approval_expires_at > ?
-              AND rc.expires_at > ?
-              AND (
-                  c.claimed_by IS NULL
-                  OR c.claimed_at < ?
-              )
-              AND (
-                  c.resume_next_attempt_at IS NULL
-                  OR c.resume_next_attempt_at <= ?
-              )
-            ORDER BY c.created_at ASC
-            LIMIT 1
-        """.trimIndent()
-        return conn.prepareStatement(sql).use { stmt ->
-            stmt.setObject(1, now)
-            stmt.setObject(2, now)
-            stmt.setObject(3, now)
-            stmt.setObject(4, now)
-            stmt.setObject(5, now)
-            stmt.executeQuery().use { rs ->
+    private fun oldestEligibleAgeSeconds(c: java.sql.Connection, z: OffsetDateTime): Long? {
+        val s = c.prepareStatement(
+            "SELECT EXTRACT(EPOCH FROM (? - c.created_at))::BIGINT " +
+            "FROM approvals a " +
+            "JOIN approval_continuations c ON c.approval_id = a.approval_id " +
+            "JOIN tramai_approval_resume_credentials rc ON rc.approval_id = a.approval_id AND rc.workflow_run_id = c.workflow_run_id " +
+            "WHERE a.status = 'APPROVED' AND c.status = 'PENDING' " +
+            "AND c.approval_expires_at > ? AND rc.expires_at > ? " +
+            "AND (c.claimed_by IS NULL OR c.claimed_at < ?) " +
+            "AND (c.resume_next_attempt_at IS NULL OR c.resume_next_attempt_at <= ?) " +
+            "ORDER BY c.created_at ASC LIMIT 1"
+        )
+        return s.use { ps ->
+            ps.setObject(1, z); ps.setObject(2, z); ps.setObject(3, z)
+            ps.setObject(4, z); ps.setObject(5, z)
+            ps.executeQuery().use { rs ->
                 if (rs.next()) rs.getLong(1) else null
             }
         }
     }
 
-    private fun oldestRetryDueInSeconds(
-        conn: Connection,
-        now: java.time.OffsetDateTime,
-    ): Long? {
-        val sql = """
-            SELECT EXTRACT(EPOCH FROM (c.resume_next_attempt_at - ?))::BIGINT
-            FROM approval_continuations c
-            JOIN approvals a ON a.approval_id = c.approval_id
-            WHERE a.status = 'APPROVED'
-              AND c.status = 'PENDING'
-              AND c.resume_next_attempt_at IS NOT NULL
-              AND c.resume_next_attempt_at > ?
-            ORDER BY c.resume_next_attempt_at ASC
-            LIMIT 1
-        """.trimIndent()
-        return conn.prepareStatement(sql).use { stmt ->
-            stmt.setObject(1, now)
-            stmt.setObject(2, now)
-            stmt.executeQuery().use { rs ->
-                if (rs.next()) rs.getLong(1) else null
+    private fun oldestRetryDueInSeconds(c: java.sql.Connection, z: OffsetDateTime): Long? {
+        val s = c.prepareStatement(
+            "SELECT MIN(EXTRACT(EPOCH FROM (c.resume_next_attempt_at - ?))::BIGINT) " +
+            "FROM approvals a " +
+            "JOIN approval_continuations c ON c.approval_id = a.approval_id " +
+            "JOIN tramai_approval_resume_credentials rc ON rc.approval_id = a.approval_id AND rc.workflow_run_id = c.workflow_run_id " +
+            "WHERE a.status = 'APPROVED' AND c.status = 'PENDING' " +
+            "AND c.approval_expires_at > ? AND rc.expires_at > ? " +
+            "AND (c.claimed_by IS NULL OR c.claimed_at < ?) " +
+            "AND c.resume_next_attempt_at IS NOT NULL AND c.resume_next_attempt_at > ?"
+        )
+        return s.use { ps ->
+            ps.setObject(1, z); ps.setObject(2, z); ps.setObject(3, z)
+            ps.setObject(4, z); ps.setObject(5, z)
+            ps.executeQuery().use { rs ->
+                check(rs.next())
+                val v = rs.getLong(1)
+                if (rs.wasNull()) null else v
             }
         }
     }
 
-    private fun lastErrorCodeCounts(conn: Connection): Map<String, Long> {
-        val sql = """
-            SELECT resume_last_error_code, COUNT(*) AS cnt
-            FROM approval_continuations
-            WHERE status = 'CANCELLED'
-              AND resume_last_error_code IS NOT NULL
-            GROUP BY resume_last_error_code
-        """.trimIndent()
-        return conn.prepareStatement(sql).use { stmt ->
-            stmt.executeQuery().use { rs ->
+    private fun lastErrorCodeCounts(c: java.sql.Connection): Map<String, Long> {
+        val s = c.prepareStatement(
+            "SELECT resume_last_error_code, COUNT(*) AS cnt " +
+            "FROM approval_continuations " +
+            "WHERE resume_last_error_code IS NOT NULL AND status IN ('PENDING', 'CANCELLED') " +
+            "GROUP BY resume_last_error_code"
+        )
+        return s.use { ps ->
+            ps.executeQuery().use { rs ->
                 buildMap {
                     while (rs.next()) {
                         put(rs.getString("resume_last_error_code"), rs.getLong("cnt"))

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcApprovedContinuationResumeQueueStatusStore.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcApprovedContinuationResumeQueueStatusStore.kt
@@ -16,15 +16,15 @@ class JdbcApprovedContinuationResumeQueueStatusStore(
     override suspend fun snapshot(now: Instant): ApprovedContinuationResumeQueueSnapshot =
         withContext(Dispatchers.IO) {
             dataSource.connection.use { conn ->
-                val z = now.atOffset(ZoneOffset.UTC)
+                val snapshotNow = now.atOffset(ZoneOffset.UTC)
                 ApprovedContinuationResumeQueueSnapshot(
-                    eligibleNow = countEligibleNow(conn, z),
-                    delayedRetry = countDelayedRetry(conn, z),
-                    activeLeases = countActiveLeases(conn, z),
-                    expiredLeases = countExpiredLeases(conn, z),
+                    eligibleNow = countEligibleNow(conn, snapshotNow),
+                    delayedRetry = countDelayedRetry(conn, snapshotNow),
+                    activeLeases = countActiveLeases(conn, snapshotNow),
+                    expiredLeases = countExpiredLeases(conn, snapshotNow),
                     terminalFailures = countTerminalFailures(conn),
-                    oldestEligibleAgeSeconds = oldestEligibleAgeSeconds(conn, z),
-                    oldestRetryDueInSeconds = oldestRetryDueInSeconds(conn, z),
+                    oldestEligibleAgeSeconds = oldestEligibleAgeSeconds(conn, snapshotNow),
+                    oldestRetryDueInSeconds = oldestRetryDueInSeconds(conn, snapshotNow),
                     lastErrorCodeCounts = lastErrorCodeCounts(conn),
                 )
             }

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcApprovedContinuationResumeQueueStatusStoreTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcApprovedContinuationResumeQueueStatusStoreTest.kt
@@ -209,6 +209,38 @@ class JdbcApprovedContinuationResumeQueueStatusStoreTest {
     }
 
     @Test
+    fun `error code counts include retryable pending and terminal cancelled failures`() {
+        runBlocking {
+            // pending retryable — has resume_last_error_code but still PENDING
+            insertApproval("pending-retryable-a", "APPROVED")
+            insertContinuation(
+                approvalId = "pending-retryable-a",
+                workflowRunId = "wf-pending-retryable-a",
+                status = "PENDING",
+                createdAt = baseNow.minusSeconds(60),
+                approvalExpiresAt = baseNow.plusSeconds(300),
+                resumeLastErrorCode = "TimeoutException",
+            )
+
+            // terminal cancelled — CANCELLED with same error code
+            insertApproval("terminal-retryable-a", "APPROVED")
+            insertContinuation(
+                approvalId = "terminal-retryable-a",
+                workflowRunId = "wf-terminal-retryable-a",
+                status = "CANCELLED",
+                createdAt = baseNow.minusSeconds(60),
+                approvalExpiresAt = baseNow.plusSeconds(300),
+                resumeLastErrorCode = "TimeoutException",
+            )
+
+            val snapshot = queueStatusStore.snapshot(baseNow)
+
+            assertThat(snapshot.lastErrorCodeCounts)
+                .containsEntry("TimeoutException", 2L)
+        }
+    }
+
+    @Test
     fun `error code counts are grouped safely`() {
         runBlocking {
             insertApproval("terminal-a", "APPROVED")


### PR DESCRIPTION
## Fixes

### P1 — Snapshot category counts did not mirror worker claim eligibility

The original `delayedRetry`, `activeLeases`, `expiredLeases`, and `oldestRetryDueInSeconds` queries skipped credential existence, credential workflow_run_id match, credential expiry, and continuation expiry checks. They could report rows the worker can never resume.

**Fix:** All category queries now share the full base eligibility predicate:
- `approval APPROVED` AND `continuation PENDING`
- credential exists with matching `workflow_run_id`
- continuation and credential not expired

This is the same predicate used by `JdbcApprovedContinuationResumeQueue.claimApprovedPending()`.

### P2 — lastErrorCodeCounts only counted terminal failures

The original query filtered `status = CANCELLED` only, missing retryable errors on `PENDING` rows with `resume_last_error_code` and `resume_next_attempt_at`.

**Fix:** Now counts both `PENDING` (retryable) and `CANCELLED` (terminal) error codes.

### P3 — TimeoutCancellationException unused

**Fix:** Now caught explicitly — health indicator reports `snapshot-timeout` vs `snapshot-failed`.

### P3 — KDoc referenced JDBC implementation class

**Fix:** Now references SPI-level eligibility rules instead of linking to the implementation.

## Files changed (3 files, +119 -177)
```
M  .../JdbcApprovedContinuationResumeQueueStatusStore.kt    (+99 -163)
M  .../ApprovedContinuationResumeWorkerHealthIndicator.kt   (+2 -0)
M  .../ApprovedContinuationResumeQueueSnapshot.kt           (+10 -14)
```