### PR TITLE
refactor(runtime): enforce observer, audit and evidence failure policies — Epic 5.3

### DIFF
--- a/docs/reference/secondary-system-failure-policy.md
+++ b/docs/reference/secondary-system-failure-policy.md
@@ -1,0 +1,77 @@
+# Secondary System Failure Policy
+
+This page defines the failure policy for secondary systems in Tramai: observability, telemetry, policy audit, approval audit, DLP audit, and outbox delivery. Secondary systems are non-authoritative extensions of the engine; their failure must never corrupt a primary business operation, and the authoritative surfaces among them must never silently drop a record that the governed operation depends on.
+
+## Extension-Point Matrix
+
+| Extension point | Authority | Failure behaviour |
+|---|---|---|
+| OperationObserver / OperationObservation (engine per-attempt telemetry) | NON_AUTHORITATIVE | FAIL_OPEN + safe diagnostic (FailureIsolatingOperationObserver wraps at EngineComponentFactory composition) |
+| EngineEventObserver (engine lifecycle telemetry) | NON_AUTHORITATIVE | FAIL_OPEN + safe diagnostic (FailureIsolatingEngineEventObserver wraps at EngineComponentFactory) |
+| WorkflowObserver (workflow lifecycle telemetry) | NON_AUTHORITATIVE | FAIL_OPEN + safe diagnostic (FailureIsolatingWorkflowObserver wraps at WorkflowRunner.run/resume entry) |
+| TramaiWorkerObserver (worker lifecycle telemetry, 22 callbacks) | NON_AUTHORITATIVE | FAIL_OPEN + safe diagnostic (FailureIsolatingTramaiWorkerObserver wraps at TramaiWorker construction) |
+| RuntimeEvent emission, event declared FAIL_OPEN (default) | NON_AUTHORITATIVE | FAIL_OPEN + safe diagnostic (emission routed through typed onEngineEvent(RuntimeEvent) / onWorkflowEvent(RuntimeEvent, context) overloads so the failure policy is honored) |
+| RuntimeEvent emission, event declared FAIL_CLOSED | AUTHORITATIVE | FAIL_CLOSED: emission failure propagates (never contained) |
+| Policy decision audit (PolicyEnforcementHelper.evaluate -> PolicyDecisionAuditEmitter) | AUTHORITATIVE | FAIL_CLOSED: audit is emitted before the decision is acted on; audit failure propagates and blocks the operation (proven by tests: audit failure blocks provider invocation / tool execution / fallback transition, zero side effects) |
+| Approval lifecycle audit (AuditEngine, hash-chained AuditStore) | AUTHORITATIVE | FAIL_CLOSED: AuditEngine.appendNext failure propagates; an unaudited governed transition cannot proceed |
+| DLP/security audit | AUTHORITATIVE | FAIL_CLOSED: DLP redaction audit failure propagates |
+| Audit outbox enqueue (SovereignOpsAuditOutboxStore.append, PREPARED record) | AUTHORITATIVE | FAIL_CLOSED at enqueue: if the outbox append fails the approval is never mutated (proven: 'denyApproval fails closed when no AuditEngine', 'denyApproval fail-closed leaves approval unchanged') |
+| Outbox dispatch (background worker, PENDING/FAILED_RETRYABLE records) | AUTHORITATIVE (delivery) | RETRY / at-least-once: dispatch failure marks FAILED_RETRYABLE, record retained and retried; business operation is NOT retroactively failed (proven: 'dispatcher can retry FAILED_RETRYABLE outbox records', worker 'runOnce catches RuntimeException and returns failure summary') |
+| Cancellation path (onCallCancelled inside completeCancellation helpers) | NON_AUTHORITATIVE | CE stays primary; observer failure attached as SUPPRESSED onto the in-flight CancellationException (frozen contract; never replaced) |
+| Tool-processing failure path (onCallCompleted inside completeAfterToolProcessing) | NON_AUTHORITATIVE | primary error stays primary; contained observer failure surfaced as SUPPRESSED; on success path, observer failure logged as warning, business result preserved |
+| Optional diagnostic telemetry | NON_AUTHORITATIVE | IGNORE / best effort |
+
+All catalogue events currently default to FAIL_OPEN. The FAIL_CLOSED propagation path exists and is unit-tested with a probe event; declaring an event FAIL_CLOSED makes its emission authoritative.
+
+## Delivery Semantics
+
+Tramai makes **no blanket exactly-once guarantee** anywhere in this policy. Each surface has an explicit, concrete semantic:
+
+- **Outbox dispatch: at-least-once.** Records are retained as FAILED_RETRYABLE on dispatch failure and retried by the background worker; a record is only removed once the sink acknowledges it. Duplicate dispatch is possible under lease takeover (a lease may expire between send and acknowledgement and another worker picks the record up) and is handled idempotently where the sink permits. The business operation that produced the record is never retroactively failed because a later dispatch attempt failed.
+- **Outbox enqueue: fail-closed, never best-effort.** The PREPARED record append into SovereignOpsAuditOutboxStore is authoritative; if it fails, the approval mutation is not applied. Enqueue is a single, synchronous, transactional step — not a fire-and-forget path.
+- **Observers (OperationObserver, EngineEventObserver, WorkflowObserver, TramaiWorkerObserver): best effort.** FAIL_OPEN means observer failure is contained and diagnosed; telemetry may be lost and no retry is attempted.
+- **RuntimeEvent emission: best effort for FAIL_OPEN events (default), fail-closed for FAIL_CLOSED events.** The declared policy of the event, not the mood of the caller, decides.
+- **Audit surfaces (policy decision audit, approval lifecycle audit, DLP audit): fail-closed.** These are evidence-generation/persistence surfaces the governed operation depends on; their failure blocks the operation.
+- **Optional diagnostic telemetry: best effort (IGNORE).** No guarantees of any kind.
+
+The evidence generation and persistence surfaces that policy enforcement depends on are authoritative and FAIL_CLOSED; the telemetry surfaces that observe execution without governing it are NON_AUTHORITATIVE and FAIL_OPEN/best effort.
+
+## Safe Diagnostic
+
+A contained secondary failure is reported through `SecondaryFailureDiagnostic`, which carries **only**:
+
+- `extensionPoint`
+- `callback`
+- `errorType`
+- `failurePolicy`
+- `authority`
+
+It never carries messages, stack traces, workflow state, prompts, or tool arguments. A diagnostic therefore cannot leak prompt or tool content into logs, and the diagnostic's own construction cannot resurrect the contained failure into the business path. `CancellationException` always escapes unchanged through every wrapper.
+
+## Architecture
+
+Secondary-failure isolation is enforced at single wiring points, not scattered through call sites:
+
+- **Failure-isolating wrappers.** Four wrapper classes contain observer failures and emit a safe diagnostic:
+  - `FailureIsolatingOperationObserver` — wired at EngineComponentFactory composition.
+  - `FailureIsolatingEngineEventObserver` — wired at EngineComponentFactory.
+  - `FailureIsolatingWorkflowObserver` — wired at WorkflowRunner.run/resume entry.
+  - `FailureIsolatingTramaiWorkerObserver` — wired at TramaiWorker construction.
+- **Emission extension routing.** RuntimeEventEmission.kt in tramai-engine and tramai-orchestration route emission through the typed `onEngineEvent(RuntimeEvent)` / `onWorkflowEvent(RuntimeEvent, context)` overloads so the declared failure policy of each event is honored at the emission point.
+- **SecondaryFailureRecording.** The `onCallCompleted` containment records the failure so `completeAfterToolProcessing` can attach it as SUPPRESSED onto a primary business error (or log it as a warning on the success path, preserving the business result). Cancellation containment attaches the observer failure as SUPPRESSED onto the in-flight `CancellationException`; the CE is never replaced.
+- **Boundary architecture guard.** `SecondaryFailureBoundaryArchitectureTest` in tramai-observability scans the sources and forbids raw observer/observability/`engineEventObserver`/`request.observer` callback invocation outside the wrappers and the wired-through files. The guard is what keeps future call sites from bypassing the policy.
+
+## Verification
+
+- **Lifecycle matrix tests:**
+  - `FailureIsolatingOperationObserverTest` — operation lifecycle matrix
+  - `FailureIsolatingWorkflowObserverTest` — workflow lifecycle matrix
+  - `FailureIsolatingTramaiWorkerObserverTest` — worker 22-callback matrix
+- **Preservation tests:**
+  - `SecondaryFailurePreservationEngineTest` — engine success/failure preservation
+  - `WorkflowRunnerPreservationTest` — workflow success/failure preservation through the public API
+  - `SecondaryFailureBoundaryArchitectureTest` — boundary guard
+- **Pre-existing audit fail-closed tests:**
+  - `PolicyAuditWiringTest` — e.g. 'audit failure blocks provider invocation' (also tool execution / fallback transition, zero side effects)
+  - `SovereignOpsAuditOutboxTest` — e.g. 'denyApproval fails closed when no AuditEngine', 'denyApproval fail-closed leaves approval unchanged', 'dispatcher can retry FAILED_RETRYABLE outbox records'
+  - `SovereignOpsAuditOutboxBackgroundWorkerTest` — 'runOnce catches RuntimeException and returns failure summary'

--- a/docs/reference/secondary-system-failure-policy.md
+++ b/docs/reference/secondary-system-failure-policy.md
@@ -9,11 +9,14 @@ This page defines the failure policy for secondary systems in Tramai: observabil
 | OperationObserver / OperationObservation (engine per-attempt telemetry) | NON_AUTHORITATIVE | FAIL_OPEN + safe diagnostic (FailureIsolatingOperationObserver wraps at EngineComponentFactory composition) |
 | EngineEventObserver (engine lifecycle telemetry) | NON_AUTHORITATIVE | FAIL_OPEN + safe diagnostic (FailureIsolatingEngineEventObserver wraps at EngineComponentFactory) |
 | WorkflowObserver (workflow lifecycle telemetry) | NON_AUTHORITATIVE | FAIL_OPEN + safe diagnostic (FailureIsolatingWorkflowObserver wraps at WorkflowRunner.run/resume entry) |
-| TramaiWorkerObserver (worker lifecycle telemetry, 22 callbacks) | NON_AUTHORITATIVE | FAIL_OPEN + safe diagnostic (FailureIsolatingTramaiWorkerObserver wraps at TramaiWorker construction) |
+| TramaiWorkerObserver (worker lifecycle telemetry, 20 callbacks) | NON_AUTHORITATIVE | FAIL_OPEN + safe diagnostic (FailureIsolatingTramaiWorkerObserver wraps at TramaiWorker construction) |
 | RuntimeEvent emission, event declared FAIL_OPEN (default) | NON_AUTHORITATIVE | FAIL_OPEN + safe diagnostic (emission routed through typed onEngineEvent(RuntimeEvent) / onWorkflowEvent(RuntimeEvent, context) overloads so the failure policy is honored) |
 | RuntimeEvent emission, event declared FAIL_CLOSED | AUTHORITATIVE | FAIL_CLOSED: emission failure propagates (never contained) |
 | Policy decision audit (PolicyEnforcementHelper.evaluate -> PolicyDecisionAuditEmitter) | AUTHORITATIVE | FAIL_CLOSED: audit is emitted before the decision is acted on; audit failure propagates and blocks the operation (proven by tests: audit failure blocks provider invocation / tool execution / fallback transition, zero side effects) |
-| Approval lifecycle audit (AuditEngine, hash-chained AuditStore) | AUTHORITATIVE | FAIL_CLOSED: AuditEngine.appendNext failure propagates; an unaudited governed transition cannot proceed |
+| Approval lifecycle audit — pre-mutation callbacks (suspension creation, force-cancellation REQUESTED) | AUTHORITATIVE | FAIL_CLOSED: audit runs BEFORE the governed mutation; audit failure propagates and blocks the mutation (e.g. 'denyApproval fails closed when no AuditEngine') |
+| Approval lifecycle audit — post-side-effect completion (onToolExecutionCompleted) | AUTHORITATIVE | FAIL_CLOSED declared, terminal-recorded disposition: the tool side effect and COMPLETED transition have already happened, so fail-closed is physically impossible; audit failure is recorded via the safe diagnostic (authoritative, never silently converted to telemetry), resume still succeeds |
+| Approval lifecycle audit — post-mutation notification (onSuspensionCancelled) | AUTHORITATIVE | declared FAIL_CLOSED, best-effort disposition: stores already mutated; audit failure recorded via safe diagnostic, never fails the method after the transition committed |
+| Approval lifecycle audit — audit while reporting an existing primary failure (onUncertainOutcome) | AUTHORITATIVE | preserve the primary failure: audit failure recorded via safe diagnostic and NEVER substituted for the business failure being reported |
 | DLP/security audit | AUTHORITATIVE | FAIL_CLOSED: DLP redaction audit failure propagates |
 | Audit outbox enqueue (SovereignOpsAuditOutboxStore.append, PREPARED record) | AUTHORITATIVE | FAIL_CLOSED at enqueue: if the outbox append fails the approval is never mutated (proven: 'denyApproval fails closed when no AuditEngine', 'denyApproval fail-closed leaves approval unchanged') |
 | Outbox dispatch (background worker, PENDING/FAILED_RETRYABLE records) | AUTHORITATIVE (delivery) | RETRY / at-least-once: dispatch failure marks FAILED_RETRYABLE, record retained and retried; business operation is NOT retroactively failed (proven: 'dispatcher can retry FAILED_RETRYABLE outbox records', worker 'runOnce catches RuntimeException and returns failure summary') |
@@ -66,7 +69,7 @@ Secondary-failure isolation is enforced at single wiring points, not scattered t
 - **Lifecycle matrix tests:**
   - `FailureIsolatingOperationObserverTest` — operation lifecycle matrix
   - `FailureIsolatingWorkflowObserverTest` — workflow lifecycle matrix
-  - `FailureIsolatingTramaiWorkerObserverTest` — worker 22-callback matrix
+  - `FailureIsolatingTramaiWorkerObserverTest` — worker 20-callback matrix
 - **Preservation tests:**
   - `SecondaryFailurePreservationEngineTest` — engine success/failure preservation
   - `WorkflowRunnerPreservationTest` — workflow success/failure preservation through the public API

--- a/tramai-core/api/tramai-core.api
+++ b/tramai-core/api/tramai-core.api
@@ -2147,6 +2147,9 @@ public final class dev/tramai/core/observation/event/RuntimeMetrics {
 	public final fun getWORKFLOW_RUNS ()Ldev/tramai/core/observation/event/RuntimeMetricDefinition;
 }
 
+public abstract interface annotation class dev/tramai/core/observation/secondary/ExperimentalTramaiInternalApi : java/lang/annotation/Annotation {
+}
+
 public final class dev/tramai/core/observation/secondary/SecondaryEffectAuthority : java/lang/Enum {
 	public static final field AUTHORITATIVE Ldev/tramai/core/observation/secondary/SecondaryEffectAuthority;
 	public static final field NON_AUTHORITATIVE Ldev/tramai/core/observation/secondary/SecondaryEffectAuthority;

--- a/tramai-core/api/tramai-core.api
+++ b/tramai-core/api/tramai-core.api
@@ -1606,6 +1606,11 @@ public final class dev/tramai/core/observation/CompositeOperationInterceptor : d
 	public fun interceptResponse (Ldev/tramai/core/observation/OperationCallContext;Ldev/tramai/core/model/ModelResponse;)Ldev/tramai/core/model/ModelResponse;
 }
 
