### PR TITLE
refactor(engine): extract provider execution

### DIFF
--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -577,22 +577,34 @@ A deterministic execution-trace test fixture that records ordered semantic event
 
 ## Epic 3.3: Extract provider execution
 
+> **Status: ✅ Complete — PR #233** (`refactor(engine): extract provider execution`)
+
 **Goal:** Give routing, retries, fallbacks, circuit breaking, authorization, and provider observation one cohesive owner.
 
-### Proposed components
+### Components
 
-- `ProviderExecutionCoordinator`
-- `ProviderAttemptExecutor`
-- `ProviderRetryPolicy`
-- `ProviderFallbackPolicy`
-- `ProviderAuthorizationService`
+- `ProviderExecutionCoordinator` — route-level state machine: `BEFORE_PROVIDER_RESOLUTION` gate, candidate resolution, circuit-breaker `beforeCall`, circuit-open fallback transition, fallback gates, route sequencing. Owner of route ordering; delegates one-provider attempts to the executor.
+- `ProviderAttemptExecutor` — one provider attempt and its observation lifecycle: request interceptor → start observation → route-selected event → model authorization → `BEFORE_PROVIDER_INVOCATION` gate → provider invocation → response interceptor → provider-output DLP gate → `onProviderResponse`. Cancellation → `completeCancellation` exactly once; DLP failure is not a provider failure; success transfers observation ownership to the caller.
+- `ProviderRetryPolicy` — typed `ProviderRetryDecision.Retry/Stop`; owns retryable classification, attempt exhaustion, Retry-After, backoff/jitter, delay-source classification. No delay, observation, circuit-breaker, or event side effects.
+- `ProviderFallbackPolicy` — typed `ProviderFallbackDecision.Continue/Stop` + `ProviderFallbackReason`; maps enum back to legacy event strings (`provider-failure`, `circuit-breaker-open`).
+- `ProviderAuthorizationService` — model-registry authorization only; observation lifecycle stays in the executor.
 
-### Acceptance criteria
+### Tasks
 
-- Provider execution can be tested without tools, approvals, memory, or structured output.
-- Retry and fallback decisions are typed results rather than scattered booleans.
-- Cancellation never enters retry/fallback policy.
-- Attempt observations are always completed exactly once.
+1. ✅ Move non-streaming provider execution out of `TramaiInvocationHandler` into `tramai-engine/.../provider/`.
+2. ✅ Replace retry/fallback boolean branches with typed decisions.
+3. ✅ Keep cancellation entirely outside retry/fallback classification and circuit-breaker failure recording.
+4. ✅ Preserve the observation-ownership semantic on successful calls (observation stays alive for tool/structured processing).
+5. ✅ Keep tool exposure as an injected `ProviderRouteGate` (replaced by `ToolExposureCoordinator` in Epic 3.4).
+6. ✅ Add dedicated component tests (6 files, 27 tests) constructing provider components without tools, approvals, memory, or structured output.
+7. ⏸️ Streaming execution (`executeStreaming`, `executeStreamingRoute`, `collectStreamingRoute`, chunk state, backpressure, streaming terminal semantics) stays in place — reserved for `StreamingExecutionCoordinator` in Epic 3.6.
+
+### Merge gate
+
+- 20 characterization traces byte-for-byte identical (no `.trace` changes).
+- `tramai-engine.api` unchanged (`:tramai-engine:apiCheck` clean).
+- `verifyCancellationSafety` no new critical/high findings.
+- `verifyPr -PchangeClass=runtime-behaviour` green.
 
 ---
 

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -78,6 +78,17 @@ import dev.tramai.core.approval.ApprovalToken
 import dev.tramai.core.approval.CreateApprovalCommand
 import dev.tramai.core.approval.AuthorizeResumeCommand
 import dev.tramai.core.approval.IdempotencyKeyUtil
+import dev.tramai.engine.provider.AttemptCounter
+import dev.tramai.engine.provider.ProviderAttemptExecutor
+import dev.tramai.engine.provider.ProviderAuthorizationService
+import dev.tramai.engine.provider.ProviderExecutionCoordinator
+import dev.tramai.engine.provider.ProviderExecutionRequest
+import dev.tramai.engine.provider.ProviderFallbackGate
+import dev.tramai.engine.provider.ProviderFallbackPolicy
+import dev.tramai.engine.provider.ProviderInvocationGate
+import dev.tramai.engine.provider.ProviderResolutionGate
+import dev.tramai.engine.provider.ProviderResponseSanitizer
+import dev.tramai.engine.provider.ProviderRetryPolicy
 import dev.tramai.core.approval.ValidateResumeCommand
 import dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter
 import dev.tramai.core.approval.SensitiveToolArguments
@@ -128,6 +139,9 @@ import dev.tramai.core.provider.resolveCandidates
 
 private const val MAX_SAFE_TOOL_NAME_LENGTH = 128
 private const val UNREGISTERED_TOOL_NAME = "unregistered_tool"
