### PR TITLE
ci: add 30-minute timeout to sovereign runtime closure step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
         run: ./gradlew :examples:spring-sovereign-starter:e2eTest
 
       - name: Verify Sovereign Runtime closure
+        timeout-minutes: 30
         run: ./gradlew verifySovereignRuntimeClosure --no-configuration-cache --rerun-tasks -PtramaiPublishReleaseUrl=
 
       - name: Upload SBOM

--- a/.github/workflows/sovereign-runtime-release-candidate.yml
+++ b/.github/workflows/sovereign-runtime-release-candidate.yml
@@ -73,6 +73,7 @@ jobs:
           echo "Resolved version: ${RESOLVED_VERSION}"
 
       - name: Verify sovereign runtime release candidate
+        timeout-minutes: 30
         run: ./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks
 
       - name: Upload test reports on failure


### PR DESCRIPTION
## Summary

CI hardening: add a **30-minute timeout** to the `Verify Sovereign Runtime closure` step in `ci.yml`.

The step aggregates a large Gradle graph (`check`, `verifySovereignRuntimeReleaseCandidate`, `:examples:spring-sovereign-starter:e2eTest`, `verifySovereignRuntimeClosureDocs`, `verifySovereignRuntimeApiBoundary`) and runs with `--rerun-tasks`. It has repeatedly stalled for hours with **no failure boundary** — one observed run remained in this step ~6 hours before termination. A deadlock inside the aggregate should fail loudly in minutes, not consume runner time indefinitely.

## Change

Two workflow files, one line each:

**`.github/workflows/ci.yml`** (closure step):

```yaml
- name: Verify Sovereign Runtime closure
  timeout-minutes: 30
  run: ./gradlew verifySovereignRuntimeClosure --no-configuration-cache --rerun-tasks -PtramaiPublishReleaseUrl=
```

**`.github/workflows/sovereign-runtime-release-candidate.yml`** (release-candidate step):

```yaml
- name: Verify sovereign runtime release candidate
  timeout-minutes: 30
  run: ./gradlew verifySovereignRuntimeReleaseCandidate --no-configuration-cache --rerun-tasks
```

(The RC step shows the same intermittent indefinite-hang pattern as the closure step — it aggregates a large `--rerun-tasks` verification graph and has been observed running well past its normal ~7-minute duration.)

## Notes

- Workflow-only change (`ci-workflow`); no production source, tests, or build files touched (`.github/AGENTS.md` rule 5 satisfied).
- This is NOT a fix for the underlying deadlock — it is a failure boundary so the next hang is diagnosed from a fresh 30-minute log instead of a 6-hour one.
- Background: PR #230's characterization tests complete successfully; the hang is inside the sovereign closure aggregate and reproduces independently of the PR's test-only changes (same code passed CI in 12m41s on an earlier commit, including this step).

## Verification

- `./gradlew verifyChangePolicy -PchangeClass=ci-workflow` — BUILD SUCCESSFUL
