### PR TITLE
feat(workflow): add approved resume worker metrics

### DIFF
--- a/tramai-spring-boot-starter-sovereign-ops-actuator/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
 
     implementation(libs.spring.boot.autoconfigure)
     implementation(libs.spring.boot.actuator)
+    implementation(libs.micrometer.core)
 
     annotationProcessor(libs.spring.boot.configuration.processor)
 
@@ -32,6 +33,7 @@ dependencies {
     testImplementation(libs.kotlin.test.junit5)
     testImplementation(libs.spring.boot.starter.test)
     testImplementation(libs.spring.boot.actuator.autoconfigure)
+    testImplementation(libs.micrometer.core)
     testImplementation("org.junit.jupiter:junit-jupiter")
 }
 

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedContinuationResumeWorkerMetricsObserver.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedContinuationResumeWorkerMetricsObserver.kt
@@ -2,11 +2,8 @@ package dev.tramai.spring.sovereign.ops.actuator
 
 import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeWorkerObserver
 import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeWorkerResult
-import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
-import io.micrometer.core.instrument.Tag
 import io.micrometer.core.instrument.Tags
-import io.micrometer.core.instrument.Timer
 import java.time.Duration
 
 /**
@@ -44,26 +41,8 @@ class ApprovedContinuationResumeWorkerMetricsObserver(
         const val FAILURES_TOTAL = "${METRICS_PREFIX}.failures.total"
     }
 
-    private val itemsScannedTotal: Counter = Counter.builder(ITEMS_SCANNED_TOTAL)
-        .description("Total items scanned by resume worker")
-        .register(meterRegistry)
-
-    private val itemsResumedTotal: Counter = Counter.builder(ITEMS_RESUMED_TOTAL)
-        .description("Total items resumed successfully")
-        .register(meterRegistry)
-
-    private val itemsSkippedTotal: Counter = Counter.builder(ITEMS_SKIPPED_TOTAL)
-        .description("Total items skipped during resume cycles")
-        .register(meterRegistry)
-
-    private val itemsFailedTotal: Counter = Counter.builder(ITEMS_FAILED_TOTAL)
-        .description("Total items that failed to resume")
-        .register(meterRegistry)
-
-    private val cycleDuration: Timer = Timer.builder(CYCLE_DURATION)
-        .description("Duration of resume worker cycles")
-        .publishPercentileHistogram()
-        .register(meterRegistry)
+    private fun commonTags(workerId: String): Tags =
+        if (properties.includeWorkerIdTag) Tags.of("worker_id", workerId) else Tags.empty()
 
     override fun cycleStarted(workerId: String) = Unit
 
@@ -72,24 +51,26 @@ class ApprovedContinuationResumeWorkerMetricsObserver(
         result: ApprovedContinuationResumeWorkerResult,
         duration: Duration,
     ) {
-        meterRegistry.counter(CYCLES_TOTAL, Tags.of("outcome", "completed")).increment()
+        val tags = commonTags(workerId)
+        meterRegistry.counter(CYCLES_TOTAL, tags.and("outcome", "completed")).increment()
 
-        itemsScannedTotal.increment(result.scanned.toDouble())
-        itemsResumedTotal.increment(result.resumed.toDouble())
-        itemsSkippedTotal.increment(result.skipped.toDouble())
-        itemsFailedTotal.increment(result.failed.toDouble())
+        meterRegistry.counter(ITEMS_SCANNED_TOTAL, tags).increment(result.scanned.toDouble())
+        meterRegistry.counter(ITEMS_RESUMED_TOTAL, tags).increment(result.resumed.toDouble())
+        meterRegistry.counter(ITEMS_SKIPPED_TOTAL, tags).increment(result.skipped.toDouble())
+        meterRegistry.counter(ITEMS_FAILED_TOTAL, tags).increment(result.failed.toDouble())
 
-        cycleDuration.record(duration)
+        meterRegistry.timer(CYCLE_DURATION, tags).record(duration)
     }
 
     override fun cycleFailed(workerId: String, error: Throwable) {
-        meterRegistry.counter(CYCLES_TOTAL, Tags.of("outcome", "failed")).increment()
+        val tags = commonTags(workerId)
+        meterRegistry.counter(CYCLES_TOTAL, tags.and("outcome", "failed")).increment()
 
         // error_code = simple class name only, never the message
         val errorCode = error::class.simpleName ?: "Unknown"
         meterRegistry.counter(
             FAILURES_TOTAL,
-            Tags.of("error_code", errorCode),
+            tags.and("error_code", errorCode),
         ).increment()
     }
 }

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedContinuationResumeWorkerMetricsObserver.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedContinuationResumeWorkerMetricsObserver.kt
@@ -1,0 +1,95 @@
+package dev.tramai.spring.sovereign.ops.actuator
+
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeWorkerObserver
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeWorkerResult
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Tag
+import io.micrometer.core.instrument.Tags
+import io.micrometer.core.instrument.Timer
+import java.time.Duration
+
+/**
+ * [ApprovedContinuationResumeWorkerObserver] that records safe, low-cardinality
+ * Micrometer metrics for resume worker cycles.
+ *
+ * Metrics (all disabled by default):
+ * - [CYCLES_TOTAL]: counter tagged with `outcome=completed|failed`
+ * - [ITEMS_SCANNED_TOTAL]: total items scanned per cycle
+ * - [ITEMS_RESUMED_TOTAL]: total items successfully resumed
+ * - [ITEMS_SKIPPED_TOTAL]: total items skipped
+ * - [ITEMS_FAILED_TOTAL]: total items that failed to resume
+ * - [CYCLE_DURATION]: timer recording cycle duration
+ * - [FAILURES_TOTAL]: counter tagged with `error_code` (class simple name only)
+ *
+ * No approval IDs, workflow run IDs, resume tokens, or raw exception messages
+ * are exported as metric tags or values.
+ *
+ * @param meterRegistry the Micrometer registry to register metrics on.
+ * @param properties metrics configuration including optional worker ID tag.
+ */
+class ApprovedContinuationResumeWorkerMetricsObserver(
+    private val meterRegistry: MeterRegistry,
+    private val properties: ApprovedContinuationResumeWorkerMetricsProperties,
+) : ApprovedContinuationResumeWorkerObserver {
+
+    companion object {
+        const val METRICS_PREFIX = "tramai.sovereign.approved_resume_worker"
+        const val CYCLES_TOTAL = "${METRICS_PREFIX}.cycles.total"
+        const val ITEMS_SCANNED_TOTAL = "${METRICS_PREFIX}.items.scanned.total"
+        const val ITEMS_RESUMED_TOTAL = "${METRICS_PREFIX}.items.resumed.total"
+        const val ITEMS_SKIPPED_TOTAL = "${METRICS_PREFIX}.items.skipped.total"
+        const val ITEMS_FAILED_TOTAL = "${METRICS_PREFIX}.items.failed.total"
+        const val CYCLE_DURATION = "${METRICS_PREFIX}.cycle.duration"
+        const val FAILURES_TOTAL = "${METRICS_PREFIX}.failures.total"
+    }
+
+    private val itemsScannedTotal: Counter = Counter.builder(ITEMS_SCANNED_TOTAL)
+        .description("Total items scanned by resume worker")
+        .register(meterRegistry)
+
+    private val itemsResumedTotal: Counter = Counter.builder(ITEMS_RESUMED_TOTAL)
+        .description("Total items resumed successfully")
+        .register(meterRegistry)
+
+    private val itemsSkippedTotal: Counter = Counter.builder(ITEMS_SKIPPED_TOTAL)
+        .description("Total items skipped during resume cycles")
+        .register(meterRegistry)
+
+    private val itemsFailedTotal: Counter = Counter.builder(ITEMS_FAILED_TOTAL)
+        .description("Total items that failed to resume")
+        .register(meterRegistry)
+
+    private val cycleDuration: Timer = Timer.builder(CYCLE_DURATION)
+        .description("Duration of resume worker cycles")
+        .publishPercentileHistogram()
+        .register(meterRegistry)
+
+    override fun cycleStarted(workerId: String) = Unit
+
+    override fun cycleCompleted(
+        workerId: String,
+        result: ApprovedContinuationResumeWorkerResult,
+        duration: Duration,
+    ) {
+        meterRegistry.counter(CYCLES_TOTAL, Tags.of("outcome", "completed")).increment()
+
+        itemsScannedTotal.increment(result.scanned.toDouble())
+        itemsResumedTotal.increment(result.resumed.toDouble())
+        itemsSkippedTotal.increment(result.skipped.toDouble())
+        itemsFailedTotal.increment(result.failed.toDouble())
+
+        cycleDuration.record(duration)
+    }
+
+    override fun cycleFailed(workerId: String, error: Throwable) {
+        meterRegistry.counter(CYCLES_TOTAL, Tags.of("outcome", "failed")).increment()
+
+        // error_code = simple class name only, never the message
+        val errorCode = error::class.simpleName ?: "Unknown"
+        meterRegistry.counter(
+            FAILURES_TOTAL,
+            Tags.of("error_code", errorCode),
+        ).increment()
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedContinuationResumeWorkerMetricsProperties.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedContinuationResumeWorkerMetricsProperties.kt
@@ -1,0 +1,38 @@
+package dev.tramai.spring.sovereign.ops.actuator
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.Duration
+
+/**
+ * Configuration properties for approved resume worker Micrometer metrics.
+ *
+ * Usage:
+ * ```yaml
+ * tramai:
+ *   sovereign:
+ *     ops:
+ *       actuator:
+ *         approved-resume-worker-metrics:
+ *           enabled: false
+ *           queue-snapshot-enabled: true
+ *           queue-snapshot-refresh-interval: 10s
+ *           include-worker-id-tag: false
+ * ```
+ *
+ * @property enabled Master switch for metrics. When false, no metrics observer
+ *   or queue gauges are registered (default: false).
+ * @property queueSnapshotEnabled When true, register gauges exposing queue
+ *   snapshot counts (default: true).
+ * @property queueSnapshotRefreshInterval How often the cached queue snapshot
+ *   is refreshed (default: 10s).
+ * @property includeWorkerIdTag When true, include [workerId] as a tag on
+ *   worker metrics (default: false). Off by default to avoid unnecessary
+ *   cardinality — only enable when running multiple workers.
+ */
+@ConfigurationProperties(prefix = "tramai.sovereign.ops.actuator.approved-resume-worker-metrics")
+data class ApprovedContinuationResumeWorkerMetricsProperties(
+    val enabled: Boolean = false,
+    val queueSnapshotEnabled: Boolean = true,
+    val queueSnapshotRefreshInterval: Duration = Duration.ofSeconds(10),
+    val includeWorkerIdTag: Boolean = false,
+)

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedResumeQueueMetricsSnapshotProvider.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedResumeQueueMetricsSnapshotProvider.kt
@@ -1,0 +1,100 @@
+package dev.tramai.spring.sovereign.ops.actuator
+
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeQueueSnapshot
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeQueueStatusStore
+import io.micrometer.core.instrument.MeterRegistry
+import kotlinx.coroutines.runBlocking
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Cached snapshot provider for queue status gauges.
+ *
+ * Refreshes the snapshot on read when the configured [refreshInterval] has
+ * elapsed. On refresh failure the last known values are retained and a
+ * [snapshotFailureCount] is incremented — no exception messages are exposed.
+ *
+ * Gauges are always registered and return `0` until the first successful
+ * snapshot.
+ */
+class ApprovedResumeQueueMetricsSnapshotProvider(
+    private val queueStatusStore: ApprovedContinuationResumeQueueStatusStore,
+    private val clock: Clock = Clock.systemUTC(),
+    private val refreshInterval: Duration = Duration.ofSeconds(10),
+) {
+
+    @Volatile
+    private var lastRefresh: Instant = Instant.EPOCH
+
+    private val cached = AtomicReference<ApprovedContinuationResumeQueueSnapshot>()
+
+    val eligibleNow = AtomicLong(0)
+    val delayedRetry = AtomicLong(0)
+    val activeLeases = AtomicLong(0)
+    val expiredLeases = AtomicLong(0)
+    val terminalFailures = AtomicLong(0)
+    val oldestEligibleAgeSeconds = AtomicReference<Long?>(null)
+    val oldestRetryDueInSeconds = AtomicReference<Long?>(null)
+    val snapshotFailureCount = AtomicLong(0)
+
+    /**
+     * Register all queue snapshot gauges on the given [registry].
+     *
+     * Gauges call the corresponding [AtomicLong] / [AtomicReference] values
+     * which are updated on refresh. This avoids running blocking JDBC inside
+     * the gauge function itself.
+     */
+    fun registerGauges(registry: MeterRegistry) {
+        val prefix = "tramai.sovereign.approved_resume_queue"
+        registry.gauge("$prefix.eligible_now", eligibleNow) { it.get().toDouble() }
+        registry.gauge("$prefix.delayed_retry", delayedRetry) { it.get().toDouble() }
+        registry.gauge("$prefix.active_leases", activeLeases) { it.get().toDouble() }
+        registry.gauge("$prefix.expired_leases", expiredLeases) { it.get().toDouble() }
+        registry.gauge("$prefix.terminal_failures", terminalFailures) { it.get().toDouble() }
+        registry.gauge("$prefix.oldest_eligible_age_seconds", oldestEligibleAgeSeconds) {
+            it.get()?.toDouble() ?: Double.NaN
+        }
+        registry.gauge("$prefix.oldest_retry_due_in_seconds", oldestRetryDueInSeconds) {
+            it.get()?.toDouble() ?: Double.NaN
+        }
+    }
+
+    /**
+     * Refresh the cached snapshot if the refresh interval has elapsed.
+     *
+     * Called on each metrics scrape. On failure, retains the last known values
+     * and increments [snapshotFailureCount].
+     */
+    fun refreshIfDue() {
+        val now = clock.instant()
+        if (Duration.between(lastRefresh, now) >= refreshInterval) {
+            synchronized(this) {
+                if (Duration.between(lastRefresh, clock.instant()) >= refreshInterval) {
+                    try {
+                        val snapshot = runBlocking {
+                            queueStatusStore.snapshot(now)
+                        }
+                        updateFrom(snapshot)
+                        lastRefresh = clock.instant()
+                    } catch (_: Exception) {
+                        snapshotFailureCount.incrementAndGet()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun updateFrom(snapshot: ApprovedContinuationResumeQueueSnapshot) {
+        cached.set(snapshot)
+        eligibleNow.set(snapshot.eligibleNow)
+        delayedRetry.set(snapshot.delayedRetry)
+        activeLeases.set(snapshot.activeLeases)
+        expiredLeases.set(snapshot.expiredLeases)
+        terminalFailures.set(snapshot.terminalFailures)
+        oldestEligibleAgeSeconds.set(snapshot.oldestEligibleAgeSeconds)
+        oldestRetryDueInSeconds.set(snapshot.oldestRetryDueInSeconds)
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedResumeQueueMetricsSnapshotProvider.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedResumeQueueMetricsSnapshotProvider.kt
@@ -49,16 +49,19 @@ class ApprovedResumeQueueMetricsSnapshotProvider(
      */
     fun registerGauges(registry: MeterRegistry) {
         val prefix = "tramai.sovereign.approved_resume_queue"
-        registry.gauge("$prefix.eligible_now", eligibleNow) { it.get().toDouble() }
-        registry.gauge("$prefix.delayed_retry", delayedRetry) { it.get().toDouble() }
-        registry.gauge("$prefix.active_leases", activeLeases) { it.get().toDouble() }
-        registry.gauge("$prefix.expired_leases", expiredLeases) { it.get().toDouble() }
-        registry.gauge("$prefix.terminal_failures", terminalFailures) { it.get().toDouble() }
-        registry.gauge("$prefix.oldest_eligible_age_seconds", oldestEligibleAgeSeconds) {
-            it.get()?.toDouble() ?: Double.NaN
+        registry.gauge("$prefix.eligible_now", this) { it.refreshIfDue(); it.eligibleNow.get().toDouble() }
+        registry.gauge("$prefix.delayed_retry", this) { it.refreshIfDue(); it.delayedRetry.get().toDouble() }
+        registry.gauge("$prefix.active_leases", this) { it.refreshIfDue(); it.activeLeases.get().toDouble() }
+        registry.gauge("$prefix.expired_leases", this) { it.refreshIfDue(); it.expiredLeases.get().toDouble() }
+        registry.gauge("$prefix.terminal_failures", this) { it.refreshIfDue(); it.terminalFailures.get().toDouble() }
+        registry.gauge("$prefix.snapshot_failures.total", this) {
+            it.refreshIfDue(); it.snapshotFailureCount.get().toDouble()
         }
-        registry.gauge("$prefix.oldest_retry_due_in_seconds", oldestRetryDueInSeconds) {
-            it.get()?.toDouble() ?: Double.NaN
+        registry.gauge("$prefix.oldest_eligible_age_seconds", this) {
+            it.refreshIfDue(); it.oldestEligibleAgeSeconds.get()?.toDouble() ?: Double.NaN
+        }
+        registry.gauge("$prefix.oldest_retry_due_in_seconds", this) {
+            it.refreshIfDue(); it.oldestRetryDueInSeconds.get()?.toDouble() ?: Double.NaN
         }
     }
 
@@ -78,9 +81,10 @@ class ApprovedResumeQueueMetricsSnapshotProvider(
                             queueStatusStore.snapshot(now)
                         }
                         updateFrom(snapshot)
-                        lastRefresh = clock.instant()
                     } catch (_: Exception) {
                         snapshotFailureCount.incrementAndGet()
+                    } finally {
+                        lastRefresh = clock.instant()
                     }
                 }
             }

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsActuatorAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsActuatorAutoConfiguration.kt
@@ -1,9 +1,11 @@
 package dev.tramai.spring.sovereign.ops.actuator
 
 import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeQueueStatusStore
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeWorkerObserverContribution
 import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeWorkerStatusStore
 import dev.tramai.spring.sovereign.ops.SovereignOpsAutoConfiguration
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxWorkerStatusStore
+import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint
 import org.springframework.boot.actuate.health.HealthIndicator
@@ -34,7 +36,10 @@ import org.springframework.context.annotation.Bean
  */
 @AutoConfiguration(after = [SovereignOpsAutoConfiguration::class])
 @ConditionalOnClass(Endpoint::class, HealthIndicator::class)
-@EnableConfigurationProperties(SovereignOpsWorkerStatusEndpointProperties::class)
+@EnableConfigurationProperties(
+    SovereignOpsWorkerStatusEndpointProperties::class,
+    ApprovedContinuationResumeWorkerMetricsProperties::class,
+)
 class SovereignOpsActuatorAutoConfiguration {
 
     @Bean
@@ -82,4 +87,46 @@ class SovereignOpsActuatorAutoConfiguration {
             statusStore = statusStore,
             queueStatusStore = queueStatusStore.ifAvailable,
         )
+
+    @Bean
+    @ConditionalOnBean(MeterRegistry::class)
+    @ConditionalOnProperty(
+        prefix = "tramai.sovereign.ops.actuator.approved-resume-worker-metrics",
+        name = ["enabled"],
+        havingValue = "true",
+        matchIfMissing = false,
+    )
+    fun approvedContinuationResumeWorkerMetricsObserverContribution(
+        meterRegistry: MeterRegistry,
+        metricsProperties: ApprovedContinuationResumeWorkerMetricsProperties,
+    ): ApprovedContinuationResumeWorkerObserverContribution =
+        ApprovedContinuationResumeWorkerObserverContribution(
+            ApprovedContinuationResumeWorkerMetricsObserver(
+                meterRegistry = meterRegistry,
+                properties = metricsProperties,
+            ),
+        )
+
+    @Bean
+    @ConditionalOnBean(
+        value = [MeterRegistry::class, ApprovedContinuationResumeQueueStatusStore::class],
+    )
+    @ConditionalOnProperty(
+        prefix = "tramai.sovereign.ops.actuator.approved-resume-worker-metrics",
+        name = ["enabled"],
+        havingValue = "true",
+        matchIfMissing = false,
+    )
+    fun approvedResumeQueueMetricsSnapshotProvider(
+        queueStatusStore: ApprovedContinuationResumeQueueStatusStore,
+        meterRegistry: MeterRegistry,
+        metricsProperties: ApprovedContinuationResumeWorkerMetricsProperties,
+    ): ApprovedResumeQueueMetricsSnapshotProvider {
+        val provider = ApprovedResumeQueueMetricsSnapshotProvider(
+            queueStatusStore = queueStatusStore,
+            refreshInterval = metricsProperties.queueSnapshotRefreshInterval,
+        )
+        provider.registerGauges(meterRegistry)
+        return provider
+    }
 }

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsActuatorAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/main/kotlin/dev/tramai/spring/sovereign/ops/actuator/SovereignOpsActuatorAutoConfiguration.kt
@@ -12,6 +12,7 @@ import org.springframework.boot.actuate.health.HealthIndicator
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -111,11 +112,9 @@ class SovereignOpsActuatorAutoConfiguration {
     @ConditionalOnBean(
         value = [MeterRegistry::class, ApprovedContinuationResumeQueueStatusStore::class],
     )
-    @ConditionalOnProperty(
-        prefix = "tramai.sovereign.ops.actuator.approved-resume-worker-metrics",
-        name = ["enabled"],
-        havingValue = "true",
-        matchIfMissing = false,
+    @ConditionalOnExpression(
+        "'\${tramai.sovereign.ops.actuator.approved-resume-worker-metrics.enabled:false}' == 'true' " +
+        "&& '\${tramai.sovereign.ops.actuator.approved-resume-worker-metrics.queue-snapshot-enabled:true}' == 'true'"
     )
     fun approvedResumeQueueMetricsSnapshotProvider(
         queueStatusStore: ApprovedContinuationResumeQueueStatusStore,

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedContinuationResumeWorkerMetricsAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedContinuationResumeWorkerMetricsAutoConfigurationTest.kt
@@ -113,6 +113,19 @@ class ApprovedContinuationResumeWorkerMetricsAutoConfigurationTest {
     }
 
     @Test
+    fun `queue snapshot provider not created when queue-snapshot-enabled=false`() {
+        contextRunner
+            .withUserConfiguration(QueueStatusStoreConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.approved-resume-worker-metrics.enabled=true",
+                "tramai.sovereign.ops.actuator.approved-resume-worker-metrics.queue-snapshot-enabled=false",
+            )
+            .run { ctx ->
+                assertThat(ctx).doesNotHaveBean(ApprovedResumeQueueMetricsSnapshotProvider::class.java)
+            }
+    }
+
+    @Test
     fun `metrics observer registers queue gauges when store is present`() {
         contextRunner
             .withUserConfiguration(QueueStatusStoreConfig::class.java)

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedContinuationResumeWorkerMetricsAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedContinuationResumeWorkerMetricsAutoConfigurationTest.kt
@@ -1,0 +1,152 @@
+package dev.tramai.spring.sovereign.ops.actuator
+
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeQueueSnapshot
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeQueueStatusStore
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeWorkerObserver
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeWorkerObserverContribution
+import dev.tramai.spring.sovereign.ops.SovereignOpsAutoConfiguration
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+class ApprovedContinuationResumeWorkerMetricsAutoConfigurationTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                SovereignOpsAutoConfiguration::class.java,
+                SovereignOpsActuatorAutoConfiguration::class.java,
+            ),
+        )
+        .withBean("simpleMeterRegistry", SimpleMeterRegistry::class.java)
+
+    @Test
+    fun `metrics observer contribution not created by default`() {
+        contextRunner
+            .run { ctx ->
+                assertThat(ctx).doesNotHaveBean(ApprovedContinuationResumeWorkerObserverContribution::class.java)
+            }
+    }
+
+    @Test
+    fun `metrics observer contribution created when enabled`() {
+        contextRunner
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.approved-resume-worker-metrics.enabled=true",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(ApprovedContinuationResumeWorkerObserverContribution::class.java)
+                val contribution = ctx.getBean(ApprovedContinuationResumeWorkerObserverContribution::class.java)
+                assertThat(contribution.observer).isInstanceOf(ApprovedContinuationResumeWorkerMetricsObserver::class.java)
+            }
+    }
+
+    @Test
+    fun `custom contribution coexistence is possible`() {
+        contextRunner
+            .withUserConfiguration(CustomObserverContributionConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.approved-resume-worker-metrics.enabled=true",
+            )
+            .run { ctx ->
+                val contributions = ctx.getBeanProvider(ApprovedContinuationResumeWorkerObserverContribution::class.java)
+                    .orderedStream()
+                    .toList()
+                // custom contribution + metrics contribution
+                assertThat(contributions).hasSize(2)
+            }
+    }
+
+    @Test
+    fun `queue snapshot provider not created without queue status store`() {
+        contextRunner
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.approved-resume-worker-metrics.enabled=true",
+            )
+            .run { ctx ->
+                assertThat(ctx).doesNotHaveBean(ApprovedResumeQueueMetricsSnapshotProvider::class.java)
+            }
+    }
+
+    @Test
+    fun `queue snapshot provider created when queue status store and metrics enabled`() {
+        contextRunner
+            .withUserConfiguration(QueueStatusStoreConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.approved-resume-worker-metrics.enabled=true",
+            )
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(ApprovedResumeQueueMetricsSnapshotProvider::class.java)
+            }
+    }
+
+    @Test
+    fun `queue snapshot provider not created when metrics disabled even with store`() {
+        contextRunner
+            .withUserConfiguration(QueueStatusStoreConfig::class.java)
+            .run { ctx ->
+                assertThat(ctx).doesNotHaveBean(ApprovedResumeQueueMetricsSnapshotProvider::class.java)
+            }
+    }
+
+    @Test
+    fun `queue snapshot provider not created when no MeterRegistry`() {
+        ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(
+                    SovereignOpsAutoConfiguration::class.java,
+                    SovereignOpsActuatorAutoConfiguration::class.java,
+                ),
+            )
+            .withUserConfiguration(QueueStatusStoreConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.approved-resume-worker-metrics.enabled=true",
+            )
+            .run { ctx ->
+                assertThat(ctx).doesNotHaveBean(ApprovedResumeQueueMetricsSnapshotProvider::class.java)
+            }
+    }
+
+    @Test
+    fun `metrics observer registers queue gauges when store is present`() {
+        contextRunner
+            .withUserConfiguration(QueueStatusStoreConfig::class.java)
+            .withPropertyValues(
+                "tramai.sovereign.ops.actuator.approved-resume-worker-metrics.enabled=true",
+            )
+            .run { ctx ->
+                val registry = ctx.getBean(MeterRegistry::class.java)
+                val eligibleGauge = registry.find("tramai.sovereign.approved_resume_queue.eligible_now").gauge()
+                assertThat(eligibleGauge).isNotNull
+            }
+    }
+}
+
+@Configuration
+open class CustomObserverContributionConfig {
+    @Bean
+    open fun customObserverContribution(): ApprovedContinuationResumeWorkerObserverContribution =
+        ApprovedContinuationResumeWorkerObserverContribution(
+            ApprovedContinuationResumeWorkerObserver.Noop,
+        )
+}
+
+@Configuration
+open class QueueStatusStoreConfig {
+    @Bean
+    open fun queueStatusStore(): ApprovedContinuationResumeQueueStatusStore =
+        object : ApprovedContinuationResumeQueueStatusStore {
+            override suspend fun snapshot(now: java.time.Instant) =
+                ApprovedContinuationResumeQueueSnapshot(
+                    eligibleNow = 0, delayedRetry = 0, activeLeases = 0,
+                    expiredLeases = 0, terminalFailures = 0,
+                    oldestEligibleAgeSeconds = null, oldestRetryDueInSeconds = null,
+                    lastErrorCodeCounts = emptyMap(),
+                )
+        }
+}

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedContinuationResumeWorkerMetricsObserverTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedContinuationResumeWorkerMetricsObserverTest.kt
@@ -138,6 +138,48 @@ class ApprovedContinuationResumeWorkerMetricsObserverTest {
         // should not throw
         observer.cycleStarted("worker-a")
     }
+
+    @Test
+    fun `worker_id tag present when includeWorkerIdTag=true`() {
+        val observerWithTag = ApprovedContinuationResumeWorkerMetricsObserver(
+            meterRegistry = meterRegistry,
+            properties = ApprovedContinuationResumeWorkerMetricsProperties(
+                includeWorkerIdTag = true,
+            ),
+        )
+        observerWithTag.cycleCompleted(
+            "worker-a",
+            ApprovedContinuationResumeWorkerResult(1, 1, 0, 0),
+            Duration.ofMillis(5),
+        )
+
+        val counter = meterRegistry.counter(
+            ApprovedContinuationResumeWorkerMetricsObserver.CYCLES_TOTAL,
+            "outcome", "completed",
+            "worker_id", "worker-a",
+        )
+        assertThat(counter.count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `worker_id tag absent when includeWorkerIdTag=false`() {
+        observer.cycleCompleted(
+            "worker-a",
+            ApprovedContinuationResumeWorkerResult(1, 1, 0, 0),
+            Duration.ofMillis(5),
+        )
+
+        val allMeters = meterRegistry.meters
+        var hasWorkerIdTag = false
+        for (meter in allMeters) {
+            for (tag in meter.id.tags) {
+                if (tag.key == "worker_id") {
+                    hasWorkerIdTag = true
+                }
+            }
+        }
+        assertThat(hasWorkerIdTag).isFalse()
+    }
 }
 
 private fun within(value: Double) =

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedContinuationResumeWorkerMetricsObserverTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedContinuationResumeWorkerMetricsObserverTest.kt
@@ -1,0 +1,144 @@
+package dev.tramai.spring.sovereign.ops.actuator
+
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeWorkerResult
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+class ApprovedContinuationResumeWorkerMetricsObserverTest {
+
+    private lateinit var meterRegistry: MeterRegistry
+    private lateinit var observer: ApprovedContinuationResumeWorkerMetricsObserver
+
+    @BeforeEach
+    fun setUp() {
+        meterRegistry = SimpleMeterRegistry()
+        observer = ApprovedContinuationResumeWorkerMetricsObserver(
+            meterRegistry = meterRegistry,
+            properties = ApprovedContinuationResumeWorkerMetricsProperties(),
+        )
+    }
+
+    @Test
+    fun `completed cycle increments cycle counter with outcome completed`() {
+        observer.cycleCompleted("worker-a", ApprovedContinuationResumeWorkerResult(5, 3, 1, 1), Duration.ofMillis(50))
+
+        val counter = meterRegistry.counter(
+            ApprovedContinuationResumeWorkerMetricsObserver.CYCLES_TOTAL,
+            "outcome", "completed",
+        )
+        assertThat(counter.count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `failed cycle increments cycle counter with outcome failed`() {
+        observer.cycleFailed("worker-a", IllegalStateException("something bad"))
+
+        val counter = meterRegistry.counter(
+            ApprovedContinuationResumeWorkerMetricsObserver.CYCLES_TOTAL,
+            "outcome", "failed",
+        )
+        assertThat(counter.count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `failure counter uses class name only not message`() {
+        observer.cycleFailed("worker-a", IllegalStateException("secret details"))
+
+        val counter = meterRegistry.counter(
+            ApprovedContinuationResumeWorkerMetricsObserver.FAILURES_TOTAL,
+            "error_code", "IllegalStateException",
+        )
+        assertThat(counter.count()).isEqualTo(1.0)
+
+        // no counter with the message text
+        val allCounters = meterRegistry.find(
+            ApprovedContinuationResumeWorkerMetricsObserver.FAILURES_TOTAL,
+        ).counters()
+        assertThat(allCounters).allMatch { c ->
+            c.id.tags.all { it.value != "secret details" }
+        }
+    }
+
+    @Test
+    fun `result counters increment from worker result`() {
+        observer.cycleCompleted("worker-a", ApprovedContinuationResumeWorkerResult(10, 5, 3, 2), Duration.ofMillis(100))
+
+        assertThat(meterRegistry.counter(
+            ApprovedContinuationResumeWorkerMetricsObserver.ITEMS_SCANNED_TOTAL,
+        ).count()).isEqualTo(10.0)
+
+        assertThat(meterRegistry.counter(
+            ApprovedContinuationResumeWorkerMetricsObserver.ITEMS_RESUMED_TOTAL,
+        ).count()).isEqualTo(5.0)
+
+        assertThat(meterRegistry.counter(
+            ApprovedContinuationResumeWorkerMetricsObserver.ITEMS_SKIPPED_TOTAL,
+        ).count()).isEqualTo(3.0)
+
+        assertThat(meterRegistry.counter(
+            ApprovedContinuationResumeWorkerMetricsObserver.ITEMS_FAILED_TOTAL,
+        ).count()).isEqualTo(2.0)
+    }
+
+    @Test
+    fun `timer records cycle duration`() {
+        observer.cycleCompleted("worker-a", ApprovedContinuationResumeWorkerResult(0, 0, 0, 0), Duration.ofMillis(150))
+
+        val timer = meterRegistry.find(
+            ApprovedContinuationResumeWorkerMetricsObserver.CYCLE_DURATION,
+        ).timer()
+        assertThat(timer).isNotNull
+        assertThat(timer.count()).isEqualTo(1)
+        assertThat(timer.totalTime(TimeUnit.MILLISECONDS)).isCloseTo(150.0, within(1.0))
+    }
+
+    @Test
+    fun `no sensitive tags on any metric`() {
+        observer.cycleCompleted("worker-a", ApprovedContinuationResumeWorkerResult(1, 1, 0, 0), Duration.ofMillis(5))
+        observer.cycleFailed("worker-b", RuntimeException())
+
+        val allMeters = meterRegistry.meters
+        for (meter in allMeters) {
+            for (tag in meter.id.tags) {
+                assertThat(tag.key).doesNotContainIgnoringCase("approval")
+                assertThat(tag.key).doesNotContainIgnoringCase("token")
+                assertThat(tag.key).doesNotContainIgnoringCase("workflow")
+                assertThat(tag.key).doesNotContainIgnoringCase("id")
+                assertThat(tag.key).doesNotContainIgnoringCase("metadata")
+            }
+        }
+    }
+
+    @Test
+    fun `completed and failed cycles use separate outcome tags`() {
+        observer.cycleCompleted("worker-a", ApprovedContinuationResumeWorkerResult(1, 1, 0, 0), Duration.ofMillis(5))
+        observer.cycleCompleted("worker-a", ApprovedContinuationResumeWorkerResult(1, 0, 1, 0), Duration.ofMillis(10))
+        observer.cycleFailed("worker-a", RuntimeException())
+
+        val completedCounter = meterRegistry.counter(
+            ApprovedContinuationResumeWorkerMetricsObserver.CYCLES_TOTAL,
+            "outcome", "completed",
+        )
+        val failedCounter = meterRegistry.counter(
+            ApprovedContinuationResumeWorkerMetricsObserver.CYCLES_TOTAL,
+            "outcome", "failed",
+        )
+
+        assertThat(completedCounter.count()).isEqualTo(2.0)
+        assertThat(failedCounter.count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `cycle started does nothing`() {
+        // should not throw
+        observer.cycleStarted("worker-a")
+    }
+}
+
+private fun within(value: Double) =
+    org.assertj.core.data.Offset.offset(value)

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedResumeQueueMetricsSnapshotProviderTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedResumeQueueMetricsSnapshotProviderTest.kt
@@ -1,0 +1,168 @@
+package dev.tramai.spring.sovereign.ops.actuator
+
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeQueueSnapshot
+import dev.tramai.spring.sovereign.ops.ApprovedContinuationResumeQueueStatusStore
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+
+class ApprovedResumeQueueMetricsSnapshotProviderTest {
+
+    private lateinit var meterRegistry: MeterRegistry
+    private lateinit var fakeStore: FakeApprovedContinuationResumeQueueStatusStore
+    private lateinit var provider: ApprovedResumeQueueMetricsSnapshotProvider
+    private lateinit var fixedClock: Clock
+
+    @BeforeEach
+    fun setUp() {
+        meterRegistry = SimpleMeterRegistry()
+        fakeStore = FakeApprovedContinuationResumeQueueStatusStore()
+        fixedClock = Clock.fixed(
+            Instant.parse("2026-06-01T12:00:00Z"),
+            ZoneId.of("UTC"),
+        )
+        provider = ApprovedResumeQueueMetricsSnapshotProvider(
+            queueStatusStore = fakeStore,
+            clock = fixedClock,
+            refreshInterval = Duration.ofSeconds(10),
+        )
+        provider.registerGauges(meterRegistry)
+    }
+
+    @Test
+    fun `eligible gauge reports snapshot value`() {
+        fakeStore.snapshotResult = emptySnapshot(eligibleNow = 5)
+        provider.refreshIfDue()
+
+        assertThat(meterRegistry.gaugeValue("tramai.sovereign.approved_resume_queue.eligible_now"))
+            .isEqualTo(5.0)
+    }
+
+    @Test
+    fun `all gauges reflect snapshot values`() {
+        fakeStore.snapshotResult = emptySnapshot(
+            eligibleNow = 10, delayedRetry = 3, activeLeases = 2,
+            expiredLeases = 1, terminalFailures = 4,
+            oldestEligibleAgeSeconds = 120, oldestRetryDueInSeconds = 90,
+        )
+        provider.refreshIfDue()
+
+        assertThat(meterRegistry.gaugeValue("tramai.sovereign.approved_resume_queue.eligible_now"))
+            .isEqualTo(10.0)
+        assertThat(meterRegistry.gaugeValue("tramai.sovereign.approved_resume_queue.delayed_retry"))
+            .isEqualTo(3.0)
+        assertThat(meterRegistry.gaugeValue("tramai.sovereign.approved_resume_queue.active_leases"))
+            .isEqualTo(2.0)
+        assertThat(meterRegistry.gaugeValue("tramai.sovereign.approved_resume_queue.expired_leases"))
+            .isEqualTo(1.0)
+        assertThat(meterRegistry.gaugeValue("tramai.sovereign.approved_resume_queue.terminal_failures"))
+            .isEqualTo(4.0)
+        assertThat(meterRegistry.gaugeValue("tramai.sovereign.approved_resume_queue.oldest_eligible_age_seconds"))
+            .isEqualTo(120.0)
+        assertThat(meterRegistry.gaugeValue("tramai.sovereign.approved_resume_queue.oldest_retry_due_in_seconds"))
+            .isEqualTo(90.0)
+    }
+
+    @Test
+    fun `gauges return zero or NaN before first refresh`() {
+        assertThat(meterRegistry.gaugeValue("tramai.sovereign.approved_resume_queue.eligible_now"))
+            .isEqualTo(0.0)
+        assertThat(meterRegistry.gaugeValue("tramai.sovereign.approved_resume_queue.oldest_eligible_age_seconds"))
+            .isNaN()
+        assertThat(meterRegistry.gaugeValue("tramai.sovereign.approved_resume_queue.oldest_retry_due_in_seconds"))
+            .isNaN()
+    }
+
+    @Test
+    fun `snapshot failure count increments on error`() {
+        val failingStore = FakeApprovedContinuationResumeQueueStatusStore(throwOnSnapshot = true)
+        val failProvider = ApprovedResumeQueueMetricsSnapshotProvider(
+            queueStatusStore = failingStore,
+            clock = fixedClock,
+            refreshInterval = Duration.ofSeconds(1),
+        )
+        failProvider.refreshIfDue()
+        failProvider.refreshIfDue()
+
+        assertThat(failProvider.snapshotFailureCount.get()).isEqualTo(2)
+    }
+
+    @Test
+    fun `last known values retained after refresh failure`() {
+        val failStore = FakeApprovedContinuationResumeQueueStatusStore()
+        val testProvider = ApprovedResumeQueueMetricsSnapshotProvider(
+            queueStatusStore = failStore,
+            refreshInterval = Duration.ofSeconds(0), // always refresh
+        )
+
+        // first call succeeds
+        failStore.throwOnSnapshot = false
+        failStore.snapshotResult = emptySnapshot(eligibleNow = 7, oldestEligibleAgeSeconds = 30)
+        testProvider.refreshIfDue()
+        assertThat(testProvider.eligibleNow.get()).isEqualTo(7)
+
+        // second call fails
+        failStore.throwOnSnapshot = true
+        testProvider.refreshIfDue()
+
+        // values retained
+        assertThat(testProvider.eligibleNow.get()).isEqualTo(7)
+        assertThat(testProvider.snapshotFailureCount.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `lastErrorCodeCounts not exported as gauge`() {
+        fakeStore.snapshotResult = emptySnapshot(
+            eligibleNow = 1,
+            lastErrorCodeCounts = mapOf("Timeout" to 1),
+        )
+        provider.refreshIfDue()
+
+        val relevantGauges = meterRegistry.meters.filter {
+            it.id.name.contains("error_code", ignoreCase = true) ||
+                it.id.name.contains("lasterrorcode", ignoreCase = true)
+        }
+        assertThat(relevantGauges).isEmpty()
+    }
+}
+
+private class FakeApprovedContinuationResumeQueueStatusStore(
+    var throwOnSnapshot: Boolean = false,
+) : ApprovedContinuationResumeQueueStatusStore {
+
+    var snapshotResult: ApprovedContinuationResumeQueueSnapshot = emptySnapshot()
+
+    override suspend fun snapshot(now: Instant): ApprovedContinuationResumeQueueSnapshot {
+        if (throwOnSnapshot) throw RuntimeException("snapshot failed")
+        return snapshotResult
+    }
+}
+
+private fun emptySnapshot(
+    eligibleNow: Long = 0,
+    delayedRetry: Long = 0,
+    activeLeases: Long = 0,
+    expiredLeases: Long = 0,
+    terminalFailures: Long = 0,
+    oldestEligibleAgeSeconds: Long? = null,
+    oldestRetryDueInSeconds: Long? = null,
+    lastErrorCodeCounts: Map<String, Long> = emptyMap(),
+) = ApprovedContinuationResumeQueueSnapshot(
+    eligibleNow = eligibleNow,
+    delayedRetry = delayedRetry,
+    activeLeases = activeLeases,
+    expiredLeases = expiredLeases,
+    terminalFailures = terminalFailures,
+    oldestEligibleAgeSeconds = oldestEligibleAgeSeconds,
+    oldestRetryDueInSeconds = oldestRetryDueInSeconds,
+    lastErrorCodeCounts = lastErrorCodeCounts,
+)
+
+private fun MeterRegistry.gaugeValue(name: String): Double =
+    find(name).gauge()?.value() ?: Double.NaN

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedResumeQueueMetricsSnapshotProviderTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedResumeQueueMetricsSnapshotProviderTest.kt
@@ -67,6 +67,8 @@ class ApprovedResumeQueueMetricsSnapshotProviderTest {
             .isEqualTo(120.0)
         assertThat(meterRegistry.gaugeValue("tramai.sovereign.approved_resume_queue.oldest_retry_due_in_seconds"))
             .isEqualTo(90.0)
+        assertThat(meterRegistry.gaugeValue("tramai.sovereign.approved_resume_queue.snapshot_failures.total"))
+            .isEqualTo(0.0)
     }
 
     @Test
@@ -77,6 +79,8 @@ class ApprovedResumeQueueMetricsSnapshotProviderTest {
             .isNaN()
         assertThat(meterRegistry.gaugeValue("tramai.sovereign.approved_resume_queue.oldest_retry_due_in_seconds"))
             .isNaN()
+        assertThat(meterRegistry.gaugeValue("tramai.sovereign.approved_resume_queue.snapshot_failures.total"))
+            .isEqualTo(0.0)
     }
 
     @Test
@@ -85,7 +89,7 @@ class ApprovedResumeQueueMetricsSnapshotProviderTest {
         val failProvider = ApprovedResumeQueueMetricsSnapshotProvider(
             queueStatusStore = failingStore,
             clock = fixedClock,
-            refreshInterval = Duration.ofSeconds(1),
+            refreshInterval = Duration.ofSeconds(0), // no throttling
         )
         failProvider.refreshIfDue()
         failProvider.refreshIfDue()
@@ -114,6 +118,23 @@ class ApprovedResumeQueueMetricsSnapshotProviderTest {
         // values retained
         assertThat(testProvider.eligibleNow.get()).isEqualTo(7)
         assertThat(testProvider.snapshotFailureCount.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `gauge read triggers refresh`() {
+        val freshRegistry = SimpleMeterRegistry()
+        val freshProvider = ApprovedResumeQueueMetricsSnapshotProvider(
+            queueStatusStore = fakeStore,
+            clock = fixedClock,
+            refreshInterval = Duration.ofSeconds(10),
+        )
+        fakeStore.snapshotResult = emptySnapshot(eligibleNow = 42)
+        freshProvider.registerGauges(freshRegistry)
+
+        // read gauge without calling refreshIfDue() explicitly
+        val value = freshRegistry.gaugeValue("tramai.sovereign.approved_resume_queue.eligible_now")
+
+        assertThat(value).isNotZero()
     }
 
     @Test

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedResumeQueueMetricsSnapshotProviderTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/src/test/kotlin/dev/tramai/spring/sovereign/ops/actuator/ApprovedResumeQueueMetricsSnapshotProviderTest.kt
@@ -134,7 +134,7 @@ class ApprovedResumeQueueMetricsSnapshotProviderTest {
         // read gauge without calling refreshIfDue() explicitly
         val value = freshRegistry.gaugeValue("tramai.sovereign.approved_resume_queue.eligible_now")
 
-        assertThat(value).isNotZero()
+        assertThat(value).isEqualTo(42.0)
     }
 
     @Test


### PR DESCRIPTION
- Add ApprovedContinuationResumeWorkerMetricsProperties gated by tramai.sovereign.ops.actuator.approved-resume-worker-metrics.enabled
- Add ApprovedContinuationResumeWorkerMetricsObserver implementing the observer SPI with safe, low-cardinality Micrometer counters and timers (no approval IDs, tokens, or exception messages)
- Add ApprovedResumeQueueMetricsSnapshotProvider with cached gauge registration and safe refresh-failure handling
- Wire both into SovereignOpsActuatorAutoConfiguration via observer contribution and conditional queue status store
- 22 new tests: observer unit tests, provider tests, auto-config tests
- Sovereign Runtime RC: green