### PR TITLE
fix(quality): cancellation comparator treats file moves as unchanged

### DIFF
--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/BaselineModel.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/BaselineModel.kt
@@ -1,5 +1,6 @@
 package dev.tramai.build.quality
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
@@ -313,7 +314,15 @@ data class CancellationCatchFinding(
     @JsonProperty("rethrowsCancellation") val rethrowsCancellation: Boolean = false,
     @JsonProperty("transformsException") val transformsException: Boolean = false,
     @JsonProperty("risk") val risk: String = "medium",
-    @JsonProperty("sourceLine") val sourceLine: Int = 0
+    @JsonProperty("sourceLine") val sourceLine: Int = 0,
+    /**
+     * Ephemeral relocation evidence: normalized source-content fingerprint of
+     * the catch site, computed at scan time and never persisted. Serialization
+     * ignores it, so the persisted baseline schema is unchanged (schema v1).
+     * Used ONLY by the comparator's relocation pass to prove a catch actually
+     * moved across files — the line number alone is never identity.
+     */
+    @get:JsonIgnore val sourceFingerprint: String = ""
 )
 
 data class GlobalStateFinding(

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/CancellationDeltaComparator.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/CancellationDeltaComparator.kt
@@ -4,15 +4,33 @@ package dev.tramai.build.quality
  * Pure, testable comparison of cancellation catch findings by risk population matching,
  * not position-based identity.
  *
+ * Phase 1 — normal matching, file-aware:
+ *
  * For each (module, file, function, catchType) group:
  *   1. Build multiset of risk values from base catches
  *   2. Build multiset of risk values from current catches
  *   3. Match identical risk values first (remove matched pairs)
  *   4. Sort remaining base and current DESCENDING by risk order
  *   5. Pair 1:1 by sorted position — if current > base → worsened
- *   6. Any left-over unmatched current entries → truly new (fail if critical/high)
- *   7. Any left-over base entries → removed (pass)
+ *   6. Left-over current entries become relocation candidates
+ *   7. Left-over base entries → removed (pass)
  *   8. Source line position used ONLY for diagnostic display, never identity
+ *
+ * Phase 2 — conservative relocation pass over UNMATCHED findings only:
+ *
+ * A finding that moved to a different file (same module, function, catchType,
+ * risk) is a relocation, not a new finding. This is deliberately conservative:
+ *   - It runs only over findings left unmatched by the file-aware phase.
+ *   - A relocation is accepted only when it is uniquely attributable:
+ *     exactly one base candidate and exactly one current candidate share the
+ *     (module, function, catchType, risk) key across different files.
+ *   - If any current candidate is ambiguous (multiple base candidates, or
+ *     vice versa), NONE of the candidates in that key are relocated — the
+ *     safe bias is to flag the current finding rather than silently accept.
+ *
+ * This keeps the primary identity file-aware (a new critical catch in the
+ * same function of a different file is still flagged) while allowing pure
+ * refactor relocations to pass.
  */
 object CancellationDeltaComparator {
 
@@ -36,20 +54,22 @@ object CancellationDeltaComparator {
 
         diagnostics.add("verifyCancellationSafety: ${currentCatches.size} current, ${baseCatches.size} base findings")
 
-        // Group by (module, function, catchType) — deliberately NOT file.
-        // A finding that moves to another file (same function, catchType and
-        // risk) is a relocation, not a new finding; including the file in the
-        // identity made every refactor that moves a broad catch read as a new
-        // critical finding. Population/risk matching still catches genuinely
-        // new findings (the current group has more entries than the base).
+        // ── Phase 1: file-aware normal matching ──
+        // Group by (module, file, function, catchType) — file is part of the
+        // primary identity so a genuinely new catch in a different file is
+        // never masked by an existing catch with the same function name.
         val groupKey: (CancellationCatchFinding) -> String = {
-            "${it.module}::${it.function}::${it.catchType}"
+            "${it.module}::${it.file}::${it.function}::${it.catchType}"
         }
 
         val baseByGroup = baseCatches.groupBy(groupKey)
         val currentByGroup = currentCatches.groupBy(groupKey)
 
         val allGroups = (baseByGroup.keys + currentByGroup.keys).toSet()
+
+        // Collect every finding that Phase 1 could not match, for Phase 2.
+        val baseRelocationCandidates = mutableListOf<CancellationCatchFinding>()
+        val currentRelocationCandidates = mutableListOf<CancellationCatchFinding>()
 
         for (group in allGroups.sorted()) {
             val baseForGroup = baseByGroup[group] ?: emptyList()
@@ -93,16 +113,64 @@ object CancellationDeltaComparator {
                 }
             }
 
-            // 4. Extra current entries are truly new (fail if critical/high)
-            for (i in pairCount until currentSorted.size) {
-                val finding = currentSorted[i]
-                if (finding.risk == "critical" || finding.risk == "high") {
-                    newCriticalHigh.add(finding)
-                }
-            }
-            // Base surplus (entries at i >= pairCount in baseSorted) are improvements — pass silently
+            // 4. Left-over current entries are relocation candidates (Phase 2),
+            //    not immediately "new" — they may have moved across files.
+            currentRelocationCandidates += currentSorted.drop(pairCount)
+            // Base surplus (entries at i >= pairCount in baseSorted) are
+            // improvements/removals — pass silently, but keep them available
+            // as relocation candidates for Phase 2.
+            baseRelocationCandidates += baseSorted.drop(pairCount)
 
             unchanged += matchedCurrentIdxs.size
+        }
+
+        // ── Phase 2: conservative relocation pass ──
+        // Only findings left unmatched by Phase 1 may be relocated. A relocation
+        // must be uniquely attributable: exactly one base and one current
+        // candidate per (module, function, catchType, risk) key, in different
+        // files. Ambiguity on either side → flag the current candidate.
+        val relocationKey: (CancellationCatchFinding) -> String = {
+            "${it.module}::${it.function}::${it.catchType}::${it.risk}"
+        }
+
+        val baseByRelocationKey = baseRelocationCandidates.groupBy(relocationKey)
+        val currentByRelocationKey = currentRelocationCandidates.groupBy(relocationKey)
+
+        val allRelocationKeys = (baseByRelocationKey.keys + currentByRelocationKey.keys).toSet()
+
+        for (key in allRelocationKeys.sorted()) {
+            val baseForKey = baseByRelocationKey[key] ?: emptyList()
+            val currentForKey = currentByRelocationKey[key] ?: emptyList()
+
+            val baseCandidate = baseForKey.singleOrNull()
+            val currentCandidate = currentForKey.singleOrNull()
+
+            // A relocation is accepted only when it is uniquely attributable:
+            // exactly one base and one current candidate per key, in different
+            // files, AND the source line changed. Two findings at the SAME
+            // source line in different files are coincidental (an unrelated
+            // replacement with matching population/risk), not a move — the safe
+            // bias is to flag the current finding.
+            val isUniqueRelocation = baseCandidate != null &&
+                currentCandidate != null &&
+                baseCandidate.file != currentCandidate.file &&
+                baseCandidate.sourceLine != currentCandidate.sourceLine
+
+            if (isUniqueRelocation) {
+                unchanged++
+                diagnostics.add(
+                    "relocated: ${baseCandidate.file}:${baseCandidate.sourceLine} → " +
+                        "${currentCandidate.file}:${currentCandidate.sourceLine} (${currentCandidate.function}, risk=${currentCandidate.risk})"
+                )
+            } else {
+                // Ambiguous (multiple candidates on either side, or same file) →
+                // treat every current candidate as new. Safe bias.
+                currentForKey.forEach { finding ->
+                    if (finding.risk == "critical" || finding.risk == "high") {
+                        newCriticalHigh.add(finding)
+                    }
+                }
+            }
         }
 
         // Build diagnostics

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/CancellationDeltaComparator.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/CancellationDeltaComparator.kt
@@ -36,9 +36,14 @@ object CancellationDeltaComparator {
 
         diagnostics.add("verifyCancellationSafety: ${currentCatches.size} current, ${baseCatches.size} base findings")
 
-        // Group by (module, file, function, catchType) — same coarse group
+        // Group by (module, function, catchType) — deliberately NOT file.
+        // A finding that moves to another file (same function, catchType and
+        // risk) is a relocation, not a new finding; including the file in the
+        // identity made every refactor that moves a broad catch read as a new
+        // critical finding. Population/risk matching still catches genuinely
+        // new findings (the current group has more entries than the base).
         val groupKey: (CancellationCatchFinding) -> String = {
-            "${it.module}::${it.file}::${it.function}::${it.catchType}"
+            "${it.module}::${it.function}::${it.catchType}"
         }
 
         val baseByGroup = baseCatches.groupBy(groupKey)

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/CancellationDeltaComparator.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/CancellationDeltaComparator.kt
@@ -21,16 +21,24 @@ package dev.tramai.build.quality
  * A finding that moved to a different file (same module, function, catchType,
  * risk) is a relocation, not a new finding. This is deliberately conservative:
  *   - It runs only over findings left unmatched by the file-aware phase.
- *   - A relocation is accepted only when it is uniquely attributable:
- *     exactly one base candidate and exactly one current candidate share the
- *     (module, function, catchType, risk) key across different files.
+ *   - A relocation is accepted only when it is uniquely attributable AND
+ *     backed by source-content evidence:
+ *       • exactly one base candidate and exactly one current candidate share
+ *         the (module, function, catchType, risk) key across different files
+ *       • both candidates carry a non-blank normalized source fingerprint of
+ *         their catch site (computed at scan time from the actual source text)
+ *       • the fingerprints match — the same code text is present at both sites
+ *   - A unique 1:1 semantic match WITHOUT matching content is NOT a relocation:
+ *     it is an unrelated replacement with coincidentally identical metadata,
+ *     and the current finding is flagged. Source line position is used ONLY
+ *     for diagnostic display, never identity.
  *   - If any current candidate is ambiguous (multiple base candidates, or
  *     vice versa), NONE of the candidates in that key are relocated — the
  *     safe bias is to flag the current finding rather than silently accept.
  *
  * This keeps the primary identity file-aware (a new critical catch in the
  * same function of a different file is still flagged) while allowing pure
- * refactor relocations to pass.
+ * refactor relocations to pass when content proves the move.
  */
 object CancellationDeltaComparator {
 
@@ -145,22 +153,28 @@ object CancellationDeltaComparator {
             val baseCandidate = baseForKey.singleOrNull()
             val currentCandidate = currentForKey.singleOrNull()
 
-            // A relocation is accepted only when it is uniquely attributable:
-            // exactly one base and one current candidate per key, in different
-            // files, AND the source line changed. Two findings at the SAME
-            // source line in different files are coincidental (an unrelated
-            // replacement with matching population/risk), not a move — the safe
-            // bias is to flag the current finding.
+            // A relocation is accepted only when it is uniquely attributable
+            // AND backed by source-content evidence: exactly one base and one
+            // current candidate per key, in different files, with matching
+            // non-blank normalized source fingerprints. The fingerprint is the
+            // proof the same code text moved; without it a unique 1:1 semantic
+            // match is an unrelated replacement (coincidental metadata), and
+            // the safe bias is to flag the current finding.
+            val baseFingerprint = baseCandidate?.sourceFingerprint.orEmpty().trim()
+            val currentFingerprint = currentCandidate?.sourceFingerprint.orEmpty().trim()
+            val fingerprintsProveMove = baseFingerprint.isNotEmpty() &&
+                baseFingerprint == currentFingerprint
+
             val isUniqueRelocation = baseCandidate != null &&
                 currentCandidate != null &&
                 baseCandidate.file != currentCandidate.file &&
-                baseCandidate.sourceLine != currentCandidate.sourceLine
+                fingerprintsProveMove
 
             if (isUniqueRelocation) {
                 unchanged++
                 diagnostics.add(
                     "relocated: ${baseCandidate.file}:${baseCandidate.sourceLine} → " +
-                        "${currentCandidate.file}:${currentCandidate.sourceLine} (${currentCandidate.function}, risk=${currentCandidate.risk})"
+                        "${currentCandidate.file}:${currentCandidate.sourceLine} (${currentCandidate.function}, risk=${currentCandidate.risk}, fingerprint match)"
                 )
             } else {
                 // Ambiguous (multiple candidates on either side, or same file) →

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/KotlinCancellationCatchScanner.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/KotlinCancellationCatchScanner.kt
@@ -86,7 +86,7 @@ object KotlinCancellationCatchScanner {
                         transformsException = transformsException,
                         risk = risk,
                         sourceLine = originalLineNum,
-                        sourceFingerprint = fingerprintConstruct(lines, originalLineIdx)
+                        sourceFingerprint = fingerprintConstruct(lines, originalLineIdx, match)
                     )
                 )
             }
@@ -183,11 +183,16 @@ object KotlinCancellationCatchScanner {
      * Conservative source-content fingerprint of the ENTIRE broad-catch
      * construct: from the line containing the catch/runCatching site through
      * its balanced body closing brace. Brace balancing is lexical-state-aware:
-     * braces inside line comments, block comments, regular strings, char
-     * literals and multi-line raw strings never change the depth. If the
+     * braces inside line comments, nested block comments, regular strings,
+     * char literals and multi-line raw strings never change the depth. If the
      * source cannot be confidently balanced (unterminated comment or string),
      * returns an empty fingerprint — Phase 2 then refuses relocation, the
      * safe direction for a safety gate.
+     *
+     * [match] anchors the construct to the ACTUAL broad-catch finding being
+     * emitted — balancing starts at the matched keyword, so an outer catch
+     * whose opening line also contains an inner runCatching balances the
+     * outer construct, never the inner one.
      *
      * Normalization is deliberately minimal — each line is trimmed at the
      * edges and blank lines dropped, but comments and string literal contents
@@ -197,8 +202,12 @@ object KotlinCancellationCatchScanner {
      *
      * Not persisted (see @JsonIgnore on CancellationCatchFinding).
      */
-    private fun fingerprintConstruct(lines: List<String>, startIdx: Int): String {
-        val endIdx = findConstructEndIdx(lines, startIdx) ?: return ""
+    private fun fingerprintConstruct(
+        lines: List<String>,
+        startIdx: Int,
+        match: MatchResult
+    ): String {
+        val endIdx = findConstructEndIdx(lines, startIdx, match) ?: return ""
         return (startIdx..endIdx)
             .map { lines[it].trim() }
             .filter { it.isNotBlank() }
@@ -210,39 +219,44 @@ object KotlinCancellationCatchScanner {
     /**
      * Finds the index of the line that closes the construct opening at
      * [startIdx], or null when the construct never closes or the source ends
-     * inside a comment/string that cannot be balanced. Brace counting starts
-     * at the catch/runCatching keyword so a `try { ... } catch` on the same
-     * line does not close the construct early. Only structural braces in
-     * normal code change the depth; braces in comments, strings, char literals
-     * and raw strings are ignored, with state carried across lines.
+     * inside a comment/string that cannot be balanced. Brace balancing starts
+     * at the position of the matched keyword in [match] (the actual finding's
+     * anchor), so a `try { ... } catch` on the same line does not close the
+     * construct early and an inner runCatching on the catch's opening line is
+     * not mistaken for the outer construct. Only structural braces in normal
+     * code change the depth; braces in comments (nested block comments
+     * included), strings, char literals and raw strings are ignored, with
+     * state carried across lines.
      */
-    private fun findConstructEndIdx(lines: List<String>, startIdx: Int): Int? {
-        val startLine = lines[startIdx]
-        val keywordPos = when {
-            startLine.contains("runCatching") -> startLine.indexOf("runCatching")
-            else -> startLine.indexOf("catch")
-        }
+    private fun findConstructEndIdx(lines: List<String>, startIdx: Int, match: MatchResult): Int? {
         var depth = 0
         var opened = false
         var state = LexState.CODE
+        var blockCommentDepth = 0
+        // Anchor: the matched keyword's position. The match may be on a joined
+        // line; for joined multiline catches the first original line contains
+        // the keyword at the same offset, so this is still a valid anchor.
+        var pos = match.range.first.coerceIn(0, lines[startIdx].length)
         for (i in startIdx until lines.size) {
             val line = lines[i]
-            var pos = if (i == startIdx) keywordPos.coerceAtLeast(0) else 0
-            while (pos < line.length) {
-                val c = line[pos]
+            val lineStart = if (i == startIdx) pos else 0
+            var j = lineStart
+            while (j < line.length) {
+                val c = line[j]
                 when (state) {
                     LexState.CODE -> when {
-                        c == '/' && pos + 1 < line.length && line[pos + 1] == '/' -> {
+                        c == '/' && j + 1 < line.length && line[j + 1] == '/' -> {
                             state = LexState.LINE_COMMENT
-                            pos++
+                            j++
                         }
-                        c == '/' && pos + 1 < line.length && line[pos + 1] == '*' -> {
+                        c == '/' && j + 1 < line.length && line[j + 1] == '*' -> {
                             state = LexState.BLOCK_COMMENT
-                            pos++
+                            blockCommentDepth = 1
+                            j++
                         }
-                        c == '"' && pos + 2 < line.length && line[pos + 1] == '"' && line[pos + 2] == '"' -> {
+                        c == '"' && j + 2 < line.length && line[j + 1] == '"' && line[j + 2] == '"' -> {
                             state = LexState.RAW_STRING
-                            pos += 2
+                            j += 2
                         }
                         c == '"' -> state = LexState.STRING
                         c == '\'' -> state = LexState.CHAR
@@ -257,24 +271,32 @@ object KotlinCancellationCatchScanner {
                         else -> {}
                     }
                     LexState.LINE_COMMENT -> { /* skip to end of line */ }
-                    LexState.BLOCK_COMMENT ->
-                        if (c == '*' && pos + 1 < line.length && line[pos + 1] == '/') {
-                            state = LexState.CODE
-                            pos++
+                    LexState.BLOCK_COMMENT -> when {
+                        c == '/' && j + 1 < line.length && line[j + 1] == '*' -> {
+                            // Kotlin block comments nest
+                            blockCommentDepth++
+                            j++
                         }
+                        c == '*' && j + 1 < line.length && line[j + 1] == '/' -> {
+                            blockCommentDepth--
+                            if (blockCommentDepth == 0) state = LexState.CODE
+                            j++
+                        }
+                        else -> {}
+                    }
                     LexState.STRING, LexState.CHAR ->
                         if (c == '\\') {
-                            pos++ // skip escaped char
+                            j++ // skip escaped char
                         } else if ((state == LexState.STRING && c == '"') || (state == LexState.CHAR && c == '\'')) {
                             state = LexState.CODE
                         }
                     LexState.RAW_STRING ->
-                        if (c == '"' && pos + 2 < line.length && line[pos + 1] == '"' && line[pos + 2] == '"') {
+                        if (c == '"' && j + 2 < line.length && line[j + 1] == '"' && line[j + 2] == '"') {
                             state = LexState.CODE
-                            pos += 2
+                            j += 2
                         }
                 }
-                pos++
+                j++
             }
             if (state == LexState.LINE_COMMENT) state = LexState.CODE
         }

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/KotlinCancellationCatchScanner.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/KotlinCancellationCatchScanner.kt
@@ -182,32 +182,41 @@ object KotlinCancellationCatchScanner {
     /**
      * Conservative source-content fingerprint of the ENTIRE broad-catch
      * construct: from the line containing the catch/runCatching site through
-     * its balanced body closing brace (string-literal-aware brace counting).
+     * its balanced body closing brace. Brace balancing is lexical-state-aware:
+     * braces inside line comments, block comments, regular strings, char
+     * literals and multi-line raw strings never change the depth. If the
+     * source cannot be confidently balanced (unterminated comment or string),
+     * returns an empty fingerprint — Phase 2 then refuses relocation, the
+     * safe direction for a safety gate.
+     *
      * Normalization is deliberately minimal — each line is trimmed at the
      * edges and blank lines dropped, but comments and string literal contents
      * are preserved verbatim. Two different pieces of executable code cannot
-     * collapse to the same fingerprint: internal whitespace (e.g. `"a b"`
-     * vs `"ab"`) and comment markers inside strings (e.g. `"https://"`) are
-     * never stripped. A formatting-only difference producing a fingerprint
-     * mismatch (false positive) is the safe direction.
+     * collapse to the same fingerprint. A formatting-only difference producing
+     * a fingerprint mismatch (false positive) is also the safe direction.
      *
      * Not persisted (see @JsonIgnore on CancellationCatchFinding).
      */
     private fun fingerprintConstruct(lines: List<String>, startIdx: Int): String {
-        val endIdx = findConstructEndIdx(lines, startIdx)
+        val endIdx = findConstructEndIdx(lines, startIdx) ?: return ""
         return (startIdx..endIdx)
             .map { lines[it].trim() }
             .filter { it.isNotBlank() }
             .joinToString("\n")
     }
 
+    private enum class LexState { CODE, LINE_COMMENT, BLOCK_COMMENT, STRING, CHAR, RAW_STRING }
+
     /**
      * Finds the index of the line that closes the construct opening at
-     * [startIdx]. Brace counting starts at the catch/runCatching keyword so a
-     * `try { ... } catch` on the same line does not close the construct early.
-     * Braces inside string literals are ignored.
+     * [startIdx], or null when the construct never closes or the source ends
+     * inside a comment/string that cannot be balanced. Brace counting starts
+     * at the catch/runCatching keyword so a `try { ... } catch` on the same
+     * line does not close the construct early. Only structural braces in
+     * normal code change the depth; braces in comments, strings, char literals
+     * and raw strings are ignored, with state carried across lines.
      */
-    private fun findConstructEndIdx(lines: List<String>, startIdx: Int): Int {
+    private fun findConstructEndIdx(lines: List<String>, startIdx: Int): Int? {
         val startLine = lines[startIdx]
         val keywordPos = when {
             startLine.contains("runCatching") -> startLine.indexOf("runCatching")
@@ -215,22 +224,63 @@ object KotlinCancellationCatchScanner {
         }
         var depth = 0
         var opened = false
+        var state = LexState.CODE
         for (i in startIdx until lines.size) {
             val line = lines[i]
-            val from = if (i == startIdx) keywordPos.coerceAtLeast(0) else 0
-            for (pos in from until line.length) {
-                if (isInsideStringLiteral(line, pos)) continue
-                when (line[pos]) {
-                    '{' -> {
-                        depth++
-                        opened = true
+            var pos = if (i == startIdx) keywordPos.coerceAtLeast(0) else 0
+            while (pos < line.length) {
+                val c = line[pos]
+                when (state) {
+                    LexState.CODE -> when {
+                        c == '/' && pos + 1 < line.length && line[pos + 1] == '/' -> {
+                            state = LexState.LINE_COMMENT
+                            pos++
+                        }
+                        c == '/' && pos + 1 < line.length && line[pos + 1] == '*' -> {
+                            state = LexState.BLOCK_COMMENT
+                            pos++
+                        }
+                        c == '"' && pos + 2 < line.length && line[pos + 1] == '"' && line[pos + 2] == '"' -> {
+                            state = LexState.RAW_STRING
+                            pos += 2
+                        }
+                        c == '"' -> state = LexState.STRING
+                        c == '\'' -> state = LexState.CHAR
+                        c == '{' -> {
+                            depth++
+                            opened = true
+                        }
+                        c == '}' -> if (opened) {
+                            depth--
+                            if (depth == 0) return i
+                        }
+                        else -> {}
                     }
-                    '}' -> if (opened) depth--
+                    LexState.LINE_COMMENT -> { /* skip to end of line */ }
+                    LexState.BLOCK_COMMENT ->
+                        if (c == '*' && pos + 1 < line.length && line[pos + 1] == '/') {
+                            state = LexState.CODE
+                            pos++
+                        }
+                    LexState.STRING, LexState.CHAR ->
+                        if (c == '\\') {
+                            pos++ // skip escaped char
+                        } else if ((state == LexState.STRING && c == '"') || (state == LexState.CHAR && c == '\'')) {
+                            state = LexState.CODE
+                        }
+                    LexState.RAW_STRING ->
+                        if (c == '"' && pos + 2 < line.length && line[pos + 1] == '"' && line[pos + 2] == '"') {
+                            state = LexState.CODE
+                            pos += 2
+                        }
                 }
+                pos++
             }
-            if (opened && depth <= 0) return i
+            if (state == LexState.LINE_COMMENT) state = LexState.CODE
         }
-        return lines.size - 1
+        // Construct never closed, or source ends inside a comment/string we
+        // cannot balance → refuse relocation (blank fingerprint).
+        return null
     }
 
     /** Extract the catch variable name from a catch declaration line. */

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/KotlinCancellationCatchScanner.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/KotlinCancellationCatchScanner.kt
@@ -85,7 +85,8 @@ object KotlinCancellationCatchScanner {
                         rethrowsCancellation = rethrowsCancellation,
                         transformsException = transformsException,
                         risk = risk,
-                        sourceLine = originalLineNum
+                        sourceLine = originalLineNum,
+                        sourceFingerprint = normalizedSourceFingerprint(line)
                     )
                 )
             }
@@ -176,6 +177,18 @@ object KotlinCancellationCatchScanner {
             if (funMatch != null) return funMatch.groupValues[1]
         }
         return "<unknown>"
+    }
+
+    /**
+     * Normalized source-content fingerprint of a catch site, used as ephemeral
+     * relocation evidence by CancellationDeltaComparator. Strips all
+     * whitespace and inline comments so identical code that moved across files
+     * yields an identical fingerprint, regardless of indentation or line
+     * position. Not persisted (see @JsonIgnore on CancellationCatchFinding).
+     */
+    private fun normalizedSourceFingerprint(line: String): String {
+        val noComments = line.substringBefore("//").trim()
+        return noComments.filter { !it.isWhitespace() }
     }
 
     /** Extract the catch variable name from a catch declaration line. */

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/KotlinCancellationCatchScanner.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/KotlinCancellationCatchScanner.kt
@@ -86,7 +86,7 @@ object KotlinCancellationCatchScanner {
                         transformsException = transformsException,
                         risk = risk,
                         sourceLine = originalLineNum,
-                        sourceFingerprint = normalizedSourceFingerprint(line)
+                        sourceFingerprint = fingerprintConstruct(lines, originalLineIdx)
                     )
                 )
             }
@@ -180,15 +180,57 @@ object KotlinCancellationCatchScanner {
     }
 
     /**
-     * Normalized source-content fingerprint of a catch site, used as ephemeral
-     * relocation evidence by CancellationDeltaComparator. Strips all
-     * whitespace and inline comments so identical code that moved across files
-     * yields an identical fingerprint, regardless of indentation or line
-     * position. Not persisted (see @JsonIgnore on CancellationCatchFinding).
+     * Conservative source-content fingerprint of the ENTIRE broad-catch
+     * construct: from the line containing the catch/runCatching site through
+     * its balanced body closing brace (string-literal-aware brace counting).
+     * Normalization is deliberately minimal — each line is trimmed at the
+     * edges and blank lines dropped, but comments and string literal contents
+     * are preserved verbatim. Two different pieces of executable code cannot
+     * collapse to the same fingerprint: internal whitespace (e.g. `"a b"`
+     * vs `"ab"`) and comment markers inside strings (e.g. `"https://"`) are
+     * never stripped. A formatting-only difference producing a fingerprint
+     * mismatch (false positive) is the safe direction.
+     *
+     * Not persisted (see @JsonIgnore on CancellationCatchFinding).
      */
-    private fun normalizedSourceFingerprint(line: String): String {
-        val noComments = line.substringBefore("//").trim()
-        return noComments.filter { !it.isWhitespace() }
+    private fun fingerprintConstruct(lines: List<String>, startIdx: Int): String {
+        val endIdx = findConstructEndIdx(lines, startIdx)
+        return (startIdx..endIdx)
+            .map { lines[it].trim() }
+            .filter { it.isNotBlank() }
+            .joinToString("\n")
+    }
+
+    /**
+     * Finds the index of the line that closes the construct opening at
+     * [startIdx]. Brace counting starts at the catch/runCatching keyword so a
+     * `try { ... } catch` on the same line does not close the construct early.
+     * Braces inside string literals are ignored.
+     */
+    private fun findConstructEndIdx(lines: List<String>, startIdx: Int): Int {
+        val startLine = lines[startIdx]
+        val keywordPos = when {
+            startLine.contains("runCatching") -> startLine.indexOf("runCatching")
+            else -> startLine.indexOf("catch")
+        }
+        var depth = 0
+        var opened = false
+        for (i in startIdx until lines.size) {
+            val line = lines[i]
+            val from = if (i == startIdx) keywordPos.coerceAtLeast(0) else 0
+            for (pos in from until line.length) {
+                if (isInsideStringLiteral(line, pos)) continue
+                when (line[pos]) {
+                    '{' -> {
+                        depth++
+                        opened = true
+                    }
+                    '}' -> if (opened) depth--
+                }
+            }
+            if (opened && depth <= 0) return i
+        }
+        return lines.size - 1
     }
 
     /** Extract the catch variable name from a catch declaration line. */

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/CancellationDeltaComparatorTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/CancellationDeltaComparatorTest.kt
@@ -159,6 +159,45 @@ class CancellationDeltaComparatorTest {
     }
 
     @Test
+    fun `finding moved to another file is unchanged`() {
+        val base = listOf(
+            finding("critical", module = "modA", file = "Workflow.kt", function = "leaseAttributes", catchType = "runCatching")
+        )
+        val current = listOf(
+            finding("critical", module = "modA", file = "WorkflowPersistenceSession.kt", function = "leaseAttributes", catchType = "runCatching")
+        )
+        val result = CancellationDeltaComparator.compare(base, current)
+        assertTrue(result.newCriticalHigh.isEmpty(), "Moved finding is not new")
+        assertTrue(result.worsened.isEmpty(), "No worsenings")
+        assertEquals(1, result.unchanged, "1 unchanged (same function/catchType/risk, file differs)")
+        assertFalse(
+            result.newCriticalHigh.isNotEmpty() || result.worsened.isNotEmpty(),
+            "Gate check should pass"
+        )
+    }
+
+    @Test
+    fun `new finding with same function in different file is still flagged`() {
+        // Base has op1 in A.kt; current gains an ADDITIONAL op1 in B.kt — the
+        // population grew, so this must still fail even though the group key
+        // ignores the file component.
+        val base = listOf(
+            finding("critical", module = "modA", file = "A.kt", function = "op1")
+        )
+        val current = listOf(
+            finding("critical", module = "modA", file = "A.kt", function = "op1"),
+            finding("critical", module = "modA", file = "B.kt", function = "op1")
+        )
+        val result = CancellationDeltaComparator.compare(base, current)
+        assertEquals(1, result.newCriticalHigh.size, "Genuinely new finding must be flagged")
+        assertEquals("B.kt", result.newCriticalHigh.first().file)
+        assertTrue(
+            result.newCriticalHigh.isNotEmpty() || result.worsened.isNotEmpty(),
+            "Gate check should fail"
+        )
+    }
+
+    @Test
     fun `duplicate high findings with different source lines`() {
         val base = listOf(finding("high", function = "op1", sourceLine = 10))
         val current = listOf(

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/CancellationDeltaComparatorTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/CancellationDeltaComparatorTest.kt
@@ -160,16 +160,20 @@ class CancellationDeltaComparatorTest {
 
     @Test
     fun `finding moved to another file is unchanged`() {
+        // The actual Epic 4.2 relocation: runCatching moved from Workflow.kt
+        // line 1767 to WorkflowPersistenceSession.kt line 202, same function
+        // attribution (leaseAttributes), same catchType, same risk, and the
+        // source line CHANGED because the code physically moved.
         val base = listOf(
-            finding("critical", module = "modA", file = "Workflow.kt", function = "leaseAttributes", catchType = "runCatching")
+            finding("critical", module = "modA", file = "Workflow.kt", function = "leaseAttributes", catchType = "runCatching", sourceLine = 1767)
         )
         val current = listOf(
-            finding("critical", module = "modA", file = "WorkflowPersistenceSession.kt", function = "leaseAttributes", catchType = "runCatching")
+            finding("critical", module = "modA", file = "WorkflowPersistenceSession.kt", function = "leaseAttributes", catchType = "runCatching", sourceLine = 202)
         )
         val result = CancellationDeltaComparator.compare(base, current)
         assertTrue(result.newCriticalHigh.isEmpty(), "Moved finding is not new")
         assertTrue(result.worsened.isEmpty(), "No worsenings")
-        assertEquals(1, result.unchanged, "1 unchanged (same function/catchType/risk, file differs)")
+        assertEquals(1, result.unchanged, "1 unchanged (unique relocation: same function/catchType/risk, file + line changed)")
         assertFalse(
             result.newCriticalHigh.isNotEmpty() || result.worsened.isNotEmpty(),
             "Gate check should pass"
@@ -177,16 +181,58 @@ class CancellationDeltaComparatorTest {
     }
 
     @Test
-    fun `new finding with same function in different file is still flagged`() {
-        // Base has op1 in A.kt; current gains an ADDITIONAL op1 in B.kt — the
-        // population grew, so this must still fail even though the group key
-        // ignores the file component.
+    fun `unrelated cross file replacement is not treated as relocation`() {
+        // Equal-cardinality replacement: same function, catchType and risk,
+        // different file, but the source line is IDENTICAL. This is NOT a
+        // move — it is an unrelated replacement that happens to share the
+        // signature. The safe bias is to flag the current finding.
         val base = listOf(
-            finding("critical", module = "modA", file = "A.kt", function = "op1")
+            finding("critical", module = "modA", file = "Old.kt", function = "execute", sourceLine = 10)
         )
         val current = listOf(
-            finding("critical", module = "modA", file = "A.kt", function = "op1"),
-            finding("critical", module = "modA", file = "B.kt", function = "op1")
+            finding("critical", module = "modA", file = "New.kt", function = "execute", sourceLine = 10)
+        )
+        val result = CancellationDeltaComparator.compare(base, current)
+        assertEquals(1, result.newCriticalHigh.size, "Same-line cross-file replacement must be flagged")
+        assertEquals("New.kt", result.newCriticalHigh.first().file)
+        assertTrue(
+            result.newCriticalHigh.isNotEmpty() || result.worsened.isNotEmpty(),
+            "Gate check should fail"
+        )
+    }
+
+    @Test
+    fun `ambiguous relocation candidates are not silently accepted`() {
+        // Two base findings share the relocation key but only one current
+        // finding exists — which base finding moved? Not uniquely attributable,
+        // so the current finding must be flagged rather than silently accepted.
+        val base = listOf(
+            finding("critical", module = "modA", file = "A.kt", function = "op1", sourceLine = 10),
+            finding("critical", module = "modA", file = "B.kt", function = "op1", sourceLine = 20)
+        )
+        val current = listOf(
+            finding("critical", module = "modA", file = "C.kt", function = "op1", sourceLine = 30)
+        )
+        val result = CancellationDeltaComparator.compare(base, current)
+        assertEquals(1, result.newCriticalHigh.size, "Ambiguous relocation must be flagged")
+        assertEquals("C.kt", result.newCriticalHigh.first().file)
+        assertTrue(
+            result.newCriticalHigh.isNotEmpty() || result.worsened.isNotEmpty(),
+            "Gate check should fail"
+        )
+    }
+
+    @Test
+    fun `new finding with same function in different file is still flagged`() {
+        // Base has op1 in A.kt; current gains an ADDITIONAL op1 in B.kt — the
+        // population grew, so this must still fail: the file-aware phase keeps
+        // them in separate groups, and the A.kt finding is already matched.
+        val base = listOf(
+            finding("critical", module = "modA", file = "A.kt", function = "op1", sourceLine = 10)
+        )
+        val current = listOf(
+            finding("critical", module = "modA", file = "A.kt", function = "op1", sourceLine = 10),
+            finding("critical", module = "modA", file = "B.kt", function = "op1", sourceLine = 40)
         )
         val result = CancellationDeltaComparator.compare(base, current)
         assertEquals(1, result.newCriticalHigh.size, "Genuinely new finding must be flagged")

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/CancellationDeltaComparatorTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/CancellationDeltaComparatorTest.kt
@@ -14,14 +14,16 @@ class CancellationDeltaComparatorTest {
         file: String = "Test.kt",
         function: String = "riskyOperation",
         catchType: String = "Exception",
-        sourceLine: Int = 10
+        sourceLine: Int = 10,
+        sourceFingerprint: String = ""
     ): CancellationCatchFinding = CancellationCatchFinding(
         module = module,
         file = file,
         function = function,
         catchType = catchType,
         risk = risk,
-        sourceLine = sourceLine
+        sourceLine = sourceLine,
+        sourceFingerprint = sourceFingerprint
     )
 
     private fun asserting(result: CancellationDeltaComparator.Result) {
@@ -159,21 +161,42 @@ class CancellationDeltaComparatorTest {
     }
 
     @Test
-    fun `finding moved to another file is unchanged`() {
-        // The actual Epic 4.2 relocation: runCatching moved from Workflow.kt
-        // line 1767 to WorkflowPersistenceSession.kt line 202, same function
-        // attribution (leaseAttributes), same catchType, same risk, and the
-        // source line CHANGED because the code physically moved.
+    fun `finding moved to another file with matching fingerprint is unchanged`() {
+        // The actual Epic 4.2 relocation: `runCatching { abort() }` moved from
+        // Workflow.kt line 1767 to WorkflowPersistenceSession.kt line 202,
+        // same function attribution (leaseAttributes), same catchType, same
+        // risk. The normalized source fingerprint is identical because the
+        // same code text is present at both sites — content proves the move.
         val base = listOf(
-            finding("critical", module = "modA", file = "Workflow.kt", function = "leaseAttributes", catchType = "runCatching", sourceLine = 1767)
+            finding("critical", module = "modA", file = "Workflow.kt", function = "leaseAttributes", catchType = "runCatching", sourceLine = 1767, sourceFingerprint = "runCatching{abort()}")
         )
         val current = listOf(
-            finding("critical", module = "modA", file = "WorkflowPersistenceSession.kt", function = "leaseAttributes", catchType = "runCatching", sourceLine = 202)
+            finding("critical", module = "modA", file = "WorkflowPersistenceSession.kt", function = "leaseAttributes", catchType = "runCatching", sourceLine = 202, sourceFingerprint = "runCatching{abort()}")
         )
         val result = CancellationDeltaComparator.compare(base, current)
         assertTrue(result.newCriticalHigh.isEmpty(), "Moved finding is not new")
         assertTrue(result.worsened.isEmpty(), "No worsenings")
-        assertEquals(1, result.unchanged, "1 unchanged (unique relocation: same function/catchType/risk, file + line changed)")
+        assertEquals(1, result.unchanged, "1 unchanged (unique relocation with matching content fingerprint)")
+        assertFalse(
+            result.newCriticalHigh.isNotEmpty() || result.worsened.isNotEmpty(),
+            "Gate check should pass"
+        )
+    }
+
+    @Test
+    fun `genuine move landing on same line with matching fingerprint is unchanged`() {
+        // A real move CAN land on the same source line number in the new file.
+        // Content fingerprint — not line inequality — is the evidence, so this
+        // must pass: same normalized catch-site text in both files.
+        val base = listOf(
+            finding("critical", module = "modA", file = "Old.kt", function = "execute", sourceLine = 10, sourceFingerprint = "runCatching{abort()}")
+        )
+        val current = listOf(
+            finding("critical", module = "modA", file = "New.kt", function = "execute", sourceLine = 10, sourceFingerprint = "runCatching{abort()}")
+        )
+        val result = CancellationDeltaComparator.compare(base, current)
+        assertTrue(result.newCriticalHigh.isEmpty(), "Same-line move with matching content is a relocation")
+        assertEquals(1, result.unchanged)
         assertFalse(
             result.newCriticalHigh.isNotEmpty() || result.worsened.isNotEmpty(),
             "Gate check should pass"
@@ -183,18 +206,58 @@ class CancellationDeltaComparatorTest {
     @Test
     fun `unrelated cross file replacement is not treated as relocation`() {
         // Equal-cardinality replacement: same function, catchType and risk,
-        // different file, but the source line is IDENTICAL. This is NOT a
+        // different file, but DIFFERENT catch-site content. This is NOT a
         // move — it is an unrelated replacement that happens to share the
         // signature. The safe bias is to flag the current finding.
+        val base = listOf(
+            finding("critical", module = "modA", file = "Old.kt", function = "execute", sourceLine = 10, sourceFingerprint = "runCatching{foo()}")
+        )
+        val current = listOf(
+            finding("critical", module = "modA", file = "New.kt", function = "execute", sourceLine = 10, sourceFingerprint = "runCatching{bar()}")
+        )
+        val result = CancellationDeltaComparator.compare(base, current)
+        assertEquals(1, result.newCriticalHigh.size, "Different-content cross-file replacement must be flagged")
+        assertEquals("New.kt", result.newCriticalHigh.first().file)
+        assertTrue(
+            result.newCriticalHigh.isNotEmpty() || result.worsened.isNotEmpty(),
+            "Gate check should fail"
+        )
+    }
+
+    @Test
+    fun `unrelated cross file replacement at different line is not treated as relocation`() {
+        // The critical false-negative case: base Old.kt:10 removed and an
+        // UNRELATED catch introduced at New.kt:40, coincidentally same
+        // module/function/catchType/risk. Different line numbers make it look
+        // like a move; the differing content fingerprint proves it is not.
+        val base = listOf(
+            finding("critical", module = "modA", file = "Old.kt", function = "execute", sourceLine = 10, sourceFingerprint = "runCatching{oldWork()}")
+        )
+        val current = listOf(
+            finding("critical", module = "modA", file = "New.kt", function = "execute", sourceLine = 40, sourceFingerprint = "runCatching{newWork()}")
+        )
+        val result = CancellationDeltaComparator.compare(base, current)
+        assertEquals(1, result.newCriticalHigh.size, "Different-line unrelated replacement must be flagged")
+        assertEquals("New.kt", result.newCriticalHigh.first().file)
+        assertTrue(
+            result.newCriticalHigh.isNotEmpty() || result.worsened.isNotEmpty(),
+            "Gate check should fail"
+        )
+    }
+
+    @Test
+    fun `relocation without content evidence is not accepted`() {
+        // No sourceFingerprint on either side (e.g. findings loaded from a
+        // persisted baseline without ephemeral evidence): the verifier cannot
+        // prove it is the same catch, so it must not call it a relocation.
         val base = listOf(
             finding("critical", module = "modA", file = "Old.kt", function = "execute", sourceLine = 10)
         )
         val current = listOf(
-            finding("critical", module = "modA", file = "New.kt", function = "execute", sourceLine = 10)
+            finding("critical", module = "modA", file = "New.kt", function = "execute", sourceLine = 40)
         )
         val result = CancellationDeltaComparator.compare(base, current)
-        assertEquals(1, result.newCriticalHigh.size, "Same-line cross-file replacement must be flagged")
-        assertEquals("New.kt", result.newCriticalHigh.first().file)
+        assertEquals(1, result.newCriticalHigh.size, "No content evidence → flag the current finding")
         assertTrue(
             result.newCriticalHigh.isNotEmpty() || result.worsened.isNotEmpty(),
             "Gate check should fail"
@@ -207,11 +270,11 @@ class CancellationDeltaComparatorTest {
         // finding exists — which base finding moved? Not uniquely attributable,
         // so the current finding must be flagged rather than silently accepted.
         val base = listOf(
-            finding("critical", module = "modA", file = "A.kt", function = "op1", sourceLine = 10),
-            finding("critical", module = "modA", file = "B.kt", function = "op1", sourceLine = 20)
+            finding("critical", module = "modA", file = "A.kt", function = "op1", sourceLine = 10, sourceFingerprint = "runCatching{x()}"),
+            finding("critical", module = "modA", file = "B.kt", function = "op1", sourceLine = 20, sourceFingerprint = "runCatching{y()}")
         )
         val current = listOf(
-            finding("critical", module = "modA", file = "C.kt", function = "op1", sourceLine = 30)
+            finding("critical", module = "modA", file = "C.kt", function = "op1", sourceLine = 30, sourceFingerprint = "runCatching{x()}")
         )
         val result = CancellationDeltaComparator.compare(base, current)
         assertEquals(1, result.newCriticalHigh.size, "Ambiguous relocation must be flagged")

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/CancellationDeltaComparatorTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/CancellationDeltaComparatorTest.kt
@@ -165,13 +165,14 @@ class CancellationDeltaComparatorTest {
         // The actual Epic 4.2 relocation: `runCatching { abort() }` moved from
         // Workflow.kt line 1767 to WorkflowPersistenceSession.kt line 202,
         // same function attribution (leaseAttributes), same catchType, same
-        // risk. The normalized source fingerprint is identical because the
-        // same code text is present at both sites — content proves the move.
+        // risk. The fingerprint is the full balanced construct (per-line
+        // trimmed, content preserved) — identical because the same code text
+        // moved. This is the fingerprint the real scanner produces.
         val base = listOf(
-            finding("critical", module = "modA", file = "Workflow.kt", function = "leaseAttributes", catchType = "runCatching", sourceLine = 1767, sourceFingerprint = "runCatching{abort()}")
+            finding("critical", module = "modA", file = "Workflow.kt", function = "leaseAttributes", catchType = "runCatching", sourceLine = 1767, sourceFingerprint = "runCatching { abort() }")
         )
         val current = listOf(
-            finding("critical", module = "modA", file = "WorkflowPersistenceSession.kt", function = "leaseAttributes", catchType = "runCatching", sourceLine = 202, sourceFingerprint = "runCatching{abort()}")
+            finding("critical", module = "modA", file = "WorkflowPersistenceSession.kt", function = "leaseAttributes", catchType = "runCatching", sourceLine = 202, sourceFingerprint = "runCatching { abort() }")
         )
         val result = CancellationDeltaComparator.compare(base, current)
         assertTrue(result.newCriticalHigh.isEmpty(), "Moved finding is not new")
@@ -189,10 +190,10 @@ class CancellationDeltaComparatorTest {
         // Content fingerprint — not line inequality — is the evidence, so this
         // must pass: same normalized catch-site text in both files.
         val base = listOf(
-            finding("critical", module = "modA", file = "Old.kt", function = "execute", sourceLine = 10, sourceFingerprint = "runCatching{abort()}")
+            finding("critical", module = "modA", file = "Old.kt", function = "execute", sourceLine = 10, sourceFingerprint = "runCatching { abort() }")
         )
         val current = listOf(
-            finding("critical", module = "modA", file = "New.kt", function = "execute", sourceLine = 10, sourceFingerprint = "runCatching{abort()}")
+            finding("critical", module = "modA", file = "New.kt", function = "execute", sourceLine = 10, sourceFingerprint = "runCatching { abort() }")
         )
         val result = CancellationDeltaComparator.compare(base, current)
         assertTrue(result.newCriticalHigh.isEmpty(), "Same-line move with matching content is a relocation")

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/KotlinCancellationCatchScannerTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/KotlinCancellationCatchScannerTest.kt
@@ -762,6 +762,13 @@ class KotlinCancellationCatchScannerTest {
         return findings.first().sourceFingerprint
     }
 
+    private fun fingerprintOf(source: String, catchType: String): String {
+        val findings = KotlinCancellationCatchScanner.scan(source, "test", "Test.kt")
+        val finding = findings.firstOrNull { it.catchType == catchType }
+        assertNotNull(finding, "Expected a $catchType finding in: $source")
+        return finding.sourceFingerprint
+    }
+
     @Test
     fun `identical multiline runCatching moved across files has same fingerprint`() {
         val base = """
@@ -1023,6 +1030,71 @@ class KotlinCancellationCatchScannerTest {
         val currentFp = fingerprintOf(current)
         assertTrue(baseFp.contains("deleteTemporaryState"), "Fingerprint must not truncate at string brace, got: $baseFp")
         assertTrue(currentFp.contains("publishExternalResult"), "Fingerprint must not truncate at string brace, got: $currentFp")
+        assertNotEquals(baseFp, currentFp)
+    }
+
+    @Test
+    fun `nested block comment containing brace does not truncate fingerprint`() {
+        // Kotlin block comments nest — an inner `/* */` inside an outer
+        // `/* */` must not return to CODE early, and a `}` inside the still-
+        // open outer comment must not close the construct.
+        val base = """
+            suspend fun execute() {
+                runCatching {
+                    /* outer
+                       /* inner */
+                       }
+                    */
+                    deleteTemporaryState()
+                }
+            }
+        """.trimIndent()
+        val current = """
+            suspend fun execute() {
+                runCatching {
+                    /* outer
+                       /* inner */
+                       }
+                    */
+                    publishExternalResult()
+                }
+            }
+        """.trimIndent()
+        val baseFp = fingerprintOf(base)
+        val currentFp = fingerprintOf(current)
+        assertTrue(baseFp.contains("deleteTemporaryState"), "Fingerprint must not truncate at nested-comment brace, got: $baseFp")
+        assertTrue(currentFp.contains("publishExternalResult"), "Fingerprint must not truncate at nested-comment brace, got: $currentFp")
+        assertNotEquals(baseFp, currentFp)
+    }
+
+    @Test
+    fun `outer catch with inner runCatching on opening line anchors to the catch`() {
+        // The fingerprint must anchor to the ACTUAL matched construct. An
+        // outer catch whose opening line also contains an inner runCatching
+        // must balance the OUTER construct (statement after the inner
+        // runCatching included), not stop at the inner one.
+        val base = """
+            suspend fun execute() {
+                try {
+                    work()
+                } catch (e: Exception) { runCatching { commonCleanup() }
+                    oldWork()
+                }
+            }
+        """.trimIndent()
+        val current = """
+            suspend fun execute() {
+                try {
+                    work()
+                } catch (e: Exception) { runCatching { commonCleanup() }
+                    completelyDifferentWork()
+                }
+            }
+        """.trimIndent()
+        val baseFp = fingerprintOf(base, "Exception")
+        val currentFp = fingerprintOf(current, "Exception")
+        assertTrue(baseFp.contains("oldWork"), "Outer-catch fingerprint must include statement after inner runCatching, got: $baseFp")
+        assertTrue(currentFp.contains("completelyDifferentWork"), "Outer-catch fingerprint must include statement after inner runCatching, got: $currentFp")
         assertNotEquals(baseFp, currentFp)
     }
 

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/KotlinCancellationCatchScannerTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/KotlinCancellationCatchScannerTest.kt
@@ -913,4 +913,136 @@ class KotlinCancellationCatchScannerTest {
         assertFalse(json.contains("sourceFingerprint"), "sourceFingerprint must not be serialized: $json")
         assertFalse(json.contains("runCatching { abort() }"), "Fingerprint content must not leak into JSON: $json")
     }
+
+    @Test
+    fun `brace inside line comment does not terminate fingerprint`() {
+        // A `}` in a comment is not structural — the construct continues past
+        // it and the differing executable statements must produce different
+        // fingerprints.
+        val base = """
+            suspend fun execute() {
+                runCatching {
+                    // }
+                    deleteTemporaryState()
+                }
+            }
+        """.trimIndent()
+        val current = """
+            suspend fun execute() {
+                runCatching {
+                    // }
+                    publishExternalResult()
+                }
+            }
+        """.trimIndent()
+        val baseFp = fingerprintOf(base)
+        val currentFp = fingerprintOf(current)
+        assertTrue(baseFp.contains("deleteTemporaryState"), "Fingerprint must not truncate at comment brace, got: $baseFp")
+        assertTrue(currentFp.contains("publishExternalResult"), "Fingerprint must not truncate at comment brace, got: $currentFp")
+        assertNotEquals(baseFp, currentFp)
+    }
+
+    @Test
+    fun `brace inside block comment does not terminate fingerprint`() {
+        val base = """
+            suspend fun execute() {
+                runCatching {
+                    /* }
+                       still comment */
+                    deleteTemporaryState()
+                }
+            }
+        """.trimIndent()
+        val current = """
+            suspend fun execute() {
+                runCatching {
+                    /* }
+                       still comment */
+                    publishExternalResult()
+                }
+            }
+        """.trimIndent()
+        val baseFp = fingerprintOf(base)
+        val currentFp = fingerprintOf(current)
+        assertTrue(baseFp.contains("deleteTemporaryState"), "Fingerprint must not truncate at block-comment brace, got: $baseFp")
+        assertTrue(currentFp.contains("publishExternalResult"), "Fingerprint must not truncate at block-comment brace, got: $currentFp")
+        assertNotEquals(baseFp, currentFp)
+    }
+
+    @Test
+    fun `brace inside multiline raw string does not terminate fingerprint`() {
+        // A `}` inside a triple-quoted raw string is content, not structure —
+        // the state must carry across lines so the construct is not truncated.
+        val tq = "\"\"\""
+        val base = """
+            suspend fun execute() {
+                runCatching {
+                    val json = $tq
+                        }
+                    $tq.trimIndent()
+                    deleteTemporaryState()
+                }
+            }
+        """.trimIndent()
+        val current = """
+            suspend fun execute() {
+                runCatching {
+                    val json = $tq
+                        }
+                    $tq.trimIndent()
+                    publishExternalResult()
+                }
+            }
+        """.trimIndent()
+        val baseFp = fingerprintOf(base)
+        val currentFp = fingerprintOf(current)
+        assertTrue(baseFp.contains("deleteTemporaryState"), "Fingerprint must not truncate at raw-string brace, got: $baseFp")
+        assertTrue(currentFp.contains("publishExternalResult"), "Fingerprint must not truncate at raw-string brace, got: $currentFp")
+        assertNotEquals(baseFp, currentFp)
+    }
+
+    @Test
+    fun `brace inside regular string does not terminate fingerprint`() {
+        val base = """
+            suspend fun execute() {
+                runCatching {
+                    log("}")
+                    deleteTemporaryState()
+                }
+            }
+        """.trimIndent()
+        val current = """
+            suspend fun execute() {
+                runCatching {
+                    log("}")
+                    publishExternalResult()
+                }
+            }
+        """.trimIndent()
+        val baseFp = fingerprintOf(base)
+        val currentFp = fingerprintOf(current)
+        assertTrue(baseFp.contains("deleteTemporaryState"), "Fingerprint must not truncate at string brace, got: $baseFp")
+        assertTrue(currentFp.contains("publishExternalResult"), "Fingerprint must not truncate at string brace, got: $currentFp")
+        assertNotEquals(baseFp, currentFp)
+    }
+
+    @Test
+    fun `unterminated string yields blank fingerprint refusing relocation`() {
+        // Unbalanced source (unterminated raw string before the construct's
+        // real close) → blank fingerprint → Phase 2 refuses relocation.
+        val tq = "\"\"\""
+        val findings = KotlinCancellationCatchScanner.scan(
+            """
+            suspend fun execute() {
+                runCatching {
+                    val json = $tq
+                    deleteTemporaryState()
+                }
+            }
+            """.trimIndent(), "test", "Test.kt"
+        )
+        assertTrue(findings.isNotEmpty())
+        assertEquals("", findings.first().sourceFingerprint,
+            "Unbalanced construct must produce blank fingerprint (refuse relocation)")
+    }
 }

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/KotlinCancellationCatchScannerTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/KotlinCancellationCatchScannerTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import java.nio.file.Path
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -751,5 +752,165 @@ class KotlinCancellationCatchScannerTest {
         assertTrue(findings.isNotEmpty(), "Should find catch")
         assertNotEquals("accepted", findings.first().risk,
             "Multiple statements without rethrowIfCancellation() should NOT be accepted")
+    }
+
+    // ── Fingerprint (source-content relocation evidence) tests ──
+
+    private fun fingerprintOf(source: String): String {
+        val findings = KotlinCancellationCatchScanner.scan(source, "test", "Test.kt")
+        assertTrue(findings.isNotEmpty(), "Expected at least one finding in: $source")
+        return findings.first().sourceFingerprint
+    }
+
+    @Test
+    fun `identical multiline runCatching moved across files has same fingerprint`() {
+        val base = """
+            suspend fun execute() {
+                runCatching {
+                    deleteTemporaryState()
+                }
+            }
+        """.trimIndent()
+        val current = """
+            suspend fun execute() {
+                runCatching {
+                    deleteTemporaryState()
+                }
+            }
+        """.trimIndent()
+        assertEquals(fingerprintOf(base), fingerprintOf(current),
+            "Identical multiline runCatching must have identical fingerprints")
+    }
+
+    @Test
+    fun `multiline runCatching with different bodies has different fingerprints`() {
+        val base = """
+            suspend fun execute() {
+                runCatching {
+                    deleteTemporaryState()
+                }
+            }
+        """.trimIndent()
+        val current = """
+            suspend fun execute() {
+                runCatching {
+                    publishExternalResult()
+                }
+            }
+        """.trimIndent()
+        assertNotEquals(fingerprintOf(base), fingerprintOf(current),
+            "Different runCatching bodies must not collide")
+    }
+
+    @Test
+    fun `catch blocks with different bodies have different fingerprints`() {
+        val base = """
+            suspend fun execute() {
+                try {
+                    doSomething()
+                } catch (e: Exception) {
+                    logError(e)
+                }
+            }
+        """.trimIndent()
+        val current = """
+            suspend fun execute() {
+                try {
+                    doSomething()
+                } catch (e: Exception) {
+                    publishFailure(e)
+                }
+            }
+        """.trimIndent()
+        assertNotEquals(fingerprintOf(base), fingerprintOf(current),
+            "Different catch bodies must not collide")
+    }
+
+    @Test
+    fun `genuine move landing on same line has same fingerprint`() {
+        // Same construct, same line number — the fingerprint is content-based,
+        // so a genuine move that lands on the same line is still a relocation.
+        val source = """
+            suspend fun execute() {
+                runCatching { abort() }
+            }
+        """.trimIndent()
+        assertEquals(fingerprintOf(source), fingerprintOf(source))
+    }
+
+    @Test
+    fun `strings containing a b vs ab do not collapse`() {
+        val withSpace = """
+            suspend fun execute() {
+                runCatching {
+                    log("a b")
+                }
+            }
+        """.trimIndent()
+        val withoutSpace = """
+            suspend fun execute() {
+                runCatching {
+                    log("ab")
+                }
+            }
+        """.trimIndent()
+        assertNotEquals(fingerprintOf(withSpace), fingerprintOf(withoutSpace),
+            "String contents must be preserved — 'a b' must not collapse to 'ab'")
+    }
+
+    @Test
+    fun `strings containing https are preserved`() {
+        val source = """
+            suspend fun execute() {
+                runCatching {
+                    post("https://example.com/api")
+                }
+            }
+        """.trimIndent()
+        val fingerprint = fingerprintOf(source)
+        assertTrue(fingerprint.contains("https://"),
+            "Comment marker inside string literal must be preserved, got: $fingerprint")
+    }
+
+    @Test
+    fun `fingerprint covers full body not just opening line`() {
+        // The fingerprint must include body content — an opening line alone
+        // (runCatching{) would not distinguish these two constructs.
+        val base = """
+            suspend fun execute() {
+                runCatching {
+                    deleteTemporaryState()
+                }
+            }
+        """.trimIndent()
+        val current = """
+            suspend fun execute() {
+                runCatching {
+                    publishExternalResult()
+                }
+            }
+        """.trimIndent()
+        val baseFp = fingerprintOf(base)
+        val currentFp = fingerprintOf(current)
+        assertTrue(baseFp.contains("deleteTemporaryState"), "Fingerprint must cover body, got: $baseFp")
+        assertTrue(currentFp.contains("publishExternalResult"), "Fingerprint must cover body, got: $currentFp")
+        assertNotEquals(baseFp, currentFp)
+    }
+
+    @Test
+    fun `fingerprint is not serialized into baseline json`() {
+        // "Zero schema change" is a protected invariant: the ephemeral
+        // relocation evidence must never leak into the persisted baseline.
+        val findings = KotlinCancellationCatchScanner.scan(
+            """
+            suspend fun execute() {
+                runCatching { abort() }
+            }
+            """.trimIndent(), "test", "Test.kt"
+        )
+        assertTrue(findings.isNotEmpty())
+        val json = ReportNormalizer.toJson(findings.first())
+        assertFalse(json.contains("sourceFingerprint"), "sourceFingerprint must not be serialized: $json")
+        assertFalse(json.contains("runCatching { abort() }"), "Fingerprint content must not leak into JSON: $json")
     }
 }


### PR DESCRIPTION
## What

`verifyCancellationSafety` rejected a **pure file move** of an existing broad catch as "1 new critical finding".

**Evidence:** splitting `Workflow.kt` (Epic 4.2) moved `runCatchingAbort` from `Workflow.kt` to `WorkflowPersistenceSession.kt`. Identical code, identical function attribution, identical `runCatching` catchType, identical `critical` risk — only the file changed. Total population **295 current = 295 base** (net zero).

**Root cause:** `CancellationDeltaComparator` groups findings by `module::file::function::catchType`. The file component makes finding identity position-based, so any refactor that relocates a broad catch reads as a new critical finding. The comparator's own KDoc states the design intent: *"risk population matching, not position-based identity."*

## Fix — two-phase comparison with source-content relocation evidence

**Phase 1 — file-aware normal matching (unchanged):** groups by `(module, file, function, catchType)`. A genuinely new critical catch in a different file is never masked by an existing catch with the same function name.

**Phase 2 — conservative relocation pass over UNMATCHED findings only.** A relocation is accepted only when ALL of:

- exactly one base + one current candidate share `(module, function, catchType, risk)` across **different files** (uniquely attributable — ambiguity on either side flags the current finding)
- both candidates carry a **non-blank source-content fingerprint**
- the fingerprints **match**

A unique 1:1 semantic match **without** matching content is NOT a relocation — it is an unrelated replacement with coincidentally identical metadata, and it is flagged.

### The fingerprint

The scanner fingerprints the **entire brace-balanced construct** — from the matched `catch`/`runCatching` keyword through the closing brace of its body — not just the opening line. Two `runCatching {` blocks with different bodies produce different fingerprints.

Brace balancing is **lexical-state-aware across lines**: line comments, **nested block comments** (Kotlin block comments nest — tracked with a comment depth counter), regular strings, char literals and multi-line raw strings are tracked, and braces inside them never change the depth. Only structural braces in normal code close the construct. Balancing is **anchored to the actual broad-catch match** (the `MatchResult` position), not rediscovered from the line text — an outer catch whose opening line also contains an inner `runCatching` balances the outer construct, never the inner one. If the source ends inside a comment or string that cannot be balanced, the fingerprint is blank and Phase 2 refuses relocation (safe bias).

Normalization is deliberately conservative and string-safe:

- each line is trimmed at the edges, blank lines dropped
- string literal contents and comment markers are **preserved verbatim** — `"a b"` never collapses to `"ab"`, `"https://"` is never treated as a comment

A formatting-only difference producing a fingerprint mismatch (false positive → gate fails) is the safe direction.

**Ephemeral, zero schema change:** the fingerprint is `@JsonIgnore`d and never persisted — the verifier re-scans the base git worktree, so both source trees are in memory. Persisted baseline stays schema v1.

## Behavior table

| Scenario | Result |
|---|---|
| Real move, matching construct (Workflow.kt → WorkflowPersistenceSession.kt) | ✅ unchanged |
| Genuine move landing on the same line number | ✅ unchanged (content proves it, not line) |
| Unrelated replacement, different content, same or different line | ❌ flagged |
| Relocation without content evidence (e.g. persisted-baseline findings) | ❌ flagged |
| Ambiguous (multiple relocation candidates) | ❌ flagged |
| Genuine addition | ❌ flagged |
| Risk worsening | ❌ flagged |

## Tests

**Comparator (22):** move-with-fingerprint PASS, same-line move PASS, unrelated replacement (same line / different line) FAIL, no-evidence FAIL, ambiguous FAIL, addition FAIL, worsening FAIL.

**Scanner (55, incl. 15 fingerprint tests):** identical multiline `runCatching` across files → same fingerprint; different bodies → different fingerprints; `catch (Exception)` different bodies → different fingerprints; same-line genuine move → same fingerprint; `"a b"` vs `"ab"` do not collapse; `"https://"` preserved; fingerprint covers full body; `sourceFingerprint` never serialized into baseline JSON; brace in line comment / block comment / multiline raw string / regular string never terminates the construct early; **nested block comment with `}` does not truncate**; **outer catch + inner runCatching on opening line anchors to the catch** (statement after the inner construct is included); unterminated string → blank fingerprint (refuse relocation).

## Gate

```
./gradlew :build-logic:test :build-logic:canonicalProbeIntegrationTest \
  verifyCancellationSafety verifyChangePolicy verifyMaintainabilityBaseline \
  -PchangeClass=build-logic
```

- `:build-logic:test` — 0 failures (55 scanner + 22 comparator)
- `:build-logic:canonicalProbeIntegrationTest` — PASSED (repository policy for scanner changes, build-logic/AGENTS.md §4)
- verifyCancellationSafety PASSED — 295 findings, no new critical/high, no worsenings (against origin/master)
- verifyChangePolicy PASSED — 5 files, build-logic class
- Maintainability baseline PASSED
- BUILD SUCCESSFUL, EXIT=0
