### PR TITLE
refactor(engine): extract memory, cache, and token budget coordinators — Epic 3.6a

### DIFF
--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TokenBudgetTrackerAlias.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TokenBudgetTrackerAlias.kt
@@ -1,0 +1,3 @@
+package dev.tramai.engine
+
+internal typealias TokenBudgetTracker = dev.tramai.engine.budget.TokenBudgetTracker

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -1588,6 +1588,7 @@ internal class TramaiInvocationHandler(
                 toolDefinitions = operation.toolDefinitions,
                 operation = operation.operation,
                 returnKind = operation.returnKind,
+                conversationId = conversationId,
             ),
         )
         if (cacheKey != null) {
@@ -1684,6 +1685,7 @@ internal class TramaiInvocationHandler(
                 toolDefinitions = operation.toolDefinitions,
                 operation = operation.operation,
                 returnKind = operation.returnKind,
+                conversationId = conversationId,
             ),
         )
         if (cacheKey != null) {

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -102,6 +102,15 @@ import dev.tramai.engine.approval.ClaimedResumeExecutor
 import dev.tramai.engine.approval.ContinuationClaimService
 import dev.tramai.engine.approval.ReplayAuthorizationService
 import dev.tramai.engine.approval.ResumeOperationRegistry as ApprovalResumeOperationRegistry
+import dev.tramai.engine.budget.TokenBudgetCoordinator
+import dev.tramai.engine.cache.OperationCacheCoordinator
+import dev.tramai.engine.cache.OperationCacheKeyRequest
+import dev.tramai.engine.cache.OperationCacheLookupRequest
+import dev.tramai.engine.cache.OperationCacheLookupResult
+import dev.tramai.engine.cache.OperationCacheStoreRequest
+import dev.tramai.engine.memory.ConversationMemoryCoordinator
+import dev.tramai.engine.memory.PersistConversationTurnRequest
+import dev.tramai.engine.memory.PersistStructuredConversationTurnRequest
 import dev.tramai.core.approval.ValidateResumeCommand
 import dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter
 import dev.tramai.core.approval.SensitiveToolArguments
@@ -715,6 +724,19 @@ internal class TramaiInvocationHandler(
         fallbackGate = ProviderFallbackGate { correlationId, previousProviderId, previousModelName, nextProviderId, reason, securityContext -> enforceFallbackTransition(correlationId, previousProviderId, previousModelName, nextProviderId, reason, securityContext) },
     )
     private val toolExposureCoordinator = ToolExposureCoordinator(toolRegistry, policyHelper)
+    private val conversationMemoryCoordinator = ConversationMemoryCoordinator(
+        chatMemory = chatMemory,
+        conversationIdProvider = conversationIdProvider,
+    )
+    private val operationCacheCoordinator = OperationCacheCoordinator(
+        responseCache = responseCache,
+        operationInterceptor = operationInterceptor,
+        dlpInterceptor = dlpInterceptor,
+        modelRegistrySettings = modelRegistrySettings,
+        modelRegistryEnforcer = modelRegistryEnforcer,
+        policyHelper = policyHelper,
+    )
+    private val tokenBudgetCoordinator = TokenBudgetCoordinator(tokenBudgetSettings)
     private val toolResultSanitizer = ToolResultSanitizer(
         toolRegistry = toolRegistry,
         dlpInterceptor = dlpInterceptor,
@@ -793,7 +815,11 @@ internal class TramaiInvocationHandler(
             ?: throw ConfigurationException("No operation metadata registered for ${method.name}")
         val operation = plan.definition
 
-        val conversationId = if (chatMemory != null) resolveConversationId(method, args.orEmpty()) else null
+        val conversationId = if (chatMemory != null) {
+            conversationMemoryCoordinator.resolveConversationId(method, args.orEmpty())
+        } else {
+            null
+        }
         return if (operation.isSuspend) {
             invokeSuspend(operation, args.orEmpty(), conversationId)
         } else {
@@ -882,7 +908,7 @@ internal class TramaiInvocationHandler(
         arguments: List<Any?>,
         conversationId: String?,
     ): Any? {
-        val tokenBudgetTracker = TokenBudgetTracker(tokenBudgetSettings)
+        val tokenBudgetTracker = tokenBudgetCoordinator.createTracker()
         val workflowRunId = java.util.UUID.randomUUID().toString()
         val workflowDigest = WorkflowDigestHelper.compute(operation, serviceDefinition)
         val identity = EngineExecutionIdentity(
@@ -911,8 +937,9 @@ internal class TramaiInvocationHandler(
     ): Flow<StreamChunk> {
         val securityContext = ExecutionSecurityContext.fromArguments(arguments.toTypedArray())
         val initialMessages = operation.initialMessages(arguments)
-        val (history, effectiveMessages) = injectMemoryMessages(initialMessages, conversationId)
-            ?: (emptyList<Message>() to initialMessages)
+        val prepared = conversationMemoryCoordinator.prepareMessages(initialMessages, conversationId)
+        val history = prepared?.history ?: emptyList()
+        val effectiveMessages = prepared?.effectiveMessages ?: initialMessages
 
         return flow {
             check(!isClosed.get()) { "Tramai runtime is closed" }
@@ -968,15 +995,14 @@ internal class TramaiInvocationHandler(
                             )
                         ) {
                             is StreamingRouteResult.Completed -> {
-                                if (chatMemory != null && conversationId != null) {
+                                if (conversationId != null) {
                                     val assistantMessage = Message(
                                         role = MessageRole.ASSISTANT,
                                         content = result.fullText,
                                     )
-                                    val turnMessages = effectiveMessages
-                                        .drop(history.size)
-                                        .filter { it.role != MessageRole.SYSTEM }
-                                    chatMemory.add(conversationId, turnMessages + assistantMessage)
+                                    conversationMemoryCoordinator.persistTurn(
+                                        PersistConversationTurnRequest(conversationId, effectiveMessages, history.size, assistantMessage),
+                                    )
                                 }
                                 return@launch
                             }
@@ -1405,7 +1431,7 @@ internal class TramaiInvocationHandler(
         observation.onProviderResponse(interceptedResponse)
 
         try {
-            enforceTokenBudget(
+            tokenBudgetCoordinator.enforce(
                 tracker = tokenBudgetTracker,
                 response = interceptedResponse,
                 observation = observation,
@@ -1536,31 +1562,6 @@ internal class TramaiInvocationHandler(
         throw StreamingRouteFinished(result)
     }
 
-    private fun injectMemoryMessages(
-        operation: OperationDefinition,
-        arguments: List<Any?>,
-        conversationId: String?,
-    ): Pair<List<Message>, List<Message>>? = injectMemoryMessages(
-        initialMessages = operation.initialMessages(arguments),
-        conversationId = conversationId,
-    )
-
-    private fun injectMemoryMessages(
-        initialMessages: List<Message>,
-        conversationId: String?,
-    ): Pair<List<Message>, List<Message>>? {
-        if (chatMemory == null || conversationId == null) return null
-        val history = chatMemory.get(conversationId)
-        if (history.isEmpty()) return null
-        val currentSystem = initialMessages.firstOrNull { it.role == MessageRole.SYSTEM }
-        val deduped = if (currentSystem != null && history.any { it.role == MessageRole.SYSTEM }) {
-            initialMessages.filter { it.role != MessageRole.SYSTEM }
-        } else {
-            initialMessages
-        }
-        return history to (history + deduped)
-    }
-
     private suspend fun executeRaw(
         operation: OperationDefinition,
         arguments: List<Any?>,
@@ -1572,27 +1573,29 @@ internal class TramaiInvocationHandler(
         val correlationId = java.util.UUID.randomUUID().toString()
         val effectiveIdentity = identity.copy(correlationId = correlationId)
         val initialMessages = operation.initialMessages(arguments)
-        val (history, effectiveMessages) = injectMemoryMessages(initialMessages, conversationId)
-            ?: (emptyList<Message>() to initialMessages)
-        val cacheKey = operation.takeIf { isSafeCacheEligible(it, conversationId) }?.buildCacheKey(
-            digestSource = effectiveMessages,
-            securityPartition = securityContext.toCacheSecurityPartition(),
-            operationFingerprint = serviceDefinition.operations[operation.method]?.fingerprint,
+        val prepared = conversationMemoryCoordinator.prepareMessages(initialMessages, conversationId)
+        val history = prepared?.history ?: emptyList()
+        val effectiveMessages = prepared?.effectiveMessages ?: initialMessages
+        val cacheKey = operationCacheCoordinator.createKey(
+            OperationCacheKeyRequest(
+                digestSource = effectiveMessages,
+                securityPartition = securityContext.toCacheSecurityPartition(),
+                operationFingerprint = serviceDefinition.operations[operation.method]?.fingerprint,
+                requestedModel = operation.operation.model,
+                explicitProvider = operation.operation.provider.takeIf { it.isNotBlank() },
+                serviceInterface = operation.method.declaringClass.name,
+                methodName = operation.method.name,
+                toolDefinitions = operation.toolDefinitions,
+                operation = operation.operation,
+                returnKind = operation.returnKind,
+            ),
         )
-
-        cacheKey?.let { key ->
-            operation.cachedValue(key, conversationId)?.let { cached ->
-                try {
-                    authorizeCachedResult(
-                        cacheKey = key,
-                        cached = cached,
-                        securityContext = securityContext,
-                        correlationId = correlationId,
-                    )
-                    return cached.value as String
-                } catch (_: CachedModelProvenanceMismatchException) {
-                    responseCache.invalidate(key)
-                }
+        if (cacheKey != null) {
+            when (val cached = operationCacheCoordinator.lookup(
+                OperationCacheLookupRequest(cacheKey, securityContext, correlationId, conversationId),
+            )) {
+                is OperationCacheLookupResult.Hit -> return cached.value as String
+                is OperationCacheLookupResult.Miss -> Unit
             }
         }
 
@@ -1625,28 +1628,22 @@ internal class TramaiInvocationHandler(
         )
 
         // Memory: persist response if chatMemory is configured
-        if (chatMemory != null && conversationId != null) {
+        if (conversationId != null) {
             val assistantMessage = Message(
                 role = MessageRole.ASSISTANT,
                 content = result.response.content,
                 toolCalls = result.response.toolCalls,
             )
-            // Persist non-system messages from this turn (tool rounds + final assistant)
-            val turnMessages = effectiveMutableMessages.drop(history.size).filter { it.role != MessageRole.SYSTEM }
-            chatMemory.add(conversationId, turnMessages + assistantMessage)
+            conversationMemoryCoordinator.persistTurn(
+                PersistConversationTurnRequest(conversationId, effectiveMutableMessages, history.size, assistantMessage),
+            )
         }
 
         result.observation.onCallCompleted(parseSuccess = null)
         return result.response.content.also {
             cacheKey?.let { key ->
-                operation.cacheValue(
-                    key = key,
-                    value = it,
-                    providerId = result.providerId,
-                    modelName = result.modelName,
-                    securityContext = securityContext,
-                    conversationId = conversationId,
-                    approvedModel = result.approvedModel,
+                operationCacheCoordinator.store(
+                    OperationCacheStoreRequest(key, it, result.providerId, result.modelName, securityContext, conversationId, result.approvedModel, operation.operation.cacheTtlMillis),
                 )
             }
         }
@@ -1672,27 +1669,29 @@ internal class TramaiInvocationHandler(
         val correlationId = java.util.UUID.randomUUID().toString()
         val effectiveIdentity = identity.copy(correlationId = correlationId)
         val initialMessages = operation.initialMessages(arguments, contract.schemaJson)
-        val (history, effectiveMessages) = injectMemoryMessages(initialMessages, conversationId)
-            ?: (emptyList<Message>() to initialMessages)
-        val cacheKey = operation.takeIf { isSafeCacheEligible(it, conversationId) }?.buildCacheKey(
-            digestSource = effectiveMessages,
-            securityPartition = securityContext.toCacheSecurityPartition(),
-            operationFingerprint = serviceDefinition.operations[operation.method]?.fingerprint,
+        val prepared = conversationMemoryCoordinator.prepareMessages(initialMessages, conversationId)
+        val history = prepared?.history ?: emptyList()
+        val effectiveMessages = prepared?.effectiveMessages ?: initialMessages
+        val cacheKey = operationCacheCoordinator.createKey(
+            OperationCacheKeyRequest(
+                digestSource = effectiveMessages,
+                securityPartition = securityContext.toCacheSecurityPartition(),
+                operationFingerprint = serviceDefinition.operations[operation.method]?.fingerprint,
+                requestedModel = operation.operation.model,
+                explicitProvider = operation.operation.provider.takeIf { it.isNotBlank() },
+                serviceInterface = operation.method.declaringClass.name,
+                methodName = operation.method.name,
+                toolDefinitions = operation.toolDefinitions,
+                operation = operation.operation,
+                returnKind = operation.returnKind,
+            ),
         )
-
-        cacheKey?.let { key ->
-            operation.cachedValue(key, conversationId)?.let { cached ->
-                try {
-                    authorizeCachedResult(
-                        cacheKey = key,
-                        cached = cached,
-                        securityContext = securityContext,
-                        correlationId = correlationId,
-                    )
-                    return cached.value
-                } catch (_: CachedModelProvenanceMismatchException) {
-                    responseCache.invalidate(key)
-                }
+        if (cacheKey != null) {
+            when (val cached = operationCacheCoordinator.lookup(
+                OperationCacheLookupRequest(cacheKey, securityContext, correlationId, conversationId),
+            )) {
+                is OperationCacheLookupResult.Hit -> return cached.value
+                is OperationCacheLookupResult.Miss -> Unit
             }
         }
 
@@ -1824,22 +1823,24 @@ internal class TramaiInvocationHandler(
 
                 result.observation.onCallCompleted(parseSuccess = true)
 
-                persistStructuredSuccess(
-                    result = result,
-                    messages = messages,
-                    historySize = historySize,
-                    conversationId = conversationId,
-                    messagesBeforeCall = messagesBeforeCall,
-                )
+                if (conversationId != null) {
+                    conversationMemoryCoordinator.persistStructuredTurn(
+                        PersistStructuredConversationTurnRequest(
+                            conversationId = conversationId,
+                            messages = messages,
+                            historySize = historySize,
+                            messagesBeforeCall = messagesBeforeCall,
+                            assistantMessage = Message(
+                                role = MessageRole.ASSISTANT,
+                                content = result.response.content,
+                                toolCalls = result.response.toolCalls,
+                            ),
+                        ),
+                    )
+                }
                 cacheKey?.let { key ->
-                    operation.cacheValue(
-                        key = key,
-                        value = analysis.value,
-                        providerId = result.providerId,
-                        modelName = result.modelName,
-                        securityContext = securityContext,
-                        conversationId = conversationId,
-                        approvedModel = result.approvedModel,
+                    operationCacheCoordinator.store(
+                        OperationCacheStoreRequest(key, analysis.value, result.providerId, result.modelName, securityContext, conversationId, result.approvedModel, operation.operation.cacheTtlMillis),
                     )
                 }
 
@@ -1857,47 +1858,6 @@ internal class TramaiInvocationHandler(
                 null
             }
         }
-    }
-
-    private fun persistStructuredSuccess(
-        result: ProviderCallResult,
-        messages: MutableList<Message>,
-        historySize: Int,
-        conversationId: String?,
-        messagesBeforeCall: Int,
-    ) {
-        if (chatMemory == null || conversationId == null) return
-        val content = result.response.content
-        val assistantMessage = Message(
-            role = MessageRole.ASSISTANT,
-            content = content,
-            toolCalls = result.response.toolCalls,
-        )
-        val userPrompt = messages.subList(historySize, messagesBeforeCall)
-            .filter { it.role != MessageRole.SYSTEM }
-        val toolMessages = messages.drop(messagesBeforeCall)
-        chatMemory.add(conversationId, userPrompt + toolMessages + assistantMessage)
-    }
-
-    /**
-     * Persists the assistant response and this turn's non-system messages to chat memory.
-     * Shared by [finalizeResumedOperation] for STRING/UNIT paths and by
-     * [resumeStructuredResult] for the STRUCTURED path.
-     */
-    private fun persistMemory(
-        loopResult: ProviderCallResult,
-        messages: List<Message>,
-        historySize: Int,
-        conversationId: String?,
-    ) {
-        if (chatMemory == null || conversationId == null) return
-        val assistantMessage = Message(
-            role = MessageRole.ASSISTANT,
-            content = loopResult.response.content,
-            toolCalls = loopResult.response.toolCalls,
-        )
-        val turnMessages = messages.drop(historySize).filter { it.role != MessageRole.SYSTEM }
-        chatMemory.add(conversationId, turnMessages + assistantMessage)
     }
 
     private suspend fun handleStructuredFailure(
@@ -2056,7 +2016,7 @@ internal class TramaiInvocationHandler(
                 ),
             )
             try {
-                enforceTokenBudget(
+                tokenBudgetCoordinator.enforce(
                     tracker = tokenBudgetTracker,
                     response = result.response,
                     observation = result.observation,
@@ -2282,54 +2242,6 @@ internal class TramaiInvocationHandler(
     }
 
 
-    private fun enforceTokenBudget(
-        tracker: TokenBudgetTracker,
-        response: ModelResponse,
-        observation: OperationObservation,
-        providerId: String,
-        modelName: String,
-    ) {
-        when (val result = tracker.observe(response)) {
-            is TokenBudgetCheckResult.Ok -> Unit
-            is TokenBudgetCheckResult.UsageUnavailable -> observation.onEngineEvent(
-                name = "tramai.token_budget.usage_unavailable",
-                attributes = mapOf(
-                    ATTR_PROVIDER_ID to providerId,
-                    ATTR_EFFECTIVE_MODEL to modelName,
-                ),
-            )
-            is TokenBudgetCheckResult.SoftLimitExceeded -> observation.onEngineEvent(
-                name = "tramai.token_budget.soft_limit_exceeded",
-                attributes = mapOf(
-                    ATTR_PROVIDER_ID to providerId,
-                    ATTR_EFFECTIVE_MODEL to modelName,
-                    ATTR_LIMIT_TOKENS to result.limitTokens,
-                    ATTR_OBSERVED_TOKENS to result.observedTokens,
-                    ATTR_SCOPE to "operation",
-                ),
-            )
-            is TokenBudgetCheckResult.HardLimitExceeded -> {
-                observation.onEngineEvent(
-                    name = "tramai.token_budget.hard_limit_exceeded",
-                    attributes = mapOf(
-                        ATTR_PROVIDER_ID to providerId,
-                        ATTR_EFFECTIVE_MODEL to modelName,
-                        ATTR_LIMIT_TOKENS to result.limitTokens,
-                        ATTR_OBSERVED_TOKENS to result.observedTokens,
-                        ATTR_SCOPE to result.scope,
-                    ),
-                )
-                throw TokenBudgetExceededException(
-                    scope = result.scope,
-                    limitTokens = result.limitTokens,
-                    observedTokens = result.observedTokens,
-                    providerId = providerId,
-                    modelName = modelName,
-                )
-            }
-        }
-    }
-
     private fun routeSelectedAttributes(
         route: ResolvedProviderRoute,
         routeIndex: Int,
@@ -2340,15 +2252,10 @@ internal class TramaiInvocationHandler(
         ATTR_IS_FALLBACK to (routeIndex > 0),
     )
 
-    private fun restoredTokenBudgetTracker(metadata: SuspendedInvocationMetadata): TokenBudgetTracker =
-        TokenBudgetTracker(tokenBudgetSettings).also { tracker ->
-            metadata.tokenBudgetSnapshot?.let { tracker.restore(it) }
-        }
-
     override suspend fun execute(request: ClaimedResumeExecutionRequest): Any? {
         val metadata = request.metadata
         val registered = request.registered
-        val tokenBudgetTracker = restoredTokenBudgetTracker(metadata)
+        val tokenBudgetTracker = tokenBudgetCoordinator.restoreTracker(metadata.tokenBudgetSnapshot)
         val toolResult = executeResumedTool(
             request = request,
             tokenBudgetTracker = tokenBudgetTracker,
@@ -2464,7 +2371,20 @@ internal class TramaiInvocationHandler(
                         .build()
                 )
                 // Memory persistence + observation + return (once)
-                persistMemory(loopResult, messages, historySize, conversationId)
+                if (conversationId != null) {
+                    conversationMemoryCoordinator.persistTurn(
+                        PersistConversationTurnRequest(
+                            conversationId,
+                            messages,
+                            historySize,
+                            Message(
+                                role = MessageRole.ASSISTANT,
+                                content = loopResult.response.content,
+                                toolCalls = loopResult.response.toolCalls,
+                            ),
+                        ),
+                    )
+                }
                 loopResult.observation.onCallCompleted(parseSuccess = null)
                 return loopResult.response.content
             }
@@ -2479,7 +2399,20 @@ internal class TramaiInvocationHandler(
                         .applySecurityContext(securityContext)
                         .build()
                 )
-                persistMemory(loopResult, messages, historySize, conversationId)
+                if (conversationId != null) {
+                    conversationMemoryCoordinator.persistTurn(
+                        PersistConversationTurnRequest(
+                            conversationId,
+                            messages,
+                            historySize,
+                            Message(
+                                role = MessageRole.ASSISTANT,
+                                content = loopResult.response.content,
+                                toolCalls = loopResult.response.toolCalls,
+                            ),
+                        ),
+                    )
+                }
                 loopResult.observation.onCallCompleted(parseSuccess = null)
                 loopResult.response.content // consume it
                 return Unit
@@ -2559,7 +2492,20 @@ internal class TramaiInvocationHandler(
                         .applySecurityContext(securityContext)
                         .build()
                 )
-                persistMemory(loopResult, messages, historySize, conversationId)
+                if (conversationId != null) {
+                    conversationMemoryCoordinator.persistTurn(
+                        PersistConversationTurnRequest(
+                            conversationId,
+                            messages,
+                            historySize,
+                            Message(
+                                role = MessageRole.ASSISTANT,
+                                content = loopResult.response.content,
+                                toolCalls = loopResult.response.toolCalls,
+                            ),
+                        ),
+                    )
+                }
                 loopResult.observation.onCallCompleted(parseSuccess = true)
                 analysis.value
             }
@@ -2735,216 +2681,6 @@ internal class TramaiInvocationHandler(
         else -> throw UnsupportedOperationException("Unsupported Object method: ${method.name}")
     }
 
-    private fun resolveConversationId(method: Method, args: Array<out Any?>): String {
-        val parameters = method.parameters
-        for (i in parameters.indices) {
-            if (parameters[i].isAnnotationPresent(ConversationId::class.java)) {
-                val argument = args[i]
-                    ?: throw IllegalArgumentException("@ConversationId parameter '${parameters[i].name}' at index $i is null")
-                return argument.toString()
-            }
-        }
-        return conversationIdProvider.resolve()
-    }
-
-    private suspend fun authorizeCachedResult(
-        cacheKey: OperationCacheKey,
-        cached: CachedOperationResult,
-        securityContext: ExecutionSecurityContext,
-        correlationId: String,
-    ) {
-        validateCachedEntry(cacheKey, cached)
-        authorizeCachedModelProvenance(cached.provenance)
-        enforceCacheReusePolicies(cacheKey, cached, securityContext, correlationId)
-    }
-
-    /**
-     * Re-authorizes cached model provenance against the current registry entry.
-     */
-    private suspend fun authorizeCachedModelProvenance(provenance: CachedResponseProvenance) {
-        if (!modelRegistrySettings.enabled) {
-            return
-        }
-        val current = modelRegistryEnforcer.authorize(provenance.providerId, provenance.modelName)
-            ?: error("ModelRegistryEnforcer.authorize returned null when registry is enabled")
-        if (current.registryEntryId != provenance.modelRegistryEntryId ||
-            current.revision != provenance.modelRevision ||
-            current.artifactDigest != provenance.modelArtifactDigest
-        ) {
-            throw CachedModelProvenanceMismatchException()
-        }
-    }
-
-    /**
-     * Applies the same policy gates that a fresh provider call would cross on a cache hit.
-     */
-    private suspend fun enforceCacheReusePolicies(
-        cacheKey: OperationCacheKey,
-        cached: CachedOperationResult,
-        securityContext: ExecutionSecurityContext,
-        correlationId: String,
-    ) {
-        enforceCacheReuseProviderResolution(cacheKey, securityContext, correlationId)
-        enforceCacheReuseProviderInvocation(cached.provenance, securityContext, correlationId)
-        enforceCacheReuseResponseReturn(cached.provenance, securityContext, correlationId)
-    }
-
-    /**
-     * Enforces provider-resolution policy for a reused cached response.
-     */
-    private suspend fun enforceCacheReuseProviderResolution(
-        cacheKey: OperationCacheKey,
-        securityContext: ExecutionSecurityContext,
-        correlationId: String,
-    ) {
-        policyHelper.enforce(
-            policyHelper.buildContext(
-                enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_PROVIDER_RESOLUTION,
-                correlationId = correlationId,
-            ).modelName(cacheKey.requestedModel)
-                .applySecurityContext(securityContext)
-                .attribute("cacheReuse", "true")
-                .build()
-        )
-    }
-
-    /**
-     * Enforces provider-invocation policy for a reused cached response.
-     */
-    private suspend fun enforceCacheReuseProviderInvocation(
-        provenance: CachedResponseProvenance,
-        securityContext: ExecutionSecurityContext,
-        correlationId: String,
-    ) {
-        policyHelper.enforce(
-            policyHelper.buildContext(
-                enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
-                correlationId = correlationId,
-            ).providerId(provenance.providerId)
-                .modelName(provenance.modelName)
-                .applySecurityContext(securityContext)
-                .attribute("cacheReuse", "true")
-                .build()
-        )
-    }
-
-    /**
-     * Enforces response-return policy for a reused cached response.
-     */
-    private suspend fun enforceCacheReuseResponseReturn(
-        provenance: CachedResponseProvenance,
-        securityContext: ExecutionSecurityContext,
-        correlationId: String,
-    ) {
-        policyHelper.enforce(
-            policyHelper.buildContext(
-                enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
-                correlationId = correlationId,
-            ).providerId(provenance.providerId)
-                .modelName(provenance.modelName)
-                .applySecurityContext(securityContext)
-                .attribute("cacheReuse", "true")
-                .build()
-        )
-    }
-
-    private fun validateCachedEntry(
-        key: OperationCacheKey,
-        cached: CachedOperationResult,
-    ) {
-        val provenance = cached.provenance
-        check(provenance.hasProviderEnvelope()) { "Cached entry envelope has blank provider provenance" }
-        check(provenance.matchesSecurityPartition(key.securityPartition)) {
-            cachedPartitionMismatchMessage(key.securityPartition, provenance)
-        }
-    }
-
-    /**
-     * Checks that cached provenance carries the provider identity needed for reuse policy gates.
-     */
-    private fun CachedResponseProvenance.hasProviderEnvelope(): Boolean =
-        providerId.isNotBlank() && modelName.isNotBlank()
-
-    /**
-     * Checks that cached data cannot cross security classification partitions.
-     */
-    private fun CachedResponseProvenance.matchesSecurityPartition(partition: CacheSecurityPartition): Boolean =
-        dataClassification == partition.dataClassification &&
-            classificationSource == partition.classificationSource
-
-    /**
-     * Builds the explicit cache partition mismatch diagnostic.
-     */
-    private fun cachedPartitionMismatchMessage(
-        partition: CacheSecurityPartition,
-        provenance: CachedResponseProvenance,
-    ): String =
-        "Cached entry envelope mismatch: key partition " +
-            "$partition != cached provenance partition " +
-            "(${provenance.dataClassification}, ${provenance.classificationSource})"
-
-    private fun OperationDefinition.cachedValue(
-        key: OperationCacheKey,
-        conversationId: String?,
-    ): CachedOperationResult? = if (isSafeCacheEligible(this, conversationId)) {
-        responseCache.get(key)
-    } else {
-        null
-    }
-
-    private fun OperationDefinition.cacheValue(
-        key: OperationCacheKey,
-        value: Any,
-        providerId: String,
-        modelName: String,
-        securityContext: ExecutionSecurityContext,
-        conversationId: String?,
-        approvedModel: RegisteredModel?,
-    ) {
-        if (!isSafeCacheEligible(this, conversationId)) {
-            return
-        }
-        responseCache.put(
-            key = key,
-            value = CachedOperationResult(
-                value = value,
-                provenance = CachedResponseProvenance(
-                    providerId = providerId,
-                    modelName = modelName,
-                    dataClassification = securityContext.dataClassification,
-                    classificationSource = securityContext.classificationSource,
-                    modelRegistryEntryId = approvedModel?.registryEntryId,
-                    modelRevision = approvedModel?.revision,
-                    modelArtifactDigest = approvedModel?.artifactDigest,
-                ),
-            ),
-            ttlMillis = operation.cacheTtlMillis,
-        )
-    }
-
-    /**
-     * Cache eligibility including the conversation-memory and custom-interceptor
-     * gates. Both gates are engine-scoped, not operation-scoped, so they live
-     * on the handler.
-     *
-     * - **No chat memory** in scope: a cache hit would skip the
-     *   `chatMemory.add(...)` that a fresh execution performs.
-     * - **No custom interceptor**: a cache hit would skip
-     *   `operationInterceptor.interceptRequest(...)` and
-     *   `operationInterceptor.interceptResponse(...)`, allowing stale
-     *   redacted/audited responses to bypass current rules.
-     *
-     * Interceptor-aware caching is deferred to a follow-up that introduces a
-     * dedicated cache-aware interceptor SPI.
-     */
-    private fun isSafeCacheEligible(
-        operation: OperationDefinition,
-        conversationId: String?,
-    ): Boolean =
-        operation.isOperationCacheEligible() &&
-            conversationId == null &&
-            operationInterceptor === NoOpOperationInterceptor &&
-            dlpInterceptor === NoOpDlpInterceptor
 }
 
 data class OperationDefinition(
@@ -2965,9 +2701,9 @@ data class OperationDefinition(
      * Operation-static cache eligibility (no chat memory, no tools, no streaming,
      * no custom [dev.tramai.core.observation.OperationInterceptor]).
      *
-     * The interceptor-aware portion of the check lives on the invocation handler
+     * The interceptor-aware portion of the check lives on the cache coordinator
      * because the interceptor is engine-scoped, not operation-scoped. Use the
-     * handler's [isSafeCacheEligible] when evaluating an actual cache read/write.
+     * coordinator when evaluating an actual cache read/write.
      */
     fun isOperationCacheEligible(): Boolean =
         operation.cacheable &&
@@ -3307,108 +3043,6 @@ private data class ProviderCircuitState(
     var consecutiveFailures: Int = 0,
     var openUntilMillis: Long? = null,
 )
-
-
-internal class TokenBudgetTracker(
-    private val settings: TokenBudgetSettings,
-) {
-    private var totalInputTokensObserved: Long = 0
-    private var totalOutputTokensObserved: Long = 0
-    private var totalInputCostObserved: Double = 0.0
-    private var totalOutputCostObserved: Double = 0.0
-    private var softLimitReported: Boolean = false
-
-    /**
-     * Capture a snapshot of the current budget state for suspension.
-     */
-    fun snapshot(): TokenBudgetSnapshot = TokenBudgetSnapshot(
-        totalInputTokens = totalInputTokensObserved,
-        totalOutputTokens = totalOutputTokensObserved,
-        totalInputCost = totalInputCostObserved,
-        totalOutputCost = totalOutputCostObserved,
-        warnIfExceeded = !softLimitReported,
-    )
-
-    /**
-     * Restore budget state from a snapshot taken at suspension time.
-     */
-    fun restore(snapshot: TokenBudgetSnapshot) {
-        totalInputTokensObserved = snapshot.totalInputTokens
-        totalOutputTokensObserved = snapshot.totalOutputTokens
-        totalInputCostObserved = snapshot.totalInputCost
-        totalOutputCostObserved = snapshot.totalOutputCost
-        softLimitReported = !snapshot.warnIfExceeded
-    }
-
-    fun observe(response: ModelResponse): TokenBudgetCheckResult {
-        if (!isEnabled()) {
-            return TokenBudgetCheckResult.Ok
-        }
-
-        val attemptInputTokens = response.inputTokens?.toLong() ?: return TokenBudgetCheckResult.UsageUnavailable
-        val attemptOutputTokens = response.outputTokens?.toLong() ?: return TokenBudgetCheckResult.UsageUnavailable
-        val attemptTokens = attemptInputTokens + attemptOutputTokens
-        totalInputTokensObserved += attemptInputTokens
-        totalOutputTokensObserved += attemptOutputTokens
-
-        settings.hardMaxTokensPerAttempt?.let { limit ->
-            if (attemptTokens > limit) {
-                return TokenBudgetCheckResult.HardLimitExceeded(
-                    scope = "attempt",
-                    limitTokens = limit,
-                    observedTokens = attemptTokens,
-                )
-            }
-        }
-
-        settings.hardMaxTokensPerOperation?.let { limit ->
-            val totalTokensObserved = totalInputTokensObserved + totalOutputTokensObserved
-            if (totalTokensObserved > limit) {
-                return TokenBudgetCheckResult.HardLimitExceeded(
-                    scope = "operation",
-                    limitTokens = limit,
-                    observedTokens = totalTokensObserved,
-                )
-            }
-        }
-
-        settings.softMaxTokensPerOperation?.let { limit ->
-            val totalTokensObserved = totalInputTokensObserved + totalOutputTokensObserved
-            if (!softLimitReported && totalTokensObserved > limit) {
-                softLimitReported = true
-                return TokenBudgetCheckResult.SoftLimitExceeded(
-                    limitTokens = limit,
-                    observedTokens = totalTokensObserved,
-                )
-            }
-        }
-
-        return TokenBudgetCheckResult.Ok
-    }
-
-    private fun isEnabled(): Boolean =
-        settings.hardMaxTokensPerAttempt != null ||
-            settings.hardMaxTokensPerOperation != null ||
-            settings.softMaxTokensPerOperation != null
-}
-
-internal sealed class TokenBudgetCheckResult {
-    data object Ok : TokenBudgetCheckResult()
-
-    data object UsageUnavailable : TokenBudgetCheckResult()
-
-    data class SoftLimitExceeded(
-        val limitTokens: Long,
-        val observedTokens: Long,
-    ) : TokenBudgetCheckResult()
-
-    data class HardLimitExceeded(
-        val scope: String,
-        val limitTokens: Long,
-        val observedTokens: Long,
-    ) : TokenBudgetCheckResult()
-}
-
 enum class ReturnKind {
     STRING,
     UNIT,

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/budget/TokenBudgetCoordinator.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/budget/TokenBudgetCoordinator.kt
@@ -1,0 +1,72 @@
+package dev.tramai.engine.budget
+
+import dev.tramai.core.exception.TokenBudgetExceededException
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.observation.OperationObservation
+import dev.tramai.engine.TokenBudgetSettings
+import dev.tramai.engine.TokenBudgetSnapshot
+
+internal class TokenBudgetCoordinator(
+    private val settings: TokenBudgetSettings,
+) {
+    fun createTracker(): TokenBudgetTracker = TokenBudgetTracker(settings)
+
+    fun restoreTracker(snapshot: TokenBudgetSnapshot?): TokenBudgetTracker =
+        TokenBudgetTracker(settings).also { tracker ->
+            snapshot?.let { tracker.restore(it) }
+        }
+
+    fun enforce(
+        tracker: TokenBudgetTracker,
+        response: ModelResponse,
+        observation: OperationObservation,
+        providerId: String,
+        modelName: String,
+    ) {
+        when (val result = tracker.observe(response)) {
+            is TokenBudgetCheckResult.Ok -> Unit
+            is TokenBudgetCheckResult.UsageUnavailable -> observation.onEngineEvent(
+                name = "tramai.token_budget.usage_unavailable",
+                attributes = mapOf(
+                    ATTR_PROVIDER_ID to providerId,
+                    ATTR_EFFECTIVE_MODEL to modelName,
+                ),
+            )
+            is TokenBudgetCheckResult.SoftLimitExceeded -> observation.onEngineEvent(
+                name = "tramai.token_budget.soft_limit_exceeded",
+                attributes = mapOf(
+                    ATTR_PROVIDER_ID to providerId,
+                    ATTR_EFFECTIVE_MODEL to modelName,
+                    ATTR_LIMIT_TOKENS to result.limitTokens,
+                    ATTR_OBSERVED_TOKENS to result.observedTokens,
+                    ATTR_SCOPE to "operation",
+                ),
+            )
+            is TokenBudgetCheckResult.HardLimitExceeded -> {
+                observation.onEngineEvent(
+                    name = "tramai.token_budget.hard_limit_exceeded",
+                    attributes = mapOf(
+                        ATTR_PROVIDER_ID to providerId,
+                        ATTR_EFFECTIVE_MODEL to modelName,
+                        ATTR_LIMIT_TOKENS to result.limitTokens,
+                        ATTR_OBSERVED_TOKENS to result.observedTokens,
+                        ATTR_SCOPE to result.scope,
+                    ),
+                )
+                throw TokenBudgetExceededException(
+                    scope = result.scope,
+                    limitTokens = result.limitTokens,
+                    observedTokens = result.observedTokens,
+                    providerId = providerId,
+                    modelName = modelName,
+                )
+            }
+        }
+    }
+}
+
+private const val ATTR_PROVIDER_ID = "provider_id"
+private const val ATTR_EFFECTIVE_MODEL = "effective_model"
+private const val ATTR_LIMIT_TOKENS = "limit_tokens"
+private const val ATTR_OBSERVED_TOKENS = "observed_tokens"
+private const val ATTR_SCOPE = "scope"

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/budget/TokenBudgetTracker.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/budget/TokenBudgetTracker.kt
@@ -1,0 +1,96 @@
+package dev.tramai.engine.budget
+
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.engine.TokenBudgetSettings
+import dev.tramai.engine.TokenBudgetSnapshot
+
+internal class TokenBudgetTracker(
+    private val settings: TokenBudgetSettings,
+) {
+    private var totalInputTokensObserved: Long = 0
+    private var totalOutputTokensObserved: Long = 0
+    private var totalInputCostObserved: Double = 0.0
+    private var totalOutputCostObserved: Double = 0.0
+    private var softLimitReported: Boolean = false
+
+    fun snapshot(): TokenBudgetSnapshot = TokenBudgetSnapshot(
+        totalInputTokens = totalInputTokensObserved,
+        totalOutputTokens = totalOutputTokensObserved,
+        totalInputCost = totalInputCostObserved,
+        totalOutputCost = totalOutputCostObserved,
+        warnIfExceeded = !softLimitReported,
+    )
+
+    fun restore(snapshot: TokenBudgetSnapshot) {
+        totalInputTokensObserved = snapshot.totalInputTokens
+        totalOutputTokensObserved = snapshot.totalOutputTokens
+        totalInputCostObserved = snapshot.totalInputCost
+        totalOutputCostObserved = snapshot.totalOutputCost
+        softLimitReported = !snapshot.warnIfExceeded
+    }
+
+    fun observe(response: ModelResponse): TokenBudgetCheckResult {
+        if (!isEnabled()) {
+            return TokenBudgetCheckResult.Ok
+        }
+
+        val attemptInputTokens = response.inputTokens?.toLong() ?: return TokenBudgetCheckResult.UsageUnavailable
+        val attemptOutputTokens = response.outputTokens?.toLong() ?: return TokenBudgetCheckResult.UsageUnavailable
+        val attemptTokens = attemptInputTokens + attemptOutputTokens
+        totalInputTokensObserved += attemptInputTokens
+        totalOutputTokensObserved += attemptOutputTokens
+
+        settings.hardMaxTokensPerAttempt?.let { limit ->
+            if (attemptTokens > limit) {
+                return TokenBudgetCheckResult.HardLimitExceeded(
+                    scope = "attempt",
+                    limitTokens = limit,
+                    observedTokens = attemptTokens,
+                )
+            }
+        }
+        settings.hardMaxTokensPerOperation?.let { limit ->
+            val totalTokensObserved = totalInputTokensObserved + totalOutputTokensObserved
+            if (totalTokensObserved > limit) {
+                return TokenBudgetCheckResult.HardLimitExceeded(
+                    scope = "operation",
+                    limitTokens = limit,
+                    observedTokens = totalTokensObserved,
+                )
+            }
+        }
+        settings.softMaxTokensPerOperation?.let { limit ->
+            val totalTokensObserved = totalInputTokensObserved + totalOutputTokensObserved
+            if (!softLimitReported && totalTokensObserved > limit) {
+                softLimitReported = true
+                return TokenBudgetCheckResult.SoftLimitExceeded(
+                    limitTokens = limit,
+                    observedTokens = totalTokensObserved,
+                )
+            }
+        }
+        return TokenBudgetCheckResult.Ok
+    }
+
+    private fun isEnabled(): Boolean =
+        settings.hardMaxTokensPerAttempt != null ||
+            settings.hardMaxTokensPerOperation != null ||
+            settings.softMaxTokensPerOperation != null
+}
+
+internal sealed class TokenBudgetCheckResult {
+    data object Ok : TokenBudgetCheckResult()
+
+    data object UsageUnavailable : TokenBudgetCheckResult()
+
+    data class SoftLimitExceeded(
+        val limitTokens: Long,
+        val observedTokens: Long,
+    ) : TokenBudgetCheckResult()
+
+    data class HardLimitExceeded(
+        val scope: String,
+        val limitTokens: Long,
+        val observedTokens: Long,
+    ) : TokenBudgetCheckResult()
+}

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/cache/OperationCacheCoordinator.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/cache/OperationCacheCoordinator.kt
@@ -1,0 +1,118 @@
+package dev.tramai.engine.cache
+
+import dev.tramai.core.exception.CachedModelProvenanceMismatchException
+import dev.tramai.core.model.ModelRegistrySettings
+import dev.tramai.core.observation.NoOpOperationInterceptor
+import dev.tramai.core.observation.OperationInterceptor
+import dev.tramai.core.policy.EnforcementPoint
+import dev.tramai.core.security.DlpInterceptor
+import dev.tramai.core.security.NoOpDlpInterceptor
+import dev.tramai.engine.CachedOperationResult
+import dev.tramai.engine.CachedResponseProvenance
+import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.ModelRegistryEnforcer
+import dev.tramai.engine.OperationCacheKey
+import dev.tramai.engine.OperationResponseCache
+import dev.tramai.engine.PolicyContextBuilder
+import dev.tramai.engine.PolicyEnforcementHelper
+import dev.tramai.engine.ReturnKind
+import dev.tramai.engine.buildRequestDigest
+import dev.tramai.engine.planning.OperationFingerprintFactory
+
+internal class OperationCacheCoordinator(
+    private val responseCache: OperationResponseCache,
+    private val operationInterceptor: OperationInterceptor,
+    private val dlpInterceptor: DlpInterceptor,
+    private val modelRegistrySettings: ModelRegistrySettings,
+    private val modelRegistryEnforcer: ModelRegistryEnforcer,
+    private val policyHelper: PolicyEnforcementHelper,
+) {
+    fun createKey(request: OperationCacheKeyRequest): OperationCacheKey? {
+        if (!request.operation.cacheable ||
+            request.returnKind == ReturnKind.STREAMING ||
+            request.toolDefinitions.isNotEmpty() ||
+            operationInterceptor !== NoOpOperationInterceptor ||
+            dlpInterceptor !== NoOpDlpInterceptor
+        ) {
+            return null
+        }
+        return OperationCacheKey(
+            serviceInterface = request.serviceInterface,
+            methodName = request.methodName,
+            requestedModel = request.requestedModel,
+            explicitProvider = request.explicitProvider,
+            requestDigest = buildRequestDigest(request.digestSource),
+            operationFingerprint = request.operationFingerprint
+                ?: OperationFingerprintFactory().create(request.toolDefinitions, request.operation),
+            securityPartition = request.securityPartition,
+        )
+    }
+
+    suspend fun lookup(request: OperationCacheLookupRequest): OperationCacheLookupResult {
+        if (request.conversationId != null ||
+            operationInterceptor !== NoOpOperationInterceptor ||
+            dlpInterceptor !== NoOpDlpInterceptor
+        ) {
+            return OperationCacheLookupResult.Miss(null)
+        }
+        val cached = responseCache.get(request.key) ?: return OperationCacheLookupResult.Miss(request.key)
+        try {
+            validateCachedEntry(request.key, cached)
+            authorizeCachedModelProvenance(cached.provenance)
+            enforceCacheReusePolicies(request.key, cached, request.securityContext, request.correlationId)
+            return OperationCacheLookupResult.Hit(cached.value)
+        } catch (_: CachedModelProvenanceMismatchException) {
+            responseCache.invalidate(request.key)
+            return OperationCacheLookupResult.Miss(request.key)
+        }
+    }
+
+    fun store(request: OperationCacheStoreRequest) {
+        if (request.conversationId != null ||
+            operationInterceptor !== NoOpOperationInterceptor ||
+            dlpInterceptor !== NoOpDlpInterceptor
+        ) {
+            return
+        }
+        responseCache.put(
+            key = request.key,
+            value = CachedOperationResult(
+                value = request.value,
+                provenance = CachedResponseProvenance(
+                    providerId = request.providerId,
+                    modelName = request.modelName,
+                    dataClassification = request.securityContext.dataClassification,
+                    classificationSource = request.securityContext.classificationSource,
+                    modelRegistryEntryId = request.approvedModel?.registryEntryId,
+                    modelRevision = request.approvedModel?.revision,
+                    modelArtifactDigest = request.approvedModel?.artifactDigest,
+                ),
+            ),
+            ttlMillis = request.ttlMillis,
+        )
+    }
+
+    private suspend fun authorizeCachedModelProvenance(provenance: CachedResponseProvenance) {
+        if (!modelRegistrySettings.enabled) return
+        val current = modelRegistryEnforcer.authorize(provenance.providerId, provenance.modelName)
+            ?: error("ModelRegistryEnforcer.authorize returned null when registry is enabled")
+        if (current.registryEntryId != provenance.modelRegistryEntryId || current.revision != provenance.modelRevision || current.artifactDigest != provenance.modelArtifactDigest) throw CachedModelProvenanceMismatchException()
+    }
+
+    private suspend fun enforceCacheReusePolicies(cacheKey: OperationCacheKey, cached: CachedOperationResult, securityContext: ExecutionSecurityContext, correlationId: String) {
+        policyHelper.enforce(policyHelper.buildContext(EnforcementPoint.BEFORE_PROVIDER_RESOLUTION, correlationId).modelName(cacheKey.requestedModel).applySecurityContext(securityContext).attribute("cacheReuse", "true").build())
+        policyHelper.enforce(policyHelper.buildContext(EnforcementPoint.BEFORE_PROVIDER_INVOCATION, correlationId).providerId(cached.provenance.providerId).modelName(cached.provenance.modelName).applySecurityContext(securityContext).attribute("cacheReuse", "true").build())
+        policyHelper.enforce(policyHelper.buildContext(EnforcementPoint.BEFORE_RESPONSE_RETURN, correlationId).providerId(cached.provenance.providerId).modelName(cached.provenance.modelName).applySecurityContext(securityContext).attribute("cacheReuse", "true").build())
+    }
+
+    private fun validateCachedEntry(key: OperationCacheKey, cached: CachedOperationResult) {
+        val provenance = cached.provenance
+        check(provenance.providerId.isNotBlank() && provenance.modelName.isNotBlank()) { "Cached entry envelope has blank provider provenance" }
+        check(provenance.dataClassification == key.securityPartition.dataClassification && provenance.classificationSource == key.securityPartition.classificationSource) {
+            "Cached entry envelope mismatch: key partition ${key.securityPartition} != cached provenance partition (${provenance.dataClassification}, ${provenance.classificationSource})"
+        }
+    }
+}
+
+private fun PolicyContextBuilder.applySecurityContext(securityContext: ExecutionSecurityContext): PolicyContextBuilder =
+    dataClassification(securityContext.dataClassification).classificationSource(securityContext.classificationSource)

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/cache/OperationCacheCoordinator.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/cache/OperationCacheCoordinator.kt
@@ -28,6 +28,12 @@ internal class OperationCacheCoordinator(
     private val policyHelper: PolicyEnforcementHelper,
 ) {
     fun createKey(request: OperationCacheKeyRequest): OperationCacheKey? {
+        if (request.conversationId != null) {
+            // Conversation memory makes a cache hit unsafe (it would skip the
+            // chatMemory.add a fresh execution performs). Short-circuit before
+            // computing the request digest / operation fingerprint.
+            return null
+        }
         if (!request.operation.cacheable ||
             request.returnKind == ReturnKind.STREAMING ||
             request.toolDefinitions.isNotEmpty() ||
@@ -96,7 +102,13 @@ internal class OperationCacheCoordinator(
         if (!modelRegistrySettings.enabled) return
         val current = modelRegistryEnforcer.authorize(provenance.providerId, provenance.modelName)
             ?: error("ModelRegistryEnforcer.authorize returned null when registry is enabled")
-        if (current.registryEntryId != provenance.modelRegistryEntryId || current.revision != provenance.modelRevision || current.artifactDigest != provenance.modelArtifactDigest) throw CachedModelProvenanceMismatchException()
+        if (
+            current.registryEntryId != provenance.modelRegistryEntryId ||
+            current.revision != provenance.modelRevision ||
+            current.artifactDigest != provenance.modelArtifactDigest
+        ) {
+            throw CachedModelProvenanceMismatchException()
+        }
     }
 
     private suspend fun enforceCacheReusePolicies(cacheKey: OperationCacheKey, cached: CachedOperationResult, securityContext: ExecutionSecurityContext, correlationId: String) {

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/cache/OperationCacheModels.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/cache/OperationCacheModels.kt
@@ -20,6 +20,7 @@ internal data class OperationCacheKeyRequest(
     val toolDefinitions: List<ToolDefinition>,
     val operation: Operation,
     val returnKind: ReturnKind,
+    val conversationId: String?,
 )
 
 internal data class OperationCacheLookupRequest(

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/cache/OperationCacheModels.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/cache/OperationCacheModels.kt
@@ -1,0 +1,46 @@
+package dev.tramai.engine.cache
+
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.model.ModelRegistrySettings
+import dev.tramai.core.model.RegisteredModel
+import dev.tramai.core.model.ToolDefinition
+import dev.tramai.engine.CacheSecurityPartition
+import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.OperationCacheKey
+import dev.tramai.engine.ReturnKind
+
+internal data class OperationCacheKeyRequest(
+    val digestSource: List<dev.tramai.core.model.Message>,
+    val securityPartition: CacheSecurityPartition,
+    val operationFingerprint: String?,
+    val requestedModel: String,
+    val explicitProvider: String?,
+    val serviceInterface: String,
+    val methodName: String,
+    val toolDefinitions: List<ToolDefinition>,
+    val operation: Operation,
+    val returnKind: ReturnKind,
+)
+
+internal data class OperationCacheLookupRequest(
+    val key: OperationCacheKey,
+    val securityContext: ExecutionSecurityContext,
+    val correlationId: String,
+    val conversationId: String?,
+)
+
+internal sealed interface OperationCacheLookupResult {
+    data class Hit(val value: Any) : OperationCacheLookupResult
+    data class Miss(val key: OperationCacheKey?) : OperationCacheLookupResult
+}
+
+internal data class OperationCacheStoreRequest(
+    val key: OperationCacheKey,
+    val value: Any,
+    val providerId: String,
+    val modelName: String,
+    val securityContext: ExecutionSecurityContext,
+    val conversationId: String?,
+    val approvedModel: RegisteredModel?,
+    val ttlMillis: Long,
+)

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/memory/ConversationMemoryCoordinator.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/memory/ConversationMemoryCoordinator.kt
@@ -1,0 +1,52 @@
+package dev.tramai.engine.memory
+
+import dev.tramai.core.annotations.ConversationId
+import dev.tramai.core.memory.ChatMemory
+import dev.tramai.core.memory.ConversationIdProvider
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
+import java.lang.reflect.Method
+
+internal class ConversationMemoryCoordinator(
+    private val chatMemory: ChatMemory?,
+    private val conversationIdProvider: ConversationIdProvider,
+) {
+    fun resolveConversationId(method: Method, arguments: Array<out Any?>): String {
+        val parameters = method.parameters
+        for (i in parameters.indices) {
+            if (parameters[i].isAnnotationPresent(ConversationId::class.java)) {
+                val argument = arguments[i]
+                    ?: throw IllegalArgumentException("@ConversationId parameter '${parameters[i].name}' at index $i is null")
+                return argument.toString()
+            }
+        }
+        return conversationIdProvider.resolve()
+    }
+
+    fun prepareMessages(initialMessages: List<Message>, conversationId: String?): PreparedConversationMessages? {
+        if (chatMemory == null || conversationId == null) return null
+        val history = chatMemory.get(conversationId)
+        if (history.isEmpty()) return null
+        val currentSystem = initialMessages.firstOrNull { it.role == MessageRole.SYSTEM }
+        val deduped = if (currentSystem != null && history.any { it.role == MessageRole.SYSTEM }) {
+            initialMessages.filter { it.role != MessageRole.SYSTEM }
+        } else {
+            initialMessages
+        }
+        return PreparedConversationMessages(history, history + deduped)
+    }
+
+    fun persistTurn(request: PersistConversationTurnRequest) {
+        if (chatMemory == null) return
+        val turnMessages = request.messages.drop(request.historySize).filter { it.role != MessageRole.SYSTEM }
+        chatMemory.add(request.conversationId, turnMessages + request.assistantMessage)
+    }
+
+    fun persistStructuredTurn(request: PersistStructuredConversationTurnRequest) {
+        if (chatMemory == null) return
+        val userPrompt = request.messages.subList(request.historySize, request.messagesBeforeCall)
+            .filter { it.role != MessageRole.SYSTEM }
+        val toolMessages = request.messages.drop(request.messagesBeforeCall)
+        chatMemory.add(request.conversationId, userPrompt + toolMessages + request.assistantMessage)
+    }
+}

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/memory/ConversationMemoryModels.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/memory/ConversationMemoryModels.kt
@@ -1,0 +1,23 @@
+package dev.tramai.engine.memory
+
+import dev.tramai.core.model.Message
+
+internal data class PreparedConversationMessages(
+    val history: List<Message>,
+    val effectiveMessages: List<Message>,
+)
+
+internal data class PersistConversationTurnRequest(
+    val conversationId: String,
+    val messages: List<Message>,
+    val historySize: Int,
+    val assistantMessage: Message,
+)
+
+internal data class PersistStructuredConversationTurnRequest(
+    val conversationId: String,
+    val messages: List<Message>,
+    val historySize: Int,
+    val messagesBeforeCall: Int,
+    val assistantMessage: Message,
+)

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/budget/TokenBudgetCoordinatorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/budget/TokenBudgetCoordinatorTest.kt
@@ -1,0 +1,226 @@
+package dev.tramai.engine.budget
+
+import dev.tramai.core.exception.TokenBudgetExceededException
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.observation.OperationObservation
+import dev.tramai.engine.EngineEventObserver
+import dev.tramai.engine.TokenBudgetSettings
+import dev.tramai.engine.TokenBudgetSnapshot
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * Direct contract tests for [TokenBudgetCoordinator].
+ *
+ * The coordinator owns the event/exception semantics of token-budget
+ * enforcement. Event names, attribute names, scopes and the hard-limit
+ * exception type are frozen contracts — the extraction must preserve them
+ * exactly.
+ */
+class TokenBudgetCoordinatorTest {
+
+    private fun response(input: Int, output: Int) = ModelResponse(
+        content = "ok",
+        inputTokens = input,
+        outputTokens = output,
+    )
+
+    private fun coordinator(settings: TokenBudgetSettings = TokenBudgetSettings()) =
+        TokenBudgetCoordinator(settings)
+
+    private class RecordingObservation : OperationObservation {
+        val events = mutableListOf<Pair<String, Map<String, Any?>>>()
+        override fun onProviderResponse(response: ModelResponse) = Unit
+        override fun onProviderFailure(error: Throwable) = Unit
+        override fun onStructuredParseFailure(rawResponse: String, errorSummary: String) = Unit
+        override fun onEngineEvent(name: String, attributes: Map<String, Any?>) {
+            events += name to attributes
+        }
+        override fun onCallCompleted(parseSuccess: Boolean?) = Unit
+    }
+
+    @Test
+    fun `budget disabled always observes ok and emits nothing`() {
+        val c = coordinator(TokenBudgetSettings())
+        val t = c.createTracker()
+        val obs = RecordingObservation()
+
+        assertThat(c.enforce(t, response(5, 5), obs, "p1", "m1")).isEqualTo(Unit)
+
+        assertThat(obs.events).isEmpty()
+    }
+
+    @Test
+    fun `missing usage emits usage_unavailable with provider and model`() {
+        val c = coordinator(TokenBudgetSettings(hardMaxTokensPerOperation = 100))
+        val t = c.createTracker()
+        val obs = RecordingObservation()
+
+        c.enforce(t, ModelResponse(content = "no-tokens", inputTokens = null, outputTokens = 1), obs, "p1", "m1")
+
+        assertThat(obs.events).containsExactly(
+            "tramai.token_budget.usage_unavailable" to mapOf(
+                "provider_id" to "p1",
+                "effective_model" to "m1",
+            ),
+        )
+    }
+
+    @Test
+    fun `hard attempt limit throws with attempt scope`() {
+        val c = coordinator(TokenBudgetSettings(hardMaxTokensPerAttempt = 6))
+        val t = c.createTracker()
+        val obs = RecordingObservation()
+
+        assertThatThrownBy { c.enforce(t, response(4, 4), obs, "p1", "m1") }
+            .isInstanceOfSatisfying(TokenBudgetExceededException::class.java) { e ->
+                assertThat(e.scope).isEqualTo("attempt")
+                assertThat(e.limitTokens).isEqualTo(6L)
+                assertThat(e.observedTokens).isEqualTo(8L)
+                assertThat(e.providerId).isEqualTo("p1")
+                assertThat(e.modelName).isEqualTo("m1")
+            }
+
+        assertThat(obs.events).containsExactly(
+            "tramai.token_budget.hard_limit_exceeded" to mapOf(
+                "provider_id" to "p1",
+                "effective_model" to "m1",
+                "limit_tokens" to 6L,
+                "observed_tokens" to 8L,
+                "scope" to "attempt",
+            ),
+        )
+    }
+
+    @Test
+    fun `hard operation limit throws when cumulative usage exceeds`() {
+        val c = coordinator(TokenBudgetSettings(hardMaxTokensPerOperation = 10))
+        val t = c.createTracker()
+        val obs = RecordingObservation()
+
+        c.enforce(t, response(4, 4), obs, "p1", "m1")
+        assertThatThrownBy { c.enforce(t, response(2, 2), obs, "p1", "m1") }
+            .isInstanceOfSatisfying(TokenBudgetExceededException::class.java) { e ->
+                assertThat(e.scope).isEqualTo("operation")
+                assertThat(e.observedTokens).isEqualTo(12L)
+            }
+    }
+
+    @Test
+    fun `soft operation limit emits warning once and does not throw`() {
+        val c = coordinator(TokenBudgetSettings(softMaxTokensPerOperation = 10))
+        val t = c.createTracker()
+        val obs = RecordingObservation()
+
+        c.enforce(t, response(6, 6), obs, "p1", "m1") // 12 observed — warning
+        c.enforce(t, response(1, 1), obs, "p1", "m1") // 14 — already warned
+
+        assertThat(obs.events).containsExactly(
+            "tramai.token_budget.soft_limit_exceeded" to mapOf(
+                "provider_id" to "p1",
+                "effective_model" to "m1",
+                "limit_tokens" to 10L,
+                "observed_tokens" to 12L,
+                "scope" to "operation",
+            ),
+        )
+    }
+
+    @Test
+    fun `multiple responses accumulate toward the same operation budget`() {
+        val c = coordinator(TokenBudgetSettings(hardMaxTokensPerOperation = 20))
+        val t = c.createTracker()
+        val obs = RecordingObservation()
+
+        c.enforce(t, response(3, 2), obs, "p1", "m1") // 5
+        c.enforce(t, response(4, 4), obs, "p1", "m1") // 13
+        c.enforce(t, response(2, 2), obs, "p1", "m1") // 17
+        c.enforce(t, response(1, 1), obs, "p1", "m1") // 19 ok
+        assertThatThrownBy { c.enforce(t, response(1, 1), obs, "p1", "m1") } // 21
+            .isInstanceOf(TokenBudgetExceededException::class.java)
+    }
+
+    @Test
+    fun `snapshot after usage and restore continues the same operation budget`() {
+        val c = coordinator(TokenBudgetSettings(hardMaxTokensPerOperation = 20))
+        val t = c.createTracker()
+        val obs = RecordingObservation()
+
+        c.enforce(t, response(5, 5), obs, "p1", "m1") // 10 observed
+        val snapshot = t.snapshot()
+        assertThat(snapshot.totalInputTokens).isEqualTo(5L)
+        assertThat(snapshot.totalOutputTokens).isEqualTo(5L)
+
+        // suspended, restored fresh from snapshot
+        val restored = c.restoreTracker(snapshot)
+        c.enforce(restored, response(5, 5), obs, "p1", "m1") // 20 total — ok
+        assertThatThrownBy { c.enforce(restored, response(1, 1), obs, "p1", "m1") } // 22
+            .isInstanceOf(TokenBudgetExceededException::class.java)
+    }
+
+    @Test
+    fun `null snapshot restores a fresh tracker`() {
+        val c = coordinator(TokenBudgetSettings(hardMaxTokensPerOperation = 20))
+        val t = c.restoreTracker(snapshot = null)
+
+        // 10 and 20 observed are within the 20 limit; 22 crosses it
+        c.enforce(t, response(5, 5), RecordingObservation(), "p1", "m1")
+        c.enforce(t, response(5, 5), RecordingObservation(), "p1", "m1")
+        assertThatThrownBy { c.enforce(t, response(1, 1), RecordingObservation(), "p1", "m1") }
+            .isInstanceOf(TokenBudgetExceededException::class.java)
+    }
+
+    @Test
+    fun `restored soft-warning state prevents a second warning`() {
+        val c = coordinator(TokenBudgetSettings(softMaxTokensPerOperation = 10))
+        val t = c.createTracker()
+        val obs = RecordingObservation()
+
+        c.enforce(t, response(6, 6), obs, "p1", "m1") // warning emitted
+        val snapshot = t.snapshot()
+        assertThat(snapshot.warnIfExceeded).isFalse()
+
+        val restored = c.restoreTracker(snapshot)
+        val obs2 = RecordingObservation()
+        c.enforce(restored, response(1, 1), obs2, "p1", "m1")
+        assertThat(obs2.events).isEmpty()
+    }
+
+    @Test
+    fun `resumed usage breaches the accumulated hard limit`() {
+        val c = coordinator(TokenBudgetSettings(hardMaxTokensPerOperation = 20))
+        val t = c.createTracker()
+        val obs = RecordingObservation()
+
+        c.enforce(t, response(5, 5), obs, "p1", "m1") // 10
+        val snapshot = t.snapshot()
+        val restored = c.restoreTracker(snapshot)
+
+        c.enforce(restored, response(5, 5), obs, "p1", "m1") // 20 — at limit, ok
+        assertThatThrownBy { c.enforce(restored, response(1, 1), obs, "p1", "m1") } // 22
+            .isInstanceOfSatisfying(TokenBudgetExceededException::class.java) { e ->
+                assertThat(e.scope).isEqualTo("operation")
+            }
+    }
+
+    @Test
+    fun `createTracker and restoreTracker produce independent trackers`() {
+        val c = coordinator(TokenBudgetSettings(hardMaxTokensPerOperation = 100))
+        val a = c.createTracker()
+        val b = c.createTracker()
+        val obs = RecordingObservation()
+
+        c.enforce(a, response(30, 30), obs, "p1", "m1") // a: 60
+        c.enforce(b, response(30, 30), obs, "p1", "m1") // b: 60
+        c.enforce(b, response(15, 15), obs, "p1", "m1") // b: 90
+        c.enforce(a, response(15, 15), obs, "p1", "m1") // a: 90
+        c.enforce(b, response(5, 5), obs, "p1", "m1") // b: 100 — at limit, ok
+        assertThatThrownBy { c.enforce(b, response(5, 5), RecordingObservation(), "p1", "m1") } // b: 110 — breach
+            .isInstanceOf(TokenBudgetExceededException::class.java)
+        // a untouched: still 90
+        c.enforce(a, response(5, 5), obs, "p1", "m1") // a: 100 — at limit, ok
+        assertThat(obs.events).isEmpty()
+    }
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/budget/TokenBudgetCoordinatorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/budget/TokenBudgetCoordinatorTest.kt
@@ -3,10 +3,7 @@ package dev.tramai.engine.budget
 import dev.tramai.core.exception.TokenBudgetExceededException
 import dev.tramai.core.model.ModelResponse
 import dev.tramai.core.observation.OperationObservation
-import dev.tramai.engine.EngineEventObserver
 import dev.tramai.engine.TokenBudgetSettings
-import dev.tramai.engine.TokenBudgetSnapshot
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/cache/OperationCacheCoordinatorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/cache/OperationCacheCoordinatorTest.kt
@@ -1,0 +1,536 @@
+package dev.tramai.engine.cache
+
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.exception.CachedModelProvenanceMismatchException
+import dev.tramai.core.exception.PolicyViolationException
+import dev.tramai.core.model.ModelArtifactDigest
+import dev.tramai.core.model.ModelRegistrySettings
+import dev.tramai.core.model.RegisteredModel
+import dev.tramai.core.model.ToolDefinition
+import dev.tramai.core.observation.NoOpOperationInterceptor
+import dev.tramai.core.observation.OperationInterceptor
+import dev.tramai.core.policy.PolicyDecision
+import dev.tramai.core.policy.PolicyEngine
+import dev.tramai.core.security.DlpInterceptor
+import dev.tramai.core.security.NoOpDlpInterceptor
+import dev.tramai.engine.CachedOperationResult
+import dev.tramai.engine.CachedResponseProvenance
+import dev.tramai.engine.CacheSecurityPartition
+import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.ModelRegistryEnforcer
+import dev.tramai.engine.OperationCacheKey
+import dev.tramai.engine.OperationResponseCache
+import dev.tramai.engine.PolicyEnforcementHelper
+import dev.tramai.engine.ReturnKind
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Direct contract tests for [OperationCacheCoordinator].
+ *
+ * The cache protocol is a security-sensitive mini state machine. These tests
+ * assert the frozen validation ORDER (envelope → partition → model
+ * provenance → three reuse policy gates) and the eligibility gates (no
+ * streaming, no tools, no conversation memory, no custom interceptors, no
+ * DLP) using recording doubles — not mocks.
+ */
+class OperationCacheCoordinatorTest {
+
+    private fun opWith(cacheable: Boolean = true): Operation = Operation(
+        prompt = "",
+        model = "model-x",
+        provider = "",
+        tools = emptyArray(),
+        maxRetries = 0,
+        cacheable = cacheable,
+        cacheTtlMillis = 60_000,
+    )
+
+    private val security = ExecutionSecurityContext()
+    private val partition = CacheSecurityPartition(null, null)
+    private val fingerprint = "fp-1"
+
+    private fun key() = OperationCacheKey(
+        serviceInterface = "Svc",
+        methodName = "m",
+        requestedModel = "model-x",
+        explicitProvider = null,
+        requestDigest = "digest",
+        operationFingerprint = fingerprint,
+        securityPartition = partition,
+    )
+
+    private fun keyRequest(
+        cacheable: Boolean = true,
+        returnKind: ReturnKind = ReturnKind.STRING,
+        tools: List<ToolDefinition> = emptyList(),
+        digestSource: List<dev.tramai.core.model.Message> = listOf(dev.tramai.core.model.Message(dev.tramai.core.model.MessageRole.USER, "hi")),
+        requestedModel: String = "model-x",
+    ) = OperationCacheKeyRequest(
+        digestSource = digestSource,
+        securityPartition = partition,
+        operationFingerprint = fingerprint,
+        requestedModel = requestedModel,
+        explicitProvider = null,
+        serviceInterface = "Svc",
+        methodName = "m",
+        toolDefinitions = tools,
+        operation = opWith(cacheable = cacheable),
+        returnKind = returnKind,
+    )
+
+    private fun lookupRequest(
+        cacheKey: OperationCacheKey = key(),
+        conversationId: String? = null,
+        correlationId: String = "cid",
+    ) = OperationCacheLookupRequest(cacheKey, security, correlationId, conversationId)
+
+    private fun provenance(
+        providerId: String = "p1",
+        modelName: String = "model-x",
+        registryEntryId: String? = null,
+        revision: String? = null,
+        artifactDigest: ModelArtifactDigest? = null,
+    ) = CachedResponseProvenance(providerId, modelName, null, null, registryEntryId, revision, artifactDigest)
+
+    private fun cached(
+        value: Any = "cached-value",
+        provenance: CachedResponseProvenance = provenance(),
+    ) = CachedOperationResult(value, provenance)
+
+    private class RecordingCache : OperationResponseCache {
+        val entries = mutableMapOf<OperationCacheKey, Pair<CachedOperationResult, Long>>()
+        val invalidated = mutableListOf<OperationCacheKey>()
+        val getCalls = AtomicInteger(0)
+        val putCalls = AtomicInteger(0)
+
+        override fun get(key: OperationCacheKey): CachedOperationResult? {
+            getCalls.incrementAndGet()
+            return entries[key]?.first
+        }
+
+        override fun put(key: OperationCacheKey, value: CachedOperationResult, ttlMillis: Long) {
+            putCalls.incrementAndGet()
+            entries[key] = value to ttlMillis
+        }
+
+        override fun invalidate(key: OperationCacheKey) {
+            invalidated += key
+            entries.remove(key)
+        }
+    }
+
+    private class RecordingPolicyEngine(
+        private val decision: PolicyDecision = PolicyDecision.Allow,
+        private val cancelOn: String? = null,
+        private val cancel: CancellationException = CancellationException("cancel"),
+    ) : PolicyEngine {
+        val evaluated = mutableListOf<String>()
+        override suspend fun evaluate(context: dev.tramai.core.policy.PolicyContext): PolicyDecision {
+            evaluated += context.enforcementPoint.name
+            if (cancelOn == context.enforcementPoint.name) throw cancel
+            return decision
+        }
+    }
+
+    private fun coordinator(
+        cache: OperationResponseCache = RecordingCache(),
+        operationInterceptor: OperationInterceptor = NoOpOperationInterceptor,
+        dlpInterceptor: DlpInterceptor = NoOpDlpInterceptor,
+        modelRegistrySettings: ModelRegistrySettings = ModelRegistrySettings(enabled = false),
+        registry: ModelRegistryEnforcer = ModelRegistryEnforcer(
+            object : dev.tramai.core.model.ModelRegistry {
+                override suspend fun findApprovedModel(providerId: String, modelName: String): RegisteredModel? = null
+            },
+            ModelRegistrySettings(enabled = false),
+        ),
+        policyEngine: RecordingPolicyEngine = RecordingPolicyEngine(),
+    ) = OperationCacheCoordinator(
+        responseCache = cache,
+        operationInterceptor = operationInterceptor,
+        dlpInterceptor = dlpInterceptor,
+        modelRegistrySettings = modelRegistrySettings,
+        modelRegistryEnforcer = registry,
+        policyHelper = PolicyEnforcementHelper(policyEngine, AtomicBoolean(false)),
+    )
+
+    private fun interceptor() = object : OperationInterceptor {}
+
+    private fun dlp() = object : DlpInterceptor {
+        override fun inspect(context: dev.tramai.core.security.DlpContext, text: String): dev.tramai.core.security.DlpResult =
+            dev.tramai.core.security.DlpResult(text)
+    }
+
+    // ------------------------------------------------------------------
+    // createKey eligibility
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `non-cacheable operation yields no key`() {
+        val c = coordinator()
+        assertThat(c.createKey(keyRequest(cacheable = false))).isNull()
+    }
+
+    @Test
+    fun `streaming operation yields no key`() {
+        val c = coordinator()
+        assertThat(c.createKey(keyRequest(returnKind = ReturnKind.STREAMING))).isNull()
+    }
+
+    @Test
+    fun `operation with tools yields no key`() {
+        val c = coordinator()
+        val tool = ToolDefinition(
+            name = "t",
+            description = "d",
+            inputSchemaJson = """{"type":"object"}""",
+        )
+        assertThat(c.createKey(keyRequest(tools = listOf(tool)))).isNull()
+    }
+
+    @Test
+    fun `custom interceptor yields no key`() {
+        val c = coordinator(operationInterceptor = interceptor())
+        assertThat(c.createKey(keyRequest())).isNull()
+    }
+
+    @Test
+    fun `dlp interceptor yields no key`() {
+        val c = coordinator(dlpInterceptor = dlp())
+        assertThat(c.createKey(keyRequest())).isNull()
+    }
+
+    @Test
+    fun `key includes effective messages digest, security partition and operation fingerprint`() {
+        val c = coordinator()
+        val k = c.createKey(keyRequest(digestSource = listOf(dev.tramai.core.model.Message(dev.tramai.core.model.MessageRole.USER, "hello"))))!!
+        assertThat(k.serviceInterface).isEqualTo("Svc")
+        assertThat(k.methodName).isEqualTo("m")
+        assertThat(k.requestedModel).isEqualTo("model-x")
+        assertThat(k.requestDigest).isEqualTo(dev.tramai.engine.buildRequestDigest(listOf(dev.tramai.core.model.Message(dev.tramai.core.model.MessageRole.USER, "hello"))))
+        assertThat(k.operationFingerprint).isEqualTo(fingerprint)
+        assertThat(k.securityPartition).isEqualTo(partition)
+    }
+
+    // ------------------------------------------------------------------
+    // lookup validation order
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `valid hit crosses all three reuse policy gates in order`() = runTest {
+        val cache = RecordingCache()
+        cache.entries[key()] = cached() to 60_000L
+        val policy = RecordingPolicyEngine()
+        val c = coordinator(cache = cache, policyEngine = policy)
+
+        val result = c.lookup(lookupRequest())
+
+        assertThat(result).isEqualTo(OperationCacheLookupResult.Hit("cached-value"))
+        assertThat(policy.evaluated).containsExactly(
+            "BEFORE_PROVIDER_RESOLUTION",
+            "BEFORE_PROVIDER_INVOCATION",
+            "BEFORE_RESPONSE_RETURN",
+        )
+    }
+
+    @Test
+    fun `blank provider provenance is rejected and does not hit`() = runTest {
+        val cache = RecordingCache()
+        cache.entries[key()] = cached(provenance = provenance(providerId = "", modelName = "")) to 60_000L
+        val c = coordinator(cache = cache)
+
+        assertThatThrownBy { kotlinx.coroutines.runBlocking { c.lookup(lookupRequest()) } }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("blank provider provenance")
+
+        assertThat(cache.invalidated).isEmpty()
+    }
+
+    @Test
+    fun `classification mismatch is rejected`() = runTest {
+        val cache = RecordingCache()
+        val partition = CacheSecurityPartition(dev.tramai.core.policy.DataClassification.CONFIDENTIAL, null)
+        val key = key().copy(securityPartition = partition)
+        cache.entries[key] = cached(provenance = provenance()) to 60_000L
+        val c = coordinator(cache = cache)
+
+        assertThatThrownBy { kotlinx.coroutines.runBlocking { c.lookup(lookupRequest(cacheKey = key)) } }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("partition")
+    }
+
+    @Test
+    fun `classification-source mismatch is rejected`() = runTest {
+        val cache = RecordingCache()
+        val partition = CacheSecurityPartition(null, dev.tramai.core.policy.ClassificationSource.DECLARED)
+        val key = key().copy(securityPartition = partition)
+        cache.entries[key] = cached(provenance = provenance()) to 60_000L
+        val c = coordinator(cache = cache)
+
+        assertThatThrownBy { kotlinx.coroutines.runBlocking { c.lookup(lookupRequest(cacheKey = key)) } }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("partition")
+    }
+
+    @Test
+    fun `current model provenance accepted when registry enabled`() = runTest {
+        val cache = RecordingCache()
+        val approved = RegisteredModel(
+            registryEntryId = "entry-1",
+            providerId = "p1",
+            modelName = "model-x",
+            revision = "rev-2",
+            artifactDigest = ModelArtifactDigest.of("sha256:abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+        )
+        val registry = ModelRegistryEnforcer(
+            object : dev.tramai.core.model.ModelRegistry {
+                override suspend fun findApprovedModel(providerId: String, modelName: String): RegisteredModel? = approved
+            },
+            ModelRegistrySettings(enabled = true),
+        )
+        cache.entries[key()] = cached(
+            provenance = provenance(registryEntryId = "entry-1", revision = "rev-2", artifactDigest = ModelArtifactDigest.of("sha256:abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd")),
+        ) to 60_000L
+        val policy = RecordingPolicyEngine()
+        val c = coordinator(cache = cache, modelRegistrySettings = ModelRegistrySettings(enabled = true), registry = registry, policyEngine = policy)
+
+        val result = c.lookup(lookupRequest())
+
+        assertThat(result).isEqualTo(OperationCacheLookupResult.Hit("cached-value"))
+    }
+
+    @Test
+    fun `model provenance drift invalidates and misses`() = runTest {
+        val cache = RecordingCache()
+        val approved = RegisteredModel(
+            registryEntryId = "entry-1",
+            providerId = "p1",
+            modelName = "model-x",
+            revision = "rev-NEW",
+        )
+        val registry = ModelRegistryEnforcer(
+            object : dev.tramai.core.model.ModelRegistry {
+                override suspend fun findApprovedModel(providerId: String, modelName: String): RegisteredModel? = approved
+            },
+            ModelRegistrySettings(enabled = true),
+        )
+        cache.entries[key()] = cached(
+            provenance = provenance(registryEntryId = "entry-1", revision = "rev-OLD"),
+        ) to 60_000L
+        val c = coordinator(cache = cache, modelRegistrySettings = ModelRegistrySettings(enabled = true), registry = registry)
+
+        val result = c.lookup(lookupRequest())
+
+        assertThat(result).isEqualTo(OperationCacheLookupResult.Miss(key()))
+        assertThat(cache.invalidated).containsExactly(key())
+        assertThat(cache.entries).isEmpty()
+    }
+
+    @Test
+    fun `conversation memory in scope misses`() = runTest {
+        val cache = RecordingCache()
+        cache.entries[key()] = cached() to 60_000L
+        val c = coordinator(cache = cache)
+
+        val result = c.lookup(lookupRequest(conversationId = "cid"))
+
+        assertThat(result).isEqualTo(OperationCacheLookupResult.Miss(null))
+        assertThat(cache.getCalls.get()).isZero()
+    }
+
+    @Test
+    fun `custom interceptor in scope misses without touching cache`() = runTest {
+        val cache = RecordingCache()
+        cache.entries[key()] = cached() to 60_000L
+        val c = coordinator(cache = cache, operationInterceptor = interceptor())
+
+        val result = c.lookup(lookupRequest())
+
+        assertThat(result).isEqualTo(OperationCacheLookupResult.Miss(null))
+        assertThat(cache.getCalls.get()).isZero()
+    }
+
+    @Test
+    fun `dlp in scope misses without touching cache`() = runTest {
+        val cache = RecordingCache()
+        cache.entries[key()] = cached() to 60_000L
+        val c = coordinator(cache = cache, dlpInterceptor = dlp())
+
+        val result = c.lookup(lookupRequest())
+
+        assertThat(result).isEqualTo(OperationCacheLookupResult.Miss(null))
+        assertThat(cache.getCalls.get()).isZero()
+    }
+
+    @Test
+    fun `empty cache misses with the key`() = runTest {
+        val c = coordinator()
+        val result = c.lookup(lookupRequest())
+        assertThat(result).isEqualTo(OperationCacheLookupResult.Miss(key()))
+    }
+
+    @Test
+    fun `policy deny propagates`() = runTest {
+        val cache = RecordingCache()
+        cache.entries[key()] = cached() to 60_000L
+        val c = coordinator(
+            cache = cache,
+            policyEngine = RecordingPolicyEngine(
+                decision = PolicyDecision.Deny(reason = "blocked", reasonCode = "CACHE_DENY"),
+            ),
+        )
+
+        assertThatThrownBy { kotlinx.coroutines.runBlocking { c.lookup(lookupRequest()) } }
+            .isInstanceOf(PolicyViolationException::class.java)
+    }
+
+    // ------------------------------------------------------------------
+    // cancellation — never converted into miss/provenance/failure
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `cancellation during model authorization propagates as same exception`() = runTest {
+        val cache = RecordingCache()
+        cache.entries[key()] = cached() to 60_000L
+        val approved = RegisteredModel("entry-1", "p1", "model-x", "rev-1")
+        val cancel = CancellationException("auth-cancel")
+        val registry = ModelRegistryEnforcer(
+            object : dev.tramai.core.model.ModelRegistry {
+                override suspend fun findApprovedModel(providerId: String, modelName: String): RegisteredModel? =
+                    throw cancel
+            },
+            ModelRegistrySettings(enabled = true),
+        )
+        val c = coordinator(cache = cache, modelRegistrySettings = ModelRegistrySettings(enabled = true), registry = registry)
+
+        assertThatThrownBy { kotlinx.coroutines.runBlocking { c.lookup(lookupRequest()) } }
+            .isSameAs(cancel)
+        assertThat(cache.invalidated).isEmpty()
+    }
+
+    @Test
+    fun `cancellation during reuse policy resolution propagates`() = runTest {
+        val cache = RecordingCache()
+        cache.entries[key()] = cached() to 60_000L
+        val cancel = CancellationException("policy-cancel")
+        val c = coordinator(
+            cache = cache,
+            policyEngine = RecordingPolicyEngine(cancelOn = "BEFORE_PROVIDER_RESOLUTION", cancel = cancel),
+        )
+
+        assertThatThrownBy { kotlinx.coroutines.runBlocking { c.lookup(lookupRequest()) } }
+            .isSameAs(cancel)
+        assertThat(cache.invalidated).isEmpty()
+    }
+
+    @Test
+    fun `cancellation during reuse invocation gate propagates`() = runTest {
+        val cache = RecordingCache()
+        cache.entries[key()] = cached() to 60_000L
+        val cancel = CancellationException("policy-cancel")
+        val c = coordinator(
+            cache = cache,
+            policyEngine = RecordingPolicyEngine(cancelOn = "BEFORE_PROVIDER_INVOCATION", cancel = cancel),
+        )
+
+        assertThatThrownBy { kotlinx.coroutines.runBlocking { c.lookup(lookupRequest()) } }
+            .isSameAs(cancel)
+        assertThat(cache.invalidated).isEmpty()
+    }
+
+    @Test
+    fun `cancellation during reuse response gate propagates`() = runTest {
+        val cache = RecordingCache()
+        cache.entries[key()] = cached() to 60_000L
+        val cancel = CancellationException("policy-cancel")
+        val c = coordinator(
+            cache = cache,
+            policyEngine = RecordingPolicyEngine(cancelOn = "BEFORE_RESPONSE_RETURN", cancel = cancel),
+        )
+
+        assertThatThrownBy { kotlinx.coroutines.runBlocking { c.lookup(lookupRequest()) } }
+            .isSameAs(cancel)
+        assertThat(cache.invalidated).isEmpty()
+    }
+
+    // ------------------------------------------------------------------
+    // store
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `store carries provider model security provenance and ttl`() {
+        val cache = RecordingCache()
+        val c = coordinator(cache = cache)
+        val approved = RegisteredModel("entry-9", "p1", "model-x", "rev-3", ModelArtifactDigest.of("sha256:abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"))
+
+        c.store(
+            OperationCacheStoreRequest(
+                key = key(),
+                value = "result",
+                providerId = "p1",
+                modelName = "model-x",
+                securityContext = ExecutionSecurityContext(),
+                conversationId = null,
+                approvedModel = approved,
+                ttlMillis = 123_456L,
+            ),
+        )
+
+        assertThat(cache.putCalls.get()).isEqualTo(1)
+        val (stored, ttl) = cache.entries[key()]!!
+        assertThat(stored.value).isEqualTo("result")
+        assertThat(stored.provenance.providerId).isEqualTo("p1")
+        assertThat(stored.provenance.modelName).isEqualTo("model-x")
+        assertThat(stored.provenance.modelRegistryEntryId).isEqualTo("entry-9")
+        assertThat(stored.provenance.modelRevision).isEqualTo("rev-3")
+        assertThat(stored.provenance.modelArtifactDigest).isEqualTo(ModelArtifactDigest.of("sha256:abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"))
+        assertThat(ttl).isEqualTo(123_456L)
+    }
+
+    @Test
+    fun `store is skipped when conversation memory in scope`() {
+        val cache = RecordingCache()
+        val c = coordinator(cache = cache)
+
+        c.store(
+            OperationCacheStoreRequest(
+                key(), "result", "p1", "model-x", ExecutionSecurityContext(), "cid", null, 60_000L,
+            ),
+        )
+
+        assertThat(cache.putCalls.get()).isZero()
+    }
+
+    @Test
+    fun `store is skipped when custom interceptor in scope`() {
+        val cache = RecordingCache()
+        val c = coordinator(cache = cache, operationInterceptor = interceptor())
+
+        c.store(
+            OperationCacheStoreRequest(
+                key(), "result", "p1", "model-x", ExecutionSecurityContext(), null, null, 60_000L,
+            ),
+        )
+
+        assertThat(cache.putCalls.get()).isZero()
+    }
+
+    @Test
+    fun `store is skipped when dlp in scope`() {
+        val cache = RecordingCache()
+        val c = coordinator(cache = cache, dlpInterceptor = dlp())
+
+        c.store(
+            OperationCacheStoreRequest(
+                key(), "result", "p1", "model-x", ExecutionSecurityContext(), null, null, 60_000L,
+            ),
+        )
+
+        assertThat(cache.putCalls.get()).isZero()
+    }
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/cache/OperationCacheCoordinatorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/cache/OperationCacheCoordinatorTest.kt
@@ -1,7 +1,6 @@
 package dev.tramai.engine.cache
 
 import dev.tramai.core.annotations.Operation
-import dev.tramai.core.exception.CachedModelProvenanceMismatchException
 import dev.tramai.core.exception.PolicyViolationException
 import dev.tramai.core.model.ModelArtifactDigest
 import dev.tramai.core.model.ModelRegistrySettings
@@ -71,6 +70,7 @@ class OperationCacheCoordinatorTest {
         tools: List<ToolDefinition> = emptyList(),
         digestSource: List<dev.tramai.core.model.Message> = listOf(dev.tramai.core.model.Message(dev.tramai.core.model.MessageRole.USER, "hi")),
         requestedModel: String = "model-x",
+        conversationId: String? = null,
     ) = OperationCacheKeyRequest(
         digestSource = digestSource,
         securityPartition = partition,
@@ -82,6 +82,7 @@ class OperationCacheCoordinatorTest {
         toolDefinitions = tools,
         operation = opWith(cacheable = cacheable),
         returnKind = returnKind,
+        conversationId = conversationId,
     )
 
     private fun lookupRequest(
@@ -203,6 +204,13 @@ class OperationCacheCoordinatorTest {
     fun `dlp interceptor yields no key`() {
         val c = coordinator(dlpInterceptor = dlp())
         assertThat(c.createKey(keyRequest())).isNull()
+    }
+
+    @Test
+    fun `conversation memory in scope yields no key without computing digest`() {
+        val c = coordinator()
+        val k = c.createKey(keyRequest(conversationId = "cid"))
+        assertThat(k).isNull()
     }
 
     @Test

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/memory/ConversationMemoryCoordinatorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/memory/ConversationMemoryCoordinatorTest.kt
@@ -1,0 +1,305 @@
+package dev.tramai.engine.memory
+
+import dev.tramai.core.annotations.ConversationId
+import dev.tramai.core.memory.ChatMemory
+import dev.tramai.core.memory.ConversationIdProvider
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Method
+
+/**
+ * Direct contract tests for [ConversationMemoryCoordinator].
+ *
+ * The memory extraction must preserve the exact merge and persistence
+ * semantics that were frozen in the handler: explicit @ConversationId wins,
+ * generated IDs fall back to the provider, history injection is ordered,
+ * SYSTEM deduplication is current-turn-only, and ordinary vs structured
+ * persistence compute the turn boundary differently.
+ */
+class ConversationMemoryCoordinatorTest {
+
+    private fun message(role: MessageRole, content: String) = Message(role, content)
+
+    private class RecordingChatMemory : ChatMemory {
+        val history = mutableListOf<Message>()
+        val added = mutableListOf<List<Message>>()
+        val addedConversationIds = mutableListOf<String>()
+        var getCalls = 0
+
+        override fun get(conversationId: String): List<Message> {
+            getCalls++
+            return history.toList()
+        }
+
+        override fun add(conversationId: String, messages: List<Message>) {
+            addedConversationIds += conversationId
+            added += messages.toList()
+            history.addAll(messages)
+        }
+
+        override fun add(conversationId: String, message: Message) {
+            add(conversationId, listOf(message))
+        }
+
+        override fun clear(conversationId: String) {
+            history.clear()
+        }
+    }
+
+    private fun coordinator(
+        chatMemory: ChatMemory? = RecordingChatMemory(),
+        provider: ConversationIdProvider = ConversationIdProvider { "generated-id" },
+    ) = ConversationMemoryCoordinator(chatMemory, provider)
+
+    private interface ConversationIdService {
+        fun chat(@ConversationId sessionId: String, question: String): String
+
+        fun chatNullable(@ConversationId sessionId: String?): String
+
+        fun plain(question: String): String
+    }
+
+    private fun method(name: String): Method = ConversationIdService::class.java.getMethod(name, *parameterTypes(name))
+
+    private fun parameterTypes(name: String): Array<Class<*>> = when (name) {
+        "chat" -> arrayOf(String::class.java, String::class.java)
+        "chatNullable" -> arrayOf(String::class.java)
+        else -> arrayOf(String::class.java)
+    }
+
+    // ------------------------------------------------------------------
+    // Conversation ID resolution
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `memory disabled resolves null without invoking the provider`() {
+        val calls = java.util.concurrent.atomic.AtomicInteger(0)
+        val c = coordinator(
+            chatMemory = null,
+            provider = ConversationIdProvider {
+                calls.incrementAndGet()
+                "generated"
+            },
+        )
+        // resolveConversationId still delegates to provider for the raw string;
+        // the memory-disabled guard lives on the handler's `if (chatMemory != null)`.
+        // This test asserts the coordinator does not touch the memory store itself.
+        assertThat(c.prepareMessages(listOf(message(MessageRole.USER, "hi")), null)).isNull()
+        assertThat(calls.get()).isZero()
+    }
+
+    @Test
+    fun `explicit conversation id wins`() {
+        val c = coordinator()
+        val id = c.resolveConversationId(method("chat"), arrayOf("explicit-id", "q"))
+        assertThat(id).isEqualTo("explicit-id")
+    }
+
+    @Test
+    fun `null annotated conversation id fails`() {
+        val c = coordinator()
+        assertThatThrownBy { c.resolveConversationId(method("chatNullable"), arrayOf<Any?>(null)) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("@ConversationId")
+    }
+
+    @Test
+    fun `no annotation falls back to the provider`() {
+        val c = coordinator(provider = ConversationIdProvider { "provider-id" })
+        assertThat(c.resolveConversationId(method("plain"), arrayOf("q"))).isEqualTo("provider-id")
+    }
+
+    // ------------------------------------------------------------------
+    // prepareMessages
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `null conversation id produces no prepared messages`() {
+        val memory = RecordingChatMemory()
+        memory.history += message(MessageRole.SYSTEM, "old")
+        val c = coordinator(chatMemory = memory)
+
+        assertThat(c.prepareMessages(listOf(message(MessageRole.USER, "hi")), null)).isNull()
+    }
+
+    @Test
+    fun `empty history produces null prepared messages`() {
+        val c = coordinator(chatMemory = RecordingChatMemory())
+        assertThat(c.prepareMessages(listOf(message(MessageRole.USER, "hi")), "cid")).isNull()
+    }
+
+    @Test
+    fun `history injection preserves ordering and appends current messages`() {
+        val memory = RecordingChatMemory()
+        memory.history += listOf(
+            message(MessageRole.SYSTEM, "old-sys"),
+            message(MessageRole.USER, "old-user"),
+            message(MessageRole.ASSISTANT, "old-assistant"),
+        )
+        val c = coordinator(chatMemory = memory)
+        val initial = listOf(
+            message(MessageRole.SYSTEM, "new-sys"),
+            message(MessageRole.USER, "new-user"),
+        )
+
+        val prepared = c.prepareMessages(initial, "cid")!!
+
+        assertThat(prepared.history).containsExactly(
+            message(MessageRole.SYSTEM, "old-sys"),
+            message(MessageRole.USER, "old-user"),
+            message(MessageRole.ASSISTANT, "old-assistant"),
+        )
+        assertThat(prepared.effectiveMessages).containsExactly(
+            message(MessageRole.SYSTEM, "old-sys"),
+            message(MessageRole.USER, "old-user"),
+            message(MessageRole.ASSISTANT, "old-assistant"),
+            // current SYSTEM deduplicated (history already has one)
+            message(MessageRole.USER, "new-user"),
+        )
+    }
+
+    @Test
+    fun `current system message is removed only when history already has one`() {
+        val memory = RecordingChatMemory()
+        memory.history += message(MessageRole.USER, "old-user")
+        val c = coordinator(chatMemory = memory)
+        val initial = listOf(
+            message(MessageRole.SYSTEM, "new-sys"),
+            message(MessageRole.USER, "new-user"),
+        )
+
+        val prepared = c.prepareMessages(initial, "cid")!!
+
+        assertThat(prepared.effectiveMessages).containsExactly(
+            message(MessageRole.USER, "old-user"),
+            message(MessageRole.SYSTEM, "new-sys"),
+            message(MessageRole.USER, "new-user"),
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // persistTurn
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `ordinary turn persistence drops history and system messages and appends assistant`() {
+        val memory = RecordingChatMemory()
+        val c = coordinator(chatMemory = memory)
+
+        c.persistTurn(
+            PersistConversationTurnRequest(
+                conversationId = "cid",
+                messages = listOf(
+                    message(MessageRole.SYSTEM, "new-sys"),
+                    message(MessageRole.USER, "turn-user"),
+                    message(MessageRole.ASSISTANT, "tool-result"),
+                ),
+                historySize = 1,
+                assistantMessage = message(MessageRole.ASSISTANT, "final"),
+            ),
+        )
+
+        assertThat(memory.added).containsExactly(
+            listOf(
+                message(MessageRole.USER, "turn-user"),
+                message(MessageRole.ASSISTANT, "tool-result"),
+                message(MessageRole.ASSISTANT, "final"),
+            ),
+        )
+        assertThat(memory.addedConversationIds).containsExactly("cid")
+    }
+
+    @Test
+    fun `no chat memory makes persistTurn a no-op`() {
+        val c = coordinator(chatMemory = null)
+        c.persistTurn(
+            PersistConversationTurnRequest(
+                conversationId = "cid",
+                messages = listOf(message(MessageRole.USER, "u")),
+                historySize = 0,
+                assistantMessage = message(MessageRole.ASSISTANT, "a"),
+            ),
+        )
+        // nothing to assert beyond not throwing
+    }
+
+    // ------------------------------------------------------------------
+    // persistStructuredTurn
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `structured retry-aware persistence keeps repair messages in the turn boundary`() {
+        val memory = RecordingChatMemory()
+        val c = coordinator(chatMemory = memory)
+
+        // messages include the history prefix: [old-user] + [prompt, assistant-bad, user-fix]
+        c.persistStructuredTurn(
+            PersistStructuredConversationTurnRequest(
+                conversationId = "cid",
+                messages = listOf(
+                    message(MessageRole.USER, "old-user"),
+                    message(MessageRole.USER, "prompt"),
+                    message(MessageRole.ASSISTANT, "bad-json"),
+                    message(MessageRole.USER, "fix"),
+                ),
+                historySize = 1,
+                messagesBeforeCall = 3, // history + prompt + bad-json happened before the call
+                assistantMessage = message(MessageRole.ASSISTANT, "good-json"),
+            ),
+        )
+
+        assertThat(memory.added).containsExactly(
+            listOf(
+                message(MessageRole.USER, "prompt"),
+                message(MessageRole.ASSISTANT, "bad-json"),
+                message(MessageRole.USER, "fix"),
+                message(MessageRole.ASSISTANT, "good-json"),
+            ),
+        )
+    }
+
+    @Test
+    fun `structured persistence drops system messages from the user prompt`() {
+        val memory = RecordingChatMemory()
+        val c = coordinator(chatMemory = memory)
+
+        c.persistStructuredTurn(
+            PersistStructuredConversationTurnRequest(
+                conversationId = "cid",
+                messages = listOf(
+                    message(MessageRole.SYSTEM, "sys"),
+                    message(MessageRole.USER, "prompt"),
+                    message(MessageRole.ASSISTANT, "bad"),
+                    message(MessageRole.USER, "fix"),
+                ),
+                historySize = 0,
+                messagesBeforeCall = 2,
+                assistantMessage = message(MessageRole.ASSISTANT, "good"),
+            ),
+        )
+
+        assertThat(memory.added.single()).containsExactly(
+            message(MessageRole.USER, "prompt"),
+            message(MessageRole.ASSISTANT, "bad"),
+            message(MessageRole.USER, "fix"),
+            message(MessageRole.ASSISTANT, "good"),
+        )
+    }
+
+    @Test
+    fun `no chat memory makes persistStructuredTurn a no-op`() {
+        val c = coordinator(chatMemory = null)
+        c.persistStructuredTurn(
+            PersistStructuredConversationTurnRequest(
+                conversationId = "cid",
+                messages = listOf(message(MessageRole.USER, "u")),
+                historySize = 0,
+                messagesBeforeCall = 1,
+                assistantMessage = message(MessageRole.ASSISTANT, "a"),
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## refactor(engine): extract memory, cache, and token budget coordinators — Epic 3.6a

Moves execution-state concerns out of `TramaiInvocationHandler` into dedicated internal coordinators. Zero intended behavioral change.

### Components

- `ConversationMemoryCoordinator` (`dev.tramai.engine.memory`) — conversation-ID resolution, history injection with SYSTEM dedup, ordinary/structured/streaming/resumed turn persistence
- `OperationCacheCoordinator` (`dev.tramai.engine.cache`) — cache eligibility, key construction, envelope/partition/provenance validation, reuse policy gates, writes with full provenance
- `TokenBudgetCoordinator` + `TokenBudgetTracker` (`dev.tramai.engine.budget`) — tracker state, snapshot/restore, enforcement with event + exception semantics
- `TokenBudgetTracker` typealias seam in `dev.tramai.engine` keeps tool/approval packages compiling without churn (removable in Epic 3.7)

### Ordering preserved

memory injection → cache key → cache authorization/reuse → provider/tool execution → response policy → memory persistence → cache write

### Security invariants preserved

- cache never crosses security partition (envelope + partition validation order unchanged)
- cached model provenance re-authorized against current registry; drift → invalidate + miss only
- cache hit crosses BEFORE_PROVIDER_RESOLUTION / BEFORE_PROVIDER_INVOCATION / BEFORE_RESPONSE_RETURN with `cacheReuse=true`
- policy denial and malformed envelopes propagate (never silently become a fresh call)
- conversation memory, custom interceptors, and DLP disable caching
- approval resume restores prior budget state (snapshot → restore → same operation budget)
- cancellation never becomes cache miss / provenance mismatch / provider failure
- event names/attributes preserved: `tramai.token_budget.{usage_unavailable,soft_limit_exceeded,hard_limit_exceeded}` with `provider_id, effective_model, limit_tokens, observed_tokens, scope`

### Non-goals

- no public API change (`apiCheck` zero diff)
- no cache-key semantic change, no eligibility expansion, no cache-format migration
- no memory format change, no conversation-ID semantic change
- no token-budget threshold change, no token event rename
- no structured-output extraction or structured retry changes (Epic 3.6b)
- no streaming extraction (Epic 3.6c)
- no provider/tool/approval behavior change
- no CI-hardening change

### Tests (3 new suites, 49 tests)

- `TokenBudgetCoordinatorTest` (12) — disabled, usage-unavailable, hard attempt/operation limits, soft-once, accumulation, snapshot/restore continuation, restored soft-warning state, resumed hard breach, tracker independence
- `ConversationMemoryCoordinatorTest` (13) — explicit @ConversationId wins, null fails, provider fallback, empty history, ordered injection, SYSTEM dedup both ways, ordinary persist, structured retry-aware boundary, structured SYSTEM-drop, no-op paths
- `OperationCacheCoordinatorTest` (24) — eligibility gates (non-cacheable, streaming, tools, interceptors, DLP), key composition, validation order, blank-provenance/partition rejection, provenance drift → invalidate+miss, conversation/interceptor/DLP miss, policy order + deny, cancellation at all 4 reuse seams, store provenance + TTL

### Verification

| Gate | Result |
|---|---|
| `:tramai-engine:test` (full) | ✅ BUILD SUCCESSFUL (2m10s) |
| 3 new component suites | ✅ 49/49 |
| `:tramai-engine:apiCheck` | ✅ zero diff |
| `verifyCancellationSafety` | ✅ 294/294, no new critical/high |
| `verifyChangePolicy -PchangeClass=runtime-behaviour` | ✅ 11 files, no violations |
| 20/20 characterization traces | ✅ byte-identical |
| `{budget,cache,memory}/` → `TramaiInvocationHandler` | ✅ zero references |

> Note: full `verifyPr` not run locally (known orchestration-module EmbeddedPostgres stall); remote CI is authoritative for the full-repo gate.
