### PR TITLE
test(workflow): guard approval workflow mapper API boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- Added API boundary guard for `ApprovalRequestResult.toWorkflowResult` Preview function (PR #123). Lists the mapper in the API stability manifest as a Preview function, documents it in the boundary doc, adds source-file existence and signature-presence checks to `verifySovereignRuntimeApiBoundary`, and adds a focused API-boundary test proving the decision-aware lambda contract.
 - Added `ApprovalRequestResult.toWorkflowResult { ... }` ergonomic Preview mapper (PR #122). Converts each gateway outcome (Suspended, AlreadyApproved, AlreadyDenied, Expired) to the corresponding `SovereignWorkflowResult` variant. The `approvedValue` lambda receives the `HumanApprovalDecision.Approved` decision and is lazy — only invoked for `AlreadyApproved`. Terminal states never execute the lambda, preventing accidental side effects.
 - Updated the approval gateway golden path proof (PR #121) to use the mapper instead of a manual `when` expression.
 - Updated golden path guide to show the mapper.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2133,6 +2133,51 @@ tasks.register("verifySovereignRuntimeApiBoundary") {
             }
         }
 
+        // ── Preview functions ──
+
+        val previewManifestFunctions = listOf(
+            "ApprovalRequestResult.toWorkflowResult",
+        )
+
+        previewManifestFunctions.forEach { func ->
+            require(manifestText.contains("- $func")) {
+                "API stability manifest preview.functions must include '$func'"
+            }
+            require(previewSection.contains(func)) {
+                "Preview Surface section must document '$func'"
+            }
+        }
+
+        // ── Preview function source file exists and maintains signature ──
+
+        val mapperFile = file(
+            "tramai-core/src/main/kotlin/dev/tramai/core/workflow/ApprovalRequestWorkflowResultMappers.kt",
+        )
+        require(mapperFile.exists()) {
+            "Missing Preview approval workflow result mapper source file at ${mapperFile.absolutePath}"
+        }
+
+        val mapperSource = mapperFile.readText()
+        require(mapperSource.contains("fun <T> ApprovalRequestResult.toWorkflowResult")) {
+            "ApprovalRequestResult.toWorkflowResult mapper must remain available."
+        }
+        require(mapperSource.contains("HumanApprovalDecision.Approved")) {
+            "ApprovalRequestResult.toWorkflowResult must expose the approved decision to the lambda."
+        }
+        require(mapperSource.contains("approvedValue(decision)")) {
+            "ApprovalRequestResult.toWorkflowResult must pass the approved decision into approvedValue."
+        }
+
+        // ── Forbidden: Preview mapper in RC+ Stable section ──
+
+        require(!stableSection.contains("ApprovalRequestResult.toWorkflowResult")) {
+            "ApprovalRequestResult.toWorkflowResult is Preview, not RC+ Stable, and must not be in the RC+ Stable section."
+        }
+
+        require(!stableSection.contains("toWorkflowResult")) {
+            "toWorkflowResult Preview function must not appear in the RC+ Stable section."
+        }
+
         // ── Internal implementation details stay internal (section-scoped) ──
 
         val internalTypes = listOf(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2135,16 +2135,27 @@ tasks.register("verifySovereignRuntimeApiBoundary") {
 
         // ── Preview functions ──
 
+        val stableManifestSection = manifestText
+            .substringAfter("rcPlusStable:")
+            .substringBefore("preview:")
+
+        val previewManifestSection = manifestText
+            .substringAfter("preview:")
+            .substringBefore("internal:")
+
         val previewManifestFunctions = listOf(
             "ApprovalRequestResult.toWorkflowResult",
         )
 
         previewManifestFunctions.forEach { func ->
-            require(manifestText.contains("- $func")) {
+            require(previewManifestSection.contains("- $func")) {
                 "API stability manifest preview.functions must include '$func'"
             }
             require(previewSection.contains(func)) {
                 "Preview Surface section must document '$func'"
+            }
+            require(!stableManifestSection.contains(func)) {
+                "'$func' is Preview and must not appear in rcPlusStable manifest section."
             }
         }
 

--- a/docs/architecture/sovereign-api-stability-boundary.md
+++ b/docs/architecture/sovereign-api-stability-boundary.md
@@ -66,6 +66,7 @@ The following capabilities are proven by working examples, but the developer-fac
 - `ApprovalGateway` — front-door contract for non-blocking human approval (`dev.tramai.core.approval.gateway`)
 - `ApprovalRequestResult` — sealed type for approval request outcomes (`dev.tramai.core.approval.gateway`)
 - `SovereignWorkflowResult` — sealed type for workflow-level outcomes (`dev.tramai.core.workflow`)
+- `ApprovalRequestResult.toWorkflowResult { ... }` — Preview mapper from approval gateway outcomes to `SovereignWorkflowResult`; decision-aware `approvedValue` lambda receives `HumanApprovalDecision.Approved` and is invoked only for `AlreadyApproved`
 - `DefaultApprovalGateway` — minimal store-backed adapter for the preview gateway SPI (`dev.tramai.engine.approval`)
 - `ApprovalGatewayRequestFactory` — internal seam for constructing low-level persistence records (`dev.tramai.engine.approval`)
 - `ApprovalGatewayPersistenceRequest` — transport object aggregating persistence records (`dev.tramai.engine.approval`)

--- a/docs/architecture/sovereign-api-stability-manifest.yml
+++ b/docs/architecture/sovereign-api-stability-manifest.yml
@@ -28,6 +28,8 @@ preview:
     - ApprovalResumeControlPlane
     - ApprovalInboxQueryService
     - ApprovalGatewayAutoConfiguration
+  functions:
+    - ApprovalRequestResult.toWorkflowResult
 
 internal:
   types:

--- a/tramai-core/src/test/kotlin/dev/tramai/core/workflow/ApprovalRequestWorkflowResultMappersApiBoundaryTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/workflow/ApprovalRequestWorkflowResultMappersApiBoundaryTest.kt
@@ -1,0 +1,40 @@
+package dev.tramai.core.workflow
+
+import dev.tramai.core.approval.gateway.ApprovalId
+import dev.tramai.core.approval.gateway.ApprovalRequestResult
+import dev.tramai.core.approval.gateway.HumanApprovalDecision
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * API boundary test for [ApprovalRequestResult.toWorkflowResult].
+ *
+ * Proves the public Preview signature remains decision-aware.
+ * This is an API contract test, not a behavior coverage test
+ * (see [ApprovalRequestWorkflowResultMappersTest] for behavior).
+ *
+ * If this test breaks, the Preview function signature has changed
+ * and must be updated in the API stability manifest and boundary doc.
+ */
+class ApprovalRequestWorkflowResultMappersApiBoundaryTest {
+
+    @Test
+    fun `toWorkflowResult exposes approved decision to continuation lambda`() {
+        val decision = HumanApprovalDecision.Approved(
+            approvalId = ApprovalId("approval-1"),
+            decidedBy = "reviewer-1",
+            decidedAt = Instant.parse("2026-06-25T10:00:00Z"),
+            comment = "approved",
+        )
+
+        val result = ApprovalRequestResult.AlreadyApproved(decision)
+            .toWorkflowResult { approved ->
+                "${approved.decidedBy}:${approved.comment}"
+            }
+
+        assertThat(result).isInstanceOf(SovereignWorkflowResult.Completed::class.java)
+        assertThat((result as SovereignWorkflowResult.Completed<*>).value)
+            .isEqualTo("reviewer-1:approved")
+    }
+}


### PR DESCRIPTION
## Summary

Lock the new `ApprovalRequestResult.toWorkflowResult { ... }` Preview mapper (PR #122) into the Sovereign Runtime API stability boundary with explicit documentation, verification guards, and a focused contract test.

## Why

PR #122 added a public Preview extension function, but the API stability manifest only tracked types — not functions. A future change could silently rename, move, or alter the mapper's decision-aware signature without the build noticing.

## Changes

| File | Change |
|:-----|:-------|
| `sovereign-api-stability-manifest.yml` | Added `preview.functions` section listing `ApprovalRequestResult.toWorkflowResult` |
| `sovereign-api-stability-boundary.md` | Added explicit Preview entry for the mapper |
| `build.gradle.kts` | `verifySovereignRuntimeApiBoundary` now checks mapper file existence, signature (`fun <T> ApprovalRequestResult.toWorkflowResult`), decision-aware lambda (`HumanApprovalDecision.Approved`, `approvedValue(decision)`), and forbids it in RC+ Stable section |
| `ApprovalRequestWorkflowResultMappersApiBoundaryTest.kt` | **New** — contract test proving the lambda receives `HumanApprovalDecision.Approved` |
| `CHANGELOG.md` | PR #123 entry |

## What gets guarded

The build will fail if any of these happen:

- The mapper source file is deleted or moved
- The function signature loses `HumanApprovalDecision.Approved` in the lambda
- `approvedValue(decision)` stops being called
- The mapper is accidentally promoted to RC+ Stable
- The manifest or boundary doc omit the mapper

## Verification

```
./gradlew :tramai-core:test --tests '*ApprovalRequestWorkflowResultMappers*'  ✓
./gradlew verifySovereignRuntimeApiBoundary                                    ✓
./gradlew verifySovereignRuntimeClosureDocs                                      ✓
./gradlew :tramai-core:check                                                     ✓
```

## Socratic Clause

The mapper stays **Preview**. This PR does not promote it. The goal is explicit documentation and build-time guards, not API freezing. Preview APIs may still change — but now the change must also update the manifest and boundary doc.
