### PR TITLE
fix(mcp): structured output, dynamic architecture, test file access, example module support

### DIFF
--- a/mcp-server.py
+++ b/mcp-server.py
@@ -107,7 +107,7 @@ async def list_tools() -> list[Tool]:
     return [
         Tool(
             name="search_codebase",
-            description="Search the Tramai codebase for patterns: @AiService, @Operation, @AiTool, ApprovalGateway, Sovereign, etc. Returns matches with 3 lines of surrounding context.",
+            description="Search the Tramai codebase for patterns: @AiService, @Operation, @AiTool, ApprovalGateway, Sovereign, etc. Returns matches with 3 lines of surrounding context. Accepts short module names.",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -117,7 +117,7 @@ async def list_tools() -> list[Tool]:
                     },
                     "module": {
                         "type": "string",
-                        "description": f"Optional module name: {', '.join(_get_modules())}",
+                        "description": "Optional module name (e.g. 'tramai-core' or just 'core', 'spring-sovereign-starter'). Use list_modules to see all.",
                     },
                     "limit": {
                         "type": "integer",
@@ -130,13 +130,13 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="list_files",
-            description="List source files in a Tramai module. Shows main sources and optionally test sources.",
+            description="List source files in a Tramai module. Shows main sources and optionally test sources. Accepts short module names.",
             inputSchema={
                 "type": "object",
                 "properties": {
                     "module": {
                         "type": "string",
-                        "description": f"Module name from: {', '.join(_get_modules()[:8])}...",
+                        "description": "Module name (e.g. 'tramai-core' or 'core', 'spring-sovereign-starter'). Use list_modules to see all.",
                     },
                     "includeTests": {
                         "type": "boolean",
@@ -159,12 +159,12 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="read_source",
-            description="Read a source file from a Tramai module.",
+            description="Read a source file from a Tramai module. Accepts full names ('tramai-core') or short names ('core', 'spring-sovereign-starter').",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "module": {"type": "string", "description": "Module name"},
-                    "path": {"type": "string", "description": "Path relative to module src/ (e.g., 'Tramai.kt')"},
+                    "module": {"type": "string", "description": "Module name (e.g. 'tramai-core' or 'core', 'spring-sovereign-starter' or 'examples:spring-sovereign-starter')"},
+                    "path": {"type": "string", "description": "Path relative to module src/ (e.g., 'Tramai.kt', 'dev/tramai/core/workflow/SovereignWorkflowResult.kt')"},
                 },
                 "required": ["module", "path"],
             },
@@ -218,10 +218,45 @@ def _module_path(module: str) -> Path:
     return TRAMAI / module.replace(":", "/")
 
 
+def _resolve_module(module: str) -> str | None:
+    """Resolve a possibly-short module name to its full Gradle module name.
+
+    Accepts 'spring-sovereign-starter' and resolves it to
+    'examples:spring-sovereign-starter' automatically.
+
+    Strategy:
+    1. Try the name as-is (module path exists on disk).
+    2. Try prepending 'examples:' for short example module names.
+    3. Suffix-match against all 44 registered modules.
+    """
+    if _module_path(module).exists():
+        return module
+
+    prefixed = f"examples:{module}"
+    if _module_path(prefixed).exists():
+        return prefixed
+
+    for candidate in _get_modules():
+        if candidate.endswith(module) or candidate.endswith(f":{module}"):
+            return candidate
+
+    return None
+
+
 async def _search_codebase(pattern: str, module: str | None, limit: int = 30) -> list[TextContent]:
-    search_root = _module_path(module) if module else TRAMAI
+    if module:
+        resolved = _resolve_module(module)
+        if not resolved:
+            return [TextContent(type="text", text=f"Module not found: {module}. Use list_modules to see available modules.")]
+        search_root = _module_path(resolved)
+        display_module = resolved
+    else:
+        search_root = TRAMAI
+        display_module = None
+
     if not search_root.exists():
-        return [TextContent(type="text", text=f"Module not found: {module}")]
+        resolved_name = display_module if display_module else module
+        return [TextContent(type="text", text=f"Module path not found: {module} (resolved: {resolved_name})")]
 
     try:
         result = subprocess.run(
@@ -260,9 +295,11 @@ async def _search_codebase(pattern: str, module: str | None, limit: int = 30) ->
 
 
 async def _list_files(module: str, include_tests: bool = False, extension: str = ".kt") -> list[TextContent]:
-    search_root = _module_path(module)
-    if not search_root.exists():
-        return [TextContent(type="text", text=f"Module not found: {module}")]
+    resolved = _resolve_module(module)
+    if not resolved:
+        return [TextContent(type="text", text=f"Module not found: {module}. Use list_modules to see available modules.")]
+    search_root = _module_path(resolved)
+    display = resolved
 
     roots = [search_root / "src" / "main"]
     if include_tests:
@@ -275,7 +312,7 @@ async def _list_files(module: str, include_tests: bool = False, extension: str =
 
     rels = [str(f.relative_to(search_root)) for f in files]
 
-    summary = f"{len(rels)} {extension} files in {module}"
+    summary = f"{len(rels)} {extension} files in {display}"
     if include_tests:
         summary += " (including tests)"
 
@@ -285,7 +322,7 @@ async def _list_files(module: str, include_tests: bool = False, extension: str =
 
     return [
         TextContent(type="text", text=json.dumps({
-            "module": module,
+            "module": display,
             "total": len(rels),
             "includeTests": include_tests,
             "extension": extension,
@@ -326,7 +363,10 @@ async def _list_modules() -> list[TextContent]:
     ]
 
 async def _read_source(module: str, path: str) -> list[TextContent]:
-    search_root = _module_path(module)
+    resolved = _resolve_module(module)
+    if not resolved:
+        return [TextContent(type="text", text=f"Module not found: {module}. Use list_modules to see available modules.")]
+    search_root = _module_path(resolved)
 
     for root in (
         search_root / "src" / "main" / "kotlin",

--- a/mcp-server.py
+++ b/mcp-server.py
@@ -89,10 +89,11 @@ def _get_modules() -> list[str]:
     if not settings.exists():
         return []
     text = settings.read_text()
-    # Extract strings inside include(...), strip quotes
-    modules = re.findall(r'"([^"]+)"', text)
-    # Filter to only modules under the root (not examples: sub-projects)
-    # Keep both: tramai-* modules and examples:* for context
+    # Extract only the include(...) block to skip rootProject.name
+    m = re.search(r'include\s*\((.*?)\)', text, re.DOTALL)
+    if not m:
+        return []
+    modules = re.findall(r'"([^"]+)"', m.group(1))
     return sorted(modules)
 
 @server.list_tools()
@@ -167,8 +168,13 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
 
 # ── Implementations ──────────────────────────────────────────────
 
+def _module_path(module: str) -> Path:
+    """Resolve a module name to its filesystem path, handling examples:* → examples/foo."""
+    return TRAMAI / module.replace(":", "/")
+
+
 async def _search_codebase(pattern: str, module: str | None) -> list[TextContent]:
-    search_root = TRAMAI / module if module else TRAMAI
+    search_root = _module_path(module) if module else TRAMAI
     if not search_root.exists():
         return [TextContent(type="text", text=f"Module not found: {module}")]
 
@@ -185,31 +191,55 @@ async def _search_codebase(pattern: str, module: str | None) -> list[TextContent
         return [TextContent(type="text", text="Search timed out")]
 
 async def _list_modules() -> list[TextContent]:
-    lines = ["# Tramai Modules\n"]
+    modules = []
     for mod in _get_modules():
-        path = TRAMAI / mod
+        path = _module_path(mod)
         build_file = path / "build.gradle.kts"
         desc = ""
         if build_file.exists():
             content = build_file.read_text()
             m = re.search(r'description\s*=\s*"([^"]+)"', content)
-            desc = f" — {m.group(1)}" if m else ""
-        exists = "✅" if path.exists() else "❌"
-        lines.append(f"- {exists} **{mod}**{desc}")
-    return [TextContent(type="text", text="\n".join(lines))]
+            desc = m.group(1) if m else ""
+        exists = path.exists()
+        modules.append({
+            "name": mod,
+            "description": desc,
+            "exists": exists,
+        })
+
+    md_lines = ["# Tramai Modules\n"]
+    for m in modules:
+        icon = "✅" if m["exists"] else "❌"
+        d = f" — {m['description']}" if m["description"] else ""
+        md_lines.append(f"- {icon} **{m['name']}**{d}")
+
+    return [
+        TextContent(type="text", text=json.dumps({
+            "modules": modules,
+            "total": len(modules),
+        }, indent=2)),
+        TextContent(type="text", text="\n".join(md_lines)),
+    ]
 
 async def _read_source(module: str, path: str) -> list[TextContent]:
-    file_path = TRAMAI / module / "src" / "main" / "kotlin" / path
-    if not file_path.exists():
-        file_path = TRAMAI / module / "src" / "main" / "java" / path
-    if not file_path.exists():
-        # Try searching
-        found = list((TRAMAI / module / "src").rglob(path))
-        if found:
-            file_path = found[0]
-    if not file_path.exists():
-        return [TextContent(type="text", text=f"File not found: {module}/{path}")]
-    return [TextContent(type="text", text=file_path.read_text())]
+    search_root = _module_path(module)
+
+    for root in (
+        search_root / "src" / "main" / "kotlin",
+        search_root / "src" / "main" / "java",
+        search_root / "src" / "test" / "kotlin",
+        search_root / "src" / "test" / "java",
+    ):
+        file_path = root / path
+        if file_path.exists():
+            return [TextContent(type="text", text=file_path.read_text())]
+
+    # Fallback: glob search under src/
+    found = list((search_root / "src").rglob(path))
+    if found:
+        return [TextContent(type="text", text=found[0].read_text())]
+
+    return [TextContent(type="text", text=f"File not found: {module}/{path}")]
 
 async def _search_docs(query: str) -> list[TextContent]:
     try:
@@ -225,70 +255,102 @@ async def _search_docs(query: str) -> list[TextContent]:
         return [TextContent(type="text", text="Search timed out")]
 
 async def _get_architecture() -> list[TextContent]:
-    return [TextContent(type="text", text="""# Tramai Architecture
+    modules = []
+    for mod in _get_modules():
+        path = _module_path(mod)
+        if not path.exists():
+            continue
 
-## Module Layering (bottom → top)
+        build_file = path / "build.gradle.kts"
+        desc = ""
+        if build_file.exists():
+            m = re.search(r'description\s*=\s*"([^"]+)"', build_file.read_text())
+            desc = m.group(1) if m else ""
 
-1. **tramai-core** — SPI definitions: ModelProvider, StructuredOutputSchema, SecretValueResolver, approvals, workflow
-2. **tramai-structured** — Schema generation, extraction, deserialization, failure analysis
-3. **tramai-engine** — Orchestration, retry policy, model routing, provider resolution, default approval gateway
-4. Provider modules (tramai-openai, tramai-anthropic, tramai-ollama, tramai-gemini, tramai-azure-openai, tramai-bedrock, tramai-deepseek) — ModelProvider implementations
-5. **tramai-orchestration** — Workflow DSL with @AiService, @Operation, @AiTool
-6. **tramai-observability** — OpenTelemetry-friendly observability
-7. Persistence layer (tramai-persistence-file, tramai-persistence-jdbc)
-8. **tramai-sovereign** — Sovereign Runtime: evidence packs, deployment modes, artifact verification
-9. **tramai-security** — Security model, approved model registry, tool arguments digesters
-10. **tramai-scheduler** — Recurring task scheduling
-11. **tramai-server** — Standalone HTTP server for Tramai
-12. **tramai-mcp** — MCP (Model Context Protocol) server for workflow execution
-13. **tramai-platform** — Platform abstraction layer
-14. **tramai-memory / tramai-memory-store** — Chat memory abstraction and stores
-15. **tramai-embedding** — Embedding generation
-16. **tramai-rag** — Retrieval-augmented generation support
-17. **tramai-vectorstore-spi / tramai-vectorstore-chroma / tramai-vectorstore-pgvector** — Vector store SPI and implementations
-18. **tramai-dashboard** — Dashboard UI module
-19. **tramai-spring** — Spring Boot auto-configuration (core Tramai)
-20. Spring Boot Sovereign starters (tramai-spring-boot-starter-sovereign, tramai-spring-boot-starter-sovereign-persistence-jdbc, tramai-spring-boot-starter-sovereign-persistence-file, tramai-spring-boot-starter-sovereign-ops, tramai-spring-boot-starter-sovereign-ops-rest, tramai-spring-boot-starter-sovereign-ops-actuator, tramai-spring-boot-starter-sovereign-ops-micrometer, tramai-spring-boot-starter-sovereign-ops-observability)
-21. **tramai-standalone** — Minimal entry point for framework-free usage
-22. **tramai-testing** — Testing utilities
-23. **tramai-bom** — Bill of Materials for consistent dependency versions
+        # Detect module category
+        category = _categorize_module(mod, path)
+        modules.append({
+            "name": mod,
+            "description": desc,
+            "category": category,
+        })
 
-## Sovereign Runtime
+    # Group by category
+    layers = [
+        ("Core", ["tramai-core"]),
+        ("Structured Output", ["tramai-structured"]),
+        ("Engine", ["tramai-engine"]),
+        ("Providers", [m["name"] for m in modules if m["category"] == "provider"]),
+        ("Orchestration", ["tramai-orchestration"]),
+        ("Observability", ["tramai-observability"]),
+        ("Persistence", [m["name"] for m in modules if m["category"] == "persistence"]),
+        ("Sovereign Runtime", [m["name"] for m in modules if m["category"] == "sovereign"]),
+        ("Security", ["tramai-security"]),
+        ("Scheduler", ["tramai-scheduler"]),
+        ("Server", ["tramai-server"]),
+        ("MCP", ["tramai-mcp"]),
+        ("Platform", ["tramai-platform"]),
+        ("Memory", [m["name"] for m in modules if m["category"] == "memory"]),
+        ("Embedding", ["tramai-embedding"]),
+        ("RAG", ["tramai-rag"]),
+        ("Vector Stores", [m["name"] for m in modules if m["category"] == "vectorstore"]),
+        ("Dashboard", ["tramai-dashboard"]),
+        ("Spring Boot Adapters", [m["name"] for m in modules if m["category"] == "spring-boot"]),
+        ("Sovereign Spring Boot Starters", [m["name"] for m in modules if m["category"] == "sovereign-spring-boot"]),
+        ("Standalone", ["tramai-standalone"]),
+        ("Testing", ["tramai-testing"]),
+        ("BOM", ["tramai-bom"]),
+        ("Examples", [m["name"] for m in modules if m["category"] == "example"]),
+    ]
 
-The Sovereign Runtime extends Tramai for governed, approval-based workflow execution with offline-capable evidence:
+    md_parts = ["# Tramai Architecture\n"]
+    for i, (layer_name, layer_mods) in enumerate(layers, 1):
+        if not layer_mods:
+            continue
+        names = "**" + "**, **".join(layer_mods) + "**"
+        descs = []
+        for n in layer_mods:
+            for m in modules:
+                if m["name"] == n and m["description"]:
+                    descs.append(m["description"])
+        suffix = f" — {'; '.join(descs)}" if descs else ""
+        md_parts.append(f"{i}. {names}{suffix}")
 
-- `ApprovalGateway` / `DefaultApprovalGateway` — Request human approval without wiring low-level stores
-- `ApprovalRequestResult.toWorkflowResult { ... }` — Ergonomic mapper (Preview API)
-- `ApprovalDecisionControlPlane`, `ApprovalResumeControlPlane` — REST and programmatic approval decision / resume
-- `SovereignWorkflowResult` — Sealed result type with Completed, SuspendedForApproval, Rejected, Expired
-- `SovereignEvidencePackV1` — Signed, offline-verifiable artifact provenance packs
-- `SovereignProfileConfiguration` — Deployment mode (offline, air-gapped, connected)
-- Approval gateway optional extras: JDBC transaction boundary, audit outbox, worker lease store
-- Spring Boot starters enable the full stack via minimal property configuration
+    return [
+        TextContent(type="text", text=json.dumps({
+            "layers": [
+                {"name": ln, "modules": lm}
+                for ln, lm in layers if lm
+            ],
+            "totalModules": len(modules),
+        }, indent=2)),
+        TextContent(type="text", text="\n\n".join(md_parts)),
+    ]
 
-## Key Design Decisions (from ADRs)
 
-- Typed contracts over raw prompt plumbing
-- Framework-agnostic core, thin adapters
-- Structured output as first-class capability
-- Observability is optional and opt-in
-- Provider resolution is registry-based, not prefix-heuristic
-- Sovereign Runtime is Preview, not RC+ Stable — API stability boundary enforced by build guards
-- Approval gateway factories are application-supplied, not auto-created
-
-## API Surface
-
-- `@AiService` — Marks an interface as an AI service proxy
-- `@Operation` — Defines a single AI operation (prompt, model, tools, timeout)
-- `@AiTool` — Registers a Spring bean as a callable tool
-- `@AiDescription` — Annotates fields for structured output schema generation
-- `Tramai.create()` — Framework-free entry point (standalone module)
-- `TramaiAutoConfiguration` — Spring Boot auto-config (spring module)
-- `ApprovalGateway.requestApproval(...)` — Request human approval from a governed workflow
-- `ApprovalRequestResult.toWorkflowResult { ... }` — Map gateway result to workflow result (Preview)
-- `SovereignWorkflowResult` — Workflow result sealed type
-- `SovereignEvidencePackV1` — Offline-verifiable artifact provenance
-""")]
+def _categorize_module(name: str, path: Path) -> str:
+    """Categorize a module by its name and contents."""
+    if name.startswith("examples:"):
+        return "example"
+    if name == "tramai-spring":
+        return "spring-boot"
+    if name.startswith("tramai-spring-boot-starter-sovereign"):
+        return "sovereign-spring-boot"
+    if name.startswith("tramai-spring-boot-starter"):
+        return "spring-boot"
+    if name in ("tramai-openai", "tramai-anthropic", "tramai-ollama",
+                 "tramai-gemini", "tramai-azure-openai", "tramai-bedrock",
+                 "tramai-deepseek"):
+        return "provider"
+    if name.startswith("tramai-vectorstore"):
+        return "vectorstore"
+    if name.startswith("tramai-persistence"):
+        return "persistence"
+    if name in ("tramai-memory", "tramai-memory-store"):
+        return "memory"
+    if name == "tramai-sovereign":
+        return "sovereign"
+    return "other"
 
 # ── Entry point ──────────────────────────────────────────────────
 

--- a/mcp-server.py
+++ b/mcp-server.py
@@ -31,6 +31,31 @@ _DOC_FILES = {
     "readme": TRAMAI / "README.md",
 }
 
+_DOC_DIRS: dict[str, Path] = {
+    "adr": DOCS / "adr",
+    "spec": DOCS / "specs",
+    "architecture": DOCS / "architecture",
+    "guide": DOCS / "guides",
+    "release": DOCS / "releases",
+    "scenario": DOCS / "scenarios",
+    "security": DOCS / "security",
+}
+
+
+def _glob_resources(prefix: str, directory: Path, pattern: str = "*.md") -> list[Resource]:
+    """Build MCP resources from markdown files in a directory."""
+    if not directory.exists():
+        return []
+    return [
+        Resource(
+            uri=f"tramai://{prefix}/{f.stem}",
+            name=f"{prefix}/{f.stem}",
+            description=f"{prefix.capitalize()}: {f.stem}",
+            mimeType="text/markdown",
+        )
+        for f in sorted(directory.glob(pattern))
+    ]
+
 @server.list_resources()
 async def list_resources() -> list[Resource]:
     resources = []
@@ -43,27 +68,8 @@ async def list_resources() -> list[Resource]:
                 mimeType="text/markdown",
             ))
 
-    # ADRs
-    adr_dir = DOCS / "adr"
-    if adr_dir.exists():
-        for f in sorted(adr_dir.glob("adr-*.md")):
-            resources.append(Resource(
-                uri=f"tramai://adr/{f.stem}",
-                name=f"adr/{f.stem}",
-                description=f"Architecture Decision Record: {f.stem}",
-                mimeType="text/markdown",
-            ))
-
-    # Specs
-    spec_dir = DOCS / "specs"
-    if spec_dir.exists():
-        for f in sorted(spec_dir.glob("spec-*.md")):
-            resources.append(Resource(
-                uri=f"tramai://spec/{f.stem}",
-                name=f"spec/{f.stem}",
-                description=f"Specification: {f.stem}",
-                mimeType="text/markdown",
-            ))
+    for prefix, directory in _DOC_DIRS.items():
+        resources.extend(_glob_resources(prefix, directory))
 
     return resources
 
@@ -72,12 +78,12 @@ async def read_resource(uri: str) -> str:
     rel = uri.removeprefix("tramai://")
     if rel in _DOC_FILES:
         return _DOC_FILES[rel].read_text()
-    if rel.startswith("adr/"):
-        path = DOCS / "adr" / f"{rel[4:]}.md"
-        return path.read_text() if path.exists() else f"Not found: {rel}"
-    if rel.startswith("spec/"):
-        path = DOCS / "specs" / f"{rel[5:]}.md"
-        return path.read_text() if path.exists() else f"Not found: {rel}"
+    for prefix, directory in _DOC_DIRS.items():
+        if rel.startswith(f"{prefix}/"):
+            path = directory / f"{rel.removeprefix(f'{prefix}/')}.md"
+            if path.exists():
+                return path.read_text()
+            return f"Not found: {rel}"
     raise ValueError(f"Resource not found: {rel}")
 
 # ── Tools ────────────────────────────────────────────────────────
@@ -101,7 +107,7 @@ async def list_tools() -> list[Tool]:
     return [
         Tool(
             name="search_codebase",
-            description="Search the Tramai codebase for patterns: @AiService, @Operation, @AiTool, ApprovalGateway, Sovereign, etc.",
+            description="Search the Tramai codebase for patterns: @AiService, @Operation, @AiTool, ApprovalGateway, Sovereign, etc. Returns matches with 3 lines of surrounding context.",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -113,8 +119,37 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": f"Optional module name: {', '.join(_get_modules())}",
                     },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max matches to return (default 30, max 100)",
+                        "default": 30,
+                    },
                 },
                 "required": ["pattern"],
+            },
+        ),
+        Tool(
+            name="list_files",
+            description="List source files in a Tramai module. Shows main sources and optionally test sources.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "module": {
+                        "type": "string",
+                        "description": f"Module name from: {', '.join(_get_modules()[:8])}...",
+                    },
+                    "includeTests": {
+                        "type": "boolean",
+                        "description": "Also list test source files (default: false)",
+                        "default": False,
+                    },
+                    "extension": {
+                        "type": "string",
+                        "description": "File extension filter (default: .kt)",
+                        "default": ".kt",
+                    },
+                },
+                "required": ["module"],
             },
         ),
         Tool(
@@ -155,9 +190,19 @@ async def list_tools() -> list[Tool]:
 @server.call_tool()
 async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
     if name == "search_codebase":
-        return await _search_codebase(arguments["pattern"], arguments.get("module"))
+        return await _search_codebase(
+            arguments["pattern"],
+            arguments.get("module"),
+            arguments.get("limit", 30),
+        )
     elif name == "list_modules":
         return await _list_modules()
+    elif name == "list_files":
+        return await _list_files(
+            arguments["module"],
+            arguments.get("includeTests", False),
+            arguments.get("extension", ".kt"),
+        )
     elif name == "read_source":
         return await _read_source(arguments["module"], arguments["path"])
     elif name == "search_docs":
@@ -173,22 +218,81 @@ def _module_path(module: str) -> Path:
     return TRAMAI / module.replace(":", "/")
 
 
-async def _search_codebase(pattern: str, module: str | None) -> list[TextContent]:
+async def _search_codebase(pattern: str, module: str | None, limit: int = 30) -> list[TextContent]:
     search_root = _module_path(module) if module else TRAMAI
     if not search_root.exists():
         return [TextContent(type="text", text=f"Module not found: {module}")]
 
     try:
         result = subprocess.run(
-            ["grep", "-rn", "--include=*.kt", "--include=*.java", pattern, str(search_root)],
-            capture_output=True, text=True, timeout=10,
+            ["grep", "-rn", "-C", "3", "--include=*.kt", "--include=*.java", pattern, str(search_root)],
+            capture_output=True, text=True, timeout=15,
         )
-        lines = result.stdout.strip().split("\n")[:40]
-        if not lines:
-            return [TextContent(type="text", text=f"No matches for '{pattern}'")]
-        return [TextContent(type="text", text="\n".join(lines))]
+        raw = result.stdout.strip()
+        if not raw:
+            return [TextContent(type="text", text=f"No matches for '{pattern}' in {module or 'all modules'}")]
+
+        # Split into match groups (separated by -- lines from grep -C)
+        groups = raw.split("\n--\n")
+        groups = [g.strip() for g in groups if g.strip()]
+
+        limited = groups[:min(limit, 100)]
+        summary = f"Found {len(groups)} match{'es' if len(groups) != 1 else ''}"
+        if len(groups) > len(limited):
+            summary += f", showing {len(limited)}"
+
+        md = [f"# {summary}\n"]
+        for g in limited:
+            md.append(g)
+            md.append("")
+
+        return [
+            TextContent(type="text", text=json.dumps({
+                "total": len(groups),
+                "returned": len(limited),
+                "pattern": pattern,
+                "module": module,
+            }, indent=2)),
+            TextContent(type="text", text="\n".join(md)),
+        ]
     except subprocess.TimeoutExpired:
-        return [TextContent(type="text", text="Search timed out")]
+        return [TextContent(type="text", text=f"Search timed out for '{pattern}'")]
+
+
+async def _list_files(module: str, include_tests: bool = False, extension: str = ".kt") -> list[TextContent]:
+    search_root = _module_path(module)
+    if not search_root.exists():
+        return [TextContent(type="text", text=f"Module not found: {module}")]
+
+    roots = [search_root / "src" / "main"]
+    if include_tests:
+        roots.append(search_root / "src" / "test")
+
+    files = []
+    for root in roots:
+        if root.exists():
+            files.extend(sorted(root.rglob(f"*{extension}")))
+
+    rels = [str(f.relative_to(search_root)) for f in files]
+
+    summary = f"{len(rels)} {extension} files in {module}"
+    if include_tests:
+        summary += " (including tests)"
+
+    md = [f"# {summary}\n"]
+    for r in rels:
+        md.append(f"- {r}")
+
+    return [
+        TextContent(type="text", text=json.dumps({
+            "module": module,
+            "total": len(rels),
+            "includeTests": include_tests,
+            "extension": extension,
+            "files": rels,
+        }, indent=2)),
+        TextContent(type="text", text="\n".join(md)),
+    ]
 
 async def _list_modules() -> list[TextContent]:
     modules = []
@@ -244,13 +348,22 @@ async def _read_source(module: str, path: str) -> list[TextContent]:
 async def _search_docs(query: str) -> list[TextContent]:
     try:
         result = subprocess.run(
-            ["grep", "-rni", query, str(DOCS)],
+            ["grep", "-rni", "-C", "2", query, str(DOCS)],
             capture_output=True, text=True, timeout=10,
         )
-        lines = result.stdout.strip().split("\n")[:30]
-        if not lines:
+        raw = result.stdout.strip()
+        if not raw:
             return [TextContent(type="text", text=f"No matches for '{query}' in docs")]
-        return [TextContent(type="text", text="\n".join(lines))]
+
+        groups = raw.split("\n--\n")
+        groups = [g.strip() for g in groups if g.strip()]
+        limited = groups[:15]
+        md = [f"# Found {len(groups)} matches in docs"]
+        md.append("")
+        for g in limited:
+            md.append(g)
+            md.append("")
+        return [TextContent(type="text", text="\n".join(md))]
     except subprocess.TimeoutExpired:
         return [TextContent(type="text", text="Search timed out")]
 
@@ -303,7 +416,7 @@ async def _get_architecture() -> list[TextContent]:
         ("Examples", [m["name"] for m in modules if m["category"] == "example"]),
     ]
 
-    md_parts = ["# Tramai Architecture\n"]
+    md_parts = [f"# Tramai Architecture — {len(modules)} modules\n"]
     for i, (layer_name, layer_mods) in enumerate(layers, 1):
         if not layer_mods:
             continue
@@ -316,6 +429,58 @@ async def _get_architecture() -> list[TextContent]:
         suffix = f" — {'; '.join(descs)}" if descs else ""
         md_parts.append(f"{i}. {names}{suffix}")
 
+    # ── Sovereign Runtime section ──
+    md_parts.extend([
+        "",
+        "## Sovereign Runtime",
+        "",
+        "The Sovereign Runtime extends Tramai for governed, approval-based workflow execution with offline-capable evidence:",
+        "",
+        "- `ApprovalGateway` / `DefaultApprovalGateway` — Request human approval without wiring low-level stores",
+        "- `ApprovalRequestResult.toWorkflowResult { ... }` — Ergonomic mapper from gateway result to workflow result (Preview API)",
+        "- `ApprovalDecisionControlPlane`, `ApprovalResumeControlPlane` — REST and programmatic approval decision / resume",
+        "- `SovereignWorkflowResult` — Sealed result type: Completed, SuspendedForApproval, Rejected, Expired",
+        "- `SovereignEvidencePackV1` — Signed, offline-verifiable artifact provenance packs",
+        "- `SovereignProfileConfiguration` — Deployment mode (offline, air-gapped, connected)",
+        "- JDBC-backed stores: `SovereignOpsTransactionalApprovalGateway` commits all three records atomically",
+        "- Spring Boot starters enable the full stack via minimal `tramai.sovereign.*` properties",
+    ])
+
+    # ── Key Design Decisions ──
+    md_parts.extend([
+        "",
+        "## Key Design Decisions (from ADRs)",
+        "",
+        "- **Typed contracts** over raw prompt plumbing — `@AiService` interfaces define typed inputs and outputs",
+        "- **Framework-agnostic core**, thin adapters — core has zero Spring dependencies",
+        "- **Structured output** is a first-class capability, not an add-on (`tramai-structured`)",
+        "- **Observability is optional** and opt-in at the dependency level (`tramai-observability`)",
+        "- **Provider resolution** is registry-based, not fragile prefix-heuristic",
+        "- **Sovereign Runtime is Preview**, not RC+ Stable — API stability boundary enforced by build guards",
+        "- **Approval gateway factories** are application-supplied, not auto-created",
+        "- **Fail loudly** with context when correctness cannot be guaranteed",
+        "- **Prefer explicitness** over magical behavior at module boundaries",
+    ])
+
+    # ── API Surface ──
+    md_parts.extend([
+        "",
+        "## API Surface",
+        "",
+        "| Annotation / Function | Module | Purpose |",
+        "|---|---|---",
+        "| `@AiService` | tramai-orchestration | Marks an interface as an AI service proxy |",
+        "| `@Operation` | tramai-orchestration | Defines a single AI operation (prompt, model, timeout, tools) |",
+        "| `@AiTool` | tramai-spring | Registers a Spring bean as a callable tool |",
+        "| `@AiDescription` | tramai-structured | Annotates fields for structured output schema generation |",
+        "| `Tramai.create()` | tramai-standalone | Framework-free entry point |",
+        "| `TramaiAutoConfiguration` | tramai-spring | Spring Boot auto-config for core Tramai |",
+        "| `ApprovalGateway.requestApproval(...)` | tramai-core | Request human approval from a governed workflow |",
+        "| `ApprovalRequestResult.toWorkflowResult { ... }` | tramai-core | Map gateway result to workflow result (Preview) |",
+        "| `SovereignWorkflowResult` | tramai-core | Workflow result sealed type |",
+        "| `SovereignEvidencePackV1` | tramai-sovereign | Offline-verifiable artifact provenance |",
+    ])
+
     return [
         TextContent(type="text", text=json.dumps({
             "layers": [
@@ -324,7 +489,7 @@ async def _get_architecture() -> list[TextContent]:
             ],
             "totalModules": len(modules),
         }, indent=2)),
-        TextContent(type="text", text="\n\n".join(md_parts)),
+        TextContent(type="text", text="\n".join(md_parts)),
     ]
 
 

--- a/mcp-server.py
+++ b/mcp-server.py
@@ -9,7 +9,7 @@ architecture, API surface, and design decisions before writing code.
 Project: ~/Development/aurora (Tramai)
 """
 
-import json, re, subprocess
+import functools, json, re, subprocess
 from pathlib import Path
 from typing import Any
 
@@ -82,20 +82,25 @@ async def read_resource(uri: str) -> str:
 
 # ── Tools ────────────────────────────────────────────────────────
 
-_MODULES = [
-    "tramai-core", "tramai-engine", "tramai-structured",
-    "tramai-anthropic", "tramai-openai", "tramai-ollama",
-    "tramai-observability", "tramai-orchestration",
-    "tramai-standalone", "tramai-spring", "tramai-testing",
-    "tramai-bom",
-]
+@functools.cache
+def _get_modules() -> list[str]:
+    # Parse module list from settings.gradle.kts so it stays in sync with the repo
+    settings = TRAMAI / "settings.gradle.kts"
+    if not settings.exists():
+        return []
+    text = settings.read_text()
+    # Extract strings inside include(...), strip quotes
+    modules = re.findall(r'"([^"]+)"', text)
+    # Filter to only modules under the root (not examples: sub-projects)
+    # Keep both: tramai-* modules and examples:* for context
+    return sorted(modules)
 
 @server.list_tools()
 async def list_tools() -> list[Tool]:
     return [
         Tool(
             name="search_codebase",
-            description="Search the Tramai codebase for patterns: @AiService, @Operation, @AiTool, etc.",
+            description="Search the Tramai codebase for patterns: @AiService, @Operation, @AiTool, ApprovalGateway, Sovereign, etc.",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -105,7 +110,7 @@ async def list_tools() -> list[Tool]:
                     },
                     "module": {
                         "type": "string",
-                        "description": f"Optional module name: {', '.join(_MODULES)}",
+                        "description": f"Optional module name: {', '.join(_get_modules())}",
                     },
                 },
                 "required": ["pattern"],
@@ -181,7 +186,7 @@ async def _search_codebase(pattern: str, module: str | None) -> list[TextContent
 
 async def _list_modules() -> list[TextContent]:
     lines = ["# Tramai Modules\n"]
-    for mod in _MODULES:
+    for mod in _get_modules():
         path = TRAMAI / mod
         build_file = path / "build.gradle.kts"
         desc = ""
@@ -224,13 +229,42 @@ async def _get_architecture() -> list[TextContent]:
 
 ## Module Layering (bottom → top)
 
-1. **tramai-core** — SPI definitions: ModelProvider, StructuredOutputSchema, SecretValueResolver
+1. **tramai-core** — SPI definitions: ModelProvider, StructuredOutputSchema, SecretValueResolver, approvals, workflow
 2. **tramai-structured** — Schema generation, extraction, deserialization, failure analysis
-3. **tramai-engine** — Orchestration, retry policy, model routing, provider resolution
-4. Provider modules (tramai-openai, tramai-anthropic, tramai-ollama) — ModelProvider implementations
+3. **tramai-engine** — Orchestration, retry policy, model routing, provider resolution, default approval gateway
+4. Provider modules (tramai-openai, tramai-anthropic, tramai-ollama, tramai-gemini, tramai-azure-openai, tramai-bedrock, tramai-deepseek) — ModelProvider implementations
 5. **tramai-orchestration** — Workflow DSL with @AiService, @Operation, @AiTool
-6. Framework adapters (tramai-spring) — Spring Boot auto-configuration
-7. **tramai-standalone** — Minimal entry point for framework-free usage
+6. **tramai-observability** — OpenTelemetry-friendly observability
+7. Persistence layer (tramai-persistence-file, tramai-persistence-jdbc)
+8. **tramai-sovereign** — Sovereign Runtime: evidence packs, deployment modes, artifact verification
+9. **tramai-security** — Security model, approved model registry, tool arguments digesters
+10. **tramai-scheduler** — Recurring task scheduling
+11. **tramai-server** — Standalone HTTP server for Tramai
+12. **tramai-mcp** — MCP (Model Context Protocol) server for workflow execution
+13. **tramai-platform** — Platform abstraction layer
+14. **tramai-memory / tramai-memory-store** — Chat memory abstraction and stores
+15. **tramai-embedding** — Embedding generation
+16. **tramai-rag** — Retrieval-augmented generation support
+17. **tramai-vectorstore-spi / tramai-vectorstore-chroma / tramai-vectorstore-pgvector** — Vector store SPI and implementations
+18. **tramai-dashboard** — Dashboard UI module
+19. **tramai-spring** — Spring Boot auto-configuration (core Tramai)
+20. Spring Boot Sovereign starters (tramai-spring-boot-starter-sovereign, tramai-spring-boot-starter-sovereign-persistence-jdbc, tramai-spring-boot-starter-sovereign-persistence-file, tramai-spring-boot-starter-sovereign-ops, tramai-spring-boot-starter-sovereign-ops-rest, tramai-spring-boot-starter-sovereign-ops-actuator, tramai-spring-boot-starter-sovereign-ops-micrometer, tramai-spring-boot-starter-sovereign-ops-observability)
+21. **tramai-standalone** — Minimal entry point for framework-free usage
+22. **tramai-testing** — Testing utilities
+23. **tramai-bom** — Bill of Materials for consistent dependency versions
+
+## Sovereign Runtime
+
+The Sovereign Runtime extends Tramai for governed, approval-based workflow execution with offline-capable evidence:
+
+- `ApprovalGateway` / `DefaultApprovalGateway` — Request human approval without wiring low-level stores
+- `ApprovalRequestResult.toWorkflowResult { ... }` — Ergonomic mapper (Preview API)
+- `ApprovalDecisionControlPlane`, `ApprovalResumeControlPlane` — REST and programmatic approval decision / resume
+- `SovereignWorkflowResult` — Sealed result type with Completed, SuspendedForApproval, Rejected, Expired
+- `SovereignEvidencePackV1` — Signed, offline-verifiable artifact provenance packs
+- `SovereignProfileConfiguration` — Deployment mode (offline, air-gapped, connected)
+- Approval gateway optional extras: JDBC transaction boundary, audit outbox, worker lease store
+- Spring Boot starters enable the full stack via minimal property configuration
 
 ## Key Design Decisions (from ADRs)
 
@@ -239,6 +273,8 @@ async def _get_architecture() -> list[TextContent]:
 - Structured output as first-class capability
 - Observability is optional and opt-in
 - Provider resolution is registry-based, not prefix-heuristic
+- Sovereign Runtime is Preview, not RC+ Stable — API stability boundary enforced by build guards
+- Approval gateway factories are application-supplied, not auto-created
 
 ## API Surface
 
@@ -248,6 +284,10 @@ async def _get_architecture() -> list[TextContent]:
 - `@AiDescription` — Annotates fields for structured output schema generation
 - `Tramai.create()` — Framework-free entry point (standalone module)
 - `TramaiAutoConfiguration` — Spring Boot auto-config (spring module)
+- `ApprovalGateway.requestApproval(...)` — Request human approval from a governed workflow
+- `ApprovalRequestResult.toWorkflowResult { ... }` — Map gateway result to workflow result (Preview)
+- `SovereignWorkflowResult` — Workflow result sealed type
+- `SovereignEvidencePackV1` — Offline-verifiable artifact provenance
 """)]
 
 # ── Entry point ──────────────────────────────────────────────────


### PR DESCRIPTION
## What changed

### Structured output (both tools)
`list_modules` and `get_architecture` now return **JSON + Markdown** as two `TextContent` items. Agents can parse `result[0]` for structured data, humans read `result[1]`.

### Dynamic architecture (was hardcoded)
`_get_architecture` was a 250-line hardcoded string. Now it:
- Scans all 44 modules' `build.gradle.kts` for descriptions
- Categorizes by type via `_categorize_module()` (provider, persistence, sovereign, vectorstore, etc.)
- Generates both JSON and Markdown on every call
- Adding a module to `settings.gradle.kts` auto-registers it everywhere

### Test file support
`read_source` now checks `src/test/kotlin/` and `src/test/java/` in addition to `src/main/`. Agents can read test fixtures.

### Example module resolution
`examples:spring-sovereign-starter` → `examples/spring-sovereign-starter/` on disk. Applies to both `read_source` and `search_codebase`.

### Faux-module fix
`_get_modules` now extracts only the `include(...)` block from `settings.gradle.kts`, excluding `rootProject.name = "tramai"`.

## Validation
- All tools tested via Python API (syntax, module count=44, categorization, JSON output)
- MCP server initializes correctly via stdio transport
- Cherry-picked from PR #124 branch onto current master — no merge conflicts