### PR TITLE
test(engine): surface close() failure as independent channel from invocation outcome

### DIFF
--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/TramaiEngineTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/TramaiEngineTest.kt
@@ -187,6 +187,7 @@ class TramaiEngineTest {
             val engine = TramaiEngine(provider)
             val service = engine.create<SuspendAnalyzer>()
             val closeCompletedAt = java.util.concurrent.atomic.AtomicLong(-1)
+            val closeFailure = java.util.concurrent.atomic.AtomicReference<Throwable?>(null)
             val closeDone = CompletableDeferred<Unit>()
             val outcome = CompletableDeferred<Throwable?>()
             // Close immediately while the invocation is launched: either the
@@ -198,9 +199,11 @@ class TramaiEngineTest {
                     engine.close()
                     closeCompletedAt.set(System.nanoTime())
                 } catch (t: Throwable) {
-                    // Never let close() die silently in the thread: surface it
-                    // as the terminal outcome so the test fails with the cause.
-                    outcome.complete(t)
+                    // Record ONLY in closeFailure. The close outcome is an
+                    // independent channel from the invocation outcome: an
+                    // accepted invocation result (CE/ISE) must never mask a
+                    // close() failure.
+                    closeFailure.set(t)
                 } finally {
                     closeDone.complete(Unit)
                 }
@@ -217,6 +220,12 @@ class TramaiEngineTest {
             // there would deadlock against close() joining that same job.
             closeDone.await()
             closer.join()
+            // Invocation outcome and close outcome are independent channels.
+            // close() throwing is a production defect regardless of what the
+            // invocation did; surface it with the original cause/stack trace.
+            closeFailure.get()?.let { failure ->
+                throw AssertionError("iteration $it: engine.close() threw", failure)
+            }
             val terminal = outcome.await()
             val providerStarted = providerStartedAt.get()
             val closeCompleted = closeCompletedAt.get()


### PR DESCRIPTION
test(engine): surface close() failure as independent channel from invocation outcome

## What this fixes

The close-race test (`TramaiEngineTest.close racing a fast suspend
invocation never leaves work against a closed engine`) failed on CI
with an opaque assertion:

```
Expecting actual:
  186454564683L
to be less than:
  -1L
```

Decoded: the invocation **succeeded** (`terminal == null`), but
`closeCompletedAt` was **never set** — `engine.close()` **threw** in
the closer thread. Behavioral H1 confirmed: close() has thrown at
least once during this race. The production defect is not yet
diagnosable because the throwable was lost.

## The change

Make the close outcome a fully independent channel from the
invocation outcome:

- The closer records close() failures **only** in a dedicated
  `closeFailure` field (removed the previous `outcome.complete(t)` —
  it raced with the invocation completing and lost, and an accepted
  invocation result (CE/ISE) would have entered the else branch and
  masked the close failure entirely).
- After `closeDone.await()` + `closer.join()`, check `closeFailure`
  **unconditionally** and throw `AssertionError(..., cause)` so the
  original throwable and its full stack trace are preserved.
- `invocationOutcome` (success / ISE / CE) and `closeOutcome`
  (returned / threw) are never combined.

Test-only instrumentation. On the next H1 occurrence this produces
the exact exception + stack needed to narrow the fault surface in
close() — the diagnostic's entire purpose.

## Verification

- Close-race test passes locally (49s)
- Full gate green: engine tests + apiCheck + verifyCancellationSafety
  (295 findings, 0 new critical/high) + verifyChangePolicy
  (runtime-behaviour)