### PR TITLE
refactor(engine): extract structured response coordinator — Epic 3.6b

### DIFF
--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -56,14 +56,8 @@ import dev.tramai.core.security.NoOpDlpInterceptor
 import dev.tramai.core.security.NoOpDlpRedactionAuditEmitter
 import dev.tramai.core.security.PromptSanitizer
 import dev.tramai.core.structured.StructuredOutputHandler
-import dev.tramai.core.structured.StructuredOutputFailureCode
-import dev.tramai.core.structured.StructuredOutputFailureDiagnosticEvent
 import dev.tramai.core.structured.StructuredOutputFailureDiagnosticObserver
 import dev.tramai.core.structured.NoOpStructuredOutputFailureDiagnosticObserver
-import dev.tramai.core.structured.StructuredOutputResult
-import dev.tramai.core.structured.boundedStructuredOutputDetailPreview
-import dev.tramai.core.exception.StructuredOutputException
-import dev.tramai.core.exception.safeStructuredOutputFailure
 import dev.tramai.core.approval.ApprovalContinuation
 import dev.tramai.core.approval.ApprovalContinuationStatus
 import dev.tramai.core.approval.ApprovalContinuationStore
@@ -110,7 +104,10 @@ import dev.tramai.engine.cache.OperationCacheLookupResult
 import dev.tramai.engine.cache.OperationCacheStoreRequest
 import dev.tramai.engine.memory.ConversationMemoryCoordinator
 import dev.tramai.engine.memory.PersistConversationTurnRequest
-import dev.tramai.engine.memory.PersistStructuredConversationTurnRequest
+import dev.tramai.engine.structured.ResumedStructuredResponseRequest
+import dev.tramai.engine.structured.StructuredAttemptExecutor
+import dev.tramai.engine.structured.StructuredResponseCoordinator
+import dev.tramai.engine.structured.StructuredResponseRequest
 import dev.tramai.core.approval.ValidateResumeCommand
 import dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter
 import dev.tramai.core.approval.SensitiveToolArguments
@@ -769,6 +766,30 @@ internal class TramaiInvocationHandler(
         invocationExecutor = toolInvocationExecutor,
         resultSanitizer = toolResultSanitizer,
     )