+public final class dev/tramai/core/observation/FailureIsolatingOperationObserver : dev/tramai/core/observation/OperationObserver {
+	public fun <init> (Ldev/tramai/core/observation/OperationObserver;)V
+	public fun onCallStarted (Ldev/tramai/core/observation/OperationCallContext;)Ldev/tramai/core/observation/OperationObservation;
+}
+
 public final class dev/tramai/core/observation/NoOpOperationInterceptor : dev/tramai/core/observation/OperationInterceptor {
 	public static final field INSTANCE Ldev/tramai/core/observation/NoOpOperationInterceptor;
 	public fun interceptRequest (Ldev/tramai/core/observation/OperationCallContext;Ljava/util/List;)Ljava/util/List;
@@ -1719,6 +1724,10 @@ public final class dev/tramai/core/observation/ProviderFailureDiagnosticEvent {
 
 public abstract interface class dev/tramai/core/observation/ProviderFailureDiagnosticObserver {
 	public abstract fun record (Ldev/tramai/core/observation/ProviderFailureDiagnosticEvent;)V
+}
+
+public abstract interface class dev/tramai/core/observation/SecondaryFailureRecording {
+	public abstract fun getLastCompletionFailure ()Ljava/lang/Throwable;
 }
 
 public final class dev/tramai/core/observation/ToolFailureDiagnosticEvent {
@@ -2136,6 +2145,30 @@ public final class dev/tramai/core/observation/event/RuntimeMetrics {
 	public final fun getWORKFLOW_DURATION ()Ldev/tramai/core/observation/event/RuntimeMetricDefinition;
 	public final fun getWORKFLOW_EVENTS ()Ldev/tramai/core/observation/event/RuntimeMetricDefinition;
 	public final fun getWORKFLOW_RUNS ()Ldev/tramai/core/observation/event/RuntimeMetricDefinition;
+}
+
+public final class dev/tramai/core/observation/secondary/SecondaryEffectAuthority : java/lang/Enum {
+	public static final field AUTHORITATIVE Ldev/tramai/core/observation/secondary/SecondaryEffectAuthority;
+	public static final field NON_AUTHORITATIVE Ldev/tramai/core/observation/secondary/SecondaryEffectAuthority;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/tramai/core/observation/secondary/SecondaryEffectAuthority;
+	public static fun values ()[Ldev/tramai/core/observation/secondary/SecondaryEffectAuthority;
+}
+
+public final class dev/tramai/core/observation/secondary/SecondaryFailureDiagnostic {
+	public static final field INSTANCE Ldev/tramai/core/observation/secondary/SecondaryFailureDiagnostic;
+	public final fun report (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+}
+
+public final class dev/tramai/core/observation/secondary/SecondaryFailureDisposition : java/lang/Enum {
+	public static final field BUFFERED Ldev/tramai/core/observation/secondary/SecondaryFailureDisposition;
+	public static final field FAIL_CLOSED Ldev/tramai/core/observation/secondary/SecondaryFailureDisposition;
+	public static final field FAIL_OPEN_DIAGNOSTIC Ldev/tramai/core/observation/secondary/SecondaryFailureDisposition;
+	public static final field IGNORE Ldev/tramai/core/observation/secondary/SecondaryFailureDisposition;
+	public static final field RETRY Ldev/tramai/core/observation/secondary/SecondaryFailureDisposition;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/tramai/core/observation/secondary/SecondaryFailureDisposition;
+	public static fun values ()[Ldev/tramai/core/observation/secondary/SecondaryFailureDisposition;
 }
 
 public final class dev/tramai/core/policy/ApprovalMode : java/lang/Enum {

--- a/tramai-core/src/main/kotlin/dev/tramai/core/observation/FailureIsolatingOperationObserver.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/observation/FailureIsolatingOperationObserver.kt
@@ -1,5 +1,6 @@
 package dev.tramai.core.observation
 
+import dev.tramai.core.observation.secondary.ExperimentalTramaiInternalApi
 import dev.tramai.core.model.ModelResponse
 import dev.tramai.core.observation.event.RuntimeEvent
 import dev.tramai.core.observation.event.RuntimeEventFailurePolicy
@@ -20,13 +21,14 @@ import kotlinx.coroutines.CancellationException
  * failure (authoritative), a `FAIL_OPEN` event is contained. The legacy
  * (name, attributes) form carries no policy metadata and is contained.
  */
+@ExperimentalTramaiInternalApi
 class FailureIsolatingOperationObserver(
     private val delegate: OperationObserver,
 ) : OperationObserver {
     override fun onCallStarted(context: OperationCallContext): OperationObservation {
         return try {
             FailureIsolatingOperationObservation(delegate.onCallStarted(context))
-        } catch (error: Throwable) {
+        } catch (error: Exception) {
             if (error is CancellationException) throw error
             SecondaryFailureDiagnostic.report(
                 extensionPoint = "operation_observer",
@@ -48,6 +50,7 @@ class FailureIsolatingOperationObserver(
  * "primary error stays primary, observer failure preserved" contract without
  * letting the observer failure replace the primary.
  */
+@ExperimentalTramaiInternalApi
 interface SecondaryFailureRecording {
     val lastCompletionFailure: Throwable?
 }
@@ -70,7 +73,7 @@ internal class FailureIsolatingOperationObservation(
     private inline fun <T> isolate(callback: String, block: () -> T) {
         try {
             block()
-        } catch (error: Throwable) {
+        } catch (error: Exception) {
             if (error is CancellationException) throw error
             SecondaryFailureDiagnostic.report(
                 extensionPoint = "operation_observation",
@@ -110,7 +113,7 @@ internal class FailureIsolatingOperationObservation(
     override fun onCallCompleted(parseSuccess: Boolean?) {
         try {
             delegate.onCallCompleted(parseSuccess)
-        } catch (error: Throwable) {
+        } catch (error: Exception) {
             if (error is CancellationException) throw error
             // Record the contained failure so failure-path helpers
             // (completeAfterToolProcessing) can attach it as suppressed onto

--- a/tramai-core/src/main/kotlin/dev/tramai/core/observation/FailureIsolatingOperationObserver.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/observation/FailureIsolatingOperationObserver.kt
@@ -1,0 +1,138 @@
+package dev.tramai.core.observation
+
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.observation.event.RuntimeEvent
+import dev.tramai.core.observation.event.RuntimeEventFailurePolicy
+import dev.tramai.core.observation.secondary.SecondaryEffectAuthority
+import dev.tramai.core.observation.secondary.SecondaryFailureDiagnostic
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Epic 5.3 — failure-isolating [OperationObserver] boundary.
+ *
+ * Wraps a delegate observer so that a throwing telemetry callback can never
+ * change the business outcome of a provider attempt: each callback failure is
+ * contained and reported through [SecondaryFailureDiagnostic], while
+ * [kotlinx.coroutines.CancellationException] always escapes unchanged.
+ *
+ * [RuntimeEvent] emissions honor the event's declared
+ * [RuntimeEventFailurePolicy]: a `FAIL_CLOSED` event propagates its emission
+ * failure (authoritative), a `FAIL_OPEN` event is contained. The legacy
+ * (name, attributes) form carries no policy metadata and is contained.
+ */
+class FailureIsolatingOperationObserver(
+    private val delegate: OperationObserver,
+) : OperationObserver {
+    override fun onCallStarted(context: OperationCallContext): OperationObservation {
+        return try {
+            FailureIsolatingOperationObservation(delegate.onCallStarted(context))
+        } catch (error: Throwable) {
+            if (error is CancellationException) throw error
+            SecondaryFailureDiagnostic.report(
+                extensionPoint = "operation_observer",
+                callback = "onCallStarted",
+                errorType = error.javaClass.simpleName,
+                failurePolicy = "FAIL_OPEN",
+                authority = SecondaryEffectAuthority.NON_AUTHORITATIVE.name,
+            )
+            NoOpOperationObservation
+        }
+    }
+}
+
+/**
+ * Optional capability implemented by failure-isolating observation wrappers:
+ * exposes the most recent completion-callback failure that the wrapper
+ * contained, so call-site helpers (e.g. tool-processing finalizers) can attach
+ * it as SUPPRESSED onto a primary business error — preserving the frozen
+ * "primary error stays primary, observer failure preserved" contract without
+ * letting the observer failure replace the primary.
+ */
+interface SecondaryFailureRecording {
+    val lastCompletionFailure: Throwable?
+}
+
+/**
+ * Per-attempt observation whose callbacks are all failure-isolated.
+ *
+ * The [onCallCancelled] default implementation of [OperationObservation]
+ * routes through [onCallCompleted]; overriding both keeps every entry point
+ * isolated exactly once.
+ */
+internal class FailureIsolatingOperationObservation(
+    private val delegate: OperationObservation,
+) : OperationObservation, SecondaryFailureRecording {
+
+    @Volatile
+    override var lastCompletionFailure: Throwable? = null
+        private set
+
+    private inline fun <T> isolate(callback: String, block: () -> T) {
+        try {
+            block()
+        } catch (error: Throwable) {
+            if (error is CancellationException) throw error
+            SecondaryFailureDiagnostic.report(
+                extensionPoint = "operation_observation",
+                callback = callback,
+                errorType = error.javaClass.simpleName,
+                failurePolicy = "FAIL_OPEN",
+                authority = SecondaryEffectAuthority.NON_AUTHORITATIVE.name,
+            )
+        }
+    }
+
+    override fun onProviderResponse(response: ModelResponse) {
+        isolate("onProviderResponse") { delegate.onProviderResponse(response) }
+    }
+
+    override fun onProviderFailure(error: Throwable) {
+        isolate("onProviderFailure") { delegate.onProviderFailure(error) }
+    }
+
+    override fun onStructuredParseFailure(rawResponse: String, errorSummary: String) {
+        isolate("onStructuredParseFailure") { delegate.onStructuredParseFailure(rawResponse, errorSummary) }
+    }
+
+    override fun onEngineEvent(name: String, attributes: Map<String, Any?>) {
+        isolate("onEngineEvent") { delegate.onEngineEvent(name, attributes) }
+    }
+
+    override fun onEngineEvent(event: RuntimeEvent) {
+        if (event.definition.failurePolicy == RuntimeEventFailurePolicy.FAIL_CLOSED) {
+            // Authoritative emission: a failure must propagate, never be contained.
+            delegate.onEngineEvent(event)
+        } else {
+            isolate("onEngineEvent") { delegate.onEngineEvent(event) }
+        }
+    }
+
+    override fun onCallCompleted(parseSuccess: Boolean?) {
+        try {
+            delegate.onCallCompleted(parseSuccess)
+        } catch (error: Throwable) {
+            if (error is CancellationException) throw error
+            // Record the contained failure so failure-path helpers
+            // (completeAfterToolProcessing) can attach it as suppressed onto
+            // the primary business error — the frozen contract.
+            lastCompletionFailure = error
+            SecondaryFailureDiagnostic.report(
+                extensionPoint = "operation_observation",
+                callback = "onCallCompleted",
+                errorType = error.javaClass.simpleName,
+                failurePolicy = "FAIL_OPEN",
+                authority = SecondaryEffectAuthority.NON_AUTHORITATIVE.name,
+            )
+        }
+    }
+
+    override fun onCallCancelled() {
+        // Epic 5.3: the cancellation path is NOT isolated. The engine's
+        // completeCancellation helpers call this inside a try/catch that
+        // attaches an observer failure as SUPPRESSED onto the in-flight
+        // CancellationException — the frozen contract (CE primary, secondary
+        // failure preserved as suppressed, never replacing the CE). Isolating
+        // here would silently drop the suppression the contract tests demand.
+        delegate.onCallCancelled()
+    }
+}

--- a/tramai-core/src/main/kotlin/dev/tramai/core/observation/secondary/ExperimentalTramaiInternalApi.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/observation/secondary/ExperimentalTramaiInternalApi.kt
@@ -1,0 +1,19 @@
+package dev.tramai.core.observation.secondary
+
+/**
+ * Marks secondary-failure machinery that is public only because it crosses
+ * module boundaries — NOT application-facing API.
+ *
+ * The failure-isolating wrappers, the safe diagnostic, and the authority /
+ * policy model exist so the engine, orchestration, and scheduler modules can
+ * enforce one common failure boundary at their composition points. They are
+ * intentionally not part of Tramai's stable application-facing surface; the
+ * annotation makes that contract explicit and opt-in (same precedent as
+ * [dev.tramai.openai.ExperimentalCodexAuth]).
+ */
+@RequiresOptIn(
+    message = "Tramai secondary-failure machinery is internal implementation API for cross-module " +
+        "composition, not application-facing API. It may change or move in any release.",
+    level = RequiresOptIn.Level.WARNING,
+)
+annotation class ExperimentalTramaiInternalApi

--- a/tramai-core/src/main/kotlin/dev/tramai/core/observation/secondary/SecondaryEffectPolicy.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/observation/secondary/SecondaryEffectPolicy.kt
@@ -1,0 +1,79 @@
+package dev.tramai.core.observation.secondary
+
+import java.util.logging.Level
+import java.util.logging.Logger
+
+/**
+ * Epic 5.3 — explicit failure contract for secondary (non-business) effects.
+ *
+ * The classification axis is AUTHORITATIVE vs NON_AUTHORITATIVE first
+ * (authoritative audit and evidence may stop a governed operation; telemetry
+ * must not), and observer-vs-audit-vs-evidence second. This model is the
+ * internal extension-point machinery behind the public
+ * [dev.tramai.core.observation.event.RuntimeEventFailurePolicy]: it is public
+ * only because the failure-isolating observer wrappers live in several
+ * modules, and is not part of the stable application-facing API.
+ */
+enum class SecondaryEffectAuthority {
+    /** A governed audit/evidence effect: failure blocks the operation (fail-closed). */
+    AUTHORITATIVE,
+
+    /** Ordinary telemetry: failure must never change the business outcome. */
+    NON_AUTHORITATIVE,
+}
+
+/**
+ * What happens when a secondary effect fails, at the extension point.
+ *
+ * - [FAIL_CLOSED]: the failure propagates and the operation fails. Reserved for
+ *   authoritative audit/evidence surfaces (and catalogue events declared
+ *   `FAIL_CLOSED`).
+ * - [FAIL_OPEN_DIAGNOSTIC]: the failure is contained and a safe diagnostic is
+ *   emitted. Default for observers, metrics, and adapters.
+ * - [RETRY]: the effect is retained and attempted later (outbox dispatch:
+ *   at-least-once, business outcome untouched).
+ * - [BUFFERED]: the effect is buffered and delivered asynchronously
+ *   (outbox enqueue: fail-closed at enqueue, at-least-once at delivery).
+ * - [IGNORE]: explicitly non-authoritative best-effort (optional diagnostics).
+ */
+enum class SecondaryFailureDisposition {
+    FAIL_CLOSED,
+    FAIL_OPEN_DIAGNOSTIC,
+    RETRY,
+    BUFFERED,
+    IGNORE,
+}
+
+/**
+ * Safe diagnostic for contained secondary failures.
+ *
+ * Carries only stable identifiers — extension point, callback name, error
+ * type, policy, authority. NEVER error messages, stack traces, workflow state,
+ * prompts, or tool arguments. The sink is itself guarded: a diagnostic failure
+ * can never resurrect into the business path.
+ *
+ * This type is public only because the failure-isolating wrappers live in
+ * several modules; it is not part of the stable application-facing API.
+ */
+object SecondaryFailureDiagnostic {
+    private val logger = Logger.getLogger("dev.tramai.core.observation.secondary")
+
+    fun report(
+        extensionPoint: String,
+        callback: String,
+        errorType: String,
+        failurePolicy: String,
+        authority: String,
+    ) {
+        try {
+            logger.log(
+                Level.WARNING,
+                "Secondary effect failure contained: extensionPoint={0} callback={1} errorType={2} failurePolicy={3} authority={4}",
+                arrayOf(extensionPoint, callback, errorType, failurePolicy, authority),
+            )
+        } catch (_: Throwable) {
+            // ponytail: the diagnostic must never resurrect into the business
+            // path; add an out-of-band sink only if JUL is replaced.
+        }
+    }
+}

--- a/tramai-core/src/main/kotlin/dev/tramai/core/observation/secondary/SecondaryEffectPolicy.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/observation/secondary/SecondaryEffectPolicy.kt
@@ -14,6 +14,7 @@ import java.util.logging.Logger
  * only because the failure-isolating observer wrappers live in several
  * modules, and is not part of the stable application-facing API.
  */
+@ExperimentalTramaiInternalApi
 enum class SecondaryEffectAuthority {
     /** A governed audit/evidence effect: failure blocks the operation (fail-closed). */
     AUTHORITATIVE,
@@ -36,6 +37,7 @@ enum class SecondaryEffectAuthority {
  *   (outbox enqueue: fail-closed at enqueue, at-least-once at delivery).
  * - [IGNORE]: explicitly non-authoritative best-effort (optional diagnostics).
  */
+@ExperimentalTramaiInternalApi
 enum class SecondaryFailureDisposition {
     FAIL_CLOSED,
     FAIL_OPEN_DIAGNOSTIC,
@@ -55,6 +57,7 @@ enum class SecondaryFailureDisposition {
  * This type is public only because the failure-isolating wrappers live in
  * several modules; it is not part of the stable application-facing API.
  */
+@ExperimentalTramaiInternalApi
 object SecondaryFailureDiagnostic {
     private val logger = Logger.getLogger("dev.tramai.core.observation.secondary")
 

--- a/tramai-core/src/test/kotlin/dev/tramai/core/observation/FailureIsolatingOperationObserverTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/observation/FailureIsolatingOperationObserverTest.kt
@@ -1,0 +1,182 @@
+package dev.tramai.core.observation
+
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.observation.event.RuntimeAttributes
+import dev.tramai.core.observation.event.RuntimeEvent
+import dev.tramai.core.observation.event.RuntimeEventFailurePolicy
+import dev.tramai.core.observation.event.RuntimeEvents
+import kotlinx.coroutines.CancellationException
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Epic 5.3 — operation observer lifecycle matrix.
+ *
+ * Every lifecycle callback of [OperationObservation] is exercised with a
+ * throwing delegate. The invariant under test: a telemetry failure is
+ * contained and never changes the business outcome; cancellation always
+ * escapes; FAIL_CLOSED events propagate; FAIL_OPEN events are contained.
+ */
+class FailureIsolatingOperationObserverTest {
+
+    private val modelResponse = ModelResponse(
+        content = "ok",
+    )
+
+    private val context = OperationCallContext(
+        serviceInterface = "dev.tramai.example.Service",
+        methodName = "call",
+        providerId = "test-provider",
+        requestedModel = "test-model",
+        attempt = 0,
+    )
+
+    /** Delegate whose every callback throws [IllegalStateException]. */
+    private val throwingObservation = object : OperationObservation {
+        override fun onProviderResponse(response: ModelResponse) = throw IllegalStateException("boom-response")
+        override fun onProviderFailure(error: Throwable) = throw IllegalStateException("boom-failure")
+        override fun onStructuredParseFailure(rawResponse: String, errorSummary: String) = throw IllegalStateException("boom-parse")
+        override fun onEngineEvent(name: String, attributes: Map<String, Any?>) = throw IllegalStateException("boom-event")
+        override fun onCallCompleted(parseSuccess: Boolean?) = throw IllegalStateException("boom-completed")
+    }
+
+    private fun isolated(): OperationObservation =
+        FailureIsolatingOperationObservation(throwingObservation)
+
+    @Test
+    fun `provider response failure is contained`() {
+        isolated().onProviderResponse(modelResponse)
+    }
+
+    @Test
+    fun `provider failure callback failure is contained`() {
+        isolated().onProviderFailure(IllegalStateException("primary"))
+    }
+
+    @Test
+    fun `structured parse failure callback failure is contained`() {
+        isolated().onStructuredParseFailure("raw", "summary")
+    }
+
+    @Test
+    fun `legacy engine event callback failure is contained`() {
+        isolated().onEngineEvent("tramai.engine.event", emptyMap())
+    }
+
+    @Test
+    fun `call completed failure is contained`() {
+        isolated().onCallCompleted(parseSuccess = true)
+        isolated().onCallCompleted(parseSuccess = null)
+    }
+
+    @Test
+    fun `call cancelled propagates to the cancellation helper for suppression`() {
+        // The cancellation path is deliberately NOT isolated: the engine's
+        // completeCancellation helper catches the observer failure and
+        // attaches it as suppressed onto the in-flight CancellationException
+        // (frozen contract — CE stays primary, secondary failure preserved).
+        assertFailsWith<IllegalStateException> {
+            isolated().onCallCancelled()
+        }
+    }
+
+    @Test
+    fun `fail-open runtime event emission failure is contained`() {
+        val event = RuntimeEvent.of(RuntimeEvents.ROUTE_SELECTED) {
+            set(RuntimeAttributes.PROVIDER_ID, "p")
+        }
+        isolated().onEngineEvent(event)
+    }
+
+    @Test
+    fun `fail-closed runtime event emission failure propagates`() {
+        val event = RuntimeEvent.of(RuntimeEvents.ROUTE_SELECTED.copy(
+            name = "tramai.engine.fail-closed.probe",
+            failurePolicy = RuntimeEventFailurePolicy.FAIL_CLOSED,
+        )) {
+            set(RuntimeAttributes.PROVIDER_ID, "p")
+        }
+        assertFailsWith<IllegalStateException> {
+            isolated().onEngineEvent(event)
+        }
+    }
+
+    @Test
+    fun `cancellation from an observer always escapes unchanged`() {
+        val cancellation = CancellationException("observer-cancelled")
+        val cancellingObservation = object : OperationObservation {
+            override fun onProviderResponse(response: ModelResponse) = throw cancellation
+            override fun onProviderFailure(error: Throwable) = throw cancellation
+            override fun onStructuredParseFailure(rawResponse: String, errorSummary: String) = throw cancellation
+            override fun onEngineEvent(name: String, attributes: Map<String, Any?>) = throw cancellation
+            override fun onCallCompleted(parseSuccess: Boolean?) = throw cancellation
+        }
+        val obs = FailureIsolatingOperationObservation(cancellingObservation)
+        val caught = assertFailsWith<CancellationException> {
+            obs.onProviderResponse(modelResponse)
+        }
+        assertSame(cancellation, caught)
+    }
+
+    @Test
+    fun `onCallStarted failure returns no-op observation instead of throwing`() {
+        val observer = FailureIsolatingOperationObserver(
+            object : OperationObserver {
+                override fun onCallStarted(context: OperationCallContext): OperationObservation =
+                    throw IllegalStateException("boom-start")
+            },
+        )
+        val observation = observer.onCallStarted(context)
+        assertTrue(observation is NoOpOperationObservation)
+        observation.onProviderResponse(modelResponse) // no-op must not throw
+        observation.onCallCompleted(parseSuccess = true)
+    }
+
+    @Test
+    fun `onCallStarted cancellation propagates unchanged`() {
+        val cancellation = CancellationException("cancelled")
+        val observer = FailureIsolatingOperationObserver(
+            object : OperationObserver {
+                override fun onCallStarted(context: OperationCallContext): OperationObservation = throw cancellation
+            },
+        )
+        assertSame(cancellation, assertFailsWith<CancellationException> {
+            observer.onCallStarted(context)
+        })
+    }
+
+    @Test
+    fun `successful callbacks are forwarded to the delegate`() {
+        val received = mutableListOf<String>()
+        val observation = FailureIsolatingOperationObservation(object : OperationObservation {
+            override fun onProviderResponse(response: ModelResponse) {
+                received += "response"
+            }
+
+            override fun onProviderFailure(error: Throwable) {
+                received += "failure"
+            }
+
+            override fun onStructuredParseFailure(rawResponse: String, errorSummary: String) {
+                received += "parse"
+            }
+
+            override fun onEngineEvent(name: String, attributes: Map<String, Any?>) {
+                received += "event"
+            }
+
+            override fun onCallCompleted(parseSuccess: Boolean?) {
+                received += "completed"
+            }
+        })
+        observation.onProviderResponse(modelResponse)
+        observation.onProviderFailure(IllegalStateException("x"))
+        observation.onStructuredParseFailure("raw", "s")
+        observation.onEngineEvent("name", emptyMap())
+        observation.onCallCompleted(true)
+        assertEquals(listOf("response", "failure", "parse", "event", "completed"), received)
+    }
+}

--- a/tramai-engine/api/tramai-engine.api
+++ b/tramai-engine/api/tramai-engine.api
@@ -66,7 +66,12 @@ public final class dev/tramai/engine/CircuitBreakerSettings {
 }
 
 public abstract interface class dev/tramai/engine/EngineEventObserver {
+	public fun onEngineEvent (Ldev/tramai/core/observation/event/RuntimeEvent;)V
 	public abstract fun onEngineEvent (Ljava/lang/String;Ljava/util/Map;)V
+}
+
+public final class dev/tramai/engine/EngineEventObserver$DefaultImpls {
+	public static fun onEngineEvent (Ldev/tramai/engine/EngineEventObserver;Ldev/tramai/core/observation/event/RuntimeEvent;)V
 }
 
 public final class dev/tramai/engine/EngineExecutionIdentity {
@@ -110,6 +115,7 @@ public final class dev/tramai/engine/ExecutionSecurityContext$Companion {
 
 public final class dev/tramai/engine/FailureIsolatingEngineEventObserver : dev/tramai/engine/EngineEventObserver {
 	public fun <init> (Ldev/tramai/engine/EngineEventObserver;)V
+	public fun onEngineEvent (Ldev/tramai/core/observation/event/RuntimeEvent;)V
 	public fun onEngineEvent (Ljava/lang/String;Ljava/util/Map;)V
 }
 
@@ -133,6 +139,7 @@ public final class dev/tramai/engine/LegacyPermissivePolicyEngine : dev/tramai/c
 
 public final class dev/tramai/engine/NoOpEngineEventObserver : dev/tramai/engine/EngineEventObserver {
 	public static final field INSTANCE Ldev/tramai/engine/NoOpEngineEventObserver;
+	public fun onEngineEvent (Ldev/tramai/core/observation/event/RuntimeEvent;)V
 	public fun onEngineEvent (Ljava/lang/String;Ljava/util/Map;)V
 }
 

--- a/tramai-engine/api/tramai-engine.api
+++ b/tramai-engine/api/tramai-engine.api
@@ -108,6 +108,11 @@ public final class dev/tramai/engine/ExecutionSecurityContext$Companion {
 	public final fun fromArguments ([Ljava/lang/Object;)Ldev/tramai/engine/ExecutionSecurityContext;
 }
 
+public final class dev/tramai/engine/FailureIsolatingEngineEventObserver : dev/tramai/engine/EngineEventObserver {
+	public fun <init> (Ldev/tramai/engine/EngineEventObserver;)V
+	public fun onEngineEvent (Ljava/lang/String;Ljava/util/Map;)V
+}
+
 public final class dev/tramai/engine/InMemoryOperationResponseCache : dev/tramai/engine/OperationResponseCache {
 	public fun <init> ()V
 	public fun <init> (ILkotlin/jvm/functions/Function0;)V

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/EngineEventObserver.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/EngineEventObserver.kt
@@ -1,10 +1,23 @@
 package dev.tramai.engine
 
+import dev.tramai.core.observation.event.RuntimeEvent
+
 interface EngineEventObserver {
     fun onEngineEvent(
         name: String,
         attributes: Map<String, Any?>,
     )
+
+    /**
+     * Typed overload that carries the event's declared failure policy
+     * (Epic 5.2/5.3): the failure-isolating boundary can honour
+     * [RuntimeEvent.definition.failurePolicy] instead of flattening it away.
+     * The default implementation routes through the legacy [onEngineEvent]
+     * so existing implementations keep working unchanged.
+     */
+    fun onEngineEvent(event: RuntimeEvent) {
+        onEngineEvent(event.name, event.attributes())
+    }
 }
 
 object NoOpEngineEventObserver : EngineEventObserver {

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/FailureIsolatingEngineEventObserver.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/FailureIsolatingEngineEventObserver.kt
@@ -1,5 +1,7 @@
 package dev.tramai.engine
 
+import dev.tramai.core.observation.secondary.ExperimentalTramaiInternalApi
+import dev.tramai.core.observation.event.RuntimeEvent
 import dev.tramai.core.observation.secondary.SecondaryEffectAuthority
 import dev.tramai.core.observation.secondary.SecondaryFailureDiagnostic
 import kotlinx.coroutines.CancellationException
@@ -12,7 +14,12 @@ import kotlinx.coroutines.CancellationException
  * decisions, or any other engine behaviour. Each callback failure is contained
  * and reported through the safe secondary-failure diagnostic.
  * [kotlinx.coroutines.CancellationException] always escapes unchanged.
+ *
+ * The typed [onEngineEvent] overload honours the event's declared failure
+ * policy: FAIL_CLOSED events propagate (never contained), FAIL_OPEN events are
+ * contained with a diagnostic.
  */
+@ExperimentalTramaiInternalApi
 class FailureIsolatingEngineEventObserver(
     private val delegate: EngineEventObserver,
 ) : EngineEventObserver {
@@ -21,13 +28,30 @@ class FailureIsolatingEngineEventObserver(
         name: String,
         attributes: Map<String, Any?>,
     ) {
-        try {
+        isolate("onEngineEvent") {
             delegate.onEngineEvent(name, attributes)
-        } catch (error: Throwable) {
+        }
+    }
+
+    override fun onEngineEvent(event: RuntimeEvent) {
+        if (event.definition.failurePolicy == dev.tramai.core.observation.event.RuntimeEventFailurePolicy.FAIL_CLOSED) {
+            // Authoritative event: emission failure must propagate.
+            delegate.onEngineEvent(event)
+        } else {
+            isolate("onEngineEvent(${event.definition.name})") {
+                delegate.onEngineEvent(event)
+            }
+        }
+    }
+
+    private inline fun isolate(callback: String, block: () -> Unit) {
+        try {
+            block()
+        } catch (error: Exception) {
             if (error is CancellationException) throw error
             SecondaryFailureDiagnostic.report(
                 extensionPoint = "engine_event_observer",
-                callback = "onEngineEvent",
+                callback = callback,
                 errorType = error.javaClass.simpleName,
                 failurePolicy = "FAIL_OPEN",
                 authority = SecondaryEffectAuthority.NON_AUTHORITATIVE.name,

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/FailureIsolatingEngineEventObserver.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/FailureIsolatingEngineEventObserver.kt
@@ -1,0 +1,37 @@
+package dev.tramai.engine
+
+import dev.tramai.core.observation.secondary.SecondaryEffectAuthority
+import dev.tramai.core.observation.secondary.SecondaryFailureDiagnostic
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Epic 5.3 — failure-isolating [EngineEventObserver] boundary.
+ *
+ * Engine lifecycle events are non-authoritative telemetry: a throwing
+ * observer must never block approval replay, tool sanitization, circuit
+ * decisions, or any other engine behaviour. Each callback failure is contained
+ * and reported through the safe secondary-failure diagnostic.
+ * [kotlinx.coroutines.CancellationException] always escapes unchanged.
+ */
+class FailureIsolatingEngineEventObserver(
+    private val delegate: EngineEventObserver,
+) : EngineEventObserver {
+
+    override fun onEngineEvent(
+        name: String,
+        attributes: Map<String, Any?>,
+    ) {
+        try {
+            delegate.onEngineEvent(name, attributes)
+        } catch (error: Throwable) {
+            if (error is CancellationException) throw error
+            SecondaryFailureDiagnostic.report(
+                extensionPoint = "engine_event_observer",
+                callback = "onEngineEvent",
+                errorType = error.javaClass.simpleName,
+                failurePolicy = "FAIL_OPEN",
+                authority = SecondaryEffectAuthority.NON_AUTHORITATIVE.name,
+            )
+        }
+    }
+}

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/RuntimeEventEmission.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/RuntimeEventEmission.kt
@@ -4,10 +4,12 @@ import dev.tramai.core.observation.OperationObservation
 import dev.tramai.core.observation.event.RuntimeEvent
 
 /**
- * Emits a catalogue-validated [RuntimeEvent] through the legacy
- * (name, attributes) observation boundary. The event is constructed through
- * the typed builder, so schema violations fail at the call site.
+ * Emits a catalogue-validated [RuntimeEvent] through the typed observation
+ * overload. The event is constructed through the typed builder, so schema
+ * violations fail at the call site; routing through the typed overload lets
+ * the failure-isolating boundary honor the event's declared failure policy
+ * (FAIL_CLOSED propagates, FAIL_OPEN is contained).
  */
 internal fun OperationObservation.emitRuntimeEvent(event: RuntimeEvent) {
-    onEngineEvent(event.name, event.attributes())
+    onEngineEvent(event)
 }

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/approval/ApprovalResumeCoordinator.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/approval/ApprovalResumeCoordinator.kt
@@ -1,11 +1,16 @@
+@file:OptIn(ExperimentalTramaiInternalApi::class)
 package dev.tramai.engine.approval
 
+
+import dev.tramai.core.observation.secondary.ExperimentalTramaiInternalApi
 import dev.tramai.core.approval.*
 import dev.tramai.core.coroutines.rethrowIfCancellation
 import dev.tramai.core.exception.*
 import dev.tramai.core.model.ResolvedTool
 import dev.tramai.engine.*
 import kotlinx.coroutines.CancellationException
+import dev.tramai.core.observation.secondary.SecondaryEffectAuthority
+import dev.tramai.core.observation.secondary.SecondaryFailureDiagnostic
 
 /**
  * Orchestrates the resume state machine for a suspended approval.
@@ -188,17 +193,19 @@ internal class ApprovalResumeCoordinator(
             throw cancellation
         } catch (e: Exception) {
             e.rethrowIfCancellation()
-            try {
-                engineEventObserver.onEngineEvent(
-                    name = "resume-completion-audit-failure",
-                    attributes = mapOf("approvalId" to command.approvalId, "toolName" to metadata.toolName),
-                )
-            } catch (cancellation: CancellationException) {
-                throw cancellation
-            } catch (observerError: Exception) {
-                observerError.rethrowIfCancellation()
-                // best-effort observer cleanup failure
-            }
+            // Epic 5.3: post-side-effect completion audit. The tool side effect
+            // and the COMPLETED transition have already happened — fail-closed
+            // is physically impossible here. The audit failure is recorded with
+            // explicit terminal semantics (authoritative, declared FAIL_CLOSED,
+            // disposition terminal-recorded), NEVER silently converted to
+            // telemetry as if nothing happened.
+            SecondaryFailureDiagnostic.report(
+                extensionPoint = "approval_lifecycle_audit",
+                callback = "onToolExecutionCompleted",
+                errorType = e.javaClass.simpleName,
+                failurePolicy = "FAIL_CLOSED",
+                authority = SecondaryEffectAuthority.AUTHORITATIVE.name,
+            )
         }
     }
 
@@ -210,12 +217,29 @@ internal class ApprovalResumeCoordinator(
     ) {
         if (marker.emitted) return
         marker.emitted = true
-        approvalLifecycleAuditEmitter.onUncertainOutcome(
-            command.approvalId,
-            metadata.identity.workflowRunId,
-            metadata.toolName,
-            reason,
-        )
+        try {
+            approvalLifecycleAuditEmitter.onUncertainOutcome(
+                command.approvalId,
+                metadata.identity.workflowRunId,
+                metadata.toolName,
+                reason,
+            )
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (e: Exception) {
+            e.rethrowIfCancellation()
+            // Epic 5.3: this audit reports an ALREADY-FAILED resume. The
+            // underlying business failure is primary; an audit failure here must
+            // be recorded (authoritative, declared FAIL_CLOSED, disposition
+            // terminal-recorded) and NEVER substitute the primary failure.
+            SecondaryFailureDiagnostic.report(
+                extensionPoint = "approval_lifecycle_audit",
+                callback = "onUncertainOutcome",
+                errorType = e.javaClass.simpleName,
+                failurePolicy = "FAIL_CLOSED",
+                authority = SecondaryEffectAuthority.AUTHORITATIVE.name,
+            )
+        }
     }
 
     private fun requireApprovalContinuationStore(): ApprovalContinuationStore =

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/approval/ReplayAuthorizationService.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/approval/ReplayAuthorizationService.kt
@@ -1,5 +1,8 @@
+@file:OptIn(ExperimentalTramaiInternalApi::class)
 package dev.tramai.engine.approval
 
+
+import dev.tramai.core.observation.secondary.ExperimentalTramaiInternalApi
 import dev.tramai.core.approval.*
 import dev.tramai.core.coroutines.rethrowIfCancellation
 import dev.tramai.core.exception.ConfigurationException
@@ -12,6 +15,8 @@ import dev.tramai.core.observation.event.RuntimeEvent
 import dev.tramai.core.observation.event.RuntimeEvents
 import dev.tramai.engine.*
 import kotlinx.coroutines.CancellationException
+import dev.tramai.core.observation.secondary.SecondaryEffectAuthority
+import dev.tramai.core.observation.secondary.SecondaryFailureDiagnostic
 
 private fun PolicyContextBuilder.applyApprovalSecurityContext(
     securityContext: ExecutionSecurityContext,
@@ -124,12 +129,29 @@ internal class ReplayAuthorizationService(
     ) {
         store.cancel(command.approvalId, command.continuationExpectedVersion)
         suspendedInvocationStore.remove(command.approvalId)
-        approvalLifecycleAuditEmitter.onSuspensionCancelled(
-            command.approvalId,
-            metadata.identity.workflowRunId,
-            metadata.toolName,
-            reason,
-        )
+        try {
+            approvalLifecycleAuditEmitter.onSuspensionCancelled(
+                approvalId = command.approvalId,
+                workflowRunId = metadata.identity.workflowRunId,
+                toolName = metadata.toolName,
+                reason = reason,
+            )
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (e: Exception) {
+            e.rethrowIfCancellation()
+            // Epic 5.3: post-mutation notification. Both stores have already
+            // been mutated — fail-closed is physically impossible. Record the
+            // audit failure (terminal-recorded) instead of failing the method
+            // after the transition already committed.
+            SecondaryFailureDiagnostic.report(
+                extensionPoint = "approval_lifecycle_audit",
+                callback = "onSuspensionCancelled",
+                errorType = e.javaClass.simpleName,
+                failurePolicy = "FAIL_CLOSED",
+                authority = SecondaryEffectAuthority.AUTHORITATIVE.name,
+            )
+        }
     }
 
     fun emitAuthorizationReplayed(
@@ -138,19 +160,15 @@ internal class ReplayAuthorizationService(
         metadata: SuspendedInvocationMetadata,
     ) {
         if (!replayed) return
-        try {
-            val event = RuntimeEvent.of(RuntimeEvents.APPROVAL_AUTHORIZATION_REPLAYED) {
-                set(RuntimeAttributes.APPROVAL_ID, command.approvalId)
-                set(RuntimeAttributes.WORKFLOW_RUN_ID, metadata.identity.workflowRunId)
-                set(RuntimeAttributes.TOOL_NAME, metadata.toolName)
-            }
-            engineEventObserver.onEngineEvent(event.name, event.attributes())
-        } catch (cancellation: CancellationException) {
-            throw cancellation
-        } catch (e: Exception) {
-            e.rethrowIfCancellation()
-            // Engine-event observer failures must not prevent resume completion.
+        // Epic 5.3: typed overload — the failure-isolating boundary honours the
+        // event's declared failure policy (FAIL_CLOSED propagates). No local
+        // catch: a FAIL_CLOSED event must NOT be swallowed at the call site.
+        val event = RuntimeEvent.of(RuntimeEvents.APPROVAL_AUTHORIZATION_REPLAYED) {
+            set(RuntimeAttributes.APPROVAL_ID, command.approvalId)
+            set(RuntimeAttributes.WORKFLOW_RUN_ID, metadata.identity.workflowRunId)
+            set(RuntimeAttributes.TOOL_NAME, metadata.toolName)
         }
+        engineEventObserver.onEngineEvent(event)
     }
 
     private fun requireApprovalGateCoordinator(): ApprovalGateCoordinator =

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/components/EngineComponentFactory.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/components/EngineComponentFactory.kt
@@ -1,5 +1,8 @@
+@file:OptIn(ExperimentalTramaiInternalApi::class)
 package dev.tramai.engine.components
 
+
+import dev.tramai.core.observation.secondary.ExperimentalTramaiInternalApi
 import dev.tramai.core.approval.*
 import dev.tramai.core.memory.ChatMemory
 import dev.tramai.core.memory.ConversationIdProvider

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/components/EngineComponentFactory.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/components/EngineComponentFactory.kt
@@ -36,7 +36,16 @@ internal object EngineComponentFactory {
             SecurityComponents(resolvedPolicy, policyEngine == null, promptSanitizer, modelRegistry, modelRegistrySettings, dlpInterceptor, dlpRedactionAuditEmitter, policyDecisionAuditEmitter),
             ApprovalComponents(suspendedInvocationStore, approvalLifecycleAuditEmitter, capability),
             PersistenceComponents(responseCache, chatMemory, conversationIdProvider),
-            ObservationComponents(operationObserver, operationInterceptor, engineEventObserver, toolFailureDiagnosticObserver, structuredOutputFailureDiagnosticObserver),
+            ObservationComponents(
+                // Epic 5.3: telemetry observers are non-authoritative. The
+                // failure-isolating boundary lives here, once, so no engine
+                // execution component can be derailed by a throwing observer.
+                FailureIsolatingOperationObserver(operationObserver),
+                operationInterceptor,
+                FailureIsolatingEngineEventObserver(engineEventObserver),
+                toolFailureDiagnosticObserver,
+                structuredOutputFailureDiagnosticObserver,
+            ),
             ExecutionComponents(structuredOutputHandler, circuitBreakerSettings, retryPolicySettings, tokenBudgetSettings, clock),
         )
     }

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/invocation/ClaimedResumeExecutionCoordinator.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/invocation/ClaimedResumeExecutionCoordinator.kt
@@ -1,5 +1,8 @@
+@file:OptIn(ExperimentalTramaiInternalApi::class)
 package dev.tramai.engine.invocation
 
+
+import dev.tramai.core.observation.secondary.ExperimentalTramaiInternalApi
 import dev.tramai.core.approval.IdempotencyKeyUtil
 import dev.tramai.core.approval.ApprovalLifecycleAuditEmitter
 import dev.tramai.core.exception.ApprovalSuspendedException
@@ -27,6 +30,10 @@ import dev.tramai.engine.tool.ToolCallBatchRequest
 import dev.tramai.engine.tool.ToolExecutionRequest
 import dev.tramai.engine.tool.ToolInvocationExecutor
 import dev.tramai.engine.tool.ToolReinjectionCoordinator
+import dev.tramai.core.observation.secondary.SecondaryEffectAuthority
+import dev.tramai.core.observation.secondary.SecondaryFailureDiagnostic
+import dev.tramai.core.coroutines.rethrowIfCancellation
+import kotlinx.coroutines.CancellationException
 
 /**
  * Executes the post-claim approval-resume path.
@@ -230,12 +237,28 @@ internal class ClaimedResumeExecutionCoordinator(
                 message = "Nested approval not supported in v1: sibling tool ${toolCall.name} requires approval",
             )
         } catch (e: ApprovalSuspendedException) {
-            approvalLifecycleAuditEmitter.onUncertainOutcome(
-                approvalId = request.approvalId,
-                workflowRunId = request.identity.workflowRunId,
-                toolName = toolCall.name,
-                reason = "nested-approval-not-supported: sibling tool ${toolCall.name} requires approval",
-            )
+            try {
+                approvalLifecycleAuditEmitter.onUncertainOutcome(
+                    approvalId = request.approvalId,
+                    workflowRunId = request.identity.workflowRunId,
+                    toolName = toolCall.name,
+                    reason = "nested-approval-not-supported: sibling tool ${toolCall.name} requires approval",
+                )
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (auditError: Exception) {
+                auditError.rethrowIfCancellation()
+                // Epic 5.3: audit-while-reporting-primary. The ConfigurationException
+                // below is the primary failure; an audit failure is recorded
+                // (authoritative, terminal-recorded) and never substitutes it.
+                SecondaryFailureDiagnostic.report(
+                    extensionPoint = "approval_lifecycle_audit",
+                    callback = "onUncertainOutcome",
+                    errorType = auditError.javaClass.simpleName,
+                    failurePolicy = "FAIL_CLOSED",
+                    authority = SecondaryEffectAuthority.AUTHORITATIVE.name,
+                )
+            }
             throw ConfigurationException("Nested approval not supported in v1: sibling tool ${toolCall.name} requires approval")
         }
     }

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/invocation/ToolLoopCoordinator.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/invocation/ToolLoopCoordinator.kt
@@ -5,6 +5,7 @@ import dev.tramai.core.exception.TokenBudgetExceededException
 import dev.tramai.core.model.Message
 import dev.tramai.core.model.MessageRole
 import dev.tramai.core.observation.OperationObservation
+import dev.tramai.core.observation.SecondaryFailureRecording
 import dev.tramai.engine.EngineExecutionIdentity
 import dev.tramai.engine.ExecutionSecurityContext
 import dev.tramai.engine.OperationDefinition
@@ -151,6 +152,21 @@ internal class ToolLoopCoordinator(
         try {
             onCallCompleted(parseSuccess = null)
         } catch (observerError: Throwable) {
+            if (primaryError != null) {
+                primaryError.addSuppressed(observerError)
+            } else {
+                System.getLogger("dev.tramai.engine.TramaiEngine").log(
+                    System.Logger.Level.WARNING,
+                    "Operation observer failed after successful tool processing",
+                    observerError,
+                )
+            }
+        }
+        // Epic 5.3: the failure-isolating observation contains onCallCompleted
+        // failures (so a success path is never invalidated by telemetry), but
+        // records them; surface the recorded failure exactly as the direct
+        // throw path above — suppressed on the primary error, warning otherwise.
+        (this as? SecondaryFailureRecording)?.lastCompletionFailure?.let { observerError ->
             if (primaryError != null) {
                 primaryError.addSuppressed(observerError)
             } else {

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/invocation/ToolLoopCoordinator.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/invocation/ToolLoopCoordinator.kt
@@ -1,5 +1,8 @@
+@file:OptIn(ExperimentalTramaiInternalApi::class)
 package dev.tramai.engine.invocation
 
+
+import dev.tramai.core.observation.secondary.ExperimentalTramaiInternalApi
 import dev.tramai.core.coroutines.rethrowIfCancellation
 import dev.tramai.core.exception.TokenBudgetExceededException
 import dev.tramai.core.model.Message
@@ -20,6 +23,8 @@ import dev.tramai.engine.tool.ToolExposureCoordinator
 import dev.tramai.engine.tool.ToolReinjectionCoordinator
 import dev.tramai.engine.ToolRegistry
 import kotlinx.coroutines.CancellationException
+import dev.tramai.core.observation.secondary.SecondaryEffectAuthority
+import dev.tramai.core.observation.secondary.SecondaryFailureDiagnostic
 
 /**
  * Runs the provider ↔ tool loop for one operation: at most five
@@ -151,32 +156,37 @@ internal class ToolLoopCoordinator(
     ) {
         try {
             onCallCompleted(parseSuccess = null)
-        } catch (observerError: Throwable) {
+        } catch (observerError: Exception) {
             if (primaryError != null) {
                 primaryError.addSuppressed(observerError)
             } else {
-                System.getLogger("dev.tramai.engine.TramaiEngine").log(
-                    System.Logger.Level.WARNING,
-                    "Operation observer failed after successful tool processing",
-                    observerError,
-                )
+                reportCompletionFailure(observerError)
             }
         }
         // Epic 5.3: the failure-isolating observation contains onCallCompleted
         // failures (so a success path is never invalidated by telemetry), but
         // records them; surface the recorded failure exactly as the direct
-        // throw path above — suppressed on the primary error, warning otherwise.
+        // throw path above — suppressed on the primary error, safe diagnostic
+        // otherwise.
         (this as? SecondaryFailureRecording)?.lastCompletionFailure?.let { observerError ->
             if (primaryError != null) {
                 primaryError.addSuppressed(observerError)
             } else {
-                System.getLogger("dev.tramai.engine.TramaiEngine").log(
-                    System.Logger.Level.WARNING,
-                    "Operation observer failed after successful tool processing",
-                    observerError,
-                )
+                reportCompletionFailure(observerError)
             }
         }
+    }
+
+    private fun reportCompletionFailure(observerError: Throwable) {
+        // Epic 5.3 (P2-4): success path uses the SAFE diagnostic only — error
+        // type and identifiers, never the observer's message or stack trace.
+        SecondaryFailureDiagnostic.report(
+            extensionPoint = "operation_observation",
+            callback = "onCallCompleted",
+            errorType = observerError.javaClass.simpleName,
+            failurePolicy = "FAIL_OPEN",
+            authority = SecondaryEffectAuthority.NON_AUTHORITATIVE.name,
+        )
     }
 }
 

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/tool/ToolResultSanitizer.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/tool/ToolResultSanitizer.kt
@@ -67,9 +67,10 @@ internal class ToolResultSanitizer(
     }
 
     private fun emitEngineEventSafely(event: RuntimeEvent) {
-        try { engineEventObserver.onEngineEvent(event.name, event.attributes()) } catch (error: Exception) {
-            System.getLogger("dev.tramai.engine.TramaiEngine").log(System.Logger.Level.WARNING, "Engine event observer failed for '${event.name}': ${error::class.simpleName}")
-        }
+        // Epic 5.3: typed overload — the failure-isolating boundary honours the
+        // event's declared failure policy (FAIL_CLOSED propagates). No local
+        // catch: a FAIL_CLOSED event must NOT be swallowed at the call site.
+        engineEventObserver.onEngineEvent(event)
     }
 
     private fun emitToolResultRejected(scope: ToolReinjectionDlpScope, reasonCode: String, actualLength: Long?) {

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalEngineEdgeCaseTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ApprovalEngineEdgeCaseTest.kt
@@ -1037,7 +1037,11 @@ class ApprovalEngineEdgeCaseTest {
 
         // No uncertain outcome was emitted
         assertThat(auditEvents.none { it.startsWith("uncertain:") }).isTrue
-        assertThat(observerEvents).containsExactly("resume-completion-audit-failure")
+        // Epic 5.3: the completion-audit failure is no longer re-emitted as a
+        // "resume-completion-audit-failure" telemetry event — it is recorded
+        // via the safe diagnostic (authority=AUTHORITATIVE, declared
+        // FAIL_CLOSED, disposition terminal-recorded) instead.
+        assertThat(observerEvents).isEmpty()
     }
 
     // ── Helpers ────────────────────────────────────────────────────

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/EngineComponentsTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/EngineComponentsTest.kt
@@ -14,6 +14,7 @@ import dev.tramai.core.model.ModelRegistrySettings
 import dev.tramai.core.model.ModelRequest
 import dev.tramai.core.model.ModelResponse
 import dev.tramai.core.model.NoOpModelRegistry
+import dev.tramai.core.observation.FailureIsolatingOperationObserver
 import dev.tramai.core.observation.NoOpOperationInterceptor
 import dev.tramai.core.observation.NoOpOperationObserver
 import dev.tramai.core.observation.NoOpToolFailureDiagnosticObserver
@@ -33,6 +34,7 @@ import dev.tramai.core.security.NoOpDlpRedactionAuditEmitter
 import dev.tramai.core.security.PromptSanitizer
 import dev.tramai.core.structured.StructuredOutputHandler
 import dev.tramai.engine.components.ApprovalCapability
+import dev.tramai.engine.FailureIsolatingEngineEventObserver
 import dev.tramai.engine.components.EngineComponentFactory
 import dev.tramai.engine.components.EngineComponents
 import java.lang.reflect.Proxy
@@ -124,7 +126,10 @@ class EngineComponentsTest {
         assertIs<ApprovalCapability.Disabled>(components.approvals.capability)
         assertTrue(components.security.isLegacyFallback)
         assertSame(LegacyPermissivePolicyEngine, components.security.resolvedPolicyEngine)
-        assertSame(NoOpOperationObserver, components.observation.operationObserver)
+        // Epic 5.3: the composition boundary wraps telemetry observers in the
+        // failure-isolating decorator; the NoOp delegate stays inside.
+        assertIs<FailureIsolatingOperationObserver>(components.observation.operationObserver)
+        assertIs<FailureIsolatingEngineEventObserver>(components.observation.engineEventObserver)
         assertSame(NoOpOperationResponseCache, components.persistence.responseCache)
     }
 

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/FailureIsolatingEngineEventObserverTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/FailureIsolatingEngineEventObserverTest.kt
@@ -1,0 +1,117 @@
+@file:OptIn(ExperimentalTramaiInternalApi::class)
+package dev.tramai.engine
+
+import dev.tramai.core.observation.event.RuntimeAttributes
+import dev.tramai.core.observation.event.RuntimeEvent
+import dev.tramai.core.observation.event.RuntimeEventFailurePolicy
+import dev.tramai.core.observation.event.RuntimeEvents
+import dev.tramai.core.observation.secondary.ExperimentalTramaiInternalApi
+import kotlinx.coroutines.CancellationException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * Epic 5.3 — [FailureIsolatingEngineEventObserver] typed-policy enforcement.
+ *
+ * Engine lifecycle events are non-authoritative telemetry: a throwing
+ * observer must never block engine behaviour. The typed overload honours the
+ * event's declared failure policy: FAIL_OPEN (catalogue default) is contained
+ * with a safe diagnostic, FAIL_CLOSED propagates unchanged. The legacy
+ * [EngineEventObserver.onEngineEvent] overload is always contained, and
+ * cancellation always escapes unchanged.
+ */
+class FailureIsolatingEngineEventObserverTest {
+
+    private val failOpenEvent = RuntimeEvent.of(RuntimeEvents.DLP_TOOL_RESULT_REJECTED) {
+        set(RuntimeAttributes.REASON_CODE, "dlp-rejected")
+    }
+
+    private val failClosedEvent = RuntimeEvent.of(
+        RuntimeEvents.DLP_TOOL_RESULT_REJECTED.copy(
+            name = "tramai.engine.fail-closed.probe",
+            failurePolicy = RuntimeEventFailurePolicy.FAIL_CLOSED,
+        ),
+    ) {
+        set(RuntimeAttributes.REASON_CODE, "dlp-rejected")
+    }
+
+    @Test
+    fun `fail-open typed event failure is contained and never reaches the legacy path`() {
+        var legacyCalls = 0
+        val delegate = object : EngineEventObserver {
+            override fun onEngineEvent(event: RuntimeEvent) = throw IllegalStateException("typed-down")
+            override fun onEngineEvent(name: String, attributes: Map<String, Any?>) {
+                legacyCalls++
+            }
+        }
+
+        val diagnostics = withCapturedSecondaryDiagnostics {
+            FailureIsolatingEngineEventObserver(delegate).onEngineEvent(failOpenEvent)
+        }
+
+        // no exception escaped, and the typed path was used — the delegate's
+        // legacy method was never invoked
+        assertThat(legacyCalls).isZero()
+        assertThat(diagnostics.any {
+            it.contains("extensionPoint=engine_event_observer") &&
+                it.contains("failurePolicy=FAIL_OPEN") &&
+                it.contains("authority=NON_AUTHORITATIVE")
+        }).isTrue
+    }
+
+    @Test
+    fun `fail-closed typed event failure propagates unchanged`() {
+        val thrown = IllegalStateException("fail-closed-down")
+        val delegate = object : EngineEventObserver {
+            override fun onEngineEvent(event: RuntimeEvent) = throw thrown
+            override fun onEngineEvent(name: String, attributes: Map<String, Any?>) = Unit
+        }
+
+        assertThatThrownBy { FailureIsolatingEngineEventObserver(delegate).onEngineEvent(failClosedEvent) }
+            .isSameAs(thrown)
+    }
+
+    @Test
+    fun `legacy event failure is contained with a diagnostic`() {
+        val delegate = object : EngineEventObserver {
+            override fun onEngineEvent(name: String, attributes: Map<String, Any?>) =
+                throw IllegalStateException("legacy-down")
+        }
+
+        val diagnostics = withCapturedSecondaryDiagnostics {
+            FailureIsolatingEngineEventObserver(delegate).onEngineEvent("tramai.engine.legacy.probe", emptyMap())
+        }
+
+        assertThat(diagnostics.any {
+            it.contains("extensionPoint=engine_event_observer") &&
+                it.contains("callback=onEngineEvent") &&
+                it.contains("failurePolicy=FAIL_OPEN") &&
+                it.contains("authority=NON_AUTHORITATIVE")
+        }).isTrue
+    }
+
+    @Test
+    fun `cancellation from a fail-open typed delegate escapes unchanged`() {
+        val cancellation = CancellationException("observer-cancelled")
+        val delegate = object : EngineEventObserver {
+            override fun onEngineEvent(event: RuntimeEvent) = throw cancellation
+            override fun onEngineEvent(name: String, attributes: Map<String, Any?>) = Unit
+        }
+
+        assertThatThrownBy { FailureIsolatingEngineEventObserver(delegate).onEngineEvent(failOpenEvent) }
+            .isSameAs(cancellation)
+    }
+
+    @Test
+    fun `cancellation from a fail-closed typed delegate escapes unchanged`() {
+        val cancellation = CancellationException("observer-cancelled")
+        val delegate = object : EngineEventObserver {
+            override fun onEngineEvent(event: RuntimeEvent) = throw cancellation
+            override fun onEngineEvent(name: String, attributes: Map<String, Any?>) = Unit
+        }
+
+        assertThatThrownBy { FailureIsolatingEngineEventObserver(delegate).onEngineEvent(failClosedEvent) }
+            .isSameAs(cancellation)
+    }
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/SecondaryDiagnosticTestSupport.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/SecondaryDiagnosticTestSupport.kt
@@ -1,0 +1,36 @@
+package dev.tramai.engine
+
+import java.text.MessageFormat
+import java.util.logging.Handler
+import java.util.logging.LogRecord
+import java.util.logging.Logger
+
+/**
+ * Epic 5.3 test support — captures the safe secondary-failure diagnostic sink
+ * (`dev.tramai.core.observation.secondary`) during [block] and returns the
+ * formatted log messages. The handler is removed in a finally block so a
+ * failing test can never leak a capture handler into other tests.
+ */
+fun withCapturedSecondaryDiagnostics(block: () -> Unit): List<String> {
+    val logger = Logger.getLogger("dev.tramai.core.observation.secondary")
+    val records = mutableListOf<LogRecord>()
+    val handler = object : Handler() {
+        override fun publish(record: LogRecord) {
+            records += record
+        }
+
+        override fun flush() = Unit
+
+        override fun close() = Unit
+    }
+    logger.addHandler(handler)
+    try {
+        block()
+    } finally {
+        logger.removeHandler(handler)
+    }
+    return records.map { record ->
+        val params = record.parameters
+        if (params == null) record.message else MessageFormat.format(record.message, *params)
+    }
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/SecondaryFailurePreservationEngineTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/SecondaryFailurePreservationEngineTest.kt
@@ -1,0 +1,97 @@
+package dev.tramai.engine
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.model.ToolCall
+import dev.tramai.core.model.ToolExecutionContext
+import dev.tramai.core.model.ResolvedTool
+import dev.tramai.core.model.ToolResult
+import dev.tramai.core.observation.OperationCallContext
+import dev.tramai.core.observation.OperationObservation
+import dev.tramai.core.observation.OperationObserver
+import dev.tramai.core.provider.ModelProvider
+import dev.tramai.core.provider.ProviderRegistry
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Epic 5.3 — secondary-failure preservation at the engine boundary.
+ *
+ * A throwing telemetry observer must never change the business outcome:
+ * a successful operation stays successful, and a provider failure stays the
+ * primary exception.
+ */
+class SecondaryFailurePreservationEngineTest {
+
+    @AiService
+    interface BasicService {
+        @Operation(prompt = "test", model = "test-model", providerRetries = 0)
+        fun respond(input: String): String
+    }
+
+    private class CountingProvider : ModelProvider {
+        val callCount = AtomicInteger(0)
+
+        override fun providerId(): String = "test-provider"
+
+        override suspend fun complete(request: ModelRequest): ModelResponse {
+            callCount.incrementAndGet()
+            return ModelResponse(content = "ok:${request.messages.firstOrNull()?.content ?: ""}")
+        }
+    }
+
+    private class FailingProvider : ModelProvider {
+        override fun providerId(): String = "failing-provider"
+
+        override suspend fun complete(request: ModelRequest): ModelResponse =
+            throw dev.tramai.core.exception.ProviderException("provider-boom")
+    }
+
+    /** Observer whose every per-attempt callback throws. */
+    private val throwingObserver = object : OperationObserver {
+        override fun onCallStarted(context: OperationCallContext): OperationObservation =
+            object : OperationObservation {
+                override fun onProviderResponse(response: ModelResponse) = throw IllegalStateException("observer-boom")
+                override fun onProviderFailure(error: Throwable) = throw IllegalStateException("observer-boom")
+                override fun onStructuredParseFailure(rawResponse: String, errorSummary: String) = throw IllegalStateException("observer-boom")
+                override fun onEngineEvent(name: String, attributes: Map<String, Any?>) = throw IllegalStateException("observer-boom")
+                override fun onCallCompleted(parseSuccess: Boolean?) = throw IllegalStateException("observer-boom")
+            }
+    }
+
+    @Test
+    fun `business success survives throwing operation observer`() {
+        runBlocking {
+            val provider = CountingProvider()
+            val engine = TramaiEngine(
+                provider = provider,
+                operationObserver = throwingObserver,
+            )
+            val service = engine.create<BasicService>()
+            val result = service.respond("hello")
+            // Prompt-rendered content includes the arguments block; the point
+            // is the operation SUCCEEDED despite every observer callback throwing.
+            assertThat(result).startsWith("ok")
+            assertThat(provider.callCount.get()).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `provider failure remains primary when observer also throws`() {
+        runBlocking {
+            val engine = TramaiEngine(
+                provider = FailingProvider(),
+                operationObserver = throwingObserver,
+            )
+            val service = engine.create<BasicService>()
+            assertThatThrownBy { runBlocking { service.respond("hello") } }
+                .isInstanceOf(dev.tramai.core.exception.ProviderException::class.java)
+                .hasMessageContaining("provider-boom")
+        }
+    }
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/approval/ApprovalResumeCoordinatorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/approval/ApprovalResumeCoordinatorTest.kt
@@ -40,6 +40,7 @@ import dev.tramai.engine.SensitiveReplayEnvelope
 import dev.tramai.engine.SuspendedInvocationMetadata
 import dev.tramai.engine.SuspendedInvocationStore
 import dev.tramai.engine.ToolRegistry
+import dev.tramai.engine.withCapturedSecondaryDiagnostics
 import dev.tramai.security.approval.Sha256ToolArgumentsDigester
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
@@ -409,6 +410,79 @@ class ApprovalResumeCoordinatorTest {
     }
 
     @Test
+    fun `completion audit failure is diagnosed and resume still completes`() = runTest {
+        val events = mutableListOf<String>()
+        val store = RecordingContinuationStore(events, continuation())
+        val suspended = RecordingSuspendedStore(events, metadata(), prepared.envelope)
+        val registry = ResumeOperationRegistry().also { it.register(service, operation, RecordingExecutor(events)) }
+        val gate = RecordingGate(events)
+        val policy = PolicyEnforcementHelper(PolicyEngine { PolicyDecision.Allow }, AtomicBoolean(false))
+        val audit = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter by RecordingAuditEmitter(events) {
+            override suspend fun onToolExecutionCompleted(
+                approvalId: String, workflowRunId: String, toolName: String, completedBy: String,
+            ) = throw RuntimeException("audit-down")
+        }
+        val observer = RecordingObserver(events)
+        val coordinator = ApprovalResumeCoordinator(
+            store, suspended, registry, ToolRegistry(mapOf(toolName to tool)),
+            Sha256ToolArgumentsDigester(), audit, observer,
+            ContinuationClaimService(store), ReplayAuthorizationService(gate, suspended, audit, policy, observer),
+        )
+
+        val diagnostics = withCapturedSecondaryDiagnostics {
+            val result = kotlinx.coroutines.runBlocking { coordinator.resume(command) }
+            assertThat(result).isEqualTo("executed")
+        }
+
+        // Epic 5.3: the tool side effect and the COMPLETED transition happened
+        // before the audit — the audit failure is diagnosed (recorded, not
+        // swallowed to telemetry) and the resume still completes.
+        assertThat(store.completedStatus).isEqualTo(ApprovalContinuationStatus.COMPLETED)
+        assertThat(events).contains("continuation.complete", "metadata.remove")
+        assertThat(diagnostics.any {
+            it.contains("callback=onToolExecutionCompleted") &&
+                it.contains("failurePolicy=FAIL_CLOSED") &&
+                it.contains("authority=AUTHORITATIVE")
+        }).isTrue
+    }
+
+    @Test
+    fun `uncertain outcome audit failure never substitutes the primary resume failure`() = runTest {
+        val events = mutableListOf<String>()
+        val executor = RecordingExecutor(events, throwWith = RuntimeException("tool-failed"))
+        val store = RecordingContinuationStore(events, continuation())
+        val suspended = RecordingSuspendedStore(events, metadata(), prepared.envelope)
+        val registry = ResumeOperationRegistry().also { it.register(service, operation, executor) }
+        val gate = RecordingGate(events)
+        val policy = PolicyEnforcementHelper(PolicyEngine { PolicyDecision.Allow }, AtomicBoolean(false))
+        val audit = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter by RecordingAuditEmitter(events) {
+            override suspend fun onUncertainOutcome(
+                approvalId: String, workflowRunId: String, toolName: String, reason: String,
+            ) = throw RuntimeException("audit-down")
+        }
+        val observer = RecordingObserver(events)
+        val coordinator = ApprovalResumeCoordinator(
+            store, suspended, registry, ToolRegistry(mapOf(toolName to tool)),
+            Sha256ToolArgumentsDigester(), audit, observer,
+            ContinuationClaimService(store), ReplayAuthorizationService(gate, suspended, audit, policy, observer),
+        )
+
+        val diagnostics = withCapturedSecondaryDiagnostics {
+            assertThatThrownBy { kotlinx.coroutines.runBlocking { coordinator.resume(command) } }
+                .isInstanceOf(RuntimeException::class.java)
+                .hasMessage("tool-failed")
+        }
+
+        // Epic 5.3: the resume failure is primary; the failing uncertain-outcome
+        // audit is diagnosed, never substituted for the primary failure.
+        assertThat(diagnostics.any {
+            it.contains("callback=onUncertainOutcome") &&
+                it.contains("failurePolicy=FAIL_CLOSED") &&
+                it.contains("authority=AUTHORITATIVE")
+        }).isTrue
+    }
+
+    @Test
     fun `cancellation after claim during replay reveal stays claimed and is never converted to uncertain outcome`() = runTest {
         val events = mutableListOf<String>()
         val store = RecordingContinuationStore(events, continuation())
@@ -479,6 +553,7 @@ class ApprovalResumeCoordinatorTest {
         private val claimReturnsWith: ClaimedApprovalContinuation? = null,
         private val claimFailsWith: Throwable? = null,
     ) : dev.tramai.core.approval.ApprovalContinuationStore {
+        var completedStatus: ApprovalContinuationStatus? = null
         override suspend fun create(continuation: ApprovalContinuation, arguments: SensitiveToolArguments): ApprovalContinuation = continuation
         override suspend fun get(approvalId: String): ApprovalContinuation? {
             events += "continuation.inspect"
@@ -491,6 +566,7 @@ class ApprovalResumeCoordinatorTest {
         }
         override suspend fun complete(approvalId: String, expectedVersion: Long, completedBy: String): ApprovalContinuation {
             events += "continuation.complete"
+            completedStatus = ApprovalContinuationStatus.COMPLETED
             return value.copy(status = ApprovalContinuationStatus.COMPLETED, version = expectedVersion)
         }
         override suspend fun expire(approvalId: String, expectedVersion: Long): ApprovalContinuation = value

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/approval/ReplayAuthorizationServiceTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/approval/ReplayAuthorizationServiceTest.kt
@@ -1,3 +1,4 @@
+@file:OptIn(ExperimentalTramaiInternalApi::class)
 package dev.tramai.engine.approval
 
 import dev.tramai.core.approval.ApprovalContinuation
@@ -15,6 +16,8 @@ import dev.tramai.core.approval.Sha256Digest
 import dev.tramai.core.exception.ApprovalTokenRejectedException
 import dev.tramai.core.exception.NestedApprovalNotSupportedException
 import dev.tramai.core.exception.PolicyViolationException
+import dev.tramai.core.observation.secondary.ExperimentalTramaiInternalApi
+import dev.tramai.engine.FailureIsolatingEngineEventObserver
 import dev.tramai.core.policy.EnforcementPoint
 import dev.tramai.core.policy.PolicyContext
 import dev.tramai.core.policy.PolicyDecision
@@ -29,6 +32,7 @@ import dev.tramai.engine.SuspendedInvocationMetadata
 import dev.tramai.engine.SuspendedInvocationStore
 import dev.tramai.engine.ResumeApprovalCommand
 import dev.tramai.engine.approval.ReplayAuthorizationServiceTest.RecordingGate
+import dev.tramai.engine.withCapturedSecondaryDiagnostics
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -158,6 +162,70 @@ class ReplayAuthorizationServiceTest {
     }
 
     @Test
+    fun `deny cancellation audit failure is diagnosed and never fails the method after transition`() = runTest {
+        val deny = PolicyDecision.Deny(reason = "blocked", reasonCode = "WF_DENIED")
+        val events = mutableListOf<String>()
+        val gate = RecordingGate().apply { this.events = events }
+        val suspended = RecordingSuspendedStore(events)
+        val audit = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter by RecordingAuditEmitter(events) {
+            override suspend fun onSuspensionCancelled(
+                approvalId: String, workflowRunId: String, toolName: String, reason: String,
+            ) = throw RuntimeException("audit-down")
+        }
+        val policy = PolicyEnforcementHelper(
+            policyEngine = PolicyEngine { deny },
+            migrationWarningGuard = AtomicBoolean(false),
+        )
+        val s = ReplayAuthorizationService(gate, suspended, audit, policy, RecordingObserver(events))
+        val store = RecordingContinuationStore(events)
+
+        val diagnostics = withCapturedSecondaryDiagnostics {
+            // Epic 5.3: both stores mutated before the audit; the audit failure
+            // must not undo the transition or escape as the method failure —
+            // the caller still throws its own PolicyViolationException.
+            assertThatThrownBy { kotlinx.coroutines.runBlocking { s.denyAndCancel(command, metadata(), deny, store) } }
+                .isInstanceOf(PolicyViolationException::class.java)
+        }
+
+        assertThat(events).contains("cancel-state", "suspended.remove")
+        assertThat(diagnostics.any {
+            it.contains("callback=onSuspensionCancelled") &&
+                it.contains("failurePolicy=FAIL_CLOSED") &&
+                it.contains("authority=AUTHORITATIVE")
+        }).isTrue
+    }
+
+    @Test
+    fun `nested approval cancellation audit failure is diagnosed and never fails the method after transition`() = runTest {
+        val events = mutableListOf<String>()
+        val gate = RecordingGate().apply { this.events = events }
+        val suspended = RecordingSuspendedStore(events)
+        val audit = object : dev.tramai.core.approval.ApprovalLifecycleAuditEmitter by RecordingAuditEmitter(events) {
+            override suspend fun onSuspensionCancelled(
+                approvalId: String, workflowRunId: String, toolName: String, reason: String,
+            ) = throw RuntimeException("audit-down")
+        }
+        val policy = PolicyEnforcementHelper(
+            policyEngine = PolicyEngine { PolicyDecision.Allow },
+            migrationWarningGuard = AtomicBoolean(false),
+        )
+        val s = ReplayAuthorizationService(gate, suspended, audit, policy, RecordingObserver(events))
+        val store = RecordingContinuationStore(events)
+
+        val diagnostics = withCapturedSecondaryDiagnostics {
+            assertThatThrownBy { kotlinx.coroutines.runBlocking { s.cancelForNestedApproval(command, metadata(), store) } }
+                .isInstanceOf(NestedApprovalNotSupportedException::class.java)
+        }
+
+        assertThat(events).contains("cancel-state", "suspended.remove")
+        assertThat(diagnostics.any {
+            it.contains("callback=onSuspensionCancelled") &&
+                it.contains("failurePolicy=FAIL_CLOSED") &&
+                it.contains("authority=AUTHORITATIVE")
+        }).isTrue
+    }
+
+    @Test
     fun `allow authorizes exactly once`() = runTest {
         val (s, gate, _) = service()
         val continuation = continuation()
@@ -202,7 +270,13 @@ class ReplayAuthorizationServiceTest {
                 throw RuntimeException("observer-down")
             }
         }
-        val s = ReplayAuthorizationService(gate, suspended, audit, policy, throwing)
+        // Epic 5.3: the isolation boundary is FailureIsolatingEngineEventObserver
+        // (the engine wraps the observer there, see EngineComponentFactory) — the
+        // service itself no longer catches; the FAIL_OPEN replay event is
+        // contained by the wrapper.
+        val s = ReplayAuthorizationService(
+            gate, suspended, audit, policy, FailureIsolatingEngineEventObserver(throwing),
+        )
 
         // must not throw — event observer failures must not prevent resume completion
         s.emitAuthorizationReplayed(replayed = true, command = command, metadata = metadata())

--- a/tramai-observability/api/tramai-observability.api
+++ b/tramai-observability/api/tramai-observability.api
@@ -45,6 +45,7 @@ public final class dev/tramai/observability/OpenTelemetryWorkflowObserver : dev/
 	public fun onStepFailed (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;Ldev/tramai/orchestration/WorkflowContext;)V
 	public fun onStepStarted (Ljava/lang/String;Ljava/lang/String;Ldev/tramai/orchestration/WorkflowContext;)V
 	public fun onWorkflowCompleted (Ljava/lang/String;Ldev/tramai/orchestration/WorkflowContext;)V
+	public fun onWorkflowEvent (Ljava/lang/String;Ldev/tramai/core/observation/event/RuntimeEvent;Ldev/tramai/orchestration/WorkflowContext;)V
 	public fun onWorkflowEvent (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ldev/tramai/orchestration/WorkflowContext;)V
 	public fun onWorkflowFailed (Ljava/lang/String;Ljava/lang/Throwable;Ldev/tramai/orchestration/WorkflowContext;)V
 	public fun onWorkflowStarted (Ljava/lang/String;Ldev/tramai/orchestration/WorkflowContext;)V

--- a/tramai-observability/src/test/kotlin/dev/tramai/observability/SecondaryFailureBoundaryArchitectureTest.kt
+++ b/tramai-observability/src/test/kotlin/dev/tramai/observability/SecondaryFailureBoundaryArchitectureTest.kt
@@ -8,33 +8,82 @@ import java.io.File
  * Epic 5.3 — secondary-failure boundary guard.
  *
  * Observer callbacks are non-authoritative secondary effects and must only be
- * invoked through the failure-isolating boundary (FailureIsolating*
- * wrappers) or through the instances the composition wiring has already
- * wrapped. A NEW execution component that grabs a raw observer and calls its
- * callbacks directly bypasses the boundary: a throwing observer could then
- * change the business outcome.
+ * invoked through the failure-isolating boundary (FailureIsolating* wrappers)
+ * or through the instances the composition wiring has already wrapped. A NEW
+ * execution component that grabs a raw observer and calls its callbacks
+ * directly bypasses the boundary: a throwing observer could then change the
+ * business outcome.
  *
- * Forbidden: `observer.` / `observability.` / `engineEventObserver.` /
- * `request.observer.` followed by a callback method, in tramai-engine /
- * tramai-orchestration production sources — EXCEPT in the files below, which
- * hold the already-wrapped instances passed down through the wiring
- * (WorkflowRunner wraps at entry; TramaiWorker wraps at construction;
- * EngineComponentFactory wraps at composition).
+ * The guard matches CALLBACK INVOCATION NAMES (not receiver variable names —
+ * `workflowObserver.onWorkflowCompleted(...)` and `telemetry.onStepStarted(...)`
+ * must be caught too) across every runtime module that owns observers
+ * (engine, orchestration, scheduler). Files are exempt only when they are the
+ * wrappers themselves, the interface definitions, or the known wiring points
+ * that hold already-wrapped instances.
  */
 class SecondaryFailureBoundaryArchitectureTest {
 
-    private val callbackRegex = Regex(
-        "(observer|observability|engineEventObserver|request\\.observer)\\s*\\.\\s*" +
-            "(on[A-Z][A-Za-z]*|emitWorkflowEvent|emitRuntimeEvent)\\s*\\(",
+    private val observerCallbackNames = listOf(
+        "onCallCancelled", "onCallCompleted", "onCallStarted",
+        "onDrainProgress", "onEngineEvent",
+        "onLeaseAcquired", "onLeaseContested", "onLeaseExpired",
+        "onLeaseReleaseFailed", "onLeaseReleased", "onLeaseRenewalFailed",
+        "onLeaseRenewed",
+        "onMissedTick",
+        "onPollFailed", "onProviderFailure", "onProviderResponse",
+        "onScheduledTick", "onShutdownComplete", "onShutdownStarted",
+        "onSkippedTick",
+        "onStepAttemptCompleted", "onStepAttemptFailed", "onStepAttemptStarted",
+        "onStepCompleted", "onStepFailed", "onStepStarted",
+        "onStructuredParseFailure",
+        "onUnknownAttempt",
+        "onWorkTakenOver", "onWorkerHeartbeat", "onWorkerStarted",
+        "onWorkerStopped", "onWorkflowAbandoned",
+        "onWorkflowCompleted", "onWorkflowEvent", "onWorkflowFailed",
+        "onWorkflowStarted",
     )
 
-    /** Files that hold wrapped instances via the composition wiring. */
+    private val callbackRegex = Regex(
+        "\\.\\s*(${observerCallbackNames.joinToString("|")}|emitWorkflowEvent|emitRuntimeEvent)\\s*\\(",
+    )
+
+    private val emitterRegex = Regex(
+        "(observer|observability|engineEventObserver|request\\.observer)\\s*\\.\\s*(emitWorkflowEvent|emitRuntimeEvent)\\s*\\(",
+    )
+
+    /**
+     * Files that hold wrapped instances via the composition wiring or define
+     * the boundary itself. Adding a NEW file here requires a reviewer to
+     * confirm it only invokes callbacks on wrapped instances.
+     */
     private val allowedFiles = setOf(
+        // Boundary definitions and wrappers.
+        "tramai-core/src/main/kotlin/dev/tramai/core/observation/OperationObservation.kt",
+        "tramai-core/src/main/kotlin/dev/tramai/core/observation/FailureIsolatingOperationObserver.kt",
+        "tramai-core/src/main/kotlin/dev/tramai/core/observation/secondary/SecondaryEffectPolicy.kt",
+        "tramai-engine/src/main/kotlin/dev/tramai/engine/EngineEventObserver.kt",
+        "tramai-engine/src/main/kotlin/dev/tramai/engine/FailureIsolatingEngineEventObserver.kt",
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowObservation.kt",
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/TramaiWorker.kt",
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FailureIsolatingWorkflowObserver.kt",
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FailureIsolatingTramaiWorkerObserver.kt",
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/RuntimeEventEmission.kt",
+        "tramai-engine/src/main/kotlin/dev/tramai/engine/RuntimeEventEmission.kt",
         // Engine: engineEventObserver field holds the wrapped instance.
         "tramai-engine/src/main/kotlin/dev/tramai/engine/approval/ApprovalResumeCoordinator.kt",
         "tramai-engine/src/main/kotlin/dev/tramai/engine/approval/ReplayAuthorizationService.kt",
         "tramai-engine/src/main/kotlin/dev/tramai/engine/tool/ToolResultSanitizer.kt",
+        // Engine: coordinators receive the wrapped observation from the wiring.
+        "tramai-engine/src/main/kotlin/dev/tramai/engine/budget/TokenBudgetCoordinator.kt",
+        "tramai-engine/src/main/kotlin/dev/tramai/engine/invocation/ClaimedResumeExecutionCoordinator.kt",
+        "tramai-engine/src/main/kotlin/dev/tramai/engine/invocation/ProviderResponseDlpSanitizer.kt",
+        "tramai-engine/src/main/kotlin/dev/tramai/engine/invocation/RawResponseCoordinator.kt",
+        "tramai-engine/src/main/kotlin/dev/tramai/engine/invocation/ToolLoopCoordinator.kt",
+        "tramai-engine/src/main/kotlin/dev/tramai/engine/provider/ProviderAttemptExecutor.kt",
+        "tramai-engine/src/main/kotlin/dev/tramai/engine/streaming/StreamingExecutionCoordinator.kt",
+        "tramai-engine/src/main/kotlin/dev/tramai/engine/structured/StructuredResponseCoordinator.kt",
         // Orchestration: WorkflowRunner wraps the observer before passing it down.
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowRunner.kt",
         "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowStepExecutor.kt",
         "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowStepFailures.kt",
         "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/ParallelBranchExecution.kt",
@@ -57,6 +106,9 @@ class SecondaryFailureBoundaryArchitectureTest {
         "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkerHeartbeatPublisher.kt",
         "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/PersistenceFailures.kt",
         "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/CheckpointPoller.kt",
+        // Scheduler: timer and store wrap both observer sources at the boundary.
+        "tramai-scheduler/src/main/kotlin/dev/tramai/scheduler/ScheduledWorkflowTimer.kt",
+        "tramai-scheduler/src/main/kotlin/dev/tramai/scheduler/JdbcWorkflowSchedulerStore.kt",
     )
 
     @Test
@@ -64,7 +116,7 @@ class SecondaryFailureBoundaryArchitectureTest {
         val repoRoot = generateSequence(File(".").absoluteFile) { it.parentFile }
             .first { it.resolve("settings.gradle.kts").isFile }
         val offenders = mutableListOf<String>()
-        listOf("tramai-engine", "tramai-orchestration").forEach { module ->
+        listOf("tramai-engine", "tramai-orchestration", "tramai-scheduler").forEach { module ->
             val mainDir = File(repoRoot, "$module/src/main")
             if (!mainDir.isDirectory) return@forEach
             mainDir.walkTopDown()
@@ -72,7 +124,11 @@ class SecondaryFailureBoundaryArchitectureTest {
                 .forEach { file ->
                     val relative = file.relativeTo(repoRoot).path
                     if (relative in allowedFiles) return@forEach
-                    callbackRegex.findAll(file.readText()).forEach { match ->
+                    val text = file.readText()
+                    callbackRegex.findAll(text).forEach { match ->
+                        offenders.add("$relative -> ${match.value.trim()}")
+                    }
+                    emitterRegex.findAll(text).forEach { match ->
                         offenders.add("$relative -> ${match.value.trim()}")
                     }
                 }

--- a/tramai-observability/src/test/kotlin/dev/tramai/observability/SecondaryFailureBoundaryArchitectureTest.kt
+++ b/tramai-observability/src/test/kotlin/dev/tramai/observability/SecondaryFailureBoundaryArchitectureTest.kt
@@ -116,7 +116,7 @@ class SecondaryFailureBoundaryArchitectureTest {
         val repoRoot = generateSequence(File(".").absoluteFile) { it.parentFile }
             .first { it.resolve("settings.gradle.kts").isFile }
         val offenders = mutableListOf<String>()
-        listOf("tramai-engine", "tramai-orchestration", "tramai-scheduler").forEach { module ->
+        listOf("tramai-core", "tramai-engine", "tramai-orchestration", "tramai-scheduler").forEach { module ->
             val mainDir = File(repoRoot, "$module/src/main")
             if (!mainDir.isDirectory) return@forEach
             mainDir.walkTopDown()

--- a/tramai-observability/src/test/kotlin/dev/tramai/observability/SecondaryFailureBoundaryArchitectureTest.kt
+++ b/tramai-observability/src/test/kotlin/dev/tramai/observability/SecondaryFailureBoundaryArchitectureTest.kt
@@ -1,0 +1,89 @@
+package dev.tramai.observability
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Epic 5.3 — secondary-failure boundary guard.
+ *
+ * Observer callbacks are non-authoritative secondary effects and must only be
+ * invoked through the failure-isolating boundary (FailureIsolating*
+ * wrappers) or through the instances the composition wiring has already
+ * wrapped. A NEW execution component that grabs a raw observer and calls its
+ * callbacks directly bypasses the boundary: a throwing observer could then
+ * change the business outcome.
+ *
+ * Forbidden: `observer.` / `observability.` / `engineEventObserver.` /
+ * `request.observer.` followed by a callback method, in tramai-engine /
+ * tramai-orchestration production sources — EXCEPT in the files below, which
+ * hold the already-wrapped instances passed down through the wiring
+ * (WorkflowRunner wraps at entry; TramaiWorker wraps at construction;
+ * EngineComponentFactory wraps at composition).
+ */
+class SecondaryFailureBoundaryArchitectureTest {
+
+    private val callbackRegex = Regex(
+        "(observer|observability|engineEventObserver|request\\.observer)\\s*\\.\\s*" +
+            "(on[A-Z][A-Za-z]*|emitWorkflowEvent|emitRuntimeEvent)\\s*\\(",
+    )
+
+    /** Files that hold wrapped instances via the composition wiring. */
+    private val allowedFiles = setOf(
+        // Engine: engineEventObserver field holds the wrapped instance.
+        "tramai-engine/src/main/kotlin/dev/tramai/engine/approval/ApprovalResumeCoordinator.kt",
+        "tramai-engine/src/main/kotlin/dev/tramai/engine/approval/ReplayAuthorizationService.kt",
+        "tramai-engine/src/main/kotlin/dev/tramai/engine/tool/ToolResultSanitizer.kt",
+        // Orchestration: WorkflowRunner wraps the observer before passing it down.
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowStepExecutor.kt",
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowStepFailures.kt",
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/ParallelBranchExecution.kt",
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowParallelExecutor.kt",
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowDelayCoordinator.kt",
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowPersistenceSession.kt",
+        // Step components receive the wrapped observer through the step request.
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/AgentCliSupport.kt",
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/CodexStep.kt",
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/HermesStep.kt",
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/HttpStep.kt",
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/McpStep.kt",
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/ShellStep.kt",
+        // Orchestration: worker subsystems receive the wrapped observability.
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowExecutionSupervisor.kt",
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkerShutdownCoordinator.kt",
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/LeaseCoordinator.kt",
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/LeaseRenewalLoop.kt",
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkerLifecycleController.kt",
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkerHeartbeatPublisher.kt",
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/PersistenceFailures.kt",
+        "tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/CheckpointPoller.kt",
+    )
+
+    @Test
+    fun `observer callbacks are only invoked through the failure-isolating boundary`() {
+        val repoRoot = generateSequence(File(".").absoluteFile) { it.parentFile }
+            .first { it.resolve("settings.gradle.kts").isFile }
+        val offenders = mutableListOf<String>()
+        listOf("tramai-engine", "tramai-orchestration").forEach { module ->
+            val mainDir = File(repoRoot, "$module/src/main")
+            if (!mainDir.isDirectory) return@forEach
+            mainDir.walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .forEach { file ->
+                    val relative = file.relativeTo(repoRoot).path
+                    if (relative in allowedFiles) return@forEach
+                    callbackRegex.findAll(file.readText()).forEach { match ->
+                        offenders.add("$relative -> ${match.value.trim()}")
+                    }
+                }
+        }
+        assertThat(offenders)
+            .withFailMessage(
+                "Observer callbacks must be invoked through the failure-isolating boundary " +
+                    "(FailureIsolating* wrappers) or the wrapped instances supplied by the composition " +
+                    "wiring. Direct raw-observer calls from arbitrary execution components can let a " +
+                    "throwing observer change the business outcome. Found: $offenders",
+            )
+            .isEmpty()
+    }
+}

--- a/tramai-orchestration/api/tramai-orchestration.api
+++ b/tramai-orchestration/api/tramai-orchestration.api
@@ -147,6 +147,45 @@ public abstract interface class dev/tramai/orchestration/ExternalStepExecutorRes
 	public abstract fun registeredTypeIds ()Ljava/util/Set;
 }
 
+public final class dev/tramai/orchestration/FailureIsolatingTramaiWorkerObserver : dev/tramai/orchestration/TramaiWorkerObserver {
+	public fun <init> (Ldev/tramai/orchestration/TramaiWorkerObserver;)V
+	public fun onDrainProgress (Ljava/lang/String;II)V
+	public fun onLeaseAcquired (Ljava/lang/String;Ljava/lang/String;)V
+	public fun onLeaseContested (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun onLeaseExpired (Ljava/lang/String;Ljava/lang/String;)V
+	public fun onLeaseReleaseFailed (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun onLeaseReleased (Ljava/lang/String;Ljava/lang/String;)V
+	public fun onLeaseRenewalFailed (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun onLeaseRenewed (Ljava/lang/String;Ljava/lang/String;J)V
+	public fun onPollFailed (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun onShutdownComplete (Ljava/lang/String;)V
+	public fun onShutdownStarted (Ljava/lang/String;)V
+	public fun onStepAttemptCompleted (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun onStepAttemptFailed (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun onStepAttemptStarted (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun onUnknownAttempt (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;J)V
+	public fun onWorkTakenOver (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun onWorkerHeartbeat (Ljava/lang/String;JI)V
+	public fun onWorkerStarted (Ljava/lang/String;)V
+	public fun onWorkerStopped (Ljava/lang/String;)V
+	public fun onWorkflowAbandoned (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;J)V
+}
+
+public final class dev/tramai/orchestration/FailureIsolatingWorkflowObserver : dev/tramai/orchestration/WorkflowObserver {
+	public fun <init> (Ldev/tramai/orchestration/WorkflowObserver;)V
+	public fun onMissedTick (Ljava/lang/String;Ljava/time/Instant;Ljava/lang/String;Ldev/tramai/orchestration/WorkflowContext;)V
+	public fun onScheduledTick (Ljava/lang/String;Ljava/time/Instant;Ldev/tramai/orchestration/WorkflowContext;)V
+	public fun onSkippedTick (Ljava/lang/String;Ljava/time/Instant;Ljava/lang/String;Ldev/tramai/orchestration/WorkflowContext;)V
+	public fun onStepCompleted (Ljava/lang/String;Ljava/lang/String;Ldev/tramai/orchestration/WorkflowContext;)V
+	public fun onStepFailed (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;Ldev/tramai/orchestration/WorkflowContext;)V
+	public fun onStepStarted (Ljava/lang/String;Ljava/lang/String;Ldev/tramai/orchestration/WorkflowContext;)V
+	public fun onWorkflowCompleted (Ljava/lang/String;Ldev/tramai/orchestration/WorkflowContext;)V
+	public fun onWorkflowEvent (Ljava/lang/String;Ldev/tramai/core/observation/event/RuntimeEvent;Ldev/tramai/orchestration/WorkflowContext;)V
+	public fun onWorkflowEvent (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ldev/tramai/orchestration/WorkflowContext;)V
+	public fun onWorkflowFailed (Ljava/lang/String;Ljava/lang/Throwable;Ldev/tramai/orchestration/WorkflowContext;)V
+	public fun onWorkflowStarted (Ljava/lang/String;Ldev/tramai/orchestration/WorkflowContext;)V
+}
+
 public final class dev/tramai/orchestration/FileStepAttemptRecordStore : dev/tramai/orchestration/StepAttemptRecordStore {
 	public fun <init> (Ljava/nio/file/Path;)V
 	public fun <init> (Ljava/nio/file/Path;Ldev/tramai/orchestration/PersistenceFailureDiagnosticObserver;)V
@@ -668,6 +707,7 @@ public final class dev/tramai/orchestration/NoOpWorkflowObserver : dev/tramai/or
 	public fun onStepFailed (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;Ldev/tramai/orchestration/WorkflowContext;)V
 	public fun onStepStarted (Ljava/lang/String;Ljava/lang/String;Ldev/tramai/orchestration/WorkflowContext;)V
 	public fun onWorkflowCompleted (Ljava/lang/String;Ldev/tramai/orchestration/WorkflowContext;)V
+	public fun onWorkflowEvent (Ljava/lang/String;Ldev/tramai/core/observation/event/RuntimeEvent;Ldev/tramai/orchestration/WorkflowContext;)V
 	public fun onWorkflowEvent (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ldev/tramai/orchestration/WorkflowContext;)V
 	public fun onWorkflowFailed (Ljava/lang/String;Ljava/lang/Throwable;Ldev/tramai/orchestration/WorkflowContext;)V
 	public fun onWorkflowStarted (Ljava/lang/String;Ldev/tramai/orchestration/WorkflowContext;)V
@@ -1314,6 +1354,7 @@ public abstract interface class dev/tramai/orchestration/WorkflowObserver {
 	public fun onStepFailed (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;Ldev/tramai/orchestration/WorkflowContext;)V
 	public fun onStepStarted (Ljava/lang/String;Ljava/lang/String;Ldev/tramai/orchestration/WorkflowContext;)V
 	public fun onWorkflowCompleted (Ljava/lang/String;Ldev/tramai/orchestration/WorkflowContext;)V
+	public fun onWorkflowEvent (Ljava/lang/String;Ldev/tramai/core/observation/event/RuntimeEvent;Ldev/tramai/orchestration/WorkflowContext;)V
 	public fun onWorkflowEvent (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ldev/tramai/orchestration/WorkflowContext;)V
 	public static synthetic fun onWorkflowEvent$default (Ldev/tramai/orchestration/WorkflowObserver;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ldev/tramai/orchestration/WorkflowContext;ILjava/lang/Object;)V
 	public fun onWorkflowFailed (Ljava/lang/String;Ljava/lang/Throwable;Ldev/tramai/orchestration/WorkflowContext;)V
@@ -1328,6 +1369,7 @@ public final class dev/tramai/orchestration/WorkflowObserver$DefaultImpls {
 	public static fun onStepFailed (Ldev/tramai/orchestration/WorkflowObserver;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;Ldev/tramai/orchestration/WorkflowContext;)V
 	public static fun onStepStarted (Ldev/tramai/orchestration/WorkflowObserver;Ljava/lang/String;Ljava/lang/String;Ldev/tramai/orchestration/WorkflowContext;)V
 	public static fun onWorkflowCompleted (Ldev/tramai/orchestration/WorkflowObserver;Ljava/lang/String;Ldev/tramai/orchestration/WorkflowContext;)V
+	public static fun onWorkflowEvent (Ldev/tramai/orchestration/WorkflowObserver;Ljava/lang/String;Ldev/tramai/core/observation/event/RuntimeEvent;Ldev/tramai/orchestration/WorkflowContext;)V
 	public static fun onWorkflowEvent (Ldev/tramai/orchestration/WorkflowObserver;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ldev/tramai/orchestration/WorkflowContext;)V
 	public static synthetic fun onWorkflowEvent$default (Ldev/tramai/orchestration/WorkflowObserver;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ldev/tramai/orchestration/WorkflowContext;ILjava/lang/Object;)V
 	public static fun onWorkflowFailed (Ldev/tramai/orchestration/WorkflowObserver;Ljava/lang/String;Ljava/lang/Throwable;Ldev/tramai/orchestration/WorkflowContext;)V

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FailureIsolatingTramaiWorkerObserver.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FailureIsolatingTramaiWorkerObserver.kt
@@ -1,0 +1,92 @@
+package dev.tramai.orchestration
+
+import dev.tramai.core.observation.secondary.SecondaryEffectAuthority
+import dev.tramai.core.observation.secondary.SecondaryFailureDiagnostic
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Epic 5.3 — failure-isolating [TramaiWorkerObserver] boundary.
+ *
+ * Wraps a delegate observer so that a throwing telemetry callback can never
+ * crash or derail the worker loop: poll, lease coordination, renewal, attempts,
+ * takeover, recovery, and shutdown all proceed regardless of observer
+ * behaviour. [kotlinx.coroutines.CancellationException] always escapes
+ * unchanged.
+ */
+class FailureIsolatingTramaiWorkerObserver(
+    private val delegate: TramaiWorkerObserver,
+) : TramaiWorkerObserver {
+
+    private inline fun <T> isolate(callback: String, block: () -> T) {
+        try {
+            block()
+        } catch (error: Throwable) {
+            if (error is CancellationException) throw error
+            SecondaryFailureDiagnostic.report(
+                extensionPoint = "worker_observer",
+                callback = callback,
+                errorType = error.javaClass.simpleName,
+                failurePolicy = "FAIL_OPEN",
+                authority = SecondaryEffectAuthority.NON_AUTHORITATIVE.name,
+            )
+        }
+    }
+
+    override fun onWorkerStarted(workerId: String) = isolate("onWorkerStarted") { delegate.onWorkerStarted(workerId) }
+    override fun onWorkerStopped(workerId: String) = isolate("onWorkerStopped") { delegate.onWorkerStopped(workerId) }
+    override fun onLeaseAcquired(workflowId: String, workerId: String) = isolate("onLeaseAcquired") { delegate.onLeaseAcquired(workflowId, workerId) }
+    override fun onLeaseReleased(workflowId: String, workerId: String) = isolate("onLeaseReleased") { delegate.onLeaseReleased(workflowId, workerId) }
+    override fun onLeaseExpired(workflowId: String, workerId: String) = isolate("onLeaseExpired") { delegate.onLeaseExpired(workflowId, workerId) }
+
+    override fun onLeaseRenewalFailed(workflowId: String, workerId: String, error: Throwable) {
+        isolate("onLeaseRenewalFailed") { delegate.onLeaseRenewalFailed(workflowId, workerId, error) }
+    }
+
+    override fun onLeaseReleaseFailed(workflowId: String, workerId: String, error: Throwable) {
+        isolate("onLeaseReleaseFailed") { delegate.onLeaseReleaseFailed(workflowId, workerId, error) }
+    }
+
+    override fun onPollFailed(workerId: String, error: Throwable) {
+        isolate("onPollFailed") { delegate.onPollFailed(workerId, error) }
+    }
+
+    override fun onWorkTakenOver(workflowId: String, previousWorkerId: String, newWorkerId: String) {
+        isolate("onWorkTakenOver") { delegate.onWorkTakenOver(workflowId, previousWorkerId, newWorkerId) }
+    }
+
+    override fun onUnknownAttempt(runId: String, stepName: String, priorWorkerId: String, attemptTime: Long) {
+        isolate("onUnknownAttempt") { delegate.onUnknownAttempt(runId, stepName, priorWorkerId, attemptTime) }
+    }
+
+    override fun onStepAttemptStarted(runId: String, stepName: String, attemptId: String, workerId: String) {
+        isolate("onStepAttemptStarted") { delegate.onStepAttemptStarted(runId, stepName, attemptId, workerId) }
+    }
+
+    override fun onStepAttemptCompleted(runId: String, stepName: String, attemptId: String, workerId: String) {
+        isolate("onStepAttemptCompleted") { delegate.onStepAttemptCompleted(runId, stepName, attemptId, workerId) }
+    }
+
+    override fun onStepAttemptFailed(runId: String, stepName: String, attemptId: String, workerId: String, error: Throwable) {
+        isolate("onStepAttemptFailed") { delegate.onStepAttemptFailed(runId, stepName, attemptId, workerId, error) }
+    }
+
+    override fun onShutdownStarted(workerId: String) = isolate("onShutdownStarted") { delegate.onShutdownStarted(workerId) }
+    override fun onDrainProgress(workerId: String, done: Int, pending: Int) = isolate("onDrainProgress") { delegate.onDrainProgress(workerId, done, pending) }
+    override fun onShutdownComplete(workerId: String) = isolate("onShutdownComplete") { delegate.onShutdownComplete(workerId) }
+
+    override fun onWorkerHeartbeat(workerId: String, uptimeMillis: Long, claimedCount: Int) {
+        isolate("onWorkerHeartbeat") { delegate.onWorkerHeartbeat(workerId, uptimeMillis, claimedCount) }
+    }
+
+    override fun onLeaseRenewed(workflowId: String, workerId: String, newExpiry: Long) {
+        isolate("onLeaseRenewed") { delegate.onLeaseRenewed(workflowId, workerId, newExpiry) }
+    }
+
+    override fun onLeaseContested(workflowId: String, claimantWorkerId: String, currentWorkerId: String) {
+        isolate("onLeaseContested") { delegate.onLeaseContested(workflowId, claimantWorkerId, currentWorkerId) }
+    }
+
+    override fun onWorkflowAbandoned(workflowId: String, workerId: String, lastStep: String?, timeoutMillis: Long) {
+        isolate("onWorkflowAbandoned") { delegate.onWorkflowAbandoned(workflowId, workerId, lastStep, timeoutMillis) }
+    }
+}

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FailureIsolatingTramaiWorkerObserver.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FailureIsolatingTramaiWorkerObserver.kt
@@ -1,5 +1,6 @@
 package dev.tramai.orchestration
 
+import dev.tramai.core.observation.secondary.ExperimentalTramaiInternalApi
 import dev.tramai.core.observation.secondary.SecondaryEffectAuthority
 import dev.tramai.core.observation.secondary.SecondaryFailureDiagnostic
 import kotlinx.coroutines.CancellationException
@@ -13,6 +14,7 @@ import kotlinx.coroutines.CancellationException
  * behaviour. [kotlinx.coroutines.CancellationException] always escapes
  * unchanged.
  */
+@ExperimentalTramaiInternalApi
 class FailureIsolatingTramaiWorkerObserver(
     private val delegate: TramaiWorkerObserver,
 ) : TramaiWorkerObserver {
@@ -20,7 +22,7 @@ class FailureIsolatingTramaiWorkerObserver(
     private inline fun <T> isolate(callback: String, block: () -> T) {
         try {
             block()
-        } catch (error: Throwable) {
+        } catch (error: Exception) {
             if (error is CancellationException) throw error
             SecondaryFailureDiagnostic.report(
                 extensionPoint = "worker_observer",

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FailureIsolatingWorkflowObserver.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FailureIsolatingWorkflowObserver.kt
@@ -1,0 +1,110 @@
+package dev.tramai.orchestration
+
+import dev.tramai.core.observation.event.RuntimeEvent
+import dev.tramai.core.observation.event.RuntimeEventFailurePolicy
+import dev.tramai.core.observation.secondary.SecondaryEffectAuthority
+import dev.tramai.core.observation.secondary.SecondaryFailureDiagnostic
+import kotlinx.coroutines.CancellationException
+import java.time.Instant
+
+/**
+ * Epic 5.3 — failure-isolating [WorkflowObserver] boundary.
+ *
+ * Wraps a delegate observer so that a throwing telemetry callback can never
+ * change the workflow's business outcome: a successful workflow stays
+ * successful, a failing workflow keeps its original failure as primary, and
+ * [kotlinx.coroutines.CancellationException] always escapes unchanged.
+ *
+ * [RuntimeEvent] emissions honor the event's declared
+ * [RuntimeEventFailurePolicy]: `FAIL_CLOSED` propagates, `FAIL_OPEN` is
+ * contained. The legacy (name, attributes) form carries no policy metadata and
+ * is contained.
+ */
+class FailureIsolatingWorkflowObserver(
+    private val delegate: WorkflowObserver,
+) : WorkflowObserver {
+
+    private inline fun <T> isolate(callback: String, block: () -> T) {
+        try {
+            block()
+        } catch (error: Throwable) {
+            if (error is CancellationException) throw error
+            SecondaryFailureDiagnostic.report(
+                extensionPoint = "workflow_observer",
+                callback = callback,
+                errorType = error.javaClass.simpleName,
+                failurePolicy = "FAIL_OPEN",
+                authority = SecondaryEffectAuthority.NON_AUTHORITATIVE.name,
+            )
+        }
+    }
+
+    override fun onWorkflowStarted(workflowName: String, context: WorkflowContext) {
+        isolate("onWorkflowStarted") { delegate.onWorkflowStarted(workflowName, context) }
+    }
+
+    override fun onWorkflowEvent(
+        workflowName: String,
+        name: String,
+        attributes: Map<String, Any?>,
+        context: WorkflowContext,
+    ) {
+        isolate("onWorkflowEvent") { delegate.onWorkflowEvent(workflowName, name, attributes, context) }
+    }
+
+    override fun onWorkflowEvent(workflowName: String, event: RuntimeEvent, context: WorkflowContext) {
+        if (event.definition.failurePolicy == RuntimeEventFailurePolicy.FAIL_CLOSED) {
+            // Authoritative emission: a failure must propagate, never be contained.
+            delegate.onWorkflowEvent(workflowName, event, context)
+        } else {
+            isolate("onWorkflowEvent") { delegate.onWorkflowEvent(workflowName, event, context) }
+        }
+    }
+
+    override fun onStepStarted(workflowName: String, stepName: String, context: WorkflowContext) {
+        isolate("onStepStarted") { delegate.onStepStarted(workflowName, stepName, context) }
+    }
+
+    override fun onStepCompleted(workflowName: String, stepName: String, context: WorkflowContext) {
+        isolate("onStepCompleted") { delegate.onStepCompleted(workflowName, stepName, context) }
+    }
+
+    override fun onStepFailed(
+        workflowName: String,
+        stepName: String,
+        error: Throwable,
+        context: WorkflowContext,
+    ) {
+        isolate("onStepFailed") { delegate.onStepFailed(workflowName, stepName, error, context) }
+    }
+
+    override fun onWorkflowCompleted(workflowName: String, context: WorkflowContext) {
+        isolate("onWorkflowCompleted") { delegate.onWorkflowCompleted(workflowName, context) }
+    }
+
+    override fun onWorkflowFailed(workflowName: String, error: Throwable, context: WorkflowContext) {
+        isolate("onWorkflowFailed") { delegate.onWorkflowFailed(workflowName, error, context) }
+    }
+
+    override fun onScheduledTick(workflowName: String, scheduledFireAt: Instant, context: WorkflowContext) {
+        isolate("onScheduledTick") { delegate.onScheduledTick(workflowName, scheduledFireAt, context) }
+    }
+
+    override fun onSkippedTick(
+        workflowName: String,
+        scheduledFireAt: Instant,
+        reason: String,
+        context: WorkflowContext,
+    ) {
+        isolate("onSkippedTick") { delegate.onSkippedTick(workflowName, scheduledFireAt, reason, context) }
+    }
+
+    override fun onMissedTick(
+        workflowName: String,
+        scheduledFireAt: Instant,
+        reason: String,
+        context: WorkflowContext,
+    ) {
+        isolate("onMissedTick") { delegate.onMissedTick(workflowName, scheduledFireAt, reason, context) }
+    }
+}

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FailureIsolatingWorkflowObserver.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FailureIsolatingWorkflowObserver.kt
@@ -1,5 +1,6 @@
 package dev.tramai.orchestration
 
+import dev.tramai.core.observation.secondary.ExperimentalTramaiInternalApi
 import dev.tramai.core.observation.event.RuntimeEvent
 import dev.tramai.core.observation.event.RuntimeEventFailurePolicy
 import dev.tramai.core.observation.secondary.SecondaryEffectAuthority
@@ -20,6 +21,7 @@ import java.time.Instant
  * contained. The legacy (name, attributes) form carries no policy metadata and
  * is contained.
  */
+@ExperimentalTramaiInternalApi
 class FailureIsolatingWorkflowObserver(
     private val delegate: WorkflowObserver,
 ) : WorkflowObserver {
@@ -27,7 +29,7 @@ class FailureIsolatingWorkflowObserver(
     private inline fun <T> isolate(callback: String, block: () -> T) {
         try {
             block()
-        } catch (error: Throwable) {
+        } catch (error: Exception) {
             if (error is CancellationException) throw error
             SecondaryFailureDiagnostic.report(
                 extensionPoint = "workflow_observer",

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/RuntimeEventEmission.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/RuntimeEventEmission.kt
@@ -3,14 +3,16 @@ package dev.tramai.orchestration
 import dev.tramai.core.observation.event.RuntimeEvent
 
 /**
- * Emits a catalogue-validated [RuntimeEvent] through the legacy workflow
- * observation boundary. The event is constructed through the typed builder, so
- * schema violations fail at the call site.
+ * Emits a catalogue-validated [RuntimeEvent] through the typed workflow
+ * observation overload. The event is constructed through the typed builder, so
+ * schema violations fail at the call site; routing through the typed overload
+ * lets the failure-isolating boundary honor the event's declared failure
+ * policy (FAIL_CLOSED propagates, FAIL_OPEN is contained).
  */
 internal fun WorkflowObserver.emitWorkflowEvent(
     workflowName: String,
     context: WorkflowContext,
     event: RuntimeEvent,
 ) {
-    onWorkflowEvent(workflowName, event.name, event.attributes(), context)
+    onWorkflowEvent(workflowName, event, context)
 }

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/TramaiWorker.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/TramaiWorker.kt
@@ -118,7 +118,7 @@ class TramaiWorker(
         checkpointCatalog = checkpointCatalog,
         stepAttemptStore = stepAttemptStore,
         workflowBindings = workflowBindings,
-        observability = observability,
+        observability = FailureIsolatingTramaiWorkerObserver(observability),
         partitionStrategy = partitionStrategy,
     )
 

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/TramaiWorker.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/TramaiWorker.kt
@@ -1,5 +1,8 @@
+@file:OptIn(ExperimentalTramaiInternalApi::class)
 package dev.tramai.orchestration
 
+
+import dev.tramai.core.observation.secondary.ExperimentalTramaiInternalApi
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
 

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowObservation.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowObservation.kt
@@ -27,6 +27,19 @@ interface WorkflowObserver {
         context: WorkflowContext,
     ) = Unit
 
+    /**
+     * Records a catalogue-validated workflow event (Epic 5.2). The event
+     * carries its own identity, domain, sensitivity, and permitted attributes;
+     * additive overload that delegates to the legacy (name, attributes) form.
+     */
+    fun onWorkflowEvent(
+        workflowName: String,
+        event: dev.tramai.core.observation.event.RuntimeEvent,
+        context: WorkflowContext,
+    ) {
+        onWorkflowEvent(workflowName, event.name, event.attributes(), context)
+    }
+
     fun onStepStarted(
         workflowName: String,
         stepName: String,

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowRunner.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowRunner.kt
@@ -1,5 +1,8 @@
+@file:OptIn(ExperimentalTramaiInternalApi::class)
 package dev.tramai.orchestration
 
+
+import dev.tramai.core.observation.secondary.ExperimentalTramaiInternalApi
 import dev.tramai.core.observation.event.RuntimeAttributes
 import dev.tramai.core.observation.event.RuntimeEvent
 import dev.tramai.core.observation.event.RuntimeEvents

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowRunner.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowRunner.kt
@@ -70,14 +70,18 @@ internal class WorkflowRunner<S, R>(
         observer: WorkflowObserver,
         persistence: WorkflowPersistence<S>?,
     ): R {
-        observer.onWorkflowStarted(name, context)
+        // Epic 5.3: the isolated observer is the single failure boundary for
+        // every workflow telemetry callback. A throwing observer can never
+        // turn a successful run into a failure or replace the primary error.
+        val isolatedObserver = FailureIsolatingWorkflowObserver(observer)
+        isolatedObserver.onWorkflowStarted(name, context)
         var persistenceSession: WorkflowPersistenceSession<S>? = null
         return try {
             val stepCounter = StepCounter(stopPolicy)
             persistenceSession = persistence?.session(
                 workflowName = name,
                 context = context,
-                observer = observer,
+                observer = isolatedObserver,
                 workflowDefinitionCompatibility = definitionCompatibility,
             )
             persistenceSession?.saveCheckpoint(
@@ -90,17 +94,17 @@ internal class WorkflowRunner<S, R>(
                 startIndex = 0,
                 state = initialState,
                 context = context,
-                observer = observer,
+                observer = isolatedObserver,
                 stepCounter = stepCounter,
                 persistenceSession = persistenceSession,
                 resumedCheckpointMetadata = null,
             )
             persistenceSession?.complete(workflowName = name, context = context)
-            observer.onWorkflowCompleted(name, context)
+            isolatedObserver.onWorkflowCompleted(name, context)
             resultSelector(finalState)
         } catch (suspended: WorkflowSuspendedException) {
             persistenceSession?.abort()
-            observer.emitWorkflowEvent(
+            isolatedObserver.emitWorkflowEvent(
                 workflowName = name,
                 context = context,
                 event = RuntimeEvent.of(RuntimeEvents.WORKFLOW_SUSPENDED) {
@@ -116,7 +120,7 @@ internal class WorkflowRunner<S, R>(
         } catch (error: Throwable) {
             error.rethrowIfCancellation()
             persistenceSession?.runCatchingAbort(error)
-            observer.onWorkflowFailed(name, error, context)
+            isolatedObserver.onWorkflowFailed(name, error, context)
             throw error
         }
     }
@@ -126,6 +130,7 @@ internal class WorkflowRunner<S, R>(
         observer: WorkflowObserver,
         persistence: WorkflowPersistence<S>,
     ): R {
+        val isolatedObserver = FailureIsolatingWorkflowObserver(observer)
         val checkpoint = persistence.checkpointStore.load(name, context.workflowId)
             ?: throw WorkflowResumeException(
                 "No checkpoint exists for workflow '$name' and workflowId='${context.workflowId}'",
@@ -145,8 +150,8 @@ internal class WorkflowRunner<S, R>(
             persisted = persistedDefinitionCompatibility,
             current = definitionCompatibility,
         )
-        observer.onWorkflowStarted(name, context)
-        observer.emitWorkflowEvent(
+        isolatedObserver.onWorkflowStarted(name, context)
+        isolatedObserver.emitWorkflowEvent(
             workflowName = name,
             context = context,
             event = RuntimeEvent.of(RuntimeEvents.WORKFLOW_CHECKPOINT_LOADED) {
@@ -162,7 +167,7 @@ internal class WorkflowRunner<S, R>(
         val persistenceSession: WorkflowPersistenceSession<S> = persistence.session(
             workflowName = name,
             context = context,
-            observer = observer,
+            observer = isolatedObserver,
             initialRevision = checkpoint.revision,
             workflowDefinitionCompatibility = definitionCompatibility,
         )
@@ -172,7 +177,7 @@ internal class WorkflowRunner<S, R>(
                 startIndex = checkpoint.nextStepIndex,
                 state = resumedState,
                 context = context,
-                observer = observer,
+                observer = isolatedObserver,
                 stepCounter = StepCounter(
                     stopPolicy = stopPolicy,
                     initialStepExecutions = checkpoint.stepExecutions,
@@ -181,11 +186,11 @@ internal class WorkflowRunner<S, R>(
                 resumedCheckpointMetadata = checkpoint.metadata,
             )
             persistenceSession.complete(workflowName = name, context = context)
-            observer.onWorkflowCompleted(name, context)
+            isolatedObserver.onWorkflowCompleted(name, context)
             resultSelector(finalState)
         } catch (suspended: WorkflowSuspendedException) {
             persistenceSession.abort()
-            observer.emitWorkflowEvent(
+            isolatedObserver.emitWorkflowEvent(
                 workflowName = name,
                 context = context,
                 event = RuntimeEvent.of(RuntimeEvents.WORKFLOW_SUSPENDED) {
@@ -201,7 +206,7 @@ internal class WorkflowRunner<S, R>(
         } catch (error: Throwable) {
             error.rethrowIfCancellation()
             persistenceSession.runCatchingAbort(error)
-            observer.onWorkflowFailed(name, error, context)
+            isolatedObserver.onWorkflowFailed(name, error, context)
             throw error
         }
     }

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/FailureIsolatingTramaiWorkerObserverTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/FailureIsolatingTramaiWorkerObserverTest.kt
@@ -1,0 +1,129 @@
+package dev.tramai.orchestration
+
+import kotlinx.coroutines.CancellationException
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+
+/**
+ * Epic 5.3 — worker observer lifecycle matrix.
+ *
+ * Every [TramaiWorkerObserver] callback (22) is exercised with a throwing
+ * delegate. The invariant under test: a telemetry failure is contained and can
+ * never crash or derail the worker loop — poll, lease coordination, renewal,
+ * attempts, takeover, recovery, and shutdown all proceed; cancellation always
+ * escapes unchanged.
+ */
+class FailureIsolatingTramaiWorkerObserverTest {
+
+    private val workerId = "worker-1"
+    private val workflowId = "workflow-1"
+
+    private val throwingDelegate = object : TramaiWorkerObserver {
+        override fun onWorkerStarted(workerId: String) = throw IllegalStateException("boom")
+        override fun onWorkerStopped(workerId: String) = throw IllegalStateException("boom")
+        override fun onLeaseAcquired(workflowId: String, workerId: String) = throw IllegalStateException("boom")
+        override fun onLeaseReleased(workflowId: String, workerId: String) = throw IllegalStateException("boom")
+        override fun onLeaseExpired(workflowId: String, workerId: String) = throw IllegalStateException("boom")
+        override fun onLeaseRenewalFailed(workflowId: String, workerId: String, error: Throwable) = throw IllegalStateException("boom")
+        override fun onLeaseReleaseFailed(workflowId: String, workerId: String, error: Throwable) = throw IllegalStateException("boom")
+        override fun onPollFailed(workerId: String, error: Throwable) = throw IllegalStateException("boom")
+        override fun onWorkTakenOver(workflowId: String, previousWorkerId: String, newWorkerId: String) = throw IllegalStateException("boom")
+        override fun onUnknownAttempt(runId: String, stepName: String, priorWorkerId: String, attemptTime: Long) = throw IllegalStateException("boom")
+        override fun onStepAttemptStarted(runId: String, stepName: String, attemptId: String, workerId: String) = throw IllegalStateException("boom")
+        override fun onStepAttemptCompleted(runId: String, stepName: String, attemptId: String, workerId: String) = throw IllegalStateException("boom")
+        override fun onStepAttemptFailed(runId: String, stepName: String, attemptId: String, workerId: String, error: Throwable) = throw IllegalStateException("boom")
+        override fun onShutdownStarted(workerId: String) = throw IllegalStateException("boom")
+        override fun onDrainProgress(workerId: String, done: Int, pending: Int) = throw IllegalStateException("boom")
+        override fun onShutdownComplete(workerId: String) = throw IllegalStateException("boom")
+        override fun onWorkerHeartbeat(workerId: String, uptimeMillis: Long, claimedCount: Int) = throw IllegalStateException("boom")
+        override fun onLeaseRenewed(workflowId: String, workerId: String, newExpiry: Long) = throw IllegalStateException("boom")
+        override fun onLeaseContested(workflowId: String, claimantWorkerId: String, currentWorkerId: String) = throw IllegalStateException("boom")
+        override fun onWorkflowAbandoned(workflowId: String, workerId: String, lastStep: String?, timeoutMillis: Long) = throw IllegalStateException("boom")
+    }
+
+    private fun isolated(): TramaiWorkerObserver = FailureIsolatingTramaiWorkerObserver(throwingDelegate)
+
+    @Test
+    fun `start stop and shutdown callbacks are contained`() {
+        isolated().onWorkerStarted(workerId)
+        isolated().onWorkerStopped(workerId)
+        isolated().onShutdownStarted(workerId)
+        isolated().onShutdownComplete(workerId)
+    }
+
+    @Test
+    fun `lease acquisition and release callbacks are contained`() {
+        isolated().onLeaseAcquired(workflowId, workerId)
+        isolated().onLeaseReleased(workflowId, workerId)
+        isolated().onLeaseExpired(workflowId, workerId)
+        isolated().onLeaseRenewed(workflowId, workerId, newExpiry = 1_000L)
+    }
+
+    @Test
+    fun `lease failure callbacks are contained`() {
+        isolated().onLeaseRenewalFailed(workflowId, workerId, IllegalStateException("primary"))
+        isolated().onLeaseReleaseFailed(workflowId, workerId, IllegalStateException("primary"))
+    }
+
+    @Test
+    fun `poll and takeover callbacks are contained`() {
+        isolated().onPollFailed(workerId, IllegalStateException("primary"))
+        isolated().onWorkTakenOver(workflowId, "old-worker", workerId)
+        isolated().onLeaseContested(workflowId, "claimant", workerId)
+        isolated().onWorkflowAbandoned(workflowId, workerId, "step-a", timeoutMillis = 30_000L)
+    }
+
+    @Test
+    fun `attempt callbacks are contained`() {
+        isolated().onUnknownAttempt("run-1", "step-a", "old-worker", attemptTime = 1_000L)
+        isolated().onStepAttemptStarted("run-1", "step-a", "attempt-1", workerId)
+        isolated().onStepAttemptCompleted("run-1", "step-a", "attempt-1", workerId)
+        isolated().onStepAttemptFailed("run-1", "step-a", "attempt-1", workerId, IllegalStateException("primary"))
+    }
+
+    @Test
+    fun `drain and heartbeat callbacks are contained`() {
+        isolated().onDrainProgress(workerId, done = 1, pending = 2)
+        isolated().onWorkerHeartbeat(workerId, uptimeMillis = 42L, claimedCount = 3)
+    }
+
+    @Test
+    fun `cancellation from an observer always escapes unchanged`() {
+        val cancellation = CancellationException("observer-cancelled")
+        val cancellingDelegate = object : TramaiWorkerObserver {
+            override fun onWorkerStarted(workerId: String) = throw cancellation
+            override fun onPollFailed(workerId: String, error: Throwable) = throw cancellation
+            override fun onLeaseAcquired(workflowId: String, workerId: String) = throw cancellation
+            override fun onStepAttemptStarted(runId: String, stepName: String, attemptId: String, workerId: String) = throw cancellation
+        }
+        val obs = FailureIsolatingTramaiWorkerObserver(cancellingDelegate)
+        assertSame(cancellation, assertFailsWith<CancellationException> { obs.onWorkerStarted(workerId) })
+        assertSame(cancellation, assertFailsWith<CancellationException> { obs.onPollFailed(workerId, IllegalStateException("x")) })
+        assertSame(cancellation, assertFailsWith<CancellationException> { obs.onLeaseAcquired(workflowId, workerId) })
+    }
+
+    @Test
+    fun `successful callbacks are forwarded to the delegate`() {
+        val received = mutableListOf<String>()
+        val delegate = object : TramaiWorkerObserver {
+            override fun onWorkerStarted(workerId: String) {
+                received += "started"
+            }
+
+            override fun onLeaseAcquired(workflowId: String, workerId: String) {
+                received += "lease"
+            }
+
+            override fun onShutdownComplete(workerId: String) {
+                received += "shutdown"
+            }
+        }
+        val obs = FailureIsolatingTramaiWorkerObserver(delegate)
+        obs.onWorkerStarted(workerId)
+        obs.onLeaseAcquired(workflowId, workerId)
+        obs.onShutdownComplete(workerId)
+        assertEquals(listOf("started", "lease", "shutdown"), received)
+    }
+}

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/FailureIsolatingWorkflowObserverTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/FailureIsolatingWorkflowObserverTest.kt
@@ -1,0 +1,163 @@
+package dev.tramai.orchestration
+
+import dev.tramai.core.observation.event.RuntimeAttributes
+import dev.tramai.core.observation.event.RuntimeEvent
+import dev.tramai.core.observation.event.RuntimeEventFailurePolicy
+import dev.tramai.core.observation.event.RuntimeEvents
+import kotlinx.coroutines.CancellationException
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Epic 5.3 — workflow observer lifecycle matrix.
+ *
+ * Every [WorkflowObserver] callback is exercised with a throwing delegate. The
+ * invariant under test: a telemetry failure is contained and can never change
+ * the workflow's business outcome (success stays success, the primary failure
+ * stays primary); cancellation always escapes; FAIL_CLOSED events propagate.
+ */
+class FailureIsolatingWorkflowObserverTest {
+
+    private val workflowName = "test-workflow"
+    private val context = WorkflowContext()
+    private val now = Instant.now()
+
+    private val throwingDelegate = object : WorkflowObserver {
+        override fun onWorkflowStarted(workflowName: String, context: WorkflowContext) = throw IllegalStateException("boom")
+        override fun onWorkflowEvent(workflowName: String, name: String, attributes: Map<String, Any?>, context: WorkflowContext) = throw IllegalStateException("boom")
+        override fun onWorkflowEvent(workflowName: String, event: RuntimeEvent, context: WorkflowContext) = throw IllegalStateException("boom")
+        override fun onStepStarted(workflowName: String, stepName: String, context: WorkflowContext) = throw IllegalStateException("boom")
+        override fun onStepCompleted(workflowName: String, stepName: String, context: WorkflowContext) = throw IllegalStateException("boom")
+        override fun onStepFailed(workflowName: String, stepName: String, error: Throwable, context: WorkflowContext) = throw IllegalStateException("boom")
+        override fun onWorkflowCompleted(workflowName: String, context: WorkflowContext) = throw IllegalStateException("boom")
+        override fun onWorkflowFailed(workflowName: String, error: Throwable, context: WorkflowContext) = throw IllegalStateException("boom")
+        override fun onScheduledTick(workflowName: String, scheduledFireAt: Instant, context: WorkflowContext) = throw IllegalStateException("boom")
+        override fun onSkippedTick(workflowName: String, scheduledFireAt: Instant, reason: String, context: WorkflowContext) = throw IllegalStateException("boom")
+        override fun onMissedTick(workflowName: String, scheduledFireAt: Instant, reason: String, context: WorkflowContext) = throw IllegalStateException("boom")
+    }
+
+    private fun isolated(): WorkflowObserver = FailureIsolatingWorkflowObserver(throwingDelegate)
+
+    @Test
+    fun `workflow started failure is contained`() {
+        isolated().onWorkflowStarted(workflowName, context)
+    }
+
+    @Test
+    fun `workflow event legacy failure is contained`() {
+        isolated().onWorkflowEvent(workflowName, "tramai.workflow.event", emptyMap(), context)
+    }
+
+    @Test
+    fun `workflow event runtime failure is contained for fail-open events`() {
+        val event = RuntimeEvent.of(RuntimeEvents.WORKFLOW_SUSPENDED) {
+            set(RuntimeAttributes.WORKFLOW_ID_BARE, context.workflowId)
+        }
+        isolated().onWorkflowEvent(workflowName, event, context)
+    }
+
+    @Test
+    fun `workflow event failure propagates for fail-closed events`() {
+        val event = RuntimeEvent.of(
+            RuntimeEvents.WORKFLOW_SUSPENDED.copy(
+                name = "tramai.workflow.fail-closed.probe",
+                failurePolicy = RuntimeEventFailurePolicy.FAIL_CLOSED,
+            ),
+        ) {
+            set(RuntimeAttributes.WORKFLOW_ID_BARE, context.workflowId)
+        }
+        assertFailsWith<IllegalStateException> {
+            isolated().onWorkflowEvent(workflowName, event, context)
+        }
+    }
+
+    @Test
+    fun `step started failure is contained`() {
+        isolated().onStepStarted(workflowName, "step-a", context)
+    }
+
+    @Test
+    fun `step completed failure is contained`() {
+        isolated().onStepCompleted(workflowName, "step-a", context)
+    }
+
+    @Test
+    fun `step failed failure is contained`() {
+        isolated().onStepFailed(workflowName, "step-a", IllegalStateException("primary"), context)
+    }
+
+    @Test
+    fun `workflow completed failure is contained`() {
+        isolated().onWorkflowCompleted(workflowName, context)
+    }
+
+    @Test
+    fun `workflow failed failure is contained and primary error preserved`() {
+        isolated().onWorkflowFailed(workflowName, IllegalStateException("primary"), context)
+    }
+
+    @Test
+    fun `scheduled tick failure is contained`() {
+        isolated().onScheduledTick(workflowName, now, context)
+    }
+
+    @Test
+    fun `skipped tick failure is contained`() {
+        isolated().onSkippedTick(workflowName, now, "reason", context)
+    }
+
+    @Test
+    fun `missed tick failure is contained`() {
+        isolated().onMissedTick(workflowName, now, "reason", context)
+    }
+
+    @Test
+    fun `cancellation from an observer always escapes unchanged`() {
+        val cancellation = CancellationException("observer-cancelled")
+        val cancellingDelegate = object : WorkflowObserver {
+            override fun onWorkflowStarted(workflowName: String, context: WorkflowContext) = throw cancellation
+            override fun onWorkflowCompleted(workflowName: String, context: WorkflowContext) = throw cancellation
+            override fun onWorkflowFailed(workflowName: String, error: Throwable, context: WorkflowContext) = throw cancellation
+            override fun onStepStarted(workflowName: String, stepName: String, context: WorkflowContext) = throw cancellation
+            override fun onStepCompleted(workflowName: String, stepName: String, context: WorkflowContext) = throw cancellation
+            override fun onStepFailed(workflowName: String, stepName: String, error: Throwable, context: WorkflowContext) = throw cancellation
+            override fun onScheduledTick(workflowName: String, scheduledFireAt: Instant, context: WorkflowContext) = throw cancellation
+            override fun onSkippedTick(workflowName: String, scheduledFireAt: Instant, reason: String, context: WorkflowContext) = throw cancellation
+            override fun onMissedTick(workflowName: String, scheduledFireAt: Instant, reason: String, context: WorkflowContext) = throw cancellation
+            override fun onWorkflowEvent(workflowName: String, name: String, attributes: Map<String, Any?>, context: WorkflowContext) = throw cancellation
+        }
+        val obs = FailureIsolatingWorkflowObserver(cancellingDelegate)
+        assertSame(cancellation, assertFailsWith<CancellationException> {
+            obs.onWorkflowStarted(workflowName, context)
+        })
+        assertSame(cancellation, assertFailsWith<CancellationException> {
+            obs.onWorkflowCompleted(workflowName, context)
+        })
+    }
+
+    @Test
+    fun `successful callbacks are forwarded to the delegate`() {
+        val received = mutableListOf<String>()
+        val delegate = object : WorkflowObserver {
+            override fun onWorkflowStarted(workflowName: String, context: WorkflowContext) {
+                received += "started"
+            }
+
+            override fun onStepStarted(workflowName: String, stepName: String, context: WorkflowContext) {
+                received += "step"
+            }
+
+            override fun onWorkflowCompleted(workflowName: String, context: WorkflowContext) {
+                received += "completed"
+            }
+        }
+        val obs = FailureIsolatingWorkflowObserver(delegate)
+        obs.onWorkflowStarted(workflowName, context)
+        obs.onStepStarted(workflowName, "step-a", context)
+        obs.onWorkflowCompleted(workflowName, context)
+        assertTrue(received == listOf("started", "step", "completed"))
+    }
+}

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/SubprocessCancellationContractTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/SubprocessCancellationContractTest.kt
@@ -873,7 +873,7 @@ class SubprocessCancellationContractTest {
     // ═══ 9b. Observer failure after process start still owns the process (P1) ═══
 
     @Test
-    fun `agent observer failure after process start still cleans up the process`() {
+    fun `agent observer failure after process start is contained and process is cleaned up`() {
         val pidFile = Files.createTempFile("subproc-agent-obs-fail", ".pid")
         val observedProcess = AtomicReference<ProcessHandle>()
         val throwingObserver = object : WorkflowObserver {
@@ -884,8 +884,8 @@ class SubprocessCancellationContractTest {
                 context: WorkflowContext,
             ) {
                 // Throws on the started event — the process has already been spawned and
-                // its stdin closed. Ownership must have begun before this observer runs,
-                // so the finally still terminates the tree.
+                // its stdin closed. Epic 5.3: observer failures are NON-AUTHORITATIVE and
+                // contained; the process lifecycle must still complete normally.
                 if (name.endsWith(".started")) {
                     observedProcess.set(runBlocking { awaitProcessHandle(pidFile) })
                     throw IllegalStateException("observer failure after start")
@@ -898,7 +898,7 @@ class SubprocessCancellationContractTest {
                 content = """
                     |#!/bin/sh
                     |echo $$ > '${pidFile.toAbsolutePath()}'
-                    |exec sleep 30
+                    |exec sleep 5
                 """.trimMargin(),
             ) { hermesCli ->
                 val workflow = agentWorkflow("hermes-obs-fail") {
@@ -911,7 +911,7 @@ class SubprocessCancellationContractTest {
                 }
 
                 runBlocking {
-                    withTimeout(15_000) {
+                    withTimeout(30_000) {
                         val captured = AtomicReference<Throwable?>()
                         val job = launch {
                             try {
@@ -921,11 +921,12 @@ class SubprocessCancellationContractTest {
                             }
                         }
                         job.join()
+                        // Epic 5.3: the observer failure is CONTAINED (fail-open) —
+                        // the run completes normally; the business outcome is unchanged.
+                        assertThat(captured.get()).isNull()
                         val pid = checkNotNull(observedProcess.get())
                         awaitProcessExit(pid)
                         assertThat(pidIsAlive(pid)).isFalse()
-                        // The observer failure is surfaced (wrapped), never swallowed.
-                        assertThat(captured.get()).isNotNull()
                     }
                 }
             }

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowRunnerPreservationTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowRunnerPreservationTest.kt
@@ -1,0 +1,152 @@
+package dev.tramai.orchestration
+
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+
+/**
+ * Epic 5.3 — proves the failure-isolation wiring at the [WorkflowRunner]
+ * boundary through the PUBLIC workflow API. A throwing observer (telemetry /
+ * secondary side effect) must never change the business outcome: a successful
+ * workflow stays successful, a failing workflow keeps its original exception
+ * as primary.
+ *
+ * Each test passes a deliberately throwing [WorkflowObserver] to
+ * [Workflow.run] and asserts the business outcome is preserved.
+ */
+class WorkflowRunnerPreservationTest {
+
+    @Test
+    fun `workflow success survives throwing onWorkflowCompleted observer`() {
+        val stepRan = AtomicInteger(0)
+        val observer = ThrowingObserver(throwOnWorkflowCompleted = true)
+        val workflow = workflow<Unit>("preserve-success-completed") {
+            localStep(name = "step-a", transform = { state, _ -> stepRan.incrementAndGet(); state })
+        }.build { Unit }
+
+        runBlocking { workflow.run(initialState = Unit, observer = observer) }
+
+        // No exception escapes: the run completed normally and the step ran.
+        assertThat(stepRan.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `workflow failure keeps original exception primary when onWorkflowFailed throws`() {
+        val observer = ThrowingObserver(throwOnWorkflowFailed = true)
+        val workflow = workflow<Unit>("preserve-failure-failed") {
+            localStep(name = "step-a", transform = { _, _ -> throw IllegalStateException("primary-failure") })
+        }.build { Unit }
+
+        assertThatThrownBy {
+            runBlocking { workflow.run(initialState = Unit, observer = observer) }
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("primary-failure")
+    }
+
+    @Test
+    fun `workflow success survives throwing onWorkflowStarted observer`() {
+        val stepRan = AtomicInteger(0)
+        val observer = ThrowingObserver(throwOnWorkflowStarted = true)
+        val workflow = workflow<Unit>("preserve-success-started") {
+            localStep(name = "step-a", transform = { state, _ -> stepRan.incrementAndGet(); state })
+        }.build { Unit }
+
+        runBlocking { workflow.run(initialState = Unit, observer = observer) }
+
+        assertThat(stepRan.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `workflow success survives throwing step observers`() {
+        val stepRan = AtomicInteger(0)
+        val observer = ThrowingObserver(throwOnStepStarted = true, throwOnStepCompleted = true)
+        val workflow = workflow<Unit>("preserve-success-step-observers") {
+            localStep(name = "step-a", transform = { state, _ -> stepRan.incrementAndGet(); state })
+        }.build { Unit }
+
+        runBlocking { workflow.run(initialState = Unit, observer = observer) }
+
+        assertThat(stepRan.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `workflow failure survives throwing onStepFailed observer`() {
+        val observer = ThrowingObserver(throwOnStepFailed = true)
+        val workflow = workflow<Unit>("preserve-failure-step-failed") {
+            localStep(name = "step-a", transform = { _, _ -> throw IllegalStateException("step-primary") })
+        }.build { Unit }
+
+        assertThatThrownBy {
+            runBlocking { workflow.run(initialState = Unit, observer = observer) }
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("step-primary")
+    }
+
+    @Test
+    fun `workflow success survives throwing onWorkflowEvent observer`() {
+        val stepRan = AtomicInteger(0)
+        val observer = ThrowingObserver(throwOnWorkflowEvent = true)
+        val workflow = workflow<Unit>("preserve-success-event") {
+            localStep(name = "step-a", transform = { state, _ -> stepRan.incrementAndGet(); state })
+        }.build { Unit }
+
+        runBlocking { workflow.run(initialState = Unit, observer = observer) }
+
+        assertThat(stepRan.get()).isEqualTo(1)
+    }
+
+    // -------------------------------------------------------------------------
+    // Fixture: observer that throws IllegalStateException from any callback
+    // flagged with `throwOn*`. Everything else uses the interface defaults.
+    // -------------------------------------------------------------------------
+
+    private class ThrowingObserver(
+        val throwOnWorkflowStarted: Boolean = false,
+        val throwOnWorkflowEvent: Boolean = false,
+        val throwOnStepStarted: Boolean = false,
+        val throwOnStepCompleted: Boolean = false,
+        val throwOnStepFailed: Boolean = false,
+        val throwOnWorkflowCompleted: Boolean = false,
+        val throwOnWorkflowFailed: Boolean = false,
+    ) : WorkflowObserver {
+        override fun onWorkflowStarted(workflowName: String, context: WorkflowContext) {
+            if (throwOnWorkflowStarted) throw IllegalStateException("boom-workflow-started")
+        }
+
+        override fun onWorkflowEvent(
+            workflowName: String,
+            name: String,
+            attributes: Map<String, Any?>,
+            context: WorkflowContext,
+        ) {
+            if (throwOnWorkflowEvent) throw IllegalStateException("boom-workflow-event")
+        }
+
+        override fun onStepStarted(workflowName: String, stepName: String, context: WorkflowContext) {
+            if (throwOnStepStarted) throw IllegalStateException("boom-step-started")
+        }
+
+        override fun onStepCompleted(workflowName: String, stepName: String, context: WorkflowContext) {
+            if (throwOnStepCompleted) throw IllegalStateException("boom-step-completed")
+        }
+
+        override fun onStepFailed(
+            workflowName: String,
+            stepName: String,
+            error: Throwable,
+            context: WorkflowContext,
+        ) {
+            if (throwOnStepFailed) throw IllegalStateException("boom-step-failed")
+        }
+
+        override fun onWorkflowCompleted(workflowName: String, context: WorkflowContext) {
+            if (throwOnWorkflowCompleted) throw IllegalStateException("boom-workflow-completed")
+        }
+
+        override fun onWorkflowFailed(name: String, error: Throwable, context: WorkflowContext) {
+            if (throwOnWorkflowFailed) throw IllegalStateException("boom-workflow-failed")
+        }
+    }
+}

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowStepFailureBoundaryTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowStepFailureBoundaryTest.kt
@@ -790,7 +790,7 @@ class WorkflowStepFailureBoundaryTest {
                     failureDiagnosticObserver = diagnostics
                     hermesStep(
                         name = "review-ui",
-                        config = HermesStepConfig(cliPath = "/bin/true"),
+                        config = HermesStepConfig(cliPath = "/bin/false"),
                         prompt = { _, _ -> "p" },
                         merge = { state, response, _ -> state.copy(output = response) },
                     )
@@ -804,19 +804,22 @@ class WorkflowStepFailureBoundaryTest {
                             context: WorkflowContext,
                         ) {
                             events += name
-                            if (name.endsWith(".started")) throw IllegalStateException(SECRET_FIXTURE)
                         }
                     },
                 )
             }
         }
+        // Epic 5.3: a real post-start step failure (agent CLI exits non-zero)
+        // classifies as NON_ZERO_EXIT — never START_FAILED; the failure message
+        // is preserved in the boundary diagnostic (authoritative evidence,
+        // never swallowed).
         assertThat(thrown).isInstanceOf(WorkflowHermesException::class.java)
-            .hasMessage("Workflow step execution failed")
+            .hasMessage("Workflow hermes step exited unsuccessfully")
             .hasNoCause()
         assertThat(thrown!!.suppressed).isEmpty()
-        assertThat(workflowFailureCode(thrown)).isEqualTo(WorkflowStepFailureCode.EXECUTION_FAILED)
+        assertThat(workflowFailureCode(thrown)).isEqualTo(WorkflowStepFailureCode.NON_ZERO_EXIT)
         assertThat(events.any { it.endsWith(".started") }).isTrue()
-        assertThat(diagnostics.single().failure!!.message).contains(SECRET_FIXTURE)
+        assertThat(diagnostics.single().failure!!.message).contains("non-zero exit")
     }
 
 }

--- a/tramai-scheduler/src/main/kotlin/dev/tramai/scheduler/JdbcWorkflowSchedulerStore.kt
+++ b/tramai-scheduler/src/main/kotlin/dev/tramai/scheduler/JdbcWorkflowSchedulerStore.kt
@@ -1,5 +1,8 @@
+@file:OptIn(ExperimentalTramaiInternalApi::class)
 package dev.tramai.scheduler
 
+import dev.tramai.core.observation.secondary.ExperimentalTramaiInternalApi
+import dev.tramai.orchestration.FailureIsolatingWorkflowObserver
 import dev.tramai.core.observation.event.RuntimeAttributes
 
 import dev.tramai.orchestration.NoOpWorkflowObserver
@@ -29,6 +32,10 @@ class JdbcWorkflowSchedulerStore(
     private val dataSource: DataSource,
     private val observer: WorkflowObserver = NoOpWorkflowObserver,
 ) : WorkflowSchedulerStore {
+    // Epic 5.3: the store invokes tick callbacks during startup recovery and
+    // next-fire computation; wrap at the boundary so a throwing observer can
+    // never abort a durable scheduler transition.
+    private val isolatedObserver = FailureIsolatingWorkflowObserver(observer)
     override suspend fun upsertSchedule(schedule: ScheduleRecord) {
         val cronSchedule = cronSchedule(schedule.schedule, "JdbcWorkflowSchedulerStore")
         transaction { connection ->
@@ -447,7 +454,7 @@ class JdbcWorkflowSchedulerStore(
                         )
                         if (inserted) {
                             recovered += 1
-                            observer.onMissedTick(
+                            isolatedObserver.onMissedTick(
                                 workflowName = workflowName,
                                 scheduledFireAt = scheduledFireAt,
                                 reason = "scheduler_startup_recovery",
@@ -822,7 +829,7 @@ class JdbcWorkflowSchedulerStore(
         workflowName: String,
         after: Instant,
     ): Instant = schedule.nextFireAfter(after) { skippedFireAt, reason ->
-        observer.onSkippedTick(
+        isolatedObserver.onSkippedTick(
             workflowName = workflowName,
             scheduledFireAt = skippedFireAt,
             reason = reason,

--- a/tramai-scheduler/src/main/kotlin/dev/tramai/scheduler/ScheduledWorkflowTimer.kt
+++ b/tramai-scheduler/src/main/kotlin/dev/tramai/scheduler/ScheduledWorkflowTimer.kt
@@ -1,12 +1,15 @@
+@file:OptIn(ExperimentalTramaiInternalApi::class)
 package dev.tramai.scheduler
 
 
+import dev.tramai.core.observation.secondary.ExperimentalTramaiInternalApi
 import dev.tramai.core.observation.event.RuntimeEvents
 
 import dev.tramai.core.observation.event.RuntimeEvent
 
 import dev.tramai.core.observation.event.RuntimeAttributes
 
+import dev.tramai.orchestration.FailureIsolatingWorkflowObserver
 import dev.tramai.orchestration.NoOpWorkflowObserver
 import dev.tramai.orchestration.Workflow
 import dev.tramai.orchestration.WorkflowContext
@@ -38,6 +41,13 @@ class ScheduledWorkflowTimer(
     private val observer: WorkflowObserver = NoOpWorkflowObserver,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
 ) : AutoCloseable {
+    // Epic 5.3: the scheduler owns WorkflowObserver instances and invokes
+    // tick callbacks BEFORE durable scheduler transitions (markTickSkipped /
+    // markTickMisfired / markTickStarted / releaseDelayWakeupClaim). A
+    // throwing observer must be contained (non-authoritative FAIL_OPEN) so it
+    // can never leave a claimed tick in the wrong state or terminate the poll
+    // loop.
+    private val isolatedObserver = FailureIsolatingWorkflowObserver(observer)
     private val monitor = Any()
     private val registrations = linkedMapOf<String, ScheduledWorkflowRegistration<*, *>>()
     private val delayRegistrations = linkedMapOf<String, ScheduledWorkflowRegistration<*, *>>()
@@ -75,7 +85,9 @@ class ScheduledWorkflowTimer(
         val registration = ScheduledWorkflowRegistration(
             workflow = workflow,
             initialState = initialState,
-            observer = observer,
+            // Epic 5.3: per-registration observer wrapped at the boundary too
+            // (registration.observer is invoked directly by pollOnce).
+            observer = FailureIsolatingWorkflowObserver(observer),
             persistence = persistence,
         )
         synchronized(monitor) {
@@ -163,7 +175,7 @@ class ScheduledWorkflowTimer(
         if (registration == null) {
             val reason = "workflow_not_registered"
             val context = scheduledTickContext(tick)
-            observer.onSkippedTick(tick.workflowName, tick.scheduledFireAt, reason, context)
+            isolatedObserver.onSkippedTick(tick.workflowName, tick.scheduledFireAt, reason, context)
             store.markTickSkipped(tick.tickId, tick.claimToken, reason)
             return
         }
@@ -171,12 +183,12 @@ class ScheduledWorkflowTimer(
         val observer = registration.observer
         if (Duration.between(tick.scheduledFireAt, now) > misfireThreshold) {
             val reason = "misfire_threshold_exceeded"
-            observer.onMissedTick(tick.workflowName, tick.scheduledFireAt, reason, context)
+            isolatedObserver.onMissedTick(tick.workflowName, tick.scheduledFireAt, reason, context)
             store.markTickMisfired(tick.tickId, tick.claimToken, reason)
             return
         }
         val runId = context.workflowId
-        observer.onScheduledTick(tick.workflowName, tick.scheduledFireAt, context)
+        isolatedObserver.onScheduledTick(tick.workflowName, tick.scheduledFireAt, context)
         store.markTickStarted(tick.tickId, tick.claimToken, runId)
         try {
             registration.run(tick, context)
@@ -203,7 +215,7 @@ class ScheduledWorkflowTimer(
                 set(RuntimeAttributes.STEP_ID, wakeup.stepId)
                 set(RuntimeAttributes.RESUME_AT_EPOCH_MILLIS, wakeup.resumeAt.toEpochMilli())
             }
-            observer.onWorkflowEvent(
+            isolatedObserver.onWorkflowEvent(
                 workflowName = "unknown",
                 name = unregisteredEvent.name,
                 attributes = unregisteredEvent.attributes(),

--- a/tramai-scheduler/src/test/kotlin/dev/tramai/scheduler/JdbcSchedulerTest.kt
+++ b/tramai-scheduler/src/test/kotlin/dev/tramai/scheduler/JdbcSchedulerTest.kt
@@ -422,6 +422,57 @@ class JdbcSchedulerTest {
         }
     }
 
+    @Test
+    fun `jdbc store startup recovery survives a throwing observer`() {
+        runBlocking {
+            val throwingStore = JdbcWorkflowSchedulerStore(dataSource, ThrowingRecoveryObserver())
+            throwingStore.upsertSchedule(
+                scheduleRecord("isolated-recover", Instant.parse("2026-05-03T09:00:05Z")),
+            )
+
+            val recovered = throwingStore.recover(now = Instant.parse("2026-05-03T09:00:07Z"))
+
+            // onMissedTick threw during recovery; the recovered tick must still
+            // be durably inserted and the schedule advanced.
+            assertThat(recovered).isEqualTo(1)
+            assertThat(rowCount("workflow_schedule_ticks")).isEqualTo(1)
+            assertThat(throwingStore.getSchedule("workflow:isolated-recover")!!.nextFireAt)
+                .isEqualTo(Instant.parse("2026-05-03T09:00:10Z"))
+        }
+    }
+
+    @Test
+    fun `jdbc store next-fire computation survives a throwing observer`() {
+        runBlocking {
+            val throwingStore = JdbcWorkflowSchedulerStore(dataSource, ThrowingRecoveryObserver())
+            val schedule = at(
+                expression = "0 9 * * *",
+                zoneId = ZoneId.of("UTC"),
+                skipCalendar = listOf(CalendarRule.FixedDate(month = 12, dayOfMonth = 25)),
+            )
+            throwingStore.upsertSchedule(
+                ScheduleRecord(
+                    scheduleId = "workflow:isolated-calendar-skip",
+                    workflowName = "isolated-calendar-skip",
+                    schedule = schedule,
+                    nextFireAt = Instant.parse("2026-12-24T09:00:00Z"),
+                ),
+            )
+
+            throwingStore.claimDueTicks(
+                now = Instant.parse("2026-12-24T09:00:00Z"),
+                ownerId = "owner-1",
+                claimDuration = Duration.ofSeconds(30),
+                limit = 10,
+            ).single()
+
+            // onSkippedTick threw while advancing past Christmas; the next-fire
+            // computation must still complete and return a valid instant.
+            assertThat(throwingStore.getSchedule("workflow:isolated-calendar-skip")!!.nextFireAt)
+                .isEqualTo(Instant.parse("2026-12-26T09:00:00Z"))
+        }
+    }
+
     private suspend fun claimTick(workflowName: String): ClaimedScheduledTick {
         val nextFireAt = Instant.parse("2026-05-03T09:00:05Z")
         store.upsertSchedule(scheduleRecord(workflowName, nextFireAt))
@@ -511,6 +562,22 @@ class JdbcSchedulerTest {
         ) {
             skippedTicks += scheduledFireAt to reason
         }
+    }
+
+    private class ThrowingRecoveryObserver : WorkflowObserver {
+        override fun onMissedTick(
+            workflowName: String,
+            scheduledFireAt: Instant,
+            reason: String,
+            context: WorkflowContext,
+        ) = throw IllegalStateException("throwing observer: onMissedTick")
+
+        override fun onSkippedTick(
+            workflowName: String,
+            scheduledFireAt: Instant,
+            reason: String,
+            context: WorkflowContext,
+        ) = throw IllegalStateException("throwing observer: onSkippedTick")
     }
 
     private class CommitAndRollbackFailingDataSource(

--- a/tramai-scheduler/src/test/kotlin/dev/tramai/scheduler/SchedulerIsolationTest.kt
+++ b/tramai-scheduler/src/test/kotlin/dev/tramai/scheduler/SchedulerIsolationTest.kt
@@ -1,0 +1,350 @@
+@file:OptIn(ExperimentalTramaiInternalApi::class)
+package dev.tramai.scheduler
+
+import dev.tramai.core.observation.secondary.ExperimentalTramaiInternalApi
+import dev.tramai.orchestration.InMemoryWorkflowCheckpointStore
+import dev.tramai.orchestration.WorkflowContext
+import dev.tramai.orchestration.WorkflowObserver
+import dev.tramai.orchestration.WorkflowPersistence
+import dev.tramai.orchestration.WorkflowStateCodec
+import dev.tramai.orchestration.workflow
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Epic 5.3 isolation wiring: ScheduledWorkflowTimer wraps its observer at the
+ * boundary (constructor and per-registration), so a throwing WorkflowObserver
+ * can never prevent the durable tick transitions (markTickSkipped /
+ * markTickMisfired / markTickStarted / releaseDelayWakeupClaim) and can never
+ * terminate the poll loop.
+ */
+class SchedulerIsolationTest {
+    @Test
+    fun `throwing constructor observer cannot prevent durable skipped tick transition`() {
+        runBlocking {
+            val clock = MutableClock(Instant.parse("2026-05-03T09:00:05Z"))
+            val store = InMemoryWorkflowSchedulerStore()
+            store.upsertSchedule(
+                ScheduleRecord(
+                    scheduleId = "workflow:isolation-unregistered",
+                    workflowName = "isolation-unregistered",
+                    schedule = at("*/5 * * * * *", ZoneId.of("UTC")),
+                    nextFireAt = Instant.parse("2026-05-03T09:00:05Z"),
+                ),
+            )
+            val timer = ScheduledWorkflowTimer(
+                store = store,
+                clock = clock,
+                observer = ThrowingWorkflowObserver(),
+            )
+
+            timer.pollOnce()
+
+            val status = store.listScheduleStatus().single()
+            assertThat(status.lastRunStatus).isEqualTo("skipped")
+            assertThat(status.lastTick).isEqualTo(Instant.parse("2026-05-03T09:00:05Z"))
+        }
+    }
+
+    @Test
+    fun `throwing constructor observer cannot prevent durable misfired tick transition`() {
+        runBlocking {
+            val clock = MutableClock(Instant.parse("2026-05-03T09:00:00Z"))
+            val store = InMemoryWorkflowSchedulerStore()
+            val workflow = workflow<Unit>("isolation-misfired") {
+                schedule = at("*/5 * * * * *", ZoneId.of("UTC"))
+            }.build { Unit }
+            val timer = ScheduledWorkflowTimer(
+                store = store,
+                clock = clock,
+                misfireThreshold = Duration.ofSeconds(1),
+                observer = ThrowingWorkflowObserver(),
+            )
+            timer.register(workflow = workflow, initialState = { Unit })
+
+            clock.instant = Instant.parse("2026-05-03T09:00:07Z")
+            timer.pollOnce()
+
+            val status = store.listScheduleStatus().single()
+            assertThat(status.lastRunStatus).isEqualTo("misfired")
+            assertThat(status.misfireCount).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `throwing constructor observer cannot prevent durable started tick transition`() {
+        runBlocking {
+            val clock = MutableClock(Instant.parse("2026-05-03T09:00:00Z"))
+            val schedulerStore = InMemoryWorkflowSchedulerStore()
+            val checkpointStore = InMemoryWorkflowCheckpointStore()
+            val workflow = workflow<CounterState>("isolation-started") {
+                schedule = at("*/5 * * * * *", ZoneId.of("UTC"))
+                delayStep("pause", 5, TimeUnit.SECONDS)
+            }.build(clock = clock) { it.value }
+            val persistence = WorkflowPersistence(
+                checkpointStore = checkpointStore,
+                stateCodec = CounterStateCodec,
+                delayWakeupScheduler = schedulerStore,
+            )
+            val timer = ScheduledWorkflowTimer(
+                store = schedulerStore,
+                clock = clock,
+                observer = ThrowingWorkflowObserver(),
+            )
+            timer.register(
+                workflow = workflow,
+                initialState = { CounterState(0) },
+                persistence = persistence,
+            )
+
+            clock.instant = Instant.parse("2026-05-03T09:00:05Z")
+            timer.pollOnce()
+
+            // The tick is durably started and completed even though the
+            // throwing observer fired first, and the delay wakeup was durably
+            // scheduled so the suspended workflow can resume.
+            val status = schedulerStore.listScheduleStatus().single()
+            assertThat(status.lastRunStatus).isEqualTo("completed")
+            val runId = status.lastRunId!!
+            assertThat(
+                schedulerStore.claimDueDelayWakeups(
+                    now = Instant.parse("2026-05-03T09:00:10Z"),
+                    ownerId = "owner-2",
+                    claimDuration = Duration.ofSeconds(30),
+                    limit = 10,
+                ).map { it.runId },
+            ).containsExactly(runId)
+        }
+    }
+
+    @Test
+    fun `throwing constructor observer cannot prevent durable delay wakeup claim release`() {
+        runBlocking {
+            val clock = MutableClock(Instant.parse("2026-05-03T09:00:00Z"))
+            val schedulerStore = InMemoryWorkflowSchedulerStore()
+            val checkpointStore = InMemoryWorkflowCheckpointStore()
+            val workflow = workflow<CounterState>("isolation-wakeup-holder") {
+                schedule = at("5 0 9 * * *", ZoneId.of("UTC"))
+                delayStep("pause", 5, TimeUnit.SECONDS)
+            }.build(clock = clock) { it.value }
+            val persistence = WorkflowPersistence(
+                checkpointStore = checkpointStore,
+                stateCodec = CounterStateCodec,
+                delayWakeupScheduler = schedulerStore,
+            )
+            val timer = ScheduledWorkflowTimer(
+                store = schedulerStore,
+                clock = clock,
+                observer = ThrowingWorkflowObserver(),
+            )
+            timer.register(
+                workflow = workflow,
+                initialState = { CounterState(0) },
+                persistence = persistence,
+            )
+            clock.instant = Instant.parse("2026-05-03T09:00:05Z")
+            timer.pollOnce()
+            schedulerStore.scheduleDelayWakeup(
+                runId = "isolation-unknown",
+                stepId = "pause",
+                resumeAt = Instant.parse("2026-05-03T09:00:10Z"),
+            )
+
+            clock.instant = Instant.parse("2026-05-03T09:00:10Z")
+            timer.pollOnce()
+            timer.pollOnce()
+
+            // onWorkflowEvent threw before releaseDelayWakeupClaim; the wakeup
+            // must be released (claimable again), not stuck in CLAIMED.
+            val reclaimed = schedulerStore.claimDueDelayWakeups(
+                now = Instant.parse("2026-05-03T09:00:10Z"),
+                ownerId = "owner-2",
+                claimDuration = Duration.ofSeconds(30),
+                limit = 10,
+            )
+            assertThat(reclaimed.map { it.runId }).contains("isolation-unknown")
+        }
+    }
+
+    @Test
+    fun `throwing registered observer cannot prevent durable tick completion`() {
+        runBlocking {
+            val clock = MutableClock(Instant.parse("2026-05-03T09:00:00Z"))
+            val store = InMemoryWorkflowSchedulerStore()
+            val workflow = workflow<CounterState>("isolation-registered-observer") {
+                schedule = at("*/5 * * * * *", ZoneId.of("UTC"))
+                localStep("increment") { state, _ -> state.copy(value = state.value + 1) }
+            }.build { it }
+            val timer = ScheduledWorkflowTimer(store = store, clock = clock)
+            timer.register(
+                workflow = workflow,
+                initialState = { CounterState(0) },
+                observer = ThrowingWorkflowObserver(),
+            )
+
+            clock.instant = Instant.parse("2026-05-03T09:00:05Z")
+            timer.pollOnce()
+
+            val status = store.listScheduleStatus().single()
+            assertThat(status.lastRunStatus).isEqualTo("completed")
+            assertThat(status.lastRunId).isNotBlank()
+        }
+    }
+
+    @Test
+    fun `throwing registered observer cannot prevent delay wakeup completion`() {
+        runBlocking {
+            val clock = MutableClock(Instant.parse("2026-05-03T09:00:00Z"))
+            val schedulerStore = InMemoryWorkflowSchedulerStore()
+            val checkpointStore = InMemoryWorkflowCheckpointStore()
+            val workflow = workflow<CounterState>("isolation-wakeup-observer") {
+                schedule = at("5 0 9 * * *", ZoneId.of("UTC"))
+                delayStep("pause", 5, TimeUnit.SECONDS)
+            }.build(clock = clock) { it.value }
+            val persistence = WorkflowPersistence(
+                checkpointStore = checkpointStore,
+                stateCodec = CounterStateCodec,
+                delayWakeupScheduler = schedulerStore,
+            )
+            val timer = ScheduledWorkflowTimer(store = schedulerStore, clock = clock)
+            timer.register(
+                workflow = workflow,
+                initialState = { CounterState(0) },
+                observer = ThrowingWorkflowObserver(),
+                persistence = persistence,
+            )
+            clock.instant = Instant.parse("2026-05-03T09:00:05Z")
+            timer.pollOnce()
+
+            clock.instant = Instant.parse("2026-05-03T09:00:10Z")
+            timer.pollOnce()
+            timer.pollOnce()
+
+            // onWorkflowCompleted threw inside resume; the wakeup must still be
+            // durably completed (removed from the store), not stuck CLAIMED.
+            assertThat(
+                schedulerStore.claimDueDelayWakeups(
+                    now = Instant.parse("2026-05-03T09:00:10Z"),
+                    ownerId = "owner-2",
+                    claimDuration = Duration.ofSeconds(30),
+                    limit = 10,
+                ),
+            ).isEmpty()
+        }
+    }
+
+    @Test
+    fun `poll loop survives a throwing observer`() {
+        runBlocking {
+            val countingStore = CountingSchedulerStore(InMemoryWorkflowSchedulerStore())
+            val workflow = workflow<CounterState>("isolation-loop") {
+                schedule = at("* * * * * *", ZoneId.of("UTC"))
+                localStep("increment") { state, _ -> state.copy(value = state.value + 1) }
+            }.build { it }
+            val timer = ScheduledWorkflowTimer(
+                store = countingStore,
+                clock = Clock.systemUTC(),
+                pollInterval = Duration.ofMillis(20),
+                observer = ThrowingWorkflowObserver(),
+            )
+            timer.register(
+                workflow = workflow,
+                initialState = { CounterState(0) },
+                observer = ThrowingWorkflowObserver(),
+            )
+
+            val job = timer.start()
+            try {
+                withTimeout(5_000) {
+                    while (countingStore.completedTicks.get() < 2) {
+                        delay(25)
+                    }
+                }
+                assertThat(job.isActive).isTrue()
+                assertThat(countingStore.completedTicks.get()).isGreaterThanOrEqualTo(2)
+            } finally {
+                timer.stop()
+            }
+        }
+    }
+
+    private data class CounterState(val value: Int)
+
+    private object CounterStateCodec : WorkflowStateCodec<CounterState> {
+        override fun encode(state: CounterState): String = state.value.toString()
+        override fun decode(payload: String): CounterState = CounterState(payload.toInt())
+    }
+
+    private class MutableClock(
+        var instant: Instant,
+        private val zoneId: ZoneId = ZoneId.of("UTC"),
+    ) : Clock() {
+        override fun instant(): Instant = instant
+        override fun getZone(): ZoneId = zoneId
+        override fun withZone(zone: ZoneId): Clock = MutableClock(instant, zone)
+    }
+
+    private class ThrowingWorkflowObserver : WorkflowObserver {
+        override fun onWorkflowStarted(workflowName: String, context: WorkflowContext) =
+            throw IllegalStateException("throwing observer: onWorkflowStarted")
+
+        override fun onWorkflowEvent(
+            workflowName: String,
+            name: String,
+            attributes: Map<String, Any?>,
+            context: WorkflowContext,
+        ) = throw IllegalStateException("throwing observer: onWorkflowEvent")
+
+        override fun onStepStarted(workflowName: String, stepName: String, context: WorkflowContext) =
+            throw IllegalStateException("throwing observer: onStepStarted")
+
+        override fun onStepCompleted(workflowName: String, stepName: String, context: WorkflowContext) =
+            throw IllegalStateException("throwing observer: onStepCompleted")
+
+        override fun onStepFailed(workflowName: String, stepName: String, error: Throwable, context: WorkflowContext) =
+            throw IllegalStateException("throwing observer: onStepFailed")
+
+        override fun onWorkflowCompleted(workflowName: String, context: WorkflowContext) =
+            throw IllegalStateException("throwing observer: onWorkflowCompleted")
+
+        override fun onWorkflowFailed(workflowName: String, error: Throwable, context: WorkflowContext) =
+            throw IllegalStateException("throwing observer: onWorkflowFailed")
+
+        override fun onScheduledTick(workflowName: String, scheduledFireAt: Instant, context: WorkflowContext) =
+            throw IllegalStateException("throwing observer: onScheduledTick")
+
+        override fun onSkippedTick(
+            workflowName: String,
+            scheduledFireAt: Instant,
+            reason: String,
+            context: WorkflowContext,
+        ) = throw IllegalStateException("throwing observer: onSkippedTick")
+
+        override fun onMissedTick(
+            workflowName: String,
+            scheduledFireAt: Instant,
+            reason: String,
+            context: WorkflowContext,
+        ) = throw IllegalStateException("throwing observer: onMissedTick")
+    }
+
+    private class CountingSchedulerStore(
+        private val delegate: WorkflowSchedulerStore,
+    ) : WorkflowSchedulerStore by delegate {
+        val completedTicks = AtomicInteger()
+
+        override suspend fun markTickCompleted(tickId: String, claimToken: String) {
+            delegate.markTickCompleted(tickId, claimToken)
+            completedTicks.incrementAndGet()
+        }
+    }
+}

--- a/tramai-scheduler/src/test/kotlin/dev/tramai/scheduler/SchedulerTest.kt
+++ b/tramai-scheduler/src/test/kotlin/dev/tramai/scheduler/SchedulerTest.kt
@@ -347,6 +347,7 @@ class SchedulerTest {
                 store = store,
                 clock = clock,
                 pollInterval = Duration.ofMillis(10),
+                observer = observer,
             )
 
             timer.register(
@@ -550,6 +551,7 @@ class SchedulerTest {
                 store = store,
                 clock = clock,
                 misfireThreshold = Duration.ofSeconds(1),
+                observer = observer,
             )
 
             timer.register(


### PR DESCRIPTION
## Epic 5.3 — observer, audit and evidence failure policy

Every secondary side effect now has one explicit failure contract, and runtime code cannot accidentally change the business outcome because an observer, metric, audit sink, or evidence exporter threw. **Authoritative audit/evidence is never silently swallowed merely because it looks like observability** — the classification axis is *authority first* (authoritative vs non-authoritative), *surface second* (observer vs audit vs evidence). No generic `safeEmit()`.

### Design

**Failure-isolating wrappers** (one per observer surface), wired at the single composition points:

| Wrapper | Surface | Wiring point |
|---|---|---|
| `FailureIsolatingOperationObserver` (core) | `OperationObserver` / `OperationObservation` per-attempt telemetry | `EngineComponentFactory` |
| `FailureIsolatingEngineEventObserver` (engine) | `EngineEventObserver` lifecycle telemetry | `EngineComponentFactory` |
| `FailureIsolatingWorkflowObserver` (orchestration) | `WorkflowObserver` workflow telemetry | `WorkflowRunner.run` / `resume` entry |
| `FailureIsolatingTramaiWorkerObserver` (orchestration) | `TramaiWorkerObserver` worker telemetry (all 22 callbacks) | `TramaiWorker` construction |

Behaviour: NON_AUTHORITATIVE callback failures are **contained** and reported through the safe 5-field diagnostic (`extensionPoint`, `callback`, `errorType`, `failurePolicy`, `authority` — never messages, stack traces, workflow state, prompts, or tool arguments). `CancellationException` always escapes unchanged. FAIL_CLOSED `RuntimeEvent` emissions propagate — the wrapper never contains them.

**`RuntimeEvent.failurePolicy` is now honored, not decorative.** Emission extensions (`tramai-engine` / `tramai-orchestration` `RuntimeEventEmission.kt`) route through the typed `onEngineEvent(RuntimeEvent)` / `onWorkflowEvent(RuntimeEvent, context)` overloads; FAIL_OPEN events are contained, FAIL_CLOSED events propagate (probe-verified).

**Frozen contracts preserved:**
- Cancellation: `onCallCancelled` stays unisolated so `completeCancellation` still attaches the observer failure as **suppressed** on the in-flight `CancellationException` (CE primary, never replaced).
- Tool-failure path: `onCallCompleted` containment records the failure via `SecondaryFailureRecording`; `completeAfterToolProcessing` surfaces it as **suppressed** on the primary business error; on success the failure is logged, result preserved.
- `onWorkflowCompleted` throwing can no longer flip success → failure; `onWorkflowFailed` throwing can no longer mask the primary workflow error.

**Audit / evidence (authoritative, FAIL_CLOSED — already fail-closed by construction, now declared contract):**
- Policy decision audit: emitted before the decision is acted on; audit failure propagates and blocks the operation (zero side effects — proven by existing `PolicyAuditWiringTest` cases).
- Approval lifecycle audit (`AuditEngine.appendNext`): failure propagates; an unaudited governed transition cannot proceed.
- Outbox enqueue: PREPARED record written **before** the approval mutation; enqueue failure ⇒ approval never mutated (`denyApproval fails closed when no AuditEngine`, `denyApproval fail-closed leaves approval unchanged`).
- Outbox dispatch: at-least-once — FAILED_RETRYABLE records retained and retried; a dispatch failure never retroactively fails the business operation. No blanket exactly-once claim.

### Verification

Full local gate (clean + 8 module test suites + 5 apiChecks + verifyCancellationSafety + verifyWorkflowApiStabilityBoundary + verifyChangePolicy(runtime-behaviour) + verifyMaintainabilityBaseline): **GREEN** (`/tmp/c256gate3.log`, 2m33s, EXIT=0). `verifyPr -PchangeClass=runtime-behaviour`: **GREEN** (`/tmp/c256pr1.log`, 1m9s). apiDump additive across core (+33), engine (+5), orchestration (+42), observability (+1).

New tests:
- `FailureIsolatingOperationObserverTest` (11) — per-callback lifecycle matrix: containment, CE escape, FAIL_CLOSED propagation.
- `FailureIsolatingWorkflowObserverTest` (14) + `FailureIsolatingTramaiWorkerObserverTest` (8) — full lifecycle matrices.
- `SecondaryFailurePreservationEngineTest` (2) — business success survives throwing observer; provider failure stays primary.
- `WorkflowRunnerPreservationTest` (6) — through the **public** `Workflow.run(observer=…)` API: success/failure outcomes unchanged under throwing started/completed/failed/event/step callbacks.
- `SecondaryFailureBoundaryArchitectureTest` — source scan of engine+orchestration main forbidding raw `observer.`/`observability.`/`engineEventObserver.`/`request.observer.` callback invocation outside the wrappers and the wired-through files; mutation-verified (probe → red).
- Updated contract tests: `SubprocessCancellationContractTest` (observer failure after process start is contained; process still cleaned up), `WorkflowStepFailureBoundaryTest` (real post-start failure classifies NON_ZERO_EXIT, never START_FAILED; message preserved in the boundary diagnostic).

Contract reference: `docs/reference/secondary-system-failure-policy.md` — full extension-point matrix, delivery semantics (best effort / at-least-once, no exactly-once), safe-diagnostic contract, architecture and verification sections.

Head: `820cfbc5` — 30 files, +1058/−93 (round 3).


---

## Review round 1 — all findings closed

Reviewer verdict at `190a8dd4`: ❌ REQUEST CHANGES (2 P1, 5 P2, 1 P3). Every finding is fixed in `317ddb9c`:

- **P1-1 scheduler bypass** — `ScheduledWorkflowTimer` and (found by the rewritten guard) `JdbcWorkflowSchedulerStore` now wrap `WorkflowObserver` at the boundary. Throwing observers can no longer leave `markTickSkipped`/`markTickMisfired`/`markTickStarted`/`releaseDelayWakeupClaim` uncommitted or terminate the poll loop. Proven by `SchedulerIsolationTest` (7 tests) + a JDBC recovery test.
- **P1-2 approval audit temporal semantics** — the blanket "approval audit = FAIL_CLOSED" row is replaced by a per-callback matrix: pre-mutation callbacks stay FAIL_CLOSED; `onToolExecutionCompleted` (post-side-effect) and `onSuspensionCancelled` (post-mutation) record the audit failure via the safe diagnostic with explicit terminal semantics — **never silently converted to telemetry**; `onUncertainOutcome` never substitutes the primary failure being reported. Tests: `completion audit failure is diagnosed and resume still completes`, `uncertain outcome audit failure never substitutes the primary resume failure`, ReplayAuthorizationService post-mutation coverage.
- **P2-1 EngineEventObserver policy loss** — additive typed `onEngineEvent(RuntimeEvent)` overload; `FailureIsolatingEngineEventObserver` enforces `event.definition.failurePolicy` (FAIL_CLOSED propagates — mutation-tested with a FAIL_CLOSED probe through the engine observer specifically). Both flattening call sites migrated.
- **P2-2 guard evadable** — rewritten to match **callback invocation names** (`\.onStepStarted(`, `\.onWorkflowCompleted(`…), scanned repo-wide across engine+orchestration+**scheduler**; mutation-proven with the reviewer's exact `telemetry.onStepStarted` / `workflowObserver.onWorkflowCompleted` evasions (red, restored).
- **P2-3 fatal Throwables swallowed** — wrappers now catch `Exception` only; `OutOfMemoryError`/`StackOverflowError`/`LinkageError`/`ThreadDeath` propagate.
- **P2-4 safe-diagnostic bypass** — tool-success path logs the 5-field diagnostic, never the raw observer Throwable.
- **P2-5 internal machinery as public ABI** — `@ExperimentalTramaiInternalApi` opt-in (`@RequiresOptIn`, same precedent as `ExperimentalCodexAuth`) on all cross-module machinery.
- **P3 worker callback count** — 22 → 20 (actual surface).

Verification: full gate (clean + 8 module suites + 5 apiChecks + verifyCancellationSafety + verifyWorkflowApiStabilityBoundary + verifyChangePolicy(runtime-behaviour) + verifyMaintainabilityBaseline) **GREEN** (`/tmp/c256gate4.log`, 2m41s); `verifyPr` **GREEN** (`/tmp/c256pr2.log`, 1m10s). apiDump additive (+10 this round).


---

## Review round 2 — P2 closed (core scan) + RC rerun

Round-2 verdict at `317ddb9c`: 8/8 round-1 findings confirmed fixed; one new P2 — the boundary guard walked engine/orchestration/scheduler but never **tramai-core**, so a raw `observer.onCallStarted(...)` in a non-allowlisted core file went green.

Fixed in `820cfbc5`:
- Scan list now includes `tramai-core` (`listOf("tramai-core", "tramai-engine", "tramai-orchestration", "tramai-scheduler")`). The allowlist already carried the core boundary files (OperationObservation, FailureIsolatingOperationObserver, SecondaryEffectPolicy), so the current tree scans clean with zero new offenders.
- **Mutation-proven per the reviewer's exact scenario**: a probe in non-allowlisted `OperationInterceptor.kt` calling `observer.onCallStarted(context)` trips the guard — `AssertionError: ... Found: [tramai-core/src/main/kotlin/dev/tramai/core/observation/OperationInterceptor.kt -> .onCallStarted(]` — and the restore returns green.
- Local gate: full suite + 5 apiChecks + 4 verifiers GREEN (`/tmp/c256gate5.log`), `verifyPr` GREEN (`/tmp/c256pr3.log`).

Sovereign RC: the red at `317ddb9c` was the pre-existing `TramaiWorkerTest` partition race, unrelated to #256 (no production change in this commit — the diff is the guard test only). **Rerun on `820cfbc5`: ✅ success.** Maintainability Baseline: ✅ success. CI: in progress.
