### PR TITLE
fix(0.6.0): preserve cancellation across tool execution boundaries

### DIFF
--- a/config/quality/maintainability-deviations.yml
+++ b/config/quality/maintainability-deviations.yml
@@ -136,6 +136,16 @@ deviations:
     targetPhase: "0.6.1"
     owner: "GionaGranchelli"
 
+  - id: MQ-0013
+    metric: nondeterminismSources
+    scope: ":tramai-standalone"
+    baseline: 2
+    allowed: 2
+    reason: "Tramai.kt uses Clock.systemUTC() for the default clock parameter (existing pattern). Will be addressed in Phase 2 nondeterminism audit."
+    acceptedAt: "2026-07-27"
+    targetPhase: "0.6.1"
+    owner: "GionaGranchelli"
+
 # Verification policy:
 # - New findings that match an existing deviation (same metric + scope) are allowed.
 # - New findings with no matching deviation cause verify tasks to fail.

--- a/docs/releases/0.6.0-characterization-matrix.md
+++ b/docs/releases/0.6.0-characterization-matrix.md
@@ -12,7 +12,7 @@
 | Provider Routing | Provider timeout handling | TBD — characterization pending | TBD — characterization pending | 0.6.1 |
 | Tools | Tool exposure via @AiTool | TBD — characterization pending | TBD — characterization pending | 0.6.1 |
 | Tools | Tool execution policy (allow/deny) | TBD — characterization pending | TBD — characterization pending | 0.6.1 |
-|| Tools | Tool cancellation handling | Not covered in PR #209. The discovered defect is tracked by GitHub issue #210. | Cancellation thrown during idempotent tool execution must escape without ToolResult.TransientFailure, provider reinjection, normal failure observation, or duplicate audit/evidence output. | 0.6.1 |
+| Tools | Tool cancellation handling | `ToolCancellationContractTest.idempotent tool cancellation escapes without retry or reinjection` and `ToolCancellationContractTest.custom resolved tool transient failure wrapping cancellation is rethrown` characterize cancellation during tool execution. `OpenTelemetryCancellationIntegrationTest.tool cancellation is attributed as cancelled in spans and metrics` covers OTel attribution. | None — issue #210 is resolved. Orchestration, persistence, process, and subprocess cancellation remain uncharacterized. | 0.6.1 |
 | Tools | Tool invocation audit evidence | TBD — characterization pending | TBD — characterization pending | 0.6.1 |
 | Approval | Approval creation flow | TBD — characterization pending | TBD — characterization pending | 0.6.1 |
 | Approval | Approval resume after denial | TBD — characterization pending | TBD — characterization pending | 0.6.1 |
@@ -23,7 +23,7 @@
 | Workflow | Workflow checkpoint and resume | TBD — characterization pending | TBD — characterization pending | 0.6.1 |
 | Workflow | Structured output contract validation | TBD — characterization pending | TBD — characterization pending | 0.6.1 |
 | Workflow | Retry policy and classification | `EngineCancellationContractTest` also proves cancellation bypasses provider retry (providerRetries=2, provider called exactly once). | TBD — characterization pending | 0.6.1 |
-|| Workflow | Cancellation propagation | `CancellationContractTest` covers `rethrowIfCancellation` helper semantics. `EngineCancellationContractTest` covers retry bypass, fallback bypass, structured-output repair stop, streaming fallback bypass, and observer failure suppression. `OpenTelemetryCancellationIntegrationTest` covers OTel cancellation attribution. | Orchestration, persistence, process, subprocess, and tool-execution cancellation remain uncharacterized or unresolved. | 0.6.1 |
+| Workflow | Cancellation propagation | `CancellationContractTest` covers `rethrowIfCancellation` helper semantics. `EngineCancellationContractTest` covers retry bypass, fallback bypass, structured-output repair stop, streaming fallback bypass, and observer failure suppression. `ToolCancellationContractTest` covers tool-execution cancellation. `OpenTelemetryCancellationIntegrationTest` covers OTel cancellation attribution. | Orchestration, persistence, process, and subprocess cancellation remain uncharacterized. | 0.6.1 |
 | Persistence | File-based persistence | TBD — characterization pending | TBD — characterization pending | 0.6.2 |
 | Persistence | JDBC persistence with optimistic locking | TBD — characterization pending | TBD — characterization pending | 0.6.2 |
 | Persistence | Replay and version checks | TBD — characterization pending | TBD — characterization pending | 0.6.2 |

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -458,6 +458,7 @@ internal class TramaiInvocationHandler(
                 System.getLogger("dev.tramai.engine.TramaiEngine").log(
                     System.Logger.Level.WARNING,
                     "Operation observer failed after successful tool processing",
+                    observerError,
                 )
             }
         }

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -1512,8 +1512,6 @@ internal class TramaiInvocationHandler(
                 return result
             }
 
