### PR TITLE
docs(ops): add approved resume worker dashboards and alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Added approved-resume worker lifecycle, status store, queue snapshot, health indicator, and Micrometer metrics (PR #113-#116). Queue diagnostics expose aggregate counts such as eligibleNow, delayedRetry, activeLeases, expiredLeases, and terminalFailures, without exposing approval IDs, workflow IDs, resume tokens, or payloads.
 - Added `ApprovedResumeLifecycleJdbcE2ETest` — a full lifecycle E2E proof for the approved-resume flow using Testcontainers PostgreSQL (PR #117). Proves: approval request → approve decision → encrypted credential custody → auto-resume worker picks up the approved continuation → continuation is replayed through the engine → terminal success state is observed. Verifies that the resume credential is never exposed in plaintext through any operational surface.
 - Added docs sync for Sovereign Runtime post-#117 closure state (PR #118). Updates quickstart with REST control plane, reviewer UI, approved-resume worker config, and human approval auto-resume section. Updates JDBC runbook with V6/V7 migrations, resume credential store, and auto-resume worker configuration. Updates CHANGELOG with PR #112–#118 entries. Updates README module table, capability list, and deferred items.
+- Added approved-resume worker Prometheus alert examples, Grafana dashboard JSON, and operator triage runbook (PR #119).
 - Sovereign runtime profile and routing foundation (`tramai-sovereign`).
 - Policy enforcement and DLP/redaction support (`tramai-security`).
 - Approval gates and replay-safe resume.

--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ The `verifySovereignRuntimeClosure` task aggregates the full verification surfac
 ./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks
 ```
 
+Approved-resume worker dashboards, alert examples, and an operator triage runbook are available under docs/observability/ and docs/runbooks/.
+
 ## Sovereign Runtime Release Readiness
 
 The sovereign runtime capabilities on `master` are actively evolving and not yet a stable 1.0 API. For the current release-readiness boundary, included modules, validation commands, and known non-goals, see:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2309,6 +2309,11 @@ tasks.register("verifySovereignRuntimeClosureDocs") {
             "Runbook must reference the real config property tramai.sovereign.ops.actuator.approved-resume-worker-metrics.queue-snapshot-refresh-interval"
         }
 
+        // Forbidden: histogram_quantile(0.95 in runbook — dashboard uses average, not p95
+        require(!runbookText.contains("histogram_quantile(0.95")) {
+            "Runbook must not recommend histogram_quantile(0.95) unless histogram buckets are explicitly documented/enabled for the cycle_duration_seconds timer."
+        }
+
         logger.lifecycle("verifySovereignRuntimeClosureDocs: all documentation consistency checks passed.")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2293,6 +2293,22 @@ tasks.register("verifySovereignRuntimeClosureDocs") {
             "STATUS.md must reference dashboard/alert examples"
         }
 
+        // Forbidden: wrong config prefix for approved-resume worker metrics
+        require(!runbookText.contains("tramai.sovereign.approved-resume.worker.metrics-enabled")) {
+            "Runbook must not use stale prefix tramai.sovereign.approved-resume.worker.metrics-enabled; use tramai.sovereign.ops.actuator.approved-resume-worker-metrics.enabled"
+        }
+        require(!runbookText.contains("tramai.sovereign.approved-resume.queue.snapshot-refresh-interval")) {
+            "Runbook must not use stale prefix tramai.sovereign.approved-resume.queue.snapshot-refresh-interval; use tramai.sovereign.ops.actuator.approved-resume-worker-metrics.queue-snapshot-refresh-interval"
+        }
+
+        // Required: correct config properties in runbook
+        require(runbookText.contains("tramai.sovereign.ops.actuator.approved-resume-worker-metrics.enabled")) {
+            "Runbook must reference the real config property tramai.sovereign.ops.actuator.approved-resume-worker-metrics.enabled"
+        }
+        require(runbookText.contains("tramai.sovereign.ops.actuator.approved-resume-worker-metrics.queue-snapshot-refresh-interval")) {
+            "Runbook must reference the real config property tramai.sovereign.ops.actuator.approved-resume-worker-metrics.queue-snapshot-refresh-interval"
+        }
+
         logger.lifecycle("verifySovereignRuntimeClosureDocs: all documentation consistency checks passed.")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2219,6 +2219,80 @@ tasks.register("verifySovereignRuntimeClosureDocs") {
             "CHANGELOG.md must reference rest-control-plane-enabled (the correct flat property name)."
         }
 
+        // ── PR #119: Approved-resume worker dashboards and alerts ──
+
+        // File existence checks
+        val dashboardsDir = file("docs/observability")
+        val alertFile = file("docs/observability/prometheus-approved-resume-worker-alerts.yml")
+        val dashboardFile = file("docs/observability/grafana-approved-resume-worker-dashboard.json")
+        val runbookFile = file("docs/runbooks/approved-resume-worker-observability.md")
+        require(alertFile.exists()) { "Prometheus alert file missing at ${alertFile.absolutePath}" }
+        require(dashboardFile.exists()) { "Grafana dashboard file missing at ${dashboardFile.absolutePath}" }
+        require(runbookFile.exists()) { "Observability runbook missing at ${runbookFile.absolutePath}" }
+
+        // Required phrases in alerts
+        val alerts = alertFile.readText()
+        require(alerts.contains("TramAIApprovedResumeWorkerFailures")) {
+            "Prometheus alerts must contain TramAIApprovedResumeWorkerFailures"
+        }
+        require(alerts.contains("TramAIApprovedResumeExpiredLeases")) {
+            "Prometheus alerts must contain TramAIApprovedResumeExpiredLeases"
+        }
+        require(alerts.contains("TramAIApprovedResumeTerminalFailures")) {
+            "Prometheus alerts must contain TramAIApprovedResumeTerminalFailures"
+        }
+
+        // Forbidden: no individual identifiers as labels in alerts or dashboard
+        val dashboard = dashboardFile.readText()
+        val runbookText = runbookFile.readText()
+        require(!alerts.contains("approval_id")) {
+            "Prometheus alerts must not contain approval_id as a label"
+        }
+        require(!dashboard.contains("\"approval_id\"")) {
+            "Grafana dashboard must not contain approval_id as a label"
+        }
+        require(!runbookText.contains("approval_id")) {
+            "Observability runbook must not contain approval_id"
+        }
+        require(!alerts.contains("workflow_run_id")) {
+            "Prometheus alerts must not contain workflow_run_id as a label"
+        }
+        require(!dashboard.contains("\"workflow_run_id\"")) {
+            "Grafana dashboard must not contain workflow_run_id as a label"
+        }
+        require(!runbookText.contains("workflow_run_id")) {
+            "Observability runbook must not contain workflow_run_id"
+        }
+        require(!alerts.contains("resume_token")) {
+            "Prometheus alerts must not contain resume_token as a label"
+        }
+        require(!dashboard.contains("\"resume_token\"")) {
+            "Grafana dashboard must not contain resume_token as a label"
+        }
+        require(!runbookText.contains("resume_token")) {
+            "Observability runbook must not contain resume_token"
+        }
+        require(!alerts.contains("exception_message")) {
+            "Prometheus alerts must not contain exception_message as a label"
+        }
+        require(!dashboard.contains("\"exception_message\"")) {
+            "Grafana dashboard must not contain exception_message as a label"
+        }
+        require(!runbookText.contains("exception_message")) {
+            "Observability runbook must not contain exception_message"
+        }
+
+        // Alert file must not claim production certification
+        require(!alerts.contains("production certified")) {
+            "Prometheus alerts must not claim production certification"
+        }
+
+        // STATUS.md must reference the new dashboard and alert examples
+        val statusText = file("docs/STATUS.md").readText()
+        require(statusText.contains("dashboard and alert examples")) {
+            "STATUS.md must reference dashboard/alert examples"
+        }
+
         logger.lifecycle("verifySovereignRuntimeClosureDocs: all documentation consistency checks passed.")
     }
 }

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -34,6 +34,7 @@ Closure boundary:
 - Approved-continuation auto-resume worker
 - Approved-resume worker lifecycle/status/health/queue snapshot/metrics
 - Approved-resume lifecycle JDBC E2E proof
+- Approved-resume worker dashboard and alert examples
 
 ### Deferred from Closure
 - Key rotation
@@ -145,7 +146,7 @@ The following are intentionally not claimed as complete. Some are planned, some 
 - Maven Central release of sovereign-runtime modules
 - key rotation
 - complete API reference documentation
-- production dashboards
+- production-certified dashboards and organization-specific alert tuning
 
 No timelines are committed for these items.
 

--- a/docs/observability/grafana-approved-resume-worker-dashboard.json
+++ b/docs/observability/grafana-approved-resume-worker-dashboard.json
@@ -554,12 +554,12 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "histogram_quantile(0.95, sum(rate(tramai_sovereign_approved_resume_worker_cycle_duration_seconds_bucket[$__rate_interval])) by (le))",
-          "legendFormat": "p95",
+          "expr": "rate(tramai_sovereign_approved_resume_worker_cycle_duration_seconds_sum[$__rate_interval]) / rate(tramai_sovereign_approved_resume_worker_cycle_duration_seconds_count[$__rate_interval])",
+          "legendFormat": "average",
           "refId": "A"
         }
       ],
-      "title": "Cycle Duration (p95)",
+      "title": "Cycle Duration Average",
       "type": "timeseries"
     },
     {

--- a/docs/observability/grafana-approved-resume-worker-dashboard.json
+++ b/docs/observability/grafana-approved-resume-worker-dashboard.json
@@ -1,0 +1,708 @@
+{
+  "title": "TramAI Approved Resume Worker",
+  "uid": "tramai-approved-resume-worker",
+  "schemaVersion": 38,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "panels": [],
+      "title": "Queue Status",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 4, "x": 0, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "tramai_sovereign_approved_resume_queue_eligible_now",
+          "legendFormat": "Eligible Now",
+          "refId": "A"
+        }
+      ],
+      "title": "Eligible Now",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 4, "x": 4, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "tramai_sovereign_approved_resume_queue_delayed_retry",
+          "legendFormat": "Delayed Retry",
+          "refId": "A"
+        }
+      ],
+      "title": "Delayed Retry",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 4, "x": 8, "y": 1 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "tramai_sovereign_approved_resume_queue_active_leases",
+          "legendFormat": "Active Leases",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Leases",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 4, "x": 12, "y": 1 },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "tramai_sovereign_approved_resume_queue_expired_leases",
+          "legendFormat": "Expired Leases",
+          "refId": "A"
+        }
+      ],
+      "title": "Expired Leases",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 4, "x": 16, "y": 1 },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "tramai_sovereign_approved_resume_queue_terminal_failures",
+          "legendFormat": "Terminal Failures",
+          "refId": "A"
+        }
+      ],
+      "title": "Terminal Failures",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 },
+      "id": 7,
+      "panels": [],
+      "title": "Worker Throughput",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "increase(tramai_sovereign_approved_resume_worker_cycles_total[$__rate_interval])",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Resume Cycles (by outcome)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 4, "x": 12, "y": 8 },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "increase(tramai_sovereign_approved_resume_worker_items_resumed_total[$__rate_interval])",
+          "legendFormat": "Items Resumed",
+          "refId": "A"
+        }
+      ],
+      "title": "Items Resumed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 4, "x": 16, "y": 8 },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "increase(tramai_sovereign_approved_resume_worker_items_failed_total[$__rate_interval])",
+          "legendFormat": "Items Failed",
+          "refId": "A"
+        }
+      ],
+      "title": "Items Failed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 4, "x": 20, "y": 8 },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "increase(tramai_sovereign_approved_resume_queue_snapshot_failures_total[$__rate_interval])",
+          "legendFormat": "Snapshot Failures",
+          "refId": "A"
+        }
+      ],
+      "title": "Snapshot Failures",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 16 },
+      "id": 12,
+      "panels": [],
+      "title": "Timing & Age",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 17 },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum(rate(tramai_sovereign_approved_resume_worker_cycle_duration_seconds_bucket[$__rate_interval])) by (le))",
+          "legendFormat": "p95",
+          "refId": "A"
+        }
+      ],
+      "title": "Cycle Duration (p95)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 120 },
+              { "color": "red", "value": 300 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 17 },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "tramai_sovereign_approved_resume_queue_oldest_eligible_age_seconds",
+          "legendFormat": "Oldest Eligible Age",
+          "refId": "A"
+        }
+      ],
+      "title": "Oldest Eligible Age",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 17 },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "tramai_sovereign_approved_resume_queue_oldest_retry_due_in_seconds",
+          "legendFormat": "Oldest Retry Due In",
+          "refId": "A"
+        }
+      ],
+      "title": "Oldest Retry Due",
+      "type": "timeseries"
+    }
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "tags": ["tramai", "approved-resume", "worker"],
+  "version": 1,
+  "links": [],
+  "refresh": "30s"
+}

--- a/docs/observability/prometheus-approved-resume-worker-alerts.yml
+++ b/docs/observability/prometheus-approved-resume-worker-alerts.yml
@@ -1,0 +1,61 @@
+# Prometheus alert rules for TramAI approved-resume worker.
+# Metric names use Prometheus-normalized form (Micrometer dots → underscores).
+# Verify exact names against /actuator/prometheus output.
+# This is an example — not a production-certified alert configuration.
+
+groups:
+  - name: tramai-approved-resume-worker
+    rules:
+      - alert: TramAIApprovedResumeWorkerFailures
+        expr: increase(tramai_sovereign_approved_resume_worker_failures_total[15m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "TramAI approved-resume worker failures detected"
+          description: "The approved-resume worker has recorded failed resume cycles in the last 15 minutes."
+
+      - alert: TramAIApprovedResumeQueueBacklogGrowing
+        expr: tramai_sovereign_approved_resume_queue_eligible_now > 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Approved-resume queue has eligible work for too long"
+          description: "Approved continuations are eligible for resume but have not been cleared for over 15 minutes."
+
+      - alert: TramAIApprovedResumeExpiredLeases
+        expr: tramai_sovereign_approved_resume_queue_expired_leases > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Expired approved-resume worker leases detected"
+          description: "One or more approved-resume items have expired leases. The worker may have died mid-cycle or a DB transaction may be stuck."
+
+      - alert: TramAIApprovedResumeTerminalFailures
+        expr: tramai_sovereign_approved_resume_queue_terminal_failures > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Approved-resume terminal failures detected"
+          description: "One or more continuations reached terminal failure and were marked CANCELLED. Investigate the safe reason code."
+
+      - alert: TramAIApprovedResumeSnapshotFailures
+        expr: increase(tramai_sovereign_approved_resume_queue_snapshot_failures_total[15m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Approved-resume queue snapshot refresh is failing"
+          description: "Queue metrics may be stale because snapshot refresh failed. Check DB connectivity."
+
+      - alert: TramAIApprovedResumeOldestEligibleTooOld
+        expr: tramai_sovereign_approved_resume_queue_oldest_eligible_age_seconds > 300
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Old approved-resume item has not resumed"
+          description: "The oldest eligible approved continuation has been waiting more than 5 minutes."

--- a/docs/releases/sovereign-runtime-closure-boundary.md
+++ b/docs/releases/sovereign-runtime-closure-boundary.md
@@ -41,6 +41,7 @@ The following capabilities are included in the closure boundary:
 - Micrometer / Prometheus metrics bridge
 - OpenTelemetry worker metrics
 - Worker observability runbook with PromQL examples and alert definitions
+- Approved-resume worker dashboard and alert examples
 - Sovereign document intelligence reference workflow (file-backed example)
 - Regulated claim triage executable JDBC E2E proof
 - CI-backed E2E verification

--- a/docs/runbooks/approved-resume-worker-observability.md
+++ b/docs/runbooks/approved-resume-worker-observability.md
@@ -1,0 +1,125 @@
+---
+title: Approved Resume Worker Observability
+description: Operator guidance for observing, triaging, and alerting on the approved-continuation auto-resume worker
+---
+
+# Approved Resume Worker Observability
+
+## Purpose
+
+The approved-resume worker is responsible for automatically resuming approved continuations (workflows that were paused pending human review and subsequently approved). This observability surface exists so operators can:
+
+- Monitor the worker's health and throughput
+- Detect when approved items are stuck and not being resumed
+- Identify lease expiration issues that signal worker crashes or stuck DB transactions
+- Observe retry backlogs caused by transient failures
+- Distinguish terminal failures (safe reasons like `rejection-revoked`, `superseded`) from transient errors
+- Verify that the queue-snapshot refresh is working (metrics are fresh)
+
+## Required Configuration
+
+Before the metrics and alerts described in this document become available, the following must be enabled:
+
+| Setting | Value | Description |
+|---------|-------|-------------|
+| `tramai.sovereign.approved-resume.worker.metrics-enabled` | `true` | Enables Micrometer metric export for the approved-resume worker |
+| `tramai.sovereign.approved-resume.queue.snapshot-refresh-interval` | — | Controls how often the in-memory queue snapshot is refreshed (affects staleness of `eligible_now`, `delayed_retry`, etc.) |
+| Prometheus scrape target | — | The application's `/actuator/prometheus` endpoint must be scraped |
+| Grafana datasource | `prometheus` | A Prometheus datasource with UID `prometheus` must exist if using the example dashboard |
+
+## Metrics
+
+All metrics are exported via Micrometer under the `tramai.sovereign.*` namespace. The table below shows Prometheus-normalized names (dots → underscores).
+
+| Metric (Prometheus form) | Type | Description |
+|--------------------------|------|-------------|
+| `tramai_sovereign_approved_resume_worker_cycles_total` | Counter | Total worker cycles completed. Tagged by `outcome` (e.g. `completed`, `failed`). |
+| `tramai_sovereign_approved_resume_worker_items_scanned_total` | Counter | Total items scanned across all cycles. |
+| `tramai_sovereign_approved_resume_worker_items_resumed_total` | Counter | Total items successfully resumed. |
+| `tramai_sovereign_approved_resume_worker_items_skipped_total` | Counter | Total items skipped (e.g. still within cooldown, already resumed by another process). |
+| `tramai_sovereign_approved_resume_worker_items_failed_total` | Counter | Total items that failed during resume. |
+| `tramai_sovereign_approved_resume_worker_cycle_duration_seconds` | Timer (histogram) | Duration of each worker cycle. Use `_bucket`, `_sum`, `_count` suffixes for Prometheus histogram queries. |
+| `tramai_sovereign_approved_resume_worker_failures_total` | Counter | Non-item-specific worker failures. Tagged by `error_code`. |
+| `tramai_sovereign_approved_resume_queue_eligible_now` | Gauge | Number of approved continuations currently eligible for immediate resume. |
+| `tramai_sovereign_approved_resume_queue_delayed_retry` | Gauge | Number of items in retry cooldown (transient failure, waiting for next attempt). |
+| `tramai_sovereign_approved_resume_queue_active_leases` | Gauge | Number of items currently leased by a worker. |
+| `tramai_sovereign_approved_resume_queue_expired_leases` | Gauge | Number of items with expired leases (worker died mid-cycle or DB transaction stuck). |
+| `tramai_sovereign_approved_resume_queue_terminal_failures` | Gauge | Number of items in terminal failure state (CANCELLED with a safe reason code). |
+| `tramai_sovereign_approved_resume_queue_oldest_eligible_age_seconds` | Gauge | Age in seconds of the oldest eligible item waiting for resume. |
+| `tramai_sovereign_approved_resume_queue_oldest_retry_due_in_seconds` | Gauge | Seconds until the oldest retry item becomes eligible again. |
+| `tramai_sovereign_approved_resume_queue_snapshot_failures_total` | Counter | Total failures refreshing the in-memory queue snapshot (DB connectivity issues). |
+
+## Dashboard
+
+An importable Grafana dashboard JSON is available at:
+
+[`docs/observability/grafana-approved-resume-worker-dashboard.json`](../observability/grafana-approved-resume-worker-dashboard.json)
+
+The dashboard provides three row groups:
+
+1. **Queue Status** — Stat panels for eligible now, delayed retry, active leases, expired leases, terminal failures.
+2. **Worker Throughput** — Time series panels for resume cycles (by outcome), items resumed, items failed, and snapshot failures.
+3. **Timing & Age** — Time series panels for cycle duration (p95), oldest eligible age, and oldest retry due.
+
+## Alerts
+
+Prometheus alert rule examples are available at:
+
+[`docs/observability/prometheus-approved-resume-worker-alerts.yml`](../observability/prometheus-approved-resume-worker-alerts.yml)
+
+| Alert | Severity | Trigger |
+|-------|----------|---------|
+| `TramAIApprovedResumeWorkerFailures` | warning | Non-zero failures in the last 15 minutes |
+| `TramAIApprovedResumeQueueBacklogGrowing` | warning | Eligible items not cleared for > 15 minutes |
+| `TramAIApprovedResumeExpiredLeases` | warning | Expired leases present for > 10 minutes |
+| `TramAIApprovedResumeTerminalFailures` | critical | Terminal failures detected |
+| `TramAIApprovedResumeSnapshotFailures` | warning | Snapshot refresh failing |
+| `TramAIApprovedResumeOldestEligibleTooOld` | warning | Oldest eligible item > 5 minutes old |
+
+## Triage: Approved but Not Resumed
+
+🔴 `tramai_sovereign_approved_resume_queue_eligible_now > 0`
+
+1. **Check the worker is running.** Verify the pod/process is alive and the worker schedule (if cron-driven) has not been paused or overridden.
+2. **Check snapshot freshness.** If `tramai_sovereign_approved_resume_queue_snapshot_failures_total` has increased recently, the snapshot may be stale — the worker may have already processed items but the metrics are not reflecting it.
+3. **Check `oldest_eligible_age_seconds`.** If this is climbing, the worker is scanning but not selecting items — investigate the eligibility predicate (cooldown check, approval status filter, etc.).
+4. **Check worker cycle outcome.** Query `increase(tramai_sovereign_approved_resume_worker_cycles_total[$__rate_interval])` grouped by `outcome`. If cycles are failing (`outcome=failed`), see "Triage: retry backlog" below.
+5. **Check for stuck DB transactions.** Prolonged transactions holding row-level locks on the continuation table can prevent the worker from progressing items.
+
+## Triage: Retry Backlog
+
+🔴 `tramai_sovereign_approved_resume_queue_delayed_retry > 0`
+
+1. **Examine `oldest_retry_due_in_seconds`.** If this value is high, items are in long cooldown — likely a persistent failure mode.
+2. **Check items_failed_total.** A spike in `increase(tramai_sovereign_approved_resume_worker_items_failed_total[$__rate_interval])` indicates a systematic problem (downstream service unavailable, invalid continuation state, etc.).
+3. **Review error codes.** Use `tramai_sovereign_approved_resume_worker_failures_total` (tagged by `error_code`) to identify the dominant failure mode.
+4. **Escalate if delayed_retry keeps growing and oldest_retry_due_in_seconds does not decrease.** This means new items are failing faster than retries are succeeding.
+
+## Triage: Expired Leases
+
+🔴 `tramai_sovereign_approved_resume_queue_expired_leases > 0`
+
+1. **Check if the worker is still alive.** If the worker process has died, leases will expire after the lease timeout.
+2. **Check for stuck DB transactions.** A DB transaction that is holding locks but not progressing may cause a worker to appear dead even if the process is running. Check the database for long-running queries on the continuation table.
+3. **Check worker cycle duration.** If `histogram_quantile(0.95, ...)` for `cycle_duration_seconds` exceeds the lease timeout, the worker may be timing out its own leases. This suggests the worker is overloaded or a downstream call is slow.
+4. **Monitor for oscillation.** If expired leases appear and then clear as another worker reaps them, the system is self-healing but may be under-provisioned.
+
+## Triage: Terminal Failures
+
+🔴 `tramai_sovereign_approved_resume_queue_terminal_failures > 0`
+
+1. **Verify the reason code.** Terminal failures are expected in some cases (e.g., an approval was revoked, or the continuation was superseded by a newer run). The reason is stored in the safe reason code field on the continuation record.
+2. **Check if terminal failures are cumulative or increasing.** A stable count of old terminal failures is normal. An increasing count suggests a new systemic issue causing items to be cancelled rather than resumed.
+3. **Correlate with upstream signals.** Terminal failures are often caused by external state changes (workflow cancelled upstream, approval revoked, parent workflow already terminated).
+4. **Manual cleanup.** Items in terminal failure state are marked CANCELLED and will not be retried. If they should be retried, manual intervention in the database may be needed.
+
+## Safety Boundary
+
+The following information is **never** included in metric labels, alert annotations, or dashboard panel descriptions:
+
+- **Approval identifiers** — Individual approval IDs are not exposed in metrics.
+- **Workflow run identifiers** — Specific workflow run IDs are not exposed.
+- **Continuation resume tokens** — Resume tokens are not exposed.
+- **Exception messages or stack traces** — Raw exception details are not propagated into observability labels or annotations.
+
+All observability surfaces described in this document use only **safe aggregate metrics**: counters, gauges, and histograms with high-level tags (e.g., `outcome`, `error_code`). No personally identifiable information (PII) or internal request identifiers are included. If deeper investigation of a specific item is required, the operator must query the database directly using the appropriate tooling outside of the observability pipeline.

--- a/docs/runbooks/approved-resume-worker-observability.md
+++ b/docs/runbooks/approved-resume-worker-observability.md
@@ -63,7 +63,7 @@ The dashboard provides three row groups:
 
 1. **Queue Status** — Stat panels for eligible now, delayed retry, active leases, expired leases, terminal failures.
 2. **Worker Throughput** — Time series panels for resume cycles (by outcome), items resumed, items failed, and snapshot failures.
-3. **Timing & Age** — Time series panels for cycle duration (p95), oldest eligible age, and oldest retry due.
+3. **Timing & Age** — Time series panels for cycle duration average, oldest eligible age, and oldest retry due.
 
 ## Alerts
 
@@ -105,7 +105,7 @@ Prometheus alert rule examples are available at:
 
 1. **Check if the worker is still alive.** If the worker process has died, leases will expire after the lease timeout.
 2. **Check for stuck DB transactions.** A DB transaction that is holding locks but not progressing may cause a worker to appear dead even if the process is running. Check the database for long-running queries on the continuation table.
-3. **Check worker cycle duration.** If `histogram_quantile(0.95, ...)` for `cycle_duration_seconds` exceeds the lease timeout, the worker may be timing out its own leases. This suggests the worker is overloaded or a downstream call is slow.
+3. **Check worker cycle duration.** If the cycle duration average exceeds the lease timeout, the worker may be timing out its own leases. If you enable histogram buckets for this timer, you can use a p95 query instead.
 4. **Monitor for oscillation.** If expired leases appear and then clear as another worker reaps them, the system is self-healing but may be under-provisioned.
 
 ## Triage: Terminal Failures

--- a/docs/runbooks/approved-resume-worker-observability.md
+++ b/docs/runbooks/approved-resume-worker-observability.md
@@ -22,8 +22,12 @@ Before the metrics and alerts described in this document become available, the f
 
 | Setting | Value | Description |
 |---------|-------|-------------|
-| `tramai.sovereign.approved-resume.worker.metrics-enabled` | `true` | Enables Micrometer metric export for the approved-resume worker |
-| `tramai.sovereign.approved-resume.queue.snapshot-refresh-interval` | — | Controls how often the in-memory queue snapshot is refreshed (affects staleness of `eligible_now`, `delayed_retry`, etc.) |
+| `tramai.sovereign.ops.approved-resume-worker.enabled` | `true` | Creates/enables the approved-resume worker. |
+| `tramai.sovereign.ops.approved-resume-worker.lifecycle-enabled` | `true` | Starts the worker lifecycle loop. |
+| `tramai.sovereign.ops.actuator.approved-resume-worker-metrics.enabled` | `true` | Enables Micrometer worker metrics and queue gauges. |
+| `tramai.sovereign.ops.actuator.approved-resume-worker-metrics.queue-snapshot-enabled` | `true` | Enables queue snapshot gauges. |
+| `tramai.sovereign.ops.actuator.approved-resume-worker-metrics.queue-snapshot-refresh-interval` | `10s` | Controls queue snapshot refresh interval. |
+| `tramai.sovereign.ops.actuator.approved-resume-worker-metrics.include-worker-id-tag` | `false` | Optional; only enable if worker-id cardinality is acceptable. |
 | Prometheus scrape target | — | The application's `/actuator/prometheus` endpoint must be scraped |
 | Grafana datasource | `prometheus` | A Prometheus datasource with UID `prometheus` must exist if using the example dashboard |
 

--- a/docs/runbooks/sovereign-jdbc-production-deployment.md
+++ b/docs/runbooks/sovereign-jdbc-production-deployment.md
@@ -124,6 +124,8 @@ tramai:
 **Worker lifecycle metrics:**
 The auto-resume worker participates in the same observability surface as the audit outbox worker — status, health, Micrometer, and OpenTelemetry metrics are available through the existing ops-actuator and ops-micrometer/ops-observability modules.
 
+For detailed approved-resume worker dashboards, alert examples, and triage guidance, see the [Approved Resume Worker Observability runbook](./approved-resume-worker-observability.md).
+
 ## Required configuration
 
 ### Minimal production YAML


### PR DESCRIPTION
Create three new observability files for the approved-resume worker:
- Prometheus alert examples (6 rules, safe aggregate metrics only)
- Grafana dashboard JSON (3 rows, importable, schema v38)
- Operator triage runbook with 4 decision trees and safety boundary

Update existing docs and validation guard to reference new files:
- STATUS.md: added dashboard/alert examples, softened 'production dashboards' to 'production-certified dashboards'
- closure-boundary.md: added as example operational evidence
- deployment-runbook.md: linked to observability runbook
- README.md: referenced docs/observability/ and docs/runbooks/
- CHANGELOG.md: PR #119 entry
- verifySovereignRuntimeClosureDocs: file existence, required phrases, forbidden safety checks on all new files

331 tasks, 0 failures. Verification: PASSED.