### PR TITLE
ci: contain test-concurrency flakes — step timeouts, thread dumps, no double test run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,50 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Print revision fingerprints
+        run: |
+          echo "HEAD=$(git rev-parse HEAD)"
+          echo "TramaiEngine.kt sha256=$(sha256sum tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt | cut -d' ' -f1)"
+          echo "TramaiEngineTest.kt sha256=$(sha256sum tramai-engine/src/test/kotlin/dev/tramai/engine/TramaiEngineTest.kt | cut -d' ' -f1)"
+
       - name: Run tests
-        run: ./gradlew test
+        timeout-minutes: 15
+        run: |
+          ./gradlew test &
+          GRADLE_PID=$!
+          DUMP_DIR=/tmp/threaddumps
+          mkdir -p "$DUMP_DIR"
+          # Containment watchdog: if tests exceed ~12 min, dump worker threads and
+          # fail fast instead of letting a concurrency flake hold the pipeline
+          # hostage for the full timeout.
+          for i in $(seq 1 18); do
+            if ! kill -0 "$GRADLE_PID" 2>/dev/null; then break; fi
+            sleep 40
+          done
+          if kill -0 "$GRADLE_PID" 2>/dev/null; then
+            echo "::error::Run tests exceeded 12 minutes — dumping threads and aborting"
+            for P in $(jps -l 2>/dev/null | grep -iE 'GradleWorkerMain|GradleDaemon' | awk '{print $1}'); do
+              jstack "$P" > "$DUMP_DIR/worker-$P-$(date +%H%M%S).txt" 2>&1 || true
+            done
+            kill "$GRADLE_PID" 2>/dev/null || true
+            wait "$GRADLE_PID" 2>/dev/null || true
+            exit 1
+          fi
+          wait "$GRADLE_PID"
+
+      - name: Upload test hang thread dumps
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-hang-threaddumps
+          path: /tmp/threaddumps/
+          if-no-files-found: warn
+
+      - name: Print compiled fingerprints
+        run: |
+          find tramai-engine/build -name 'TramaiEngine*.class' 2>/dev/null | sort | while read -r f; do
+            echo "$(sha256sum "$f" | cut -d' ' -f1)  ${f#tramai-engine/build/}"
+          done
 
       - name: Verify cancellation safety against PR base
         if: github.event_name == 'pull_request'
@@ -90,8 +132,12 @@ jobs:
         run: ./gradlew :examples:spring-sovereign-starter:e2eTest
 
       - name: Verify Sovereign Runtime closure
-        timeout-minutes: 30
-        run: ./gradlew verifySovereignRuntimeClosure --no-configuration-cache --rerun-tasks -PtramaiPublishReleaseUrl=
+        timeout-minutes: 15
+        # No --rerun-tasks: the normal test phase already ran the full suite.
+        # Rerunning here doubles the exposure to probabilistic concurrency flakes
+        # (observed: JdbcStepAttemptRecordStoreContractTest #19 failed only in
+        # the closure re-run, with the same head passing the initial Run tests).
+        run: ./gradlew verifySovereignRuntimeClosure --no-configuration-cache -PtramaiPublishReleaseUrl=
 
       - name: Upload SBOM
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
# CI containment: stop test-concurrency flakes from holding the pipeline hostage

## Problem

Two probabilistic cancellation-sensitive tests have repeatedly hung/failed the build
job for 90+ minutes (worst: 2h19m) across #235/#236/#239/#240:

- `TramaiEngineTest."close racing a fast suspend invocation..."` — hang (lost resume; under investigation as a suspend-ABI race, PR #240 adds a 30s JUnit timeout)
- `JdbcStepAttemptRecordStoreContractTest #19 "cancellation does not partially replace a record"` — failed in #240's run **only in the Verify Sovereign Runtime closure re-run**, same head passed the initial Run tests

The workflow made it worse by running `verifySovereignRuntimeClosure --rerun-tasks`,
which re-executes the ENTIRE test suite a second time after the normal Run tests phase —
doubling every flake's exposure on every PR.

## Changes (ci.yml only)

1. **Print revision fingerprints** — HEAD + sha256 of TramaiEngine.kt / TramaiEngineTest.kt
   at step start, and compiled `TramaiEngine*.class` hashes after tests. Definitively
   closes the "CI ran stale source/class files" hypothesis (Codex's suggestion).
2. **Run tests: 15-min step timeout + 12-min thread-dump watchdog** — if tests exceed
   ~12 min, jstack every Gradle worker/daemon, upload as `test-hang-threaddumps`
   artifact, fail fast. A flake now costs minutes, not 90+.
3. **Upload test hang thread dumps** — `if: always()`; empty dir just warns.
4. **Verify Sovereign Runtime closure: no `--rerun-tasks`, timeout 30→15** — the normal
   test phase already ran the full suite; the closure's `check`/`verifySovereignRuntimeReleaseCandidate`
   deps resolve to UP-TO-DATE instead of re-running every test. Halves flake exposure.
   (The separate `sovereign-runtime-release-candidate.yml` validate job keeps its
   `--rerun-tasks`: it's an independent job with no prior test run, so removing it there
   would skip tests via restored build-cache outputs.)

## Verification

- YAML parse OK
- All changes are workflow-only (`.github/AGENTS.md` rule 5: tested independently of runtime changes)
- No production code touched

## Out of scope

The actual suspend-ABI fix (if confirmed) and the `JdbcStepAttemptRecordStoreContractTest`
flake — separate PRs. This PR only stops the 60–90 minute feedback loop.
