### PR TITLE
refactor(engine): extract operation planning

### DIFF
--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -549,22 +549,29 @@ A deterministic execution-trace test fixture that records ordered semantic event
 
 ## Epic 3.2: Extract operation planning
 
+> **Status: ✅ Complete — PR #232** (`refactor(engine): extract operation planning`)
+
 **Goal:** Separate reflection and operation-definition work from runtime execution.
 
 ### Components
 
-- `ServiceDefinitionCompiler`
-- `OperationDefinitionCompiler`
-- `OperationExecutionPlan`
-- `OperationFingerprintFactory`
+- `ServiceDefinitionCompiler` — service validation, `@SystemPrompt` extraction, method enumeration
+- `OperationDefinitionCompiler` — tool resolution + plan construction (delegates to public `OperationDefinition.create`)
+- `OperationExecutionPlan` — internal immutable plan (definition + fingerprint + service/method identity)
+- `OperationFingerprintFactory` — canonical cache fingerprint, byte-identical to pre-extraction
 
 ### Tasks
 
-1. Move service and operation metadata compilation out of the engine file.
-2. Make operation plans immutable.
-3. Cache safe reusable metadata where appropriate.
-4. Keep reflection failures explicit and deterministic.
-5. Preserve Java and Kotlin interop behaviour.
+1. ✅ Move service and operation metadata compilation out of the engine file (`tramai-engine/.../planning/`).
+2. ✅ Make operation plans immutable (`OperationExecutionPlan` internal data class).
+3. ⏸️ Cache safe reusable metadata — deferred: no process-global reflection cache per 0.6.0 goals; engine-scoped compiler instance only. Revisit after benchmark evidence.
+4. ✅ Keep reflection failures explicit and deterministic (compiler throws `ConfigurationException`/`IllegalArgumentException` identically to pre-extraction).
+5. ✅ Preserve Java and Kotlin interop behaviour (Java fixture `JavaPlanningService` + Kotlin service tests through the compiler).
+
+### Merge gate
+
+- 20 characterization traces byte-identical (no `.trace` changes).
+- `OperationDefinition` public API unchanged (`:tramai-engine:apiCheck` clean).
 
 ---
 

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -556,7 +556,7 @@ A deterministic execution-trace test fixture that records ordered semantic event
 ### Components
 
 - `ServiceDefinitionCompiler` — service validation, `@SystemPrompt` extraction, method enumeration
-- `OperationDefinitionCompiler` — tool resolution + plan construction (delegates to public `OperationDefinition.create`)
+- `OperationDefinitionCompiler` — authoritative operation reflection/metadata compiler; `OperationDefinition.create()` is a public compatibility façade delegating to it
 - `OperationExecutionPlan` — internal immutable plan (definition + fingerprint + service/method identity)
 - `OperationFingerprintFactory` — canonical cache fingerprint, byte-identical to pre-extraction
 

