### PR TITLE
test(worker): re-enable HTTP takeover tests with private-destination policy

### DIFF
--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TramaiWorkerTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TramaiWorkerTest.kt
@@ -148,7 +148,6 @@ class TramaiWorkerTest {
         }
     }
 
-    @Disabled("Pre-existing: fails identically on master 5267fdbe (TimeoutCancellationException — idempotent HTTP-step takeover never re-executes). Was never discovered by the Gradle gate until #251 fixed the non-void @Test signatures. Tracked for a follow-up HTTP-step recovery PR.")
     @Test
     fun `worker takeover re executes idempotent http put step after crash`(): Unit = runBlocking {
         val checkpointStore = InMemoryWorkflowCheckpointStore()
@@ -161,6 +160,7 @@ class TramaiWorkerTest {
             exchange.respondText(200, "updated")
         }.use { server ->
             val workflow = workerWorkflow("idempotent-put") {
+                outboundNetworkPolicy = OutboundNetworkPolicies.defenceInDepth(allowPrivateDestinations = true)
                 httpStep(
                     name = "update",
                     config = workerHttpConfig(),
@@ -198,7 +198,6 @@ class TramaiWorkerTest {
         }
     }
 
-    @Disabled("Pre-existing: fails identically on master 5267fdbe (TimeoutCancellationException — idempotent HTTP-step takeover never re-executes). Was never discovered by the Gradle gate until #251 fixed the non-void @Test signatures. Tracked for a follow-up HTTP-step recovery PR.")
     @Test
     fun `worker takeover re executes externally idempotent http post step with stable key`(): Unit = runBlocking {
         val checkpointStore = InMemoryWorkflowCheckpointStore()
@@ -211,6 +210,7 @@ class TramaiWorkerTest {
             exchange.respondText(201, "created")
         }.use { server ->
             val workflow = workerWorkflow("external-idempotent-post") {
+                outboundNetworkPolicy = OutboundNetworkPolicies.defenceInDepth(allowPrivateDestinations = true)
                 httpStep(
                     name = "create",
                     config = workerHttpConfig(),


### PR DESCRIPTION
## Fix: re-enable the two HTTP-step takeover characterization tests

### Context

Both tests were never executing until #251 fixed the non-void `@Test` signatures (JUnit 5 silently skips them). Enabling them exposed a **test-configuration defect**, not a recovery-logic bug:

- The tests send HTTP requests to a local test server at `127.0.0.1`
- The workflow's default `OutboundNetworkPolicies.defenceInDepth()` policy **rejects private destinations** (`allowPrivateDestinations = false`)
- The step-level `HttpStepConfig.allowedHosts = {127.0.0.1, localhost}` allowlist is a **ceiling, not a lift** — it narrows, never widens, per the documented policy contract
- Result: the step was rejected (`POLICY_REJECTED` at resolved-address admission) on the **first** execution, before any request reached the server — the takeover scenario never even started

### Fix

`outboundNetworkPolicy = OutboundNetworkPolicies.defenceInDepth(allowPrivateDestinations = true)` on both workflows — the same convention already used by `WorkflowHttpStepTest.localPolicy()` and `WorkflowStepFailureBoundaryTest`.

### Verification

- Both tests pass: `worker takeover re executes idempotent http put step after crash`, `worker takeover re executes externally idempotent http post step with stable key`
- `TramaiWorkerTest`: **33/33, 0 skipped, 0 failures** (no disabled tests remain)
- Full gate EXIT=0: `apiCheck` zero diff, `verifyCancellationSafety` **295=295**, `verifyChangePolicy` PASSED (runtime-behaviour), `verifyMaintainabilityBaseline` PASS
- `verifyPr` EXIT=0
