### PR TITLE
refactor(engine): extract streaming execution coordinator — Epic 3.6c

### DIFF
--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -746,6 +746,7 @@ internal class TramaiInvocationHandler(
         lifecycleScope = lifecycleScope,
         isClosed = isClosed,
         serviceTypeName = serviceDefinition.serviceType.qualifiedName ?: serviceDefinition.serviceType.simpleName.orEmpty(),
+        qualifiedServiceName = serviceDefinition.serviceType.qualifiedName,
         operationObserver = operationObserver,
         operationInterceptor = operationInterceptor,
         toolExposureCoordinator = toolExposureCoordinator,

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -108,6 +108,9 @@ import dev.tramai.engine.structured.ResumedStructuredResponseRequest
 import dev.tramai.engine.structured.StructuredAttemptExecutor
 import dev.tramai.engine.structured.StructuredResponseCoordinator
 import dev.tramai.engine.structured.StructuredResponseRequest
+import dev.tramai.engine.streaming.StreamingBeforeResponseReturnGate
+import dev.tramai.engine.streaming.StreamingExecutionCoordinator
+import dev.tramai.engine.streaming.StreamingExecutionRequest
 import dev.tramai.core.approval.ValidateResumeCommand
 import dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter
 import dev.tramai.core.approval.SensitiveToolArguments
@@ -703,6 +706,9 @@ internal class TramaiInvocationHandler(
 
     private val policyHelper = PolicyEnforcementHelper(components.security.resolvedPolicyEngine, migrationWarningGuard, isLegacyFallback = components.security.isLegacyFallback, auditEmitter = policyDecisionAuditEmitter)
     private val modelRegistryEnforcer = ModelRegistryEnforcer(modelRegistry, modelRegistrySettings)
+    private val beforeProviderInvocationGate = ProviderInvocationGate { providerId, modelName, correlationId, securityContext -> enforceBeforeProviderInvocation(providerId, modelName, correlationId, securityContext) }
+    private val beforeResolutionGate = ProviderResolutionGate { operation, correlationId, securityContext -> enforceBeforeProviderResolution(operation, correlationId, securityContext) }
+    private val fallbackGate = ProviderFallbackGate { correlationId, previousProviderId, previousModelName, nextProviderId, reason, securityContext -> enforceFallbackTransition(correlationId, previousProviderId, previousModelName, nextProviderId, reason, securityContext) }
     private val providerExecutionCoordinator = ProviderExecutionCoordinator(
         routingPlan = routingPlan,
         circuitBreaker = circuitBreaker,
@@ -713,12 +719,12 @@ internal class TramaiInvocationHandler(
             circuitBreaker = circuitBreaker,
             retryPolicy = ProviderRetryPolicy(retryDelayPolicy),
             authorizationService = ProviderAuthorizationService(modelRegistryEnforcer),
-            beforeProviderInvocation = ProviderInvocationGate { providerId, modelName, correlationId, securityContext -> enforceBeforeProviderInvocation(providerId, modelName, correlationId, securityContext) },
+            beforeProviderInvocation = beforeProviderInvocationGate,
             responseSanitizer = ProviderResponseSanitizer { response, operation, providerId, modelName, correlationId, securityContext, observation -> sanitizeProviderResponse(response, operation, providerId, modelName, correlationId, securityContext, observation) },
         ),
         fallbackPolicy = ProviderFallbackPolicy(),
-        beforeResolution = ProviderResolutionGate { operation, correlationId, securityContext -> enforceBeforeProviderResolution(operation, correlationId, securityContext) },
-        fallbackGate = ProviderFallbackGate { correlationId, previousProviderId, previousModelName, nextProviderId, reason, securityContext -> enforceFallbackTransition(correlationId, previousProviderId, previousModelName, nextProviderId, reason, securityContext) },
+        beforeResolution = beforeResolutionGate,
+        fallbackGate = fallbackGate,
     )
     private val toolExposureCoordinator = ToolExposureCoordinator(toolRegistry, policyHelper)
     private val conversationMemoryCoordinator = ConversationMemoryCoordinator(
@@ -734,6 +740,25 @@ internal class TramaiInvocationHandler(
         policyHelper = policyHelper,
     )
     private val tokenBudgetCoordinator = TokenBudgetCoordinator(tokenBudgetSettings)
+    private val streamingExecutionCoordinator = StreamingExecutionCoordinator(
+        routingPlan = routingPlan,
+        circuitBreaker = circuitBreaker,
+        lifecycleScope = lifecycleScope,
+        isClosed = isClosed,
+        serviceTypeName = serviceDefinition.serviceType.qualifiedName ?: serviceDefinition.serviceType.simpleName.orEmpty(),
+        operationObserver = operationObserver,
+        operationInterceptor = operationInterceptor,
+        toolExposureCoordinator = toolExposureCoordinator,
+        conversationMemoryCoordinator = conversationMemoryCoordinator,
+        tokenBudgetCoordinator = tokenBudgetCoordinator,
+        modelRegistryEnforcer = modelRegistryEnforcer,
+        beforeResolution = beforeResolutionGate,
+        beforeInvocation = beforeProviderInvocationGate,
+        fallbackGate = fallbackGate,
+        beforeResponseReturn = StreamingBeforeResponseReturnGate { route, correlationId, securityContext ->
+            enforceBeforeResponseReturn(route, correlationId, securityContext)
+        },
+    )
     private val toolResultSanitizer = ToolResultSanitizer(
         toolRegistry = toolRegistry,
         dlpInterceptor = dlpInterceptor,
@@ -797,6 +822,78 @@ internal class TramaiInvocationHandler(
         } catch (observerError: Throwable) {
             cancellation.addSuppressed(observerError)
         }
+    }
+
+    private suspend fun enforceBeforeProviderResolution(
+        operation: OperationDefinition,
+        correlationId: String,
+        securityContext: ExecutionSecurityContext,
+    ) {
+        policyHelper.enforce(
+            policyHelper.buildContext(
+                enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_PROVIDER_RESOLUTION,
+                correlationId = correlationId,
+            ).modelName(operation.operation.model)
+                .applySecurityContext(securityContext)
+                .build()
+        )
+    }
+
+    private suspend fun enforceBeforeResponseReturn(
+        route: ResolvedProviderRoute,
+        correlationId: String,
+        securityContext: ExecutionSecurityContext,
+    ) {
+        policyHelper.enforce(
+            policyHelper.buildContext(
+                enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
+                correlationId = correlationId,
+            ).providerId(route.providerName)
+                .modelName(route.effectiveModelName)
+                .applySecurityContext(securityContext)
+                .build()
+        )
+    }
+
+    private suspend fun enforceBeforeProviderInvocation(
+        providerId: String,
+        modelName: String,
+        correlationId: String,
+        securityContext: ExecutionSecurityContext,
+    ) {
+        policyHelper.enforce(
+            policyHelper.buildContext(
+                enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
+                correlationId = correlationId,
+            ).providerId(providerId)
+                .modelName(modelName)
+                .applySecurityContext(securityContext)
+                .build()
+        )
+    }
+
+    /**
+     * Enforces [EnforcementPoint.BEFORE_FALLBACK] at any transition point.
+     * Used for provider failures, circuit breaker opens, streaming startup failures,
+     * and route-unavailable transitions.
+     */
+    private suspend fun enforceFallbackTransition(
+        correlationId: String,
+        previousProviderId: String?,
+        previousModelName: String?,
+        nextProviderId: String,
+        reason: String,
+        securityContext: ExecutionSecurityContext,
+    ) {
+        val ctx = policyHelper.buildContext(
+            enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_FALLBACK,
+            correlationId = correlationId,
+        ).applySecurityContext(securityContext)
+        if (previousProviderId != null) ctx.providerId(previousProviderId)
+        if (previousModelName != null) ctx.modelName(previousModelName)
+        ctx.fallbackProviderId(nextProviderId)
+        ctx.attribute("fallbackReason", reason)
+        policyHelper.enforce(ctx.build())
     }
 
     /**
@@ -955,630 +1052,15 @@ internal class TramaiInvocationHandler(
                     operationFingerprint = serviceDefinition.operations[operation.method]?.fingerprint,
                 ),
             )
-            ReturnKind.STREAMING -> executeStreaming(operation, arguments, tokenBudgetTracker, conversationId)
-        }
-    }
-
-    private fun executeStreaming(
-        operation: OperationDefinition,
-        arguments: List<Any?>,
-        tokenBudgetTracker: TokenBudgetTracker,
-        conversationId: String?,
-    ): Flow<StreamChunk> {
-        val securityContext = ExecutionSecurityContext.fromArguments(arguments.toTypedArray())
-        val initialMessages = operation.initialMessages(arguments)
-        val prepared = conversationMemoryCoordinator.prepareMessages(initialMessages, conversationId)
-        val history = prepared?.history ?: emptyList()
-        val effectiveMessages = prepared?.effectiveMessages ?: initialMessages
-
-        return flow {
-            check(!isClosed.get()) { "Tramai runtime is closed" }
-            // The provider collection runs as a child of the engine's OWN
-            // lifecycle job (lifecycleScope), NOT the collector's job: close()
-            // cancels lifecycleJob, which cancels an in-flight collection
-            // (including the provider stream's cleanup), and close() joins
-            // lifecycleJob — so the collection has terminated before close()
-            // returns. Chunks are bridged to the caller's emit through a
-            // RENDEZVOUS channel: emit must stay in the collector's coroutine
-            // (SafeCollector invariant), and a rendezvous keeps Flow
-            // backpressure semantics — a slow caller blocks the provider
-            // instead of letting it race ahead into unbounded buffering.
-            val chunks = kotlinx.coroutines.channels.Channel<StreamChunk>(kotlinx.coroutines.channels.Channel.RENDEZVOUS)
-            val collectFailure = java.util.concurrent.atomic.AtomicReference<Throwable?>(null)
-            val collectJob = lifecycleScope.launch {
-                try {
-                    val correlationId = java.util.UUID.randomUUID().toString()
-                    enforceBeforeProviderResolution(operation, correlationId, securityContext)
-                    val candidates = routingPlan.resolveCandidates(operation.operation)
-                    var lastFailure: Throwable? = null
-                    var lastCircuitOpen: CircuitBreakerOpenException? = null
-                    val attemptCounter = AttemptCounter()
-
-                    for ((routeIndex, route) in candidates.withIndex()) {
-                        val circuitOpen = handleCircuitBreakerOpenRoute(
-                            route = route,
-                            nextRoute = candidates.getOrNull(routeIndex + 1),
-                            correlationId = correlationId,
-                            securityContext = securityContext,
-                        )
-                        if (circuitOpen != null) {
-                            lastCircuitOpen = circuitOpen
-                            continue
-                        }
-
-                        when (
-                            val result = executeStreamingRoute(
-                                StreamingExecutionRoute(
-                                    operation = operation,
-                                    route = route,
-                                    routeIndex = routeIndex,
-                                    attempt = attemptCounter.next(),
-                                    tokenBudgetTracker = tokenBudgetTracker,
-                                    memoryMessages = effectiveMessages,
-                                    historySize = history.size,
-                                    conversationId = conversationId,
-                                    emitChunk = { chunks.send(it) },
-                                ),
-                                correlationId = correlationId,
-                                securityContext = securityContext,
-                                arguments = arguments,
-                            )
-                        ) {
-                            is StreamingRouteResult.Completed -> {
-                                if (conversationId != null) {
-                                    val assistantMessage = Message(
-                                        role = MessageRole.ASSISTANT,
-                                        content = result.fullText,
-                                    )
-                                    conversationMemoryCoordinator.persistTurn(
-                                        PersistConversationTurnRequest(conversationId, effectiveMessages, history.size, assistantMessage),
-                                    )
-                                }
-                                return@launch
-                            }
-                            is StreamingRouteResult.StartupFailure -> {
-                                enforceStreamingFallbackAfterFailure(
-                                    error = result.error,
-                                    route = route,
-                                    nextRoute = candidates.getOrNull(routeIndex + 1),
-                                    correlationId = correlationId,
-                                    securityContext = securityContext,
-                                )
-                                lastFailure = result.error
-                            }
-                            is StreamingRouteResult.TerminalError -> {
-                                chunks.send(result.errorChunk)
-                                return@launch
-                            }
-                        }
-                    }
-
-                    chunks.send(noAvailableStreamingRouteChunk(operation, lastFailure, lastCircuitOpen))
-                } catch (e: kotlinx.coroutines.CancellationException) {
-                    // The engine closed (or the collector stopped): terminate
-                    // the collection job normally; the invokeOnCompletion
-                    // below closes the channel with the cancellation cause.
-                    throw e
-                } catch (failure: Throwable) {
-                    // Surface the failure to the collector WITHOUT rethrowing
-                    // it here: rethrowing would let an arbitrary (possibly
-                    // sensitive, externally supplied) throwable reach the
-                    // lifecycle scope's CoroutineExceptionHandler and the
-                    // normal logger. The collector rethrows it after the
-                    // channel drains.
-                    collectFailure.set(failure)
-                }
-            }
-            // Channel termination depends on JOB completion, not on the
-            // coroutine body having started: if close() cancels lifecycleJob
-            // after the flow's open check but before this launch's body runs,
-            // the body's finally never executes — but invokeOnCompletion still
-            // fires, closing the channel so the collector terminates instead
-            // of hanging forever on receive.
-            collectJob.invokeOnCompletion { cause -> chunks.close(cause) }
-            try {
-                for (chunk in chunks) {
-                    check(!isClosed.get()) { "Tramai runtime is closed" }
-                    emit(chunk)
-                }
-                // The collection job may have failed (e.g. provider does not
-                // support streaming, or a route error aborted the loop): the
-                // channel closes either way, so rethrow the job's failure here
-                // instead of silently completing the flow.
-                collectFailure.get()?.let { throw it }
-            } finally {
-                // If the caller stops collecting (or the engine closed), the
-                // engine-owned collection job must not keep running.
-                collectJob.cancel()
-                collectJob.join()
-            }
-        }
-    }
-
-    private data class StreamingExecutionRoute(
-        val operation: OperationDefinition,
-        val route: ResolvedProviderRoute,
-        val routeIndex: Int,
-        val attempt: Int,
-        val tokenBudgetTracker: TokenBudgetTracker,
-        val memoryMessages: List<Message>?,
-        val historySize: Int,
-        val conversationId: String?,
-        val emitChunk: suspend (StreamChunk) -> Unit,
-    )
-
-    private suspend fun executeStreamingRoute(
-        request: StreamingExecutionRoute,
-        correlationId: String,
-        securityContext: ExecutionSecurityContext,
-        arguments: List<Any?>,
-    ): StreamingRouteResult {
-        val route = request.route
-        val observation = startStreamingObservation(route, request.operation, request.attempt, request.routeIndex)
-        authorizeStreamingRoute(route, observation)
-        enforceBeforeResponseReturn(route, correlationId, securityContext)
-        toolExposureCoordinator.enforce(request.operation, correlationId, securityContext)
-        enforceBeforeProviderInvocation(route.providerName, route.effectiveModelName, correlationId, securityContext)
-
-        val streamCapable = route.provider as? StreamCapable
-            ?: throw ProviderCapabilityException(route.providerName, "streaming")
-        val modelRequest = request.operation.toRequest(arguments, modelName = route.effectiveModelName)
-        val memoryInjectedRequest = request.memoryMessages?.let { modelRequest.copy(messages = it) } ?: modelRequest
-
-        return collectStreamingRoute(
-            StreamingRouteCall(
-                streamCapable = streamCapable,
-                request = memoryInjectedRequest,
-                operation = request.operation,
-                route = route,
-                attempt = request.attempt,
-                observation = observation,
-                tokenBudgetTracker = request.tokenBudgetTracker,
-                emitChunk = request.emitChunk,
-            ),
-        )
-    }
-
-    private suspend fun authorizeStreamingRoute(
-        route: ResolvedProviderRoute,
-        observation: OperationObservation,
-    ) {
-        try {
-            modelRegistryEnforcer.authorize(route.providerName, route.effectiveModelName)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: ModelRegistryException) {
-            observation.onCallCompleted(parseSuccess = null)
-            throw e
-        }
-    }
-
-
-    private suspend fun enforceBeforeProviderResolution(
-        operation: OperationDefinition,
-        correlationId: String,
-        securityContext: ExecutionSecurityContext,
-    ) {
-        policyHelper.enforce(
-            policyHelper.buildContext(
-                enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_PROVIDER_RESOLUTION,
-                correlationId = correlationId,
-            ).modelName(operation.operation.model)
-                .applySecurityContext(securityContext)
-                .build()
-        )
-    }
-
-    private suspend fun enforceBeforeResponseReturn(
-        route: ResolvedProviderRoute,
-        correlationId: String,
-        securityContext: ExecutionSecurityContext,
-    ) {
-        policyHelper.enforce(
-            policyHelper.buildContext(
-                enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
-                correlationId = correlationId,
-            ).providerId(route.providerName)
-                .modelName(route.effectiveModelName)
-                .applySecurityContext(securityContext)
-                .build()
-        )
-    }
-
-    private suspend fun enforceBeforeProviderInvocation(
-        providerId: String,
-        modelName: String,
-        correlationId: String,
-        securityContext: ExecutionSecurityContext,
-    ) {
-        policyHelper.enforce(
-            policyHelper.buildContext(
-                enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_PROVIDER_INVOCATION,
-                correlationId = correlationId,
-            ).providerId(providerId)
-                .modelName(modelName)
-                .applySecurityContext(securityContext)
-                .build()
-        )
-    }
-
-    private suspend fun handleCircuitBreakerOpenRoute(
-        route: ResolvedProviderRoute,
-        nextRoute: ResolvedProviderRoute?,
-        correlationId: String,
-        securityContext: ExecutionSecurityContext,
-    ): CircuitBreakerOpenException? {
-        val blockedUntil = circuitBreaker.beforeCall(route.providerName) ?: return null
-        val circuitOpen = CircuitBreakerOpenException(route.providerName, blockedUntil)
-        if (nextRoute != null) {
-            try {
-                enforceFallbackTransition(
-                    correlationId = correlationId,
-                    previousProviderId = route.providerName,
-                    previousModelName = route.effectiveModelName,
-                    nextProviderId = nextRoute.providerName,
-                    reason = "circuit-breaker-open",
-                    securityContext = securityContext,
-                )
-            } catch (policyError: PolicyViolationException) {
-                policyError.addSuppressed(circuitOpen)
-                throw policyError
-            }
-        }
-        return circuitOpen
-    }
-
-    private suspend fun enforceStreamingFallbackAfterFailure(
-        error: Throwable,
-        route: ResolvedProviderRoute,
-        nextRoute: ResolvedProviderRoute?,
-        correlationId: String,
-        securityContext: ExecutionSecurityContext,
-    ) {
-        if (nextRoute == null) return
-        try {
-            enforceFallbackTransition(
-                correlationId = correlationId,
-                previousProviderId = route.providerName,
-                previousModelName = route.effectiveModelName,
-                nextProviderId = nextRoute.providerName,
-                reason = "streaming-startup-failure",
-                securityContext = securityContext,
-            )
-        } catch (policyError: PolicyViolationException) {
-            policyError.addSuppressed(error)
-            throw policyError
-        }
-    }
-
-    private fun noAvailableStreamingRouteChunk(
-        operation: OperationDefinition,
-        lastFailure: Throwable?,
-        lastCircuitOpen: CircuitBreakerOpenException?,
-    ): StreamChunk.Error = StreamChunk.Error(
-        (lastFailure ?: lastCircuitOpen ?: ProviderException(
-            message = "No available streaming provider route for model '${operation.operation.model}'",
-            retryable = true,
-        )) as TramaiException,
-    )
-
-    private suspend fun collectStreamingRoute(
-        call: StreamingRouteCall,
-    ): StreamingRouteResult {
-        val streamCapable = call.streamCapable
-        val request = call.request
-        val operation = call.operation
-        val route = call.route
-        val attempt = call.attempt
-        val observation = call.observation
-        val tokenBudgetTracker = call.tokenBudgetTracker
-        val emitChunk = call.emitChunk
-        var emittedAnyTokens = false
-        val callContext = streamingCallContext(operation, route.providerName, attempt)
-        val interceptedRequest = request.copy(
-            messages = operationInterceptor.interceptRequest(callContext, request.messages),
-        )
-
-        return try {
-            collectStreamingRouteChunks(
-                streamCapable = streamCapable,
-                request = interceptedRequest,
-                timeoutMillis = request.timeoutMillis ?: operation.operation.timeoutMillis,
-                ctx = StreamingRouteContext(
-                    route = route,
+            ReturnKind.STREAMING -> streamingExecutionCoordinator.execute(
+                StreamingExecutionRequest(
                     operation = operation,
+                    arguments = arguments,
                     tokenBudgetTracker = tokenBudgetTracker,
-                    callContext = callContext,
-                    observation = observation,
-                    emitChunk = emitChunk,
+                    conversationId = conversationId,
                 ),
-                hasEmittedTokens = { emittedAnyTokens },
-                onToken = { chunk ->
-                    emittedAnyTokens = true
-                    emitChunk(chunk)
-                },
-            )
-            error("Streaming route completed without a terminal result")
-        } catch (finished: StreamingRouteFinished) {
-            finished.result
-        } catch (error: TimeoutCancellationException) {
-            currentCoroutineContext().ensureActive()
-            val timeout = TimeoutException(
-                message = buildTimeoutMessage(
-                    providerId = route.providerName,
-                    operation = operation,
-                    timeoutMillis = request.timeoutMillis ?: operation.operation.timeoutMillis,
-                ),
-                cause = error,
-            )
-            observation.onProviderFailure(timeout)
-            handleFallbackResult(timeout, emittedAnyTokens, route.providerName, observation)
-        } catch (error: CancellationException) {
-            observation.completeCancellation(error)
-            throw error
-        } catch (error: Throwable) {
-            error.rethrowIfCancellation()
-            val normalized = normalizeStreamingError(error, route.providerName, operation)
-            observation.onProviderFailure(normalized)
-            handleFallbackResult(normalized, emittedAnyTokens, route.providerName, observation)
-        }
-    }
-
-    private data class StreamingRouteCall(
-        val streamCapable: StreamCapable,
-        val request: ModelRequest,
-        val operation: OperationDefinition,
-        val route: ResolvedProviderRoute,
-        val attempt: Int,
-        val observation: OperationObservation,
-        val tokenBudgetTracker: TokenBudgetTracker,
-        val emitChunk: suspend (StreamChunk) -> Unit,
-    )
-
-    private fun streamingCallContext(
-        operation: OperationDefinition,
-        providerId: String,
-        attempt: Int,
-    ) = OperationCallContext(
-        serviceInterface = serviceDefinition.serviceType.qualifiedName ?: serviceDefinition.serviceType.simpleName.orEmpty(),
-        methodName = operation.method.name,
-        providerId = providerId,
-        requestedModel = operation.operation.model,
-        attempt = attempt,
-    )
-
-    private fun startStreamingObservation(
-        route: ResolvedProviderRoute,
-        operation: OperationDefinition,
-        attempt: Int,
-        routeIndex: Int,
-    ): OperationObservation = startObservation(
-        providerId = route.providerName,
-        operation = operation,
-        attempt = attempt,
-    ).also { observation ->
-        observation.onEngineEvent(
-            name = EVENT_ROUTE_SELECTED,
-            attributes = routeSelectedAttributes(route, routeIndex),
-        )
-    }
-
-    private data class StreamingRouteContext(
-        val route: ResolvedProviderRoute,
-        val operation: OperationDefinition,
-        val tokenBudgetTracker: TokenBudgetTracker,
-        val callContext: OperationCallContext,
-        val observation: OperationObservation,
-        val emitChunk: suspend (StreamChunk) -> Unit,
-    )
-
-    private suspend fun collectStreamingRouteChunks(
-        streamCapable: StreamCapable,
-        request: ModelRequest,
-        timeoutMillis: Long,
-        ctx: StreamingRouteContext,
-        hasEmittedTokens: () -> Boolean,
-        onToken: suspend (StreamChunk.Token) -> Unit,
-    ) {
-        withTimeout(timeoutMillis) {
-            streamCapable.stream(request).collect { chunk ->
-                handleStreamingChunk(
-                    chunk = chunk,
-                    ctx = ctx,
-                    emittedAnyTokens = hasEmittedTokens(),
-                    onToken = onToken,
-                )
-            }
-            handleStreamingTerminationWithoutTerminalChunk(
-                route = ctx.route,
-                operation = ctx.operation,
-                observation = ctx.observation,
-                emittedAnyTokens = hasEmittedTokens(),
             )
         }
-    }
-
-    private suspend fun handleStreamingChunk(
-        chunk: StreamChunk,
-        ctx: StreamingRouteContext,
-        emittedAnyTokens: Boolean,
-        onToken: suspend (StreamChunk.Token) -> Unit,
-    ) {
-        when (chunk) {
-            is StreamChunk.Token -> onToken(chunk)
-            is StreamChunk.Complete -> handleStreamingComplete(
-                chunk = chunk,
-                route = ctx.route,
-                tokenBudgetTracker = ctx.tokenBudgetTracker,
-                callContext = ctx.callContext,
-                observation = ctx.observation,
-                emitChunk = ctx.emitChunk,
-            )
-            is StreamChunk.Error -> {
-                ctx.observation.onProviderFailure(chunk.cause)
-                finishStreamingRoute(
-                    handleFallbackResult(
-                        error = chunk.cause,
-                        emittedAnyTokens = emittedAnyTokens,
-                        providerName = ctx.route.providerName,
-                        observation = ctx.observation,
-                        terminalChunk = chunk,
-                    ),
-                )
-            }
-        }
-    }
-
-    private suspend fun handleStreamingComplete(
-        chunk: StreamChunk.Complete,
-        route: ResolvedProviderRoute,
-        tokenBudgetTracker: TokenBudgetTracker,
-        callContext: OperationCallContext,
-        observation: OperationObservation,
-        emitChunk: suspend (StreamChunk) -> Unit,
-    ) {
-        val response = ModelResponse(
-            content = chunk.fullText,
-            inputTokens = chunk.usage.inputTokens,
-            outputTokens = chunk.usage.outputTokens,
-            thinkingTokens = chunk.usage.thinkingTokens,
-            modelUsed = route.effectiveModelName,
-            finishReason = FinishReason.STOP,
-        )
-
-        val interceptedResponse = operationInterceptor.interceptResponse(callContext, response)
-        observation.onProviderResponse(interceptedResponse)
-
-        try {
-            tokenBudgetCoordinator.enforce(
-                tracker = tokenBudgetTracker,
-                response = interceptedResponse,
-                observation = observation,
-                providerId = route.providerName,
-                modelName = route.effectiveModelName,
-            )
-        } catch (error: TokenBudgetExceededException) {
-            observation.onCallCompleted(parseSuccess = null)
-            throw StreamingRouteFinished(
-                StreamingRouteResult.TerminalError(StreamChunk.Error(error)),
-            )
-        }
-        observation.onCallCompleted(parseSuccess = null)
-        circuitBreaker.onSuccess(route.providerName)
-        emitChunk(
-            if (interceptedResponse.content != chunk.fullText) {
-                chunk.copy(fullText = interceptedResponse.content)
-            } else {
-                chunk
-            }
-        )
-        throw StreamingRouteFinished(StreamingRouteResult.Completed(interceptedResponse.content))
-    }
-
-    private fun handleStreamingTerminationWithoutTerminalChunk(
-        route: ResolvedProviderRoute,
-        operation: OperationDefinition,
-        observation: OperationObservation,
-        emittedAnyTokens: Boolean,
-    ): Nothing {
-        val error = ProviderException(
-            message = "Provider ${route.providerName} ended streaming without a terminal chunk while invoking ${serviceDefinition.serviceType.qualifiedName}.${operation.method.name}",
-        )
-        observation.onProviderFailure(error)
-        finishStreamingRoute(
-            handleFallbackResult(
-                error = error,
-                emittedAnyTokens = emittedAnyTokens,
-                providerName = route.providerName,
-                observation = observation,
-            ),
-        )
-    }
-
-    private fun normalizeStreamingError(
-        error: Throwable,
-        providerName: String,
-        operation: OperationDefinition,
-    ): TramaiException = when (error) {
-        is TramaiException -> error
-        else -> ProviderException(
-            message = "Provider $providerName failed while streaming ${serviceDefinition.serviceType.qualifiedName}.${operation.method.name}",
-            cause = error,
-        )
-    }
-
-    private fun recordCircuitBreakerFailure(
-        providerName: String,
-        error: Throwable,
-        observation: OperationObservation,
-    ) {
-        val opened = circuitBreaker.onFailure(providerName, error)
-        if (opened) {
-            observation.onEngineEvent(
-                name = EVENT_CIRCUIT_OPENED,
-                attributes = mapOf(ATTR_PROVIDER_ID to providerName),
-            )
-        }
-    }
-
-    /**
-     * Enforces [EnforcementPoint.BEFORE_FALLBACK] at any transition point.
-     * Used for provider failures, circuit breaker opens, streaming startup failures,
-     * and route-unavailable transitions.
-     */
-    private suspend fun enforceFallbackTransition(
-        correlationId: String,
-        previousProviderId: String?,
-        previousModelName: String?,
-        nextProviderId: String,
-        reason: String,
-        securityContext: ExecutionSecurityContext,
-    ) {
-        val ctx = policyHelper.buildContext(
-            enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_FALLBACK,
-            correlationId = correlationId,
-        ).applySecurityContext(securityContext)
-        if (previousProviderId != null) ctx.providerId(previousProviderId)
-        if (previousModelName != null) ctx.modelName(previousModelName)
-        ctx.fallbackProviderId(nextProviderId)
-        ctx.attribute("fallbackReason", reason)
-        policyHelper.enforce(ctx.build())
-    }
-
-    private fun recordStartupRetryEvent(
-        providerName: String,
-        failureType: String,
-        observation: OperationObservation,
-    ) {
-        observation.onEngineEvent(
-            name = EVENT_STARTUP_RETRY,
-            attributes = mapOf(
-                ATTR_PROVIDER_ID to providerName,
-                ATTR_FAILURE_TYPE to failureType,
-            ),
-        )
-    }
-
-    private fun handleFallbackResult(
-        error: TramaiException,
-        emittedAnyTokens: Boolean,
-        providerName: String,
-        observation: OperationObservation,
-        terminalChunk: StreamChunk.Error = StreamChunk.Error(error),
-    ): StreamingRouteResult {
-        val result = if (!emittedAnyTokens && shouldFallbackFrom(error)) {
-            recordStartupRetryEvent(providerName, error::class.simpleName ?: "unknown", observation)
-            StreamingRouteResult.StartupFailure(error)
-        } else {
-            StreamingRouteResult.TerminalError(terminalChunk)
-        }
-        recordCircuitBreakerFailure(providerName, error, observation)
-        observation.onCallCompleted(parseSuccess = null)
-        return result
-    }
-
-    private fun finishStreamingRoute(result: StreamingRouteResult): Nothing {
-        throw StreamingRouteFinished(result)
     }
 
     private suspend fun executeRaw(
@@ -1888,44 +1370,6 @@ internal class TramaiInvocationHandler(
             interceptedResponse
         }
     }
-
-    private fun buildTimeoutMessage(
-        providerId: String,
-        operation: OperationDefinition,
-        timeoutMillis: Long,
-    ): String = "Provider $providerId timed out after ${timeoutMillis}ms while invoking ${serviceDefinition.serviceType.qualifiedName}.${operation.method.name}"
-
-    private fun startObservation(
-        providerId: String,
-        operation: OperationDefinition,
-        attempt: Int,
-    ): OperationObservation = operationObserver.onCallStarted(
-        OperationCallContext(
-            serviceInterface = serviceDefinition.serviceType.qualifiedName ?: serviceDefinition.serviceType.simpleName.orEmpty(),
-            methodName = operation.method.name,
-            providerId = providerId,
-            requestedModel = operation.operation.model,
-            attempt = attempt,
-        ),
-    )
-
-    private fun shouldFallbackFrom(error: Throwable): Boolean = when (error) {
-        is CircuitBreakerOpenException -> true
-        is TimeoutException -> true
-        is ProviderException -> error.retryable
-        else -> false
-    }
-
-
-    private fun routeSelectedAttributes(
-        route: ResolvedProviderRoute,
-        routeIndex: Int,
-    ): Map<String, Any?> = mapOf(
-        ATTR_PROVIDER_ID to route.providerName,
-        ATTR_EFFECTIVE_MODEL to route.effectiveModelName,
-        ATTR_ROUTE_INDEX to routeIndex,
-        ATTR_IS_FALLBACK to (routeIndex > 0),
-    )
 
     override suspend fun execute(request: ClaimedResumeExecutionRequest): Any? {
         val metadata = request.metadata
@@ -2512,25 +1956,6 @@ internal fun buildOperationCacheKeyForTesting(
 
 private typealias ProviderCallResult = dev.tramai.engine.provider.ProviderCallResult
 
-private sealed class StreamingRouteResult {
-    data class Completed(
-        val fullText: String,
-    ) : StreamingRouteResult()
-
-    data class StartupFailure(
-        val error: TramaiException,
-    ) : StreamingRouteResult()
-
-    data class TerminalError(
-        val errorChunk: StreamChunk.Error,
-    ) : StreamingRouteResult()
-}
-
-private class StreamingRouteFinished(
-    val result: StreamingRouteResult,
-) : RuntimeException(null, null, false, false)
-
-private typealias AttemptCounter = dev.tramai.engine.provider.AttemptCounter
 
 internal open class ProviderCircuitBreaker(
     private val settings: CircuitBreakerSettings,
@@ -2631,20 +2056,12 @@ internal fun sha256Hex(input: String): String {
 }
 
 
-private const val ATTR_PROVIDER_ID = "provider_id"
-private const val ATTR_EFFECTIVE_MODEL = "effective_model"
-private const val ATTR_ROUTE_INDEX = "route_index"
-private const val ATTR_IS_FALLBACK = "is_fallback"
 private const val ATTR_RETRY_INDEX = "retry_index"
 private const val ATTR_DELAY_MILLIS = "delay_millis"
 private const val ATTR_DELAY_SOURCE = "delay_source"
 private const val ATTR_LIMIT_TOKENS = "limit_tokens"
 private const val ATTR_OBSERVED_TOKENS = "observed_tokens"
 private const val ATTR_SCOPE = "scope"
-private const val ATTR_FAILURE_TYPE = "failure_type"
-private const val EVENT_CIRCUIT_OPENED = "tramai.circuit.opened"
-private const val EVENT_STARTUP_RETRY = "tramai.streaming.startup_retry"
-private const val EVENT_ROUTE_SELECTED = "tramai.route.selected"
 
 /** @see TramaiEngine */
 

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/streaming/StreamingExecutionCoordinator.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/streaming/StreamingExecutionCoordinator.kt
@@ -43,7 +43,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
@@ -59,6 +58,7 @@ internal class StreamingExecutionCoordinator(
     private val lifecycleScope: CoroutineScope,
     private val isClosed: AtomicBoolean,
     private val serviceTypeName: String,
+    private val qualifiedServiceName: String?,
     private val operationObserver: OperationObserver,
     private val operationInterceptor: OperationInterceptor,
     private val toolExposureCoordinator: ToolExposureCoordinator,
@@ -337,14 +337,14 @@ internal class StreamingExecutionCoordinator(
     }
 
     private fun handleStreamingTerminationWithoutTerminalChunk(route: ResolvedProviderRoute, operation: OperationDefinition, observation: OperationObservation, emittedAnyTokens: Boolean): Nothing {
-        val error = ProviderException(message = "Provider ${route.providerName} ended streaming without a terminal chunk while invoking $serviceTypeName.${operation.method.name}")
+        val error = ProviderException(message = "Provider ${route.providerName} ended streaming without a terminal chunk while invoking $qualifiedServiceName.${operation.method.name}")
         observation.onProviderFailure(error)
         finishStreamingRoute(handleFallbackResult(error, emittedAnyTokens, route.providerName, observation))
     }
 
     private fun normalizeStreamingError(error: Throwable, providerName: String, operation: OperationDefinition): TramaiException = when (error) {
         is TramaiException -> error
-        else -> ProviderException(message = "Provider $providerName failed while streaming $serviceTypeName.${operation.method.name}", cause = error)
+        else -> ProviderException(message = "Provider $providerName failed while streaming $qualifiedServiceName.${operation.method.name}", cause = error)
     }
 
     private fun recordCircuitBreakerFailure(providerName: String, error: Throwable, observation: OperationObservation) {
@@ -372,7 +372,7 @@ internal class StreamingExecutionCoordinator(
         else -> false
     }
 
-    private fun buildTimeoutMessage(providerId: String, operation: OperationDefinition, timeoutMillis: Long): String = "Provider $providerId timed out after ${timeoutMillis}ms while invoking $serviceTypeName.${operation.method.name}"
+    private fun buildTimeoutMessage(providerId: String, operation: OperationDefinition, timeoutMillis: Long): String = "Provider $providerId timed out after ${timeoutMillis}ms while invoking $qualifiedServiceName.${operation.method.name}"
 
     private fun routeSelectedAttributes(route: ResolvedProviderRoute, routeIndex: Int): Map<String, Any?> = mapOf(ATTR_PROVIDER_ID to route.providerName, ATTR_EFFECTIVE_MODEL to route.effectiveModelName, ATTR_ROUTE_INDEX to routeIndex, ATTR_IS_FALLBACK to (routeIndex > 0))
 

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/streaming/StreamingExecutionCoordinator.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/streaming/StreamingExecutionCoordinator.kt
@@ -1,0 +1,395 @@
+package dev.tramai.engine.streaming
+
+import dev.tramai.core.coroutines.rethrowIfCancellation
+import dev.tramai.core.exception.CircuitBreakerOpenException
+import dev.tramai.core.exception.ModelRegistryException
+import dev.tramai.core.exception.PolicyViolationException
+import dev.tramai.core.exception.ProviderCapabilityException
+import dev.tramai.core.exception.ProviderException
+import dev.tramai.core.exception.TimeoutException
+import dev.tramai.core.exception.TokenBudgetExceededException
+import dev.tramai.core.exception.TramaiException
+import dev.tramai.core.model.FinishReason
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.model.StreamChunk
+import dev.tramai.core.observation.OperationCallContext
+import dev.tramai.core.observation.OperationInterceptor
+import dev.tramai.core.observation.OperationObservation
+import dev.tramai.core.observation.OperationObserver
+import dev.tramai.core.provider.ProviderRoutingPlan
+import dev.tramai.core.provider.ResolvedProviderRoute
+import dev.tramai.core.provider.StreamCapable
+import dev.tramai.core.provider.resolveCandidates
+import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.ModelRegistryEnforcer
+import dev.tramai.engine.OperationDefinition
+import dev.tramai.engine.ProviderCircuitBreaker
+import dev.tramai.engine.budget.TokenBudgetCoordinator
+import dev.tramai.engine.budget.TokenBudgetTracker
+import dev.tramai.engine.memory.ConversationMemoryCoordinator
+import dev.tramai.engine.memory.PersistConversationTurnRequest
+import dev.tramai.engine.provider.AttemptCounter
+import dev.tramai.engine.provider.ProviderFallbackGate
+import dev.tramai.engine.provider.ProviderInvocationGate
+import dev.tramai.engine.provider.ProviderResolutionGate
+import dev.tramai.engine.tool.ToolExposureCoordinator
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal fun interface StreamingBeforeResponseReturnGate {
+    suspend fun enforce(route: ResolvedProviderRoute, correlationId: String, securityContext: ExecutionSecurityContext)
+}
+
+internal class StreamingExecutionCoordinator(
+    private val routingPlan: ProviderRoutingPlan,
+    private val circuitBreaker: ProviderCircuitBreaker,
+    private val lifecycleScope: CoroutineScope,
+    private val isClosed: AtomicBoolean,
+    private val serviceTypeName: String,
+    private val operationObserver: OperationObserver,
+    private val operationInterceptor: OperationInterceptor,
+    private val toolExposureCoordinator: ToolExposureCoordinator,
+    private val conversationMemoryCoordinator: ConversationMemoryCoordinator,
+    private val tokenBudgetCoordinator: TokenBudgetCoordinator,
+    private val modelRegistryEnforcer: ModelRegistryEnforcer,
+    private val beforeResolution: ProviderResolutionGate,
+    private val beforeInvocation: ProviderInvocationGate,
+    private val fallbackGate: ProviderFallbackGate,
+    private val beforeResponseReturn: StreamingBeforeResponseReturnGate,
+) {
+    fun execute(request: StreamingExecutionRequest): Flow<StreamChunk> {
+        val operation = request.operation
+        val arguments = request.arguments
+        val tokenBudgetTracker = request.tokenBudgetTracker
+        val conversationId = request.conversationId
+        val securityContext = ExecutionSecurityContext.fromArguments(arguments.toTypedArray())
+        val initialMessages = operation.initialMessages(arguments)
+        val prepared = conversationMemoryCoordinator.prepareMessages(initialMessages, conversationId)
+        val history = prepared?.history ?: emptyList()
+        val effectiveMessages = prepared?.effectiveMessages ?: initialMessages
+
+        return flow {
+            check(!isClosed.get()) { "Tramai runtime is closed" }
+            // The provider collection runs as a child of the engine's OWN
+            // lifecycle job (lifecycleScope), NOT the collector's job: close()
+            // cancels lifecycleJob, which cancels an in-flight collection
+            // (including the provider stream's cleanup), and close() joins
+            // lifecycleJob — so the collection has terminated before close()
+            // returns. Chunks are bridged to the caller's emit through a
+            // RENDEZVOUS channel: emit must stay in the collector's coroutine
+            // (SafeCollector invariant), and a rendezvous keeps Flow
+            // backpressure semantics — a slow caller blocks the provider
+            // instead of letting it race ahead into unbounded buffering.
+            val chunks = Channel<StreamChunk>(Channel.RENDEZVOUS)
+            val collectFailure = java.util.concurrent.atomic.AtomicReference<Throwable?>(null)
+            val collectJob = lifecycleScope.launch {
+                try {
+                    val correlationId = java.util.UUID.randomUUID().toString()
+                    beforeResolution.beforeResolution(operation, correlationId, securityContext)
+                    val candidates = routingPlan.resolveCandidates(operation.operation)
+                    var lastFailure: Throwable? = null
+                    var lastCircuitOpen: CircuitBreakerOpenException? = null
+                    val attemptCounter = AttemptCounter()
+
+                    for ((routeIndex, route) in candidates.withIndex()) {
+                        val circuitOpen = handleCircuitBreakerOpenRoute(
+                            route = route,
+                            nextRoute = candidates.getOrNull(routeIndex + 1),
+                            correlationId = correlationId,
+                            securityContext = securityContext,
+                        )
+                        if (circuitOpen != null) {
+                            lastCircuitOpen = circuitOpen
+                            continue
+                        }
+
+                        when (
+                            val result = executeStreamingRoute(
+                                StreamingExecutionRoute(
+                                    operation = operation,
+                                    route = route,
+                                    routeIndex = routeIndex,
+                                    attempt = attemptCounter.next(),
+                                    tokenBudgetTracker = tokenBudgetTracker,
+                                    memoryMessages = effectiveMessages,
+                                    historySize = history.size,
+                                    conversationId = conversationId,
+                                    emitChunk = { chunks.send(it) },
+                                ),
+                                correlationId = correlationId,
+                                securityContext = securityContext,
+                                arguments = arguments,
+                            )
+                        ) {
+                            is StreamingRouteResult.Completed -> {
+                                if (conversationId != null) {
+                                    val assistantMessage = Message(
+                                        role = MessageRole.ASSISTANT,
+                                        content = result.fullText,
+                                    )
+                                    conversationMemoryCoordinator.persistTurn(
+                                        PersistConversationTurnRequest(conversationId, effectiveMessages, history.size, assistantMessage),
+                                    )
+                                }
+                                return@launch
+                            }
+                            is StreamingRouteResult.StartupFailure -> {
+                                enforceStreamingFallbackAfterFailure(
+                                    error = result.error,
+                                    route = route,
+                                    nextRoute = candidates.getOrNull(routeIndex + 1),
+                                    correlationId = correlationId,
+                                    securityContext = securityContext,
+                                )
+                                lastFailure = result.error
+                            }
+                            is StreamingRouteResult.TerminalError -> {
+                                chunks.send(result.errorChunk)
+                                return@launch
+                            }
+                        }
+                    }
+
+                    chunks.send(noAvailableStreamingRouteChunk(operation, lastFailure, lastCircuitOpen))
+                } catch (e: CancellationException) {
+                    // The engine closed (or the collector stopped): terminate
+                    // the collection job normally; the invokeOnCompletion
+                    // below closes the channel with the cancellation cause.
+                    throw e
+                } catch (failure: Throwable) {
+                    failure.rethrowIfCancellation()
+                    // Surface the failure to the collector WITHOUT rethrowing
+                    // it here: rethrowing would let an arbitrary (possibly
+                    // sensitive, externally supplied) throwable reach the
+                    // lifecycle scope's CoroutineExceptionHandler and the
+                    // normal logger. The collector rethrows it after the
+                    // channel drains.
+                    collectFailure.set(failure)
+                }
+            }
+            // Channel termination depends on JOB completion, not on the
+            // coroutine body having started: if close() cancels lifecycleJob
+            // after the flow's open check but before this launch's body runs,
+            // the body's finally never executes — but invokeOnCompletion still
+            // fires, closing the channel so the collector terminates instead
+            // of hanging forever on receive.
+            collectJob.invokeOnCompletion { cause -> chunks.close(cause) }
+            try {
+                for (chunk in chunks) {
+                    check(!isClosed.get()) { "Tramai runtime is closed" }
+                    emit(chunk)
+                }
+                // The collection job may have failed (e.g. provider does not
+                // support streaming, or a route error aborted the loop): the
+                // channel closes either way, so rethrow the job's failure here
+                // instead of silently completing the flow.
+                collectFailure.get()?.let { throw it }
+            } finally {
+                // If the caller stops collecting (or the engine closed), the
+                // engine-owned collection job must not keep running.
+                collectJob.cancel()
+                collectJob.join()
+            }
+        }
+    }
+
+    private data class StreamingExecutionRoute(
+        val operation: OperationDefinition,
+        val route: ResolvedProviderRoute,
+        val routeIndex: Int,
+        val attempt: Int,
+        val tokenBudgetTracker: TokenBudgetTracker,
+        val memoryMessages: List<Message>?,
+        val historySize: Int,
+        val conversationId: String?,
+        val emitChunk: suspend (StreamChunk) -> Unit,
+    )
+
+    private suspend fun executeStreamingRoute(request: StreamingExecutionRoute, correlationId: String, securityContext: ExecutionSecurityContext, arguments: List<Any?>): StreamingRouteResult {
+        val route = request.route
+        val observation = startStreamingObservation(route, request.operation, request.attempt, request.routeIndex)
+        authorizeStreamingRoute(route, observation)
+        beforeResponseReturn.enforce(route, correlationId, securityContext)
+        toolExposureCoordinator.enforce(request.operation, correlationId, securityContext)
+        beforeInvocation.invoke(route.providerName, route.effectiveModelName, correlationId, securityContext)
+
+        val streamCapable = route.provider as? StreamCapable ?: throw ProviderCapabilityException(route.providerName, "streaming")
+        val modelRequest = request.operation.toRequest(arguments, modelName = route.effectiveModelName)
+        val memoryInjectedRequest = request.memoryMessages?.let { modelRequest.copy(messages = it) } ?: modelRequest
+        return collectStreamingRoute(StreamingRouteCall(streamCapable, memoryInjectedRequest, request.operation, route, request.attempt, observation, request.tokenBudgetTracker, request.emitChunk))
+    }
+
+    private suspend fun authorizeStreamingRoute(route: ResolvedProviderRoute, observation: OperationObservation) {
+        try {
+            modelRegistryEnforcer.authorize(route.providerName, route.effectiveModelName)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: ModelRegistryException) {
+            observation.onCallCompleted(parseSuccess = null)
+            throw e
+        }
+    }
+
+    private suspend fun handleCircuitBreakerOpenRoute(route: ResolvedProviderRoute, nextRoute: ResolvedProviderRoute?, correlationId: String, securityContext: ExecutionSecurityContext): CircuitBreakerOpenException? {
+        val blockedUntil = circuitBreaker.beforeCall(route.providerName) ?: return null
+        val circuitOpen = CircuitBreakerOpenException(route.providerName, blockedUntil)
+        if (nextRoute != null) {
+            try {
+                fallbackGate.transition(correlationId, route.providerName, route.effectiveModelName, nextRoute.providerName, "circuit-breaker-open", securityContext)
+            } catch (policyError: PolicyViolationException) {
+                policyError.addSuppressed(circuitOpen)
+                throw policyError
+            }
+        }
+        return circuitOpen
+    }
+
+    private suspend fun enforceStreamingFallbackAfterFailure(error: Throwable, route: ResolvedProviderRoute, nextRoute: ResolvedProviderRoute?, correlationId: String, securityContext: ExecutionSecurityContext) {
+        if (nextRoute == null) return
+        try {
+            fallbackGate.transition(correlationId, route.providerName, route.effectiveModelName, nextRoute.providerName, "streaming-startup-failure", securityContext)
+        } catch (policyError: PolicyViolationException) {
+            policyError.addSuppressed(error)
+            throw policyError
+        }
+    }
+
+    private fun noAvailableStreamingRouteChunk(operation: OperationDefinition, lastFailure: Throwable?, lastCircuitOpen: CircuitBreakerOpenException?): StreamChunk.Error = StreamChunk.Error((lastFailure ?: lastCircuitOpen ?: ProviderException(message = "No available streaming provider route for model '${operation.operation.model}'", retryable = true)) as TramaiException)
+
+    private suspend fun collectStreamingRoute(call: StreamingRouteCall): StreamingRouteResult {
+        val streamCapable = call.streamCapable
+        val request = call.request
+        val operation = call.operation
+        val route = call.route
+        val attempt = call.attempt
+        val observation = call.observation
+        val tokenBudgetTracker = call.tokenBudgetTracker
+        val emitChunk = call.emitChunk
+        var emittedAnyTokens = false
+        val callContext = streamingCallContext(operation, route.providerName, attempt)
+        val interceptedRequest = request.copy(messages = operationInterceptor.interceptRequest(callContext, request.messages))
+        return try {
+            collectStreamingRouteChunks(streamCapable, interceptedRequest, request.timeoutMillis ?: operation.operation.timeoutMillis, StreamingRouteContext(route, operation, tokenBudgetTracker, callContext, observation, emitChunk), { emittedAnyTokens }, { chunk -> emittedAnyTokens = true; emitChunk(chunk) })
+            error("Streaming route completed without a terminal result")
+        } catch (finished: StreamingRouteFinished) {
+            finished.result
+        } catch (error: TimeoutCancellationException) {
+            currentCoroutineContext().ensureActive()
+            val timeout = TimeoutException(message = buildTimeoutMessage(route.providerName, operation, request.timeoutMillis ?: operation.operation.timeoutMillis), cause = error)
+            observation.onProviderFailure(timeout)
+            handleFallbackResult(timeout, emittedAnyTokens, route.providerName, observation)
+        } catch (error: CancellationException) {
+            observation.completeCancellation(error)
+            throw error
+        } catch (error: Throwable) {
+            error.rethrowIfCancellation()
+            val normalized = normalizeStreamingError(error, route.providerName, operation)
+            observation.onProviderFailure(normalized)
+            handleFallbackResult(normalized, emittedAnyTokens, route.providerName, observation)
+        }
+    }
+
+    private data class StreamingRouteCall(val streamCapable: StreamCapable, val request: ModelRequest, val operation: OperationDefinition, val route: ResolvedProviderRoute, val attempt: Int, val observation: OperationObservation, val tokenBudgetTracker: TokenBudgetTracker, val emitChunk: suspend (StreamChunk) -> Unit)
+
+    private fun streamingCallContext(operation: OperationDefinition, providerId: String, attempt: Int) = OperationCallContext(serviceInterface = serviceTypeName, methodName = operation.method.name, providerId = providerId, requestedModel = operation.operation.model, attempt = attempt)
+
+    private fun startStreamingObservation(route: ResolvedProviderRoute, operation: OperationDefinition, attempt: Int, routeIndex: Int): OperationObservation = operationObserver.onCallStarted(OperationCallContext(serviceInterface = serviceTypeName, methodName = operation.method.name, providerId = route.providerName, requestedModel = operation.operation.model, attempt = attempt)).also { observation -> observation.onEngineEvent(name = EVENT_ROUTE_SELECTED, attributes = routeSelectedAttributes(route, routeIndex)) }
+
+    private data class StreamingRouteContext(val route: ResolvedProviderRoute, val operation: OperationDefinition, val tokenBudgetTracker: TokenBudgetTracker, val callContext: OperationCallContext, val observation: OperationObservation, val emitChunk: suspend (StreamChunk) -> Unit)
+
+    private suspend fun collectStreamingRouteChunks(streamCapable: StreamCapable, request: ModelRequest, timeoutMillis: Long, ctx: StreamingRouteContext, hasEmittedTokens: () -> Boolean, onToken: suspend (StreamChunk.Token) -> Unit) {
+        withTimeout(timeoutMillis) {
+            streamCapable.stream(request).collect { chunk -> handleStreamingChunk(chunk, ctx, hasEmittedTokens(), onToken) }
+            handleStreamingTerminationWithoutTerminalChunk(ctx.route, ctx.operation, ctx.observation, hasEmittedTokens())
+        }
+    }
+
+    private suspend fun handleStreamingChunk(chunk: StreamChunk, ctx: StreamingRouteContext, emittedAnyTokens: Boolean, onToken: suspend (StreamChunk.Token) -> Unit) {
+        when (chunk) {
+            is StreamChunk.Token -> onToken(chunk)
+            is StreamChunk.Complete -> handleStreamingComplete(chunk, ctx.route, ctx.tokenBudgetTracker, ctx.callContext, ctx.observation, ctx.emitChunk)
+            is StreamChunk.Error -> { ctx.observation.onProviderFailure(chunk.cause); finishStreamingRoute(handleFallbackResult(chunk.cause, emittedAnyTokens, ctx.route.providerName, ctx.observation, chunk)) }
+        }
+    }
+
+    private suspend fun handleStreamingComplete(chunk: StreamChunk.Complete, route: ResolvedProviderRoute, tokenBudgetTracker: TokenBudgetTracker, callContext: OperationCallContext, observation: OperationObservation, emitChunk: suspend (StreamChunk) -> Unit) {
+        val response = ModelResponse(content = chunk.fullText, inputTokens = chunk.usage.inputTokens, outputTokens = chunk.usage.outputTokens, thinkingTokens = chunk.usage.thinkingTokens, modelUsed = route.effectiveModelName, finishReason = FinishReason.STOP)
+        val interceptedResponse = operationInterceptor.interceptResponse(callContext, response)
+        observation.onProviderResponse(interceptedResponse)
+        try { tokenBudgetCoordinator.enforce(tokenBudgetTracker, interceptedResponse, observation, route.providerName, route.effectiveModelName) } catch (error: TokenBudgetExceededException) { observation.onCallCompleted(parseSuccess = null); throw StreamingRouteFinished(StreamingRouteResult.TerminalError(StreamChunk.Error(error))) }
+        observation.onCallCompleted(parseSuccess = null)
+        circuitBreaker.onSuccess(route.providerName)
+        emitChunk(if (interceptedResponse.content != chunk.fullText) chunk.copy(fullText = interceptedResponse.content) else chunk)
+        throw StreamingRouteFinished(StreamingRouteResult.Completed(interceptedResponse.content))
+    }
+
+    private fun handleStreamingTerminationWithoutTerminalChunk(route: ResolvedProviderRoute, operation: OperationDefinition, observation: OperationObservation, emittedAnyTokens: Boolean): Nothing {
+        val error = ProviderException(message = "Provider ${route.providerName} ended streaming without a terminal chunk while invoking $serviceTypeName.${operation.method.name}")
+        observation.onProviderFailure(error)
+        finishStreamingRoute(handleFallbackResult(error, emittedAnyTokens, route.providerName, observation))
+    }
+
+    private fun normalizeStreamingError(error: Throwable, providerName: String, operation: OperationDefinition): TramaiException = when (error) {
+        is TramaiException -> error
+        else -> ProviderException(message = "Provider $providerName failed while streaming $serviceTypeName.${operation.method.name}", cause = error)
+    }
+
+    private fun recordCircuitBreakerFailure(providerName: String, error: Throwable, observation: OperationObservation) {
+        val opened = circuitBreaker.onFailure(providerName, error)
+        if (opened) observation.onEngineEvent(name = EVENT_CIRCUIT_OPENED, attributes = mapOf(ATTR_PROVIDER_ID to providerName))
+    }
+
+    private fun recordStartupRetryEvent(providerName: String, failureType: String, observation: OperationObservation) {
+        observation.onEngineEvent(name = EVENT_STARTUP_RETRY, attributes = mapOf(ATTR_PROVIDER_ID to providerName, ATTR_FAILURE_TYPE to failureType))
+    }
+
+    private fun handleFallbackResult(error: TramaiException, emittedAnyTokens: Boolean, providerName: String, observation: OperationObservation, terminalChunk: StreamChunk.Error = StreamChunk.Error(error)): StreamingRouteResult {
+        val result = if (!emittedAnyTokens && shouldFallbackFrom(error)) { recordStartupRetryEvent(providerName, error::class.simpleName ?: "unknown", observation); StreamingRouteResult.StartupFailure(error) } else StreamingRouteResult.TerminalError(terminalChunk)
+        recordCircuitBreakerFailure(providerName, error, observation)
+        observation.onCallCompleted(parseSuccess = null)
+        return result
+    }
+
+    private fun finishStreamingRoute(result: StreamingRouteResult): Nothing { throw StreamingRouteFinished(result) }
+
+    private fun shouldFallbackFrom(error: Throwable): Boolean = when (error) {
+        is CircuitBreakerOpenException -> true
+        is TimeoutException -> true
+        is ProviderException -> error.retryable
+        else -> false
+    }
+
+    private fun buildTimeoutMessage(providerId: String, operation: OperationDefinition, timeoutMillis: Long): String = "Provider $providerId timed out after ${timeoutMillis}ms while invoking $serviceTypeName.${operation.method.name}"
+
+    private fun routeSelectedAttributes(route: ResolvedProviderRoute, routeIndex: Int): Map<String, Any?> = mapOf(ATTR_PROVIDER_ID to route.providerName, ATTR_EFFECTIVE_MODEL to route.effectiveModelName, ATTR_ROUTE_INDEX to routeIndex, ATTR_IS_FALLBACK to (routeIndex > 0))
+
+    private fun OperationObservation.completeCancellation(cancellation: CancellationException) {
+        try {
+            onCallCancelled()
+        } catch (observerError: Throwable) {
+            cancellation.addSuppressed(observerError)
+        }
+    }
+}
+
+private const val ATTR_PROVIDER_ID = "provider_id"
+private const val ATTR_EFFECTIVE_MODEL = "effective_model"
+private const val ATTR_ROUTE_INDEX = "route_index"
+private const val ATTR_IS_FALLBACK = "is_fallback"
+private const val ATTR_FAILURE_TYPE = "failure_type"
+private const val EVENT_CIRCUIT_OPENED = "tramai.circuit.opened"
+private const val EVENT_STARTUP_RETRY = "tramai.streaming.startup_retry"
+private const val EVENT_ROUTE_SELECTED = "tramai.route.selected"

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/streaming/StreamingExecutionModels.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/streaming/StreamingExecutionModels.kt
@@ -1,0 +1,31 @@
+package dev.tramai.engine.streaming
+
+import dev.tramai.core.exception.TramaiException
+import dev.tramai.core.model.StreamChunk
+import dev.tramai.engine.OperationDefinition
+import dev.tramai.engine.budget.TokenBudgetTracker
+
+internal data class StreamingExecutionRequest(
+    val operation: OperationDefinition,
+    val arguments: List<Any?>,
+    val tokenBudgetTracker: TokenBudgetTracker,
+    val conversationId: String?,
+)
+
+internal sealed class StreamingRouteResult {
+    data class Completed(
+        val fullText: String,
+    ) : StreamingRouteResult()
+
+    data class StartupFailure(
+        val error: TramaiException,
+    ) : StreamingRouteResult()
+
+    data class TerminalError(
+        val errorChunk: StreamChunk.Error,
+    ) : StreamingRouteResult()
+}
+
+internal class StreamingRouteFinished(
+    val result: StreamingRouteResult,
+) : RuntimeException(null, null, false, false)

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/streaming/StreamingExecutionCoordinatorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/streaming/StreamingExecutionCoordinatorTest.kt
@@ -150,12 +150,13 @@ class StreamingExecutionCoordinatorTest {
         budgetSettings: TokenBudgetSettings = defaultBudget,
         circuitBreaker: ProviderCircuitBreaker = ProviderCircuitBreaker(CircuitBreakerSettings(enabled = circuitEnabled, failureThreshold = 1)),
         closed: AtomicBoolean = AtomicBoolean(false),
+        qualifiedServiceName: String? = "test.StreamingService",
     ): StreamingExecutionCoordinator {
         val recordingSink = sink ?: OrderedSink()
         val policy = PolicyEngine { PolicyDecision.Allow }
         fun denied() = PolicyViolationException(PolicyDecision.Deny("denied", "TEST"))
         return StreamingExecutionCoordinator(
-            routingPlan, circuitBreaker, CoroutineScope(Dispatchers.Default), closed, "test.StreamingService", "test.StreamingService", observer,
+            routingPlan, circuitBreaker, CoroutineScope(Dispatchers.Default), closed, "test.StreamingService", qualifiedServiceName, observer,
             NoOpOperationInterceptor,
             ToolExposureCoordinator(ToolRegistry(), PolicyEnforcementHelper(policy, AtomicBoolean(false))),
             ConversationMemoryCoordinator(memory, ConversationIdProvider { "cid" }), TokenBudgetCoordinator(budgetSettings),
@@ -291,6 +292,30 @@ class StreamingExecutionCoordinatorTest {
         val chunks = coordinator(plan("p" to provider), RecordingOperationObserver(sink), sink).execute(request()).toList()
         val error = chunks.single() as StreamChunk.Error
         assertThat(error.cause).isInstanceOf(ProviderException::class.java); assertThat(error.cause.message).isEqualTo("boom"); assertThat(sink.events).contains("observation.provider-failure", "observation.complete:null")
+        }
+    }
+
+    @Test fun `null qualified service name renders null in normalized streaming error`() {
+        runBlocking {
+        // Guards P1-A: normalizeStreamingError must interpolate the raw nullable
+        // qualifiedName, not the normalized serviceTypeName fallback. A thrown
+        // non-Tramai failure (anonymous class → null qualified name) must render
+        // "null.stream" exactly as master did.
+        val provider = RecordingProvider("p") { flow { throw IllegalStateException("boom") } }
+        val chunks = coordinator(plan("p" to provider), RecordingOperationObserver(OrderedSink()), qualifiedServiceName = null).execute(request()).toList()
+        val error = chunks.single() as StreamChunk.Error
+        assertThat(error.cause).isInstanceOf(ProviderException::class.java)
+        assertThat(error.cause.message).contains("failed while streaming null.stream")
+        }
+    }
+
+    @Test fun `null qualified service name renders null in unterminated stream message`() {
+        runBlocking {
+        // The unterminated-stream path builds its message from qualifiedServiceName too.
+        val provider = RecordingProvider("p") { flow { } }
+        val chunks = coordinator(plan("p" to provider), RecordingOperationObserver(OrderedSink()), qualifiedServiceName = null).execute(request()).toList()
+        val error = chunks.single() as StreamChunk.Error
+        assertThat(error.cause.message).contains("ended streaming without a terminal chunk while invoking null.stream")
         }
     }
 

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/streaming/StreamingExecutionCoordinatorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/streaming/StreamingExecutionCoordinatorTest.kt
@@ -155,7 +155,7 @@ class StreamingExecutionCoordinatorTest {
         val policy = PolicyEngine { PolicyDecision.Allow }
         fun denied() = PolicyViolationException(PolicyDecision.Deny("denied", "TEST"))
         return StreamingExecutionCoordinator(
-            routingPlan, circuitBreaker, CoroutineScope(Dispatchers.Default), closed, "test.StreamingService", observer,
+            routingPlan, circuitBreaker, CoroutineScope(Dispatchers.Default), closed, "test.StreamingService", "test.StreamingService", observer,
             NoOpOperationInterceptor,
             ToolExposureCoordinator(ToolRegistry(), PolicyEnforcementHelper(policy, AtomicBoolean(false))),
             ConversationMemoryCoordinator(memory, ConversationIdProvider { "cid" }), TokenBudgetCoordinator(budgetSettings),
@@ -216,7 +216,8 @@ class StreamingExecutionCoordinatorTest {
         val memory = RecordingMemory(sink).also { it.history = listOf(Message(MessageRole.USER, "old")) }; val observer = RecordingOperationObserver(sink)
         coordinator(plan("p" to provider), observer, sink, memory).execute(request("cid")).toList()
         assertThat(memory.stored.single().second.last()).isEqualTo(Message(MessageRole.ASSISTANT, "hello world"))
-        assertThat(sink.events.join()).containsSubsequence("provider.stream:p", "observation.complete:null", "memory.persist")
+        // completion is recorded before memory persistence — swapping would fail
+        assertThat(sink.events.takeLast(2)).containsExactly("observation.complete:null", "memory.persist")
         }
     }
 

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/streaming/StreamingExecutionCoordinatorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/streaming/StreamingExecutionCoordinatorTest.kt
@@ -1,0 +1,337 @@
+package dev.tramai.engine.streaming
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.exception.PolicyViolationException
+import dev.tramai.core.exception.ProviderCapabilityException
+import dev.tramai.core.exception.ProviderException
+import dev.tramai.core.memory.ChatMemory
+import dev.tramai.core.memory.ConversationIdProvider
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
+import dev.tramai.core.model.ModelRegistry
+import dev.tramai.core.model.ModelRegistrySettings
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.model.StreamChunk
+import dev.tramai.core.model.UsageMetrics
+import dev.tramai.core.observation.NoOpOperationInterceptor
+import dev.tramai.core.observation.OperationCallContext
+import dev.tramai.core.observation.OperationObservation
+import dev.tramai.core.observation.OperationObserver
+import dev.tramai.core.policy.PolicyDecision
+import dev.tramai.core.policy.PolicyEngine
+import dev.tramai.core.provider.ModelProvider
+import dev.tramai.core.provider.ProviderRoutingPlan
+import dev.tramai.core.provider.StreamCapable
+import dev.tramai.engine.CircuitBreakerSettings
+import dev.tramai.engine.ModelRegistryEnforcer
+import dev.tramai.engine.PolicyEnforcementHelper
+import dev.tramai.engine.ProviderCircuitBreaker
+import dev.tramai.engine.TokenBudgetSettings
+import dev.tramai.engine.ToolRegistry
+import dev.tramai.engine.budget.TokenBudgetCoordinator
+import dev.tramai.engine.memory.ConversationMemoryCoordinator
+import dev.tramai.engine.planning.OperationDefinitionCompiler
+import dev.tramai.engine.planning.OperationFingerprintFactory
+import dev.tramai.engine.planning.ServiceDefinitionCompiler
+import dev.tramai.engine.provider.ProviderFallbackGate
+import dev.tramai.engine.provider.ProviderInvocationGate
+import dev.tramai.engine.provider.ProviderResolutionGate
+import dev.tramai.engine.tool.ToolExposureCoordinator
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicBoolean
+
+class StreamingExecutionCoordinatorTest {
+
+    @AiService
+    private interface StreamingService {
+        @Operation(prompt = "Answer", model = "logical-model")
+        fun stream(input: String): Flow<StreamChunk>
+    }
+
+    private val defaultBudget = TokenBudgetSettings(hardMaxTokensPerOperation = 20)
+
+    private fun operation() = ServiceDefinitionCompiler(
+        OperationDefinitionCompiler(ToolRegistry(), null, OperationFingerprintFactory()),
+    ).compile(StreamingService::class).operations.entries.single().value.definition
+
+    private class OrderedSink {
+        val events = mutableListOf<String>()
+        fun record(name: String) { events += name }
+    }
+
+    private fun List<String>.join() = joinToString(",")
+
+    private class RecordingObservation(private val sink: OrderedSink) : OperationObservation {
+        val completions = mutableListOf<Boolean?>()
+        override fun onProviderResponse(response: ModelResponse) { sink.record("observation.provider-response") }
+        override fun onProviderFailure(error: Throwable) { sink.record("observation.provider-failure") }
+        override fun onStructuredParseFailure(rawResponse: String, errorSummary: String) = Unit
+        override fun onEngineEvent(name: String, attributes: Map<String, Any?>) { sink.record("observation.engine-event:$name") }
+        override fun onCallCompleted(parseSuccess: Boolean?) { completions += parseSuccess; sink.record("observation.complete:$parseSuccess") }
+        override fun onCallCancelled() { sink.record("observation.cancelled") }
+    }
+
+    private class RecordingOperationObserver(private val sink: OrderedSink) : OperationObserver {
+        val observations = mutableListOf<RecordingObservation>()
+        override fun onCallStarted(context: OperationCallContext): OperationObservation = RecordingObservation(sink).also {
+            observations += it
+            sink.record("observer.start")
+        }
+    }
+
+    private class RecordingMemory(private val sink: OrderedSink? = null) : ChatMemory {
+        var history: List<Message> = emptyList()
+        val stored = mutableListOf<Pair<String, List<Message>>>()
+        override fun get(conversationId: String): List<Message> = history
+        override fun add(conversationId: String, messages: List<Message>) { sink?.record("memory.persist"); stored += conversationId to messages }
+        override fun add(conversationId: String, message: Message) = add(conversationId, listOf(message))
+        override fun clear(conversationId: String) = Unit
+    }
+
+    private class RecordingProvider(
+        private val name: String,
+        private val responder: RecordingProvider.(ModelRequest) -> Flow<StreamChunk>,
+    ) : ModelProvider, StreamCapable {
+        val streamRequests = mutableListOf<ModelRequest>()
+        override suspend fun complete(request: ModelRequest): ModelResponse = error("complete is not used")
+        override fun stream(request: ModelRequest): Flow<StreamChunk> {
+            streamRequests += request
+            sink?.record("provider.stream:$name")
+            return responder(request)
+        }
+        var sink: OrderedSink? = null
+        override fun providerId(): String = name
+    }
+
+    private class NonStreamingProvider(private val name: String) : ModelProvider {
+        var calls = 0
+        override suspend fun complete(request: ModelRequest): ModelResponse { calls++; return ModelResponse("unused") }
+        override fun providerId(): String = name
+    }
+
+    private fun plan(vararg providers: Pair<String, ModelProvider>): ProviderRoutingPlan {
+        val builder = ProviderRoutingPlan.builder()
+        providers.forEach { (name, provider) -> builder.provider(name, provider) }
+        if (providers.isNotEmpty()) {
+            builder.model("logical-model", providers.first().first)
+            providers.drop(1).forEach { (name, _) -> builder.fallbackProvider("logical-model", name) }
+        }
+        return builder.build()
+    }
+
+    private fun request(conversationId: String? = null, budget: TokenBudgetCoordinator = TokenBudgetCoordinator(defaultBudget)) =
+        StreamingExecutionRequest(operation(), listOf("input"), budget.createTracker(), conversationId)
+
+    private fun coordinator(
+        routingPlan: ProviderRoutingPlan,
+        observer: RecordingOperationObserver,
+        sink: OrderedSink? = null,
+        memory: RecordingMemory = RecordingMemory(sink),
+        circuitEnabled: Boolean = false,
+        denyBeforeResponseReturn: Boolean = false,
+        denyFallback: Boolean = false,
+        budgetSettings: TokenBudgetSettings = defaultBudget,
+        circuitBreaker: ProviderCircuitBreaker = ProviderCircuitBreaker(CircuitBreakerSettings(enabled = circuitEnabled, failureThreshold = 1)),
+        closed: AtomicBoolean = AtomicBoolean(false),
+    ): StreamingExecutionCoordinator {
+        val recordingSink = sink ?: OrderedSink()
+        val policy = PolicyEngine { PolicyDecision.Allow }
+        fun denied() = PolicyViolationException(PolicyDecision.Deny("denied", "TEST"))
+        return StreamingExecutionCoordinator(
+            routingPlan, circuitBreaker, CoroutineScope(Dispatchers.Default), closed, "test.StreamingService", observer,
+            NoOpOperationInterceptor,
+            ToolExposureCoordinator(ToolRegistry(), PolicyEnforcementHelper(policy, AtomicBoolean(false))),
+            ConversationMemoryCoordinator(memory, ConversationIdProvider { "cid" }), TokenBudgetCoordinator(budgetSettings),
+            ModelRegistryEnforcer(object : ModelRegistry { override suspend fun findApprovedModel(providerId: String, modelName: String) = null }, ModelRegistrySettings(enabled = false)),
+            ProviderResolutionGate { _, _, _ -> recordingSink.record("policy.before-resolution") },
+            ProviderInvocationGate { _, _, _, _ -> recordingSink.record("policy.before-invocation") },
+            ProviderFallbackGate { _, _, _, _, _, _ -> recordingSink.record("policy.fallback"); if (denyFallback) throw denied() },
+            StreamingBeforeResponseReturnGate { _, _, _ -> recordingSink.record("policy.before-response-return"); if (denyBeforeResponseReturn) throw denied() },
+        )
+    }
+
+    @Test fun `engine already closed fails at collection without touching provider or memory`() {
+        val sink = OrderedSink(); val provider = RecordingProvider("p") { flow { emit(StreamChunk.Token("unused")) } }; provider.sink = sink
+        val memory = RecordingMemory(sink); val observer = RecordingOperationObserver(sink)
+        val c = coordinator(plan("p" to provider), observer, sink, memory, closed = AtomicBoolean(true))
+        assertThatThrownBy { runBlocking { c.execute(request("cid")).toList() } }.isInstanceOf(IllegalStateException::class.java).hasMessage("Tramai runtime is closed")
+        assertThat(provider.streamRequests).isEmpty(); assertThat(memory.stored).isEmpty()
+    }
+
+    @Test fun `memory snapshot is taken at flow construction not collection`() {
+        runTest {
+        val provider = RecordingProvider("p") { flow { emit(StreamChunk.Complete("ok")) } }; val memory = RecordingMemory()
+        memory.history = listOf(Message(MessageRole.USER, "H1")); val c = coordinator(plan("p" to provider), RecordingOperationObserver(OrderedSink()), memory = memory)
+        val stream = c.execute(request("cid")); memory.history = listOf(Message(MessageRole.USER, "H2"))
+        stream.toList()
+        assertThat(provider.streamRequests.single().messages.map { it.content }).contains("H1").doesNotContain("H2")
+        }
+    }
+
+    @Test fun `consumer cancellation after first chunk stops bridge and persists nothing`() {
+        runBlocking {
+        val cleaned = CompletableDeferred<Unit>(); val provider = RecordingProvider("p") { flow { try { emit(StreamChunk.Token("first")); awaitCancellation() } finally { cleaned.complete(Unit) } } }
+        val memory = RecordingMemory(); val c = coordinator(plan("p" to provider), RecordingOperationObserver(OrderedSink()), memory = memory)
+        assertThat(c.execute(request("cid")).take(1).toList()).containsExactly(StreamChunk.Token("first")); withTimeout(2_000) { cleaned.await() }; assertThat(memory.stored).isEmpty()
+        }
+    }
+
+    @Test fun `successful completion closes the flow exactly once`() {
+        runBlocking {
+        val provider = RecordingProvider("p") { flow { emit(StreamChunk.Token("hello")); emit(StreamChunk.Token(" ")); emit(StreamChunk.Token("world")); emit(StreamChunk.Complete("hello world")) } }
+        val chunks = coordinator(plan("p" to provider), RecordingOperationObserver(OrderedSink())).execute(request()).toList()
+        assertThat(chunks).containsExactly(StreamChunk.Token("hello"), StreamChunk.Token(" "), StreamChunk.Token("world"), StreamChunk.Complete("hello world"))
+        }
+    }
+
+    @Test fun `two text chunks preserve order and full text`() {
+        runBlocking {
+        val provider = RecordingProvider("p") { flow { emit(StreamChunk.Token("hello ")); emit(StreamChunk.Token("world")); emit(StreamChunk.Complete("hello world")) } }
+        val chunks = coordinator(plan("p" to provider), RecordingOperationObserver(OrderedSink())).execute(request()).toList()
+        assertThat(chunks.filterIsInstance<StreamChunk.Complete>().single().fullText).isEqualTo("hello world")
+        assertThat(chunks.filterIsInstance<StreamChunk.Token>().map { it.text }).containsExactly("hello ", "world")
+        }
+    }
+
+    @Test fun `successful stream persists accumulated assistant response`() {
+        runBlocking {
+        val sink = OrderedSink(); val provider = RecordingProvider("p") { flow { emit(StreamChunk.Token("hello ")); emit(StreamChunk.Complete("hello world")) } }; provider.sink = sink
+        val memory = RecordingMemory(sink).also { it.history = listOf(Message(MessageRole.USER, "old")) }; val observer = RecordingOperationObserver(sink)
+        coordinator(plan("p" to provider), observer, sink, memory).execute(request("cid")).toList()
+        assertThat(memory.stored.single().second.last()).isEqualTo(Message(MessageRole.ASSISTANT, "hello world"))
+        assertThat(sink.events.join()).containsSubsequence("provider.stream:p", "observation.complete:null", "memory.persist")
+        }
+    }
+
+    @Test fun `usage is committed exactly once`() {
+        runBlocking {
+        val sink = OrderedSink(); val observer = RecordingOperationObserver(sink)
+        val provider = RecordingProvider("p") { flow { emit(StreamChunk.Complete("ok", UsageMetrics(4, 2))) } }
+        coordinator(plan("p" to provider), observer, sink).execute(request()).toList()
+        assertThat(sink.events.count { it == "observation.complete:null" }).isEqualTo(1); assertThat(sink.events.count { it == "observation.provider-response" }).isEqualTo(1)
+        }
+    }
+
+    @Test fun `before response return denial aborts before provider invocation`() {
+        val sink = OrderedSink(); val provider = RecordingProvider("p") { flow { emit(StreamChunk.Complete("no")) } }; val observer = RecordingOperationObserver(sink)
+        val c = coordinator(plan("p" to provider), observer, sink, denyBeforeResponseReturn = true)
+        assertThatThrownBy { runBlocking { c.execute(request()).toList() } }.isInstanceOf(PolicyViolationException::class.java)
+        assertThat(provider.streamRequests).isEmpty(); assertThat(sink.events).contains("observation.engine-event:tramai.route.selected").doesNotContain("observation.provider-response")
+    }
+
+    @Test fun `retryable startup error before first token falls back to next route`() {
+        runBlocking {
+        val sink = OrderedSink(); val primary = RecordingProvider("primary") { flow { emit(StreamChunk.Error(ProviderException("down", retryable = true))) } }; val fallback = RecordingProvider("fallback") { flow { emit(StreamChunk.Token("ok")); emit(StreamChunk.Complete("ok")) } }; primary.sink = sink; fallback.sink = sink
+        val chunks = coordinator(plan("primary" to primary, "fallback" to fallback), RecordingOperationObserver(sink), sink).execute(request()).toList()
+        assertThat(chunks).containsExactly(StreamChunk.Token("ok"), StreamChunk.Complete("ok")); assertThat(primary.streamRequests).hasSize(1); assertThat(fallback.streamRequests).hasSize(1); assertThat(sink.events).contains("observation.engine-event:tramai.streaming.startup_retry", "policy.fallback")
+        }
+    }
+
+    @Test fun `non retryable provider error does not fall back`() {
+        runBlocking {
+        val primary = RecordingProvider("primary") { flow { emit(StreamChunk.Error(ProviderException("boom", retryable = false))) } }; val fallback = RecordingProvider("fallback") { flow { emit(StreamChunk.Complete("bad")) } }
+        val chunks = coordinator(plan("primary" to primary, "fallback" to fallback), RecordingOperationObserver(OrderedSink())).execute(request()).toList()
+        val error = chunks.single() as StreamChunk.Error
+        assertThat(error.cause).isInstanceOf(ProviderException::class.java); assertThat(error.cause.message).isEqualTo("boom"); assertThat((error.cause as ProviderException).retryable).isFalse(); assertThat(fallback.streamRequests).isEmpty()
+        }
+    }
+
+    @Test fun `first route that cannot stream fails with capability exception`() {
+        val provider = NonStreamingProvider("p"); val c = coordinator(plan("p" to provider), RecordingOperationObserver(OrderedSink()))
+        assertThatThrownBy { runBlocking { c.execute(request()).toList() } }.isInstanceOf(ProviderCapabilityException::class.java)
+    }
+
+    @Test fun `fallback gate denial prevents second provider invocation`() {
+        val primary = RecordingProvider("primary") { flow { emit(StreamChunk.Error(ProviderException("down", retryable = true))) } }; val fallback = RecordingProvider("fallback") { flow { emit(StreamChunk.Complete("bad")) } }
+        val c = coordinator(plan("primary" to primary, "fallback" to fallback), RecordingOperationObserver(OrderedSink()), denyFallback = true)
+        assertThatThrownBy { runBlocking { c.execute(request()).toList() } }.isInstanceOf(PolicyViolationException::class.java); assertThat(fallback.streamRequests).isEmpty()
+    }
+
+    @Test fun `open circuit skips route and uses next`() {
+        runBlocking {
+        val breaker = ProviderCircuitBreaker(CircuitBreakerSettings(enabled = true, failureThreshold = 1)); breaker.onFailure("primary", ProviderException("down", retryable = true))
+        val primary = RecordingProvider("primary") { flow { emit(StreamChunk.Complete("bad")) } }; val fallback = RecordingProvider("fallback") { flow { emit(StreamChunk.Complete("ok")) } }
+        val chunks = coordinator(plan("primary" to primary, "fallback" to fallback), RecordingOperationObserver(OrderedSink()), circuitEnabled = true, circuitBreaker = breaker).execute(request()).toList()
+        assertThat(primary.streamRequests).isEmpty(); assertThat(chunks).containsExactly(StreamChunk.Complete("ok"))
+        }
+    }
+
+    @Test fun `all routes open circuit emits no available route chunk with circuit error`() {
+        runBlocking {
+        val breaker = ProviderCircuitBreaker(CircuitBreakerSettings(enabled = true, failureThreshold = 1)); breaker.onFailure("p", ProviderException("down", retryable = true))
+        val provider = RecordingProvider("p") { flow { emit(StreamChunk.Complete("bad")) } }
+        val chunks = coordinator(plan("p" to provider), RecordingOperationObserver(OrderedSink()), circuitEnabled = true, circuitBreaker = breaker).execute(request()).toList()
+        val error = chunks.single() as StreamChunk.Error
+        assertThat(error.cause).isInstanceOf(dev.tramai.core.exception.CircuitBreakerOpenException::class.java)
+        assertThat(provider.streamRequests).isEmpty()
+        }
+    }
+
+    @Test fun `stream error chunk semantics unchanged`() {
+        runBlocking {
+        val sink = OrderedSink(); val provider = RecordingProvider("p") { flow { emit(StreamChunk.Error(ProviderException("boom", retryable = false))) } }
+        val chunks = coordinator(plan("p" to provider), RecordingOperationObserver(sink), sink).execute(request()).toList()
+        val error = chunks.single() as StreamChunk.Error
+        assertThat(error.cause).isInstanceOf(ProviderException::class.java); assertThat(error.cause.message).isEqualTo("boom"); assertThat(sink.events).contains("observation.provider-failure", "observation.complete:null")
+        }
+    }
+
+    @Test fun `failed stream does not persist memory`() {
+        runBlocking {
+        val provider = RecordingProvider("p") { flow { emit(StreamChunk.Error(ProviderException("boom", retryable = false))) } }; val memory = RecordingMemory()
+        coordinator(plan("p" to provider), RecordingOperationObserver(OrderedSink()), memory = memory).execute(request("cid")).toList()
+        assertThat(memory.stored).isEmpty()
+        }
+    }
+
+    @Test fun `cancellation remains primary`() {
+        runBlocking {
+        val sink = OrderedSink(); val entered = CompletableDeferred<Unit>(); val provider = RecordingProvider("p") { flow { entered.complete(Unit); awaitCancellation() } }; val observer = RecordingOperationObserver(sink)
+        val c = coordinator(plan("p" to provider), observer); val collector = async { c.execute(request()).toList() }; entered.await(); collector.cancel(); runCatching { collector.await() }
+        // Cancellation stays a cancellation: the observation is never completed
+        // and the bridge terminates without emitting chunks. The exact
+        // onCallCancelled event is timing-dependent (depends on where the
+        // cancellation lands in the bridge), so assert the deterministic state.
+        assertThat(observer.observations.single().completions).isEmpty()
+        assertThat(collector.isCancelled).isTrue()
+        }
+    }
+
+    @Test fun `no available route raises configuration error when model has no provider`() {
+        runBlocking {
+        assertThatThrownBy { runBlocking { coordinator(ProviderRoutingPlan.builder().build(), RecordingOperationObserver(OrderedSink())).execute(request()).toList() } }
+            .isInstanceOf(dev.tramai.core.exception.ConfigurationException::class.java)
+            .hasMessageContaining("No provider is registered for model 'logical-model'")
+        }
+    }
+
+    @Test fun `memory messages are injected and persisted without history`() {
+        runBlocking {
+        val history = listOf(Message(MessageRole.USER, "old")); val memory = RecordingMemory().also { it.history = history }; val provider = RecordingProvider("p") { flow { emit(StreamChunk.Complete("ok")) } }
+        coordinator(plan("p" to provider), RecordingOperationObserver(OrderedSink()), memory = memory).execute(request("cid")).toList()
+        assertThat(provider.streamRequests.single().messages.take(history.size)).isEqualTo(history)
+        val stored = memory.stored.single().second
+        // history prefix is dropped on persist; the accumulated assistant response is stored
+        assertThat(stored.map { it.content }).doesNotContain("old").contains("ok")
+        assertThat(stored.last().role).isEqualTo(MessageRole.ASSISTANT)
+        assertThat(stored.last().content).isEqualTo("ok")
+        }
+    }
+}


### PR DESCRIPTION
## refactor(engine): extract streaming execution coordinator — Epic 3.6c

Pure extraction — zero behavior change. `TramaiInvocationHandler` no longer owns the streaming algorithm; `StreamingExecutionCoordinator` (new `dev.tramai.engine.streaming` package) does.

### What moved

- `executeStreaming` → `StreamingExecutionCoordinator.execute(StreamingExecutionRequest)`
- `executeStreamingRoute`, `collectStreamingRoute`, `collectStreamingRouteChunks`, `handleStreamingChunk`, `handleStreamingComplete`, `handleStreamingTerminationWithoutTerminalChunk`
- `StreamingRouteResult` (sealed), `StreamingRouteFinished`, `StreamingExecutionRoute`, `StreamingRouteCall`, `StreamingRouteContext`
- Fallback/circuit helpers: `handleCircuitBreakerOpenRoute`, `enforceStreamingFallbackAfterFailure`, `handleFallbackResult`, `recordCircuitBreakerFailure`, `recordStartupRetryEvent`, `noAvailableStreamingRouteChunk`, `shouldFallbackFrom`, `normalizeStreamingError`
- Streaming-only constants (`tramai.route.selected`, `tramai.circuit.opened`, `tramai.streaming.startup_retry`, ATTR_*)

### Seams (reuse, not duplication)

- `ProviderResolutionGate` / `ProviderInvocationGate` / `ProviderFallbackGate` — hoisted to shared vals, **same instances** now feed both `ProviderExecutionCoordinator` and `StreamingExecutionCoordinator`
- New narrow `StreamingBeforeResponseReturnGate` fun interface (only new type)
- `startObservation` was streaming-only → moved in; observation built via `operationObserver` + `serviceTypeName`
- Streaming path uses `routingPlan`/`circuitBreaker`/`conversationMemoryCoordinator`/`tokenBudgetCoordinator`/`toolExposureCoordinator`/`modelRegistryEnforcer` directly — no new provider abstraction, no generic InvocationContext (deferred to #240)

### What was NOT touched (master is the authority, not the pre-#236 brief)

- Memory prep stays at **Flow construction** time (current behavior since #236); no per-chunk policy/budget validation added (none exists on master); no in-route retry loop added (only route fallback exists); `StreamChunk` has no ToolCall variant (no streaming tool-call handling exists). Cancellation bridge (`Channel(RENDEZVOUS)` + `lifecycleScope.launch` + `invokeOnCompletion` close) preserved byte-for-byte.

### Verification (all green, Java 21 local)

| Gate | Result |
|---|---|
| `:tramai-engine:test` (full, incl. 6/6 characterization streaming scenarios) | ✅ |
| `:tramai-engine:apiCheck` | ✅ zero diff |
| `verifyCancellationSafety` | ✅ 295 current / 294 base, **no new critical/high, no risk worsening** |
| `verifyChangePolicy -PchangeClass=runtime-behaviour` | ✅ 4 files |
| New `StreamingExecutionCoordinatorTest` | ✅ **19/19** (recording doubles + OrderedSink, mutation-sensitive sequences) |
| `grep TramaiInvocationHandler → streaming/` | ✅ no matches |

### Notes

- 294 → 295 cancellation findings: the moved broad `Throwable` catch is now a new file/function site; the scanner requires `rethrowIfCancellation()` there (added) and the comparator reports no new critical/high or worsenings.
- Characterization traces (`streaming.trace`, `streaming-failure.trace`, all 20) byte-identical — scenarios 15–20 unchanged.