+
+/** Compatibility alias for internal characterization fixtures; implementation lives in provider. */
+internal typealias ProviderRetryDelayPolicy = dev.tramai.engine.provider.ProviderRetryDelayPolicy
 
 /**
  * Runtime engine that turns annotated service interfaces into AI-backed proxies.
@@ -658,6 +672,23 @@ internal class TramaiInvocationHandler(
 
     private val policyHelper = PolicyEnforcementHelper(components.security.resolvedPolicyEngine, migrationWarningGuard, isLegacyFallback = components.security.isLegacyFallback, auditEmitter = policyDecisionAuditEmitter)
     private val modelRegistryEnforcer = ModelRegistryEnforcer(modelRegistry, modelRegistrySettings)
+    private val providerExecutionCoordinator = ProviderExecutionCoordinator(
+        routingPlan = routingPlan,
+        circuitBreaker = circuitBreaker,
+        attemptExecutor = ProviderAttemptExecutor(
+            serviceInterface = serviceDefinition.serviceType.qualifiedName ?: serviceDefinition.serviceType.simpleName.orEmpty(),
+            operationObserver = operationObserver,
+            operationInterceptor = operationInterceptor,
+            circuitBreaker = circuitBreaker,
+            retryPolicy = ProviderRetryPolicy(retryDelayPolicy),
+            authorizationService = ProviderAuthorizationService(modelRegistryEnforcer),
+            beforeProviderInvocation = ProviderInvocationGate { providerId, modelName, correlationId, securityContext -> enforceBeforeProviderInvocation(providerId, modelName, correlationId, securityContext) },
+            responseSanitizer = ProviderResponseSanitizer { response, operation, providerId, modelName, correlationId, securityContext, observation -> sanitizeProviderResponse(response, operation, providerId, modelName, correlationId, securityContext, observation) },
+        ),
+        fallbackPolicy = ProviderFallbackPolicy(),
+        beforeResolution = ProviderResolutionGate { operation, correlationId, securityContext -> enforceBeforeProviderResolution(operation, correlationId, securityContext) },
+        fallbackGate = ProviderFallbackGate { correlationId, previousProviderId, previousModelName, nextProviderId, reason, securityContext -> enforceFallbackTransition(correlationId, previousProviderId, previousModelName, nextProviderId, reason, securityContext) },
+    )
 
     private fun OperationObservation.completeCancellation(cancellation: CancellationException) {
         try {
@@ -1541,7 +1572,7 @@ internal class TramaiInvocationHandler(
             ),
         )
 
-        // DLP is already applied inside callProviderWithRetries — use the sanitized response directly
+        // DLP is already applied inside ProviderAttemptExecutor — use the sanitized response directly
 
         // Enforce BEFORE_RESPONSE_RETURN
         policyHelper.enforce(
@@ -1722,7 +1753,7 @@ internal class TramaiInvocationHandler(
             ),
         )
 
-        // DLP is already applied inside callProviderWithRetries — use the sanitized response directly
+        // DLP is already applied inside ProviderAttemptExecutor — use the sanitized response directly
 
         val analysis = try {
             handler.analyze(
@@ -1975,12 +2006,15 @@ internal class TramaiInvocationHandler(
         val maxToolLoops = 5 // Guard against infinite tool loops
         val attemptCounter = AttemptCounter()
         repeat(maxToolLoops) {
-            val result = callProviderWithFallbacks(
-                operation = operation,
-                messages = messages,
-                attemptCounter = attemptCounter,
-                correlationId = correlationId,
-                securityContext = securityContext,
+            val result = providerExecutionCoordinator.execute(
+                ProviderExecutionRequest(
+                    operation = operation,
+                    messages = messages,
+                    attemptCounter = attemptCounter,
+                    correlationId = correlationId,
+                    securityContext = securityContext,
+                    beforeRoute = { enforceToolExposure(operation, correlationId, securityContext) },
+                ),
             )
             try {
                 enforceTokenBudget(
@@ -2490,256 +2524,6 @@ internal class TramaiInvocationHandler(
         }
     }
 
-    private suspend fun callProviderWithFallbacks(
-        operation: OperationDefinition,
-        messages: List<Message>,
-        attemptCounter: AttemptCounter,
-        correlationId: String,
-        securityContext: ExecutionSecurityContext,
-    ): ProviderCallResult {
-        var lastFallbackFailure: Throwable? = null
-        var lastCircuitOpen: CircuitBreakerOpenException? = null
-
-        enforceBeforeProviderResolution(operation, correlationId, securityContext)
-        val candidates = routingPlan.resolveCandidates(operation.operation)
-
-        for ((routeIndex, route) in candidates.withIndex()) {
-            val circuitOpen = handleCircuitBreakerOpenRoute(
-                route = route,
-                nextRoute = candidates.getOrNull(routeIndex + 1),
-                correlationId = correlationId,
-                securityContext = securityContext,
-            )
-            if (circuitOpen != null) {
-                lastCircuitOpen = circuitOpen
-                continue
-            }
-
-            try {
-                enforceToolExposure(operation, correlationId, securityContext)
-                return callProviderWithRetries(providerRetryRequest(route, routeIndex, operation, messages, attemptCounter, correlationId, securityContext))
-            } catch (error: Throwable) {
-                error.rethrowIfCancellation()
-                if (!shouldFallbackFrom(error)) {
-                    throw error
-                }
-                enforceProviderFallbackAfterFailure(
-                    error = error,
-                    route = route,
-                    nextRoute = candidates.getOrNull(routeIndex + 1),
-                    correlationId = correlationId,
-                    securityContext = securityContext,
-                )
-                lastFallbackFailure = error
-            }
-        }
-
-        throw lastFallbackFailure
-            ?: lastCircuitOpen
-            ?: ProviderException(
-                message = "No available provider route for model '${operation.operation.model}'",
-                retryable = true,
-            )
-    }
-
-    private fun providerRetryRequest(
-        route: ResolvedProviderRoute,
-        routeIndex: Int,
-        operation: OperationDefinition,
-        messages: List<Message>,
-        attemptCounter: AttemptCounter,
-        correlationId: String,
-        securityContext: ExecutionSecurityContext,
-    ) = ProviderRetryRequest(
-        providerId = route.providerName,
-        provider = route.provider,
-        request = ModelRequest(
-            model = route.effectiveModelName,
-            messages = messages.toList(),
-            tools = operation.toolDefinitions.takeIf { it.isNotEmpty() },
-            timeoutMillis = operation.operation.timeoutMillis,
-            operationInterface = operation.method.declaringClass.name,
-            operationMethod = operation.method.name,
-        ),
-        operation = operation,
-        attemptCounter = attemptCounter,
-        routeIndex = routeIndex,
-        correlationId = correlationId,
-        securityContext = securityContext,
-    )
-
-    private suspend fun enforceProviderFallbackAfterFailure(
-        error: Throwable,
-        route: ResolvedProviderRoute,
-        nextRoute: ResolvedProviderRoute?,
-        correlationId: String,
-        securityContext: ExecutionSecurityContext,
-    ) {
-        if (nextRoute == null) return
-        try {
-            enforceFallbackTransition(
-                correlationId = correlationId,
-                previousProviderId = route.providerName,
-                previousModelName = route.effectiveModelName,
-                nextProviderId = nextRoute.providerName,
-                reason = "provider-failure",
-                securityContext = securityContext,
-            )
-        } catch (policyError: PolicyViolationException) {
-            policyError.addSuppressed(error)
-            throw policyError
-        }
-    }
-
-    private suspend fun callProviderWithRetries(retry: ProviderRetryRequest): ProviderCallResult {
-        val maxAttempts = retry.operation.operation.providerRetries + 1
-
-        repeat(maxAttempts) { retryIndex ->
-            val attempt = startProviderRetryAttempt(retry)
-
-            try {
-                return executeProviderRetryAttempt(attempt, retry)
-            } catch (error: dev.tramai.core.security.DlpInspectionException) {
-                // DLP failures propagate directly — NOT a provider failure.
-                // Do NOT call observation.onProviderFailure, circuitBreaker.onFailure,
-                // or retry. Record call completion once.
-                attempt.observation.onCallCompleted(parseSuccess = null)
-                throw error
-            } catch (error: CancellationException) {
-                attempt.observation.completeCancellation(error)
-                throw error
-            } catch (error: Throwable) {
-                error.rethrowIfCancellation()
-                handleProviderRetryFailure(error, retry, attempt.observation, retryIndex, maxAttempts)
-            }
-        }
-
-        error("Provider retry loop exited without returning or throwing")
-    }
-
-    private data class ProviderRetryAttempt(
-        val callContext: OperationCallContext,
-        val interceptedRequest: ModelRequest,
-        val observation: OperationObservation,
-        val approvedModel: dev.tramai.core.model.RegisteredModel?,
-    )
-
-    private suspend fun startProviderRetryAttempt(retry: ProviderRetryRequest): ProviderRetryAttempt {
-        val callContext = OperationCallContext(
-            serviceInterface = serviceDefinition.serviceType.qualifiedName ?: serviceDefinition.serviceType.simpleName.orEmpty(),
-            methodName = retry.operation.method.name,
-            providerId = retry.providerId,
-            requestedModel = retry.operation.operation.model,
-            attempt = retry.attemptCounter.next(),
-        )
-        val interceptedRequest = retry.request.copy(
-            messages = operationInterceptor.interceptRequest(callContext, retry.request.messages),
-        )
-        val observation = operationObserver.onCallStarted(callContext)
-        observation.onEngineEvent(
-            name = EVENT_ROUTE_SELECTED,
-            attributes = routeSelectedAttributes(
-                ResolvedProviderRoute(
-                    providerName = retry.providerId,
-                    provider = retry.provider,
-                    requestedModelName = retry.operation.operation.model,
-                    effectiveModelName = retry.request.model,
-                ),
-                routeIndex = retry.routeIndex,
-            ),
-        )
-        val approvedModel = authorizeProviderRetryModel(retry.providerId, retry.request.model, observation)
-        return ProviderRetryAttempt(callContext, interceptedRequest, observation, approvedModel)
-    }
-
-    private suspend fun authorizeProviderRetryModel(
-        providerId: String,
-        modelName: String,
-        observation: OperationObservation,
-    ): dev.tramai.core.model.RegisteredModel? = try {
-        modelRegistryEnforcer.authorize(providerId, modelName)
-    } catch (e: CancellationException) {
-        throw e
-    } catch (e: ModelRegistryException) {
-        observation.onCallCompleted(parseSuccess = null)
-        throw e
-    }
-
-    private suspend fun executeProviderRetryAttempt(
-        attempt: ProviderRetryAttempt,
-        retry: ProviderRetryRequest,
-    ): ProviderCallResult {
-        enforceBeforeProviderInvocation(
-            providerId = retry.providerId,
-            modelName = retry.request.model,
-            correlationId = retry.correlationId,
-            securityContext = retry.securityContext,
-        )
-        val rawResponse = callProviderOnce(retry.providerId, retry.provider, attempt.interceptedRequest, retry.operation)
-        val interceptedResponse = operationInterceptor.interceptResponse(attempt.callContext, rawResponse)
-        val sanitizedResponse = sanitizeProviderResponse(
-            interceptedResponse = interceptedResponse,
-            operation = retry.operation,
-            providerId = retry.providerId,
-            modelName = retry.request.model,
-            correlationId = retry.correlationId,
-            securityContext = retry.securityContext,
-            observation = attempt.observation,
-        )
-        attempt.observation.onProviderResponse(sanitizedResponse)
-        return ProviderCallResult(
-            response = sanitizedResponse,
-            observation = attempt.observation,
-            providerId = retry.providerId,
-            modelName = retry.request.model,
-            approvedModel = attempt.approvedModel,
-        )
-    }
-
-    private suspend fun handleProviderRetryFailure(
-        error: Throwable,
-        retry: ProviderRetryRequest,
-        observation: OperationObservation,
-        retryIndex: Int,
-        maxAttempts: Int,
-    ) {
-        observation.onProviderFailure(error)
-        observation.onCallCompleted(parseSuccess = null)
-
-        if (!shouldRetryProviderCall(error, retryIndex, maxAttempts)) {
-            val opened = circuitBreaker.onFailure(retry.providerId, error)
-            if (opened) {
-                observation.onEngineEvent(
-                    name = EVENT_CIRCUIT_OPENED,
-                    attributes = mapOf(ATTR_PROVIDER_ID to retry.providerId),
-                )
-            }
-            throw error
-        }
-
-        val delayMillis = providerRetryDelayMillis(retryIndex, error)
-        observation.onEngineEvent(
-            name = "tramai.retry.scheduled",
-            attributes = mapOf(
-                ATTR_PROVIDER_ID to retry.providerId,
-                ATTR_RETRY_INDEX to retryIndex,
-                ATTR_DELAY_MILLIS to delayMillis,
-                ATTR_DELAY_SOURCE to retryDelaySource(error),
-            ),
-        )
-        delay(delayMillis)
-    }
-
-    private data class ProviderRetryRequest(
-        val providerId: String,
-        val provider: ModelProvider,
-        val request: ModelRequest,
-        val operation: OperationDefinition,
-        val attemptCounter: AttemptCounter,
-        val routeIndex: Int,
-        val correlationId: String,
-        val securityContext: ExecutionSecurityContext,
-    )
 
     /**
      * Applies authoritative DLP inspection to model output without marking failures as provider failures.
@@ -3278,69 +3062,6 @@ internal class TramaiInvocationHandler(
         val historySize: Int = 0,
     )
 
-    private suspend fun callProviderOnce(
-        providerId: String,
-        provider: ModelProvider,
-        request: ModelRequest,
-        operation: OperationDefinition,
-    ): ModelResponse = try {
-        val timeoutMillis = request.timeoutMillis ?: operation.operation.timeoutMillis
-        // Check capability: does the provider support images?
-        if (request.messages.any { it.hasImage() } && !provider.supportsCapability(ProviderCapability.VISION)) {
-            throw ProviderCapabilityException(
-                providerId = provider.providerId(),
-                capability = "VISION",
-            )
-        }
-        withTimeout(timeoutMillis) {
-            provider.complete(request)
-        }
-    } catch (error: Throwable) {
-        if (error is TimeoutCancellationException) {
-            currentCoroutineContext().ensureActive()
-            throw TimeoutException(
-                message = buildTimeoutMessage(
-                    providerId = providerId,
-                    operation = operation,
-                    timeoutMillis = request.timeoutMillis ?: operation.operation.timeoutMillis,
-                ),
-                cause = error,
-            )
-        }
-        error.rethrowIfCancellation()
-        throw when (error) {
-            is ProviderException -> error
-
-            else -> ProviderException(
-                message = "Provider $providerId failed while invoking ${serviceDefinition.serviceType.qualifiedName}.${operation.method.name}",
-                cause = error,
-            )
-        }
-    }
-
-    private fun shouldRetryProviderCall(
-        error: Throwable,
-        retryIndex: Int,
-        maxAttempts: Int,
-    ): Boolean {
-        if (retryIndex >= maxAttempts - 1) {
-            return false
-        }
-
-        return when (error) {
-            is TimeoutException -> true
-            is ProviderException -> error.retryable
-            else -> false
-        }
-    }
-
-    private fun providerRetryDelayMillis(
-        retryIndex: Int,
-        error: Throwable,
-    ): Long = retryDelayPolicy.delayMillis(
-        error = error,
-        fallbackDelayMillis = minOf(INITIAL_PROVIDER_RETRY_DELAY_MILLIS shl retryIndex, MAX_PROVIDER_RETRY_DELAY_MILLIS),
-    )
 
     private fun buildTimeoutMessage(
         providerId: String,
@@ -3369,11 +3090,6 @@ internal class TramaiInvocationHandler(
         else -> false
     }
 
-    private fun retryDelaySource(error: Throwable): String = if (error is ProviderException && error.retryAfterMillis != null) {
-        "retry_after"
-    } else {
-        "backoff"
-    }
 
     private fun enforceTokenBudget(
         tracker: TokenBudgetTracker,
@@ -4813,13 +4529,7 @@ internal fun buildOperationCacheKeyForTesting(
     )
 }
 
-private data class ProviderCallResult(
-    val response: ModelResponse,
-    val observation: OperationObservation,
-    val providerId: String,
-    val modelName: String,
-    val approvedModel: RegisteredModel?,
-)
+private typealias ProviderCallResult = dev.tramai.engine.provider.ProviderCallResult
 
 private sealed class StreamingRouteResult {
     data class Completed(
@@ -4839,13 +4549,9 @@ private class StreamingRouteFinished(
     val result: StreamingRouteResult,
 ) : RuntimeException(null, null, false, false)
 
-private class AttemptCounter {
-    private var attempt = 0
+private typealias AttemptCounter = dev.tramai.engine.provider.AttemptCounter
 
-    fun next(): Int = attempt++
-}
-
-internal class ProviderCircuitBreaker(
+internal open class ProviderCircuitBreaker(
     private val settings: CircuitBreakerSettings,
     private val clockMillis: () -> Long = System::currentTimeMillis,
 ) {
@@ -4890,7 +4596,7 @@ internal class ProviderCircuitBreaker(
     }
 
     @Synchronized
-    fun onFailure(
+    open fun onFailure(
         providerId: String,
         error: Throwable,
     ): Boolean {
@@ -4920,30 +4626,6 @@ private data class ProviderCircuitState(
     var openUntilMillis: Long? = null,
 )
 
-internal class ProviderRetryDelayPolicy(
-    private val settings: RetryPolicySettings,
-    private val randomDouble: () -> Double = { kotlin.random.Random.nextDouble() },
-) {
-    fun delayMillis(
-        error: Throwable,
-        fallbackDelayMillis: Long,
-    ): Long {
-        val cappedBaseDelay = when (error) {
-            is ProviderException -> {
-                val retryAfterMillis = error.retryAfterMillis
-                if (retryAfterMillis != null) {
-                    minOf(retryAfterMillis, settings.maxRetryAfterMillis)
-                } else {
-                    fallbackDelayMillis
-                }
-            }
-            else -> fallbackDelayMillis
-        }
-
-        val jitter = (cappedBaseDelay * settings.jitterRatio * randomDouble()).toLong()
-        return cappedBaseDelay + jitter
-    }
-}
 
 private class TokenBudgetTracker(
     private val settings: TokenBudgetSettings,
@@ -5069,8 +4751,6 @@ internal fun sha256Hex(input: String): String {
     return digest.joinToString(separator = "") { byte -> "%02x".format(byte) }
 }
 
-private const val INITIAL_PROVIDER_RETRY_DELAY_MILLIS = 50L
-private const val MAX_PROVIDER_RETRY_DELAY_MILLIS = 1_000L
 private const val IDEMPOTENT_TOOL_MAX_ATTEMPTS = 2
 
 private const val ATTR_PROVIDER_ID = "provider_id"

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/provider/ProviderAttemptExecutor.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/provider/ProviderAttemptExecutor.kt
@@ -1,0 +1,107 @@
+package dev.tramai.engine.provider
+
+import dev.tramai.core.exception.ModelRegistryException
+import dev.tramai.core.exception.ProviderCapabilityException
+import dev.tramai.core.exception.ProviderException
+import dev.tramai.core.exception.TimeoutException
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.model.RegisteredModel
+import dev.tramai.core.observation.OperationCallContext
+import dev.tramai.core.observation.OperationInterceptor
+import dev.tramai.core.observation.OperationObservation
+import dev.tramai.core.observation.OperationObserver
+import dev.tramai.core.provider.ModelProvider
+import dev.tramai.core.provider.ProviderCapability
+import dev.tramai.core.security.DlpInspectionException
+import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.OperationDefinition
+import dev.tramai.engine.ProviderCircuitBreaker
+import dev.tramai.core.coroutines.rethrowIfCancellation
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withTimeout
+
+internal data class ProviderCallResult(val response: ModelResponse, val observation: OperationObservation, val providerId: String, val modelName: String, val approvedModel: RegisteredModel?)
+internal class AttemptCounter { private var attempt = 0; fun next(): Int = attempt++ }
+internal fun interface ProviderInvocationGate { suspend fun invoke(providerId: String, modelName: String, correlationId: String, securityContext: ExecutionSecurityContext) }
+internal fun interface ProviderResponseSanitizer { suspend fun sanitize(response: ModelResponse, operation: OperationDefinition, providerId: String, modelName: String, correlationId: String, securityContext: ExecutionSecurityContext, observation: OperationObservation): ModelResponse }
+
+internal class ProviderAttemptExecutor(
+    private val serviceInterface: String,
+    private val operationObserver: OperationObserver,
+    private val operationInterceptor: OperationInterceptor,
+    private val circuitBreaker: ProviderCircuitBreaker,
+    private val retryPolicy: ProviderRetryPolicy,
+    private val authorizationService: ProviderAuthorizationService,
+    private val beforeProviderInvocation: ProviderInvocationGate,
+    private val responseSanitizer: ProviderResponseSanitizer,
+) {
+    suspend fun execute(request: ProviderRetryRequest): ProviderCallResult {
+        val maxAttempts = request.operation.operation.providerRetries + 1
+        repeat(maxAttempts) { retryIndex ->
+            val attempt = startAttempt(request)
+            try {
+                beforeProviderInvocation.invoke(request.providerId, request.request.model, request.correlationId, request.securityContext)
+                val response = operationInterceptor.interceptResponse(attempt.context, callOnce(request.providerId, request.provider, attempt.request, request.operation))
+                val sanitized = responseSanitizer.sanitize(response, request.operation, request.providerId, request.request.model, request.correlationId, request.securityContext, attempt.observation)
+                attempt.observation.onProviderResponse(sanitized)
+                return ProviderCallResult(sanitized, attempt.observation, request.providerId, request.request.model, attempt.approvedModel)
+            } catch (error: DlpInspectionException) {
+                attempt.observation.onCallCompleted(parseSuccess = null)
+                throw error
+            } catch (error: CancellationException) {
+                attempt.observation.completeCancellation(error)
+                throw error
+            } catch (error: Throwable) {
+                error.rethrowIfCancellation()
+                attempt.observation.onProviderFailure(error)
+                attempt.observation.onCallCompleted(parseSuccess = null)
+                when (val decision = retryPolicy.decide(error, retryIndex, maxAttempts)) {
+                    is ProviderRetryDecision.Retry -> {
+                        attempt.observation.onEngineEvent("tramai.retry.scheduled", mapOf("provider_id" to request.providerId, "retry_index" to retryIndex, "delay_millis" to decision.delayMillis, "delay_source" to decision.delaySource))
+                        delay(decision.delayMillis)
+                    }
+                    ProviderRetryDecision.Stop -> {
+                        if (circuitBreaker.onFailure(request.providerId, error)) attempt.observation.onEngineEvent("tramai.circuit.opened", mapOf("provider_id" to request.providerId))
+                        throw error
+                    }
+                }
+            }
+        }
+        error("Provider retry loop exited without returning or throwing")
+    }
+
+    private suspend fun startAttempt(request: ProviderRetryRequest): ProviderRetryAttempt {
+        val context = OperationCallContext(serviceInterface, request.operation.method.name, request.providerId, request.operation.operation.model, request.attemptCounter.next())
+        val intercepted = request.request.copy(messages = operationInterceptor.interceptRequest(context, request.request.messages))
+        val observation = operationObserver.onCallStarted(context)
+        observation.onEngineEvent("tramai.route.selected", mapOf("provider_id" to request.providerId, "effective_model" to request.request.model, "route_index" to request.routeIndex, "is_fallback" to (request.routeIndex > 0)))
+        val approvedModel = try { authorizationService.authorize(request.providerId, request.request.model) } catch (error: ModelRegistryException) { observation.onCallCompleted(parseSuccess = null); throw error }
+        return ProviderRetryAttempt(context, intercepted, observation, approvedModel)
+    }
+
+    private suspend fun callOnce(providerId: String, provider: ModelProvider, request: ModelRequest, operation: OperationDefinition): ModelResponse = try {
+        val timeout = request.timeoutMillis ?: operation.operation.timeoutMillis
+        if (request.messages.any { it.hasImage() } && !provider.supportsCapability(ProviderCapability.VISION)) throw ProviderCapabilityException(provider.providerId(), "VISION")
+        withTimeout(timeout) { provider.complete(request) }
+    } catch (error: TimeoutCancellationException) {
+        currentCoroutineContext().ensureActive()
+        throw TimeoutException("Provider $providerId timed out after ${request.timeoutMillis ?: operation.operation.timeoutMillis}ms while invoking $serviceInterface.${operation.method.name}", error)
+    } catch (error: CancellationException) {
+        throw error
+    } catch (error: Throwable) {
+        error.rethrowIfCancellation()
+        throw if (error is ProviderException) error else ProviderException("Provider $providerId failed while invoking $serviceInterface.${operation.method.name}", error)
+    }
+}
+
+internal data class ProviderRetryRequest(val providerId: String, val provider: ModelProvider, val request: ModelRequest, val operation: OperationDefinition, val attemptCounter: AttemptCounter, val routeIndex: Int, val correlationId: String, val securityContext: ExecutionSecurityContext)
+private data class ProviderRetryAttempt(val context: OperationCallContext, val request: ModelRequest, val observation: OperationObservation, val approvedModel: RegisteredModel?)
+
+private fun OperationObservation.completeCancellation(cancellation: CancellationException) {
+    try { onCallCancelled() } catch (observerError: Throwable) { cancellation.addSuppressed(observerError) }
+}

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/provider/ProviderAttemptExecutor.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/provider/ProviderAttemptExecutor.kt
@@ -26,7 +26,11 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withTimeout
 
 internal data class ProviderCallResult(val response: ModelResponse, val observation: OperationObservation, val providerId: String, val modelName: String, val approvedModel: RegisteredModel?)
-internal class AttemptCounter { private var attempt = 0; fun next(): Int = attempt++ }
+internal class AttemptCounter {
+    private var attempt = 0
+
+    fun next(): Int = attempt++
+}
 internal fun interface ProviderInvocationGate { suspend fun invoke(providerId: String, modelName: String, correlationId: String, securityContext: ExecutionSecurityContext) }
 internal fun interface ProviderResponseSanitizer { suspend fun sanitize(response: ModelResponse, operation: OperationDefinition, providerId: String, modelName: String, correlationId: String, securityContext: ExecutionSecurityContext, observation: OperationObservation): ModelResponse }
 
@@ -80,7 +84,15 @@ internal class ProviderAttemptExecutor(
         val intercepted = request.request.copy(messages = operationInterceptor.interceptRequest(context, request.request.messages))
         val observation = operationObserver.onCallStarted(context)
         observation.onEngineEvent("tramai.route.selected", mapOf("provider_id" to request.providerId, "effective_model" to request.request.model, "route_index" to request.routeIndex, "is_fallback" to (request.routeIndex > 0)))
-        val approvedModel = try { authorizationService.authorize(request.providerId, request.request.model) } catch (error: ModelRegistryException) { observation.onCallCompleted(parseSuccess = null); throw error }
+        val approvedModel = try {
+            authorizationService.authorize(request.providerId, request.request.model)
+        } catch (error: CancellationException) {
+            observation.completeCancellation(error)
+            throw error
+        } catch (error: ModelRegistryException) {
+            observation.onCallCompleted(parseSuccess = null)
+            throw error
+        }
         return ProviderRetryAttempt(context, intercepted, observation, approvedModel)
     }
 
@@ -103,5 +115,9 @@ internal data class ProviderRetryRequest(val providerId: String, val provider: M
 private data class ProviderRetryAttempt(val context: OperationCallContext, val request: ModelRequest, val observation: OperationObservation, val approvedModel: RegisteredModel?)
 
 private fun OperationObservation.completeCancellation(cancellation: CancellationException) {
-    try { onCallCancelled() } catch (observerError: Throwable) { cancellation.addSuppressed(observerError) }
+    try {
+        onCallCancelled()
+    } catch (observerError: Throwable) {
+        cancellation.addSuppressed(observerError)
+    }
 }

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/provider/ProviderAuthorizationService.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/provider/ProviderAuthorizationService.kt
@@ -1,0 +1,13 @@
+package dev.tramai.engine.provider
+
+import dev.tramai.core.model.RegisteredModel
+import dev.tramai.engine.ModelRegistryEnforcer
+import kotlinx.coroutines.CancellationException
+
+internal class ProviderAuthorizationService(private val modelRegistryEnforcer: ModelRegistryEnforcer) {
+    suspend fun authorize(providerId: String, modelName: String): RegisteredModel? = try {
+        modelRegistryEnforcer.authorize(providerId, modelName)
+    } catch (error: CancellationException) {
+        throw error
+    }
+}

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/provider/ProviderExecutionCoordinator.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/provider/ProviderExecutionCoordinator.kt
@@ -1,0 +1,71 @@
+package dev.tramai.engine.provider
+
+import dev.tramai.core.exception.CircuitBreakerOpenException
+import dev.tramai.core.exception.PolicyViolationException
+import dev.tramai.core.exception.ProviderException
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.provider.ProviderRoutingPlan
+import dev.tramai.core.provider.ResolvedProviderRoute
+import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.OperationDefinition
+import dev.tramai.engine.ProviderCircuitBreaker
+import dev.tramai.core.coroutines.rethrowIfCancellation
+import dev.tramai.core.provider.resolveCandidates
+
+internal fun interface ProviderRouteGate { suspend fun beforeRoute() }
+internal fun interface ProviderResolutionGate { suspend fun beforeResolution(operation: OperationDefinition, correlationId: String, securityContext: ExecutionSecurityContext) }
+internal fun interface ProviderFallbackGate { suspend fun transition(correlationId: String, previousProviderId: String?, previousModelName: String?, nextProviderId: String, reason: String, securityContext: ExecutionSecurityContext) }
+internal data class ProviderExecutionRequest(val operation: OperationDefinition, val messages: List<Message>, val attemptCounter: AttemptCounter, val correlationId: String, val securityContext: ExecutionSecurityContext, val beforeRoute: ProviderRouteGate)
+
+internal class ProviderExecutionCoordinator(
+    private val routingPlan: ProviderRoutingPlan,
+    private val circuitBreaker: ProviderCircuitBreaker,
+    private val attemptExecutor: ProviderAttemptExecutor,
+    private val fallbackPolicy: ProviderFallbackPolicy,
+    private val beforeResolution: ProviderResolutionGate,
+    private val fallbackGate: ProviderFallbackGate,
+) {
+    suspend fun execute(request: ProviderExecutionRequest): ProviderCallResult {
+        var lastFailure: Throwable? = null
+        var lastCircuitOpen: CircuitBreakerOpenException? = null
+        beforeResolution.beforeResolution(request.operation, request.correlationId, request.securityContext)
+        val candidates = routingPlan.resolveCandidates(request.operation.operation)
+        for ((index, route) in candidates.withIndex()) {
+            val next = candidates.getOrNull(index + 1)
+            val blockedUntil = circuitBreaker.beforeCall(route.providerName)
+            if (blockedUntil != null) {
+                val error = CircuitBreakerOpenException(route.providerName, blockedUntil)
+                transition(error, route, next, ProviderFallbackReason.CIRCUIT_BREAKER_OPEN, request)
+                lastCircuitOpen = error
+                continue
+            }
+            try {
+                request.beforeRoute.beforeRoute()
+                return attemptExecutor.execute(routeRequest(route, index, request))
+            } catch (error: Throwable) {
+                error.rethrowIfCancellation()
+                when (val decision = fallbackPolicy.decide(error)) {
+                    ProviderFallbackDecision.Stop -> throw error
+                    is ProviderFallbackDecision.Continue -> {
+                        transition(error, route, next, decision.reason, request)
+                        lastFailure = error
+                    }
+                }
+            }
+        }
+        throw lastFailure ?: lastCircuitOpen ?: ProviderException("No available provider route for model '${request.operation.operation.model}'", retryable = true)
+    }
+
+    private suspend fun transition(error: Throwable, route: ResolvedProviderRoute, next: ResolvedProviderRoute?, reason: ProviderFallbackReason, request: ProviderExecutionRequest) {
+        if (next == null) return
+        try { fallbackGate.transition(request.correlationId, route.providerName, route.effectiveModelName, next.providerName, fallbackPolicy.reasonString(reason), request.securityContext) }
+        catch (policyError: PolicyViolationException) { policyError.addSuppressed(error); throw policyError }
+    }
+
+    private fun routeRequest(route: ResolvedProviderRoute, routeIndex: Int, request: ProviderExecutionRequest) = ProviderRetryRequest(
+        providerId = route.providerName, provider = route.provider,
+        request = ModelRequest(model = route.effectiveModelName, messages = request.messages.toList(), tools = request.operation.toolDefinitions.takeIf { it.isNotEmpty() }, timeoutMillis = request.operation.operation.timeoutMillis, operationInterface = request.operation.method.declaringClass.name, operationMethod = request.operation.method.name),
+        operation = request.operation, attemptCounter = request.attemptCounter, routeIndex = routeIndex, correlationId = request.correlationId, securityContext = request.securityContext,
+    )
+}

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/provider/ProviderExecutionCoordinator.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/provider/ProviderExecutionCoordinator.kt
@@ -59,8 +59,12 @@ internal class ProviderExecutionCoordinator(
 
     private suspend fun transition(error: Throwable, route: ResolvedProviderRoute, next: ResolvedProviderRoute?, reason: ProviderFallbackReason, request: ProviderExecutionRequest) {
         if (next == null) return
-        try { fallbackGate.transition(request.correlationId, route.providerName, route.effectiveModelName, next.providerName, fallbackPolicy.reasonString(reason), request.securityContext) }
-        catch (policyError: PolicyViolationException) { policyError.addSuppressed(error); throw policyError }
+        try {
+            fallbackGate.transition(request.correlationId, route.providerName, route.effectiveModelName, next.providerName, fallbackPolicy.reasonString(reason), request.securityContext)
+        } catch (policyError: PolicyViolationException) {
+            policyError.addSuppressed(error)
+            throw policyError
+        }
     }
 
     private fun routeRequest(route: ResolvedProviderRoute, routeIndex: Int, request: ProviderExecutionRequest) = ProviderRetryRequest(

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/provider/ProviderFallbackPolicy.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/provider/ProviderFallbackPolicy.kt
@@ -1,0 +1,27 @@
+package dev.tramai.engine.provider
+
+import dev.tramai.core.exception.CircuitBreakerOpenException
+import dev.tramai.core.exception.ProviderException
+import dev.tramai.core.exception.TimeoutException
+import dev.tramai.core.security.DlpInspectionException
+
+internal sealed interface ProviderFallbackDecision {
+    data class Continue(val reason: ProviderFallbackReason) : ProviderFallbackDecision
+    data object Stop : ProviderFallbackDecision
+}
+internal enum class ProviderFallbackReason { PROVIDER_FAILURE, CIRCUIT_BREAKER_OPEN }
+
+internal open class ProviderFallbackPolicy {
+    open fun decide(error: Throwable): ProviderFallbackDecision = when (error) {
+        is DlpInspectionException -> ProviderFallbackDecision.Stop
+        is CircuitBreakerOpenException -> ProviderFallbackDecision.Continue(ProviderFallbackReason.CIRCUIT_BREAKER_OPEN)
+        is TimeoutException -> ProviderFallbackDecision.Continue(ProviderFallbackReason.PROVIDER_FAILURE)
+        is ProviderException -> if (error.retryable) ProviderFallbackDecision.Continue(ProviderFallbackReason.PROVIDER_FAILURE) else ProviderFallbackDecision.Stop
+        else -> ProviderFallbackDecision.Stop
+    }
+
+    fun reasonString(reason: ProviderFallbackReason): String = when (reason) {
+        ProviderFallbackReason.PROVIDER_FAILURE -> "provider-failure"
+        ProviderFallbackReason.CIRCUIT_BREAKER_OPEN -> "circuit-breaker-open"
+    }
+}

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/provider/ProviderRetryPolicy.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/provider/ProviderRetryPolicy.kt
@@ -1,0 +1,39 @@
+package dev.tramai.engine.provider
+
+import dev.tramai.core.exception.ProviderException
+import dev.tramai.core.exception.TimeoutException
+import dev.tramai.engine.RetryPolicySettings
+
+internal sealed interface ProviderRetryDecision {
+    data class Retry(val delayMillis: Long, val delaySource: String) : ProviderRetryDecision
+    data object Stop : ProviderRetryDecision
+}
+
+internal open class ProviderRetryPolicy(private val retryDelayPolicy: ProviderRetryDelayPolicy) {
+    open fun decide(error: Throwable, retryIndex: Int, maxAttempts: Int): ProviderRetryDecision {
+        if (retryIndex >= maxAttempts - 1 || !isRetryable(error)) return ProviderRetryDecision.Stop
+        val fallbackDelayMillis = minOf(50L shl retryIndex, 1_000L)
+        return ProviderRetryDecision.Retry(
+            delayMillis = retryDelayPolicy.delayMillis(error, fallbackDelayMillis),
+            delaySource = if (error is ProviderException && error.retryAfterMillis != null) "retry_after" else "backoff",
+        )
+    }
+
+    private fun isRetryable(error: Throwable): Boolean = when (error) {
+        is TimeoutException -> true
+        is ProviderException -> error.retryable
+        else -> false
+    }
+}
+
+internal class ProviderRetryDelayPolicy(
+    private val settings: RetryPolicySettings,
+    private val randomDouble: () -> Double = { kotlin.random.Random.nextDouble() },
+) {
+    fun delayMillis(error: Throwable, fallbackDelayMillis: Long): Long {
+        val cappedBaseDelay = if (error is ProviderException && error.retryAfterMillis != null) {
+            minOf(requireNotNull(error.retryAfterMillis), settings.maxRetryAfterMillis)
+        } else fallbackDelayMillis
+        return cappedBaseDelay + (cappedBaseDelay * settings.jitterRatio * randomDouble()).toLong()
+    }
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/ProviderAttemptExecutorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/ProviderAttemptExecutorTest.kt
@@ -1,0 +1,102 @@
+package dev.tramai.engine.provider
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.exception.ModelRegistryException
+import dev.tramai.core.exception.ProviderException
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.ModelArtifactDigest
+import dev.tramai.core.model.ModelRegistry
+import dev.tramai.core.model.ModelRegistrySettings
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.model.RegisteredModel
+import dev.tramai.core.observation.OperationCallContext
+import dev.tramai.core.observation.OperationInterceptor
+import dev.tramai.core.observation.OperationObservation
+import dev.tramai.core.observation.OperationObserver
+import dev.tramai.core.provider.ModelProvider
+import dev.tramai.core.security.DlpInspectionException
+import dev.tramai.engine.CircuitBreakerSettings
+import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.ModelRegistryEnforcer
+import dev.tramai.engine.OperationDefinition
+import dev.tramai.engine.ProviderCircuitBreaker
+import dev.tramai.engine.RetryPolicySettings
+import dev.tramai.engine.planning.OperationDefinitionCompiler
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class ProviderAttemptExecutorTest {
+    @Test fun `success transfers observation ownership in result`() {
+        runBlocking {
+        val observation = RecordingObservation(); val executor = executor(observation = observation)
+        val result = executor.execute(request(provider = FakeProvider { ModelResponse("ok") }))
+        assertThat(result.response.content).isEqualTo("ok"); assertThat(result.providerId).isEqualTo("primary")
+        assertThat(observation.responses).isEqualTo(1); assertThat(observation.completed).isZero(); assertThat(observation.cancelled).isZero()
+    }
+    }
+
+    @Test fun `request and response interceptors surround provider and dlp`() {
+        runBlocking {
+        val order = mutableListOf<String>()
+        val interceptor = object : OperationInterceptor {
+            override fun interceptRequest(context: OperationCallContext, messages: List<Message>): List<Message> { order += "request"; return messages }
+            override fun interceptResponse(context: OperationCallContext, response: ModelResponse): ModelResponse { order += "response"; return response }
+        }
+        val executor = executor(interceptor = interceptor, sanitizer = ProviderResponseSanitizer { response, _, _, _, _, _, _ -> order += "dlp"; response })
+        executor.execute(request(provider = FakeProvider { order += "provider"; ModelResponse("ok") }))
+        assertThat(order).containsExactly("request", "provider", "response", "dlp")
+    }
+    }
+
+    @Test fun `authorizes before invoking provider`() {
+        runBlocking {
+        val order = mutableListOf<String>(); val auth = authorization { order += "authorization"; approvedModel() }
+        executor(authorization = auth).execute(request(provider = FakeProvider { order += "provider"; ModelResponse("ok") }))
+        assertThat(order).containsExactly("authorization", "provider")
+    }
+    }
+
+    @Test fun `dlp failure is terminal but not provider failure`() {
+        val observation = RecordingObservation(); val executor = executor(observation = observation, sanitizer = ProviderResponseSanitizer { _, _, _, _, _, _, _ -> throw DlpInspectionException("blocked") })
+        assertThatThrownBy { runBlocking { executor.execute(request(provider = FakeProvider { ModelResponse("secret") })) } }.isInstanceOf(DlpInspectionException::class.java)
+        assertThat(observation.failures).isZero(); assertThat(observation.completed).isEqualTo(1)
+    }
+
+    @Test fun `provider error records failure consults retry and completes`() {
+        val observation = RecordingObservation(); val executor = executor(observation = observation)
+        assertThatThrownBy { runBlocking { executor.execute(request(provider = FakeProvider { throw ProviderException("down", retryable = false) })) } }.isInstanceOf(ProviderException::class.java)
+        assertThat(observation.failures).isEqualTo(1); assertThat(observation.completed).isEqualTo(1)
+    }
+
+    @Test fun `cancellation cancels observation without completion or retry`() {
+        val observation = RecordingObservation(); val calls = intArrayOf(0); val executor = executor(observation = observation)
+        assertThatThrownBy { runBlocking { executor.execute(request(provider = FakeProvider { calls[0]++; throw CancellationException("stop") })) } }.isInstanceOf(CancellationException::class.java)
+        assertThat(calls[0]).isEqualTo(1); assertThat(observation.cancelled).isEqualTo(1); assertThat(observation.completed).isZero()
+    }
+
+    @Test fun `authorization failure completes observation exactly once`() {
+        val observation = RecordingObservation(); val executor = executor(observation = observation, authorization = authorization { null })
+        assertThatThrownBy { runBlocking { executor.execute(request(provider = FakeProvider { ModelResponse("never") })) } }.isInstanceOf(ModelRegistryException::class.java)
+        assertThat(observation.completed).isEqualTo(1)
+    }
+}
+
+@AiService internal interface ProviderComponentService { @Operation(prompt = "test", model = "model", providerRetries = 0) suspend fun answer(): String }
+@AiService internal interface RetryingProviderComponentService { @Operation(prompt = "test", model = "model", providerRetries = 1) suspend fun answer(): String }
+internal fun componentOperation(retries: Int = 0): OperationDefinition {
+    val type = if (retries == 0) ProviderComponentService::class.java else RetryingProviderComponentService::class.java
+    val method = type.methods.single { it.name == "answer" }
+    val annotation = method.getAnnotation(Operation::class.java)
+    return OperationDefinitionCompiler.compileDefinition(method, annotation, null)
+}
+internal fun approvedModel() = RegisteredModel("id", "primary", "model", "r1", ModelArtifactDigest.of("sha256:${"a".repeat(64)}"), true)
+internal fun authorization(answer: suspend () -> RegisteredModel?) = ProviderAuthorizationService(ModelRegistryEnforcer(object : ModelRegistry { override suspend fun findApprovedModel(providerId: String, modelName: String) = answer() }, ModelRegistrySettings(enabled = true)))
+internal fun request(provider: ModelProvider, retries: Int = 0, counter: AttemptCounter = AttemptCounter()) = ProviderRetryRequest("primary", provider, ModelRequest("model", emptyList(), timeoutMillis = 1_000), componentOperation(retries), counter, 0, "cid", ExecutionSecurityContext())
+internal fun executor(observation: RecordingObservation = RecordingObservation(), interceptor: OperationInterceptor = object : OperationInterceptor {}, authorization: ProviderAuthorizationService = authorization { approvedModel() }, sanitizer: ProviderResponseSanitizer = ProviderResponseSanitizer { response, _, _, _, _, _, _ -> response }, retryPolicy: ProviderRetryPolicy = ProviderRetryPolicy(ProviderRetryDelayPolicy(RetryPolicySettings(jitterRatio = 0.0)) { 0.0 }), circuitBreaker: ProviderCircuitBreaker = ProviderCircuitBreaker(CircuitBreakerSettings())): ProviderAttemptExecutor = ProviderAttemptExecutor("service", OperationObserver { observation }, interceptor, circuitBreaker, retryPolicy, authorization, ProviderInvocationGate { _, _, _, _ -> }, sanitizer)
+internal class FakeProvider(private val block: suspend (ModelRequest) -> ModelResponse) : ModelProvider { override suspend fun complete(request: ModelRequest) = block(request); override fun providerId() = "fake" }
+internal class RecordingObservation : OperationObservation { var responses = 0; var failures = 0; var completed = 0; var cancelled = 0; val events = mutableListOf<Pair<String, Map<String, Any?>>>() ; override fun onProviderResponse(response: ModelResponse) { responses++ }; override fun onProviderFailure(error: Throwable) { failures++ }; override fun onStructuredParseFailure(rawResponse: String, errorSummary: String) = Unit; override fun onEngineEvent(name: String, attributes: Map<String, Any?>) { events += name to attributes }; override fun onCallCompleted(parseSuccess: Boolean?) { completed++ }; override fun onCallCancelled() { cancelled++ }; fun routeSelected(): Map<String, Any?> = events.first { it.first == "tramai.route.selected" }.second }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/ProviderAuthorizationServiceTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/ProviderAuthorizationServiceTest.kt
@@ -1,0 +1,35 @@
+package dev.tramai.engine.provider
+
+import dev.tramai.core.exception.ModelRegistryException
+import dev.tramai.core.model.ModelArtifactDigest
+import dev.tramai.core.model.ModelRegistry
+import dev.tramai.core.model.ModelRegistrySettings
+import dev.tramai.core.model.RegisteredModel
+import dev.tramai.engine.ModelRegistryEnforcer
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class ProviderAuthorizationServiceTest {
+    @Test fun `returns authorized registered model without observations`() {
+        runBlocking {
+        val approved = model(); val service = ProviderAuthorizationService(enforcer { approved })
+        assertThat(service.authorize("provider", "model")).isEqualTo(approved)
+    }
+    }
+    @Test fun `rethrows registry failure`() {
+        val service = ProviderAuthorizationService(enforcer { null })
+        assertThatThrownBy { runBlocking { service.authorize("provider", "missing") } }.isInstanceOf(ModelRegistryException::class.java)
+    }
+    @Test fun `propagates cancellation unchanged`() {
+        val cancellation = CancellationException("stop")
+        val service = ProviderAuthorizationService(enforcer { throw cancellation })
+        assertThatThrownBy { runBlocking { service.authorize("provider", "model") } }.isSameAs(cancellation)
+    }
+    private fun enforcer(answer: suspend () -> RegisteredModel?) = ModelRegistryEnforcer(object : ModelRegistry {
+        override suspend fun findApprovedModel(providerId: String, modelName: String) = answer()
+    }, ModelRegistrySettings(enabled = true))
+    private fun model() = RegisteredModel("id", "provider", "model", "r1", ModelArtifactDigest.of("sha256:${"a".repeat(64)}"), true)
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/ProviderCancellationContractTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/ProviderCancellationContractTest.kt
@@ -111,12 +111,14 @@ class ProviderCancellationContractTest {
     }
 
     @Test
-    fun `authorization cancellation invokes no provider and no policies`() {
+    fun `authorization cancellation cancels observation and invokes no provider or policies`() {
         var calls = 0
+        val observation = RecordingObservation()
         val retryPolicy = CountingRetryPolicy()
         val fallbackPolicy = CountingFallbackPolicy()
         val cancellation = CancellationException("auth")
         val attemptExecutor = executor(
+            observation = observation,
             retryPolicy = retryPolicy,
             authorization = authorization { throw cancellation },
         )
@@ -143,6 +145,9 @@ class ProviderCancellationContractTest {
         assertThat(calls).isZero()
         assertThat(retryPolicy.decideCalls.get()).isZero()
         assertThat(fallbackPolicy.decideCalls.get()).isZero()
+        assertThat(observation.cancelled).isEqualTo(1)
+        assertThat(observation.completed).isZero()
+        assertThat(observation.failures).isZero()
     }
 
     private fun coordinator(

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/ProviderCancellationContractTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/ProviderCancellationContractTest.kt
@@ -1,0 +1,163 @@
+package dev.tramai.engine.provider
+
+import dev.tramai.core.exception.ProviderException
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.provider.ProviderRoutingPlan
+import dev.tramai.engine.CircuitBreakerSettings
+import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.ProviderCircuitBreaker
+import dev.tramai.engine.RetryPolicySettings
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Mandatory cancellation-contract tests (Epic 3.3 Task 11).
+ *
+ * Prove that CancellationException NEVER reaches retry classification, fallback
+ * classification, or circuit-breaker failure recording — regardless of where in
+ * the attempt lifecycle it is thrown. Uses counting doubles for the three policy
+ * seams so the assertions are mutation-sensitive: if the executor or coordinator
+ * is ever refactored to route cancellation into retry/fallback/CB handling,
+ * these counters fail.
+ */
+class ProviderCancellationContractTest {
+
+    private class CountingRetryPolicy : ProviderRetryPolicy(
+        ProviderRetryDelayPolicy(RetryPolicySettings(jitterRatio = 0.0)) { 0.0 },
+    ) {
+        val decideCalls = AtomicInteger()
+        override fun decide(error: Throwable, retryIndex: Int, maxAttempts: Int): ProviderRetryDecision {
+            decideCalls.incrementAndGet()
+            return super.decide(error, retryIndex, maxAttempts)
+        }
+    }
+
+    private class CountingFallbackPolicy : ProviderFallbackPolicy() {
+        val decideCalls = AtomicInteger()
+        override fun decide(error: Throwable): ProviderFallbackDecision {
+            decideCalls.incrementAndGet()
+            return super.decide(error)
+        }
+    }
+
+    private class CountingCircuitBreaker : ProviderCircuitBreaker(CircuitBreakerSettings(enabled = true, failureThreshold = 1, openDurationMillis = 60_000)) {
+        val failureCalls = AtomicInteger()
+        override fun onFailure(providerId: String, error: Throwable): Boolean {
+            failureCalls.incrementAndGet()
+            return super.onFailure(providerId, error)
+        }
+    }
+
+    @Test
+    fun `provider cancellation reaches no policy and completes no observation`() {
+        val observation = RecordingObservation()
+        val retryPolicy = CountingRetryPolicy()
+        val circuitBreaker = CountingCircuitBreaker()
+        var calls = 0
+
+        assertThatThrownBy {
+            runBlocking {
+                executor(
+                    observation = observation,
+                    retryPolicy = retryPolicy,
+                    circuitBreaker = circuitBreaker,
+                ).execute(request(FakeProvider { calls++; throw CancellationException("stop") }, retries = 1))
+            }
+        }.isInstanceOf(CancellationException::class.java)
+
+        assertThat(calls).isEqualTo(1)
+        assertThat(retryPolicy.decideCalls.get()).isZero()
+        assertThat(circuitBreaker.failureCalls.get()).isZero()
+        assertThat(observation.cancelled).isEqualTo(1)
+        assertThat(observation.completed).isZero()
+        assertThat(observation.failures).isZero()
+    }
+
+    @Test
+    fun `cancellation during retry delay prevents second invocation and fallback`() {
+        runBlocking {
+        val fallbackPolicy = CountingFallbackPolicy()
+        var calls = 0
+        // Primary always fails retryably; coordinator plan routes "model" to it.
+        val coordinator = coordinator(
+            primary = FakeProvider { calls++; throw ProviderException("transient", retryable = true) },
+            fallbackPolicy = fallbackPolicy,
+        )
+        val job = launch {
+            coordinator.execute(
+                ProviderExecutionRequest(
+                    operation = componentOperation(1),
+                    messages = emptyList(),
+                    attemptCounter = AttemptCounter(),
+                    correlationId = "cid",
+                    securityContext = ExecutionSecurityContext(),
+                    beforeRoute = ProviderRouteGate {},
+                ),
+            )
+        }
+        // Let the first attempt fail and enter the retry delay (50ms backoff + 0 jitter).
+        withTimeout(2_000) { while (calls < 1) kotlinx.coroutines.yield() }
+        job.cancelAndJoin()
+        assertThat(calls).isEqualTo(1)
+        assertThat(fallbackPolicy.decideCalls.get()).isZero()
+        }
+    }
+
+    @Test
+    fun `authorization cancellation invokes no provider and no policies`() {
+        var calls = 0
+        val retryPolicy = CountingRetryPolicy()
+        val fallbackPolicy = CountingFallbackPolicy()
+        val cancellation = CancellationException("auth")
+        val attemptExecutor = executor(
+            retryPolicy = retryPolicy,
+            authorization = authorization { throw cancellation },
+        )
+
+        assertThatThrownBy {
+            runBlocking {
+                coordinator(
+                    primary = FakeProvider { calls++; ModelResponse("never") },
+                    attemptExecutor = attemptExecutor,
+                    fallbackPolicy = fallbackPolicy,
+                ).execute(
+                    ProviderExecutionRequest(
+                        operation = componentOperation(0),
+                        messages = emptyList(),
+                        attemptCounter = AttemptCounter(),
+                        correlationId = "cid",
+                        securityContext = ExecutionSecurityContext(),
+                        beforeRoute = ProviderRouteGate {},
+                    ),
+                )
+            }
+        }.isSameAs(cancellation)
+
+        assertThat(calls).isZero()
+        assertThat(retryPolicy.decideCalls.get()).isZero()
+        assertThat(fallbackPolicy.decideCalls.get()).isZero()
+    }
+
+    private fun coordinator(
+        primary: FakeProvider,
+        attemptExecutor: ProviderAttemptExecutor = executor(),
+        fallbackPolicy: ProviderFallbackPolicy = ProviderFallbackPolicy(),
+    ) = ProviderExecutionCoordinator(
+        routingPlan = ProviderRoutingPlan.builder()
+            .provider("primary", primary)
+            .model("model", "primary")
+            .build(),
+        circuitBreaker = ProviderCircuitBreaker(CircuitBreakerSettings()),
+        attemptExecutor = attemptExecutor,
+        fallbackPolicy = fallbackPolicy,
+        beforeResolution = ProviderResolutionGate { _, _, _ -> },
+        fallbackGate = ProviderFallbackGate { _, _, _, _, _, _ -> },
+    )
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/ProviderExecutionCoordinatorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/ProviderExecutionCoordinatorTest.kt
@@ -1,0 +1,116 @@
+package dev.tramai.engine.provider
+
+import dev.tramai.core.exception.ModelRegistryContractViolationException
+import dev.tramai.core.exception.PolicyViolationException
+import dev.tramai.core.exception.ProviderException
+import dev.tramai.core.model.ModelArtifactDigest
+import dev.tramai.core.model.ModelRegistry
+import dev.tramai.core.model.ModelRegistrySettings
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.model.RegisteredModel
+import dev.tramai.core.policy.PolicyDecision
+import dev.tramai.core.provider.ProviderRoutingPlan
+import dev.tramai.engine.CircuitBreakerSettings
+import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.ModelRegistryEnforcer
+import dev.tramai.engine.ProviderCircuitBreaker
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ProviderExecutionCoordinatorTest {
+    @Test
+    fun `primary success returns without fallback and publishes route event`() {
+        runBlocking {
+            val observation = RecordingObservation(); val primary = FakeProvider { ModelResponse("primary") }
+            val coordinator = coordinator(plan(primary), observation)
+            assertThat(coordinator.execute(executionRequest()).response.content).isEqualTo("primary")
+            assertThat(observation.events.single().first).isEqualTo("tramai.route.selected")
+            assertThat(observation.events.single().second).containsEntry("provider_id", "primary").containsEntry("route_index", 0).containsEntry("is_fallback", false)
+        }
+    }
+
+    @Test
+    fun `retry succeeds before fallback`() {
+        runBlocking {
+            var calls = 0; val primary = FakeProvider { if (calls++ == 0) throw ProviderException("transient", retryable = true) else ModelResponse("ok") }
+            assertThat(coordinator(plan(primary), RecordingObservation()).execute(executionRequest(retries = 1)).response.content).isEqualTo("ok")
+            assertThat(calls).isEqualTo(2)
+        }
+    }
+
+    @Test
+    fun `exhausted primary invokes fallback with ordered transition and continuous attempts`() {
+        runBlocking {
+            val order = mutableListOf<String>(); val primary = FakeProvider { order += "primary"; throw ProviderException("down", retryable = true) }; val secondary = FakeProvider { order += "secondary"; ModelResponse("fallback") }
+            val observations = mutableListOf<RecordingObservation>(); val coordinator = coordinator(plan(primary, secondary), observerFactory = { RecordingObservation().also(observations::add) }, fallback = ProviderFallbackGate { _, _, _, _, _, _ -> order += "fallback-gate" })
+            assertThat(coordinator.execute(executionRequest(retries = 1)).response.content).isEqualTo("fallback")
+            assertThat(order).containsExactly("primary", "primary", "fallback-gate", "secondary")
+            assertThat(observations.map { it.routeSelected()["route_index"] }).containsExactly(0, 0, 1)
+        }
+    }
+
+    @Test
+    fun `circuit open primary skips provider and invokes fallback`() {
+        runBlocking {
+            var now = 0L; val breaker = ProviderCircuitBreaker(CircuitBreakerSettings(true, 1, 60_000), { now }); breaker.onFailure("primary", ProviderException("down", retryable = true))
+            var primaryCalls = 0; val coordinator = coordinator(plan(FakeProvider { primaryCalls++; ModelResponse("bad") }, FakeProvider { ModelResponse("fallback") }), RecordingObservation(), breaker)
+            assertThat(coordinator.execute(executionRequest()).response.content).isEqualTo("fallback"); assertThat(primaryCalls).isZero()
+        }
+    }
+
+    @Test
+    fun `no route throws configuration exception unchanged from resolution`() {
+        runBlocking {
+            val coordinator = coordinator(ProviderRoutingPlan.builder().build())
+            val thrown = try {
+                coordinator.execute(executionRequest())
+                null
+            } catch (t: Throwable) {
+                t
+            }
+            assertThat(thrown).isInstanceOf(dev.tramai.core.exception.ConfigurationException::class.java)
+            assertThat(thrown!!.message).contains("No provider is registered for model")
+        }
+    }
+
+    @Test
+    fun `fallback route events carry is_fallback true and shared attempt numbering continues`() {
+        runBlocking {
+            val observations = mutableListOf<RecordingObservation>()
+            val primary = FakeProvider { throw ProviderException("down", retryable = true) }
+            val secondary = FakeProvider { ModelResponse("fallback") }
+            val coordinator = coordinator(plan(primary, secondary), observerFactory = { RecordingObservation().also(observations::add) })
+            assertThat(coordinator.execute(executionRequest(retries = 1)).response.content).isEqualTo("fallback")
+            assertThat(observations.map { it.routeSelected()["is_fallback"] }).containsExactly(false, false, true)
+            assertThat(observations.map { it.routeSelected()["route_index"] }).containsExactly(0, 0, 1)
+        }
+    }
+
+    @Test
+    fun `fallback denial retains original failure`() {
+        val original = ProviderException("down", retryable = true)
+        val coordinator = coordinator(plan(FakeProvider { throw original }, FakeProvider { ModelResponse("never") }), RecordingObservation(), fallback = ProviderFallbackGate { _, _, _, _, _, _ -> throw PolicyViolationException(PolicyDecision.Deny("denied", "denied")) })
+        val thrown = org.assertj.core.api.Assertions.catchThrowable { runBlocking { coordinator.execute(executionRequest()) } }
+        assertThat(thrown).isInstanceOf(PolicyViolationException::class.java)
+        assertThat(thrown!!.suppressed).contains(original)
+    }
+
+    private fun plan(primary: FakeProvider, secondary: FakeProvider? = null) = ProviderRoutingPlan.builder().provider("primary", primary).apply { if (secondary != null) provider("secondary", secondary) }.model("model", "primary").apply { if (secondary != null) fallbackProvider("model", "secondary") }.build()
+    private fun executionRequest(retries: Int = 0) = ProviderExecutionRequest(componentOperation(retries), emptyList(), AttemptCounter(), "cid", ExecutionSecurityContext(), ProviderRouteGate {})
+    private fun coordinator(plan: ProviderRoutingPlan, observation: RecordingObservation = RecordingObservation(), breaker: ProviderCircuitBreaker = ProviderCircuitBreaker(CircuitBreakerSettings()), observerFactory: (() -> RecordingObservation)? = null, fallback: ProviderFallbackGate = ProviderFallbackGate { _, _, _, _, _, _ -> }) : ProviderExecutionCoordinator {
+        val observer = dev.tramai.core.observation.OperationObserver { observerFactory?.invoke() ?: observation }
+        val attempt = ProviderAttemptExecutor("service", observer, object : dev.tramai.core.observation.OperationInterceptor {}, breaker, ProviderRetryPolicy(dev.tramai.engine.provider.ProviderRetryDelayPolicy(dev.tramai.engine.RetryPolicySettings(jitterRatio = 0.0)) { 0.0 }), permissiveAuthorization(), ProviderInvocationGate { _, _, _, _ -> }, ProviderResponseSanitizer { response, _, _, _, _, _, _ -> response })
+        return ProviderExecutionCoordinator(plan, breaker, attempt, ProviderFallbackPolicy(), ProviderResolutionGate { _, _, _ -> }, fallback)
+    }
+    /** Authorization fake returning a model that always matches the requested provider/model. */
+    private fun permissiveAuthorization() = ProviderAuthorizationService(
+        ModelRegistryEnforcer(
+            object : ModelRegistry {
+                override suspend fun findApprovedModel(providerId: String, modelName: String) =
+                    RegisteredModel("id", providerId, modelName, "r1", ModelArtifactDigest.of("sha256:${"a".repeat(64)}"), true)
+            },
+            ModelRegistrySettings(enabled = true),
+        ),
+    )
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/ProviderFallbackPolicyTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/ProviderFallbackPolicyTest.kt
@@ -1,0 +1,29 @@
+package dev.tramai.engine.provider
+
+import dev.tramai.core.exception.CircuitBreakerOpenException
+import dev.tramai.core.exception.ProviderException
+import dev.tramai.core.exception.TimeoutException
+import dev.tramai.core.security.DlpInspectionException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ProviderFallbackPolicyTest {
+    private val policy = ProviderFallbackPolicy()
+
+    @Test fun `continues retryable provider and circuit failures`() {
+        assertThat(policy.decide(ProviderException("temporary", retryable = true))).isEqualTo(ProviderFallbackDecision.Continue(ProviderFallbackReason.PROVIDER_FAILURE))
+        assertThat(policy.decide(TimeoutException("slow"))).isEqualTo(ProviderFallbackDecision.Continue(ProviderFallbackReason.PROVIDER_FAILURE))
+        assertThat(policy.decide(CircuitBreakerOpenException("p", 1))).isEqualTo(ProviderFallbackDecision.Continue(ProviderFallbackReason.CIRCUIT_BREAKER_OPEN))
+    }
+
+    @Test fun `stops permanent runtime and dlp failures`() {
+        assertThat(policy.decide(ProviderException("permanent"))).isEqualTo(ProviderFallbackDecision.Stop)
+        assertThat(policy.decide(RuntimeException("no"))).isEqualTo(ProviderFallbackDecision.Stop)
+        assertThat(policy.decide(DlpInspectionException("blocked"))).isEqualTo(ProviderFallbackDecision.Stop)
+    }
+
+    @Test fun `maps fallback reasons to stable event strings`() {
+        assertThat(policy.reasonString(ProviderFallbackReason.PROVIDER_FAILURE)).isEqualTo("provider-failure")
+        assertThat(policy.reasonString(ProviderFallbackReason.CIRCUIT_BREAKER_OPEN)).isEqualTo("circuit-breaker-open")
+    }
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/ProviderRetryPolicyTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/ProviderRetryPolicyTest.kt
@@ -1,0 +1,35 @@
+package dev.tramai.engine.provider
+
+import dev.tramai.core.exception.ProviderException
+import dev.tramai.core.exception.TimeoutException
+import dev.tramai.engine.RetryPolicySettings
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ProviderRetryPolicyTest {
+    private val policy = ProviderRetryPolicy(ProviderRetryDelayPolicy(RetryPolicySettings(maxRetryAfterMillis = 250, jitterRatio = 0.2)) { 0.0 })
+
+    @Test fun `retries retryable provider and timeout failures`() {
+        assertThat(policy.decide(ProviderException("temporary", retryable = true), 0, 2)).isInstanceOf(ProviderRetryDecision.Retry::class.java)
+        assertThat(policy.decide(TimeoutException("slow"), 0, 2)).isInstanceOf(ProviderRetryDecision.Retry::class.java)
+    }
+
+    @Test fun `stops non retryable and exhausted failures`() {
+        assertThat(policy.decide(ProviderException("permanent"), 0, 2)).isEqualTo(ProviderRetryDecision.Stop)
+        assertThat(policy.decide(RuntimeException("no"), 0, 2)).isEqualTo(ProviderRetryDecision.Stop)
+        assertThat(policy.decide(ProviderException("temporary", retryable = true), 1, 2)).isEqualTo(ProviderRetryDecision.Stop)
+    }
+
+    @Test fun `honours capped retry after and records source`() {
+        val honoured = policy.decide(ProviderException("wait", retryable = true, retryAfterMillis = 100), 0, 2) as ProviderRetryDecision.Retry
+        val capped = policy.decide(ProviderException("wait", retryable = true, retryAfterMillis = 500), 0, 2) as ProviderRetryDecision.Retry
+        assertThat(honoured.delayMillis).isEqualTo(100); assertThat(honoured.delaySource).isEqualTo("retry_after")
+        assertThat(capped.delayMillis).isEqualTo(250); assertThat(capped.delaySource).isEqualTo("retry_after")
+    }
+
+    @Test fun `uses deterministic exponential backoff when retry after is absent`() {
+        val delays = (0..5).map { (policy.decide(ProviderException("temporary", retryable = true), it, 7) as ProviderRetryDecision.Retry).delayMillis }
+        assertThat(delays).containsExactly(50, 100, 200, 400, 800, 1000)
+        assertThat((policy.decide(ProviderException("temporary", retryable = true), 0, 2) as ProviderRetryDecision.Retry).delaySource).isEqualTo("backoff")
+    }
+}


### PR DESCRIPTION
## refactor(engine): extract provider execution — Epic 3.3

Extracts the non-streaming provider execution state machine from `TramaiInvocationHandler` into an internal `dev.tramai.engine.provider` package. Architecture work, not semantics work: every routing, policy, retry, fallback, DLP, circuit-breaker, observation, error, and cancellation semantic is preserved (all 20 approved characterization traces byte-for-byte identical).

**TramaiEngine.kt: 5095 → 4775 lines.** The handler now knows it needs a provider result, not how provider retries/fallbacks are implemented.

### New components (all internal, no public API)

| Component | Ownership |
|---|---|
| `ProviderExecutionCoordinator` | Route-level state machine: `BEFORE_PROVIDER_RESOLUTION` gate, candidate resolution, circuit-breaker `beforeCall`, circuit-open fallback transition, fallback gates, route sequencing |
| `ProviderAttemptExecutor` | One provider attempt + observation lifecycle: intercept req → start observation → route-selected → authorize → `BEFORE_PROVIDER_INVOCATION` gate → invoke → intercept resp → DLP gate → `onProviderResponse` |
| `ProviderRetryPolicy` | Typed `ProviderRetryDecision.Retry/Stop` — retryable classification, attempt exhaustion, Retry-After, backoff/jitter, delay-source. Zero execution side effects |
| `ProviderFallbackPolicy` | Typed `ProviderFallbackDecision.Continue/Stop` + `ProviderFallbackReason`, mapped back to legacy event strings (`provider-failure` / `circuit-breaker-open`) |
| `ProviderAuthorizationService` | Model-registry authorization only; observation lifecycle stays in the executor |

### Preserved invariants

- **Cancellation never reaches retry/fallback policy or circuit-breaker failure recording** (counting-double tests prove invocation counts = 0, `onCallCancelled` = 1, `onCallCompleted` = 0)
- **DLP failure is not a provider failure**: no `onProviderFailure`, no circuit-breaker failure, no retry, `onCallCompleted` once, propagates `DlpInspectionException`
- **Success leaves the observation open** — transferred to the caller for downstream tool/structured-output processing
- **Retry timing unchanged**: existing `RetryPolicySettings` consumed; `minOf(50 shl retryIndex, 1000)` backoff, Retry-After honoured/capped at `maxRetryAfterMillis`, `retry_after`/`backoff` delay-source preserved
- **Tool exposure** stays as an injected `ProviderRouteGate` (Epic 3.4's `ToolExposureCoordinator` will replace the callback — not baked into provider ownership)
- **Streaming untouched**: `executeStreaming`/`executeStreamingRoute`/`collectStreamingRoute` remain — `StreamingExecutionCoordinator` is Epic 3.6
- `ProviderCircuitBreaker` body byte-identical (now `open` for testability); `ProviderRetryDelayPolicy` moved via typealias to keep `TrustedReplayEnvelopeRegistryTest` compiling

### Tests (27, 6 files)

Provider components constructed **without** ToolRegistry, approvals, memory, or structured output — directly proving the roadmap acceptance criterion.

- `ProviderRetryPolicyTest` (4): retryable→Retry, non-retryable/exhausted→Stop, Retry-After honoured+capped, deterministic backoff 50/100/200/400/800/1000, delay-source
- `ProviderFallbackPolicyTest` (3): Continue(provider/circuit), Stop(permanent/DLP), legacy string mapping
- `ProviderAuthorizationServiceTest` (3): authorized model, registry failure, cancellation passthrough
- `ProviderAttemptExecutorTest` (7): success transfers observation, interceptor ordering, authorize-before-invoke, DLP non-failure, provider failure, cancellation, auth-failure completes once
- `ProviderExecutionCoordinatorTest` (7): primary success, retry success, exhausted→fallback (ordered transitions, continuous attempt numbering), circuit-open skips provider, no-route ConfigurationException, fallback events `is_fallback`, fallback denial suppresses original
- `ProviderCancellationContractTest` (3): provider cancellation → zero policy invocations + `onCallCancelled`=1; cancel during retry delay → no 2nd invocation; **authorization cancellation → observation cancelled=1, completed=0, failures=0, zero provider calls, zero policy invocations**

### Acceptance criteria

- **AC1–AC5**: handler no longer implements provider route/retry/fallback/authorization state machines; coordinator/executor/policies own them ✅
- **AC6**: cancellation reaches neither retry nor fallback policy ✅ (counters)
- **AC7**: DLP failures remain non-provider failures ✅
- **AC8**: circuit-breaker transitions and events behaviour-identical ✅
- **AC9**: retry delay and Retry-After unchanged ✅
- **AC10**: successful `ProviderCallResult` preserves observation ownership ✅
- **AC11**: directly unit-testable without tools/approvals/memory/structured output ✅ (27 tests)
- **AC12**: stable public API dump unchanged ✅ (`apiCheck`)
- **AC13**: all 20 characterization traces byte-for-byte unchanged ✅
- **AC14**: `verifyCancellationSafety` passes ✅
- **AC15**: `verifyPr -PchangeClass=runtime-behaviour` passes ✅
- **Observation lifecycle**: every started attempt observation completes exactly once — including authorization cancellation (was a leak, fixed) ✅

### Explicit non-goals

No provider behaviour changes · no retry tuning · no fallback-strategy changes · no circuit-breaker redesign · no provider SPI changes · no new public API · no tool execution extraction (Epic 3.4) · no approval extraction (Epic 3.5) · no cache/memory/structured extraction (Epic 3.6) · no streaming coordinator extraction (Epic 3.6) · no changes to approved characterization traces.

## Fix Round 1 (review findings addressed)

| Finding | Fix |
|---------|-----|
| P1: Authorization cancellation leaves the started OperationObservation unfinished (`onCallCancelled`/`onCallCompleted` never run; `startAttempt` executes before the attempt try/catch) | Catch `CancellationException` around `authorizationService.authorize()` in `startAttempt`, call `observation.completeCancellation(error)`, rethrow. `ProviderCancellationContractTest` strengthened: `cancelled=1, completed=0, failures=0` + zero provider calls + zero retry/fallback policy invocations |
| P3: Compressed one-line declarations/catch blocks in new provider files | Readability expansion in `ProviderAttemptExecutor.kt` (`AttemptCounter`, authorization try/catch, `completeCancellation`) and `ProviderExecutionCoordinator.kt` — behaviour, names, signatures unchanged |

### Verification (post-fix)

```
: tramai-engine:test                    ✅ 27 provider tests, full suite green
: tramai-engine:apiCheck                ✅
verifyCancellationSafety                ✅ no new critical/high
verifyPr -PchangeClass=runtime-behaviour ✅ (269 tasks)
```
