### PR TITLE
refactor(provider): centralize safe transport utilities (Epic 6.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@
 
 ### Added
 
+- **Shared provider transport utilities (PR #258, Epic 6.2).** New
+  `dev.tramai.core.provider.transport` package in `tramai-core` centralises
+  the low-level HTTP/stream mechanics that were duplicated across adapters:
+  `parseRetryAfterMillis` (injected `java.time.Clock`, default `systemUTC` —
+  the hidden `System.currentTimeMillis()` wall-clock dependency in
+  `Retry-After` date parsing is gone), `rejectedProviderHttpResponse` (one
+  primitive for the rejected-response lifecycle: bounded 8 KiB body read,
+  deterministic closure, debug-metadata logging, fail-open diagnostic
+  observer delivery, `Retry-After` propagation — the caller decides throw vs
+  `StreamChunk.Error`), `providerJsonRequest` (URI + JSON `Content-Type` +
+  normalized timeout + POST framing), and SSE framing helpers
+  (`readSseDataPayload`, `sseDataPayload`, `sseEventName` — prefix stripping
+  and field skipping only; payload interpretation stays in each adapter).
+  Migrated in order: OpenAI-compatible (DeepSeek benefits via delegation),
+  Azure OpenAI, Anthropic, Gemini, Ollama; Bedrock intentionally keeps its
+  AWS SDK transport. Authentication headers, endpoints, JSON wire formats,
+  tool semantics, usage extraction, and stream interpretation remain
+  adapter-owned so each provider's wire contract stays visible in its
+  source. No universal provider transport abstraction (Epic 6.2 guardrail).
+  New transport unit tests: `ProviderRetryAfterTest`,
+  `ProviderHttpResponseTest`, `ProviderSseTest`; all eight #257 TCK runners
+  stay green. API surface: 6 additive transport functions recorded in the
+  `tramai-core` dump; no existing signature changed.
+
 - **Provider Technology Compatibility Kit (PR #257, Epic 6.1).** Every published provider now runs the same deterministic, offline contract in `tramai-testing` test fixtures: `ProviderTck` (~29 tests per runner) against a `StubHttpClient` (JDK-21 `HttpClient` stub with canned responses, transport failures, cancellation arm, and body-close tracking) plus protocol-shaped fixture bodies per wire format (OpenAI-compatible, Anthropic, Ollama, Gemini). The harness pins the expected provider id and the exact capability set from the test, not from the provider under test — a provider cannot skip a contract by returning `supportsCapability(...) == false` (capability pins require their fixture specs at construction). Coverage: identity, cancellation, safe-error redaction (credentials/parser detail/bounded preview), HTTP timeout propagation, retryable-status mapping, numeric Retry-After, usage/reasoning-token extraction, outbound tool serialization + tool-call parsing (tool-only responses are not empty-text failures), vision base64+mime encoding, structured output, streaming (order, single Complete, fullText, terminal Error, malformed termination, closure on cancellation/early stop/completion). Runners for OpenAI-compatible, OpenAI, Azure OpenAI, Anthropic, Ollama, Gemini, Bedrock, and DeepSeek all green; `ProviderTckEnrollmentArchitectureTest` fails the build if a roadmap provider loses its runner or a new `ModelProvider` appears without one. Contract doc: `docs/reference/provider-compatibility-contract.md`. The TCK forced three production fixes: Anthropic tool translation (outbound `tools`/`input_schema`, inbound `tool_use` → `ToolCall`, tool-only responses valid), Ollama `VISION` + `STREAMING` pinned via a protocol-aware `VisionSpec` (base64 image payload without a MIME marker, per the Ollama wire protocol), and Bedrock — internal `BedrockRuntimeClientFactory` seam (AWS types stay out of the public API), production-owned client closure, and real incremental streaming via `BedrockRuntimeAsyncClient.invokeModelWithResponseStream` (was a synchronous whole-result single token). No shared transport abstraction introduced (Epic 6.2 owns that); zero public API diff.
 
 - **Typed runtime event catalogue (PR #254, Epic 5.2).** `tramai-core` now owns every runtime event identifier, attribute key, and metric descriptor in `dev.tramai.core.observation.event`: `RuntimeEventCatalogue` (domain, sensitivity, audit/evidence eligibility, allowed + required attributes, metric mapping per event), typed `RuntimeAttributeKey<T>` with one canonical value type per key, `RuntimeMetrics` (20 descriptors), and a compile-time `RuntimeEvents` registry. `RuntimeEvent.of(...)` builds validated events and rejects out-of-schema keys, missing required attributes, and wrong value types at construction (value types are also enforced at runtime against generic erasure); catalogue initialisation fails fast on duplicates and type conflicts. The engine, workflow, worker/operation OTEL observers, scheduler, server/platform run-store protocol, and sovereign ops outbox metrics all consume the catalogue — event and metric names preserved byte-for-byte, `OperationObservation.onEngineEvent(RuntimeEvent)` is an additive overload (no public API break), and dynamic workflow context stays under the explicitly declared `DynamicAttributeNamespaces.WORKFLOW_CONTEXT`. A fail-closed two-layer architecture test — ASM LDC bytecode scan of the four core modules' built jars plus a repository-wide source scan of every `tramai-*` module (with a declared Spring config-property-namespace allowance) — rejects any `tramai.*` identifier literal outside the catalogue (mutation-verified on both layers); it drove the migration of 40+ real un-catalogued literals (approval replay, token budget, provider route, workflow security/delay/http/mcp/shell, persistence leases/checkpoints, runner suspension, scheduler wake-ups, run-store SSE events, sovereign outbox worker). Reference docs are generated from the catalogue (`docs/reference/runtime-event-catalogue.md`) and drift-checked by a committed-doc test. Note: size/attempt/route-index/prompt/response/duration/exit-code attribute values are now `Long` (canonical catalogue types) where legacy code mixed `Int`.

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1009,21 +1009,49 @@ abstraction was introduced — Epic 6.2 owns transport consolidation.
 
 ---
 
-## Epic 6.2: Shared provider transport utilities
+## Epic 6.2: Shared provider transport utilities ✅
 
 **Goal:** Remove repeated low-level HTTP and streaming concerns without hiding provider protocol differences.
 
+**Status: complete (PR #258).** `dev.tramai.core.provider.transport` in
+`tramai-core` centralises the transport invariants that are genuinely
+identical between adapters:
+
+- `parseRetryAfterMillis(value, clock)` — deterministic `Retry-After`
+  parsing with an injected `Clock` (default `systemUTC`), removing the hidden
+  `System.currentTimeMillis()` wall-clock dependency.
+- `rejectedProviderHttpResponse(...)` — one primitive for the rejected-
+  response lifecycle: bounded 8 KiB body read, deterministic closure,
+  debug-metadata logging, fail-open diagnostic observer delivery, and
+  `Retry-After` propagation. The caller decides throw vs `StreamChunk.Error`.
+- `providerJsonRequest(uri, request, body)` — URI + JSON `Content-Type` +
+  normalized timeout + POST framing; authentication and provider-protocol
+  headers remain adapter-owned so the wire contract stays visible in each
+  provider's source.
+- `readSseDataPayload(reader)` / `sseDataPayload(line)` / `sseEventName(line)`
+  — SSE framing only (prefix stripping, field skipping, EOF); payload
+  interpretation (`[DONE]`, deltas, Anthropic event semantics, Gemini
+  candidates) stays in the adapters.
+
+Migrated in order: OpenAI-compatible (DeepSeek benefits via delegation),
+Azure OpenAI, Anthropic, Gemini, Ollama. Bedrock intentionally keeps its
+AWS SDK transport. The #257 TCK is the regression oracle and was not
+weakened; all eight provider runners stay green. Deliberately NOT extracted
+(in line with the guardrail): a Jackson-typed successful-body helper
+(`tramai-core` has no Jackson dependency; stream closure is stdlib `use{}`),
+usage-metrics adapters, and any universal provider transport abstraction.
+
 ### Candidate utilities
 
-- Safe request builder
-- Timeout application
-- Retry-after parser using an injected clock
-- Bounded response reader
-- Safe provider error decoder
-- SSE line parser primitives
-- JSON response guards
-- Resource-closing helpers
-- Common usage-metrics model adapters
+- Safe request builder ✅ (as `providerJsonRequest`)
+- Timeout application ✅ (pre-existing, reused)
+- Retry-after parser using an injected clock ✅
+- Bounded response reader ✅ (pre-existing, reused)
+- Safe provider error decoder ✅ (pre-existing, reused)
+- SSE line parser primitives ✅
+- JSON response guards — skipped (see above)
+- Resource-closing helpers ✅ (stdlib `use` at call sites)
+- Common usage-metrics model adapters — skipped (not mechanically equivalent)
 
 ### Guardrail
 

--- a/tramai-anthropic/src/main/kotlin/dev/tramai/anthropic/AnthropicProvider.kt
+++ b/tramai-anthropic/src/main/kotlin/dev/tramai/anthropic/AnthropicProvider.kt
@@ -30,7 +30,6 @@ import kotlin.coroutines.CoroutineContext
 import java.net.URI
 import java.io.InputStream
 import java.net.http.HttpClient
-import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.util.Base64
 import java.nio.charset.StandardCharsets.UTF_8

--- a/tramai-anthropic/src/main/kotlin/dev/tramai/anthropic/AnthropicProvider.kt
+++ b/tramai-anthropic/src/main/kotlin/dev/tramai/anthropic/AnthropicProvider.kt
@@ -1,3 +1,5 @@
+@file:OptIn(dev.tramai.core.provider.transport.ExperimentalProviderTransportApi::class)
+
 package dev.tramai.anthropic
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/tramai-anthropic/src/main/kotlin/dev/tramai/anthropic/AnthropicProvider.kt
+++ b/tramai-anthropic/src/main/kotlin/dev/tramai/anthropic/AnthropicProvider.kt
@@ -15,11 +15,11 @@ import dev.tramai.core.observation.ProviderFailureDiagnosticObserver
 import dev.tramai.core.provider.ModelProvider
 import dev.tramai.core.provider.ProviderCapability
 import dev.tramai.core.coroutines.rethrowIfCancellation
-import dev.tramai.core.provider.applyTramaiTimeout
-import dev.tramai.core.provider.logProviderHttpFailureDebug
-import dev.tramai.core.provider.providerHttpFailureObserved
 import dev.tramai.core.provider.providerTransportFailureObserved
-import dev.tramai.core.provider.readErrorBodyPreview
+import dev.tramai.core.provider.transport.providerJsonRequest
+import dev.tramai.core.provider.transport.rejectedProviderHttpResponse
+import dev.tramai.core.provider.transport.sseDataPayload
+import dev.tramai.core.provider.transport.sseEventName
 import dev.tramai.core.provider.safeProviderFailure
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -75,31 +75,23 @@ class AnthropicProvider @JvmOverloads constructor(
                 }
             }
 
-            val httpRequest = HttpRequest.newBuilder()
-                .uri(URI.create("${baseUrl.trimEnd('/')}/v1/messages"))
-                .header("Content-Type", "application/json")
-                .header("x-api-key", apiKey)
-                .header("anthropic-version", anthropicVersion)
-                .applyTramaiTimeout(request)
-                .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)))
-                .build()
+            val httpRequest = providerJsonRequest(
+                URI.create("${baseUrl.trimEnd('/')}/v1/messages"),
+                request,
+                objectMapper.writeValueAsString(payload),
+            ).apply {
+                header("x-api-key", apiKey)
+                header("anthropic-version", anthropicVersion)
+            }.build()
 
             val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
             if (response.statusCode() !in 200..299) {
-                val errorBody = readErrorBodyPreview(response.body())
-                logProviderHttpFailureDebug(
-                    logger = providerLogger,
-                    providerName = PROVIDER_ID,
-                    statusCode = response.statusCode(),
-                    body = errorBody.text,
-                )
-                throw providerHttpFailureObserved(
+                throw rejectedProviderHttpResponse(
                     providerId = PROVIDER_ID,
-                    statusCode = response.statusCode(),
-                    body = errorBody.text,
-                    bodyTruncated = errorBody.truncated,
-                    retryAfterHeader = response.headers().firstValue("Retry-After").orElse(null),
+                    providerAlias = null,
+                    response = response,
                     observer = providerFailureDiagnosticObserver,
+                    logger = providerLogger,
                 )
             }
 
@@ -177,14 +169,14 @@ class AnthropicProvider @JvmOverloads constructor(
                     }
                 }
 
-                val httpRequest = HttpRequest.newBuilder()
-                    .uri(URI.create("${baseUrl.trimEnd('/')}/v1/messages"))
-                    .header("Content-Type", "application/json")
-                    .header("x-api-key", apiKey)
-                    .header("anthropic-version", anthropicVersion)
-                    .applyTramaiTimeout(request)
-                    .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)))
-                    .build()
+                val httpRequest = providerJsonRequest(
+                    URI.create("${baseUrl.trimEnd('/')}/v1/messages"),
+                    request,
+                    objectMapper.writeValueAsString(payload),
+                ).apply {
+                    header("x-api-key", apiKey)
+                    header("anthropic-version", anthropicVersion)
+                }.build()
                 httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
             }
         } catch (error: Throwable) {
@@ -210,28 +202,13 @@ class AnthropicProvider @JvmOverloads constructor(
         response: HttpResponse<InputStream>,
     ): StreamChunk.Error? {
         if (response.statusCode() in 200..299) return null
-        val errorBody = try {
-            readErrorBodyPreview(response.body())
-        } catch (error: Throwable) {
-            error.rethrowIfCancellation()
-            return StreamChunk.Error(
-                providerTransportFailureObserved(PROVIDER_ID, error, providerFailureDiagnosticObserver),
-            )
-        }
-        logProviderHttpFailureDebug(
-            logger = providerLogger,
-            providerName = PROVIDER_ID,
-            statusCode = response.statusCode(),
-            body = errorBody.text,
-        )
         return StreamChunk.Error(
-            providerHttpFailureObserved(
+            rejectedProviderHttpResponse(
                 providerId = PROVIDER_ID,
-                statusCode = response.statusCode(),
-                body = errorBody.text,
-                bodyTruncated = errorBody.truncated,
-                retryAfterHeader = response.headers().firstValue("Retry-After").orElse(null),
+                providerAlias = null,
+                response = response,
                 observer = providerFailureDiagnosticObserver,
+                logger = providerLogger,
             ),
         )
     }
@@ -253,13 +230,10 @@ class AnthropicProvider @JvmOverloads constructor(
                 var currentEvent: String? = null
                 while (true) {
                     val line = reader.readLine() ?: break
-                    if (line.startsWith("event: ")) {
-                        currentEvent = line.substring(7).trim()
-                    } else if (line.startsWith("data: ")) {
-                        val data = line.substring(6).trim()
-                        val node = objectMapper.readTree(data)
-                        lastUsage = handleAnthropicEvent(currentEvent, node, fullText, lastUsage)
-                    }
+                    sseEventName(line)?.let { currentEvent = it }
+                    val data = sseDataPayload(line) ?: continue
+                    val node = objectMapper.readTree(data)
+                    lastUsage = handleAnthropicEvent(currentEvent, node, fullText, lastUsage)
                 }
             }
             emit(StreamChunk.Complete(fullText.toString(), lastUsage ?: UsageMetrics()))

--- a/tramai-azure-openai/src/main/kotlin/dev/tramai/azureopenai/AzureOpenAiProvider.kt
+++ b/tramai-azure-openai/src/main/kotlin/dev/tramai/azureopenai/AzureOpenAiProvider.kt
@@ -16,11 +16,10 @@ import dev.tramai.core.observation.ProviderFailureDiagnosticObserver
 import dev.tramai.core.provider.ModelProvider
 import dev.tramai.core.provider.ProviderCapability
 import dev.tramai.core.provider.StreamCapable
-import dev.tramai.core.provider.applyTramaiTimeout
-import dev.tramai.core.provider.logProviderHttpFailureDebug
-import dev.tramai.core.provider.providerHttpFailureObserved
 import dev.tramai.core.provider.providerTransportFailureObserved
-import dev.tramai.core.provider.readErrorBodyPreview
+import dev.tramai.core.provider.transport.providerJsonRequest
+import dev.tramai.core.provider.transport.readSseDataPayload
+import dev.tramai.core.provider.transport.rejectedProviderHttpResponse
 import dev.tramai.core.provider.safeProviderFailure
 import dev.tramai.core.coroutines.rethrowIfCancellation
 import kotlinx.coroutines.Dispatchers
@@ -123,38 +122,27 @@ class AzureOpenAiProvider @JvmOverloads constructor(
             request.temperature?.let { payload["temperature"] = it }
 
             val authToken = resolveAuthToken()
-            val httpRequestBuilder = HttpRequest.newBuilder()
-                .uri(URI.create(buildUrl()))
-                .header("Content-Type", "application/json")
-                .applyTramaiTimeout(request)
-
-            // API key auth uses the api-key header; Entra ID uses Bearer auth
-            if (apiKey != null) {
-                httpRequestBuilder.header("api-key", authToken!!)
-            } else {
-                httpRequestBuilder.header("Authorization", "Bearer $authToken")
-            }
-
-            val httpRequest = httpRequestBuilder
-                .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)))
-                .build()
+            val httpRequest = providerJsonRequest(
+                URI.create(buildUrl()),
+                request,
+                objectMapper.writeValueAsString(payload),
+            ).apply {
+                // API key auth uses the api-key header; Entra ID uses Bearer auth
+                if (apiKey != null) {
+                    header("api-key", authToken!!)
+                } else {
+                    header("Authorization", "Bearer $authToken")
+                }
+            }.build()
 
             val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
             if (response.statusCode() !in 200..299) {
-                val errorBody = readErrorBodyPreview(response.body())
-                logProviderHttpFailureDebug(
-                    logger = providerLogger,
-                    providerName = PROVIDER_ID,
-                    statusCode = response.statusCode(),
-                    body = errorBody.text,
-                )
-                throw providerHttpFailureObserved(
+                throw rejectedProviderHttpResponse(
                     providerId = PROVIDER_ID,
-                    statusCode = response.statusCode(),
-                    body = errorBody.text,
-                    bodyTruncated = errorBody.truncated,
-                    retryAfterHeader = response.headers().firstValue("Retry-After").orElse(null),
+                    providerAlias = null,
+                    response = response,
                     observer = providerFailureDiagnosticObserver,
+                    logger = providerLogger,
                 )
             }
 
@@ -177,20 +165,17 @@ class AzureOpenAiProvider @JvmOverloads constructor(
                 request.temperature?.let { payload["temperature"] = it }
 
                 val authToken = resolveAuthToken()
-                val httpRequestBuilder = HttpRequest.newBuilder()
-                    .uri(URI.create(buildUrl()))
-                    .header("Content-Type", "application/json")
-                    .applyTramaiTimeout(request)
-
-                if (apiKey != null) {
-                    httpRequestBuilder.header("api-key", authToken!!)
-                } else {
-                    httpRequestBuilder.header("Authorization", "Bearer $authToken")
-                }
-
-                val httpRequest = httpRequestBuilder
-                    .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)))
-                    .build()
+                val httpRequest = providerJsonRequest(
+                    URI.create(buildUrl()),
+                    request,
+                    objectMapper.writeValueAsString(payload),
+                ).apply {
+                    if (apiKey != null) {
+                        header("api-key", authToken!!)
+                    } else {
+                        header("Authorization", "Bearer $authToken")
+                    }
+                }.build()
                 httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
             }
         } catch (error: Throwable) {
@@ -216,28 +201,13 @@ class AzureOpenAiProvider @JvmOverloads constructor(
         response: HttpResponse<InputStream>,
     ): StreamChunk.Error? {
         if (response.statusCode() in 200..299) return null
-        val errorBody = try {
-            readErrorBodyPreview(response.body())
-        } catch (error: Throwable) {
-            error.rethrowIfCancellation()
-            return StreamChunk.Error(
-                providerTransportFailureObserved(PROVIDER_ID, error, providerFailureDiagnosticObserver),
-            )
-        }
-        logProviderHttpFailureDebug(
-            logger = providerLogger,
-            providerName = PROVIDER_ID,
-            statusCode = response.statusCode(),
-            body = errorBody.text,
-        )
         return StreamChunk.Error(
-            providerHttpFailureObserved(
+            rejectedProviderHttpResponse(
                 providerId = PROVIDER_ID,
-                statusCode = response.statusCode(),
-                body = errorBody.text,
-                bodyTruncated = errorBody.truncated,
-                retryAfterHeader = response.headers().firstValue("Retry-After").orElse(null),
+                providerAlias = null,
+                response = response,
                 observer = providerFailureDiagnosticObserver,
+                logger = providerLogger,
             ),
         )
     }
@@ -255,12 +225,9 @@ class AzureOpenAiProvider @JvmOverloads constructor(
         try {
             response.body().bufferedReader(UTF_8).use { reader ->
                 while (true) {
-                    val line = reader.readLine() ?: break
-                    if (line.startsWith("data: ")) {
-                        val data = line.substring(6).trim()
-                        if (data == "[DONE]") break
-                        lastUsage = handleAzureDataLine(data, fullText, lastUsage)
-                    }
+                    val data = readSseDataPayload(reader) ?: break
+                    if (data == "[DONE]") break
+                    lastUsage = handleAzureDataLine(data, fullText, lastUsage)
                 }
             }
             emit(StreamChunk.Complete(fullText.toString(), lastUsage ?: UsageMetrics()))

--- a/tramai-azure-openai/src/main/kotlin/dev/tramai/azureopenai/AzureOpenAiProvider.kt
+++ b/tramai-azure-openai/src/main/kotlin/dev/tramai/azureopenai/AzureOpenAiProvider.kt
@@ -31,7 +31,6 @@ import kotlin.coroutines.CoroutineContext
 import java.net.URI
 import java.io.InputStream
 import java.net.http.HttpClient
-import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.util.Base64
 import java.nio.charset.StandardCharsets.UTF_8

--- a/tramai-azure-openai/src/main/kotlin/dev/tramai/azureopenai/AzureOpenAiProvider.kt
+++ b/tramai-azure-openai/src/main/kotlin/dev/tramai/azureopenai/AzureOpenAiProvider.kt
@@ -1,3 +1,5 @@
+@file:OptIn(dev.tramai.core.provider.transport.ExperimentalProviderTransportApi::class)
+
 package dev.tramai.azureopenai
 
 import com.fasterxml.jackson.databind.JsonNode

--- a/tramai-core/api/tramai-core.api
+++ b/tramai-core/api/tramai-core.api
@@ -2596,6 +2596,9 @@ public abstract interface class dev/tramai/core/provider/StreamCapable {
 	public abstract fun stream (Ldev/tramai/core/model/ModelRequest;)Lkotlinx/coroutines/flow/Flow;
 }
 
+public abstract interface annotation class dev/tramai/core/provider/transport/ExperimentalProviderTransportApi : java/lang/annotation/Annotation {
+}
+
 public final class dev/tramai/core/provider/transport/ProviderTransportKt {
 	public static final fun providerJsonRequest (Ljava/net/URI;Ldev/tramai/core/model/ModelRequest;Ljava/lang/String;)Ljava/net/http/HttpRequest$Builder;
 	public static final fun readSseDataPayload (Ljava/io/BufferedReader;)Ljava/lang/String;

--- a/tramai-core/api/tramai-core.api
+++ b/tramai-core/api/tramai-core.api
@@ -2596,6 +2596,20 @@ public abstract interface class dev/tramai/core/provider/StreamCapable {
 	public abstract fun stream (Ldev/tramai/core/model/ModelRequest;)Lkotlinx/coroutines/flow/Flow;
 }
 
+public final class dev/tramai/core/provider/transport/ProviderTransportKt {
+	public static final fun providerJsonRequest (Ljava/net/URI;Ldev/tramai/core/model/ModelRequest;Ljava/lang/String;)Ljava/net/http/HttpRequest$Builder;
+	public static final fun readSseDataPayload (Ljava/io/BufferedReader;)Ljava/lang/String;
+	public static final fun rejectedProviderHttpResponse (Ljava/lang/String;Ljava/lang/String;Ljava/net/http/HttpResponse;Ldev/tramai/core/observation/ProviderFailureDiagnosticObserver;Ljava/lang/System$Logger;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun rejectedProviderHttpResponse$default (Ljava/lang/String;Ljava/lang/String;Ljava/net/http/HttpResponse;Ldev/tramai/core/observation/ProviderFailureDiagnosticObserver;Ljava/lang/System$Logger;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun sseDataPayload (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun sseEventName (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class dev/tramai/core/provider/transport/RetryAfterKt {
+	public static final fun parseRetryAfterMillis (Ljava/lang/String;Ljava/time/Clock;)Ljava/lang/Long;
+	public static synthetic fun parseRetryAfterMillis$default (Ljava/lang/String;Ljava/time/Clock;ILjava/lang/Object;)Ljava/lang/Long;
+}
+
 public final class dev/tramai/core/secret/CompositeSecretValueResolver : dev/tramai/core/secret/SecretValueResolver {
 	public fun <init> (Ljava/util/List;)V
 	public fun resolve (Ljava/lang/String;)Ljava/lang/String;

--- a/tramai-core/src/main/kotlin/dev/tramai/core/provider/ProviderFailures.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/provider/ProviderFailures.kt
@@ -6,6 +6,7 @@ import dev.tramai.core.exception.ProviderFailureCode
 import dev.tramai.core.model.ModelRequest
 import dev.tramai.core.observation.ProviderFailureDiagnosticEvent
 import dev.tramai.core.observation.ProviderFailureDiagnosticObserver
+import dev.tramai.core.provider.transport.parseRetryAfterMillis
 import java.io.ByteArrayInputStream
 import java.io.IOException
 import java.io.InputStream
@@ -14,9 +15,6 @@ import java.net.ConnectException
 import java.net.http.HttpRequest
 import java.net.http.HttpTimeoutException
 import java.time.Duration
-import java.time.Instant
-import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
@@ -298,16 +296,3 @@ private suspend fun deliver(
 }
 
 private fun isRetryableStatus(statusCode: Int): Boolean = statusCode in setOf(408, 425, 429, 500, 502, 503, 504)
-
-private fun parseRetryAfterMillis(value: String?): Long? {
-    val trimmed = value?.trim()?.takeIf { it.isNotEmpty() } ?: return null
-    trimmed.toLongOrNull()?.let { seconds ->
-        return if (seconds >= 0) seconds * 1_000 else null
-    }
-
-    val retryAt = runCatching {
-        Instant.from(DateTimeFormatter.RFC_1123_DATE_TIME.withZone(ZoneOffset.UTC).parse(trimmed))
-    }.getOrNull() ?: return null
-
-    return (retryAt.toEpochMilli() - System.currentTimeMillis()).coerceAtLeast(0L)
-}

--- a/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/ExperimentalProviderTransportApi.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/ExperimentalProviderTransportApi.kt
@@ -1,0 +1,22 @@
+package dev.tramai.core.provider.transport
+
+/**
+ * Marks provider-transport utilities that are public only because the
+ * built-in provider adapters consume them across module boundaries — NOT
+ * stable application-facing API.
+ *
+ * These helpers centralise transport invariants (rejected-response
+ * handling, JSON request framing, SSE line framing, `Retry-After` parsing)
+ * for the adapters shipped in `tramai-openai`, `tramai-azure-openai`,
+ * `tramai-anthropic`, `tramai-gemini`, and `tramai-ollama`. They are
+ * intentionally not part of Tramai's stable application-facing surface; the
+ * annotation makes that contract explicit and opt-in (same precedent as
+ * [dev.tramai.core.observation.secondary.ExperimentalTramaiInternalApi],
+ * scoped to the transport domain).
+ */
+@RequiresOptIn(
+    message = "Tramai provider-transport utilities are internal implementation API for the built-in " +
+        "provider adapters, not application-facing API. They may change or move in any release.",
+    level = RequiresOptIn.Level.WARNING,
+)
+annotation class ExperimentalProviderTransportApi

--- a/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/ProviderTransport.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/ProviderTransport.kt
@@ -1,0 +1,117 @@
+package dev.tramai.core.provider.transport
+
+import dev.tramai.core.coroutines.rethrowIfCancellation
+import dev.tramai.core.exception.ProviderException
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.observation.ProviderFailureDiagnosticObserver
+import dev.tramai.core.provider.applyTramaiTimeout
+import dev.tramai.core.provider.logProviderHttpFailureDebug
+import dev.tramai.core.provider.providerHttpFailureObserved
+import dev.tramai.core.provider.providerTransportFailureObserved
+import dev.tramai.core.provider.readErrorBodyPreview
+import java.io.BufferedReader
+import java.io.InputStream
+import java.net.URI
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+/**
+ * Low-level HTTP/stream transport machinery shared by provider adapters.
+ *
+ * This package centralises transport invariants only: request framing,
+ * timeout application, rejected-response handling, bounded body reads, body
+ * closure, and SSE framing. Endpoint construction, authentication, JSON wire
+ * formats, tool semantics, usage extraction, and stream interpretation remain
+ * inside each adapter so the wire contract stays visible in provider source.
+ *
+ * This is cross-module implementation machinery for the built-in adapters,
+ * not stable application-facing API; it may change or move in any release.
+ */
+
+/**
+ * Builds a JSON HTTP request for a provider endpoint with the normalized
+ * Tramai timeout applied.
+ *
+ * Authentication and provider-protocol headers are added by the caller so a
+ * reviewer can still see the wire contract from the provider source:
+ *
+ * ```
+ * providerJsonRequest(uri, request, jsonBody)
+ *     .header("Authorization", "Bearer ...")   // provider-specific auth
+ *     .build()
+ * ```
+ */
+fun providerJsonRequest(
+    uri: URI,
+    request: ModelRequest,
+    body: String,
+): HttpRequest.Builder = HttpRequest.newBuilder()
+    .uri(uri)
+    .header("Content-Type", "application/json")
+    .applyTramaiTimeout(request)
+    .POST(HttpRequest.BodyPublishers.ofString(body))
+
+/**
+ * Builds the safe failure for a rejected (non-2xx) provider HTTP response.
+ *
+ * Performs the shared rejected-response lifecycle:
+ * 1. reads a bounded preview of the error body (8 KiB diagnostic bound);
+ * 2. closes the response body on every exit;
+ * 3. logs debug metadata only (never the body content);
+ * 4. delivers the diagnostic observer event (fail-open);
+ * 5. propagates `Retry-After` through the returned exception.
+ *
+ * A body-read failure is normalized to a transport failure. Cancellation is
+ * preserved. The caller decides whether the returned [ProviderException] is
+ * thrown (non-streaming) or emitted as a `StreamChunk.Error` (streaming);
+ * this utility does not decide provider protocol behaviour.
+ */
+suspend fun rejectedProviderHttpResponse(
+    providerId: String,
+    providerAlias: String?,
+    response: HttpResponse<InputStream>,
+    observer: ProviderFailureDiagnosticObserver,
+    logger: System.Logger? = null,
+): ProviderException {
+    val errorBody = try {
+        readErrorBodyPreview(response.body())
+    } catch (error: Throwable) {
+        error.rethrowIfCancellation()
+        return providerTransportFailureObserved(providerId, providerAlias, error, observer)
+    }
+    logProviderHttpFailureDebug(logger, providerId, response.statusCode(), errorBody.text)
+    return providerHttpFailureObserved(
+        providerId = providerId,
+        providerAlias = providerAlias,
+        statusCode = response.statusCode(),
+        body = errorBody.text,
+        bodyTruncated = errorBody.truncated,
+        retryAfterHeader = response.headers().firstValue("Retry-After").orElse(null),
+        observer = observer,
+    )
+}
+
+/**
+ * Returns the payload of the next SSE `data: ` line in [reader], or `null` at
+ * end of stream.
+ *
+ * SSE framing only: unrelated fields (`event:`, `id:`, comments, blank lines)
+ * are skipped, the `data: ` prefix is stripped, and the payload is returned
+ * verbatim (trimmed). Payload interpretation — `[DONE]`, delta parsing,
+ * Anthropic event semantics — is the caller's responsibility. The reader is
+ * intentionally left open; the caller owns closure (typically `use`).
+ */
+fun readSseDataPayload(reader: BufferedReader): String? {
+    while (true) {
+        val line = reader.readLine() ?: return null
+        if (line.startsWith("data: ")) return line.substring(6).trim()
+    }
+}
+
+/**
+ * Returns the event name of an SSE `event: ` line, or `null` for any other
+ * line. Callers that need event context (e.g. Anthropic) pair this with
+ * [readSseDataPayload] in their own loop.
+ */
+fun sseEventName(line: String): String? =
+    if (line.startsWith("event: ")) line.substring(7).trim() else null

--- a/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/ProviderTransport.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/ProviderTransport.kt
@@ -104,14 +104,22 @@ suspend fun rejectedProviderHttpResponse(
 fun readSseDataPayload(reader: BufferedReader): String? {
     while (true) {
         val line = reader.readLine() ?: return null
-        if (line.startsWith("data: ")) return line.substring(6).trim()
+        sseDataPayload(line)?.let { return it }
     }
 }
 
 /**
+ * Returns the payload of an SSE `data: ` line, or `null` for any other line.
+ * Callers that need event context (e.g. Anthropic) pair this with
+ * [sseEventName] in their own loop.
+ */
+fun sseDataPayload(line: String): String? =
+    if (line.startsWith("data: ")) line.substring(6).trim() else null
+
+/**
  * Returns the event name of an SSE `event: ` line, or `null` for any other
  * line. Callers that need event context (e.g. Anthropic) pair this with
- * [readSseDataPayload] in their own loop.
+ * [sseDataPayload] in their own loop.
  */
 fun sseEventName(line: String): String? =
     if (line.startsWith("event: ")) line.substring(7).trim() else null

--- a/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/ProviderTransport.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/ProviderTransport.kt
@@ -41,6 +41,7 @@ import java.net.http.HttpResponse
  *     .build()
  * ```
  */
+@ExperimentalProviderTransportApi
 fun providerJsonRequest(
     uri: URI,
     request: ModelRequest,
@@ -66,6 +67,7 @@ fun providerJsonRequest(
  * thrown (non-streaming) or emitted as a `StreamChunk.Error` (streaming);
  * this utility does not decide provider protocol behaviour.
  */
+@ExperimentalProviderTransportApi
 suspend fun rejectedProviderHttpResponse(
     providerId: String,
     providerAlias: String?,
@@ -101,6 +103,7 @@ suspend fun rejectedProviderHttpResponse(
  * Anthropic event semantics — is the caller's responsibility. The reader is
  * intentionally left open; the caller owns closure (typically `use`).
  */
+@ExperimentalProviderTransportApi
 fun readSseDataPayload(reader: BufferedReader): String? {
     while (true) {
         val line = reader.readLine() ?: return null
@@ -113,6 +116,7 @@ fun readSseDataPayload(reader: BufferedReader): String? {
  * Callers that need event context (e.g. Anthropic) pair this with
  * [sseEventName] in their own loop.
  */
+@ExperimentalProviderTransportApi
 fun sseDataPayload(line: String): String? =
     if (line.startsWith("data: ")) line.substring(6).trim() else null
 
@@ -121,5 +125,6 @@ fun sseDataPayload(line: String): String? =
  * line. Callers that need event context (e.g. Anthropic) pair this with
  * [sseDataPayload] in their own loop.
  */
+@ExperimentalProviderTransportApi
 fun sseEventName(line: String): String? =
     if (line.startsWith("event: ")) line.substring(7).trim() else null

--- a/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/RetryAfter.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/RetryAfter.kt
@@ -24,7 +24,10 @@ fun parseRetryAfterMillis(
 ): Long? {
     val trimmed = value?.trim()?.takeIf { it.isNotEmpty() } ?: return null
     trimmed.toLongOrNull()?.let { seconds ->
-        return if (seconds >= 0) seconds * 1_000 else null
+        // Guard against millisecond multiplication overflow so the documented
+        // non-negative contract holds for any parseable Long value.
+        if (seconds < 0 || seconds > Long.MAX_VALUE / 1_000) return null
+        return seconds * 1_000
     }
 
     val retryAt = runCatching {

--- a/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/RetryAfter.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/RetryAfter.kt
@@ -1,0 +1,35 @@
+package dev.tramai.core.provider.transport
+
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+/**
+ * Parses an HTTP `Retry-After` header value into a retry delay in milliseconds.
+ *
+ * Accepts:
+ * - a non-negative integer number of seconds (`Retry-After: 120`);
+ * - an RFC-1123 HTTP-date (`Retry-After: Wed, 21 Oct 2026 07:28:00 GMT`),
+ *   evaluated against the supplied [clock] so tests are deterministic.
+ *
+ * Returns:
+ * - `0` for a date in the past (retry immediately);
+ * - `null` for a malformed value, a blank value, or a negative number of
+ *   seconds (no retry-after information).
+ */
+fun parseRetryAfterMillis(
+    value: String?,
+    clock: Clock = Clock.systemUTC(),
+): Long? {
+    val trimmed = value?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+    trimmed.toLongOrNull()?.let { seconds ->
+        return if (seconds >= 0) seconds * 1_000 else null
+    }
+
+    val retryAt = runCatching {
+        Instant.from(DateTimeFormatter.RFC_1123_DATE_TIME.withZone(ZoneOffset.UTC).parse(trimmed))
+    }.getOrNull() ?: return null
+
+    return (retryAt.toEpochMilli() - clock.millis()).coerceAtLeast(0L)
+}

--- a/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/RetryAfter.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/RetryAfter.kt
@@ -18,6 +18,7 @@ import java.time.format.DateTimeFormatter
  * - `null` for a malformed value, a blank value, or a negative number of
  *   seconds (no retry-after information).
  */
+@ExperimentalProviderTransportApi
 fun parseRetryAfterMillis(
     value: String?,
     clock: Clock = Clock.systemUTC(),

--- a/tramai-core/src/test/kotlin/dev/tramai/core/provider/transport/ProviderHttpResponseTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/provider/transport/ProviderHttpResponseTest.kt
@@ -1,0 +1,153 @@
+package dev.tramai.core.provider.transport
+
+import dev.tramai.core.exception.ProviderFailureCode
+import dev.tramai.core.observation.ProviderFailureDiagnosticEvent
+import dev.tramai.core.observation.ProviderFailureDiagnosticObserver
+import dev.tramai.core.provider.PROVIDER_ERROR_BODY_LIMIT_BYTES
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.io.InputStream
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpHeaders
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.util.Optional
+import javax.net.ssl.SSLSession
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class ProviderHttpResponseTest {
+
+    private class CloseTrackingStream(bytes: ByteArray) : ByteArrayInputStream(bytes) {
+        var closed = false
+            private set
+
+        override fun close() {
+            closed = true
+            super.close()
+        }
+    }
+
+    private class ThrowingStream : InputStream() {
+        override fun read(): Int = throw IOException("body read failed")
+    }
+
+    private class FakeResponse<S : InputStream>(
+        private val status: Int,
+        val bodyStream: S,
+        private val retryAfter: String? = null,
+    ) : HttpResponse<InputStream> {
+        override fun statusCode(): Int = status
+        override fun body(): InputStream = bodyStream
+        override fun headers(): HttpHeaders = HttpHeaders.of(
+            mapOf("Retry-After" to listOfNotNull(retryAfter)),
+        ) { _: String, _: String -> true }
+
+        override fun uri(): URI = URI.create("https://example.invalid/chat/completions")
+        override fun request(): HttpRequest = throw UnsupportedOperationException()
+        override fun version(): HttpClient.Version? = HttpClient.Version.HTTP_1_1
+        override fun previousResponse(): Optional<HttpResponse<InputStream>>? = Optional.empty()
+        override fun sslSession(): Optional<SSLSession> = Optional.empty()
+    }
+
+    private fun fake(status: Int, body: String, retryAfter: String? = null): FakeResponse<CloseTrackingStream> =
+        FakeResponse(status, CloseTrackingStream(body.toByteArray()), retryAfter)
+
+    private val events = mutableListOf<ProviderFailureDiagnosticEvent>()
+    private val observer = ProviderFailureDiagnosticObserver(events::add)
+
+    @Test
+    fun `rejected response maps to http rejected failure with retry after`() = runBlocking {
+        val response = fake(429, "{\"error\":\"rate limited\"}", retryAfter = "5")
+
+        val error = rejectedProviderHttpResponse("openai", "customer-openai", response, observer)
+
+        assertThat(error.failureCode).isEqualTo(ProviderFailureCode.HTTP_REJECTED)
+        assertThat(error.statusCode).isEqualTo(429)
+        assertThat(error.retryable).isTrue()
+        assertThat(error.retryAfterMillis).isEqualTo(5_000)
+        assertThat(error.message).isEqualTo("Provider request failed with HTTP 429")
+        assertThat(error.message).doesNotContain("rate limited")
+        assertThat(events.single().providerAlias).isEqualTo("customer-openai")
+        assertThat(events.single().httpBodyPreview).isEqualTo("{\"error\":\"rate limited\"}")
+    }
+
+    @Test
+    fun `rejected response body closes on failure`() = runBlocking {
+        val response = fake(500, "boom")
+
+        rejectedProviderHttpResponse("openai", null, response, observer)
+
+        assertThat(response.bodyStream.closed).isTrue()
+    }
+
+    @Test
+    fun `permanent status stays non retryable`() = runBlocking {
+        val error = rejectedProviderHttpResponse("openai", null, fake(401, "unauthorized"), observer)
+
+        assertThat(error.retryable).isFalse()
+        assertThat(error.retryAfterMillis).isNull()
+    }
+
+    @Test
+    fun `body preview is bounded at the diagnostic limit`() = runBlocking {
+        val oversized = "x".repeat(PROVIDER_ERROR_BODY_LIMIT_BYTES + 1_000)
+
+        val error = rejectedProviderHttpResponse("openai", null, fake(500, oversized), observer)
+
+        assertThat(error.failureCode).isEqualTo(ProviderFailureCode.HTTP_REJECTED)
+        val event = events.single()
+        assertThat(event.httpBodyPreview!!.toByteArray()).hasSizeLessThanOrEqualTo(PROVIDER_ERROR_BODY_LIMIT_BYTES)
+        assertThat(event.httpBodyPreviewTruncated).isTrue()
+    }
+
+    @Test
+    fun `body read failure becomes a transport failure`() = runBlocking {
+        val response = FakeResponse(500, ThrowingStream())
+
+        val error = rejectedProviderHttpResponse("openai", null, response, observer)
+
+        assertThat(error.failureCode).isEqualTo(ProviderFailureCode.TRANSPORT_FAILED)
+        assertThat(error.retryable).isTrue()
+        assertThat(events.single().failure).isInstanceOf(IOException::class.java)
+    }
+
+    @Test
+    fun `observer failure stays fail open`() = runBlocking {
+        val throwingObserver = ProviderFailureDiagnosticObserver {
+            throw IllegalStateException("observer exploded")
+        }
+
+        val error = rejectedProviderHttpResponse("openai", null, fake(429, "x"), throwingObserver)
+
+        assertThat(error.failureCode).isEqualTo(ProviderFailureCode.HTTP_REJECTED)
+    }
+
+    @Test
+    fun `observer thrown cancellation is swallowed while the coroutine is active`() = runBlocking {
+        // Fail-open diagnostic semantics: an observer-thrown CancellationException
+        // must not replace the provider failure while the enclosing coroutine is
+        // still active. (Cancellation rethrow of a genuinely cancelled coroutine
+        // is exercised end-to-end by the provider TCK stream-cancellation test.)
+        val observer = ProviderFailureDiagnosticObserver { throw CancellationException("observer") }
+
+        val error = rejectedProviderHttpResponse("openai", null, fake(429, "x"), observer)
+
+        assertThat(error.failureCode).isEqualTo(ProviderFailureCode.HTTP_REJECTED)
+    }
+
+    @Test
+    fun `rejected handling does not classify status itself`() = runBlocking {
+        // The adapter checks 2xx before invoking the rejected handler; the
+        // handler must pass the status through verbatim without deciding
+        // whether it is an error.
+        val error = rejectedProviderHttpResponse("openai", null, fake(200, "{}"), observer)
+
+        assertThat(error.statusCode).isEqualTo(200)
+        assertThat(error.failureCode).isEqualTo(ProviderFailureCode.HTTP_REJECTED)
+    }
+}

--- a/tramai-core/src/test/kotlin/dev/tramai/core/provider/transport/ProviderHttpResponseTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/provider/transport/ProviderHttpResponseTest.kt
@@ -61,7 +61,7 @@ class ProviderHttpResponseTest {
     private val observer = ProviderFailureDiagnosticObserver(events::add)
 
     @Test
-    fun `rejected response maps to http rejected failure with retry after`() = runBlocking {
+    fun `rejected response maps to http rejected failure with retry after`() = runBlocking<Unit> {
         val response = fake(429, "{\"error\":\"rate limited\"}", retryAfter = "5")
 
         val error = rejectedProviderHttpResponse("openai", "customer-openai", response, observer)
@@ -77,7 +77,7 @@ class ProviderHttpResponseTest {
     }
 
     @Test
-    fun `rejected response body closes on failure`() = runBlocking {
+    fun `rejected response body closes on failure`() = runBlocking<Unit> {
         val response = fake(500, "boom")
 
         rejectedProviderHttpResponse("openai", null, response, observer)
@@ -86,7 +86,7 @@ class ProviderHttpResponseTest {
     }
 
     @Test
-    fun `permanent status stays non retryable`() = runBlocking {
+    fun `permanent status stays non retryable`() = runBlocking<Unit> {
         val error = rejectedProviderHttpResponse("openai", null, fake(401, "unauthorized"), observer)
 
         assertThat(error.retryable).isFalse()
@@ -94,7 +94,7 @@ class ProviderHttpResponseTest {
     }
 
     @Test
-    fun `body preview is bounded at the diagnostic limit`() = runBlocking {
+    fun `body preview is bounded at the diagnostic limit`() = runBlocking<Unit> {
         val oversized = "x".repeat(PROVIDER_ERROR_BODY_LIMIT_BYTES + 1_000)
 
         val error = rejectedProviderHttpResponse("openai", null, fake(500, oversized), observer)
@@ -106,7 +106,7 @@ class ProviderHttpResponseTest {
     }
 
     @Test
-    fun `body read failure becomes a transport failure`() = runBlocking {
+    fun `body read failure becomes a transport failure`() = runBlocking<Unit> {
         val response = FakeResponse(500, ThrowingStream())
 
         val error = rejectedProviderHttpResponse("openai", null, response, observer)
@@ -117,7 +117,7 @@ class ProviderHttpResponseTest {
     }
 
     @Test
-    fun `observer failure stays fail open`() = runBlocking {
+    fun `observer failure stays fail open`() = runBlocking<Unit> {
         val throwingObserver = ProviderFailureDiagnosticObserver {
             throw IllegalStateException("observer exploded")
         }
@@ -128,7 +128,7 @@ class ProviderHttpResponseTest {
     }
 
     @Test
-    fun `observer thrown cancellation is swallowed while the coroutine is active`() = runBlocking {
+    fun `observer thrown cancellation is swallowed while the coroutine is active`() = runBlocking<Unit> {
         // Fail-open diagnostic semantics: an observer-thrown CancellationException
         // must not replace the provider failure while the enclosing coroutine is
         // still active. (Cancellation rethrow of a genuinely cancelled coroutine
@@ -141,7 +141,7 @@ class ProviderHttpResponseTest {
     }
 
     @Test
-    fun `rejected handling does not classify status itself`() = runBlocking {
+    fun `rejected handling does not classify status itself`() = runBlocking<Unit> {
         // The adapter checks 2xx before invoking the rejected handler; the
         // handler must pass the status through verbatim without deciding
         // whether it is an error.

--- a/tramai-core/src/test/kotlin/dev/tramai/core/provider/transport/ProviderRetryAfterTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/provider/transport/ProviderRetryAfterTest.kt
@@ -1,0 +1,56 @@
+package dev.tramai.core.provider.transport
+
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ProviderRetryAfterTest {
+
+    private val fixedClock = Clock.fixed(Instant.parse("2026-08-21T10:00:00Z"), ZoneId.of("UTC"))
+
+    @Test
+    fun `numeric seconds become millis`() {
+        assertThat(parseRetryAfterMillis("120")).isEqualTo(120_000)
+        assertThat(parseRetryAfterMillis(" 30 ")).isEqualTo(30_000)
+        assertThat(parseRetryAfterMillis("0")).isEqualTo(0)
+    }
+
+    @Test
+    fun `rfc1123 future timestamp is deterministic against the supplied clock`() {
+        assertThat(parseRetryAfterMillis("Fri, 21 Aug 2026 10:00:10 GMT", fixedClock)).isEqualTo(10_000)
+    }
+
+    @Test
+    fun `rfc1123 timestamp at the clock instant yields zero`() {
+        assertThat(parseRetryAfterMillis("Fri, 21 Aug 2026 10:00:00 GMT", fixedClock)).isEqualTo(0)
+    }
+
+    @Test
+    fun `rfc1123 past timestamp yields zero`() {
+        assertThat(parseRetryAfterMillis("Fri, 21 Aug 2026 09:59:50 GMT", fixedClock)).isEqualTo(0)
+    }
+
+    @Test
+    fun `rfc1123 parsing is deterministic regardless of wall clock`() {
+        // Same input parsed against a different fixed instant still yields a
+        // stable, clock-derived result rather than depending on real time.
+        val laterClock = Clock.fixed(Instant.parse("2026-08-21T10:00:05Z"), ZoneId.of("UTC"))
+        assertThat(parseRetryAfterMillis("Fri, 21 Aug 2026 10:00:10 GMT", laterClock)).isEqualTo(5_000)
+    }
+
+    @Test
+    fun `malformed value yields null`() {
+        assertThat(parseRetryAfterMillis("not-a-date")).isNull()
+        assertThat(parseRetryAfterMillis("120 seconds")).isNull()
+        assertThat(parseRetryAfterMillis("")).isNull()
+        assertThat(parseRetryAfterMillis("   ")).isNull()
+        assertThat(parseRetryAfterMillis(null)).isNull()
+    }
+
+    @Test
+    fun `negative numeric value yields null`() {
+        assertThat(parseRetryAfterMillis("-5")).isNull()
+    }
+}

--- a/tramai-core/src/test/kotlin/dev/tramai/core/provider/transport/ProviderRetryAfterTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/provider/transport/ProviderRetryAfterTest.kt
@@ -53,4 +53,10 @@ class ProviderRetryAfterTest {
     fun `negative numeric value yields null`() {
         assertThat(parseRetryAfterMillis("-5")).isNull()
     }
+
+    @Test
+    fun `huge numeric value that would overflow millis yields null`() {
+        assertThat(parseRetryAfterMillis(Long.MAX_VALUE.toString())).isNull()
+        assertThat(parseRetryAfterMillis("9223372036854776")).isNull()
+    }
 }

--- a/tramai-core/src/test/kotlin/dev/tramai/core/provider/transport/ProviderSseTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/provider/transport/ProviderSseTest.kt
@@ -1,0 +1,82 @@
+package dev.tramai.core.provider.transport
+
+import java.io.BufferedReader
+import java.io.IOException
+import java.io.Reader
+import java.io.StringReader
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class ProviderSseTest {
+
+    private fun reader(vararg lines: String): BufferedReader =
+        BufferedReader(StringReader(if (lines.isEmpty()) "" else lines.joinToString("\n") + "\n"))
+
+    private open class CloseTrackingReader(reader: Reader) : BufferedReader(reader) {
+        var closed = false
+            private set
+
+        override fun close() {
+            closed = true
+            super.close()
+        }
+    }
+
+    @Test
+    fun `data frame payload is extracted`() {
+        assertThat(readSseDataPayload(reader("data: hello world"))).isEqualTo("hello world")
+    }
+
+    @Test
+    fun `unrelated sse fields do not become payload`() {
+        assertThat(
+            readSseDataPayload(reader(": comment", "id: 1", "event: ping", "", "data: real")),
+        ).isEqualTo("real")
+    }
+
+    @Test
+    fun `malformed payload is returned verbatim for provider interpretation`() {
+        assertThat(readSseDataPayload(reader("data: {not json"))).isEqualTo("{not json")
+        assertThat(readSseDataPayload(reader("data: "))).isEqualTo("")
+    }
+
+    @Test
+    fun `eof terminates cleanly with null`() {
+        assertThat(readSseDataPayload(reader())).isNull()
+        assertThat(readSseDataPayload(reader("event: ping", ": note", "id: 9"))).isNull()
+    }
+
+    @Test
+    fun `subsequent data lines are framed after the first`() {
+        val r = reader("event: message", "data: first", "data: second")
+        assertThat(readSseDataPayload(r)).isEqualTo("first")
+        assertThat(readSseDataPayload(r)).isEqualTo("second")
+        assertThat(readSseDataPayload(r)).isNull()
+    }
+
+    @Test
+    fun `sse event name is extracted only from event lines`() {
+        assertThat(sseEventName("event: content_block_delta")).isEqualTo("content_block_delta")
+        assertThat(sseEventName("data: x")).isNull()
+        assertThat(sseEventName(": comment")).isNull()
+    }
+
+    @Test
+    fun `caller use block closes the reader on completion`() {
+        val r = CloseTrackingReader(reader("data: x"))
+        r.use { readSseDataPayload(it) }
+        assertThat(r.closed).isTrue()
+    }
+
+    @Test
+    fun `exception propagates and caller use block still closes`() {
+        val r = CloseTrackingReader(object : Reader() {
+            override fun read(cbuf: CharArray, off: Int, len: Int): Int = throw IOException("boom")
+            override fun close() = Unit
+        })
+        assertThatThrownBy { r.use { readSseDataPayload(it) } }
+            .isInstanceOf(IOException::class.java)
+        assertThat(r.closed).isTrue()
+    }
+}

--- a/tramai-gemini/src/main/kotlin/dev/tramai/gemini/GeminiProvider.kt
+++ b/tramai-gemini/src/main/kotlin/dev/tramai/gemini/GeminiProvider.kt
@@ -1,3 +1,5 @@
+@file:OptIn(dev.tramai.core.provider.transport.ExperimentalProviderTransportApi::class)
+
 package dev.tramai.gemini
 
 import com.fasterxml.jackson.databind.JsonNode

--- a/tramai-gemini/src/main/kotlin/dev/tramai/gemini/GeminiProvider.kt
+++ b/tramai-gemini/src/main/kotlin/dev/tramai/gemini/GeminiProvider.kt
@@ -16,11 +16,10 @@ import dev.tramai.core.observation.ProviderFailureDiagnosticObserver
 import dev.tramai.core.provider.ModelProvider
 import dev.tramai.core.provider.ProviderCapability
 import dev.tramai.core.provider.StreamCapable
-import dev.tramai.core.provider.applyTramaiTimeout
-import dev.tramai.core.provider.logProviderHttpFailureDebug
-import dev.tramai.core.provider.providerHttpFailureObserved
 import dev.tramai.core.provider.providerTransportFailureObserved
-import dev.tramai.core.provider.readErrorBodyPreview
+import dev.tramai.core.provider.transport.providerJsonRequest
+import dev.tramai.core.provider.transport.readSseDataPayload
+import dev.tramai.core.provider.transport.rejectedProviderHttpResponse
 import dev.tramai.core.provider.safeProviderFailure
 import dev.tramai.core.coroutines.rethrowIfCancellation
 import dev.tramai.core.util.ImageDownloader
@@ -83,30 +82,22 @@ class GeminiProvider @JvmOverloads constructor(
             val modelName = request.model.takeIf { it.isNotBlank() } ?: DEFAULT_MODEL
             val url = "${baseUrl.trimEnd('/')}/$apiVersion/models/$modelName:generateContent"
             val payload = buildPayload(request)
-            val httpRequest = HttpRequest.newBuilder()
-                .uri(URI.create(url))
-                .header("Content-Type", APPLICATION_JSON)
-                .header("X-Goog-Api-Key", apiKey)
-                .applyTramaiTimeout(request)
-                .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)))
-                .build()
+            val httpRequest = providerJsonRequest(
+                URI.create(url),
+                request,
+                objectMapper.writeValueAsString(payload),
+            ).apply {
+                header("X-Goog-Api-Key", apiKey)
+            }.build()
 
             val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
             if (response.statusCode() !in 200..299) {
-                val errorBody = readErrorBodyPreview(response.body())
-                logProviderHttpFailureDebug(
-                    logger = providerLogger,
-                    providerName = PROVIDER_ID,
-                    statusCode = response.statusCode(),
-                    body = errorBody.text,
-                )
-                throw providerHttpFailureObserved(
+                throw rejectedProviderHttpResponse(
                     providerId = PROVIDER_ID,
-                    statusCode = response.statusCode(),
-                    body = errorBody.text,
-                    bodyTruncated = errorBody.truncated,
-                    retryAfterHeader = response.headers().firstValue("Retry-After").orElse(null),
+                    providerAlias = null,
+                    response = response,
                     observer = providerFailureDiagnosticObserver,
+                    logger = providerLogger,
                 )
             }
 
@@ -124,13 +115,13 @@ class GeminiProvider @JvmOverloads constructor(
                 val modelName = request.model.takeIf { it.isNotBlank() } ?: DEFAULT_MODEL
                 val url = "${baseUrl.trimEnd('/')}/$apiVersion/models/$modelName:streamGenerateContent?alt=sse"
                 val payload = buildPayload(request)
-                val httpRequest = HttpRequest.newBuilder()
-                    .uri(URI.create(url))
-                    .header("Content-Type", APPLICATION_JSON)
-                    .header("X-Goog-Api-Key", apiKey)
-                    .applyTramaiTimeout(request)
-                    .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)))
-                    .build()
+                val httpRequest = providerJsonRequest(
+                    URI.create(url),
+                    request,
+                    objectMapper.writeValueAsString(payload),
+                ).apply {
+                    header("X-Goog-Api-Key", apiKey)
+                }.build()
                 httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
             }
         } catch (error: Throwable) {
@@ -156,28 +147,13 @@ class GeminiProvider @JvmOverloads constructor(
         response: HttpResponse<InputStream>,
     ): StreamChunk.Error? {
         if (response.statusCode() in 200..299) return null
-        val errorBody = try {
-            readErrorBodyPreview(response.body())
-        } catch (error: Throwable) {
-            error.rethrowIfCancellation()
-            return StreamChunk.Error(
-                providerTransportFailureObserved(PROVIDER_ID, error, providerFailureDiagnosticObserver),
-            )
-        }
-        logProviderHttpFailureDebug(
-            logger = providerLogger,
-            providerName = PROVIDER_ID,
-            statusCode = response.statusCode(),
-            body = errorBody.text,
-        )
         return StreamChunk.Error(
-            providerHttpFailureObserved(
+            rejectedProviderHttpResponse(
                 providerId = PROVIDER_ID,
-                statusCode = response.statusCode(),
-                body = errorBody.text,
-                bodyTruncated = errorBody.truncated,
-                retryAfterHeader = response.headers().firstValue("Retry-After").orElse(null),
+                providerAlias = null,
+                response = response,
                 observer = providerFailureDiagnosticObserver,
+                logger = providerLogger,
             ),
         )
     }
@@ -196,14 +172,11 @@ class GeminiProvider @JvmOverloads constructor(
         try {
             response.body().bufferedReader(UTF_8).use { reader ->
                 while (true) {
-                    val line = reader.readLine() ?: break
+                    val data = readSseDataPayload(reader) ?: break
                     // Gemini SSE format: "data: {...}"
-                    if (line.startsWith("data: ")) {
-                        val data = line.substring(6).trim()
-                        if (data.isEmpty()) continue
-                        if (data == "[DONE]") break
-                        lastUsage = handleGeminiDataLine(data, fullText, lastUsage)
-                    }
+                    if (data.isEmpty()) continue
+                    if (data == "[DONE]") break
+                    lastUsage = handleGeminiDataLine(data, fullText, lastUsage)
                 }
             }
             emit(StreamChunk.Complete(fullText.toString(), lastUsage ?: UsageMetrics()))

--- a/tramai-gemini/src/main/kotlin/dev/tramai/gemini/GeminiProvider.kt
+++ b/tramai-gemini/src/main/kotlin/dev/tramai/gemini/GeminiProvider.kt
@@ -32,7 +32,6 @@ import kotlin.coroutines.CoroutineContext
 import java.net.URI
 import java.io.InputStream
 import java.net.http.HttpClient
-import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.util.Base64
 import java.nio.charset.StandardCharsets.UTF_8

--- a/tramai-ollama/src/main/kotlin/dev/tramai/ollama/OllamaProvider.kt
+++ b/tramai-ollama/src/main/kotlin/dev/tramai/ollama/OllamaProvider.kt
@@ -13,11 +13,9 @@ import dev.tramai.core.observation.NoOpProviderFailureDiagnosticObserver
 import dev.tramai.core.observation.ProviderFailureDiagnosticObserver
 import dev.tramai.core.provider.ModelProvider
 import dev.tramai.core.provider.ProviderCapability
-import dev.tramai.core.provider.applyTramaiTimeout
-import dev.tramai.core.provider.logProviderHttpFailureDebug
-import dev.tramai.core.provider.providerHttpFailureObserved
 import dev.tramai.core.provider.providerTransportFailureObserved
-import dev.tramai.core.provider.readErrorBodyPreview
+import dev.tramai.core.provider.transport.providerJsonRequest
+import dev.tramai.core.provider.transport.rejectedProviderHttpResponse
 import dev.tramai.core.provider.safeProviderFailure
 import dev.tramai.core.coroutines.rethrowIfCancellation
 import kotlinx.coroutines.Dispatchers
@@ -54,29 +52,20 @@ class OllamaProvider @JvmOverloads constructor(
                 "messages" to request.messages.map { message -> messageToMap(message) },
             )
 
-            val httpRequest = HttpRequest.newBuilder()
-                .uri(URI.create("${baseUrl.trimEnd('/')}/api/chat"))
-                .header("Content-Type", "application/json")
-                .applyTramaiTimeout(request)
-                .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)))
-                .build()
+            val httpRequest = providerJsonRequest(
+                URI.create("${baseUrl.trimEnd('/')}/api/chat"),
+                request,
+                objectMapper.writeValueAsString(payload),
+            ).build()
 
             val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
             if (response.statusCode() !in 200..299) {
-                val errorBody = readErrorBodyPreview(response.body())
-                logProviderHttpFailureDebug(
-                    logger = providerLogger,
-                    providerName = PROVIDER_ID,
-                    statusCode = response.statusCode(),
-                    body = errorBody.text,
-                )
-                throw providerHttpFailureObserved(
+                throw rejectedProviderHttpResponse(
                     providerId = PROVIDER_ID,
-                    statusCode = response.statusCode(),
-                    body = errorBody.text,
-                    bodyTruncated = errorBody.truncated,
-                    retryAfterHeader = response.headers().firstValue("Retry-After").orElse(null),
+                    providerAlias = null,
+                    response = response,
                     observer = providerFailureDiagnosticObserver,
+                    logger = providerLogger,
                 )
             }
 
@@ -133,12 +122,11 @@ class OllamaProvider @JvmOverloads constructor(
                     "stream" to true,
                     "messages" to request.messages.map { message -> messageToMap(message) },
                 )
-                val httpRequest = HttpRequest.newBuilder()
-                    .uri(URI.create("${baseUrl.trimEnd('/')}/api/chat"))
-                    .header("Content-Type", "application/json")
-                    .applyTramaiTimeout(request)
-                    .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)))
-                    .build()
+                val httpRequest = providerJsonRequest(
+                    URI.create("${baseUrl.trimEnd('/')}/api/chat"),
+                    request,
+                    objectMapper.writeValueAsString(payload),
+                ).build()
                 httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
             }
         } catch (error: Throwable) {
@@ -168,28 +156,13 @@ class OllamaProvider @JvmOverloads constructor(
         response: HttpResponse<InputStream>,
     ): dev.tramai.core.model.StreamChunk.Error? {
         if (response.statusCode() in 200..299) return null
-        val errorBody = try {
-            readErrorBodyPreview(response.body())
-        } catch (error: Throwable) {
-            error.rethrowIfCancellation()
-            return dev.tramai.core.model.StreamChunk.Error(
-                providerTransportFailureObserved(PROVIDER_ID, error, providerFailureDiagnosticObserver),
-            )
-        }
-        logProviderHttpFailureDebug(
-            logger = providerLogger,
-            providerName = PROVIDER_ID,
-            statusCode = response.statusCode(),
-            body = errorBody.text,
-        )
         return dev.tramai.core.model.StreamChunk.Error(
-            providerHttpFailureObserved(
+            rejectedProviderHttpResponse(
                 providerId = PROVIDER_ID,
-                statusCode = response.statusCode(),
-                body = errorBody.text,
-                bodyTruncated = errorBody.truncated,
-                retryAfterHeader = response.headers().firstValue("Retry-After").orElse(null),
+                providerAlias = null,
+                response = response,
                 observer = providerFailureDiagnosticObserver,
+                logger = providerLogger,
             ),
         )
     }

--- a/tramai-ollama/src/main/kotlin/dev/tramai/ollama/OllamaProvider.kt
+++ b/tramai-ollama/src/main/kotlin/dev/tramai/ollama/OllamaProvider.kt
@@ -27,7 +27,6 @@ import kotlin.coroutines.CoroutineContext
 import java.net.URI
 import java.io.InputStream
 import java.net.http.HttpClient
-import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.util.Base64
 import java.nio.charset.StandardCharsets.UTF_8

--- a/tramai-ollama/src/main/kotlin/dev/tramai/ollama/OllamaProvider.kt
+++ b/tramai-ollama/src/main/kotlin/dev/tramai/ollama/OllamaProvider.kt
@@ -1,3 +1,5 @@
+@file:OptIn(dev.tramai.core.provider.transport.ExperimentalProviderTransportApi::class)
+
 package dev.tramai.ollama
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/tramai-openai/src/main/kotlin/dev/tramai/openai/OpenAiProvider.kt
+++ b/tramai-openai/src/main/kotlin/dev/tramai/openai/OpenAiProvider.kt
@@ -17,12 +17,11 @@ import dev.tramai.core.provider.ModelProvider
 import dev.tramai.core.provider.ProviderCapability
 import dev.tramai.core.provider.StreamCapable
 import dev.tramai.core.coroutines.rethrowIfCancellation
-import dev.tramai.core.provider.applyTramaiTimeout
-import dev.tramai.core.provider.logProviderHttpFailureDebug
-import dev.tramai.core.provider.providerHttpFailureObserved
 import dev.tramai.core.provider.providerTransportFailureObserved
-import dev.tramai.core.provider.readErrorBodyPreview
 import dev.tramai.core.provider.safeProviderFailure
+import dev.tramai.core.provider.transport.providerJsonRequest
+import dev.tramai.core.provider.transport.readSseDataPayload
+import dev.tramai.core.provider.transport.rejectedProviderHttpResponse
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
@@ -137,35 +136,24 @@ open class OpenAiCompatibleProvider @JvmOverloads constructor(
             request.maxTokens?.let { payload["max_tokens"] = it }
             request.temperature?.let { payload["temperature"] = it }
 
-            val httpRequest = HttpRequest.newBuilder()
-                .uri(URI.create("${baseUrl.trimEnd('/')}/chat/completions"))
-                .header("Authorization", "Bearer ${accessTokenSource.accessToken()}")
-                .header("Content-Type", "application/json")
-                .apply {
-                    organization?.takeIf { it.isNotBlank() }?.let { header("OpenAI-Organization", it) }
-                    project?.takeIf { it.isNotBlank() }?.let { header("OpenAI-Project", it) }
-                }
-                .applyTramaiTimeout(request)
-                .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)))
-                .build()
+            val httpRequest = providerJsonRequest(
+                URI.create("${baseUrl.trimEnd('/')}/chat/completions"),
+                request,
+                objectMapper.writeValueAsString(payload),
+            ).apply {
+                header("Authorization", "Bearer ${accessTokenSource.accessToken()}")
+                organization?.takeIf { it.isNotBlank() }?.let { header("OpenAI-Organization", it) }
+                project?.takeIf { it.isNotBlank() }?.let { header("OpenAI-Project", it) }
+            }.build()
 
             val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
             if (response.statusCode() !in 200..299) {
-                val errorBody = readErrorBodyPreview(response.body())
-                logProviderHttpFailureDebug(
-                    logger = providerLogger,
-                    providerName = diagnosticProviderId,
-                    statusCode = response.statusCode(),
-                    body = errorBody.text,
-                )
-                throw providerHttpFailureObserved(
+                throw rejectedProviderHttpResponse(
                     providerId = diagnosticProviderId,
                     providerAlias = providerName,
-                    statusCode = response.statusCode(),
-                    body = errorBody.text,
-                    bodyTruncated = errorBody.truncated,
-                    retryAfterHeader = response.headers().firstValue("Retry-After").orElse(null),
+                    response = response,
                     observer = providerFailureDiagnosticObserver,
+                    logger = providerLogger,
                 )
             }
 
@@ -231,17 +219,15 @@ open class OpenAiCompatibleProvider @JvmOverloads constructor(
                 request.maxTokens?.let { payload["max_tokens"] = it }
                 request.temperature?.let { payload["temperature"] = it }
 
-                val httpRequest = HttpRequest.newBuilder()
-                    .uri(URI.create("${baseUrl.trimEnd('/')}/chat/completions"))
-                    .header("Authorization", "Bearer ${accessTokenSource.accessToken()}")
-                    .header("Content-Type", "application/json")
-                    .apply {
-                        organization?.takeIf { it.isNotBlank() }?.let { header("OpenAI-Organization", it) }
-                        project?.takeIf { it.isNotBlank() }?.let { header("OpenAI-Project", it) }
-                    }
-                    .applyTramaiTimeout(request)
-                    .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)))
-                    .build()
+                val httpRequest = providerJsonRequest(
+                    URI.create("${baseUrl.trimEnd('/')}/chat/completions"),
+                    request,
+                    objectMapper.writeValueAsString(payload),
+                ).apply {
+                    header("Authorization", "Bearer ${accessTokenSource.accessToken()}")
+                    organization?.takeIf { it.isNotBlank() }?.let { header("OpenAI-Organization", it) }
+                    project?.takeIf { it.isNotBlank() }?.let { header("OpenAI-Project", it) }
+                }.build()
 
                 httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
             }
@@ -268,10 +254,7 @@ open class OpenAiCompatibleProvider @JvmOverloads constructor(
                 var lastUsage: UsageMetrics? = null
 
                 while (true) {
-                    val line = reader.readLine() ?: break
-                    if (!line.startsWith("data: ")) continue
-
-                    val data = line.substring(6).trim()
+                    val data = readSseDataPayload(reader) ?: break
                     val result = parseSseData(data)
                     if (result.isDone) break
                     if (result.tokenText.isNotEmpty()) {
@@ -312,38 +295,14 @@ open class OpenAiCompatibleProvider @JvmOverloads constructor(
     ): Boolean {
         if (response.statusCode() in 200..299) return false
 
-        val errorBody = try {
-            readErrorBodyPreview(response.body())
-        } catch (error: Throwable) {
-            error.rethrowIfCancellation()
-            emit(
-                StreamChunk.Error(
-                    providerTransportFailureObserved(
-                        diagnosticProviderId,
-                        providerName,
-                        error,
-                        providerFailureDiagnosticObserver,
-                    ),
-                ),
-            )
-            return true
-        }
-        logProviderHttpFailureDebug(
-            logger = providerLogger,
-            providerName = diagnosticProviderId,
-            statusCode = response.statusCode(),
-            body = errorBody.text,
-        )
         emit(
             StreamChunk.Error(
-                providerHttpFailureObserved(
+                rejectedProviderHttpResponse(
                     providerId = diagnosticProviderId,
                     providerAlias = providerName,
-                    statusCode = response.statusCode(),
-                    body = errorBody.text,
-                    bodyTruncated = errorBody.truncated,
-                    retryAfterHeader = response.headers().firstValue("Retry-After").orElse(null),
+                    response = response,
                     observer = providerFailureDiagnosticObserver,
+                    logger = providerLogger,
                 ),
             ),
         )

--- a/tramai-openai/src/main/kotlin/dev/tramai/openai/OpenAiProvider.kt
+++ b/tramai-openai/src/main/kotlin/dev/tramai/openai/OpenAiProvider.kt
@@ -1,3 +1,5 @@
+@file:OptIn(dev.tramai.core.provider.transport.ExperimentalProviderTransportApi::class)
+
 package dev.tramai.openai
 
 import com.fasterxml.jackson.databind.JsonNode

--- a/tramai-openai/src/main/kotlin/dev/tramai/openai/OpenAiProvider.kt
+++ b/tramai-openai/src/main/kotlin/dev/tramai/openai/OpenAiProvider.kt
@@ -30,7 +30,6 @@ import kotlin.coroutines.CoroutineContext
 import java.net.URI
 import java.io.InputStream
 import java.net.http.HttpClient
-import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.nio.file.Files
 import java.nio.file.Path


### PR DESCRIPTION
# refactor(provider): centralize safe transport utilities (Epic 6.2)

## What

Shared low-level HTTP/stream transport invariants in a new `dev.tramai.core.provider.transport` package (tramai-core), migrated across the HTTP adapters. Transport mechanics that are genuinely identical between providers are centralized; endpoint construction, authentication, JSON wire formats, tool semantics, usage extraction, and stream interpretation remain inside each adapter.

## New shared utilities

| Utility | Replaces |
|---|---|
| `parseRetryAfterMillis(value, clock = systemUTC)` | hidden `System.currentTimeMillis()` wall-clock dependency in RFC-1123 `Retry-After` parsing — now deterministic under a fixed clock |
| `rejectedProviderHttpResponse(providerId, alias, response, observer, logger)` | the duplicated rejected-response lifecycle in every adapter: bounded 8 KiB body read, deterministic closure, debug-metadata logging, fail-open diagnostic observer delivery, `Retry-After` propagation. Caller decides throw vs `StreamChunk.Error` |
| `providerJsonRequest(uri, request, body)` | URI + JSON `Content-Type` + normalized timeout + POST framing; auth/protocol headers stay adapter-owned so the wire contract remains visible in provider source |
| `readSseDataPayload` / `sseDataPayload` / `sseEventName` | SSE framing only (prefix strip, field skip, EOF); `[DONE]`, deltas, Anthropic event semantics, Gemini candidates stay in adapters |

Builds on #222's existing `ProviderFailures.kt` primitives (bounded reader, safe factories, timeout) rather than replacing them.

## Migration order (regression-attributable)

1. **OpenAI-compatible** — widest leverage; **DeepSeek benefits** via delegation with no separate change
2. **Azure OpenAI** (api-key vs Bearer conditional stays adapter-owned)
3. **Anthropic** (event-name tracking via `sseEventName` + `sseDataPayload` in one loop; `x-api-key`/`anthropic-version` stay)
4. **Gemini** (`X-Goog-Api-Key` stays; candidates interpretation untouched)
5. **Ollama** (NDJSON interpretation untouched; request/rejected handling only)
6. **Bedrock** — intentionally NOT migrated; keeps its AWS SDK transport

Each migration was committed separately and its provider suite + TCK runner verified green before the next.

## Deliberately NOT extracted (Epic 6.2 guardrail)

- **No universal provider transport abstraction** — OpenAI and Anthropic can disagree about semantics without either being wrong; those stay provider-owned.
- **No Jackson-typed successful-body helper** — `tramai-core` has no Jackson dependency; the stream-closure invariant is already stdlib `use{}`.
- **No usage-metrics adapters** — not mechanically equivalent across providers.

## Tests

- New: `ProviderRetryAfterTest` (numeric / RFC-1123 fixed-clock / past→0 / malformed / negative), `ProviderHttpResponseTest` (Retry-After propagation, bounded body at/above 8 KiB, body closes on failure, body-read failure → transport failure, observer fail-open incl. CancellationException swallow while active, status passthrough), `ProviderSseTest` (data extraction, unrelated fields skipped, verbatim malformed payload, EOF null, event names, caller-owned closure incl. exception path).
- **All eight #257 TCK runners remain green** — the TCK is the regression oracle and was not weakened.

## Verification

- Full 16-module gate + 5 apiChecks + `verifyCancellationSafety` + `verifyWorkflowApiStabilityBoundary` + `verifyChangePolicy` (`-PchangeClass=runtime-behaviour`) + `verifyMaintainabilityBaseline`: **GREEN** (JDK 21)
- `verifyPr`: **GREEN**
- Provider suites under JDK 25 (CI parity): **GREEN**
- API surface: 6 additive functions in the `tramai-core` dump; **zero existing signatures changed**
- No baseline/deviation/analyzer changes; no new dependencies

## Docs

- `docs/ROADMAP-0.6.0.md` → Epic 6.2 ✅
- `CHANGELOG.md` → Unreleased/Added entry