+    private val structuredResponseCoordinator = StructuredResponseCoordinator(
+        structuredOutputHandler = structuredOutputHandler,
+        structuredOutputFailureDiagnosticObserver = structuredOutputFailureDiagnosticObserver,
+        conversationMemoryCoordinator = conversationMemoryCoordinator,
+        operationCacheCoordinator = operationCacheCoordinator,
+        policyHelper = policyHelper,
+        attemptExecutor = StructuredAttemptExecutor { request ->
+            executeWithTools(
+                ToolLoopContext(
+                    operation = request.operation,
+                    messages = request.messages,
+                    tokenBudgetTracker = request.tokenBudgetTracker,
+                    correlationId = request.correlationId,
+                    securityContext = request.securityContext,
+                    identity = request.identity,
+                    conversationId = request.conversationId,
+                    historySize = request.historySize,
+                ),
+            )
+        },
+        serviceTypeName = serviceDefinition.serviceType.qualifiedName
+            ?: serviceDefinition.serviceType.simpleName
+            ?: "<unknown>",
+    )
 
     private fun OperationObservation.completeCancellation(cancellation: CancellationException) {
         try {
@@ -913,7 +934,7 @@ internal class TramaiInvocationHandler(
         val workflowDigest = WorkflowDigestHelper.compute(operation, serviceDefinition)
         val identity = EngineExecutionIdentity(
             workflowRunId = workflowRunId,
-            correlationId = "", // Will be set in executeRaw/executeStructured
+            correlationId = "", // Will be set in executeRaw/the structured coordinator
             workflowDigest = workflowDigest,
             policyVersion = policyHelper.getPolicyVersion(),
             actorId = PolicyEnforcementHelper.ACTOR_ANONYMOUS,
@@ -924,7 +945,16 @@ internal class TramaiInvocationHandler(
                 executeRaw(operation, arguments, tokenBudgetTracker, conversationId, identity)
                 Unit
             }
-            ReturnKind.STRUCTURED -> executeStructured(operation, arguments, tokenBudgetTracker, conversationId, identity)
+            ReturnKind.STRUCTURED -> structuredResponseCoordinator.execute(
+                StructuredResponseRequest(
+                    operation = operation,
+                    arguments = arguments,
+                    tokenBudgetTracker = tokenBudgetTracker,
+                    conversationId = conversationId,
+                    identity = identity,
+                    operationFingerprint = serviceDefinition.operations[operation.method]?.fingerprint,
+                ),
+            )
             ReturnKind.STREAMING -> executeStreaming(operation, arguments, tokenBudgetTracker, conversationId)
         }
     }
@@ -1342,17 +1372,6 @@ internal class TramaiInvocationHandler(
         val emitChunk: suspend (StreamChunk) -> Unit,
     )
 
-    private data class StructuredAttemptContext(
-        val operation: OperationDefinition,
-        val arguments: List<Any?>,
-        val schemaJson: String,
-        val handler: StructuredOutputHandler,
-        val messages: MutableList<Message>,
-        val historySize: Int,
-        val tokenBudgetTracker: TokenBudgetTracker,
-        val conversationId: String?,
-    )
-
     private suspend fun collectStreamingRouteChunks(
         streamCapable: StreamCapable,
         request: ModelRequest,
@@ -1648,352 +1667,6 @@ internal class TramaiInvocationHandler(
                 )
             }
         }
-    }
-
-    private suspend fun executeStructured(
-        operation: OperationDefinition,
-        arguments: List<Any?>,
-        tokenBudgetTracker: TokenBudgetTracker,
-        conversationId: String?,
-        identity: EngineExecutionIdentity,
-    ): Any {
-        val securityContext = ExecutionSecurityContext.fromArguments(arguments.toTypedArray())
-        val handler = structuredOutputHandler ?: throw ConfigurationException(
-            "Structured return type ${operation.returnTypeDescription} requires a StructuredOutputHandler implementation from tramai-structured",
-        )
-        val contract = try {
-            operation.structuredContract(handler)
-        } catch (failure: Throwable) {
-            failure.rethrowIfCancellation()
-            rethrowContractFailure(operation, failure)
-        }
-        val correlationId = java.util.UUID.randomUUID().toString()
-        val effectiveIdentity = identity.copy(correlationId = correlationId)
-        val initialMessages = operation.initialMessages(arguments, contract.schemaJson)
-        val prepared = conversationMemoryCoordinator.prepareMessages(initialMessages, conversationId)
-        val history = prepared?.history ?: emptyList()
-        val effectiveMessages = prepared?.effectiveMessages ?: initialMessages
-        val cacheKey = operationCacheCoordinator.createKey(
-            OperationCacheKeyRequest(
-                digestSource = effectiveMessages,
-                securityPartition = securityContext.toCacheSecurityPartition(),
-                operationFingerprint = serviceDefinition.operations[operation.method]?.fingerprint,
-                requestedModel = operation.operation.model,
-                explicitProvider = operation.operation.provider.takeIf { it.isNotBlank() },
-                serviceInterface = operation.method.declaringClass.name,
-                methodName = operation.method.name,
-                toolDefinitions = operation.toolDefinitions,
-                operation = operation.operation,
-                returnKind = operation.returnKind,
-                conversationId = conversationId,
-            ),
-        )
-        if (cacheKey != null) {
-            when (val cached = operationCacheCoordinator.lookup(
-                OperationCacheLookupRequest(cacheKey, securityContext, correlationId, conversationId),
-            )) {
-                is OperationCacheLookupResult.Hit -> return cached.value
-                is OperationCacheLookupResult.Miss -> Unit
-            }
-        }
-
-        // Re-initialize messages list with history-injected content
-        val messages = effectiveMessages.toMutableList()
-        val initialTurnCount = history.size
-
-        return executeStructuredRetryLoop(
-            StructuredRetryContext(
-                operation = operation,
-                cacheKey = cacheKey,
-                handler = handler,
-                messages = messages,
-                historySize = initialTurnCount,
-                tokenBudgetTracker = tokenBudgetTracker,
-                conversationId = conversationId,
-                correlationId = correlationId,
-                securityContext = securityContext,
-                identity = effectiveIdentity,
-            ),
-        )
-    }
-
-    private suspend fun executeStructuredRetryLoop(
-        context: StructuredRetryContext,
-    ): Any {
-        val operation = context.operation
-        val maxAttempts = operation.operation.maxRetries + 1
-        val targetType = requireNotNull(operation.returnType) {
-            "Structured return type ${operation.returnTypeDescription} could not be inspected without Kotlin reflection metadata"
-        }
-
-        repeat(maxAttempts) { attemptIndex ->
-            val value = executeStructuredAttempt(
-                StructuredRetryAttemptContext(
-                    retry = context,
-                    targetType = targetType,
-                    attemptIndex = attemptIndex,
-                    maxAttempts = maxAttempts,
-                ),
-            )
-            if (value != null) {
-                return value
-            }
-        }
-
-        error("Structured retry loop exited without returning or throwing")
-    }
-
-    private data class StructuredRetryContext(
-        val operation: OperationDefinition,
-        val cacheKey: OperationCacheKey?,
-        val handler: StructuredOutputHandler,
-        val messages: MutableList<Message>,
-        val historySize: Int,
-        val tokenBudgetTracker: TokenBudgetTracker,
-        val conversationId: String?,
-        val correlationId: String,
-        val securityContext: ExecutionSecurityContext,
-        val identity: EngineExecutionIdentity,
-    )
-
-    private data class StructuredRetryAttemptContext(
-        val retry: StructuredRetryContext,
-        val targetType: kotlin.reflect.KType,
-        val attemptIndex: Int,
-        val maxAttempts: Int,
-    )
-
-    private suspend fun executeStructuredAttempt(
-        context: StructuredRetryAttemptContext,
-    ): Any? {
-        val operation = context.retry.operation
-        val cacheKey = context.retry.cacheKey
-        val handler = context.retry.handler
-        val messages = context.retry.messages
-        val historySize = context.retry.historySize
-        val tokenBudgetTracker = context.retry.tokenBudgetTracker
-        val conversationId = context.retry.conversationId
-        val targetType = context.targetType
-        val attemptIndex = context.attemptIndex
-        val maxAttempts = context.maxAttempts
-        val correlationId = context.retry.correlationId
-        val securityContext = context.retry.securityContext
-        val identity = context.retry.identity
-        val messagesBeforeCall = messages.size
-        val result = executeWithTools(
-            ToolLoopContext(
-                operation = operation,
-                messages = messages,
-                tokenBudgetTracker = tokenBudgetTracker,
-                correlationId = correlationId,
-                securityContext = securityContext,
-                identity = identity,
-                conversationId = conversationId,
-                historySize = historySize,
-            ),
-        )
-
-        // DLP is already applied inside ProviderAttemptExecutor — use the sanitized response directly
-
-        val analysis = try {
-            handler.analyze(
-                rawResponse = result.response.content,
-                targetType = targetType,
-            )
-        } catch (failure: Throwable) {
-            failure.rethrowIfCancellation()
-            rethrowOrSanitizeStructuredHandlerFailure(
-                operation = operation,
-                result = result,
-                failure = failure,
-                attempt = attemptIndex + 1,
-            )
-        }
-        return when (analysis) {
-            is StructuredOutputResult.Success -> {
-                // Enforce BEFORE_RESPONSE_RETURN before any side effects (persist, cache)
-                // and before onCallCompleted so external consumers don't assume availability
-                policyHelper.enforce(
-                    policyHelper.buildContext(
-                        enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
-                        correlationId = correlationId,
-                    ).providerId(result.providerId)
-                        .modelName(result.modelName)
-                        .applySecurityContext(securityContext)
-                        .build()
-                )
-
-                result.observation.onCallCompleted(parseSuccess = true)
-
-                if (conversationId != null) {
-                    conversationMemoryCoordinator.persistStructuredTurn(
-                        PersistStructuredConversationTurnRequest(
-                            conversationId = conversationId,
-                            messages = messages,
-                            historySize = historySize,
-                            messagesBeforeCall = messagesBeforeCall,
-                            assistantMessage = Message(
-                                role = MessageRole.ASSISTANT,
-                                content = result.response.content,
-                                toolCalls = result.response.toolCalls,
-                            ),
-                        ),
-                    )
-                }
-                cacheKey?.let { key ->
-                    operationCacheCoordinator.store(
-                        OperationCacheStoreRequest(key, analysis.value, result.providerId, result.modelName, securityContext, conversationId, result.approvedModel, operation.operation.cacheTtlMillis),
-                    )
-                }
-
-                analysis.value
-            }
-            is StructuredOutputResult.Failure -> {
-                handleStructuredFailure(
-                    operation = operation,
-                    analysis = analysis,
-                    result = result,
-                    messages = messages,
-                    attemptIndex = attemptIndex,
-                    maxAttempts = maxAttempts,
-                )
-                null
-            }
-        }
-    }
-
-    private suspend fun handleStructuredFailure(
-        operation: OperationDefinition,
-        analysis: StructuredOutputResult.Failure,
-        result: ProviderCallResult,
-        messages: MutableList<Message>,
-        attemptIndex: Int,
-        maxAttempts: Int,
-    ) {
-        currentCoroutineContext().ensureActive()
-        val rawPreview = boundedStructuredOutputDetailPreview(analysis.rawResponse)
-        // Privileged diagnostics keep the ACTUAL validation reason (original
-        // throwable message) when one exists; the ordinary summary stays
-        // compatibility-safe fixed text.
-        val detailSource = analysis.failure?.message ?: analysis.errorSummary
-        val detailPreview = boundedStructuredOutputDetailPreview(detailSource)
-        deliverStructuredOutputFailure(
-            StructuredOutputFailureDiagnosticEvent(
-                serviceName = structuredDiagnosticServiceName(),
-                methodName = operation.method.name,
-                code = StructuredOutputFailureCode.OUTPUT_REJECTED,
-                attempt = attemptIndex + 1,
-                willRetry = attemptIndex < maxAttempts - 1,
-                rawResponsePreview = rawPreview.text,
-                rawResponseTruncated = rawPreview.truncated,
-                detailPreview = detailPreview.text,
-                detailTruncated = detailPreview.truncated,
-                failure = analysis.failure,
-                numericMetadata = mapOf("attempt" to (attemptIndex + 1).toLong()),
-            ),
-        )
-        result.observation.onStructuredParseFailure(
-            rawResponse = "<redacted structured-output failure>",
-            errorSummary = "Structured output failed validation",
-        )
-        if (attemptIndex == maxAttempts - 1) {
-            result.observation.onCallCompleted(parseSuccess = false)
-            throw safeStructuredOutputFailure(
-                code = StructuredOutputFailureCode.REPAIR_EXHAUSTED,
-                attemptCount = maxAttempts,
-            )
-        }
-
-        result.observation.onCallCompleted(parseSuccess = false)
-        messages += Message(MessageRole.ASSISTANT, analysis.rawResponse)
-        messages += Message(MessageRole.USER, analysis.feedbackMessage)
-    }
-
-    private suspend fun rethrowOrSanitizeStructuredHandlerFailure(
-        operation: OperationDefinition,
-        result: ProviderCallResult,
-        failure: Throwable,
-        attempt: Int,
-    ): Nothing {
-        failure.rethrowIfCancellation()
-        currentCoroutineContext().ensureActive()
-        // Anything thrown by a handler is UNTRUSTED regardless of exception
-        // type — including exceptions produced by the public factory. The
-        // factory only guarantees fixed text; a handler could still construct
-        // a raw StructuredOutputException with arbitrary text, so it is always
-        // re-sanitized here.
-        deliverStructuredOutputFailure(
-            StructuredOutputFailureDiagnosticEvent(
-                serviceName = structuredDiagnosticServiceName(),
-                methodName = operation.method.name,
-                code = StructuredOutputFailureCode.HANDLER_FAILED,
-                attempt = attempt,
-                // A thrown handler failure is always terminal: the safe
-                // exception is thrown below, never retried.
-                willRetry = false,
-                rawResponsePreview = null,
-                rawResponseTruncated = false,
-                detailPreview = null,
-                detailTruncated = false,
-                failure = failure,
-                numericMetadata = mapOf("attempt" to attempt.toLong()),
-            ),
-        )
-        // Complete the ordinary observation exactly like the terminal
-        // structured-failure path: parse-failure signal + terminal completion.
-        result.observation.onStructuredParseFailure(
-            rawResponse = "<redacted structured-output failure>",
-            errorSummary = "Structured output failed validation",
-        )
-        result.observation.onCallCompleted(parseSuccess = false)
-        throw safeStructuredOutputFailure(
-            code = StructuredOutputFailureCode.HANDLER_FAILED,
-            attemptCount = attempt,
-        )
-    }
-
-    private suspend fun rethrowContractFailure(
-        operation: OperationDefinition,
-        failure: Throwable,
-    ): Nothing {
-        failure.rethrowIfCancellation()
-        currentCoroutineContext().ensureActive()
-        deliverStructuredOutputFailure(
-            StructuredOutputFailureDiagnosticEvent(
-                serviceName = structuredDiagnosticServiceName(),
-                methodName = operation.method.name,
-                code = StructuredOutputFailureCode.CONTRACT_FAILED,
-                attempt = 1,
-                willRetry = false,
-                rawResponsePreview = null,
-                rawResponseTruncated = false,
-                detailPreview = null,
-                detailTruncated = false,
-                failure = failure,
-                numericMetadata = mapOf("attempt" to 1L),
-            ),
-        )
-        throw safeStructuredOutputFailure(
-            code = StructuredOutputFailureCode.CONTRACT_FAILED,
-            attemptCount = 1,
-        )
-    }
-
-    /** Service identity for structured diagnostic events (qualified name when available). */
-    private fun structuredDiagnosticServiceName(): String =
-        serviceDefinition.serviceType.qualifiedName
-            ?: serviceDefinition.serviceType.simpleName
-            ?: "<unknown>"
-
-    private suspend fun deliverStructuredOutputFailure(event: StructuredOutputFailureDiagnosticEvent) {
-        try {
-            structuredOutputFailureDiagnosticObserver.onFailure(event)
-        } catch (e: CancellationException) {
-            currentCoroutineContext().ensureActive()
-        } catch (e: Throwable) {
-            e.rethrowIfCancellation()
-        }
-        currentCoroutineContext().ensureActive()
     }
 
     private suspend fun executeWithTools(
@@ -2346,10 +2019,8 @@ internal class TramaiInvocationHandler(
      * structured parsing. Enforces BEFORE_RESPONSE_RETURN, persists conversation
      * memory, completes the observation, and returns the appropriate result.
      *
-     * For [ReturnKind.STRUCTURED] callers must handle parsing separately via
-     * [resumeStructuredResult] — this method enforces only the shared parts
-     * (BEFORE_RESPONSE_RETURN, memory, observation) and then throws so the
-     * caller knows to use the structured path instead.
+     * The [ReturnKind.STRUCTURED] branch delegates parsing, memory, and
+     * observation completion to the structured response coordinator.
      */
     private suspend fun finalizeResumedOperation(
         operation: OperationDefinition,
@@ -2420,129 +2091,19 @@ internal class TramaiInvocationHandler(
                 return Unit
             }
             ReturnKind.STRUCTURED -> {
-                // Structured: delegate to resumeStructuredResult which handles
-                // BEFORE_RESPONSE_RETURN (on success only), memory, observation, and parse
-                return resumeStructuredResult(
-                    operation = operation,
-                    loopResult = loopResult,
-                    messages = messages,
-                    correlationId = correlationId,
-                    securityContext = securityContext,
-                    conversationId = conversationId,
-                    historySize = historySize,
+                return structuredResponseCoordinator.finalizeResumed(
+                    ResumedStructuredResponseRequest(
+                        operation = operation,
+                        loopResult = loopResult,
+                        messages = messages,
+                        correlationId = correlationId,
+                        securityContext = securityContext,
+                        conversationId = conversationId,
+                        historySize = historySize,
+                    ),
                 )
             }
             ReturnKind.STREAMING -> throw ConfigurationException("Streaming approval resume not supported")
-        }
-    }
-
-    /**
-     * Parses the structured (typed) result from a resumed provider loop.
-     *
-     * **Single-attempt limitation (v1):** Unlike the normal flow, which retries structured
-     * parsing when the provider responds with content that cannot be parsed — feeding
-     * the error back to the provider for a corrected attempt — this resume path makes
-     * exactly one parse attempt. If parsing fails, the exception is thrown immediately
-     * without a retry cycle. This is a deliberate v1 limitation: the resume path is a
-     * linear re-entrant flow, not a multi-turn conversation, so retry-with-feedback
-     * semantics are not available here.
-     */
-    private suspend fun resumeStructuredResult(
-        operation: OperationDefinition,
-        loopResult: ProviderCallResult,
-        messages: List<Message>,
-        correlationId: String,
-        securityContext: ExecutionSecurityContext,
-        conversationId: String?,
-        historySize: Int,
-    ): Any {
-        val handler = structuredOutputHandler
-            ?: throw ConfigurationException(
-                "Structured return type ${operation.returnTypeDescription} requires a StructuredOutputHandler implementation from tramai-structured",
-            )
-        val targetType = operation.returnType
-            ?: throw ConfigurationException(
-                "Structured return type ${operation.returnTypeDescription} could not be inspected without Kotlin reflection metadata",
-            )
-
-        // Fix 3: Parse FIRST before memory persistence and BEFORE_RESPONSE_RETURN
-        val analysis = try {
-            handler.analyze(
-                rawResponse = loopResult.response.content,
-                targetType = targetType,
-            )
-        } catch (failure: Throwable) {
-            failure.rethrowIfCancellation()
-            rethrowOrSanitizeStructuredHandlerFailure(
-                operation = operation,
-                result = loopResult,
-                failure = failure,
-                attempt = 1,
-            )
-        }
-        return when (analysis) {
-            is StructuredOutputResult.Success -> {
-                // On success: enforce BEFORE_RESPONSE_RETURN, persist memory, complete observation, return value
-                // BEFORE_RESPONSE_RETURN is enforced HERE (not in finalizeResumedOperation) per Fix 3
-                // so that parse failure does not trip BEFORE_RESPONSE_RETURN
-                policyHelper.enforce(
-                    policyHelper.buildContext(
-                        enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
-                        correlationId = correlationId,
-                    ).providerId(loopResult.providerId)
-                        .modelName(loopResult.modelName)
-                        .applySecurityContext(securityContext)
-                        .build()
-                )
-                if (conversationId != null) {
-                    conversationMemoryCoordinator.persistTurn(
-                        PersistConversationTurnRequest(
-                            conversationId,
-                            messages,
-                            historySize,
-                            Message(
-                                role = MessageRole.ASSISTANT,
-                                content = loopResult.response.content,
-                                toolCalls = loopResult.response.toolCalls,
-                            ),
-                        ),
-                    )
-                }
-                loopResult.observation.onCallCompleted(parseSuccess = true)
-                analysis.value
-            }
-            is StructuredOutputResult.Failure -> {
-                // On failure: record parse failure, do NOT enforce BEFORE_RESPONSE_RETURN,
-                // do NOT persist invalid data, leave continuation CLAIMED
-                currentCoroutineContext().ensureActive()
-                val rawPreview = boundedStructuredOutputDetailPreview(analysis.rawResponse)
-                val detailSource = analysis.failure?.message ?: analysis.errorSummary
-                val detailPreview = boundedStructuredOutputDetailPreview(detailSource)
-                deliverStructuredOutputFailure(
-                    StructuredOutputFailureDiagnosticEvent(
-                        serviceName = structuredDiagnosticServiceName(),
-                        methodName = operation.method.name,
-                        code = StructuredOutputFailureCode.OUTPUT_REJECTED,
-                        attempt = 1,
-                        willRetry = false,
-                        rawResponsePreview = rawPreview.text,
-                        rawResponseTruncated = rawPreview.truncated,
-                        detailPreview = detailPreview.text,
-                        detailTruncated = detailPreview.truncated,
-                        failure = analysis.failure,
-                        numericMetadata = mapOf("attempt" to 1L),
-                    ),
-                )
-                loopResult.observation.onStructuredParseFailure(
-                    rawResponse = "<redacted structured-output failure>",
-                    errorSummary = "Structured output failed validation",
-                )
-                loopResult.observation.onCallCompleted(parseSuccess = false)
-                throw safeStructuredOutputFailure(
-                    code = StructuredOutputFailureCode.OUTPUT_REJECTED,
-                    attemptCount = 1,
-                )
-            }
         }
     }
 

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/structured/StructuredResponseCoordinator.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/structured/StructuredResponseCoordinator.kt
@@ -1,0 +1,485 @@
+package dev.tramai.engine.structured
+
+import dev.tramai.core.coroutines.rethrowIfCancellation
+import dev.tramai.core.exception.ConfigurationException
+import dev.tramai.core.exception.safeStructuredOutputFailure
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
+import dev.tramai.core.structured.StructuredOutputFailureCode
+import dev.tramai.core.structured.StructuredOutputFailureDiagnosticEvent
+import dev.tramai.core.structured.StructuredOutputFailureDiagnosticObserver
+import dev.tramai.core.structured.StructuredOutputHandler
+import dev.tramai.core.structured.StructuredOutputResult
+import dev.tramai.core.structured.boundedStructuredOutputDetailPreview
+import dev.tramai.engine.CacheSecurityPartition
+import dev.tramai.engine.EngineExecutionIdentity
+import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.OperationCacheKey
+import dev.tramai.engine.OperationDefinition
+import dev.tramai.engine.PolicyEnforcementHelper
+import dev.tramai.engine.PolicyContextBuilder
+import dev.tramai.engine.budget.TokenBudgetTracker
+import dev.tramai.engine.cache.OperationCacheCoordinator
+import dev.tramai.engine.cache.OperationCacheKeyRequest
+import dev.tramai.engine.cache.OperationCacheLookupRequest
+import dev.tramai.engine.cache.OperationCacheLookupResult
+import dev.tramai.engine.cache.OperationCacheStoreRequest
+import dev.tramai.engine.memory.ConversationMemoryCoordinator
+import dev.tramai.engine.memory.PersistConversationTurnRequest
+import dev.tramai.engine.memory.PersistStructuredConversationTurnRequest
+import dev.tramai.engine.provider.ProviderCallResult
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+
+internal fun interface StructuredAttemptExecutor {
+    suspend fun execute(request: StructuredAttemptExecutionRequest): ProviderCallResult
+}
+
+internal class StructuredResponseCoordinator(
+    private val structuredOutputHandler: StructuredOutputHandler?,
+    private val structuredOutputFailureDiagnosticObserver: StructuredOutputFailureDiagnosticObserver,
+    private val conversationMemoryCoordinator: ConversationMemoryCoordinator,
+    private val operationCacheCoordinator: OperationCacheCoordinator,
+    private val policyHelper: PolicyEnforcementHelper,
+    private val attemptExecutor: StructuredAttemptExecutor,
+    private val serviceTypeName: String,
+) {
+    suspend fun execute(request: StructuredResponseRequest): Any {
+        val operation = request.operation
+        val securityContext = ExecutionSecurityContext.fromArguments(request.arguments.toTypedArray())
+        val handler = structuredOutputHandler ?: throw ConfigurationException(
+            "Structured return type ${operation.returnTypeDescription} requires a StructuredOutputHandler implementation from tramai-structured",
+        )
+        val contract = try {
+            operation.structuredContract(handler)
+        } catch (failure: Throwable) {
+            failure.rethrowIfCancellation()
+            rethrowContractFailure(operation, failure)
+        }
+        val correlationId = java.util.UUID.randomUUID().toString()
+        val effectiveIdentity = request.identity.copy(correlationId = correlationId)
+        val initialMessages = operation.initialMessages(request.arguments, contract.schemaJson)
+        val prepared = conversationMemoryCoordinator.prepareMessages(initialMessages, request.conversationId)
+        val history = prepared?.history ?: emptyList()
+        val effectiveMessages = prepared?.effectiveMessages ?: initialMessages
+        val cacheKey = operationCacheCoordinator.createKey(
+            OperationCacheKeyRequest(
+                digestSource = effectiveMessages,
+                securityPartition = securityContext.toCacheSecurityPartition(),
+                operationFingerprint = request.operationFingerprint,
+                requestedModel = operation.operation.model,
+                explicitProvider = operation.operation.provider.takeIf { it.isNotBlank() },
+                serviceInterface = operation.method.declaringClass.name,
+                methodName = operation.method.name,
+                toolDefinitions = operation.toolDefinitions,
+                operation = operation.operation,
+                returnKind = operation.returnKind,
+                conversationId = request.conversationId,
+            ),
+        )
+        if (cacheKey != null) {
+            when (val cached = operationCacheCoordinator.lookup(
+                OperationCacheLookupRequest(cacheKey, securityContext, correlationId, request.conversationId),
+            )) {
+                is OperationCacheLookupResult.Hit -> return cached.value
+                is OperationCacheLookupResult.Miss -> Unit
+            }
+        }
+
+        // Re-initialize messages list with history-injected content
+        val messages = effectiveMessages.toMutableList()
+        val initialTurnCount = history.size
+
+        return executeStructuredRetryLoop(
+            StructuredRetryContext(
+                operation = operation,
+                cacheKey = cacheKey,
+                handler = handler,
+                messages = messages,
+                historySize = initialTurnCount,
+                tokenBudgetTracker = request.tokenBudgetTracker,
+                conversationId = request.conversationId,
+                correlationId = correlationId,
+                securityContext = securityContext,
+                identity = effectiveIdentity,
+            ),
+        )
+    }
+
+    suspend fun finalizeResumed(request: ResumedStructuredResponseRequest): Any {
+        val operation = request.operation
+        val loopResult = request.loopResult
+        val handler = structuredOutputHandler
+            ?: throw ConfigurationException(
+                "Structured return type ${operation.returnTypeDescription} requires a StructuredOutputHandler implementation from tramai-structured",
+            )
+        val targetType = operation.returnType
+            ?: throw ConfigurationException(
+                "Structured return type ${operation.returnTypeDescription} could not be inspected without Kotlin reflection metadata",
+            )
+
+        // Fix 3: Parse FIRST before memory persistence and BEFORE_RESPONSE_RETURN
+        val analysis = try {
+            handler.analyze(
+                rawResponse = loopResult.response.content,
+                targetType = targetType,
+            )
+        } catch (failure: Throwable) {
+            failure.rethrowIfCancellation()
+            rethrowOrSanitizeStructuredHandlerFailure(
+                operation = operation,
+                result = loopResult,
+                failure = failure,
+                attempt = 1,
+            )
+        }
+        return when (analysis) {
+            is StructuredOutputResult.Success -> {
+                // On success: enforce BEFORE_RESPONSE_RETURN, persist memory, complete observation, return value
+                // BEFORE_RESPONSE_RETURN is enforced HERE (not in finalizeResumedOperation) per Fix 3
+                // so that parse failure does not trip BEFORE_RESPONSE_RETURN
+                policyHelper.enforce(
+                    policyHelper.buildContext(
+                        enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
+                        correlationId = request.correlationId,
+                    ).providerId(loopResult.providerId)
+                        .modelName(loopResult.modelName)
+                        .applySecurityContext(request.securityContext)
+                        .build()
+                )
+                if (request.conversationId != null) {
+                    conversationMemoryCoordinator.persistTurn(
+                        PersistConversationTurnRequest(
+                            request.conversationId,
+                            request.messages,
+                            request.historySize,
+                            Message(
+                                role = MessageRole.ASSISTANT,
+                                content = loopResult.response.content,
+                                toolCalls = loopResult.response.toolCalls,
+                            ),
+                        ),
+                    )
+                }
+                loopResult.observation.onCallCompleted(parseSuccess = true)
+                analysis.value
+            }
+            is StructuredOutputResult.Failure -> {
+                // On failure: record parse failure, do NOT enforce BEFORE_RESPONSE_RETURN,
+                // do NOT persist invalid data, leave continuation CLAIMED
+                currentCoroutineContext().ensureActive()
+                val rawPreview = boundedStructuredOutputDetailPreview(analysis.rawResponse)
+                val detailSource = analysis.failure?.message ?: analysis.errorSummary
+                val detailPreview = boundedStructuredOutputDetailPreview(detailSource)
+                deliverStructuredOutputFailure(
+                    StructuredOutputFailureDiagnosticEvent(
+                        serviceName = serviceTypeName,
+                        methodName = operation.method.name,
+                        code = StructuredOutputFailureCode.OUTPUT_REJECTED,
+                        attempt = 1,
+                        willRetry = false,
+                        rawResponsePreview = rawPreview.text,
+                        rawResponseTruncated = rawPreview.truncated,
+                        detailPreview = detailPreview.text,
+                        detailTruncated = detailPreview.truncated,
+                        failure = analysis.failure,
+                        numericMetadata = mapOf("attempt" to 1L),
+                    ),
+                )
+                loopResult.observation.onStructuredParseFailure(
+                    rawResponse = "<redacted structured-output failure>",
+                    errorSummary = "Structured output failed validation",
+                )
+                loopResult.observation.onCallCompleted(parseSuccess = false)
+                throw safeStructuredOutputFailure(
+                    code = StructuredOutputFailureCode.OUTPUT_REJECTED,
+                    attemptCount = 1,
+                )
+            }
+        }
+    }
+
+    private suspend fun executeStructuredRetryLoop(
+        context: StructuredRetryContext,
+    ): Any {
+        val operation = context.operation
+        val maxAttempts = operation.operation.maxRetries + 1
+        val targetType = requireNotNull(operation.returnType) {
+            "Structured return type ${operation.returnTypeDescription} could not be inspected without Kotlin reflection metadata"
+        }
+
+        repeat(maxAttempts) { attemptIndex ->
+            val value = executeStructuredAttempt(
+                StructuredRetryAttemptContext(
+                    retry = context,
+                    targetType = targetType,
+                    attemptIndex = attemptIndex,
+                    maxAttempts = maxAttempts,
+                ),
+            )
+            if (value != null) {
+                return value
+            }
+        }
+
+        error("Structured retry loop exited without returning or throwing")
+    }
+
+    private data class StructuredRetryContext(
+        val operation: OperationDefinition,
+        val cacheKey: OperationCacheKey?,
+        val handler: StructuredOutputHandler,
+        val messages: MutableList<Message>,
+        val historySize: Int,
+        val tokenBudgetTracker: TokenBudgetTracker,
+        val conversationId: String?,
+        val correlationId: String,
+        val securityContext: ExecutionSecurityContext,
+        val identity: EngineExecutionIdentity,
+    )
+
+    private data class StructuredRetryAttemptContext(
+        val retry: StructuredRetryContext,
+        val targetType: kotlin.reflect.KType,
+        val attemptIndex: Int,
+        val maxAttempts: Int,
+    )
+
+    private suspend fun executeStructuredAttempt(
+        context: StructuredRetryAttemptContext,
+    ): Any? {
+        val operation = context.retry.operation
+        val cacheKey = context.retry.cacheKey
+        val handler = context.retry.handler
+        val messages = context.retry.messages
+        val historySize = context.retry.historySize
+        val tokenBudgetTracker = context.retry.tokenBudgetTracker
+        val conversationId = context.retry.conversationId
+        val targetType = context.targetType
+        val attemptIndex = context.attemptIndex
+        val maxAttempts = context.maxAttempts
+        val correlationId = context.retry.correlationId
+        val securityContext = context.retry.securityContext
+        val identity = context.retry.identity
+        val messagesBeforeCall = messages.size
+        val result = attemptExecutor.execute(
+            StructuredAttemptExecutionRequest(
+                operation = operation,
+                messages = messages,
+                tokenBudgetTracker = tokenBudgetTracker,
+                correlationId = correlationId,
+                securityContext = securityContext,
+                identity = identity,
+                conversationId = conversationId,
+                historySize = historySize,
+            ),
+        )
+
+        // DLP is already applied inside ProviderAttemptExecutor — use the sanitized response directly
+
+        val analysis = try {
+            handler.analyze(
+                rawResponse = result.response.content,
+                targetType = targetType,
+            )
+        } catch (failure: Throwable) {
+            failure.rethrowIfCancellation()
+            rethrowOrSanitizeStructuredHandlerFailure(
+                operation = operation,
+                result = result,
+                failure = failure,
+                attempt = attemptIndex + 1,
+            )
+        }
+        return when (analysis) {
+            is StructuredOutputResult.Success -> {
+                // Enforce BEFORE_RESPONSE_RETURN before any side effects (persist, cache)
+                // and before onCallCompleted so external consumers don't assume availability
+                policyHelper.enforce(
+                    policyHelper.buildContext(
+                        enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
+                        correlationId = correlationId,
+                    ).providerId(result.providerId)
+                        .modelName(result.modelName)
+                        .applySecurityContext(securityContext)
+                        .build()
+                )
+
+                result.observation.onCallCompleted(parseSuccess = true)
+
+                if (conversationId != null) {
+                    conversationMemoryCoordinator.persistStructuredTurn(
+                        PersistStructuredConversationTurnRequest(
+                            conversationId = conversationId,
+                            messages = messages,
+                            historySize = historySize,
+                            messagesBeforeCall = messagesBeforeCall,
+                            assistantMessage = Message(
+                                role = MessageRole.ASSISTANT,
+                                content = result.response.content,
+                                toolCalls = result.response.toolCalls,
+                            ),
+                        ),
+                    )
+                }
+                cacheKey?.let { key ->
+                    operationCacheCoordinator.store(
+                        OperationCacheStoreRequest(key, analysis.value, result.providerId, result.modelName, securityContext, conversationId, result.approvedModel, operation.operation.cacheTtlMillis),
+                    )
+                }
+
+                analysis.value
+            }
+            is StructuredOutputResult.Failure -> {
+                handleStructuredFailure(
+                    operation = operation,
+                    analysis = analysis,
+                    result = result,
+                    messages = messages,
+                    attemptIndex = attemptIndex,
+                    maxAttempts = maxAttempts,
+                )
+                null
+            }
+        }
+    }
+
+    private suspend fun handleStructuredFailure(
+        operation: OperationDefinition,
+        analysis: StructuredOutputResult.Failure,
+        result: ProviderCallResult,
+        messages: MutableList<Message>,
+        attemptIndex: Int,
+        maxAttempts: Int,
+    ) {
+        currentCoroutineContext().ensureActive()
+        val rawPreview = boundedStructuredOutputDetailPreview(analysis.rawResponse)
+        // Privileged diagnostics keep the ACTUAL validation reason (original
+        // throwable message) when one exists; the ordinary summary stays
+        // compatibility-safe fixed text.
+        val detailSource = analysis.failure?.message ?: analysis.errorSummary
+        val detailPreview = boundedStructuredOutputDetailPreview(detailSource)
+        deliverStructuredOutputFailure(
+            StructuredOutputFailureDiagnosticEvent(
+                serviceName = serviceTypeName,
+                methodName = operation.method.name,
+                code = StructuredOutputFailureCode.OUTPUT_REJECTED,
+                attempt = attemptIndex + 1,
+                willRetry = attemptIndex < maxAttempts - 1,
+                rawResponsePreview = rawPreview.text,
+                rawResponseTruncated = rawPreview.truncated,
+                detailPreview = detailPreview.text,
+                detailTruncated = detailPreview.truncated,
+                failure = analysis.failure,
+                numericMetadata = mapOf("attempt" to (attemptIndex + 1).toLong()),
+            ),
+        )
+        result.observation.onStructuredParseFailure(
+            rawResponse = "<redacted structured-output failure>",
+            errorSummary = "Structured output failed validation",
+        )
+        if (attemptIndex == maxAttempts - 1) {
+            result.observation.onCallCompleted(parseSuccess = false)
+            throw safeStructuredOutputFailure(
+                code = StructuredOutputFailureCode.REPAIR_EXHAUSTED,
+                attemptCount = maxAttempts,
+            )
+        }
+
+        result.observation.onCallCompleted(parseSuccess = false)
+        messages += Message(MessageRole.ASSISTANT, analysis.rawResponse)
+        messages += Message(MessageRole.USER, analysis.feedbackMessage)
+    }
+
+    private suspend fun rethrowOrSanitizeStructuredHandlerFailure(
+        operation: OperationDefinition,
+        result: ProviderCallResult,
+        failure: Throwable,
+        attempt: Int,
+    ): Nothing {
+        failure.rethrowIfCancellation()
+        currentCoroutineContext().ensureActive()
+        // Anything thrown by a handler is UNTRUSTED regardless of exception
+        // type — including exceptions produced by the public factory. The
+        // factory only guarantees fixed text; a handler could still construct
+        // a raw StructuredOutputException with arbitrary text, so it is always
+        // re-sanitized here.
+        deliverStructuredOutputFailure(
+            StructuredOutputFailureDiagnosticEvent(
+                serviceName = serviceTypeName,
+                methodName = operation.method.name,
+                code = StructuredOutputFailureCode.HANDLER_FAILED,
+                attempt = attempt,
+                // A thrown handler failure is always terminal: the safe
+                // exception is thrown below, never retried.
+                willRetry = false,
+                rawResponsePreview = null,
+                rawResponseTruncated = false,
+                detailPreview = null,
+                detailTruncated = false,
+                failure = failure,
+                numericMetadata = mapOf("attempt" to attempt.toLong()),
+            ),
+        )
+        // Complete the ordinary observation exactly like the terminal
+        // structured-failure path: parse-failure signal + terminal completion.
+        result.observation.onStructuredParseFailure(
+            rawResponse = "<redacted structured-output failure>",
+            errorSummary = "Structured output failed validation",
+        )
+        result.observation.onCallCompleted(parseSuccess = false)
+        throw safeStructuredOutputFailure(
+            code = StructuredOutputFailureCode.HANDLER_FAILED,
+            attemptCount = attempt,
+        )
+    }
+
+    private suspend fun rethrowContractFailure(
+        operation: OperationDefinition,
+        failure: Throwable,
+    ): Nothing {
+        failure.rethrowIfCancellation()
+        currentCoroutineContext().ensureActive()
+        deliverStructuredOutputFailure(
+            StructuredOutputFailureDiagnosticEvent(
+                serviceName = serviceTypeName,
+                methodName = operation.method.name,
+                code = StructuredOutputFailureCode.CONTRACT_FAILED,
+                attempt = 1,
+                willRetry = false,
+                rawResponsePreview = null,
+                rawResponseTruncated = false,
+                detailPreview = null,
+                detailTruncated = false,
+                failure = failure,
+                numericMetadata = mapOf("attempt" to 1L),
+            ),
+        )
+        throw safeStructuredOutputFailure(
+            code = StructuredOutputFailureCode.CONTRACT_FAILED,
+            attemptCount = 1,
+        )
+    }
+
+    private suspend fun deliverStructuredOutputFailure(event: StructuredOutputFailureDiagnosticEvent) {
+        try {
+            structuredOutputFailureDiagnosticObserver.onFailure(event)
+        } catch (e: CancellationException) {
+            currentCoroutineContext().ensureActive()
+        } catch (e: Throwable) {
+            e.rethrowIfCancellation()
+        }
+        currentCoroutineContext().ensureActive()
+    }
+}
+
+private fun ExecutionSecurityContext.toCacheSecurityPartition() = CacheSecurityPartition(
+    dataClassification = dataClassification,
+    classificationSource = classificationSource,
+)
+
+private fun PolicyContextBuilder.applySecurityContext(
+    securityContext: ExecutionSecurityContext,
+): PolicyContextBuilder = dataClassification(securityContext.dataClassification)
+    .classificationSource(securityContext.classificationSource)

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/structured/StructuredResponseModels.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/structured/StructuredResponseModels.kt
@@ -1,0 +1,38 @@
+package dev.tramai.engine.structured
+
+import dev.tramai.core.model.Message
+import dev.tramai.engine.EngineExecutionIdentity
+import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.OperationDefinition
+import dev.tramai.engine.budget.TokenBudgetTracker
+import dev.tramai.engine.provider.ProviderCallResult
+
+internal data class StructuredResponseRequest(
+    val operation: OperationDefinition,
+    val arguments: List<Any?>,
+    val tokenBudgetTracker: TokenBudgetTracker,
+    val conversationId: String?,
+    val identity: EngineExecutionIdentity,
+    val operationFingerprint: String?,
+)
+
+internal data class ResumedStructuredResponseRequest(
+    val operation: OperationDefinition,
+    val loopResult: ProviderCallResult,
+    val messages: List<Message>,
+    val correlationId: String,
+    val securityContext: ExecutionSecurityContext,
+    val conversationId: String?,
+    val historySize: Int,
+)
+
+internal data class StructuredAttemptExecutionRequest(
+    val operation: OperationDefinition,
+    val messages: MutableList<Message>,
+    val tokenBudgetTracker: TokenBudgetTracker,
+    val correlationId: String,
+    val securityContext: ExecutionSecurityContext,
+    val identity: EngineExecutionIdentity,
+    val conversationId: String?,
+    val historySize: Int,
+)

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/structured/StructuredResponseCoordinatorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/structured/StructuredResponseCoordinatorTest.kt
@@ -1,0 +1,627 @@
+package dev.tramai.engine.structured
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.exception.ConfigurationException
+import dev.tramai.core.exception.StructuredOutputException
+import dev.tramai.core.exception.safeStructuredOutputFailure
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
+import dev.tramai.core.model.ModelRegistrySettings
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.model.RegisteredModel
+import dev.tramai.core.observation.NoOpOperationInterceptor
+import dev.tramai.core.observation.OperationObservation
+import dev.tramai.core.policy.PolicyDecision
+import dev.tramai.core.policy.PolicyEngine
+import dev.tramai.core.security.NoOpDlpInterceptor
+import dev.tramai.core.structured.StructuredOutputContract
+import dev.tramai.core.structured.StructuredOutputFailureCode
+import dev.tramai.core.structured.StructuredOutputFailureDiagnosticEvent
+import dev.tramai.core.structured.StructuredOutputFailureDiagnosticObserver
+import dev.tramai.core.structured.StructuredOutputHandler
+import dev.tramai.core.structured.StructuredOutputResult
+import dev.tramai.core.structured.NoOpStructuredOutputFailureDiagnosticObserver
+import dev.tramai.engine.CachedOperationResult
+import dev.tramai.engine.EngineExecutionIdentity
+import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.ModelRegistryEnforcer
+import dev.tramai.engine.OperationCacheKey
+import dev.tramai.engine.OperationResponseCache
+import dev.tramai.engine.PolicyEnforcementHelper
+import dev.tramai.engine.ToolRegistry
+import dev.tramai.engine.planning.OperationDefinitionCompiler
+import dev.tramai.engine.planning.OperationFingerprintFactory
+import dev.tramai.engine.planning.ServiceDefinitionCompiler
+import dev.tramai.engine.memory.ConversationMemoryCoordinator
+import dev.tramai.engine.cache.OperationCacheCoordinator
+import dev.tramai.engine.cache.OperationCacheLookupResult
+import dev.tramai.engine.cache.OperationCacheKeyRequest
+import dev.tramai.engine.cache.OperationCacheLookupRequest
+import dev.tramai.engine.cache.OperationCacheStoreRequest
+import dev.tramai.core.memory.ChatMemory
+import dev.tramai.engine.memory.PersistConversationTurnRequest
+import dev.tramai.engine.memory.PersistStructuredConversationTurnRequest
+import dev.tramai.engine.memory.PreparedConversationMessages
+import dev.tramai.engine.provider.ProviderCallResult
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Direct contract tests for [StructuredResponseCoordinator].
+ *
+ * The structured path is a security-sensitive orchestration: retry repair,
+ * privileged diagnostics, redacted ordinary observations, safe exceptions,
+ * cache/memory side effects and approval-resume semantics must survive the
+ * extraction byte-for-byte. These tests drive the coordinator through
+ * recording doubles so ordering is observable.
+ */
+class StructuredResponseCoordinatorTest {
+
+    @AiService
+    private interface StructuredService {
+        @Operation(prompt = "Answer", model = "logical-model", providerRetries = 0)
+        suspend fun answer(input: String): StructuredValue
+
+        @Operation(prompt = "Answer", model = "logical-model", cacheable = true, providerRetries = 0)
+        suspend fun cached(input: String): StructuredValue
+
+        @Operation(prompt = "Answer", model = "logical-model", providerRetries = 0, maxRetries = 2)
+        suspend fun repairable(input: String): StructuredValue
+    }
+
+    private data class StructuredValue(val value: String)
+
+    private fun operation(name: String) = ServiceDefinitionCompiler(
+        OperationDefinitionCompiler(ToolRegistry(), null, OperationFingerprintFactory()),
+    ).compile(StructuredService::class).operations
+        .entries.first { it.key.name == name }.value.definition
+
+    private val identity = EngineExecutionIdentity(
+        workflowRunId = "run-1",
+        correlationId = "",
+        workflowDigest = Sha256Digest.of("sha256:" + "a".repeat(64)),
+        policyVersion = "v1",
+        actorId = "actor",
+    )
+
+    private fun response(content: String) = ModelResponse(content = content)
+
+    private class RecordingObservation : OperationObservation {
+        val completions = mutableListOf<Boolean?>()
+        val parseFailures = mutableListOf<String>()
+        val engineEvents = mutableListOf<Pair<String, Map<String, Any?>>>()
+        override fun onProviderResponse(response: ModelResponse) = Unit
+        override fun onProviderFailure(error: Throwable) = Unit
+        override fun onStructuredParseFailure(rawResponse: String, errorSummary: String) {
+            parseFailures += rawResponse
+        }
+        override fun onEngineEvent(name: String, attributes: Map<String, Any?>) {
+            engineEvents += name to attributes
+        }
+        override fun onCallCompleted(parseSuccess: Boolean?) {
+            completions += parseSuccess
+        }
+    }
+
+    private class RecordingHandler(
+        private val results: MutableList<StructuredOutputResult>,
+        private val analyzeThrows: Throwable? = null,
+        private val contractThrows: Throwable? = null,
+    ) : StructuredOutputHandler {
+        val analyzeCalls = AtomicInteger(0)
+        override fun createContract(targetType: kotlin.reflect.KType): StructuredOutputContract {
+            contractThrows?.let { throw it }
+            return StructuredOutputContract(targetType, """{"type":"object"}""")
+        }
+        override fun analyze(rawResponse: String, targetType: kotlin.reflect.KType): StructuredOutputResult {
+            analyzeThrows?.let { throw it }
+            val next = results.removeAt(0)
+            analyzeCalls.incrementAndGet()
+            return next
+        }
+        override fun generateSchema(type: kotlin.reflect.KType) = "{}"
+        override fun deserialize(input: Any, targetType: kotlin.reflect.KType): Any = error("unused")
+        override fun serialize(value: Any): Any = value
+    }
+
+    private fun success(value: Any = StructuredValue("ok")) =
+        StructuredOutputResult.Success(value, "raw-ok")
+
+    private fun failure(feedback: String = "fix it", failure: Throwable? = null): StructuredOutputResult.Failure =
+        StructuredOutputResult.Failure("raw-bad", "compat summary", feedback).also { it.failure = failure }
+
+    private class RecordingAttemptExecutor : StructuredAttemptExecutor {
+        val calls = mutableListOf<StructuredAttemptExecutionRequest>()
+        var result: ProviderCallResult = ProviderCallResult(
+            response = ModelResponse(content = "raw-ok"),
+            observation = RecordingObservation(),
+            providerId = "p1",
+            modelName = "logical-model",
+            approvedModel = null,
+        )
+        override suspend fun execute(request: StructuredAttemptExecutionRequest): ProviderCallResult {
+            calls += request
+            return result
+        }
+    }
+
+    private open class RecordingDiagnostics : StructuredOutputFailureDiagnosticObserver {
+        val events = mutableListOf<StructuredOutputFailureDiagnosticEvent>()
+        var throwOnFailure: Throwable? = null
+        override suspend fun onFailure(event: StructuredOutputFailureDiagnosticEvent) {
+            throwOnFailure?.let { throw it }
+            events += event
+        }
+    }
+
+    private class RecordingMemory : ChatMemory {
+        val stored = mutableListOf<Pair<String, List<Message>>>()
+        var history: List<Message> = emptyList()
+        override fun get(conversationId: String): List<Message> = history
+        override fun add(conversationId: String, messages: List<Message>) {
+            stored += conversationId to messages
+        }
+        override fun add(conversationId: String, message: Message) = add(conversationId, listOf(message))
+        override fun clear(conversationId: String) = Unit
+    }
+
+    private class RecordingCache : OperationResponseCache {
+        val stored = mutableListOf<Pair<OperationCacheKey, CachedOperationResult>>()
+        val invalidated = mutableListOf<OperationCacheKey>()
+        var hit: CachedOperationResult? = null
+        override fun get(key: OperationCacheKey): CachedOperationResult? = hit
+        override fun put(key: OperationCacheKey, value: CachedOperationResult, ttlMillis: Long) {
+            stored += key to value
+        }
+        override fun invalidate(key: OperationCacheKey) {
+            invalidated += key
+        }
+    }
+
+    private class RecordingPolicyEngine(
+        private val denyAt: dev.tramai.core.policy.EnforcementPoint? = null,
+        private val cancelAt: dev.tramai.core.policy.EnforcementPoint? = null,
+        private val cancel: CancellationException = CancellationException("policy-cancel"),
+    ) : PolicyEngine {
+        val evaluated = mutableListOf<String>()
+        override suspend fun evaluate(context: dev.tramai.core.policy.PolicyContext): PolicyDecision {
+            evaluated += context.enforcementPoint.name
+            if (cancelAt == context.enforcementPoint) throw cancel
+            return if (denyAt == context.enforcementPoint) {
+                PolicyDecision.Deny(reason = "denied", reasonCode = "TEST")
+            } else {
+                PolicyDecision.Allow
+            }
+        }
+    }
+
+    private fun coordinator(
+        handler: StructuredOutputHandler,
+        attemptExecutor: RecordingAttemptExecutor = RecordingAttemptExecutor(),
+        diagnostics: RecordingDiagnostics = RecordingDiagnostics(),
+        memory: RecordingMemory = RecordingMemory(),
+        cache: RecordingCache = RecordingCache(),
+        policyEngine: RecordingPolicyEngine = RecordingPolicyEngine(),
+        conversationId: String? = null,
+    ) = StructuredResponseCoordinator(
+        structuredOutputHandler = handler,
+        structuredOutputFailureDiagnosticObserver = diagnostics,
+        conversationMemoryCoordinator = ConversationMemoryCoordinator(memory, dev.tramai.core.memory.ConversationIdProvider { "gen" }),
+        operationCacheCoordinator = OperationCacheCoordinator(
+            responseCache = cache,
+            operationInterceptor = NoOpOperationInterceptor,
+            dlpInterceptor = NoOpDlpInterceptor,
+            modelRegistrySettings = ModelRegistrySettings(enabled = false),
+            modelRegistryEnforcer = ModelRegistryEnforcer(
+                object : dev.tramai.core.model.ModelRegistry {
+                    override suspend fun findApprovedModel(providerId: String, modelName: String): RegisteredModel? = null
+                },
+                ModelRegistrySettings(enabled = false),
+            ),
+            policyHelper = PolicyEnforcementHelper(policyEngine, AtomicBoolean(false)),
+        ),
+        policyHelper = PolicyEnforcementHelper(policyEngine, AtomicBoolean(false)),
+        attemptExecutor = attemptExecutor,
+        serviceTypeName = "dev.tramai.engine.structured.StructuredService",
+    )
+
+    private fun executeRequest(
+        op: dev.tramai.engine.OperationDefinition,
+        conversationId: String? = null,
+    ) = StructuredResponseRequest(
+        operation = op,
+        arguments = listOf("input"),
+        tokenBudgetTracker = dev.tramai.engine.budget.TokenBudgetTracker(dev.tramai.engine.TokenBudgetSettings()),
+        conversationId = conversationId,
+        identity = identity,
+        operationFingerprint = "fp",
+    )
+
+    private fun resumedRequest(
+        op: dev.tramai.engine.OperationDefinition,
+        loopResult: ProviderCallResult = ProviderCallResult(
+            response = ModelResponse(content = "raw-ok"),
+            observation = RecordingObservation(),
+            providerId = "p1",
+            modelName = "logical-model",
+            approvedModel = null,
+        ),
+        messages: List<Message> = listOf(Message(MessageRole.USER, "input")),
+        conversationId: String? = null,
+    ) = ResumedStructuredResponseRequest(
+        operation = op,
+        loopResult = loopResult,
+        messages = messages,
+        correlationId = "cid",
+        securityContext = ExecutionSecurityContext(),
+        conversationId = conversationId,
+        historySize = 0,
+    )
+
+    // ------------------------------------------------------------------
+    // contract / cache short-circuit
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `contract failure short-circuits without provider call`() = runTest {
+        val handler = RecordingHandler(mutableListOf<StructuredOutputResult>(), contractThrows = IllegalStateException("schema boom"))
+        val executor = RecordingAttemptExecutor()
+        val diagnostics = RecordingDiagnostics()
+        val c = coordinator(handler, attemptExecutor = executor, diagnostics = diagnostics)
+
+        assertThatThrownBy { kotlinx.coroutines.runBlocking { c.execute(executeRequest(operation("answer"))) } }
+            .isInstanceOf(StructuredOutputException::class.java)
+        assertThat(executor.calls).isEmpty()
+        assertThat(diagnostics.events.single().code).isEqualTo(StructuredOutputFailureCode.CONTRACT_FAILED)
+    }
+
+    @Test
+    fun `cache hit short-circuits attempt executor`() = runTest {
+        val handler = RecordingHandler(mutableListOf<StructuredOutputResult>())
+        val executor = RecordingAttemptExecutor()
+        val cache = RecordingCache()
+        cache.hit = CachedOperationResult(
+            value = StructuredValue("cached"),
+            provenance = dev.tramai.engine.CachedResponseProvenance("p1", "logical-model", null, null),
+        )
+        val c = coordinator(handler, attemptExecutor = executor, cache = cache)
+
+        val result = c.execute(executeRequest(operation("cached")))
+
+        assertThat(result).isEqualTo(StructuredValue("cached"))
+        assertThat(executor.calls).isEmpty()
+    }
+
+    // ------------------------------------------------------------------
+    // first-attempt success ordering
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `first attempt success enforces policy then completes observation then persists and caches`() = runTest {
+        val op = operation("answer")
+        val handler = RecordingHandler(mutableListOf(success()))
+        val executor = RecordingAttemptExecutor()
+        executor.result = ProviderCallResult(response( "raw-ok"), RecordingObservation(), "p1", "logical-model", null)
+        val memory = RecordingMemory()
+        val cache = RecordingCache()
+        val policy = RecordingPolicyEngine()
+        val c = coordinator(handler, executor, memory = memory, cache = cache, policyEngine = policy)
+
+        val result = c.execute(executeRequest(op))
+
+        assertThat(result).isEqualTo(StructuredValue("ok"))
+        // BEFORE_RESPONSE_RETURN was evaluated
+        assertThat(policy.evaluated).containsExactly("BEFORE_RESPONSE_RETURN")
+        // conversationId null → no memory, no cache
+        assertThat(memory.stored).isEmpty()
+        assertThat(cache.stored).isEmpty()
+    }
+
+    @Test
+    fun `first attempt success with conversation persists structured turn and disables cache`() = runTest {
+        val op = operation("cached")
+        val handler = RecordingHandler(mutableListOf(success()))
+        val executor = RecordingAttemptExecutor()
+        val memory = RecordingMemory()
+        memory.history = listOf(Message(MessageRole.USER, "old"))
+        val cache = RecordingCache()
+        val c = coordinator(handler, executor, memory = memory, cache = cache, conversationId = "cid")
+
+        val result = c.execute(executeRequest(op, conversationId = "cid"))
+
+        assertThat(result).isEqualTo(StructuredValue("ok"))
+        assertThat(memory.stored.single().first).isEqualTo("cid")
+        // conversation memory makes caching ineligible → no cache write
+        assertThat(cache.stored).isEmpty()
+    }
+
+    @Test
+    fun `first attempt success without conversation stores cache`() = runTest {
+        val op = operation("cached")
+        val handler = RecordingHandler(mutableListOf(success()))
+        val executor = RecordingAttemptExecutor()
+        val memory = RecordingMemory()
+        val cache = RecordingCache()
+        val c = coordinator(handler, executor, memory = memory, cache = cache)
+
+        val result = c.execute(executeRequest(op))
+
+        assertThat(result).isEqualTo(StructuredValue("ok"))
+        assertThat(memory.stored).isEmpty()
+        assertThat(cache.stored).hasSize(1)
+    }
+
+    @Test
+    fun `completion true is recorded before memory persistence`() = runTest {
+        val op = operation("answer")
+        val handler = RecordingHandler(mutableListOf(success()))
+        val executor = RecordingAttemptExecutor()
+        val obs = RecordingObservation()
+        executor.result = ProviderCallResult(response("raw-ok"), obs, "p1", "logical-model", null)
+        val memory = RecordingMemory()
+        val cache = RecordingCache()
+        val c = coordinator(handler, executor, memory = memory, cache = cache, conversationId = "cid")
+
+        c.execute(executeRequest(op, conversationId = "cid"))
+
+        // completion true happens first; memory persistence follows (order frozen, not "fixed")
+        assertThat(obs.completions).containsExactly(true)
+        assertThat(memory.stored).hasSize(1)
+        assertThat(cache.stored).isEmpty()
+    }
+
+    // ------------------------------------------------------------------
+    // repair path
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `repairable failure appends raw assistant and feedback then retries`() = runTest {
+        val op = operation("repairable")
+        val handler = RecordingHandler(mutableListOf(failure(feedback = "fix it"), success()))
+        val executor = RecordingAttemptExecutor()
+        val c = coordinator(handler, executor)
+
+        val result = c.execute(executeRequest(op))
+
+        assertThat(result).isEqualTo(StructuredValue("ok"))
+        assertThat(handler.analyzeCalls.get()).isEqualTo(2)
+        // repair messages were appended to the shared message list
+        assertThat(executor.calls[1].messages.takeLast(2)).containsExactly(
+            Message(MessageRole.ASSISTANT, "raw-bad"),
+            Message(MessageRole.USER, "fix it"),
+        )
+    }
+
+    @Test
+    fun `repair exhaustion throws REPAIR_EXHAUSTED with exact count`() = runTest {
+        val op = operation("repairable") // maxRetries = 2 → 3 attempts
+        val handler = RecordingHandler(mutableListOf(failure(), failure(), failure()))
+        val executor = RecordingAttemptExecutor()
+        val c = coordinator(handler, executor)
+
+        assertThatThrownBy { kotlinx.coroutines.runBlocking { c.execute(executeRequest(op)) } }
+            .isInstanceOfSatisfying(StructuredOutputException::class.java) { e ->
+                assertThat(e.failureCode).isEqualTo(StructuredOutputFailureCode.REPAIR_EXHAUSTED)
+                assertThat(e.attemptCount).isEqualTo(3)
+            }
+        assertThat(executor.calls).hasSize(3)
+    }
+
+    @Test
+    fun `handler throw is sanitized as HANDLER_FAILED`() = runTest {
+        val op = operation("answer")
+        val handler = RecordingHandler(mutableListOf<StructuredOutputResult>(), analyzeThrows = IllegalStateException("handler secret"))
+        val executor = RecordingAttemptExecutor()
+        val diagnostics = RecordingDiagnostics()
+        val c = coordinator(handler, executor, diagnostics = diagnostics)
+
+        assertThatThrownBy { kotlinx.coroutines.runBlocking { c.execute(executeRequest(op)) } }
+            .isInstanceOfSatisfying(StructuredOutputException::class.java) { e ->
+                assertThat(e.failureCode).isEqualTo(StructuredOutputFailureCode.HANDLER_FAILED)
+            }
+        assertThat(diagnostics.events.single().code).isEqualTo(StructuredOutputFailureCode.HANDLER_FAILED)
+    }
+
+    @Test
+    fun `diagnostic observer throw is fail-open`() = runTest {
+        val op = operation("answer")
+        val handler = RecordingHandler(mutableListOf(failure()))
+        val executor = RecordingAttemptExecutor()
+        val diagnostics = RecordingDiagnostics().also { it.throwOnFailure = IllegalStateException("observer boom") }
+        val c = coordinator(handler, executor, diagnostics = diagnostics)
+
+        assertThatThrownBy { kotlinx.coroutines.runBlocking { c.execute(executeRequest(op)) } }
+            .isInstanceOf(StructuredOutputException::class.java)
+            .isNotSameAs(diagnostics.throwOnFailure)
+    }
+
+    @Test
+    fun `real parent cancellation during diagnostics stays primary`() = runTest {
+        val op = operation("answer")
+        val handler = RecordingHandler(mutableListOf(failure()))
+        val executor = RecordingAttemptExecutor()
+        val c = coordinator(handler, executor)
+
+        val observerEntered = kotlinx.coroutines.CompletableDeferred<Unit>()
+        val observerRelease = kotlinx.coroutines.CompletableDeferred<Unit>()
+        val diagnostics = object : RecordingDiagnostics() {
+            override suspend fun onFailure(event: StructuredOutputFailureDiagnosticEvent) {
+                // Block inside diagnostic delivery so the parent can cancel mid-delivery
+                observerEntered.complete(Unit)
+                observerRelease.await()
+            }
+        }
+        val c2 = StructuredResponseCoordinator(
+            structuredOutputHandler = handler,
+            structuredOutputFailureDiagnosticObserver = diagnostics,
+            conversationMemoryCoordinator = ConversationMemoryCoordinator(RecordingMemory(), dev.tramai.core.memory.ConversationIdProvider { "gen" }),
+            operationCacheCoordinator = OperationCacheCoordinator(
+                responseCache = RecordingCache(),
+                operationInterceptor = NoOpOperationInterceptor,
+                dlpInterceptor = NoOpDlpInterceptor,
+                modelRegistrySettings = ModelRegistrySettings(enabled = false),
+                modelRegistryEnforcer = ModelRegistryEnforcer(
+                    object : dev.tramai.core.model.ModelRegistry {
+                        override suspend fun findApprovedModel(providerId: String, modelName: String): RegisteredModel? = null
+                    },
+                    ModelRegistrySettings(enabled = false),
+                ),
+                policyHelper = PolicyEnforcementHelper(RecordingPolicyEngine(), AtomicBoolean(false)),
+            ),
+            policyHelper = PolicyEnforcementHelper(RecordingPolicyEngine(), AtomicBoolean(false)),
+            attemptExecutor = executor,
+            serviceTypeName = "dev.tramai.engine.structured.StructuredService",
+        )
+
+        val outcome = kotlinx.coroutines.CompletableDeferred<Throwable?>()
+        kotlinx.coroutines.coroutineScope {
+            val executionJob = launch {
+                try {
+                    c2.execute(executeRequest(op))
+                    outcome.complete(null)
+                } catch (t: Throwable) {
+                    outcome.complete(t)
+                }
+            }
+            observerEntered.await()
+            // Genuine parent cancellation while the diagnostic is being delivered
+            executionJob.cancel(CancellationException("parent-cancel"))
+            observerRelease.complete(Unit)
+            val terminal = outcome.await()
+            assertThat(terminal).isInstanceOf(CancellationException::class.java)
+            assertThat(terminal).isNotInstanceOf(StructuredOutputException::class.java)
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // policy deny on success → no side effects
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `BEFORE_RESPONSE_RETURN deny prevents persistence and cache store`() = runTest {
+        val op = operation("cached")
+        val handler = RecordingHandler(mutableListOf(success()))
+        val executor = RecordingAttemptExecutor()
+        val memory = RecordingMemory()
+        val cache = RecordingCache()
+        val policy = RecordingPolicyEngine(denyAt = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN)
+        val c = coordinator(handler, executor, memory = memory, cache = cache, policyEngine = policy, conversationId = "cid")
+
+        assertThatThrownBy { kotlinx.coroutines.runBlocking { c.execute(executeRequest(op, conversationId = "cid")) } }
+            .isInstanceOf(dev.tramai.core.exception.PolicyViolationException::class.java)
+        assertThat(memory.stored).isEmpty()
+        assertThat(cache.stored).isEmpty()
+    }
+
+    // ------------------------------------------------------------------
+    // resumed path
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `resumed success is single attempt with policy memory and observation`() = runTest {
+        val op = operation("answer")
+        val handler = RecordingHandler(mutableListOf(success()))
+        val executor = RecordingAttemptExecutor()
+        val obs = RecordingObservation()
+        val memory = RecordingMemory()
+        val policy = RecordingPolicyEngine()
+        val c = coordinator(handler, executor, memory = memory, policyEngine = policy, conversationId = "cid")
+
+        val result = c.finalizeResumed(resumedRequest(op, loopResult = ProviderCallResult(response("raw-ok"), obs, "p1", "logical-model", null), conversationId = "cid"))
+
+        assertThat(result).isEqualTo(StructuredValue("ok"))
+        assertThat(handler.analyzeCalls.get()).isEqualTo(1)
+        assertThat(executor.calls).isEmpty() // no attempt executor on resume
+        assertThat(policy.evaluated).containsExactly("BEFORE_RESPONSE_RETURN")
+        assertThat(obs.completions).containsExactly(true)
+        assertThat(memory.stored.single().first).isEqualTo("cid")
+    }
+
+    @Test
+    fun `resumed invalid response has no policy memory or cache side effects`() = runTest {
+        val op = operation("answer")
+        val handler = RecordingHandler(mutableListOf(failure()))
+        val executor = RecordingAttemptExecutor()
+        val memory = RecordingMemory()
+        val cache = RecordingCache()
+        val policy = RecordingPolicyEngine()
+        val c = coordinator(handler, executor, memory = memory, cache = cache, policyEngine = policy, conversationId = "cid")
+
+        assertThatThrownBy { kotlinx.coroutines.runBlocking { c.finalizeResumed(resumedRequest(op, conversationId = "cid")) } }
+            .isInstanceOfSatisfying(StructuredOutputException::class.java) { e ->
+                assertThat(e.failureCode).isEqualTo(StructuredOutputFailureCode.OUTPUT_REJECTED)
+                assertThat(e.attemptCount).isEqualTo(1)
+            }
+        assertThat(policy.evaluated).isEmpty() // NO BEFORE_RESPONSE_RETURN on failure
+        assertThat(memory.stored).isEmpty()
+        assertThat(cache.stored).isEmpty()
+    }
+
+    @Test
+    fun `resumed handler failure is HANDLER_FAILED`() = runTest {
+        val op = operation("answer")
+        val handler = RecordingHandler(mutableListOf<StructuredOutputResult>(), analyzeThrows = IllegalStateException("resume secret"))
+        val executor = RecordingAttemptExecutor()
+        val diagnostics = RecordingDiagnostics()
+        val c = coordinator(handler, executor, diagnostics = diagnostics)
+
+        assertThatThrownBy { kotlinx.coroutines.runBlocking { c.finalizeResumed(resumedRequest(op)) } }
+            .isInstanceOfSatisfying(StructuredOutputException::class.java) { e ->
+                assertThat(e.failureCode).isEqualTo(StructuredOutputFailureCode.HANDLER_FAILED)
+            }
+        assertThat(diagnostics.events.single().code).isEqualTo(StructuredOutputFailureCode.HANDLER_FAILED)
+    }
+
+    @Test
+    fun `resumed path never retries`() = runTest {
+        val op = operation("repairable")
+        val handler = RecordingHandler(mutableListOf(failure(), success()))
+        val executor = RecordingAttemptExecutor()
+        val c = coordinator(handler, executor)
+
+        assertThatThrownBy { kotlinx.coroutines.runBlocking { c.finalizeResumed(resumedRequest(op)) } }
+            .isInstanceOf(StructuredOutputException::class.java)
+        assertThat(handler.analyzeCalls.get()).isEqualTo(1) // exactly one parse, no repair
+    }
+
+    @Test
+    fun `missing structured handler throws configuration error`() = runTest {
+        val op = operation("answer")
+        val c = StructuredResponseCoordinator(
+            structuredOutputHandler = null,
+            structuredOutputFailureDiagnosticObserver = NoOpStructuredOutputFailureDiagnosticObserver,
+            conversationMemoryCoordinator = ConversationMemoryCoordinator(null, dev.tramai.core.memory.ConversationIdProvider { "gen" }),
+            operationCacheCoordinator = OperationCacheCoordinator(
+                responseCache = RecordingCache(),
+                operationInterceptor = NoOpOperationInterceptor,
+                dlpInterceptor = NoOpDlpInterceptor,
+                modelRegistrySettings = ModelRegistrySettings(enabled = false),
+                modelRegistryEnforcer = ModelRegistryEnforcer(
+                    object : dev.tramai.core.model.ModelRegistry {
+                        override suspend fun findApprovedModel(providerId: String, modelName: String): RegisteredModel? = null
+                    },
+                    ModelRegistrySettings(enabled = false),
+                ),
+                policyHelper = PolicyEnforcementHelper(RecordingPolicyEngine(), AtomicBoolean(false)),
+            ),
+            policyHelper = PolicyEnforcementHelper(RecordingPolicyEngine(), AtomicBoolean(false)),
+            attemptExecutor = RecordingAttemptExecutor(),
+            serviceTypeName = "dev.tramai.engine.structured.StructuredService",
+        )
+
+        assertThatThrownBy { kotlinx.coroutines.runBlocking { c.execute(executeRequest(op)) } }
+            .isInstanceOf(ConfigurationException::class.java)
+    }
+}


### PR DESCRIPTION
## refactor(engine): extract structured response coordinator — Epic 3.6b

Moves ALL structured-response orchestration out of `TramaiInvocationHandler` into `dev.tramai.engine.structured`. Zero intended behavioral change.

### Component

- `StructuredResponseCoordinator` — owns both structured flows:
  - `execute(request)` — normal structured path (contract → memory → cache → provider/tool → analyze → policy → observation → persist → cache store → retry repair)
  - `finalizeResumed(request)` — resumed approval path (single-attempt, no cache, no repair)
- `StructuredResponseModels` — `StructuredResponseRequest`, `ResumedStructuredResponseRequest`, `StructuredAttemptExecutionRequest`
- `StructuredAttemptExecutor` — narrow temporary seam (same tactic as `ClaimedResumedExecutor` in 3.5): the handler implements it via `executeWithTools(ToolLoopContext(...))`; **no** tool-loop extraction in this PR

Moved verbatim: `executeStructured`, `executeStructuredRetryLoop`, `executeStructuredAttempt`, `handleStructuredFailure`, `rethrowOrSanitizeStructuredHandlerFailure`, `rethrowContractFailure`, `deliverStructuredOutputFailure`, `resumeStructuredResult`, `StructuredRetryContext`, `StructuredRetryAttemptContext`. Dead `StructuredAttemptContext` deleted.

### Frozen semantics (byte-for-byte preserved)

**Normal success:** contract → memory → cache key → lookup → provider/tool → analyze → BEFORE_RESPONSE_RETURN → `onCallCompleted(true)` → structured memory persist → cache store → return. `onCallCompleted(true)` BEFORE memory/cache is intentional and unchanged.

**Repairable failure:** privileged diagnostic `OUTPUT_REJECTED` → redacted ordinary parse-failure → `onCallCompleted(false)` → append raw assistant + repair feedback → next attempt.

**Repair exhaustion:** diagnostic → redacted failure → `onCallCompleted(false)` → safe `REPAIR_EXHAUSTED`, `attemptCount == maxRetries + 1`, raw response absent from public exception, handler cause absent.

**Handler throw:** sanitized as safe `HANDLER_FAILED`, `willRetry = false` (never retried).

**Contract failure:** safe `CONTRACT_FAILED`.

**Resumed success:** analyze once → BEFORE_RESPONSE_RETURN → `persistTurn` (ordinary, not structured-retry) → `onCallCompleted(true)` → value.

**Resumed failure:** `OUTPUT_REJECTED` diagnostic (attempt=1, willRetry=false) → redacted failure → `onCallCompleted(false)` → safe `OUTPUT_REJECTED` with **NO** BEFORE_RESPONSE_RETURN, **NO** memory persistence, **NO** cache — continuation stays CLAIMED.

### Cancellation + diagnostics invariants (merge-blocking)

1. Raw validation detail only reaches the privileged diagnostic observer.
2. Ordinary observers see fixed redacted text.
3. Arbitrary handler exceptions → safe `HANDLER_FAILED`.
4. Contract-generation failures → safe `CONTRACT_FAILED`.
5. Diagnostic observer failures fail open.
6. Fake observer-thrown CancellationException does not replace the real structured failure while the coroutine is active.
7. Real parent cancellation during diagnostic delivery stays primary.
8. Diagnostic previews bounded to 8192 bytes.

All verified by unchanged `StructuredOutputFailureBoundaryTest` + new coordinator suite.

### Tests

`StructuredResponseCoordinatorTest` — 17 tests (recording doubles, no mocks):

- contract failure short-circuits execution (no provider call)
- cache hit short-circuits attempt executor
- first-attempt success: policy order, completion-before-persistence, memory persist + cache disabled with conversationId, cache store without
- repair → success: message mutation + retry
- repair exhaustion: exact `REPAIR_EXHAUSTED` code/count (3 attempts for maxRetries=2)
- handler throws → `HANDLER_FAILED`
- diagnostic observer throws → fail-open
- real parent cancellation in diagnostics → CE remains primary
- BEFORE_RESPONSE_RETURN deny → no persistence/cache
- resumed success: single attempt, policy/memory/observation
- resumed invalid response: no policy/memory/cache
- resumed handler failure → `HANDLER_FAILED`
- resumed path never retries
- missing handler → `ConfigurationException`

### Verification

| Gate | Result |
|---|---|
| `:tramai-engine:test` (full) | ✅ BUILD SUCCESSFUL (2m15s) |
| New `StructuredResponseCoordinatorTest` | ✅ 17/17 |
| `:tramai-engine:apiCheck` | ✅ zero diff |
| `verifyCancellationSafety` | ✅ 294/294, no new critical/high |
| `verifyChangePolicy -PchangeClass=runtime-behaviour` | ✅ 4 files, no violations |
| 20/20 characterization traces | ✅ byte-identical |
| `structured/` → `TramaiInvocationHandler` refs | ✅ 0 |

> Full `verifyPr` not run locally (known orchestration-module EmbeddedPostgres stall); remote CI authoritative.

### Non-goals

- no streaming extraction (#238 / 3.6c)
- no `executeWithTools` / tool-loop extraction (#239 / Epic 3.7)
- no invocation-context redesign
- no structured descriptor/schema redesign (Phase 7)
- no retry-count, repair-feedback, safe-error, observer-order, memory/cache semantic changes
- no resumed structured multi-attempt repair
- no streaming approval resume
- no public API changes
