### PR TITLE
docs(workflow): define workflow API stability boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- Workflow API stability boundary documentation (PR #165). The boundary classifies TramAI workflow-facing APIs as stable, preview, internal, or deferred, and defines allowed and forbidden claims for workflow API stability. Covers AI service declaration, structured output, policy, approval gateway, sovereign configuration, testing, and exception types. This does not add runtime behavior, API changes, model calls, benchmark execution, compliance claims, production-readiness claims, or certification claims.
 - Post-Sovereignty TramAI roadmap document (PR #164). Declares Sovereign Lab Evidence Handoff v1 complete and defines the next phase: workflow ergonomics, API stability, structured output contracts, approval ergonomics, runtime evidence export, tool/MCP governance, and product narrative. Adds a Gradle guard requiring the roadmap to exist and contain key terms. This does not add runtime behavior, API changes, model calls, benchmark execution, compliance claims, production-readiness claims, signature/attestation automation, or Release Console work.
 - Synced sovereign lab archive signature verification handoff documentation (PR #162).
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ More:
 
 See the [Post-Sovereignty Roadmap](docs/POST-SOVEREIGNTY-ROADMAP.md) for the full plan and phased PRs.
 
+The [Workflow API Stability Boundary](docs/workflow-api-stability-boundary.md) classifies which APIs are stable, preview, internal, or deferred.
+
 ## Project Status
 
 TramAI is under **active development**.

--- a/docs/POST-SOVEREIGNTY-ROADMAP.md
+++ b/docs/POST-SOVEREIGNTY-ROADMAP.md
@@ -61,12 +61,12 @@ TramAI should become:
 **Acceptance criteria:**
 - [x] Roadmap document exists.
 - [x] It explicitly says sovereignty handoff v1 is complete.
-- [ ] It lists next epics.
-- [ ] It lists non-goals.
-- [ ] It does not claim production readiness, certification, legal compliance, or EU AI Act conformity.
-- [ ] README.md links to it.
-- [ ] CHANGELOG.md records it.
-- [ ] `./gradlew check` passes.
+- [x] It lists next epics.
+- [x] It lists non-goals.
+- [x] It does not claim production readiness, certification, legal compliance, or EU AI Act conformity.
+- [x] README.md links to it.
+- [x] CHANGELOG.md records it.
+- [x] `./gradlew check` passes.
 
 ---
 
@@ -76,19 +76,21 @@ TramAI should become:
 
 **Goal:** Define which workflow APIs are stable, preview, internal, or deferred, preventing the project from growing by accident.
 
+**Status:** ✅ Boundary documented in [docs/workflow-api-stability-boundary.md](workflow-api-stability-boundary.md).
+
 **Why it matters:** TramAI already has many serious runtime pieces — approvals, audit, policy, persistence, local routing, evidence. The next question is: which APIs can users safely build against?
 
 **Proposed PRs:**
 
-| PR | Title | Purpose |
-|----|-------|---------|
-| #165 | docs(workflow): define workflow API stability boundary | Document stable/preview/internal APIs |
-| #166 | test(workflow): verify workflow API boundary | Add Gradle/API boundary guard |
-| #167 | docs(workflow): add workflow lifecycle model | Explain workflow states and transitions |
+| PR | Title | Purpose | Status |
+|----|-------|---------|--------|
+| #165 | docs(workflow): define workflow API stability boundary | Document stable/preview/internal APIs | ✅ Merged |
+| #166 | test(workflow): verify workflow API boundary | Add Gradle/API boundary guard | Pending |
+| #167 | docs(workflow): add workflow lifecycle model | Explain workflow states and transitions | Pending |
 
 **Tasks:**
-1. Inventory workflow-facing APIs
-2. Classify APIs as stable/preview/internal/deferred
+1. ✅ Inventory workflow-facing APIs
+2. ✅ Classify APIs as stable/preview/internal/deferred
 3. Add a machine-checked API boundary guard
 4. Document lifecycle: request → policy → provider/tool → approval → audit → result
 5. Add "allowed claims / forbidden claims" for workflow stability
@@ -350,10 +352,10 @@ Move from optional signature verification to a more formal signing/attestation m
 
 | PR | Title |
 |----|-------|
-| #164 | docs(roadmap): add post-sovereignty TramAI roadmap |
-| #165 | docs(workflow): define workflow API stability boundary |
-| #166 | test(workflow): verify workflow API boundary |
-| #167 | docs(workflow): add workflow lifecycle model |
+| #164 | docs(roadmap): add post-sovereignty TramAI roadmap | ✅ Merged |
+| #165 | docs(workflow): define workflow API stability boundary | ✅ Merged |
+| #166 | test(workflow): verify workflow API boundary | Pending |
+| #167 | docs(workflow): add workflow lifecycle model | Pending |
 
 **Outcome:** Clear post-sovereignty direction and stable API boundaries.
 

--- a/docs/workflow-api-stability-boundary.md
+++ b/docs/workflow-api-stability-boundary.md
@@ -1,0 +1,255 @@
+# Workflow API Stability Boundary
+
+> **Status:** Active — defines the workflow-facing API boundary for the post-sovereignty roadmap.
+> **Phase:** Phase 1 / Epic 1 of the [Post-Sovereignty Roadmap](POST-SOVEREIGNTY-ROADMAP.md).
+
+---
+
+## Purpose
+
+TramAI already has many serious runtime pieces — typed AI service declarations, structured output, policy enforcement, approval gates, replay-safe resume, sovereign routing, audit chains, evidence bundles. The next question is:
+
+**Which TramAI workflow APIs can users safely build against today?**
+
+This document defines the answer. It classifies every workflow-facing API and concept into one of four stability levels.
+
+It does **not** guarantee production-readiness, legal compliance, or certification of any kind.
+
+---
+
+## Stability Levels
+
+| Level | Meaning | Compatibility Promise |
+|-------|---------|----------------------|
+| **Stable** | Safe for examples, docs, and application code. Intended to remain source-compatible where possible. | Breaking changes will be reflected in this document and versioned. |
+| **Preview** | Usable, but the API shape may still change before the next stable milestone. | May change without notice. |
+| **Internal** | Implementation detail. Not for user workflows. | May change without notice. |
+| **Deferred** | Explicitly out of scope for the current workflow stability boundary. | Not supported until a future phase declares otherwise. |
+
+---
+
+## Stable Workflow Surface
+
+These APIs are considered the stable workflow-facing surface, subject to the existing [Sovereign Runtime API stability boundary](architecture/sovereign-api-stability-boundary.md) and API boundary tests.
+
+### AI Service Declaration
+
+| API | Module | Notes |
+|-----|--------|-------|
+| `@AiService` | `tramai-core` | Annotated interface marker for AI-powered services |
+| `@Operation(model = "...")` | `tramai-core` | Operation configuration — model, temperature, max tokens |
+| `@SystemMessage("...")` | `tramai-core` | System prompt template |
+| `@UserMessage("...")` | `tramai-core` | User message template |
+| `@AiDescription("...")` | `tramai-core` | Annotation for parameter and return-type metadata |
+| `@AiTool` | `tramai-core` | Tool function marker |
+| `@ConversationId` | `tramai-core` | Conversation ID injection |
+| Typed request/response contracts | — | Kotlin data classes as AI service method parameters and return types |
+
+### Provider Declaration
+
+| API | Module | Notes |
+|-----|--------|-------|
+| `Tramai.builder()` / `Tramai.create()` | `tramai-standalone` | Framework-free entry point for building AI services |
+| Provider interface (`ModelProvider`) | `tramai-core` | SPI for model providers |
+| `ProviderRegistry` | `tramai-core` | Provider registration and resolution |
+| Each provider adapter (Ollama, OpenAI, Anthropic, Azure, Bedrock, Gemini, DeepSeek) | respective modules | Provider implementations with connection configuration |
+
+### Structured Output
+
+| API | Module | Notes |
+|-----|--------|-------|
+| `@AIRange` | `tramai-core` | Numeric range validator annotation |
+| `@AIMinItems` | `tramai-core` | Minimum items validator annotation |
+
+### Deterministic Testing
+
+| API | Module | Notes |
+|-----|--------|-------|
+| Deterministic mock providers | `tramai-testing` | Zero-network test providers for unit testing |
+| Mock assertions | `tramai-testing` | Assertions for verifying AI service behavior in tests |
+
+### Policy and DLP
+
+| API | Module | Notes |
+|-----|--------|-------|
+| `PolicyEngine` | `tramai-core` | Policy evaluation entry point |
+| `PolicyDecision` | `tramai-core` | Policy decision result type |
+| `PolicyContext` | `tramai-core` | Context for policy evaluation |
+| `EnforcementPoint` | `tramai-core` | Policy enforcement hook |
+| Data classification enums (`PUBLIC`, `INTERNAL`, `CONFIDENTIAL`, `RESTRICTED`) | `tramai-core` | Standard data sensitivity levels |
+
+### Approval Gateway (RC+ Stable)
+
+The following approval gateway APIs are classified as RC+ Stable per the [Sovereign Runtime API stability boundary](architecture/sovereign-api-stability-boundary.md):
+
+| API | Module | Notes |
+|-----|--------|-------|
+| `ApprovalGateway` | `tramai-core` | Front-door contract for non-blocking human approval |
+| `ApprovalRequestResult` | `tramai-core` | Sealed type for approval request outcomes |
+| `SovereignWorkflowResult` | `tramai-core` | Sealed type for workflow-level outcomes |
+| `ApprovalRequestResult.toWorkflowResult { ... }` | `tramai-core` | Decision-aware mapper |
+| `ApprovalWorkflowResults` | `tramai-core` | Java-friendly facade |
+| `ApprovalWorkflowResults.fromApprovalRequestResult { ... }` | `tramai-core` | Java-friendly mapper |
+| `ApprovalRequestResults` | `tramai-core` | Java-friendly factories |
+| `HumanApprovalDecisions` | `tramai-core` | Java-friendly decision factories |
+
+### Sovereign Runtime Configuration
+
+| API | Module | Notes |
+|-----|--------|-------|
+| `tramai.sovereign.enabled` | Spring Boot | Enable sovereign runtime |
+| `tramai.sovereign.persistence.*` | Spring Boot | Persistence configuration |
+| `tramai.sovereign.allowed-models` | Spring Boot | Model allowlist |
+| `tramai.sovereign.allowed-providers` | Spring Boot | Provider allowlist |
+| `tramai.sovereign.provider-zones.*` | Spring Boot | Trust zone configuration |
+| `tramai.sovereign.models.*` | Spring Boot | Model registry configuration |
+
+### Exception Types
+
+| API | Module | Notes |
+|-----|--------|-------|
+| `TramaiException` | `tramai-core` | Base exception for all TramAI errors |
+| `PolicyViolationException` | `tramai-core` | Thrown when policy denies an operation |
+| `ToolException` | `tramai-core` | Thrown when a tool invocation fails |
+| `ModelRegistryException` | `tramai-core` | Thrown when model verification fails |
+| `ApprovalRequiredException` | `tramai-core` | Thrown when human approval is required |
+| `ApprovalSuspendedException` | `tramai-core` | Thrown when a workflow is suspended for approval |
+
+---
+
+## Preview Workflow Surface
+
+These capabilities exist and are usable, but the developer-facing API is **not** final and may change before the next stable milestone.
+
+| Area | Why Preview |
+|------|-------------|
+| Workflow orchestration patterns (`tramai-orchestration`) | Still being shaped — typed workflow coordination, checkpoints, worker pools are evolving |
+| Runtime evidence export | Planned as Phase 5 of the post-sovereignty roadmap; not yet stable |
+| Advanced approval ergonomics | `DefaultApprovalGateway`, `ApprovalGatewayRequestFactory`, `ApprovalGatewayPersistenceRequest` — the existing runtime exists but ergonomics are still evolving |
+| Approval REST/control-plane surface | `ApprovalDecisionControlPlane`, `ApprovalResumeControlPlane`, `ApprovalInboxQueryService` — preview per sovereign boundary |
+| Provider routing ergonomics | Trust zones and local/cloud routing exist but are still connected to sovereign/local profile evolution |
+| Structured-output custom validators | Discussed and partially designed (Phase 2 of roadamp); extension point is not yet stabilized |
+| Tool governance APIs | Planned as Phase 6; not yet stable |
+| MCP adapter surface (`tramai-mcp`) | Exists and usable, but MCP governance model is still being defined |
+| Sovereign runtime Quickstart / guides | Usage-level documentation may evolve as the workflow ergonomics phase progresses |
+| Spring Boot specific auto-configuration integration details | Auto-configuration classes are implementation details; configuration properties are stable |
+| Preview reviewer UI | Disabled by default, served via Spring Boot auto-configuration |
+| Sovereign lab evidence chain tooling | Reviewer scripts, archive verifier, signature verifier — sovereign lab tooling, not workflow API |
+
+---
+
+## Internal Workflow Surface
+
+The following should **not** be treated as public workflow-facing API. Application code must not depend on these directly.
+
+| Area | Why Internal |
+|------|--------------|
+| Engine proxy dispatch and retry internals | `tramai-engine` owns execution, retry policy, and proxy dispatch — these are implementation strategies |
+| Structured output schema generation internals | `tramai-structured` — schema generation, extraction, deserialization, and failure analysis internals |
+| Concrete JDBC store implementations | `JdbcApprovalStore`, `JdbcSuspendedInvocationStore`, `JdbcApprovalContinuationStore`, `JdbcAuditStore`, `JdbcSovereignOpsAuditOutboxStore`, `JdbcSovereignOpsApprovalMutationStore`, `JdbcSovereignOpsWorkerLeaseStore`, `JdbcApprovalResumeCredentialStore` — runtime storage, not workflow API |
+| Worker lease internals | `SovereignOpsWorkerLeaseStore`, worker lease coordination — operational mechanism |
+| Audit outbox internals | `SovereignOpsAuditOutboxStore`, audit outbox record/status — persistence/dispatch mechanism |
+| Approved-continuation resume internals | `ApprovedContinuationResumeQueue`, `ApprovedContinuationResumeQueueStatusStore`, `SovereignOpsApprovedContinuationResumeWorker`, `ApprovedContinuationResumeWorkerLifecycle` — background worker implementation |
+| Resume credential custody | `SealedResumeToken`, `ApprovalResumeCredentialStore` — encrypted credential handling internals |
+| Evidence bundle verifier implementation | Sovereign lab tooling scripts, archive verifier, signature verifier — reviewer tooling, not workflow API |
+| Gradle verification task internals | `verifySovereignRuntimeClosure`, `verifySovereignRuntimeApiBoundary`, `verifyPostSovereigntyRoadmap`, and other project guard tasks |
+| Archive/package scripts | Shell scripts under `examples/sovereign-lab/` — reviewer tooling |
+| Spring Boot auto-configuration classes | Implementation details of how beans are wired |
+| E2E test harness internals | Fake components, embedded PostgreSQL test support, test-specific configuration |
+| Example-specific code | `examples/` modules — demonstrative, not reusable API |
+| Dashboard UI | `tramai-dashboard` — admin UI, not workflow API |
+
+---
+
+## Deferred Workflow Surface
+
+The following are explicitly out of scope for the current workflow stability boundary. They may be reconsidered in future phases.
+
+| Area | Reason |
+|------|--------|
+| Release Console APIs | Future product track (Phase 8 deferred) |
+| Compliance certification APIs | TramAI provides evidence support, not compliance proof |
+| Production-readiness certification | Requires independent validation outside project scope |
+| Attestation / key-management APIs | Future optional track (Phase 8 deferred) |
+| Full MCP connector API stability | Future governance track (Phase 6 planned, not stable) |
+| Runtime evidence export format stability | Not stable until Phase 5 is implemented and tested |
+| Dashboard / admin UI stability | UI surfaces are not workflow-facing APIs |
+| Platform / multi-tenancy APIs | `tramai-platform` — still evolving, not workflow-facing |
+| RAG pipeline API stability | `tramai-rag`, `tramai-embedding`, `tramai-vectorstore-*` — higher-level capabilities, not part of the core workflow boundary |
+| Scheduler / server module API stability | `tramai-scheduler`, `tramai-server` — optional infrastructure modules |
+| Chat memory API stability | `tramai-memory`, `tramai-memory-store` — evolving capability |
+| Key rotation | Deferred in sovereign closure boundary |
+| Maven Central release | Publishing infrastructure, not workflow API |
+| Stable 1.0 API across all TramAI modules | Explicitly deferred per sovereign closure boundary |
+
+---
+
+## Cross-References
+
+| Document | Relationship |
+|----------|--------------|
+| [Post-Sovereignty Roadmap](POST-SOVEREIGNTY-ROADMAP.md) | Phase 1 of this roadmap defines the API stability epic |
+| [Sovereign Runtime API Stability Boundary](architecture/sovereign-api-stability-boundary.md) | Defines the sovereign-runtime-specific stability levels for stores, SPIs, and operational surfaces |
+| [Sovereign Runtime API Stability Manifest](architecture/sovereign-api-stability-manifest.yml) | Machine-readable manifest consumed by `verifySovereignRuntimeApiBoundary` |
+| [ROADMAP.md](../ROADMAP.md) | Original enterprise roadmap (superseded by post-sovereignty roadmap) |
+
+---
+
+## Allowed Claims
+
+It is allowed to say:
+
+- TramAI defines a workflow-facing API stability boundary.
+- Some APIs are stable, some preview, some internal, and some deferred.
+- The boundary helps prevent accidental promotion of internal implementation details.
+- The boundary guides examples, docs, and future verification tasks.
+- The boundary is the foundation for machine-checked API stability verification (planned in PR #166).
+- Stable APIs are safe to build examples and applications against, subject to the existing sovereign boundary tests.
+- Preview APIs are usable but may change.
+
+## Forbidden Claims
+
+It is not allowed to say:
+
+- All workflow APIs are stable.
+- TramAI is production-certified.
+- TramAI guarantees backward compatibility for preview APIs.
+- TramAI proves legal or regulatory compliance.
+- TramAI provides EU AI Act conformity certification.
+- Internal persistence, worker, audit, verifier, or archive APIs are public workflow APIs.
+- The stability boundary is complete or frozen — it will evolve as the roadmap progresses.
+- Deferred capabilities are secretly stable.
+
+---
+
+## Acceptance Criteria
+
+This document is considered complete when:
+
+1. It defines Stable, Preview, Internal, and Deferred stability levels.
+2. It lists the current stable workflow-facing surface.
+3. It lists preview workflow areas.
+4. It lists internal implementation areas.
+5. It lists deferred areas.
+6. It includes allowed and forbidden claims sections.
+7. It links back to the post-sovereignty roadmap.
+8. The post-sovereignty roadmap links forward to this document.
+9. The changelog records PR #165.
+10. `./gradlew check` passes.
+
+---
+
+## Maintenance
+
+This document should be updated when:
+
+- An API moves between stability levels (e.g., Preview → Stable).
+- A new workflow-facing API is added to the stable surface.
+- An internal implementation detail is accidentally promoted to preview or stable.
+- A deferred capability is reconsidered for an upcoming phase.
+
+A new PR should add a machine-checked verification task for this boundary (planned as PR #166).
+
+---
+
+*Part of Phase 1 / Epic 1 of the [Post-Sovereignty TramAI Roadmap](POST-SOVEREIGNTY-ROADMAP.md).*


### PR DESCRIPTION
## Situation

PR #164 made the post-sovereignty roadmap canonical and shifted the project from sovereign evidence handoff toward workflow ergonomics, API stability, structured output contracts, and runtime evidence.

## Context

Phase 1 of the roadmap calls for API stability. Without a boundary document, the next code PRs risk accidentally promoting or drifting APIs.

## Goal

Add the first Phase 1 document: a workflow API stability boundary that classifies workflow-facing TramAI APIs as stable, preview, internal, or deferred.

## Files

| File | Change |
|------|--------|
| docs/workflow-api-stability-boundary.md | New — classifies all workflow-facing APIs into 4 stability levels |
| docs/POST-SOVEREIGNTY-ROADMAP.md | Marks Phase 1 tasks 1-2 complete, links to boundary doc |
| README.md | Adds link to boundary doc under Roadmap section |
| CHANGELOG.md | PR #165 entry |

## Implementation Detail

- Classifies AI service declaration (`@AiService`, `@Operation`, `@SystemMessage`, `@UserMessage`, `@AiTool`, `@ConversationId`, typed contracts) as **Stable**.
- Classifies structured output annotations (`@AIRange`, `@AIMinItems`), policy types (`PolicyEngine`, `PolicyDecision`), approval gateway (RC+ Stable), sovereign configuration, testing, and exception types as **Stable**.
- Classifies orchestration patterns, evidence export, advanced approval ergonomics, MCP adapter, tool governance, and REST/control-plane as **Preview**.
- Classifies JDBC stores, worker leases, audit outbox, resume internals, and Gradle tasks as **Internal**.
- Classifies Release Console, compliance, attestation, dashboard, RAG, scheduler, and chat memory APIs as **Deferred**.
- Includes Allowed Claims, Forbidden Claims, and Cross-References sections.

## Verification

```
./gradlew check
```

## Non-goals

This PR does not add:
- runtime behavior changes
- API changes
- new workflow DSL
- model calls
- benchmark execution
- runtime evidence export
- compliance claims
- production-readiness claims
- certification claims
- a Gradle guard (deferred to PR #166)

## Socratic Clause

If the classification is too aggressive (overstabilizing what should be preview) or too conservative (deferring what should be stable), the boundary should be updated before PR #166 as it will enforce it machine-checkably.

## Summary

Defines the workflow-facing API boundary for the post-sovereignty roadmap. Docs-only — no guard yet. PR #166 will add the machine-checked verification.