### PR TITLE
fix(quality): suspend-range walk must not skip the line after a block

### DIFF
--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/KotlinCancellationCatchScanner.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/KotlinCancellationCatchScanner.kt
@@ -151,7 +151,10 @@ object KotlinCancellationCatchScanner {
                 val start = i + 1
                 val end = findBlockEnd(lines, i)
                 ranges.add(start..end)
-                i = end
+                // findBlockEnd returns one past the closing brace; stepping to
+                // end-1 lets the loop's i++ land ON end, so a suspend fun whose
+                // declaration sits immediately after a block is not skipped.
+                i = end - 1
             }
             i++
         }

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/KotlinCancellationCatchScannerTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/KotlinCancellationCatchScannerTest.kt
@@ -1117,4 +1117,32 @@ class KotlinCancellationCatchScannerTest {
         assertEquals("", findings.first().sourceFingerprint,
             "Unbalanced construct must produce blank fingerprint (refuse relocation)")
     }
+
+    @Test
+    fun `suspend fun immediately after another block is still detected as suspend`() {
+        // Regression for the suspend-range walk: findSuspendRanges advanced
+        // with `i = end` then the loop's `i++` skipped the line at index end —
+        // exactly where a `private suspend fun` declaration can sit. Its body
+        // was then never in a suspend range and the runCatching was classified
+        // medium instead of critical. The declaration here follows another
+        // block's closing brace directly (previous findBlockEnd == declaration
+        // line), reproducing the Workflow.kt:1763 layout.
+        val source = """
+            suspend fun previousBlock() {
+                doWork()
+            }
+            private suspend fun runCatchingAbort(
+                error: Throwable,
+            ) {
+                runCatching { abort() }
+                    .onFailure { error.addSuppressed(it) }
+            }
+        """.trimIndent()
+        val findings = KotlinCancellationCatchScanner.scan(source, "test", "Test.kt")
+        val rc = findings.firstOrNull { it.catchType == "runCatching" }
+        assertNotNull(rc, "runCatching finding expected")
+        assertEquals("critical", rc.risk,
+            "runCatching inside suspend fun directly after another block must be critical, got ${rc.risk}")
+        assertEquals(true, rc.isSuspendCapable)
+    }
 }

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/KotlinCancellationCatchScannerTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/KotlinCancellationCatchScannerTest.kt
@@ -1145,4 +1145,23 @@ class KotlinCancellationCatchScannerTest {
             "runCatching inside suspend fun directly after another block must be critical, got ${rc.risk}")
         assertEquals(true, rc.isSuspendCapable)
     }
+
+    @Test
+    fun `broad catch immediately after suspend function is not suspend capable`() {
+        val source = """
+            suspend fun previousBlock() {
+                doWork()
+            }
+            val result = runCatching { doOutsideWork() }
+        """.trimIndent()
+
+        val findings =
+            KotlinCancellationCatchScanner.scan(source, "test", "Test.kt")
+
+        val rc = findings.single { it.catchType == "runCatching" }
+
+        assertEquals(false, rc.isSuspendCapable)
+        assertEquals("medium", rc.risk)
+    }
+
 }


### PR DESCRIPTION
## Problem

`verifyCancellationSafety` misclassifies a broad catch inside a `suspend fun` as **medium** when the suspend function's declaration sits immediately after another block's closing brace.

**Root cause:** `KotlinCancellationCatchScanner.findSuspendRanges` advances with `i = end` and the while-loop's `i++` then skips the line at index `end` — exactly where a `private suspend fun` declaration can sit. Its body is never inside a suspend range, so `runCatching`/`catch` inside it never gets the suspend-context risk bump (medium instead of critical).

**Evidence (Epic 4.2 split):** in the 1923-line `Workflow.kt`, `runCatchingAbort`'s declaration sits at line 1763, one line after the previous block's `findBlockEnd` → skipped → its `runCatching { abort() }` is classified `medium`. In the extracted `WorkflowPersistenceSession.kt` (204 lines) the walk sees the declaration → correctly `critical`. The canonical baseline records `medium` for this finding — a long-standing analyzer false-negative that the split exposes.

## Fix

```
i = end          →   i = end - 1
```

`findBlockEnd` returns one past the closing brace; stepping to `end - 1` lets the loop's `i++` land **on** `end`, so a suspend function whose declaration directly follows a block is examined instead of skipped.

**Blast radius on master: exactly one finding reclassifies** — `tramai-orchestration/Workflow.kt:1767 leaseAttributes runCatching medium → critical` (113 = 113 findings before/after across all modules). `critical` is the correct classification: the code IS inside `private suspend fun`.

## Tests

- New regression: `suspend fun immediately after another block is still detected as suspend` — reproduces the declaration-immediately-after-block layout; asserts `risk=critical` and `isSuspendCapable=true`. **Mutation-verified**: fails on the old walk, passes on the fix.

## Gates

```
./gradlew :build-logic:test :build-logic:canonicalProbeIntegrationTest \
  verifyCancellationSafety verifyChangePolicy verifyMaintainabilityBaseline \
  -PchangeClass=build-logic
```

EXIT=0:

- `:build-logic:test` — 0 failures (56 scanner tests)
- `:build-logic:canonicalProbeIntegrationTest` — PASSED
- verifyCancellationSafety PASSED — 295 findings, no new critical/high, no worsenings
- verifyChangePolicy PASSED — 2 files, build-logic class
- Maintainability baseline PASSED (no new deviations)

This is a prerequisite for the Workflow.kt split (#249): with this merged, the split's cancellation gate reads the moved finding as `critical` on both sides and the relocation matches via fingerprint.
