### PR TITLE
test(workflow): add approval gateway golden path ergonomics proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Added docs sync for Sovereign Runtime post-#117 closure state (PR #118). Updates quickstart with REST control plane, reviewer UI, approved-resume worker config, and human approval auto-resume section. Updates JDBC runbook with V6/V7 migrations, resume credential store, and auto-resume worker configuration. Updates CHANGELOG with PR #112–#118 entries. Updates README module table, capability list, and deferred items.
 - Added approved-resume worker Prometheus alert examples, Grafana dashboard JSON, and operator triage runbook (PR #119).
 - Added `verifySovereignRuntimeApiBoundary` verification task, API stability manifest, and source-file existence checks (PR #120). The task guards against accidental API promotion, moved/deleted stable source files, and GA/production overclaims. Wired into `verifySovereignRuntimeClosure` and `verifySovereignRuntimeReleaseCandidate`.
+- Added approval gateway golden path ergonomics proof (PR #121). Introduces an executable test using `ApprovalGateway` only — no low-level persistence stores — covering Suspended, AlreadyApproved, AlreadyDenied, and Expired outcomes. Updated golden path guide to reflect preview reviewer UI availability. Added docs guard against the stale "Reviewer UI | Not implemented yet" limitation.
 - Sovereign runtime profile and routing foundation (`tramai-sovereign`).
 - Policy enforcement and DLP/redaction support (`tramai-security`).
 - Approval gates and replay-safe resume.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2536,6 +2536,55 @@ tasks.register("verifySovereignRuntimeClosureDocs") {
             "Runbook must not recommend histogram_quantile(0.95) unless histogram buckets are explicitly documented/enabled for the cycle_duration_seconds timer."
         }
 
+        // ── Golden path guide consistency ──
+
+        val goldenPathGuide = file("docs/guides/approval-gateway-golden-path.md")
+        require(goldenPathGuide.exists()) {
+            "Missing approval gateway golden path guide at ${goldenPathGuide.absolutePath}"
+        }
+
+        val goldenPathText = goldenPathGuide.readText()
+
+        // Forbidden: stale "Reviewer UI | Not implemented yet" limitation
+        require(!goldenPathText.contains("Reviewer UI | Not implemented yet")) {
+            "Approval gateway golden path guide must not say reviewer UI is not implemented; " +
+                "preview reviewer UI exists and is disabled by default."
+        }
+
+        // Required: golden path mentions updated reviewer UI status
+        require(goldenPathText.contains("Preview reviewer UI available, disabled by default")) {
+            "Approval gateway golden path guide must document that preview reviewer UI is available " +
+                "and disabled by default."
+        }
+
+        // ── Golden path test must not reference low-level stores ──
+
+        val goldenPathTest = file(
+            "tramai-core/src/test/kotlin/dev/tramai/core/workflow/ApprovalGatewayGoldenPathErgonomicsTest.kt",
+        )
+        require(goldenPathTest.exists()) {
+            "Missing approval gateway golden path test at ${goldenPathTest.absolutePath}"
+        }
+
+        val forbiddenStoreReferences = listOf(
+            "ApprovalStore",
+            "SuspendedInvocationStore",
+            "ApprovalContinuationStore",
+            "JdbcApprovalStore",
+            "JdbcSuspendedInvocationStore",
+            "JdbcApprovalContinuationStore",
+            "SovereignOpsAuditOutboxStore",
+            "SovereignOpsApprovalMutationStore",
+            "SovereignOpsWorkerLeaseStore",
+            "ApprovalResumeCredentialStore",
+        )
+        val testSource = goldenPathTest.readText()
+        forbiddenStoreReferences.forEach { forbidden ->
+            require(!testSource.contains(forbidden)) {
+                "ApprovalGateway golden path test must not reference low-level store type: $forbidden"
+            }
+        }
+
         logger.lifecycle("verifySovereignRuntimeClosureDocs: all documentation consistency checks passed.")
     }
 }

--- a/docs/guides/approval-gateway-golden-path.md
+++ b/docs/guides/approval-gateway-golden-path.md
@@ -183,8 +183,8 @@ The Preview approval gateway has the following limitations:
 
 | Area | Status |
 |------|--------|
-| Full workflow resume runtime | Service-level `ApprovalResumeControlPlane` available |
-| Reviewer UI | Not implemented yet |
+| Full workflow resume runtime | Service-level `ApprovalResumeControlPlane` available; approved auto-resume worker lifecycle, observability, and E2E proof available (PRs #112–#117) |
+| Reviewer UI | Preview reviewer UI available, disabled by default |
 | REST control plane for approvals | Preview REST control plane available (`POST /tramai/sovereign/approvals/{id}/approve`, `.../deny`, `.../resume`, `GET .../{id}`) |
 | Approval inbox / work queue query API | Preview inbox query API available (`GET .../approvals`, `GET .../approvals/{id}/work-item`) |
 | Cross-store transaction boundary at creation | ✅ Implemented for JDBC-backed stores via `SovereignOpsApprovalRequestMutationStore` |

--- a/tramai-core/src/test/kotlin/dev/tramai/core/workflow/ApprovalGatewayGoldenPathErgonomicsTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/workflow/ApprovalGatewayGoldenPathErgonomicsTest.kt
@@ -1,0 +1,199 @@
+package dev.tramai.core.workflow
+
+import dev.tramai.core.approval.gateway.ApprovalGateway
+import dev.tramai.core.approval.gateway.ApprovalId
+import dev.tramai.core.approval.gateway.ApprovalRecommendation
+import dev.tramai.core.approval.gateway.ApprovalRequestResult
+import dev.tramai.core.approval.gateway.ApprovalSubject
+import dev.tramai.core.approval.gateway.ApproverRole
+import dev.tramai.core.approval.gateway.AuditStreamId
+import dev.tramai.core.approval.gateway.HumanApprovalDecision
+import dev.tramai.core.approval.gateway.ResumeToken
+import dev.tramai.core.approval.gateway.WorkflowRunId
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * Golden-path ergonomics proof for the Preview ApprovalGateway.
+ *
+ * This test demonstrates that a sovereign workflow can use only
+ * [ApprovalGateway] as its human-approval dependency — without
+ * directly wiring low-level approval, continuation, JDBC,
+ * outbox, worker-lease, or resume-credential stores.
+ */
+class ApprovalGatewayGoldenPathErgonomicsTest {
+
+    // ── Recording fake gateway ──
+
+    private class RecordingApprovalGateway(
+        private val result: ApprovalRequestResult,
+    ) : ApprovalGateway {
+        var capturedSubject: ApprovalSubject? = null
+        var capturedRecommendation: ApprovalRecommendation? = null
+        var capturedRequiredRole: ApproverRole? = null
+        var capturedWorkflowRunId: WorkflowRunId? = null
+
+        override suspend fun requestApproval(
+            subject: ApprovalSubject,
+            recommendation: ApprovalRecommendation,
+            requiredRole: ApproverRole,
+            workflowRunId: WorkflowRunId?,
+        ): ApprovalRequestResult {
+            capturedSubject = subject
+            capturedRecommendation = recommendation
+            capturedRequiredRole = requiredRole
+            capturedWorkflowRunId = workflowRunId
+            return result
+        }
+    }
+
+    // ── Tiny example workflow ──
+
+    /**
+     * Minimal workflow that routes an approval request through the
+     * gateway and maps each outcome to a [SovereignWorkflowResult].
+     *
+     * This is the developer-facing ergonomic shape: the workflow
+     * expresses its approval boundary through a single gateway call
+     * and a `when` expression, with zero knowledge of the persistence
+     * layer underneath.
+     */
+    private class ExampleClaimWorkflow(
+        private val gateway: ApprovalGateway,
+    ) {
+        suspend fun triage(input: ClaimInput): SovereignWorkflowResult<String> {
+            val approvalResult = gateway.requestApproval(
+                subject = ApprovalSubject(input.claimId),
+                recommendation = ApprovalRecommendation(
+                    type = "claim-triage",
+                    summary = "Claim requires medical review",
+                ),
+                requiredRole = ApproverRole("medical-reviewer"),
+                workflowRunId = WorkflowRunId(input.workflowRunId),
+            )
+
+            return when (approvalResult) {
+                is ApprovalRequestResult.Suspended ->
+                    SovereignWorkflowResult.SuspendedForApproval(
+                        approvalId = approvalResult.approvalId,
+                        workflowRunId = approvalResult.workflowRunId,
+                        auditStreamId = approvalResult.auditStreamId,
+                        resumeToken = approvalResult.resumeToken,
+                    )
+
+                is ApprovalRequestResult.AlreadyApproved ->
+                    SovereignWorkflowResult.Completed("approved-continue")
+
+                is ApprovalRequestResult.AlreadyDenied ->
+                    SovereignWorkflowResult.Rejected(approvalResult.decision.reason)
+
+                is ApprovalRequestResult.Expired ->
+                    SovereignWorkflowResult.Expired(approvalResult.reason)
+            }
+        }
+    }
+
+    private data class ClaimInput(
+        val claimId: String,
+        val workflowRunId: String,
+    )
+
+    // ── 1. Suspended → SuspendedForApproval ──
+
+    @Test
+    fun `high risk workflow suspends through approval gateway without store wiring`() = runTest {
+        val gateway = RecordingApprovalGateway(
+            ApprovalRequestResult.Suspended(
+                approvalId = ApprovalId("approval-1"),
+                workflowRunId = WorkflowRunId("run-1"),
+                auditStreamId = AuditStreamId("audit-1"),
+                resumeToken = ResumeToken("token-1"),
+            ),
+        )
+
+        val workflow = ExampleClaimWorkflow(gateway)
+        val result = workflow.triage(ClaimInput("claim-1", "run-1"))
+
+        // Proves correct request construction
+        assertThat(gateway.capturedSubject).isEqualTo(ApprovalSubject("claim-1"))
+        assertThat(gateway.capturedRecommendation!!.type).isEqualTo("claim-triage")
+        assertThat(gateway.capturedRecommendation!!.summary).isEqualTo("Claim requires medical review")
+        assertThat(gateway.capturedRequiredRole).isEqualTo(ApproverRole("medical-reviewer"))
+        assertThat(gateway.capturedWorkflowRunId).isEqualTo(WorkflowRunId("run-1"))
+
+        // Proves correct result mapping
+        assertThat(result).isInstanceOf(SovereignWorkflowResult.SuspendedForApproval::class.java)
+        val suspended = result as SovereignWorkflowResult.SuspendedForApproval
+        assertThat(suspended.approvalId).isEqualTo(ApprovalId("approval-1"))
+        assertThat(suspended.workflowRunId).isEqualTo(WorkflowRunId("run-1"))
+        assertThat(suspended.auditStreamId).isEqualTo(AuditStreamId("audit-1"))
+        assertThat(suspended.resumeToken).isEqualTo(ResumeToken("token-1"))
+    }
+
+    // ── 2. AlreadyApproved → Completed ──
+
+    @Test
+    fun `already approved result maps to Completed workflow result`() = runTest {
+        val gateway = RecordingApprovalGateway(
+            ApprovalRequestResult.AlreadyApproved(
+                decision = HumanApprovalDecision.Approved(
+                    approvalId = ApprovalId("approval-1"),
+                    decidedBy = "reviewer-1",
+                    decidedAt = Instant.parse("2026-06-25T10:00:00Z"),
+                ),
+            ),
+        )
+
+        val workflow = ExampleClaimWorkflow(gateway)
+        val result = workflow.triage(ClaimInput("claim-2", "run-2"))
+
+        assertThat(result).isInstanceOf(SovereignWorkflowResult.Completed::class.java)
+        val completed = result as SovereignWorkflowResult.Completed
+        assertThat(completed.value).isEqualTo("approved-continue")
+    }
+
+    // ── 3. AlreadyDenied → Rejected ──
+
+    @Test
+    fun `already denied result maps to Rejected workflow result`() = runTest {
+        val gateway = RecordingApprovalGateway(
+            ApprovalRequestResult.AlreadyDenied(
+                decision = HumanApprovalDecision.Denied(
+                    approvalId = ApprovalId("approval-1"),
+                    decidedBy = "reviewer-1",
+                    decidedAt = Instant.parse("2026-06-25T10:00:00Z"),
+                    reason = "requires-legal-review",
+                ),
+            ),
+        )
+
+        val workflow = ExampleClaimWorkflow(gateway)
+        val result = workflow.triage(ClaimInput("claim-3", "run-3"))
+
+        assertThat(result).isInstanceOf(SovereignWorkflowResult.Rejected::class.java)
+        val rejected = result as SovereignWorkflowResult.Rejected
+        assertThat(rejected.reason).isEqualTo("requires-legal-review")
+    }
+
+    // ── 4. Expired → Expired ──
+
+    @Test
+    fun `expired approval result maps to Expired workflow result`() = runTest {
+        val gateway = RecordingApprovalGateway(
+            ApprovalRequestResult.Expired(
+                approvalId = ApprovalId("approval-1"),
+                expiredAt = Instant.parse("2026-06-25T10:00:00Z"),
+                reason = "approval-expired",
+            ),
+        )
+
+        val workflow = ExampleClaimWorkflow(gateway)
+        val result = workflow.triage(ClaimInput("claim-4", "run-4"))
+
+        assertThat(result).isInstanceOf(SovereignWorkflowResult.Expired::class.java)
+        val expired = result as SovereignWorkflowResult.Expired
+        assertThat(expired.reason).isEqualTo("approval-expired")
+    }
+}


### PR DESCRIPTION
## Summary

Add an executable, developer-facing proof that a sovereign workflow can use the Preview `ApprovalGateway` without directly wiring low-level persistence stores.

## Changes

- **New test:** `ApprovalGatewayGoldenPathErgonomicsTest` in `tramai-core` demonstrating a tiny `ExampleClaimWorkflow` using only `ApprovalGateway` as its human-approval dependency
- **4 outcome coverage:** Suspended → `SovereignWorkflowResult.SuspendedForApproval`, AlreadyApproved → `Completed`, AlreadyDenied → `Rejected`, Expired → `Expired`
- **No store imports:** The test imports only gateway types (`ApprovalGateway`, `ApprovalRequestResult`, `SovereignWorkflowResult`, etc.) — zero references to `ApprovalStore`, `SuspendedInvocationStore`, `ApprovalContinuationStore`, JDBC stores, outbox stores, worker leases, or resume credential stores
- **Updated golden path guide:** Replaced stale `Reviewer UI | Not implemented yet` with `Preview reviewer UI available, disabled by default`; expanded resume runtime limitation to mention approved auto-resume worker lifecycle and E2E proof
- **Docs guard:** `verifySovereignRuntimeClosureDocs` now prevents the stale "Reviewer UI | Not implemented yet" line from returning
- Updated CHANGELOG.md

## Non-goals

- No broad workflow DSL
- No API promotion to RC+ Stable
- No runtime/JDBC/REST changes
- No production IAM or production-grade reviewer UI

## Verification

```
./gradlew :tramai-core:test --tests "*ApprovalGatewayGoldenPathErgonomicsTest*"  # passes
./gradlew verifySovereignRuntimeApiBoundary    # passes
./gradlew verifySovereignRuntimeClosureDocs     # passes
./gradlew check                                 # 185 tasks pass
```