--- a/docs/journal/2026-08-15-operation-planning.md
+++ b/docs/journal/2026-08-15-operation-planning.md
@@ -1,0 +1,29 @@
+# Implementation Status — 2026-08-15
+
+## What's Been Implemented
+
+**PR #232 — `refactor(engine): extract operation planning`** (Phase 3 / Epic 3.2: Extract operation planning)
+
+- New `dev.tramai.engine.planning` package with 4 internal components:
+  - `ServiceDefinitionCompiler` — service validation, @SystemPrompt extraction, method enumeration
+  - `OperationDefinitionCompiler` — tool resolution + plan construction (delegates to public `OperationDefinition.create`)
+  - `OperationExecutionPlan` — immutable plan (definition + fingerprint + service/method identity)
+  - `OperationFingerprintFactory` — canonical cache fingerprint, byte-identical to pre-extraction
+- `create()` / `registerService()` share one engine-scoped compiler (no duplicated `ServiceDefinition.create`)
+- `ServiceDefinition.operations` → `Map<Method, OperationExecutionPlan>`; handler resolves plan, consumes `plan.definition`
+- 23 new tests: compiler suites (Kotlin + Java interop fixture `JavaPlanningService.java`), fingerprint determinism + byte-identity vs legacy, repeated-compilation plan equality, engine wiring
+- 20 PR #230 characterization traces byte-identical; `OperationDefinition` public API unchanged (`:tramai-engine:apiCheck` clean)
+- Roadmap: Epic 3.2 → ✅ Complete (PR #232)
+
+## What's Missing / Blocked
+
+- Task 3 of Epic 3.2 ("cache safe reusable metadata") deliberately deferred — no process-global reflection cache per 0.6.0 goals; revisit after benchmark evidence
+- Plan `fingerprint` field is compile-time metadata; threading it into runtime cache-key construction deferred to Epic 3.3 (reviewer P3)
+- Next: Epic 3.3 — Extract provider execution (`ProviderExecutionCoordinator`, `ProviderAttemptExecutor`, `ProviderRetryPolicy`, `ProviderFallbackPolicy`, `ProviderAuthorizationService`)
+
+## Current State
+
+- Branch `refactor/0.6.0-operation-planning` pushed; PR #232 open: https://github.com/GionaGranchelli/tramAI/pull/232
+- Local gates green: engine suite (2m14s), characterization ×3 (20/20), `:tramai-engine:apiCheck`, `verifyCancellationSafety`, `verifyPr -PchangeClass=runtime-behaviour`
+- Review (delegate_task subagent): APPROVE — no P1/P2, 4 P3 (2 addressed: repeated-compilation equality test + legacy-snapshot comment; 2 deferred to Epic 3.3)
+- Known pre-existing (not this PR): `examples/governed-workflow` apiCheck fails on master itself

--- a/docs/journal/2026-08-15-operation-planning.md
+++ b/docs/journal/2026-08-15-operation-planning.md
@@ -6,11 +6,12 @@
 
 - New `dev.tramai.engine.planning` package with 4 internal components:
   - `ServiceDefinitionCompiler` — service validation, @SystemPrompt extraction, method enumeration
-  - `OperationDefinitionCompiler` — tool resolution + plan construction (delegates to public `OperationDefinition.create`)
+  - `OperationDefinitionCompiler` — authoritative operation reflection/metadata compiler (Kotlin reflection, suspend detection, parameter metadata, return-kind/type resolution, annotation validation); `OperationDefinition.create()` is a public compatibility façade delegating to it
   - `OperationExecutionPlan` — immutable plan (definition + fingerprint + service/method identity)
   - `OperationFingerprintFactory` — canonical cache fingerprint, byte-identical to pre-extraction
 - `create()` / `registerService()` share one engine-scoped compiler (no duplicated `ServiceDefinition.create`)
 - `ServiceDefinition.operations` → `Map<Method, OperationExecutionPlan>`; handler resolves plan, consumes `plan.definition`
+- `OperationExecutionPlan.fingerprint` is consumed by the runtime cache path — no per-invocation fingerprint recomputation on normal compiled execution (`buildCacheKey` accepts the precomputed fingerprint; `executeRaw`/`executeStructured` pass `plan.fingerprint`)
 - 23 new tests: compiler suites (Kotlin + Java interop fixture `JavaPlanningService.java`), fingerprint determinism + byte-identity vs legacy, repeated-compilation plan equality, engine wiring
 - 20 PR #230 characterization traces byte-identical; `OperationDefinition` public API unchanged (`:tramai-engine:apiCheck` clean)
 - Roadmap: Epic 3.2 → ✅ Complete (PR #232)
@@ -18,12 +19,11 @@
 ## What's Missing / Blocked
 
 - Task 3 of Epic 3.2 ("cache safe reusable metadata") deliberately deferred — no process-global reflection cache per 0.6.0 goals; revisit after benchmark evidence
-- Plan `fingerprint` field is compile-time metadata; threading it into runtime cache-key construction deferred to Epic 3.3 (reviewer P3)
 - Next: Epic 3.3 — Extract provider execution (`ProviderExecutionCoordinator`, `ProviderAttemptExecutor`, `ProviderRetryPolicy`, `ProviderFallbackPolicy`, `ProviderAuthorizationService`)
 
 ## Current State
 
 - Branch `refactor/0.6.0-operation-planning` pushed; PR #232 open: https://github.com/GionaGranchelli/tramAI/pull/232
 - Local gates green: engine suite (2m14s), characterization ×3 (20/20), `:tramai-engine:apiCheck`, `verifyCancellationSafety`, `verifyPr -PchangeClass=runtime-behaviour`
-- Review (delegate_task subagent): APPROVE — no P1/P2, 4 P3 (2 addressed: repeated-compilation equality test + legacy-snapshot comment; 2 deferred to Epic 3.3)
+- Review round 1 (delegate_task subagent): APPROVE — no P1/P2, 4 P3 (2 addressed in-PR, 2 noted). Review round 2 (user): P2 on reflection ownership fixed by moving the implementation into `OperationDefinitionCompiler` (public `create()` now a façade); P3 fingerprint threading completed in-PR. Final verdict: code-ready, no P1/P2.
 - Known pre-existing (not this PR): `examples/governed-workflow` apiCheck fails on master itself

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ResumeDefinitionDigestHelper.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ResumeDefinitionDigestHelper.kt
@@ -1,6 +1,7 @@
 package dev.tramai.engine
 
 import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.engine.planning.ServiceDefinition
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ResumeOperationRegistry.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ResumeOperationRegistry.kt
@@ -1,6 +1,7 @@
 package dev.tramai.engine
 
 import dev.tramai.core.exception.ConfigurationException
+import dev.tramai.engine.planning.ServiceDefinition
 import java.util.concurrent.locks.ReentrantReadWriteLock
 
 /**
@@ -96,7 +97,8 @@ internal class ResumeOperationRegistry {
         serviceDefinition: ServiceDefinition,
         handler: TramaiInvocationHandler,
     ) = withWriteLock {
-        val entries = serviceDefinition.operations.entries.map { (_, operation) ->
+        val entries = serviceDefinition.operations.entries.map { (_, plan) ->
+            val operation = plan.definition
             val key = createKey(serviceDefinition, operation)
             val reference = ResumeOperationReference(
                 serviceInterface = key.serviceInterface,

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -117,9 +117,6 @@ import java.util.Base64
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
 import kotlin.reflect.KClass
-import kotlin.reflect.KFunction
-import kotlin.reflect.KParameter
-import kotlin.reflect.jvm.kotlinFunction
 import dev.tramai.engine.components.ApprovalCapability
 import dev.tramai.engine.components.EngineComponentFactory
 import dev.tramai.engine.components.EngineComponents
@@ -1510,6 +1507,7 @@ internal class TramaiInvocationHandler(
         val cacheKey = operation.takeIf { isSafeCacheEligible(it, conversationId) }?.buildCacheKey(
             digestSource = effectiveMessages,
             securityPartition = securityContext.toCacheSecurityPartition(),
+            operationFingerprint = serviceDefinition.operations[operation.method]?.fingerprint,
         )
 
         cacheKey?.let { key ->
@@ -1609,6 +1607,7 @@ internal class TramaiInvocationHandler(
         val cacheKey = operation.takeIf { isSafeCacheEligible(it, conversationId) }?.buildCacheKey(
             digestSource = effectiveMessages,
             securityPartition = securityContext.toCacheSecurityPartition(),
+            operationFingerprint = serviceDefinition.operations[operation.method]?.fingerprint,
         )
 
         cacheKey?.let { key ->
@@ -4751,13 +4750,14 @@ data class OperationDefinition(
     internal fun buildCacheKey(
         digestSource: List<Message>,
         securityPartition: CacheSecurityPartition,
+        operationFingerprint: String? = null,
     ): OperationCacheKey = OperationCacheKey(
         serviceInterface = method.declaringClass.name,
         methodName = method.name,
         requestedModel = operation.model,
         explicitProvider = operation.provider.takeIf { it.isNotBlank() },
         requestDigest = sha256Hex(CanonicalMessageEncoder.encode(digestSource)),
-        operationFingerprint = OperationFingerprintFactory().create(toolDefinitions, operation),
+        operationFingerprint = operationFingerprint ?: OperationFingerprintFactory().create(toolDefinitions, operation),
         securityPartition = securityPartition,
     )
 
@@ -4768,6 +4768,10 @@ data class OperationDefinition(
     )
 
     companion object {
+        /**
+         * Public compatibility façade. The reflection/validation implementation
+         * lives in [dev.tramai.engine.planning.OperationDefinitionCompiler.compileDefinition].
+         */
         fun create(
             method: Method,
             operation: Operation,
@@ -4776,119 +4780,15 @@ data class OperationDefinition(
             userAnnotations: List<String> = emptyList(),
             toolDefinitions: List<ToolDefinition> = emptyList(),
             promptSanitizer: PromptSanitizer? = null,
-        ): OperationDefinition {
-            validateOperationAnnotation(method, operation)
-            warnOnSystemPromptShadowing(method, systemAnnotations, classLevelSystemPrompt)
-
-            val kotlinFunction = runCatching { method.kotlinFunction }.getOrNull()
-            val isSuspend = kotlinFunction?.isSuspend ?: method.isSuspendSignature()
-            val parameterNames = resolveParameterNames(method, kotlinFunction)
-            val returnType = resolveReturnType(kotlinFunction)
-            val returnKind = resolveReturnKind(method, isSuspend, returnType)
-            val returnTypeDescription = resolveReturnTypeDescription(method, returnType)
-
-            return OperationDefinition(
-                method = method,
-                operation = operation,
-                classLevelSystemPrompt = classLevelSystemPrompt,
-                systemAnnotations = systemAnnotations,
-                userAnnotations = userAnnotations,
-                isSuspend = isSuspend,
-                parameterNames = parameterNames,
-                returnKind = returnKind,
-                returnType = returnType,
-                returnTypeDescription = returnTypeDescription,
-                toolDefinitions = toolDefinitions,
-                promptSanitizer = promptSanitizer,
-            )
-        }
-
-        /**
-         * Validates operation annotation values before building executable metadata.
-         */
-        private fun validateOperationAnnotation(method: Method, operation: Operation) {
-            require(operation.maxRetries >= 0) {
-                "@Operation(maxRetries) must be zero or greater for ${method.declaringClass.name}.${method.name}"
-            }
-            require(operation.providerRetries >= 0) {
-                "@Operation(providerRetries) must be zero or greater for ${method.declaringClass.name}.${method.name}"
-            }
-            require(operation.timeoutMillis > 0) {
-                "@Operation(timeoutMillis) must be greater than zero for ${method.declaringClass.name}.${method.name}"
-            }
-            require(!operation.cacheable || operation.cacheTtlMillis > 0) {
-                "@Operation(cacheTtlMillis) must be greater than zero when caching is enabled for ${method.declaringClass.name}.${method.name}"
-            }
-        }
-
-        /**
-         * Emits the precedence warning when method-level system messages shadow the class prompt.
-         */
-        private fun warnOnSystemPromptShadowing(
-            method: Method,
-            systemAnnotations: List<String>,
-            classLevelSystemPrompt: String?,
-        ) {
-            if (systemAnnotations.isEmpty() || classLevelSystemPrompt.isNullOrBlank()) {
-                return
-            }
-            val logger = System.getLogger("dev.tramai.engine.OperationDefinition")
-            logger.log(
-                System.Logger.Level.WARNING,
-                "@System on ${method.declaringClass.name}.${method.name} takes precedence over @SystemPrompt on the class",
-            )
-        }
-
-        private fun resolveParameterNames(
-            method: Method,
-            kotlinFunction: KFunction<*>?,
-        ): List<String> {
-            val valueParameters = kotlinFunction?.parameters
-                ?.filter { it.kind == KParameter.Kind.VALUE }
-                ?.map { it.name ?: "arg${it.index}" }
-            if (valueParameters != null) {
-                return valueParameters
-            }
-
-            return method.parameters.mapIndexed { index, parameter ->
-                parameter.name?.takeIf { it.isNotBlank() } ?: "arg$index"
-            }
-        }
-
-        private fun resolveReturnKind(
-            method: Method,
-            isSuspend: Boolean,
-            returnType: kotlin.reflect.KType?,
-        ): ReturnKind {
-            val classifier = returnType?.classifier
-            return when (classifier) {
-                String::class -> ReturnKind.STRING
-                Unit::class -> ReturnKind.UNIT
-                kotlinx.coroutines.flow.Flow::class -> ReturnKind.STREAMING
-                null -> when {
-                    isSuspend -> throw ConfigurationException(
-                        "Suspend method ${method.declaringClass.name}.${method.name} requires Kotlin reflection metadata to inspect its return type",
-                    )
-                    method.returnType == String::class.java -> ReturnKind.STRING
-                    method.returnType == Void.TYPE -> ReturnKind.UNIT
-                    kotlinx.coroutines.flow.Flow::class.java.isAssignableFrom(method.returnType) -> ReturnKind.STREAMING
-                    else -> ReturnKind.STRUCTURED
-                }
-                else -> ReturnKind.STRUCTURED
-            }
-        }
-
-        private fun resolveReturnType(
-            kotlinFunction: KFunction<*>?,
-        ) = kotlinFunction?.returnType
-
-        private fun resolveReturnTypeDescription(
-            method: Method,
-            returnType: kotlin.reflect.KType?,
-        ): String = returnType?.toString() ?: method.genericReturnType.typeName
-
-        private fun Method.isSuspendSignature(): Boolean =
-            parameterTypes.lastOrNull()?.name == "kotlin.coroutines.Continuation"
+        ): OperationDefinition = dev.tramai.engine.planning.OperationDefinitionCompiler.compileDefinition(
+            method = method,
+            operation = operation,
+            classLevelSystemPrompt = classLevelSystemPrompt,
+            systemAnnotations = systemAnnotations,
+            userAnnotations = userAnnotations,
+            toolDefinitions = toolDefinitions,
+            promptSanitizer = promptSanitizer,
+        )
     }
 }
 

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -123,6 +123,10 @@ import kotlin.reflect.jvm.kotlinFunction
 import dev.tramai.engine.components.ApprovalCapability
 import dev.tramai.engine.components.EngineComponentFactory
 import dev.tramai.engine.components.EngineComponents
