### PR TITLE
fix(engine): synchronize invocation-registry removal with close() snapshot

### DIFF
--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -1008,7 +1008,16 @@ internal class TramaiInvocationHandler(
             job
         }
         launched.invokeOnCompletion { cause ->
-            activeInvocationJobs -= launched
+            // Registry mutations obey the same monitor: launch+add (above) and
+            // close()'s snapshot (in close()) are synchronized on
+            // activeInvocationJobs, so removal must be too. An unsynchronized
+            // removal can race Kotlin's toList() size-1 fast path inside the
+            // snapshot (size()==1, then remove, then iterator().next() throws
+            // NoSuchElementException), making close() throw and the closer
+            // thread die silently — the original CI hang.
+            synchronized(activeInvocationJobs) {
+                activeInvocationJobs -= launched
+            }
             if (resumed.get() == null) {
                 // Block never ran (e.g. cancelled before the dispatcher started
                 // it): resume so the caller's suspension does not freeze.

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/InvocationRegistryLockTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/InvocationRegistryLockTest.kt
@@ -1,0 +1,103 @@
+package dev.tramai.engine
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.provider.ModelProvider
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Regression for the invocation-registry lock protocol.
+ *
+ * Production invariant: every mutation of [TramaiEngine]'s
+ * `activeInvocationJobs` registry — launch+add (in invokeSuspend), snapshot
+ * (in close()), and completion removal (in invokeOnCompletion) — participates
+ * in the same monitor (`synchronized(activeInvocationJobs)`).
+ *
+ * When removal was unsynchronized, close() could throw
+ * NoSuchElementException: Kotlin's `toList()` size-1 fast path reads
+ * `size()==1`, a concurrent completion removed the job, then
+ * `iterator().next()` hit an empty map. close() throwing killed the closer
+ * thread silently, which hung the close-race test for 60–90 minutes on CI.
+ *
+ * This test fails if the removal is changed back to unsynchronized.
+ */
+class InvocationRegistryLockTest {
+    @Test
+    @Timeout(value = 30, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+    fun `completion removal participates in the registry lock`() = runBlocking {
+        val gate = CompletableDeferred<Unit>()
+        val providerCalls = AtomicInteger()
+        val provider = object : ModelProvider {
+            override suspend fun complete(request: ModelRequest): ModelResponse {
+                providerCalls.incrementAndGet()
+                gate.await()
+                return ModelResponse(content = "ok")
+            }
+        }
+        val engine = TramaiEngine(provider)
+        val service = engine.create<HandshakeService>()
+        val invocation = async(Dispatchers.Default) { runCatching { service.answer() } }
+
+        val registry = activeInvocationJobsOf(engine)
+        awaitUntil(10, TimeUnit.SECONDS) { registry.size == 1 }
+        val tracked = registry.first()
+
+        // Hold the registry monitor, THEN release the provider. The invocation
+        // completes on a Default worker; its invokeOnCompletion removal must
+        // block on the monitor we hold. If removal were unsynchronized, it
+        // would run immediately and the registry would already be empty.
+        synchronized(registry) {
+            gate.complete(Unit)
+            awaitUntil(10, TimeUnit.SECONDS) { tracked.isCompleted }
+            // Give the completing worker time to attempt the removal while we
+            // still hold the monitor: with the fix it stays blocked here for
+            // the whole window; without it the registry empties immediately.
+            val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(200)
+            while (System.nanoTime() < deadline) {
+                Thread.yield()
+            }
+            assertThat(registry)
+                .describedAs("completion removal must wait for the registry monitor held by close()'s snapshot")
+                .contains(tracked)
+        }
+
+        // Monitor released: the blocked removal completes.
+        awaitUntil(10, TimeUnit.SECONDS) { registry.isEmpty() }
+
+        assertThat(providerCalls.get()).isEqualTo(1)
+        assertThat(invocation.await().exceptionOrNull()).isNull()
+        engine.close()
+    }
+
+    private fun awaitUntil(timeout: Long, unit: TimeUnit, condition: () -> Boolean) {
+        val deadline = System.nanoTime() + unit.toNanos(timeout)
+        while (!condition()) {
+            check(System.nanoTime() < deadline) { "condition not met within ${unit.toSeconds(timeout)}s" }
+            Thread.yield()
+        }
+    }
+
+    private fun activeInvocationJobsOf(engine: TramaiEngine): MutableSet<Job> {
+        val field = TramaiEngine::class.java.getDeclaredField("activeInvocationJobs")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        return field.get(engine) as MutableSet<Job>
+    }
+}
+
+@AiService
+private interface HandshakeService {
+    @Operation(prompt = "Answer", model = "test-model")
+    suspend fun answer(): String
+}


### PR DESCRIPTION
fix(engine): synchronize invocation-registry removal with close() snapshot

## Root cause (the original CI hang, finally proven)

The recurring 60–90 minute CI deadlock in
`TramaiEngineTest.close racing a fast suspend invocation never leaves
work against a closed engine` was close() **throwing**, not a lost
coroutine resume.

Captured live with the #243 diagnostic (iteration 7):

```
java.lang.AssertionError: iteration 7: engine.close() threw
Caused by: java.util.NoSuchElementException
    at ConcurrentHashMap$KeyIterator.next(ConcurrentHashMap.java:3460)
    at kotlin.collections.CollectionsKt___CollectionsKt.toList(_Collections.kt:1346)
    at dev.tramai.engine.TramaiEngine.close(TramaiEngine.kt:621)
```

`close()` snapshots the invocation registry under
`synchronized(activeInvocationJobs) { activeInvocationJobs.toList() }`,
and launch+add in `invokeSuspend` is synchronized the same way — but the
completion removal in `invokeOnCompletion` was **not** synchronized.

Kotlin's `toList()` has a size-1 fast path: `size()==1` →
`iterator().next()` with no `hasNext()` check. The race:

```
close thread                    completion thread
synchronized(set) {
  toList()
    reads size == 1
                                set.remove(job)   // unsynchronized
    iterator().next()
    → empty map → NoSuchElementException
}
```

close() threw; the pre-#240 closer thread died silently; the test hung
at `closeDone.await()` forever. This is the rare, timing-dependent
defect behind all the CI hangs.

## The fix

All registry mutations obey the same monitor:

```kotlin
launched.invokeOnCompletion { cause ->
    synchronized(activeInvocationJobs) {
        activeInvocationJobs -= launched
    }
    ...
}
```

One-line synchronization of the missing mutation. No snapshot-algorithm
change needed — the intended invariant (registration/snapshot
synchronized) was already documented; removal simply wasn't participating.

## Regression

`InvocationRegistryLockTest` manufactures the race deterministically:
holds the registry monitor while completing an invocation on a Default
worker, then asserts the removal **blocks** on the monitor. Verified by
mutation: with the removal temporarily made unsynchronized, the test
fails.

## Verification

- `:tramai-engine:test` — full suite green (incl. new regression +
  close-race test)
- `verifyCancellationSafety` vs origin/master — PASSED, 0 new
  critical/high findings
- `:tramai-engine:apiCheck` — clean (no public API change)
- `verifyChangePolicy -PchangeClass=runtime-behaviour` — PASSED
