### PR TITLE
refactor(workflow): introduce polymorphic step execution — Epic 4.1

### DIFF
--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -736,30 +736,45 @@ claimed-resume approval execution all live in dedicated coordinators under
 
 ## Epic 4.1: Replace concrete-type central dispatch
 
+**Status:** ✅ COMPLETE — PR #246 (2026-08-18, open at writing; expected merge squash).
+
 **Goal:** Make workflow steps polymorphic through a shared execution request and result contract.
 
-### Proposed contract
+### Delivered contract
 
 ```kotlin
-internal interface InternalWorkflowStep<S> {
+internal sealed interface InternalWorkflowStep<S> {
     val name: String
+    val suspensionMode: WorkflowStepSuspensionMode   // NONE | TOP_LEVEL_CHECKPOINT
     suspend fun execute(request: WorkflowStepExecutionRequest<S>): WorkflowStepExecutionResult<S>
 }
 ```
 
+- `Workflow.executeStep()` is now the common wrapper only: step budget → onStepStarted → `step.execute(request)` → cancellation rethrow → sanitisation → onStepFailed/onStepCompleted. The 12-arm concrete `when` is gone.
+- Runtime collaborators are grouped in `WorkflowStepExecutionServices`; nested steps re-enter the wrapper via the `executeNestedSteps` callback (same context/observer/counter, `persistenceSession = null`, `topLevelStepIndex = null`, no inherited resume metadata).
+- Suspension is explicit via `suspensionMode`; only `DelayWorkflowStep` is `TOP_LEVEL_CHECKPOINT`.
+- Nested checkpoint-suspending steps are rejected at `build()` (previously a runtime error).
+- Hardened HTTP/Shell/Hermes/Codex/MCP execution algorithms untouched — thin contract adapters only.
+
 ### Tasks
 
-1. Move each built-in step's execution behind the step contract or a registered executor.
-2. Remove the growing central `when` over concrete step types.
-3. Keep common observation, step counting, persistence, and error handling in one wrapper.
-4. Define which step types can suspend and checkpoint.
-5. Define nested-step suspension semantics explicitly.
+1. ✅ Each built-in step executes through the step contract.
+2. ✅ Central `when` over concrete step types removed from runtime execution.
+3. ✅ Observation, step counting, persistence, and error handling remain in one wrapper.
+4. ✅ `WorkflowStepSuspensionMode` models which steps can suspend/checkpoint.
+5. ✅ Nested suspension semantics explicit + build-time validation.
 
 ### Acceptance criteria
 