+import dev.tramai.engine.planning.OperationDefinitionCompiler
+import dev.tramai.engine.planning.OperationFingerprintFactory
+import dev.tramai.engine.planning.ServiceDefinition
+import dev.tramai.engine.planning.ServiceDefinitionCompiler
 import dev.tramai.core.provider.resolveCandidates
 
 private const val MAX_SAFE_TOOL_NAME_LENGTH = 128
@@ -146,6 +150,11 @@ class TramaiEngine private constructor(
     private val retryPolicySettings = components.execution.retryPolicySettings
     private val tokenBudgetSettings = components.execution.tokenBudgetSettings
     private val promptSanitizer = components.security.promptSanitizer
+    private val serviceDefinitionCompiler by lazy {
+        ServiceDefinitionCompiler(
+            OperationDefinitionCompiler(toolRegistry, promptSanitizer, OperationFingerprintFactory()),
+        )
+    }
     private val chatMemory = components.persistence.chatMemory
     private val conversationIdProvider = components.persistence.conversationIdProvider
     private val dlpInterceptor = components.security.dlpInterceptor
@@ -451,11 +460,7 @@ class TramaiEngine private constructor(
      */
     fun <T : Any> create(serviceType: KClass<T>): T {
         check(!closed.get()) { "Tramai runtime is closed" }
-        val definition = ServiceDefinition.create(
-            serviceType = serviceType,
-            toolRegistry = toolRegistry,
-            promptSanitizer = promptSanitizer,
-        )
+        val definition = serviceDefinitionCompiler.compile(serviceType)
         val handler = TramaiInvocationHandler(
             components = components,
             circuitBreaker = circuitBreaker,
@@ -493,11 +498,7 @@ class TramaiEngine private constructor(
      */
     fun registerService(serviceType: KClass<*>) {
         check(!closed.get()) { "Tramai runtime is closed" }
-        val definition = ServiceDefinition.create(
-            serviceType = serviceType,
-            toolRegistry = toolRegistry,
-            promptSanitizer = promptSanitizer,
-        )
+        val definition = serviceDefinitionCompiler.compile(serviceType)
         val handler = TramaiInvocationHandler(
             components = components,
             circuitBreaker = circuitBreaker,
@@ -702,8 +703,9 @@ internal class TramaiInvocationHandler(
 
         check(!isClosed.get()) { "Tramai runtime is closed" }
 
-        val operation = serviceDefinition.operations[method]
+        val plan = serviceDefinition.operations[method]
             ?: throw ConfigurationException("No operation metadata registered for ${method.name}")
+        val operation = plan.definition
 
         val conversationId = if (chatMemory != null) resolveConversationId(method, args.orEmpty()) else null
         return if (operation.isSuspend) {
@@ -4548,85 +4550,6 @@ internal class TramaiInvocationHandler(
             dlpInterceptor === NoOpDlpInterceptor
 }
 
-internal data class ServiceDefinition(
-    val serviceType: KClass<*>,
-    val systemPrompt: String?,
-    val operations: Map<Method, OperationDefinition>,
-) {
-    companion object {
-        fun create(
-            serviceType: KClass<*>,
-            toolRegistry: ToolRegistry,
-            promptSanitizer: PromptSanitizer?,
-        ): ServiceDefinition {
-            val javaType = validateServiceType(serviceType)
-
-            val systemPrompt = serviceType.java.getAnnotation(SystemPrompt::class.java)?.value?.takeIf { it.isNotBlank() }
-            val operations = javaType.methods
-                .filterNot { it.declaringClass == Any::class.java }
-                .associateWith { method ->
-                    createOperationDefinition(javaType, method, systemPrompt, toolRegistry, promptSanitizer)
-                }
-
-            return ServiceDefinition(
-                serviceType = serviceType,
-                systemPrompt = systemPrompt,
-                operations = operations,
-            )
-        }
-
-        /**
-         * Validates that a service type can be proxied by the runtime.
-         */
-        private fun validateServiceType(serviceType: KClass<*>): Class<*> {
-            val javaType = serviceType.java
-            if (!javaType.isInterface) {
-                throw ConfigurationException("${javaType.name} must be an interface")
-            }
-            if (!javaType.isAnnotationPresent(AiService::class.java)) {
-                throw ConfigurationException("${javaType.name} must be annotated with @AiService")
-            }
-            return javaType
-        }
-
-        /**
-         * Builds an operation definition from method annotations and resolved tool metadata.
-         */
-        private fun createOperationDefinition(
-            javaType: Class<*>,
-            method: Method,
-            systemPrompt: String?,
-            toolRegistry: ToolRegistry,
-            promptSanitizer: PromptSanitizer?,
-        ): OperationDefinition {
-            val operation = method.getAnnotation(Operation::class.java)
-                ?: throw ConfigurationException("${javaType.name}.${method.name} must be annotated with @Operation")
-            return OperationDefinition.create(
-                method = method,
-                operation = operation,
-                classLevelSystemPrompt = systemPrompt,
-                systemAnnotations = method.getAnnotationsByType(SystemMessage::class.java).map { it.value },
-                userAnnotations = method.getAnnotationsByType(UserMessage::class.java).map { it.value },
-                toolDefinitions = resolveToolDefinitions(method, operation, toolRegistry),
-                promptSanitizer = promptSanitizer,
-            )
-        }
-
-        /**
-         * Converts declared tool names into provider-facing definitions.
-         */
-        private fun resolveToolDefinitions(
-            method: Method,
-            operation: Operation,
-            toolRegistry: ToolRegistry,
-        ): List<ToolDefinition> = operation.tools.map { toolName ->
-            val tool = toolRegistry.resolve(toolName)
-                ?: throw ConfigurationException("Tool '$toolName' requested by ${method.name} is not registered in the engine")
-            ToolDefinition(tool.name, tool.description, tool.inputSchemaJson)
-        }
-    }
-}
-
 data class OperationDefinition(
     val method: Method,
     val operation: Operation,
@@ -4834,25 +4757,9 @@ data class OperationDefinition(
         requestedModel = operation.model,
         explicitProvider = operation.provider.takeIf { it.isNotBlank() },
         requestDigest = sha256Hex(CanonicalMessageEncoder.encode(digestSource)),
-        operationFingerprint = operationFingerprint(),
+        operationFingerprint = OperationFingerprintFactory().create(toolDefinitions, operation),
         securityPartition = securityPartition,
     )
-
-    private fun operationFingerprint(): String {
-        val canonical = buildString {
-            append("tools_count=").append(toolDefinitions.size).append('\n')
-            toolDefinitions.forEachIndexed { index, tool ->
-                append("tool_").append(index).append("_name_len=").append(tool.name.length).append('\n')
-                append(tool.name).append('\n')
-                append("tool_").append(index).append("_schema_len=").append(tool.inputSchemaJson.length).append('\n')
-                append(tool.inputSchemaJson).append('\n')
-            }
-            append("timeout_millis=").append(operation.timeoutMillis).append('\n')
-            append("cacheable=").append(operation.cacheable).append('\n')
-            append("cache_ttl_millis=").append(operation.cacheTtlMillis).append('\n')
-        }
-        return sha256Hex(canonical)
-    }
 
     fun structuredContract(handler: StructuredOutputHandler) = handler.createContract(
         requireNotNull(returnType) {
@@ -4993,14 +4900,12 @@ internal fun buildOperationCacheKeyForTesting(
     promptSanitizer: PromptSanitizer? = null,
     toolRegistry: ToolRegistry = ToolRegistry(),
 ): OperationCacheKey {
-    val definition = ServiceDefinition.create(
-        serviceType = serviceType,
-        toolRegistry = toolRegistry,
-        promptSanitizer = promptSanitizer,
-    )
+    val definition = ServiceDefinitionCompiler(
+        OperationDefinitionCompiler(toolRegistry, promptSanitizer, OperationFingerprintFactory()),
+    ).compile(serviceType)
     val method = serviceType.java.methods.firstOrNull { it.name == methodName }
         ?: throw IllegalArgumentException("No method named '$methodName' on ${serviceType.java.name}")
-    val operation = definition.operations[method]
+    val operation = definition.operations[method]?.definition
         ?: throw IllegalArgumentException("No operation metadata for ${serviceType.java.name}.$methodName")
     return operation.buildCacheKey(
         digestSource = operation.initialMessages(arguments, schemaJson),
@@ -5259,7 +5164,7 @@ private fun ExecutionSecurityContext.toCacheSecurityPartition() = CacheSecurityP
 
 internal fun buildRequestDigest(messages: List<Message>): String = sha256Hex(CanonicalMessageEncoder.encode(messages))
 
-private fun sha256Hex(input: String): String {
+internal fun sha256Hex(input: String): String {
     val digest = MessageDigest.getInstance("SHA-256").digest(input.toByteArray(StandardCharsets.UTF_8))
     return digest.joinToString(separator = "") { byte -> "%02x".format(byte) }
 }

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/WorkflowDigestHelper.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/WorkflowDigestHelper.kt
@@ -1,6 +1,7 @@
 package dev.tramai.engine
 
 import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.engine.planning.ServiceDefinition
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/planning/OperationDefinitionCompiler.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/planning/OperationDefinitionCompiler.kt
@@ -1,0 +1,50 @@
+package dev.tramai.engine.planning
+
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.annotations.System as SystemMessage
+import dev.tramai.core.annotations.User as UserMessage
+import dev.tramai.core.exception.ConfigurationException
+import dev.tramai.core.model.ToolDefinition
+import dev.tramai.core.security.PromptSanitizer
+import dev.tramai.engine.OperationDefinition
+import dev.tramai.engine.ToolRegistry
+import java.lang.reflect.Method
+
+/** Compiles resolved tool metadata and reflection-derived operation metadata into a plan. */
+internal class OperationDefinitionCompiler(
+    private val toolRegistry: ToolRegistry,
+    private val promptSanitizer: PromptSanitizer?,
+    private val fingerprintFactory: OperationFingerprintFactory,
+) {
+    fun compile(
+        javaType: Class<*>,
+        method: Method,
+        classLevelSystemPrompt: String?,
+    ): OperationExecutionPlan {
+        val operation = method.getAnnotation(Operation::class.java)
+            ?: throw ConfigurationException("${javaType.name}.${method.name} must be annotated with @Operation")
+        val toolDefinitions = resolveToolDefinitions(method, operation)
+        val definition = OperationDefinition.create(
+            method = method,
+            operation = operation,
+            classLevelSystemPrompt = classLevelSystemPrompt,
+            systemAnnotations = method.getAnnotationsByType(SystemMessage::class.java).map { it.value },
+            userAnnotations = method.getAnnotationsByType(UserMessage::class.java).map { it.value },
+            toolDefinitions = toolDefinitions,
+            promptSanitizer = promptSanitizer,
+        )
+        return OperationExecutionPlan(
+            definition = definition,
+            fingerprint = fingerprintFactory.create(toolDefinitions, operation),
+            serviceInterface = method.declaringClass.name,
+            methodName = method.name,
+        )
+    }
+
+    private fun resolveToolDefinitions(method: Method, operation: Operation): List<ToolDefinition> =
+        operation.tools.map { toolName ->
+            val tool = toolRegistry.resolve(toolName)
+                ?: throw ConfigurationException("Tool '$toolName' requested by ${method.name} is not registered in the engine")
+            ToolDefinition(tool.name, tool.description, tool.inputSchemaJson)
+        }
+}

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/planning/OperationDefinitionCompiler.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/planning/OperationDefinitionCompiler.kt
@@ -7,10 +7,23 @@ import dev.tramai.core.exception.ConfigurationException
 import dev.tramai.core.model.ToolDefinition
 import dev.tramai.core.security.PromptSanitizer
 import dev.tramai.engine.OperationDefinition
+import dev.tramai.engine.ReturnKind
 import dev.tramai.engine.ToolRegistry
 import java.lang.reflect.Method
+import kotlin.reflect.KFunction
+import kotlin.reflect.KParameter
+import kotlin.reflect.jvm.kotlinFunction
 
-/** Compiles resolved tool metadata and reflection-derived operation metadata into a plan. */
+/**
+ * Compiles a service method into an immutable [OperationExecutionPlan].
+ *
+ * Owns ALL reflection → metadata work: Kotlin reflection lookup, suspend
+ * detection, parameter-name discovery, @System/@User annotation processing,
+ * return-kind resolution, structured return-type metadata, tool-definition
+ * resolution, operation annotation interpretation/validation, and the cache
+ * fingerprint. The public [OperationDefinition.create] delegates here, so the
+ * planning package is the single owner of operation compilation.
+ */
 internal class OperationDefinitionCompiler(
     private val toolRegistry: ToolRegistry,
     private val promptSanitizer: PromptSanitizer?,
@@ -24,7 +37,7 @@ internal class OperationDefinitionCompiler(
         val operation = method.getAnnotation(Operation::class.java)
             ?: throw ConfigurationException("${javaType.name}.${method.name} must be annotated with @Operation")
         val toolDefinitions = resolveToolDefinitions(method, operation)
-        val definition = OperationDefinition.create(
+        val definition = compileDefinition(
             method = method,
             operation = operation,
             classLevelSystemPrompt = classLevelSystemPrompt,
@@ -47,4 +60,135 @@ internal class OperationDefinitionCompiler(
                 ?: throw ConfigurationException("Tool '$toolName' requested by ${method.name} is not registered in the engine")
             ToolDefinition(tool.name, tool.description, tool.inputSchemaJson)
         }
+
+    internal companion object {
+        /**
+         * Builds an [OperationDefinition] from method annotations and resolved tool metadata.
+         *
+         * This is the single implementation of operation reflection/validation. The public
+         * [OperationDefinition.create] façade delegates here; the engine execution path
+         * reaches it through [compile].
+         */
+        fun compileDefinition(
+            method: Method,
+            operation: Operation,
+            classLevelSystemPrompt: String?,
+            systemAnnotations: List<String> = emptyList(),
+            userAnnotations: List<String> = emptyList(),
+            toolDefinitions: List<ToolDefinition> = emptyList(),
+            promptSanitizer: PromptSanitizer? = null,
+        ): OperationDefinition {
+            validateOperationAnnotation(method, operation)
+            warnOnSystemPromptShadowing(method, systemAnnotations, classLevelSystemPrompt)
+
+            val kotlinFunction = runCatching { method.kotlinFunction }.getOrNull()
+            val isSuspend = kotlinFunction?.isSuspend ?: method.isSuspendSignature()
+            val parameterNames = resolveParameterNames(method, kotlinFunction)
+            val returnType = resolveReturnType(kotlinFunction)
+            val returnKind = resolveReturnKind(method, isSuspend, returnType)
+            val returnTypeDescription = resolveReturnTypeDescription(method, returnType)
+
+            return OperationDefinition(
+                method = method,
+                operation = operation,
+                classLevelSystemPrompt = classLevelSystemPrompt,
+                systemAnnotations = systemAnnotations,
+                userAnnotations = userAnnotations,
+                isSuspend = isSuspend,
+                parameterNames = parameterNames,
+                returnKind = returnKind,
+                returnType = returnType,
+                returnTypeDescription = returnTypeDescription,
+                toolDefinitions = toolDefinitions,
+                promptSanitizer = promptSanitizer,
+            )
+        }
+
+        /**
+         * Validates operation annotation values before building executable metadata.
+         */
+        private fun validateOperationAnnotation(method: Method, operation: Operation) {
+            require(operation.maxRetries >= 0) {
+                "@Operation(maxRetries) must be zero or greater for ${method.declaringClass.name}.${method.name}"
+            }
+            require(operation.providerRetries >= 0) {
+                "@Operation(providerRetries) must be zero or greater for ${method.declaringClass.name}.${method.name}"
+            }
+            require(operation.timeoutMillis > 0) {
+                "@Operation(timeoutMillis) must be greater than zero for ${method.declaringClass.name}.${method.name}"
+            }
+            require(!operation.cacheable || operation.cacheTtlMillis > 0) {
+                "@Operation(cacheTtlMillis) must be greater than zero when caching is enabled for ${method.declaringClass.name}.${method.name}"
+            }
+        }
+
+        /**
+         * Emits the precedence warning when method-level system messages shadow the class prompt.
+         */
+        private fun warnOnSystemPromptShadowing(
+            method: Method,
+            systemAnnotations: List<String>,
+            classLevelSystemPrompt: String?,
+        ) {
+            if (systemAnnotations.isEmpty() || classLevelSystemPrompt.isNullOrBlank()) {
+                return
+            }
+            val logger = System.getLogger("dev.tramai.engine.OperationDefinition")
+            logger.log(
+                System.Logger.Level.WARNING,
+                "@System on ${method.declaringClass.name}.${method.name} takes precedence over @SystemPrompt on the class",
+            )
+        }
+
+        private fun resolveParameterNames(
+            method: Method,
+            kotlinFunction: KFunction<*>?,
+        ): List<String> {
+            val valueParameters = kotlinFunction?.parameters
+                ?.filter { it.kind == KParameter.Kind.VALUE }
+                ?.map { it.name ?: "arg${it.index}" }
+            if (valueParameters != null) {
+                return valueParameters
+            }
+
+            return method.parameters.mapIndexed { index, parameter ->
+                parameter.name?.takeIf { it.isNotBlank() } ?: "arg$index"
+            }
+        }
+
+        private fun resolveReturnKind(
+            method: Method,
+            isSuspend: Boolean,
+            returnType: kotlin.reflect.KType?,
+        ): ReturnKind {
+            val classifier = returnType?.classifier
+            return when (classifier) {
+                String::class -> ReturnKind.STRING
+                Unit::class -> ReturnKind.UNIT
+                kotlinx.coroutines.flow.Flow::class -> ReturnKind.STREAMING
+                null -> when {
+                    isSuspend -> throw ConfigurationException(
+                        "Suspend method ${method.declaringClass.name}.${method.name} requires Kotlin reflection metadata to inspect its return type",
+                    )
+                    method.returnType == String::class.java -> ReturnKind.STRING
+                    method.returnType == Void.TYPE -> ReturnKind.UNIT
+                    kotlinx.coroutines.flow.Flow::class.java.isAssignableFrom(method.returnType) -> ReturnKind.STREAMING
+                    else -> ReturnKind.STRUCTURED
+                }
+                else -> ReturnKind.STRUCTURED
+            }
+        }
+
+        private fun resolveReturnType(
+            kotlinFunction: KFunction<*>?,
+        ) = kotlinFunction?.returnType
+
+        private fun resolveReturnTypeDescription(
+            method: Method,
+            returnType: kotlin.reflect.KType?,
+        ): String = returnType?.toString() ?: method.genericReturnType.typeName
+
+        private fun Method.isSuspendSignature(): Boolean =
+            parameterTypes.lastOrNull()?.name == "kotlin.coroutines.Continuation"
+    }
 }

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/planning/OperationExecutionPlan.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/planning/OperationExecutionPlan.kt
@@ -1,0 +1,11 @@
+package dev.tramai.engine.planning
+
+import dev.tramai.engine.OperationDefinition
+
+/** Immutable metadata compiled for one service operation before invocation. */
+internal data class OperationExecutionPlan(
+    val definition: OperationDefinition,
+    val fingerprint: String,
+    val serviceInterface: String,
+    val methodName: String,
+)

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/planning/OperationFingerprintFactory.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/planning/OperationFingerprintFactory.kt
@@ -1,0 +1,24 @@
+package dev.tramai.engine.planning
+
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.model.ToolDefinition
+import dev.tramai.engine.sha256Hex
+
+/** Builds the canonical operation-cache fingerprint without runtime state. */
+internal class OperationFingerprintFactory {
+    fun create(toolDefinitions: List<ToolDefinition>, operation: Operation): String {
+        val canonical = buildString {
+            append("tools_count=").append(toolDefinitions.size).append('\n')
+            toolDefinitions.forEachIndexed { index, tool ->
+                append("tool_").append(index).append("_name_len=").append(tool.name.length).append('\n')
+                append(tool.name).append('\n')
+                append("tool_").append(index).append("_schema_len=").append(tool.inputSchemaJson.length).append('\n')
+                append(tool.inputSchemaJson).append('\n')
+            }
+            append("timeout_millis=").append(operation.timeoutMillis).append('\n')
+            append("cacheable=").append(operation.cacheable).append('\n')
+            append("cache_ttl_millis=").append(operation.cacheTtlMillis).append('\n')
+        }
+        return sha256Hex(canonical)
+    }
+}

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/planning/ServiceDefinitionCompiler.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/planning/ServiceDefinitionCompiler.kt
@@ -1,0 +1,38 @@
+package dev.tramai.engine.planning
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.SystemPrompt
+import dev.tramai.core.exception.ConfigurationException
+import kotlin.reflect.KClass
+import java.lang.reflect.Method
+
+internal data class ServiceDefinition(
+    val serviceType: KClass<*>,
+    val systemPrompt: String?,
+    val operations: Map<Method, OperationExecutionPlan>,
+)
+
+/** Compiles a validated service interface into its immutable operation plans. */
+internal class ServiceDefinitionCompiler(
+    private val operationCompiler: OperationDefinitionCompiler,
+) {
+    fun compile(serviceType: KClass<*>): ServiceDefinition {
+        val javaType = validateServiceType(serviceType)
+        val systemPrompt = javaType.getAnnotation(SystemPrompt::class.java)?.value?.takeIf { it.isNotBlank() }
+        val operations = javaType.methods
+            .filterNot { it.declaringClass == Any::class.java }
+            .associateWith { method -> operationCompiler.compile(javaType, method, systemPrompt) }
+        return ServiceDefinition(serviceType, systemPrompt, operations)
+    }
+
+    private fun validateServiceType(serviceType: KClass<*>): Class<*> {
+        val javaType = serviceType.java
+        if (!javaType.isInterface) {
+            throw ConfigurationException("${javaType.name} must be an interface")
+        }
+        if (!javaType.isAnnotationPresent(AiService::class.java)) {
+            throw ConfigurationException("${javaType.name} must be annotated with @AiService")
+        }
+        return javaType
+    }
+}

--- a/tramai-engine/src/test/java/dev/tramai/engine/planning/JavaPlanningService.java
+++ b/tramai-engine/src/test/java/dev/tramai/engine/planning/JavaPlanningService.java
@@ -1,0 +1,10 @@
+package dev.tramai.engine.planning;
+
+import dev.tramai.core.annotations.AiService;
+import dev.tramai.core.annotations.Operation;
+
+@AiService
+public interface JavaPlanningService {
+    @Operation(prompt = "Java echo", model = "test-model")
+    String javaEcho(String input);
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/TrustedReplayEnvelopeRegistryTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/TrustedReplayEnvelopeRegistryTest.kt
@@ -2,6 +2,9 @@ package dev.tramai.engine
 
 import dev.tramai.core.approval.Sha256Digest
 import dev.tramai.engine.components.EngineComponentFactory
+import dev.tramai.engine.planning.OperationExecutionPlan
+import dev.tramai.engine.planning.OperationFingerprintFactory
+import dev.tramai.engine.planning.ServiceDefinition
 import dev.tramai.core.memory.UuidConversationIdProvider
 import dev.tramai.core.model.Message
 import dev.tramai.core.model.MessageRole
@@ -202,7 +205,7 @@ class TrustedReplayEnvelopeRegistryTest {
             toolDefinitions = emptyTools, promptSanitizer = null,
         )
 
-        val fooOnlySvc = ServiceDefinition(svcClass.kotlin, null, mapOf(fooMethod to origFooDef))
+        val fooOnlySvc = ServiceDefinition(svcClass.kotlin, null, mapOf(fooMethod to plan(origFooDef)))
         val handler = dummyHandler(fooOnlySvc, registry)
 
         // Register foo with the original definition
@@ -210,8 +213,8 @@ class TrustedReplayEnvelopeRegistryTest {
 
         // RegisterAll with foo (conflicting) + bar (new)
         val bulkSvc = ServiceDefinition(svcClass.kotlin, null, mapOf(
-            fooMethod to conflictFooDef,
-            barMethod to barDef,
+            fooMethod to plan(conflictFooDef),
+            barMethod to plan(barDef),
         ))
         val bulkHandler = dummyHandler(bulkSvc, registry)
 
@@ -261,8 +264,8 @@ class TrustedReplayEnvelopeRegistryTest {
             toolDefinitions = emptyTools, promptSanitizer = null,
         )
         val svcDef = ServiceDefinition(svcClass.kotlin, null, mapOf(
-            fooMethod to fooDef,
-            barMethod to barDef,
+            fooMethod to plan(fooDef),
+            barMethod to plan(barDef),
         ))
         val handler = dummyHandler(svcDef, registry)
 
@@ -410,4 +413,11 @@ class TrustedReplayEnvelopeRegistryTest {
             resumeOperationRegistry = registry,
         )
     }
+
+    private fun plan(definition: OperationDefinition) = OperationExecutionPlan(
+        definition = definition,
+        fingerprint = OperationFingerprintFactory().create(definition.toolDefinitions, definition.operation),
+        serviceInterface = definition.method.declaringClass.name,
+        methodName = definition.method.name,
+    )
 }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/planning/EnginePlanningIntegrationTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/planning/EnginePlanningIntegrationTest.kt
@@ -1,0 +1,63 @@
+package dev.tramai.engine.planning
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.provider.ModelProvider
+import dev.tramai.engine.TramaiEngine
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class EnginePlanningIntegrationTest {
+
+    @Test
+    fun `registered and created services execute through compiled operation plans`() {
+        val provider = RecordingProvider()
+        val engine = TramaiEngine(provider)
+        engine.registerService(EnginePlanningService::class)
+        val service = engine.create(EnginePlanningService::class)
+
+        val result = runBlocking { service.echo("value") }
+
+        assertThat(result).isEqualTo("planned response")
+        assertThat(provider.requests.single().operationInterface).isEqualTo(EnginePlanningService::class.java.name)
+        assertThat(provider.requests.single().operationMethod).isEqualTo("echo")
+        engine.close()
+    }
+
+    @Test
+    fun `repeated compilation of the same service yields equal plans`() {
+        val compiler = ServiceDefinitionCompiler(
+            OperationDefinitionCompiler(
+                toolRegistry = dev.tramai.engine.ToolRegistry(),
+                promptSanitizer = null,
+                fingerprintFactory = OperationFingerprintFactory(),
+            ),
+        )
+        val first = compiler.compile(EnginePlanningService::class)
+        val second = compiler.compile(EnginePlanningService::class)
+
+        assertThat(second.operations.keys).isEqualTo(first.operations.keys)
+        assertThat(second.operations.values.map { it.definition })
+            .containsExactlyElementsOf(first.operations.values.map { it.definition })
+        assertThat(second.operations.values.map { it.fingerprint })
+            .containsExactlyElementsOf(first.operations.values.map { it.fingerprint })
+    }
+
+    private class RecordingProvider : ModelProvider {
+        val requests = mutableListOf<ModelRequest>()
+
+        override suspend fun complete(request: ModelRequest): ModelResponse {
+            requests += request
+            return ModelResponse(content = "planned response")
+        }
+    }
+
+    @AiService
+    private interface EnginePlanningService {
+        @Operation(prompt = "Echo", model = "test-model")
+        suspend fun echo(input: String): String
+    }
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/planning/OperationDefinitionCompilerTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/planning/OperationDefinitionCompilerTest.kt
@@ -1,0 +1,158 @@
+package dev.tramai.engine.planning
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.annotations.System
+import dev.tramai.core.annotations.User
+import dev.tramai.core.exception.ConfigurationException
+import dev.tramai.core.model.ResolvedTool
+import dev.tramai.core.model.SideEffectLevel
+import dev.tramai.core.model.ToolExecutionContext
+import dev.tramai.core.model.ToolResult
+import dev.tramai.engine.ReturnKind
+import dev.tramai.engine.ToolRegistry
+import kotlinx.coroutines.flow.Flow
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class OperationDefinitionCompilerTest {
+
+    @Test
+    fun `compiles suspend and blocking methods with declaration parameter names`() {
+        val compiler = compiler()
+        val suspendPlan = compiler.compile(SuspendAndBlockingService::class.java, method(SuspendAndBlockingService::class, "suspendEcho"), null)
+        val blockingPlan = compiler.compile(SuspendAndBlockingService::class.java, method(SuspendAndBlockingService::class, "blockingCount"), null)
+
+        assertThat(suspendPlan.definition.isSuspend).isTrue()
+        assertThat(blockingPlan.definition.isSuspend).isFalse()
+        assertThat(blockingPlan.definition.parameterNames).containsExactly("first", "second")
+    }
+
+    @Test
+    fun `captures method message annotations`() {
+        val plan = compiler().compile(AnnotatedMessagesService::class.java, method(AnnotatedMessagesService::class, "answer"), null)
+
+        assertThat(plan.definition.systemAnnotations).containsExactly("System {input}")
+        assertThat(plan.definition.userAnnotations).containsExactly("First {input}")
+    }
+
+    @Test
+    fun `uses Java reflection fallback metadata deterministically`() {
+        val method = JavaPlanningService::class.java.methods.single { it.name == "javaEcho" }
+        val first = compiler().compile(JavaPlanningService::class.java, method, null)
+        val second = compiler().compile(JavaPlanningService::class.java, method, null)
+
+        assertThat(first.definition.parameterNames).isNotEmpty()
+        assertThat(first.definition.parameterNames).isEqualTo(second.definition.parameterNames)
+    }
+
+    @Test
+    fun `resolves all supported return kinds`() {
+        val compiler = compiler()
+
+        val structured = compiler.compile(ReturnKindsService::class.java, method(ReturnKindsService::class, "structured"), null).definition
+        assertThat(structured.returnKind).isEqualTo(ReturnKind.STRUCTURED)
+        assertThat(structured.returnType?.classifier).isEqualTo(Result::class)
+        assertThat(compiler.compile(ReturnKindsService::class.java, method(ReturnKindsService::class, "string"), null).definition.returnKind)
+            .isEqualTo(ReturnKind.STRING)
+        assertThat(compiler.compile(ReturnKindsService::class.java, method(ReturnKindsService::class, "unit"), null).definition.returnKind)
+            .isEqualTo(ReturnKind.UNIT)
+        assertThat(compiler.compile(ReturnKindsService::class.java, method(ReturnKindsService::class, "stream"), null).definition.returnKind)
+            .isEqualTo(ReturnKind.STREAMING)
+    }
+
+    @Test
+    fun `resolves tool definitions from the registry`() {
+        val plan = compiler().compile(ToolService::class.java, method(ToolService::class, "pay"), null)
+
+        assertThat(plan.definition.toolDefinitions)
+            .containsExactly(dev.tramai.core.model.ToolDefinition("payment", "Process a payment", "{\"type\":\"object\"}"))
+    }
+
+    @Test
+    fun `rejects tools absent from the registry`() {
+        assertThatThrownBy {
+            emptyCompiler().compile(ToolService::class.java, method(ToolService::class, "pay"), null)
+        }
+            .isInstanceOf(ConfigurationException::class.java)
+            .hasMessageContaining("is not registered in the engine")
+    }
+
+    @Test
+    fun `propagates operation annotation validation`() {
+        assertThatThrownBy {
+            compiler().compile(InvalidRetriesService::class.java, method(InvalidRetriesService::class, "answer"), null)
+        }.isInstanceOf(IllegalArgumentException::class.java).hasMessageContaining("maxRetries")
+        assertThatThrownBy {
+            compiler().compile(InvalidCacheService::class.java, method(InvalidCacheService::class, "answer"), null)
+        }.isInstanceOf(IllegalArgumentException::class.java).hasMessageContaining("cacheTtlMillis")
+    }
+
+    @Test
+    fun `plan carries method identity and fingerprint`() {
+        val plan = compiler().compile(ToolService::class.java, method(ToolService::class, "pay"), null)
+
+        assertThat(plan.fingerprint).matches("[a-f0-9]{64}")
+        assertThat(plan.serviceInterface).isEqualTo(ToolService::class.java.name)
+        assertThat(plan.methodName).isEqualTo("pay")
+    }
+
+    private fun compiler() = OperationDefinitionCompiler(ToolRegistry(mapOf("payment" to FakeTool())), null, OperationFingerprintFactory())
+    private fun emptyCompiler() = OperationDefinitionCompiler(ToolRegistry(), null, OperationFingerprintFactory())
+    private fun method(serviceType: kotlin.reflect.KClass<*>, name: String) = serviceType.java.methods.single { it.name == name }
+
+    private class FakeTool : ResolvedTool {
+        override val name = "payment"
+        override val description = "Process a payment"
+        override val inputSchemaJson = "{\"type\":\"object\"}"
+        override val idempotent = true
+        override val sideEffectLevel = SideEffectLevel.READ_ONLY
+        override suspend fun execute(input: Any, context: ToolExecutionContext): ToolResult = ToolResult.Success("{}")
+    }
+
+    internal data class Result(val value: String)
+
+    @AiService
+    private interface SuspendAndBlockingService {
+        @Operation(prompt = "Echo", model = "test-model")
+        suspend fun suspendEcho(input: String): String
+
+        @Operation(prompt = "Count", model = "test-model")
+        fun blockingCount(first: Int, second: Int): Int
+    }
+
+    @AiService
+    private interface AnnotatedMessagesService {
+        @System("System {input}")
+        @User("First {input}")
+        @Operation(prompt = "Ignored", model = "test-model")
+        fun answer(input: String): String
+    }
+
+    @AiService
+    private interface ReturnKindsService {
+        @Operation(prompt = "Structured", model = "test-model") fun structured(): Result
+        @Operation(prompt = "String", model = "test-model") fun string(): String
+        @Operation(prompt = "Unit", model = "test-model") fun unit()
+        @Operation(prompt = "Stream", model = "test-model") fun stream(): Flow<String>
+    }
+
+    @AiService
+    private interface ToolService {
+        @Operation(prompt = "Pay", model = "test-model", tools = ["payment"])
+        fun pay(amount: Double): String
+    }
+
+    @AiService
+    private interface InvalidRetriesService {
+        @Operation(prompt = "Invalid", model = "test-model", maxRetries = -1)
+        fun answer(): String
+    }
+
+    @AiService
+    private interface InvalidCacheService {
+        @Operation(prompt = "Invalid", model = "test-model", cacheable = true, cacheTtlMillis = 0)
+        fun answer(): String
+    }
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/planning/OperationExecutionPlanTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/planning/OperationExecutionPlanTest.kt
@@ -1,0 +1,40 @@
+package dev.tramai.engine.planning
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.engine.ToolRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class OperationExecutionPlanTest {
+
+    @Test
+    fun `wraps compiled definition and method identity`() {
+        val method = PlanService::class.java.methods.single { it.name == "answer" }
+        val plan = OperationDefinitionCompiler(ToolRegistry(), null, OperationFingerprintFactory())
+            .compile(PlanService::class.java, method, null)
+
+        assertThat(plan.definition.method).isSameAs(method)
+        assertThat(plan.fingerprint).matches("[a-f0-9]{64}")
+        assertThat(plan.serviceInterface).isEqualTo(PlanService::class.java.name)
+        assertThat(plan.methodName).isEqualTo("answer")
+    }
+
+    @Test
+    fun `copy preserves immutable plan values and definition identity`() {
+        val method = PlanService::class.java.methods.single { it.name == "answer" }
+        val plan = OperationDefinitionCompiler(ToolRegistry(), null, OperationFingerprintFactory())
+            .compile(PlanService::class.java, method, null)
+
+        val copy = plan.copy()
+
+        assertThat(copy).isEqualTo(plan)
+        assertThat(copy.definition).isSameAs(plan.definition)
+    }
+
+    @AiService
+    private interface PlanService {
+        @Operation(prompt = "Answer", model = "test-model")
+        fun answer(input: String): String
+    }
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/planning/OperationFingerprintFactoryTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/planning/OperationFingerprintFactoryTest.kt
@@ -1,0 +1,85 @@
+package dev.tramai.engine.planning
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.model.ToolDefinition
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.security.MessageDigest
+
+class OperationFingerprintFactoryTest {
+
+    @Test
+    fun `creates deterministic fingerprints`() {
+        val operation = operation("base")
+
+        assertThat(factory.create(tools, operation)).isEqualTo(factory.create(tools, operation))
+    }
+
+    @Test
+    fun `changes fingerprint when meaningful cache metadata changes`() {
+        val base = factory.create(tools, operation("base"))
+
+        assertThat(factory.create(listOf(ToolDefinition("other", "Payment", schema)), operation("base"))).isNotEqualTo(base)
+        assertThat(factory.create(listOf(ToolDefinition("payment", "Payment", "{\"type\":\"string\"}")), operation("base"))).isNotEqualTo(base)
+        assertThat(factory.create(tools, operation("timeout"))).isNotEqualTo(base)
+        assertThat(factory.create(tools, operation("cacheable"))).isNotEqualTo(base)
+        assertThat(factory.create(tools, operation("cachedDefault")))
+            .isNotEqualTo(factory.create(tools, operation("ttl")))
+        assertThat(factory.create(tools + ToolDefinition("second", "Second", "{}"), operation("base"))).isNotEqualTo(base)
+    }
+
+    @Test
+    fun `does not include the prompt in the fingerprint`() {
+        assertThat(factory.create(tools, operation("base"))).isEqualTo(factory.create(tools, operation("sameMetadataDifferentPrompt")))
+    }
+
+    @Test
+    fun `is byte identical to the pre extraction algorithm`() {
+        val operation = operation("base")
+
+        assertThat(factory.create(tools, operation)).isEqualTo(legacyFingerprint(tools, operation))
+    }
+
+    private fun operation(name: String): Operation = FingerprintOperations::class.java.methods
+        .single { it.name == name }
+        .getAnnotation(Operation::class.java)
+
+    /**
+     * Snapshot of the ORIGINAL pre-extraction algorithm (TramaiEngine.kt private
+     * operationFingerprint). Kept deliberately as a copy to prove the extracted
+     * OperationFingerprintFactory is byte-identical — if you change the factory,
+     * this snapshot must change with it (or be replaced by a pinned hash constant).
+     */
+    private fun legacyFingerprint(toolDefinitions: List<ToolDefinition>, operation: Operation): String {
+        val canonical = buildString {
+            append("tools_count=").append(toolDefinitions.size).append('\n')
+            toolDefinitions.forEachIndexed { index, tool ->
+                append("tool_").append(index).append("_name_len=").append(tool.name.length).append('\n')
+                append(tool.name).append('\n')
+                append("tool_").append(index).append("_schema_len=").append(tool.inputSchemaJson.length).append('\n')
+                append(tool.inputSchemaJson).append('\n')
+            }
+            append("timeout_millis=").append(operation.timeoutMillis).append('\n')
+            append("cacheable=").append(operation.cacheable).append('\n')
+            append("cache_ttl_millis=").append(operation.cacheTtlMillis).append('\n')
+        }
+        return MessageDigest.getInstance("SHA-256").digest(canonical.toByteArray()).joinToString("") { "%02x".format(it) }
+    }
+
+    private companion object {
+        val factory = OperationFingerprintFactory()
+        const val schema = "{\"type\":\"object\"}"
+        val tools = listOf(ToolDefinition("payment", "Payment", schema))
+    }
+
+    @AiService
+    private interface FingerprintOperations {
+        @Operation(prompt = "Base", model = "test-model", timeoutMillis = 100) fun base(): String
+        @Operation(prompt = "Different prompt", model = "test-model", timeoutMillis = 100) fun sameMetadataDifferentPrompt(): String
+        @Operation(prompt = "Timeout", model = "test-model", timeoutMillis = 101) fun timeout(): String
+        @Operation(prompt = "Cacheable", model = "test-model", timeoutMillis = 100, cacheable = true) fun cacheable(): String
+        @Operation(prompt = "Cached default", model = "test-model", timeoutMillis = 100, cacheable = true) fun cachedDefault(): String
+        @Operation(prompt = "Ttl", model = "test-model", timeoutMillis = 100, cacheable = true, cacheTtlMillis = 101) fun ttl(): String
+    }
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/planning/ServiceDefinitionCompilerTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/planning/ServiceDefinitionCompilerTest.kt
@@ -1,0 +1,141 @@
+package dev.tramai.engine.planning
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.annotations.SystemPrompt
+import dev.tramai.core.exception.ConfigurationException
+import dev.tramai.core.model.ResolvedTool
+import dev.tramai.core.model.SideEffectLevel
+import dev.tramai.core.model.ToolExecutionContext
+import dev.tramai.core.model.ToolResult
+import dev.tramai.engine.ReturnKind
+import dev.tramai.engine.ToolRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class ServiceDefinitionCompilerTest {
+
+    @Test
+    fun `compiles an annotated Kotlin service into operation plans`() {
+        val definition = compiler().compile(TestPlanningService::class)
+
+        assertThat(definition.serviceType).isEqualTo(TestPlanningService::class)
+        assertThat(definition.systemPrompt).isNull()
+        assertThat(definition.operations.keys.map { it.name }).containsExactlyInAnyOrder("echo", "count", "pay")
+        assertThat(definition.operations[method(TestPlanningService::class, "pay")]?.definition?.toolDefinitions)
+            .extracting("name")
+            .containsExactly("payment")
+    }
+
+    @Test
+    fun `extracts class system prompt and treats a blank prompt as absent`() {
+        assertThat(compiler().compile(PromptedPlanningService::class).systemPrompt).isEqualTo("Be precise")
+        assertThat(compiler().compile(BlankPromptPlanningService::class).systemPrompt).isNull()
+    }
+
+    @Test
+    fun `rejects a service class`() {
+        assertThatThrownBy { compiler().compile(NotAnInterface::class) }
+            .isInstanceOf(ConfigurationException::class.java)
+            .hasMessageContaining("must be an interface")
+    }
+
+    @Test
+    fun `rejects an interface without AiService`() {
+        assertThatThrownBy { compiler().compile(MissingAiService::class) }
+            .isInstanceOf(ConfigurationException::class.java)
+            .hasMessageContaining("must be annotated with @AiService")
+    }
+
+    @Test
+    fun `rejects methods without Operation`() {
+        assertThatThrownBy { compiler().compile(ServiceWithUnannotatedMethod::class) }
+            .isInstanceOf(ConfigurationException::class.java)
+            .hasMessageContaining("must be annotated with @Operation")
+    }
+
+    @Test
+    fun `does not compile Object methods as operations`() {
+        val operations = compiler().compile(TestPlanningService::class).operations
+
+        assertThat(operations.keys.map { it.name }).doesNotContain("toString", "equals", "hashCode")
+    }
+
+    @Test
+    fun `compilation has deterministic operation metadata`() {
+        val first = compiler().compile(TestPlanningService::class)
+        val second = compiler().compile(TestPlanningService::class)
+
+        assertThat(first.operations).isEqualTo(second.operations)
+    }
+
+    @Test
+    fun `compiles an actual Java service interface`() {
+        val plan = compiler().compile(JavaPlanningService::class).operations.values.single()
+
+        assertThat(plan.methodName).isEqualTo("javaEcho")
+        assertThat(plan.definition.returnKind).isEqualTo(ReturnKind.STRING)
+        assertThat(plan.definition.isSuspend).isFalse()
+        assertThat(plan.definition.parameterNames).isNotEmpty()
+    }
+
+    private fun compiler() = ServiceDefinitionCompiler(
+        OperationDefinitionCompiler(
+            ToolRegistry(mapOf("payment" to FakeTool())),
+            null,
+            OperationFingerprintFactory(),
+        ),
+    )
+
+    private fun method(serviceType: kotlin.reflect.KClass<*>, name: String) =
+        serviceType.java.methods.single { it.name == name }
+
+    private class FakeTool : ResolvedTool {
+        override val name = "payment"
+        override val description = "Process a payment"
+        override val inputSchemaJson = "{\"type\":\"object\"}"
+        override val idempotent = true
+        override val sideEffectLevel = SideEffectLevel.READ_ONLY
+
+        override suspend fun execute(input: Any, context: ToolExecutionContext): ToolResult = ToolResult.Success("{}")
+    }
+
+    @AiService
+    internal interface TestPlanningService {
+        @Operation(prompt = "Echo", model = "test-model")
+        suspend fun echo(input: String): String
+
+        @Operation(prompt = "Count", model = "test-model")
+        fun count(a: Int, b: Int): Int
+
+        @Operation(prompt = "Parse", model = "test-model", tools = ["payment"])
+        fun pay(amount: Double): String
+    }
+
+    @AiService
+    @SystemPrompt("Be precise")
+    private interface PromptedPlanningService {
+        @Operation(prompt = "Prompt", model = "test-model")
+        fun answer(input: String): String
+    }
+
+    @AiService
+    @SystemPrompt("   ")
+    private interface BlankPromptPlanningService {
+        @Operation(prompt = "Prompt", model = "test-model")
+        fun answer(input: String): String
+    }
+
+    private class NotAnInterface
+
+    private interface MissingAiService {
+        @Operation(prompt = "Prompt", model = "test-model")
+        fun answer(input: String): String
+    }
+
+    @AiService
+    private interface ServiceWithUnannotatedMethod {
+        fun answer(input: String): String
+    }
+}


### PR DESCRIPTION
## Summary

**Epic 3.2: Extract operation planning.** Moves service/operation compilation and reflection work out of `TramaiEngine.kt` (5290 lines) into a dedicated `dev.tramai.engine.planning` package. Runtime execution now consumes a **precompiled immutable operation plan** instead of deriving metadata during invocation.

The invariant: *compilation happens before invocation; invocation consumes metadata rather than discovering it.*

Protected by the PR #230 trace gate: all 20 characterization traces remain **byte-for-byte identical** (no `.trace` changes).

## What

**New (internal, `dev.tramai.engine.planning/`):**

| File | Responsibility |
|---|---|
| `ServiceDefinitionCompiler` | Service validation (`@AiService`, interface), class-level `@SystemPrompt` extraction, method enumeration, delegating operations to `OperationDefinitionCompiler` |
| `OperationDefinitionCompiler` | **Owns all operation compilation**: Kotlin reflection, suspend detection, parameter metadata, return-kind/type resolution, annotation validation + tool resolution + fingerprint. `OperationDefinition.create()` delegates here |
| `OperationExecutionPlan` | Internal immutable data class: `definition` + `fingerprint` + `serviceInterface` + `methodName` |
| `OperationFingerprintFactory` | Canonical cache fingerprint — exact algorithm extracted from the old private `operationFingerprint()`, **byte-identical output** |

**Engine wiring:**
- `create()` and `registerService()` now share one **engine-scoped** `ServiceDefinitionCompiler` (previously duplicated `ServiceDefinition.create(...)` call sites)
- `ServiceDefinition.operations` changed to `Map<Method, OperationExecutionPlan>`; handler resolves the plan and consumes `plan.definition`
- `ResumeOperationRegistry` + `buildOperationCacheKeyForTesting` adapted
- `WorkflowDigestHelper` / `ResumeDefinitionDigestHelper` — import-only changes (moved `ServiceDefinition`), **three digest concepts deliberately NOT unified**

**Tests (23 new):**
- `ServiceDefinitionCompilerTest` (8) — valid Kotlin/Java interfaces, system prompt, blank prompt, not-interface, missing `@AiService`, unannotated method, Object-method exclusion
- `OperationDefinitionCompilerTest` (8) — suspend/blocking, annotations, multiple args, structured/string/unit/streaming returns, tool resolution, missing tool, annotation validation
- `OperationFingerprintFactoryTest` (4) — determinism, meaningful-change-differs, prompt-irrelevance, **byte-identical to legacy algorithm**
- `OperationExecutionPlanTest` (2) — plan immutability/identity
- `EnginePlanningIntegrationTest` (2) — create+registerService execute through plans; repeated compilation yields equal plans
- Java fixture `JavaPlanningService.java` — real Java interface through the compiler (interop regression)

## Verification (all run locally)

```
: tramai-engine:test --rerun-tasks            BUILD SUCCESSFUL (2m14s)
: characterization suite ×3 --rerun-tasks     20/20 green each (no nondeterminism)
: tramai-engine:apiCheck                       BUILD SUCCESSFUL (API dump unchanged)
verifyCancellationSafety                       BUILD SUCCESSFUL
verifyPr -PchangeClass=runtime-behaviour       BUILD SUCCESSFUL
```

## Non-claims

- **No** provider retry/fallback, tool execution, approval state machine, DLP, policy ordering, streaming, routing, workflow execution, Spring, quality baselines, or CI changes
- **No** process-global reflection cache (per 0.6.0 hidden-global-state goal); compiler is engine-scoped
- **No** change to `OperationDefinition` public API (constructor, `cacheKey`, `toRequest`, `initialMessages`, `structuredContract`, `isOperationCacheEligible`, companion `create` all untouched — `:tramai-engine:apiCheck` clean)
- **No** unification of `OperationFingerprintFactory` / `WorkflowDigestHelper` / `ResumeDefinitionDigestHelper` (intentionally separate contracts)
- Plan's `fingerprint` is now threaded into runtime cache-key construction: `buildCacheKey` accepts the precomputed fingerprint and `executeRaw`/`executeStructured` pass `plan.fingerprint` instead of recomputing it per invocation (internal API only).

## Files (17)

- 4 new production files (`planning/`), 5 new test files + 1 Java fixture
- 5 modified: `TramaiEngine.kt` (−230+ net after P2: reflection moved out, companion is a façade), `ResumeOperationRegistry.kt`, `WorkflowDigestHelper.kt`/`ResumeDefinitionDigestHelper.kt` (import only), `TrustedReplayEnvelopeRegistryTest.kt`
- 1 doc: `docs/ROADMAP-0.6.0.md` (Epic 3.2 → ✅ Complete)

This PR needs review before merge.
