### PR TITLE
test(0.6.0): isolate MCP cancellation workflow runs from test-scope failure propagation

### DIFF
--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/SubprocessCancellationContractTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/SubprocessCancellationContractTest.kt
@@ -342,14 +342,23 @@ class SubprocessCancellationContractTest {
                             val deferred = async {
                                 workflow.run(SubprocessMcpState())
                             }
-                            val parentPid = awaitProcessHandle(parentPidFile)
-                            val childPid = awaitProcessHandle(childPidFile)
+                            val parentProcess = checkNotNull(awaitProcessHandle(parentPidFile))
+                            val childProcess = checkNotNull(awaitProcessHandle(childPidFile))
+                            assertThat(parentProcess.isAlive).isTrue()
+                            assertThat(childProcess.isAlive).isTrue()
+
                             deferred.cancel()
-                            runCatching { deferred.await() }
-                            awaitProcessExit(parentPid)
-                            awaitProcessExit(childPid)
-                            assertThat(pidIsAlive(parentPid)).isFalse()
-                            assertThat(pidIsAlive(childPid)).isFalse()
+
+                            // Cancellation must remain the workflow's primary
+                            // outcome; an unexpected WorkflowMcpException must
+                            // still fail the test rather than being swallowed.
+                            val failure = runCatching { deferred.await() }.exceptionOrNull()
+                            assertThat(failure).isInstanceOf(CancellationException::class.java)
+
+                            awaitProcessExit(parentProcess)
+                            awaitProcessExit(childProcess)
+                            assertThat(parentProcess.isAlive).isFalse()
+                            assertThat(childProcess.isAlive).isFalse()
                         }
                     }
                 }
