### PR TITLE
refactor(0.6.0): introduce immutable runtime component groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Refactored the engine's internal runtime composition into an immutable component snapshot; public API and runtime behaviour are unchanged. Partially configured approval suspension now fails at the engine component boundary.
+- Refactored the engine's internal runtime composition into an immutable component snapshot; zero public API change and no execution-semantic changes, except the intentional fail-fast rejection of invalid partial approval composition at the engine component boundary.
 
 - **Explicit runtime lifecycle ownership (PR #226).** `Tramai` and `SovereignTramai` are now `AutoCloseable` and own exactly one lazily-created runtime (one engine) shared by every `create()`/`runtime()` call — previously every `create()` leaked an unreachable engine. Closing is idempotent and concurrency-safe; after close, `create()`/`runtime()` and old proxies fail fast with a fixed `IllegalStateException` before any provider work. `TramaiEngine.close()` cancels once and awaits engine-hierarchy termination (self-close safe), and terminates in-flight suspend invocations; the caller continuation is always resumed exactly once. Spring closes the shared runtime via `destroyMethod = "close"`, so multiple `@AiService` beans share one owned engine. TramAI closes only resources it creates; externally supplied providers/stores/clients/observers remain caller-owned. API surface addition is additive: `Tramai`/`SovereignTramai` gain `close()`; all constructor descriptors remain byte-identical to 0.5.0 (note: adding the `AutoCloseable` supertype is source-compatible but affects compiled negative-`instanceof` checks). Epic 1.3 Runtime Lifecycle Ownership is complete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Refactored the engine's internal runtime composition into an immutable component snapshot; public API and runtime behaviour are unchanged. Partially configured approval suspension now fails at the engine component boundary.
+
 - **Explicit runtime lifecycle ownership (PR #226).** `Tramai` and `SovereignTramai` are now `AutoCloseable` and own exactly one lazily-created runtime (one engine) shared by every `create()`/`runtime()` call — previously every `create()` leaked an unreachable engine. Closing is idempotent and concurrency-safe; after close, `create()`/`runtime()` and old proxies fail fast with a fixed `IllegalStateException` before any provider work. `TramaiEngine.close()` cancels once and awaits engine-hierarchy termination (self-close safe), and terminates in-flight suspend invocations; the caller continuation is always resumed exactly once. Spring closes the shared runtime via `destroyMethod = "close"`, so multiple `@AiService` beans share one owned engine. TramAI closes only resources it creates; externally supplied providers/stores/clients/observers remain caller-owned. API surface addition is additive: `Tramai`/`SovereignTramai` gain `close()`; all constructor descriptors remain byte-identical to 0.5.0 (note: adding the `AutoCloseable` supertype is source-compatible but affects compiled negative-`instanceof` checks). Epic 1.3 Runtime Lifecycle Ownership is complete.
 
 - **Safe persistence failure boundaries (PR #225).** Persistence stores expose fixed, cause-free failure text; raw paths, SQL, and payloads flow only to `PersistenceFailureDiagnosticObserver`; worker observers receive safe failures; existing exception and store ABI is preserved by the binary fixture. Epic 1.2 Safe Error Boundaries is complete.

--- a/config/quality/maintainability-deviations.yml
+++ b/config/quality/maintainability-deviations.yml
@@ -156,6 +156,16 @@ deviations:
     targetPhase: "0.6.1"
     owner: "GionaGranchelli"
 
+  - id: MQ-0017
+    metric: globalMutableState
+    scope: ":tramai-engine"
+    baseline: 18
+    allowed: 22
+    reason: "Epic 2.1 EngineComponents snapshot: internal data-class fields typed as ProviderRegistry/ToolRegistry/ModelRegistry are immutable final snapshot references, not mutable registries. Scanner counts them as exposed registry state; they are the frozen configuration boundary (EngineComponentFactory is the sole construction path). Findings resolve when the scanner learns to distinguish snapshot references."
+    acceptedAt: "2026-08-12"
+    targetPhase: "0.6.1"
+    owner: "GionaGranchelli"
+
   - id: MQ-0015
     metric: nondeterminismSources
     scope: ":tramai-orchestration"

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -421,6 +421,8 @@ This phase is intentionally completed before large decomposition work.
 
 ## Epic 2.1: Introduce immutable runtime component groups
 
+**Status: ✅ Complete — PR #228**
+
 **Goal:** Replace constructor and builder explosion with cohesive, inspectable runtime configuration.
 
 ### Proposed component model
@@ -441,18 +443,18 @@ The exact API may differ, but each group must have one responsibility and explic
 
 ### Tasks
 
-1. Introduce immutable component groups without changing public builder APIs initially.
-2. Move all all-or-none composition validation into component constructors or factories.
-3. Distinguish required components, optional capabilities, and no-op implementations.
-4. Replace nullable dependency clusters with explicit capability types where possible.
-5. Document thread-safety and lifecycle ownership for every component group.
-6. Ensure component snapshots are immutable after runtime construction.
+1. ✅ Introduce immutable component groups without changing public builder APIs initially.
+2. ✅ Move all all-or-none composition validation into component constructors or factories.
+3. ✅ Distinguish required components, optional capabilities, and no-op implementations.
+4. ✅ Replace nullable dependency clusters with explicit capability types where possible.
+5. ✅ Document thread-safety and lifecycle ownership for every component group.
+6. ✅ Ensure component snapshots are immutable after runtime construction.
 
 ### Acceptance criteria
 
-- `TramaiEngine` and its main execution coordinators receive cohesive component groups rather than dozens of unrelated dependencies.
-- Invalid partial approval, policy, persistence, or evidence configurations fail during build.
-- Runtime code does not discover configuration dynamically.
+- ✅ `TramaiEngine` and its main execution coordinators receive cohesive component groups rather than dozens of unrelated dependencies.
+- ✅ Invalid partial approval, policy, persistence, or evidence configurations fail during build.
+- ✅ Runtime code does not discover configuration dynamically.
 
 ---
 

--- a/docs/modules/tramai-engine.md
+++ b/docs/modules/tramai-engine.md
@@ -70,6 +70,7 @@ implementation("dev.tramai:tramai-engine")
 ### Quick usage
 
 The most common pattern: create a `TramaiEngine` with a single provider, then call `engine.create<T>()` to obtain a proxy.
+Public construction remains unchanged. Internally, each construction call validates and freezes an immutable component snapshot before runtime use.
 
 ```kotlin
 import dev.tramai.engine.TramaiEngine

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -211,7 +211,7 @@ class TramaiEngine private constructor(
     /**
      * Internally owned lifecycle job and scope. The engine's OWN work (blocking
      * calls, streaming collections) parents here — never to the caller-supplied
-     * [job]/[scope] constructor parameters, which remain for ABI compatibility
+     * legacy job / scope constructor parameters, which remain for ABI compatibility
      * only. close() cancels and joins [lifecycleJob], so it can prove that
      * engine-initiated work has terminated, regardless of where the caller's
      * job lives (and without risking the caller-job join deadlock).
@@ -456,43 +456,17 @@ class TramaiEngine private constructor(
             promptSanitizer = promptSanitizer,
         )
         val handler = TramaiInvocationHandler(
-            providerRegistry = providerRegistry,
-            structuredOutputHandler = structuredOutputHandler,
-            toolRegistry = toolRegistry,
-            operationObserver = operationObserver,
-            operationInterceptor = operationInterceptor,
-            responseCache = responseCache,
-            modelRegistry = modelRegistry,
-            modelRegistrySettings = modelRegistrySettings,
+            components = components,
             circuitBreaker = circuitBreaker,
             retryDelayPolicy = retryDelayPolicy,
-            tokenBudgetSettings = tokenBudgetSettings,
-            promptSanitizer = promptSanitizer,
-            chatMemory = chatMemory,
-            conversationIdProvider = conversationIdProvider,
+            migrationWarningGuard = migrationWarningGuard,
             lifecycleJob = lifecycleJob,
             lifecycleScope = lifecycleScope,
             isClosed = closed,
             engineThreadMarker = engineThreadMarker,
             activeInvocationJobs = activeInvocationJobs,
             serviceDefinition = definition,
-            policyEngine = resolvedPolicyEngine,
-            migrationWarningGuard = migrationWarningGuard,
-            isLegacyFallback = isLegacyFallback,
-            dlpInterceptor = dlpInterceptor,
-            dlpRedactionAuditEmitter = dlpRedactionAuditEmitter,
-            toolResultFilteringSettings = toolResultFilteringSettings,
-            engineEventObserver = engineEventObserver,
-            toolFailureDiagnosticObserver = toolFailureDiagnosticObserver,
-            structuredOutputFailureDiagnosticObserver = structuredOutputFailureDiagnosticObserver,
-            policyDecisionAuditEmitter = policyDecisionAuditEmitter,
-            suspendedInvocationStore = suspendedInvocationStore,
-            approvalContinuationStore = approvalContinuationStore,
-            toolArgumentsDigester = toolArgumentsDigester,
-            approvalGateCoordinator = approvalGateCoordinator,
-            approvalLifecycleAuditEmitter = approvalLifecycleAuditEmitter,
             resumeOperationRegistry = resumeOperationRegistry,
-            clock = clock,
         )
 
         @Suppress("UNCHECKED_CAST")
@@ -524,43 +498,17 @@ class TramaiEngine private constructor(
             promptSanitizer = promptSanitizer,
         )
         val handler = TramaiInvocationHandler(
-            providerRegistry = providerRegistry,
-            structuredOutputHandler = structuredOutputHandler,
-            toolRegistry = toolRegistry,
-            operationObserver = operationObserver,
-            operationInterceptor = operationInterceptor,
-            responseCache = responseCache,
-            modelRegistry = modelRegistry,
-            modelRegistrySettings = modelRegistrySettings,
+            components = components,
             circuitBreaker = circuitBreaker,
             retryDelayPolicy = retryDelayPolicy,
-            tokenBudgetSettings = tokenBudgetSettings,
-            promptSanitizer = promptSanitizer,
-            chatMemory = chatMemory,
-            conversationIdProvider = conversationIdProvider,
+            migrationWarningGuard = migrationWarningGuard,
             lifecycleJob = lifecycleJob,
             lifecycleScope = lifecycleScope,
             isClosed = closed,
             engineThreadMarker = engineThreadMarker,
             activeInvocationJobs = activeInvocationJobs,
             serviceDefinition = definition,
-            policyEngine = resolvedPolicyEngine,
-            migrationWarningGuard = migrationWarningGuard,
-            isLegacyFallback = isLegacyFallback,
-            dlpInterceptor = dlpInterceptor,
-            dlpRedactionAuditEmitter = dlpRedactionAuditEmitter,
-            toolResultFilteringSettings = toolResultFilteringSettings,
-            engineEventObserver = engineEventObserver,
-            toolFailureDiagnosticObserver = toolFailureDiagnosticObserver,
-            structuredOutputFailureDiagnosticObserver = structuredOutputFailureDiagnosticObserver,
-            policyDecisionAuditEmitter = policyDecisionAuditEmitter,
-            suspendedInvocationStore = suspendedInvocationStore,
-            approvalContinuationStore = approvalContinuationStore,
-            toolArgumentsDigester = toolArgumentsDigester,
-            approvalGateCoordinator = approvalGateCoordinator,
-            approvalLifecycleAuditEmitter = approvalLifecycleAuditEmitter,
             resumeOperationRegistry = resumeOperationRegistry,
-            clock = clock,
         )
         resumeOperationRegistry.registerAll(
             serviceDefinition = definition,
@@ -608,8 +556,8 @@ class TramaiEngine private constructor(
 
     /**
      * Cancels all engine-initiated work and, except from one of the engine's
-     * own coroutines, waits for it to terminate. The caller-supplied [job] and
-     * [scope] constructor parameters are NEVER cancelled or joined here — the
+     * own coroutines, waits for it to terminate. The caller-supplied legacy job /
+     * scope constructor parameters are NEVER cancelled or joined here — the
      * engine owns its own [lifecycleJob], so closing cannot deadlock a caller
      * that passed its current job. Dependencies supplied by callers are not
      * closed.
@@ -670,47 +618,46 @@ data class ResumeApprovalCommand(
 )
 
 internal class TramaiInvocationHandler(
-    private val providerRegistry: ProviderRegistry,
-    private val structuredOutputHandler: StructuredOutputHandler?,
-    private val toolRegistry: ToolRegistry,
-    private val operationObserver: OperationObserver,
-    private val operationInterceptor: OperationInterceptor,
-    private val responseCache: OperationResponseCache,
-    private val modelRegistry: ModelRegistry,
-    private val modelRegistrySettings: ModelRegistrySettings,
+    private val components: EngineComponents,
     private val circuitBreaker: ProviderCircuitBreaker,
     private val retryDelayPolicy: ProviderRetryDelayPolicy,
-    private val tokenBudgetSettings: TokenBudgetSettings,
-    private val promptSanitizer: PromptSanitizer?,
-    private val chatMemory: ChatMemory?,
-    private val conversationIdProvider: ConversationIdProvider,
+    private val migrationWarningGuard: java.util.concurrent.atomic.AtomicBoolean,
     private val lifecycleJob: Job,
     private val lifecycleScope: CoroutineScope,
     private val isClosed: java.util.concurrent.atomic.AtomicBoolean = java.util.concurrent.atomic.AtomicBoolean(false),
     private val engineThreadMarker: ThreadLocal<Boolean> = ThreadLocal(),
     private val activeInvocationJobs: MutableSet<Job> = java.util.concurrent.ConcurrentHashMap.newKeySet(),
     private val serviceDefinition: ServiceDefinition,
-    policyEngine: PolicyEngine,
-    private val migrationWarningGuard: java.util.concurrent.atomic.AtomicBoolean,
-    isLegacyFallback: Boolean,
-    private val dlpInterceptor: DlpInterceptor,
-    private val dlpRedactionAuditEmitter: DlpRedactionAuditEmitter,
-    private val toolResultFilteringSettings: ToolResultFilteringSettings,
-    private val engineEventObserver: EngineEventObserver,
-    private val toolFailureDiagnosticObserver: ToolFailureDiagnosticObserver,
-    private val structuredOutputFailureDiagnosticObserver: StructuredOutputFailureDiagnosticObserver,
-    private val policyDecisionAuditEmitter: PolicyDecisionAuditEmitter,
-    // Approval suspension dependencies
-    private val suspendedInvocationStore: SuspendedInvocationStore,
-    private val approvalContinuationStore: ApprovalContinuationStore?,
-    private val toolArgumentsDigester: ToolArgumentsDigester?,
-    private val approvalGateCoordinator: ApprovalGateCoordinator?,
-    private val approvalLifecycleAuditEmitter: ApprovalLifecycleAuditEmitter,
     private val resumeOperationRegistry: ResumeOperationRegistry,
-    private val clock: Clock,
 ) : InvocationHandler {
 
-    private val policyHelper = PolicyEnforcementHelper(policyEngine, migrationWarningGuard, isLegacyFallback = isLegacyFallback, auditEmitter = policyDecisionAuditEmitter)
+    private val providerRegistry = components.providers.providerRegistry
+    private val structuredOutputHandler = components.execution.structuredOutputHandler
+    private val toolRegistry = components.tools.toolRegistry
+    private val operationObserver = components.observation.operationObserver
+    private val operationInterceptor = components.observation.operationInterceptor
+    private val responseCache = components.persistence.responseCache
+    private val modelRegistry = components.security.modelRegistry
+    private val modelRegistrySettings = components.security.modelRegistrySettings
+    private val tokenBudgetSettings = components.execution.tokenBudgetSettings
+    private val promptSanitizer = components.security.promptSanitizer
+    private val chatMemory = components.persistence.chatMemory
+    private val conversationIdProvider = components.persistence.conversationIdProvider
+    private val dlpInterceptor = components.security.dlpInterceptor
+    private val dlpRedactionAuditEmitter = components.security.dlpRedactionAuditEmitter
+    private val toolResultFilteringSettings = components.tools.toolResultFilteringSettings
+    private val engineEventObserver = components.observation.engineEventObserver
+    private val toolFailureDiagnosticObserver = components.observation.toolFailureDiagnosticObserver
+    private val structuredOutputFailureDiagnosticObserver = components.observation.structuredOutputFailureDiagnosticObserver
+    private val policyDecisionAuditEmitter = components.security.policyDecisionAuditEmitter
+    private val suspendedInvocationStore = components.approvals.suspendedInvocationStore
+    private val approvalLifecycleAuditEmitter = components.approvals.approvalLifecycleAuditEmitter
+    private val clock = components.execution.clock
+    private val approvalContinuationStore = (components.approvals.capability as? ApprovalCapability.Enabled)?.continuationStore
+    private val toolArgumentsDigester = (components.approvals.capability as? ApprovalCapability.Enabled)?.argumentsDigester
+    private val approvalGateCoordinator = (components.approvals.capability as? ApprovalCapability.Enabled)?.gateCoordinator
+
+    private val policyHelper = PolicyEnforcementHelper(components.security.resolvedPolicyEngine, migrationWarningGuard, isLegacyFallback = components.security.isLegacyFallback, auditEmitter = policyDecisionAuditEmitter)
     private val modelRegistryEnforcer = ModelRegistryEnforcer(modelRegistry, modelRegistrySettings)
 
     private fun OperationObservation.completeCancellation(cancellation: CancellationException) {
@@ -2288,7 +2235,7 @@ internal class TramaiInvocationHandler(
             return message.copy(
                 content = sanitizeToolText(
                     scope = scope,
-                            text = message.content,
+                    text = message.content,
                     contentLocation = DlpContentLocation.TOOL_MESSAGE_CONTENT,
                     authoritative = true,
                 ),
@@ -2429,8 +2376,8 @@ internal class TramaiInvocationHandler(
                 textRun.forEach(::append)
             }
             val sanitizedText = sanitizeToolText(
-                    scope = scope,
-                    text = combinedText,
+                scope = scope,
+                text = combinedText,
                 contentLocation = DlpContentLocation.TOOL_MESSAGE_TEXT_RUN,
                 authoritative = true,
             )
@@ -2462,8 +2409,8 @@ internal class TramaiInvocationHandler(
         if (allTextParts.size > 1) {
             val projectedText = allTextParts.joinToString("")
             val projectedResult = sanitizeToolText(
-                    scope = scope,
-                    text = projectedText,
+                scope = scope,
+                text = projectedText,
                 contentLocation = DlpContentLocation.TOOL_MESSAGE_CONTENT,
                 authoritative = false,
             )
@@ -2471,8 +2418,8 @@ internal class TramaiInvocationHandler(
                 sanitizedTextRuns.forEach(::append)
             }
             val combinedResanitized = sanitizeToolText(
-                    scope = scope,
-                    text = individualCombined,
+                scope = scope,
+                text = individualCombined,
                 contentLocation = DlpContentLocation.TOOL_MESSAGE_CONTENT,
                 authoritative = false,
             )

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -147,8 +147,6 @@ class TramaiEngine private constructor(
     private val promptSanitizer = components.security.promptSanitizer
     private val chatMemory = components.persistence.chatMemory
     private val conversationIdProvider = components.persistence.conversationIdProvider
-    private val job = components.execution.job
-    private val scope = components.execution.scope
     private val dlpInterceptor = components.security.dlpInterceptor
     private val dlpRedactionAuditEmitter = components.security.dlpRedactionAuditEmitter
     private val toolResultFilteringSettings = components.tools.toolResultFilteringSettings
@@ -197,7 +195,7 @@ class TramaiEngine private constructor(
 ) : this(EngineComponentFactory.create(
     providerRegistry, structuredOutputHandler, toolRegistry, operationObserver, operationInterceptor, responseCache,
     modelRegistry, modelRegistrySettings, circuitBreakerSettings, retryPolicySettings, tokenBudgetSettings, promptSanitizer,
-    chatMemory, conversationIdProvider, job, scope, policyEngine, dlpInterceptor, dlpRedactionAuditEmitter,
+    chatMemory, conversationIdProvider, policyEngine, dlpInterceptor, dlpRedactionAuditEmitter,
     toolResultFilteringSettings, engineEventObserver, toolFailureDiagnosticObserver, policyDecisionAuditEmitter,
     suspendedInvocationStore, approvalContinuationStore, toolArgumentsDigester, approvalGateCoordinator,
     approvalLifecycleAuditEmitter, clock,
@@ -295,8 +293,6 @@ class TramaiEngine private constructor(
         promptSanitizer = promptSanitizer,
         chatMemory = chatMemory,
         conversationIdProvider = conversationIdProvider,
-        job = job,
-        scope = scope,
         policyEngine = policyEngine,
         dlpInterceptor = dlpInterceptor,
         dlpRedactionAuditEmitter = dlpRedactionAuditEmitter,
@@ -365,8 +361,6 @@ class TramaiEngine private constructor(
         promptSanitizer = promptSanitizer,
         chatMemory = chatMemory,
         conversationIdProvider = conversationIdProvider,
-        job = job,
-        scope = scope,
         policyEngine = policyEngine,
         dlpInterceptor = dlpInterceptor,
         dlpRedactionAuditEmitter = dlpRedactionAuditEmitter,
@@ -435,8 +429,6 @@ class TramaiEngine private constructor(
         promptSanitizer = promptSanitizer,
         chatMemory = chatMemory,
         conversationIdProvider = conversationIdProvider,
-        job = job,
-        scope = scope,
         policyEngine = policyEngine,
         dlpInterceptor = dlpInterceptor,
         dlpRedactionAuditEmitter = dlpRedactionAuditEmitter,
@@ -478,7 +470,6 @@ class TramaiEngine private constructor(
             promptSanitizer = promptSanitizer,
             chatMemory = chatMemory,
             conversationIdProvider = conversationIdProvider,
-            scope = scope,
             lifecycleJob = lifecycleJob,
             lifecycleScope = lifecycleScope,
             isClosed = closed,
@@ -547,7 +538,6 @@ class TramaiEngine private constructor(
             promptSanitizer = promptSanitizer,
             chatMemory = chatMemory,
             conversationIdProvider = conversationIdProvider,
-            scope = scope,
             lifecycleJob = lifecycleJob,
             lifecycleScope = lifecycleScope,
             isClosed = closed,
@@ -694,7 +684,6 @@ internal class TramaiInvocationHandler(
     private val promptSanitizer: PromptSanitizer?,
     private val chatMemory: ChatMemory?,
     private val conversationIdProvider: ConversationIdProvider,
-    private val scope: CoroutineScope,
     private val lifecycleJob: Job,
     private val lifecycleScope: CoroutineScope,
     private val isClosed: java.util.concurrent.atomic.AtomicBoolean = java.util.concurrent.atomic.AtomicBoolean(false),
@@ -2299,7 +2288,7 @@ internal class TramaiInvocationHandler(
             return message.copy(
                 content = sanitizeToolText(
                     scope = scope,
-                    text = message.content,
+                            text = message.content,
                     contentLocation = DlpContentLocation.TOOL_MESSAGE_CONTENT,
                     authoritative = true,
                 ),
@@ -2440,8 +2429,8 @@ internal class TramaiInvocationHandler(
                 textRun.forEach(::append)
             }
             val sanitizedText = sanitizeToolText(
-                scope = scope,
-                text = combinedText,
+                    scope = scope,
+                    text = combinedText,
                 contentLocation = DlpContentLocation.TOOL_MESSAGE_TEXT_RUN,
                 authoritative = true,
             )
@@ -2473,8 +2462,8 @@ internal class TramaiInvocationHandler(
         if (allTextParts.size > 1) {
             val projectedText = allTextParts.joinToString("")
             val projectedResult = sanitizeToolText(
-                scope = scope,
-                text = projectedText,
+                    scope = scope,
+                    text = projectedText,
                 contentLocation = DlpContentLocation.TOOL_MESSAGE_CONTENT,
                 authoritative = false,
             )
@@ -2482,8 +2471,8 @@ internal class TramaiInvocationHandler(
                 sanitizedTextRuns.forEach(::append)
             }
             val combinedResanitized = sanitizeToolText(
-                scope = scope,
-                text = individualCombined,
+                    scope = scope,
+                    text = individualCombined,
                 contentLocation = DlpContentLocation.TOOL_MESSAGE_CONTENT,
                 authoritative = false,
             )

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -120,6 +120,9 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.jvm.kotlinFunction
+import dev.tramai.engine.components.ApprovalCapability
+import dev.tramai.engine.components.EngineComponentFactory
+import dev.tramai.engine.components.EngineComponents
 
 private const val MAX_SAFE_TOOL_NAME_LENGTH = 128
 private const val UNREGISTERED_TOOL_NAME = "unregistered_tool"
@@ -127,52 +130,83 @@ private const val UNREGISTERED_TOOL_NAME = "unregistered_tool"
 /**
  * Runtime engine that turns annotated service interfaces into AI-backed proxies.
  */
-class TramaiEngine(
-    private val providerRegistry: ProviderRegistry,
-    private val structuredOutputHandler: StructuredOutputHandler? = null,
-    private val toolRegistry: ToolRegistry = ToolRegistry(),
-    private val operationObserver: OperationObserver = NoOpOperationObserver,
-    private val operationInterceptor: OperationInterceptor = NoOpOperationInterceptor,
-    private val responseCache: OperationResponseCache = NoOpOperationResponseCache,
-    private val modelRegistry: ModelRegistry = NoOpModelRegistry,
-    private val modelRegistrySettings: ModelRegistrySettings = ModelRegistrySettings(),
-    private val circuitBreakerSettings: CircuitBreakerSettings = CircuitBreakerSettings(),
-    private val retryPolicySettings: RetryPolicySettings = RetryPolicySettings(),
-    private val tokenBudgetSettings: TokenBudgetSettings = TokenBudgetSettings(),
-    private val promptSanitizer: PromptSanitizer? = null,
-    private val chatMemory: ChatMemory? = null,
-    private val conversationIdProvider: ConversationIdProvider = UuidConversationIdProvider(),
-    private val job: Job = SupervisorJob(),
-    private val scope: CoroutineScope = CoroutineScope(job + Dispatchers.Default),
-    private val policyEngine: dev.tramai.core.policy.PolicyEngine? = null,
-    private val dlpInterceptor: DlpInterceptor = NoOpDlpInterceptor,
-    private val dlpRedactionAuditEmitter: DlpRedactionAuditEmitter = NoOpDlpRedactionAuditEmitter,
-    private val toolResultFilteringSettings: ToolResultFilteringSettings = ToolResultFilteringSettings(),
-    private val engineEventObserver: EngineEventObserver = NoOpEngineEventObserver,
-    private val toolFailureDiagnosticObserver: ToolFailureDiagnosticObserver = NoOpToolFailureDiagnosticObserver,
-    private val policyDecisionAuditEmitter: PolicyDecisionAuditEmitter = NoOpPolicyDecisionAuditEmitter,
-    // Approval suspension dependencies
-    private val suspendedInvocationStore: SuspendedInvocationStore = InMemorySuspendedInvocationStore(),
-    private val approvalContinuationStore: ApprovalContinuationStore? = null,
-    private val toolArgumentsDigester: ToolArgumentsDigester? = null,
-    private val approvalGateCoordinator: ApprovalGateCoordinator? = null,
-    private val approvalLifecycleAuditEmitter: ApprovalLifecycleAuditEmitter = NoOpApprovalLifecycleAuditEmitter,
-    private val clock: Clock = Clock.systemUTC(),
+class TramaiEngine private constructor(
+    private val components: EngineComponents,
 ) : AutoCloseable {
-    /**
-     * Structured-output failure diagnostic observer. Additive configuration
-     * (not a primary-constructor parameter — preserves the published JVM
-     * constructor descriptors); set via the observer-aware secondary
-     * constructor. Defaults to no-op.
-     */
-    private var structuredOutputFailureDiagnosticObserver: StructuredOutputFailureDiagnosticObserver =
-        NoOpStructuredOutputFailureDiagnosticObserver
+    private val providerRegistry = components.providers.providerRegistry
+    private val structuredOutputHandler = components.execution.structuredOutputHandler
+    private val toolRegistry = components.tools.toolRegistry
+    private val operationObserver = components.observation.operationObserver
+    private val operationInterceptor = components.observation.operationInterceptor
+    private val responseCache = components.persistence.responseCache
+    private val modelRegistry = components.security.modelRegistry
+    private val modelRegistrySettings = components.security.modelRegistrySettings
+    private val circuitBreakerSettings = components.execution.circuitBreakerSettings
+    private val retryPolicySettings = components.execution.retryPolicySettings
+    private val tokenBudgetSettings = components.execution.tokenBudgetSettings
+    private val promptSanitizer = components.security.promptSanitizer
+    private val chatMemory = components.persistence.chatMemory
+    private val conversationIdProvider = components.persistence.conversationIdProvider
+    private val job = components.execution.job
+    private val scope = components.execution.scope
+    private val dlpInterceptor = components.security.dlpInterceptor
+    private val dlpRedactionAuditEmitter = components.security.dlpRedactionAuditEmitter
+    private val toolResultFilteringSettings = components.tools.toolResultFilteringSettings
+    private val engineEventObserver = components.observation.engineEventObserver
+    private val toolFailureDiagnosticObserver = components.observation.toolFailureDiagnosticObserver
+    private val policyDecisionAuditEmitter = components.security.policyDecisionAuditEmitter
+    private val suspendedInvocationStore = components.approvals.suspendedInvocationStore
+    private val approvalContinuationStore = (components.approvals.capability as? ApprovalCapability.Enabled)?.continuationStore
+    private val toolArgumentsDigester = (components.approvals.capability as? ApprovalCapability.Enabled)?.argumentsDigester
+    private val approvalGateCoordinator = (components.approvals.capability as? ApprovalCapability.Enabled)?.gateCoordinator
+    private val approvalLifecycleAuditEmitter = components.approvals.approvalLifecycleAuditEmitter
+    private val clock = components.execution.clock
+    private val structuredOutputFailureDiagnosticObserver = components.observation.structuredOutputFailureDiagnosticObserver
+
+    constructor(
+        providerRegistry: ProviderRegistry,
+    structuredOutputHandler: StructuredOutputHandler? = null,
+    toolRegistry: ToolRegistry = ToolRegistry(),
+    operationObserver: OperationObserver = NoOpOperationObserver,
+    operationInterceptor: OperationInterceptor = NoOpOperationInterceptor,
+    responseCache: OperationResponseCache = NoOpOperationResponseCache,
+    modelRegistry: ModelRegistry = NoOpModelRegistry,
+    modelRegistrySettings: ModelRegistrySettings = ModelRegistrySettings(),
+    circuitBreakerSettings: CircuitBreakerSettings = CircuitBreakerSettings(),
+    retryPolicySettings: RetryPolicySettings = RetryPolicySettings(),
+    tokenBudgetSettings: TokenBudgetSettings = TokenBudgetSettings(),
+    promptSanitizer: PromptSanitizer? = null,
+    chatMemory: ChatMemory? = null,
+    conversationIdProvider: ConversationIdProvider = UuidConversationIdProvider(),
+    job: Job = SupervisorJob(),
+    scope: CoroutineScope = CoroutineScope(job + Dispatchers.Default),
+    policyEngine: dev.tramai.core.policy.PolicyEngine? = null,
+    dlpInterceptor: DlpInterceptor = NoOpDlpInterceptor,
+    dlpRedactionAuditEmitter: DlpRedactionAuditEmitter = NoOpDlpRedactionAuditEmitter,
+    toolResultFilteringSettings: ToolResultFilteringSettings = ToolResultFilteringSettings(),
+    engineEventObserver: EngineEventObserver = NoOpEngineEventObserver,
+    toolFailureDiagnosticObserver: ToolFailureDiagnosticObserver = NoOpToolFailureDiagnosticObserver,
+    policyDecisionAuditEmitter: PolicyDecisionAuditEmitter = NoOpPolicyDecisionAuditEmitter,
+    // Approval suspension dependencies
+    suspendedInvocationStore: SuspendedInvocationStore = InMemorySuspendedInvocationStore(),
+    approvalContinuationStore: ApprovalContinuationStore? = null,
+    toolArgumentsDigester: ToolArgumentsDigester? = null,
+    approvalGateCoordinator: ApprovalGateCoordinator? = null,
+    approvalLifecycleAuditEmitter: ApprovalLifecycleAuditEmitter = NoOpApprovalLifecycleAuditEmitter,
+    clock: Clock = Clock.systemUTC(),
+) : this(EngineComponentFactory.create(
+    providerRegistry, structuredOutputHandler, toolRegistry, operationObserver, operationInterceptor, responseCache,
+    modelRegistry, modelRegistrySettings, circuitBreakerSettings, retryPolicySettings, tokenBudgetSettings, promptSanitizer,
+    chatMemory, conversationIdProvider, job, scope, policyEngine, dlpInterceptor, dlpRedactionAuditEmitter,
+    toolResultFilteringSettings, engineEventObserver, toolFailureDiagnosticObserver, policyDecisionAuditEmitter,
+    suspendedInvocationStore, approvalContinuationStore, toolArgumentsDigester, approvalGateCoordinator,
+    approvalLifecycleAuditEmitter, clock,
+))
     private val circuitBreaker = ProviderCircuitBreaker(circuitBreakerSettings)
     private val retryDelayPolicy = ProviderRetryDelayPolicy(retryPolicySettings)
     private val migrationWarningGuard = java.util.concurrent.atomic.AtomicBoolean(false)
-    private val resolvedPolicyEngine: PolicyEngine = policyEngine
-        ?: LegacyPermissivePolicyEngine
-    private val isLegacyFallback: Boolean = policyEngine == null
+    private val resolvedPolicyEngine: PolicyEngine = components.security.resolvedPolicyEngine
+    private val isLegacyFallback: Boolean = components.security.isLegacyFallback
     private val resumeOperationRegistry: ResumeOperationRegistry = ResumeOperationRegistry()
     private val closed = java.util.concurrent.atomic.AtomicBoolean(false)
     private val engineThreadMarker = ThreadLocal<Boolean>()
@@ -316,8 +350,8 @@ class TramaiEngine(
         approvalGateCoordinator: ApprovalGateCoordinator? = null,
         approvalLifecycleAuditEmitter: ApprovalLifecycleAuditEmitter = NoOpApprovalLifecycleAuditEmitter,
         clock: Clock = Clock.systemUTC(),
-    ) : this(
-        provider = provider,
+    ) : this(EngineComponentFactory.create(
+        providerRegistry = ProviderRegistry.singleProvider(provider),
         structuredOutputHandler = structuredOutputHandler,
         toolRegistry = toolRegistry,
         operationObserver = operationObserver,
@@ -346,9 +380,8 @@ class TramaiEngine(
         approvalGateCoordinator = approvalGateCoordinator,
         approvalLifecycleAuditEmitter = approvalLifecycleAuditEmitter,
         clock = clock,
-    ) {
-        this.structuredOutputFailureDiagnosticObserver = structuredOutputFailureDiagnosticObserver
-    }
+        structuredOutputFailureDiagnosticObserver = structuredOutputFailureDiagnosticObserver,
+    ))
 
     /**
      * Additive configuration: creates an engine from a provider registry with
@@ -387,7 +420,7 @@ class TramaiEngine(
         approvalGateCoordinator: ApprovalGateCoordinator? = null,
         approvalLifecycleAuditEmitter: ApprovalLifecycleAuditEmitter = NoOpApprovalLifecycleAuditEmitter,
         clock: Clock = Clock.systemUTC(),
-    ) : this(
+    ) : this(EngineComponentFactory.create(
         providerRegistry = providerRegistry,
         structuredOutputHandler = structuredOutputHandler,
         toolRegistry = toolRegistry,
@@ -417,9 +450,8 @@ class TramaiEngine(
         approvalGateCoordinator = approvalGateCoordinator,
         approvalLifecycleAuditEmitter = approvalLifecycleAuditEmitter,
         clock = clock,
-    ) {
-        this.structuredOutputFailureDiagnosticObserver = structuredOutputFailureDiagnosticObserver
-    }
+        structuredOutputFailureDiagnosticObserver = structuredOutputFailureDiagnosticObserver,
+    ))
 
     /**
      * Creates a proxy implementation for the given Tramai service interface.

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/components/EngineComponentFactory.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/components/EngineComponentFactory.kt
@@ -11,8 +11,6 @@ import dev.tramai.core.provider.ProviderRegistry
 import dev.tramai.core.security.*
 import dev.tramai.core.structured.*
 import dev.tramai.engine.*
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
 import java.time.Clock
 
 /** One authoritative composition boundary: validates collaborators and creates the immutable snapshot. */
@@ -22,7 +20,7 @@ internal object EngineComponentFactory {
         operationObserver: OperationObserver, operationInterceptor: OperationInterceptor, responseCache: OperationResponseCache,
         modelRegistry: ModelRegistry, modelRegistrySettings: ModelRegistrySettings, circuitBreakerSettings: CircuitBreakerSettings,
         retryPolicySettings: RetryPolicySettings, tokenBudgetSettings: TokenBudgetSettings, promptSanitizer: PromptSanitizer?,
-        chatMemory: ChatMemory?, conversationIdProvider: ConversationIdProvider, job: Job, scope: CoroutineScope,
+        chatMemory: ChatMemory?, conversationIdProvider: ConversationIdProvider,
         policyEngine: PolicyEngine?, dlpInterceptor: DlpInterceptor, dlpRedactionAuditEmitter: DlpRedactionAuditEmitter,
         toolResultFilteringSettings: ToolResultFilteringSettings, engineEventObserver: EngineEventObserver,
         toolFailureDiagnosticObserver: ToolFailureDiagnosticObserver, policyDecisionAuditEmitter: PolicyDecisionAuditEmitter,
@@ -39,7 +37,7 @@ internal object EngineComponentFactory {
             ApprovalComponents(suspendedInvocationStore, approvalLifecycleAuditEmitter, capability),
             PersistenceComponents(responseCache, chatMemory, conversationIdProvider),
             ObservationComponents(operationObserver, operationInterceptor, engineEventObserver, toolFailureDiagnosticObserver, structuredOutputFailureDiagnosticObserver),
-            ExecutionComponents(structuredOutputHandler, circuitBreakerSettings, retryPolicySettings, tokenBudgetSettings, clock, job, scope),
+            ExecutionComponents(structuredOutputHandler, circuitBreakerSettings, retryPolicySettings, tokenBudgetSettings, clock),
         )
     }
 

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/components/EngineComponentFactory.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/components/EngineComponentFactory.kt
@@ -1,0 +1,55 @@
+package dev.tramai.engine.components
+
+import dev.tramai.core.approval.*
+import dev.tramai.core.memory.ChatMemory
+import dev.tramai.core.memory.ConversationIdProvider
+import dev.tramai.core.model.ModelRegistry
+import dev.tramai.core.model.ModelRegistrySettings
+import dev.tramai.core.observation.*
+import dev.tramai.core.policy.*
+import dev.tramai.core.provider.ProviderRegistry
+import dev.tramai.core.security.*
+import dev.tramai.core.structured.*
+import dev.tramai.engine.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import java.time.Clock
+
+/** One authoritative composition boundary: validates collaborators and creates the immutable snapshot. */
+internal object EngineComponentFactory {
+    @Suppress("LongParameterList")
+    fun create(providerRegistry: ProviderRegistry, structuredOutputHandler: StructuredOutputHandler?, toolRegistry: ToolRegistry,
+        operationObserver: OperationObserver, operationInterceptor: OperationInterceptor, responseCache: OperationResponseCache,
+        modelRegistry: ModelRegistry, modelRegistrySettings: ModelRegistrySettings, circuitBreakerSettings: CircuitBreakerSettings,
+        retryPolicySettings: RetryPolicySettings, tokenBudgetSettings: TokenBudgetSettings, promptSanitizer: PromptSanitizer?,
+        chatMemory: ChatMemory?, conversationIdProvider: ConversationIdProvider, job: Job, scope: CoroutineScope,
+        policyEngine: PolicyEngine?, dlpInterceptor: DlpInterceptor, dlpRedactionAuditEmitter: DlpRedactionAuditEmitter,
+        toolResultFilteringSettings: ToolResultFilteringSettings, engineEventObserver: EngineEventObserver,
+        toolFailureDiagnosticObserver: ToolFailureDiagnosticObserver, policyDecisionAuditEmitter: PolicyDecisionAuditEmitter,
+        suspendedInvocationStore: SuspendedInvocationStore, approvalContinuationStore: ApprovalContinuationStore?,
+        toolArgumentsDigester: ToolArgumentsDigester?, approvalGateCoordinator: ApprovalGateCoordinator?,
+        approvalLifecycleAuditEmitter: ApprovalLifecycleAuditEmitter, clock: Clock,
+        structuredOutputFailureDiagnosticObserver: StructuredOutputFailureDiagnosticObserver = NoOpStructuredOutputFailureDiagnosticObserver,
+    ): EngineComponents {
+        val capability = approvalCapability(approvalContinuationStore, toolArgumentsDigester, approvalGateCoordinator)
+        val resolvedPolicy = policyEngine ?: LegacyPermissivePolicyEngine
+        return EngineComponents(
+            ProviderComponents(providerRegistry), ToolComponents(toolRegistry, toolResultFilteringSettings),
+            SecurityComponents(resolvedPolicy, policyEngine == null, promptSanitizer, modelRegistry, modelRegistrySettings, dlpInterceptor, dlpRedactionAuditEmitter, policyDecisionAuditEmitter),
+            ApprovalComponents(suspendedInvocationStore, approvalLifecycleAuditEmitter, capability),
+            PersistenceComponents(responseCache, chatMemory, conversationIdProvider),
+            ObservationComponents(operationObserver, operationInterceptor, engineEventObserver, toolFailureDiagnosticObserver, structuredOutputFailureDiagnosticObserver),
+            ExecutionComponents(structuredOutputHandler, circuitBreakerSettings, retryPolicySettings, tokenBudgetSettings, clock, job, scope),
+        )
+    }
+
+    fun approvalCapability(continuationStore: ApprovalContinuationStore?, digester: ToolArgumentsDigester?, coordinator: ApprovalGateCoordinator?): ApprovalCapability = when {
+        continuationStore != null || digester != null || coordinator != null -> {
+            require(continuationStore != null && digester != null && coordinator != null) {
+                "Approval suspension requires continuation store, arguments digester, and gate coordinator"
+            }
+            ApprovalCapability.Enabled(continuationStore, digester, coordinator)
+        }
+        else -> ApprovalCapability.Disabled
+    }
+}

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/components/EngineComponents.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/components/EngineComponents.kt
@@ -27,8 +27,6 @@ import dev.tramai.engine.SuspendedInvocationStore
 import dev.tramai.engine.TokenBudgetSettings
 import dev.tramai.engine.ToolRegistry
 import dev.tramai.engine.ToolResultFilteringSettings
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
 import java.time.Clock
 
 /**
@@ -46,13 +44,13 @@ internal data class EngineComponents(
     val execution: ExecutionComponents,
 )
 
-/** Provider routing owned by the engine; registry thread-safety remains its contract. */
+/** Runtime snapshot of provider routing. The snapshot reference is immutable; supplied providers retain their existing ownership and thread-safety contracts. */
 internal data class ProviderComponents(val providerRegistry: ProviderRegistry)
 
-/** Tool resolution owned by the engine; registry/settings are immutable composition references. */
+/** Runtime snapshot of tool resolution and filtering settings. Caller-supplied registries remain caller-owned. */
 internal data class ToolComponents(val toolRegistry: ToolRegistry, val toolResultFilteringSettings: ToolResultFilteringSettings)
 
-/** Security enforcement owned by the engine; collaborators retain their documented thread-safety. */
+/** Runtime snapshot of security enforcement. Caller-supplied policy, registry, DLP, and audit collaborators remain caller-owned. */
 internal data class SecurityComponents(
     val resolvedPolicyEngine: PolicyEngine,
     val isLegacyFallback: Boolean,
@@ -64,7 +62,7 @@ internal data class SecurityComponents(
     val policyDecisionAuditEmitter: PolicyDecisionAuditEmitter,
 )
 
-/** Complete approval capability owned by the engine; partial approval state is unrepresentable. */
+/** Explicit approval capability: partial approval state is unrepresentable. */
 internal sealed interface ApprovalCapability {
     data object Disabled : ApprovalCapability
     data class Enabled(
@@ -74,21 +72,21 @@ internal sealed interface ApprovalCapability {
     ) : ApprovalCapability
 }
 
-/** Approval persistence and auditing owned by the engine; stores define their own thread-safety. */
+/** Approval collaborators used by the engine. Caller-supplied stores and emitters remain caller-owned. */
 internal data class ApprovalComponents(
     val suspendedInvocationStore: SuspendedInvocationStore,
     val approvalLifecycleAuditEmitter: ApprovalLifecycleAuditEmitter,
     val capability: ApprovalCapability,
 )
 
-/** Response persistence owned by the engine; supplied cache and memory retain their contracts. */
+/** Runtime snapshot of persistence. Caller-supplied cache and memory remain caller-owned. */
 internal data class PersistenceComponents(
     val responseCache: OperationResponseCache,
     val chatMemory: ChatMemory?,
     val conversationIdProvider: ConversationIdProvider,
 )
 
-/** Observation hooks owned by the engine; observers must meet their existing thread-safety contracts. */
+/** Runtime snapshot of observation hooks. Caller-supplied observers and interceptors remain caller-owned. */
 internal data class ObservationComponents(
     val operationObserver: OperationObserver,
     val operationInterceptor: OperationInterceptor,
@@ -97,13 +95,16 @@ internal data class ObservationComponents(
     val structuredOutputFailureDiagnosticObserver: StructuredOutputFailureDiagnosticObserver,
 )
 
-/** Execution mechanics owned by the engine; caller-supplied job/scope are retained for ABI compatibility only — close() cancels the engine's internally owned lifecycle job. */
+/**
+ * Runtime snapshot of execution mechanics. Engine execution parents to its internally owned
+ * lifecycle job/scope (PR #226 lifecycle model); the legacy job/scope constructor parameters
+ * of [dev.tramai.engine.TramaiEngine] exist for ABI compatibility only and never cross into
+ * this snapshot.
+ */
 internal data class ExecutionComponents(
     val structuredOutputHandler: StructuredOutputHandler?,
     val circuitBreakerSettings: CircuitBreakerSettings,
     val retryPolicySettings: RetryPolicySettings,
     val tokenBudgetSettings: TokenBudgetSettings,
     val clock: Clock,
-    val job: Job,
-    val scope: CoroutineScope,
 )

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/components/EngineComponents.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/components/EngineComponents.kt
@@ -1,0 +1,109 @@
+package dev.tramai.engine.components
+
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.core.approval.ApprovalGateCoordinator
+import dev.tramai.core.approval.ApprovalLifecycleAuditEmitter
+import dev.tramai.core.approval.ToolArgumentsDigester
+import dev.tramai.core.memory.ChatMemory
+import dev.tramai.core.memory.ConversationIdProvider
+import dev.tramai.core.model.ModelRegistry
+import dev.tramai.core.model.ModelRegistrySettings
+import dev.tramai.core.observation.OperationInterceptor
+import dev.tramai.core.observation.OperationObserver
+import dev.tramai.core.observation.ToolFailureDiagnosticObserver
+import dev.tramai.core.policy.PolicyDecisionAuditEmitter
+import dev.tramai.core.policy.PolicyEngine
+import dev.tramai.core.provider.ProviderRegistry
+import dev.tramai.core.security.DlpInterceptor
+import dev.tramai.core.security.DlpRedactionAuditEmitter
+import dev.tramai.core.security.PromptSanitizer
+import dev.tramai.core.structured.StructuredOutputFailureDiagnosticObserver
+import dev.tramai.core.structured.StructuredOutputHandler
+import dev.tramai.engine.CircuitBreakerSettings
+import dev.tramai.engine.EngineEventObserver
+import dev.tramai.engine.OperationResponseCache
+import dev.tramai.engine.RetryPolicySettings
+import dev.tramai.engine.SuspendedInvocationStore
+import dev.tramai.engine.TokenBudgetSettings
+import dev.tramai.engine.ToolRegistry
+import dev.tramai.engine.ToolResultFilteringSettings
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import java.time.Clock
+
+/**
+ * Immutable, validated runtime configuration snapshot. It is the single frozen
+ * composition input to an engine: all references are final, it retains no builder,
+ * and it performs no lazy reads of builder configuration.
+ */
+internal data class EngineComponents(
+    val providers: ProviderComponents,
+    val tools: ToolComponents,
+    val security: SecurityComponents,
+    val approvals: ApprovalComponents,
+    val persistence: PersistenceComponents,
+    val observation: ObservationComponents,
+    val execution: ExecutionComponents,
+)
+
+/** Provider routing owned by the engine; registry thread-safety remains its contract. */
+internal data class ProviderComponents(val providerRegistry: ProviderRegistry)
+
+/** Tool resolution owned by the engine; registry/settings are immutable composition references. */
+internal data class ToolComponents(val toolRegistry: ToolRegistry, val toolResultFilteringSettings: ToolResultFilteringSettings)
+
+/** Security enforcement owned by the engine; collaborators retain their documented thread-safety. */
+internal data class SecurityComponents(
+    val resolvedPolicyEngine: PolicyEngine,
+    val isLegacyFallback: Boolean,
+    val promptSanitizer: PromptSanitizer?,
+    val modelRegistry: ModelRegistry,
+    val modelRegistrySettings: ModelRegistrySettings,
+    val dlpInterceptor: DlpInterceptor,
+    val dlpRedactionAuditEmitter: DlpRedactionAuditEmitter,
+    val policyDecisionAuditEmitter: PolicyDecisionAuditEmitter,
+)
+
+/** Complete approval capability owned by the engine; partial approval state is unrepresentable. */
+internal sealed interface ApprovalCapability {
+    data object Disabled : ApprovalCapability
+    data class Enabled(
+        val continuationStore: ApprovalContinuationStore,
+        val argumentsDigester: ToolArgumentsDigester,
+        val gateCoordinator: ApprovalGateCoordinator,
+    ) : ApprovalCapability
+}
+
+/** Approval persistence and auditing owned by the engine; stores define their own thread-safety. */
+internal data class ApprovalComponents(
+    val suspendedInvocationStore: SuspendedInvocationStore,
+    val approvalLifecycleAuditEmitter: ApprovalLifecycleAuditEmitter,
+    val capability: ApprovalCapability,
+)
+
+/** Response persistence owned by the engine; supplied cache and memory retain their contracts. */
+internal data class PersistenceComponents(
+    val responseCache: OperationResponseCache,
+    val chatMemory: ChatMemory?,
+    val conversationIdProvider: ConversationIdProvider,
+)
+
+/** Observation hooks owned by the engine; observers must meet their existing thread-safety contracts. */
+internal data class ObservationComponents(
+    val operationObserver: OperationObserver,
+    val operationInterceptor: OperationInterceptor,
+    val engineEventObserver: EngineEventObserver,
+    val toolFailureDiagnosticObserver: ToolFailureDiagnosticObserver,
+    val structuredOutputFailureDiagnosticObserver: StructuredOutputFailureDiagnosticObserver,
+)
+
+/** Execution mechanics owned by the engine. The engine owns scope/job and close() cancels them. */
+internal data class ExecutionComponents(
+    val structuredOutputHandler: StructuredOutputHandler?,
+    val circuitBreakerSettings: CircuitBreakerSettings,
+    val retryPolicySettings: RetryPolicySettings,
+    val tokenBudgetSettings: TokenBudgetSettings,
+    val clock: Clock,
+    val job: Job,
+    val scope: CoroutineScope,
+)

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/components/EngineComponents.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/components/EngineComponents.kt
@@ -97,7 +97,7 @@ internal data class ObservationComponents(
     val structuredOutputFailureDiagnosticObserver: StructuredOutputFailureDiagnosticObserver,
 )
 
-/** Execution mechanics owned by the engine. The engine owns scope/job and close() cancels them. */
+/** Execution mechanics owned by the engine; caller-supplied job/scope are retained for ABI compatibility only — close() cancels the engine's internally owned lifecycle job. */
 internal data class ExecutionComponents(
     val structuredOutputHandler: StructuredOutputHandler?,
     val circuitBreakerSettings: CircuitBreakerSettings,

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalEngineEdgeCaseTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalEngineEdgeCaseTest.kt
@@ -891,33 +891,24 @@ class ApprovalEngineEdgeCaseTest {
     }
 
     @Test
-    fun `missing digester does not consume token`() {
-        // Engine without digester — suspension will fail early because
-        // tool execution requires a digester for approval binding validation.
+    fun `missing digester fails at construction`() {
+        // Epic 2.1: partial approval composition (continuation store + coordinator
+        // without a digester) is unrepresentable in the component model and is
+        // rejected at engine construction — not lazily at tool execution.
         val coordinator = ConfigurableApprovalGateCoordinator()
-        val engine = TramaiEngine(
-            provider = provider,
-            toolRegistry = toolRegistry,
-            policyEngine = policyEngine,
-            suspendedInvocationStore = suspendedInvocationStore,
-            approvalContinuationStore = continuationStore,
-            // No digester
-            approvalGateCoordinator = coordinator,
-            clock = fixedClock,
-        )
-
-        val service = engine.create<TriggerService>()
-
-        // The initial tool execution should fail with ConfigurationException
-        // because the digester is required for approval binding validation.
         assertThatThrownBy {
-            runBlocking { service.execute("input") }
-        }.isInstanceOf(dev.tramai.core.exception.ConfigurationException::class.java)
-            .hasMessageContaining("ToolArgumentsDigester")
-
-        // Coordinator was NEVER called — suspension failed before any approval
-        assertThat(coordinator.lastCreateCommand).isNull()
-        assertThat(coordinator.lastAuthorizeCommand).isNull()
+            TramaiEngine(
+                provider = provider,
+                toolRegistry = toolRegistry,
+                policyEngine = policyEngine,
+                suspendedInvocationStore = suspendedInvocationStore,
+                approvalContinuationStore = continuationStore,
+                // No digester
+                approvalGateCoordinator = coordinator,
+                clock = fixedClock,
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("Approval suspension requires continuation store, arguments digester, and gate coordinator")
     }
 
     @Test

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/EngineComponentsTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/EngineComponentsTest.kt
@@ -41,10 +41,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 
 class EngineComponentsTest {
     @Test
@@ -107,8 +103,6 @@ class EngineComponentsTest {
             promptSanitizer = null,
             chatMemory = null,
             conversationIdProvider = UuidConversationIdProvider(),
-            job = SupervisorJob(),
-            scope = CoroutineScope(Dispatchers.Default),
             policyEngine = null,
             dlpInterceptor = NoOpDlpInterceptor,
             dlpRedactionAuditEmitter = NoOpDlpRedactionAuditEmitter,
@@ -177,8 +171,6 @@ class EngineComponentsTest {
         promptSanitizer: PromptSanitizer? = null,
         chatMemory: ChatMemory? = null,
         conversationIdProvider: ConversationIdProvider = UuidConversationIdProvider(),
-        job: Job = SupervisorJob(),
-        scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
         policyEngine: PolicyEngine? = null,
         dlpInterceptor: DlpInterceptor = NoOpDlpInterceptor,
         dlpRedactionAuditEmitter: DlpRedactionAuditEmitter = NoOpDlpRedactionAuditEmitter,
@@ -207,8 +199,6 @@ class EngineComponentsTest {
         promptSanitizer = promptSanitizer,
         chatMemory = chatMemory,
         conversationIdProvider = conversationIdProvider,
-        job = job,
-        scope = scope,
         policyEngine = policyEngine,
         dlpInterceptor = dlpInterceptor,
         dlpRedactionAuditEmitter = dlpRedactionAuditEmitter,

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/EngineComponentsTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/EngineComponentsTest.kt
@@ -1,0 +1,237 @@
+package dev.tramai.engine
+
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.core.approval.ApprovalGateCoordinator
+import dev.tramai.core.approval.ApprovalLifecycleAuditEmitter
+import dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter
+import dev.tramai.core.approval.ToolArgumentsDigester
+import dev.tramai.core.memory.ChatMemory
+import dev.tramai.core.memory.ConversationIdProvider
+import dev.tramai.core.memory.UuidConversationIdProvider
+import dev.tramai.core.model.ModelRegistry
+import dev.tramai.core.model.ModelRegistrySettings
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.model.NoOpModelRegistry
+import dev.tramai.core.observation.NoOpOperationInterceptor
+import dev.tramai.core.observation.NoOpOperationObserver
+import dev.tramai.core.observation.NoOpToolFailureDiagnosticObserver
+import dev.tramai.core.observation.OperationInterceptor
+import dev.tramai.core.observation.OperationObserver
+import dev.tramai.core.observation.ToolFailureDiagnosticObserver
+import dev.tramai.core.policy.NoOpPolicyDecisionAuditEmitter
+import dev.tramai.core.policy.PolicyDecisionAuditEmitter
+import dev.tramai.core.policy.PolicyEngine
+import dev.tramai.core.provider.ModelProvider
+import dev.tramai.core.provider.ProviderRegistry
+import dev.tramai.core.security.DlpInterceptor
+import dev.tramai.core.security.DlpRedactionAuditEmitter
+import dev.tramai.core.security.NoOpDlpInterceptor
+import dev.tramai.core.security.NoOpDlpRedactionAuditEmitter
+import dev.tramai.core.security.PromptSanitizer
+import dev.tramai.core.structured.StructuredOutputHandler
+import dev.tramai.engine.components.ApprovalCapability
+import dev.tramai.engine.components.EngineComponentFactory
+import dev.tramai.engine.components.EngineComponents
+import java.lang.reflect.Proxy
+import java.time.Clock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+
+class EngineComponentsTest {
+    @Test
+    fun `approval disabled is explicit`() {
+        assertIs<ApprovalCapability.Disabled>(EngineComponentFactory.approvalCapability(null, null, null))
+    }
+
+    @Test
+    fun `complete approval capability is accepted`() {
+        val store = collaborator<ApprovalContinuationStore>()
+        val digester = collaborator<ToolArgumentsDigester>()
+        val coordinator = collaborator<ApprovalGateCoordinator>()
+
+        val capability = assertIs<ApprovalCapability.Enabled>(
+            EngineComponentFactory.approvalCapability(store, digester, coordinator),
+        )
+
+        assertSame(store, capability.continuationStore)
+        assertSame(digester, capability.argumentsDigester)
+        assertSame(coordinator, capability.gateCoordinator)
+    }
+
+    @Test
+    fun `every partial approval combination fails at the composition boundary`() {
+        val store = collaborator<ApprovalContinuationStore>()
+        val digester = collaborator<ToolArgumentsDigester>()
+        val coordinator = collaborator<ApprovalGateCoordinator>()
+        val partials = listOf(
+            Triple(store, null, null), Triple(null, digester, null), Triple(null, null, coordinator),
+            Triple(store, digester, null), Triple(store, null, coordinator), Triple(null, digester, coordinator),
+        )
+
+        partials.forEach { (continuationStore, argumentsDigester, gateCoordinator) ->
+            val failure = runCatching {
+                EngineComponentFactory.approvalCapability(continuationStore, argumentsDigester, gateCoordinator)
+            }.exceptionOrNull()
+            assertIs<IllegalArgumentException>(failure)
+            assertEquals(
+                "Approval suspension requires continuation store, arguments digester, and gate coordinator",
+                failure.message,
+            )
+        }
+    }
+
+    @Test
+    fun `creates a complete default component snapshot`() {
+        val registry = ProviderRegistry.singleProvider(registryTestProvider())
+        val components = EngineComponentFactory.create(
+            providerRegistry = registry,
+            structuredOutputHandler = null,
+            toolRegistry = ToolRegistry(),
+            operationObserver = NoOpOperationObserver,
+            operationInterceptor = NoOpOperationInterceptor,
+            responseCache = NoOpOperationResponseCache,
+            modelRegistry = NoOpModelRegistry,
+            modelRegistrySettings = ModelRegistrySettings(),
+            circuitBreakerSettings = CircuitBreakerSettings(),
+            retryPolicySettings = RetryPolicySettings(),
+            tokenBudgetSettings = TokenBudgetSettings(),
+            promptSanitizer = null,
+            chatMemory = null,
+            conversationIdProvider = UuidConversationIdProvider(),
+            job = SupervisorJob(),
+            scope = CoroutineScope(Dispatchers.Default),
+            policyEngine = null,
+            dlpInterceptor = NoOpDlpInterceptor,
+            dlpRedactionAuditEmitter = NoOpDlpRedactionAuditEmitter,
+            toolResultFilteringSettings = ToolResultFilteringSettings(),
+            engineEventObserver = NoOpEngineEventObserver,
+            toolFailureDiagnosticObserver = NoOpToolFailureDiagnosticObserver,
+            policyDecisionAuditEmitter = NoOpPolicyDecisionAuditEmitter,
+            suspendedInvocationStore = InMemorySuspendedInvocationStore(),
+            approvalContinuationStore = null,
+            toolArgumentsDigester = null,
+            approvalGateCoordinator = null,
+            approvalLifecycleAuditEmitter = NoOpApprovalLifecycleAuditEmitter,
+            clock = Clock.systemUTC(),
+        )
+
+        assertSame(registry, components.providers.providerRegistry)
+        assertIs<ApprovalCapability.Disabled>(components.approvals.capability)
+        assertTrue(components.security.isLegacyFallback)
+        assertSame(LegacyPermissivePolicyEngine, components.security.resolvedPolicyEngine)
+        assertSame(NoOpOperationObserver, components.observation.operationObserver)
+        assertSame(NoOpOperationResponseCache, components.persistence.responseCache)
+    }
+
+    @Test
+    fun `policy resolution happens once at construction`() {
+        val customPolicy = collaborator<PolicyEngine>()
+        val components = createComponents(policyEngine = customPolicy)
+
+        assertFalse(components.security.isLegacyFallback)
+        assertSame(customPolicy, components.security.resolvedPolicyEngine)
+    }
+
+    @Test
+    fun `component snapshot holds final references to the supplied collaborators`() {
+        val store = collaborator<ApprovalContinuationStore>()
+        val digester = collaborator<ToolArgumentsDigester>()
+        val coordinator = collaborator<ApprovalGateCoordinator>()
+        val suspended = InMemorySuspendedInvocationStore()
+
+        val components = createComponents(
+            suspendedInvocationStore = suspended,
+            approvalContinuationStore = store,
+            toolArgumentsDigester = digester,
+            approvalGateCoordinator = coordinator,
+        )
+
+        val enabled = assertIs<ApprovalCapability.Enabled>(components.approvals.capability)
+        assertSame(store, enabled.continuationStore)
+        assertSame(digester, enabled.argumentsDigester)
+        assertSame(coordinator, enabled.gateCoordinator)
+        assertSame(suspended, components.approvals.suspendedInvocationStore)
+    }
+
+    private fun createComponents(
+        providerRegistry: ProviderRegistry = ProviderRegistry.singleProvider(registryTestProvider()),
+        structuredOutputHandler: StructuredOutputHandler? = null,
+        toolRegistry: ToolRegistry = ToolRegistry(),
+        operationObserver: OperationObserver = NoOpOperationObserver,
+        operationInterceptor: OperationInterceptor = NoOpOperationInterceptor,
+        responseCache: OperationResponseCache = NoOpOperationResponseCache,
+        modelRegistry: ModelRegistry = NoOpModelRegistry,
+        modelRegistrySettings: ModelRegistrySettings = ModelRegistrySettings(),
+        circuitBreakerSettings: CircuitBreakerSettings = CircuitBreakerSettings(),
+        retryPolicySettings: RetryPolicySettings = RetryPolicySettings(),
+        tokenBudgetSettings: TokenBudgetSettings = TokenBudgetSettings(),
+        promptSanitizer: PromptSanitizer? = null,
+        chatMemory: ChatMemory? = null,
+        conversationIdProvider: ConversationIdProvider = UuidConversationIdProvider(),
+        job: Job = SupervisorJob(),
+        scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
+        policyEngine: PolicyEngine? = null,
+        dlpInterceptor: DlpInterceptor = NoOpDlpInterceptor,
+        dlpRedactionAuditEmitter: DlpRedactionAuditEmitter = NoOpDlpRedactionAuditEmitter,
+        toolResultFilteringSettings: ToolResultFilteringSettings = ToolResultFilteringSettings(),
+        engineEventObserver: EngineEventObserver = NoOpEngineEventObserver,
+        toolFailureDiagnosticObserver: ToolFailureDiagnosticObserver = NoOpToolFailureDiagnosticObserver,
+        policyDecisionAuditEmitter: PolicyDecisionAuditEmitter = NoOpPolicyDecisionAuditEmitter,
+        suspendedInvocationStore: SuspendedInvocationStore = InMemorySuspendedInvocationStore(),
+        approvalContinuationStore: ApprovalContinuationStore? = null,
+        toolArgumentsDigester: ToolArgumentsDigester? = null,
+        approvalGateCoordinator: ApprovalGateCoordinator? = null,
+        approvalLifecycleAuditEmitter: ApprovalLifecycleAuditEmitter = NoOpApprovalLifecycleAuditEmitter,
+        clock: Clock = Clock.systemUTC(),
+    ): EngineComponents = EngineComponentFactory.create(
+        providerRegistry = providerRegistry,
+        structuredOutputHandler = structuredOutputHandler,
+        toolRegistry = toolRegistry,
+        operationObserver = operationObserver,
+        operationInterceptor = operationInterceptor,
+        responseCache = responseCache,
+        modelRegistry = modelRegistry,
+        modelRegistrySettings = modelRegistrySettings,
+        circuitBreakerSettings = circuitBreakerSettings,
+        retryPolicySettings = retryPolicySettings,
+        tokenBudgetSettings = tokenBudgetSettings,
+        promptSanitizer = promptSanitizer,
+        chatMemory = chatMemory,
+        conversationIdProvider = conversationIdProvider,
+        job = job,
+        scope = scope,
+        policyEngine = policyEngine,
+        dlpInterceptor = dlpInterceptor,
+        dlpRedactionAuditEmitter = dlpRedactionAuditEmitter,
+        toolResultFilteringSettings = toolResultFilteringSettings,
+        engineEventObserver = engineEventObserver,
+        toolFailureDiagnosticObserver = toolFailureDiagnosticObserver,
+        policyDecisionAuditEmitter = policyDecisionAuditEmitter,
+        suspendedInvocationStore = suspendedInvocationStore,
+        approvalContinuationStore = approvalContinuationStore,
+        toolArgumentsDigester = toolArgumentsDigester,
+        approvalGateCoordinator = approvalGateCoordinator,
+        approvalLifecycleAuditEmitter = approvalLifecycleAuditEmitter,
+        clock = clock,
+    )
+
+    private fun registryTestProvider(): ModelProvider = object : ModelProvider {
+        override suspend fun complete(request: ModelRequest): ModelResponse = ModelResponse(content = "test")
+        override fun providerId(): String = "test-provider"
+    }
+
+    private inline fun <reified T> collaborator(): T {
+        assertTrue(T::class.java.isInterface)
+        @Suppress("UNCHECKED_CAST")
+        return Proxy.newProxyInstance(T::class.java.classLoader, arrayOf(T::class.java)) { _, _, _ -> error("unused") } as T
+    }
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/TrustedReplayEnvelopeRegistryTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/TrustedReplayEnvelopeRegistryTest.kt
@@ -384,7 +384,6 @@ class TrustedReplayEnvelopeRegistryTest {
             promptSanitizer = null,
             chatMemory = null,
             conversationIdProvider = UuidConversationIdProvider(),
-            scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
             serviceDefinition = svcDef,
             policyEngine = PolicyEngine { _ -> PolicyDecision.Allow },
             migrationWarningGuard = AtomicBoolean(false),

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/TrustedReplayEnvelopeRegistryTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/TrustedReplayEnvelopeRegistryTest.kt
@@ -1,6 +1,7 @@
 package dev.tramai.engine
 
 import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.engine.components.EngineComponentFactory
 import dev.tramai.core.memory.UuidConversationIdProvider
 import dev.tramai.core.model.Message
 import dev.tramai.core.model.MessageRole
@@ -369,7 +370,7 @@ class TrustedReplayEnvelopeRegistryTest {
 
     /** Creates a [TramaiInvocationHandler] with minimal viable defaults (never dereferenced during registration). */
     private fun dummyHandler(svcDef: ServiceDefinition, registry: ResumeOperationRegistry): TramaiInvocationHandler {
-        return TramaiInvocationHandler(
+        val components = EngineComponentFactory.create(
             providerRegistry = ProviderRegistry.builder().build(),
             structuredOutputHandler = null,
             toolRegistry = ToolRegistry(),
@@ -378,32 +379,35 @@ class TrustedReplayEnvelopeRegistryTest {
             responseCache = NoOpOperationResponseCache,
             modelRegistry = dev.tramai.core.model.NoOpModelRegistry,
             modelRegistrySettings = dev.tramai.core.model.ModelRegistrySettings(),
-            circuitBreaker = ProviderCircuitBreaker(CircuitBreakerSettings()),
-            retryDelayPolicy = ProviderRetryDelayPolicy(RetryPolicySettings()),
+            circuitBreakerSettings = CircuitBreakerSettings(),
+            retryPolicySettings = RetryPolicySettings(),
             tokenBudgetSettings = TokenBudgetSettings(),
             promptSanitizer = null,
             chatMemory = null,
             conversationIdProvider = UuidConversationIdProvider(),
-            serviceDefinition = svcDef,
             policyEngine = PolicyEngine { _ -> PolicyDecision.Allow },
-            migrationWarningGuard = AtomicBoolean(false),
-            isLegacyFallback = false,
             dlpInterceptor = NoOpDlpInterceptor,
             dlpRedactionAuditEmitter = NoOpDlpRedactionAuditEmitter,
             toolResultFilteringSettings = ToolResultFilteringSettings(),
             engineEventObserver = NoOpEngineEventObserver,
             toolFailureDiagnosticObserver = NoOpToolFailureDiagnosticObserver,
-            structuredOutputFailureDiagnosticObserver = dev.tramai.core.structured.NoOpStructuredOutputFailureDiagnosticObserver,
             policyDecisionAuditEmitter = NoOpPolicyDecisionAuditEmitter,
             suspendedInvocationStore = InMemorySuspendedInvocationStore(),
             approvalContinuationStore = null,
             toolArgumentsDigester = null,
             approvalGateCoordinator = null,
             approvalLifecycleAuditEmitter = NoOpApprovalLifecycleAuditEmitter,
-            resumeOperationRegistry = registry,
+            clock = Clock.systemUTC(),
+        )
+        return TramaiInvocationHandler(
+            components = components,
+            circuitBreaker = ProviderCircuitBreaker(CircuitBreakerSettings()),
+            retryDelayPolicy = ProviderRetryDelayPolicy(RetryPolicySettings()),
+            migrationWarningGuard = AtomicBoolean(false),
             lifecycleJob = kotlinx.coroutines.SupervisorJob(),
             lifecycleScope = kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Default),
-            clock = Clock.systemUTC(),
+            serviceDefinition = svcDef,
+            resumeOperationRegistry = registry,
         )
     }
 }

--- a/tramai-standalone/src/main/kotlin/dev/tramai/standalone/Tramai.kt
+++ b/tramai-standalone/src/main/kotlin/dev/tramai/standalone/Tramai.kt
@@ -479,6 +479,9 @@ class Tramai private constructor(
          *
          * @throws IllegalStateException if approval composition is partially configured
          *   (continuation store, digester, and coordinator must all be set or all be null).
+         *   Note: the engine component boundary reports the same misconfiguration as
+         *   [IllegalArgumentException]; this guard intentionally preserves the historical
+         *   builder contract until the lazy-materialization compatibility guard is retired.
          */
         fun build(): Tramai {
             // Compatibility pre-flight: Tramai materializes its engine lazily, but partial

--- a/tramai-standalone/src/main/kotlin/dev/tramai/standalone/Tramai.kt
+++ b/tramai-standalone/src/main/kotlin/dev/tramai/standalone/Tramai.kt
@@ -481,7 +481,10 @@ class Tramai private constructor(
          *   (continuation store, digester, and coordinator must all be set or all be null).
          */
         fun build(): Tramai {
-            // Approval composition must be complete or absent
+            // Compatibility pre-flight: Tramai materializes its engine lazily, but partial
+            // approval composition has historically failed from Builder.build().
+            // EngineComponentFactory remains the authoritative runtime composition boundary.
+            // check() (IllegalStateException) preserves the pre-#228 public contract.
             val hasContinuation = approvalContinuationStore != null
             val hasDigester = toolArgumentsDigester != null
             val hasCoordinator = approvalGateCoordinator != null

--- a/tramai-standalone/src/test/kotlin/dev/tramai/standalone/TramaiComponentCompositionTest.kt
+++ b/tramai-standalone/src/test/kotlin/dev/tramai/standalone/TramaiComponentCompositionTest.kt
@@ -1,0 +1,149 @@
+package dev.tramai.standalone
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.core.approval.ApprovalGateCoordinator
+import dev.tramai.core.approval.ToolArgumentsDigester
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.observation.NoOpOperationObservation
+import dev.tramai.core.observation.OperationObserver
+import dev.tramai.core.provider.ModelProvider
+import java.lang.reflect.Proxy
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * Proves that the standalone composition path produces the same immutable,
+ * validated runtime snapshot as the engine component model — with the public
+ * builder API unchanged.
+ */
+class TramaiComponentCompositionTest {
+
+    @Test
+    fun `partial approval configuration fails at build`() {
+        val store = collaborator<ApprovalContinuationStore>()
+        val digester = collaborator<ToolArgumentsDigester>()
+        val coordinator = collaborator<ApprovalGateCoordinator>()
+
+        val partials = listOf(
+            Triple(store, null, null),
+            Triple(null, digester, null),
+            Triple(null, null, coordinator),
+            Triple(store, digester, null),
+            Triple(store, null, coordinator),
+            Triple(null, digester, coordinator),
+        )
+
+        partials.forEach { (continuationStore, argumentsDigester, gateCoordinator) ->
+            val builder = baseBuilder()
+            if (continuationStore != null) builder.approvalContinuationStore(continuationStore)
+            if (argumentsDigester != null) builder.toolArgumentsDigester(argumentsDigester)
+            if (gateCoordinator != null) builder.approvalGateCoordinator(gateCoordinator)
+
+            assertThatThrownBy { builder.build() }
+                .isInstanceOf(IllegalStateException::class.java)
+                .hasMessage("Approval suspension requires continuation store, arguments digester, and gate coordinator")
+        }
+    }
+
+    @Test
+    fun `complete approval configuration builds and materializes the runtime`() {
+        val tramai = baseBuilder()
+            .approvalContinuationStore(collaborator<ApprovalContinuationStore>())
+            .toolArgumentsDigester(collaborator<ToolArgumentsDigester>())
+            .approvalGateCoordinator(collaborator<ApprovalGateCoordinator>())
+            .build()
+
+        // The capability wiring through the public bridge must not fail.
+        assertThat(tramai.runtime()).isNotNull()
+    }
+
+    @Test
+    fun `builder mutation after build cannot mutate the built runtime`() {
+        val providerACalls = AtomicInteger()
+        val providerA = object : ModelProvider {
+            override suspend fun complete(request: ModelRequest): ModelResponse =
+                ModelResponse(content = "provider-a:${providerACalls.incrementAndGet()}")
+
+            override fun providerId(): String = "mock"
+        }
+        val observerACalls = AtomicInteger()
+        val observerA = OperationObserver {
+            observerACalls.incrementAndGet()
+            NoOpOperationObservation
+        }
+
+        val builder = baseBuilder()
+            .provider(providerA, default = true)
+            .observer(observerA)
+
+        val runtimeA = builder.build()
+
+        // Mutate the builder after build — must not affect the built runtime.
+        val providerBCalls = AtomicInteger()
+        val providerB = object : ModelProvider {
+            override suspend fun complete(request: ModelRequest): ModelResponse =
+                ModelResponse(content = "provider-b:${providerBCalls.incrementAndGet()}")
+
+            override fun providerId(): String = "other"
+        }
+        builder
+            .provider(providerB, default = true)
+            .observer(OperationObserver { NoOpOperationObservation })
+
+        val service = runtimeA.create<GreetingService>()
+        val result = runBlocking { service.greet("world") }
+
+        assertThat(result).isEqualTo("provider-a:1")
+        assertThat(providerBCalls.get()).isZero()
+        assertThat(observerACalls.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `no-op default behaviour remains unchanged`() {
+        val tramai = baseBuilder().build()
+
+        val service = tramai.create<GreetingService>()
+        val result = runBlocking { service.greet("world") }
+
+        assertThat(result).isEqualTo("hello")
+    }
+
+    @Test
+    fun `legacy policy behaviour remains unchanged`() {
+        // No policyEngine configured → permissive legacy fallback, call succeeds.
+        val tramai = baseBuilder().build()
+
+        val service = tramai.create<GreetingService>()
+        assertThat(runBlocking { service.greet("world") }).isEqualTo("hello")
+    }
+
+    @AiService
+    private interface GreetingService {
+        @Operation(model = "mock-model")
+        suspend fun greet(name: String): String
+    }
+
+    private fun baseBuilder(): Tramai.Builder = Tramai.builder()
+        .provider(
+            object : ModelProvider {
+                override suspend fun complete(request: ModelRequest): ModelResponse =
+                    ModelResponse(content = "hello")
+
+                override fun providerId(): String = "mock"
+            },
+            default = true,
+        )
+        .model("mock-model", "mock")
+
+    private inline fun <reified T> collaborator(): T {
+        assertThat(T::class.java.isInterface).isTrue()
+        @Suppress("UNCHECKED_CAST")
+        return Proxy.newProxyInstance(T::class.java.classLoader, arrayOf(T::class.java)) { _, _, _ -> error("unused") } as T
+    }
+}


### PR DESCRIPTION
# refactor(0.6.0): introduce immutable runtime component groups

Closes **Epic 2.1** (Runtime Composition Model — Phase 2, first PR).

## What & why

`TramaiEngine` had ~30 flat constructor dependencies (registries, observers, caches, policy,
DLP, approval stores, lifecycle objects, clock) with nullable capability clusters validated
scattered across builders and discovered lazily at runtime. This PR replaces that with an
**immutable, validated runtime configuration snapshot** — one authoritative composition
boundary. Pure architectural refactor: zero public API change and no execution-semantic changes,
except the intentional Epic 2.1 fail-fast rejection of invalid partial composition.

## Component model

```
EngineComponents
├── ProviderComponents     providerRegistry
├── ToolComponents         toolRegistry, toolResultFilteringSettings
├── SecurityComponents     resolvedPolicyEngine (+isLegacyFallback), promptSanitizer,
│                          modelRegistry/settings, DLP interceptor + redaction audit,
│                          policy decision audit
├── ApprovalComponents     suspendedInvocationStore, approvalLifecycleAuditEmitter,
│                          capability: ApprovalCapability (Disabled | Enabled)
├── PersistenceComponents  responseCache, chatMemory, conversationIdProvider
├── ObservationComponents  operationObserver/interceptor, engineEventObserver,
│                          toolFailure + structured-output diagnostic observers
└── ExecutionComponents    structuredOutputHandler, circuitBreaker/retry/tokenBudget
                           settings, clock, job, scope
```

- **`ApprovalCapability`** (sealed): the nullable continuation-store/digester/coordinator
  triple is replaced by an explicit `Disabled`/`Enabled` state — partial approval composition
  is unrepresentable in the runtime model.
- **`EngineComponentFactory`**: the one boundary where validation + snapshot happens.
  Policy fallback (`policyEngine ?: LegacyPermissivePolicyEngine`) is resolved at
  construction, not during execution. All 6 partial approval states are rejected with
  `IllegalArgumentException`; 2 valid states accepted.
- **`TramaiEngine`**: canonical internal constructor takes the snapshot; the 5 published JVM
  constructor descriptors are preserved **byte-identical** via a compatibility bridge
  (`public ctor → EngineComponentFactory.create(...) → internal ctor`). The engine and its
  central `TramaiInvocationHandler` coordinator both consume the snapshot directly and derive
  same-named locals from it — execution method bodies are untouched.
- **`Tramai.Builder.build()`**: keeps its `check()` pre-flight (IllegalStateException) as a
  compatibility guard — `Tramai` materializes its engine lazily, so this keeps the public
  failure point at `build()`; the factory remains authoritative.

## Behaviour change (intentional, per Epic 2.1)

| Before | After |
|--------|-------|
| Partial approval config accepted by `TramaiEngine`, fails lazily at tool execution | Partial approval config rejected at construction (`IllegalArgumentException`) |
| Policy fallback resolved in the engine body | Policy fallback resolved once at construction |

## Immutability contract

The composition snapshot is immutable after construction: TramAI does not dynamically
substitute dependencies or retain mutable builder configuration. Caller-supplied
collaborators (providers, stores, observers) retain their documented ownership/thread-safety
semantics — snapshot immutability is claimed, not deep immutability of caller-owned objects.

## Tests

- `EngineComponentsTest` (tramai-engine): default snapshot complete; policy resolution at
  construction (legacy + custom); final-reference identity; all 8 approval states
  (2 valid + 6 partial, exact message asserted)
- `TramaiComponentCompositionTest` (standalone): partial approval fails at `build()`
  (IllegalStateException, pre-#228 contract); builder mutation after build cannot mutate the
  built runtime (provider + observer freeze); no-op defaults; legacy policy; complete
  approval wires through the bridge
- `ApprovalEngineEdgeCaseTest.missing digester`: adapted from lazy-execution failure to
  construction rejection (the old premise no longer exists — that is the epic's invariant)

## Quality

- `verifyPr -PchangeClass=runtime-behaviour` ✅ (maintainability baseline PASSED via MQ-0017,
  change policy PASSED)
- `:tramai-engine:apiCheck` / `:tramai-standalone:apiCheck` ✅ — API dumps **byte-identical**
- `verifyCancellationSafety` ✅ (292 findings, no new critical/high)

**MQ-0017 deviation** (4 `NEW_GLOBAL_STATE_FINDING` in `:tramai-engine`): the scanner counts
the component snapshot's public data-class fields (typed `ProviderRegistry`/`ToolRegistry`/
`ModelRegistry`) as exposed registry state. They are immutable final snapshot references —
the frozen configuration boundary. Resolves when the scanner distinguishes snapshot refs.

## Non-goals (explicit)

1. No provider-routing redesign — Epic 2.2 (ProviderComponents wraps today's authoritative registry)
2. No execution-pipeline extraction — Phase 3 (the snapshot-derived locals are intentionally
   kept; they dissolve naturally during coordinator extraction)
3. No policy/approval/retry semantic changes
4. No new public configuration API
5. No constructor cleanup that breaks ABI
6. No opportunistic `TramaiEngine.kt` cleanup


---

## Fix Round 1 (review findings addressed)

| Finding | Fix |
|---------|-----|
| P2: ABI-only caller job/scope in ExecutionComponents look like real runtime dependencies | Removed `job`/`scope` from `ExecutionComponents` and `EngineComponentFactory.create(...)`; public ctor descriptors untouched (still accept `job`/`scope`); the dead handler `scope` param and dead engine locals removed. Runtime already parents all work to the internally owned `lifecycleJob`/`lifecycleScope` (PR #226) — verified no launch path ever used the compat scope |
| P3: Component KDocs blur caller vs engine ownership | Reworded all 7 group KDocs: "Runtime snapshot of X; caller-supplied collaborators remain caller-owned" |
| P3: PR claimed Epic 2.1 complete without roadmap update | `docs/ROADMAP-0.6.0.md`: Epic 2.1 marked ✅ Complete — PR #228 (tasks + acceptance criteria checked) |
| P3: "zero intentional behaviour change" contradicts the documented approval fail-fast | Opening + CHANGELOG reworded: "zero public API change and no execution-semantic changes, except the intentional Epic 2.1 fail-fast rejection of invalid partial composition" |


---

## Fix Round 2 (review findings addressed)

| Finding | Fix |
|---------|-----|
| **P2**: `TramaiInvocationHandler` still received the flat 30-dependency explosion, so the composition boundary stopped one layer too early | Handler now takes `EngineComponents` + explicit runtime-created state (circuit breaker, retry policy, lifecycle job/scope, service definition, resume registry); the ~30 config dependencies are derived as same-named locals from the snapshot. Method bodies untouched; the approval triple derives from `ApprovalCapability` |
| P3: PR body still listed job/scope in ExecutionComponents | Body corrected (job/scope removed; engine/handler snapshot-consumption phrasing updated) |
| P3: stale `[job]`/`[scope]` KDoc symbol links | Reworded to plain text: "legacy caller-supplied job / scope constructor parameters" (lifecycle + close() docs) |
| P3: recovered DLP named-arg indentation | All 4 `sanitizeToolText` call blocks re-aligned to the original indentation |

Gates on the new head: `verifyPr -PchangeClass=runtime-behaviour` ✅ · `apiCheck` (both) ✅ · `verifyCancellationSafety` ✅ (292/292) · engine + standalone suites green.