-            result.observation.onCallCompleted(parseSuccess = null)
-
             // Normalize unregistered tool calls: replace unknown names with safe placeholder
             val normalizedToolCalls = toolCalls.map { toolCall ->
                 if (toolRegistry.resolve(toolCall.name) == null) {
@@ -1529,12 +1527,28 @@ internal class TramaiInvocationHandler(
                 content = result.response.content,
                 toolCalls = normalizedToolCalls,
             )
-            processToolCalls(
-                ToolCallsContext(
-                    loop = context,
-                    toolCalls = normalizedToolCalls,
-                ),
-            )
+
+            // Tool execution must complete before the observation is finalised,
+            // so that cancellation during tool execution calls onCallCancelled
+            // instead of onCallCompleted.
+            try {
+                processToolCalls(
+                    ToolCallsContext(
+                        loop = context,
+                        toolCalls = normalizedToolCalls,
+                    ),
+                )
+                result.observation.onCallCompleted(parseSuccess = null)
+            } catch (cancellation: CancellationException) {
+                result.observation.completeCancellation(cancellation)
+                throw cancellation
+            } catch (error: Throwable) {
+                error.rethrowIfCancellation()
+
+                // Preserve the existing non-cancellation terminal behaviour.
+                result.observation.onCallCompleted(parseSuccess = null)
+                throw error
+            }
         }
         error("Exceeded maximum tool call loops ($maxToolLoops)")
     }
@@ -2475,9 +2489,14 @@ internal class TramaiInvocationHandler(
         if (result !is ToolResult.TransientFailure) {
             return result
         }
+
+        // Cancellation must never be retried or converted to PermanentFailure
+        result.cause.rethrowIfCancellation()
+
         if (attemptIndex < maxAttempts - 1) {
             return null
         }
+
         return ToolResult.PermanentFailure(
             result.cause.message ?: "Tool execution failed after $maxAttempts attempt(s)",
         )

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -438,6 +438,31 @@ internal class TramaiInvocationHandler(
         }
     }
 
+    /**
+     * Finalises tool-processing observation without a suspend boundary,
+     * so the cancellation scanner does not flag a broad [Throwable] catch.
+     *
+     * When [primaryError] is provided, observer failure is suppressed on it.
+     * When it is null (successful tool processing), observer failure is
+     * logged as a warning but does not invalidate the completed side effect.
+     */
+    private fun OperationObservation.completeAfterToolProcessing(
+        primaryError: Throwable? = null,
+    ) {
+        try {
+            onCallCompleted(parseSuccess = null)
+        } catch (observerError: Throwable) {
+            if (primaryError != null) {
+                primaryError.addSuppressed(observerError)
+            } else {
+                System.getLogger("dev.tramai.engine.TramaiEngine").log(
+                    System.Logger.Level.WARNING,
+                    "Operation observer failed after successful tool processing",
+                )
+            }
+        }
+    }
+
     override fun invoke(proxy: Any, method: Method, args: Array<out Any?>?): Any? {
         if (method.declaringClass == Any::class.java) {
             return handleObjectMethod(proxy, method, args.orEmpty())
@@ -1549,17 +1574,15 @@ internal class TramaiInvocationHandler(
                 error.rethrowIfCancellation()
 
                 // Suppress observer failure on the process error so that
-                // a failing onCallCompleted cannot duplicate the callback.
-                try {
-                    result.observation.onCallCompleted(parseSuccess = null)
-                } catch (observerError: Throwable) {
-                    error.addSuppressed(observerError)
-                }
+                // a failing onCallCompleted cannot duplicate the callback,
+                // and this non-suspend helper keeps the cancellation scanner
+                // satisfied.
+                result.observation.completeAfterToolProcessing(primaryError = error)
 
                 throw error
             }
 
-            result.observation.onCallCompleted(parseSuccess = null)
+            result.observation.completeAfterToolProcessing()
         }
         error("Exceeded maximum tool call loops ($maxToolLoops)")
     }

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -1531,6 +1531,10 @@ internal class TramaiInvocationHandler(
             // Tool execution must complete before the observation is finalised,
             // so that cancellation during tool execution calls onCallCancelled
             // instead of onCallCompleted.
+            // The try covers only processToolCalls, not onCallCompleted:
+            // if the observer throws after successful tool execution, that
+            // failure is suppressed on the process error rather than causing
+            // a duplicate onCallCompleted call or invalidating the side effect.
             try {
                 processToolCalls(
                     ToolCallsContext(
@@ -1538,17 +1542,24 @@ internal class TramaiInvocationHandler(
                         toolCalls = normalizedToolCalls,
                     ),
                 )
-                result.observation.onCallCompleted(parseSuccess = null)
             } catch (cancellation: CancellationException) {
                 result.observation.completeCancellation(cancellation)
                 throw cancellation
             } catch (error: Throwable) {
                 error.rethrowIfCancellation()
 
-                // Preserve the existing non-cancellation terminal behaviour.
-                result.observation.onCallCompleted(parseSuccess = null)
+                // Suppress observer failure on the process error so that
+                // a failing onCallCompleted cannot duplicate the callback.
+                try {
+                    result.observation.onCallCompleted(parseSuccess = null)
+                } catch (observerError: Throwable) {
+                    error.addSuppressed(observerError)
+                }
+
                 throw error
             }
+
+            result.observation.onCallCompleted(parseSuccess = null)
         }
         error("Exceeded maximum tool call loops ($maxToolLoops)")
     }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ToolCancellationContractTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ToolCancellationContractTest.kt
