### PR TITLE
test(sovereign): add API stability boundary verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Added `ApprovedResumeLifecycleJdbcE2ETest` — a full lifecycle E2E proof for the approved-resume flow using Testcontainers PostgreSQL (PR #117). Proves: approval request → approve decision → encrypted credential custody → auto-resume worker picks up the approved continuation → continuation is replayed through the engine → terminal success state is observed. Verifies that the resume credential is never exposed in plaintext through any operational surface.
 - Added docs sync for Sovereign Runtime post-#117 closure state (PR #118). Updates quickstart with REST control plane, reviewer UI, approved-resume worker config, and human approval auto-resume section. Updates JDBC runbook with V6/V7 migrations, resume credential store, and auto-resume worker configuration. Updates CHANGELOG with PR #112–#118 entries. Updates README module table, capability list, and deferred items.
 - Added approved-resume worker Prometheus alert examples, Grafana dashboard JSON, and operator triage runbook (PR #119).
+- Added `verifySovereignRuntimeApiBoundary` verification task, API stability manifest, and source-file existence checks (PR #120). The task guards against accidental API promotion, moved/deleted stable source files, and GA/production overclaims. Wired into `verifySovereignRuntimeClosure` and `verifySovereignRuntimeReleaseCandidate`.
 - Sovereign runtime profile and routing foundation (`tramai-sovereign`).
 - Policy enforcement and DLP/redaction support (`tramai-security`).
 - Approval gates and replay-safe resume.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2052,9 +2052,28 @@ tasks.register("verifySovereignRuntimeApiBoundary") {
         }
 
         val boundaryText = boundaryDoc.readText()
+        val manifestText = manifestFile.readText()
         val statusText = statusDoc.readText()
 
-        // ── RC+ Stable types are documented ──
+        // ── Section scopes ──
+
+        val stableSection = boundaryText
+            .substringAfter("## RC+ Stable Surface")
+            .substringBefore("## Preview Surface")
+
+        val previewSection = boundaryText
+            .substringAfter("## Preview Surface")
+            .substringBefore("## Internal Implementation Details")
+
+        val internalSection = boundaryText
+            .substringAfter("## Internal Implementation Details")
+            .substringBefore("## Deferred to Future Roadmaps")
+
+        val deferredSection = boundaryText
+            .substringAfter("## Deferred to Future Roadmaps")
+            .substringBefore("## Compatibility Promise")
+
+        // ── RC+ Stable types ──
 
         val rcPlusStableTypes = listOf(
             "ApprovalStore",
@@ -2067,20 +2086,22 @@ tasks.register("verifySovereignRuntimeApiBoundary") {
         )
 
         rcPlusStableTypes.forEach { type ->
-            require(boundaryText.contains(type)) {
+            require(stableSection.contains(type)) {
                 "RC+ Stable section must document $type"
+            }
+            require(manifestText.contains("- $type")) {
+                "API stability manifest rcPlusStable.types must include $type"
             }
         }
 
-        // RC+ stable verification tasks are documented
-        require(boundaryText.contains("verifySovereignRuntimeClosure")) {
+        require(stableSection.contains("verifySovereignRuntimeClosure")) {
             "RC+ Stable section must document verifySovereignRuntimeClosure"
         }
-        require(boundaryText.contains("verifySovereignRuntimeReleaseCandidate")) {
+        require(stableSection.contains("verifySovereignRuntimeReleaseCandidate")) {
             "RC+ Stable section must document verifySovereignRuntimeReleaseCandidate"
         }
 
-        // ── Preview types are documented ──
+        // ── Preview types (section-scoped) ──
 
         val previewTypes = listOf(
             "ApprovalGateway",
@@ -2092,13 +2113,27 @@ tasks.register("verifySovereignRuntimeApiBoundary") {
             "Workflow ergonomics",
         )
 
+        val previewManifestTypes = listOf(
+            "ApprovalGateway",
+            "ApprovalDecisionControlPlane",
+            "ApprovalResumeControlPlane",
+            "ApprovalInboxQueryService",
+            "ApprovalGatewayAutoConfiguration",
+        )
+
         previewTypes.forEach { type ->
-            require(boundaryText.contains(type, ignoreCase = true)) {
+            require(previewSection.contains(type, ignoreCase = true)) {
                 "Preview Surface section must document '$type'"
             }
         }
 
-        // ── Internal implementation details stay internal ──
+        previewManifestTypes.forEach { type ->
+            require(manifestText.contains("- $type")) {
+                "API stability manifest preview.types must include $type"
+            }
+        }
+
+        // ── Internal implementation details stay internal (section-scoped) ──
 
         val internalTypes = listOf(
             "JdbcApprovalStore",
@@ -2110,25 +2145,31 @@ tasks.register("verifySovereignRuntimeApiBoundary") {
         )
 
         internalTypes.forEach { type ->
-            require(boundaryText.contains(type)) {
+            require(internalSection.contains(type)) {
                 "Internal Implementation Details section must document '$type'"
+            }
+            require(manifestText.contains("- $type")) {
+                "API stability manifest internal.types must include $type"
             }
         }
 
-        // ── Deferred capabilities stay deferred ──
+        // ── Deferred capabilities stay deferred (section-scoped) ──
 
         val deferredCapabilities = listOf(
             "Key rotation",
             "Production certification",
             "Production-grade reviewer UI",
-            "Enterprise identity",
+            "Enterprise IAM",
             "Maven Central release",
             "Stable 1.0 API",
         )
 
         deferredCapabilities.forEach { cap ->
-            require(boundaryText.contains(cap, ignoreCase = true)) {
+            require(deferredSection.contains(cap, ignoreCase = true)) {
                 "Deferred to Future Roadmaps section must document '$cap'"
+            }
+            require(manifestText.contains("- $cap", ignoreCase = true)) {
+                "API stability manifest deferred.capabilities must include '$cap'"
             }
         }
 
@@ -2160,38 +2201,38 @@ tasks.register("verifySovereignRuntimeApiBoundary") {
             "ApprovedResumeQueueMetricsSnapshotProvider",
         )
 
-        val stableSection = boundaryText.substringAfter("## RC+ Stable Surface")
-            .substringBefore("## Preview Surface")
-
         internalJdbcClasses.forEach { clazz ->
             require(!stableSection.contains(clazz)) {
                 "Internal JDBC/worker class '$clazz' must not appear in the RC+ Stable section"
             }
         }
 
-        // ── Forbidden: GA/production/Maven/key-rotation overclaims in STATUS and README ──
-        // (The boundary document legitimately uses "not a GA-certified production release"
-        // as a disclaimer; exclude it from this check.)
+        // ── Forbidden: positive overclaims in STATUS and README ──
+        // Uses regex patterns that match affirmative claims but not safe
+        // negated disclaimers like "not GA-certified" or "not production-certified".
 
         val statusAndReadmeText = StringBuilder(statusText)
         val readmeFile = file("README.md")
         if (readmeFile.exists()) {
             statusAndReadmeText.append("\n").append(readmeFile.readText())
         }
+        val combinedText = statusAndReadmeText.toString()
 
-        val forbiddenPhrases = listOf(
-            "GA-certified",
-            "production certified",
-            "stable 1.0 public API complete",
-            "Maven Central release complete",
-            "enterprise IAM complete",
-            "key rotation complete",
-            "production-grade reviewer UI complete",
+        val forbiddenOverclaimPatterns = listOf(
+            Regex("\\bis\\s+GA-certified\\b", RegexOption.IGNORE_CASE),
+            Regex("\\bproduction\\s+certified\\b", RegexOption.IGNORE_CASE),
+            Regex("\\bstable\\s+1\\.0\\s+public\\s+API\\s+complete\\b", RegexOption.IGNORE_CASE),
+            Regex("\\bMaven\\s+Central\\s+release\\s+complete\\b", RegexOption.IGNORE_CASE),
+            Regex("\\benterprise\\s+IAM\\s+complete\\b", RegexOption.IGNORE_CASE),
+            Regex("\\bkey\\s+rotation\\s+complete\\b", RegexOption.IGNORE_CASE),
+            Regex("\\bproduction\\-grade\\s+reviewer\\s+UI\\s+complete\\b", RegexOption.IGNORE_CASE),
         )
 
-        forbiddenPhrases.forEach { phrase ->
-            require(!statusAndReadmeText.contains(phrase, ignoreCase = true)) {
-                "Forbidden overclaim phrase found: '$phrase'. API boundary docs must not claim GA/production/Maven/key-rotation completion."
+        forbiddenOverclaimPatterns.forEach { pattern ->
+            require(!combinedText.contains(pattern)) {
+                "Forbidden affirmative overclaim pattern found: '${pattern.pattern}'. " +
+                    "API boundary docs must not claim GA/production/Maven/key-rotation completion. " +
+                    "Safe negated forms (e.g. 'not GA-certified') are permitted."
             }
         }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2007,6 +2007,7 @@ tasks.register("verifySovereignRuntimeReleaseCandidate") {
         "generateSovereignReleaseEvidenceIndex",
         "verifySovereignRuntimeConsumerSmoke",
         "verifySovereignDocumentIntelligenceEvidenceRun",
+        "verifySovereignRuntimeApiBoundary",
     )
 
     doLast {
@@ -2021,6 +2022,186 @@ tasks.register("verifySovereignRuntimeReleaseCandidate") {
         logger.lifecycle("  - sovereign document intelligence evidence run")
         logger.lifecycle("No remote repository was published to.")
         logger.lifecycle("No tag or GitHub release was created.")
+    }
+}
+
+// ──────────────────────────────────────────────
+// Task: verifySovereignRuntimeApiBoundary
+// ──────────────────────────────────────────────
+
+tasks.register("verifySovereignRuntimeApiBoundary") {
+    group = "verification"
+    description = "Verifies the documented Sovereign Runtime API stability boundary."
+
+    doLast {
+        // ── Required files exist ──
+
+        val manifestFile = file("docs/architecture/sovereign-api-stability-manifest.yml")
+        require(manifestFile.exists()) {
+            "Missing API stability manifest at ${manifestFile.absolutePath}"
+        }
+
+        val boundaryDoc = file("docs/architecture/sovereign-api-stability-boundary.md")
+        require(boundaryDoc.exists()) {
+            "Missing API stability boundary document at ${boundaryDoc.absolutePath}"
+        }
+
+        val statusDoc = file("docs/STATUS.md")
+        require(statusDoc.exists()) {
+            "Missing STATUS.md at ${statusDoc.absolutePath}"
+        }
+
+        val boundaryText = boundaryDoc.readText()
+        val statusText = statusDoc.readText()
+
+        // ── RC+ Stable types are documented ──
+
+        val rcPlusStableTypes = listOf(
+            "ApprovalStore",
+            "SuspendedInvocationStore",
+            "ApprovalContinuationStore",
+            "AuditStore",
+            "SovereignOpsAuditOutboxStore",
+            "SovereignOpsApprovalMutationStore",
+            "SovereignOpsWorkerLeaseStore",
+        )
+
+        rcPlusStableTypes.forEach { type ->
+            require(boundaryText.contains(type)) {
+                "RC+ Stable section must document $type"
+            }
+        }
+
+        // RC+ stable verification tasks are documented
+        require(boundaryText.contains("verifySovereignRuntimeClosure")) {
+            "RC+ Stable section must document verifySovereignRuntimeClosure"
+        }
+        require(boundaryText.contains("verifySovereignRuntimeReleaseCandidate")) {
+            "RC+ Stable section must document verifySovereignRuntimeReleaseCandidate"
+        }
+
+        // ── Preview types are documented ──
+
+        val previewTypes = listOf(
+            "ApprovalGateway",
+            "ApprovalDecisionControlPlane",
+            "ApprovalResumeControlPlane",
+            "ApprovalInboxQueryService",
+            "REST control plane endpoints",
+            "Preview reviewer UI",
+            "Workflow ergonomics",
+        )
+
+        previewTypes.forEach { type ->
+            require(boundaryText.contains(type, ignoreCase = true)) {
+                "Preview Surface section must document '$type'"
+            }
+        }
+
+        // ── Internal implementation details stay internal ──
+
+        val internalTypes = listOf(
+            "JdbcApprovalStore",
+            "JdbcApprovalResumeCredentialStore",
+            "ApprovedContinuationResumeQueue",
+            "SovereignOpsApprovedContinuationResumeWorker",
+            "ApprovedContinuationResumeWorkerMetricsObserver",
+            "ApprovedResumeQueueMetricsSnapshotProvider",
+        )
+
+        internalTypes.forEach { type ->
+            require(boundaryText.contains(type)) {
+                "Internal Implementation Details section must document '$type'"
+            }
+        }
+
+        // ── Deferred capabilities stay deferred ──
+
+        val deferredCapabilities = listOf(
+            "Key rotation",
+            "Production certification",
+            "Production-grade reviewer UI",
+            "Enterprise identity",
+            "Maven Central release",
+            "Stable 1.0 API",
+        )
+
+        deferredCapabilities.forEach { cap ->
+            require(boundaryText.contains(cap, ignoreCase = true)) {
+                "Deferred to Future Roadmaps section must document '$cap'"
+            }
+        }
+
+        // ── Stable API source files exist ──
+
+        val stableApiFiles = listOf(
+            "tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalStore.kt",
+            "tramai-engine/src/main/kotlin/dev/tramai/engine/SuspendedInvocationStore.kt",
+            "tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalContinuationStore.kt",
+            "tramai-security/src/main/kotlin/dev/tramai/security/audit/AuditStore.kt",
+            "tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxStore.kt",
+            "tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsApprovalMutationStore.kt",
+            "tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/lease/SovereignOpsWorkerLeaseStore.kt",
+        )
+
+        stableApiFiles.forEach { path ->
+            val sourceFile = file(path)
+            require(sourceFile.exists()) {
+                "Stable API source file missing: $path"
+            }
+        }
+
+        // ── Forbidden: internal implementation classes in RC+ Stable section ──
+
+        val internalJdbcClasses = listOf(
+            "JdbcApprovalStore",
+            "JdbcApprovalResumeCredentialStore",
+            "SovereignOpsApprovedContinuationResumeWorker",
+            "ApprovedResumeQueueMetricsSnapshotProvider",
+        )
+
+        val stableSection = boundaryText.substringAfter("## RC+ Stable Surface")
+            .substringBefore("## Preview Surface")
+
+        internalJdbcClasses.forEach { clazz ->
+            require(!stableSection.contains(clazz)) {
+                "Internal JDBC/worker class '$clazz' must not appear in the RC+ Stable section"
+            }
+        }
+
+        // ── Forbidden: GA/production/Maven/key-rotation overclaims in STATUS and README ──
+        // (The boundary document legitimately uses "not a GA-certified production release"
+        // as a disclaimer; exclude it from this check.)
+
+        val statusAndReadmeText = StringBuilder(statusText)
+        val readmeFile = file("README.md")
+        if (readmeFile.exists()) {
+            statusAndReadmeText.append("\n").append(readmeFile.readText())
+        }
+
+        val forbiddenPhrases = listOf(
+            "GA-certified",
+            "production certified",
+            "stable 1.0 public API complete",
+            "Maven Central release complete",
+            "enterprise IAM complete",
+            "key rotation complete",
+            "production-grade reviewer UI complete",
+        )
+
+        forbiddenPhrases.forEach { phrase ->
+            require(!statusAndReadmeText.contains(phrase, ignoreCase = true)) {
+                "Forbidden overclaim phrase found: '$phrase'. API boundary docs must not claim GA/production/Maven/key-rotation completion."
+            }
+        }
+
+        // ── STATUS.md must reference the API stability boundary ──
+
+        require(statusText.contains("Sovereign Runtime API Stability")) {
+            "STATUS.md must reference Sovereign Runtime API Stability section"
+        }
+
+        logger.lifecycle("verifySovereignRuntimeApiBoundary: all API stability boundary checks passed.")
     }
 }
 
@@ -2335,6 +2516,7 @@ tasks.register("verifySovereignRuntimeClosure") {
         "verifySovereignRuntimeReleaseCandidate",
         ":examples:spring-sovereign-starter:e2eTest",
         "verifySovereignRuntimeClosureDocs",
+        "verifySovereignRuntimeApiBoundary",
     )
 
     doLast {
@@ -2344,6 +2526,7 @@ tasks.register("verifySovereignRuntimeClosure") {
         logger.lifecycle("  - verifySovereignRuntimeReleaseCandidate")
         logger.lifecycle("  - :examples:spring-sovereign-starter:e2eTest")
         logger.lifecycle("  - verifySovereignRuntimeClosureDocs (documentation consistency)")
+        logger.lifecycle("  - verifySovereignRuntimeApiBoundary (API stability boundary)")
         logger.lifecycle("Sovereignty roadmap is closed at the RC+ / enterprise proof level.")
     }
 }

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -47,11 +47,16 @@ The next roadmap after this closure is API stabilization and workflow ergonomics
 
 ## Sovereign Runtime API Stability
 
-The Sovereign Runtime RC+ / enterprise proof milestone has a documented API stability boundary.
+The Sovereign Runtime RC+ / enterprise proof milestone has a documented API stability boundary, executable verification task, and manifest. Run with:
+
+```bash
+./gradlew verifySovereignRuntimeApiBoundary
+```
 
 See:
 
 - [Sovereign Runtime API Stability Boundary](architecture/sovereign-api-stability-boundary.md)
+- [Sovereign Runtime API Stability Manifest](architecture/sovereign-api-stability-manifest.yml)
 
 Summary:
 

--- a/docs/architecture/sovereign-api-stability-manifest.yml
+++ b/docs/architecture/sovereign-api-stability-manifest.yml
@@ -1,0 +1,58 @@
+# Sovereign Runtime API Stability Manifest
+#
+# This manifest documents every Sovereign Runtime API type and its
+# stability level. It is consumed by verifySovereignRuntimeApiBoundary.
+#
+# Keep aligned with docs/architecture/sovereign-api-stability-boundary.md.
+
+rcPlusStable:
+  types:
+    - ApprovalStore
+    - SuspendedInvocationStore
+    - ApprovalContinuationStore
+    - AuditStore
+    - SovereignOpsAuditOutboxStore
+    - SovereignOpsApprovalMutationStore
+    - SovereignOpsWorkerLeaseStore
+  verificationTasks:
+    - verifySovereignRuntimeClosure
+    - verifySovereignRuntimeReleaseCandidate
+    - ":examples:spring-sovereign-starter:e2eTest"
+
+preview:
+  types:
+    - ApprovalGateway
+    - ApprovalRequestResult
+    - SovereignWorkflowResult
+    - ApprovalDecisionControlPlane
+    - ApprovalResumeControlPlane
+    - ApprovalInboxQueryService
+    - ApprovalGatewayAutoConfiguration
+
+internal:
+  types:
+    - JdbcApprovalStore
+    - JdbcSuspendedInvocationStore
+    - JdbcApprovalContinuationStore
+    - JdbcAuditStore
+    - JdbcSovereignOpsAuditOutboxStore
+    - JdbcSovereignOpsApprovalMutationStore
+    - JdbcSovereignOpsWorkerLeaseStore
+    - JdbcApprovalResumeCredentialStore
+    - ApprovalResumeCredentialStore
+    - ApprovedContinuationResumeQueue
+    - ApprovedContinuationResumeQueueStatusStore
+    - SovereignOpsApprovedContinuationResumeWorker
+    - ApprovedContinuationResumeWorkerLifecycle
+    - ApprovedContinuationResumeWorkerMetricsObserver
+    - ApprovedResumeQueueMetricsSnapshotProvider
+
+deferred:
+  capabilities:
+    - key rotation
+    - production certification
+    - production-grade reviewer UI
+    - enterprise IAM
+    - production-grade admin REST surface
+    - Maven Central release
+    - stable 1.0 API


### PR DESCRIPTION
## Summary

Turn the documented API stability boundary into an executable verification guard.

## Changes

- Added `docs/architecture/sovereign-api-stability-manifest.yml` — YAML manifest enumerating RC+ Stable, Preview, Internal, and Deferred surfaces aligned with the existing boundary doc.
- Added `verifySovereignRuntimeApiBoundary` Gradle task that:
  - Checks manifest, boundary doc, and STATUS.md exist
  - Verifies RC+ stable types (ApprovalStore, SuspendedInvocationStore, etc.) are documented
  - Verifies Preview types (ApprovalGateway, ApprovalDecisionControlPlane, etc.) are documented
  - Verifies Internal detail types (JdbcApprovalStore, ApprovedContinuationResumeQueue, etc.) are documented
  - Verifies Deferred capabilities (Key rotation, Production certification, etc.) are documented
  - Verifies RC+ stable source files exist at their actual repo paths
  - Prevents internal JDBC/worker classes from appearing in the RC+ Stable section
  - Blocks GA/production/Maven/key-rotation overclaims in STATUS.md and README.md
- Wired the new task into `verifySovereignRuntimeReleaseCandidate` and `verifySovereignRuntimeClosure`.
- Updated STATUS.md with verification command reference and manifest link.
- Updated CHANGELOG.md.

## Non-goals

- No binary compatibility tooling
- No runtime behavior changes
- No API promotion
- No package refactors

## Verification

```
./gradlew verifySovereignRuntimeApiBoundary    # passes
./gradlew verifySovereignRuntimeClosureDocs     # passes
./gradlew check                                 # 185 tasks pass
```