@@ -395,14 +404,14 @@ class SubprocessCancellationContractTest {
                 runBlocking {
                     withTimeout(15_000) {
                         supervisorScope {
-                        val deferred = async {
-                            workflow.run(SubprocessMcpState(), observer = observer)
-                        }
-                        awaitProcessHandle(parentPidFile)
-                        deferred.cancel()
-                        val outcome = runCatching { deferred.await() }
-                        assertThat(outcome.exceptionOrNull()).isInstanceOf(CancellationException::class.java)
-                        assertThat(observer.eventNames).doesNotContain("tramai.workflow.mcp.reconnecting")
+                            val deferred = async {
+                                workflow.run(SubprocessMcpState(), observer = observer)
+                            }
+                            awaitProcessHandle(parentPidFile)
+                            deferred.cancel()
+                            val outcome = runCatching { deferred.await() }
+                            assertThat(outcome.exceptionOrNull()).isInstanceOf(CancellationException::class.java)
+                            assertThat(observer.eventNames).doesNotContain("tramai.workflow.mcp.reconnecting")
                         }
                     }
                 }
@@ -532,20 +541,20 @@ class SubprocessCancellationContractTest {
         runBlocking {
             withTimeout(15_000) {
                 supervisorScope {
-                val captured = AtomicReference<Throwable?>()
-                val deferred = async {
-                    try {
-                        workflow.run(SubprocessMcpState())
-                    } catch (error: Throwable) {
-                        captured.set(error)
-                        throw error
+                    val captured = AtomicReference<Throwable?>()
+                    val deferred = async {
+                        try {
+                            workflow.run(SubprocessMcpState())
+                        } catch (error: Throwable) {
+                            captured.set(error)
+                            throw error
+                        }
                     }
-                }
-                delay(1_500)
-                deferred.cancel()
-                runCatching { deferred.await() }
-                assertThat(captured.get()).isInstanceOf(CancellationException::class.java)
-                assertThat(cleanupRan.get()).isTrue()
+                    delay(1_500)
+                    deferred.cancel()
+                    runCatching { deferred.await() }
+                    assertThat(captured.get()).isInstanceOf(CancellationException::class.java)
+                    assertThat(cleanupRan.get()).isTrue()
                 }
             }
         }

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/SubprocessCancellationContractTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/SubprocessCancellationContractTest.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
@@ -337,17 +338,19 @@ class SubprocessCancellationContractTest {
 
                 runBlocking {
                     withTimeout(15_000) {
-                        val deferred = async {
-                            workflow.run(SubprocessMcpState())
+                        supervisorScope {
+                            val deferred = async {
+                                workflow.run(SubprocessMcpState())
+                            }
+                            val parentPid = awaitProcessHandle(parentPidFile)
+                            val childPid = awaitProcessHandle(childPidFile)
+                            deferred.cancel()
+                            runCatching { deferred.await() }
+                            awaitProcessExit(parentPid)
+                            awaitProcessExit(childPid)
+                            assertThat(pidIsAlive(parentPid)).isFalse()
+                            assertThat(pidIsAlive(childPid)).isFalse()
                         }
-                        val parentPid = awaitProcessHandle(parentPidFile)
-                        val childPid = awaitProcessHandle(childPidFile)
-                        deferred.cancel()
-                        runCatching { deferred.await() }
-                        awaitProcessExit(parentPid)
-                        awaitProcessExit(childPid)
-                        assertThat(pidIsAlive(parentPid)).isFalse()
-                        assertThat(pidIsAlive(childPid)).isFalse()
                     }
                 }
             }
@@ -391,6 +394,7 @@ class SubprocessCancellationContractTest {
 
                 runBlocking {
                     withTimeout(15_000) {
+                        supervisorScope {
                         val deferred = async {
                             workflow.run(SubprocessMcpState(), observer = observer)
                         }
@@ -399,6 +403,7 @@ class SubprocessCancellationContractTest {
                         val outcome = runCatching { deferred.await() }
                         assertThat(outcome.exceptionOrNull()).isInstanceOf(CancellationException::class.java)
                         assertThat(observer.eventNames).doesNotContain("tramai.workflow.mcp.reconnecting")
+                        }
                     }
                 }
             }
@@ -526,6 +531,7 @@ class SubprocessCancellationContractTest {
 
         runBlocking {
             withTimeout(15_000) {
+                supervisorScope {
                 val captured = AtomicReference<Throwable?>()
                 val deferred = async {
                     try {
@@ -540,6 +546,7 @@ class SubprocessCancellationContractTest {
                 runCatching { deferred.await() }
                 assertThat(captured.get()).isInstanceOf(CancellationException::class.java)
                 assertThat(cleanupRan.get()).isTrue()
+                }
             }
         }
     }

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowMcpStepTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowMcpStepTest.kt
@@ -150,6 +150,7 @@ class WorkflowMcpStepTest {
         val workflow = buildWorkflow(listOf(step))
 
         runBlocking {
+            supervisorScope {
             val deferred = async {
                 workflow.run(McpState())
             }
@@ -157,6 +158,7 @@ class WorkflowMcpStepTest {
             deferred.cancel()
             val result = runCatching { deferred.await() }
             assertThat(result.exceptionOrNull()).isInstanceOf(CancellationException::class.java)
+            }
         }
     }
 
@@ -193,6 +195,7 @@ class WorkflowMcpStepTest {
                 val workflow = buildWorkflow(listOf(step))
 
                 runBlocking {
+                    supervisorScope {
                     val deferred = async {
                         workflow.run(McpState())
                     }
@@ -205,6 +208,7 @@ class WorkflowMcpStepTest {
                     awaitMcpProcessExit(childProcess)
                     assertThat(parentProcess?.isAlive ?: false).isFalse()
                     assertThat(childProcess?.isAlive ?: false).isFalse()
+                    }
                 }
             }
         } finally {

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowMcpStepTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowMcpStepTest.kt
@@ -151,13 +151,13 @@ class WorkflowMcpStepTest {
 
         runBlocking {
             supervisorScope {
-            val deferred = async {
-                workflow.run(McpState())
-            }
-            delay(500)
-            deferred.cancel()
-            val result = runCatching { deferred.await() }
-            assertThat(result.exceptionOrNull()).isInstanceOf(CancellationException::class.java)
+                val deferred = async {
+                    workflow.run(McpState())
+                }
+                delay(500)
+                deferred.cancel()
+                val result = runCatching { deferred.await() }
+                assertThat(result.exceptionOrNull()).isInstanceOf(CancellationException::class.java)
             }
         }
     }
@@ -196,18 +196,26 @@ class WorkflowMcpStepTest {
 
                 runBlocking {
                     supervisorScope {
-                    val deferred = async {
-                        workflow.run(McpState())
-                    }
-                    val parentProcess = awaitMcpProcessHandle(parentPidFile)
-                    val childProcess = awaitMcpProcessHandle(childPidFile)
-                    deferred.cancel()
-                    runCatching { deferred.await() }
+                        val deferred = async {
+                            workflow.run(McpState())
+                        }
+                        val parentProcess = checkNotNull(awaitMcpProcessHandle(parentPidFile))
+                        val childProcess = checkNotNull(awaitMcpProcessHandle(childPidFile))
+                        assertThat(parentProcess.isAlive).isTrue()
+                        assertThat(childProcess.isAlive).isTrue()
 
-                    awaitMcpProcessExit(parentProcess)
-                    awaitMcpProcessExit(childProcess)
-                    assertThat(parentProcess?.isAlive ?: false).isFalse()
-                    assertThat(childProcess?.isAlive ?: false).isFalse()
+                        deferred.cancel()
+
+                        // Cancellation must remain the workflow's primary
+                        // outcome; an unexpected WorkflowMcpException must
+                        // still fail the test rather than being swallowed.
+                        val failure = runCatching { deferred.await() }.exceptionOrNull()
+                        assertThat(failure).isInstanceOf(CancellationException::class.java)
+
+                        awaitMcpProcessExit(parentProcess)
+                        awaitMcpProcessExit(childProcess)
+                        assertThat(parentProcess.isAlive).isFalse()
+                        assertThat(childProcess.isAlive).isFalse()
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Follow-up to the merged #220: isolates the MCP cancellation workflow runs in `tramai-orchestration` tests from test-scope failure propagation, closing the last observed CI flake in the family.

## Root cause

`SubprocessCancellationContractTest > mcp cancellation terminates its subprocess tree` failed CI-only with `WorkflowMcpException` escaping `runBlocking` (test line 338). The test launches `workflow.run()` as a plain `async` child of `runBlocking`; when the MCP transport fails mid-cancellation, structured concurrency propagates the child failure to the test scope **before** `runCatching { deferred.await() }` observes it. Passes locally; rare on loaded runners.

## Fix

Launch the workflow runs inside `supervisorScope`: child failures no longer propagate to the test scope and are observed exactly where the tests intend (via `await()`/`runCatching`), while parent cancellation (`deferred.cancel()`, `withTimeout`) still flows to the workflow. Five sites: 3 in `SubprocessCancellationContractTest`, 2 in `WorkflowMcpStepTest` (same risk class).

## Scope

- Test-only; zero production code, zero baselines, zero workflow changes.
- No assertion removed or relaxed — exit guarantees, survivor checks, exception-type assertions, and cleanup assertions are unchanged.

## Verification (proxy-free, JDK 21)

- `:tramai-orchestration:test --tests WorkflowMcpStepTest --tests SubprocessCancellationContractTest` — passed (29s)
- `:tramai-orchestration:test --rerun-tasks` — passed twice (52s each)
- `verifyPr -PchangeClass=runtime-behaviour` — passed

## Review round 1 — resolved

| Finding | Resolution |
|---|---|
| P1 Two cleanup tests swallowed the deferred outcome | Both sites now `checkNotNull` the process handles, assert `isAlive` **before** cancel, and assert the awaited outcome is `CancellationException` — an unexpected `WorkflowMcpException` fails the test instead of passing |
| P1 (reinforcement) nullable handles masked failed workflows | `checkNotNull` makes an exited-before-capture process a test failure, not a silent pass |
| P3 indentation | All five `supervisorScope` bodies re-indented |

Rebased onto current master (post-#219-merge). Verified: orchestration suite x2 (52s each), `verifyPr -PchangeClass=runtime-behaviour` (266 tasks).