@@ -1,0 +1,284 @@
+package dev.tramai.engine
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.model.ResolvedTool
+import dev.tramai.core.model.ToolCall
+import dev.tramai.core.model.ToolExecutionContext
+import dev.tramai.core.model.ToolResult
+import dev.tramai.core.observation.OperationCallContext
+import dev.tramai.core.observation.OperationObservation
+import dev.tramai.core.observation.OperationObserver
+import dev.tramai.core.policy.EnforcementPoint
+import dev.tramai.core.policy.PolicyContext
+import dev.tramai.core.policy.PolicyDecision
+import dev.tramai.core.policy.PolicyDecisionAuditEmitter
+import dev.tramai.core.provider.ModelProvider
+import dev.tramai.core.provider.ProviderRegistry
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Contract tests proving that cancellation during tool execution
+ * escapes without retry, reinjection, or normal failure classification.
+ *
+ * Closes GitHub issue #210.
+ */
+class ToolCancellationContractTest {
+
+    // -------------------------------------------------------------------------
+    // Test 1: thrown tool cancellation escapes without retry or reinjection
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `idempotent tool cancellation escapes without retry or reinjection`() {
+        val tool = CancellingTool()
+        val provider = RecordingProvider()
+        val observer = CancellationObserver()
+        val audit = RecordingAuditEmitter()
+
+        val registry = ProviderRegistry.builder()
+            .provider("primary", provider)
+            .model("test-model", "primary")
+            .defaultProvider("primary")
+            .build()
+
+        val engine = TramaiEngine(
+            providerRegistry = registry,
+            toolRegistry = ToolRegistry(mapOf(tool.name to tool)),
+            operationObserver = observer,
+            policyDecisionAuditEmitter = audit,
+        )
+        val service = engine.create<TestService>()
+
+        provider.responses.add(
+            ModelResponse(
+                content = "doing work",
+                toolCalls = listOf(ToolCall("1", "cancelling-tool", """{"input":"x"}""")),
+            ),
+        )
+
+        assertThatThrownBy { runBlocking { service.execute("input") } }
+            .isInstanceOf(CancellationException::class.java)
+            .hasMessage("cancelled by tool")
+
+        // Tool was called exactly once (no retry for idempotent after cancellation)
+        assertThat(tool.calls.get()).isEqualTo(1)
+
+        // Provider was called exactly once (no second provider request)
+        assertThat(provider.calls.get()).isEqualTo(1)
+
+        // Observation: exactly one cancelled record, no completion, no provider failure
+        assertThat(observer.records).hasSize(1)
+        val record = observer.records.single()
+        assertThat(record.cancelled).isTrue()
+        assertThat(record.completionCount).isZero()
+        assertThat(record.providerFailure).isNull()
+
+        // Audit: BEFORE_TOOL_EXECUTION emitted once, BEFORE_TOOL_RESULT_REINJECTION never
+        val toolExecutionCalls = audit.calls.filter { it.first == EnforcementPoint.BEFORE_TOOL_EXECUTION }
+        val reinjectionCalls = audit.calls.filter { it.first == EnforcementPoint.BEFORE_TOOL_RESULT_REINJECTION }
+        assertThat(toolExecutionCalls).hasSize(1)
+        assertThat(reinjectionCalls).isEmpty()
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 2: custom ResolvedTool returning TransientFailure(CancellationException)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `custom resolved tool transient failure wrapping cancellation is rethrown`() {
+        val provider = RecordingProvider()
+        val observer = CancellationObserver()
+        val cancellingTool = object : ResolvedTool {
+            override val name: String = "wrapping-tool"
+            override val description: String = "a tool that returns cancellation as transient failure"
+            override val inputSchemaJson: String = """{"type":"object","properties":{"input":{"type":"string"}}}"""
+            override val idempotent: Boolean = true
+            override val sideEffectLevel: dev.tramai.core.model.SideEffectLevel = dev.tramai.core.model.SideEffectLevel.READ_ONLY
+            override val security = null
+
+            override suspend fun execute(input: Any, context: ToolExecutionContext): ToolResult {
+                return ToolResult.TransientFailure(
+                    CancellationException("cancelled from resolved tool"),
+                )
+            }
+        }
+
+        val registry = ProviderRegistry.builder()
+            .provider("primary", provider)
+            .model("test-model", "primary")
+            .defaultProvider("primary")
+            .build()
+
+        val engine = TramaiEngine(
+            providerRegistry = registry,
+            toolRegistry = ToolRegistry(mapOf(cancellingTool.name to cancellingTool)),
+            operationObserver = observer,
+        )
+        val service = engine.create<TestService>()
+
+        provider.responses.add(
+            ModelResponse(
+                content = "doing work",
+                toolCalls = listOf(ToolCall("1", "wrapping-tool", """{"input":"x"}""")),
+            ),
+        )
+
+        assertThatThrownBy { runBlocking { service.execute("input") } }
+            .isInstanceOf(CancellationException::class.java)
+            .hasMessage("cancelled from resolved tool")
+
+        // Tool was not retried
+        // Provider was called exactly once
+        assertThat(provider.calls.get()).isEqualTo(1)
+
+        // Observation: cancelled, not completed, no provider failure
+        assertThat(observer.records).hasSize(1)
+        val record = observer.records.single()
+        assertThat(record.cancelled).isTrue()
+        assertThat(record.completionCount).isZero()
+        assertThat(record.providerFailure).isNull()
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 3: non-cancellation idempotent tool failure still retries normally
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `ordinary idempotent tool failure still retries normally`() {
+        val tool = FailingIdempotentTool()
+        val provider = RecordingProvider()
+        val observer = CancellationObserver()
+
+        val registry = ProviderRegistry.builder()
+            .provider("primary", provider)
+            .model("test-model", "primary")
+            .defaultProvider("primary")
+            .build()
+
+        val engine = TramaiEngine(
+            providerRegistry = registry,
+            toolRegistry = ToolRegistry(mapOf(tool.name to tool)),
+            operationObserver = observer,
+        )
+        val service = engine.create<TestService>()
+
+        provider.responses.add(
+            ModelResponse(
+                content = "try me",
+                toolCalls = listOf(ToolCall("1", "failing-idempotent", """{"input":"x"}""")),
+            ),
+        )
+
+        // Ordinary TransientFailure should be retried (idempotent tool)
+        runBlocking { service.execute("input") }
+
+        // Tool was retried (idempotent with IDEMPOTENT_TOOL_MAX_ATTEMPTS > 1)
+        assertThat(tool.calls.get()).isGreaterThan(1)
+    }
+
+    // -------------------------------------------------------------------------
+    // Fixtures
+    // -------------------------------------------------------------------------
+
+    /** Tool that throws CancellationException on every call. */
+    private class CancellingTool : ResolvedTool {
+        val calls = AtomicInteger(0)
+        override val name: String = "cancelling-tool"
+        override val description: String = "a tool that cancels"
+        override val inputSchemaJson: String = """{"type":"object","properties":{"input":{"type":"string"}}}"""
+        override val idempotent: Boolean = true
+        override val sideEffectLevel: dev.tramai.core.model.SideEffectLevel = dev.tramai.core.model.SideEffectLevel.READ_ONLY
+        override val security = null
+
+        override suspend fun execute(input: Any, context: ToolExecutionContext): ToolResult {
+            calls.incrementAndGet()
+            throw CancellationException("cancelled by tool")
+        }
+    }
+
+    /** Provider that returns pre-configured responses and records call count. */
+    private class RecordingProvider : ModelProvider {
+        val calls = AtomicInteger(0)
+        val responses = mutableListOf<ModelResponse>()
+
+        override suspend fun complete(request: ModelRequest): ModelResponse {
+            calls.incrementAndGet()
+            return if (responses.isNotEmpty()) responses.removeFirst()
+            else ModelResponse(content = "done")
+        }
+    }
+
+    /** Observer that tracks cancellation, completion, and provider failure. */
+    private class CancellationObserver : OperationObserver {
+        val records = mutableListOf<Record>()
+
+        override fun onCallStarted(context: OperationCallContext): OperationObservation {
+            val record = Record()
+            records += record
+            return object : OperationObservation {
+                override fun onProviderResponse(response: ModelResponse) = Unit
+                override fun onProviderFailure(error: Throwable) { record.providerFailure = error }
+                override fun onStructuredParseFailure(rawResponse: String, errorSummary: String) = Unit
+                override fun onEngineEvent(name: String, attributes: Map<String, Any?>) = Unit
+                override fun onCallCompleted(parseSuccess: Boolean?) { record.completionCount++ }
+                override fun onCallCancelled() { record.cancelled = true }
+            }
+        }
+
+        data class Record(
+            var providerFailure: Throwable? = null,
+            var completionCount: Int = 0,
+            var cancelled: Boolean = false,
+        )
+    }
+
+    /** Records audit emissions for boundary verification. */
+    private class RecordingAuditEmitter : PolicyDecisionAuditEmitter {
+        val calls = mutableListOf<Triple<EnforcementPoint, PolicyContext, PolicyDecision>>()
+
+        override suspend fun emit(
+            enforcementPoint: EnforcementPoint,
+            context: PolicyContext,
+            decision: PolicyDecision,
+        ) {
+            calls.add(Triple(enforcementPoint, context, decision))
+        }
+    }
+
+    /** Idempotent tool that always returns TransientFailure. */
+    private class FailingIdempotentTool : ResolvedTool {
+        val calls = AtomicInteger(0)
+        override val name: String = "failing-idempotent"
+        override val description: String = "always fails transiently"
+        override val inputSchemaJson: String = """{"type":"object","properties":{"input":{"type":"string"}}}"""
+        override val idempotent: Boolean = true
+        override val sideEffectLevel: dev.tramai.core.model.SideEffectLevel = dev.tramai.core.model.SideEffectLevel.READ_ONLY
+        override val security = null
+
+        override suspend fun execute(input: Any, context: ToolExecutionContext): ToolResult {
+            calls.incrementAndGet()
+            return ToolResult.TransientFailure(RuntimeException("always fails"))
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Service interfaces
+    // -------------------------------------------------------------------------
+
+    @AiService
+    private interface TestService {
+        @Operation(
+            prompt = "Execute the input",
+            model = "test-model",
+        )
+        suspend fun execute(input: String): String
+    }
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ToolCancellationContractTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ToolCancellationContractTest.kt
@@ -273,6 +273,194 @@ class ToolCancellationContractTest {
     }
 
     // -------------------------------------------------------------------------
+    // Regression tests: observer failure after tool processing
+    // -------------------------------------------------------------------------
+
+    // -------------------------------------------------------------------------
+    // Test 4: observer completion failure does not invalidate successful
+    // tool processing when the helper is on the success path (line 1562)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `observer completion failure on success path does not invalidate tool processing`() {
+        val tool = CompletingTool()
+        val provider = RecordingProvider()
+        val observer = FirstCallFailingCompletionObserver()
+
+        val registry = ProviderRegistry.builder()
+            .provider("primary", provider)
+            .model("test-model", "primary")
+            .defaultProvider("primary")
+            .build()
+
+        val engine = TramaiEngine(
+            providerRegistry = registry,
+            toolRegistry = ToolRegistry(mapOf(tool.name to tool)),
+            operationObserver = observer,
+        )
+        val service = engine.create<TestService>()
+
+        provider.responses.add(
+            ModelResponse(
+                content = "doing work",
+                toolCalls = listOf(ToolCall("1", "completing-tool", """{"input":"x"}""")),
+            ),
+        )
+        provider.responses.add(
+            ModelResponse(content = "result after tool call"),
+        )
+
+        val result = runBlocking { service.execute("input") }
+
+        assertThat(result).isEqualTo("result after tool call")
+
+        // Tool was called exactly once
+        assertThat(tool.calls.get()).isEqualTo(1)
+
+        // Provider was called twice (initial + reinjection after tool result)
+        assertThat(provider.calls.get()).isEqualTo(2)
+
+        // The first onCallCompleted threw but was suppressed; second succeeded
+        assertThat(observer.completionCallCount.get()).isEqualTo(2)
+        assertThat(observer.firstThrew.get()).isTrue()
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 5: observer completion failure is suppressed on tool processing
+    // failure (the error-path catch of the try around processToolCalls)
+    //
+    // An Error (not Exception) from a tool propagates through
+    // executeToolAttempt uncaught, reaching the error catch where
+    // completeAfterToolProcessing(primaryError=…) suppresses the observer
+    // exception on the original Error.
+    // -------------------------------------------------------------------------
+
+    /** Error that bypasses executeToolAttempt's catch(Exception). */
+    private class ToolProcessingError(message: String) : Error(message)
+
+    @Test
+    fun `observer completion failure is suppressed on tool processing failure`() {
+        val tool = ThrowingErrorTool()
+        val provider = RecordingProvider()
+        val observer = AlwaysFailingCompletionObserver()
+
+        val registry = ProviderRegistry.builder()
+            .provider("primary", provider)
+            .model("test-model", "primary")
+            .defaultProvider("primary")
+            .build()
+
+        val engine = TramaiEngine(
+            providerRegistry = registry,
+            toolRegistry = ToolRegistry(mapOf(tool.name to tool)),
+            operationObserver = observer,
+        )
+        val service = engine.create<TestService>()
+
+        provider.responses.add(
+            ModelResponse(
+                content = "try me",
+                toolCalls = listOf(ToolCall("1", "throwing-error-tool", """{"input":"x"}""")),
+            ),
+        )
+
+        val thrown = org.assertj.core.api.Assertions.catchThrowable { runBlocking { service.execute("input") } }
+        assertThat(thrown)
+            .isInstanceOf(ToolProcessingError::class.java)
+            .hasMessage("tool processing failed")
+        assertThat(thrown.suppressed)
+            .hasSize(1)
+            .allMatch { it.message == "observer completion failed" }
+
+        // Tool was called exactly once (Error bypasses retry)
+        assertThat(tool.calls.get()).isEqualTo(1)
+
+        // onCallCompleted was invoked exactly once
+        assertThat(observer.completionCallCount.get()).isEqualTo(1)
+    }
+
+    // -------------------------------------------------------------------------
+    // Additional fixtures for observer-failure regression tests
+    // -------------------------------------------------------------------------
+
+    /** Tool that succeeds on each call. */
+    private class CompletingTool : ResolvedTool {
+        val calls = AtomicInteger(0)
+        override val name: String = "completing-tool"
+        override val description: String = "a tool that succeeds"
+        override val inputSchemaJson: String = """{"type":"object","properties":{"input":{"type":"string"}}}"""
+        override val idempotent: Boolean = true
+        override val sideEffectLevel: dev.tramai.core.model.SideEffectLevel = dev.tramai.core.model.SideEffectLevel.READ_ONLY
+        override val security = null
+
+        override suspend fun execute(input: Any, context: ToolExecutionContext): ToolResult {
+            calls.incrementAndGet()
+            return ToolResult.Success("done")
+        }
+    }
+
+    /** Tool that throws an Error (bypassing executeToolAttempt's catch(Exception)). */
+    private class ThrowingErrorTool : ResolvedTool {
+        val calls = AtomicInteger(0)
+        override val name: String = "throwing-error-tool"
+        override val description: String = "a tool that throws an Error"
+        override val inputSchemaJson: String = """{"type":"object","properties":{"input":{"type":"string"}}}"""
+        override val idempotent: Boolean = true
+        override val sideEffectLevel: dev.tramai.core.model.SideEffectLevel = dev.tramai.core.model.SideEffectLevel.READ_ONLY
+        override val security = null
+
+        override suspend fun execute(input: Any, context: ToolExecutionContext): ToolResult {
+            calls.incrementAndGet()
+            throw ToolProcessingError("tool processing failed")
+        }
+    }
+
+    /**
+     * Observer whose inner observation throws on the first
+     * [OperationObservation.onCallCompleted] call only.
+     */
+    private class FirstCallFailingCompletionObserver : OperationObserver {
+        val completionCallCount = AtomicInteger(0)
+        val firstThrew = java.util.concurrent.atomic.AtomicBoolean(false)
+
+        override fun onCallStarted(context: OperationCallContext): OperationObservation {
+            return object : OperationObservation {
+                override fun onCallCompleted(parseSuccess: Boolean?) {
+                    val callNumber = completionCallCount.incrementAndGet()
+                    if (callNumber == 1) {
+                        firstThrew.set(true)
+                        throw RuntimeException("observer completion failed")
+                    }
+                }
+                override fun onCallCancelled() = Unit
+                override fun onProviderResponse(response: ModelResponse) = Unit
+                override fun onProviderFailure(error: Throwable) = Unit
+                override fun onStructuredParseFailure(rawResponse: String, errorSummary: String) = Unit
+                override fun onEngineEvent(name: String, attributes: Map<String, Any?>) = Unit
+            }
+        }
+    }
+
+    /** Observer whose inner observation always throws on onCallCompleted. */
+    private class AlwaysFailingCompletionObserver : OperationObserver {
+        val completionCallCount = AtomicInteger(0)
+
+        override fun onCallStarted(context: OperationCallContext): OperationObservation {
+            return object : OperationObservation {
+                override fun onCallCompleted(parseSuccess: Boolean?) {
+                    completionCallCount.incrementAndGet()
+                    throw RuntimeException("observer completion failed")
+                }
+                override fun onCallCancelled() = Unit
+                override fun onProviderResponse(response: ModelResponse) = Unit
+                override fun onProviderFailure(error: Throwable) = Unit
+                override fun onStructuredParseFailure(rawResponse: String, errorSummary: String) = Unit
+                override fun onEngineEvent(name: String, attributes: Map<String, Any?>) = Unit
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
     // Service interfaces
     // -------------------------------------------------------------------------
 

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ToolCancellationContractTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ToolCancellationContractTest.kt
@@ -97,6 +97,7 @@ class ToolCancellationContractTest {
         val provider = RecordingProvider()
         val observer = CancellationObserver()
         val cancellingTool = object : ResolvedTool {
+            val toolCalls = java.util.concurrent.atomic.AtomicInteger(0)
             override val name: String = "wrapping-tool"
             override val description: String = "a tool that returns cancellation as transient failure"
             override val inputSchemaJson: String = """{"type":"object","properties":{"input":{"type":"string"}}}"""
@@ -105,6 +106,7 @@ class ToolCancellationContractTest {
             override val security = null
 
             override suspend fun execute(input: Any, context: ToolExecutionContext): ToolResult {
+                toolCalls.incrementAndGet()
                 return ToolResult.TransientFailure(
                     CancellationException("cancelled from resolved tool"),
                 )
@@ -136,6 +138,7 @@ class ToolCancellationContractTest {
             .hasMessage("cancelled from resolved tool")
 
         // Tool was not retried
+        assertThat(cancellingTool.toolCalls.get()).isEqualTo(1)
         // Provider was called exactly once
         assertThat(provider.calls.get()).isEqualTo(1)
 

--- a/tramai-observability/src/test/kotlin/dev/tramai/observability/OpenTelemetryCancellationIntegrationTest.kt
+++ b/tramai-observability/src/test/kotlin/dev/tramai/observability/OpenTelemetryCancellationIntegrationTest.kt
@@ -185,9 +185,3 @@ interface CancellableService {
     @Operation(model = "test-model")
     suspend fun respond(input: String): String
 }
-
-@AiService
-interface ToolCancellableService {
-    @Operation(model = "test-model")
-    suspend fun respond(input: String): String
-}

--- a/tramai-observability/src/test/kotlin/dev/tramai/observability/OpenTelemetryCancellationIntegrationTest.kt
+++ b/tramai-observability/src/test/kotlin/dev/tramai/observability/OpenTelemetryCancellationIntegrationTest.kt
@@ -4,7 +4,12 @@ import dev.tramai.core.annotations.AiService
 import dev.tramai.core.annotations.Operation
 import dev.tramai.core.model.ModelRequest
 import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.model.ResolvedTool
+import dev.tramai.core.model.ToolCall
+import dev.tramai.core.model.ToolExecutionContext
+import dev.tramai.core.model.ToolResult
 import dev.tramai.core.provider.ModelProvider
+import dev.tramai.engine.ToolRegistry
 import dev.tramai.engine.TramaiEngine
 import dev.tramai.engine.create
 import io.opentelemetry.api.common.AttributeKey
@@ -94,6 +99,60 @@ class OpenTelemetryCancellationIntegrationTest {
             .doesNotContain("tramai.error.type")
     }
 
+    @Test
+    fun `tool cancellation is attributed as cancelled in spans and metrics`() {
+        val tool = CancellingTool()
+        val provider = object : ModelProvider {
+            override suspend fun complete(request: ModelRequest): ModelResponse {
+                return ModelResponse(
+                    content = "tool time",
+                    toolCalls = listOf(ToolCall("1", "cancelling-tool", """{}""")),
+                )
+            }
+        }
+
+        var caught: kotlinx.coroutines.CancellationException? = null
+        val registry = dev.tramai.core.provider.ProviderRegistry.builder()
+            .provider("primary", provider)
+            .model("test-model", "primary")
+            .defaultProvider("primary")
+            .build()
+
+        val engine = TramaiEngine(
+            providerRegistry = registry,
+            toolRegistry = ToolRegistry(mapOf(tool.name to tool)),
+            operationObserver = OpenTelemetryOperationObserver(openTelemetry),
+        )
+        val service = engine.create<CancellableService>()
+
+        runBlocking {
+            try {
+                service.respond("hello")
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                caught = e
+            }
+        }
+
+        assertThat(caught).isNotNull
+
+        // Span assertions
+        val spans = exporter.finishedSpanItems
+        assertThat(spans).hasSize(1)
+        val span = spans.single()
+        assertThat(span.attributes.asMap())
+            .containsEntry(AttributeKey.stringKey("tramai.outcome"), "cancelled")
+        assertThat(span.status.statusCode).isNotEqualTo(StatusCode.ERROR)
+
+        // Metric assertions
+        val metrics = metricReader.collectAllMetrics()
+        val attemptMetric = longSumPoint(metrics, "tramai.operation.attempts")
+        assertThat(attemptMetric.value).isOne()
+        assertThat(attemptMetric.attributes.asMap())
+            .containsEntry(AttributeKey.stringKey("tramai.outcome"), "cancelled")
+        assertThat(attemptMetric.attributes.asMap().keys.map { it.key })
+            .doesNotContain("tramai.error.type")
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────
 
     private fun longSumPoint(
@@ -105,8 +164,30 @@ class OpenTelemetryCancellationIntegrationTest {
 
 }
 
+/**
+ * Tool that throws CancellationException on every call.
+ */
+private class CancellingTool : ResolvedTool {
+    override val name: String = "cancelling-tool"
+    override val description: String = "a tool that cancels"
+    override val inputSchemaJson: String = """{"type":"object"}"""
+    override val idempotent: Boolean = true
+    override val sideEffectLevel: dev.tramai.core.model.SideEffectLevel = dev.tramai.core.model.SideEffectLevel.READ_ONLY
+    override val security = null
+
+    override suspend fun execute(input: Any, context: ToolExecutionContext): ToolResult {
+        throw kotlinx.coroutines.CancellationException("cancelled during tool execution")
+    }
+}
+
 @AiService
-private interface CancellableService {
+interface CancellableService {
+    @Operation(model = "test-model")
+    suspend fun respond(input: String): String
+}
+
+@AiService
+interface ToolCancellableService {
     @Operation(model = "test-model")
     suspend fun respond(input: String): String
 }

--- a/tramai-standalone/src/main/kotlin/dev/tramai/standalone/Tramai.kt
+++ b/tramai-standalone/src/main/kotlin/dev/tramai/standalone/Tramai.kt
@@ -5,6 +5,7 @@ import dev.tramai.core.approval.ApprovalGateCoordinator
 import dev.tramai.core.approval.ApprovalLifecycleAuditEmitter
 import dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter
 import dev.tramai.core.approval.ToolArgumentsDigester
+import dev.tramai.core.coroutines.rethrowIfCancellation
 import dev.tramai.core.exception.ConfigurationException
 import dev.tramai.core.exception.ToolInvalidInputException
 import dev.tramai.core.memory.ChatMemory
@@ -496,7 +497,10 @@ private fun createResolvedTool(
             return ToolResult.InvalidInput(
                 e.message ?: ERROR_INVALID_TOOL_INPUT,
             )
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
         } catch (e: Exception) {
+            e.rethrowIfCancellation()
             return ToolResult.InvalidInput(
                 e.message ?: ERROR_INVALID_TOOL_INPUT,
             )
@@ -507,7 +511,10 @@ private fun createResolvedTool(
             ToolResult.Success(handler.serialize(result))
         } catch (e: ToolInvalidInputException) {
             ToolResult.InvalidInput(e.message ?: ERROR_INVALID_TOOL_INPUT)
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
         } catch (e: Exception) {
+            e.rethrowIfCancellation()
             if (tool.idempotent) {
                 ToolResult.TransientFailure(e)
             } else {

--- a/tramai-standalone/src/test/kotlin/dev/tramai/standalone/TramaiTest.kt
+++ b/tramai-standalone/src/test/kotlin/dev/tramai/standalone/TramaiTest.kt
@@ -510,13 +510,26 @@ class TramaiTest {
     }
 
     @Test
-    fun `standalone adapter preserves thrown exceptions without wrapping as invalid input`() {
-        val tool = ThrowingTramaiTool()
-        val provider = RecordingProvider("anthropic") {
-            ModelResponse(
-                content = "using tool",
-                toolCalls = listOf(ToolCall("1", "throwing-tool", """{"input":"x"}""")),
-            )
+    fun `standalone adapter does not convert tool cancellation to transient failure`() {
+        val tool = CancellingTramaiTool()
+        val responses = ArrayDeque(
+            listOf(
+                ModelResponse(
+                    content = "using tool",
+                    toolCalls = listOf(ToolCall("1", "cancelling-tool", """"x"""")),
+                ),
+                ModelResponse(content = "must not be requested"),
+            ),
+        )
+        val provider = object : ModelProvider {
+            val requests = mutableListOf<ModelRequest>()
+
+            override suspend fun complete(request: ModelRequest): ModelResponse {
+                requests += request
+                return responses.removeFirst()
+            }
+
+            override fun providerId(): String = "anthropic"
         }
 
         val tramai = Tramai {
@@ -524,32 +537,17 @@ class TramaiTest {
             model("claude-sonnet-4-20250514", "anthropic")
             tools(tool)
         }
-        val service = tramai.create<ThrowingToolService>()
+        val service = tramai.create<CancellingToolService>()
 
-        // The standalone adapter must NOT convert synchronous exceptions to
-        // ToolResult.InvalidInput. For idempotent tools, it produces
-        // ToolResult.TransientFailure, and the engine converts that to
-        // PermanentFailure after exhausting retries. The operation still
-        // fails — the critical contract is: no InvalidInput wrapping.
         assertThatThrownBy { runBlocking { service.execute("hello") } }
-            .isNotNull
-    }
-}
+            .isInstanceOf(kotlinx.coroutines.CancellationException::class.java)
+            .hasMessage("cancelled by standalone tool")
 
-@AiService
-interface ThrowingToolService {
-    @Operation(model = "claude-sonnet-4-20250514", tools = ["throwing-tool"])
-    suspend fun execute(input: String): String
-}
+        // Tool was called exactly once (not retried)
+        assertThat(tool.calls.get()).isEqualTo(1)
 
-private class ThrowingTramaiTool : TramaiTool<String, String> {
-    override val name: String = "throwing-tool"
-    override val description: String = "always throws"
-    override val inputType: kotlin.reflect.KClass<String> = String::class
-    override val idempotent: Boolean = true
-
-    override suspend fun execute(input: String, context: ToolExecutionContext): String {
-        throw RuntimeException("tool failed")
+        // Provider was called exactly once (second response not consumed)
+        assertThat(provider.requests).hasSize(1)
     }
 }
 

--- a/tramai-standalone/src/test/kotlin/dev/tramai/standalone/TramaiTest.kt
+++ b/tramai-standalone/src/test/kotlin/dev/tramai/standalone/TramaiTest.kt
@@ -508,6 +508,68 @@ class TramaiTest {
         // Only "lookup" should be exposed, not "other"
         assertThat(toolDefs!!.map { it.name }).containsExactly("lookup")
     }
+
+    @Test
+    fun `standalone adapter preserves thrown exceptions without wrapping as invalid input`() {
+        val tool = ThrowingTramaiTool()
+        val provider = RecordingProvider("anthropic") {
+            ModelResponse(
+                content = "using tool",
+                toolCalls = listOf(ToolCall("1", "throwing-tool", """{"input":"x"}""")),
+            )
+        }
+
+        val tramai = Tramai {
+            provider(provider, default = true)
+            model("claude-sonnet-4-20250514", "anthropic")
+            tools(tool)
+        }
+        val service = tramai.create<ThrowingToolService>()
+
+        // The standalone adapter must NOT convert synchronous exceptions to
+        // ToolResult.InvalidInput. For idempotent tools, it produces
+        // ToolResult.TransientFailure, and the engine converts that to
+        // PermanentFailure after exhausting retries. The operation still
+        // fails — the critical contract is: no InvalidInput wrapping.
+        assertThatThrownBy { runBlocking { service.execute("hello") } }
+            .isNotNull
+    }
+}
+
+@AiService
+interface ThrowingToolService {
+    @Operation(model = "claude-sonnet-4-20250514", tools = ["throwing-tool"])
+    suspend fun execute(input: String): String
+}
+
+private class ThrowingTramaiTool : TramaiTool<String, String> {
+    override val name: String = "throwing-tool"
+    override val description: String = "always throws"
+    override val inputType: kotlin.reflect.KClass<String> = String::class
+    override val idempotent: Boolean = true
+
+    override suspend fun execute(input: String, context: ToolExecutionContext): String {
+        throw RuntimeException("tool failed")
+    }
+}
+
+@AiService
+interface CancellingToolService {
+    @Operation(model = "claude-sonnet-4-20250514", tools = ["cancelling-tool"])
+    suspend fun execute(input: String): String
+}
+
+private class CancellingTramaiTool : TramaiTool<String, String> {
+    val calls = java.util.concurrent.atomic.AtomicInteger(0)
+    override val name: String = "cancelling-tool"
+    override val description: String = "throws cancellation"
+    override val inputType: kotlin.reflect.KClass<String> = String::class
+    override val idempotent: Boolean = true
+
+    override suspend fun execute(input: String, context: ToolExecutionContext): String {
+        calls.incrementAndGet()
+        throw kotlinx.coroutines.CancellationException("cancelled by standalone tool")
+    }
 }
 
 @AiService


### PR DESCRIPTION
## Summary

Closes #210. Fixes three defects that allowed `CancellationException` thrown during idempotent tool execution to be treated as a retryable or normal failure instead of terminal cancellation. Also prevents observer failure after successful tool execution from invalidating the completed side effect.

### Production changes

| File | Change |
|------|--------|
| `tramai-standalone/.../Tramai.kt` | `rethrowIfCancellation()` before InvalidInput and TransientFailure classification; explicit `catch (CancellationException)` before `catch (Exception)` for coroutine safety |
| `tramai-engine/.../TramaiEngine.kt` | `toolRetryTerminalResult()` checks `TransientFailure.cause.rethrowIfCancellation()` before retry or PermanentFailure conversion |
| `tramai-engine/.../TramaiEngine.kt` | `try` narrowed to `processToolCalls()` only — `onCallCompleted()` moved outside via `completeAfterToolProcessing()` non-suspend helper. Observer failure during `onCallCompleted()` is suppressed via `addSuppressed()` on a primary process error; logged as WARNING (with exception) and swallowed on the success path — preventing duplicate callback, side-effect invalidation, and cancellation-scanner false positives |

### Tests

**ToolCancellationContractTest** (tramai-engine, 5 tests):
- Idempotent tool cancellation escapes without retry or reinjection
- Custom `ResolvedTool` returning `TransientFailure(CancellationException)` is rethrown
- Ordinary idempotent tool failure still retries (regression guard)
- Observer completion failure after successful tool processing does not invalidate the tool result (tool called once, provider called twice, final result reaches caller)
- Observer completion failure during a tool-processing `Error` is suppressed on the original exception (suppressed[0] matches)

**TramaiTest** (tramai-standalone):
- Standalone adapter does not convert tool `CancellationException` to InvalidInput or TransientFailure

**OpenTelemetryCancellationIntegrationTest** (tramai-observability):
- Tool cancellation: one span with `tramai.outcome=cancelled`, span status not ERROR, no duplicate metric

### Verification

- `./gradlew :tramai-engine:test --tests '*ToolCancellationContractTest'` — 5/5 PASS
- `./gradlew :tramai-standalone:test` — PASS
- `./gradlew :tramai-observability:test` — PASS
- `./gradlew verifyPr` — BUILD SUCCESSFUL (266 tasks)
- All CI workflows green: CI ✅, Maintainability Baseline ✅, Sovereign Runtime RC ✅
