### PR TITLE
fix(build-logic): line-independent FindingIdentity keys (phantom maintainability findings)

### DIFF
--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/FindingIdentity.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/FindingIdentity.kt
@@ -52,10 +52,9 @@ data class FindingIdentity(
 
     companion object {
         fun fromCancellationCatch(f: CancellationCatchFinding, occurrence: Int? = null): FindingIdentity {
-            val modulePath = if (f.module.startsWith(":")) f.module else ":${f.module}"
             return FindingIdentity(
                 category = FindingCategory.CANCELLATION_CATCH,
-                modulePath = modulePath,
+                modulePath = normalizeModulePath(f.module),
                 repositoryPath = normalizePath(f.file),
                 declaration = f.function.ifBlank { null },
                 discriminator = f.catchType,
@@ -64,10 +63,9 @@ data class FindingIdentity(
         }
 
         fun fromGlobalState(f: GlobalStateFinding, occurrence: Int? = null): FindingIdentity {
-            val modulePath = if (f.module.startsWith(":")) f.module else ":${f.module}"
             return FindingIdentity(
                 category = FindingCategory.GLOBAL_STATE,
-                modulePath = modulePath,
+                modulePath = normalizeModulePath(f.module),
                 repositoryPath = normalizePath(f.file),
                 declaration = f.declaration.ifBlank { null },
                 discriminator = f.kind,
@@ -76,10 +74,9 @@ data class FindingIdentity(
         }
 
         fun fromNondeterminism(f: NondeterminismFinding, occurrence: Int? = null): FindingIdentity {
-            val modulePath = if (f.module.startsWith(":")) f.module else ":${f.module}"
             return FindingIdentity(
                 category = FindingCategory.NONDETERMINISM,
-                modulePath = modulePath,
+                modulePath = normalizeModulePath(f.module),
                 repositoryPath = normalizePath(f.file),
                 declaration = f.source,
                 discriminator = f.category + "::" + f.source,
@@ -88,16 +85,19 @@ data class FindingIdentity(
         }
 
         fun fromStructuralHotspot(h: StructuralHotspot): FindingIdentity {
-            val modulePath = if (h.module.startsWith(":")) h.module else ":$h.module"
             return FindingIdentity(
                 category = FindingCategory.STRUCTURAL_HOTSPOT,
-                modulePath = modulePath,
+                modulePath = normalizeModulePath(h.module),
                 repositoryPath = normalizePath(h.path),
                 declaration = h.declaration.ifBlank { null },
                 discriminator = h.metric,
                 occurrence = null
             )
         }
+
+        /** Normalize a module path to canonical Gradle format (leading ':'). */
+        private fun normalizeModulePath(module: String): String =
+            if (module.startsWith(":")) module else ":$module"
 
         /** Normalize a source path to use consistent separators and remove redundant prefixes. */
         private fun normalizePath(path: String): String =

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/FindingIdentity.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/FindingIdentity.kt
@@ -52,7 +52,7 @@ data class FindingIdentity(
 
     companion object {
         fun fromCancellationCatch(f: CancellationCatchFinding, occurrence: Int? = null): FindingIdentity {
-            val modulePath = if (f.module.startsWith(":")) f.module else ":$f.module"
+            val modulePath = if (f.module.startsWith(":")) f.module else ":${f.module}"
             return FindingIdentity(
                 category = FindingCategory.CANCELLATION_CATCH,
                 modulePath = modulePath,
@@ -64,7 +64,7 @@ data class FindingIdentity(
         }
 
         fun fromGlobalState(f: GlobalStateFinding, occurrence: Int? = null): FindingIdentity {
-            val modulePath = if (f.module.startsWith(":")) f.module else ":$f.module"
+            val modulePath = if (f.module.startsWith(":")) f.module else ":${f.module}"
             return FindingIdentity(
                 category = FindingCategory.GLOBAL_STATE,
                 modulePath = modulePath,
@@ -76,7 +76,7 @@ data class FindingIdentity(
         }
 
         fun fromNondeterminism(f: NondeterminismFinding, occurrence: Int? = null): FindingIdentity {
-            val modulePath = if (f.module.startsWith(":")) f.module else ":$f.module"
+            val modulePath = if (f.module.startsWith(":")) f.module else ":${f.module}"
             return FindingIdentity(
                 category = FindingCategory.NONDETERMINISM,
                 modulePath = modulePath,

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/FindingIdentityTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/FindingIdentityTest.kt
@@ -1,0 +1,61 @@
+package dev.tramai.build.quality
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * Regression tests for FindingIdentity.fromNondeterminism/fromCancellationCatch/fromGlobalState.
+ *
+ * The identity key must be *line-independent*: a finding that shifts lines (e.g. due to an
+ * unrelated refactor) must not register as a new finding. This guards the string-template
+ * precedence bug where `":$f.module"` interpolated the finding's `toString()` (which embeds
+ * the line number) instead of its `module` property.
+ */
+class FindingIdentityTest {
+
+    private fun nd(
+        line: Int,
+        file: String = "tramai-scheduler/src/main/kotlin/dev/tramai/scheduler/Timer.kt",
+        source: String = "Instant.now()",
+        category: String = "clock",
+        module: String = "tramai-scheduler"
+    ) = NondeterminismFinding(
+        module = module, file = file, line = line,
+        source = source, classification = "business_time", category = category
+    )
+
+    @Test
+    fun `nondeterminism identity is independent of line number`() {
+        val before = FindingIdentity.fromNondeterminism(nd(line = 32)).toIdentityKey()
+        val after = FindingIdentity.fromNondeterminism(nd(line = 91)).toIdentityKey()
+        assertEquals(before, after, "line shift must not change the identity key")
+    }
+
+    @Test
+    fun `nondeterminism identity differs when source or category differs`() {
+        val a = FindingIdentity.fromNondeterminism(nd(line = 1, source = "Instant.now()", category = "clock")).toIdentityKey()
+        val b = FindingIdentity.fromNondeterminism(nd(line = 1, source = "UUID.randomUUID()", category = "identity")).toIdentityKey()
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun `module without colon normalizes identically to module with colon`() {
+        val bare = FindingIdentity.fromNondeterminism(nd(line = 1, module = "tramai-scheduler")).toIdentityKey()
+        val colonized = FindingIdentity.fromNondeterminism(nd(line = 1, module = ":tramai-scheduler")).toIdentityKey()
+        assertEquals(bare, colonized)
+    }
+
+    @Test
+    fun `cancellation identity is independent of line number`() {
+        val a = FindingIdentity.fromCancellationCatch(
+            CancellationCatchFinding(module = "tramai-core", file = "A.kt", function = "foo", catchType = "Exception", risk = "medium")
+        ).toIdentityKey()
+        // fromCancellationCatch has no line field; key must be stable and not embed the object toString
+        val b = FindingIdentity.fromCancellationCatch(
+            CancellationCatchFinding(module = "tramai-core", file = "A.kt", function = "foo", catchType = "Exception", risk = "medium")
+        ).toIdentityKey()
+        assertEquals(a, b)
+        assertEquals(b.split("::")[1], ":tramai-core", "modulePath must be the module, not the object toString")
+    }
+}

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/FindingIdentityTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/FindingIdentityTest.kt
@@ -5,57 +5,128 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
 /**
- * Regression tests for FindingIdentity.fromNondeterminism/fromCancellationCatch/fromGlobalState.
+ * Regression tests for the FindingIdentity from* factories.
  *
- * The identity key must be *line-independent*: a finding that shifts lines (e.g. due to an
- * unrelated refactor) must not register as a new finding. This guards the string-template
- * precedence bug where `":$f.module"` interpolated the finding's `toString()` (which embeds
- * the line number) instead of its `module` property.
+ * Identity keys must be *line-independent* (and independent of any measured
+ * value that participates in a finding's toString()): a finding that shifts
+ * lines or changes its measured value must not register as a new finding.
+ * This guards the string-template precedence bug where `":$f.module"`
+ * interpolated the finding's `toString()` (which embeds the line/value)
+ * instead of its `module` property.
  */
 class FindingIdentityTest {
 
-    private fun nd(
+    // ─── Factory helpers ───
+
+    private fun catchFinding(
+        sourceLine: Int,
+        module: String = "tramai-scheduler",
+        file: String = "tramai-scheduler/src/main/kotlin/dev/tramai/scheduler/Timer.kt",
+        function: String = "tick",
+        catchType: String = "Exception"
+    ) = CancellationCatchFinding(
+        module = module, file = file, function = function,
+        catchType = catchType, risk = "medium", sourceLine = sourceLine
+    )
+
+    private fun globalFinding(
+        module: String = "tramai-engine",
+        file: String = "tramai-engine/src/main/kotlin/dev/tramai/engine/Engine.kt",
+        declaration: String = "Engine",
+        kind: String = "mutable-state"
+    ) = GlobalStateFinding(
+        module = module, file = file, declaration = declaration,
+        kind = kind, type = "Boolean", mutable = true
+    )
+
+    private fun ndFinding(
         line: Int,
+        module: String = "tramai-scheduler",
         file: String = "tramai-scheduler/src/main/kotlin/dev/tramai/scheduler/Timer.kt",
         source: String = "Instant.now()",
-        category: String = "clock",
-        module: String = "tramai-scheduler"
+        category: String = "clock"
     ) = NondeterminismFinding(
         module = module, file = file, line = line,
         source = source, classification = "business_time", category = category
     )
 
+    private fun hotspot(
+        value: Int,
+        module: String = "tramai-engine",
+        path: String = "tramai-engine/src/main/kotlin/dev/tramai/engine/Engine.kt",
+        declaration: String = "run",
+        metric: String = "cyclomaticComplexity"
+    ) = StructuralHotspot(
+        module = module, path = path, declaration = declaration,
+        metric = metric, value = value
+    )
+
+    // ─── Identity stability (the regression) ───
+
     @Test
-    fun `nondeterminism identity is independent of line number`() {
-        val before = FindingIdentity.fromNondeterminism(nd(line = 32)).toIdentityKey()
-        val after = FindingIdentity.fromNondeterminism(nd(line = 91)).toIdentityKey()
-        assertEquals(before, after, "line shift must not change the identity key")
+    fun `cancellation identity is independent of sourceLine`() {
+        assertEquals(
+            FindingIdentity.fromCancellationCatch(catchFinding(sourceLine = 20)).toIdentityKey(),
+            FindingIdentity.fromCancellationCatch(catchFinding(sourceLine = 200)).toIdentityKey()
+        )
     }
 
     @Test
+    fun `global state identity is stable for the same semantic finding`() {
+        assertEquals(
+            FindingIdentity.fromGlobalState(globalFinding()).toIdentityKey(),
+            FindingIdentity.fromGlobalState(globalFinding()).toIdentityKey()
+        )
+    }
+
+    @Test
+    fun `nondeterminism identity is independent of line`() {
+        assertEquals(
+            FindingIdentity.fromNondeterminism(ndFinding(line = 32)).toIdentityKey(),
+            FindingIdentity.fromNondeterminism(ndFinding(line = 91)).toIdentityKey()
+        )
+    }
+
+    @Test
+    fun `structural hotspot identity is independent of value`() {
+        // value participates in StructuralHotspot.toString(); a change must not churn identity
+        assertEquals(
+            FindingIdentity.fromStructuralHotspot(hotspot(value = 4)).toIdentityKey(),
+            FindingIdentity.fromStructuralHotspot(hotspot(value = 723)).toIdentityKey()
+        )
+    }
+
+    @Test
+    fun `module without colon normalizes identically to module with colon for all factories`() {
+        for (keyOf in listOf(
+            { m: String -> FindingIdentity.fromCancellationCatch(catchFinding(sourceLine = 1, module = m)).toIdentityKey() },
+            { m: String -> FindingIdentity.fromGlobalState(globalFinding(module = m)).toIdentityKey() },
+            { m: String -> FindingIdentity.fromNondeterminism(ndFinding(line = 1, module = m)).toIdentityKey() },
+            { m: String -> FindingIdentity.fromStructuralHotspot(hotspot(value = 1, module = m)).toIdentityKey() }
+        )) {
+            assertEquals(keyOf("tramai-scheduler"), keyOf(":tramai-scheduler"))
+        }
+    }
+
+    // ─── Identity must not be too coarse ───
+
+    @Test
     fun `nondeterminism identity differs when source or category differs`() {
-        val a = FindingIdentity.fromNondeterminism(nd(line = 1, source = "Instant.now()", category = "clock")).toIdentityKey()
-        val b = FindingIdentity.fromNondeterminism(nd(line = 1, source = "UUID.randomUUID()", category = "identity")).toIdentityKey()
+        val a = FindingIdentity.fromNondeterminism(ndFinding(line = 1, source = "Instant.now()", category = "clock")).toIdentityKey()
+        val b = FindingIdentity.fromNondeterminism(ndFinding(line = 1, source = "UUID.randomUUID()", category = "identity")).toIdentityKey()
         assertNotEquals(a, b)
     }
 
     @Test
-    fun `module without colon normalizes identically to module with colon`() {
-        val bare = FindingIdentity.fromNondeterminism(nd(line = 1, module = "tramai-scheduler")).toIdentityKey()
-        val colonized = FindingIdentity.fromNondeterminism(nd(line = 1, module = ":tramai-scheduler")).toIdentityKey()
-        assertEquals(bare, colonized)
+    fun `identity differs across modules`() {
+        val scheduler = FindingIdentity.fromNondeterminism(ndFinding(line = 1, module = "tramai-scheduler")).toIdentityKey()
+        val server = FindingIdentity.fromNondeterminism(ndFinding(line = 1, module = "tramai-server")).toIdentityKey()
+        assertNotEquals(scheduler, server)
     }
 
     @Test
-    fun `cancellation identity is independent of line number`() {
-        val a = FindingIdentity.fromCancellationCatch(
-            CancellationCatchFinding(module = "tramai-core", file = "A.kt", function = "foo", catchType = "Exception", risk = "medium")
-        ).toIdentityKey()
-        // fromCancellationCatch has no line field; key must be stable and not embed the object toString
-        val b = FindingIdentity.fromCancellationCatch(
-            CancellationCatchFinding(module = "tramai-core", file = "A.kt", function = "foo", catchType = "Exception", risk = "medium")
-        ).toIdentityKey()
-        assertEquals(a, b)
-        assertEquals(b.split("::")[1], ":tramai-core", "modulePath must be the module, not the object toString")
+    fun `modulePath is the module, not the object toString`() {
+        val key = FindingIdentity.fromCancellationCatch(catchFinding(sourceLine = 20)).toIdentityKey()
+        assertEquals(":tramai-scheduler", key.split("::")[1], "modulePath must be the module, not the object toString")
     }
 }


### PR DESCRIPTION
## Summary

Fix a string-template precedence bug in `FindingIdentity` that made identity keys
**line-number-dependent**, causing phantom "new finding" failures in
`verifyMaintainabilityBaseline` whenever a scanned line shifts.

### Root cause

```kotlin
val modulePath = if (f.module.startsWith(":")) f.module else ":$f.module"
```

In Kotlin, `":$f.module"` interpolates `$f` (the finding's `toString()`, which
**embeds the line number** — and for `StructuralHotspot`, the measured `value`)
followed by the literal `.module` — it does not interpolate the `module`
property. The identity key therefore changes whenever a finding moves lines or
its measured value changes, so any unrelated refactor registers phantom new
findings.

This is the churn historically papered over in deviations:
`MQ-0006`, `MQ-0015`, `MQ-0016` all cite "line-shift identity churn" in their
reasons. With this fix, line-shift churn disappears at the source.

### Fix (review round)

The invariant "modulePath is derived from the finding's actual `module`
property, never from the object's `toString()`" is now centralized:

- `normalizeModulePath(module)` helper used by **all four** `from*` factories:
  `fromCancellationCatch`, `fromGlobalState`, `fromNondeterminism`,
  `fromStructuralHotspot` (the fourth had the same bug — value changes churned
  hotspot identities).
- A fifth copy/paste regression is now impossible.

### Tests

`FindingIdentityTest` covers all four factories:
- cancellation: `sourceLine` change (20 → 200) → same identity
- global state: same semantic finding → same identity
- nondeterminism: line change (32 → 91) → same identity
- structural hotspot: `value` change (4 → 723) → same identity
- bare module `tramai-x` ≡ `:tramai-x` for all four factories
- distinct source/category/module → distinct identity (not too coarse)

### Evidence

Verified against a real failure: on a branch whose edited files produced
12 phantom findings (6 scheduler, 5 server, 1 platform), this fix makes
`verifyMaintainabilityBaseline` PASS with the committed baseline untouched
and no deviation changes.

### Verification

- `./gradlew build-logic:test --tests dev.tramai.build.quality.FindingIdentityTest`
- `./gradlew verifyPr -PchangeClass=build-logic` — PASSED (change policy:
  2 files, build-logic, no violations; maintainability baseline PASSED)