-- Adding a new built-in step does not require editing a central type-dispatch list.
-- Shared execution rules remain consistent across all steps.
-- Unsupported nested suspension fails at validation time where possible.
+- ✅ Adding a new built-in step does not require editing a central type-dispatch list.
+- ✅ Shared execution rules remain consistent across all steps.
+- ✅ Unsupported nested suspension fails at validation time.
+
+### Non-goals (deferred to #247+)
+
+- Splitting `Workflow.kt` into runner/builder/step-executor files (Epic 4.2).
+- Concrete dispatch in replay descriptors / canonical rendering / static validation (definition-level, deliberately untouched).
+- Worker bindings, replay/retry semantics, public plugin API.
 
 ---
 

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/CodexStep.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/CodexStep.kt
@@ -39,6 +39,18 @@ internal data class CodexWorkflowStep<S>(
     val merge: suspend (S, String, WorkflowContext) -> S,
     val config: CodexStepConfig = CodexStepConfig(),
 ) : InternalWorkflowStep<S> {
+    override suspend fun execute(
+        request: WorkflowStepExecutionRequest<S>,
+    ): WorkflowStepExecutionResult<S> = WorkflowStepExecutionResult.Completed(
+        execute(
+            workflowName = request.workflowName,
+            state = request.state,
+            context = request.context,
+            observer = request.observer,
+            failureDiagnosticObserver = request.services.failureDiagnosticObserver,
+        ),
+    )
+
     suspend fun execute(
         workflowName: String,
         state: S,

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/HermesStep.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/HermesStep.kt
@@ -38,6 +38,18 @@ internal data class HermesWorkflowStep<S>(
     val merge: suspend (S, String, WorkflowContext) -> S,
     val config: HermesStepConfig = HermesStepConfig(),
 ) : InternalWorkflowStep<S> {
+    override suspend fun execute(
+        request: WorkflowStepExecutionRequest<S>,
+    ): WorkflowStepExecutionResult<S> = WorkflowStepExecutionResult.Completed(
+        execute(
+            workflowName = request.workflowName,
+            state = request.state,
+            context = request.context,
+            observer = request.observer,
+            failureDiagnosticObserver = request.services.failureDiagnosticObserver,
+        ),
+    )
+
     suspend fun execute(
         workflowName: String,
         state: S,

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/HttpStep.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/HttpStep.kt
@@ -122,6 +122,20 @@ internal data class HttpWorkflowStep<S>(
     val config: HttpStepConfig = HttpStepConfig(),
     val blockingDispatcher: CoroutineContext = Dispatchers.IO,
 ) : InternalWorkflowStep<S> {
+    override suspend fun execute(
+        request: WorkflowStepExecutionRequest<S>,
+    ): WorkflowStepExecutionResult<S> = WorkflowStepExecutionResult.Completed(
+        execute(
+            workflowName = request.workflowName,
+            state = request.state,
+            context = request.context,
+            observer = request.observer,
+            transport = request.services.httpTransport,
+            policy = request.services.outboundNetworkPolicy,
+            failureDiagnosticObserver = request.services.failureDiagnosticObserver,
+        ),
+    )
+
     suspend fun execute(
         workflowName: String,
         state: S,

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/McpStep.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/McpStep.kt
@@ -217,6 +217,18 @@ internal data class McpWorkflowStep<S>(
     val config: McpStepConfig = McpStepConfig(),
     val transportProvider: McpTransportProvider = SubprocessMcpTransportProvider(),
 ) : InternalWorkflowStep<S> {
+    override suspend fun execute(
+        request: WorkflowStepExecutionRequest<S>,
+    ): WorkflowStepExecutionResult<S> = WorkflowStepExecutionResult.Completed(
+        execute(
+            workflowName = request.workflowName,
+            state = request.state,
+            context = request.context,
+            observer = request.observer,
+            failureDiagnosticObserver = request.services.failureDiagnosticObserver,
+        ),
+    )
+
     internal fun validateStaticCommandPolicy(workflowName: String) {
         val commandIdentifiers = definition.serverCommand.commandIdentifiers()
         val allowedCommands = config.allowedCommands

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/ShellStep.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/ShellStep.kt
@@ -96,6 +96,17 @@ internal data class ShellWorkflowStep<S>(
     val config: ShellStepConfig = ShellStepConfig(),
     val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : InternalWorkflowStep<S> {
+    override suspend fun execute(
+        request: WorkflowStepExecutionRequest<S>,
+    ): WorkflowStepExecutionResult<S> = WorkflowStepExecutionResult.Completed(
+        execute(
+            workflowName = request.workflowName,
+            state = request.state,
+            context = request.context,
+            observer = request.observer,
+            failureDiagnosticObserver = request.services.failureDiagnosticObserver,
+        ),
+    )
 
     suspend fun execute(
         workflowName: String,

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/Workflow.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/Workflow.kt
@@ -406,22 +406,33 @@ class Workflow<S, R> internal constructor(
         resumedCheckpointMetadata: Map<String, String>?,
     ): S {
         var currentState = state
+        val services = executionServices()
         for (index in startIndex until steps.size) {
             val step = steps[index]
-            when (val result = executeStep(
-                StepExecutionRequest(
-                    step = step,
-                    state = currentState,
-                    context = context,
-                    observer = observer,
-                    stepCounter = stepCounter,
-                    persistenceSession = persistenceSession,
-                    topLevelStepIndex = index,
-                    resumedCheckpointMetadata = if (index == startIndex) resumedCheckpointMetadata else null,
-                ),
-            )) {
-                is StepExecutionResult.Completed -> currentState = result.state
-                StepExecutionResult.Suspended -> throw WorkflowSuspendedException(
+            val request = WorkflowStepExecutionRequest(
+                workflowName = name,
+                state = currentState,
+                context = context,
+                observer = observer,
+                stepCounter = stepCounter,
+                persistenceSession = persistenceSession,
+                topLevelStepIndex = index,
+                resumedCheckpointMetadata = if (index == startIndex) resumedCheckpointMetadata else null,
+                services = services,
+                executeNestedSteps = { nestedSteps, nestedState ->
+                    executeSteps(
+                        steps = nestedSteps,
+                        state = nestedState,
+                        context = context,
+                        observer = observer,
+                        stepCounter = stepCounter,
+                        services = services,
+                    )
+                },
+            )
+            when (val result = executeStep(step, request)) {
+                is WorkflowStepExecutionResult.Completed -> currentState = result.state
+                WorkflowStepExecutionResult.Suspended -> throw WorkflowSuspendedException(
                     "Workflow '$name' suspended at step '${step.name}' for workflowId='${context.workflowId}'",
                 )
             }
@@ -440,132 +451,66 @@ class Workflow<S, R> internal constructor(
         context: WorkflowContext,
         observer: WorkflowObserver,
         stepCounter: StepCounter,
+        services: WorkflowStepExecutionServices,
     ): S {
         var currentState = state
         for (step in steps) {
-            when (val result = executeStep(
-                StepExecutionRequest(
-                    step = step,
-                    state = currentState,
-                    context = context,
-                    observer = observer,
-                    stepCounter = stepCounter,
-                    persistenceSession = null,
-                    topLevelStepIndex = null,
-                    resumedCheckpointMetadata = null,
-                ),
-            )) {
-                is StepExecutionResult.Completed -> currentState = result.state
-                StepExecutionResult.Suspended -> throw WorkflowSuspendedException(
+            val request = WorkflowStepExecutionRequest(
+                workflowName = name,
+                state = currentState,
+                context = context,
+                observer = observer,
+                stepCounter = stepCounter,
+                persistenceSession = null,
+                topLevelStepIndex = null,
+                resumedCheckpointMetadata = null,
+                services = services,
+                executeNestedSteps = { nestedSteps, nestedState ->
+                    executeSteps(
+                        steps = nestedSteps,
+                        state = nestedState,
+                        context = context,
+                        observer = observer,
+                        stepCounter = stepCounter,
+                        services = services,
+                    )
+                },
+            )
+            when (val result = executeStep(step, request)) {
+                is WorkflowStepExecutionResult.Completed -> currentState = result.state
+                WorkflowStepExecutionResult.Suspended -> throw WorkflowSuspendedException(
                     "Workflow '$name' suspended at nested step '${step.name}', but nested delay checkpointing is not supported",
                 )
             }
         }
         return currentState
     }
-    private suspend fun executeStep(request: StepExecutionRequest<S>): StepExecutionResult<S> {
-        val step = request.step
-        val state = request.state
-        val context = request.context
-        val observer = request.observer
-        val stepCounter = request.stepCounter
-        stepCounter.beforeStep(name, step.name)
-        observer.onStepStarted(name, step.name, context)
-        val nextState = try {
-            when (step) {
-                is LocalWorkflowStep -> step.transform(state, context)
-                is AiWorkflowStep<S, *, *> -> step.execute(state, context)
-                is HttpWorkflowStep<S> -> step.execute(
-                    workflowName = name,
-                    state = state,
-                    context = context,
-                    observer = observer,
-                    transport = httpTransport ?: JdkHttpTransport(httpClient),
-                    policy = outboundNetworkPolicy,
-                    failureDiagnosticObserver = failureDiagnosticObserver,
-                )
-                is ShellWorkflowStep<S> -> step.execute(
-                    workflowName = name,
-                    state = state,
-                    context = context,
-                    observer = observer, failureDiagnosticObserver = failureDiagnosticObserver,
-                )
-                is HermesWorkflowStep<S> -> step.execute(
-                    workflowName = name,
-                    state = state,
-                    context = context,
-                    observer = observer, failureDiagnosticObserver = failureDiagnosticObserver,
-                )
-                is CodexWorkflowStep<S> -> step.execute(
-                    workflowName = name,
-                    state = state,
-                    context = context,
-                    observer = observer, failureDiagnosticObserver = failureDiagnosticObserver,
-                )
-                is McpWorkflowStep<S> -> step.execute(
-                    workflowName = name,
-                    state = state,
-                    context = context,
-                    observer = observer, failureDiagnosticObserver = failureDiagnosticObserver,
-                )
-                is PluginWorkflowStep<S> -> step.execute(
-                    workflowName = name,
-                    state = state,
-                    context = context,
-                    executorResolver = externalStepExecutorResolver,
-                )
-                is GateWorkflowStep -> step.execute(state, context)
-                is DelayWorkflowStep -> {
-                    val result = step.execute(
-                        DelayExecutionRequest(
-                            workflowName = name,
-                            state = state,
-                            context = context,
-                            observer = observer,
-                            persistenceSession = request.persistenceSession,
-                            topLevelStepIndex = request.topLevelStepIndex,
-                            stepExecutions = stepCounter.stepExecutions,
-                            resumedCheckpointMetadata = request.resumedCheckpointMetadata,
-                            clock = clock,
-                        ),
-                    )
-                    if (result == DelayExecutionResult.Suspended) {
-                        return StepExecutionResult.Suspended
-                    }
-                    state
-                }
-                is BranchWorkflowStep -> {
-                    val branchKey = step.select(state)
-                    val branchSteps = step.branches[branchKey] ?: step.defaultSteps
-                    if (branchSteps == null) {
-                        throw WorkflowBranchSelectionException(
-                            "Workflow '$name' selected unknown branch '$branchKey' at step '${step.name}'",
-                        )
-                    }
-                    executeSteps(
-                        steps = branchSteps,
-                        state = state,
-                        context = context,
-                        observer = observer,
-                        stepCounter = stepCounter,
-                    )
-                }
-                is ParallelWorkflowStep<S, *, *> -> step.execute(
-                    workflowName = name,
-                    state = state,
-                    context = context,
-                    observer = observer,
-                    stepCounter = stepCounter,
-                )
-            }
+    private suspend fun executeStep(
+        step: InternalWorkflowStep<S>,
+        request: WorkflowStepExecutionRequest<S>,
+    ): WorkflowStepExecutionResult<S> {
+        request.stepCounter.beforeStep(name, step.name)
+        request.observer.onStepStarted(name, step.name, request.context)
+        val result = try {
+            step.execute(request)
         } catch (error: Throwable) {
             error.rethrowIfCancellation()
             val sanitized = sanitizeStepFailure(step, name, failureDiagnosticObserver, error)
-            observer.onStepFailed(name, step.name, sanitized, context); throw sanitized
+            request.observer.onStepFailed(name, step.name, sanitized, request.context)
+            throw sanitized
         }
-        observer.onStepCompleted(name, step.name, context)
-        return StepExecutionResult.Completed(nextState)
+        if (result is WorkflowStepExecutionResult.Completed) {
+            request.observer.onStepCompleted(name, step.name, request.context)
+        }
+        return result
     }
+    private fun executionServices(): WorkflowStepExecutionServices = WorkflowStepExecutionServices(
+        clock = clock,
+        httpTransport = httpTransport ?: JdkHttpTransport(httpClient),
+        outboundNetworkPolicy = outboundNetworkPolicy,
+        externalStepExecutorResolver = externalStepExecutorResolver,
+        failureDiagnosticObserver = failureDiagnosticObserver,
+    )
 }
 class WorkflowBuilder<S> constructor(
     private val workflowName: String,
@@ -953,13 +898,16 @@ class BranchBuilder<S> {
 }
 class BranchWorkflowBuilder<S> : AbstractWorkflowBuilder<S>() {
 }
-internal sealed interface InternalWorkflowStep<S> {
-    val name: String
-}
 private data class LocalWorkflowStep<S>(
     override val name: String,
     val transform: suspend (S, WorkflowContext) -> S,
-) : InternalWorkflowStep<S>
+) : InternalWorkflowStep<S> {
+    override suspend fun execute(
+        request: WorkflowStepExecutionRequest<S>,
+    ): WorkflowStepExecutionResult<S> = WorkflowStepExecutionResult.Completed(
+        transform(request.state, request.context),
+    )
+}
 private data class AiWorkflowStep<S, I, O>(
     override val name: String,
     val replayDescriptor: (S, WorkflowContext) -> WorkflowStepReplayDescriptor,
@@ -971,6 +919,12 @@ private data class AiWorkflowStep<S, I, O>(
         state: S,
         context: WorkflowContext,
     ): S = merge(state, invoke(input(state, context), context), context)
+
+    override suspend fun execute(
+        request: WorkflowStepExecutionRequest<S>,
+    ): WorkflowStepExecutionResult<S> = WorkflowStepExecutionResult.Completed(
+        execute(request.state, request.context),
+    )
 }
 
 private fun validateAiReplayPolicy(
@@ -1017,17 +971,16 @@ private data class GateWorkflowStep<S>(
     override val name: String,
     val decide: suspend (S, WorkflowContext) -> GateDecision,
 ) : InternalWorkflowStep<S> {
-    suspend fun execute(
-        state: S,
-        context: WorkflowContext,
-    ): S {
-        val decision = decide(state, context)
+    override suspend fun execute(
+        request: WorkflowStepExecutionRequest<S>,
+    ): WorkflowStepExecutionResult<S> {
+        val decision = decide(request.state, request.context)
         if (!decision.allowed) {
             throw WorkflowGateRejectedException(
                 "Workflow gate '$name' rejected execution: ${decision.reason}",
             )
         }
-        return state
+        return WorkflowStepExecutionResult.Completed(request.state)
     }
 }
 private data class PluginWorkflowStep<S>(
@@ -1048,17 +1001,33 @@ private data class PluginWorkflowStep<S>(
         val result = executorResolver.create(type).execute(config)
         return merge(state, result, context)
     }
+
+    override suspend fun execute(
+        request: WorkflowStepExecutionRequest<S>,
+    ): WorkflowStepExecutionResult<S> = WorkflowStepExecutionResult.Completed(
+        execute(
+            workflowName = request.workflowName,
+            state = request.state,
+            context = request.context,
+            executorResolver = request.services.externalStepExecutorResolver,
+        ),
+    )
 }
 private data class DelayWorkflowStep<S>(
     override val name: String,
     val duration: Long,
     val unit: TimeUnit,
 ) : InternalWorkflowStep<S> {
-    suspend fun execute(request: DelayExecutionRequest<S>): DelayExecutionResult {
+    override val suspensionMode: WorkflowStepSuspensionMode
+        get() = WorkflowStepSuspensionMode.TOP_LEVEL_CHECKPOINT
+
+    override suspend fun execute(
+        request: WorkflowStepExecutionRequest<S>,
+    ): WorkflowStepExecutionResult<S> {
         val workflowName = request.workflowName
         val context = request.context
         val observer = request.observer
-        val clock = request.clock
+        val clock = request.services.clock
         val now = clock.instant()
         val resumedResumeAt = request.resumedCheckpointMetadata?.delayResumeAt(workflowName, context.workflowId, name)
         val resumeAt = resumedResumeAt ?: now.plusMillis(unit.toMillis(duration))
@@ -1069,7 +1038,7 @@ private data class DelayWorkflowStep<S>(
                 attributes = delayAttributes(context.workflowId, name, resumeAt),
                 context = context,
             )
-            return DelayExecutionResult.Completed
+            return WorkflowStepExecutionResult.Completed(request.state)
         }
         val session = request.persistenceSession
             ?: throw WorkflowResumeException(
@@ -1083,7 +1052,7 @@ private data class DelayWorkflowStep<S>(
             state = request.state,
             nextStepIndex = stepIndex,
             lastCompletedStepName = null,
-            stepExecutions = request.stepExecutions,
+            stepExecutions = request.stepCounter.stepExecutions,
             extraMetadata = delayMetadata(name, resumeAt),
         )
         session.scheduleDelayWakeup(
@@ -1100,7 +1069,7 @@ private data class DelayWorkflowStep<S>(
             attributes = delayAttributes(context.workflowId, name, resumeAt),
             context = context,
         )
-        return DelayExecutionResult.Suspended
+        return WorkflowStepExecutionResult.Suspended
     }
 }
 private data class BranchWorkflowStep<S>(
@@ -1108,7 +1077,20 @@ private data class BranchWorkflowStep<S>(
     val select: (S) -> String,
     val branches: Map<String, List<InternalWorkflowStep<S>>>,
     val defaultSteps: List<InternalWorkflowStep<S>>?,
-) : InternalWorkflowStep<S>
+) : InternalWorkflowStep<S> {
+    override suspend fun execute(
+        request: WorkflowStepExecutionRequest<S>,
+    ): WorkflowStepExecutionResult<S> {
+        val key = select(request.state)
+        val selected = branches[key] ?: defaultSteps
+            ?: throw WorkflowBranchSelectionException(
+                "Workflow '${request.workflowName}' selected unknown branch '$key' at step '${name}'",
+            )
+        return WorkflowStepExecutionResult.Completed(
+            request.executeNestedSteps(selected, request.state),
+        )
+    }
+}
 
 private suspend fun <S> InternalWorkflowStep<S>.replayDescriptor(
     state: S,
@@ -1161,37 +1143,6 @@ private suspend fun <S> HttpWorkflowStep<S>.replayDescriptor(
         else -> WorkflowStepReplayDescriptor(ReplayPolicy.NON_REPLAYABLE)
     }
 }
-private enum class DelayExecutionResult {
-    Completed,
-    Suspended,
-}
-private sealed interface StepExecutionResult<out S> {
-    data class Completed<S>(val state: S) : StepExecutionResult<S>
-    data object Suspended : StepExecutionResult<Nothing>
-}
-
-private data class StepExecutionRequest<S>(
-    val step: InternalWorkflowStep<S>,
-    val state: S,
-    val context: WorkflowContext,
-    val observer: WorkflowObserver,
-    val stepCounter: StepCounter,
-    val persistenceSession: WorkflowPersistenceSession<S>?,
-    val topLevelStepIndex: Int?,
-    val resumedCheckpointMetadata: Map<String, String>?,
-)
-
-private data class DelayExecutionRequest<S>(
-    val workflowName: String,
-    val state: S,
-    val context: WorkflowContext,
-    val observer: WorkflowObserver,
-    val persistenceSession: WorkflowPersistenceSession<S>?,
-    val topLevelStepIndex: Int?,
-    val stepExecutions: Int,
-    val resumedCheckpointMetadata: Map<String, String>?,
-    val clock: Clock,
-)
 
 private data class ParallelWorkflowStep<S, I, O>(
     override val name: String,
@@ -1226,6 +1177,18 @@ private data class ParallelWorkflowStep<S, I, O>(
         }.awaitAll()
         merge(state, results)
     }
+
+    override suspend fun execute(
+        request: WorkflowStepExecutionRequest<S>,
+    ): WorkflowStepExecutionResult<S> = WorkflowStepExecutionResult.Completed(
+        execute(
+            workflowName = request.workflowName,
+            state = request.state,
+            context = request.context,
+            observer = request.observer,
+            stepCounter = request.stepCounter,
+        ),
+    )
 }
 private fun <I> collectPendingItems(
     source: Iterable<I>,
@@ -1241,7 +1204,7 @@ private fun <I> collectPendingItems(
     }
     return if (iterator.hasNext()) null else pending
 }
-private class StepCounter(
+internal class StepCounter(
     val stopPolicy: StopPolicy,
     initialStepExecutions: Int = 0,
 ) {
@@ -1290,6 +1253,38 @@ private fun <S> validateWorkflowDefinition(
         )
     }
     validateStaticCommandPolicies(workflowName, steps)
+    validateNoNestedSuspendingSteps(workflowName, steps)
+}
+
+private fun <S> validateNoNestedSuspendingSteps(
+    workflowName: String,
+    steps: List<InternalWorkflowStep<S>>,
+) {
+    for (step in steps) {
+        if (step is BranchWorkflowStep) {
+            step.branches.values.forEach { branchSteps ->
+                rejectNestedSuspendingSteps(workflowName, branchSteps)
+            }
+            step.defaultSteps?.let { rejectNestedSuspendingSteps(workflowName, it) }
+        }
+    }
+}
+
+private fun <S> rejectNestedSuspendingSteps(
+    workflowName: String,
+    steps: List<InternalWorkflowStep<S>>,
+) {
+    for (step in steps) {
+        if (step.suspensionMode != WorkflowStepSuspensionMode.NONE) {
+            throw IllegalArgumentException(
+                "Workflow '$workflowName' step '${step.name}' uses ${step.suspensionMode} suspension inside a nested branch. Checkpoint-suspending steps must be top-level.",
+            )
+        }
+        if (step is BranchWorkflowStep) {
+            step.branches.values.forEach { rejectNestedSuspendingSteps(workflowName, it) }
+            step.defaultSteps?.let { rejectNestedSuspendingSteps(workflowName, it) }
+        }
+    }
 }
 
 private fun <S> validateStaticCommandPolicies(
@@ -1584,12 +1579,12 @@ private const val WORKFLOW_DELAY_STEP_METADATA_KEY: String =
     "tramai.workflow.delay.step"
 private const val WORKFLOW_DELAY_RESUME_AT_EPOCH_MILLIS_METADATA_KEY: String =
     "tramai.workflow.delay.resume_at_epoch_millis"
-private data class WorkflowDefinitionCompatibility(
+internal data class WorkflowDefinitionCompatibility(
     val version: String,
     val digest: String,
     val digestAlgorithm: String,
 )
-private class WorkflowPersistenceSession<S>(
+internal class WorkflowPersistenceSession<S>(
     private val persistence: WorkflowPersistence<S>,
     private val workflowName: String,
     private val context: WorkflowContext,

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/Workflow.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/Workflow.kt
@@ -479,7 +479,7 @@ class Workflow<S, R> internal constructor(
             when (val result = executeStep(step, request)) {
                 is WorkflowStepExecutionResult.Completed -> currentState = result.state
                 WorkflowStepExecutionResult.Suspended -> throw WorkflowSuspendedException(
-                    "Workflow '$name' suspended at nested step '${step.name}', but nested delay checkpointing is not supported",
+                    "Workflow '$name' suspended at nested step '${step.name}', but nested checkpoint suspension is not supported",
                 )
             }
         }

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowStepExecution.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowStepExecution.kt
@@ -1,0 +1,88 @@
+package dev.tramai.orchestration
+
+import java.time.Clock
+
+/**
+ * Whether a workflow step may checkpoint the whole workflow run.
+ *
+ * [NONE] steps never suspend; [TOP_LEVEL_CHECKPOINT] steps may persist a
+ * checkpoint and suspend the run at a top-level step boundary.
+ */
+internal enum class WorkflowStepSuspensionMode {
+    NONE,
+    TOP_LEVEL_CHECKPOINT,
+}
+
+/**
+ * Contract-level result of executing one workflow step.
+ *
+ * A step returns [Completed] with the next state, or [Suspended] to
+ * checkpoint and suspend the workflow run. Suspension is modelled as a value,
+ * never as an exception thrown from inside a step; the workflow runner
+ * converts [Suspended] into the outer [WorkflowSuspendedException] at the
+ * existing boundary.
+ */
+internal sealed interface WorkflowStepExecutionResult<out S> {
+    data class Completed<S>(
+        val state: S,
+    ) : WorkflowStepExecutionResult<S>
+
+    data object Suspended : WorkflowStepExecutionResult<Nothing>
+}
+
+/**
+ * Runtime-only collaborators handed to a step's execute implementation.
+ *
+ * This is the deliberate boundary that keeps steps from reaching into the
+ * whole [Workflow] object: a step may use these services and nothing else.
+ */
+internal data class WorkflowStepExecutionServices(
+    val clock: Clock,
+    val httpTransport: HttpTransport,
+    val outboundNetworkPolicy: OutboundNetworkPolicy,
+    val externalStepExecutorResolver: ExternalStepExecutorResolver,
+    val failureDiagnosticObserver: WorkflowStepFailureDiagnosticObserver,
+)
+
+/**
+ * Everything a step needs to execute, without the step itself: the receiver
+ * of [InternalWorkflowStep.execute] is the step.
+ *
+ * [executeNestedSteps] routes nested steps through the same common step
+ * wrapper (step counting, observation, cancellation, sanitisation) instead of
+ * letting a step call child [InternalWorkflowStep.execute] directly.
+ */
+internal data class WorkflowStepExecutionRequest<S>(
+    val workflowName: String,
+    val state: S,
+    val context: WorkflowContext,
+    val observer: WorkflowObserver,
+    val stepCounter: StepCounter,
+    val persistenceSession: WorkflowPersistenceSession<S>?,
+    val topLevelStepIndex: Int?,
+    val resumedCheckpointMetadata: Map<String, String>?,
+    val services: WorkflowStepExecutionServices,
+    val executeNestedSteps: suspend (
+        steps: List<InternalWorkflowStep<S>>,
+        state: S,
+    ) -> S,
+)
+
+/**
+ * Internal runtime execution contract for every built-in workflow step.
+ *
+ * The workflow runner sequences steps through this single boundary; it no
+ * longer knows how any concrete step type executes. [suspensionMode] makes
+ * the topology constraint part of the model: only [WorkflowStepSuspensionMode.TOP_LEVEL_CHECKPOINT]
+ * steps may suspend, and only at top level.
+ */
+internal sealed interface InternalWorkflowStep<S> {
+    val name: String
+
+    val suspensionMode: WorkflowStepSuspensionMode
+        get() = WorkflowStepSuspensionMode.NONE
+
+    suspend fun execute(
+        request: WorkflowStepExecutionRequest<S>,
+    ): WorkflowStepExecutionResult<S>
+}

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowStepExecutionArchitectureTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowStepExecutionArchitectureTest.kt
@@ -1,6 +1,10 @@
 package dev.tramai.orchestration
 
 import kotlinx.coroutines.runBlocking
+import net.bytebuddy.jar.asm.ClassReader
+import net.bytebuddy.jar.asm.ClassVisitor
+import net.bytebuddy.jar.asm.MethodVisitor
+import net.bytebuddy.jar.asm.Opcodes
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.Clock
@@ -11,6 +15,88 @@ import kotlin.coroutines.Continuation
 
 private fun sealedStepClasses(): List<Class<*>> =
     InternalWorkflowStep::class.java.permittedSubclasses?.toList() ?: emptyList()
+
+private fun stepClassResource(stepClass: Class<*>): java.io.InputStream? =
+    stepClass.getResourceAsStream("/${stepClass.name.replace('.', '/')}.class")
+
+/**
+ * Inspects the compiled [getSuspensionMode] body of a step class: reports
+ * true only when the getter directly returns the [WorkflowStepSuspensionMode.TOP_LEVEL_CHECKPOINT]
+ * constant (GETSTATIC), i.e. the class declares the capability itself rather
+ * than inheriting the interface default. Never instantiates the step, so a
+ * class cannot silently disappear from the assertion.
+ */
+private fun stepClassDeclaresTopLevelCheckpoint(stepClass: Class<*>): Boolean {
+    var declares = false
+    ClassReader(stepClassResource(stepClass)).accept(object : ClassVisitor(Opcodes.ASM9) {
+        override fun visitMethod(
+            access: Int,
+            name: String,
+            descriptor: String,
+            signature: String?,
+            exceptions: Array<out String>?,
+        ): MethodVisitor? {
+            if (name != "getSuspensionMode") return super.visitMethod(access, name, descriptor, signature, exceptions)
+            return object : MethodVisitor(Opcodes.ASM9) {
+                override fun visitFieldInsn(opcode: Int, owner: String, fieldName: String, descriptor: String) {
+                    if (opcode == Opcodes.GETSTATIC &&
+                        owner == "dev/tramai/orchestration/WorkflowStepSuspensionMode" &&
+                        fieldName == "TOP_LEVEL_CHECKPOINT"
+                    ) {
+                        declares = true
+                    }
+                }
+            }
+        }
+    }, 0)
+    return declares
+}
+
+/**
+ * Collects every class the compiled [Workflow.executeStep] (and its suspend
+ * state-machine helper classes) references. If central concrete dispatch is
+ * reintroduced, the step classes appear here and the guard fails.
+ */
+private fun executeStepReferencedClasses(): Set<String> {
+    val referenced = linkedSetOf<String>()
+    val workflowClass = Workflow::class.java
+    val targets = buildList {
+        add(workflowClass)
+        workflowClass.declaredClasses.forEach { nested ->
+            if (nested.simpleName.startsWith("executeStep")) add(nested)
+        }
+    }
+    targets.forEach { target ->
+        val resource = target.getResourceAsStream("/${target.name.replace('.', '/')}.class")
+            ?: return@forEach
+        ClassReader(resource).accept(object : ClassVisitor(Opcodes.ASM9) {
+            override fun visitMethod(
+                access: Int,
+                name: String,
+                descriptor: String,
+                signature: String?,
+                exceptions: Array<out String>?,
+            ): MethodVisitor? {
+                return object : MethodVisitor(Opcodes.ASM9) {
+                    override fun visitTypeInsn(opcode: Int, type: String) {
+                        referenced += type
+                    }
+
+                    override fun visitMethodInsn(
+                        opcode: Int,
+                        owner: String,
+                        methodName: String,
+                        descriptor: String,
+                        isInterface: Boolean,
+                    ) {
+                        referenced += owner
+                    }
+                }
+            }
+        }, 0)
+    }
+    return referenced
+}
 
 /**
  * Architectural assertions for Epic 4.1: runtime step execution is
@@ -33,29 +119,21 @@ class WorkflowStepExecutionArchitectureTest {
     }
 
     @Test
-    fun `only delay reports TOP_LEVEL_CHECKPOINT`() {
-        val actual = sealedStepClasses().mapNotNull { stepClass ->
-            val ctor = stepClass.declaredConstructors.first()
-            ctor.isAccessible = true
-            val instance = try {
-                ctor.newInstance(*Array(ctor.parameterCount) { i ->
-                    when (ctor.parameterTypes[i]) {
-                        java.lang.String::class.java -> "s"
-                        java.lang.Long.TYPE -> 0L as Any
-                        java.lang.Integer.TYPE -> 0 as Any
-                        java.util.concurrent.TimeUnit::class.java -> java.util.concurrent.TimeUnit.SECONDS
-                        else -> null
-                    }
-                })
-            } catch (e: Exception) {
-                return@mapNotNull null
-            }
-            val mode = runCatching {
-                stepClass.getMethod("getSuspensionMode").invoke(instance) as WorkflowStepSuspensionMode
-            }.getOrNull()
-            if (mode != null) stepClass.simpleName to mode else null
-        }
-        assertThat(actual).containsExactly("DelayWorkflowStep" to WorkflowStepSuspensionMode.TOP_LEVEL_CHECKPOINT)
+    fun `only delay declares TOP_LEVEL_CHECKPOINT`() {
+        val declaring = sealedStepClasses()
+            .filter { stepClassDeclaresTopLevelCheckpoint(it) }
+            .map { it.simpleName }
+        assertThat(declaring).containsExactly("DelayWorkflowStep")
+    }
+
+    @Test
+    fun `executeStep has no concrete-step dispatch`() {
+        val stepClassNames = sealedStepClasses()
+            .map { it.name.replace('.', '/') }
+            .toSet()
+        val referenced = executeStepReferencedClasses()
+        val dispatchRefs = referenced.filter { it in stepClassNames }
+        assertThat(dispatchRefs).isEmpty()
     }
 
     @Test

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowStepExecutionArchitectureTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowStepExecutionArchitectureTest.kt
@@ -1,0 +1,343 @@
+package dev.tramai.orchestration
+
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.Continuation
+
+private fun sealedStepClasses(): List<Class<*>> =
+    InternalWorkflowStep::class.java.permittedSubclasses?.toList() ?: emptyList()
+
+/**
+ * Architectural assertions for Epic 4.1: runtime step execution is
+ * polymorphic through [InternalWorkflowStep.execute], and
+ * [Workflow]'s step wrapper contains no concrete-step dispatch.
+ */
+class WorkflowStepExecutionArchitectureTest {
+
+    @Test
+    fun `every built-in step implements the polymorphic execute contract`() {
+        val missing = sealedStepClasses().filter { stepClass ->
+            val execute = stepClass
+                .declaredMethods
+                .firstOrNull { it.name == "execute" && it.parameterCount == 2 }
+            execute == null ||
+                execute.parameterTypes[0] != WorkflowStepExecutionRequest::class.java ||
+                execute.parameterTypes[1] != Continuation::class.java
+        }
+        assertThat(missing.map { it.simpleName }).isEmpty()
+    }
+
+    @Test
+    fun `only delay reports TOP_LEVEL_CHECKPOINT`() {
+        val actual = sealedStepClasses().mapNotNull { stepClass ->
+            val ctor = stepClass.declaredConstructors.first()
+            ctor.isAccessible = true
+            val instance = try {
+                ctor.newInstance(*Array(ctor.parameterCount) { i ->
+                    when (ctor.parameterTypes[i]) {
+                        java.lang.String::class.java -> "s"
+                        java.lang.Long.TYPE -> 0L as Any
+                        java.lang.Integer.TYPE -> 0 as Any
+                        java.util.concurrent.TimeUnit::class.java -> java.util.concurrent.TimeUnit.SECONDS
+                        else -> null
+                    }
+                })
+            } catch (e: Exception) {
+                return@mapNotNull null
+            }
+            val mode = runCatching {
+                stepClass.getMethod("getSuspensionMode").invoke(instance) as WorkflowStepSuspensionMode
+            }.getOrNull()
+            if (mode != null) stepClass.simpleName to mode else null
+        }
+        assertThat(actual).containsExactly("DelayWorkflowStep" to WorkflowStepSuspensionMode.TOP_LEVEL_CHECKPOINT)
+    }
+
+    @Test
+    fun `observer ordering is start then completed for successful steps`() {
+        val observer = ArchRecordingWorkflowObserver()
+        val workflow = workflow<WorkflowState>("obs-order") {
+            localStep("one") { state, _ -> state.copy(log = state.log + "one:") }
+            localStep("two") { state, _ -> state.copy(log = state.log + "two:") }
+        }.build(clock = Clock.systemUTC()) { it.log }
+
+        runBlocking { workflow.run(initialState = WorkflowState(""), observer = observer) }
+
+        assertThat(observer.startedSteps).containsExactly("one", "two")
+        assertThat(observer.completedSteps).containsExactly("one", "two")
+    }
+
+    @Test
+    fun `observer ordering is start then failed for failing steps`() {
+        val observer = ArchRecordingWorkflowObserver()
+        val workflow = workflow<WorkflowState>("obs-fail") {
+            localStep("ok") { state, _ -> state.copy(log = state.log + "ok:") }
+            gateStep("gate") { _, _ ->
+                throw WorkflowGateRejectedException("Workflow gate 'gate' rejected execution: no")
+            }
+        }.build(clock = Clock.systemUTC()) { it.log }
+
+        runBlocking {
+            runCatching { workflow.run(initialState = WorkflowState(""), observer = observer) }
+        }
+
+        assertThat(observer.startedSteps).containsExactly("ok", "gate")
+        assertThat(observer.completedSteps).containsExactly("ok")
+        assertThat(observer.failedSteps).containsExactly("gate")
+    }
+
+    @Test
+    fun `cancellation escapes without sanitisation or onStepFailed`() {
+        val observer = ArchRecordingWorkflowObserver()
+        val workflow = workflow<WorkflowState>("cancel") {
+            localStep("cancel-me") { _, _ ->
+                throw kotlinx.coroutines.CancellationException("cancelled")
+            }
+        }.build(clock = Clock.systemUTC()) { it.log }
+
+        val error = runBlocking {
+            runCatching { workflow.run(initialState = WorkflowState(""), observer = observer) }
+                .exceptionOrNull()
+        }
+
+        assertThat(error).isInstanceOf(kotlinx.coroutines.CancellationException::class.java)
+        assertThat(error).hasMessage("cancelled")
+        assertThat(observer.failedSteps).isEmpty()
+        assertThat(observer.completedSteps).isEmpty()
+    }
+
+    @Test
+    fun `suspended delay emits started but not completed until actual resume`() {
+        val clock = ArchMutableClock(Instant.parse("2026-05-03T09:00:00Z"))
+        val store = InMemoryWorkflowCheckpointStore()
+        val delayScheduler = ArchRecordingDelayWakeupScheduler()
+        val persistence = WorkflowPersistence(
+            checkpointStore = store,
+            stateCodec = ArchResumeStateCodec,
+            delayWakeupScheduler = delayScheduler,
+        )
+        val context = WorkflowContext(workflowId = "arch-delay-1")
+        val observer = ArchRecordingWorkflowObserver()
+        val workflow = workflow<ArchResumeState>("arch-delay") {
+            delayStep("pause", 5, TimeUnit.SECONDS)
+            localStep("after") { state, _ -> state.copy(finalAnswer = "done") }
+        }.build(clock = clock) { it.finalAnswer }
+
+        val suspended = runBlocking {
+            runCatching {
+                workflow.run(
+                    initialState = ArchResumeState(request = "x"),
+                    context = context,
+                    observer = observer,
+                    persistence = persistence,
+                )
+            }.exceptionOrNull()
+        }
+        assertThat(suspended).isInstanceOf(WorkflowSuspendedException::class.java)
+        assertThat(observer.startedSteps).containsExactly("pause")
+        assertThat(observer.completedSteps).isEmpty()
+
+        // Resume after the delay elapses: completion is only emitted now.
+        clock.instant = Instant.parse("2026-05-03T09:00:06Z")
+        val result = runBlocking {
+            workflow.resume(
+                context = context,
+                observer = observer,
+                persistence = persistence,
+            )
+        }
+        assertThat(result).isEqualTo("done")
+        assertThat(observer.completedSteps).containsExactly("pause", "after")
+    }
+
+    @Test
+    fun `nested delay is rejected during build`() {
+        val error = runCatching {
+            workflow<WorkflowState>("nested-delay") {
+                branchStep("branch", select = { "a" }) {
+                    branch("a") {
+                        delayStep("pause", 5, TimeUnit.SECONDS)
+                    }
+                    default {
+                        localStep("other") { state, _ -> state }
+                    }
+                }
+            }.build(clock = Clock.systemUTC()) { it.log }
+        }.exceptionOrNull()
+
+        assertThat(error).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(error).hasMessage(
+            "Workflow 'nested-delay' step 'pause' uses TOP_LEVEL_CHECKPOINT suspension inside a nested branch. Checkpoint-suspending steps must be top-level.",
+        )
+    }
+
+    @Test
+    fun `deeply nested delay is rejected during build`() {
+        val error = runCatching {
+            workflow<WorkflowState>("deep-nested-delay") {
+                branchStep("outer", select = { "a" }) {
+                    branch("a") {
+                        branchStep("inner", select = { "x" }) {
+                            branch("x") {
+                                delayStep("pause", 5, TimeUnit.SECONDS)
+                            }
+                            default {
+                                localStep("other") { state, _ -> state }
+                            }
+                        }
+                    }
+                    default {
+                        localStep("outer-other") { state, _ -> state }
+                    }
+                }
+            }.build(clock = Clock.systemUTC()) { it.log }
+        }.exceptionOrNull()
+
+        assertThat(error).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(error).hasMessage(
+            "Workflow 'deep-nested-delay' step 'pause' uses TOP_LEVEL_CHECKPOINT suspension inside a nested branch. Checkpoint-suspending steps must be top-level.",
+        )
+    }
+
+    @Test
+    fun `top-level delay remains valid`() {
+        val workflow = workflow<WorkflowState>("top-delay") {
+            delayStep("pause", 0, TimeUnit.SECONDS)
+        }.build(clock = Clock.systemUTC()) { it.log }
+
+        assertThat(runBlocking { workflow.run(initialState = WorkflowState("")) }).isEqualTo("")
+    }
+
+    @Test
+    fun `branch execution routes nested steps through the shared wrapper`() {
+        val observer = ArchRecordingWorkflowObserver()
+        val workflow = workflow<WorkflowState>("branch-wrap") {
+            branchStep("branch", select = { "a" }) {
+                branch("a") {
+                    localStep("a1") { state, _ -> state.copy(log = state.log + "a1:") }
+                    localStep("a2") { state, _ -> state.copy(log = state.log + "a2:") }
+                }
+                default {
+                    localStep("d1") { state, _ -> state.copy(log = state.log + "d1:") }
+                }
+            }
+        }.build(clock = Clock.systemUTC()) { it.log }
+
+        val result = runBlocking { workflow.run(initialState = WorkflowState(""), observer = observer) }
+
+        assertThat(result).isEqualTo("a1:a2:")
+        assertThat(observer.startedSteps).containsExactly("branch", "a1", "a2")
+        assertThat(observer.completedSteps).containsExactly("a1", "a2", "branch")
+    }
+
+    @Test
+    fun `branch nested steps still consume step budget`() {
+        val observer = ArchRecordingWorkflowObserver()
+        val workflow = workflow<WorkflowState>("branch-budget") {
+            branchStep("branch", select = { "a" }) {
+                branch("a") {
+                    localStep("a1") { state, _ -> state.copy(log = state.log + "a1:") }
+                    localStep("a2") { state, _ -> state.copy(log = state.log + "a2:") }
+                }
+                default {
+                    localStep("d1") { state, _ -> state.copy(log = state.log + "d1:") }
+                }
+            }
+        }.build(clock = Clock.systemUTC(), stopPolicy = StopPolicy(maxStepExecutions = 2)) { it.log }
+
+        val error = runBlocking {
+            runCatching { workflow.run(initialState = WorkflowState(""), observer = observer) }
+                .exceptionOrNull()
+        }
+
+        assertThat(error).isInstanceOf(WorkflowLimitExceededException::class.java)
+        assertThat(error!!.message).contains("maxStepExecutions=2")
+    }
+
+    private data class WorkflowState(val log: String = "")
+}
+
+private data class ArchResumeState(
+    val request: String,
+    val draft: String? = null,
+    val finalAnswer: String? = null,
+)
+
+private object ArchResumeStateCodec : WorkflowStateCodec<ArchResumeState> {
+    override fun encode(state: ArchResumeState): String = "${state.request}|${state.draft}|${state.finalAnswer}"
+    override fun decode(payload: String): ArchResumeState {
+        val parts = payload.split("|")
+        return ArchResumeState(parts[0], parts.getOrNull(1).takeIf { it != "null" }, parts.getOrNull(2).takeIf { it != "null" })
+    }
+}
+
+private data class ArchDelayWakeup(
+    val runId: String,
+    val stepId: String,
+    val resumeAt: Instant,
+)
+
+private class ArchRecordingDelayWakeupScheduler : WorkflowDelayWakeupScheduler {
+    val wakeups = mutableListOf<ArchDelayWakeup>()
+    override suspend fun scheduleDelayWakeup(
+        runId: String,
+        stepId: String,
+        resumeAt: Instant,
+    ) {
+        wakeups += ArchDelayWakeup(runId, stepId, resumeAt)
+    }
+}
+
+private class ArchMutableClock(
+    var instant: Instant,
+    private val zoneId: ZoneId = ZoneId.of("UTC"),
+) : Clock() {
+    override fun instant(): Instant = instant
+    override fun getZone(): ZoneId = zoneId
+    override fun withZone(zone: ZoneId): Clock = ArchMutableClock(instant, zone)
+}
+
+private class ArchRecordingWorkflowObserver : WorkflowObserver {
+    val startedSteps = mutableListOf<String>()
+    val completedSteps = mutableListOf<String>()
+    val failedSteps = mutableListOf<String>()
+    val workflowEvents = mutableListOf<String>()
+    override fun onWorkflowEvent(
+        workflowName: String,
+        name: String,
+        attributes: Map<String, Any?>,
+        context: WorkflowContext,
+    ) {
+        workflowEvents += name
+    }
+    override fun onStepStarted(
+        workflowName: String,
+        stepName: String,
+        context: WorkflowContext,
+    ) {
+        startedSteps += stepName
+    }
+    override fun onStepCompleted(
+        workflowName: String,
+        stepName: String,
+        context: WorkflowContext,
+    ) {
+        completedSteps += stepName
+    }
+    override fun onStepFailed(
+        workflowName: String,
+        stepName: String,
+        error: Throwable,
+        context: WorkflowContext,
+    ) {
+        failedSteps += stepName
+    }
+    override fun onWorkflowStarted(workflowName: String, context: WorkflowContext) = Unit
+    override fun onWorkflowCompleted(workflowName: String, context: WorkflowContext) = Unit
+    override fun onWorkflowFailed(workflowName: String, error: Throwable, context: WorkflowContext) = Unit
+}


### PR DESCRIPTION
# refactor(workflow): introduce polymorphic step execution — Epic 4.1

## What

Removes the 12-arm concrete-type `when` from `Workflow.executeStep()` and makes
`InternalWorkflowStep<S>` the runtime execution boundary:

```kotlin
internal sealed interface InternalWorkflowStep<S> {
    val name: String
    val suspensionMode: WorkflowStepSuspensionMode   // NONE | TOP_LEVEL_CHECKPOINT
    suspend fun execute(request: WorkflowStepExecutionRequest<S>): WorkflowStepExecutionResult<S>
}
```

Dependency direction changes:
```
Before:  Workflow --knows--> Local/AI/HTTP/Shell/Hermes/Codex/MCP/Plugin/Gate/Delay/Branch/Parallel
After:   Workflow --calls--> InternalWorkflowStep.execute(request) <--implemented by-- all steps
```

## Architecture (per review spec A–K)

- **Common wrapper preserved** in `Workflow.executeStep()`: step budget → onStepStarted → `step.execute(request)` → cancellation rethrow (no sanitisation, no onStepFailed) → sanitise non-cancellation → onStepFailed → onStepCompleted only for `Completed` results (Suspended never emits onStepCompleted — verified by test).
- **`WorkflowStepExecutionRequest`** carries no step property; grouped runtime collaborators in `WorkflowStepExecutionServices` (clock, httpTransport, outboundNetworkPolicy, executorResolver, failureDiagnosticObserver).
- **Branch recursion** goes through the `executeNestedSteps` callback → the shared wrapper, so nested steps keep step counting, observation, cancellation and sanitisation. Nested requests are constructed with `persistenceSession = null`, `topLevelStepIndex = null`, `resumedCheckpointMetadata = null` — no inherited top-level checkpoint semantics.
- **Suspension is explicit**: `WorkflowStepSuspensionMode` enum; only `DelayWorkflowStep` reports `TOP_LEVEL_CHECKPOINT`. Validation checks `step.suspensionMode != NONE`, never `is DelayWorkflowStep` — adding a future suspending step needs no central validation edit.
- **Nested checkpoint suspension fails at build()** (was a runtime error): `Workflow 'foo' step 'pause' uses TOP_LEVEL_CHECKPOINT suspension inside a nested branch. Checkpoint-suspending steps must be top-level.`
- **Hardened algorithms untouched**: HTTP/Shell/Hermes/Codex/MCP `execute(workflowName, …)` bodies unchanged; thin `execute(request)` adapters added.
- **New file** `WorkflowStepExecution.kt` (contract types). No `Workflow.kt` split — that is Epic 4.2 / #247.

## Visibility promotions (private → internal)

- `StepCounter` — referenced by `WorkflowStepExecutionRequest`.
- `WorkflowPersistenceSession` — referenced by `WorkflowStepExecutionRequest`.
- `WorkflowDefinitionCompatibility` — transitive: it is a constructor parameter of the now-internal `WorkflowPersistenceSession`, so Kotlin's visibility rules require it internal too. Not required by polymorphic execution itself, but unavoidable without hiding the session type.

## Tests (`WorkflowStepExecutionArchitectureTest`, 12 tests)

- Every built-in step (reflected via `permittedSubclasses`) implements the polymorphic `execute(request)` contract.
- Only `DelayWorkflowStep` reports `TOP_LEVEL_CHECKPOINT` (value-based reflection over all sealed subclasses).
- Observer ordering: start→completed for success; start→failed for failure.
- Cancellation escapes without sanitisation or onStepFailed.
- Suspended delay: onStepStarted emitted, onStepCompleted NOT emitted until actual resumed completion.
- Nested + deeply nested delay rejected at build(); top-level delay still valid.
- Branch routes nested steps through the wrapper (ordering + step-budget consumption).

## Verification

```
./gradlew :tramai-orchestration:test :tramai-orchestration:apiCheck \
  verifyCancellationSafety verifyChangePolicy verifyMaintainabilityBaseline \
  -PchangeClass=runtime-behaviour --no-daemon
```

- BUILD SUCCESSFUL; full orchestration suite (incl. delay suspend/resume, branch budgets, cancellation contracts, safe-failure) green.
- Maintainability baseline PASSED (12 accepted deviations; no ceiling change).
- `apiCheck`: zero public API diff.
- Nested suspension is the one intended observable change: runtime failure → build-time failure.

## Non-goals (deferred)

- `Workflow.kt` split (Epic 4.2 / #247)
- Worker bindings, replay/retry semantics, workflow DSL, checkpoint schema, canonical digest, event names, safe-failure codes
- Exposing `InternalWorkflowStep` as a public plugin API
