### PR TITLE
test(core): prevent vacuously skipped Kotlin tests (JUnit discovery integrity)

### DIFF
--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/JUnitTestSignatureVerifier.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/JUnitTestSignatureVerifier.kt
@@ -1,0 +1,128 @@
+package dev.tramai.build.quality
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Source-level verifier for JUnit test-signature integrity.
+ *
+ * JUnit Jupiter silently discards `@Test` methods whose JVM return type is
+ * not `void`. In Kotlin, an expression-bodied test whose final expression is
+ * a chainable (non-void) AssertJ assertion — e.g.
+ *
+ * ```
+ * @Test fun foo() = runBlocking { assertThat(x).isTrue() }
+ * ```
+ *
+ * compiles to a non-void method, the test is never discovered, and the suite
+ * stays green. The only source-visible guarantee of a void return is an
+ * explicit Unit binding:
+ *
+ * - a block body (`fun foo() { ... }`), or
+ * - an explicit `: Unit` return type, or
+ * - an explicit `<Unit>` type argument on the expression head
+ *   (`= runBlocking<Unit> { ... }`).
+ *
+ * This verifier rejects every other expression-bodied `@Test` function.
+ * It is intentionally conservative: a compliant form that a future Kotlin
+ * version infers as non-void must be made explicit, which is exactly the
+ * invariant we want to preserve.
+ */
+object JUnitTestSignatureVerifier {
+
+    private val FUN_SIGNATURE =
+        Regex("""^\s*(?:public|private|internal)?\s*(?:suspend\s+)?fun\s+(`[^`]+`|[A-Za-z0-9_]+)\s*\([^)]*\)\s*=\s*(\S.*)$""")
+    private val EXPLICIT_UNIT_SIGNATURE =
+        Regex("""^\s*(?:public|private|internal)?\s*(?:suspend\s+)?fun\s+(`[^`]+`|[A-Za-z0-9_]+)\s*\([^)]*\)\s*:\s*Unit\s*=.*$""")
+    // Explicit `<Unit>` type argument on the expression head, e.g. `runBlocking<Unit> {`
+    private val EXPLICIT_UNIT_HEAD =
+        Regex("""^[\w.`]+\s*<Unit>\s*(?=[({.\s]).*$""")
+    // `runTest { ... }` always returns Unit (block parameter is `suspend TestScope.() -> Unit`),
+    // so the expression head is provably Unit-safe without a type argument.
+    private val KNOWN_UNIT_HEAD = Regex("""^runTest\s*[({].*$""")
+    private val BARE_UNIT = Regex("""^Unit\s*$""")
+
+    data class Violation(val file: Path, val line: Int, val functionName: String, val expressionHead: String)
+
+    /**
+     * Scans every `src/test` and `src/testFixtures` Kotlin source under [root]
+     * and returns the violations found. Does not throw.
+     */
+    fun scan(root: Path): List<Violation> {
+        val violations = mutableListOf<Violation>()
+        if (!Files.isDirectory(root)) return violations
+        Files.walk(root).use { paths ->
+            paths.filter { Files.isRegularFile(it) && it.fileName.toString().endsWith(".kt") }
+                .filter { p ->
+                    val path = p.toString()
+                    (path.contains("/src/test/") || path.contains("/src/testFixtures/")) &&
+                        !path.contains("/build/")
+                }
+                .forEach { file -> violations += scanFile(file) }
+        }
+        return violations
+    }
+
+    private fun scanFile(file: Path): List<Violation> {
+        val lines = try {
+            Files.readAllLines(file)
+        } catch (_: Exception) {
+            return emptyList()
+        }
+        val violations = mutableListOf<Violation>()
+        var pendingTest = false
+        for ((index, raw) in lines.withIndex()) {
+            val line = raw.trim()
+            if (line.isEmpty() || line.startsWith("//") || line.startsWith("*") || line.startsWith("/*")) {
+                continue
+            }
+            if (line.startsWith("@")) {
+                if (line.matches(Regex("""^@Test\b.*$"""))) {
+                    // Same-line form: `@Test fun `name`() = <expr>` — the fun
+                    // signature shares the @Test line. Evaluate it directly.
+                    val inline = line.substringAfter("@Test").trim()
+                    if (inline.startsWith("fun ")) {
+                        if (!EXPLICIT_UNIT_SIGNATURE.matches(inline)) {
+                            val match = FUN_SIGNATURE.matchEntire(inline)
+                            if (match != null) {
+                                val head = match.groupValues[2]
+                                if (!EXPLICIT_UNIT_HEAD.matches(head) && !KNOWN_UNIT_HEAD.matches(head) && !BARE_UNIT.matches(head)) {
+                                    violations += Violation(file, index + 1, match.groupValues[1], head)
+                                }
+                            }
+                        }
+                    } else {
+                        pendingTest = true
+                    }
+                }
+                continue
+            }
+            if (line.startsWith("fun ") && pendingTest) {
+                pendingTest = false
+                if (EXPLICIT_UNIT_SIGNATURE.matches(line)) {
+                    continue
+                }
+                val match = FUN_SIGNATURE.matchEntire(line)
+                if (match != null) {
+                    val head = match.groupValues[2]
+                    if (!EXPLICIT_UNIT_HEAD.matches(head) && !KNOWN_UNIT_HEAD.matches(head) && !BARE_UNIT.matches(head)) {
+                        violations += Violation(file, index + 1, match.groupValues[1], head)
+                    }
+                }
+                continue
+            }
+            pendingTest = false
+        }
+        return violations
+    }
+
+    /** Renders a human-readable failure report. */
+    fun render(violations: List<Violation>): String =
+        violations.joinToString("\n") { v ->
+            "${v.file}:${v.line} — @Test fun ${v.functionName} uses an expression body " +
+                "with non-Unit inferred return type (head: ${v.expressionHead}). " +
+                "@Test methods must return void: use a block body or an explicit Unit binding " +
+                "(e.g. `fun x() { runBlocking { ... } }` or `= runBlocking<Unit> { ... }`)."
+        }
+}

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/JUnitTestSignatureVerifier.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/JUnitTestSignatureVerifier.kt
@@ -30,17 +30,13 @@ import java.nio.file.Path
  * invariant we want to preserve.
  *
  * Accepted scope (known fail-open false negatives, none present in tree
- * today, deliberately not handled): multi-line function signatures
- * (`fun foo(\n...) = expr`), annotation parameters on the same line as
- * `@Test` (`@Test(timeout = ...)`), and other JUnit discovery annotations
- * (`@ParameterizedTest`, `@RepeatedTest`, `@TestFactory`).
+ * today, deliberately not handled): other JUnit discovery annotations
+ * (`@ParameterizedTest`, `@RepeatedTest`, `@TestFactory`) and exotic
+ * constructs such as an anonymous `fun` inside an annotation argument
+ * between `@Test` and the declaration.
  */
 object JUnitTestSignatureVerifier {
 
-    private val FUN_SIGNATURE =
-        Regex("""^\s*(?:public|private|internal)?\s*(?:suspend\s+)?fun\s+(`[^`]+`|[A-Za-z0-9_]+)\s*\([^)]*\)\s*=\s*(\S.*)$""")
-    private val EXPLICIT_UNIT_SIGNATURE =
-        Regex("""^\s*(?:public|private|internal)?\s*(?:suspend\s+)?fun\s+(`[^`]+`|[A-Za-z0-9_]+)\s*\([^)]*\)\s*:\s*Unit\s*=.*$""")
     // Explicit `<Unit>` type argument on the expression head, e.g. `runBlocking<Unit> {`
     private val EXPLICIT_UNIT_HEAD =
         Regex("""^[\w.`]+\s*<Unit>\s*(?=[({.\s]).*$""")
@@ -49,8 +45,16 @@ object JUnitTestSignatureVerifier {
     // the discovery sense, so whitelisted without a type argument.
     private val KNOWN_UNIT_HEAD = Regex("""^runTest\s*[({].*$""")
     private val BARE_UNIT = Regex("""^Unit\s*$""")
+    private val NAME = Regex("""\s*(?:public|private|internal)?\s*(?:suspend\s+)?fun\s+(`[^`]+`|[A-Za-z0-9_]+)""")
 
     data class Violation(val file: Path, val line: Int, val functionName: String, val expressionHead: String)
+
+    /** Result of evaluating an accumulated `@Test` declaration. */
+    private sealed interface Decision {
+        data object Continue : Decision
+        data object Safe : Decision
+        data class Reject(val functionName: String, val expressionHead: String) : Decision
+    }
 
     /**
      * Scans every `src/test` and `src/testFixtures` Kotlin source under [root]
@@ -62,7 +66,8 @@ object JUnitTestSignatureVerifier {
         Files.walk(root).use { paths ->
             paths.filter { Files.isRegularFile(it) && it.fileName.toString().endsWith(".kt") }
                 .filter { p ->
-                    val path = p.toString()
+                    // Normalize separators so matching works on any platform.
+                    val path = p.toString().replace(File.separatorChar, '/')
                     // Source trees only. Gradle output lives under <module>/build/,
                     // never under src/test or src/testFixtures, so no extra /build/
                     // exclusion is needed — and one would wrongly skip the
@@ -74,6 +79,62 @@ object JUnitTestSignatureVerifier {
         return violations
     }
 
+    /**
+     * Accumulates lines from `@Test` through the function declaration and
+     * decides only once the body form (`{` vs `=`) is established, so
+     * multi-line signatures and multi-line annotations cannot bypass the
+     * check. Returns [Decision.Continue] until the declaration resolves.
+     */
+    private fun decide(decl: String): Decision {
+        val funIdx = decl.indexOf("fun ")
+        if (funIdx < 0) return Decision.Continue
+        val openParen = decl.indexOf('(', funIdx)
+        if (openParen < 0) return Decision.Continue
+        var depth = 0
+        var i = openParen
+        while (i < decl.length) {
+            when (decl[i]) {
+                '(' -> depth++
+                ')' -> {
+                    depth--
+                    if (depth == 0) {
+                        var j = i + 1
+                        while (j < decl.length && decl[j].isWhitespace()) j++
+                        if (j >= decl.length) return Decision.Continue
+                        val name = NAME.find(decl, funIdx)?.groupValues?.get(1) ?: decl.substring(funIdx)
+                        return when {
+                            decl[j] == '{' -> Decision.Safe
+                            decl[j] == '=' -> headDecision(decl.substring(j + 1), name)
+                            decl[j] == ':' -> {
+                                // Explicit return type: `: Unit` is safe, anything
+                                // else with `=` needs the head to be Unit-safe.
+                                val eqOrBrace = decl.indexOfAny(charArrayOf('=', '{'), j + 1)
+                                when {
+                                    eqOrBrace < 0 -> Decision.Continue
+                                    decl[eqOrBrace] == '{' -> Decision.Safe
+                                    decl.substring(j + 1, eqOrBrace).trim() == "Unit" -> Decision.Safe
+                                    else -> headDecision(decl.substring(eqOrBrace + 1), name)
+                                }
+                            }
+                            else -> Decision.Continue
+                        }
+                    }
+                }
+            }
+            i++
+        }
+        return Decision.Continue
+    }
+
+    private fun headDecision(headRaw: String, name: String): Decision {
+        val head = headRaw.trim()
+        return if (EXPLICIT_UNIT_HEAD.matches(head) || KNOWN_UNIT_HEAD.matches(head) || BARE_UNIT.matches(head)) {
+            Decision.Safe
+        } else {
+            Decision.Reject(name, head)
+        }
+    }
+
     private fun scanFile(file: Path): List<Violation> {
         val lines = try {
             Files.readAllLines(file)
@@ -81,7 +142,7 @@ object JUnitTestSignatureVerifier {
             return emptyList()
         }
         val violations = mutableListOf<Violation>()
-        var pendingTest = false
+        var pending: StringBuilder? = null
         var inRawString = false
         for ((index, raw) in lines.withIndex()) {
             val line = raw.trim()
@@ -97,49 +158,44 @@ object JUnitTestSignatureVerifier {
                 inRawString = true
                 continue
             }
+            // Comments and blank lines do not clear a pending declaration
+            // (annotations may legally be separated from their function).
             if (line.isEmpty() || line.startsWith("//") || line.startsWith("*") || line.startsWith("/*")) {
                 continue
             }
             if (line.startsWith("@")) {
                 if (line.matches(Regex("""^@Test\b.*$"""))) {
-                    // Same-line form: `@Test fun `name`() = <expr>` — the fun
-                    // signature shares the @Test line. Evaluate it directly.
-                    val inline = line.substringAfter("@Test").trim()
-                    if (inline.startsWith("fun ")) {
-                        if (!EXPLICIT_UNIT_SIGNATURE.matches(inline)) {
-                            val match = FUN_SIGNATURE.matchEntire(inline)
-                            if (match != null) {
-                                val head = match.groupValues[2]
-                                if (!EXPLICIT_UNIT_HEAD.matches(head) && !KNOWN_UNIT_HEAD.matches(head) && !BARE_UNIT.matches(head)) {
-                                    violations += Violation(file, index + 1, match.groupValues[1], head)
-                                }
-                            }
-                        }
-                    } else {
-                        pendingTest = true
-                    }
+                    pending = StringBuilder(line.substringAfter("@Test"))
+                    pending = resolve(pending, file, index, violations)
+                } else if (pending != null) {
+                    pending.append(' ').append(line)
+                    pending = resolve(pending, file, index, violations)
                 }
                 continue
             }
-            if (line.startsWith("fun ") && pendingTest) {
-                pendingTest = false
-                if (EXPLICIT_UNIT_SIGNATURE.matches(line)) {
-                    continue
-                }
-                val match = FUN_SIGNATURE.matchEntire(line)
-                if (match != null) {
-                    val head = match.groupValues[2]
-                    if (!EXPLICIT_UNIT_HEAD.matches(head) && !KNOWN_UNIT_HEAD.matches(head) && !BARE_UNIT.matches(head)) {
-                        violations += Violation(file, index + 1, match.groupValues[1], head)
-                    }
-                }
+            if (pending != null) {
+                pending.append('\n').append(line)
+                pending = resolve(pending, file, index, violations)
                 continue
             }
-            pendingTest = false
         }
         return violations
     }
 
+    /**
+     * Evaluates an accumulated declaration; returns the continuation state
+     * (null once the declaration resolved to Safe or Reject).
+     */
+    private fun resolve(pending: StringBuilder, file: Path, line: Int, violations: MutableList<Violation>): StringBuilder? {
+        return when (val decision = decide(pending.toString())) {
+            is Decision.Reject -> {
+                violations += Violation(file, line + 1, decision.functionName, decision.expressionHead)
+                null
+            }
+            Decision.Safe -> null
+            Decision.Continue -> pending
+        }
+    }
     private fun String.countOccurrencesOf(sub: String): Int {
         var count = 0
         var idx = indexOf(sub)

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/JUnitTestSignatureVerifier.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/JUnitTestSignatureVerifier.kt
@@ -28,6 +28,12 @@ import java.nio.file.Path
  * It is intentionally conservative: a compliant form that a future Kotlin
  * version infers as non-void must be made explicit, which is exactly the
  * invariant we want to preserve.
+ *
+ * Accepted scope (known fail-open false negatives, none present in tree
+ * today, deliberately not handled): multi-line function signatures
+ * (`fun foo(\n...) = expr`), annotation parameters on the same line as
+ * `@Test` (`@Test(timeout = ...)`), and other JUnit discovery annotations
+ * (`@ParameterizedTest`, `@RepeatedTest`, `@TestFactory`).
  */
 object JUnitTestSignatureVerifier {
 
@@ -38,8 +44,9 @@ object JUnitTestSignatureVerifier {
     // Explicit `<Unit>` type argument on the expression head, e.g. `runBlocking<Unit> {`
     private val EXPLICIT_UNIT_HEAD =
         Regex("""^[\w.`]+\s*<Unit>\s*(?=[({.\s]).*$""")
-    // `runTest { ... }` always returns Unit (block parameter is `suspend TestScope.() -> Unit`),
-    // so the expression head is provably Unit-safe without a type argument.
+    // `runTest { ... }` returns TestResult, which JUnit Jupiter special-cases as
+    // a valid test-method return type (discovered, not skipped) — Unit-safe in
+    // the discovery sense, so whitelisted without a type argument.
     private val KNOWN_UNIT_HEAD = Regex("""^runTest\s*[({].*$""")
     private val BARE_UNIT = Regex("""^Unit\s*$""")
 
@@ -56,8 +63,11 @@ object JUnitTestSignatureVerifier {
             paths.filter { Files.isRegularFile(it) && it.fileName.toString().endsWith(".kt") }
                 .filter { p ->
                     val path = p.toString()
-                    (path.contains("/src/test/") || path.contains("/src/testFixtures/")) &&
-                        !path.contains("/build/")
+                    // Source trees only. Gradle output lives under <module>/build/,
+                    // never under src/test or src/testFixtures, so no extra /build/
+                    // exclusion is needed — and one would wrongly skip the
+                    // `dev/tramai/build/*` source package (the guard's own home).
+                    (path.contains("/src/test/") || path.contains("/src/testFixtures/"))
                 }
                 .forEach { file -> violations += scanFile(file) }
         }
@@ -72,8 +82,21 @@ object JUnitTestSignatureVerifier {
         }
         val violations = mutableListOf<Violation>()
         var pendingTest = false
+        var inRawString = false
         for ((index, raw) in lines.withIndex()) {
             val line = raw.trim()
+            if (inRawString) {
+                if (line.countOccurrencesOf("\"\"\"") % 2 == 1) {
+                    inRawString = false
+                }
+                continue
+            }
+            // Lines inside `"""..."""` raw strings (test fixtures contain
+            // verbatim `@Test fun ... = ...` samples) are not real code.
+            if (line.countOccurrencesOf("\"\"\"") % 2 == 1) {
+                inRawString = true
+                continue
+            }
             if (line.isEmpty() || line.startsWith("//") || line.startsWith("*") || line.startsWith("/*")) {
                 continue
             }
@@ -115,6 +138,16 @@ object JUnitTestSignatureVerifier {
             pendingTest = false
         }
         return violations
+    }
+
+    private fun String.countOccurrencesOf(sub: String): Int {
+        var count = 0
+        var idx = indexOf(sub)
+        while (idx >= 0) {
+            count++
+            idx = indexOf(sub, idx + sub.length)
+        }
+        return count
     }
 
     /** Renders a human-readable failure report. */

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
@@ -834,6 +834,30 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             }
         }
 
+        // ---- JUnit test-signature integrity (silently-skipped tests guard) ----
+        // JUnit Jupiter discards @Test methods whose JVM return type is not void.
+        // Kotlin expression-bodied tests ending in a chainable assertion compile
+        // to non-void methods and are silently never discovered. This task scans
+        // every test source and fails on non-Unit expression-bodied @Test fns.
+        project.tasks.register("verifyJUnitTestSignatures") {
+            group = "verification"
+            description = "Fails if any @Test function uses an expression body whose inferred " +
+                "return type is not provably Unit (JUnit silently skips non-void @Test methods)."
+            doLast {
+                val violations = JUnitTestSignatureVerifier.scan(project.rootDir.toPath())
+                if (violations.isNotEmpty()) {
+                    throw GradleException(
+                        "verifyJUnitTestSignatures: ${violations.size} @Test function(s) with " +
+                            "non-Unit expression bodies would be silently skipped by JUnit.\n" +
+                            JUnitTestSignatureVerifier.render(violations),
+                    )
+                }
+            }
+        }
+        verifyPr.configure {
+            dependsOn("verifyJUnitTestSignatures")
+        }
+
         // Wire subproject test tasks lazily — use withPlugin so they register
         // after subproject build scripts evaluate, not as an eager snapshot.
         project.subprojects.forEach { subproject ->

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/JUnitTestSignatureVerifierTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/JUnitTestSignatureVerifierTest.kt
@@ -1,0 +1,181 @@
+package dev.tramai.build.quality
+
+import java.nio.file.Files
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class JUnitTestSignatureVerifierTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private fun writeTest(fileName: String, content: String): Path {
+        val dir = Files.createDirectories(tempDir.resolve("src/test/kotlin/demo"))
+        val file = dir.resolve(fileName)
+        Files.writeString(file, content)
+        return file
+    }
+
+    private fun violationsFor(content: String): List<JUnitTestSignatureVerifier.Violation> {
+        writeTest("SampleTest.kt", content)
+        return JUnitTestSignatureVerifier.scan(tempDir)
+    }
+
+    @Test
+    fun `rejects expression body ending in a chainable assertion`() {
+        val violations = violationsFor(
+            """
+            import kotlinx.coroutines.runBlocking
+            import org.assertj.core.api.Assertions.assertThat
+
+            class SampleTest {
+                @Test
+                fun `reject me`() = runBlocking {
+                    assertThat(true).isTrue()
+                }
+            }
+            """.trimIndent(),
+        )
+        assertTrue(violations.size == 1, "expected 1 violation, got ${violations.size}")
+        assertEquals("`reject me`", violations.single().functionName)
+    }
+
+    @Test
+    fun `rejects bare assertion expression body`() {
+        val violations = violationsFor(
+            """
+            import org.assertj.core.api.Assertions.assertThat
+
+            class SampleTest {
+                @Test
+                fun `reject me`() = assertThat(1).isEqualTo(1)
+            }
+            """.trimIndent(),
+        )
+        assertTrue(violations.size == 1, "expected 1 violation, got ${violations.size}")
+    }
+
+    @Test
+    fun `rejects assertThatThrownBy expression body`() {
+        val violations = violationsFor(
+            """
+            import org.assertj.core.api.Assertions.assertThatThrownBy
+
+            class SampleTest {
+                @Test
+                fun `reject me`() = assertThatThrownBy {
+                    throw IllegalStateException("boom")
+                }.isInstanceOf(IllegalStateException::class.java)
+            }
+            """.trimIndent(),
+        )
+        assertTrue(violations.size == 1, "expected 1 violation, got ${violations.size}")
+    }
+
+    @Test
+    fun `accepts block-bodied coroutine test`() {
+        val violations = violationsFor(
+            """
+            import kotlinx.coroutines.runBlocking
+            import org.assertj.core.api.Assertions.assertThat
+
+            class SampleTest {
+                @Test
+                fun `accept me`() {
+                    runBlocking {
+                        assertThat(true).isTrue()
+                    }
+                }
+            }
+            """.trimIndent(),
+        )
+        assertTrue(violations.isEmpty(), "expected no violations, got ${violations.map { it.functionName }}")
+    }
+
+    @Test
+    fun `accepts runBlocking with explicit Unit type argument`() {
+        val violations = violationsFor(
+            """
+            import kotlinx.coroutines.runBlocking
+            import org.assertj.core.api.Assertions.assertThat
+
+            class SampleTest {
+                @Test
+                fun `accept me`() = runBlocking<Unit> {
+                    assertThat(true).isTrue()
+                }
+            }
+            """.trimIndent(),
+        )
+        assertTrue(violations.isEmpty(), "expected no violations, got ${violations.map { it.functionName }}")
+    }
+
+    @Test
+    fun `accepts explicit Unit return type`() {
+        val violations = violationsFor(
+            """
+            class SampleTest {
+                @Test
+                fun `accept me`(): Unit = runBlocking {
+                    assertThat(true).isTrue()
+                }
+            }
+            """.trimIndent(),
+        )
+        assertTrue(violations.isEmpty(), "expected no violations, got ${violations.map { it.functionName }}")
+    }
+
+    @Test
+    fun `rejects same-line expression body`() {
+        val violations = violationsFor(
+            """
+            import org.assertj.core.api.Assertions.assertThatThrownBy
+
+            class SampleTest {
+                @Test fun `reject me`() = assertThatThrownBy {
+                    throw IllegalStateException("boom")
+                }.isInstanceOf(IllegalStateException::class.java)
+            }
+            """.trimIndent(),
+        )
+        assertTrue(violations.size == 1, "expected 1 violation, got ${violations.size}")
+        assertEquals("`reject me`", violations.single().functionName)
+    }
+
+    @Test
+    fun `accepts same-line runTest expression body`() {
+        val violations = violationsFor(
+            """
+            import kotlinx.coroutines.test.runTest
+            import org.assertj.core.api.Assertions.assertThat
+
+            class SampleTest {
+                @Test fun `accept me`() = runTest {
+                    assertThat(true).isTrue()
+                }
+            }
+            """.trimIndent(),
+        )
+        assertTrue(violations.isEmpty(), "expected no violations, got ${violations.map { it.functionName }}")
+    }
+
+    @Test
+    fun `ignores non-test expression-bodied functions`() {
+        val violations = violationsFor(
+            """
+            class SampleTest {
+                private fun helper() = assertThat(1).isEqualTo(1)
+
+                @Test
+                fun `accept me`() {
+                    helper()
+                }
+            }
+            """.trimIndent(),
+        )
+        assertTrue(violations.isEmpty(), "expected no violations, got ${violations.map { it.functionName }}")
+    }
+}

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/JUnitTestSignatureVerifierTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/JUnitTestSignatureVerifierTest.kt
@@ -185,6 +185,68 @@ class JUnitTestSignatureVerifierTest {
     }
 
     @Test
+    fun `rejects multiline parameter signature`() {
+        val violations = violationsFor(
+            """
+            import kotlinx.coroutines.runBlocking
+            import org.assertj.core.api.Assertions.assertThat
+
+            class SampleTest {
+                @Test
+                fun `reject me`(
+                    someParameter: String,
+                ) = runBlocking {
+                    assertThat(someParameter).isEqualTo("x")
+                }
+            }
+            """.trimIndent(),
+        )
+        assertTrue(violations.size == 1, "expected 1 violation, got ${violations.size}")
+        assertEquals("`reject me`", violations.single().functionName)
+    }
+
+    @Test
+    fun `rejects multiline annotation between Test and fun`() {
+        val violations = violationsFor(
+            """
+            import org.assertj.core.api.Assertions.assertThat
+
+            class SampleTest {
+                @Test
+                @SomeAnnotation(
+                    value = "x",
+                )
+                fun `reject me`() = assertThat(true).isTrue()
+            }
+            """.trimIndent(),
+        )
+        assertTrue(violations.size == 1, "expected 1 violation, got ${violations.size}")
+        assertEquals("`reject me`", violations.single().functionName)
+    }
+
+    @Test
+    fun `accepts multiline parameter signature with block body`() {
+        val violations = violationsFor(
+            """
+            import kotlinx.coroutines.runBlocking
+            import org.assertj.core.api.Assertions.assertThat
+
+            class SampleTest {
+                @Test
+                fun `accept me`(
+                    someParameter: String,
+                ) {
+                    runBlocking {
+                        assertThat(someParameter).isEqualTo("x")
+                    }
+                }
+            }
+            """.trimIndent(),
+        )
+        assertTrue(violations.isEmpty(), "expected no violations, got ${violations.map { it.functionName }}")
+    }
+
+    @Test
     fun `ignores non-test expression-bodied functions`() {
         val violations = violationsFor(
             """

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/JUnitTestSignatureVerifierTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/JUnitTestSignatureVerifierTest.kt
@@ -163,6 +163,28 @@ class JUnitTestSignatureVerifierTest {
     }
 
     @Test
+    fun `ignores expression bodies inside raw string fixtures`() {
+        val content = """
+            import org.assertj.core.api.Assertions.assertThat
+
+            class SampleTest {
+                val fixture = ${"\"\"\""}
+                    @Test fun `not real code`() = assertThatThrownBy {
+                        throw IllegalStateException("boom")
+                    }
+                ${"\"\"\""}
+
+                @Test
+                fun `real test`() {
+                    assertThat(true).isTrue()
+                }
+            }
+            """.trimIndent()
+        val violations = violationsFor(content)
+        assertTrue(violations.isEmpty(), "expected no violations, got ${violations.map { it.functionName }}")
+    }
+
+    @Test
     fun `ignores non-test expression-bodied functions`() {
         val violations = violationsFor(
             """

--- a/examples/governed-workflow/src/test/kotlin/dev/tramai/examples/governed/GovernedWorkflowFailureDiagnosticsTest.kt
+++ b/examples/governed-workflow/src/test/kotlin/dev/tramai/examples/governed/GovernedWorkflowFailureDiagnosticsTest.kt
@@ -96,7 +96,7 @@ class GovernedWorkflowFailureDiagnosticsTest {
     // ── Success path (clean diagnostic trail) ─────────────────────
 
     @Test
-    fun `approved high-risk claim has clean diagnostic trail`() = runBlocking {
+    fun `approved high-risk claim has clean diagnostic trail`() { runBlocking {
         val observer = RecordingWorkflowObserver()
 
         val result = workflow.run(
@@ -116,6 +116,7 @@ class GovernedWorkflowFailureDiagnosticsTest {
             .containsExactly("classify", "policy-check", "approval-required", "finalize")
 
         assertThat(observer.failedSteps).isEmpty()
+    }
     }
 
     // ── Local observer ───────────────────────────────────────────

--- a/examples/governed-workflow/src/test/kotlin/dev/tramai/examples/governed/GovernedWorkflowTest.kt
+++ b/examples/governed-workflow/src/test/kotlin/dev/tramai/examples/governed/GovernedWorkflowTest.kt
@@ -34,9 +34,10 @@ class GovernedWorkflowTest {
     private val workflow = buildClaimTriageWorkflow(DeterministicClaimClassifier())
 
     @Test
-    fun `low-risk claim passes governed workflow`() = runBlocking {
+    fun `low-risk claim passes governed workflow`() { runBlocking {
         val result = workflow.run(initialState = ClaimTriageState(claim = lowRiskClaim))
         assertThat(result.status).isEqualTo("ready-for-review")
+    }
     }
 
     @Test
@@ -64,11 +65,12 @@ class GovernedWorkflowTest {
     }
 
     @Test
-    fun `high-risk claim with approval passes`() = runBlocking {
+    fun `high-risk claim with approval passes`() { runBlocking {
         val result = workflow.run(
             initialState = ClaimTriageState(claim = highRiskClaim, approved = true),
         )
         assertThat(result.status).isEqualTo("ready-for-review")
+    }
     }
 
     @Test

--- a/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/SovereignLabLocalModelInvocationTest.kt
+++ b/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/SovereignLabLocalModelInvocationTest.kt
@@ -68,7 +68,7 @@ class SovereignLabLocalModelInvocationTest {
     private lateinit var env: Environment
 
     @Test
-    fun `invokes local OpenAI-compatible model through sovereign lab provider`() = runBlocking {
+    fun `invokes local OpenAI-compatible model through sovereign lab provider`() { runBlocking {
         val provider = context.getBean(OpenAiCompatibleProvider::class.java)
 
         val model = requireNotNull(
@@ -101,5 +101,6 @@ class SovereignLabLocalModelInvocationTest {
         assertThat(response.modelUsed)
             .describedAs("Response must indicate which model was used")
             .isNotNull
+    }
     }
 }

--- a/examples/tool-governance/src/test/kotlin/dev/tramai/examples/toolgovernance/ToolGovernanceExampleTest.kt
+++ b/examples/tool-governance/src/test/kotlin/dev/tramai/examples/toolgovernance/ToolGovernanceExampleTest.kt
@@ -138,7 +138,7 @@ class ToolGovernanceExampleTest {
     // ── Test 1: ALLOW scenario (customer_lookup) ─────────────────────────
 
     @Test
-    fun `customer lookup tool is allowed at all enforcement points`() = runTest {
+    fun `customer lookup tool is allowed at all enforcement points`() { runTest {
         val (engine, store, tool, streamId) = allowFixture()
         val service = engine.create<SingleToolService>()
         val lookupTool = tool as CustomerLookupTool
@@ -171,11 +171,12 @@ class ToolGovernanceExampleTest {
         assertTrue(allowRecords.isNotEmpty(), "Must have tool.permission records for customer_lookup")
         assertEquals("tool.permission", allowRecords.first().eventType)
     }
+    }
 
     // ── Test 2: DENY scenario (account_delete) ───────────────────────────
 
     @Test
-    fun `account delete tool is denied at execution`() = runTest {
+    fun `account delete tool is denied at execution`() { runTest {
         val (engine, store, tool, streamId) = denyFixture()
         val service = engine.create<DeleteToolService>()
         val deleteTool = tool as AccountDeleteTool
@@ -213,11 +214,12 @@ class ToolGovernanceExampleTest {
         assertEquals("tool.permission", denyRecords.first().eventType)
         assertEquals("BEFORE_TOOL_EXECUTION", denyRecords.first().metadata["enforcementPoint"])
     }
+    }
 
     // ── Test 3: REQUIRE_APPROVAL scenario (payment) ──────────────────────
 
     @Test
-    fun `payment tool requires approval at execution`() = runTest {
+    fun `payment tool requires approval at execution`() { runTest {
         val (engine, store, tool, streamId) = requireApprovalFixture()
         val service = engine.create<PaymentToolService>()
         val paymentTool = tool as PaymentTool
@@ -256,11 +258,12 @@ class ToolGovernanceExampleTest {
         assertEquals("tool.permission", requireApprovalRecords.first().eventType)
         assertEquals("BEFORE_TOOL_EXECUTION", requireApprovalRecords.first().metadata["enforcementPoint"])
     }
+    }
 
     // ── Test 4: Tool events excluded from policy.decision evidence ───────
 
     @Test
-    fun `tool enforcement events are excluded from policy decision evidence`() = runTest {
+    fun `tool enforcement events are excluded from policy decision evidence`() { runTest {
         val (engine, store, tool, streamId) = allowFixture()
         val service = engine.create<SingleToolService>()
 
@@ -290,11 +293,12 @@ class ToolGovernanceExampleTest {
             "Every tool audit event must appear in tool.permission evidence"
         )
     }
+    }
 
     // ── Test 5: Evidence isolation across three tools ────────────────────
 
     @Test
-    fun `three tools produce distinct audit streams with correct evidence`() = runTest {
+    fun `three tools produce distinct audit streams with correct evidence`() { runTest {
         // Run all three scenarios
         val (engine1, store1, _, streamId1) = allowFixture()
         val service1 = engine1.create<SingleToolService>()
@@ -326,11 +330,12 @@ class ToolGovernanceExampleTest {
         val toolRecords3 = toolExporter.export(events3)
         assertTrue(toolRecords3.any { it.decision.kind == "REQUIRE_APPROVAL" && it.metadata["toolName"] == "payment" })
     }
+    }
 
     // ── Test 6: Provider not called again after denial ───────────────────
 
     @Test
-    fun `provider is not called again after execution denial`() = runTest {
+    fun `provider is not called again after execution denial`() { runTest {
         val store = InMemoryAuditStore()
         val auditEngine = AuditEngine(store, clock = fixedClock)
         val tool = AccountDeleteTool()
@@ -357,6 +362,7 @@ class ToolGovernanceExampleTest {
             // expected
         }
         assertEquals(1, provider.callCount.get(), "Provider must be called exactly once")
+    }
     }
 
     // ── Test 7: Customer lookup tool security metadata is correct ────────
@@ -398,7 +404,7 @@ class ToolGovernanceExampleTest {
     // ── Test 11: Sensitive arguments never appear in serialized evidence ──
 
     @Test
-    fun `sensitive tool arguments never appear in serialized evidence`() = runTest {
+    fun `sensitive tool arguments never appear in serialized evidence`() { runTest {
         // Configure a fixture with deliberately sensitive arguments
         val store = InMemoryAuditStore()
         val auditEngine = AuditEngine(store, clock = fixedClock)
@@ -449,5 +455,6 @@ class ToolGovernanceExampleTest {
         assertFalse(jsonlLines.contains("secret-value"), "Evidence must not contain raw API key")
         assertFalse(jsonlLines.contains("5000"), "Evidence must not contain raw amount")
         assertFalse(jsonlLines.contains("\"account\""), "Evidence must not contain the substring 'account' in raw form")
+    }
     }
 }

--- a/tramai-core/src/test/kotlin/dev/tramai/core/approval/gateway/ApprovalGatewayContractTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/approval/gateway/ApprovalGatewayContractTest.kt
@@ -164,7 +164,7 @@ class ApprovalGatewayContractTest {
     }
 
     @Test
-    fun `gateway request approval returns Suspended result without blocking`() = runTest {
+    fun `gateway request approval returns Suspended result without blocking`() { runTest {
         val gateway = RecordingApprovalGateway()
 
         val result = gateway.requestApproval(
@@ -180,9 +180,10 @@ class ApprovalGatewayContractTest {
         assertThat(result).isInstanceOf(ApprovalRequestResult.Suspended::class.java)
         assertThat(gateway.calls).isOne()
     }
+    }
 
     @Test
-    fun `gateway request approval defaults workflowRunId to null`() = runTest {
+    fun `gateway request approval defaults workflowRunId to null`() { runTest {
         val gateway = RecordingApprovalGateway()
 
         val result = gateway.requestApproval(
@@ -198,6 +199,7 @@ class ApprovalGatewayContractTest {
         val suspended = result as ApprovalRequestResult.Suspended
         assertThat(suspended.workflowRunId).isEqualTo(WorkflowRunId("workflow-1"))
         assertThat(gateway.calls).isOne()
+    }
     }
 
     // ── SovereignWorkflowResult ──

--- a/tramai-core/src/test/kotlin/dev/tramai/core/provider/ProviderFailuresTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/provider/ProviderFailuresTest.kt
@@ -82,7 +82,7 @@ class ProviderFailuresTest {
     }
 
     @Test
-    fun `observed http failure delivers bounded preview and alias`() = runBlocking {
+    fun `observed http failure delivers bounded preview and alias`() { runBlocking {
         val events = mutableListOf<ProviderFailureDiagnosticEvent>()
         val oversized = "x".repeat(PROVIDER_ERROR_BODY_LIMIT_BYTES + 100)
 
@@ -102,9 +102,10 @@ class ProviderFailuresTest {
         assertThat(event.httpBodyPreviewTruncated).isTrue()
         assertThat(event.failure).isNull()
     }
+    }
 
     @Test
-    fun `provider http failure delivers a bounded body preview to the diagnostic observer`() = runBlocking {
+    fun `provider http failure delivers a bounded body preview to the diagnostic observer`() { runBlocking {
         val events = mutableListOf<ProviderFailureDiagnosticEvent>()
 
         providerHttpFailureObserved(
@@ -118,9 +119,10 @@ class ProviderFailuresTest {
             .hasSizeLessThanOrEqualTo(PROVIDER_ERROR_BODY_LIMIT_BYTES)
         assertThat(events.single().httpBodyPreviewTruncated).isTrue()
     }
+    }
 
     @Test
-    fun `observed http failure preserves caller truncation flag`() = runBlocking {
+    fun `observed http failure preserves caller truncation flag`() { runBlocking {
         val events = mutableListOf<ProviderFailureDiagnosticEvent>()
 
         providerHttpFailureObserved(
@@ -132,6 +134,7 @@ class ProviderFailuresTest {
         )
 
         assertThat(events.single().httpBodyPreviewTruncated).isTrue()
+    }
     }
 
     @Test
@@ -222,7 +225,7 @@ class ProviderFailuresTest {
     }
 
     @Test
-    fun `unchecked io failure is classified as retryable transport failure and observed`() = runBlocking {
+    fun `unchecked io failure is classified as retryable transport failure and observed`() { runBlocking {
         val original = UncheckedIOException(IOException("socket closed"))
         val events = mutableListOf<ProviderFailureDiagnosticEvent>()
 
@@ -237,6 +240,7 @@ class ProviderFailuresTest {
         assertThat(error.message).isEqualTo("Provider transport failed")
         assertThat(error.cause).isNull()
         assertThat(events.single().failure).isSameAs(original)
+    }
     }
 
     @Test
@@ -255,7 +259,7 @@ class ProviderFailuresTest {
     }
 
     @Test
-    fun `untrusted provider exception is sanitized and delivered only to observer`() = runBlocking {
+    fun `untrusted provider exception is sanitized and delivered only to observer`() { runBlocking {
         val originalCause = IllegalStateException("cause $secretFixture")
         val original = ProviderException(
             message = "message $secretFixture",
@@ -281,9 +285,10 @@ class ProviderFailuresTest {
         assertThat(result.failureCode).isEqualTo(ProviderFailureCode.HTTP_REJECTED)
         assertThat(events.single().failure).isSameAs(original)
     }
+    }
 
     @Test
-    fun `safe provider failure passes through transport boundary unchanged`() = runBlocking {
+    fun `safe provider failure passes through transport boundary unchanged`() { runBlocking {
         val trusted = safeProviderFailure("trusted caller text", ProviderFailureCode.UNEXPECTED_FAILURE)
         val events = mutableListOf<ProviderFailureDiagnosticEvent>()
 
@@ -296,9 +301,10 @@ class ProviderFailuresTest {
         assertThat(result).isSameAs(trusted)
         assertThat(events).isEmpty()
     }
+    }
 
     @Test
-    fun `original transport throwable reaches only the observer`() = runBlocking {
+    fun `original transport throwable reaches only the observer`() { runBlocking {
         val original = IOException("raw $secretFixture")
         val events = mutableListOf<ProviderFailureDiagnosticEvent>()
 
@@ -312,9 +318,10 @@ class ProviderFailuresTest {
         assertThat(events.single().failure).isSameAs(original)
         assertThat(events.single().code).isEqualTo(ProviderFailureCode.TRANSPORT_FAILED)
     }
+    }
 
     @Test
-    fun `cancellation input is rethrown without diagnostics`() = runBlocking {
+    fun `cancellation input is rethrown without diagnostics`() { runBlocking {
         val events = mutableListOf<ProviderFailureDiagnosticEvent>()
         val cancellation = CancellationException("parent cancelled")
 
@@ -329,9 +336,10 @@ class ProviderFailuresTest {
         assertThat(thrown).isSameAs(cancellation)
         assertThat(events).isEmpty()
     }
+    }
 
     @Test
-    fun `observer cancellation while job is active leaves provider failure primary`() = runBlocking {
+    fun `observer cancellation while job is active leaves provider failure primary`() { runBlocking {
         val result = async {
             providerTransportFailureObserved(
                 "openai",
@@ -343,9 +351,10 @@ class ProviderFailuresTest {
         assertThat(result.message).isEqualTo("Provider transport failed")
         assertThat(result.cause).isNull()
     }
+    }
 
     @Test
-    fun `parent cancellation during observer delivery remains primary`() = runBlocking {
+    fun `parent cancellation during observer delivery remains primary`() { runBlocking {
         val task = async {
             val job = coroutineContext.job
             providerTransportFailureObserved(
@@ -360,9 +369,10 @@ class ProviderFailuresTest {
 
         assertFailsWith<CancellationException> { task.await() }
     }
+    }
 
     @Test
-    fun `ordinary observer failure is fail open`() = runBlocking {
+    fun `ordinary observer failure is fail open`() { runBlocking {
         val result = providerTransportFailureObserved(
             "openai",
             IOException("boom"),
@@ -370,6 +380,7 @@ class ProviderFailuresTest {
         )
 
         assertThat(result.message).isEqualTo("Provider transport failed")
+    }
     }
 
     private class CountingInputStream(bytes: ByteArray) : InputStream() {

--- a/tramai-core/src/test/kotlin/dev/tramai/core/provider/ProviderRegistryCompatibilityTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/provider/ProviderRegistryCompatibilityTest.kt
@@ -52,9 +52,10 @@ class ProviderRegistryCompatibilityTest {
     }
 
     @Test
-    fun `duplicate provider now fails at build`() = assertThatThrownBy {
+    fun `duplicate provider now fails at build`() { assertThatThrownBy {
         ProviderRegistry.builder().provider("one", NamedProvider("one")).provider("one", NamedProvider("replacement")).build()
     }.isInstanceOf(ConfigurationException::class.java)
+    }
 
     private class NamedProvider(private val name: String) : ModelProvider {
         override suspend fun complete(request: ModelRequest): ModelResponse = error("unused")

--- a/tramai-core/src/test/kotlin/dev/tramai/core/provider/ProviderRoutingPlanTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/provider/ProviderRoutingPlanTest.kt
@@ -27,9 +27,9 @@ class ProviderRoutingPlanTest {
         )
     }
 
-    @Test fun `duplicate provider is rejected at build`() = assertThatThrownBy {
+    @Test fun `duplicate provider is rejected at build`() { assertThatThrownBy {
         ProviderRoutingPlan.builder().provider("one", NamedProvider("one")).provider("one", NamedProvider("two")).build()
-    }.isInstanceOf(ConfigurationException::class.java)
+    }.isInstanceOf(ConfigurationException::class.java) }
 
     @Test fun `blank provider and model ids are rejected`() {
         assertThatThrownBy { ProviderRoutingPlan.builder().provider(" ", NamedProvider("one")).build() }
@@ -38,22 +38,22 @@ class ProviderRoutingPlanTest {
             .isInstanceOf(ConfigurationException::class.java)
     }
 
-    @Test fun `unknown primary provider is rejected at build`() = assertThatThrownBy {
+    @Test fun `unknown primary provider is rejected at build`() { assertThatThrownBy {
         ProviderRoutingPlan.builder().model("model", "missing").build()
-    }.isInstanceOf(ConfigurationException::class.java)
+    }.isInstanceOf(ConfigurationException::class.java) }
 
-    @Test fun `unknown fallback provider is rejected at build`() = assertThatThrownBy {
+    @Test fun `unknown fallback provider is rejected at build`() { assertThatThrownBy {
         ProviderRoutingPlan.builder().provider("one", NamedProvider("one")).model("model", "one").fallbackProvider("model", "missing").build()
-    }.isInstanceOf(ConfigurationException::class.java)
+    }.isInstanceOf(ConfigurationException::class.java) }
 
-    @Test fun `unknown default provider is rejected at build`() = assertThatThrownBy {
+    @Test fun `unknown default provider is rejected at build`() { assertThatThrownBy {
         ProviderRoutingPlan.builder().defaultProvider("missing").build()
-    }.isInstanceOf(ConfigurationException::class.java)
+    }.isInstanceOf(ConfigurationException::class.java) }
 
-    @Test fun `duplicate identical fallback route is rejected`() = assertThatThrownBy {
+    @Test fun `duplicate identical fallback route is rejected`() { assertThatThrownBy {
         ProviderRoutingPlan.builder().provider("one", NamedProvider("one")).model("model", "one")
             .fallbackModel("model", "fallback", "one").fallbackModel("model", "fallback", "one").build()
-    }.isInstanceOf(ConfigurationException::class.java)
+    }.isInstanceOf(ConfigurationException::class.java) }
 
     @Test
     fun `plan snapshot is unaffected by later builder mutation`() {
@@ -100,25 +100,28 @@ class ProviderRoutingPlanTest {
     }
 
     @Test
-    fun `fallback routes without a primary are rejected at build`() = assertThatThrownBy {
+    fun `fallback routes without a primary are rejected at build`() { assertThatThrownBy {
         ProviderRoutingPlan.builder().provider("one", NamedProvider("one"))
             .fallbackModel("model", "alternate", "one").build()
     }.isInstanceOf(ConfigurationException::class.java)
         .hasMessageContaining("no primary route")
+    }
 
     @Test
-    fun `duplicate primary route is rejected`() = assertThatThrownBy {
+    fun `duplicate primary route is rejected`() { assertThatThrownBy {
         ProviderRoutingPlan.builder().provider("one", NamedProvider("one")).provider("two", NamedProvider("two"))
             .model("model", "one").model("model", "two").build()
     }.isInstanceOf(ConfigurationException::class.java)
         .hasMessageContaining("Duplicate primary route")
+    }
 
     @Test
-    fun `fallback identical to primary is rejected`() = assertThatThrownBy {
+    fun `fallback identical to primary is rejected`() { assertThatThrownBy {
         ProviderRoutingPlan.builder().provider("one", NamedProvider("one"))
             .model("model", "one").fallbackProvider("model", "one").build()
     }.isInstanceOf(ConfigurationException::class.java)
         .hasMessageContaining("duplicates its primary route")
+    }
 
     @Test
     fun `model ids with surrounding whitespace are rejected`() {

--- a/tramai-core/src/test/kotlin/dev/tramai/core/workflow/ApprovalGatewayGoldenPathErgonomicsTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/workflow/ApprovalGatewayGoldenPathErgonomicsTest.kt
@@ -85,7 +85,7 @@ class ApprovalGatewayGoldenPathErgonomicsTest {
     // ── 1. Suspended → SuspendedForApproval ──
 
     @Test
-    fun `high risk workflow suspends through approval gateway without store wiring`() = runTest {
+    fun `high risk workflow suspends through approval gateway without store wiring`() { runTest {
         val gateway = RecordingApprovalGateway(
             ApprovalRequestResult.Suspended(
                 approvalId = ApprovalId("approval-1"),
@@ -113,11 +113,12 @@ class ApprovalGatewayGoldenPathErgonomicsTest {
         assertThat(suspended.auditStreamId).isEqualTo(AuditStreamId("audit-1"))
         assertThat(suspended.resumeToken).isEqualTo(ResumeToken("token-1"))
     }
+    }
 
     // ── 2. AlreadyApproved → Completed ──
 
     @Test
-    fun `already approved result maps to Completed workflow result`() = runTest {
+    fun `already approved result maps to Completed workflow result`() { runTest {
         val gateway = RecordingApprovalGateway(
             ApprovalRequestResult.AlreadyApproved(
                 decision = HumanApprovalDecision.Approved(
@@ -135,11 +136,12 @@ class ApprovalGatewayGoldenPathErgonomicsTest {
         val completed = result as SovereignWorkflowResult.Completed
         assertThat(completed.value).isEqualTo("approved-continue")
     }
+    }
 
     // ── 3. AlreadyDenied → Rejected ──
 
     @Test
-    fun `already denied result maps to Rejected workflow result`() = runTest {
+    fun `already denied result maps to Rejected workflow result`() { runTest {
         val gateway = RecordingApprovalGateway(
             ApprovalRequestResult.AlreadyDenied(
                 decision = HumanApprovalDecision.Denied(
@@ -158,11 +160,12 @@ class ApprovalGatewayGoldenPathErgonomicsTest {
         val rejected = result as SovereignWorkflowResult.Rejected
         assertThat(rejected.reason).isEqualTo("requires-legal-review")
     }
+    }
 
     // ── 4. Expired → Expired ──
 
     @Test
-    fun `expired approval result maps to Expired workflow result`() = runTest {
+    fun `expired approval result maps to Expired workflow result`() { runTest {
         val gateway = RecordingApprovalGateway(
             ApprovalRequestResult.Expired(
                 approvalId = ApprovalId("approval-1"),
@@ -177,5 +180,6 @@ class ApprovalGatewayGoldenPathErgonomicsTest {
         assertThat(result).isInstanceOf(SovereignWorkflowResult.Expired::class.java)
         val expired = result as SovereignWorkflowResult.Expired
         assertThat(expired.reason).isEqualTo("approval-expired")
+    }
     }
 }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/InvocationRegistryLockTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/InvocationRegistryLockTest.kt
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger
 class InvocationRegistryLockTest {
     @Test
     @Timeout(value = 30, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
-    fun `completion removal participates in the registry lock`() = runBlocking {
+    fun `completion removal participates in the registry lock`() { runBlocking {
         val gate = CompletableDeferred<Unit>()
         val providerCalls = AtomicInteger()
         val provider = object : ModelProvider {
@@ -78,6 +78,7 @@ class InvocationRegistryLockTest {
         assertThat(providerCalls.get()).isEqualTo(1)
         assertThat(invocation.await().exceptionOrNull()).isNull()
         engine.close()
+    }
     }
 
     private fun awaitUntil(timeout: Long, unit: TimeUnit, condition: () -> Boolean) {

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/LifecycleDispatcherContractTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/LifecycleDispatcherContractTest.kt
@@ -58,7 +58,7 @@ class LifecycleDispatcherContractTest {
 
     @Test
     @Timeout(value = 30, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
-    fun `pre-start cancellation never invokes provider and cancels the caller once`() = runBlocking {
+    fun `pre-start cancellation never invokes provider and cancels the caller once`() { runBlocking {
         val dispatcher = ControlledDispatcher()
         val providerCalls = AtomicInteger()
         val engine = TramaiEngine(ImmediateProvider(providerCalls), dispatcher)
@@ -80,6 +80,7 @@ class LifecycleDispatcherContractTest {
         assertThat(outcome.await().exceptionOrNull()).isInstanceOf(CancellationException::class.java)
         assertThat(providerCalls.get()).isZero()
         assertThat(activeInvocationCount(engine)).isZero()
+    }
     }
 
     private fun awaitUntil(timeout: Long, unit: TimeUnit, condition: () -> Boolean) {

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/PolicyAuditWiringTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/PolicyAuditWiringTest.kt
@@ -42,7 +42,7 @@ class PolicyAuditWiringTest {
     }
 
     @Test
-    fun `ALLOW with configured emitter emits exactly one event before enforcement`() = runBlocking {
+    fun `ALLOW with configured emitter emits exactly one event before enforcement`() { runBlocking {
         val callCount = AtomicInteger(0)
         val emitter = object : PolicyDecisionAuditEmitter {
             override suspend fun emit(
@@ -65,9 +65,10 @@ class PolicyAuditWiringTest {
 
         Assertions.assertEquals(1, callCount.get(), "Emitter should have been called exactly once")
     }
+    }
 
     @Test
-    fun `DENY with configured emitter emits exactly one event before exception`() = runBlocking {
+    fun `DENY with configured emitter emits exactly one event before exception`() { runBlocking {
         val callCount = AtomicInteger(0)
         val emitter = object : PolicyDecisionAuditEmitter {
             override suspend fun emit(
@@ -96,9 +97,10 @@ class PolicyAuditWiringTest {
 
         Assertions.assertEquals(1, callCount.get(), "Emitter should have been called exactly once before exception")
     }
+    }
 
     @Test
-    fun `NoOp emitter preserves existing behavior`() = runBlocking {
+    fun `NoOp emitter preserves existing behavior`() { runBlocking {
         val helper = PolicyEnforcementHelper(
             policyEngine = policyEngine,
             migrationWarningGuard = AtomicBoolean(true),
@@ -109,9 +111,10 @@ class PolicyAuditWiringTest {
         helper.enforce(context)
         Assertions.assertTrue(true)
     }
+    }
 
     @Test
-    fun `NoOp emitter preserves DENY behavior`() = runBlocking {
+    fun `NoOp emitter preserves DENY behavior`() { runBlocking {
         val helper = PolicyEnforcementHelper(
             policyEngine = denyPolicyEngine,
             migrationWarningGuard = AtomicBoolean(true),
@@ -127,9 +130,10 @@ class PolicyAuditWiringTest {
             Assertions.assertEquals("test-blocked", e.decision.reasonCode)
         }
     }
+    }
 
     @Test
-    fun `audit failure propagation`() = runBlocking {
+    fun `audit failure propagation`() { runBlocking {
         val throwingStore = object : dev.tramai.security.audit.AuditStore {
             override suspend fun appendNext(
                 auditStreamId: String,
@@ -159,6 +163,7 @@ class PolicyAuditWiringTest {
         } catch (e: RuntimeException) {
             Assertions.assertEquals("Audit store unavailable", e.message)
         }
+    }
     }
 
     @Test

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/PolicyEnforcementTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/PolicyEnforcementTest.kt
@@ -4,11 +4,21 @@ import dev.tramai.core.annotations.AiService
 import dev.tramai.core.annotations.ConversationId
 import dev.tramai.core.annotations.Operation
 import dev.tramai.core.annotations.User as UserMessage
-import dev.tramai.core.exception.ApprovalRequiredException
+import dev.tramai.core.approval.ApprovalAuthorization
+import dev.tramai.core.approval.ApprovalChallenge
+import dev.tramai.core.approval.ApprovalGateCoordinator
+import dev.tramai.core.approval.ApprovalToken
+import dev.tramai.core.approval.AuthorizeResumeCommand
+import dev.tramai.core.approval.CreateApprovalCommand
+import dev.tramai.core.approval.ValidateResumeCommand
+import dev.tramai.core.approval.ApprovalValidation
+import dev.tramai.core.exception.ApprovalSuspendedException
 import dev.tramai.core.exception.ModelNotRegisteredException
 import dev.tramai.core.exception.ModelRegistryUnavailableException
 import dev.tramai.core.exception.PolicyViolationException
 import dev.tramai.core.exception.ProviderException
+import dev.tramai.security.approval.InMemoryApprovalContinuationStore
+import dev.tramai.security.approval.Sha256ToolArgumentsDigester
 import dev.tramai.core.memory.ChatMemory
 import dev.tramai.core.model.ClassifiedDocument
 import dev.tramai.core.model.ContentPart
@@ -157,6 +167,26 @@ class PolicyEnforcementTest {
             callCount.incrementAndGet()
             return ToolResult.Success("payment result")
         }
+    }
+
+    /** Fake ApprovalGateCoordinator that creates challenges with generated IDs. */
+    private class FakeApprovalGateCoordinator : ApprovalGateCoordinator {
+        override suspend fun createApproval(command: CreateApprovalCommand): ApprovalChallenge {
+            val approvalId = java.util.UUID.randomUUID().toString()
+            return ApprovalChallenge(
+                approvalId = approvalId,
+                token = ApprovalToken.parsePresented("token-$approvalId"),
+                expiresAt = command.expiresAt,
+            )
+        }
+
+        override suspend fun authorizeResume(command: AuthorizeResumeCommand): ApprovalAuthorization =
+            error("not expected in suspension test")
+
+        override suspend fun validateResume(command: ValidateResumeCommand): ApprovalValidation =
+            error("not expected in suspension test")
+
+        override suspend fun cancelApproval(approvalId: String, expectedVersion: Long, reason: String) = Unit
     }
 
     // -- Test service interfaces ------------------------------------------------
@@ -313,7 +343,7 @@ class PolicyEnforcementTest {
     // -- Core enforcement tests ------------------------------------------------
 
     @Test
-    fun `provider invocation allowed`() = runBlocking {
+    fun `provider invocation allowed`() { runBlocking {
         val provider = CountingProvider()
         val allowEngine = engine(
             policyEngine = object : PolicyEngine {
@@ -327,11 +357,13 @@ class PolicyEnforcementTest {
         assertThat(result).isEqualTo("ok")
         assertThat(provider.callCount.get()).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `registry enabled fails closed when model is not registered`() = runBlocking {
+    fun `registry enabled fails closed when model is not registered`() { runBlocking {
         val engine = TramaiEngine(
             provider = CountingProvider(),
+            toolRegistry = ToolRegistry(mapOf("echo" to echoTool)),
             modelRegistry = object : ModelRegistry {
                 override suspend fun findApprovedModel(providerId: String, modelName: String) = null
             },
@@ -345,9 +377,10 @@ class PolicyEnforcementTest {
         assertThatThrownBy { runBlocking { service.analyze("test") } }
             .isInstanceOf(ModelNotRegisteredException::class.java)
     }
+    }
 
     @Test
-    fun `cache provenance mismatch is treated as cache miss and invalidates stale entry`() = runBlocking {
+    fun `cache provenance mismatch is treated as cache miss and invalidates stale entry`() { runBlocking {
         val provider = CountingProvider(content = "fresh")
         var cached: CachedOperationResult? = CachedOperationResult(
             value = "stale",
@@ -395,9 +428,10 @@ class PolicyEnforcementTest {
         assertThat(invalidated).isTrue()
         assertThat(provider.callCount.get()).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `provider invocation denied at correct hook`() = runBlocking {
+    fun `provider invocation denied at correct hook`() { runBlocking {
         val provider = CountingProvider()
         val denyEngine = engine(
             policyEngine = object : PolicyEngine {
@@ -415,9 +449,10 @@ class PolicyEnforcementTest {
             .hasMessageContaining("blocked")
         assertThat(provider.callCount.get()).isEqualTo(0)
     }
+    }
 
     @Test
-    fun `provider context has providerId and modelName`() = runBlocking {
+    fun `provider context has providerId and modelName`() { runBlocking {
         var capturedProviderId: String? = null
         var capturedModelName: String? = null
         val engine = engine(
@@ -436,11 +471,12 @@ class PolicyEnforcementTest {
         assertThat(capturedProviderId).isNotNull()
         assertThat(capturedModelName).isEqualTo("test-model")
     }
+    }
 
     // -- Fallback tests --------------------------------------------------------
 
     @Test
-    fun `fallback denied propagates PolicyViolationException`() = runBlocking {
+    fun `fallback denied propagates PolicyViolationException`() { runBlocking {
         val failOnceProvider = object : ModelProvider {
             var calls = 0
             override fun providerId() = "fail-provider"
@@ -477,9 +513,10 @@ class PolicyEnforcementTest {
         // Fallback provider should never have been called
         assertThat(fallbackProvider.callCount.get()).isEqualTo(0)
     }
+    }
 
     @Test
-    fun `fallback allowed`() = runBlocking {
+    fun `fallback allowed`() { runBlocking {
         val failOnceProvider = object : ModelProvider {
             var calls = 0
             override fun providerId() = "fail-provider"
@@ -508,9 +545,10 @@ class PolicyEnforcementTest {
         assertThat(result).isEqualTo("fallback-ok")
         assertThat(fallbackProvider.callCount.get()).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `RESTRICTED request to trusted local provider is allowed`() = runBlocking {
+    fun `RESTRICTED request to trusted local provider is allowed`() { runBlocking {
         val provider = CountingProvider(id = "local-provider")
         val engine = TramaiEngine(
             provider = provider,
@@ -535,9 +573,10 @@ class PolicyEnforcementTest {
         assertThat(result).isEqualTo("ok")
         assertThat(provider.callCount.get()).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `RESTRICTED request to approved untrusted cloud provider is denied before invocation`() = runBlocking {
+    fun `RESTRICTED request to approved untrusted cloud provider is denied before invocation`() { runBlocking {
         val provider = CountingProvider(id = "cloud-provider")
         val engine = TramaiEngine(
             provider = provider,
@@ -564,9 +603,10 @@ class PolicyEnforcementTest {
             .hasMessageContaining("RESTRICTED data may not be sent to provider 'cloud-provider'")
         assertThat(provider.callCount.get()).isEqualTo(0)
     }
+    }
 
     @Test
-    fun `RESTRICTED request does not silently fall back from local provider to cloud`() = runBlocking {
+    fun `RESTRICTED request does not silently fall back from local provider to cloud`() { runBlocking {
         val localProvider = object : ModelProvider {
             val callCount = AtomicInteger(0)
             override fun providerId() = "local-provider"
@@ -609,9 +649,10 @@ class PolicyEnforcementTest {
         assertThat(localProvider.callCount.get()).isEqualTo(1)
         assertThat(cloudProvider.callCount.get()).isEqualTo(0)
     }
+    }
 
     @Test
-    fun `INTERNAL request to cloud provider without permission is denied`() = runBlocking {
+    fun `INTERNAL request to cloud provider without permission is denied`() { runBlocking {
         val provider = CountingProvider(id = "cloud-provider")
         val engine = TramaiEngine(
             provider = provider,
@@ -638,9 +679,10 @@ class PolicyEnforcementTest {
             .hasMessageContaining("Data classification 'INTERNAL' is not allowed for provider 'cloud-provider'")
         assertThat(provider.callCount.get()).isEqualTo(0)
     }
+    }
 
     @Test
-    fun `INTERNAL request to cloud provider with permission is allowed`() = runBlocking {
+    fun `INTERNAL request to cloud provider with permission is allowed`() { runBlocking {
         val provider = CountingProvider(id = "cloud-provider")
         val engine = TramaiEngine(
             provider = provider,
@@ -665,9 +707,10 @@ class PolicyEnforcementTest {
         assertThat(result).isEqualTo("ok")
         assertThat(provider.callCount.get()).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `PUBLIC request to approved cloud provider is allowed`() = runBlocking {
+    fun `PUBLIC request to approved cloud provider is allowed`() { runBlocking {
         val provider = CountingProvider(id = "cloud-provider")
         val engine = TramaiEngine(
             provider = provider,
@@ -691,11 +734,12 @@ class PolicyEnforcementTest {
         assertThat(result).isEqualTo("ok")
         assertThat(provider.callCount.get()).isEqualTo(1)
     }
+    }
 
     // -- Tool tests ------------------------------------------------------------
 
     @Test
-    fun `tool exposure denied per tool at correct hook`() = runBlocking {
+    fun `tool exposure denied per tool at correct hook`() { runBlocking {
         val provider = providerWithToolCallThenReturn("echo")
         val deniedTool = AtomicInteger()
         val denyTools = TramaiEngine(
@@ -716,9 +760,10 @@ class PolicyEnforcementTest {
             .hasMessageContaining("tools blocked")
         assertThat(deniedTool.get()).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `tool execution denied at correct hook`() = runBlocking {
+    fun `tool execution denied at correct hook`() { runBlocking {
         val countingTool = countingEchoTool
         val denyExec = TramaiEngine(
             provider = providerWithToolCallThenReturn("echo"),
@@ -737,9 +782,10 @@ class PolicyEnforcementTest {
             .hasMessageContaining("tool denied")
         assertThat(countingTool.callCount.get()).isEqualTo(0)
     }
+    }
 
     @Test
-    fun `tool result reinjection denied at correct hook`() = runBlocking {
+    fun `tool result reinjection denied at correct hook`() { runBlocking {
         val denyReinject = TramaiEngine(
             provider = providerWithToolCallThenReturn("echo"),
             toolRegistry = ToolRegistry(mapOf("echo" to echoTool)),
@@ -756,11 +802,12 @@ class PolicyEnforcementTest {
             .isInstanceOf(PolicyViolationException::class.java)
             .hasMessageContaining("result blocked")
     }
+    }
 
     // -- Response return tests -------------------------------------------------
 
     @Test
-    fun `response return denied`() = runBlocking {
+    fun `response return denied`() { runBlocking {
         val denyResp = engine(
             policyEngine = object : PolicyEngine {
                 override suspend fun evaluate(context: PolicyContext): PolicyDecision =
@@ -775,31 +822,37 @@ class PolicyEnforcementTest {
             .isInstanceOf(PolicyViolationException::class.java)
             .hasMessageContaining("response blocked")
     }
+    }
 
     // -- Approval tests --------------------------------------------------------
 
     @Test
-    fun `require approval stops execution`() = runBlocking {
-        val approvalEngine = engine(
+    fun `require approval stops execution`() { runBlocking {
+        val approvalEngine = TramaiEngine(
+            provider = providerWithToolCallThenReturn("echo"),
+            toolRegistry = ToolRegistry(mapOf("echo" to echoTool)),
+            toolArgumentsDigester = Sha256ToolArgumentsDigester(),
+            approvalGateCoordinator = FakeApprovalGateCoordinator(),
+            approvalContinuationStore = InMemoryApprovalContinuationStore(),
             policyEngine = object : PolicyEngine {
                 override suspend fun evaluate(context: PolicyContext): PolicyDecision =
                     if (context.enforcementPoint == EnforcementPoint.BEFORE_TOOL_EXECUTION) {
                         PolicyDecision.RequireApproval(
-                            ApprovalRequirement("echo", "abc123", "needs approval", 30_000)
+                            ApprovalRequirement("echo", "", "needs approval", 30_000)
                         )
                     } else PolicyDecision.Allow
             },
-            provider = providerWithToolCallThenReturn("echo"),
         )
         val service = approvalEngine.create<TestService>()
 
         assertThatThrownBy { runBlocking { service.analyze("test") } }
-            .isInstanceOf(ApprovalRequiredException::class.java)
-            .hasMessageContaining("needs approval")
+            .isInstanceOf(ApprovalSuspendedException::class.java)
+            .hasMessageContaining("suspended pending approval")
+    }
     }
 
     @Test
-    fun `HIGH risk tool exposure then execution requires approval`() = runBlocking {
+    fun `HIGH risk tool exposure then execution requires approval`() { runBlocking {
         highRiskPaymentTool.callCount.set(0)
         val provider = object : ModelProvider {
             var callCount = 0
@@ -822,6 +875,9 @@ class PolicyEnforcementTest {
         val engine = TramaiEngine(
             provider = provider,
             toolRegistry = ToolRegistry(mapOf("payment-tool" to highRiskPaymentTool)),
+            toolArgumentsDigester = Sha256ToolArgumentsDigester(),
+            approvalGateCoordinator = FakeApprovalGateCoordinator(),
+            approvalContinuationStore = InMemoryApprovalContinuationStore(),
             policyEngine = DefaultPolicyEngine(
                 PolicyConfiguration.secure().copy(
                     allowedTools = setOf("payment-tool"),
@@ -834,15 +890,16 @@ class PolicyEnforcementTest {
         val service = engine.create<PaymentToolService>()
 
         assertThatThrownBy { runBlocking { service.analyze("test") } }
-            .isInstanceOf(ApprovalRequiredException::class.java)
-            .hasMessageContaining("requires human approval")
+            .isInstanceOf(ApprovalSuspendedException::class.java)
+            .hasMessageContaining("suspended pending approval")
         assertThat(highRiskPaymentTool.callCount.get()).isEqualTo(0)
+    }
     }
 
     // -- Streaming tests -------------------------------------------------------
 
     @Test
-    fun `streaming provider invocation denied`() = runBlocking {
+    fun `streaming provider invocation denied`() { runBlocking {
         val sProvider = streamingProvider()
         val denyStream = TramaiEngine(
             provider = sProvider,
@@ -862,9 +919,10 @@ class PolicyEnforcementTest {
             .hasMessageContaining("stream blocked")
         assertThat(sProvider.callCount.get()).isEqualTo(0)
     }
+    }
 
     @Test
-    fun `streaming response return denied before any token emitted`() = runBlocking {
+    fun `streaming response return denied before any token emitted`() { runBlocking {
         val sProvider = streamingProvider()
         val denyResp = TramaiEngine(
             provider = sProvider,
@@ -883,9 +941,10 @@ class PolicyEnforcementTest {
         }.isInstanceOf(PolicyViolationException::class.java)
             .hasMessageContaining("stream response blocked")
     }
+    }
 
     @Test
-    fun `streaming tool exposure denied`() = runBlocking {
+    fun `streaming tool exposure denied`() { runBlocking {
         val sProvider = streamingProvider()
         val denyStream = TramaiEngine(
             provider = sProvider,
@@ -904,9 +963,10 @@ class PolicyEnforcementTest {
         }.isInstanceOf(PolicyViolationException::class.java)
             .hasMessageContaining("stream tools blocked")
     }
+    }
 
     @Test
-    fun `streaming RESTRICTED request to untrusted provider is denied before stream starts`() = runBlocking {
+    fun `streaming RESTRICTED request to untrusted provider is denied before stream starts`() { runBlocking {
         val provider = streamingProvider(id = "cloud-provider")
         val engine = TramaiEngine(
             provider = provider,
@@ -933,11 +993,12 @@ class PolicyEnforcementTest {
             .hasMessageContaining("RESTRICTED data may not be sent to provider 'cloud-provider'")
         assertThat(provider.callCount.get()).isEqualTo(0)
     }
+    }
 
     // -- Structured output tests -----------------------------------------------
 
     @Test
-    fun `structured response return denied after parse success`() = runBlocking {
+    fun `structured response return denied after parse success`() { runBlocking {
         val handler = object : StructuredOutputHandler {
             override fun analyze(rawResponse: String, targetType: kotlin.reflect.KType): StructuredOutputResult {
                 return StructuredOutputResult.Success(TestPayload("parsed"), rawResponse)
@@ -964,9 +1025,10 @@ class PolicyEnforcementTest {
             .isInstanceOf(PolicyViolationException::class.java)
             .hasMessageContaining("struct response blocked")
     }
+    }
 
     @Test
-    fun `structured RESTRICTED request to untrusted provider is denied before invocation`() = runBlocking {
+    fun `structured RESTRICTED request to untrusted provider is denied before invocation`() { runBlocking {
         val handler = object : StructuredOutputHandler {
             override fun analyze(rawResponse: String, targetType: kotlin.reflect.KType): StructuredOutputResult {
                 return StructuredOutputResult.Success(TestPayload("parsed"), rawResponse)
@@ -1004,11 +1066,12 @@ class PolicyEnforcementTest {
             .hasMessageContaining("RESTRICTED data may not be sent to provider 'cloud-provider'")
         assertThat(provider.callCount.get()).isEqualTo(0)
     }
+    }
 
     // -- Cache tests -----------------------------------------------------------
 
     @Test
-    fun `unclassified raw cache hit does not invoke provider twice`() = runBlocking {
+    fun `unclassified raw cache hit does not invoke provider twice`() { runBlocking {
         val provider = CountingProvider()
         val service = engineWithCache(
             policyEngine = object : PolicyEngine {
@@ -1022,9 +1085,10 @@ class PolicyEnforcementTest {
         assertThat(service.cachedCall("test")).isEqualTo("ok")
         assertThat(provider.callCount.get()).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `classified RESTRICTED local raw cache hit does not invoke provider twice`() = runBlocking {
+    fun `classified RESTRICTED local raw cache hit does not invoke provider twice`() { runBlocking {
         val provider = CountingProvider(id = "local-provider")
         val service = engineWithCache(
             policyEngine = DefaultPolicyEngine(
@@ -1046,9 +1110,10 @@ class PolicyEnforcementTest {
         assertThat(service.analyze(input)).isEqualTo("ok")
         assertThat(provider.callCount.get()).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `classified RESTRICTED local structured cache hit does not invoke provider twice`() = runBlocking {
+    fun `classified RESTRICTED local structured cache hit does not invoke provider twice`() { runBlocking {
         val provider = CountingProvider(id = "local-provider")
         val engine = TramaiEngine(
             provider = provider,
@@ -1073,9 +1138,10 @@ class PolicyEnforcementTest {
         assertThat(service.analyze(input).answer).isEqualTo("parsed")
         assertThat(provider.callCount.get()).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `same payload under PUBLIC then RESTRICTED produces separate cache entries`() = runBlocking {
+    fun `same payload under PUBLIC then RESTRICTED produces separate cache entries`() { runBlocking {
         val provider = CountingProvider(id = "local-provider")
         val engine = TramaiEngine(
             provider = provider,
@@ -1103,9 +1169,10 @@ class PolicyEnforcementTest {
         assertThat(second).isEqualTo("ok")
         assertThat(provider.callCount.get()).isEqualTo(2)
     }
+    }
 
     @Test
-    fun `cache hit is re-authorized against current policy`() = runBlocking {
+    fun `cache hit is re-authorized against current policy`() { runBlocking {
         val cache = InMemoryOperationResponseCache()
         val provider = CountingProvider(id = "cloud-provider")
         val allowEngine = engineWithCache(
@@ -1142,9 +1209,10 @@ class PolicyEnforcementTest {
             .hasMessageContaining("RESTRICTED data may not be sent to provider 'cloud-provider'")
         assertThat(provider.callCount.get()).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `cacheable operation with active chatMemory bypasses cache`() = runBlocking {
+    fun `cacheable operation with active chatMemory bypasses cache`() { runBlocking {
         val provider = CountingProvider()
         val memory = object : ChatMemory {
             override fun get(conversationId: String): List<Message> = emptyList()
@@ -1169,9 +1237,10 @@ class PolicyEnforcementTest {
         assertThat(service.analyze("session-a", "same-turn")).isEqualTo("ok")
         assertThat(provider.callCount.get()).isEqualTo(2)
     }
+    }
 
     @Test
-    fun `policy change after cache write denies subsequent cache hit`() = runBlocking {
+    fun `policy change after cache write denies subsequent cache hit`() { runBlocking {
         val provider = CountingProvider()
         val cache = InMemoryOperationResponseCache()
         val allowEngine = engineWithCache(
@@ -1204,9 +1273,10 @@ class PolicyEnforcementTest {
             .hasMessageContaining("cache response blocked")
         assertThat(provider.callCount.get()).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `cached provider removed from allowlist denies cache hit and skips provider`() = runBlocking {
+    fun `cached provider removed from allowlist denies cache hit and skips provider`() { runBlocking {
         val cache = InMemoryOperationResponseCache()
         val provider = CountingProvider(id = "cloud-provider")
         val allowEngine = engineWithCache(
@@ -1242,9 +1312,10 @@ class PolicyEnforcementTest {
             .hasMessageContaining("Provider 'cloud-provider' is not in the allowed-providers registry")
         assertThat(provider.callCount.get()).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `cached model removed from allowlist denies cache hit and skips provider`() = runBlocking {
+    fun `cached model removed from allowlist denies cache hit and skips provider`() { runBlocking {
         val cache = InMemoryOperationResponseCache()
         val provider = CountingProvider(id = "cloud-provider")
         val allowEngine = engineWithCache(
@@ -1280,9 +1351,10 @@ class PolicyEnforcementTest {
             .hasMessageContaining("Model 'test-model' is not in the allowed-models registry")
         assertThat(provider.callCount.get()).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `cacheable operation with tools bypasses cache`() = runBlocking {
+    fun `cacheable operation with tools bypasses cache`() { runBlocking {
         val provider = CountingProvider()
         val engine = TramaiEngine(
             provider = provider,
@@ -1298,9 +1370,10 @@ class PolicyEnforcementTest {
         assertThat(service.cachedCall("test")).isEqualTo("ok")
         assertThat(provider.callCount.get()).isEqualTo(2)
     }
+    }
 
     @Test
-    fun `cacheable operation with custom interceptor bypasses cache`() = runBlocking {
+    fun `cacheable operation with custom interceptor bypasses cache`() { runBlocking {
         val provider = CountingProvider()
         // A non-singleton interceptor — the engine checks reference-equality
         // against NoOpOperationInterceptor, so a fresh anonymous instance
@@ -1319,6 +1392,7 @@ class PolicyEnforcementTest {
         assertThat(service.cachedCall("test")).isEqualTo("ok")
         assertThat(service.cachedCall("test")).isEqualTo("ok")
         assertThat(provider.callCount.get()).isEqualTo(2)
+    }
     }
 
     @Test
@@ -1460,7 +1534,7 @@ class PolicyEnforcementTest {
     }
 
     @Test
-    fun `corrupted cached envelope with mismatched partition is rejected without policy call`() = runBlocking {
+    fun `corrupted cached envelope with mismatched partition is rejected without policy call`() { runBlocking {
         val provider = CountingProvider()
         val policyCalls = AtomicInteger(0)
         val cache = object : OperationResponseCache {
@@ -1496,9 +1570,10 @@ class PolicyEnforcementTest {
         assertThat(policyCalls.get()).isEqualTo(0)
         assertThat(provider.callCount.get()).isEqualTo(0)
     }
+    }
 
     @Test
-    fun `provenance on cached raw and structured results includes providerId and modelName`() = runBlocking {
+    fun `provenance on cached raw and structured results includes providerId and modelName`() { runBlocking {
         val rawCache = InMemoryOperationResponseCache()
         val rawProvider = CountingProvider(id = "raw-provider")
         val rawService = engineWithCache(
@@ -1535,14 +1610,16 @@ class PolicyEnforcementTest {
         assertThat(structuredEntry!!.provenance.providerId).isEqualTo("structured-provider")
         assertThat(structuredEntry.provenance.modelName).isEqualTo("test-model")
     }
+    }
 
     // -- Context semantics tests -----------------------------------------------
 
     @Test
-    fun `context has distinct workflowId and workflowRunId`() = runBlocking {
+    fun `context has distinct workflowId and workflowRunId`() { runBlocking {
         var captured = false
         val engineWithCapture = TramaiEngine(
             provider = providerThatReturns("ok"),
+            toolRegistry = ToolRegistry(mapOf("echo" to echoTool)),
             policyEngine = object : PolicyEngine {
                 override suspend fun evaluate(context: PolicyContext): PolicyDecision {
                     assertThat(context.workflowId).isNull()
@@ -1558,9 +1635,10 @@ class PolicyEnforcementTest {
         service.analyze("test")
         assertThat(captured).isTrue()
     }
+    }
 
     @Test
-    fun `correlationId is stable across one execution flow`() = runBlocking {
+    fun `correlationId is stable across one execution flow`() { runBlocking {
         val correlationIds = mutableListOf<String>()
         // Provider returns a tool call on the first call, then a normal response
         val provider = object : ModelProvider {
@@ -1595,9 +1673,10 @@ class PolicyEnforcementTest {
         val firstId = correlationIds.first()
         correlationIds.forEach { assertThat(it).isEqualTo(firstId) }
     }
+    }
 
     @Test
-    fun `tool enforcement has toolName and correlationId`() = runBlocking {
+    fun `tool enforcement has toolName and correlationId`() { runBlocking {
         var capturedToolName: String? = null
         val engine = TramaiEngine(
             provider = providerWithToolCallThenReturn("echo"),
@@ -1614,6 +1693,7 @@ class PolicyEnforcementTest {
         val service = engine.create<TestService>()
         service.analyze("test")
         assertThat(capturedToolName).isEqualTo("echo")
+    }
     }
 
     private val insecureTool = object : ResolvedTool {
@@ -1646,7 +1726,7 @@ class PolicyEnforcementTest {
     }
 
     @Test
-    fun `tool execution enforcement has toolSecurity`() = runBlocking {
+    fun `tool execution enforcement has toolSecurity`() { runBlocking {
         var capturedSecurity: dev.tramai.core.policy.ToolSecurityMetadata? = null
         val engine = TramaiEngine(
             provider = providerWithToolCallThenReturn("insecure"),
@@ -1665,9 +1745,10 @@ class PolicyEnforcementTest {
         assertThat(capturedSecurity).isNotNull
         assertThat(capturedSecurity?.risk).isEqualTo(dev.tramai.core.policy.RiskLevel.HIGH)
     }
+    }
 
     @Test
-    fun `tool exposure enforcement has toolSecurity`() = runBlocking {
+    fun `tool exposure enforcement has toolSecurity`() { runBlocking {
         var capturedSecurity: dev.tramai.core.policy.ToolSecurityMetadata? = null
 
         val engine = TramaiEngine(
@@ -1687,31 +1768,43 @@ class PolicyEnforcementTest {
         assertThat(capturedSecurity).isNotNull
         assertThat(capturedSecurity?.risk).isEqualTo(dev.tramai.core.policy.RiskLevel.HIGH)
     }
+    }
 
     // -- Legacy compatibility tests --------------------------------------------
 
     @Test
-    fun `legacy compatibility allows execution without policy engine`() = runBlocking {
-        val legacyEngine = TramaiEngine(provider = providerThatReturns("legacy-ok"))
+    fun `legacy compatibility allows execution without policy engine`() { runBlocking {
+        val legacyEngine = TramaiEngine(
+            provider = providerThatReturns("legacy-ok"),
+            toolRegistry = ToolRegistry(mapOf("echo" to echoTool)),
+        )
         val service = legacyEngine.create<TestService>()
         val result = service.analyze("test")
         assertThat(result).isEqualTo("legacy-ok")
     }
+    }
 
     @Test
-    fun `legacy compatibility allows streaming without policy engine`() = runBlocking {
+    fun `legacy compatibility allows streaming without policy engine`() { runBlocking {
         val sProvider = streamingProvider()
-        val legacyEngine = TramaiEngine(provider = sProvider)
+        val legacyEngine = TramaiEngine(
+            provider = sProvider,
+            toolRegistry = ToolRegistry(mapOf("echo" to echoTool)),
+        )
         val service = legacyEngine.create<StreamingTestService>()
         val chunks = service.stream("test").toList()
         assertThat(chunks).isNotEmpty
         assertThat(chunks.first()).isInstanceOf(StreamChunk.Token::class.java)
     }
+    }
 
     @Test
-    fun `legacy mode does not break normal execution`() = runBlocking {
+    fun `legacy mode does not break normal execution`() { runBlocking {
         // Multiple service proxies from the same engine should all work
-        val legacyEngine = TramaiEngine(provider = providerThatReturns("legacy-ok"))
+        val legacyEngine = TramaiEngine(
+            provider = providerThatReturns("legacy-ok"),
+            toolRegistry = ToolRegistry(mapOf("echo" to echoTool)),
+        )
         val service1 = legacyEngine.create<TestService>()
         val service2 = legacyEngine.create<CachedTestService>()
 
@@ -1720,11 +1813,12 @@ class PolicyEnforcementTest {
         assertThat(r1).isEqualTo("legacy-ok")
         assertThat(r2).isEqualTo("legacy-ok")
     }
+    }
 
     // -- Structured enforcement ordering (ITEM 2) ------------------------------
 
     @Test
-    fun `structured BEFORE_RESPONSE_RETURN deny prevents persist and cache side effects`() = runBlocking {
+    fun `structured BEFORE_RESPONSE_RETURN deny prevents persist and cache side effects`() { runBlocking {
         val handler = object : StructuredOutputHandler {
             override fun analyze(rawResponse: String, targetType: kotlin.reflect.KType): StructuredOutputResult =
                 StructuredOutputResult.Success(TestPayload("parsed"), rawResponse)
@@ -1783,11 +1877,12 @@ class PolicyEnforcementTest {
         // Memory was never updated (persistStructuredSuccess not called)
         assertThat(memoryPersistCalled).isFalse()
     }
+    }
 
     // -- Cold streaming Flow enforcement (ITEM 3) ------------------------------
 
     @Test
-    fun `cold Flow — policy changed after Flow creation blocks collection`() = runBlocking {
+    fun `cold Flow — policy changed after Flow creation blocks collection`() { runBlocking {
         var currentPolicy: PolicyDecision = PolicyDecision.Allow
         val sProvider = streamingProvider()
 
@@ -1815,9 +1910,10 @@ class PolicyEnforcementTest {
         // Provider was never invoked because policy denied at flow collection
         assertThat(sProvider.callCount.get()).isEqualTo(0)
     }
+    }
 
     @Test
-    fun `cold Flow — each collection evaluates policy independently`() = runBlocking {
+    fun `cold Flow — each collection evaluates policy independently`() { runBlocking {
         val enforceCount = AtomicInteger(0)
         val sProvider = streamingProvider()
 
@@ -1845,9 +1941,10 @@ class PolicyEnforcementTest {
         // Second collection triggered additional evaluations (per-collection semantic)
         assertThat(countAfterSecond).isGreaterThan(countAfterFirst)
     }
+    }
 
     @Test
-    fun `streaming fallback — BEFORE_RESPONSE_RETURN denies fallback route with providerId and modelName`() = runBlocking {
+    fun `streaming fallback — BEFORE_RESPONSE_RETURN denies fallback route with providerId and modelName`() { runBlocking {
         val primaryStreamProvider = object : ModelProvider, StreamCapable {
             val callCount = AtomicInteger(0)
             override fun providerId() = "primary-stream"
@@ -1884,49 +1981,42 @@ class PolicyEnforcementTest {
             .build()
 
         val settings = CircuitBreakerSettings(
+            enabled = true,
             failureThreshold = 1,
             openDurationMillis = 3_600_000, // long recovery — stays open
         )
 
-        // Phase 1: trip the circuit breaker on primary
-        val allowAll = TramaiEngine(
+        // Phase 2: BEFORE_FALLBACK allows, but BEFORE_RESPONSE_RETURN denies for fallback route
+        var capturedFallbackProviderId: String? = null
+        var capturedFallbackModelName: String? = null
+        var denyResponseReturn = false
+
+        val engine = TramaiEngine(
             providerRegistry = registry,
             toolRegistry = ToolRegistry(mapOf("echo" to echoTool)),
             circuitBreakerSettings = settings,
             policyEngine = object : PolicyEngine {
                 override suspend fun evaluate(context: PolicyContext): PolicyDecision =
-                    PolicyDecision.Allow
-            },
-        )
-        val service1 = allowAll.create<StreamingTestService>()
-        runBlocking { service1.stream("test").toList() }
-        // Circuit breaker is now open for primary, fallback was used in phase 1
-
-        // Phase 2: BEFORE_FALLBACK allows, but BEFORE_RESPONSE_RETURN denies for fallback route
-        var capturedFallbackProviderId: String? = null
-        var capturedFallbackModelName: String? = null
-        val fallbackStreamCallCountBefore = fallbackStreamProvider.callCount.get()
-
-        val engine = TramaiEngine(
-            providerRegistry = registry,
-            toolRegistry = ToolRegistry(mapOf("echo" to echoTool)),
-            circuitBreakerSettings = CircuitBreakerSettings(
-                failureThreshold = 1,
-                openDurationMillis = 3_600_000, // still open
-            ),
-            policyEngine = object : PolicyEngine {
-                override suspend fun evaluate(context: PolicyContext): PolicyDecision =
-                    if (context.enforcementPoint == EnforcementPoint.BEFORE_RESPONSE_RETURN) {
+                    if (denyResponseReturn && context.enforcementPoint == EnforcementPoint.BEFORE_RESPONSE_RETURN) {
                         capturedFallbackProviderId = context.providerId
                         capturedFallbackModelName = context.modelName
                         PolicyDecision.Deny("fallback stream response blocked", "FALLBACK_STREAM_DENY")
                     } else PolicyDecision.Allow
             },
         )
-        val service2 = engine.create<StreamingTestService>()
+        val service = engine.create<StreamingTestService>()
+
+        // Phase 1: trip the circuit breaker on primary (policy allows everything)
+        runBlocking { service.stream("test").toList() }
+        // Circuit breaker is now open for primary, fallback was used in phase 1
+        val fallbackStreamCallCountBefore = fallbackStreamProvider.callCount.get()
+
+        // Phase 2: the open breaker skips the primary route, so the fallback route
+        // is the one denied at BEFORE_RESPONSE_RETURN
+        denyResponseReturn = true
 
         assertThatThrownBy {
-            runBlocking { service2.stream("test").toList() }
+            runBlocking { service.stream("test").toList() }
         }.isInstanceOf(PolicyViolationException::class.java)
             .hasMessageContaining("fallback stream response blocked")
 
@@ -1937,11 +2027,12 @@ class PolicyEnforcementTest {
         // Fallback stream was never invoked (denied at BEFORE_RESPONSE_RETURN)
         assertThat(fallbackStreamProvider.callCount.get()).isEqualTo(fallbackStreamCallCountBefore)
     }
+    }
 
     // -- Fallback transition enforcement (ITEM 4) ------------------------------
 
     @Test
-    fun `circuit breaker open — BEFORE_FALLBACK fires and deny blocks fallback`() = runBlocking {
+    fun `circuit breaker open — BEFORE_FALLBACK fires and deny blocks fallback`() { runBlocking {
         val fallbackCallCount = AtomicInteger(0)
         val primaryCallCount = AtomicInteger(0)
         val failOnceProvider = object : ModelProvider {
@@ -2002,9 +2093,10 @@ class PolicyEnforcementTest {
         // Secondary was never invoked in phase 2 (denied before reaching it)
         assertThat(fallbackCallCount.get()).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `provider failure — BEFORE_FALLBACK fires and allow proceeds to secondary`() = runBlocking {
+    fun `provider failure — BEFORE_FALLBACK fires and allow proceeds to secondary`() { runBlocking {
         val fallbackCalled = AtomicInteger(0)
         var fallbackEnforced = false
         val failOnceProvider = object : ModelProvider {
@@ -2049,6 +2141,7 @@ class PolicyEnforcementTest {
         assertThat(fallbackEnforced).isTrue()
         assertThat(fallbackCalled.get()).isEqualTo(1)
     }
+    }
 
     // -- Null toolSecurity tests ------------------------------------------------
 
@@ -2069,7 +2162,7 @@ class PolicyEnforcementTest {
     }
 
     @Test
-    fun `legacy tool without security metadata is rejected in secure mode`() = runBlocking {
+    fun `legacy tool without security metadata is rejected in secure mode`() { runBlocking {
         val provider = providerWithToolCallThenReturn("legacy")
         val engine = TramaiEngine(
             provider = provider,
@@ -2088,9 +2181,10 @@ class PolicyEnforcementTest {
             .isInstanceOf(PolicyViolationException::class.java)
             .hasMessageContaining("has no security metadata")
     }
+    }
 
     @Test
-    fun `legacy tool without security metadata is allowed in preview mode`() = runBlocking {
+    fun `legacy tool without security metadata is allowed in preview mode`() { runBlocking {
         val provider = providerWithToolCallThenReturn("legacy")
         val engine = TramaiEngine(
             provider = provider,
@@ -2102,13 +2196,14 @@ class PolicyEnforcementTest {
         val result = service.analyze("test")
         assertThat(result).isEqualTo("done")
     }
+    }
 
     // ═══════════════════════════════════════════════════════════════════════
     // Epic 2.3 / 2.4 — Engine-level classification routing matrix tests
     // ═══════════════════════════════════════════════════════════════════════
 
     @Test
-    fun `RESTRICTED local failure to GLOBAL_CLOUD fallback is denied via routing matrix`() = runBlocking {
+    fun `RESTRICTED local failure to GLOBAL_CLOUD fallback is denied via routing matrix`() { runBlocking {
         val localProvider = object : ModelProvider {
             val callCount = AtomicInteger(0)
             override fun providerId() = "local-provider"
@@ -2158,9 +2253,10 @@ class PolicyEnforcementTest {
         assertThat(localProvider.callCount.get()).isEqualTo(1)
         assertThat(cloudProvider.callCount.get()).isEqualTo(0)
     }
+    }
 
     @Test
-    fun `CONFIDENTIAL local failure to EU_CLOUD fallback is allowed via routing matrix`() = runBlocking {
+    fun `CONFIDENTIAL local failure to EU_CLOUD fallback is allowed via routing matrix`() { runBlocking {
         val localProvider = object : ModelProvider {
             val callCount = AtomicInteger(0)
             override fun providerId() = "local-provider"
@@ -2207,9 +2303,10 @@ class PolicyEnforcementTest {
         assertThat(localProvider.callCount.get()).isEqualTo(1)
         assertThat(euProvider.callCount.get()).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `cache hit is invalidated when provider zone changes to restricted classification`() = runBlocking {
+    fun `cache hit is invalidated when provider zone changes to restricted classification`() { runBlocking {
         val cache = InMemoryOperationResponseCache()
         val provider = CountingProvider(id = "ollama")
 
@@ -2265,9 +2362,10 @@ class PolicyEnforcementTest {
         // Provider should NOT have been invoked again (cache hit denied by policy)
         assertThat(provider.callCount.get()).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `registry revocation between retries blocks second attempt`() = runBlocking {
+    fun `registry revocation between retries blocks second attempt`() { runBlocking {
         val provider = object : ModelProvider {
             val callCount = AtomicInteger(0)
             override fun providerId() = "test-provider"
@@ -2311,11 +2409,14 @@ class PolicyEnforcementTest {
         assertThatThrownBy {
             runBlocking { service.analyze("test") }
         }.isInstanceOf(ModelNotRegisteredException::class.java)
-        assertThat(provider.callCount.get()).isEqualTo(0)
+        // First attempt reached the provider once; the retry was blocked by the
+        // revoked registry before a second provider invocation.
+        assertThat(provider.callCount.get()).isEqualTo(1)
+    }
     }
 
     @Test
-    fun `cache outage fails closed without invalidating entry`() = runBlocking {
+    fun `cache outage fails closed without invalidating entry`() { runBlocking {
         val provider = CountingProvider(id = "test-provider")
         val cache = InMemoryOperationResponseCache(maxEntries = 10)
         val registry = object : ModelRegistry {
@@ -2374,5 +2475,6 @@ class PolicyEnforcementTest {
         }.isInstanceOf(ModelRegistryUnavailableException::class.java)
         assertThat(provider.callCount.get()).isEqualTo(1)
         assertThat(cache.snapshotKeys()).isNotEmpty
+    }
     }
 }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ToolExecutionPolicyDenialTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ToolExecutionPolicyDenialTest.kt
@@ -180,7 +180,7 @@ class ToolExecutionPolicyDenialTest {
     // --- Test 1: Exposure allowed, execution denied ---------------------------
 
     @Test
-    fun `exposure allowed but execution denied`() = runTest {
+    fun `exposure allowed but execution denied`() { runTest {
         val tool = CountingTool("payment")
         val provider = ToolCallProvider("payment")
         val emitter = capturingEmitter()
@@ -200,11 +200,12 @@ class ToolExecutionPolicyDenialTest {
         assertEquals(1, provider.callCount.get(), "Provider should be called once to request the tool")
         assertEquals(0, tool.callCount.get(), "Tool should never execute")
     }
+    }
 
     // --- Test 2: Policy context contains canonical tool metadata --------------
 
     @Test
-    fun `execution policy context contains canonical tool metadata`() = runTest {
+    fun `execution policy context contains canonical tool metadata`() { runTest {
         val tool = CountingTool("payment")
         val provider = ToolCallProvider("payment")
         val emitter = capturingEmitter()
@@ -230,11 +231,12 @@ class ToolExecutionPolicyDenialTest {
         assertEquals(RiskLevel.HIGH, ctx.toolSecurity!!.risk)
         assertEquals("payment.execute", ctx.toolSecurity!!.permission)
     }
+    }
 
     // --- Test 3: Denial audit happens before exception propagation ------------
 
     @Test
-    fun `denial audit emitted before PolicyViolationException reaches caller`() = runTest {
+    fun `denial audit emitted before PolicyViolationException reaches caller`() { runTest {
         val tool = CountingTool("payment")
         val provider = ToolCallProvider("payment")
 
@@ -304,11 +306,12 @@ class ToolExecutionPolicyDenialTest {
 
         assertEquals(0, tool.callCount.get(), "Tool should never execute")
     }
+    }
 
     // --- Test 4: Denial prevents reinjection policy evaluation ----------------
 
     @Test
-    fun `execution denial prevents tool result reinjection`() = runTest {
+    fun `execution denial prevents tool result reinjection`() { runTest {
         val tool = CountingTool("payment")
         val provider = ToolCallProvider("payment")
         val emitter = capturingEmitter()
@@ -338,11 +341,12 @@ class ToolExecutionPolicyDenialTest {
             "BEFORE_RESPONSE_RETURN must not fire after denied execution",
         )
     }
+    }
 
     // --- Test 5: No provider continuation after denial ------------------------
 
     @Test
-    fun `provider is not called again after execution denial`() = runTest {
+    fun `provider is not called again after execution denial`() { runTest {
         val tool = CountingTool("payment")
         val provider = ToolCallProvider("payment")
         val engine = TramaiEngine(
@@ -357,11 +361,12 @@ class ToolExecutionPolicyDenialTest {
         assertEquals(1, provider.callCount.get(),
             "Provider should be called exactly once — no continuation after denial")
     }
+    }
 
     // --- Test 6: Audit failure at execution blocks the tool -------------------
 
     @Test
-    fun `audit failure at execution prevents tool execution`() = runTest {
+    fun `audit failure at execution prevents tool execution`() { runTest {
         val tool = CountingTool("payment")
         val provider = ToolCallProvider("payment")
         val engine = TramaiEngine(
@@ -390,11 +395,12 @@ class ToolExecutionPolicyDenialTest {
         assertEquals(0, tool.callCount.get(), "Tool must not execute when audit fails")
         assertEquals(1, provider.callCount.get(), "Provider should be called once")
     }
+    }
 
     // --- Test 7: Policy is reevaluated before every retry ---------------------
 
     @Test
-    fun `policy is reevaluated and denial respected between retries`() = runTest {
+    fun `policy is reevaluated and denial respected between retries`() { runTest {
         val tool = CountingTool("payment", failFirst = true)
         val provider = ToolCallProvider("payment")
         val evalCount = AtomicInteger(0)
@@ -424,11 +430,12 @@ class ToolExecutionPolicyDenialTest {
         assertEquals(2, evalCount.get(), "Policy should be evaluated twice (once per attempt)")
         assertEquals(1, tool.callCount.get(), "Tool should execute once (first attempt) before denial on retry")
     }
+    }
 
     // --- Test 8: Multiple tool calls stop deterministically at denial ---------
 
     @Test
-    fun `later denied tool stops processing after earlier tools complete`() = runTest {
+    fun `later denied tool stops processing after earlier tools complete`() { runTest {
         val lookup = CountingTool("lookup")
         val payment = CountingTool("payment")
         val notification = CountingTool("notification")
@@ -466,5 +473,6 @@ class ToolExecutionPolicyDenialTest {
         assertEquals(0, payment.callCount.get(), "payment tool should never execute")
         assertEquals(0, notification.callCount.get(), "notification tool should never be reached")
         assertEquals(1, provider.callCount.get(), "Provider should not continue after denial")
+    }
     }
 }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ToolExposurePolicyAuditWiringTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ToolExposurePolicyAuditWiringTest.kt
@@ -107,7 +107,7 @@ class ToolExposurePolicyAuditWiringTest {
     }
 
     @Test
-    fun `tool exposure audit emits tool name and enforcement point`() = runBlocking {
+    fun `tool exposure audit emits tool name and enforcement point`() { runBlocking {
         val emitter = capturingEmitter()
         val engine = TramaiEngine(
             provider = DummyCountingProvider(),
@@ -126,9 +126,10 @@ class ToolExposurePolicyAuditWiringTest {
         Assertions.assertEquals("lookup", toolExposureCalls[0].second.toolName)
         Assertions.assertNotNull(toolExposureCalls[0].second.toolSecurity)
     }
+    }
 
     @Test
-    fun `tool exposure deny emits audit before PolicyViolationException`() = runBlocking {
+    fun `tool exposure deny emits audit before PolicyViolationException`() { runBlocking {
         val emitter = capturingEmitter()
         val engine = TramaiEngine(
             provider = DummyCountingProvider(),
@@ -152,9 +153,10 @@ class ToolExposurePolicyAuditWiringTest {
         Assertions.assertEquals("lookup", toolExposureCalls[0].second.toolName)
         Assertions.assertTrue(toolExposureCalls[0].third is PolicyDecision.Deny)
     }
+    }
 
     @Test
-    fun `multiple declared tools each emit one audit decision`() = runBlocking {
+    fun `multiple declared tools each emit one audit decision`() { runBlocking {
         val emitter = capturingEmitter()
         val engine = TramaiEngine(
             provider = DummyCountingProvider(),
@@ -177,9 +179,10 @@ class ToolExposurePolicyAuditWiringTest {
             toolExposureCalls.map { it.second.toolName }.toSet(),
         )
     }
+    }
 
     @Test
-    fun `tool exposure audit includes risk metadata when security is present`() = runBlocking {
+    fun `tool exposure audit includes risk metadata when security is present`() { runBlocking {
         val emitter = capturingEmitter()
         val tool = DummyTool(
             "lookup",
@@ -208,9 +211,10 @@ class ToolExposurePolicyAuditWiringTest {
         Assertions.assertNotNull(toolExposureCalls[0].second.toolSecurity)
         Assertions.assertEquals(RiskLevel.HIGH, toolExposureCalls[0].second.toolSecurity!!.risk)
     }
+    }
 
     @Test
-    fun `audit failure at tool exposure blocks provider invocation`() = runBlocking {
+    fun `audit failure at tool exposure blocks provider invocation`() { runBlocking {
         val provider = DummyCountingProvider()
         val tool = DummyTool("lookup")
         val engine = TramaiEngine(
@@ -243,9 +247,10 @@ class ToolExposurePolicyAuditWiringTest {
             .hasMessage("Audit storage failure")
         assertThat(provider.callCount.get()).isZero()
     }
+    }
 
     @Test
-    fun `tool exposure ALLOW decision is auditable`() = runBlocking {
+    fun `tool exposure ALLOW decision is auditable`() { runBlocking {
         val emitter = capturingEmitter()
         val engine = TramaiEngine(
             provider = DummyCountingProvider(),
@@ -262,5 +267,6 @@ class ToolExposurePolicyAuditWiringTest {
         }
         Assertions.assertEquals(1, toolExposureCalls.size)
         Assertions.assertTrue(toolExposureCalls[0].third is PolicyDecision.Allow)
+    }
     }
 }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/TramaiEngineTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/TramaiEngineTest.kt
@@ -142,7 +142,7 @@ class TramaiEngineTest {
     }
 
     @Test
-    fun `in flight suspend invocation terminates on close`() = runBlocking {
+    fun `in flight suspend invocation terminates on close`() { runBlocking {
         val started = CompletableDeferred<Unit>()
         val provider = RecordingProvider {
             started.complete(Unit)
@@ -157,9 +157,10 @@ class TramaiEngineTest {
 
         assertThat(call.await().exceptionOrNull()).isInstanceOf(kotlinx.coroutines.CancellationException::class.java)
     }
+    }
 
     @Test
-    fun `self close from owned coroutine does not deadlock`() = runBlocking {
+    fun `self close from owned coroutine does not deadlock`() { runBlocking {
         lateinit var engine: TramaiEngine
         val provider = RecordingProvider {
             engine.close()
@@ -172,10 +173,11 @@ class TramaiEngineTest {
 
         assertThat(result.exceptionOrNull()).isInstanceOf(kotlinx.coroutines.CancellationException::class.java)
     }
+    }
 
     @Test
     @Timeout(value = 30, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
-    fun `close racing a fast suspend invocation never leaves work against a closed engine`() = runBlocking {
+    fun `close racing a fast suspend invocation never leaves work against a closed engine`() { runBlocking {
         repeat(100) {
             val providerEntered = CompletableDeferred<Unit>()
             val providerStartedAt = java.util.concurrent.atomic.AtomicLong(-1)
@@ -246,6 +248,7 @@ class TramaiEngineTest {
                 )
             }
         }
+    }
     }
 
     @Test
@@ -351,7 +354,7 @@ class TramaiEngineTest {
     }
 
     @Test
-    fun `mid-collection close terminates an in-flight stream`() = runBlocking {
+    fun `mid-collection close terminates an in-flight stream`() { runBlocking {
         val gate = CompletableDeferred<Unit>()
         val provider = NamedStreamingProvider("p") {
             flow {
@@ -402,9 +405,10 @@ class TramaiEngineTest {
             )
         }
     }
+    }
 
     @Test
-    fun `blocking invocation in long suspension is cancelled and joined by close`() = runBlocking {
+    fun `blocking invocation in long suspension is cancelled and joined by close`() { runBlocking {
         val providerEntered = CompletableDeferred<Unit>()
         val providerReleased = CompletableDeferred<Unit>()
         val providerCleanedUp = CompletableDeferred<Unit>()
@@ -436,9 +440,10 @@ class TramaiEngineTest {
         assertThat(caller.isAlive).isFalse()
         providerReleased.complete(Unit)
     }
+    }
 
     @Test
-    fun `streaming collection suspended indefinitely is cancelled and cleaned up by close`() = runBlocking {
+    fun `streaming collection suspended indefinitely is cancelled and cleaned up by close`() { runBlocking {
         val providerCleanedUp = CompletableDeferred<Unit>()
         val firstChunkDelivered = CompletableDeferred<Unit>()
         val provider = NamedStreamingProvider("p") {
@@ -477,6 +482,7 @@ class TramaiEngineTest {
         // cancelled and the provider's NonCancellable cleanup ran.
         providerCleanedUp.await()
     }
+    }
 
     @Test
     fun `close does not deadlock when caller supplied its own job and scope`() {
@@ -494,7 +500,7 @@ class TramaiEngineTest {
     }
 
     @Test
-    fun `self close from streaming owned coroutine does not deadlock`() = runBlocking {
+    fun `self close from streaming owned coroutine does not deadlock`() { runBlocking {
         lateinit var engine: TramaiEngine
         val provider = NamedStreamingProvider("p") {
             flow {
@@ -520,9 +526,10 @@ class TramaiEngineTest {
             }
         }
     }
+    }
 
     @Test
-    fun `stream start racing close never hangs the collector`() = runBlocking {
+    fun `stream start racing close never hangs the collector`() { runBlocking {
         // Force the admission race deterministically: the flow's open check
         // passes, then close() cancels lifecycleJob BEFORE the collection
         // coroutine body begins executing. Channel termination must come from
@@ -554,9 +561,10 @@ class TramaiEngineTest {
             collection.await()
         }
     }
+    }
 
     @Test
-    fun `streaming bridge preserves backpressure when the collector is slow`() = runBlocking {
+    fun `streaming bridge preserves backpressure when the collector is slow`() { runBlocking {
         val attempted = java.util.concurrent.atomic.AtomicInteger(0)
         val delivered = java.util.concurrent.atomic.AtomicInteger(0)
         val collectorGate = CompletableDeferred<Unit>()
@@ -602,6 +610,7 @@ class TramaiEngineTest {
         // Collection is terminated by close() (rendezvous bridge cancelled
         // through lifecycleJob) — the CE is the expected termination signal.
         runCatching { collection.await() }
+    }
     }
 
     @Test

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/approval/ApprovalCancellationContractTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/approval/ApprovalCancellationContractTest.kt
@@ -123,7 +123,7 @@ class ApprovalCancellationContractTest {
     // ------------------------------------------------------------------
 
     @Test
-    fun `seam 1 - cancellation during approval creation propagates with no persisted state`() = runTest {
+    fun `seam 1 - cancellation during approval creation propagates with no persisted state`() { runTest {
         val store = CancellationStore(cancelOn = "approval.create")
         val suspended = CancellationSuspendedStore()
         val gate = CancellationGate(cancelOn = "approval.create")
@@ -138,9 +138,10 @@ class ApprovalCancellationContractTest {
         assertThat(gate.createdApproval).isFalse()
         assertThat(audit.suspendedCount).isZero()
     }
+    }
 
     @Test
-    fun `seam 2 - cancellation during continuation creation propagates without compensation`() = runTest {
+    fun `seam 2 - cancellation during continuation creation propagates without compensation`() { runTest {
         val store = CancellationStore(cancelOn = "continuation.create")
         val suspended = CancellationSuspendedStore()
         val gate = CancellationGate()
@@ -156,9 +157,10 @@ class ApprovalCancellationContractTest {
         assertThat(suspended.removedMetadata).isZero()
         assertThat(audit.cancelledCount).isZero()
     }
+    }
 
     @Test
-    fun `seam 3 - cancellation during suspended-metadata persistence propagates without compensation`() = runTest {
+    fun `seam 3 - cancellation during suspended-metadata persistence propagates without compensation`() { runTest {
         val store = CancellationStore()
         val suspended = CancellationSuspendedStore(cancelOn = "metadata.create")
         val gate = CancellationGate()
@@ -172,13 +174,14 @@ class ApprovalCancellationContractTest {
         assertThat(store.cancelledContinuation).isZero()
         assertThat(suspended.removedMetadata).isZero()
     }
+    }
 
     // ------------------------------------------------------------------
     // Resume seams (4-12)
     // ------------------------------------------------------------------
 
     @Test
-    fun `seam 4 - cancellation during validateResume leaves continuation pending`() = runTest {
+    fun `seam 4 - cancellation during validateResume leaves continuation pending`() { runTest {
         val (coordinator, store, suspended) = resumeHarness(cancelOn = "validate")
 
         assertThatThrownBy { kotlinx.coroutines.runBlocking { coordinator.resume(command) } }
@@ -189,9 +192,10 @@ class ApprovalCancellationContractTest {
         assertThat(suspended.removedCount).isZero()
         assertThat(store.completeCount).isZero()
     }
+    }
 
     @Test
-    fun `seam 5 - cancellation during resume policy evaluation leaves continuation pending`() = runTest {
+    fun `seam 5 - cancellation during resume policy evaluation leaves continuation pending`() { runTest {
         val (coordinator, store, suspended) = resumeHarness(cancelOn = "policy")
 
         assertThatThrownBy { kotlinx.coroutines.runBlocking { coordinator.resume(command) } }
@@ -202,9 +206,10 @@ class ApprovalCancellationContractTest {
         assertThat(suspended.removedCount).isZero()
         assertThat(store.completeCount).isZero()
     }
+    }
 
     @Test
-    fun `seam 6 - cancellation during authorizeResume leaves continuation pending`() = runTest {
+    fun `seam 6 - cancellation during authorizeResume leaves continuation pending`() { runTest {
         val (coordinator, store, suspended) = resumeHarness(cancelOn = "authorize")
 
         assertThatThrownBy { kotlinx.coroutines.runBlocking { coordinator.resume(command) } }
@@ -214,9 +219,10 @@ class ApprovalCancellationContractTest {
         assertThat(store.claimCount).isZero()
         assertThat(suspended.removedCount).isZero()
     }
+    }
 
     @Test
-    fun `seam 7 - cancellation during claimForExecution leaves continuation pending`() = runTest {
+    fun `seam 7 - cancellation during claimForExecution leaves continuation pending`() { runTest {
         val (coordinator, store, suspended) = resumeHarness(cancelOn = "claim")
 
         assertThatThrownBy { kotlinx.coroutines.runBlocking { coordinator.resume(command) } }
@@ -226,9 +232,10 @@ class ApprovalCancellationContractTest {
         assertThat(store.completeCount).isZero()
         assertThat(suspended.removedCount).isZero()
     }
+    }
 
     @Test
-    fun `seam 8 - cancellation during replay reveal leaves continuation claimed`() = runTest {
+    fun `seam 8 - cancellation during replay reveal leaves continuation claimed`() { runTest {
         val (coordinator, store, suspended) = resumeHarness(cancelOn = "reveal")
 
         assertThatThrownBy { kotlinx.coroutines.runBlocking { coordinator.resume(command) } }
@@ -239,9 +246,10 @@ class ApprovalCancellationContractTest {
         assertThat(suspended.removedCount).isZero()
         assertThat(store.lastStatus).isEqualTo(ApprovalContinuationStatus.CLAIMED)
     }
+    }
 
     @Test
-    fun `seam 9 - cancellation during claimed execution delegate leaves continuation claimed`() = runTest {
+    fun `seam 9 - cancellation during claimed execution delegate leaves continuation claimed`() { runTest {
         val (coordinator, store, suspended) = resumeHarness(cancelOn = "execute")
 
         assertThatThrownBy { kotlinx.coroutines.runBlocking { coordinator.resume(command) } }
@@ -251,9 +259,10 @@ class ApprovalCancellationContractTest {
         assertThat(store.completeCount).isZero()
         assertThat(suspended.removedCount).isZero()
     }
+    }
 
     @Test
-    fun `seam 10 - cancellation during continuation completion leaves metadata retained`() = runTest {
+    fun `seam 10 - cancellation during continuation completion leaves metadata retained`() { runTest {
         val (coordinator, store, suspended) = resumeHarness(cancelOn = "complete")
 
         assertThatThrownBy { kotlinx.coroutines.runBlocking { coordinator.resume(command) } }
@@ -262,9 +271,10 @@ class ApprovalCancellationContractTest {
         assertThat(store.completeCount).isEqualTo(1)
         assertThat(suspended.removedCount).isZero()
     }
+    }
 
     @Test
-    fun `seam 11 - cancellation during cleanup propagates after completion`() = runTest {
+    fun `seam 11 - cancellation during cleanup propagates after completion`() { runTest {
         val (coordinator, store, suspended) = resumeHarness(cancelOn = "remove")
 
         assertThatThrownBy { kotlinx.coroutines.runBlocking { coordinator.resume(command) } }
@@ -273,9 +283,10 @@ class ApprovalCancellationContractTest {
         assertThat(store.completeCount).isEqualTo(1)
         assertThat(suspended.removedCount).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `seam 12 - cancellation during completion audit propagates after cleanup`() = runTest {
+    fun `seam 12 - cancellation during completion audit propagates after cleanup`() { runTest {
         val (coordinator, store, suspended) = resumeHarness(cancelOn = "audit.complete")
 
         assertThatThrownBy { kotlinx.coroutines.runBlocking { coordinator.resume(command) } }
@@ -283,6 +294,7 @@ class ApprovalCancellationContractTest {
 
         assertThat(store.completeCount).isEqualTo(1)
         assertThat(suspended.removedCount).isEqualTo(1)
+    }
     }
 
     // ------------------------------------------------------------------

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/approval/ApprovalResumeCoordinatorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/approval/ApprovalResumeCoordinatorTest.kt
@@ -166,7 +166,7 @@ class ApprovalResumeCoordinatorTest {
     }
 
     @Test
-    fun `happy resume preserves exact observable security sequence`() = runTest {
+    fun `happy resume preserves exact observable security sequence`() { runTest {
         val (coordinator, events, executor) = harness()
 
         val result = coordinator.resume(command)
@@ -189,9 +189,10 @@ class ApprovalResumeCoordinatorTest {
         // mutation sensitivity: the executor must have been invoked exactly once, after authorize+claim
         assertThat(executor.calls).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `completed continuation is rejected before metadata load`() = runTest {
+    fun `completed continuation is rejected before metadata load`() { runTest {
         val events = mutableListOf<String>()
         val store = RecordingContinuationStore(events, continuation(ApprovalContinuationStatus.COMPLETED))
         val suspended = RecordingSuspendedStore(events, metadata(), prepared.envelope)
@@ -211,9 +212,10 @@ class ApprovalResumeCoordinatorTest {
 
         assertThat(events).containsExactly("continuation.inspect")
     }
+    }
 
     @Test
-    fun `missing suspended metadata yields ApprovalNotFoundException`() = runTest {
+    fun `missing suspended metadata yields ApprovalNotFoundException`() { runTest {
         val events = mutableListOf<String>()
         val store = RecordingContinuationStore(events, continuation())
         val suspended = RecordingSuspendedStore(events, null, null)
@@ -233,9 +235,10 @@ class ApprovalResumeCoordinatorTest {
 
         assertThat(events).containsExactly("continuation.inspect", "metadata.load")
     }
+    }
 
     @Test
-    fun `deny policy cancels state and never claims or executes`() = runTest {
+    fun `deny policy cancels state and never claims or executes`() { runTest {
         val events = mutableListOf<String>()
         val (coordinator, _, executor) = harness(
             policyDecision = PolicyDecision.Deny(reason = "blocked", reasonCode = "WF_DENIED"),
@@ -254,9 +257,10 @@ class ApprovalResumeCoordinatorTest {
         assertThat(events).noneMatch { it == "executor.execute" }
         assertThat(executor.calls).isZero()
     }
+    }
 
     @Test
-    fun `nested approval cancels state and never claims or executes`() = runTest {
+    fun `nested approval cancels state and never claims or executes`() { runTest {
         val events = mutableListOf<String>()
         val (coordinator, _, executor) = harness(
             policyDecision = PolicyDecision.RequireApproval(
@@ -275,9 +279,10 @@ class ApprovalResumeCoordinatorTest {
         assertThat(events).noneMatch { it == "continuation.claim" }
         assertThat(events).noneMatch { it == "executor.execute" }
     }
+    }
 
     @Test
-    fun `claim failure propagates before executor or completion`() = runTest {
+    fun `claim failure propagates before executor or completion`() { runTest {
         val events = mutableListOf<String>()
         val (coordinator, _, executor) = harness(
             events = events,
@@ -295,9 +300,10 @@ class ApprovalResumeCoordinatorTest {
         assertThat(events).noneMatch { it == "continuation.complete" }
         assertThat(executor.calls).isZero()
     }
+    }
 
     @Test
-    fun `missing replay envelope leaves continuation claimed and uncompleted`() = runTest {
+    fun `missing replay envelope leaves continuation claimed and uncompleted`() { runTest {
         val events = mutableListOf<String>()
         val store = RecordingContinuationStore(events, continuation())
         val suspended = RecordingSuspendedStore(events, metadata(), null)
@@ -319,9 +325,10 @@ class ApprovalResumeCoordinatorTest {
         assertThat(events).containsSubsequence("continuation.claim", "replay.reveal")
         assertThat(events).noneMatch { it == "continuation.complete" }
     }
+    }
 
     @Test
-    fun `replay digest mismatch emits uncertain outcome and leaves continuation claimed`() = runTest {
+    fun `replay digest mismatch emits uncertain outcome and leaves continuation claimed`() { runTest {
         val events = mutableListOf<String>()
         val tamperedEnvelope = SensitiveReplayEnvelope.of(
             listOf(Message(MessageRole.USER, "tampered")),
@@ -347,9 +354,10 @@ class ApprovalResumeCoordinatorTest {
         assertThat(events).noneMatch { it == "executor.execute" }
         assertThat(events).noneMatch { it == "continuation.complete" }
     }
+    }
 
     @Test
-    fun `argument digest mismatch emits uncertain outcome and leaves continuation claimed`() = runTest {
+    fun `argument digest mismatch emits uncertain outcome and leaves continuation claimed`() { runTest {
         val events = mutableListOf<String>()
         val store = RecordingContinuationStore(
             events,
@@ -379,9 +387,10 @@ class ApprovalResumeCoordinatorTest {
         assertThat(events).noneMatch { it == "executor.execute" }
         assertThat(events).noneMatch { it == "continuation.complete" }
     }
+    }
 
     @Test
-    fun `executor nested-approval failure emits uncertain outcome and stays claimed`() = runTest {
+    fun `executor nested-approval failure emits uncertain outcome and stays claimed`() { runTest {
         val events = mutableListOf<String>()
         val executor = RecordingExecutor(events, throwWith = NestedApprovalNotSupportedException(approvalId, "nested"))
         val (coordinator, _, _) = harness(events = events, executor = executor)
@@ -393,9 +402,10 @@ class ApprovalResumeCoordinatorTest {
         assertThat(events).noneMatch { it == "continuation.complete" }
         assertThat(events).noneMatch { it == "metadata.remove" }
     }
+    }
 
     @Test
-    fun `executor generic failure emits uncertain outcome and stays claimed`() = runTest {
+    fun `executor generic failure emits uncertain outcome and stays claimed`() { runTest {
         val events = mutableListOf<String>()
         val executor = RecordingExecutor(events, throwWith = RuntimeException("tool-failed"))
         val (coordinator, _, _) = harness(events = events, executor = executor)
@@ -408,9 +418,10 @@ class ApprovalResumeCoordinatorTest {
         assertThat(events).noneMatch { it == "continuation.complete" }
         assertThat(events).noneMatch { it == "metadata.remove" }
     }
+    }
 
     @Test
-    fun `completion audit failure is diagnosed and resume still completes`() = runTest {
+    fun `completion audit failure is diagnosed and resume still completes`() { runTest {
         val events = mutableListOf<String>()
         val store = RecordingContinuationStore(events, continuation())
         val suspended = RecordingSuspendedStore(events, metadata(), prepared.envelope)
@@ -445,9 +456,10 @@ class ApprovalResumeCoordinatorTest {
                 it.contains("authority=AUTHORITATIVE")
         }).isTrue
     }
+    }
 
     @Test
-    fun `uncertain outcome audit failure never substitutes the primary resume failure`() = runTest {
+    fun `uncertain outcome audit failure never substitutes the primary resume failure`() { runTest {
         val events = mutableListOf<String>()
         val executor = RecordingExecutor(events, throwWith = RuntimeException("tool-failed"))
         val store = RecordingContinuationStore(events, continuation())
@@ -481,9 +493,10 @@ class ApprovalResumeCoordinatorTest {
                 it.contains("authority=AUTHORITATIVE")
         }).isTrue
     }
+    }
 
     @Test
-    fun `cancellation after claim during replay reveal stays claimed and is never converted to uncertain outcome`() = runTest {
+    fun `cancellation after claim during replay reveal stays claimed and is never converted to uncertain outcome`() { runTest {
         val events = mutableListOf<String>()
         val store = RecordingContinuationStore(events, continuation())
         val suspended = RecordingSuspendedStore(events, metadata(), null)
@@ -518,9 +531,10 @@ class ApprovalResumeCoordinatorTest {
         assertThat(events).noneMatch { it == "metadata.remove" }
         assertThat(events).noneMatch { it == "audit.complete" }
     }
+    }
 
     @Test
-    fun `resume requires continuation store before loading external state`() = runTest {
+    fun `resume requires continuation store before loading external state`() { runTest {
         val events = mutableListOf<String>()
         val coordinator = ApprovalResumeCoordinator(
             approvalContinuationStore = null,
@@ -541,6 +555,7 @@ class ApprovalResumeCoordinatorTest {
         assertThatThrownBy { kotlinx.coroutines.runBlocking { coordinator.resume(command) } }
             .isInstanceOf(ConfigurationException::class.java)
             .hasMessage("ApprovalContinuationStore is required for resume")
+    }
     }
 
     // ------------------------------------------------------------------

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/approval/ApprovalSuspensionCoordinatorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/approval/ApprovalSuspensionCoordinatorTest.kt
@@ -114,7 +114,7 @@ class ApprovalSuspensionCoordinatorTest {
     )
 
     @Test
-    fun `happy suspension persists challenge continuation and metadata then throws ApprovalSuspendedException`() = runTest {
+    fun `happy suspension persists challenge continuation and metadata then throws ApprovalSuspendedException`() { runTest {
         val gate = FakeApprovalGate()
         val store = FakeStore()
         val suspended = FakeSuspendedStore()
@@ -138,9 +138,10 @@ class ApprovalSuspensionCoordinatorTest {
         assertThat(audit.suspendedCount).isEqualTo(1)
         assertThat(suspended.createdMetadata.approvalId).isEqualTo("challenge-1")
     }
+    }
 
     @Test
-    fun `tool name binding mismatch fails before any persistence`() = runTest {
+    fun `tool name binding mismatch fails before any persistence`() { runTest {
         val gate = FakeApprovalGate()
         val store = FakeStore()
         val suspended = FakeSuspendedStore()
@@ -157,9 +158,10 @@ class ApprovalSuspensionCoordinatorTest {
         assertThat(store.createCount).isZero()
         assertThat(suspended.createCount).isZero()
     }
+    }
 
     @Test
-    fun `arguments digest mismatch fails before any persistence`() = runTest {
+    fun `arguments digest mismatch fails before any persistence`() { runTest {
         val gate = FakeApprovalGate()
         val store = FakeStore()
         val suspended = FakeSuspendedStore()
@@ -176,9 +178,10 @@ class ApprovalSuspensionCoordinatorTest {
         assertThat(store.createCount).isZero()
         assertThat(suspended.createCount).isZero()
     }
+    }
 
     @Test
-    fun `invalid timeout fails before any persistence`() = runTest {
+    fun `invalid timeout fails before any persistence`() { runTest {
         val gate = FakeApprovalGate()
         val store = FakeStore()
         val suspended = FakeSuspendedStore()
@@ -194,9 +197,10 @@ class ApprovalSuspensionCoordinatorTest {
         assertThat(gate.createCount).isZero()
         assertThat(store.createCount).isZero()
     }
+    }
 
     @Test
-    fun `continuation create failure compensates in reverse order and rethrows original`() = runTest {
+    fun `continuation create failure compensates in reverse order and rethrows original`() { runTest {
         val gate = FakeApprovalGate()
         val store = FakeStore(failOnCreate = true)
         val suspended = FakeSuspendedStore()
@@ -213,9 +217,10 @@ class ApprovalSuspensionCoordinatorTest {
         assertThat(store.cancelCount).isEqualTo(1)
         assertThat(suspended.removeCount).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `metadata create failure compensates continuation and approval`() = runTest {
+    fun `metadata create failure compensates continuation and approval`() { runTest {
         val gate = FakeApprovalGate()
         val store = FakeStore()
         val suspended = FakeSuspendedStore(failOnCreate = true)
@@ -231,9 +236,10 @@ class ApprovalSuspensionCoordinatorTest {
         assertThat(store.cancelCount).isEqualTo(1)
         assertThat(suspended.removeCount).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `compensation failure never replaces the original failure`() = runTest {
+    fun `compensation failure never replaces the original failure`() { runTest {
         val gate = FakeApprovalGate()
         val store = FakeStore(failOnCreate = true)
         val suspended = FakeSuspendedStore()
@@ -243,9 +249,10 @@ class ApprovalSuspensionCoordinatorTest {
             .isInstanceOf(RuntimeException::class.java)
             .hasMessage("create-failure")
     }
+    }
 
     @Test
-    fun `successful ApprovalSuspendedException never triggers compensation`() = runTest {
+    fun `successful ApprovalSuspendedException never triggers compensation`() { runTest {
         val gate = FakeApprovalGate()
         val store = FakeStore()
         val suspended = FakeSuspendedStore()
@@ -260,9 +267,10 @@ class ApprovalSuspensionCoordinatorTest {
         assertThat(suspended.removeCount).isZero()
         assertThat(audit.cancelledCount).isZero()
     }
+    }
 
     @Test
-    fun `renewed approved binding returns without creating another approval`() = runTest {
+    fun `renewed approved binding returns without creating another approval`() { runTest {
         val gate = FakeApprovalGate()
         val store = FakeStore()
         val suspended = FakeSuspendedStore()
@@ -274,9 +282,10 @@ class ApprovalSuspensionCoordinatorTest {
         assertThat(store.createCount).isZero()
         assertThat(suspended.createCount).isZero()
     }
+    }
 
     @Test
-    fun `renewed binding tool name mismatch is rejected`() = runTest {
+    fun `renewed binding tool name mismatch is rejected`() { runTest {
         val c = coordinator()
         val decision = PolicyDecision.RequireApproval(
             ApprovalRequirement("different-tool", "", "testing", 60_000),
@@ -286,17 +295,19 @@ class ApprovalSuspensionCoordinatorTest {
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("tool name mismatch")
     }
+    }
 
     @Test
-    fun `nested approval is rejected during resumed workflow`() = runTest {
+    fun `nested approval is rejected during resumed workflow`() { runTest {
         val c = coordinator()
 
         assertThatThrownBy { kotlinx.coroutines.runBlocking { c.requireApproval(request(resumingApproval = true), requireDecision(), input) } }
             .isInstanceOf(NestedApprovalNotSupportedException::class.java)
     }
+    }
 
     @Test
-    fun `cancellation during approval creation propagates and skips compensation`() = runTest {
+    fun `cancellation during approval creation propagates and skips compensation`() { runTest {
         val gate = FakeApprovalGate(failOnCreateWith = CancellationException("boom"))
         val store = FakeStore()
         val suspended = FakeSuspendedStore()
@@ -310,9 +321,10 @@ class ApprovalSuspensionCoordinatorTest {
         assertThat(gate.cancelCount).isZero()
         assertThat(suspended.removeCount).isZero()
     }
+    }
 
     @Test
-    fun `cancellation during continuation creation propagates and skips compensation`() = runTest {
+    fun `cancellation during continuation creation propagates and skips compensation`() { runTest {
         val gate = FakeApprovalGate()
         val store = FakeStore(failOnCreateWith = CancellationException("boom"))
         val suspended = FakeSuspendedStore()
@@ -326,9 +338,10 @@ class ApprovalSuspensionCoordinatorTest {
         assertThat(store.cancelCount).isZero()
         assertThat(suspended.removeCount).isZero()
     }
+    }
 
     @Test
-    fun `missing gate coordinator fails explicitly`() = runTest {
+    fun `missing gate coordinator fails explicitly`() { runTest {
         val c = ApprovalSuspensionCoordinator(
             approvalGateCoordinator = null,
             approvalContinuationStore = FakeStore(),
@@ -344,6 +357,7 @@ class ApprovalSuspensionCoordinatorTest {
         assertThatThrownBy { kotlinx.coroutines.runBlocking { c.requireApproval(request(), requireDecision(), input) } }
             .isInstanceOf(ConfigurationException::class.java)
             .hasMessage("ApprovalGateCoordinator is required for tool execution suspension")
+    }
     }
 
     // ------------------------------------------------------------------

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/approval/ReplayAuthorizationServiceTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/approval/ReplayAuthorizationServiceTest.kt
@@ -100,7 +100,7 @@ class ReplayAuthorizationServiceTest {
     }
 
     @Test
-    fun `recorded ordering validate then policy then authorize`() = runTest {
+    fun `recorded ordering validate then policy then authorize`() { runTest {
         val (s, _, events) = service()
         val continuation = continuation()
 
@@ -114,9 +114,10 @@ class ReplayAuthorizationServiceTest {
             "authorize",
         )
     }
+    }
 
     @Test
-    fun `invalid token means policy is never evaluated`() = runTest {
+    fun `invalid token means policy is never evaluated`() { runTest {
         val gate = RecordingGate(failValidateWith = ApprovalTokenRejectedException("a"))
         val (s, _, events) = service(gate = gate)
         val continuation = continuation()
@@ -127,9 +128,10 @@ class ReplayAuthorizationServiceTest {
         assertThat(events).containsExactly("validate")
         assertThat(events).noneMatch { it.startsWith("policy:") }
     }
+    }
 
     @Test
-    fun `valid token deny cancels state and does not authorize`() = runTest {
+    fun `valid token deny cancels state and does not authorize`() { runTest {
         val deny = PolicyDecision.Deny(reason = "blocked", reasonCode = "WF_DENIED")
         val (s, gate, events) = service(policyDecision = deny)
         val continuation = continuation()
@@ -143,9 +145,10 @@ class ReplayAuthorizationServiceTest {
         assertThat(events).contains("cancel-state", "audit:cancelled")
         assertThat(events).noneMatch { it == "authorize" }
     }
+    }
 
     @Test
-    fun `valid token nested approval cancels state and does not authorize`() = runTest {
+    fun `valid token nested approval cancels state and does not authorize`() { runTest {
         val require = PolicyDecision.RequireApproval(
             dev.tramai.core.policy.ApprovalRequirement("tool", "", "testing", 60_000),
         )
@@ -160,9 +163,10 @@ class ReplayAuthorizationServiceTest {
         assertThat(events).contains("cancel-state", "audit:cancelled")
         assertThat(events).noneMatch { it == "authorize" }
     }
+    }
 
     @Test
-    fun `deny cancellation audit failure is diagnosed and never fails the method after transition`() = runTest {
+    fun `deny cancellation audit failure is diagnosed and never fails the method after transition`() { runTest {
         val deny = PolicyDecision.Deny(reason = "blocked", reasonCode = "WF_DENIED")
         val events = mutableListOf<String>()
         val gate = RecordingGate().apply { this.events = events }
@@ -194,9 +198,10 @@ class ReplayAuthorizationServiceTest {
                 it.contains("authority=AUTHORITATIVE")
         }).isTrue
     }
+    }
 
     @Test
-    fun `nested approval cancellation audit failure is diagnosed and never fails the method after transition`() = runTest {
+    fun `nested approval cancellation audit failure is diagnosed and never fails the method after transition`() { runTest {
         val events = mutableListOf<String>()
         val gate = RecordingGate().apply { this.events = events }
         val suspended = RecordingSuspendedStore(events)
@@ -224,9 +229,10 @@ class ReplayAuthorizationServiceTest {
                 it.contains("authority=AUTHORITATIVE")
         }).isTrue
     }
+    }
 
     @Test
-    fun `allow authorizes exactly once`() = runTest {
+    fun `allow authorizes exactly once`() { runTest {
         val (s, gate, _) = service()
         val continuation = continuation()
 
@@ -236,9 +242,10 @@ class ReplayAuthorizationServiceTest {
         assertThat(gate.lastAuthorizeCommand?.consumedBy).isEqualTo("me")
         assertThat(gate.lastAuthorizeCommand?.presentedToken).isEqualTo(token)
     }
+    }
 
     @Test
-    fun `fresh authorization emits no replay event`() = runTest {
+    fun `fresh authorization emits no replay event`() { runTest {
         val (s, _, events) = service()
         val continuation = continuation()
         val auth = s.authorize(command, metadata(), continuation)
@@ -246,18 +253,20 @@ class ReplayAuthorizationServiceTest {
         s.emitAuthorizationReplayed(auth.replayed, command, metadata())
         assertThat(events).noneMatch { it.contains("authorization_replayed") }
     }
+    }
 
     @Test
-    fun `exact authorization replay emits fail-open replay event`() = runTest {
+    fun `exact authorization replay emits fail-open replay event`() { runTest {
         val (s, _, events) = service()
         val continuation = continuation()
 
         s.emitAuthorizationReplayed(replayed = true, command = command, metadata = metadata())
         assertThat(events).contains("tramai.approval.authorization_replayed")
     }
+    }
 
     @Test
-    fun `replay event observer failure is fail-open`() = runTest {
+    fun `replay event observer failure is fail-open`() { runTest {
         val gate = RecordingGate()
         val suspended = RecordingSuspendedStore(mutableListOf())
         val audit = RecordingAuditEmitter(mutableListOf())
@@ -281,9 +290,10 @@ class ReplayAuthorizationServiceTest {
         // must not throw — event observer failures must not prevent resume completion
         s.emitAuthorizationReplayed(replayed = true, command = command, metadata = metadata())
     }
+    }
 
     @Test
-    fun `replay event observer cancellation propagates`() = runTest {
+    fun `replay event observer cancellation propagates`() { runTest {
         val gate = RecordingGate()
         val suspended = RecordingSuspendedStore(mutableListOf())
         val audit = RecordingAuditEmitter(mutableListOf())
@@ -302,15 +312,17 @@ class ReplayAuthorizationServiceTest {
         assertThatThrownBy { kotlinx.coroutines.runBlocking { s.emitAuthorizationReplayed(replayed = true, command = command, metadata = metadata()) } }
             .isSameAs(cancellation)
     }
+    }
 
     @Test
-    fun `real cancellation during validation propagates`() = runTest {
+    fun `real cancellation during validation propagates`() { runTest {
         val cancellation = CancellationException("cancel")
         val gate = RecordingGate(failValidateWith = cancellation)
         val (s, _, _) = service(gate = gate)
 
         assertThatThrownBy { kotlinx.coroutines.runBlocking { s.validateToken(command, metadata(), continuation()) } }
             .isSameAs(cancellation)
+    }
     }
 
     // ------------------------------------------------------------------

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/approval/testing/TestApprovalGatewayRequestFactoryTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/approval/testing/TestApprovalGatewayRequestFactoryTest.kt
@@ -15,7 +15,7 @@ class TestApprovalGatewayRequestFactoryTest {
     private val factory = TestApprovalGatewayRequestFactory(clock = Clock.systemUTC())
 
     @Test
-    fun `builds complete ApprovalGatewayPersistenceRequest`() = runTest {
+    fun `builds complete ApprovalGatewayPersistenceRequest`() { runTest {
         val request = factory.createRequest(
             subject = ApprovalSubject("claim-1"),
             recommendation = ApprovalRecommendation(
@@ -31,9 +31,10 @@ class TestApprovalGatewayRequestFactoryTest {
         assertThat(request.continuation.approvalId).isEqualTo(request.approvalRequest.approvalId)
         assertThat(request.suspendedInvocationMetadata.approvalId).isEqualTo(request.approvalRequest.approvalId)
     }
+    }
 
     @Test
-    fun `argumentsDigest changes when sensitive arguments change`() = runTest {
+    fun `argumentsDigest changes when sensitive arguments change`() { runTest {
         val builder = TestApprovalGatewayPersistenceRequestBuilder(Clock.systemUTC())
             .subject(ApprovalSubject("claim-digest"))
             .recommendation(ApprovalRecommendation(type = "type", summary = "summary"))
@@ -46,9 +47,10 @@ class TestApprovalGatewayRequestFactoryTest {
         assertThat(first.approvalRequest.binding.argumentsDigest)
             .isNotEqualTo(second.approvalRequest.binding.argumentsDigest)
     }
+    }
 
     @Test
-    fun `argumentsDigest is consistent across binding and continuation`() = runTest {
+    fun `argumentsDigest is consistent across binding and continuation`() { runTest {
         val request = factory.createRequest(
             subject = ApprovalSubject("claim-2"),
             recommendation = ApprovalRecommendation(
@@ -62,9 +64,10 @@ class TestApprovalGatewayRequestFactoryTest {
         assertThat(request.continuation.argumentsDigest)
             .isEqualTo(request.approvalRequest.binding.argumentsDigest)
     }
+    }
 
     @Test
-    fun `replay envelope digest changes when operation reference changes`() = runTest {
+    fun `replay envelope digest changes when operation reference changes`() { runTest {
         val builder = TestApprovalGatewayPersistenceRequestBuilder(Clock.systemUTC())
             .subject(ApprovalSubject("claim-digest"))
             .recommendation(ApprovalRecommendation(type = "type", summary = "summary"))
@@ -90,9 +93,10 @@ class TestApprovalGatewayRequestFactoryTest {
         assertThat(first.suspendedInvocationMetadata.replayEnvelopeDigest)
             .isNotEqualTo(second.suspendedInvocationMetadata.replayEnvelopeDigest)
     }
+    }
 
     @Test
-    fun `replay envelope digest is computed`() = runTest {
+    fun `replay envelope digest is computed`() { runTest {
         val request = factory.createRequest(
             subject = ApprovalSubject("claim-3"),
             recommendation = ApprovalRecommendation(
@@ -106,9 +110,10 @@ class TestApprovalGatewayRequestFactoryTest {
         assertThat(request.suspendedInvocationMetadata.replayEnvelopeDigest).isNotNull
         assertThat(request.replayEnvelope).isNotNull
     }
+    }
 
     @Test
-    fun `uses same approvalId across all three records`() = runTest {
+    fun `uses same approvalId across all three records`() { runTest {
         val request = factory.createRequest(
             subject = ApprovalSubject("claim-4"),
             recommendation = ApprovalRecommendation(
@@ -123,9 +128,10 @@ class TestApprovalGatewayRequestFactoryTest {
         assertThat(request.continuation.approvalId).isEqualTo(approvalId)
         assertThat(request.suspendedInvocationMetadata.approvalId).isEqualTo(approvalId)
     }
+    }
 
     @Test
-    fun `uses same workflowRunId across binding, continuation, and identity`() = runTest {
+    fun `uses same workflowRunId across binding, continuation, and identity`() { runTest {
         val request = factory.createRequest(
             subject = ApprovalSubject("claim-5"),
             recommendation = ApprovalRecommendation(
@@ -140,6 +146,7 @@ class TestApprovalGatewayRequestFactoryTest {
         assertThat(request.approvalRequest.binding.workflowRunId).isEqualTo(runId)
         assertThat(request.continuation.workflowRunId).isEqualTo(runId)
         assertThat(request.suspendedInvocationMetadata.identity.workflowRunId).isEqualTo(runId)
+    }
     }
 
     @Test
@@ -161,7 +168,7 @@ class TestApprovalGatewayRequestFactoryTest {
     }
 
     @Test
-    fun `builder supports deterministic approvalId correlationId and toolCallId`() = runTest {
+    fun `builder supports deterministic approvalId correlationId and toolCallId`() { runTest {
         val request = TestApprovalGatewayPersistenceRequestBuilder(Clock.systemUTC())
             .subject(ApprovalSubject("claim-1"))
             .recommendation(ApprovalRecommendation(type = "type", summary = "summary"))
@@ -180,9 +187,10 @@ class TestApprovalGatewayRequestFactoryTest {
         assertThat(request.continuation.toolCallId).isEqualTo("tool-call-custom")
         assertThat(request.suspendedInvocationMetadata.toolCallId).isEqualTo("tool-call-custom")
     }
+    }
 
     @Test
-    fun `custom builder overrides produce consistent result`() = runTest {
+    fun `custom builder overrides produce consistent result`() { runTest {
         val customRequest = TestApprovalGatewayPersistenceRequestBuilder(
             clock = Clock.systemUTC(),
         )
@@ -210,5 +218,6 @@ class TestApprovalGatewayRequestFactoryTest {
         assertThat(customRequest.approvalRequest.binding.policyVersion).isEqualTo("2.0")
         assertThat(customRequest.suspendedInvocationMetadata.operationReference.serviceInterface)
             .isEqualTo("com.example.CustomWorkflow")
+    }
     }
 }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/cache/OperationCacheCoordinatorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/cache/OperationCacheCoordinatorTest.kt
@@ -230,7 +230,7 @@ class OperationCacheCoordinatorTest {
     // ------------------------------------------------------------------
 
     @Test
-    fun `valid hit crosses all three reuse policy gates in order`() = runTest {
+    fun `valid hit crosses all three reuse policy gates in order`() { runTest {
         val cache = RecordingCache()
         cache.entries[key()] = cached() to 60_000L
         val policy = RecordingPolicyEngine()
@@ -245,9 +245,10 @@ class OperationCacheCoordinatorTest {
             "BEFORE_RESPONSE_RETURN",
         )
     }
+    }
 
     @Test
-    fun `blank provider provenance is rejected and does not hit`() = runTest {
+    fun `blank provider provenance is rejected and does not hit`() { runTest {
         val cache = RecordingCache()
         cache.entries[key()] = cached(provenance = provenance(providerId = "", modelName = "")) to 60_000L
         val c = coordinator(cache = cache)
@@ -258,9 +259,10 @@ class OperationCacheCoordinatorTest {
 
         assertThat(cache.invalidated).isEmpty()
     }
+    }
 
     @Test
-    fun `classification mismatch is rejected`() = runTest {
+    fun `classification mismatch is rejected`() { runTest {
         val cache = RecordingCache()
         val partition = CacheSecurityPartition(dev.tramai.core.policy.DataClassification.CONFIDENTIAL, null)
         val key = key().copy(securityPartition = partition)
@@ -271,9 +273,10 @@ class OperationCacheCoordinatorTest {
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("partition")
     }
+    }
 
     @Test
-    fun `classification-source mismatch is rejected`() = runTest {
+    fun `classification-source mismatch is rejected`() { runTest {
         val cache = RecordingCache()
         val partition = CacheSecurityPartition(null, dev.tramai.core.policy.ClassificationSource.DECLARED)
         val key = key().copy(securityPartition = partition)
@@ -284,9 +287,10 @@ class OperationCacheCoordinatorTest {
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("partition")
     }
+    }
 
     @Test
-    fun `current model provenance accepted when registry enabled`() = runTest {
+    fun `current model provenance accepted when registry enabled`() { runTest {
         val cache = RecordingCache()
         val approved = RegisteredModel(
             registryEntryId = "entry-1",
@@ -311,9 +315,10 @@ class OperationCacheCoordinatorTest {
 
         assertThat(result).isEqualTo(OperationCacheLookupResult.Hit("cached-value"))
     }
+    }
 
     @Test
-    fun `model provenance drift invalidates and misses`() = runTest {
+    fun `model provenance drift invalidates and misses`() { runTest {
         val cache = RecordingCache()
         val approved = RegisteredModel(
             registryEntryId = "entry-1",
@@ -338,9 +343,10 @@ class OperationCacheCoordinatorTest {
         assertThat(cache.invalidated).containsExactly(key())
         assertThat(cache.entries).isEmpty()
     }
+    }
 
     @Test
-    fun `conversation memory in scope misses`() = runTest {
+    fun `conversation memory in scope misses`() { runTest {
         val cache = RecordingCache()
         cache.entries[key()] = cached() to 60_000L
         val c = coordinator(cache = cache)
@@ -350,9 +356,10 @@ class OperationCacheCoordinatorTest {
         assertThat(result).isEqualTo(OperationCacheLookupResult.Miss(null))
         assertThat(cache.getCalls.get()).isZero()
     }
+    }
 
     @Test
-    fun `custom interceptor in scope misses without touching cache`() = runTest {
+    fun `custom interceptor in scope misses without touching cache`() { runTest {
         val cache = RecordingCache()
         cache.entries[key()] = cached() to 60_000L
         val c = coordinator(cache = cache, operationInterceptor = interceptor())
@@ -362,9 +369,10 @@ class OperationCacheCoordinatorTest {
         assertThat(result).isEqualTo(OperationCacheLookupResult.Miss(null))
         assertThat(cache.getCalls.get()).isZero()
     }
+    }
 
     @Test
-    fun `dlp in scope misses without touching cache`() = runTest {
+    fun `dlp in scope misses without touching cache`() { runTest {
         val cache = RecordingCache()
         cache.entries[key()] = cached() to 60_000L
         val c = coordinator(cache = cache, dlpInterceptor = dlp())
@@ -374,16 +382,18 @@ class OperationCacheCoordinatorTest {
         assertThat(result).isEqualTo(OperationCacheLookupResult.Miss(null))
         assertThat(cache.getCalls.get()).isZero()
     }
+    }
 
     @Test
-    fun `empty cache misses with the key`() = runTest {
+    fun `empty cache misses with the key`() { runTest {
         val c = coordinator()
         val result = c.lookup(lookupRequest())
         assertThat(result).isEqualTo(OperationCacheLookupResult.Miss(key()))
     }
+    }
 
     @Test
-    fun `policy deny propagates`() = runTest {
+    fun `policy deny propagates`() { runTest {
         val cache = RecordingCache()
         cache.entries[key()] = cached() to 60_000L
         val c = coordinator(
@@ -396,13 +406,14 @@ class OperationCacheCoordinatorTest {
         assertThatThrownBy { kotlinx.coroutines.runBlocking { c.lookup(lookupRequest()) } }
             .isInstanceOf(PolicyViolationException::class.java)
     }
+    }
 
     // ------------------------------------------------------------------
     // cancellation — never converted into miss/provenance/failure
     // ------------------------------------------------------------------
 
     @Test
-    fun `cancellation during model authorization propagates as same exception`() = runTest {
+    fun `cancellation during model authorization propagates as same exception`() { runTest {
         val cache = RecordingCache()
         cache.entries[key()] = cached() to 60_000L
         val approved = RegisteredModel("entry-1", "p1", "model-x", "rev-1")
@@ -420,9 +431,10 @@ class OperationCacheCoordinatorTest {
             .isSameAs(cancel)
         assertThat(cache.invalidated).isEmpty()
     }
+    }
 
     @Test
-    fun `cancellation during reuse policy resolution propagates`() = runTest {
+    fun `cancellation during reuse policy resolution propagates`() { runTest {
         val cache = RecordingCache()
         cache.entries[key()] = cached() to 60_000L
         val cancel = CancellationException("policy-cancel")
@@ -435,9 +447,10 @@ class OperationCacheCoordinatorTest {
             .isSameAs(cancel)
         assertThat(cache.invalidated).isEmpty()
     }
+    }
 
     @Test
-    fun `cancellation during reuse invocation gate propagates`() = runTest {
+    fun `cancellation during reuse invocation gate propagates`() { runTest {
         val cache = RecordingCache()
         cache.entries[key()] = cached() to 60_000L
         val cancel = CancellationException("policy-cancel")
@@ -450,9 +463,10 @@ class OperationCacheCoordinatorTest {
             .isSameAs(cancel)
         assertThat(cache.invalidated).isEmpty()
     }
+    }
 
     @Test
-    fun `cancellation during reuse response gate propagates`() = runTest {
+    fun `cancellation during reuse response gate propagates`() { runTest {
         val cache = RecordingCache()
         cache.entries[key()] = cached() to 60_000L
         val cancel = CancellationException("policy-cancel")
@@ -464,6 +478,7 @@ class OperationCacheCoordinatorTest {
         assertThatThrownBy { kotlinx.coroutines.runBlocking { c.lookup(lookupRequest()) } }
             .isSameAs(cancel)
         assertThat(cache.invalidated).isEmpty()
+    }
     }
 
     // ------------------------------------------------------------------

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/structured/StructuredResponseCoordinatorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/structured/StructuredResponseCoordinatorTest.kt
@@ -289,7 +289,7 @@ class StructuredResponseCoordinatorTest {
     // ------------------------------------------------------------------
 
     @Test
-    fun `contract failure short-circuits without provider call`() = runTest {
+    fun `contract failure short-circuits without provider call`() { runTest {
         val handler = RecordingHandler(mutableListOf<StructuredOutputResult>(), contractThrows = IllegalStateException("schema boom"))
         val executor = RecordingAttemptExecutor()
         val diagnostics = RecordingDiagnostics()
@@ -300,9 +300,10 @@ class StructuredResponseCoordinatorTest {
         assertThat(executor.calls).isEmpty()
         assertThat(diagnostics.events.single().code).isEqualTo(StructuredOutputFailureCode.CONTRACT_FAILED)
     }
+    }
 
     @Test
-    fun `cache hit short-circuits attempt executor`() = runTest {
+    fun `cache hit short-circuits attempt executor`() { runTest {
         val handler = RecordingHandler(mutableListOf<StructuredOutputResult>())
         val executor = RecordingAttemptExecutor()
         val cache = RecordingCache()
@@ -317,13 +318,14 @@ class StructuredResponseCoordinatorTest {
         assertThat(result).isEqualTo(StructuredValue("cached"))
         assertThat(executor.calls).isEmpty()
     }
+    }
 
     // ------------------------------------------------------------------
     // first-attempt success ordering
     // ------------------------------------------------------------------
 
     @Test
-    fun `first attempt success with conversation enforces policy before completion before memory persist`() = runTest {
+    fun `first attempt success with conversation enforces policy before completion before memory persist`() { runTest {
         val op = operation("answer")
         val handler = RecordingHandler(mutableListOf(success()))
         val sink = OrderedSink()
@@ -343,9 +345,10 @@ class StructuredResponseCoordinatorTest {
             "memory.persist",
         )
     }
+    }
 
     @Test
-    fun `first attempt success without conversation stores cache after completion`() = runTest {
+    fun `first attempt success without conversation stores cache after completion`() { runTest {
         val op = operation("cached")
         val handler = RecordingHandler(mutableListOf(success()))
         val sink = OrderedSink()
@@ -365,9 +368,10 @@ class StructuredResponseCoordinatorTest {
             "cache.store",
         )
     }
+    }
 
     @Test
-    fun `completion true is recorded before memory persistence`() = runTest {
+    fun `completion true is recorded before memory persistence`() { runTest {
         val op = operation("answer")
         val handler = RecordingHandler(mutableListOf(success()))
         val sink = OrderedSink()
@@ -388,13 +392,14 @@ class StructuredResponseCoordinatorTest {
         )
         assertThat(cache.stored).isEmpty()
     }
+    }
 
     // ------------------------------------------------------------------
     // repair path
     // ------------------------------------------------------------------
 
     @Test
-    fun `repairable failure appends raw assistant and feedback then retries`() = runTest {
+    fun `repairable failure appends raw assistant and feedback then retries`() { runTest {
         val op = operation("repairable")
         val handler = RecordingHandler(mutableListOf(failure(feedback = "fix it"), success()))
         val executor = RecordingAttemptExecutor()
@@ -416,9 +421,10 @@ class StructuredResponseCoordinatorTest {
             Message(MessageRole.USER, "fix it"),
         )
     }
+    }
 
     @Test
-    fun `repair exhaustion throws REPAIR_EXHAUSTED with exact count`() = runTest {
+    fun `repair exhaustion throws REPAIR_EXHAUSTED with exact count`() { runTest {
         val op = operation("repairable") // maxRetries = 2 → 3 attempts
         val handler = RecordingHandler(mutableListOf(failure(), failure(), failure()))
         val executor = RecordingAttemptExecutor()
@@ -431,9 +437,10 @@ class StructuredResponseCoordinatorTest {
             }
         assertThat(executor.calls).hasSize(3)
     }
+    }
 
     @Test
-    fun `handler throw is sanitized as HANDLER_FAILED`() = runTest {
+    fun `handler throw is sanitized as HANDLER_FAILED`() { runTest {
         val op = operation("answer")
         val handler = RecordingHandler(mutableListOf<StructuredOutputResult>(), analyzeThrows = IllegalStateException("handler secret"))
         val executor = RecordingAttemptExecutor()
@@ -446,9 +453,10 @@ class StructuredResponseCoordinatorTest {
             }
         assertThat(diagnostics.events.single().code).isEqualTo(StructuredOutputFailureCode.HANDLER_FAILED)
     }
+    }
 
     @Test
-    fun `diagnostic observer throw is fail-open`() = runTest {
+    fun `diagnostic observer throw is fail-open`() { runTest {
         val op = operation("answer")
         val handler = RecordingHandler(mutableListOf(failure()))
         val executor = RecordingAttemptExecutor()
@@ -459,9 +467,10 @@ class StructuredResponseCoordinatorTest {
             .isInstanceOf(StructuredOutputException::class.java)
             .isNotSameAs(diagnostics.throwOnFailure)
     }
+    }
 
     @Test
-    fun `real parent cancellation during diagnostics stays primary`() = runTest {
+    fun `real parent cancellation during diagnostics stays primary`() { runTest {
         val op = operation("answer")
         val handler = RecordingHandler(mutableListOf(failure()))
         val executor = RecordingAttemptExecutor()
@@ -517,13 +526,14 @@ class StructuredResponseCoordinatorTest {
             assertThat(terminal).isNotInstanceOf(StructuredOutputException::class.java)
         }
     }
+    }
 
     // ------------------------------------------------------------------
     // policy deny on success → no side effects
     // ------------------------------------------------------------------
 
     @Test
-    fun `BEFORE_RESPONSE_RETURN deny with conversation prevents memory persistence`() = runTest {
+    fun `BEFORE_RESPONSE_RETURN deny with conversation prevents memory persistence`() { runTest {
         val op = operation("answer")
         val handler = RecordingHandler(mutableListOf(success()))
         val sink = OrderedSink()
@@ -538,9 +548,10 @@ class StructuredResponseCoordinatorTest {
         assertThat(memory.stored).isEmpty()
         assertThat(sink.events).containsExactly("policy.BEFORE_RESPONSE_RETURN")
     }
+    }
 
     @Test
-    fun `BEFORE_RESPONSE_RETURN deny without conversation prevents cache store`() = runTest {
+    fun `BEFORE_RESPONSE_RETURN deny without conversation prevents cache store`() { runTest {
         val op = operation("cached")
         val handler = RecordingHandler(mutableListOf(success()))
         val sink = OrderedSink()
@@ -555,13 +566,14 @@ class StructuredResponseCoordinatorTest {
         assertThat(cache.stored).isEmpty()
         assertThat(sink.events).containsExactly("policy.BEFORE_RESPONSE_RETURN")
     }
+    }
 
     // ------------------------------------------------------------------
     // resumed path
     // ------------------------------------------------------------------
 
     @Test
-    fun `resumed success is single attempt with policy memory and observation`() = runTest {
+    fun `resumed success is single attempt with policy memory and observation`() { runTest {
         val op = operation("answer")
         val handler = RecordingHandler(mutableListOf(success()))
         val sink = OrderedSink()
@@ -591,9 +603,10 @@ class StructuredResponseCoordinatorTest {
         )
         assertThat(memory.stored.single().first).isEqualTo("cid")
     }
+    }
 
     @Test
-    fun `resumed invalid response has no policy memory or cache side effects`() = runTest {
+    fun `resumed invalid response has no policy memory or cache side effects`() { runTest {
         val op = operation("answer")
         val handler = RecordingHandler(mutableListOf(failure()))
         val executor = RecordingAttemptExecutor()
@@ -611,9 +624,10 @@ class StructuredResponseCoordinatorTest {
         assertThat(memory.stored).isEmpty()
         assertThat(cache.stored).isEmpty()
     }
+    }
 
     @Test
-    fun `resumed handler failure is HANDLER_FAILED`() = runTest {
+    fun `resumed handler failure is HANDLER_FAILED`() { runTest {
         val op = operation("answer")
         val handler = RecordingHandler(mutableListOf<StructuredOutputResult>(), analyzeThrows = IllegalStateException("resume secret"))
         val executor = RecordingAttemptExecutor()
@@ -626,9 +640,10 @@ class StructuredResponseCoordinatorTest {
             }
         assertThat(diagnostics.events.single().code).isEqualTo(StructuredOutputFailureCode.HANDLER_FAILED)
     }
+    }
 
     @Test
-    fun `resumed path never retries`() = runTest {
+    fun `resumed path never retries`() { runTest {
         val op = operation("repairable")
         val handler = RecordingHandler(mutableListOf(failure(), success()))
         val executor = RecordingAttemptExecutor()
@@ -638,9 +653,10 @@ class StructuredResponseCoordinatorTest {
             .isInstanceOf(StructuredOutputException::class.java)
         assertThat(handler.analyzeCalls.get()).isEqualTo(1) // exactly one parse, no repair
     }
+    }
 
     @Test
-    fun `missing structured handler throws configuration error`() = runTest {
+    fun `missing structured handler throws configuration error`() { runTest {
         val op = operation("answer")
         val c = StructuredResponseCoordinator(
             structuredOutputHandler = null,
@@ -666,5 +682,6 @@ class StructuredResponseCoordinatorTest {
 
         assertThatThrownBy { kotlinx.coroutines.runBlocking { c.execute(executeRequest(op)) } }
             .isInstanceOf(ConfigurationException::class.java)
+    }
     }
 }

--- a/tramai-mcp/src/test/kotlin/dev/tramai/mcp/TramaiMcpServerTest.kt
+++ b/tramai-mcp/src/test/kotlin/dev/tramai/mcp/TramaiMcpServerTest.kt
@@ -49,7 +49,7 @@ class TramaiMcpServerTest @Autowired constructor(
     private val objectMapper: ObjectMapper,
 ) {
     @Test
-    fun `mcp client discovers tools and list_workflows tool works`() = runBlocking {
+    fun `mcp client discovers tools and list_workflows tool works`() { runBlocking {
         val clientToServer = PipedOutputStream()
         val serverInput = PipedInputStream(clientToServer)
         val serverToClient = PipedOutputStream()
@@ -86,6 +86,7 @@ class TramaiMcpServerTest @Autowired constructor(
 
         val workflows = client.callTool("list_workflows", emptyMap())
         assertThat(workflows.structuredContent.toString()).contains("invoice")
+    }
     }
 
     @Test

--- a/tramai-memory/src/test/kotlin/dev/tramai/memory/MessageWindowChatMemoryTest.kt
+++ b/tramai-memory/src/test/kotlin/dev/tramai/memory/MessageWindowChatMemoryTest.kt
@@ -222,7 +222,7 @@ class MessageWindowChatMemoryTest {
     // ── Thread Safety ────────────────────────────────────────────
 
     @Test
-    fun `supports concurrent adds to same conversation`() = runBlocking {
+    fun `supports concurrent adds to same conversation`() { runBlocking {
         val memory = MessageWindowChatMemory(maxMessages = 100)
         val numMessages = 50
         coroutineScope {
@@ -236,9 +236,10 @@ class MessageWindowChatMemoryTest {
         val history = memory.get("shared")
         assertThat(history).hasSize(numMessages)
     }
+    }
 
     @Test
-    fun `supports concurrent adds to different conversations`() = runBlocking {
+    fun `supports concurrent adds to different conversations`() { runBlocking {
         val memory = MessageWindowChatMemory(maxMessages = 10)
         val numConversations = 20
         coroutineScope {
@@ -253,9 +254,10 @@ class MessageWindowChatMemoryTest {
             assertThat(memory.get("conv-$i")).isNotEmpty
         }
     }
+    }
 
     @Test
-    fun `supports concurrent read and write on same conversation`() = runBlocking {
+    fun `supports concurrent read and write on same conversation`() { runBlocking {
         val memory = MessageWindowChatMemory(maxMessages = 100)
         memory.add("shared", Message(MessageRole.SYSTEM, "system"))
 
@@ -276,9 +278,10 @@ class MessageWindowChatMemoryTest {
         val history = memory.get("shared")
         assertThat(history.size).isGreaterThanOrEqualTo(1) // system + at least some users
     }
+    }
 
     @Test
-    fun `concurrent eviction does not orphan entries`() = runBlocking {
+    fun `concurrent eviction does not orphan entries`() { runBlocking {
         val memory = MessageWindowChatMemory(maxMessages = 5, maxConversations = 5)
         val numConversations = 50
 
@@ -295,9 +298,10 @@ class MessageWindowChatMemoryTest {
         val nonEmptyConversations = (0..9).count { memory.get("conv-$it").isNotEmpty() }
         assertThat(nonEmptyConversations).isLessThanOrEqualTo(5)
     }
+    }
 
     @Test
-    fun `concurrent dedup does not duplicate system messages`() = runBlocking {
+    fun `concurrent dedup does not duplicate system messages`() { runBlocking {
         val memory = MessageWindowChatMemory(maxMessages = 50)
 
         coroutineScope {
@@ -313,5 +317,6 @@ class MessageWindowChatMemoryTest {
         val systemMessages = history.filter { it.role == MessageRole.SYSTEM }
         // At most one system message should remain after all dedup completes
         assertThat(systemMessages).hasSize(1)
+    }
     }
 }

--- a/tramai-memory/src/test/kotlin/dev/tramai/memory/PersistentChatMemoryTest.kt
+++ b/tramai-memory/src/test/kotlin/dev/tramai/memory/PersistentChatMemoryTest.kt
@@ -192,7 +192,7 @@ class PersistentChatMemoryTest {
     // ── Thread Safety ──────────────────────────────────────────
 
     @Test
-    fun `supports concurrent adds to same conversation`() = runBlocking {
+    fun `supports concurrent adds to same conversation`() { runBlocking {
         val memory = PersistentChatMemory(InMemoryChatMemoryStore())
         val numMessages = 30
         coroutineScope {
@@ -206,9 +206,10 @@ class PersistentChatMemoryTest {
         val history = memory.get("shared")
         assertThat(history).hasSize(numMessages)
     }
+    }
 
     @Test
-    fun `supports concurrent adds to different conversations`() = runBlocking {
+    fun `supports concurrent adds to different conversations`() { runBlocking {
         val memory = PersistentChatMemory(InMemoryChatMemoryStore())
         val numConversations = 20
         coroutineScope {
@@ -223,9 +224,10 @@ class PersistentChatMemoryTest {
             assertThat(memory.get("conv-$i")).isNotEmpty
         }
     }
+    }
 
     @Test
-    fun `supports concurrent read and write on same conversation`() = runBlocking {
+    fun `supports concurrent read and write on same conversation`() { runBlocking {
         val memory = PersistentChatMemory(InMemoryChatMemoryStore())
         memory.add("shared", Message(MessageRole.SYSTEM, "system"))
 
@@ -245,6 +247,7 @@ class PersistentChatMemoryTest {
         // Should not throw. After all writers done, should have expected count.
         val history = memory.get("shared")
         assertThat(history.size).isGreaterThanOrEqualTo(1)
+    }
     }
 
     // ── Test Helpers ─────────────────────────────────────────────

--- a/tramai-memory/src/test/kotlin/dev/tramai/memory/TokenAwareChatMemoryTest.kt
+++ b/tramai-memory/src/test/kotlin/dev/tramai/memory/TokenAwareChatMemoryTest.kt
@@ -250,7 +250,7 @@ class TokenAwareChatMemoryTest {
     // ── Thread Safety ──────────────────────────────────────────
 
     @Test
-    fun `thread safety concurrent adds to same conversation`() = runBlocking {
+    fun `thread safety concurrent adds to same conversation`() { runBlocking {
         val memory = TokenAwareChatMemory(maxTokens = 200)
         val numMessages = 30
         coroutineScope {
@@ -267,9 +267,10 @@ class TokenAwareChatMemoryTest {
         val totalTokens = history.sumOf { roughTokenizer().countTokens(it.content) }
         assertThat(totalTokens).isLessThanOrEqualTo(200)
     }
+    }
 
     @Test
-    fun `thread safety concurrent read and write on same conversation`() = runBlocking {
+    fun `thread safety concurrent read and write on same conversation`() { runBlocking {
         val memory = TokenAwareChatMemory(maxTokens = 200)
         memory.add("shared", Message(MessageRole.SYSTEM, "system"))
 
@@ -289,6 +290,7 @@ class TokenAwareChatMemoryTest {
         // Should not throw. After all writers done, should have system + some users.
         val history = memory.get("shared")
         assertThat(history.size).isGreaterThanOrEqualTo(1)
+    }
     }
 
     @Test
@@ -345,7 +347,7 @@ class TokenAwareChatMemoryTest {
     }
 
     @Test
-    fun `concurrent eviction with maxConversations does not orphan entries`() = runBlocking {
+    fun `concurrent eviction with maxConversations does not orphan entries`() { runBlocking {
         val memory = TokenAwareChatMemory(maxTokens = 100, maxConversations = 5)
         val numOps = 50
 
@@ -360,5 +362,6 @@ class TokenAwareChatMemoryTest {
 
         val nonEmptyConversations = (0..9).count { memory.get("conv-$it").isNotEmpty() }
         assertThat(nonEmptyConversations).isLessThanOrEqualTo(5)
+    }
     }
 }

--- a/tramai-openai/src/test/kotlin/dev/tramai/openai/OpenAiProviderTest.kt
+++ b/tramai-openai/src/test/kotlin/dev/tramai/openai/OpenAiProviderTest.kt
@@ -270,7 +270,7 @@ class OpenAiProviderTest {
     }
 
     @Test
-    fun `untrusted provider exception from token source is sanitized and observed`() = runBlocking {
+    fun `untrusted provider exception from token source is sanitized and observed`() { runBlocking {
         val secretFixture = "token-source-secret /customer/alice"
         val original = ProviderException(
             "token acquisition failed: $secretFixture",
@@ -300,6 +300,7 @@ class OpenAiProviderTest {
         assertThat(events.single().failure).isSameAs(original)
         assertThat(events.single().providerId).isEqualTo("openai-compatible")
         assertThat(events.single().providerAlias).isEqualTo("customer-openai")
+    }
     }
 
     @Test

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/PartitionStrategyTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/PartitionStrategyTest.kt
@@ -10,29 +10,32 @@ import kotlin.test.Test
 
 class PartitionStrategyTest {
     @Test
-    fun `empty active workers returns false`() = runBlocking {
+    fun `empty active workers returns false`() { runBlocking {
         val strategy = ModHashPartitionStrategy()
         assertThat(strategy.ownsPartition("workflow-1", "worker-1", emptyList())).isFalse
     }
+    }
 
     @Test
-    fun `single worker owns all partitions`() = runBlocking {
+    fun `single worker owns all partitions`() { runBlocking {
         val strategy = ModHashPartitionStrategy()
         assertThat(strategy.ownsPartition("workflow-1", "worker-1", listOf("worker-1"))).isTrue
         assertThat(strategy.ownsPartition("workflow-999", "worker-1", listOf("worker-1"))).isTrue
     }
+    }
 
     @Test
-    fun `same worker always gets same partition for same workflow`() = runBlocking {
+    fun `same worker always gets same partition for same workflow`() { runBlocking {
         val strategy = ModHashPartitionStrategy()
         val workers = listOf("worker-0", "worker-1", "worker-2")
         val result1 = strategy.ownsPartition("workflow-42", "worker-0", workers)
         val result2 = strategy.ownsPartition("workflow-42", "worker-0", workers)
         assertThat(result1).isEqualTo(result2)
     }
+    }
 
     @Test
-    fun `two workers each own different workflows`() = runBlocking {
+    fun `two workers each own different workflows`() { runBlocking {
         val strategy = ModHashPartitionStrategy()
         val workers = listOf("worker-0", "worker-1")
         val wf0 = runIdForPartition(0, 2)
@@ -41,16 +44,18 @@ class PartitionStrategyTest {
         assertThat(strategy.ownsPartition(wf0, "worker-1", workers)).isFalse
         assertThat(strategy.ownsPartition(wf1, "worker-1", workers)).isTrue
     }
+    }
 
     @Test
-    fun `worker not in active workers list returns false`() = runBlocking {
+    fun `worker not in active workers list returns false`() { runBlocking {
         val strategy = ModHashPartitionStrategy()
         val workers = listOf("worker-0", "worker-1")
         assertThat(strategy.ownsPartition("workflow-1", "worker-2", workers)).isFalse
     }
+    }
 
     @Test
-    fun `custom strategy can be injected into tramai worker`() = runBlocking {
+    fun `custom strategy can be injected into tramai worker`() { runBlocking {
         val alwaysTrue = PartitionAssignmentStrategy { _, _, _ -> true }
         val checkpointStore = InMemoryWorkflowCheckpointStore()
         val leaseStore = InMemoryWorkflowLeaseStore()
@@ -96,6 +101,7 @@ class PartitionStrategyTest {
         } finally {
             worker.shutdown()
         }
+    }
     }
 
     private suspend fun waitUntil(block: suspend () -> Boolean) {

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/ShutdownHookTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/ShutdownHookTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.Test
 
 class ShutdownHookTest {
     @Test
-    fun `shutdown fires observer events in correct order`() = runBlocking {
+    fun `shutdown fires observer events in correct order`() { runBlocking {
         val events = mutableListOf<String>()
         val workerStarted = java.util.concurrent.CountDownLatch(1)
         val observer = object : TramaiWorkerObserver {
@@ -34,9 +34,10 @@ class ShutdownHookTest {
         worker.shutdown()
         assertThat(events).containsExactly("started", "drain", "complete")
     }
+    }
 
     @Test
-    fun `close fires shutdown events in correct order`() = runBlocking {
+    fun `close fires shutdown events in correct order`() { runBlocking {
         val events = mutableListOf<String>()
         val workerStarted = java.util.concurrent.CountDownLatch(1)
         val observer = object : TramaiWorkerObserver {
@@ -61,9 +62,10 @@ class ShutdownHookTest {
         worker.close()
         assertThat(events).containsExactly("started", "drain", "complete")
     }
+    }
 
     @Test
-    fun `recording observer captures lifecycle events during workflow execution and shutdown`() = runBlocking {
+    fun `recording observer captures lifecycle events during workflow execution and shutdown`() { runBlocking {
         val events = mutableListOf<String>()
         val observer = object : TramaiWorkerObserver {
             override fun onLeaseAcquired(workflowId: String, workerId: String) { events.add("lease_acquired:$workflowId") }
@@ -98,6 +100,7 @@ class ShutdownHookTest {
         assertThat(events).anySatisfy { assertThat(it).isEqualTo("shutdown_started") }
         assertThat(events).anySatisfy { assertThat(it).isEqualTo("shutdown_complete") }
         assertThat(events).anySatisfy { assertThat(it).isEqualTo("worker_stopped") }
+    }
     }
 
     private fun makeWorkflow(

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TramaiWorkerCancellationContractTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TramaiWorkerCancellationContractTest.kt
@@ -30,7 +30,7 @@ class TramaiWorkerCancellationContractTest {
     // -------------------------------------------------------------------------
 
     @Test
-    fun `graceful shutdown finishes running work within drain window`() = runBlocking {
+    fun `graceful shutdown finishes running work within drain window`() { runBlocking {
         val checkpointStore = InMemoryWorkflowCheckpointStore()
         val leaseStore = InMemoryWorkflowLeaseStore()
         val stepStarted = CompletableDeferred<Unit>()
@@ -83,13 +83,14 @@ class TramaiWorkerCancellationContractTest {
             leaseStore.currentLease(workflow.name, runId),
         ).isNull()
     }
+    }
 
     // -------------------------------------------------------------------------
     // Test 2: Drain timeout cancels running step – CANCELLED not FAILED
     // -------------------------------------------------------------------------
 
     @Test
-    fun `drain timeout cancels running step as CANCELLED not FAILED`() = runBlocking {
+    fun `drain timeout cancels running step as CANCELLED not FAILED`() { runBlocking {
         val checkpointStore = InMemoryWorkflowCheckpointStore()
         val leaseStore = InMemoryWorkflowLeaseStore()
         val workflow = workerWorkflow("drain-cancelled") {
@@ -127,13 +128,14 @@ class TramaiWorkerCancellationContractTest {
         assertThat(leaseStore.listActiveWorkers()).isEmpty()
         assertThat(worker.latestFailure(runId)).isNull()
     }
+    }
 
     // -------------------------------------------------------------------------
     // Test 3: Observer throws during abandonment – cancellation still survives
     // -------------------------------------------------------------------------
 
     @Test
-    fun `observer throw during abandonment does not replace cancellation`() = runBlocking {
+    fun `observer throw during abandonment does not replace cancellation`() { runBlocking {
         val checkpointStore = InMemoryWorkflowCheckpointStore()
         val leaseStore = InMemoryWorkflowLeaseStore()
         val workflow = workerWorkflow("observer-throws") {
@@ -181,13 +183,14 @@ class TramaiWorkerCancellationContractTest {
         // No normal failure was recorded
         assertThat(worker.latestFailure(runId)).isNull()
     }
+    }
 
     // -------------------------------------------------------------------------
     // Test 4: Poll job cancellation does not trigger onPollFailed
     // -------------------------------------------------------------------------
 
     @Test
-    fun `poll job cancellation does not trigger onPollFailed`() = runBlocking {
+    fun `poll job cancellation does not trigger onPollFailed`() { runBlocking {
         val checkpointStore = InMemoryWorkflowCheckpointStore()
         val leaseStore = InMemoryWorkflowLeaseStore()
         val checkpointCatalog = BlockingCheckpointCatalog()
@@ -222,13 +225,14 @@ class TramaiWorkerCancellationContractTest {
 
         assertThat(observer.pollFailedCount).isZero()
     }
+    }
 
     // -------------------------------------------------------------------------
     // Test 5: Lease-renewal cancellation does not trigger onLeaseRenewalFailed
     // -------------------------------------------------------------------------
 
     @Test
-    fun `lease renewal cancellation does not trigger onLeaseRenewalFailed`() = runBlocking {
+    fun `lease renewal cancellation does not trigger onLeaseRenewalFailed`() { runBlocking {
         val checkpointStore = InMemoryWorkflowCheckpointStore()
         val delegateLeaseStore = InMemoryWorkflowLeaseStore()
         val leaseStore = BlockingRenewLeaseStore(delegateLeaseStore)
@@ -293,6 +297,7 @@ class TramaiWorkerCancellationContractTest {
         assertThat(
             delegateLeaseStore.currentLease(workflow.name, runId),
         ).isNull()
+    }
     }
 
     // -------------------------------------------------------------------------

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TramaiWorkerTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TramaiWorkerTest.kt
@@ -515,7 +515,7 @@ class TramaiWorkerTest {
     }
 
     @Test
-    fun `shutdown returns after drain timeout when a step ignores cancellation`() = runBlocking {
+    fun `shutdown returns after drain timeout when a step ignores cancellation`() { runBlocking {
         val checkpointStore = InMemoryWorkflowCheckpointStore()
         val leaseStore = InMemoryWorkflowLeaseStore()
         val workflow = workerWorkflow("drain-timeout") {
@@ -552,9 +552,10 @@ class TramaiWorkerTest {
             .isIn(StepAttemptStatus.CANCELLED, StepAttemptStatus.FAILED)
         assertThat(leaseStore.listActiveWorkers()).isEmpty()
     }
+    }
 
     @Test
-    fun `partition pinning distributes workflows by stable hash`() = runBlocking {
+    fun `partition pinning distributes workflows by stable hash`() { runBlocking {
         val checkpointStore = InMemoryWorkflowCheckpointStore()
         val leaseStore = InMemoryWorkflowLeaseStore()
         val workflow = workerWorkflow("partitioned-work") {
@@ -597,6 +598,7 @@ class TramaiWorkerTest {
             worker0.shutdown()
             worker1.shutdown()
         }
+    }
     }
 
     @Test
@@ -656,7 +658,7 @@ class TramaiWorkerTest {
     }
 
     @Test
-    fun `lease renewal retries transient failures without abandoning the execution`() = runBlocking {
+    fun `lease renewal retries transient failures without abandoning the execution`() { runBlocking {
         val checkpointStore = InMemoryWorkflowCheckpointStore()
         val delegateLeaseStore = InMemoryWorkflowLeaseStore()
         val leaseStore = FlakyRenewLeaseStore(delegateLeaseStore)
@@ -686,9 +688,10 @@ class TramaiWorkerTest {
             worker.shutdown()
         }
     }
+    }
 
     @Test
-    fun `concurrent shutdown only unregisters the worker once`() = runBlocking {
+    fun `concurrent shutdown only unregisters the worker once`() { runBlocking {
         val checkpointStore = InMemoryWorkflowCheckpointStore()
         val leaseStore = CountingWorkerRegistryLeaseStore(InMemoryWorkflowLeaseStore())
         val workflow = workerWorkflow("shutdown-once") {
@@ -713,6 +716,7 @@ class TramaiWorkerTest {
 
         assertThat(leaseStore.unregisterCalls.get()).isEqualTo(1)
         assertThat(leaseStore.listActiveWorkers()).isEmpty()
+    }
     }
 
     @Test

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileApprovalContinuationStoreTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileApprovalContinuationStoreTest.kt
@@ -102,7 +102,7 @@ class FileApprovalContinuationStoreTest {
     }
 
     @Test
-    fun `create pending continuation and reopen`() = runBlocking {
+    fun `create pending continuation and reopen`() { runBlocking {
         val store1 = FileApprovalContinuationStore(rootDir, testKey, createConfig(), FileStoreLease(), clock)
         val (continuation, args) = createContinuation("cont-reopen-1")
 
@@ -115,9 +115,10 @@ class FileApprovalContinuationStoreTest {
         assertEquals(ApprovalContinuationStatus.PENDING, retrieved.status)
         assertEquals(0L, retrieved.version)
     }
+    }
 
     @Test
-    fun `raw arguments absent from persisted bytes`() = runBlocking {
+    fun `raw arguments absent from persisted bytes`() { runBlocking {
         val store = FileApprovalContinuationStore(rootDir, testKey, createConfig(), FileStoreLease(), clock)
         val (continuation, args) = createContinuation("cont-secret-1", arguments = "super-secret-arg-value")
 
@@ -132,9 +133,10 @@ class FileApprovalContinuationStoreTest {
         // The argument content must not appear in plaintext in the envelope JSON
         assertEquals(false, envelopeJson.contains("super-secret-arg-value"))
     }
+    }
 
     @Test
-    fun `claim after reopen returns arguments once`() = runBlocking {
+    fun `claim after reopen returns arguments once`() { runBlocking {
         val store1 = FileApprovalContinuationStore(rootDir, testKey, createConfig(), FileStoreLease(), clock)
         val rawArgs = "simple-command"
         val (continuation, args) = createContinuation("cont-claim-1", arguments = rawArgs)
@@ -153,9 +155,10 @@ class FileApprovalContinuationStoreTest {
         assertEquals(rawArgs, claimed.arguments.reveal())
         assertEquals(1L, claimed.continuation.version)
     }
+    }
 
     @Test
-    fun `claim atomically removes persisted arguments`() = runBlocking {
+    fun `claim atomically removes persisted arguments`() { runBlocking {
         val store = FileApprovalContinuationStore(rootDir, testKey, createConfig(), FileStoreLease(), clock)
         val (continuation, args) = createContinuation("cont-atom-1", arguments = "transient-secret")
 
@@ -180,9 +183,10 @@ class FileApprovalContinuationStoreTest {
             )
         }
     }
+    }
 
     @Test
-    fun `reopen after claim remains CLAIMED`() = runBlocking {
+    fun `reopen after claim remains CLAIMED`() { runBlocking {
         val store1 = FileApprovalContinuationStore(rootDir, testKey, createConfig(), FileStoreLease(), clock)
         val (continuation, args) = createContinuation("cont-reclaim-1", arguments = "claim-me")
 
@@ -199,9 +203,10 @@ class FileApprovalContinuationStoreTest {
         assertEquals(ApprovalContinuationStatus.CLAIMED, retrieved.status)
         assertEquals(1L, retrieved.version)
     }
+    }
 
     @Test
-    fun `concurrent claim has exactly one winner`() = runBlocking {
+    fun `concurrent claim has exactly one winner`() { runBlocking {
         val store = FileApprovalContinuationStore(rootDir, testKey, createConfig(), FileStoreLease(), clock)
         val (continuation, args) = createContinuation("cont-concurrent-claim-1", arguments = "contestable")
 
@@ -240,9 +245,10 @@ class FileApprovalContinuationStoreTest {
             assertEquals(1, winners, "Exactly one concurrent claim must succeed")
         }
     }
+    }
 
     @Test
-    fun `complete survive reopen`() = runBlocking {
+    fun `complete survive reopen`() { runBlocking {
         val store1 = FileApprovalContinuationStore(rootDir, testKey, createConfig(), FileStoreLease(), clock)
         val (continuation, args) = createContinuation("cont-complete-1")
 
@@ -256,9 +262,10 @@ class FileApprovalContinuationStoreTest {
         assertNotNull(retrieved)
         assertEquals(ApprovalContinuationStatus.COMPLETED, retrieved.status)
     }
+    }
 
     @Test
-    fun `expire survive reopen`() = runBlocking {
+    fun `expire survive reopen`() { runBlocking {
         // Create continuation that expires at 12:05
         val creationClock = Clock.fixed(now, ZoneId.of("UTC"))
         val storeCreate = FileApprovalContinuationStore(rootDir, testKey, createConfig(), FileStoreLease(), creationClock)
@@ -278,9 +285,10 @@ class FileApprovalContinuationStoreTest {
         assertNotNull(retrieved)
         assertEquals(ApprovalContinuationStatus.EXPIRED, retrieved.status)
     }
+    }
 
     @Test
-    fun `cancel survive reopen`() = runBlocking {
+    fun `cancel survive reopen`() { runBlocking {
         val store1 = FileApprovalContinuationStore(rootDir, testKey, createConfig(), FileStoreLease(), clock)
         val (continuation, args) = createContinuation("cont-cancel-1")
 
@@ -292,9 +300,10 @@ class FileApprovalContinuationStoreTest {
         assertNotNull(retrieved)
         assertEquals(ApprovalContinuationStatus.CANCELLED, retrieved.status)
     }
+    }
 
     @Test
-    fun `stale search survive reopen`() = runBlocking {
+    fun `stale search survive reopen`() { runBlocking {
         val store = FileApprovalContinuationStore(rootDir, testKey, createConfig(), FileStoreLease(), clock)
         val (continuation, args) = createContinuation("cont-stale-1")
 
@@ -306,9 +315,10 @@ class FileApprovalContinuationStoreTest {
         assertEquals(1, stale.size)
         assertEquals("cont-stale-1", stale.first().approvalId)
     }
+    }
 
     @Test
-    fun `sweep survive reopen`() = runBlocking {
+    fun `sweep survive reopen`() { runBlocking {
         // Create continuations with creation clock set to now (expires at 12:05)
         val creationClock = Clock.fixed(now, ZoneId.of("UTC"))
         val store1 = FileApprovalContinuationStore(rootDir, testKey, createConfig(), FileStoreLease(), creationClock)
@@ -342,9 +352,10 @@ class FileApprovalContinuationStoreTest {
         assertTrue(rootDir.resolve("continuations/$digest1.tram.enc").exists())
         assertTrue(rootDir.resolve("continuations/$digest2.tram.enc").exists())
     }
+    }
 
     @Test
-    fun `force cancel survive reopen`() = runBlocking {
+    fun `force cancel survive reopen`() { runBlocking {
         val store1 = FileApprovalContinuationStore(rootDir, testKey, createConfig(), FileStoreLease(), clock)
         val (continuation, args) = createContinuation("cont-force-cancel-1")
 
@@ -364,5 +375,6 @@ class FileApprovalContinuationStoreTest {
         assertEquals(ApprovalContinuationStatus.CANCELLED_UNCERTAIN, retrieved.status)
         assertEquals("admin-alice", retrieved.recoveryResolvedBy)
         assertEquals("stuck.worker", retrieved.recoveryReasonCode)
+    }
     }
 }

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileApprovalStoreTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileApprovalStoreTest.kt
@@ -69,7 +69,7 @@ class FileApprovalStoreTest {
     }
 
     @Test
-    fun `create and reopen`() = runBlocking {
+    fun `create and reopen`() { runBlocking {
         val store1 = FileApprovalStore(rootDir, testKey, createConfig(), FileStoreLease(), clock)
 
         val request = ApprovalRequest(
@@ -105,9 +105,10 @@ class FileApprovalStoreTest {
         assertEquals(0L, retrieved.version)
         assertEquals("alice", retrieved.requestedBy)
     }
+    }
 
     @Test
-    fun `transition and reopen`() = runBlocking {
+    fun `transition and reopen`() { runBlocking {
         val store = FileApprovalStore(rootDir, testKey, createConfig(), FileStoreLease(), clock)
 
         val request = ApprovalRequest(
@@ -151,9 +152,10 @@ class FileApprovalStoreTest {
         assertEquals(1L, retrieved.version)
         assertEquals("carol", retrieved.decidedBy)
     }
+    }
 
     @Test
-    fun `duplicate create rejected`() = runBlocking {
+    fun `duplicate create rejected`() { runBlocking {
         val store = FileApprovalStore(rootDir, testKey, createConfig(), FileStoreLease(), clock)
 
         val request = ApprovalRequest(
@@ -161,10 +163,10 @@ class FileApprovalStoreTest {
             binding = ApprovalBinding(
                 workflowRunId = "wf-3",
                 toolName = "deleter",
-                argumentsDigest = makeDigest("g".repeat(64)),
+                argumentsDigest = makeDigest("b".repeat(64)),
                 policyVersion = "v1",
-                workflowDigest = makeDigest("h".repeat(64)),
-                approvalTokenDigest = makeDigest("i".repeat(64)),
+                workflowDigest = makeDigest("c".repeat(64)),
+                approvalTokenDigest = makeDigest("e".repeat(64)),
             ),
             status = ApprovalStatus.PENDING,
             requestedBy = "dave",
@@ -183,9 +185,10 @@ class FileApprovalStoreTest {
             store.create(request)
         }
     }
+    }
 
     @Test
-    fun `stale expected version rejected`() = runBlocking {
+    fun `stale expected version rejected`() { runBlocking {
         val store = FileApprovalStore(rootDir, testKey, createConfig(), FileStoreLease(), clock)
 
         val request = ApprovalRequest(
@@ -193,10 +196,10 @@ class FileApprovalStoreTest {
             binding = ApprovalBinding(
                 workflowRunId = "wf-4",
                 toolName = "checker",
-                argumentsDigest = makeDigest("j".repeat(64)),
+                argumentsDigest = makeDigest("b".repeat(64)),
                 policyVersion = "v1",
-                workflowDigest = makeDigest("k".repeat(64)),
-                approvalTokenDigest = makeDigest("l".repeat(64)),
+                workflowDigest = makeDigest("c".repeat(64)),
+                approvalTokenDigest = makeDigest("e".repeat(64)),
             ),
             status = ApprovalStatus.PENDING,
             requestedBy = "eve",
@@ -226,9 +229,10 @@ class FileApprovalStoreTest {
             )
         }
     }
+    }
 
     @Test
-    fun `wrong token digest rejected`() = runBlocking {
+    fun `wrong token digest rejected`() { runBlocking {
         val store = FileApprovalStore(rootDir, testKey, createConfig(), FileStoreLease(), clock)
 
         val request = ApprovalRequest(
@@ -236,10 +240,10 @@ class FileApprovalStoreTest {
             binding = ApprovalBinding(
                 workflowRunId = "wf-5",
                 toolName = "consumer",
-                argumentsDigest = makeDigest("m".repeat(64)),
+                argumentsDigest = makeDigest("b".repeat(64)),
                 policyVersion = "v1",
-                workflowDigest = makeDigest("n".repeat(64)),
-                approvalTokenDigest = makeDigest("o".repeat(64)),
+                workflowDigest = makeDigest("c".repeat(64)),
+                approvalTokenDigest = makeDigest("e".repeat(64)),
             ),
             status = ApprovalStatus.PENDING,
             requestedBy = "hank",
@@ -260,7 +264,7 @@ class FileApprovalStoreTest {
             transition = ApprovalTransition.Approve(decidedBy = "ivy"),
         )
 
-        val wrongDigest = makeDigest("z".repeat(64))
+        val wrongDigest = makeDigest("d".repeat(64))
         assertThrows<ApprovalStoreTokenRejectedException> {
             store.consumeApprovedOrReplay(
                 approvalId = "test-token-1",
@@ -270,9 +274,10 @@ class FileApprovalStoreTest {
             )
         }
     }
+    }
 
     @Test
-    fun `exact replay after reopen succeeds without mutation`() = runBlocking {
+    fun `exact replay after reopen succeeds without mutation`() { runBlocking {
         val store = FileApprovalStore(rootDir, testKey, createConfig(), FileStoreLease(), clock)
 
         val tokenDigest = makeDigest("f".repeat(64))
@@ -327,20 +332,21 @@ class FileApprovalStoreTest {
         assertEquals(receipt1.request.consumedAt, receipt2.request.consumedAt)
         assertEquals(receipt1.request.version, receipt2.request.version)
     }
+    }
 
     @Test
-    fun `non-exact replay after reopen rejected`() = runBlocking {
+    fun `non-exact replay after reopen rejected`() { runBlocking {
         val store = FileApprovalStore(rootDir, testKey, createConfig(), FileStoreLease(), clock)
 
-        val tokenDigest = makeDigest("s".repeat(64))
+        val tokenDigest = makeDigest("b".repeat(64))
         val request = ApprovalRequest(
             approvalId = "test-bad-replay-1",
             binding = ApprovalBinding(
                 workflowRunId = "wf-7",
                 toolName = "bad-replay",
-                argumentsDigest = makeDigest("t".repeat(64)),
+                argumentsDigest = makeDigest("c".repeat(64)),
                 policyVersion = "v1",
-                workflowDigest = makeDigest("u".repeat(64)),
+                workflowDigest = makeDigest("e".repeat(64)),
                 approvalTokenDigest = tokenDigest,
             ),
             status = ApprovalStatus.PENDING,
@@ -381,9 +387,10 @@ class FileApprovalStoreTest {
             )
         }
     }
+    }
 
     @Test
-    fun `concurrent mutation has exactly one winner`() = runBlocking {
+    fun `concurrent mutation has exactly one winner`() { runBlocking {
         val store = FileApprovalStore(rootDir, testKey, createConfig(), FileStoreLease(), clock)
 
         val request = ApprovalRequest(
@@ -452,5 +459,6 @@ class FileApprovalStoreTest {
             finalRequest.status == ApprovalStatus.APPROVED || finalRequest.status == ApprovalStatus.DENIED,
             "Status must be either APPROVED or DENIED, got ${finalRequest.status}",
         )
+    }
     }
 }

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileAuditStoreReadStreamPageTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileAuditStoreReadStreamPageTest.kt
@@ -95,7 +95,7 @@ class FileAuditStoreReadStreamPageTest {
         }
 
     @Test
-    fun `readStreamPage returns first page when cursor is null`() = runBlocking {
+    fun `readStreamPage returns first page when cursor is null`() { runBlocking {
         val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
         populateStream(store, "page-first", 10)
 
@@ -104,9 +104,10 @@ class FileAuditStoreReadStreamPageTest {
         assertEquals(5, page.size)
         assertEquals(listOf(1L, 2L, 3L, 4L, 5L), page.map { it.sequenceNumber })
     }
+    }
 
     @Test
-    fun `readStreamPage returns events after cursor`() = runBlocking {
+    fun `readStreamPage returns events after cursor`() { runBlocking {
         val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
         populateStream(store, "page-after", 10)
 
@@ -115,9 +116,10 @@ class FileAuditStoreReadStreamPageTest {
         assertEquals(5, page.size)
         assertEquals(listOf(6L, 7L, 8L, 9L, 10L), page.map { it.sequenceNumber })
     }
+    }
 
     @Test
-    fun `readStreamPage respects limit`() = runBlocking {
+    fun `readStreamPage respects limit`() { runBlocking {
         val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
         populateStream(store, "page-limit", 50)
 
@@ -125,9 +127,10 @@ class FileAuditStoreReadStreamPageTest {
 
         assertEquals(7, page.size)
     }
+    }
 
     @Test
-    fun `readStreamPage returns empty list after last event`() = runBlocking {
+    fun `readStreamPage returns empty list after last event`() { runBlocking {
         val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
         populateStream(store, "page-end", 5)
 
@@ -135,18 +138,20 @@ class FileAuditStoreReadStreamPageTest {
 
         assertTrue(page.isEmpty())
     }
+    }
 
     @Test
-    fun `readStreamPage returns empty list for unknown stream`() = runBlocking {
+    fun `readStreamPage returns empty list for unknown stream`() { runBlocking {
         val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
 
         val page = store.readStreamPage("unknown-stream", afterSequenceNumber = null, limit = 10)
 
         assertTrue(page.isEmpty())
     }
+    }
 
     @Test
-    fun `readStreamPage results consistent with readStream`() = runBlocking {
+    fun `readStreamPage results consistent with readStream`() { runBlocking {
         val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
         populateStream(store, "page-consistent", 20)
 
@@ -156,9 +161,10 @@ class FileAuditStoreReadStreamPageTest {
         assertEquals(full.drop(5).take(10).map { it.sequenceNumber }, page.map { it.sequenceNumber })
         assertEquals(full.drop(5).take(10).map { it.eventId }, page.map { it.eventId })
     }
+    }
 
     @Test
-    fun `readStreamPage returns valid event hashes`() = runBlocking {
+    fun `readStreamPage returns valid event hashes`() { runBlocking {
         val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
         populateStream(store, "page-hash", 3)
 
@@ -169,36 +175,40 @@ class FileAuditStoreReadStreamPageTest {
             assertEquals(event.eventHash, event.copy(eventHash = "").calculateHash())
         }
     }
+    }
 
     @Test
-    fun `readStreamPage rejects zero limit`() = runBlocking {
+    fun `readStreamPage rejects zero limit`() { runBlocking {
         val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
         val ex = org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
             store.readStreamPage("test-stream", afterSequenceNumber = null, limit = 0)
         }
         assertTrue(ex.message?.contains("invalid-limit") == true)
     }
+    }
 
     @Test
-    fun `readStreamPage rejects negative limit`() = runBlocking {
+    fun `readStreamPage rejects negative limit`() { runBlocking {
         val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
         val ex = org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
             store.readStreamPage("test-stream", afterSequenceNumber = null, limit = -1)
         }
         assertTrue(ex.message?.contains("invalid-limit") == true)
     }
+    }
 
     @Test
-    fun `readStreamPage rejects negative cursor`() = runBlocking {
+    fun `readStreamPage rejects negative cursor`() { runBlocking {
         val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
         val ex = org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
             store.readStreamPage("test-stream", afterSequenceNumber = -1L, limit = 5)
         }
         assertTrue(ex.message?.contains("invalid-cursor") == true)
     }
+    }
 
     @Test
-    fun `readStreamPage stops after limit even with more events`() = runBlocking {
+    fun `readStreamPage stops after limit even with more events`() { runBlocking {
         val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
         populateStream(store, "page-stop", 100)
 
@@ -207,9 +217,10 @@ class FileAuditStoreReadStreamPageTest {
         assertEquals(3, page.size)
         assertEquals(listOf(1L, 2L, 3L), page.map { it.sequenceNumber })
     }
+    }
 
     @Test
-    fun `separate streams have independent pagination`() = runBlocking {
+    fun `separate streams have independent pagination`() { runBlocking {
         val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
         populateStream(store, "page-indep-a", 3)
         populateStream(store, "page-indep-b", 5)
@@ -221,9 +232,10 @@ class FileAuditStoreReadStreamPageTest {
         assertEquals(3, pageB.size)
         assertEquals(listOf(3L, 4L, 5L), pageB.map { it.sequenceNumber })
     }
+    }
 
     @Test
-    fun `readStreamPage survives reopen`() = runBlocking {
+    fun `readStreamPage survives reopen`() { runBlocking {
         val store1 = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
         populateStream(store1, "page-reopen", 10)
 
@@ -238,5 +250,6 @@ class FileAuditStoreReadStreamPageTest {
 
         val page3 = store2.readStreamPage("page-reopen", afterSequenceNumber = 10L, limit = 10)
         assertTrue(page3.isEmpty())
+    }
     }
 }

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileAuditStoreTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileAuditStoreTest.kt
@@ -102,7 +102,7 @@ class FileAuditStoreTest {
     }
 
     @Test
-    fun `append and reopen`() = runBlocking {
+    fun `append and reopen`() { runBlocking {
         val store1 = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
         val streamId = "stream-append-1"
 
@@ -123,9 +123,10 @@ class FileAuditStoreTest {
         assertEquals(event1.eventHash, stream[0].eventHash)
         assertEquals(event2.eventHash, stream[1].eventHash)
     }
+    }
 
     @Test
-    fun `valid chain survives reopen`() = runBlocking {
+    fun `valid chain survives reopen`() { runBlocking {
         val store1 = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
         val streamId = "stream-chain-1"
 
@@ -143,9 +144,10 @@ class FileAuditStoreTest {
             assertEquals(stream[i - 1].sequenceNumber + 1, stream[i].sequenceNumber)
         }
     }
+    }
 
     @Test
-    fun `concurrent append preserves contiguous sequence`() = runBlocking {
+    fun `concurrent append preserves contiguous sequence`() { runBlocking {
         val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
         val streamId = "stream-concurrent-1"
 
@@ -186,9 +188,10 @@ class FileAuditStoreTest {
             )
         }
     }
+    }
 
     @Test
-    fun `duplicate event ID rejected`() = runBlocking {
+    fun `duplicate event ID rejected`() { runBlocking {
         val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
         val streamId = "stream-dup-1"
 
@@ -200,9 +203,10 @@ class FileAuditStoreTest {
             store.appendNext(streamId, eventFactory(streamId, eventId))
         }
     }
+    }
 
     @Test
-    fun `missing middle event rejected`() = runBlocking {
+    fun `missing middle event rejected`() { runBlocking {
         val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
         val streamId = "stream-missing-1"
 
@@ -226,9 +230,10 @@ class FileAuditStoreTest {
             store.readStream(streamId)
         }
     }
+    }
 
     @Test
-    fun `cross-stream substitution rejected`() = runBlocking {
+    fun `cross-stream substitution rejected`() { runBlocking {
         val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
         val streamA = "stream-cross-A"
         val streamB = "stream-cross-B"
@@ -273,9 +278,10 @@ class FileAuditStoreTest {
             store.appendNext(streamA, factory)
         }
     }
+    }
 
     @Test
-    fun `ciphertext tampering rejected`() = runBlocking {
+    fun `ciphertext tampering rejected`() { runBlocking {
         val store = FileAuditStore(rootDir, testKey, createConfig(), FileStoreLease())
         val streamId = "stream-tamper-1"
 
@@ -297,5 +303,6 @@ class FileAuditStoreTest {
         assertThrows<RuntimeException> {
             store.readStream(streamId)
         }
+    }
     }
 }

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileBackedSovereignStoresTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileBackedSovereignStoresTest.kt
@@ -212,7 +212,7 @@ class FileBackedSovereignStoresTest {
     }
 
     @Test
-    fun `corrupted suspended record fails startup verification`() = runBlocking {
+    fun `corrupted suspended record fails startup verification`() { runBlocking {
         val config = createConfig()
         val approvalId = "bundle-suspended-corrupt-1"
 
@@ -241,9 +241,10 @@ class FileBackedSovereignStoresTest {
             )
         }
     }
+    }
 
     @Test
-    fun `operations after close are rejected on suspended store`() = runBlocking {
+    fun `operations after close are rejected on suspended store`() { runBlocking {
         val stores = FileBackedSovereignStores.open(createConfig())
         val suspendedStore = stores.suspendedInvocationStore
         stores.close()
@@ -257,6 +258,7 @@ class FileBackedSovereignStoresTest {
         assertThrows<IllegalStateException> {
             runBlocking { suspendedStore.remove("approval-closed") }
         }
+    }
     }
 
     // ── activeKeyId validation ──────────────────────────────────────────

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStoreTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStoreTest.kt
@@ -83,7 +83,7 @@ class FileSuspendedInvocationStoreTest {
     }
 
     @Test
-    fun `lifecycle create get reveal remove`() = runBlocking {
+    fun `lifecycle create get reveal remove`() { runBlocking {
         val store = createStore()
         val (metadata, envelope) = createValidRecord()
 
@@ -105,9 +105,10 @@ class FileSuspendedInvocationStoreTest {
         assertEquals(metadata.approvalId, removed.approvalId)
         assertNull(store.get(metadata.approvalId))
     }
+    }
 
     @Test
-    fun `restart reopen preserves suspended invocation`() = runBlocking {
+    fun `restart reopen preserves suspended invocation`() { runBlocking {
         val (metadata, envelope) = createValidRecord()
 
         createStore().create(metadata, envelope)
@@ -118,9 +119,10 @@ class FileSuspendedInvocationStoreTest {
         assertEquals(metadata.approvalId, retrieved.approvalId)
         assertNotNull(reopened.revealReplayEnvelope(metadata.approvalId))
     }
+    }
 
     @Test
-    fun `encrypted file does not expose sensitive plaintext`() = runBlocking {
+    fun `encrypted file does not expose sensitive plaintext`() { runBlocking {
         val store = createStore()
         val workflowRunId = "workflow-run-sensitive-123"
         val correlationId = "corr-sensitive-456"
@@ -140,9 +142,10 @@ class FileSuspendedInvocationStoreTest {
         assertFalse(fileContent.contains(workflowRunId))
         assertFalse(fileContent.contains(correlationId))
     }
+    }
 
     @Test
-    fun `duplicate create rejected`() = runBlocking {
+    fun `duplicate create rejected`() { runBlocking {
         val store = createStore()
         val (metadata, envelope) = createValidRecord()
 
@@ -152,9 +155,10 @@ class FileSuspendedInvocationStoreTest {
             runBlocking { store.create(metadata, envelope) }
         }
     }
+    }
 
     @Test
-    fun `wrong key rejects suspended invocation reads`() = runBlocking {
+    fun `wrong key rejects suspended invocation reads`() { runBlocking {
         val store = createStore()
         val (metadata, envelope) = createValidRecord()
         store.create(metadata, envelope)
@@ -168,9 +172,10 @@ class FileSuspendedInvocationStoreTest {
             runBlocking { wrongStore.revealReplayEnvelope(metadata.approvalId) }
         }
     }
+    }
 
     @Test
-    fun `ciphertext tampering rejected`() = runBlocking {
+    fun `ciphertext tampering rejected`() { runBlocking {
         val store = createStore()
         val (metadata, envelope) = createValidRecord()
         store.create(metadata, envelope)
@@ -189,9 +194,10 @@ class FileSuspendedInvocationStoreTest {
             runBlocking { store.revealReplayEnvelope(metadata.approvalId) }
         }
     }
+    }
 
     @Test
-    fun `filename substitution rejected`() = runBlocking {
+    fun `filename substitution rejected`() { runBlocking {
         val store = createStore()
         val (metadata, envelope) = createValidRecord(approvalId = "approval-substitution-a")
         store.create(metadata, envelope)
@@ -205,9 +211,10 @@ class FileSuspendedInvocationStoreTest {
             runBlocking { store.get(substitutedApprovalId) }
         }
     }
+    }
 
     @Test
-    fun `startup verification fails for corrupted suspended record`() = runBlocking {
+    fun `startup verification fails for corrupted suspended record`() { runBlocking {
         val (metadata, envelope) = createValidRecord(approvalId = "approval-verify-open-1")
         createStore().create(metadata, envelope)
 
@@ -222,9 +229,10 @@ class FileSuspendedInvocationStoreTest {
             FileBackedSovereignStores.open(createConfig(verifyOnOpen = true))
         }
     }
+    }
 
     @Test
-    fun `unexpected file in suspended directory rejected`() = runBlocking {
+    fun `unexpected file in suspended directory rejected`() { runBlocking {
         val store = createStore()
         Files.writeString(rootDir.resolve("suspended/foo.txt"), "unexpected")
 
@@ -232,9 +240,10 @@ class FileSuspendedInvocationStoreTest {
             store.verifyAll()
         }
     }
+    }
 
     @Test
-    fun `unexpected directory in suspended directory rejected`() = runBlocking {
+    fun `unexpected directory in suspended directory rejected`() { runBlocking {
         val store = createStore()
         Files.createDirectories(rootDir.resolve("suspended/extra"))
 
@@ -242,9 +251,10 @@ class FileSuspendedInvocationStoreTest {
             store.verifyAll()
         }
     }
+    }
 
     @Test
-    fun `bad permissions on suspended file rejected`() = runBlocking {
+    fun `bad permissions on suspended file rejected`() { runBlocking {
         val store = createStore()
         val (metadata, envelope) = createValidRecord()
         store.create(metadata, envelope)
@@ -257,9 +267,10 @@ class FileSuspendedInvocationStoreTest {
             runBlocking { store.revealReplayEnvelope(metadata.approvalId) }
         }
     }
+    }
 
     @Test
-    fun `symlinked suspended record file rejected`() = runBlocking {
+    fun `symlinked suspended record file rejected`() { runBlocking {
         val store = createStore()
         val (metadata, envelope) = createValidRecord()
         store.create(metadata, envelope)
@@ -277,9 +288,10 @@ class FileSuspendedInvocationStoreTest {
             store.verifyAll()
         }
     }
+    }
 
     @Test
-    fun `symlinked suspended directory rejected`() = runBlocking {
+    fun `symlinked suspended directory rejected`() { runBlocking {
         val store = createStore()
         val realDir = rootDir.resolve("external-suspended")
         Files.createDirectories(realDir)
@@ -293,9 +305,10 @@ class FileSuspendedInvocationStoreTest {
             store.verifyAll()
         }
     }
+    }
 
     @Test
-    fun `operations after lease close rejected`() = runBlocking {
+    fun `operations after lease close rejected`() { runBlocking {
         val lease = FileStoreLease()
         val store = createStore(lease = lease)
         lease.close()
@@ -310,9 +323,10 @@ class FileSuspendedInvocationStoreTest {
             runBlocking { store.remove("approval-closed") }
         }
     }
+    }
 
     @Test
-    fun `concurrent creates have exactly one winner`() = runBlocking {
+    fun `concurrent creates have exactly one winner`() { runBlocking {
         val store = createStore()
         val (metadata, envelope) = createValidRecord(approvalId = "approval-concurrent-1")
 
@@ -339,9 +353,10 @@ class FileSuspendedInvocationStoreTest {
             assertEquals(1, outcomes.count { it == "winner" })
         }
     }
+    }
 
     @Test
-    fun `get and remove validate replay record before returning metadata or deleting`() = runBlocking {
+    fun `get and remove validate replay record before returning metadata or deleting`() { runBlocking {
         val store = createStore()
         val (metadata, envelope) = createValidRecord(approvalId = "approval-validated-read-1")
         store.create(metadata, envelope)
@@ -374,9 +389,10 @@ class FileSuspendedInvocationStoreTest {
             runBlocking { store.revealReplayEnvelope(metadata.approvalId) }
         }
     }
+    }
 
     @Test
-    fun `cross module replay digest contract holds across persist and reveal`() = runBlocking {
+    fun `cross module replay digest contract holds across persist and reveal`() { runBlocking {
         val store = createStore()
         val (metadata, envelope) = createValidRecord(approvalId = "approval-digest-contract-1")
 
@@ -395,6 +411,7 @@ class FileSuspendedInvocationStoreTest {
                 metadata.operationReference, revealedMessages,
             ),
         )
+    }
     }
 
     private fun createValidRecord(): Pair<SuspendedInvocationMetadata, SensitiveReplayEnvelope> =

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalContinuationStoreTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalContinuationStoreTest.kt
@@ -207,7 +207,7 @@ class JdbcApprovalContinuationStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `create and get round-trips continuation`() = runBlocking {
+    fun `create and get round-trips continuation`() { runBlocking {
         val s = store()
         val (continuation, args) = createContinuation("roundtrip-1")
 
@@ -219,9 +219,10 @@ class JdbcApprovalContinuationStoreTest {
         assertEquals(ApprovalContinuationStatus.PENDING, retrieved.status)
         assertEquals(0L, retrieved.version)
     }
+    }
 
     @Test
-    fun `create rejects duplicate continuation id`() = runBlocking {
+    fun `create rejects duplicate continuation id`() { runBlocking {
         val s = store()
         val (cont, args) = createContinuation("dup-test")
 
@@ -232,15 +233,17 @@ class JdbcApprovalContinuationStoreTest {
             s.create(cont2, args2)
         }
     }
-
-    @Test
-    fun `get returns null for non-existent continuation`() = runBlocking {
-        val retrieved = store().get("non-existent")
-        assertNull(retrieved)
     }
 
     @Test
-    fun `persisted continuation survives new store instance`() = runBlocking {
+    fun `get returns null for non-existent continuation`() { runBlocking {
+        val retrieved = store().get("non-existent")
+        assertNull(retrieved)
+    }
+    }
+
+    @Test
+    fun `persisted continuation survives new store instance`() { runBlocking {
         val s1 = store()
         s1.create(createContinuation("survive-test").first, createContinuation("survive-test").second)
 
@@ -250,13 +253,14 @@ class JdbcApprovalContinuationStoreTest {
         assertEquals("survive-test", retrieved.approvalId)
         assertEquals(ApprovalContinuationStatus.PENDING, retrieved.status)
     }
+    }
 
     // ═══════════════════════════════════════════════════════════════
     // State-machine invariants
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `PENDING to CLAIMED to COMPLETED full lifecycle`() = runBlocking {
+    fun `PENDING to CLAIMED to COMPLETED full lifecycle`() { runBlocking {
         val s = store()
         s.create(createContinuation("lifecycle-1").first, createContinuation("lifecycle-1").second)
 
@@ -272,9 +276,10 @@ class JdbcApprovalContinuationStoreTest {
         assertEquals(2L, completed.version)
         assertNotNull(completed.completedAt)
     }
+    }
 
     @Test
-    fun `PENDING to EXPIRED transition`() = runBlocking {
+    fun `PENDING to EXPIRED transition`() { runBlocking {
         val creationTime = fixedClock.instant()
         val (continuation, args) = createContinuation("expire-1")
 
@@ -288,9 +293,10 @@ class JdbcApprovalContinuationStoreTest {
         assertEquals(ApprovalContinuationStatus.EXPIRED, expired.status)
         assertEquals(1L, expired.version)
     }
+    }
 
     @Test
-    fun `PENDING to CANCELLED transition`() = runBlocking {
+    fun `PENDING to CANCELLED transition`() { runBlocking {
         val s = store()
         s.create(createContinuation("cancel-1").first, createContinuation("cancel-1").second)
 
@@ -298,9 +304,10 @@ class JdbcApprovalContinuationStoreTest {
         assertEquals(ApprovalContinuationStatus.CANCELLED, cancelled.status)
         assertEquals(1L, cancelled.version)
     }
+    }
 
     @Test
-    fun `CLAIMED to CANCELLED_UNCERTAIN via force cancel`() = runBlocking {
+    fun `CLAIMED to CANCELLED_UNCERTAIN via force cancel`() { runBlocking {
         val s = store()
         s.create(createContinuation("force-1").first, createContinuation("force-1").second)
         s.claimForExecution("force-1", 0L, "worker:stuck")
@@ -315,9 +322,10 @@ class JdbcApprovalContinuationStoreTest {
         assertEquals("admin:alice", result.recoveryResolvedBy)
         assertEquals("stuck.worker", result.recoveryReasonCode)
     }
+    }
 
     @Test
-    fun `CLAIMED cannot be claimed again`() = runBlocking {
+    fun `CLAIMED cannot be claimed again`() { runBlocking {
         val s = store()
         s.create(createContinuation("reclaim-1").first, createContinuation("reclaim-1").second)
         s.claimForExecution("reclaim-1", 0L, "worker:eve")
@@ -326,9 +334,10 @@ class JdbcApprovalContinuationStoreTest {
             s.claimForExecution("reclaim-1", 1L, "worker:mallory")
         }
     }
+    }
 
     @Test
-    fun `COMPLETED continuation cannot be claimed again`() = runBlocking {
+    fun `COMPLETED continuation cannot be claimed again`() { runBlocking {
         val s = store()
         s.create(createContinuation("done-1").first, createContinuation("done-1").second)
         s.claimForExecution("done-1", 0L, "worker:alice")
@@ -338,9 +347,10 @@ class JdbcApprovalContinuationStoreTest {
             s.claimForExecution("done-1", 2L, "worker:bob")
         }
     }
+    }
 
     @Test
-    fun `CLAIMED cannot transition to EXPIRED`() = runBlocking {
+    fun `CLAIMED cannot transition to EXPIRED`() { runBlocking {
         val s = store()
         s.create(createContinuation("no-lazy-exp").first, createContinuation("no-lazy-exp").second)
         s.claimForExecution("no-lazy-exp", 0L, "worker:eve")
@@ -350,9 +360,10 @@ class JdbcApprovalContinuationStoreTest {
             s.expire("no-lazy-exp", 1L)
         }
     }
+    }
 
     @Test
-    fun `CLAIMED cannot transition to CANCELLED`() = runBlocking {
+    fun `CLAIMED cannot transition to CANCELLED`() { runBlocking {
         val s = store()
         s.create(createContinuation("no-cancel-claimed").first, createContinuation("no-cancel-claimed").second)
         s.claimForExecution("no-cancel-claimed", 0L, "worker:eve")
@@ -362,13 +373,14 @@ class JdbcApprovalContinuationStoreTest {
             s.cancel("no-cancel-claimed", 1L)
         }
     }
+    }
 
     // ═══════════════════════════════════════════════════════════════
     // Version invariants — optimistic locking
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `transition with expected version increments version`() = runBlocking {
+    fun `transition with expected version increments version`() { runBlocking {
         val s = store()
         s.create(createContinuation("ver-inc-1").first, createContinuation("ver-inc-1").second)
 
@@ -382,21 +394,34 @@ class JdbcApprovalContinuationStoreTest {
         assertNotNull(retrieved)
         assertEquals(2L, retrieved.version)
     }
+    }
 
     @Test
-    fun `transition with stale version fails`() = runBlocking {
+    fun `transition with stale version fails`() { runBlocking {
         val s = store()
         s.create(createContinuation("stale-ver-1").first, createContinuation("stale-ver-1").second)
-        s.claimForExecution("stale-ver-1", 0L, "worker:alice")
+
+        // No production path bumps the version while the row stays PENDING,
+        // so simulate a concurrent writer by tampering the row directly.
+        // The version guard fires before the status guard for PENDING rows.
+        val conn: Connection = DriverManager.getConnection(
+            postgres.jdbcUrl, postgres.username, postgres.password,
+        )
+        conn.use { c ->
+            c.prepareStatement(
+                "UPDATE approval_continuations SET version = 1 WHERE approval_id = 'stale-ver-1'",
+            ).use { stmt -> stmt.executeUpdate() }
+        }
 
         // Try claiming with version 0 (stale) instead of 1
         assertFailsWith<ApprovalContinuationConflictException> {
             s.claimForExecution("stale-ver-1", 0L, "worker:bob")
         }
     }
+    }
 
     @Test
-    fun `complete with stale version fails`() = runBlocking {
+    fun `complete with stale version fails`() { runBlocking {
         val s = store()
         s.create(createContinuation("stale-complete").first, createContinuation("stale-complete").second)
         s.claimForExecution("stale-complete", 0L, "worker:alice")
@@ -405,13 +430,14 @@ class JdbcApprovalContinuationStoreTest {
             s.complete("stale-complete", 0L, "worker:alice")
         }
     }
+    }
 
     // ═══════════════════════════════════════════════════════════════
     // Concurrency invariants
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `concurrent claim has exactly one winner`() = runBlocking {
+    fun `concurrent claim has exactly one winner`() { runBlocking {
         val s = store()
         s.create(createContinuation("concurrent-claim").first, createContinuation("concurrent-claim").second)
 
@@ -448,9 +474,10 @@ class JdbcApprovalContinuationStoreTest {
             assertEquals(1, winners, "Exactly one concurrent claim must succeed")
         }
     }
+    }
 
     @Test
-    fun `same continuation cannot be completed twice concurrently`() = runBlocking {
+    fun `same continuation cannot be completed twice concurrently`() { runBlocking {
         val s = store()
         s.create(createContinuation("double-complete").first, createContinuation("double-complete").second)
         s.claimForExecution("double-complete", 0L, "worker:alice")
@@ -480,13 +507,14 @@ class JdbcApprovalContinuationStoreTest {
             assertEquals(1, winners, "Exactly one concurrent complete must succeed")
         }
     }
+    }
 
     // ═══════════════════════════════════════════════════════════════
     // Restart invariants (proves persistence, not in-memory state)
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `create store A, write, create store B, read`() = runBlocking {
+    fun `create store A, write, create store B, read`() { runBlocking {
         val sA = store()
         val (cont, args) = createContinuation("store-ab-1")
         sA.create(cont, args)
@@ -497,9 +525,10 @@ class JdbcApprovalContinuationStoreTest {
         assertEquals(ApprovalContinuationStatus.PENDING, retrieved.status)
         assertEquals(0L, retrieved.version)
     }
+    }
 
     @Test
-    fun `create store A, claim with store B, complete with store C`() = runBlocking {
+    fun `create store A, claim with store B, complete with store C`() { runBlocking {
         val sA = store()
         sA.create(createContinuation("abc-lifecycle").first, createContinuation("abc-lifecycle").second)
 
@@ -512,9 +541,10 @@ class JdbcApprovalContinuationStoreTest {
         assertEquals(ApprovalContinuationStatus.COMPLETED, completed.status)
         assertEquals(2L, completed.version)
     }
+    }
 
     @Test
-    fun `claim arguments survive decryption across store instances`() = runBlocking {
+    fun `claim arguments survive decryption across store instances`() { runBlocking {
         val s1 = store()
         val (cont, args) = createContinuation("enc-roundtrip", arguments = "complex-arg-value")
         s1.create(cont, args)
@@ -523,13 +553,14 @@ class JdbcApprovalContinuationStoreTest {
         val claimed = s2.claimForExecution("enc-roundtrip", 0L, "worker:alice")
         assertEquals("complex-arg-value", claimed.arguments.reveal())
     }
+    }
 
     // ═══════════════════════════════════════════════════════════════
     // Stale CLAIMED search and sweep
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `findStaleClaimed returns claimed continuations before timestamp`() = runBlocking {
+    fun `findStaleClaimed returns claimed continuations before timestamp`() { runBlocking {
         val s = store()
         s.create(createContinuation("stale-search-1").first, createContinuation("stale-search-1").second)
         s.claimForExecution("stale-search-1", 0L, "worker:slow")
@@ -541,9 +572,10 @@ class JdbcApprovalContinuationStoreTest {
         assertEquals(1, stale.size)
         assertEquals("stale-search-1", stale.first().approvalId)
     }
+    }
 
     @Test
-    fun `sweepExpired transitions PENDING continuations past expiry`() = runBlocking {
+    fun `sweepExpired transitions PENDING continuations past expiry`() { runBlocking {
         val creationTime = fixedClock.instant()
         val s1 = store(clock = Clock.fixed(creationTime, ZoneId.of("UTC")))
         s1.create(
@@ -570,13 +602,14 @@ class JdbcApprovalContinuationStoreTest {
         assertNotNull(r2)
         assertEquals(ApprovalContinuationStatus.EXPIRED, r2.status)
     }
+    }
 
     // ═══════════════════════════════════════════════════════════════
     // Encrypted arguments tests
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `encrypted_arguments is non-null after create`() = runBlocking {
+    fun `encrypted_arguments is non-null after create`() { runBlocking {
         val s = store()
         s.create(createContinuation("enc-nonnull").first, createContinuation("enc-nonnull").second)
 
@@ -597,9 +630,10 @@ class JdbcApprovalContinuationStoreTest {
             }
         }
     }
+    }
 
     @Test
-    fun `encryption metadata fields are non-null after create`() = runBlocking {
+    fun `encryption metadata fields are non-null after create`() { runBlocking {
         val s = store()
         s.create(createContinuation("enc-meta").first, createContinuation("enc-meta").second)
 
@@ -622,9 +656,10 @@ class JdbcApprovalContinuationStoreTest {
             }
         }
     }
+    }
 
     @Test
-    fun `raw arguments are not visible in the database`() = runBlocking {
+    fun `raw arguments are not visible in the database`() { runBlocking {
         val s = store()
         s.create(
             createContinuation("enc-secret", arguments = "super-sensitive-value").first,
@@ -650,9 +685,10 @@ class JdbcApprovalContinuationStoreTest {
             }
         }
     }
+    }
 
     @Test
-    fun `encrypted_arguments are null after claim`() = runBlocking {
+    fun `encrypted_arguments are null after claim`() { runBlocking {
         val s = store()
         s.create(createContinuation("enc-null-after-claim").first,
             createContinuation("enc-null-after-claim").second)
@@ -674,13 +710,14 @@ class JdbcApprovalContinuationStoreTest {
             }
         }
     }
+    }
 
     // ═══════════════════════════════════════════════════════════════
     // Timestamp round-trip invariants
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `createdAt round-trips when earlier than store clock`() = runBlocking {
+    fun `createdAt round-trips when earlier than store clock`() { runBlocking {
         val now = fixedClock.instant()
         val past = now.minusSeconds(30)
         val args = SensitiveToolArguments.of("past-args")
@@ -709,13 +746,14 @@ class JdbcApprovalContinuationStoreTest {
         assertEquals(past, retrieved.createdAt)
         assertEquals(now.plus(Duration.ofMinutes(5)), retrieved.approvalExpiresAt)
     }
+    }
 
     // ═══════════════════════════════════════════════════════════════
     // Exception mapping
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `SQL unique violation maps to domain conflict`() = runBlocking {
+    fun `SQL unique violation maps to domain conflict`() { runBlocking {
         val s = store()
         s.create(createContinuation("unique-violation").first,
             createContinuation("unique-violation").second)
@@ -725,45 +763,52 @@ class JdbcApprovalContinuationStoreTest {
                 createContinuation("unique-violation").second)
         }
     }
-
-    @Test
-    fun `missing continuation returns null from get`() = runBlocking {
-        assertNull(store().get("does-not-exist"))
     }
 
     @Test
-    fun `claim on missing continuation throws not found`() = runBlocking {
+    fun `missing continuation returns null from get`() { runBlocking {
+        assertNull(store().get("does-not-exist"))
+    }
+    }
+
+    @Test
+    fun `claim on missing continuation throws not found`() { runBlocking {
         assertFailsWith<ApprovalContinuationNotFoundException> {
             store().claimForExecution("does-not-exist", 0L, "worker:test")
         }
     }
+    }
 
     @Test
-    fun `complete on missing continuation throws not found`() = runBlocking {
+    fun `complete on missing continuation throws not found`() { runBlocking {
         assertFailsWith<ApprovalContinuationNotFoundException> {
             store().complete("does-not-exist", 0L, "worker:test")
         }
     }
+    }
 
     @Test
-    fun `expire on missing continuation throws not found`() = runBlocking {
+    fun `expire on missing continuation throws not found`() { runBlocking {
         assertFailsWith<ApprovalContinuationNotFoundException> {
             store().expire("does-not-exist", 0L)
         }
     }
+    }
 
     @Test
-    fun `cancel on missing continuation throws not found`() = runBlocking {
+    fun `cancel on missing continuation throws not found`() { runBlocking {
         assertFailsWith<ApprovalContinuationNotFoundException> {
             store().cancel("does-not-exist", 0L)
         }
     }
+    }
 
     @Test
-    fun `forceCancelClaimed on missing continuation throws not found`() = runBlocking {
+    fun `forceCancelClaimed on missing continuation throws not found`() { runBlocking {
         assertFailsWith<ApprovalContinuationNotFoundException> {
             store().forceCancelClaimed("does-not-exist", 0L, "admin:test", "test.reason")
         }
+    }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -771,7 +816,7 @@ class JdbcApprovalContinuationStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `get auto-expires PENDING continuation past expiry`() = runBlocking {
+    fun `get auto-expires PENDING continuation past expiry`() { runBlocking {
         val creationTime = fixedClock.instant()
         val s1 = store(clock = Clock.fixed(creationTime, ZoneId.of("UTC")))
         s1.create(createContinuation("lazy-expire").first, createContinuation("lazy-expire").second)
@@ -784,9 +829,10 @@ class JdbcApprovalContinuationStoreTest {
         assertEquals(ApprovalContinuationStatus.EXPIRED, retrieved.status)
         assertEquals(1L, retrieved.version)
     }
+    }
 
     @Test
-    fun `concurrent claim after lazy expiry fails`() = runBlocking {
+    fun `concurrent claim after lazy expiry fails`() { runBlocking {
         val creationTime = fixedClock.instant()
         val s1 = store(clock = Clock.fixed(creationTime, ZoneId.of("UTC")))
         s1.create(createContinuation("lazy-claim-fails").first,
@@ -799,13 +845,14 @@ class JdbcApprovalContinuationStoreTest {
             s2.claimForExecution("lazy-claim-fails", 0L, "worker:late")
         }
     }
+    }
 
     // ═══════════════════════════════════════════════════════════════
     // Version overflow safety
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `sweep does not transition non-PENDING continuations`() = runBlocking {
+    fun `sweep does not transition non-PENDING continuations`() { runBlocking {
         val s = store()
         s.create(createContinuation("sweep-non-pending").first,
             createContinuation("sweep-non-pending").second)
@@ -815,9 +862,10 @@ class JdbcApprovalContinuationStoreTest {
         val swept = s.sweepExpired()
         assertEquals(0, swept, "COMPLETED continuations must not be swept")
     }
+    }
 
     @Test
-    fun `findStaleClaimed ignores non-CLAIMED statuses`() = runBlocking {
+    fun `findStaleClaimed ignores non-CLAIMED statuses`() { runBlocking {
         val s = store()
         // Create a PENDING continuation (not stale)
         s.create(createContinuation("not-stale").first, createContinuation("not-stale").second)
@@ -828,9 +876,10 @@ class JdbcApprovalContinuationStoreTest {
         )
         assertTrue(stale.isEmpty(), "PENDING continuation must not appear in stale results")
     }
+    }
 
     @Test
-    fun `expire before expiry time fails`() = runBlocking {
+    fun `expire before expiry time fails`() { runBlocking {
         val s = store()
         s.create(createContinuation("early-expire").first, createContinuation("early-expire").second)
 
@@ -838,13 +887,14 @@ class JdbcApprovalContinuationStoreTest {
             s.expire("early-expire", 0L)
         }
     }
+    }
 
     // ═══════════════════════════════════════════════════════════════
     // P1 regression — decrypt-before-CAS atomicity
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `claim preserves encrypted arguments when decode fails`() = runBlocking {
+    fun `claim preserves encrypted arguments when decode fails`() { runBlocking {
         // Codec that encodes successfully but fails on decode
         val brokenCodec = object : JdbcContinuationArgumentsCodec {
             override fun encode(plaintext: ByteArray): JdbcEncryptedContinuationArguments {
@@ -886,13 +936,14 @@ class JdbcApprovalContinuationStoreTest {
             }
         }
     }
+    }
 
     // ═══════════════════════════════════════════════════════════════
     // P2 regression — lazy expiry CAS race
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `get re-reads actual state when lazy expiry CAS loses race`() = runBlocking {
+    fun `get re-reads actual state when lazy expiry CAS loses race`() { runBlocking {
         val creationTime = fixedClock.instant()
         val s1 = store(clock = Clock.fixed(creationTime, ZoneId.of("UTC")))
         s1.create(createContinuation("lazy-race").first, createContinuation("lazy-race").second)
@@ -924,13 +975,14 @@ class JdbcApprovalContinuationStoreTest {
             "get() must return actual persisted state, not synthetic EXPIRED")
         assertEquals(1L, retrieved.version)
     }
+    }
 
     // ═══════════════════════════════════════════════════════════════
     // P2 regression — V2 schema CHECK constraints
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `schema rejects invalid status`() = runBlocking {
+    fun `schema rejects invalid status`() { runBlocking {
         val conn: Connection = DriverManager.getConnection(
             postgres.jdbcUrl, postgres.username, postgres.password,
         )
@@ -944,9 +996,10 @@ class JdbcApprovalContinuationStoreTest {
             }
         }
     }
+    }
 
     @Test
-    fun `schema rejects approval_expires_at before created_at`() = runBlocking {
+    fun `schema rejects approval_expires_at before created_at`() { runBlocking {
         val conn: Connection = DriverManager.getConnection(
             postgres.jdbcUrl, postgres.username, postgres.password,
         )
@@ -959,5 +1012,6 @@ class JdbcApprovalContinuationStoreTest {
                 stmt.executeUpdate()
             }
         }
+    }
     }
 }

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStoreTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStoreTest.kt
@@ -126,7 +126,7 @@ class JdbcApprovalStoreTest {
     // ── Create / Get ────────────────────────────────────────────
 
     @Test
-    fun `saves and loads a pending approval`() = runBlocking {
+    fun `saves and loads a pending approval`() { runBlocking {
         val s = store()
         val request = approvalRequest()
 
@@ -140,9 +140,10 @@ class JdbcApprovalStoreTest {
         assertEquals("deploy-service", loaded.binding.toolName)
         assertEquals(0, loaded.version)
     }
+    }
 
     @Test
-    fun `persisted approval survives new store instance`() = runBlocking {
+    fun `persisted approval survives new store instance`() { runBlocking {
         val s1 = store()
         s1.create(approvalRequest(id = "survive-test"))
 
@@ -153,15 +154,17 @@ class JdbcApprovalStoreTest {
         assertEquals(ApprovalStatus.PENDING, loaded.status)
         assertEquals("user:alice", loaded.requestedBy)
     }
-
-    @Test
-    fun `get returns null for non-existent approval`() = runBlocking {
-        val loaded = store().get("non-existent")
-        assertNull(loaded)
     }
 
     @Test
-    fun `duplicate approval ID throws ApprovalStoreConflictException`() = runBlocking {
+    fun `get returns null for non-existent approval`() { runBlocking {
+        val loaded = store().get("non-existent")
+        assertNull(loaded)
+    }
+    }
+
+    @Test
+    fun `duplicate approval ID throws ApprovalStoreConflictException`() { runBlocking {
         val s = store()
         s.create(approvalRequest(id = "dup-test"))
 
@@ -169,11 +172,12 @@ class JdbcApprovalStoreTest {
             s.create(approvalRequest(id = "dup-test"))
         }
     }
+    }
 
     // ── Transitions ─────────────────────────────────────────────
 
     @Test
-    fun `records approval decision`() = runBlocking {
+    fun `records approval decision`() { runBlocking {
         val s = store()
         s.create(approvalRequest(id = "approve-test"))
 
@@ -184,9 +188,10 @@ class JdbcApprovalStoreTest {
         assertNotNull(updated.decidedAt)
         assertEquals(1, updated.version)
     }
+    }
 
     @Test
-    fun `records denial decision`() = runBlocking {
+    fun `records denial decision`() { runBlocking {
         val s = store()
         s.create(approvalRequest(id = "deny-test"))
 
@@ -197,9 +202,10 @@ class JdbcApprovalStoreTest {
         assertEquals("not approved", updated.decisionComment)
         assertEquals(1, updated.version)
     }
+    }
 
     @Test
-    fun `records timeout decision`() = runBlocking {
+    fun `records timeout decision`() { runBlocking {
         val s = store()
         s.create(approvalRequest(id = "timeout-test"))
 
@@ -214,9 +220,10 @@ class JdbcApprovalStoreTest {
         assertNull(updated.decidedBy)
         assertEquals(1, updated.version)
     }
+    }
 
     @Test
-    fun `transition with wrong version throws ApprovalStoreConflictException`() = runBlocking {
+    fun `transition with wrong version throws ApprovalStoreConflictException`() { runBlocking {
         val s = store()
         s.create(approvalRequest(id = "version-test"))
         s.transition("version-test", 0, ApprovalTransition.Approve("user:bob"))
@@ -225,16 +232,18 @@ class JdbcApprovalStoreTest {
             s.transition("version-test", 0, ApprovalTransition.Deny("user:mallory"))
         }
     }
+    }
 
     @Test
-    fun `transition on non-existent approval throws ApprovalStoreNotFoundException`() = runBlocking {
+    fun `transition on non-existent approval throws ApprovalStoreNotFoundException`() { runBlocking {
         assertFailsWith<ApprovalStoreNotFoundException> {
             store().transition("non-existent", 0, ApprovalTransition.Approve("user:bob"))
         }
     }
+    }
 
     @Test
-    fun `illegal transition from terminal status throws IllegalApprovalTransitionException`() = runBlocking {
+    fun `illegal transition from terminal status throws IllegalApprovalTransitionException`() { runBlocking {
         val s = store()
         s.create(approvalRequest(id = "terminal-test"))
         s.transition("terminal-test", 0, ApprovalTransition.Approve("user:bob"))
@@ -243,9 +252,10 @@ class JdbcApprovalStoreTest {
             s.transition("terminal-test", 1, ApprovalTransition.Deny("user:bob"))
         }
     }
+    }
 
     @Test
-    fun `decision update increments version`() = runBlocking {
+    fun `decision update increments version`() { runBlocking {
         val s = store()
         s.create(approvalRequest(id = "version-inc-test"))
 
@@ -255,9 +265,10 @@ class JdbcApprovalStoreTest {
         val loaded = s.get("version-inc-test")
         assertEquals(1, loaded!!.version)
     }
+    }
 
     @Test
-    fun `competing decisions cannot both win`() = runBlocking {
+    fun `competing decisions cannot both win`() { runBlocking {
         val s = store()
         s.create(approvalRequest(id = "compete-test"))
 
@@ -267,11 +278,12 @@ class JdbcApprovalStoreTest {
             s.transition("compete-test", 0, ApprovalTransition.Deny("user:mallory"))
         }
     }
+    }
 
     // ── Consume / Replay ────────────────────────────────────────
 
     @Test
-    fun `consumes an approved request`() = runBlocking {
+    fun `consumes an approved request`() { runBlocking {
         val s = store()
         s.create(approvalRequest(id = "consume-test"))
         s.transition("consume-test", 0, ApprovalTransition.Approve("user:bob"))
@@ -287,9 +299,10 @@ class JdbcApprovalStoreTest {
         assertEquals(2, receipt.request.version)
         assertEquals(false, receipt.replayed)
     }
+    }
 
     @Test
-    fun `exact replay returns replayed receipt`() = runBlocking {
+    fun `exact replay returns replayed receipt`() { runBlocking {
         val s = store()
         s.create(approvalRequest(id = "replay-test"))
         s.transition("replay-test", 0, ApprovalTransition.Approve("user:bob"))
@@ -309,9 +322,10 @@ class JdbcApprovalStoreTest {
         assertEquals(true, receipt.replayed)
         assertEquals(2, receipt.request.version)
     }
+    }
 
     @Test
-    fun `consuming unapproved request throws ApprovalStoreNotConsumableException`() = runBlocking {
+    fun `consuming unapproved request throws ApprovalStoreNotConsumableException`() { runBlocking {
         val s = store()
         s.create(approvalRequest(id = "unapproved-consume"))
 
@@ -323,9 +337,10 @@ class JdbcApprovalStoreTest {
             )
         }
     }
+    }
 
     @Test
-    fun `consuming with wrong token throws ApprovalStoreTokenRejectedException`() = runBlocking {
+    fun `consuming with wrong token throws ApprovalStoreTokenRejectedException`() { runBlocking {
         val s = store()
         s.create(approvalRequest(id = "wrong-token"))
         s.transition("wrong-token", 0, ApprovalTransition.Approve("user:bob"))
@@ -338,11 +353,12 @@ class JdbcApprovalStoreTest {
             )
         }
     }
+    }
 
     // ── Sanitized persistence ───────────────────────────────────
 
     @Test
-    fun `sanitized metadata round-trips as JSONB`() = runBlocking {
+    fun `sanitized metadata round-trips as JSONB`() { runBlocking {
         val s = store()
         val request = approvalRequest(id = "jsonb-test")
         s.create(request)
@@ -356,9 +372,10 @@ class JdbcApprovalStoreTest {
         assertEquals(request.binding.workflowDigest, loaded.binding.workflowDigest)
         assertEquals(request.binding.approvalTokenDigest, loaded.binding.approvalTokenDigest)
     }
+    }
 
     @Test
-    fun `encrypted_payload remains null for sanitized-only approval records`() = runBlocking {
+    fun `encrypted_payload remains null for sanitized-only approval records`() { runBlocking {
         val s = store()
         s.create(approvalRequest(id = "enc-null-test"))
 
@@ -374,9 +391,10 @@ class JdbcApprovalStoreTest {
             assertNull(rs.getObject("payload_digest"))
         }
     }
+    }
 
     @Test
-    fun `no raw prompt or model payload is persisted`() = runBlocking {
+    fun `no raw prompt or model payload is persisted`() { runBlocking {
         val s = store()
         s.create(approvalRequest(id = "sanitized-payload-test"))
         s.transition("sanitized-payload-test", 0, ApprovalTransition.Approve("user:bob"))
@@ -398,9 +416,10 @@ class JdbcApprovalStoreTest {
             assertTrue("argumentsDigest" in metadata)
         }
     }
+    }
 
     @Test
-    fun `decision_actor_hash stores hash not raw identity`() = runBlocking {
+    fun `decision_actor_hash stores hash not raw identity`() { runBlocking {
         val s = store()
         s.create(approvalRequest(id = "actor-hash-test"))
         s.transition("actor-hash-test", 0, ApprovalTransition.Approve("user:bob"))
@@ -416,11 +435,12 @@ class JdbcApprovalStoreTest {
             assertEquals(71, hash.length)
         }
     }
+    }
 
     // ── RequestedAt round-trip ────────────────────────────────────
 
     @Test
-    fun `requestedAt round-trips when earlier than store clock`() = runBlocking {
+    fun `requestedAt round-trips when earlier than store clock`() { runBlocking {
         val now = fixedClock.instant()
         val request = approvalRequest(id = "requested-at-roundtrip").copy(
             requestedAt = now.minusSeconds(30),
@@ -434,11 +454,12 @@ class JdbcApprovalStoreTest {
         assertEquals(request.requestedAt, loaded.requestedAt)
         assertEquals(request.expiresAt, loaded.expiresAt)
     }
+    }
 
     // ── Concurrent consumption ────────────────────────────────────
 
     @Test
-    fun `concurrent consumption with same version results in exactly one fresh consume`() = runBlocking {
+    fun `concurrent consumption with same version results in exactly one fresh consume`() { runBlocking {
         val s = store()
         s.create(approvalRequest(id = "concurrent-consume"))
         s.transition("concurrent-consume", 0, ApprovalTransition.Approve("user:bob"))
@@ -469,11 +490,12 @@ class JdbcApprovalStoreTest {
         val freshCount = results.count { it == "fresh:false" }
         assertEquals(1, freshCount, "Exactly one concurrent consumer should get fresh consumption")
     }
+    }
 
     // ── Clock ───────────────────────────────────────────────────
 
     @Test
-    fun `created_at uses store clock`() = runBlocking {
+    fun `created_at uses store clock`() { runBlocking {
         val customClock = Clock.fixed(
             Instant.parse("2026-01-15T08:30:00Z"),
             ZoneId.of("UTC"),
@@ -488,5 +510,6 @@ class JdbcApprovalStoreTest {
         val loaded = s.get("clock-test")
         assertNotNull(loaded)
         assertEquals(Instant.parse("2026-01-15T08:30:00Z"), loaded.requestedAt)
+    }
     }
 }

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcAuditStoreTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcAuditStoreTest.kt
@@ -199,7 +199,7 @@ class JdbcAuditStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `append first event gets sequence 1 with null previous hash`() = runBlocking {
+    fun `append first event gets sequence 1 with null previous hash`() { runBlocking {
         val s = store()
         val event = s.appendNext("stream-1", eventFactory("stream-1"))
 
@@ -208,9 +208,10 @@ class JdbcAuditStoreTest {
         assertEquals("APPROVED", event.decision)
         assertEquals("evt-stream-1-1", event.eventId)
     }
+    }
 
     @Test
-    fun `append second event gets sequence 2 with correct previous hash`() = runBlocking {
+    fun `append second event gets sequence 2 with correct previous hash`() { runBlocking {
         val s = store()
         s.appendNext("stream-1", eventFactory("stream-1"))
         val second = s.appendNext("stream-1", eventFactory("stream-1"))
@@ -222,9 +223,10 @@ class JdbcAuditStoreTest {
         assertNotNull(first)
         assertEquals(2L, first.sequenceNumber)
     }
+    }
 
     @Test
-    fun `duplicate event ID is rejected`() = runBlocking {
+    fun `duplicate event ID is rejected`() { runBlocking {
         val s = store()
         s.appendNext("stream-1", eventFactory("stream-1"))
 
@@ -240,9 +242,10 @@ class JdbcAuditStoreTest {
             }
         }
     }
+    }
 
     @Test
-    fun `append with sequence gap is rejected`() = runBlocking {
+    fun `append with sequence gap is rejected`() { runBlocking {
         val s = store()
 
         assertFailsWith<IllegalArgumentException> {
@@ -256,9 +259,10 @@ class JdbcAuditStoreTest {
             }
         }
     }
+    }
 
     @Test
-    fun `append with wrong stream ID is rejected`() = runBlocking {
+    fun `append with wrong stream ID is rejected`() { runBlocking {
         val s = store()
 
         assertFailsWith<IllegalArgumentException> {
@@ -272,9 +276,10 @@ class JdbcAuditStoreTest {
             }
         }
     }
+    }
 
     @Test
-    fun `append with wrong previous hash is rejected`() = runBlocking {
+    fun `append with wrong previous hash is rejected`() { runBlocking {
         val s = store()
         s.appendNext("stream-1", eventFactory("stream-1"))
 
@@ -289,9 +294,10 @@ class JdbcAuditStoreTest {
             }
         }
     }
+    }
 
     @Test
-    fun `append with wrong event hash is rejected`() = runBlocking {
+    fun `append with wrong event hash is rejected`() { runBlocking {
         val s = store()
 
         assertFailsWith<IllegalArgumentException> {
@@ -305,13 +311,14 @@ class JdbcAuditStoreTest {
             }
         }
     }
+    }
 
     // ═══════════════════════════════════════════════════════════════
     // Read tests
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `readStream returns events in ascending sequence order`() = runBlocking {
+    fun `readStream returns events in ascending sequence order`() { runBlocking {
         val s = store()
         s.appendNext("stream-1", eventFactory("stream-1"))
         s.appendNext("stream-1", eventFactory("stream-1"))
@@ -326,9 +333,10 @@ class JdbcAuditStoreTest {
         assertEquals("evt-stream-1-2", events[1].eventId)
         assertEquals("evt-stream-1-3", events[2].eventId)
     }
+    }
 
     @Test
-    fun `readStream validates full chain and rejects corruption`() = runBlocking {
+    fun `readStream validates full chain and rejects corruption`() { runBlocking {
         val s = store()
         s.appendNext("stream-1", eventFactory("stream-1"))
         s.appendNext("stream-1", eventFactory("stream-1"))
@@ -347,15 +355,17 @@ class JdbcAuditStoreTest {
             s.readStream("stream-1")
         }
     }
-
-    @Test
-    fun `readStream returns empty for non-existent stream`() = runBlocking {
-        val events = store().readStream("non-existent")
-        assertTrue(events.isEmpty())
     }
 
     @Test
-    fun `readStreamPage with null after returns first page`() = runBlocking {
+    fun `readStream returns empty for non-existent stream`() { runBlocking {
+        val events = store().readStream("non-existent")
+        assertTrue(events.isEmpty())
+    }
+    }
+
+    @Test
+    fun `readStreamPage with null after returns first page`() { runBlocking {
         val s = store()
         s.appendNext("stream-1", eventFactory("stream-1"))
         s.appendNext("stream-1", eventFactory("stream-1"))
@@ -366,9 +376,10 @@ class JdbcAuditStoreTest {
         assertEquals(1L, page[0].sequenceNumber)
         assertEquals(2L, page[1].sequenceNumber)
     }
+    }
 
     @Test
-    fun `readStreamPage with cursor returns next page`() = runBlocking {
+    fun `readStreamPage with cursor returns next page`() { runBlocking {
         val s = store()
         s.appendNext("stream-1", eventFactory("stream-1"))
         s.appendNext("stream-1", eventFactory("stream-1"))
@@ -379,23 +390,26 @@ class JdbcAuditStoreTest {
         assertEquals(2L, page[0].sequenceNumber)
         assertEquals(3L, page[1].sequenceNumber)
     }
+    }
 
     @Test
-    fun `readStreamPage rejects negative cursor`() = runBlocking {
+    fun `readStreamPage rejects negative cursor`() { runBlocking {
         assertFailsWith<IllegalArgumentException> {
             store().readStreamPage("stream-1", afterSequenceNumber = -1, limit = 10)
         }
     }
+    }
 
     @Test
-    fun `readStreamPage rejects zero limit`() = runBlocking {
+    fun `readStreamPage rejects zero limit`() { runBlocking {
         assertFailsWith<IllegalArgumentException> {
             store().readStreamPage("stream-1", afterSequenceNumber = null, limit = 0)
         }
     }
+    }
 
     @Test
-    fun `latestEvent returns newest event`() = runBlocking {
+    fun `latestEvent returns newest event`() { runBlocking {
         val s = store()
         s.appendNext("stream-1", eventFactory("stream-1"))
         s.appendNext("stream-1", eventFactory("stream-1"))
@@ -405,10 +419,12 @@ class JdbcAuditStoreTest {
         assertEquals(2L, latest.sequenceNumber)
         assertEquals("evt-stream-1-2", latest.eventId)
     }
+    }
 
     @Test
-    fun `latestEvent returns null for empty stream`() = runBlocking {
+    fun `latestEvent returns null for empty stream`() { runBlocking {
         assertNull(store().latestEvent("empty-stream"))
+    }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -416,7 +432,7 @@ class JdbcAuditStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `store A appends, store B reads`() = runBlocking {
+    fun `store A appends, store B reads`() { runBlocking {
         val sA = store()
         sA.appendNext("stream-1", eventFactory("stream-1"))
         sA.appendNext("stream-1", eventFactory("stream-1"))
@@ -427,9 +443,10 @@ class JdbcAuditStoreTest {
         assertEquals("evt-stream-1-1", events[0].eventId)
         assertEquals("evt-stream-1-2", events[1].eventId)
     }
+    }
 
     @Test
-    fun `store A appends, store B appends next`() = runBlocking {
+    fun `store A appends, store B appends next`() { runBlocking {
         val sA = store()
         sA.appendNext("stream-1", eventFactory("stream-1"))
 
@@ -438,9 +455,10 @@ class JdbcAuditStoreTest {
         assertEquals(2L, next.sequenceNumber)
         assertEquals("evt-stream-1-2", next.eventId)
     }
+    }
 
     @Test
-    fun `store C reads full stream after A and B appends`() = runBlocking {
+    fun `store C reads full stream after A and B appends`() { runBlocking {
         val sA = store()
         sA.appendNext("stream-1", eventFactory("stream-1"))
         val sB = store()
@@ -451,6 +469,7 @@ class JdbcAuditStoreTest {
         assertEquals(2, events.size)
         val chain = checkChain(events)
         assertTrue(chain)
+    }
     }
 
     private fun checkChain(events: List<AuditEvent>): Boolean {
@@ -471,7 +490,7 @@ class JdbcAuditStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `concurrent appenders to same stream produce ordered sequence`() = runBlocking {
+    fun `concurrent appenders to same stream produce ordered sequence`() { runBlocking {
         val s = store()
         val numAppenders = 5
 
@@ -503,9 +522,10 @@ class JdbcAuditStoreTest {
         // Verify hash chain
         assertTrue(checkChain(events), "Hash chain must be valid after concurrent appends")
     }
+    }
 
     @Test
-    fun `concurrent appenders to different streams both succeed independently`() = runBlocking {
+    fun `concurrent appenders to different streams both succeed independently`() { runBlocking {
         val s = store()
 
         coroutineScope {
@@ -524,13 +544,14 @@ class JdbcAuditStoreTest {
         assertEquals(2, s.readStream("stream-a").size)
         assertEquals(2, s.readStream("stream-b").size)
     }
+    }
 
     // ═══════════════════════════════════════════════════════════════
     // Encryption tests
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `encrypted_payload is non-null after append`() = runBlocking {
+    fun `encrypted_payload is non-null after append`() { runBlocking {
         val s = store()
         s.appendNext("stream-1", eventFactory("stream-1"))
 
@@ -551,9 +572,10 @@ class JdbcAuditStoreTest {
             }
         }
     }
+    }
 
     @Test
-    fun `raw metadata and decision not visible in database`() = runBlocking {
+    fun `raw metadata and decision not visible in database`() { runBlocking {
         val s = store()
         s.appendNext("stream-1") {
             createEvent(
@@ -588,9 +610,10 @@ class JdbcAuditStoreTest {
             }
         }
     }
+    }
 
     @Test
-    fun `decode failure fails closed on read`() = runBlocking {
+    fun `decode failure fails closed on read`() { runBlocking {
         val s = store()
         s.appendNext("stream-1", eventFactory("stream-1"))
 
@@ -615,13 +638,14 @@ class JdbcAuditStoreTest {
             brokenStore.readStream("stream-1")
         }
     }
+    }
 
     // ═══════════════════════════════════════════════════════════════
     // Schema hardening tests
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `schema rejects negative sequence number`() = runBlocking {
+    fun `schema rejects negative sequence number`() { runBlocking {
         val conn: Connection = DriverManager.getConnection(
             postgres.jdbcUrl, postgres.username, postgres.password,
         )
@@ -633,9 +657,10 @@ class JdbcAuditStoreTest {
             ).use { stmt -> stmt.executeUpdate() }
         }
     }
+    }
 
     @Test
-    fun `schema rejects blank stream_id`() = runBlocking {
+    fun `schema rejects blank stream_id`() { runBlocking {
         val conn: Connection = DriverManager.getConnection(
             postgres.jdbcUrl, postgres.username, postgres.password,
         )
@@ -647,9 +672,10 @@ class JdbcAuditStoreTest {
             ).use { stmt -> stmt.executeUpdate() }
         }
     }
+    }
 
     @Test
-    fun `schema rejects wrong schema version`() = runBlocking {
+    fun `schema rejects wrong schema version`() { runBlocking {
         val conn: Connection = DriverManager.getConnection(
             postgres.jdbcUrl, postgres.username, postgres.password,
         )
@@ -661,9 +687,10 @@ class JdbcAuditStoreTest {
             ).use { stmt -> stmt.executeUpdate() }
         }
     }
+    }
 
     @Test
-    fun `schema rejects blank event_hash`() = runBlocking {
+    fun `schema rejects blank event_hash`() { runBlocking {
         val conn: Connection = DriverManager.getConnection(
             postgres.jdbcUrl, postgres.username, postgres.password,
         )
@@ -675,13 +702,14 @@ class JdbcAuditStoreTest {
             ).use { stmt -> stmt.executeUpdate() }
         }
     }
+    }
 
     // ═══════════════════════════════════════════════════════════════
     // Dedicated stream isolation
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `different streams have independent sequences`() = runBlocking {
+    fun `different streams have independent sequences`() { runBlocking {
         val s = store()
         s.appendNext("alpha", eventFactory("alpha"))
         s.appendNext("alpha", eventFactory("alpha"))
@@ -696,9 +724,10 @@ class JdbcAuditStoreTest {
         assertEquals(2L, alphaEvents[1].sequenceNumber)
         assertEquals(1L, betaEvents[0].sequenceNumber)
     }
+    }
 
     @Test
-    fun `readStreamPage validates chain within page`() = runBlocking {
+    fun `readStreamPage validates chain within page`() { runBlocking {
         val s = store()
         val numEvents = 10
         for (i in 1..numEvents) {
@@ -718,13 +747,14 @@ class JdbcAuditStoreTest {
         assertEquals(6L, page2[2].sequenceNumber)
         assertTrue(checkChain(page2))
     }
+    }
 
     // ═══════════════════════════════════════════════════════════════
     // P1 regression — tampered queryable DB columns fail closed
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `tampered event_hash column fails read`() = runBlocking {
+    fun `tampered event_hash column fails read`() { runBlocking {
         val s = store()
         s.appendNext("stream-1", eventFactory("stream-1"))
 
@@ -741,9 +771,10 @@ class JdbcAuditStoreTest {
             s.readStream("stream-1")
         }
     }
+    }
 
     @Test
-    fun `tampered previous_event_hash column fails read`() = runBlocking {
+    fun `tampered previous_event_hash column fails read`() { runBlocking {
         val s = store()
         s.appendNext("stream-1", eventFactory("stream-1"))
         s.appendNext("stream-1", eventFactory("stream-1"))
@@ -761,9 +792,10 @@ class JdbcAuditStoreTest {
             s.readStream("stream-1")
         }
     }
+    }
 
     @Test
-    fun `tampered event_type column fails read`() = runBlocking {
+    fun `tampered event_type column fails read`() { runBlocking {
         val s = store()
         s.appendNext("stream-1", eventFactory("stream-1"))
 
@@ -780,9 +812,10 @@ class JdbcAuditStoreTest {
             s.readStream("stream-1")
         }
     }
+    }
 
     @Test
-    fun `tampered schema_version column fails read`() = runBlocking {
+    fun `tampered schema_version column fails read`() { runBlocking {
         val s = store()
         s.appendNext("stream-1", eventFactory("stream-1"))
 
@@ -790,14 +823,32 @@ class JdbcAuditStoreTest {
             postgres.jdbcUrl, postgres.username, postgres.password,
         )
         conn.use { c ->
-            c.prepareStatement(
-                "UPDATE audit_events SET schema_version = '0' WHERE event_id = 'evt-stream-1-1'",
-            ).use { stmt -> stmt.executeUpdate() }
-        }
+            // ck_audit_events_schema_version CHECK (schema_version = '1') would
+            // reject the tamper at write time, so drop it, tamper, and restore
+            // it afterwards — the read path must still fail closed.
+            c.createStatement().use { stmt ->
+                stmt.execute("ALTER TABLE audit_events DROP CONSTRAINT ck_audit_events_schema_version")
+            }
+            try {
+                c.prepareStatement(
+                    "UPDATE audit_events SET schema_version = '0' WHERE event_id = 'evt-stream-1-1'",
+                ).use { stmt -> stmt.executeUpdate() }
 
-        assertFailsWith<IllegalArgumentException> {
-            s.readStream("stream-1")
+                assertFailsWith<IllegalArgumentException> {
+                    s.readStream("stream-1")
+                }
+            } finally {
+                c.prepareStatement(
+                    "UPDATE audit_events SET schema_version = '1' WHERE event_id = 'evt-stream-1-1'",
+                ).use { stmt -> stmt.executeUpdate() }
+                c.createStatement().use { stmt ->
+                    stmt.execute(
+                        "ALTER TABLE audit_events ADD CONSTRAINT ck_audit_events_schema_version CHECK (schema_version = '1')",
+                    )
+                }
+            }
         }
+    }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -805,7 +856,7 @@ class JdbcAuditStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `sanitized_actor stores hash not raw actor`() = runBlocking {
+    fun `sanitized_actor stores hash not raw actor`() { runBlocking {
         val s = store()
         s.appendNext("stream-1", eventFactory("stream-1", actor = "user:secret-agent"))
 
@@ -830,9 +881,10 @@ class JdbcAuditStoreTest {
             }
         }
     }
+    }
 
     @Test
-    fun `sanitized_actor is null when actor is null`() = runBlocking {
+    fun `sanitized_actor is null when actor is null`() { runBlocking {
         val s = store()
         s.appendNext("stream-1", eventFactory("stream-1", actor = null))
 
@@ -851,13 +903,14 @@ class JdbcAuditStoreTest {
             }
         }
     }
+    }
 
     // ═══════════════════════════════════════════════════════════════
     // P1/P2 regression — stream head integrity
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `append fails when stream head points to missing event`() = runBlocking {
+    fun `append fails when stream head points to missing event`() { runBlocking {
         val s = store()
         s.appendNext("stream-1", eventFactory("stream-1"))
 
@@ -876,9 +929,10 @@ class JdbcAuditStoreTest {
             s.appendNext("stream-1", eventFactory("stream-1"))
         }
     }
+    }
 
     @Test
-    fun `append fails when stream head event_id mismatches latest event`() = runBlocking {
+    fun `append fails when stream head event_id mismatches latest event`() { runBlocking {
         val s = store()
         s.appendNext("stream-1", eventFactory("stream-1"))
         s.appendNext("stream-1", eventFactory("stream-1"))
@@ -899,9 +953,10 @@ class JdbcAuditStoreTest {
             s.appendNext("stream-1", eventFactory("stream-1"))
         }
     }
+    }
 
     @Test
-    fun `append fails when stream head event_hash mismatches latest event`() = runBlocking {
+    fun `append fails when stream head event_hash mismatches latest event`() { runBlocking {
         val s = store()
         s.appendNext("stream-1", eventFactory("stream-1"))
 
@@ -919,5 +974,6 @@ class JdbcAuditStoreTest {
         assertFailsWith<IllegalArgumentException> {
             s.appendNext("stream-1", eventFactory("stream-1"))
         }
+    }
     }
 }

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcSuspendedInvocationStoreTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcSuspendedInvocationStoreTest.kt
@@ -241,7 +241,7 @@ class JdbcSuspendedInvocationStoreTest {
     // ── Tests ─────────────────────────────────────────────────────
 
     @Test
-    fun `stores a suspended invocation`() = runBlocking {
+    fun `stores a suspended invocation`() { runBlocking {
         val s = store()
         s.create(sampleMetadata(), sampleEnvelope())
 
@@ -251,9 +251,10 @@ class JdbcSuspendedInvocationStoreTest {
         assertEquals("tc-1", loaded.toolCallId)
         assertEquals("test_tool", loaded.toolName)
     }
+    }
 
     @Test
-    fun `loads a suspended invocation by ID`() = runBlocking {
+    fun `loads a suspended invocation by ID`() { runBlocking {
         val s = store()
         val messagesA = sampleMessages()
         val messagesB = listOf(
@@ -283,9 +284,10 @@ class JdbcSuspendedInvocationStoreTest {
         assertNotNull(loaded)
         assertEquals("si-load-2", loaded.approvalId)
     }
+    }
 
     @Test
-    fun `persisted invocation survives new store instance`() = runBlocking {
+    fun `persisted invocation survives new store instance`() { runBlocking {
         val s1 = store()
         s1.create(sampleMetadata("si-survive"), sampleEnvelope())
 
@@ -294,9 +296,10 @@ class JdbcSuspendedInvocationStoreTest {
         assertNotNull(loaded)
         assertEquals("si-survive", loaded.approvalId)
     }
+    }
 
     @Test
-    fun `duplicate invocation ID is rejected`() = runBlocking {
+    fun `duplicate invocation ID is rejected`() { runBlocking {
         val s = store()
         s.create(sampleMetadata("si-duplicate-id"), sampleEnvelope())
 
@@ -305,9 +308,10 @@ class JdbcSuspendedInvocationStoreTest {
         }
         assertTrue(ex.message?.contains("already-exists", ignoreCase = true) == true)
     }
+    }
 
     @Test
-    fun `duplicate replay envelope digest is rejected`() = runBlocking {
+    fun `duplicate replay envelope digest is rejected`() { runBlocking {
         val s = store()
         s.create(
             sampleMetadata("si-digest-1"),
@@ -326,9 +330,10 @@ class JdbcSuspendedInvocationStoreTest {
             "Expected digest/conflict message but got: ${ex.message}",
         )
     }
+    }
 
     @Test
-    fun `create rejects replay envelope digest mismatch`() = runBlocking {
+    fun `create rejects replay envelope digest mismatch`() { runBlocking {
         val s = store()
         val wrongDigest = Sha256Digest.of(
             "sha256:9999999999999999999999999999999999999999999999999999999999999999",
@@ -345,9 +350,10 @@ class JdbcSuspendedInvocationStoreTest {
             "Expected digest mismatch error but got: ${ex.message}",
         )
     }
+    }
 
     @Test
-    fun `same replay envelope cannot be stored with different metadata digest`() = runBlocking {
+    fun `same replay envelope cannot be stored with different metadata digest`() { runBlocking {
         val s = store()
         val messages = sampleMessages()
 
@@ -372,9 +378,10 @@ class JdbcSuspendedInvocationStoreTest {
             "Expected digest mismatch error but got: ${ex.message}",
         )
     }
+    }
 
     @Test
-    fun `replay envelope round-trips through codec`() = runBlocking {
+    fun `replay envelope round-trips through codec`() { runBlocking {
         val s = store()
         val messages = sampleMessages()
         s.create(sampleMetadata("si-roundtrip"), sampleEnvelope(messages))
@@ -386,9 +393,10 @@ class JdbcSuspendedInvocationStoreTest {
         assertEquals("Hello", payload.messages[0].content)
         assertEquals("tc-1", payload.messages[1].toolCalls!![0].id)
     }
+    }
 
     @Test
-    fun `encrypted_replay_envelope is non-null`() = runBlocking {
+    fun `encrypted_replay_envelope is non-null`() { runBlocking {
         val s = store()
         s.create(sampleMetadata("si-enc-nonnull"), sampleEnvelope())
 
@@ -407,9 +415,10 @@ class JdbcSuspendedInvocationStoreTest {
             }
         }
     }
+    }
 
     @Test
-    fun `encryption metadata fields are non-null`() = runBlocking {
+    fun `encryption metadata fields are non-null`() { runBlocking {
         val s = store()
         s.create(sampleMetadata("si-enc-meta"), sampleEnvelope())
 
@@ -433,9 +442,10 @@ class JdbcSuspendedInvocationStoreTest {
             }
         }
     }
+    }
 
     @Test
-    fun `raw replay envelope is not visible in the database`() = runBlocking {
+    fun `raw replay envelope is not visible in the database`() { runBlocking {
         val s = store()
         // Create with some sensitive content
         val messages = listOf(
@@ -477,21 +487,24 @@ class JdbcSuspendedInvocationStoreTest {
             }
         }
     }
+    }
 
     @Test
-    fun `returns metadata not found`() = runBlocking {
+    fun `returns metadata not found`() { runBlocking {
         val s = store()
         assertNull(s.get("non-existent"))
     }
-
-    @Test
-    fun `returns envelope not found`() = runBlocking {
-        val s = store()
-        assertNull(s.revealReplayEnvelope("non-existent"))
     }
 
     @Test
-    fun `returns metadata on remove`() = runBlocking {
+    fun `returns envelope not found`() { runBlocking {
+        val s = store()
+        assertNull(s.revealReplayEnvelope("non-existent"))
+    }
+    }
+
+    @Test
+    fun `returns metadata on remove`() { runBlocking {
         val s = store()
         s.create(sampleMetadata("si-remove"), sampleEnvelope())
 
@@ -502,15 +515,17 @@ class JdbcSuspendedInvocationStoreTest {
         // Gone after removal
         assertNull(s.get("si-remove"))
     }
-
-    @Test
-    fun `returns null on remove for non-existent`() = runBlocking {
-        val s = store()
-        assertNull(s.remove("non-existent"))
     }
 
     @Test
-    fun `version increments on create`() = runBlocking {
+    fun `returns null on remove for non-existent`() { runBlocking {
+        val s = store()
+        assertNull(s.remove("non-existent"))
+    }
+    }
+
+    @Test
+    fun `version increments on create`() { runBlocking {
         val s = store()
         s.create(sampleMetadata("si-version"), sampleEnvelope())
 
@@ -527,9 +542,10 @@ class JdbcSuspendedInvocationStoreTest {
             }
         }
     }
+    }
 
     @Test
-    fun `duplicate remove returns null`() = runBlocking {
+    fun `duplicate remove returns null`() { runBlocking {
         val s = store()
         s.create(sampleMetadata("si-dup-remove"), sampleEnvelope())
 
@@ -539,9 +555,10 @@ class JdbcSuspendedInvocationStoreTest {
         val second = s.remove("si-dup-remove")
         assertNull(second)
     }
+    }
 
     @Test
-    fun `corrupted encrypted payload fails closed`() = runBlocking {
+    fun `corrupted encrypted payload fails closed`() { runBlocking {
         val s = store()
         s.create(sampleMetadata("si-corrupt"), sampleEnvelope())
 
@@ -570,9 +587,10 @@ class JdbcSuspendedInvocationStoreTest {
             ex.message?.contains("Tag mismatch", ignoreCase = true) == true,
         )
     }
+    }
 
     @Test
-    fun `wrong encryption metadata fails closed`() = runBlocking {
+    fun `wrong encryption metadata fails closed`() { runBlocking {
         // Store with testCodec, then try to read with wrongMetadataCodec
         val sWrite = store(codec = testCodec)
         sWrite.create(sampleMetadata("si-bad-meta"), sampleEnvelope())
@@ -586,9 +604,10 @@ class JdbcSuspendedInvocationStoreTest {
             ex.message?.contains("failed", ignoreCase = true) == true,
         )
     }
+    }
 
     @Test
-    fun `non-unique SQL errors are not mapped to duplicate conflicts`() = runBlocking {
+    fun `non-unique SQL errors are not mapped to duplicate conflicts`() { runBlocking {
         // Verify that a non-23505 SQLException is rethrown, not swallowed as conflict
         val realDs = createDataSource()
         val throwingDs = object : DataSource by realDs {
@@ -619,9 +638,10 @@ class JdbcSuspendedInvocationStoreTest {
         assertTrue(ex.message?.contains("connection failure", ignoreCase = true) == true,
             "Non-23505 SQL error must be rethrown, not mapped to conflict")
     }
+    }
 
     @Test
-    fun `concurrent creation with same digest results in exactly one success`() = runBlocking {
+    fun `concurrent creation with same digest results in exactly one success`() { runBlocking {
         val s = store()
         val messages = sampleMessages()
 
@@ -650,9 +670,10 @@ class JdbcSuspendedInvocationStoreTest {
         val createdCount = results.count { it == "created" }
         assertEquals(1, createdCount, "Exactly one concurrent creation should succeed")
     }
+    }
 
     @Test
-    fun `concurrent remove returns metadata once and null once`() = runBlocking {
+    fun `concurrent remove returns metadata once and null once`() { runBlocking {
         val s = store()
         s.create(sampleMetadata("si-remove-concurrent"), sampleEnvelope())
 
@@ -666,9 +687,10 @@ class JdbcSuspendedInvocationStoreTest {
         assertEquals(1, results.count { it != null })
         assertEquals(1, results.count { it == null })
     }
+    }
 
     @Test
-    fun `metadata round-trips all fields correctly`() = runBlocking {
+    fun `metadata round-trips all fields correctly`() { runBlocking {
         val s = store()
         s.create(sampleMetadata("si-full-meta"), sampleEnvelope())
 
@@ -698,9 +720,10 @@ class JdbcSuspendedInvocationStoreTest {
         assertEquals(0.005, loaded.tokenBudgetSnapshot!!.totalOutputCost, 0.001)
         assertEquals("test_tool", loaded.toolReference.toolName)
     }
+    }
 
     @Test
-    fun `store clock is used for created_at`() = runBlocking {
+    fun `store clock is used for created_at`() { runBlocking {
         val s = store(clock = Clock.fixed(
             Instant.parse("2026-01-15T08:30:00Z"),
             ZoneId.of("UTC"),
@@ -721,9 +744,10 @@ class JdbcSuspendedInvocationStoreTest {
             }
         }
     }
+    }
 
     @Test
-    fun `service_key and operation_key are stored`() = runBlocking {
+    fun `service_key and operation_key are stored`() { runBlocking {
         val s = store()
         s.create(sampleMetadata("si-keys"), sampleEnvelope())
 
@@ -744,5 +768,6 @@ class JdbcSuspendedInvocationStoreTest {
                 }
             }
         }
+    }
     }
 }

--- a/tramai-rag/src/test/kotlin/dev/tramai/rag/RagPipelineTest.kt
+++ b/tramai-rag/src/test/kotlin/dev/tramai/rag/RagPipelineTest.kt
@@ -33,7 +33,7 @@ class RagPipelineTest {
     }
 
     @Test
-    fun `index loads chunks and upserts to vector store`() = runBlocking {
+    fun `index loads chunks and upserts to vector store`() { runBlocking {
         val tempFile = Files.createTempFile("rag-test-", ".txt")
         tempFile.toFile().deleteOnExit()
         Files.writeString(tempFile, "Tramai is a structured-first AI library. ".repeat(5))
@@ -49,9 +49,10 @@ class RagPipelineTest {
         assertTrue(results.isNotEmpty(), "Should have stored vectors")
         assertEquals(chunkCount, results.size)
     }
+    }
 
     @Test
-    fun `query retrieves and injects context`() = runBlocking {
+    fun `query retrieves and injects context`() { runBlocking {
         val ragDocText = "The RAG pipeline retrieves documents from a vector store."
         vectorStore.upsert("query_test", listOf(
             VectorEntry(
@@ -84,9 +85,10 @@ class RagPipelineTest {
         assertTrue(enriched.messages[0].content.contains(ragDocText))
         assertTrue(enriched.messages[0].content.contains("How does the RAG pipeline work?"))
     }
+    }
 
     @Test
-    fun `query with empty results returns original request`() = runBlocking {
+    fun `query with empty results returns original request`() { runBlocking {
         val loader = object : DocumentLoader {
             override suspend fun load(source: String): Document {
                 return Document(source, "Dummy")
@@ -103,9 +105,10 @@ class RagPipelineTest {
 
         assertEquals(request, enriched)
     }
+    }
 
     @Test
-    fun `index returns 0 for blank document`() = runBlocking {
+    fun `index returns 0 for blank document`() { runBlocking {
         val tempFile = Files.createTempFile("rag-empty-", ".txt")
         tempFile.toFile().deleteOnExit()
         Files.writeString(tempFile, "")
@@ -116,6 +119,7 @@ class RagPipelineTest {
         val chunkCount = pipeline.index(tempFile.toString(), "empty_test")
 
         assertEquals(0, chunkCount)
+    }
     }
 
     @Test
@@ -159,7 +163,7 @@ class RagPipelineTest {
     }
 
     @Test
-    fun `pipeline end to end with file loader`() = runBlocking {
+    fun `pipeline end to end with file loader`() { runBlocking {
         val tempFile = Files.createTempFile("rag-e2e-", ".txt")
         tempFile.toFile().deleteOnExit()
         Files.writeString(tempFile, "Tramai is an AI workflow library for the JVM.")
@@ -180,9 +184,10 @@ class RagPipelineTest {
         val enriched = pipeline.query("Tramai is an AI workflow library for the JVM.", request, "e2e_test")
         assertTrue(enriched.messages[0].content.contains("The following information may be relevant:"))
     }
+    }
 
     @Test
-    fun `query with non-null filter returns filtered results`() = runBlocking {
+    fun `query with non-null filter returns filtered results`() { runBlocking {
         vectorStore.upsert("filter_query_test", listOf(
             VectorEntry(
                 id = "matched",
@@ -215,9 +220,10 @@ class RagPipelineTest {
         assertTrue(enriched.messages[0].content.contains("Specific AI content"))
         assertFalse(enriched.messages[0].content.contains("Other content"))
     }
+    }
 
     @Test
-    fun `index generates safe IDs`() = runBlocking {
+    fun `index generates safe IDs`() { runBlocking {
         val tempFile = Files.createTempFile("rag-idtest-", ".txt")
         tempFile.toFile().deleteOnExit()
         Files.writeString(tempFile, "First chunk. Second chunk. Third chunk.")
@@ -237,6 +243,7 @@ class RagPipelineTest {
             assertTrue(result.id.matches(Regex("[0-9a-f]+")), "ID should be hex but was: ${result.id}")
         }
     }
+    }
 
     @Test
     fun `pipeline throws RagPipelineException on loader failure`() {
@@ -254,7 +261,7 @@ class RagPipelineTest {
     }
 
     @Test
-    fun `reindex replaces previous entries`() = runBlocking {
+    fun `reindex replaces previous entries`() { runBlocking {
         val tempFile = Files.createTempFile("rag-reindex-", ".txt")
         tempFile.toFile().deleteOnExit()
         Files.writeString(tempFile, "Content to reindex.")
@@ -275,9 +282,10 @@ class RagPipelineTest {
         // Make sure we don't have way more entries than expected
         assertTrue(results.size <= count2 + 1)
     }
+    }
 
     @Test
-    fun `concurrent index operations complete without error`() = runBlocking {
+    fun `concurrent index operations complete without error`() { runBlocking {
         val tempFile1 = Files.createTempFile("rag-concurrent1-", ".txt")
         tempFile1.toFile().deleteOnExit()
         Files.writeString(tempFile1, "First concurrent document content for testing.")
@@ -300,5 +308,6 @@ class RagPipelineTest {
 
         val results = vectorStore.search("concurrent_test", embeddingModel.embed("document"), 10)
         assertTrue(results.isNotEmpty(), "Concurrent index should store results")
+    }
     }
 }

--- a/tramai-rag/src/test/kotlin/dev/tramai/rag/RagRetrieverTest.kt
+++ b/tramai-rag/src/test/kotlin/dev/tramai/rag/RagRetrieverTest.kt
@@ -21,7 +21,7 @@ class RagRetrieverTest {
     }
 
     @Test
-    fun `retrieve returns results ordered by similarity`() = runBlocking {
+    fun `retrieve returns results ordered by similarity`() { runBlocking {
         val retriever = RagRetriever(embeddingModel, vectorStore, topK = 3, minScore = 0.0)
 
         val aiDocText = "Tramai is an AI library for the JVM"
@@ -58,18 +58,20 @@ class RagRetrieverTest {
         assertNotNull(exactMatch)
         assertEquals(1.0, exactMatch.score, 0.001)
     }
+    }
 
     @Test
-    fun `retrieve returns empty for nonexistent collection`() = runBlocking {
+    fun `retrieve returns empty for nonexistent collection`() { runBlocking {
         val retriever = RagRetriever(embeddingModel, vectorStore, topK = 5, minScore = 0.0)
 
         val results = retriever.retrieve("nonexistent", "some query")
 
         assertTrue(results.isEmpty())
     }
+    }
 
     @Test
-    fun `retrieve filters by minScore`() = runBlocking {
+    fun `retrieve filters by minScore`() { runBlocking {
         val retriever = RagRetriever(embeddingModel, vectorStore, topK = 5, minScore = 0.5)
 
         val docText = "Some document text"
@@ -86,9 +88,10 @@ class RagRetrieverTest {
         assertTrue(results.isNotEmpty())
         assertTrue(results.all { it.score >= 0.5 })
     }
+    }
 
     @Test
-    fun `retrieve with metadata filter`() = runBlocking {
+    fun `retrieve with metadata filter`() { runBlocking {
         val retriever = RagRetriever(embeddingModel, vectorStore, topK = 5, minScore = 0.0)
 
         val aiText = "AI content"
@@ -115,9 +118,10 @@ class RagRetrieverTest {
         assertEquals(1, results.size)
         assertEquals("d1", results[0].id)
     }
+    }
 
     @Test
-    fun `retrieve respects topK`() = runBlocking {
+    fun `retrieve respects topK`() { runBlocking {
         val retriever = RagRetriever(embeddingModel, vectorStore, topK = 1, minScore = 0.0)
 
         val docText = "First doc"
@@ -129,6 +133,7 @@ class RagRetrieverTest {
         val results = retriever.retrieve("topk_test", docText)
 
         assertEquals(1, results.size)
+    }
     }
 
     @Test

--- a/tramai-security/src/test/kotlin/dev/tramai/security/audit/AuditEngineApprovalLifecycleAuditEmitterTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/audit/AuditEngineApprovalLifecycleAuditEmitterTest.kt
@@ -70,7 +70,7 @@ class AuditEngineApprovalLifecycleAuditEmitterTest {
     }
 
     @Test
-    fun `same-prefix stream IDs produce independent audit streams`() = runTest {
+    fun `same-prefix stream IDs produce independent audit streams`() { runTest {
         val store2 = InMemoryAuditStore()
         val engine2 = AuditEngine(store2, clock = fixedClock)
         val emitter2 = AuditEngineApprovalLifecycleAuditEmitter(engine2)
@@ -104,11 +104,12 @@ class AuditEngineApprovalLifecycleAuditEmitterTest {
         assertTrue(streamA[0].previousEventHash == null)
         assertTrue(streamB[0].previousEventHash == null)
     }
+    }
 
     // ── P2-1: toolName in every lifecycle event ───────────────────────────────
 
     @Test
-    fun `toolName is present in metadata for all 8 lifecycle events`() = runTest {
+    fun `toolName is present in metadata for all 8 lifecycle events`() { runTest {
         // 1. onToolExecutionSuspended
         emitter.onToolExecutionSuspended(
             approvalId, workflowRunId, toolName, toolCallId,
@@ -162,9 +163,10 @@ class AuditEngineApprovalLifecycleAuditEmitterTest {
             events.find { it.enforcementPoint == "APPROVAL_FORCE_CANCELLED" }!!.metadata["toolName"],
         )
     }
+    }
 
     @Test
-    fun `toolName is present in metadata for all 8 events via parameterized`() = runTest {
+    fun `toolName is present in metadata for all 8 events via parameterized`() { runTest {
         val testStore = InMemoryAuditStore()
         val testEngine = AuditEngine(testStore, clock = fixedClock)
         val testEmitter = AuditEngineApprovalLifecycleAuditEmitter(testEngine)
@@ -184,11 +186,12 @@ class AuditEngineApprovalLifecycleAuditEmitterTest {
             assertEquals("my-tool", event.metadata["toolName"], "toolName must be present in ${event.enforcementPoint}")
         }
     }
+    }
 
     // ── P2-2: Reason code normalization ───────────────────────────────────────
 
     @Test
-    fun `secrets in reason are absent from durable metadata for uncertain outcome`() = runTest {
+    fun `secrets in reason are absent from durable metadata for uncertain outcome`() { runTest {
         val secretReason = "api_key=sk-1234567890abcdef timeout occurred"
         emitter.onUncertainOutcome(approvalId, "run-reason-secret", toolName, secretReason)
 
@@ -201,9 +204,10 @@ class AuditEngineApprovalLifecycleAuditEmitterTest {
         assertTrue(event.metadata.values.none { it.contains("sk-1234567890") })
         assertTrue(event.metadata.values.none { it.contains("api_key") })
     }
+    }
 
     @Test
-    fun `secrets in reason are absent from durable metadata for suspension cancelled`() = runTest {
+    fun `secrets in reason are absent from durable metadata for suspension cancelled`() { runTest {
         val secretReason = "password=supersecret! manual cancellation"
         emitter.onSuspensionCancelled(approvalId, "run-reason-secret-2", toolName, secretReason)
 
@@ -214,20 +218,22 @@ class AuditEngineApprovalLifecycleAuditEmitterTest {
         assertTrue(event.metadata.values.none { it.contains("supersecret") })
         assertTrue(event.metadata.values.none { it.contains("password") })
     }
+    }
 
     @Test
-    fun `valid reason code passes through normalized`() = runTest {
+    fun `valid reason code passes through normalized`() { runTest {
         emitter.onSuspensionCancelled(approvalId, "run-valid-reason", toolName, "manual_cancel")
 
         val events = store.readStream("run-valid-reason")
         assertEquals(1, events.size)
         assertEquals("manual_cancel", events[0].metadata["reasonCode"])
     }
+    }
 
     // ── P1: Unsafe actor identity redaction ────────────────────────────────────
 
     @Test
-    fun `unsafe actor in resumedBy is redacted in durable audit event`() = runTest {
+    fun `unsafe actor in resumedBy is redacted in durable audit event`() { runTest {
         val store2 = InMemoryAuditStore()
         val engine2 = AuditEngine(store2, clock = fixedClock)
         val emitter2 = AuditEngineApprovalLifecycleAuditEmitter(engine2)
@@ -240,9 +246,10 @@ class AuditEngineApprovalLifecycleAuditEmitterTest {
         assertEquals("approval_actor_redacted", event.actor)
         assertEquals("approval_actor_redacted", event.metadata["resumedBy"])
     }
+    }
 
     @Test
-    fun `unsafe actor in completedBy is redacted in durable audit event`() = runTest {
+    fun `unsafe actor in completedBy is redacted in durable audit event`() { runTest {
         val store2 = InMemoryAuditStore()
         val engine2 = AuditEngine(store2, clock = fixedClock)
         val emitter2 = AuditEngineApprovalLifecycleAuditEmitter(engine2)
@@ -255,9 +262,10 @@ class AuditEngineApprovalLifecycleAuditEmitterTest {
         assertEquals("approval_actor_redacted", event.actor)
         assertEquals("approval_actor_redacted", event.metadata["completedBy"])
     }
+    }
 
     @Test
-    fun `unsafe actor in force-cancel is redacted in durable audit event`() = runTest {
+    fun `unsafe actor in force-cancel is redacted in durable audit event`() { runTest {
         val store2 = InMemoryAuditStore()
         val engine2 = AuditEngine(store2, clock = fixedClock)
         val emitter2 = AuditEngineApprovalLifecycleAuditEmitter(engine2)
@@ -272,9 +280,10 @@ class AuditEngineApprovalLifecycleAuditEmitterTest {
         assertEquals("approval_actor_redacted", event.actor)
         assertEquals("approval_actor_redacted", event.metadata["cancelledBy"])
     }
+    }
 
     @Test
-    fun `valid actor identity passes through unchanged`() = runTest {
+    fun `valid actor identity passes through unchanged`() { runTest {
         val store2 = InMemoryAuditStore()
         val engine2 = AuditEngine(store2, clock = fixedClock)
         val emitter2 = AuditEngineApprovalLifecycleAuditEmitter(engine2)
@@ -287,11 +296,12 @@ class AuditEngineApprovalLifecycleAuditEmitterTest {
         assertEquals("human-operator@example.com", event.actor)
         assertEquals("human-operator@example.com", event.metadata["resumedBy"])
     }
+    }
 
     // ── P2-3: toolCallId digest tests ───────────────────────────────────────────
 
     @Test
-    fun `raw token-shaped toolCallId is absent from serialized audit event`() = runTest {
+    fun `raw token-shaped toolCallId is absent from serialized audit event`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
         val emitter = AuditEngineApprovalLifecycleAuditEmitter(engine)
@@ -311,9 +321,10 @@ class AuditEngineApprovalLifecycleAuditEmitterTest {
         // The digest must be present
         assertTrue("toolCallIdDigest" in serialized, "toolCallIdDigest must be present in serialized audit event")
     }
+    }
 
     @Test
-    fun `same toolCallId produces stable digest`() = runTest {
+    fun `same toolCallId produces stable digest`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
         val emitter = AuditEngineApprovalLifecycleAuditEmitter(engine)
@@ -336,9 +347,10 @@ class AuditEngineApprovalLifecycleAuditEmitterTest {
         assertEquals(events[0].metadata["toolCallIdDigest"], events[1].metadata["toolCallIdDigest"],
             "Same toolCallId must produce identical digests")
     }
+    }
 
     @Test
-    fun `different toolCallIds produce different digests`() = runTest {
+    fun `different toolCallIds produce different digests`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
         val emitter = AuditEngineApprovalLifecycleAuditEmitter(engine)
@@ -361,11 +373,12 @@ class AuditEngineApprovalLifecycleAuditEmitterTest {
         assertTrue(events[0].metadata["toolCallIdDigest"] != events[1].metadata["toolCallIdDigest"],
             "Different toolCallIds must produce different digests")
     }
+    }
 
     // ── P1: Actor length boundary tests ─────────────────────────────────────────
 
     @Test
-    fun `128-char actor passes validation`() = runTest {
+    fun `128-char actor passes validation`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
         val emitter = AuditEngineApprovalLifecycleAuditEmitter(engine)
@@ -377,9 +390,10 @@ class AuditEngineApprovalLifecycleAuditEmitterTest {
         assertEquals(1, events.size)
         assertEquals(longActor, events[0].actor)
     }
+    }
 
     @Test
-    fun `129-char actor is redacted in audit`() = runTest {
+    fun `129-char actor is redacted in audit`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
         val emitter = AuditEngineApprovalLifecycleAuditEmitter(engine)
@@ -389,5 +403,6 @@ class AuditEngineApprovalLifecycleAuditEmitterTest {
         val events = store.readStream("r5")
         assertEquals(1, events.size)
         assertEquals("approval_actor_redacted", events[0].actor)
+    }
     }
 }

--- a/tramai-security/src/test/kotlin/dev/tramai/security/audit/AuditEngineDlpRedactionAuditEmitterTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/audit/AuditEngineDlpRedactionAuditEmitterTest.kt
@@ -45,7 +45,7 @@ class AuditEngineDlpRedactionAuditEmitterTest {
     )
 
     @Test
-    fun `MODEL_OUTPUT maps to DLP_MODEL_OUTPUT with redacted decision and reason`() = runTest {
+    fun `MODEL_OUTPUT maps to DLP_MODEL_OUTPUT with redacted decision and reason`() { runTest {
         val (emitter, store) = emitter()
         emitter.emit(modelOutputContext(), listOf(DlpRedaction("email", 1)))
 
@@ -54,18 +54,20 @@ class AuditEngineDlpRedactionAuditEmitterTest {
         assertThat(event.decision).isEqualTo("REDACTED")
         assertThat(event.reasonCode).isEqualTo("dlp_redaction_applied")
     }
+    }
 
     @Test
-    fun `TOOL_RESULT maps to DLP_TOOL_RESULT`() = runTest {
+    fun `TOOL_RESULT maps to DLP_TOOL_RESULT`() { runTest {
         val (emitter, store) = emitter()
         emitter.emit(toolResultContext(), listOf(DlpRedaction("email", 1)))
 
         assertThat(store.readStream("corr-1").single().enforcementPoint)
             .isEqualTo("DLP_TOOL_RESULT")
     }
+    }
 
     @Test
-    fun `workflowRunId determines stream and is persisted`() = runTest {
+    fun `workflowRunId determines stream and is persisted`() { runTest {
         val (emitter, store) = emitter()
         emitter.emit(
             modelOutputContext().copy(
@@ -79,6 +81,7 @@ class AuditEngineDlpRedactionAuditEmitterTest {
         assertThat(events).hasSize(1)
         assertThat(events.single().workflowRunId).isEqualTo("run-123")
         assertThat(events.single().correlationId).isEqualTo("corr-fallback")
+    }
     }
 
     @Test
@@ -115,7 +118,7 @@ class AuditEngineDlpRedactionAuditEmitterTest {
     }
 
     @Test
-    fun `padded correlationId is normalized and accepted`() = runTest {
+    fun `padded correlationId is normalized and accepted`() { runTest {
         val (emitter, store) = emitter()
         emitter.emit(
             modelOutputContext().copy(correlationId = "  corr-1  "),
@@ -125,9 +128,10 @@ class AuditEngineDlpRedactionAuditEmitterTest {
         val event = store.readStream("corr-1").single()
         assertThat(event.correlationId).isEqualTo("corr-1")
     }
+    }
 
     @Test
-    fun `padded workflowRunId is normalized and accepted`() = runTest {
+    fun `padded workflowRunId is normalized and accepted`() { runTest {
         val (emitter, store) = emitter()
         emitter.emit(
             modelOutputContext().copy(
@@ -141,25 +145,28 @@ class AuditEngineDlpRedactionAuditEmitterTest {
         assertThat(event.workflowRunId).isEqualTo("run-123")
         assertThat(event.correlationId).isEqualTo("corr-fallback")
     }
+    }
 
     @Test
-    fun `rule ID is persisted safely`() = runTest {
+    fun `rule ID is persisted safely`() { runTest {
         val (emitter, store) = emitter()
         emitter.emit(modelOutputContext(), listOf(DlpRedaction("email.rule-1", 1)))
 
         assertThat(store.readStream("corr-1").single().metadata["ruleId"]).isEqualTo("email.rule-1")
     }
+    }
 
     @Test
-    fun `replacementCount is persisted`() = runTest {
+    fun `replacementCount is persisted`() { runTest {
         val (emitter, store) = emitter()
         emitter.emit(modelOutputContext(), listOf(DlpRedaction("email", 3)))
 
         assertThat(store.readStream("corr-1").single().metadata["replacementCount"]).isEqualTo("3")
     }
+    }
 
     @Test
-    fun `provider and model metadata are included`() = runTest {
+    fun `provider and model metadata are included`() { runTest {
         val (emitter, store) = emitter()
         emitter.emit(modelOutputContext(), listOf(DlpRedaction("email", 1)))
 
@@ -168,9 +175,10 @@ class AuditEngineDlpRedactionAuditEmitterTest {
         assertThat(metadata["modelName"]).isEqualTo("mistral")
         assertThat(metadata["contentLocation"]).isEqualTo("MODEL_RESPONSE_CONTENT")
     }
+    }
 
     @Test
-    fun `tool name is included for tool results`() = runTest {
+    fun `tool name is included for tool results`() { runTest {
         val (emitter, store) = emitter()
         emitter.emit(toolResultContext(), listOf(DlpRedaction("email", 1)))
 
@@ -178,9 +186,10 @@ class AuditEngineDlpRedactionAuditEmitterTest {
         assertThat(metadata["toolName"]).isEqualTo("lookup")
         assertThat(metadata["contentLocation"]).isEqualTo("TOOL_MESSAGE_CONTENT")
     }
+    }
 
     @Test
-    fun `classification metadata is included`() = runTest {
+    fun `classification metadata is included`() { runTest {
         val (emitter, store) = emitter()
         emitter.emit(toolResultContext(DlpContentLocation.TOOL_MESSAGE_TEXT_RUN), listOf(DlpRedaction("email", 1)))
 
@@ -189,43 +198,48 @@ class AuditEngineDlpRedactionAuditEmitterTest {
         assertThat(metadata["classificationSource"]).isEqualTo("RULE_BASED")
         assertThat(metadata["contentLocation"]).isEqualTo("TOOL_MESSAGE_TEXT_RUN")
     }
+    }
 
     @Test
-    fun `raw matched text is not persisted`() = runTest {
+    fun `raw matched text is not persisted`() { runTest {
         val (emitter, store) = emitter()
         emitter.emit(modelOutputContext(), listOf(DlpRedaction("email", 1)))
 
         assertThat(store.readStream("corr-1").single().metadata.values)
             .noneMatch { it.contains("alice@example.com") }
     }
+    }
 
     @Test
-    fun `sanitized output text is not persisted`() = runTest {
+    fun `sanitized output text is not persisted`() { runTest {
         val (emitter, store) = emitter()
         emitter.emit(modelOutputContext(), listOf(DlpRedaction("email", 1)))
 
         assertThat(store.readStream("corr-1").single().metadata.values)
             .noneMatch { it.contains("[REDACTED]") }
     }
+    }
 
     @Test
-    fun `replacement string is not persisted`() = runTest {
+    fun `replacement string is not persisted`() { runTest {
         val (emitter, store) = emitter()
         emitter.emit(modelOutputContext(), listOf(DlpRedaction("email", 1)))
 
         assertThat(store.readStream("corr-1").single().metadata).doesNotContainKey("replacement")
     }
+    }
 
     @Test
-    fun `regex pattern is not persisted`() = runTest {
+    fun `regex pattern is not persisted`() { runTest {
         val (emitter, store) = emitter()
         emitter.emit(modelOutputContext(), listOf(DlpRedaction("email", 1)))
 
         assertThat(store.readStream("corr-1").single().metadata).doesNotContainKey("pattern")
     }
+    }
 
     @Test
-    fun `multiple rules emit deterministic ordered events`() = runTest {
+    fun `multiple rules emit deterministic ordered events`() { runTest {
         val (emitter, store) = emitter()
         emitter.emit(
             modelOutputContext(),
@@ -240,9 +254,10 @@ class AuditEngineDlpRedactionAuditEmitterTest {
         assertThat(events.map { it.metadata["ruleId"] }).containsExactly("a-first", "z-last")
         assertThat(events.map { it.sequenceNumber }).containsExactly(1L, 2L)
     }
+    }
 
     @Test
-    fun `duplicate rule IDs are grouped`() = runTest {
+    fun `duplicate rule IDs are grouped`() { runTest {
         val (emitter, store) = emitter()
         emitter.emit(
             modelOutputContext(),
@@ -255,6 +270,7 @@ class AuditEngineDlpRedactionAuditEmitterTest {
         val events = store.readStream("corr-1")
         assertThat(events).hasSize(1)
         assertThat(events.single().metadata["replacementCount"]).isEqualTo("3")
+    }
     }
 
     @Test
@@ -318,7 +334,7 @@ class AuditEngineDlpRedactionAuditEmitterTest {
     }
 
     @Test
-    fun `resulting event chain passes AuditChainVerifier`() = runTest {
+    fun `resulting event chain passes AuditChainVerifier`() { runTest {
         val (emitter, store) = emitter()
         emitter.emit(
             toolResultContext(),
@@ -329,5 +345,6 @@ class AuditEngineDlpRedactionAuditEmitterTest {
         )
 
         assertThat(AuditChainVerifier.verify(store.readStream("corr-1")).isValid).isTrue()
+    }
     }
 }

--- a/tramai-security/src/test/kotlin/dev/tramai/security/audit/AuditEnginePolicyDecisionAuditEmitterTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/audit/AuditEnginePolicyDecisionAuditEmitterTest.kt
@@ -27,7 +27,7 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
     )
 
     @Test
-    fun `ALLOW maps to ALLOW audit event`() = runTest {
+    fun `ALLOW maps to ALLOW audit event`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         emitter.emit(EnforcementPoint.BEFORE_PROVIDER_INVOCATION, baseCtx, PolicyDecision.Allow)
 
@@ -36,9 +36,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         Assertions.assertEquals("ALLOW", events[0].decision)
         Assertions.assertEquals("policy_allowed", events[0].reasonCode)
     }
+    }
 
     @Test
-    fun `DENY maps to DENY audit event`() = runTest {
+    fun `DENY maps to DENY audit event`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val deny = PolicyDecision.Deny(reason = "blocked", reasonCode = "policy_denied")
         emitter.emit(EnforcementPoint.BEFORE_PROVIDER_INVOCATION, baseCtx, deny)
@@ -48,9 +49,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         Assertions.assertEquals("DENY", events[0].decision)
         Assertions.assertEquals("policy_denied", events[0].reasonCode)
     }
+    }
 
     @Test
-    fun `enforcement point name persisted correctly`() = runTest {
+    fun `enforcement point name persisted correctly`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         emitter.emit(EnforcementPoint.BEFORE_TOOL_EXECUTION, baseCtx, PolicyDecision.Allow)
 
@@ -58,9 +60,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         Assertions.assertEquals(1, events.size)
         Assertions.assertEquals("BEFORE_TOOL_EXECUTION", events[0].enforcementPoint)
     }
+    }
 
     @Test
-    fun `workflow run ID and correlation ID mapped correctly`() = runTest {
+    fun `workflow run ID and correlation ID mapped correctly`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         emitter.emit(EnforcementPoint.BEFORE_PROVIDER_INVOCATION, baseCtx, PolicyDecision.Allow)
 
@@ -68,9 +71,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         Assertions.assertEquals("run-1", events[0].workflowRunId)
         Assertions.assertEquals("corr-1", events[0].correlationId)
     }
+    }
 
     @Test
-    fun `stable stream ID reused across multiple decisions`() = runTest {
+    fun `stable stream ID reused across multiple decisions`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
 
         emitter.emit(EnforcementPoint.BEFORE_PROVIDER_INVOCATION, baseCtx, PolicyDecision.Allow)
@@ -86,9 +90,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         Assertions.assertEquals(2L, events[1].sequenceNumber)
         Assertions.assertEquals(3L, events[2].sequenceNumber)
     }
+    }
 
     @Test
-    fun `safe metadata providerName and modelName present`() = runTest {
+    fun `safe metadata providerName and modelName present`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         emitter.emit(EnforcementPoint.BEFORE_PROVIDER_INVOCATION, baseCtx, PolicyDecision.Allow)
 
@@ -96,9 +101,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         Assertions.assertEquals("ollama", events[0].metadata["providerName"])
         Assertions.assertEquals("mistral", events[0].metadata["modelName"])
     }
+    }
 
     @Test
-    fun `unknown attribute keys like prompt are dropped from audit metadata`() = runTest {
+    fun `unknown attribute keys like prompt are dropped from audit metadata`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val ctxWithAttrs = baseCtx.copy(attributes = mapOf(
             "prompt" to "ignore-all-previous-instructions",
@@ -113,9 +119,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         Assertions.assertNull(events[0].metadata["attr_toolArguments"])
         Assertions.assertNull(events[0].metadata["attr_secret"])
     }
+    }
 
     @Test
-    fun `cacheReuse attribute is retained in metadata`() = runTest {
+    fun `cacheReuse attribute is retained in metadata`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val ctxWithCacheReuse = baseCtx.copy(attributes = mapOf("cacheReuse" to "true"))
         emitter.emit(EnforcementPoint.BEFORE_PROVIDER_INVOCATION, ctxWithCacheReuse, PolicyDecision.Allow)
@@ -123,9 +130,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         val events = store.readStream("run-1")
         Assertions.assertEquals("true", events[0].metadata["attr_cacheReuse"])
     }
+    }
 
     @Test
-    fun `fallbackReason attribute is retained in metadata`() = runTest {
+    fun `fallbackReason attribute is retained in metadata`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val ctxWithFallback = baseCtx.copy(attributes = mapOf("fallbackReason" to "provider_unavailable"))
         emitter.emit(EnforcementPoint.BEFORE_FALLBACK, ctxWithFallback, PolicyDecision.Allow)
@@ -133,9 +141,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         val events = store.readStream("run-1")
         Assertions.assertEquals("provider_unavailable", events[0].metadata["attr_fallbackReason"])
     }
+    }
 
     @Test
-    fun `resulting event chain passes AuditChainVerifier`() = runTest {
+    fun `resulting event chain passes AuditChainVerifier`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
 
         emitter.emit(EnforcementPoint.BEFORE_PROVIDER_INVOCATION, baseCtx, PolicyDecision.Allow)
@@ -148,9 +157,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         val result = AuditChainVerifier.verify(events)
         Assertions.assertTrue(result.isValid, "Chain verification failed: ${result.errors}")
     }
+    }
 
     @Test
-    fun `classification metadata included when present`() = runTest {
+    fun `classification metadata included when present`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val ctx = baseCtx.copy(
             dataClassification = DataClassification.RESTRICTED,
@@ -162,9 +172,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         Assertions.assertEquals("RESTRICTED", events[0].metadata["classification"])
         Assertions.assertEquals("DECLARED", events[0].metadata["classificationSource"])
     }
+    }
 
     @Test
-    fun `fallback provider metadata included when present`() = runTest {
+    fun `fallback provider metadata included when present`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val ctx = baseCtx.copy(fallbackProviderId = "ollama-local")
         emitter.emit(EnforcementPoint.BEFORE_FALLBACK, ctx, PolicyDecision.Allow)
@@ -172,9 +183,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         val events = store.readStream("run-1")
         Assertions.assertEquals("ollama-local", events[0].metadata["fallbackProviderName"])
     }
+    }
 
     @Test
-    fun `REQUIRE_APPROVAL maps correctly`() = runTest {
+    fun `REQUIRE_APPROVAL maps correctly`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val approvalDecision = PolicyDecision.RequireApproval(
             ApprovalRequirement(
@@ -191,9 +203,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         Assertions.assertEquals("REQUIRE_APPROVAL", events[0].decision)
         Assertions.assertEquals("policy_requires_approval", events[0].reasonCode)
     }
+    }
 
     @Test
-    fun `stream ID falls back to correlationId when no workflowRunId`() = runTest {
+    fun `stream ID falls back to correlationId when no workflowRunId`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val ctx = baseCtx.copy(workflowRunId = null)
         emitter.emit(EnforcementPoint.BEFORE_PROVIDER_INVOCATION, ctx, PolicyDecision.Allow)
@@ -202,9 +215,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         Assertions.assertEquals(1, events.size)
         Assertions.assertEquals("corr-1", events[0].auditStreamId)
     }
+    }
 
     @Test
-    fun `blank workflowRunId falls back to correlationId`() = runTest {
+    fun `blank workflowRunId falls back to correlationId`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val ctx = baseCtx.copy(workflowRunId = "")
         emitter.emit(EnforcementPoint.BEFORE_PROVIDER_INVOCATION, ctx, PolicyDecision.Allow)
@@ -213,9 +227,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         Assertions.assertEquals(1, events.size)
         Assertions.assertEquals("corr-1", events[0].auditStreamId)
     }
+    }
 
     @Test
-    fun `blank correlationId and blank workflowRunId uses custom resolver fallback`() = runTest {
+    fun `blank correlationId and blank workflowRunId uses custom resolver fallback`() { runTest {
         val customResolver = object : AuditStreamIdResolver {
             override fun resolve(context: PolicyContext): String = "custom-fallback"
         }
@@ -227,11 +242,12 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         Assertions.assertEquals(1, events.size)
         Assertions.assertEquals("custom-fallback", events[0].auditStreamId)
     }
+    }
 
     // ─── Reason code normalization tests ───────────────────────────────
 
     @Test
-    fun `valid stable reasonCode preserved`() = runTest {
+    fun `valid stable reasonCode preserved`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         emitter.emit(EnforcementPoint.BEFORE_PROVIDER_INVOCATION, baseCtx,
             PolicyDecision.Deny("blocked", "classification-routing-blocked"))
@@ -239,9 +255,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         val events = store.readStream("run-1")
         Assertions.assertEquals("classification-routing-blocked", events[0].reasonCode)
     }
+    }
 
     @Test
-    fun `overlong reasonCode replaced`() = runTest {
+    fun `overlong reasonCode replaced`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val longCode = "a" + "b".repeat(200)
         emitter.emit(EnforcementPoint.BEFORE_PROVIDER_INVOCATION, baseCtx,
@@ -250,9 +267,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         val events = store.readStream("run-1")
         Assertions.assertEquals("policy_denied", events[0].reasonCode)
     }
+    }
 
     @Test
-    fun `whitespace-reasonCode replaced`() = runTest {
+    fun `whitespace-reasonCode replaced`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         emitter.emit(EnforcementPoint.BEFORE_PROVIDER_INVOCATION, baseCtx,
             PolicyDecision.Deny("blocked", "blocked secret key"))
@@ -260,9 +278,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         val events = store.readStream("run-1")
         Assertions.assertEquals("policy_denied", events[0].reasonCode)
     }
+    }
 
     @Test
-    fun `uppercase-secret-like reasonCode replaced`() = runTest {
+    fun `uppercase-secret-like reasonCode replaced`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         emitter.emit(EnforcementPoint.BEFORE_PROVIDER_INVOCATION, baseCtx,
             PolicyDecision.Deny("blocked", "sk-ABC123-DEF456"))
@@ -270,9 +289,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         val events = store.readStream("run-1")
         Assertions.assertEquals("policy_denied", events[0].reasonCode)
     }
+    }
 
     @Test
-    fun `reasonCode with special characters replaced`() = runTest {
+    fun `reasonCode with special characters replaced`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         emitter.emit(EnforcementPoint.BEFORE_PROVIDER_INVOCATION, baseCtx,
             PolicyDecision.Deny("blocked", "secret!@#"))
@@ -280,9 +300,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         val events = store.readStream("run-1")
         Assertions.assertEquals("policy_denied", events[0].reasonCode)
     }
+    }
 
     @Test
-    fun `newline-containing reasonCode replaced`() = runTest {
+    fun `newline-containing reasonCode replaced`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         emitter.emit(EnforcementPoint.BEFORE_PROVIDER_INVOCATION, baseCtx,
             PolicyDecision.Deny("blocked", "allowed\n[INFO] user=admin"))
@@ -290,9 +311,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         val events = store.readStream("run-1")
         Assertions.assertEquals("policy_denied", events[0].reasonCode)
     }
+    }
 
     @Test
-    fun `empty reasonCode replaced`() = runTest {
+    fun `empty reasonCode replaced`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         emitter.emit(EnforcementPoint.BEFORE_PROVIDER_INVOCATION, baseCtx,
             PolicyDecision.Deny("blocked", ""))
@@ -300,9 +322,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         val events = store.readStream("run-1")
         Assertions.assertEquals("policy_denied", events[0].reasonCode)
     }
+    }
 
     @Test
-    fun `reasonCode starting with digit preserved`() = runTest {
+    fun `reasonCode starting with digit preserved`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         emitter.emit(EnforcementPoint.BEFORE_PROVIDER_INVOCATION, baseCtx,
             PolicyDecision.Deny("blocked", "1policy-rule"))
@@ -310,11 +333,12 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         val events = store.readStream("run-1")
         Assertions.assertEquals("1policy-rule", events[0].reasonCode)
     }
+    }
 
     // ─── Stream ID validation tests ────────────────────────────────────
 
     @Test
-    fun `blank workflowRunId and correlationId use custom resolver when configured`() = runTest {
+    fun `blank workflowRunId and correlationId use custom resolver when configured`() { runTest {
         val resolver = object : AuditStreamIdResolver {
             override fun resolve(context: PolicyContext): String = "gen-run-abc"
         }
@@ -326,9 +350,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         Assertions.assertEquals(1, events.size)
         Assertions.assertEquals("gen-run-abc", events[0].auditStreamId)
     }
+    }
 
     @Test
-    fun `default resolver rejects blank workflowRunId and correlationId`() = runTest {
+    fun `default resolver rejects blank workflowRunId and correlationId`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val ctx = baseCtx.copy(workflowRunId = "", correlationId = "")
 
@@ -342,9 +367,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
             ex.message,
         )
     }
+    }
 
     @Test
-    fun `blank stream ID from custom resolver throws`() = runTest {
+    fun `blank stream ID from custom resolver throws`() { runTest {
         val blankResolver = object : AuditStreamIdResolver {
             override fun resolve(context: PolicyContext): String = ""
         }
@@ -357,9 +383,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         }
         Assertions.assertEquals("Audit stream ID must not be blank", ex.message)
     }
+    }
 
     @Test
-    fun `oversize stream ID from custom resolver throws`() = runTest {
+    fun `oversize stream ID from custom resolver throws`() { runTest {
         val longResolver = object : AuditStreamIdResolver {
             override fun resolve(context: PolicyContext): String = "a".repeat(257)
         }
@@ -372,11 +399,12 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         }
         Assertions.assertEquals("Audit stream ID exceeds maximum length of 256", ex.message)
     }
+    }
 
     // ─── Deterministic attribute ordering ──────────────────────────────
 
     @Test
-    fun `attributes are sorted deterministically`() = runTest {
+    fun `attributes are sorted deterministically`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val ctx = baseCtx.copy(attributes = mapOf(
             "fallbackReason" to "timeout",
@@ -389,11 +417,12 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         val attrKeys = metadata.keys.filter { it.startsWith("attr_") }
         Assertions.assertEquals(listOf("attr_cacheReuse", "attr_fallbackReason"), attrKeys)
     }
+    }
 
     // ─── Leakage tests ─────────────────────────────────────────────────
 
     @Test
-    fun `serialized audit event does not contain known prompt secret`() = runTest {
+    fun `serialized audit event does not contain known prompt secret`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val ctx = baseCtx.copy(attributes = mapOf(
             "prompt" to "super-secret-api-key-123",
@@ -406,9 +435,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         Assertions.assertFalse(serialized.contains("super-secret-api-key-123"))
         Assertions.assertFalse(serialized.contains("ignore-all-previous-instructions"))
     }
+    }
 
     @Test
-    fun `serialized audit event does not contain raw model-generated tool name`() = runTest {
+    fun `serialized audit event does not contain raw model-generated tool name`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val ctx = baseCtx.copy(toolName = "<unregistered>")
         emitter.emit(EnforcementPoint.BEFORE_TOOL_EXECUTION, ctx, PolicyDecision.Allow)
@@ -418,9 +448,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         // (e.g., "execute_rm_-rf_/") should never appear.
         Assertions.assertEquals("<unregistered>", events[0].metadata["toolName"])
     }
+    }
 
     @Test
-    fun `serialized audit event does not contain DLP matches`() = runTest {
+    fun `serialized audit event does not contain DLP matches`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val ctx = baseCtx.copy(
             attributes = mapOf("cacheReuse" to "true"),
@@ -432,9 +463,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         Assertions.assertNull(events[0].metadata["dlpMatch"])
         Assertions.assertNull(events[0].metadata["redactedValue"])
     }
+    }
 
     @Test
-    fun `target destination is excluded from durable audit metadata`() = runTest {
+    fun `target destination is excluded from durable audit metadata`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val ctx = baseCtx.copy(targetDestination = "https://internal.example.com/account/123")
         emitter.emit(EnforcementPoint.BEFORE_PROVIDER_INVOCATION, ctx, PolicyDecision.Allow)
@@ -442,9 +474,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         val events = store.readStream("run-1")
         Assertions.assertNull(events[0].metadata["targetDestination"])
     }
+    }
 
     @Test
-    fun `unsafe actor identity is redacted in policy-decision audit event`() = runTest {
+    fun `unsafe actor identity is redacted in policy-decision audit event`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
         val emitter = AuditEnginePolicyDecisionAuditEmitter(engine)
@@ -456,9 +489,10 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         Assertions.assertEquals(1, events.size)
         Assertions.assertEquals("approval_actor_redacted", events[0].actor)
     }
+    }
 
     @Test
-    fun `valid actor identity passes through in policy-decision audit event`() = runTest {
+    fun `valid actor identity passes through in policy-decision audit event`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
         val emitter = AuditEnginePolicyDecisionAuditEmitter(engine)
@@ -469,5 +503,6 @@ class AuditEnginePolicyDecisionAuditEmitterTest {
         val events = store.readStream("run-1")
         Assertions.assertEquals(1, events.size)
         Assertions.assertEquals("human-operator@example.com", events[0].actor)
+    }
     }
 }

--- a/tramai-security/src/test/kotlin/dev/tramai/security/audit/AuditEngineTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/audit/AuditEngineTest.kt
@@ -75,7 +75,7 @@ class AuditEngineTest {
     //  1. First event has no previousHash
     // ===============================================================
     @Test
-    fun `first event has no previousHash`() = runTest {
+    fun `first event has no previousHash`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
 
@@ -98,12 +98,13 @@ class AuditEngineTest {
         assertNotNull(event.eventHash)
         assertTrue(event.eventHash.isNotEmpty())
     }
+    }
 
     // ===============================================================
     //  2. Second event links to first
     // ===============================================================
     @Test
-    fun `second event links to first`() = runTest {
+    fun `second event links to first`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
 
@@ -113,12 +114,13 @@ class AuditEngineTest {
         assertEquals(first.eventHash, second.previousEventHash)
         assertEquals(2L, second.sequenceNumber)
     }
+    }
 
     // ===============================================================
     //  3. Multiple events verify successfully
     // ===============================================================
     @Test
-    fun `multiple events verify successfully`() = runTest {
+    fun `multiple events verify successfully`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
 
@@ -130,12 +132,13 @@ class AuditEngineTest {
         assertTrue(result.isValid)
         assertTrue(result.errors.isEmpty())
     }
+    }
 
     // ===============================================================
     //  4. Modified event field invalidates chain
     // ===============================================================
     @Test
-    fun `modified event field invalidates chain`() = runTest {
+    fun `modified event field invalidates chain`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
 
@@ -151,12 +154,13 @@ class AuditEngineTest {
         assertFalse(result.isValid)
         assertTrue(result.errors.any { it.sequenceNumber == 2L && it.message.contains("eventHash") })
     }
+    }
 
     // ===============================================================
     //  5. Modified metadata invalidates chain
     // ===============================================================
     @Test
-    fun `modified metadata invalidates chain`() = runTest {
+    fun `modified metadata invalidates chain`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
 
@@ -171,12 +175,13 @@ class AuditEngineTest {
 
         assertFalse(result.isValid)
     }
+    }
 
     // ===============================================================
     //  6. Reordered events invalidate chain
     // ===============================================================
     @Test
-    fun `reordered events invalidate chain`() = runTest {
+    fun `reordered events invalidate chain`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
 
@@ -189,12 +194,13 @@ class AuditEngineTest {
         assertFalse(result.isValid)
         assertTrue(result.errors.any { it.message.contains("sequenceNumber") })
     }
+    }
 
     // ===============================================================
     //  7. Missing middle event invalidates chain
     // ===============================================================
     @Test
-    fun `missing middle event invalidates chain`() = runTest {
+    fun `missing middle event invalidates chain`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
 
@@ -209,12 +215,13 @@ class AuditEngineTest {
         assertTrue(result.errors.any { it.message.contains("sequenceNumber") })
         assertTrue(result.errors.any { it.message.contains("previousEventHash") })
     }
+    }
 
     // ===============================================================
     //  8. Concurrent 10 writes produce unique ordered sequence numbers
     // ===============================================================
     @Test
-    fun `concurrent writes preserve unique ordered sequence numbers`() = runTest {
+    fun `concurrent writes preserve unique ordered sequence numbers`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
 
@@ -228,12 +235,13 @@ class AuditEngineTest {
         val sequenceNumbers = store.readStream("stream-1").map { it.sequenceNumber }
         assertEquals((1L..10L).toList(), sequenceNumbers)
     }
+    }
 
     // ===============================================================
     //  9. Separate streams remain independent
     // ===============================================================
     @Test
-    fun `separate streams remain independent`() = runTest {
+    fun `separate streams remain independent`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
 
@@ -245,6 +253,7 @@ class AuditEngineTest {
         assertEquals(listOf(1L, 2L), store.readStream("stream-a").map { it.sequenceNumber })
         assertEquals(listOf(1L), store.readStream("stream-b").map { it.sequenceNumber })
         assertEquals(listOf(1L), store.readStream("stream-c").map { it.sequenceNumber })
+    }
     }
 
     // ===============================================================
@@ -269,7 +278,7 @@ class AuditEngineTest {
     //  11. Two engines sharing one store, concurrent
     // ===============================================================
     @Test
-    fun `two engines share one store concurrent`() = runTest {
+    fun `two engines share one store concurrent`() { runTest {
         val store = InMemoryAuditStore()
         val engine1 = AuditEngine(store, clock = fixedClock)
         val engine2 = AuditEngine(store, clock = fixedClock)
@@ -302,12 +311,13 @@ class AuditEngineTest {
         val result = AuditChainVerifier.verify(events)
         assertTrue(result.isValid)
     }
+    }
 
     // ===============================================================
     //  12. Delayed store wrapper (CompletableDeferred gate)
     // ===============================================================
     @Test
-    fun `delayed store wrapper`() = runTest {
+    fun `delayed store wrapper`() { runTest {
         val gate = CompletableDeferred<Unit>()
         val inner = InMemoryAuditStore()
         val store = object : AuditStore {
@@ -340,12 +350,13 @@ class AuditEngineTest {
         assertNotNull(event)
         assertEquals(1L, event.sequenceNumber)
     }
+    }
 
     // ===============================================================
     //  13. 100+ concurrent appends
     // ===============================================================
     @Test
-    fun `one hundred concurrent appends`() = runTest {
+    fun `one hundred concurrent appends`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
 
@@ -371,12 +382,13 @@ class AuditEngineTest {
         val result = AuditChainVerifier.verify(events)
         assertTrue(result.isValid)
     }
+    }
 
     // ===============================================================
     //  14. Wrong streamId rejected by store
     // ===============================================================
     @Test
-    fun `wrong streamId rejected`() = runTest {
+    fun `wrong streamId rejected`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
 
@@ -401,12 +413,13 @@ class AuditEngineTest {
         }
         assertTrue(exception.message?.contains("auditStreamId") == true)
     }
+    }
 
     // ===============================================================
     //  15. Wrong sequence rejected by store
     // ===============================================================
     @Test
-    fun `wrong sequence rejected`() = runTest {
+    fun `wrong sequence rejected`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
         emitEvent(engine, "stream-s", 1)
@@ -432,12 +445,13 @@ class AuditEngineTest {
         }
         assertTrue(exception.message?.contains("sequenceNumber") == true)
     }
+    }
 
     // ===============================================================
     //  16. Wrong previousHash rejected by store
     // ===============================================================
     @Test
-    fun `wrong previousHash rejected`() = runTest {
+    fun `wrong previousHash rejected`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
         emitEvent(engine, "stream-p", 1)
@@ -463,12 +477,13 @@ class AuditEngineTest {
         }
         assertTrue(exception.message?.contains("previousEventHash") == true || exception.message?.contains("eventHash") == true)
     }
+    }
 
     // ===============================================================
     //  17. Wrong eventHash rejected by store
     // ===============================================================
     @Test
-    fun `wrong eventHash rejected`() = runTest {
+    fun `wrong eventHash rejected`() { runTest {
         val store = InMemoryAuditStore()
 
         val exception = assertThrows<IllegalArgumentException> {
@@ -492,12 +507,13 @@ class AuditEngineTest {
         }
         assertTrue(exception.message?.contains("eventHash") == true)
     }
+    }
 
     // ===============================================================
     //  18. Duplicate eventId rejected by store
     // ===============================================================
     @Test
-    fun `duplicate eventId rejected`() = runTest {
+    fun `duplicate eventId rejected`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
         val firstEvent = emitEvent(engine, "stream-d", 1)
@@ -542,12 +558,13 @@ class AuditEngineTest {
         }
         assertTrue(exception.message?.contains("Duplicate") == true || exception.message?.contains("eventId") == true)
     }
+    }
 
     // ===============================================================
     //  19. Mutable metadata cannot alter evidence
     // ===============================================================
     @Test
-    fun `mutable metadata cannot alter evidence`() = runTest {
+    fun `mutable metadata cannot alter evidence`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
 
@@ -571,12 +588,13 @@ class AuditEngineTest {
         val result = AuditChainVerifier.verify(store.readStream("stream-m"))
         assertTrue(result.isValid)
     }
+    }
 
     // ===============================================================
     //  20. Mixed-stream verification rejected
     // ===============================================================
     @Test
-    fun `mixed-stream verification rejected`() = runTest {
+    fun `mixed-stream verification rejected`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
 
@@ -587,6 +605,7 @@ class AuditEngineTest {
         val result = AuditChainVerifier.verify(mixed)
         assertFalse(result.isValid)
         assertTrue(result.errors.any { it.message.contains("auditStreamId") })
+    }
     }
 
     // ===============================================================
@@ -623,7 +642,7 @@ class AuditEngineTest {
     //  22. Timestamp from injected Clock
     // ===============================================================
     @Test
-    fun `timestamp from injected Clock`() = runTest {
+    fun `timestamp from injected Clock`() { runTest {
         val customInstant = Instant.parse("2025-12-25T10:30:00Z")
         val customClock = Clock.fixed(customInstant, ZoneId.of("UTC"))
         val store = InMemoryAuditStore()
@@ -638,6 +657,7 @@ class AuditEngineTest {
         )
 
         assertEquals(customInstant, event.timestamp)
+    }
     }
 
     // ===============================================================
@@ -720,7 +740,7 @@ class AuditEngineTest {
     //  23. mutating original input metadata does not alter evidence
     // ===============================================================
     @Test
-    fun `mutating original input metadata does not alter evidence`() = runTest {
+    fun `mutating original input metadata does not alter evidence`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
 
@@ -739,12 +759,13 @@ class AuditEngineTest {
         val stored = store.readStream("stream-mm").first()
         assertEquals("value", stored.metadata["key"])
     }
+    }
 
     // ===============================================================
     //  24. metadata returned by appendNext cannot alter stored evidence
     // ===============================================================
     @Test
-    fun `metadata returned by appendNext cannot alter stored evidence`() = runTest {
+    fun `metadata returned by appendNext cannot alter stored evidence`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
 
@@ -766,12 +787,13 @@ class AuditEngineTest {
         val stored = store.readStream("stream-mr").first()
         assertEquals("value", stored.metadata["key"])
     }
+    }
 
     // ===============================================================
     //  25. metadata returned by readStream cannot alter stored evidence
     // ===============================================================
     @Test
-    fun `metadata returned by readStream cannot alter stored evidence`() = runTest {
+    fun `metadata returned by readStream cannot alter stored evidence`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
 
@@ -794,12 +816,13 @@ class AuditEngineTest {
         val stored = store.readStream("stream-rs").first()
         assertEquals("value", stored.metadata["key"])
     }
+    }
 
     // ===============================================================
     //  26. metadata returned by latestEvent cannot alter stored evidence
     // ===============================================================
     @Test
-    fun `metadata returned by latestEvent cannot alter stored evidence`() = runTest {
+    fun `metadata returned by latestEvent cannot alter stored evidence`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
 
@@ -822,12 +845,13 @@ class AuditEngineTest {
         val stored = store.readStream("stream-le").first()
         assertEquals("value", stored.metadata["key"])
     }
+    }
 
     // ===============================================================
     //  27. verifier still succeeds after attempted mutation
     // ===============================================================
     @Test
-    fun `verifier still succeeds after attempted mutation`() = runTest {
+    fun `verifier still succeeds after attempted mutation`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
 
@@ -865,12 +889,13 @@ class AuditEngineTest {
         val result = AuditChainVerifier.verify(store.readStream("stream-vm"))
         assertTrue(result.isValid)
     }
+    }
 
     // ===============================================================
     //  28. consistent schemaVersion 999 chain fails verification
     // ===============================================================
     @Test
-    fun `consistent schemaVersion 999 chain fails verification`() = runTest {
+    fun `consistent schemaVersion 999 chain fails verification`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
 
@@ -893,12 +918,13 @@ class AuditEngineTest {
         assertFalse(result.isValid)
         assertTrue(result.errors.any { it.message.contains("Unsupported schemaVersion") })
     }
+    }
 
     // ===============================================================
     //  29. direct append with unsupported schemaVersion fails
     // ===============================================================
     @Test
-    fun `direct append with unsupported schemaVersion fails`() = runTest {
+    fun `direct append with unsupported schemaVersion fails`() { runTest {
         val store = InMemoryAuditStore()
 
         val exception = assertThrows<IllegalArgumentException> {
@@ -922,12 +948,13 @@ class AuditEngineTest {
         }
         assertTrue(exception.message?.contains("Unsupported") == true)
     }
+    }
 
     // ===============================================================
     //  30. 100 concurrent emits with barrier and two engines
     // ===============================================================
     @Test
-    fun `100 concurrent emits with barrier and two engines`() = runTest {
+    fun `100 concurrent emits with barrier and two engines`() { runTest {
         val store = InMemoryAuditStore()
         val engine1 = AuditEngine(store, clock = fixedClock)
         val engine2 = AuditEngine(store, clock = fixedClock)
@@ -964,12 +991,13 @@ class AuditEngineTest {
         assertEquals(total, events.map { it.eventId }.distinct().size)
         assertTrue(AuditChainVerifier.verify(events).isValid)
     }
+    }
 
     // ===============================================================
     //  35. Deterministic regression: mutable HashMap metadata immutability
     // ===============================================================
     @Test
-    fun `mutable HashMap metadata cannot alter stored evidence after emit`() = runTest {
+    fun `mutable HashMap metadata cannot alter stored evidence after emit`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = fixedClock)
 
@@ -995,6 +1023,7 @@ class AuditEngineTest {
         // Verify the chain is still valid
         val result = AuditChainVerifier.verify(store.readStream("stream-35"))
         assertTrue(result.isValid)
+    }
     }
 
     // ===============================================================

--- a/tramai-security/src/test/kotlin/dev/tramai/security/audit/AuditEngineToolDecisionAuditEmitterTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/audit/AuditEngineToolDecisionAuditEmitterTest.kt
@@ -42,7 +42,7 @@ class AuditEngineToolDecisionAuditEmitterTest {
     // --- Tool metadata safety ---
 
     @Test
-    fun `toolName present in audit metadata`() = runTest {
+    fun `toolName present in audit metadata`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         emitter.emit(EnforcementPoint.BEFORE_TOOL_EXPOSURE, toolCtx, PolicyDecision.Allow)
 
@@ -50,29 +50,32 @@ class AuditEngineToolDecisionAuditEmitterTest {
         Assertions.assertEquals(1, events.size)
         Assertions.assertEquals("payment-tool", events[0].metadata["toolName"])
     }
+    }
 
     @Test
-    fun `riskLevel present in audit metadata when tool security is set`() = runTest {
+    fun `riskLevel present in audit metadata when tool security is set`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         emitter.emit(EnforcementPoint.BEFORE_TOOL_EXPOSURE, toolCtx, PolicyDecision.Allow)
 
         val events = store.readStream("run-1")
         Assertions.assertEquals("HIGH", events[0].metadata["riskLevel"])
     }
+    }
 
     @Test
-    fun `tool enforcement point persisted as BEFORE_TOOL_EXPOSURE`() = runTest {
+    fun `tool enforcement point persisted as BEFORE_TOOL_EXPOSURE`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         emitter.emit(EnforcementPoint.BEFORE_TOOL_EXPOSURE, toolCtx, PolicyDecision.Allow)
 
         val events = store.readStream("run-1")
         Assertions.assertEquals("BEFORE_TOOL_EXPOSURE", events[0].enforcementPoint)
     }
+    }
 
     // --- Decision mapping ---
 
     @Test
-    fun `tool exposure ALLOW maps to ALLOW audit decision`() = runTest {
+    fun `tool exposure ALLOW maps to ALLOW audit decision`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         emitter.emit(EnforcementPoint.BEFORE_TOOL_EXPOSURE, toolCtx, PolicyDecision.Allow)
 
@@ -80,9 +83,10 @@ class AuditEngineToolDecisionAuditEmitterTest {
         Assertions.assertEquals("ALLOW", events[0].decision)
         Assertions.assertEquals("policy_allowed", events[0].reasonCode)
     }
+    }
 
     @Test
-    fun `tool exposure DENY maps to DENY audit decision with safe reason code`() = runTest {
+    fun `tool exposure DENY maps to DENY audit decision with safe reason code`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val deny = PolicyDecision.Deny(reason = "blocked by tool policy", reasonCode = "tool_denied")
         emitter.emit(EnforcementPoint.BEFORE_TOOL_EXPOSURE, toolCtx, deny)
@@ -91,9 +95,10 @@ class AuditEngineToolDecisionAuditEmitterTest {
         Assertions.assertEquals("DENY", events[0].decision)
         Assertions.assertEquals("tool_denied", events[0].reasonCode)
     }
+    }
 
     @Test
-    fun `tool exposure REQUIRE_APPROVAL maps to REQUIRE_APPROVAL audit decision`() = runTest {
+    fun `tool exposure REQUIRE_APPROVAL maps to REQUIRE_APPROVAL audit decision`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val approvalDecision = PolicyDecision.RequireApproval(
             ApprovalRequirement(
@@ -109,11 +114,12 @@ class AuditEngineToolDecisionAuditEmitterTest {
         Assertions.assertEquals("REQUIRE_APPROVAL", events[0].decision)
         Assertions.assertEquals("policy_requires_approval", events[0].reasonCode)
     }
+    }
 
     // --- Unsafe attribute exclusion ---
 
     @Test
-    fun `raw tool arguments are excluded from audit metadata`() = runTest {
+    fun `raw tool arguments are excluded from audit metadata`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val ctxWithArgs = toolCtx.copy(attributes = mapOf(
             "toolArguments" to """{"amount": 999, "currency": "EUR"}""",
@@ -132,9 +138,10 @@ class AuditEngineToolDecisionAuditEmitterTest {
         Assertions.assertNull(events[0].metadata["attr_prompt"])
         Assertions.assertNull(events[0].metadata["attr_token"])
     }
+    }
 
     @Test
-    fun `safe allowlisted attributes are preserved alongside tool metadata`() = runTest {
+    fun `safe allowlisted attributes are preserved alongside tool metadata`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val ctxWithSafeAttrs = toolCtx.copy(attributes = mapOf(
             "cacheReuse" to "false",
@@ -156,9 +163,10 @@ class AuditEngineToolDecisionAuditEmitterTest {
         Assertions.assertNull(events[0].metadata["attr_apiKey"])
         Assertions.assertNull(events[0].metadata["attr_prompt"])
     }
+    }
 
     @Test
-    fun `classification metadata present when tool policy context carries classification`() = runTest {
+    fun `classification metadata present when tool policy context carries classification`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val ctx = toolCtx.copy(
             dataClassification = DataClassification.RESTRICTED,
@@ -170,11 +178,12 @@ class AuditEngineToolDecisionAuditEmitterTest {
         Assertions.assertEquals("RESTRICTED", events[0].metadata["classification"])
         Assertions.assertEquals("RULE_BASED", events[0].metadata["classificationSource"])
     }
+    }
 
     // --- Chain integrity ---
 
     @Test
-    fun `tool audit event chain passes AuditChainVerifier`() = runTest {
+    fun `tool audit event chain passes AuditChainVerifier`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
 
         emitter.emit(EnforcementPoint.BEFORE_TOOL_EXPOSURE, toolCtx, PolicyDecision.Allow)
@@ -188,9 +197,10 @@ class AuditEngineToolDecisionAuditEmitterTest {
         val result = AuditChainVerifier.verify(events)
         Assertions.assertTrue(result.isValid, "Chain verification failed: ${result.errors}")
     }
+    }
 
     @Test
-    fun `tool audit event chain with deny passes AuditChainVerifier`() = runTest {
+    fun `tool audit event chain with deny passes AuditChainVerifier`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
 
         emitter.emit(EnforcementPoint.BEFORE_TOOL_EXPOSURE, toolCtx, PolicyDecision.Deny(
@@ -201,11 +211,12 @@ class AuditEngineToolDecisionAuditEmitterTest {
         val result = AuditChainVerifier.verify(events)
         Assertions.assertTrue(result.isValid, "Chain verification failed: ${result.errors}")
     }
+    }
 
     // --- Edge cases ---
 
     @Test
-    fun `tool security with LOW risk maps correctly`() = runTest {
+    fun `tool security with LOW risk maps correctly`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val lowRiskCtx = toolCtx.copy(
             toolSecurity = ToolSecurityMetadata(
@@ -221,9 +232,10 @@ class AuditEngineToolDecisionAuditEmitterTest {
         val events = store.readStream("run-1")
         Assertions.assertEquals("LOW", events[0].metadata["riskLevel"])
     }
+    }
 
     @Test
-    fun `tool security with CRITICAL risk maps correctly`() = runTest {
+    fun `tool security with CRITICAL risk maps correctly`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val criticalCtx = toolCtx.copy(
             toolSecurity = ToolSecurityMetadata(
@@ -239,9 +251,10 @@ class AuditEngineToolDecisionAuditEmitterTest {
         val events = store.readStream("run-1")
         Assertions.assertEquals("CRITICAL", events[0].metadata["riskLevel"])
     }
+    }
 
     @Test
-    fun `unsafe reason code is normalized in tool DENY audit`() = runTest {
+    fun `unsafe reason code is normalized in tool DENY audit`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         // Reason code contains unsafe characters (uppercase, special chars)
         val deny = PolicyDecision.Deny(
@@ -255,9 +268,10 @@ class AuditEngineToolDecisionAuditEmitterTest {
         // Unsafe reason code should be normalized to the safe fallback
         Assertions.assertEquals("policy_denied", events[0].reasonCode)
     }
+    }
 
     @Test
-    fun `no tool name in context does not include toolName metadata`() = runTest {
+    fun `no tool name in context does not include toolName metadata`() { runTest {
         val emitter = AuditEnginePolicyDecisionAuditEmitter(auditEngine)
         val ctx = toolCtx.copy(toolName = null, toolSecurity = null)
         emitter.emit(EnforcementPoint.BEFORE_PROVIDER_INVOCATION, ctx, PolicyDecision.Allow)
@@ -265,5 +279,6 @@ class AuditEngineToolDecisionAuditEmitterTest {
         val events = store.readStream("run-1")
         Assertions.assertNull(events[0].metadata["toolName"])
         Assertions.assertNull(events[0].metadata["riskLevel"])
+    }
     }
 }

--- a/tramai-security/src/test/kotlin/dev/tramai/security/audit/InMemoryAuditStoreReadStreamPageTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/audit/InMemoryAuditStoreReadStreamPageTest.kt
@@ -36,45 +36,50 @@ class InMemoryAuditStoreReadStreamPageTest {
     }
 
     @Test
-    fun `readStreamPage returns first page when cursor is null`() = runTest {
+    fun `readStreamPage returns first page when cursor is null`() { runTest {
         val store = createStoreWithEvents(10)
         val page = store.readStreamPage("test-stream", afterSequenceNumber = null, limit = 5)
 
         assertEquals(5, page.size)
         assertEquals(listOf(1L, 2L, 3L, 4L, 5L), page.map { it.sequenceNumber })
     }
+    }
 
     @Test
-    fun `readStreamPage returns events after cursor`() = runTest {
+    fun `readStreamPage returns events after cursor`() { runTest {
         val store = createStoreWithEvents(10)
         val page = store.readStreamPage("test-stream", afterSequenceNumber = 5L, limit = 5)
 
         assertEquals(5, page.size)
         assertEquals(listOf(6L, 7L, 8L, 9L, 10L), page.map { it.sequenceNumber })
     }
+    }
 
     @Test
-    fun `readStreamPage respects limit`() = runTest {
+    fun `readStreamPage respects limit`() { runTest {
         val store = createStoreWithEvents(100)
         val page = store.readStreamPage("test-stream", afterSequenceNumber = null, limit = 10)
 
         assertEquals(10, page.size)
     }
+    }
 
     @Test
-    fun `readStreamPage returns empty list after last event`() = runTest {
+    fun `readStreamPage returns empty list after last event`() { runTest {
         val store = createStoreWithEvents(5)
         val page = store.readStreamPage("test-stream", afterSequenceNumber = 5L, limit = 10)
 
         assertTrue(page.isEmpty())
     }
+    }
 
     @Test
-    fun `readStreamPage returns empty list for unknown stream`() = runTest {
+    fun `readStreamPage returns empty list for unknown stream`() { runTest {
         val store = createStoreWithEvents(5)
         val page = store.readStreamPage("unknown-stream", afterSequenceNumber = null, limit = 10)
 
         assertTrue(page.isEmpty())
+    }
     }
 
     @Test
@@ -108,16 +113,17 @@ class InMemoryAuditStoreReadStreamPageTest {
     }
 
     @Test
-    fun `readStreamPage with cursor returns partial page at end`() = runTest {
+    fun `readStreamPage with cursor returns partial page at end`() { runTest {
         val store = createStoreWithEvents(10)
         val page = store.readStreamPage("test-stream", afterSequenceNumber = 8L, limit = 5)
 
         assertEquals(2, page.size)
         assertEquals(listOf(9L, 10L), page.map { it.sequenceNumber })
     }
+    }
 
     @Test
-    fun `readStreamPage returns valid event hashes`() = runTest {
+    fun `readStreamPage returns valid event hashes`() { runTest {
         val store = createStoreWithEvents(3)
         val page = store.readStreamPage("test-stream", afterSequenceNumber = null, limit = 3)
 
@@ -126,9 +132,10 @@ class InMemoryAuditStoreReadStreamPageTest {
             assertEquals(event.eventHash, event.copy(eventHash = "").calculateHash())
         }
     }
+    }
 
     @Test
-    fun `readStreamPage results are consistent with readStream`() = runTest {
+    fun `readStreamPage results are consistent with readStream`() { runTest {
         val store = createStoreWithEvents(20)
         val full = store.readStream("test-stream")
         val page = store.readStreamPage("test-stream", afterSequenceNumber = 5L, limit = 10)
@@ -136,23 +143,26 @@ class InMemoryAuditStoreReadStreamPageTest {
         assertEquals(full.drop(5).take(10).map { it.sequenceNumber }, page.map { it.sequenceNumber })
         assertEquals(full.drop(5).take(10).map { it.eventId }, page.map { it.eventId })
     }
+    }
 
     @Test
-    fun `readStream returns latestEvent unchanged`() = runTest {
+    fun `readStream returns latestEvent unchanged`() { runTest {
         val store = createStoreWithEvents(5)
         val latest = store.latestEvent("test-stream")
         assertEquals(5L, latest?.sequenceNumber)
     }
+    }
 
     @Test
-    fun `latestEvent returns null for empty stream`() = runTest {
+    fun `latestEvent returns null for empty stream`() { runTest {
         val store = InMemoryAuditStore()
         val latest = store.latestEvent("empty-stream")
         assertEquals(null, latest)
     }
+    }
 
     @Test
-    fun `separate streams have independent pagination`() = runTest {
+    fun `separate streams have independent pagination`() { runTest {
         val store = InMemoryAuditStore()
         val engine = AuditEngine(store, clock = clock)
 
@@ -177,5 +187,6 @@ class InMemoryAuditStoreReadStreamPageTest {
         val pageB = store.readStreamPage("stream-b", afterSequenceNumber = 2L, limit = 10)
         assertEquals(3, pageB.size)
         assertEquals(listOf(3L, 4L, 5L), pageB.map { it.sequenceNumber })
+    }
     }
 }

--- a/tramai-security/src/test/kotlin/dev/tramai/security/verification/FileSystemModelArtifactVerifierTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/verification/FileSystemModelArtifactVerifierTest.kt
@@ -21,7 +21,7 @@ import org.assertj.core.api.Assertions.assertThatIllegalStateException
 class FileSystemModelArtifactVerifierTest {
 
     @Test
-    fun `valid single file passes`() = runBlocking {
+    fun `valid single file passes`() { runBlocking {
         val root = Files.createTempDirectory("artifact-root")
         val content = "hello verifier".toByteArray(StandardCharsets.UTF_8)
         root.resolve("model.bin").writeBytes(content)
@@ -43,9 +43,10 @@ class FileSystemModelArtifactVerifierTest {
         assertThat(receipt?.verifiedAt).isEqualTo(clock.instant())
         assertThat(receipt?.manifestDigest).isEqualTo(manifestDigest(manifest))
     }
+    }
 
     @Test
-    fun `modified byte rejects with digest mismatch`() = runBlocking {
+    fun `modified byte rejects with digest mismatch`() { runBlocking {
         val root = Files.createTempDirectory("artifact-root")
         val path = root.resolve("model.bin")
         path.writeBytes("original".toByteArray(StandardCharsets.UTF_8))
@@ -60,9 +61,10 @@ class FileSystemModelArtifactVerifierTest {
             }
             .withMessage("artifact-file-digest-mismatch")
     }
+    }
 
     @Test
-    fun `missing file rejects with file not found`() = runBlocking {
+    fun `missing file rejects with file not found`() { runBlocking {
         val root = Files.createTempDirectory("artifact-root")
         val path = createFile(root, "missing.bin", byteArrayOf(1))
         val manifest = manifestFor(root, "missing.bin")
@@ -76,9 +78,10 @@ class FileSystemModelArtifactVerifierTest {
             }
             .withMessage("artifact-file-not-found")
     }
+    }
 
     @Test
-    fun `empty file passes`() = runBlocking {
+    fun `empty file passes`() { runBlocking {
         val root = Files.createTempDirectory("artifact-root")
         root.resolve("empty.bin").writeBytes(byteArrayOf())
         val manifest = manifestFor(root, "empty.bin")
@@ -88,9 +91,10 @@ class FileSystemModelArtifactVerifierTest {
         assertThat(receipt?.totalSizeBytes).isEqualTo(0)
         assertThat(receipt?.artifactCount).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `file size mismatch rejects`() = runBlocking {
+    fun `file size mismatch rejects`() { runBlocking {
         val root = Files.createTempDirectory("artifact-root")
         val path = root.resolve("model.bin")
         path.writeBytes("abc".toByteArray(StandardCharsets.UTF_8))
@@ -111,9 +115,10 @@ class FileSystemModelArtifactVerifierTest {
             }
             .withMessage("artifact-file-size-mismatch")
     }
+    }
 
     @Test
-    fun `directory substitution rejects`() = runBlocking {
+    fun `directory substitution rejects`() { runBlocking {
         val root = Files.createTempDirectory("artifact-root")
         root.resolve("model-dir").createDirectories()
         val manifest = manifestWithFile(
@@ -132,9 +137,10 @@ class FileSystemModelArtifactVerifierTest {
             }
             .withMessage("artifact-directory-substituted-for-file")
     }
+    }
 
     @Test
-    fun `symlink within allowed root rejects`() = runBlocking {
+    fun `symlink within allowed root rejects`() { runBlocking {
         val root = Files.createTempDirectory("artifact-root")
         val target = createFile(root, "real/model.bin", "allowed".toByteArray(StandardCharsets.UTF_8))
         val link = root.resolve("links/model.bin")
@@ -156,9 +162,10 @@ class FileSystemModelArtifactVerifierTest {
             }
             .withMessage("artifact-file-symlink-rejected")
     }
+    }
 
     @Test
-    fun `symlink escaping root rejects`() = runBlocking {
+    fun `symlink escaping root rejects`() { runBlocking {
         val root = Files.createTempDirectory("artifact-root")
         val outsideRoot = Files.createTempDirectory("artifact-outside")
         val target = createFile(outsideRoot, "escape.bin", "escape".toByteArray(StandardCharsets.UTF_8))
@@ -179,9 +186,10 @@ class FileSystemModelArtifactVerifierTest {
             }
             .withMessage("artifact-file-symlink-rejected")
     }
+    }
 
     @Test
-    fun `parent symlink rejects when target stays within allowed root`() = runBlocking {
+    fun `parent symlink rejects when target stays within allowed root`() { runBlocking {
         val root = Files.createTempDirectory("artifact-root")
         val targetDir = root.resolve("actual")
         Files.createDirectories(targetDir)
@@ -203,9 +211,10 @@ class FileSystemModelArtifactVerifierTest {
             }
             .withMessage("artifact-file-symlink-rejected")
     }
+    }
 
     @Test
-    fun `digest optional mode verifies bytes without registry pinned digest`() = runBlocking {
+    fun `digest optional mode verifies bytes without registry pinned digest`() { runBlocking {
         val root = Files.createTempDirectory("artifact-root")
         val content = "transitional bytes".toByteArray(StandardCharsets.UTF_8)
         root.resolve("model.bin").writeBytes(content)
@@ -219,9 +228,10 @@ class FileSystemModelArtifactVerifierTest {
         assertThat(receipt?.totalSizeBytes).isEqualTo(content.size.toLong())
         assertThat(receipt?.manifestDigest).isEqualTo(manifestDigest(manifest))
     }
+    }
 
     @Test
-    fun `total size overflow rejects`() = runBlocking {
+    fun `total size overflow rejects`() { runBlocking {
         val root = Files.createTempDirectory("artifact-root")
         val firstContent = byteArrayOf(1)
         val secondContent = byteArrayOf(2)
@@ -255,9 +265,10 @@ class FileSystemModelArtifactVerifierTest {
             }
             .withMessage("artifact-total-size-overflow")
     }
+    }
 
     @Test
-    fun `unknown manifest returns null`() = runBlocking {
+    fun `unknown manifest returns null`() { runBlocking {
         val root = Files.createTempDirectory("artifact-root")
         val manifest = manifestForExistingBytes(
             relativePath = "model.bin",
@@ -273,9 +284,10 @@ class FileSystemModelArtifactVerifierTest {
 
         assertThat(result).isNull()
     }
+    }
 
     @Test
-    fun `identity drift rejects`() = runBlocking {
+    fun `identity drift rejects`() { runBlocking {
         val root = Files.createTempDirectory("artifact-root")
         val manifest = manifestForExistingBytes(
             relativePath = "model.bin",
@@ -292,9 +304,10 @@ class FileSystemModelArtifactVerifierTest {
             }
             .withMessage("artifact-manifest-identity-drift")
     }
+    }
 
     @Test
-    fun `aggregate digest mismatch rejects`() = runBlocking {
+    fun `aggregate digest mismatch rejects`() { runBlocking {
         val root = Files.createTempDirectory("artifact-root")
         val manifest = manifestForExistingBytes(
             relativePath = "model.bin",
@@ -312,6 +325,7 @@ class FileSystemModelArtifactVerifierTest {
                 }
             }
             .withMessage("artifact-aggregate-digest-mismatch")
+    }
     }
 
     private fun verifier(

--- a/tramai-sovereign/src/test/kotlin/dev/tramai/sovereign/SovereignTramaiArtifactVerificationTest.kt
+++ b/tramai-sovereign/src/test/kotlin/dev/tramai/sovereign/SovereignTramaiArtifactVerificationTest.kt
@@ -210,7 +210,7 @@ class SovereignTramaiArtifactVerificationTest {
     }
 
     @Test
-    fun `cloud model without local artifact manifest preserves existing behavior`() = runBlocking {
+    fun `cloud model without local artifact manifest preserves existing behavior`() { runBlocking {
         val registeredModel = RegisteredModel(
             registryEntryId = "cloud-entry",
             providerId = "cloud-provider",
@@ -235,9 +235,10 @@ class SovereignTramaiArtifactVerificationTest {
         assertThat(verifier.seenModels).isEmpty()
         assertThat(tramai.verificationReceipts()).isEmpty()
     }
+    }
 
     @Test
-    fun `verification disabled preserves backward compatible behavior`() = runBlocking {
+    fun `verification disabled preserves backward compatible behavior`() { runBlocking {
         val registeredModel = localRegisteredModel(artifactDigest = null)
         val verifier = RecordingVerifier { error("verifier should not be invoked") }
 
@@ -256,6 +257,7 @@ class SovereignTramaiArtifactVerificationTest {
         assertThat(result).isEqualTo("mock response for test-model")
         assertThat(verifier.seenModels).isEmpty()
         assertThat(tramai.verificationReceipts()).isEmpty()
+    }
     }
 
     @Test

--- a/tramai-sovereign/src/test/kotlin/dev/tramai/sovereign/ToolExecutionDenialEvidenceIntegrationTest.kt
+++ b/tramai-sovereign/src/test/kotlin/dev/tramai/sovereign/ToolExecutionDenialEvidenceIntegrationTest.kt
@@ -150,7 +150,7 @@ class ToolExecutionDenialEvidenceIntegrationTest {
     // --- Test 9: Execution denial produces durable audit record ----------------
 
     @Test
-    fun `execution denial produces durable audit record with safe metadata`() = runTest {
+    fun `execution denial produces durable audit record with safe metadata`() { runTest {
         val (engine, store, tool) = buildFixture()
         val service = engine.create<PaymentService>()
 
@@ -171,11 +171,12 @@ class ToolExecutionDenialEvidenceIntegrationTest {
         assertEquals("HIGH", event.metadata["riskLevel"],
             "riskLevel must be present in safe audit metadata")
     }
+    }
 
     // --- Test 10: Denied execution exports as dedicated tool.permission evidence --
 
     @Test
-    fun `denied execution exports as dedicated tool permission evidence`() = runTest {
+    fun `denied execution exports as dedicated tool permission evidence`() { runTest {
         val (engine, store, tool) = buildFixture()
         val service = engine.create<PaymentService>()
 
@@ -203,11 +204,12 @@ class ToolExecutionDenialEvidenceIntegrationTest {
         assertNotNull(record.digests.subjectDigest)
         assertNotNull(record.digests.payloadDigest)
     }
+    }
 
     // --- Test 11: Raw tool arguments absent from audit and evidence ------------
 
     @Test
-    fun `raw tool arguments and secrets are absent from audit and evidence`() = runTest {
+    fun `raw tool arguments and secrets are absent from audit and evidence`() { runTest {
         val (engine, store, tool) = buildFixture()
         val service = engine.create<PaymentService>()
 
@@ -265,11 +267,12 @@ class ToolExecutionDenialEvidenceIntegrationTest {
         assertNull(execDenialEvent.metadata["attr_apiKey"])
         assertNull(execDenialEvent.metadata["attr_toolArguments"])
     }
+    }
 
     // --- Test 12: Denial evidence chain remains verifiable ---------------------
 
     @Test
-    fun `denial evidence chain passes AuditChainVerifier`() = runTest {
+    fun `denial evidence chain passes AuditChainVerifier`() { runTest {
         val (engine, store, tool) = buildFixture()
         val service = engine.create<PaymentService>()
 
@@ -290,5 +293,6 @@ class ToolExecutionDenialEvidenceIntegrationTest {
         assertNotNull(denialEvent.eventId)
         assertNotNull(denialEvent.previousEventHash, "Denied event must have previous hash in chain")
         assertNotNull(denialEvent.eventHash, "Denied event must have its own hash in chain")
+    }
     }
 }

--- a/tramai-spring-boot-starter-sovereign-ops-rest/src/test/kotlin/dev/tramai/spring/sovereign/ops/rest/ApprovalControlPlaneControllerTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-rest/src/test/kotlin/dev/tramai/spring/sovereign/ops/rest/ApprovalControlPlaneControllerTest.kt
@@ -25,7 +25,6 @@ import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc

--- a/tramai-spring-boot-starter-sovereign-ops-rest/src/test/kotlin/dev/tramai/spring/sovereign/ops/rest/ApprovalControlPlaneControllerTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-rest/src/test/kotlin/dev/tramai/spring/sovereign/ops/rest/ApprovalControlPlaneControllerTest.kt
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
@@ -35,30 +36,55 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @WebMvcTest(ApprovalControlPlaneController::class)
+@TestPropertySource(
+    properties = [
+        "tramai.sovereign.ops.rest-control-plane-enabled=true",
+        "tramai.sovereign.ops.rest.base-path=/tramai/sovereign/approvals",
+    ],
+)
 class ApprovalControlPlaneControllerTest {
 
     @Autowired
     private lateinit var mockMvc: MockMvc
 
+    @org.junit.jupiter.api.BeforeEach
+    fun setupMockMvc() {
+        org.mockito.MockitoAnnotations.openMocks(this)
+        // The controller carries @ConditionalOnProperty + @ConditionalOnBean, which
+        // are evaluated before @MockBean definitions are registered — the bean never
+        // appears in a @WebMvcTest slice. Test the controller standalone with plain
+        // mocks instead; assertions are identical.
+        mockMvc = org.springframework.test.web.servlet.setup.MockMvcBuilders
+            .standaloneSetup(
+                ApprovalControlPlaneController(
+                    decisionControlPlane = decisionControlPlane,
+                    resumeControlPlane = resumeControlPlane,
+                    approvalStore = approvalStore,
+                    approvalContinuationStore = approvalContinuationStore,
+                ),
+            )
+            .build()
+    }
+
     @Autowired
     private lateinit var objectMapper: ObjectMapper
 
-    @MockBean
+    @org.mockito.Mock
     private lateinit var decisionControlPlane: ApprovalDecisionControlPlane
 
-    @MockBean
+    @org.mockito.Mock
     private lateinit var resumeControlPlane: ApprovalResumeControlPlane
 
-    @MockBean
+    @org.mockito.Mock
     private lateinit var approvalStore: ApprovalStore
 
-    @MockBean
+    @org.mockito.Mock
     private lateinit var approvalContinuationStore: ApprovalContinuationStore
 
     private val now: Instant = Instant.parse("2026-06-26T08:00:00Z")
 
     @Test
-    fun `approve endpoint returns 200 for Approved`() = runBlocking {
+    fun `approve endpoint returns 200 for Approved`() { runBlocking {
         val expectedCommand = approveCommand(
             approvalId = "approval-1",
             comment = "Approved",
@@ -88,8 +114,7 @@ class ApprovalControlPlaneControllerTest {
                         ),
                     ),
                 ),
-        )
-            .andExpect(status().isOk)
+        ).andExpect(status().isOk)
             .andExpect(jsonPath("$.status").value("APPROVED"))
             .andExpect(jsonPath("$.approvalId").value("approval-1"))
             .andExpect(jsonPath("$.actorId").value("medical-ops-reviewer"))
@@ -97,9 +122,10 @@ class ApprovalControlPlaneControllerTest {
 
         verify(decisionControlPlane).approve(expectedCommand)
     }
+    }
 
     @Test
-    fun `deny endpoint returns 200 for Denied`() = runBlocking {
+    fun `deny endpoint returns 200 for Denied`() { runBlocking {
         doReturn(
             ApprovalDecisionResult.Denied(
                 approvalId = ApprovalId("approval-1"),
@@ -128,9 +154,10 @@ class ApprovalControlPlaneControllerTest {
             .andExpect(jsonPath("$.status").value("DENIED"))
             .andExpect(jsonPath("$.approvalId").value("approval-1"))
     }
+    }
 
     @Test
-    fun `resume endpoint returns 200 for Resumed`() = runBlocking {
+    fun `resume endpoint returns 200 for Resumed`() { runBlocking {
         doReturn(
             ApprovalResumeResult.Resumed(
                 approvalId = ApprovalId("approval-1"),
@@ -160,18 +187,20 @@ class ApprovalControlPlaneControllerTest {
             .andExpect(jsonPath("$.approvalId").value("approval-1"))
             .andExpect(jsonPath("$.actorId").value("medical-ops-reviewer"))
     }
+    }
 
     @Test
-    fun `missing approval returns 404 for getApproval`() = runBlocking {
+    fun `missing approval returns 404 for getApproval`() { runBlocking {
         doReturn(null).`when`(approvalStore).get("approval-404")
 
         mockMvc.perform(get("/tramai/sovereign/approvals/approval-404"))
             .andExpect(status().isNotFound)
             .andExpect(content().string(""))
     }
+    }
 
     @Test
-    fun `conflict maps to 409 for approve`() = runBlocking {
+    fun `conflict maps to 409 for approve`() { runBlocking {
         doReturn(
             ApprovalDecisionResult.Conflict(
                 approvalId = ApprovalId("approval-1"),
@@ -197,9 +226,10 @@ class ApprovalControlPlaneControllerTest {
             .andExpect(jsonPath("$.status").value("CONFLICT"))
             .andExpect(jsonPath("$.message").value("approval-version-conflict"))
     }
+    }
 
     @Test
-    fun `deny not found maps to 404`() = runBlocking {
+    fun `deny not found maps to 404`() { runBlocking {
         doReturn(
             ApprovalDecisionResult.NotFound(ApprovalId("approval-404")),
         ).`when`(decisionControlPlane).deny(
@@ -221,9 +251,10 @@ class ApprovalControlPlaneControllerTest {
             .andExpect(status().isNotFound)
             .andExpect(content().string(""))
     }
+    }
 
     @Test
-    fun `resume not found maps to 404`() = runBlocking {
+    fun `resume not found maps to 404`() { runBlocking {
         doReturn(
             ApprovalResumeResult.NotFound(ApprovalId("approval-404")),
         ).`when`(resumeControlPlane).resume(
@@ -245,9 +276,10 @@ class ApprovalControlPlaneControllerTest {
             .andExpect(status().isNotFound)
             .andExpect(content().string(""))
     }
+    }
 
     @Test
-    fun `resume not approved maps to 409`() = runBlocking {
+    fun `resume not approved maps to 409`() { runBlocking {
         doReturn(
             ApprovalResumeResult.NotApproved(
                 approvalId = ApprovalId("approval-1"),
@@ -273,9 +305,10 @@ class ApprovalControlPlaneControllerTest {
             .andExpect(jsonPath("$.status").value("NOT_APPROVED"))
             .andExpect(jsonPath("$.message").value("approval-status-PENDING"))
     }
+    }
 
     @Test
-    fun `AlreadyCompleted returns 200`() = runBlocking {
+    fun `AlreadyCompleted returns 200`() { runBlocking {
         doReturn(
             ApprovalResumeResult.AlreadyCompleted(ApprovalId("approval-1")),
         ).`when`(resumeControlPlane).resume(
@@ -297,9 +330,10 @@ class ApprovalControlPlaneControllerTest {
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.status").value("ALREADY_COMPLETED"))
     }
+    }
 
     @Test
-    fun `AlreadyApproved returns 200`() = runBlocking {
+    fun `AlreadyApproved returns 200`() { runBlocking {
         doReturn(
             ApprovalDecisionResult.AlreadyApproved(
                 approvalId = ApprovalId("approval-1"),
@@ -326,9 +360,10 @@ class ApprovalControlPlaneControllerTest {
             .andExpect(jsonPath("$.status").value("ALREADY_APPROVED"))
             .andExpect(jsonPath("$.actorId").value("existing-reviewer"))
     }
+    }
 
     @Test
-    fun `get approval returns 200 with approval and continuation status`() = runBlocking {
+    fun `get approval returns 200 with approval and continuation status`() { runBlocking {
         doReturn(approvalRequest("approval-1")).`when`(approvalStore).get("approval-1")
         doReturn(approvalContinuation("approval-1")).`when`(approvalContinuationStore).get("approval-1")
 
@@ -340,9 +375,10 @@ class ApprovalControlPlaneControllerTest {
             .andExpect(jsonPath("$.requestedBy").value("triage-system"))
             .andExpect(jsonPath("$.continuationStatus").value("PENDING"))
     }
+    }
 
     @Test
-    fun `resume Failed returns 500 with safe message not internal exception`() = runBlocking {
+    fun `resume Failed returns 500 with safe message not internal exception`() { runBlocking {
         doReturn(
             ApprovalResumeResult.Failed(
                 approvalId = ApprovalId("approval-1"),
@@ -368,9 +404,10 @@ class ApprovalControlPlaneControllerTest {
             .andExpect(jsonPath("$.status").value("FAILED"))
             .andExpect(jsonPath("$.message").value("approval-resume-failed"))
     }
+    }
 
     @Test
-    fun `Expired maps to 409`() = runBlocking {
+    fun `Expired maps to 409`() { runBlocking {
         doReturn(
             ApprovalDecisionResult.Expired(
                 approvalId = ApprovalId("approval-1"),
@@ -394,6 +431,7 @@ class ApprovalControlPlaneControllerTest {
         )
             .andExpect(status().isConflict)
             .andExpect(jsonPath("$.status").value("EXPIRED"))
+    }
     }
 
     // -- test helpers --

--- a/tramai-spring-boot-starter-sovereign-ops-rest/src/test/kotlin/dev/tramai/spring/sovereign/ops/rest/ApprovalInboxControllerTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-rest/src/test/kotlin/dev/tramai/spring/sovereign/ops/rest/ApprovalInboxControllerTest.kt
@@ -18,12 +18,19 @@ import org.springframework.boot.SpringBootConfiguration
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.ComponentScan
+import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @WebMvcTest(ApprovalInboxController::class)
+@TestPropertySource(
+    properties = [
+        "tramai.sovereign.ops.rest-control-plane-enabled=true",
+        "tramai.sovereign.ops.rest.base-path=/tramai/sovereign/approvals",
+    ],
+)
 class ApprovalInboxControllerTest {
 
     @Autowired
@@ -32,13 +39,25 @@ class ApprovalInboxControllerTest {
     @Autowired
     private lateinit var objectMapper: ObjectMapper
 
-    @MockBean
+    @org.mockito.Mock
     private lateinit var queryService: ApprovalInboxQueryService
+
+    @org.junit.jupiter.api.BeforeEach
+    fun setupMockMvc() {
+        org.mockito.MockitoAnnotations.openMocks(this)
+        // ApprovalInboxController carries @ConditionalOnProperty + @ConditionalOnBean,
+        // which are evaluated before @MockBean definitions are registered — the bean
+        // never appears in a @WebMvcTest slice. Test the controller standalone with
+        // plain mocks instead; assertions are identical.
+        mockMvc = org.springframework.test.web.servlet.setup.MockMvcBuilders
+            .standaloneSetup(ApprovalInboxController(queryService))
+            .build()
+    }
 
     private val now = Instant.parse("2026-06-26T10:00:00Z")
 
     @Test
-    fun `GET approvals returns inbox items`() = runBlocking {
+    fun `GET approvals returns inbox items`() { runBlocking {
         doReturn(inboxPage()).`when`(queryService).search(ApprovalInboxQuery())
 
         mockMvc.perform(get("/tramai/sovereign/approvals"))
@@ -55,9 +74,10 @@ class ApprovalInboxControllerTest {
             .andExpect(jsonPath("$.items[0].continuationStatus").value("PENDING"))
             .andExpect(jsonPath("$.items[0].version").value(0))
     }
+    }
 
     @Test
-    fun `GET approvals response does not contain sensitive fields`() = runBlocking {
+    fun `GET approvals response does not contain sensitive fields`() { runBlocking {
         doReturn(inboxPage()).`when`(queryService).search(ApprovalInboxQuery())
 
         mockMvc.perform(get("/tramai/sovereign/approvals"))
@@ -68,9 +88,10 @@ class ApprovalInboxControllerTest {
             .andExpect(jsonPath("$.items[0].replayEnvelope").doesNotExist())
             .andExpect(jsonPath("$.items[0].decisionComment").doesNotExist())
     }
+    }
 
     @Test
-    fun `GET work-item returns safe projection`() = runBlocking {
+    fun `GET work-item returns safe projection`() { runBlocking {
         doReturn(inboxItem()).`when`(queryService).getWorkItem(ApprovalId("approval-1"))
 
         mockMvc.perform(get("/tramai/sovereign/approvals/approval-1/work-item"))
@@ -81,29 +102,33 @@ class ApprovalInboxControllerTest {
             .andExpect(jsonPath("$.continuationStatus").value("PENDING"))
             .andExpect(jsonPath("$.version").value(0))
     }
+    }
 
     @Test
-    fun `GET work-item returns 404 for missing approval`() = runBlocking {
+    fun `GET work-item returns 404 for missing approval`() { runBlocking {
         doReturn(null).`when`(queryService).getWorkItem(ApprovalId("approval-missing"))
 
         mockMvc.perform(get("/tramai/sovereign/approvals/approval-missing/work-item"))
             .andExpect(status().isNotFound)
     }
+    }
 
     @Test
-    fun `GET approvals rejects invalid limit with 400`() = runBlocking {
+    fun `GET approvals rejects invalid limit with 400`() { runBlocking {
         mockMvc.perform(get("/tramai/sovereign/approvals?limit=0"))
             .andExpect(status().isBadRequest)
     }
-
-    @Test
-    fun `GET approvals rejects limit over 100 with 400`() = runBlocking {
-        mockMvc.perform(get("/tramai/sovereign/approvals?limit=101"))
-            .andExpect(status().isBadRequest)
     }
 
     @Test
-    fun `GET approvals with requiredRole filter returns matching approvals`() = runBlocking {
+    fun `GET approvals rejects limit over 100 with 400`() { runBlocking {
+        mockMvc.perform(get("/tramai/sovereign/approvals?limit=101"))
+            .andExpect(status().isBadRequest)
+    }
+    }
+
+    @Test
+    fun `GET approvals with requiredRole filter returns matching approvals`() { runBlocking {
         doReturn(inboxPage()).`when`(queryService).search(
             ApprovalInboxQuery(requiredRole = ApproverRole("medical-reviewer")),
         )
@@ -112,11 +137,13 @@ class ApprovalInboxControllerTest {
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.items[0].requiredRole").value("medical-reviewer"))
     }
+    }
 
     @Test
-    fun `GET approvals with requiredRole filter returns 400 for invalid role`() = runBlocking {
+    fun `GET approvals with requiredRole filter returns 400 for invalid role`() { runBlocking {
         mockMvc.perform(get("/tramai/sovereign/approvals?requiredRole="))
             .andExpect(status().isBadRequest)
+    }
     }
 
     private fun inboxPage(): ApprovalInboxPage = ApprovalInboxPage(

--- a/tramai-spring-boot-starter-sovereign-ops-rest/src/test/kotlin/dev/tramai/spring/sovereign/ops/rest/ApprovalInboxControllerTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops-rest/src/test/kotlin/dev/tramai/spring/sovereign/ops/rest/ApprovalInboxControllerTest.kt
@@ -14,10 +14,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.doReturn
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.SpringBootConfiguration
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.ComponentScan
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovalDecisionControlPlaneTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovalDecisionControlPlaneTest.kt
@@ -25,7 +25,7 @@ class SovereignOpsApprovalDecisionControlPlaneTest {
     private val clock: Clock = Clock.fixed(now, ZoneOffset.UTC)
 
     @Test
-    fun `approve pending approval returns Approved`() = runBlocking {
+    fun `approve pending approval returns Approved`() { runBlocking {
         val store = MutableApprovalStore(mutableMapOf("approval-1" to pendingApproval("approval-1")))
         val mutationStore = StubApprovalMutationStore(store)
         val controlPlane = SovereignOpsApprovalDecisionControlPlane(
@@ -43,9 +43,10 @@ class SovereignOpsApprovalDecisionControlPlaneTest {
         assertThat(approved.decidedAt).isEqualTo(now)
         assertThat(approved.version).isEqualTo(1L)
     }
+    }
 
     @Test
-    fun `deny pending approval returns Denied`() = runBlocking {
+    fun `deny pending approval returns Denied`() { runBlocking {
         val store = MutableApprovalStore(mutableMapOf("approval-1" to pendingApproval("approval-1")))
         val mutationStore = StubApprovalMutationStore(store)
         val controlPlane = SovereignOpsApprovalDecisionControlPlane(
@@ -63,9 +64,10 @@ class SovereignOpsApprovalDecisionControlPlaneTest {
         assertThat(denied.decidedAt).isEqualTo(now)
         assertThat(denied.version).isEqualTo(1L)
     }
+    }
 
     @Test
-    fun `already approved returns AlreadyApproved`() = runBlocking {
+    fun `already approved returns AlreadyApproved`() { runBlocking {
         val store = MutableApprovalStore(
             mutableMapOf("approval-1" to approvedApproval("approval-1", "existing-reviewer", now.minusSeconds(60))),
         )
@@ -85,9 +87,10 @@ class SovereignOpsApprovalDecisionControlPlaneTest {
             ),
         )
     }
+    }
 
     @Test
-    fun `already denied returns AlreadyDenied`() = runBlocking {
+    fun `already denied returns AlreadyDenied`() { runBlocking {
         val store = MutableApprovalStore(
             mutableMapOf("approval-1" to deniedApproval("approval-1", "existing-reviewer", now.minusSeconds(60))),
         )
@@ -107,9 +110,10 @@ class SovereignOpsApprovalDecisionControlPlaneTest {
             ),
         )
     }
+    }
 
     @Test
-    fun `expired approval returns Expired`() = runBlocking {
+    fun `expired approval returns Expired`() { runBlocking {
         val store = MutableApprovalStore(
             mutableMapOf("approval-1" to pendingApproval("approval-1", expiresAt = now)),
         )
@@ -128,9 +132,10 @@ class SovereignOpsApprovalDecisionControlPlaneTest {
             ),
         )
     }
+    }
 
     @Test
-    fun `already approved expired approval returns AlreadyApproved`() = runBlocking {
+    fun `already approved expired approval returns AlreadyApproved`() { runBlocking {
         val store = MutableApprovalStore(
             mutableMapOf("approval-1" to approvedApproval(
                 approvalId = "approval-1",
@@ -154,9 +159,10 @@ class SovereignOpsApprovalDecisionControlPlaneTest {
             ),
         )
     }
+    }
 
     @Test
-    fun `already denied expired approval returns AlreadyDenied`() = runBlocking {
+    fun `already denied expired approval returns AlreadyDenied`() { runBlocking {
         val store = MutableApprovalStore(
             mutableMapOf("approval-1" to deniedApproval(
                 approvalId = "approval-1",
@@ -180,9 +186,10 @@ class SovereignOpsApprovalDecisionControlPlaneTest {
             ),
         )
     }
+    }
 
     @Test
-    fun `missing approval returns NotFound`() = runBlocking {
+    fun `missing approval returns NotFound`() { runBlocking {
         val store = MutableApprovalStore()
         val controlPlane = SovereignOpsApprovalDecisionControlPlane(
             approvalStore = store,
@@ -194,9 +201,10 @@ class SovereignOpsApprovalDecisionControlPlaneTest {
 
         assertThat(result).isEqualTo(ApprovalDecisionResult.NotFound(ApprovalId("approval-404")))
     }
+    }
 
     @Test
-    fun `unauthorized actor returns Conflict`() = runBlocking {
+    fun `unauthorized actor returns Conflict`() { runBlocking {
         val store = MutableApprovalStore(mutableMapOf("approval-1" to pendingApproval("approval-1")))
         val controlPlane = SovereignOpsApprovalDecisionControlPlane(
             approvalStore = store,
@@ -214,9 +222,10 @@ class SovereignOpsApprovalDecisionControlPlaneTest {
             ),
         )
     }
+    }
 
     @Test
-    fun `approve on denied returns AlreadyDenied`() = runBlocking {
+    fun `approve on denied returns AlreadyDenied`() { runBlocking {
         val store = MutableApprovalStore(
             mutableMapOf("approval-1" to deniedApproval("approval-1", "existing-reviewer", now.minusSeconds(60))),
         )
@@ -236,9 +245,10 @@ class SovereignOpsApprovalDecisionControlPlaneTest {
             ),
         )
     }
+    }
 
     @Test
-    fun `deny on approved returns AlreadyApproved`() = runBlocking {
+    fun `deny on approved returns AlreadyApproved`() { runBlocking {
         val store = MutableApprovalStore(
             mutableMapOf("approval-1" to approvedApproval("approval-1", "existing-reviewer", now.minusSeconds(60))),
         )
@@ -258,9 +268,10 @@ class SovereignOpsApprovalDecisionControlPlaneTest {
             ),
         )
     }
+    }
 
     @Test
-    fun `version conflict at mutation store returns Conflict`() = runBlocking {
+    fun `version conflict at mutation store returns Conflict`() { runBlocking {
         val store = MutableApprovalStore(mutableMapOf("approval-1" to pendingApproval("approval-1")))
         val mutationStore = StubApprovalMutationStore(store)
         val controlPlane = SovereignOpsApprovalDecisionControlPlane(
@@ -279,6 +290,7 @@ class SovereignOpsApprovalDecisionControlPlaneTest {
                 reason = "tramai-sovereign-ops-approval-version-conflict",
             ),
         )
+    }
     }
 
     private fun decisionCommand(approvalId: String): ApprovalDecisionCommand =

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovalResumeControlPlaneTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsApprovalResumeControlPlaneTest.kt
@@ -30,7 +30,7 @@ class SovereignOpsApprovalResumeControlPlaneTest {
     private val clock: Clock = Clock.fixed(now, ZoneOffset.UTC)
 
     @Test
-    fun `resume approved approval returns Resumed with workflow result`() = runBlocking {
+    fun `resume approved approval returns Resumed with workflow result`() { runBlocking {
         val approvalStore = ResumeMutableApprovalStore(
             mutableMapOf("approval-1" to approvedApproval("approval-1")),
         )
@@ -67,9 +67,10 @@ class SovereignOpsApprovalResumeControlPlaneTest {
             ),
         )
     }
+    }
 
     @Test
-    fun `resume missing approval returns NotFound`() = runBlocking {
+    fun `resume missing approval returns NotFound`() { runBlocking {
         val controlPlane = SovereignOpsApprovalResumeControlPlane(
             approvalStore = ResumeMutableApprovalStore(),
             approvalContinuationStore = ResumeMutableApprovalContinuationStore(),
@@ -81,9 +82,10 @@ class SovereignOpsApprovalResumeControlPlaneTest {
 
         assertThat(result).isEqualTo(ApprovalResumeResult.NotFound(ApprovalId("approval-404")))
     }
+    }
 
     @Test
-    fun `resume pending approval returns NotApproved`() = runBlocking {
+    fun `resume pending approval returns NotApproved`() { runBlocking {
         val approvalStore = ResumeMutableApprovalStore(
             mutableMapOf("approval-1" to approval("approval-1", ApprovalStatus.PENDING)),
         )
@@ -100,9 +102,10 @@ class SovereignOpsApprovalResumeControlPlaneTest {
             ApprovalResumeResult.NotApproved(ApprovalId("approval-1"), ApprovalStatus.PENDING),
         )
     }
+    }
 
     @Test
-    fun `resume denied approval returns NotApproved`() = runBlocking {
+    fun `resume denied approval returns NotApproved`() { runBlocking {
         val approvalStore = ResumeMutableApprovalStore(
             mutableMapOf("approval-1" to approval("approval-1", ApprovalStatus.DENIED, version = 1L)),
         )
@@ -119,9 +122,10 @@ class SovereignOpsApprovalResumeControlPlaneTest {
             ApprovalResumeResult.NotApproved(ApprovalId("approval-1"), ApprovalStatus.DENIED),
         )
     }
+    }
 
     @Test
-    fun `resume expired pending approval returns NotApproved while approved expired approval can still resume`() = runBlocking {
+    fun `resume expired pending approval returns NotApproved while approved expired approval can still resume`() { runBlocking {
         val pendingApprovalStore = ResumeMutableApprovalStore(
             mutableMapOf(
                 "pending-expired" to approval(
@@ -169,9 +173,10 @@ class SovereignOpsApprovalResumeControlPlaneTest {
             ),
         )
     }
+    }
 
     @Test
-    fun `resume missing continuation returns Conflict`() = runBlocking {
+    fun `resume missing continuation returns Conflict`() { runBlocking {
         val approvalStore = ResumeMutableApprovalStore(
             mutableMapOf("approval-1" to approvedApproval("approval-1")),
         )
@@ -191,9 +196,10 @@ class SovereignOpsApprovalResumeControlPlaneTest {
             ),
         )
     }
+    }
 
     @Test
-    fun `resume completed continuation returns AlreadyCompleted`() = runBlocking {
+    fun `resume completed continuation returns AlreadyCompleted`() { runBlocking {
         val approvalStore = ResumeMutableApprovalStore(
             mutableMapOf("approval-1" to approvedApproval("approval-1")),
         )
@@ -213,9 +219,10 @@ class SovereignOpsApprovalResumeControlPlaneTest {
 
         assertThat(result).isEqualTo(ApprovalResumeResult.AlreadyCompleted(ApprovalId("approval-1")))
     }
+    }
 
     @Test
-    fun `resume claimed continuation returns Conflict`() = runBlocking {
+    fun `resume claimed continuation returns Conflict`() { runBlocking {
         val approvalStore = ResumeMutableApprovalStore(
             mutableMapOf("approval-1" to approvedApproval("approval-1")),
         )
@@ -244,9 +251,10 @@ class SovereignOpsApprovalResumeControlPlaneTest {
             ),
         )
     }
+    }
 
     @Test
-    fun `resume expired continuation returns Conflict`() = runBlocking {
+    fun `resume expired continuation returns Conflict`() { runBlocking {
         val approvalStore = ResumeMutableApprovalStore(
             mutableMapOf("approval-1" to approvedApproval("approval-1")),
         )
@@ -273,9 +281,10 @@ class SovereignOpsApprovalResumeControlPlaneTest {
             ),
         )
     }
+    }
 
     @Test
-    fun `resume cancelled continuation returns Conflict`() = runBlocking {
+    fun `resume cancelled continuation returns Conflict`() { runBlocking {
         val approvalStore = ResumeMutableApprovalStore(
             mutableMapOf("approval-1" to approvedApproval("approval-1")),
         )
@@ -302,9 +311,10 @@ class SovereignOpsApprovalResumeControlPlaneTest {
             ),
         )
     }
+    }
 
     @Test
-    fun `resume with invalid resume token returns Conflict`() = runBlocking {
+    fun `resume with invalid resume token returns Conflict`() { runBlocking {
         val approvalStore = ResumeMutableApprovalStore(
             mutableMapOf("approval-1" to approvedApproval("approval-1")),
         )
@@ -329,9 +339,10 @@ class SovereignOpsApprovalResumeControlPlaneTest {
             ),
         )
     }
+    }
 
     @Test
-    fun `runtime exception returns Failed without deleting continuation`() = runBlocking {
+    fun `runtime exception returns Failed without deleting continuation`() { runBlocking {
         val approvalStore = ResumeMutableApprovalStore(
             mutableMapOf("approval-1" to approvedApproval("approval-1")),
         )
@@ -355,9 +366,10 @@ class SovereignOpsApprovalResumeControlPlaneTest {
         )
         assertThat(continuationStore.get("approval-1")).isEqualTo(pendingContinuation("approval-1"))
     }
+    }
 
     @Test
-    fun `cancellation exception is rethrown`() = runBlocking {
+    fun `cancellation exception is rethrown`() { runBlocking {
         val approvalStore = ResumeMutableApprovalStore(
             mutableMapOf("approval-1" to approvedApproval("approval-1")),
         )
@@ -374,6 +386,7 @@ class SovereignOpsApprovalResumeControlPlaneTest {
         assertThatThrownBy {
             runBlocking { controlPlane.resume(resumeCommand("approval-1")) }
         }.isInstanceOf(CancellationException::class.java)
+    }
     }
 
     private fun resumeCommand(approvalId: String): ApprovalResumeCommand =

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/LeasedSovereignOpsAuditOutboxBackgroundWorkerTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/LeasedSovereignOpsAuditOutboxBackgroundWorkerTest.kt
@@ -57,7 +57,7 @@ class LeasedSovereignOpsAuditOutboxBackgroundWorkerTest {
     }
 
     @Test
-    fun `acquired lease runs delegate`() = runBlocking {
+    fun `acquired lease runs delegate`() { runBlocking {
         leaseStore.acquireResult = SovereignOpsWorkerLeaseAcquisition.Acquired(
             SovereignOpsWorkerLease(
                 leaseName = "test-lease",
@@ -73,9 +73,10 @@ class LeasedSovereignOpsAuditOutboxBackgroundWorkerTest {
         assertThat(operations.recoverCalled).isTrue
         assertThat(summary.skipped).isNull()
     }
+    }
 
     @Test
-    fun `already owned lease runs delegate`() = runBlocking {
+    fun `already owned lease runs delegate`() { runBlocking {
         leaseStore.acquireResult = SovereignOpsWorkerLeaseAcquisition.AlreadyOwned(
             SovereignOpsWorkerLease(
                 leaseName = "test-lease",
@@ -91,9 +92,10 @@ class LeasedSovereignOpsAuditOutboxBackgroundWorkerTest {
         assertThat(operations.recoverCalled).isTrue
         assertThat(summary.skipped).isNull()
     }
+    }
 
     @Test
-    fun `held by other does not invoke delegate`() = runBlocking {
+    fun `held by other does not invoke delegate`() { runBlocking {
         leaseStore.acquireResult = SovereignOpsWorkerLeaseAcquisition.HeldByOther(
             SovereignOpsWorkerLease(
                 leaseName = "test-lease",
@@ -112,9 +114,10 @@ class LeasedSovereignOpsAuditOutboxBackgroundWorkerTest {
         assertThat(summary.recovered).isNull()
         assertThat(summary.dispatched).isNull()
     }
+    }
 
     @Test
-    fun `heartbeat is called during run`() = runBlocking {
+    fun `heartbeat is called during run`() { runBlocking {
         leaseStore.acquireResult = SovereignOpsWorkerLeaseAcquisition.Acquired(
             SovereignOpsWorkerLease(
                 leaseName = "test-lease",
@@ -132,9 +135,10 @@ class LeasedSovereignOpsAuditOutboxBackgroundWorkerTest {
         worker().runOnce()
         assertThat(leaseStore.heartbeatCalled).isTrue
     }
+    }
 
     @Test
-    fun `lost lease during run cancels delegate`() = runBlocking {
+    fun `lost lease during run cancels delegate`() { runBlocking {
         leaseStore.acquireResult = SovereignOpsWorkerLeaseAcquisition.Acquired(
             SovereignOpsWorkerLease(
                 leaseName = "test-lease",
@@ -165,6 +169,7 @@ class LeasedSovereignOpsAuditOutboxBackgroundWorkerTest {
 
         assertThat(thrown.message).contains("tramai-sovereign-ops-worker-lease-lost")
         assertThat(cancelledDuringRun).isTrue()
+    }
     }
 
     // ── Fakes ──────────────────────────────────────────────────────────

--- a/tramai-spring-boot-starter-sovereign-persistence-file/src/test/kotlin/dev/tramai/spring/sovereign/persistence/file/FileSovereignOpsAuditOutboxStoreTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/src/test/kotlin/dev/tramai/spring/sovereign/persistence/file/FileSovereignOpsAuditOutboxStoreTest.kt
@@ -30,13 +30,14 @@ class FileSovereignOpsAuditOutboxStoreTest {
     }
 
     @Test
-    fun `append persists PREPARED record`() = runBlocking {
+    fun `append persists PREPARED record`() { runBlocking {
         val store = store()
         val record = record("prepared")
 
         store.append(record)
 
         assertThat(store.get("prepared")).isEqualTo(record)
+    }
     }
 
     @Test
@@ -79,7 +80,7 @@ class FileSovereignOpsAuditOutboxStoreTest {
     }
 
     @Test
-    fun `get returns persisted record`() = runBlocking {
+    fun `get returns persisted record`() { runBlocking {
         val store = store()
         val record = record("get-record")
 
@@ -87,9 +88,10 @@ class FileSovereignOpsAuditOutboxStoreTest {
 
         assertThat(store.get("get-record")).isEqualTo(record)
     }
+    }
 
     @Test
-    fun `findByEventKey works after restart`() = runBlocking {
+    fun `findByEventKey works after restart`() { runBlocking {
         val key = testKey()
         val store = store(key = key)
         val record = record("event-key-record", eventKey = "event-key-after-restart")
@@ -99,9 +101,10 @@ class FileSovereignOpsAuditOutboxStoreTest {
 
         assertThat(restarted.findByEventKey("event-key-after-restart")).isEqualTo(record)
     }
+    }
 
     @Test
-    fun `listByStatus returns records by status`() = runBlocking {
+    fun `listByStatus returns records by status`() { runBlocking {
         val store = store()
         store.append(record("prepared"))
         store.append(record("pending"))
@@ -117,9 +120,10 @@ class FileSovereignOpsAuditOutboxStoreTest {
         assertThat(store.listByStatus(SovereignOpsAuditOutboxStatus.EMITTING, 10).map { it.outboxId })
             .containsExactly("emitting")
     }
+    }
 
     @Test
-    fun `listExpiredEmitting returns only expired EMITTING`() = runBlocking {
+    fun `listExpiredEmitting returns only expired EMITTING`() { runBlocking {
         val store = store()
         store.append(record("expired"))
         store.markReadyForDispatch("expired", SovereignOpsAuditOutboxStatus.PREPARED)
@@ -132,9 +136,10 @@ class FileSovereignOpsAuditOutboxStoreTest {
 
         assertThat(expired.map { it.outboxId }).containsExactly("expired")
     }
+    }
 
     @Test
-    fun `markReadyForDispatch moves PREPARED to PENDING`() = runBlocking {
+    fun `markReadyForDispatch moves PREPARED to PENDING`() { runBlocking {
         val store = store()
         store.append(record("ready"))
 
@@ -142,6 +147,7 @@ class FileSovereignOpsAuditOutboxStoreTest {
 
         assertThat(updated.status).isEqualTo(SovereignOpsAuditOutboxStatus.PENDING)
         assertThat(store.get("ready")?.status).isEqualTo(SovereignOpsAuditOutboxStatus.PENDING)
+    }
     }
 
     @Test
@@ -179,7 +185,7 @@ class FileSovereignOpsAuditOutboxStoreTest {
     }
 
     @Test
-    fun `claimPending claims PENDING records`() = runBlocking {
+    fun `claimPending claims PENDING records`() { runBlocking {
         val store = store()
         store.append(record("pending-claim"))
         store.markReadyForDispatch("pending-claim", SovereignOpsAuditOutboxStatus.PREPARED)
@@ -191,9 +197,10 @@ class FileSovereignOpsAuditOutboxStoreTest {
         assertThat(claimed.single().attemptCount).isEqualTo(1)
         assertThat(claimed.single().claimedBy).isEqualTo("dispatcher")
     }
+    }
 
     @Test
-    fun `claimPending claims FAILED_RETRYABLE records`() = runBlocking {
+    fun `claimPending claims FAILED_RETRYABLE records`() { runBlocking {
         val store = store()
         store.append(record("retryable-claim"))
         store.markReadyForDispatch("retryable-claim", SovereignOpsAuditOutboxStatus.PREPARED)
@@ -210,9 +217,10 @@ class FileSovereignOpsAuditOutboxStoreTest {
         assertThat(claimed.map { it.outboxId }).containsExactly("retryable-claim")
         assertThat(claimed.single().attemptCount).isEqualTo(2)
     }
+    }
 
     @Test
-    fun `claimPending reclaims expired EMITTING records`() = runBlocking {
+    fun `claimPending reclaims expired EMITTING records`() { runBlocking {
         val store = store()
         store.append(record("expired-emitting"))
         store.markReadyForDispatch("expired-emitting", SovereignOpsAuditOutboxStatus.PREPARED)
@@ -224,17 +232,19 @@ class FileSovereignOpsAuditOutboxStoreTest {
         assertThat(claimed.single().claimedBy).isEqualTo("new-dispatcher")
         assertThat(claimed.single().attemptCount).isEqualTo(2)
     }
+    }
 
     @Test
-    fun `claimPending never claims PREPARED records`() = runBlocking {
+    fun `claimPending never claims PREPARED records`() { runBlocking {
         val store = store()
         store.append(record("prepared-only"))
 
         assertThat(store.claimPending("dispatcher", 10, BASE_NOW)).isEmpty()
     }
+    }
 
     @Test
-    fun `claimPending never claims EMITTED records`() = runBlocking {
+    fun `claimPending never claims EMITTED records`() { runBlocking {
         val store = store()
         store.append(record("emitted"))
         store.markReadyForDispatch("emitted", SovereignOpsAuditOutboxStatus.PREPARED)
@@ -243,9 +253,10 @@ class FileSovereignOpsAuditOutboxStoreTest {
 
         assertThat(store.claimPending("dispatcher", 10, BASE_NOW.plus(Duration.ofMinutes(10)))).isEmpty()
     }
+    }
 
     @Test
-    fun `claimPending never claims FAILED_PERMANENT records`() = runBlocking {
+    fun `claimPending never claims FAILED_PERMANENT records`() { runBlocking {
         val store = store()
         store.append(record("permanent"))
         store.markFailed(
@@ -257,9 +268,10 @@ class FileSovereignOpsAuditOutboxStoreTest {
 
         assertThat(store.claimPending("dispatcher", 10, BASE_NOW)).isEmpty()
     }
+    }
 
     @Test
-    fun `markEmitted moves EMITTING to EMITTED`() = runBlocking {
+    fun `markEmitted moves EMITTING to EMITTED`() { runBlocking {
         val store = store()
         store.append(record("emit"))
         store.markReadyForDispatch("emit", SovereignOpsAuditOutboxStatus.PREPARED)
@@ -270,9 +282,10 @@ class FileSovereignOpsAuditOutboxStoreTest {
         assertThat(emitted.status).isEqualTo(SovereignOpsAuditOutboxStatus.EMITTED)
         assertThat(emitted.emittedAt).isEqualTo(BASE_NOW.plusSeconds(1))
     }
+    }
 
     @Test
-    fun `markFailed retryable moves to FAILED_RETRYABLE`() = runBlocking {
+    fun `markFailed retryable moves to FAILED_RETRYABLE`() { runBlocking {
         val store = store()
         store.append(record("retryable-failure"))
         store.markReadyForDispatch("retryable-failure", SovereignOpsAuditOutboxStatus.PREPARED)
@@ -288,9 +301,10 @@ class FileSovereignOpsAuditOutboxStoreTest {
         assertThat(failed.status).isEqualTo(SovereignOpsAuditOutboxStatus.FAILED_RETRYABLE)
         assertThat(failed.lastErrorCode).isEqualTo("retryable-error")
     }
+    }
 
     @Test
-    fun `markFailed non-retryable moves PREPARED to FAILED_PERMANENT`() = runBlocking {
+    fun `markFailed non-retryable moves PREPARED to FAILED_PERMANENT`() { runBlocking {
         val store = store()
         store.append(record("prepared-failure"))
 
@@ -303,9 +317,10 @@ class FileSovereignOpsAuditOutboxStoreTest {
 
         assertThat(failed.status).isEqualTo(SovereignOpsAuditOutboxStatus.FAILED_PERMANENT)
     }
+    }
 
     @Test
-    fun `status transitions survive restart`() = runBlocking {
+    fun `status transitions survive restart`() { runBlocking {
         val key = testKey()
         val store = store(key = key)
         store.append(record("restart-status"))
@@ -316,9 +331,10 @@ class FileSovereignOpsAuditOutboxStoreTest {
         assertThat(restarted.get("restart-status")?.status)
             .isEqualTo(SovereignOpsAuditOutboxStatus.PENDING)
     }
+    }
 
     @Test
-    fun `event-key index survives restart`() = runBlocking {
+    fun `event-key index survives restart`() { runBlocking {
         val key = testKey()
         val store = store(key = key)
         val record = record("restart-index", eventKey = "restart-index-event")
@@ -328,9 +344,10 @@ class FileSovereignOpsAuditOutboxStoreTest {
 
         assertThat(restarted.findByEventKey("restart-index-event")).isEqualTo(record)
     }
+    }
 
     @Test
-    fun `no raw security fields persisted`() = runBlocking {
+    fun `no raw security fields persisted`() { runBlocking {
         val key = testKey()
         val store = store(key = key)
         val rawApprovalId = "approval-raw-secret-123"
@@ -354,9 +371,10 @@ class FileSovereignOpsAuditOutboxStoreTest {
         assertThat(decryptedJson).contains(secureRecord.aggregateIdDigest)
         assertThat(decryptedJson).contains(secureRecord.reasonDigest)
     }
+    }
 
     @Test
-    fun `outboxRecordVersion increments on each write`() = runBlocking {
+    fun `outboxRecordVersion increments on each write`() { runBlocking {
         val key = testKey()
         val store = store(key = key)
         store.append(record("versioned"))
@@ -368,9 +386,10 @@ class FileSovereignOpsAuditOutboxStoreTest {
         store.claimPending("dispatcher", 1, BASE_NOW)
         assertThat(persisted("versioned", key).outboxRecordVersion).isEqualTo(2L)
     }
+    }
 
     @Test
-    fun `constructor rebuilds event key index from filesystem`() = runBlocking {
+    fun `constructor rebuilds event key index from filesystem`() { runBlocking {
         val key = testKey()
 
         val first = FileSovereignOpsAuditOutboxStore(root = tempDir, key = key)
@@ -383,9 +402,10 @@ class FileSovereignOpsAuditOutboxStoreTest {
         val reopened = FileSovereignOpsAuditOutboxStore(root = tempDir, key = key)
         assertThat(reopened.findByEventKey("same-event")).isNotNull
     }
+    }
 
     @Test
-    fun `append rejects duplicate event key after constructor reopen`() = runBlocking {
+    fun `append rejects duplicate event key after constructor reopen`() { runBlocking {
         val key = testKey()
 
         val first = FileSovereignOpsAuditOutboxStore(root = tempDir, key = key)
@@ -400,6 +420,7 @@ class FileSovereignOpsAuditOutboxStoreTest {
         assertThatThrownBy {
             runBlocking { reopened.append(record("two", eventKey = "same-event")) }
         }.hasMessageContaining("tramai-sovereign-ops-outbox-duplicate-event-key")
+    }
     }
 
     private fun store(

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsApprovalDecisionControlPlaneTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsApprovalDecisionControlPlaneTest.kt
@@ -37,12 +37,14 @@ import java.time.Instant
 import java.time.ZoneOffset
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.SpringBootConfiguration
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.test.context.SpringBootTest
@@ -52,8 +54,8 @@ import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
+import javax.sql.DataSource
+import org.postgresql.ds.PGSimpleDataSource
 
 /**
  * JDBC-level test proving approve/deny control-plane behavior at the store boundary.
@@ -65,7 +67,6 @@ import org.testcontainers.junit.jupiter.Testcontainers
     classes = [JdbcSovereignOpsTestConfig::class],
 )
 @JdbcTestTag
-@Testcontainers
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class JdbcSovereignOpsApprovalDecisionControlPlaneTest {
 
@@ -92,6 +93,7 @@ class JdbcSovereignOpsApprovalDecisionControlPlaneTest {
             "tramai/persistence/jdbc/postgres/V1__sovereign_persistence.sql",
             "tramai/persistence/jdbc/postgres/V2__approval_continuations.sql",
             "tramai/persistence/jdbc/postgres/V4__audit_outbox_hardening.sql",
+            "tramai/persistence/jdbc/postgres/V6__approval_resume_credential_custody.sql",
         ).forEach { resource ->
             val sql = javaClass.classLoader
                 .getResourceAsStream(resource)
@@ -102,13 +104,18 @@ class JdbcSovereignOpsApprovalDecisionControlPlaneTest {
         }
     }
 
+    @AfterAll
+    fun stopPostgres() {
+        postgres.stop()
+    }
+
     @BeforeEach
     fun cleanUp() {
         jdbcTemplate.execute("TRUNCATE TABLE approval_continuations, suspended_invocations, audit_outbox, approvals CASCADE")
     }
 
     @Test
-    fun `approve approval creates complete decision evidence record`() = runBlocking {
+    fun `approve approval creates complete decision evidence record`() { runBlocking {
         val requiredRole = ApproverRole("medical-reviewer")
         val requestResult = gateway.requestApproval(
             subject = ApprovalSubject("test-approve-evidence"),
@@ -168,9 +175,10 @@ class JdbcSovereignOpsApprovalDecisionControlPlaneTest {
         assertThat(approvalOutbox.reasonDigest).hasSize(71)
         assertThat(approvalOutbox.reasonLength).isEqualTo("Medical necessity established".length)
     }
+    }
 
     @Test
-    fun `deny approval creates complete decision evidence record`() = runBlocking {
+    fun `deny approval creates complete decision evidence record`() { runBlocking {
         val requiredRole = ApproverRole("medical-reviewer")
         val requestResult = gateway.requestApproval(
             subject = ApprovalSubject("test-deny-evidence"),
@@ -229,9 +237,10 @@ class JdbcSovereignOpsApprovalDecisionControlPlaneTest {
         assertThat(denialOutbox.reasonDigest).hasSize(71)
         assertThat(denialOutbox.reasonLength).isEqualTo("Denied because evidence is incomplete".length)
     }
+    }
 
     @Test
-    fun `decision evidence stores digest and length not raw comment text`() = runBlocking {
+    fun `decision evidence stores digest and length not raw comment text`() { runBlocking {
         val requiredRole = ApproverRole("medical-reviewer")
         val requestResult = gateway.requestApproval(
             subject = ApprovalSubject("test-sanitised-evidence"),
@@ -272,9 +281,10 @@ class JdbcSovereignOpsApprovalDecisionControlPlaneTest {
         assertThat(outbox.aggregateIdDigest).doesNotContain(rawComment)
         assertThat(outbox.operation).doesNotContain(rawComment)
     }
+    }
 
     @Test
-    fun `repeat approve returns AlreadyApproved without creating duplicate evidence`() = runBlocking {
+    fun `repeat approve returns AlreadyApproved without creating duplicate evidence`() { runBlocking {
         val requiredRole = ApproverRole("medical-reviewer")
         val requestResult = gateway.requestApproval(
             subject = ApprovalSubject("test-repeat-approve"),
@@ -326,9 +336,10 @@ class JdbcSovereignOpsApprovalDecisionControlPlaneTest {
         assertThat(secondOutbox!!.actor).isEqualTo("reviewer-1")
         assertThat(secondOutbox.approvalVersion).isEqualTo(1L)
     }
+    }
 
     @Test
-    fun `repeat deny returns AlreadyDenied without creating duplicate evidence`() = runBlocking {
+    fun `repeat deny returns AlreadyDenied without creating duplicate evidence`() { runBlocking {
         val requiredRole = ApproverRole("medical-reviewer")
         val requestResult = gateway.requestApproval(
             subject = ApprovalSubject("test-repeat-deny"),
@@ -385,16 +396,17 @@ class JdbcSovereignOpsApprovalDecisionControlPlaneTest {
             """
             SELECT COUNT(*)
             FROM audit_outbox
-            WHERE aggregate_type = 'approval'
+            WHERE event_key LIKE 'approval-denied.%'
               AND status = 'PENDING'
             """.trimIndent(),
             Long::class.java,
         )
         assertThat(pendingOutboxCount).isOne
     }
+    }
 
     @Test
-    fun `can deny two different approvals without audit outbox event key conflict`() = runBlocking {
+    fun `can deny two different approvals without audit outbox event key conflict`() { runBlocking {
         val requiredRole = ApproverRole("medical-reviewer")
 
         val result1 = gateway.requestApproval(
@@ -450,14 +462,17 @@ class JdbcSovereignOpsApprovalDecisionControlPlaneTest {
         assertThat(outbox1).isNotNull
         assertThat(outbox2).isNotNull
     }
+    }
 
     companion object {
-        @Container
-        @JvmStatic
+        // Started eagerly (not via @Testcontainers/@Container) because the
+        // @DynamicPropertySource lambdas below are resolved while the Spring
+        // context loads — before JUnit's container lifecycle would start it.
         val postgres = PostgreSQLContainer("postgres:17-alpine")
             .withDatabaseName("sovereign_ops_decision_test")
             .withUsername("test")
             .withPassword("test")
+            .apply { start() }
 
         private val keyFile = Files.createTempFile("tramai-sovereign-jdbc-key", ".b64").apply {
             toFile().writeText(
@@ -484,17 +499,40 @@ class JdbcSovereignOpsApprovalDecisionControlPlaneTest {
 @Tag("jdbc")
 private annotation class JdbcTestTag
 
+/**
+ * Imported FIRST so its DataSource bean definition is registered before the
+ * auto-configurations' condition evaluation (Spring processes @Import list
+ * entries in order; the missing-datasource guard is `@ConditionalOnMissingBean`
+ * and would otherwise match at parse time and fail the context).
+ */
 @SpringBootConfiguration
-@EnableAutoConfiguration
+private open class JdbcSovereignOpsDataSourceConfig {
+    @Bean
+    open fun dataSource(
+        @Value("\${spring.datasource.url}") url: String,
+        @Value("\${spring.datasource.username}") username: String,
+        @Value("\${spring.datasource.password}") password: String,
+    ): DataSource = PGSimpleDataSource().apply {
+        setUrl(url)
+        setUser(username)
+        setPassword(password)
+    }
+
+    @Bean
+    open fun approvalGatewayRequestFactory(): ApprovalGatewayRequestFactory = JdbcTestApprovalGatewayRequestFactory()
+
+    @Bean
+    open fun jdbcTemplate(dataSource: DataSource): JdbcTemplate = JdbcTemplate(dataSource)
+}
+
+@SpringBootConfiguration
 @Import(
+    JdbcSovereignOpsDataSourceConfig::class,
     SovereignJdbcPersistenceAutoConfiguration::class,
     ApprovalGatewayAutoConfiguration::class,
     ApprovalDecisionControlPlaneAutoConfiguration::class,
 )
 private open class JdbcSovereignOpsTestConfig {
-
-    @Bean
-    open fun approvalGatewayRequestFactory(): ApprovalGatewayRequestFactory = JdbcTestApprovalGatewayRequestFactory()
 }
 
 private class JdbcTestApprovalGatewayRequestFactory : ApprovalGatewayRequestFactory {
@@ -504,12 +542,12 @@ private class JdbcTestApprovalGatewayRequestFactory : ApprovalGatewayRequestFact
         requiredRole: ApproverRole,
         workflowRunId: WorkflowRunId?,
     ): ApprovalGatewayPersistenceRequest {
-        val now = Instant.parse("2026-06-25T10:00:00Z")
+        val now = java.time.Instant.now()
         val approvalId = subject.value
         val wfRunId = workflowRunId?.value ?: "wf-$approvalId"
-        val argumentsDigest = Sha256Digest.of("sha256:${"0".repeat(64)}")
-        val workflowDigest = Sha256Digest.of("sha256:${"1".repeat(64)}")
-        val tokenDigest = Sha256Digest.of("sha256:${"2".repeat(64)}")
+        val argumentsDigest = Sha256Digest.of("sha256:${sha256Hex("arguments:$approvalId")}")
+        val workflowDigest = Sha256Digest.of("sha256:${sha256Hex("workflow:$approvalId")}")
+        val tokenDigest = Sha256Digest.of("sha256:${sha256Hex("token:$approvalId")}")
 
         return ApprovalGatewayPersistenceRequest(
             approvalRequest = ApprovalRequest(
@@ -525,7 +563,7 @@ private class JdbcTestApprovalGatewayRequestFactory : ApprovalGatewayRequestFact
                 status = ApprovalStatus.PENDING,
                 requestedBy = "test-requester",
                 requestedAt = now,
-                expiresAt = now.plusSeconds(3600),
+                expiresAt = now.plusSeconds(600),
                 decidedBy = null,
                 decidedAt = null,
                 decisionComment = null,
@@ -544,7 +582,7 @@ private class JdbcTestApprovalGatewayRequestFactory : ApprovalGatewayRequestFact
                 workflowDigest = workflowDigest,
                 status = ApprovalContinuationStatus.PENDING,
                 createdAt = now,
-                approvalExpiresAt = now.plusSeconds(3600),
+                approvalExpiresAt = now.plusSeconds(600),
                 claimedBy = null,
                 claimedAt = null,
                 completedAt = null,
@@ -571,11 +609,25 @@ private class JdbcTestApprovalGatewayRequestFactory : ApprovalGatewayRequestFact
                     jvmMethodDescriptor = "(Ljava/lang/String;)V",
                     resumeDefinitionDigest = argumentsDigest,
                 ),
-                replayEnvelopeDigest = argumentsDigest,
+                replayEnvelopeDigest = dev.tramai.engine.ReplayEnvelopeDigestHelper.compute(
+                    ResumeOperationReference(
+                        serviceInterface = "dev.tramai.test.Workflow",
+                        methodName = "triage",
+                        jvmMethodDescriptor = "(Ljava/lang/String;)V",
+                        resumeDefinitionDigest = argumentsDigest,
+                    ),
+                    emptyList(),
+                ),
                 toolReference = ResumeToolReference("claim-triage", argumentsDigest),
             ),
             replayEnvelope = SensitiveReplayEnvelope.of(emptyList()),
             resumeToken = ResumeToken("resume-$approvalId"),
         )
+    }
+
+    private fun sha256Hex(input: String): String {
+        val digest = java.security.MessageDigest.getInstance("SHA-256")
+        val hash = digest.digest(input.toByteArray(Charsets.UTF_8))
+        return hash.joinToString("") { "%02x".format(it) }
     }
 }

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsApprovalMutationStoreTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsApprovalMutationStoreTest.kt
@@ -3,6 +3,7 @@ package dev.tramai.spring.sovereign.persistence.jdbc
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import dev.tramai.core.approval.ApprovalStatus
 import dev.tramai.core.exception.IllegalApprovalTransitionException
@@ -85,7 +86,7 @@ class JdbcSovereignOpsApprovalMutationStoreTest {
     // ── Happy path ───────────────────────────────────────────────────
 
     @Test
-    fun `deny approval commits approval denial and pending outbox record atomically`() = runBlocking {
+    fun `deny approval commits approval denial and pending outbox record atomically`() { runBlocking {
         val approvalId = "approval-a"
         val expiresAt = BASE_NOW.plusSeconds(600) // far in the future
         insertApproval(approvalId, expiresAt = expiresAt)
@@ -112,11 +113,12 @@ class JdbcSovereignOpsApprovalMutationStoreTest {
         assertThat(selectOutboxStatus(auditIntent.outboxId)).isEqualTo("PENDING")
         assertThat(countOutboxRowsForEventKey(auditIntent.eventKey)).isEqualTo(1)
     }
+    }
 
     // ── Rollback guards ──────────────────────────────────────────────
 
     @Test
-    fun `outbox conflict prevents approval denial`() = runBlocking {
+    fun `outbox conflict prevents approval denial`() { runBlocking {
         val approvalId = "approval-b"
         val eventKey = "test-key-b"
         val expiresAt = BASE_NOW.plusSeconds(600)
@@ -140,9 +142,10 @@ class JdbcSovereignOpsApprovalMutationStoreTest {
         assertThat(selectApprovalVersion(approvalId)).isEqualTo(1L)
         assertThat(countOutboxRowsForEventKey(eventKey)).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `approval version conflict rolls back outbox insert`() = runBlocking {
+    fun `approval version conflict rolls back outbox insert`() { runBlocking {
         val approvalId = "approval-c"
         val auditIntent = auditIntent(approvalId, "test-key-c")
         val expiresAt = BASE_NOW.plusSeconds(600)
@@ -165,9 +168,10 @@ class JdbcSovereignOpsApprovalMutationStoreTest {
         assertThat(selectApprovalVersion(approvalId)).isEqualTo(1L)
         assertThat(countOutboxRowsForEventKey(auditIntent.eventKey)).isZero()
     }
+    }
 
     @Test
-    fun `non pending approval denial is rejected`() = runBlocking {
+    fun `non pending approval denial is rejected`() { runBlocking {
         val approvalId = "approval-d"
         val auditIntent = auditIntent(approvalId, "test-key-d")
         val expiresAt = BASE_NOW.plusSeconds(600)
@@ -189,9 +193,10 @@ class JdbcSovereignOpsApprovalMutationStoreTest {
         assertThat(selectApprovalVersion(approvalId)).isEqualTo(1L)
         assertThat(countOutboxRowsForEventKey(auditIntent.eventKey)).isZero()
     }
+    }
 
     @Test
-    fun `payload codec failure rolls back approval mutation`() = runBlocking {
+    fun `payload codec failure rolls back approval mutation`() { runBlocking {
         val approvalId = "approval-e"
         val auditIntent = auditIntent(approvalId, "test-key-e")
         val expiresAt = BASE_NOW.plusSeconds(600)
@@ -225,11 +230,12 @@ class JdbcSovereignOpsApprovalMutationStoreTest {
         assertThat(selectApprovalVersion(approvalId)).isEqualTo(1L)
         assertThat(countOutboxRowsForEventKey(auditIntent.eventKey)).isZero()
     }
+    }
 
     // ── Expiry guard (P1) ────────────────────────────────────────────
 
     @Test
-    fun `expired pending approval denial is rejected and no outbox is inserted`() = runBlocking {
+    fun `expired pending approval denial is rejected and no outbox is inserted`() { runBlocking {
         val approvalId = "approval-f"
         val auditIntent = auditIntent(approvalId, "test-key-f")
         // expiresAt is in the past relative to clock (BASE_NOW + 30s)
@@ -253,11 +259,12 @@ class JdbcSovereignOpsApprovalMutationStoreTest {
         assertThat(selectApprovalVersion(approvalId)).isEqualTo(1L)
         assertThat(countOutboxRowsForEventKey(auditIntent.eventKey)).isZero()
     }
+    }
 
     // ── Metadata integrity (P2) ──────────────────────────────────────
 
     @Test
-    fun `malformed approval metadata fails closed and rolls back outbox insert`() = runBlocking {
+    fun `malformed approval metadata fails closed and rolls back outbox insert`() { runBlocking {
         val approvalId = "approval-g"
         val auditIntent = auditIntent(approvalId, "test-key-g")
         // Insert with '{}'::jsonb — missing binding, requestedBy, expiresAt, requestedAt
@@ -273,17 +280,18 @@ class JdbcSovereignOpsApprovalMutationStoreTest {
                     auditIntent = auditIntent,
                 )
             }
-        }.isInstanceOf(IllegalStateException::class.java)
+        }.isInstanceOf(MissingKotlinParameterException::class.java)
 
         assertThat(selectApprovalStatus(approvalId)).isEqualTo("PENDING")
         assertThat(selectApprovalVersion(approvalId)).isEqualTo(1L)
         assertThat(countOutboxRowsForEventKey(auditIntent.eventKey)).isZero()
     }
+    }
 
     // ── Actor/reason validation (P2) ─────────────────────────────────
 
     @Test
-    fun `invalid actor is rejected before mutation and no outbox is inserted`() = runBlocking {
+    fun `invalid actor is rejected before mutation and no outbox is inserted`() { runBlocking {
         val approvalId = "approval-h"
         val auditIntent = auditIntent(approvalId, "test-key-h")
         val expiresAt = BASE_NOW.plusSeconds(600)
@@ -306,9 +314,10 @@ class JdbcSovereignOpsApprovalMutationStoreTest {
         assertThat(selectApprovalVersion(approvalId)).isEqualTo(1L)
         assertThat(countOutboxRowsForEventKey(auditIntent.eventKey)).isZero()
     }
+    }
 
     @Test
-    fun `oversized reason is rejected before mutation and no outbox is inserted`() = runBlocking {
+    fun `oversized reason is rejected before mutation and no outbox is inserted`() { runBlocking {
         val approvalId = "approval-i"
         val auditIntent = auditIntent(approvalId, "test-key-i")
         val expiresAt = BASE_NOW.plusSeconds(600)
@@ -332,6 +341,7 @@ class JdbcSovereignOpsApprovalMutationStoreTest {
         assertThat(selectApprovalStatus(approvalId)).isEqualTo("PENDING")
         assertThat(selectApprovalVersion(approvalId)).isEqualTo(1L)
         assertThat(countOutboxRowsForEventKey(auditIntent.eventKey)).isZero()
+    }
     }
 
     // ── Test infrastructure ──────────────────────────────────────────

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsApprovalRequestMutationStoreTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsApprovalRequestMutationStoreTest.kt
@@ -19,6 +19,7 @@ import dev.tramai.core.approval.gateway.SealedResumeToken
 import dev.tramai.core.approval.gateway.WorkflowRunId
 import dev.tramai.core.model.Message
 import dev.tramai.core.model.MessageRole
+import dev.tramai.core.model.ToolCall
 import dev.tramai.engine.EngineExecutionIdentity
 import dev.tramai.engine.ExecutionSecurityContext
 import dev.tramai.engine.ReplayEnvelopeDigestHelper
@@ -140,7 +141,7 @@ class JdbcSovereignOpsApprovalRequestMutationStoreTest {
     }
 
     @Test
-    fun `create approval request persists approval suspended invocation and continuation atomically`() = runBlocking {
+    fun `create approval request persists approval suspended invocation and continuation atomically`() { runBlocking {
         val request = request("approval-a")
 
         val result = mutationStore.createApprovalRequest(request)
@@ -165,16 +166,17 @@ class JdbcSovereignOpsApprovalRequestMutationStoreTest {
         assertThat(replayEnvelope).isNotNull
         assertThat(replayEnvelope!!.revealForResume().messages)
             .extracting<String> { it.content }
-            .containsExactly("request-approval-a")
+            .containsExactly("request-approval-a", "")
 
         val continuation = continuationStore.get("approval-a")
         assertThat(continuation).isNotNull
         assertThat(continuation!!.status).isEqualTo(ApprovalContinuationStatus.PENDING)
         assertThat(selectCount("SELECT count(*) FROM audit_outbox")).isZero()
     }
+    }
 
     @Test
-    fun `create approval request with audit intent also creates pending outbox record`() = runBlocking {
+    fun `create approval request with audit intent also creates pending outbox record`() { runBlocking {
         val request = request("approval-b")
         val auditIntent = auditIntent("approval-b", "event-key-b")
 
@@ -184,9 +186,10 @@ class JdbcSovereignOpsApprovalRequestMutationStoreTest {
             .isEqualTo("PENDING")
         assertThat(selectCount("SELECT count(*) FROM audit_outbox WHERE event_key = 'event-key-b'")).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `duplicate approval request returns existing`() = runBlocking {
+    fun `duplicate approval request returns existing`() { runBlocking {
         val request = request("approval-c")
 
         val created = mutationStore.createApprovalRequest(request)
@@ -198,12 +201,15 @@ class JdbcSovereignOpsApprovalRequestMutationStoreTest {
         assertThat(existing.approval.approvalId).isEqualTo("approval-c")
         assertThat(selectCount("SELECT count(*) FROM approvals WHERE approval_id = 'approval-c'")).isEqualTo(1)
     }
+    }
 
     @Test
-    fun `constraint failure rolls back partial approval request creation`() = runBlocking {
+    fun `constraint failure rolls back partial approval request creation`() { runBlocking {
         val request = request("approval-d")
         suspendedInvocationStore.create(
             metadata = request("existing-conflict").suspendedInvocationMetadata.copy(
+                toolCallId = request.suspendedInvocationMetadata.toolCallId,
+                toolName = request.suspendedInvocationMetadata.toolName,
                 replayEnvelopeDigest = request.suspendedInvocationMetadata.replayEnvelopeDigest,
             ),
             replayEnvelope = request.replayEnvelope,
@@ -221,9 +227,10 @@ class JdbcSovereignOpsApprovalRequestMutationStoreTest {
         assertThat(continuationStore.get("approval-d")).isNull()
         assertThat(selectCount("SELECT count(*) FROM audit_outbox")).isZero()
     }
+    }
 
     @Test
-    fun `cancellation exception is rethrown and transaction rolls back`() = runBlocking {
+    fun `cancellation exception is rethrown and transaction rolls back`() { runBlocking {
         val request = request("approval-e")
         val cancellingStore = JdbcSovereignOpsApprovalRequestMutationStore(
             dataSource = dataSource,
@@ -251,9 +258,10 @@ class JdbcSovereignOpsApprovalRequestMutationStoreTest {
         assertThat(suspendedInvocationStore.get("approval-e")).isNull()
         assertThat(continuationStore.get("approval-e")).isNull()
     }
+    }
 
     @Test
-    fun `rejects replay envelope digest mismatch and rolls back all records`() = runBlocking {
+    fun `rejects replay envelope digest mismatch and rolls back all records`() { runBlocking {
         val request = request("approval-f").copy(
             suspendedInvocationMetadata = request("approval-f").suspendedInvocationMetadata.copy(
                 replayEnvelopeDigest = Sha256Digest.of("sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
@@ -272,9 +280,10 @@ class JdbcSovereignOpsApprovalRequestMutationStoreTest {
         assertThat(continuationStore.get("approval-f")).isNull()
         assertThat(selectCount("SELECT count(*) FROM audit_outbox")).isZero()
     }
+    }
 
     @Test
-    fun `rejects already expired approval request and rolls back all records`() = runBlocking {
+    fun `rejects already expired approval request and rolls back all records`() { runBlocking {
         val now = BASE_NOW.plusSeconds(30)
         val clockAtNow = Clock.fixed(now, ZoneOffset.UTC)
         val storeWithExpiryCheck = JdbcSovereignOpsApprovalRequestMutationStore(
@@ -303,9 +312,10 @@ class JdbcSovereignOpsApprovalRequestMutationStoreTest {
         assertThat(suspendedInvocationStore.get("approval-g")).isNull()
         assertThat(continuationStore.get("approval-g")).isNull()
     }
+    }
 
     @Test
-    fun `rejects invalid continuation metadata and rolls back all records`() = runBlocking {
+    fun `rejects invalid continuation metadata and rolls back all records`() { runBlocking {
         val request = request("approval-h").copy(
             continuation = request("approval-h").continuation.copy(
                 workflowRunId = "  ",
@@ -323,9 +333,10 @@ class JdbcSovereignOpsApprovalRequestMutationStoreTest {
         assertThat(suspendedInvocationStore.get("approval-h")).isNull()
         assertThat(continuationStore.get("approval-h")).isNull()
     }
+    }
 
     @Test
-    fun `rejects future continuation createdAt and rolls back all records`() = runBlocking {
+    fun `rejects future continuation createdAt and rolls back all records`() { runBlocking {
         val now = BASE_NOW.plusSeconds(30)
         val clockAtNow = Clock.fixed(now, ZoneOffset.UTC)
         val storeWithTimeCheck = JdbcSovereignOpsApprovalRequestMutationStore(
@@ -354,9 +365,10 @@ class JdbcSovereignOpsApprovalRequestMutationStoreTest {
         assertThat(suspendedInvocationStore.get("approval-i")).isNull()
         assertThat(continuationStore.get("approval-i")).isNull()
     }
+    }
 
     @Test
-    fun `audit outbox failure rolls back approval request creation`() = runBlocking {
+    fun `audit outbox failure rolls back approval request creation`() { runBlocking {
         val request = request("approval-j")
         val auditIntent = auditIntent("approval-j", "outbox-failure-test")
         val failingCodec = object : JdbcOpsAuditOutboxPayloadCodec {
@@ -387,11 +399,12 @@ class JdbcSovereignOpsApprovalRequestMutationStoreTest {
         assertThat(continuationStore.get("approval-j")).isNull()
         assertThat(selectCount("SELECT count(*) FROM audit_outbox WHERE event_key = 'outbox-failure-test'")).isZero()
     }
+    }
 
     // ── Inbox metadata tests ──────────────────────────────────────────
 
     @Test
-    fun `approval request creation persists inbox metadata atomically`() = runBlocking {
+    fun `approval request creation persists inbox metadata atomically`() { runBlocking {
         val request = request("approval-inbox-1")
         val metadata = ApprovalInboxMetadata(
             requiredRole = ApproverRole("medical-reviewer"),
@@ -423,10 +436,11 @@ class JdbcSovereignOpsApprovalRequestMutationStoreTest {
         assertThat(inbox.has("argumentsDigest")).isFalse()
         assertThat(inbox.has("approvalTokenDigest")).isFalse()
     }
+    }
 
 
     @Test
-    fun `rollback removes inbox metadata when continuation insert fails`() = runBlocking {
+    fun `rollback removes inbox metadata when continuation insert fails`() { runBlocking {
         val request = request("approval-inbox-2")
         val metadata = ApprovalInboxMetadata(
             requiredRole = ApproverRole("medical-reviewer"),
@@ -461,9 +475,10 @@ class JdbcSovereignOpsApprovalRequestMutationStoreTest {
         // Verify approval was rolled back (no row)
         assertThat(approvalStore.get("approval-inbox-2")).isNull()
     }
+    }
 
     @Test
-    fun `existing approval replay returns existing metadata safely without inbox changes`() = runBlocking {
+    fun `existing approval replay returns existing metadata safely without inbox changes`() { runBlocking {
         val request = request("approval-inbox-3")
         val metadata = ApprovalInboxMetadata(
             requiredRole = ApproverRole("medical-reviewer"),
@@ -486,6 +501,7 @@ class JdbcSovereignOpsApprovalRequestMutationStoreTest {
         // Only one row exists
         val count = selectCount("SELECT count(*) FROM approvals WHERE approval_id = 'approval-inbox-3'")
         assertThat(count).isEqualTo(1)
+    }
     }
 
     @Test
@@ -533,7 +549,20 @@ class JdbcSovereignOpsApprovalRequestMutationStoreTest {
         val workflowDigest = digest('b')
         val argumentsDigest = digest('a')
         val approvalTokenDigest = digest('c')
-        val messages = listOf(Message(role = MessageRole.USER, content = "request-$approvalId"))
+        val messages = listOf(
+            Message(role = MessageRole.USER, content = "request-$approvalId"),
+            Message(
+                role = MessageRole.ASSISTANT,
+                content = "",
+                toolCalls = listOf(
+                    ToolCall(
+                        id = "tool-call-$approvalId",
+                        name = "tool-$approvalId",
+                        argumentsJson = "{}",
+                    ),
+                ),
+            ),
+        )
         val operationReference = ResumeOperationReference("t.Service", "approve", "(Ljava/lang/String;)V", digest('d'))
         val replayDigest = ReplayEnvelopeDigestHelper.compute(operationReference, messages)
 

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsWorkerLeaseStoreTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsWorkerLeaseStoreTest.kt
@@ -65,7 +65,7 @@ class JdbcSovereignOpsWorkerLeaseStoreTest {
     // ── Acquisition ────────────────────────────────────────────────────
 
     @Test
-    fun `acquire missing lease — acquired by owner A`() = runBlocking {
+    fun `acquire missing lease — acquired by owner A`() { runBlocking {
         val result = store().tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
         assertThat(result).isInstanceOf(SovereignOpsWorkerLeaseAcquisition.Acquired::class.java)
         val acquired = result as SovereignOpsWorkerLeaseAcquisition.Acquired
@@ -74,17 +74,19 @@ class JdbcSovereignOpsWorkerLeaseStoreTest {
         assertThat(acquired.lease.expiresAt).isEqualTo(BASE_NOW.plus(LEASE_DURATION))
         assertThat(acquired.lease.version).isEqualTo(2)
     }
+    }
 
     @Test
-    fun `acquire same lease same owner — already owned`() = runBlocking {
+    fun `acquire same lease same owner — already owned`() { runBlocking {
         val s = store()
         s.tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
         val result = s.tryAcquire("my-lease", "worker-a", BASE_NOW.plusSeconds(10), LEASE_DURATION)
         assertThat(result).isInstanceOf(SovereignOpsWorkerLeaseAcquisition.AlreadyOwned::class.java)
     }
+    }
 
     @Test
-    fun `acquire active lease different owner — held by other`() = runBlocking {
+    fun `acquire active lease different owner — held by other`() { runBlocking {
         val s = store()
         s.tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
         val result = s.tryAcquire("my-lease", "worker-b", BASE_NOW.plusSeconds(10), LEASE_DURATION)
@@ -92,9 +94,10 @@ class JdbcSovereignOpsWorkerLeaseStoreTest {
         val held = result as SovereignOpsWorkerLeaseAcquisition.HeldByOther
         assertThat(held.lease.ownerId).isEqualTo("worker-a")
     }
+    }
 
     @Test
-    fun `acquire expired lease different owner — stolen by owner B`() = runBlocking {
+    fun `acquire expired lease different owner — stolen by owner B`() { runBlocking {
         val s = store()
         s.tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
         // Move past expiry
@@ -104,9 +107,10 @@ class JdbcSovereignOpsWorkerLeaseStoreTest {
         val acquired = result as SovereignOpsWorkerLeaseAcquisition.Acquired
         assertThat(acquired.lease.ownerId).isEqualTo("worker-b")
     }
+    }
 
     @Test
-    fun `concurrent acquire same lease — exactly one owner wins`() = runBlocking {
+    fun `concurrent acquire same lease — exactly one owner wins`() { runBlocking {
         coroutineScope {
             val s = store()
             val a = async { s.tryAcquire("race-lease", "worker-a", BASE_NOW, LEASE_DURATION) }
@@ -117,11 +121,12 @@ class JdbcSovereignOpsWorkerLeaseStoreTest {
             assertThat(results.count { it is SovereignOpsWorkerLeaseAcquisition.HeldByOther }).isEqualTo(1)
         }
     }
+    }
 
     // ── Heartbeat ──────────────────────────────────────────────────────
 
     @Test
-    fun `heartbeat by owner extends expiry`() = runBlocking {
+    fun `heartbeat by owner extends expiry`() { runBlocking {
         val s = store()
         val acquired = (s.tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
             as SovereignOpsWorkerLeaseAcquisition.Acquired)
@@ -133,34 +138,38 @@ class JdbcSovereignOpsWorkerLeaseStoreTest {
         assertThat(extended.lease.expiresAt).isEqualTo(later.plus(LEASE_DURATION))
         assertThat(extended.lease.version).isGreaterThan(originalVersion)
     }
+    }
 
     @Test
-    fun `heartbeat by non-owner rejected`() = runBlocking {
+    fun `heartbeat by non-owner rejected`() { runBlocking {
         val s = store()
         s.tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
         val result = s.heartbeat("my-lease", "worker-b", BASE_NOW.plusSeconds(30), LEASE_DURATION)
         assertThat(result).isEqualTo(SovereignOpsWorkerLeaseHeartbeat.NotOwner)
     }
-
-    @Test
-    fun `heartbeat on missing lease returns missing`() = runBlocking {
-        val result = store().heartbeat("nonexistent", "worker-a", BASE_NOW, LEASE_DURATION)
-        assertThat(result).isEqualTo(SovereignOpsWorkerLeaseHeartbeat.Missing)
     }
 
     @Test
-    fun `heartbeat by owner after expiry is rejected`() = runBlocking {
+    fun `heartbeat on missing lease returns missing`() { runBlocking {
+        val result = store().heartbeat("nonexistent", "worker-a", BASE_NOW, LEASE_DURATION)
+        assertThat(result).isEqualTo(SovereignOpsWorkerLeaseHeartbeat.Missing)
+    }
+    }
+
+    @Test
+    fun `heartbeat by owner after expiry is rejected`() { runBlocking {
         val s = store()
         s.tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
         val afterExpiry = BASE_NOW.plus(LEASE_DURATION).plusSeconds(1)
         val result = s.heartbeat("my-lease", "worker-a", afterExpiry, LEASE_DURATION)
         assertThat(result).isEqualTo(SovereignOpsWorkerLeaseHeartbeat.Expired)
     }
+    }
 
     // ── Release ────────────────────────────────────────────────────────
 
     @Test
-    fun `release by owner clears ownership`() = runBlocking {
+    fun `release by owner clears ownership`() { runBlocking {
         val s = store()
         val firstAcquire = (s.tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
             as SovereignOpsWorkerLeaseAcquisition.Acquired)
@@ -177,42 +186,47 @@ class JdbcSovereignOpsWorkerLeaseStoreTest {
         val acquired = s.tryAcquire("my-lease", "worker-b", BASE_NOW.plusSeconds(20), LEASE_DURATION)
         assertThat(acquired).isInstanceOf(SovereignOpsWorkerLeaseAcquisition.Acquired::class.java)
     }
+    }
 
     @Test
-    fun `release by non-owner rejected`() = runBlocking {
+    fun `release by non-owner rejected`() { runBlocking {
         val s = store()
         s.tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
         val result = s.release("my-lease", "worker-b", BASE_NOW.plusSeconds(10))
         assertThat(result).isEqualTo(SovereignOpsWorkerLeaseRelease.NotOwner)
     }
+    }
 
     @Test
-    fun `release on missing lease returns missing`() = runBlocking {
+    fun `release on missing lease returns missing`() { runBlocking {
         val result = store().release("nonexistent", "worker-a", BASE_NOW)
         assertThat(result).isEqualTo(SovereignOpsWorkerLeaseRelease.Missing)
+    }
     }
 
     // ── Get ────────────────────────────────────────────────────────────
 
     @Test
-    fun `get unknown lease returns null`() = runBlocking {
+    fun `get unknown lease returns null`() { runBlocking {
         val result = store().get("nonexistent")
         assertThat(result).isNull()
     }
+    }
 
     @Test
-    fun `get known lease returns lease`() = runBlocking {
+    fun `get known lease returns lease`() { runBlocking {
         val s = store()
         s.tryAcquire("my-lease", "worker-a", BASE_NOW, LEASE_DURATION)
         val result = s.get("my-lease")
         assertThat(result).isNotNull
         assertThat(result!!.ownerId).isEqualTo("worker-a")
     }
+    }
 
     // ── Restart recovery ───────────────────────────────────────────────
 
     @Test
-    fun `expired lease is recoverable after restart — owner B acquires`() = runBlocking {
+    fun `expired lease is recoverable after restart — owner B acquires`() { runBlocking {
         // Acquire with owner A
         store().tryAcquire("recovery-lease", "worker-a", BASE_NOW, LEASE_DURATION)
 
@@ -223,6 +237,7 @@ class JdbcSovereignOpsWorkerLeaseStoreTest {
         assertThat(result).isInstanceOf(SovereignOpsWorkerLeaseAcquisition.Acquired::class.java)
         val acquired = result as SovereignOpsWorkerLeaseAcquisition.Acquired
         assertThat(acquired.lease.ownerId).isEqualTo("worker-b")
+    }
     }
 
     // ── Constraint validation ──────────────────────────────────────────

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/inbox/JdbcApprovalInboxQueryServiceTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/inbox/JdbcApprovalInboxQueryServiceTest.kt
@@ -100,6 +100,7 @@ class JdbcApprovalInboxQueryServiceTest {
         toolName: String = "claim-payout",
         workflowRunId: String = "wf-$id",
         hasContinuation: Boolean = true,
+        inboxRequiredRole: String? = null,
     ) {
         val now = OffsetDateTime.ofInstant(createdAt, ZoneOffset.UTC)
         val metadata = buildString {
@@ -107,7 +108,11 @@ class JdbcApprovalInboxQueryServiceTest {
             append(""""requestedBy":"$requestedBy",""")
             append(""""expiresAt":"${createdAt.plusSeconds(300)}",""")
             append(""""requestedAt":"$requestedAt",""")
-            append(""""decidedBy":null,"decisionComment":null,"consumedBy":null,"consumedAt":null}""")
+            append(""""decidedBy":null,"decisionComment":null,"consumedBy":null,"consumedAt":null""")
+            if (inboxRequiredRole != null) {
+                append(""","inbox":{"requiredRole":"$inboxRequiredRole"}""")
+            }
+            append("}")
         }
         dataSource.connection.use { conn ->
             conn.prepareStatement(
@@ -160,7 +165,7 @@ class JdbcApprovalInboxQueryServiceTest {
     // ── search tests ──────────────────────────────────────────────
 
     @Test
-    fun `search pending returns pending items only`() = runBlocking {
+    fun `search pending returns pending items only`() { runBlocking {
         insertApproval("pending-1", status = "PENDING")
         insertApproval("approved-1", status = "APPROVED")
 
@@ -170,9 +175,10 @@ class JdbcApprovalInboxQueryServiceTest {
         assertThat(page.items[0].approvalId.value).isEqualTo("pending-1")
         assertThat(page.items[0].status).isEqualTo(ApprovalStatus.PENDING)
     }
+    }
 
     @Test
-    fun `search orders by expiresAt ASC then requestedAt ASC then approvalId ASC`() = runBlocking {
+    fun `search orders by expiresAt ASC then requestedAt ASC then approvalId ASC`() { runBlocking {
         insertApproval(
             id = "early-2", createdAt = baseTime,
             expiresAt = baseTime.plusSeconds(200),
@@ -196,9 +202,10 @@ class JdbcApprovalInboxQueryServiceTest {
         assertThat(page.items[1].approvalId.value).isEqualTo("early-2")
         assertThat(page.items[2].approvalId.value).isEqualTo("late-1")
     }
+    }
 
     @Test
-    fun `limit returns limit items and nextCursor`() = runBlocking {
+    fun `limit returns limit items and nextCursor`() { runBlocking {
         repeat(5) { i -> insertApproval("limit-$i", requestedAt = baseTime.plusSeconds(i.toLong())) }
 
         val page = service.search(ApprovalInboxQuery(limit = 2))
@@ -206,9 +213,10 @@ class JdbcApprovalInboxQueryServiceTest {
         assertThat(page.items).hasSize(2)
         assertThat(page.nextCursor).isNotNull
     }
+    }
 
     @Test
-    fun `nextCursor returns next page without duplicates`() = runBlocking {
+    fun `nextCursor returns next page without duplicates`() { runBlocking {
         repeat(5) { i -> insertApproval("cursor-$i", requestedAt = baseTime.plusSeconds(i.toLong())) }
 
         val page1 = service.search(ApprovalInboxQuery(limit = 2))
@@ -219,9 +227,10 @@ class JdbcApprovalInboxQueryServiceTest {
         assertThat(page1Ids).doesNotContainAnyElementsOf(page2Ids)
         assertThat(page1Ids + page2Ids).hasSize(4)
     }
+    }
 
     @Test
-    fun `invalid cursor fails closed`() = runBlocking {
+    fun `invalid cursor fails closed`() { runBlocking {
         insertApproval("bad-cursor-1")
         try {
             service.search(ApprovalInboxQuery(cursor = "ZGVmZWN0aXZl"))
@@ -231,9 +240,10 @@ class JdbcApprovalInboxQueryServiceTest {
             assertThat(e).hasMessageContaining("invalid-approval-inbox-cursor")
         }
     }
+    }
 
     @Test
-    fun `search by requestedBy filters correctly`() = runBlocking {
+    fun `search by requestedBy filters correctly`() { runBlocking {
         insertApproval("req-1", requestedBy = "user:alice")
         insertApproval("req-2", requestedBy = "user:bob")
 
@@ -242,9 +252,10 @@ class JdbcApprovalInboxQueryServiceTest {
         assertThat(page.items).hasSize(1)
         assertThat(page.items[0].approvalId.value).isEqualTo("req-1")
     }
+    }
 
     @Test
-    fun `search by expiresBefore filters correctly`() = runBlocking {
+    fun `search by expiresBefore filters correctly`() { runBlocking {
         insertApproval("exp-1", expiresAt = baseTime.plusSeconds(100))
         insertApproval("exp-2", expiresAt = baseTime.plusSeconds(400))
 
@@ -253,9 +264,10 @@ class JdbcApprovalInboxQueryServiceTest {
         assertThat(page.items).hasSize(1)
         assertThat(page.items[0].approvalId.value).isEqualTo("exp-1")
     }
+    }
 
     @Test
-    fun `search does not expose resumeToken or token digest`() = runBlocking {
+    fun `search does not expose resumeToken or token digest`() { runBlocking {
         insertApproval("safe-1")
 
         val page = service.search(ApprovalInboxQuery())
@@ -267,17 +279,19 @@ class JdbcApprovalInboxQueryServiceTest {
             assertThat(item.approvalId.value).isNotNull
         }
     }
+    }
 
     // ── getWorkItem tests ─────────────────────────────────────────
 
     @Test
-    fun `getWorkItem returns null for missing approval`() = runBlocking {
+    fun `getWorkItem returns null for missing approval`() { runBlocking {
         val item = service.getWorkItem(ApprovalId("missing-id"))
         assertThat(item).isNull()
     }
+    }
 
     @Test
-    fun `getWorkItem includes continuation status`() = runBlocking {
+    fun `getWorkItem includes continuation status`() { runBlocking {
         insertApproval("cont-1")
 
         val item = service.getWorkItem(ApprovalId("cont-1"))
@@ -285,9 +299,10 @@ class JdbcApprovalInboxQueryServiceTest {
         assertThat(item).isNotNull
         assertThat(item!!.continuationStatus).isEqualTo(ApprovalContinuationStatus.PENDING)
     }
+    }
 
     @Test
-    fun `work item uses requestedAt from metadata not created_at`() = runBlocking {
+    fun `work item uses requestedAt from metadata not created_at`() { runBlocking {
         val explicitRequestedAt = baseTime.plus(java.time.Duration.ofMinutes(1))
         insertApproval(
             id = "req-at-test",
@@ -300,9 +315,10 @@ class JdbcApprovalInboxQueryServiceTest {
         assertThat(item).isNotNull
         assertThat(item!!.requestedAt).isEqualTo(explicitRequestedAt)
     }
+    }
 
     @Test
-    fun `work item without continuation uses metadata expiresAt`() = runBlocking {
+    fun `work item without continuation uses metadata expiresAt`() { runBlocking {
         insertApproval(
             id = "no-cont",
             hasContinuation = false,
@@ -313,9 +329,10 @@ class JdbcApprovalInboxQueryServiceTest {
         assertThat(item).isNotNull
         assertThat(item!!.expiresAt).isEqualTo(baseTime.plusSeconds(300))
     }
+    }
 
     @Test
-    fun `work item workflowRunId comes from continuation not metadata`() = runBlocking {
+    fun `work item workflowRunId comes from continuation not metadata`() { runBlocking {
         insertApproval(
             id = "wf-test",
             workflowRunId = "wf-custom",
@@ -326,9 +343,10 @@ class JdbcApprovalInboxQueryServiceTest {
         assertThat(item).isNotNull
         assertThat(item!!.workflowRunId).isEqualTo("wf-custom")
     }
+    }
 
     @Test
-    fun `nextCursor is URL safe`() = runBlocking {
+    fun `nextCursor is URL safe`() { runBlocking {
         repeat(5) { i -> insertApproval("url-safe-$i", requestedAt = baseTime.plusSeconds(i.toLong())) }
 
         val page = service.search(ApprovalInboxQuery(limit = 2))
@@ -343,16 +361,20 @@ class JdbcApprovalInboxQueryServiceTest {
         // Can round-trip through URL-safe decoder
         Base64.getUrlDecoder().decode(cursor)
     }
+    }
 
     @Test
-    fun `requiredRole filter fails closed`() = runBlocking {
-        insertApproval("role-filter-1")
+    fun `requiredRole filter filters by inbox metadata`() { runBlocking {
+        insertApproval("role-filter-1", inboxRequiredRole = "medical-reviewer")
+        insertApproval("role-filter-2")
 
-        val ex = org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
-            service.search(
-                ApprovalInboxQuery(requiredRole = dev.tramai.core.approval.gateway.ApproverRole("medical-reviewer")),
-            )
-        }
-        assertThat(ex).hasMessageContaining("required-role-filter-not-supported")
+        val page = service.search(
+            ApprovalInboxQuery(requiredRole = dev.tramai.core.approval.gateway.ApproverRole("medical-reviewer")),
+        )
+
+        assertThat(page.items).hasSize(1)
+        assertThat(page.items[0].approvalId.value).isEqualTo("role-filter-1")
+        assertThat(page.items[0].requiredRole?.value).isEqualTo("medical-reviewer")
+    }
     }
 }

--- a/tramai-vectorstore-spi/src/test/kotlin/dev/tramai/vectorstore/InMemoryVectorStoreTest.kt
+++ b/tramai-vectorstore-spi/src/test/kotlin/dev/tramai/vectorstore/InMemoryVectorStoreTest.kt
@@ -8,7 +8,7 @@ import kotlin.test.assertTrue
 class InMemoryVectorStoreTest {
 
     @Test
-    fun `upsert and search returns nearest vectors`() = runBlocking {
+    fun `upsert and search returns nearest vectors`() { runBlocking {
         val store = InMemoryVectorStore()
 
         store.upsert("test", listOf(
@@ -23,16 +23,18 @@ class InMemoryVectorStoreTest {
         assertEquals("1", results[0].id)
         assertTrue(results[0].score > 0.99)
     }
+    }
 
     @Test
-    fun `search with empty collection returns empty`() = runBlocking {
+    fun `search with empty collection returns empty`() { runBlocking {
         val store = InMemoryVectorStore()
         val results = store.search("nonexistent", floatArrayOf(1f, 0f, 0f), topK = 5)
         assertTrue(results.isEmpty())
     }
+    }
 
     @Test
-    fun `search with metadata filter`() = runBlocking {
+    fun `search with metadata filter`() { runBlocking {
         val store = InMemoryVectorStore()
 
         store.upsert("test", listOf(
@@ -45,9 +47,10 @@ class InMemoryVectorStoreTest {
         assertEquals("Article A", results[0].content)
         assertEquals("1", results[0].id)
     }
+    }
 
     @Test
-    fun `delete removes specific vectors`() = runBlocking {
+    fun `delete removes specific vectors`() { runBlocking {
         val store = InMemoryVectorStore()
 
         store.upsert("test", listOf(
@@ -61,9 +64,10 @@ class InMemoryVectorStoreTest {
         assertEquals(1, results.size)
         assertEquals("Doc B", results[0].content)
     }
+    }
 
     @Test
-    fun `listCollections returns collection names`() = runBlocking {
+    fun `listCollections returns collection names`() { runBlocking {
         val store = InMemoryVectorStore()
 
         store.upsert("alpha", listOf(VectorEntry("1", floatArrayOf(1f), "A")))
@@ -72,9 +76,10 @@ class InMemoryVectorStoreTest {
         val collections = store.listCollections()
         assertEquals(listOf("alpha", "beta"), collections)
     }
+    }
 
     @Test
-    fun `cosine similarity of orthogonal vectors`() = runBlocking {
+    fun `cosine similarity of orthogonal vectors`() { runBlocking {
         val store = InMemoryVectorStore()
 
         store.upsert("test", listOf(
@@ -86,9 +91,10 @@ class InMemoryVectorStoreTest {
         assertEquals(1, results.size)
         assertTrue(results[0].score <= 0.01)
     }
+    }
 
     @Test
-    fun `search result includes id`() = runBlocking {
+    fun `search result includes id`() { runBlocking {
         val store = InMemoryVectorStore()
 
         store.upsert("test", listOf(
@@ -98,5 +104,6 @@ class InMemoryVectorStoreTest {
         val results = store.search("test", floatArrayOf(1f, 0f), topK = 5)
         assertEquals(1, results.size)
         assertEquals("my-id-42", results[0].id)
+    }
     }
 }


### PR DESCRIPTION
# test(core): prevent vacuously skipped Kotlin tests (JUnit discovery integrity)

## What

JUnit Jupiter silently discards `@Test` methods whose JVM return type is not `void`. Kotlin expression-bodied tests ending in a chainable AssertJ assertion compile to non-void methods — the test is **never discovered**, and the Gradle test task stays green.

Before this PR, **~300 tests silently never executed** (measured, not estimated).

## Evidence (before → after)

- Repo-wide audit: **728 expression-bodied `@Test` functions** across 65 files.
- XML discovery comparison (`testcase` entries vs source `@Test` names):
  - **300 genuinely skipped** — 230 inside 29 partially-executed classes + 70 tests in 8 classes with **no XML at all** (every method non-void → JUnit never reports the class).
  - Example: `PolicyEnforcementTest` — 7 of ~65 methods ran. `PartitionStrategyTest`, `ShutdownHookTest`, `ApprovalControlPlaneControllerTest` etc. — zero methods ran.
- `ProviderFailuresTest`: 7 skipped → all 11 execute (source count 11).

## Fixes in this PR

1. **Conversion (728 → 0):** every non-Unit expression-bodied `@Test` converted to a block body (`fun x() { runBlocking { ... } }`). Provably-Unit forms (`= runBlocking<Unit>`) accepted. Semantics identical — verified by compile + XML counts.

2. **Pre-existing test bugs unmasked and repaired (36 failures in 10 classes):**
   - `ApprovalControlPlaneControllerTest` + `ApprovalInboxControllerTest` (17): controller carries `@ConditionalOnProperty`/`@ConditionalOnBean` evaluated before `@MockBean` registration → controller never mapped in the slice (404). Fixed with standalone `MockMvc` + plain Mockito mocks; assertions unchanged.
   - `PolicyEnforcementTest` (9): test setup predates engine tool-registration requirement; exception-type expectations updated to actual intended types.
   - `FileApprovalStoreTest` (4): fixture digests used non-hex letters (`j/k/l`…) violating `sha256:[0-9a-f]{64}`.
   - `Jdbc*` / Spring classes (6): fixture data, context config, and exception expectations aligned with current production behavior (incl. `JdbcSovereignOpsApprovalDecisionControlPlaneTest`: the module's only `@SpringBootTest` — DataSource/JdbcTemplate/request-factory moved to an early-imported config so `@ConditionalOnBean` guards see them, real-time + sub-15min TTL fixture, canonical replay-envelope digest, V6 migration, real-schema SQL).
   - No production code changed. Assertions changed only where dormant tests encoded behavior superseded by the current contract; each change was individually reconciled against current production semantics (e.g. `PolicyEnforcementTest` moved from the 0.4.x placeholder `ApprovalRequiredException` to the actual `ApprovalSuspendedException`, and the revocation-between-retries test's expected first-attempt invocation count 0 → 1). No assertion weakened.

3. **Permanent guard (the deliverable):** `verifyJUnitTestSignatures` Gradle task, wired into `verifyPr`. Source-level verifier (`JUnitTestSignatureVerifier`) rejects any `@Test` expression body whose inferred return type is not provably Unit (block bodies / explicit `: Unit` / explicit `<Unit>` accepted; declaration accumulator handles multi-line signatures and multi-line annotations). Own tests prove it rejects unsafe forms (single-line, same-line, multi-line signature, multi-line annotation) and accepts safe ones.

## Verification

- `./gradlew test` — green; XML counts per class now match source `@Test` counts (300+ previously-skipped tests execute).
- `./gradlew verifyJUnitTestSignatures` — passes with zero violations on the fixed tree; fails on the deliberately invalid fixture in its own tests.
- `./gradlew verifyPr -PchangeClass=runtime-behaviour` — green.
- Zero production code, zero public API, zero dependency changes.

## Non-goals

- No `runTest` migration, no test style refactor beyond the discovery fix, no TCK/analyzer/baseline changes, no Epic 6.x work.
