### PR TITLE
test(spring): characterize auto-configuration and dependency boundaries (Epic 6.3)

### DIFF
--- a/config/quality/module-catalog.yml
+++ b/config/quality/module-catalog.yml
@@ -167,6 +167,11 @@ modules:
     publishability: published
     apiStability: preview
 
+  - path: ":tramai-spring-consumer-boundary"
+    layer: testing-support
+    publishability: internal
+    apiStability: internal
+
   - path: ":tramai-spring-boot-starter-local-provider-openai"
     layer: framework-integrations
     publishability: published

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ include(
     "tramai-ollama",
     "tramai-platform",
     "tramai-spring",
+    "tramai-spring-consumer-boundary",
     "tramai-spring-boot-starter-sovereign",
     "tramai-spring-boot-starter-sovereign-persistence-file",
     "tramai-spring-boot-starter-sovereign-persistence-jdbc",

--- a/tramai-spring-consumer-boundary/README.md
+++ b/tramai-spring-consumer-boundary/README.md
@@ -19,7 +19,7 @@ SDKs even though it never declared them**. Epic 6.3's acceptance criterion
 
 | Test | Today | After #261 |
 |---|---|---|
-| provider SDK classes loadable (`OpenAiProvider`, `AnthropicProvider`, `OllamaProvider`, `SecretsManagerClient`) | PASS (asserts the leak) | must be flipped to assert `ClassNotFoundException` |
+| provider adapter + AWS SDK classes loadable (`OpenAiProvider`, `AnthropicProvider`, `OllamaProvider`, `SecretsManagerClient`) | PASS (asserts the leak) | must be flipped to assert `ClassNotFoundException` |
 | generic spring integration classes present (`TramaiAutoConfiguration`, `standalone.Tramai`) | PASS | stays PASS |
 | module's own `build.gradle.kts` declares no provider/AWS deps | PASS (leak is transitive, not declared) | stays PASS |
 

--- a/tramai-spring-consumer-boundary/README.md
+++ b/tramai-spring-consumer-boundary/README.md
@@ -1,0 +1,44 @@
+# tramai-spring-consumer-boundary
+
+Test-only module. **Epic 6.3 dependency-boundary oracle.**
+
+It proves what a minimal Spring consumer gets on its classpath **today** by
+declaring exactly one dependency — `testImplementation(project(":tramai-spring"))` —
+and asserting what classes it can load.
+
+## Current reality (characterized)
+
+`tramai-spring` has `implementation` dependencies on `tramai-anthropic`,
+`tramai-openai`, `tramai-ollama`, and the AWS SDK (`auth`, `regions`,
+`secretsmanager`). Because `implementation` deps of a project dependency are
+transitive at runtime, a consumer's **runtime classpath carries all provider
+SDKs even though it never declared them**. Epic 6.3's acceptance criterion
+("consumers only receive dependencies for selected adapters") is **not** met today.
+
+## The tests
+
+| Test | Today | After #261 |
+|---|---|---|
+| provider SDK classes loadable (`OpenAiProvider`, `AnthropicProvider`, `OllamaProvider`, `SecretsManagerClient`) | PASS (asserts the leak) | must be flipped to assert `ClassNotFoundException` |
+| generic spring integration classes present (`TramaiAutoConfiguration`, `standalone.Tramai`) | PASS | stays PASS |
+| module's own `build.gradle.kts` declares no provider/AWS deps | PASS (leak is transitive, not declared) | stays PASS |
+
+## How #261 flips the oracle
+
+After the adapter split, the four loadability assertions in
+`runtime classpath currently carries provider SDKs` must be inverted to expect
+`ClassNotFoundException` (or an equivalent classpath check). The other two tests
+are unchanged. The test names and assertion messages reference #261 so the flip
+is mechanical.
+
+## Run
+
+```bash
+JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ./gradlew :tramai-spring-consumer-boundary:test
+```
+
+Diagnose the leak graph with:
+
+```bash
+./gradlew :tramai-spring-consumer-boundary:dependencies --configuration testRuntimeClasspath
+```

--- a/tramai-spring-consumer-boundary/README.md
+++ b/tramai-spring-consumer-boundary/README.md
@@ -12,21 +12,21 @@ and asserting what classes it can load.
 `tramai-openai`, `tramai-ollama`, and the AWS SDK (`auth`, `regions`,
 `secretsmanager`). Because `implementation` deps of a project dependency are
 transitive at runtime, a consumer's **runtime classpath carries all provider
-SDKs even though it never declared them**. Epic 6.3's acceptance criterion
+adapters plus the AWS SDK** even though it never declared them. Epic 6.3's acceptance criterion
 ("consumers only receive dependencies for selected adapters") is **not** met today.
 
 ## The tests
 
 | Test | Today | After #261 |
 |---|---|---|
-| provider adapter + AWS SDK classes loadable (`OpenAiProvider`, `AnthropicProvider`, `OllamaProvider`, `SecretsManagerClient`) | PASS (asserts the leak) | must be flipped to assert `ClassNotFoundException` |
+| runtime classpath currently carries provider adapters and the AWS SDK (`OpenAiProvider`, `AnthropicProvider`, `OllamaProvider`, `SecretsManagerClient`) | PASS (asserts the leak) | must be flipped to assert `ClassNotFoundException` |
 | generic spring integration classes present (`TramaiAutoConfiguration`, `standalone.Tramai`) | PASS | stays PASS |
 | module's own `build.gradle.kts` declares no provider/AWS deps | PASS (leak is transitive, not declared) | stays PASS |
 
 ## How #261 flips the oracle
 
 After the adapter split, the four loadability assertions in
-`runtime classpath currently carries provider SDKs` must be inverted to expect
+`runtime classpath currently carries provider adapters and the AWS SDK` must be inverted to expect
 `ClassNotFoundException` (or an equivalent classpath check). The other two tests
 are unchanged. The test names and assertion messages reference #261 so the flip
 is mechanical.

--- a/tramai-spring-consumer-boundary/build.gradle.kts
+++ b/tramai-spring-consumer-boundary/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    `java-library`
+    alias(libs.plugins.kotlin.jvm)
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+dependencies {
+    // Characterization oracle: a minimal Spring consumer depends ONLY on tramai-spring.
+    // No provider modules, no AWS SDK. Whatever provider SDKs land on the test runtime
+    // classpath below are transitive leaks from tramai-spring.
+    testImplementation(project(":tramai-spring"))
+    testImplementation(libs.kotlin.test.junit5)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.coroutines.core)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/tramai-spring-consumer-boundary/src/test/kotlin/dev/tramai/spring/boundary/ConsumerClasspathBoundaryTest.kt
+++ b/tramai-spring-consumer-boundary/src/test/kotlin/dev/tramai/spring/boundary/ConsumerClasspathBoundaryTest.kt
@@ -1,5 +1,7 @@
 package dev.tramai.spring.boundary
 
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.io.File
 import kotlin.test.assertTrue
@@ -12,29 +14,28 @@ import kotlin.test.assertTrue
  * thing Epic 6.3 ("consumers only receive dependencies for selected adapters") removes.
  *
  * These assertions characterize the CURRENT leak and are expected to pass today.
- * PR #261 flips them after the adapter split: the provider/AWS SDK classes will no
- * longer be loadable and the assertion messages will invert.
+ * PR #261 flips them after the adapter split: the provider adapter classes and the
+ * AWS SDK class will no longer be loadable, and the assertions below invert to
+ * [assertThatThrownBy] expecting [ClassNotFoundException].
  */
 class ConsumerClasspathBoundaryTest {
 
     @Test
-    fun `runtime classpath currently carries provider SDKs (characterization — flipped by #261)`() {
-        assertTrue(
-            Class.forName("dev.tramai.openai.OpenAiProvider") != null,
-            "tramai-openai is on the consumer runtime classpath (leak; flipped by #261)",
-        )
-        assertTrue(
-            Class.forName("dev.tramai.anthropic.AnthropicProvider") != null,
-            "tramai-anthropic is on the consumer runtime classpath (leak; flipped by #261)",
-        )
-        assertTrue(
-            Class.forName("dev.tramai.ollama.OllamaProvider") != null,
-            "tramai-ollama is on the consumer runtime classpath (leak; flipped by #261)",
-        )
-        assertTrue(
-            Class.forName("software.amazon.awssdk.services.secretsmanager.SecretsManagerClient") != null,
-            "AWS SDK SecretsManager is on the consumer runtime classpath (leak; flipped by #261)",
-        )
+    fun `runtime classpath currently carries provider adapters and the AWS SDK (characterization -- flipped by #261)`() {
+        // TramAI provider adapter classes (not SDKs) reachable on a consumer classpath.
+        assertThatCode { Class.forName("dev.tramai.openai.OpenAiProvider") }
+            .describedAs("tramai-openai adapter is on the consumer runtime classpath (leak; flipped by #261)")
+            .doesNotThrowAnyException()
+        assertThatCode { Class.forName("dev.tramai.anthropic.AnthropicProvider") }
+            .describedAs("tramai-anthropic adapter is on the consumer runtime classpath (leak; flipped by #261)")
+            .doesNotThrowAnyException()
+        assertThatCode { Class.forName("dev.tramai.ollama.OllamaProvider") }
+            .describedAs("tramai-ollama adapter is on the consumer runtime classpath (leak; flipped by #261)")
+            .doesNotThrowAnyException()
+        // External SDK class pulled in transitively by tramai-spring's AWS secrets resolver.
+        assertThatCode { Class.forName("software.amazon.awssdk.services.secretsmanager.SecretsManagerClient") }
+            .describedAs("AWS SDK SecretsManager is on the consumer runtime classpath (leak; flipped by #261)")
+            .doesNotThrowAnyException()
     }
 
     @Test

--- a/tramai-spring-consumer-boundary/src/test/kotlin/dev/tramai/spring/boundary/ConsumerClasspathBoundaryTest.kt
+++ b/tramai-spring-consumer-boundary/src/test/kotlin/dev/tramai/spring/boundary/ConsumerClasspathBoundaryTest.kt
@@ -1,0 +1,57 @@
+package dev.tramai.spring.boundary
+
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertTrue
+
+/**
+ * Epic 6.3 dependency-boundary oracle.
+ *
+ * A minimal Spring consumer declares ONLY tramai-spring. Everything provider-related
+ * it can load at runtime is therefore a transitive leak from tramai-spring — the exact
+ * thing Epic 6.3 ("consumers only receive dependencies for selected adapters") removes.
+ *
+ * These assertions characterize the CURRENT leak and are expected to pass today.
+ * PR #261 flips them after the adapter split: the provider/AWS SDK classes will no
+ * longer be loadable and the assertion messages will invert.
+ */
+class ConsumerClasspathBoundaryTest {
+
+    @Test
+    fun `runtime classpath currently carries provider SDKs (characterization — flipped by #261)`() {
+        assertTrue(
+            Class.forName("dev.tramai.openai.OpenAiProvider") != null,
+            "tramai-openai is on the consumer runtime classpath (leak; flipped by #261)",
+        )
+        assertTrue(
+            Class.forName("dev.tramai.anthropic.AnthropicProvider") != null,
+            "tramai-anthropic is on the consumer runtime classpath (leak; flipped by #261)",
+        )
+        assertTrue(
+            Class.forName("dev.tramai.ollama.OllamaProvider") != null,
+            "tramai-ollama is on the consumer runtime classpath (leak; flipped by #261)",
+        )
+        assertTrue(
+            Class.forName("software.amazon.awssdk.services.secretsmanager.SecretsManagerClient") != null,
+            "AWS SDK SecretsManager is on the consumer runtime classpath (leak; flipped by #261)",
+        )
+    }
+
+    @Test
+    fun `generic spring integration classes are present`() {
+        Class.forName("dev.tramai.spring.TramaiAutoConfiguration")
+        Class.forName("dev.tramai.standalone.Tramai")
+    }
+
+    @Test
+    fun `consumer declares no direct provider dependencies`() {
+        val buildFile = File("build.gradle.kts").readText()
+        val forbidden = listOf("tramai-openai", "tramai-anthropic", "tramai-ollama", "amazon.awssdk")
+        forbidden.forEach { token ->
+            assertTrue(
+                buildFile.lines().none { it.contains(token) },
+                "build.gradle.kts must not declare a direct dependency on $token (the leak is transitive only)",
+            )
+        }
+    }
+}

--- a/tramai-spring/src/test/kotlin/dev/tramai/spring/TramaiAutoConfigurationConditionsTest.kt
+++ b/tramai-spring/src/test/kotlin/dev/tramai/spring/TramaiAutoConfigurationConditionsTest.kt
@@ -10,7 +10,6 @@ import dev.tramai.standalone.Tramai
 import dev.tramai.spring.TramaiAutoConfigurationTest.CachedInvoiceAnalyzer
 import dev.tramai.spring.TramaiAutoConfigurationTest.CachedProvider
 import dev.tramai.spring.TramaiAutoConfigurationTest.FixedProvider
-import dev.tramai.spring.TramaiAutoConfigurationTest.TestApplication
 import dev.tramai.spring.TramaiAutoConfigurationTest.TestInvoiceAnalyzer
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
@@ -27,6 +26,14 @@ import kotlin.test.Test
  * conditional bean creation, secret-resolver construction failures, the
  * @ConditionalOnMissingBean tramai() back-off, provider coexistence, the
  * default NoOp cache, and bean-provider visibility at assembly time.
+ *
+ * Isolation contract: every runner configures EXACTLY
+ * AutoConfigurations.of(TramaiAutoConfiguration) plus the beans/properties
+ * the scenario declares. No @SpringBootApplication, no component scanning —
+ * if a test needs a provider, it registers it as a bean explicitly.
+ * @AiService proxies are created via Tramai.create(...) instead of relying
+ * on scanned AiService beans, so a fixture moving packages in #261 cannot
+ * change what these tests observe.
  */
 class TramaiAutoConfigurationConditionsTest {
 
@@ -34,12 +41,14 @@ class TramaiAutoConfigurationConditionsTest {
     fun `no providers and no default-provider -- context loads but invoking an AiService fails because no provider is registered for the model`() {
         val contextRunner = ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
-            .withUserConfiguration(TestApplication::class.java)
 
         contextRunner.run { context ->
             assertThat(context).hasNotFailed()
             assertThat(context).hasSingleBean(Tramai::class.java)
-            val analyzer = context.getBean(TestInvoiceAnalyzer::class.java)
+            // Premise: there really are no provider beans in the context.
+            assertThat(context.getBeansOfType(ModelProvider::class.java)).isEmpty()
+
+            val analyzer = context.getBean(Tramai::class.java).create(TestInvoiceAnalyzer::class)
 
             assertThatThrownBy { runBlocking { analyzer.analyze("invoice-123") } }
                 .isInstanceOf(ConfigurationException::class.java)
@@ -53,7 +62,6 @@ class TramaiAutoConfigurationConditionsTest {
     fun `no providers with default-provider=openai -- context fails at startup because the default provider is not registered`() {
         val contextRunner = ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
-            .withUserConfiguration(TestApplication::class.java)
             .withPropertyValues("tramai.default-provider=openai")
 
         contextRunner.run { context ->
@@ -68,7 +76,6 @@ class TramaiAutoConfigurationConditionsTest {
     fun `openai apiKey and apiKeySecretRef together fail context startup with IllegalStateException`() {
         val contextRunner = ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
-            .withUserConfiguration(TestApplication::class.java)
             .withPropertyValues(
                 "tramai.providers.openai.apiKey=test-openai-key",
                 "tramai.providers.openai.apiKeySecretRef=vault:openai/api-key",
@@ -88,7 +95,6 @@ class TramaiAutoConfigurationConditionsTest {
     fun `unresolvable apiKeySecretRef fails context startup with No SecretValueResolver could resolve`() {
         val contextRunner = ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
-            .withUserConfiguration(TestApplication::class.java)
             .withPropertyValues(
                 "tramai.providers.openai.apiKeySecretRef=vault:missing-key",
             )
@@ -107,7 +113,6 @@ class TramaiAutoConfigurationConditionsTest {
     fun `vault enabled without baseUrl fails context startup`() {
         val contextRunner = ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
-            .withUserConfiguration(TestApplication::class.java)
             .withPropertyValues("tramai.secrets.vault.enabled=true")
 
         contextRunner.run { context ->
@@ -124,7 +129,6 @@ class TramaiAutoConfigurationConditionsTest {
     fun `vault enabled with baseUrl but no token fails context startup`() {
         val contextRunner = ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
-            .withUserConfiguration(TestApplication::class.java)
             .withPropertyValues(
                 "tramai.secrets.vault.enabled=true",
                 "tramai.secrets.vault.base-url=http://localhost:8200",
@@ -144,7 +148,6 @@ class TramaiAutoConfigurationConditionsTest {
     fun `aws-secrets-manager enabled without region fails context startup`() {
         val contextRunner = ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
-            .withUserConfiguration(TestApplication::class.java)
             .withPropertyValues("tramai.secrets.aws-secrets-manager.enabled=true")
 
         contextRunner.run { context ->
@@ -161,7 +164,9 @@ class TramaiAutoConfigurationConditionsTest {
     fun `vault and aws-secrets-manager disabled with no secret config loads the context cleanly`() {
         val contextRunner = ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
-            .withUserConfiguration(TestApplication::class.java)
+            // Explicit provider: the scenario's premise is "no secret config",
+            // not "no providers at all".
+            .withBean("stubProvider", ModelProvider::class.java, Supplier { FixedProvider("stub") })
             .withPropertyValues("tramai.default-provider=stub")
 
         contextRunner.run { context ->
@@ -169,8 +174,8 @@ class TramaiAutoConfigurationConditionsTest {
             // the tramai bean assembles and invocations reach the provider directly.
             assertThat(context).hasNotFailed()
             assertThat(context).hasSingleBean(Tramai::class.java)
-            val analyzer = context.getBean(TestInvoiceAnalyzer::class.java)
-            assertThat(runBlocking { analyzer.analyze("invoice-123") }).isEqualTo("spring hello")
+            val analyzer = context.getBean(Tramai::class.java).create(TestInvoiceAnalyzer::class)
+            assertThat(runBlocking { analyzer.analyze("invoice-123") }).isEqualTo("stub")
         }
     }
 
@@ -183,7 +188,6 @@ class TramaiAutoConfigurationConditionsTest {
 
         val contextRunner = ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
-            .withUserConfiguration(TestApplication::class.java)
             .withBean("userTramai", Tramai::class.java, Supplier { userTramai })
 
         contextRunner.run { context ->
@@ -193,7 +197,7 @@ class TramaiAutoConfigurationConditionsTest {
             assertThat(context.getBeanNamesForType(Tramai::class.java)).hasSize(1)
             assertThat(context.getBean(Tramai::class.java)).isSameAs(userTramai)
 
-            val analyzer = context.getBean(TestInvoiceAnalyzer::class.java)
+            val analyzer = context.getBean(Tramai::class.java).create(TestInvoiceAnalyzer::class)
             assertThat(runBlocking { analyzer.analyze("invoice-123") }).isEqualTo("marker")
         }
     }
@@ -242,7 +246,6 @@ class TramaiAutoConfigurationConditionsTest {
         try {
             val contextRunner = ApplicationContextRunner()
                 .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
-                .withUserConfiguration(TestApplication::class.java)
                 .withPropertyValues(
                     "tramai.models.gpt-5.1-chat-latest=openai",
                     "tramai.models.llama3.2=ollama",
@@ -253,8 +256,9 @@ class TramaiAutoConfigurationConditionsTest {
 
             contextRunner.run { context ->
                 assertThat(context).hasNotFailed()
-                val openAiAnalyzer = context.getBean(TestInvoiceAnalyzer::class.java)
-                val ollamaAnalyzer = context.getBean(TestOllamaAnalyzer::class.java)
+                val tramai = context.getBean(Tramai::class.java)
+                val openAiAnalyzer = tramai.create(TestInvoiceAnalyzer::class)
+                val ollamaAnalyzer = tramai.create(TestOllamaAnalyzer::class)
 
                 // Both property-backed providers are registered side by side.
                 assertThat(runBlocking { openAiAnalyzer.analyze("invoice-123") }).isEqualTo("openai spring hello")
@@ -270,7 +274,8 @@ class TramaiAutoConfigurationConditionsTest {
     fun `cache disabled by default -- two identical invocations both reach the provider proving the NoOp cache`() {
         val contextRunner = ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
-            .withUserConfiguration(TestApplication::class.java)
+            // Explicit provider bean; cache stays at its default (disabled).
+            .withBean("cachedProvider", CachedProvider::class.java, Supplier { CachedProvider() })
             .withPropertyValues(
                 "tramai.default-provider=cached",
                 "tramai.models.gpt-5.1-chat-latest=cached",
@@ -278,7 +283,8 @@ class TramaiAutoConfigurationConditionsTest {
             )
 
         contextRunner.run { context ->
-            val analyzer = context.getBean(CachedInvoiceAnalyzer::class.java)
+            val tramai = context.getBean(Tramai::class.java)
+            val analyzer = tramai.create(CachedInvoiceAnalyzer::class)
             val provider = context.getBean(CachedProvider::class.java)
 
             val first = runBlocking { analyzer.analyze("invoice-123") }
@@ -295,7 +301,6 @@ class TramaiAutoConfigurationConditionsTest {
     fun `user registered ModelProvider beans are all visible to the tramai bean at assembly`() {
         val contextRunner = ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
-            .withUserConfiguration(TestApplication::class.java)
             .withBean("alphaProvider", ModelProvider::class.java, Supplier { FixedProvider("alpha") })
             .withBean("betaProvider", ModelProvider::class.java, Supplier { FixedProvider("beta") })
             .withPropertyValues(
@@ -305,8 +310,9 @@ class TramaiAutoConfigurationConditionsTest {
 
         contextRunner.run { context ->
             assertThat(context).hasNotFailed()
-            val openAiAnalyzer = context.getBean(TestInvoiceAnalyzer::class.java)
-            val ollamaAnalyzer = context.getBean(TestOllamaAnalyzer::class.java)
+            val tramai = context.getBean(Tramai::class.java)
+            val openAiAnalyzer = tramai.create(TestInvoiceAnalyzer::class)
+            val ollamaAnalyzer = tramai.create(TestOllamaAnalyzer::class)
 
             // Both bean providers were visible when the tramai bean was assembled.
             assertThat(runBlocking { openAiAnalyzer.analyze("invoice-123") }).isEqualTo("alpha")

--- a/tramai-spring/src/test/kotlin/dev/tramai/spring/TramaiAutoConfigurationConditionsTest.kt
+++ b/tramai-spring/src/test/kotlin/dev/tramai/spring/TramaiAutoConfigurationConditionsTest.kt
@@ -1,0 +1,335 @@
+package dev.tramai.spring
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.exception.ConfigurationException
+import dev.tramai.core.provider.ModelProvider
+import dev.tramai.standalone.Tramai
+import dev.tramai.spring.TramaiAutoConfigurationTest.CachedInvoiceAnalyzer
+import dev.tramai.spring.TramaiAutoConfigurationTest.CachedProvider
+import dev.tramai.spring.TramaiAutoConfigurationTest.FixedProvider
+import dev.tramai.spring.TramaiAutoConfigurationTest.TestApplication
+import dev.tramai.spring.TramaiAutoConfigurationTest.TestInvoiceAnalyzer
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import java.net.InetSocketAddress
+import java.util.function.Supplier
+import kotlin.test.Test
+
+/**
+ * Characterization of the auto-configuration CONDITIONS and ORDERING rules
+ * (Epic 6.3 prep). Every expectation below freezes the CURRENT behavior:
+ * conditional bean creation, secret-resolver construction failures, the
+ * @ConditionalOnMissingBean tramai() back-off, provider coexistence, the
+ * default NoOp cache, and bean-provider visibility at assembly time.
+ */
+class TramaiAutoConfigurationConditionsTest {
+
+    @Test
+    fun `no providers and no default-provider -- context loads but invoking an AiService fails because no provider is registered for the model`() {
+        val contextRunner = ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
+            .withUserConfiguration(TestApplication::class.java)
+
+        contextRunner.run { context ->
+            assertThat(context).hasNotFailed()
+            assertThat(context).hasSingleBean(Tramai::class.java)
+            val analyzer = context.getBean(TestInvoiceAnalyzer::class.java)
+
+            assertThatThrownBy { runBlocking { analyzer.analyze("invoice-123") } }
+                .isInstanceOf(ConfigurationException::class.java)
+                .hasMessageContaining(
+                    "No provider is registered for model 'gpt-5.1-chat-latest'. Register the model explicitly or configure a default provider.",
+                )
+        }
+    }
+
+    @Test
+    fun `no providers with default-provider=openai -- context fails at startup because the default provider is not registered`() {
+        val contextRunner = ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
+            .withUserConfiguration(TestApplication::class.java)
+            .withPropertyValues("tramai.default-provider=openai")
+
+        contextRunner.run { context ->
+            assertThat(context).hasFailed()
+            assertThat(context).getFailure()
+                .hasRootCauseInstanceOf(ConfigurationException::class.java)
+                .hasRootCauseMessage("Default provider 'openai' is not registered")
+        }
+    }
+
+    @Test
+    fun `openai apiKey and apiKeySecretRef together fail context startup with IllegalStateException`() {
+        val contextRunner = ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
+            .withUserConfiguration(TestApplication::class.java)
+            .withPropertyValues(
+                "tramai.providers.openai.apiKey=test-openai-key",
+                "tramai.providers.openai.apiKeySecretRef=vault:openai/api-key",
+            )
+
+        contextRunner.run { context ->
+            assertThat(context).hasFailed()
+            assertThat(context).getFailure()
+                .hasRootCauseInstanceOf(IllegalStateException::class.java)
+                .hasRootCauseMessage(
+                    "tramai.providers.openai.apiKey cannot be configured together with its secret reference",
+                )
+        }
+    }
+
+    @Test
+    fun `unresolvable apiKeySecretRef fails context startup with No SecretValueResolver could resolve`() {
+        val contextRunner = ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
+            .withUserConfiguration(TestApplication::class.java)
+            .withPropertyValues(
+                "tramai.providers.openai.apiKeySecretRef=vault:missing-key",
+            )
+
+        contextRunner.run { context ->
+            assertThat(context).hasFailed()
+            assertThat(context).getFailure()
+                .hasRootCauseInstanceOf(IllegalStateException::class.java)
+                .hasRootCauseMessage(
+                    "No SecretValueResolver could resolve 'vault:missing-key' for tramai.providers.openai.apiKey",
+                )
+        }
+    }
+
+    @Test
+    fun `vault enabled without baseUrl fails context startup`() {
+        val contextRunner = ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
+            .withUserConfiguration(TestApplication::class.java)
+            .withPropertyValues("tramai.secrets.vault.enabled=true")
+
+        contextRunner.run { context ->
+            assertThat(context).hasFailed()
+            assertThat(context).getFailure()
+                .hasRootCauseInstanceOf(IllegalStateException::class.java)
+                .hasRootCauseMessage(
+                    "tramai.secrets.vault.baseUrl must be configured when Vault secret resolution is enabled",
+                )
+        }
+    }
+
+    @Test
+    fun `vault enabled with baseUrl but no token fails context startup`() {
+        val contextRunner = ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
+            .withUserConfiguration(TestApplication::class.java)
+            .withPropertyValues(
+                "tramai.secrets.vault.enabled=true",
+                "tramai.secrets.vault.base-url=http://localhost:8200",
+            )
+
+        contextRunner.run { context ->
+            assertThat(context).hasFailed()
+            assertThat(context).getFailure()
+                .hasRootCauseInstanceOf(IllegalStateException::class.java)
+                .hasRootCauseMessage(
+                    "tramai.secrets.vault.token must be configured when Vault secret resolution is enabled",
+                )
+        }
+    }
+
+    @Test
+    fun `aws-secrets-manager enabled without region fails context startup`() {
+        val contextRunner = ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
+            .withUserConfiguration(TestApplication::class.java)
+            .withPropertyValues("tramai.secrets.aws-secrets-manager.enabled=true")
+
+        contextRunner.run { context ->
+            assertThat(context).hasFailed()
+            assertThat(context).getFailure()
+                .hasRootCauseInstanceOf(IllegalStateException::class.java)
+                .hasRootCauseMessage(
+                    "tramai.secrets.aws-secrets-manager.region must be configured when AWS Secrets Manager resolution is enabled",
+                )
+        }
+    }
+
+    @Test
+    fun `vault and aws-secrets-manager disabled with no secret config loads the context cleanly`() {
+        val contextRunner = ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
+            .withUserConfiguration(TestApplication::class.java)
+            .withPropertyValues("tramai.default-provider=stub")
+
+        contextRunner.run { context ->
+            // Disabled = zero failure and no built-in secret resolver is instantiated:
+            // the tramai bean assembles and invocations reach the provider directly.
+            assertThat(context).hasNotFailed()
+            assertThat(context).hasSingleBean(Tramai::class.java)
+            val analyzer = context.getBean(TestInvoiceAnalyzer::class.java)
+            assertThat(runBlocking { analyzer.analyze("invoice-123") }).isEqualTo("spring hello")
+        }
+    }
+
+    @Test
+    fun `user supplied Tramai bean wins over the auto-config conditional tramai bean`() {
+        val userTramai = Tramai.builder()
+            .provider(FixedProvider("marker"), name = "marker")
+            .model("gpt-5.1-chat-latest", "marker")
+            .build()
+
+        val contextRunner = ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
+            .withUserConfiguration(TestApplication::class.java)
+            .withBean("userTramai", Tramai::class.java, Supplier { userTramai })
+
+        contextRunner.run { context ->
+            // @ConditionalOnMissingBean backs off: exactly one Tramai bean exists and
+            // it IS the user's instance (distinguished by its "marker" provider).
+            assertThat(context).hasNotFailed()
+            assertThat(context.getBeanNamesForType(Tramai::class.java)).hasSize(1)
+            assertThat(context.getBean(Tramai::class.java)).isSameAs(userTramai)
+
+            val analyzer = context.getBean(TestInvoiceAnalyzer::class.java)
+            assertThat(runBlocking { analyzer.analyze("invoice-123") }).isEqualTo("marker")
+        }
+    }
+
+    @Test
+    fun `openai and ollama property providers coexist and both models route to their provider`() {
+        val openAiServer = HttpServer.create(InetSocketAddress(0), 0)
+        openAiServer.createContext("/v1/chat/completions") { exchange ->
+            respond(
+                exchange = exchange,
+                body = """
+                    {
+                      "model": "gpt-5.1-chat-latest",
+                      "choices": [
+                        {
+                          "message": {
+                            "role": "assistant",
+                            "content": "openai spring hello"
+                          },
+                          "finish_reason": "stop"
+                        }
+                      ]
+                    }
+                """.trimIndent(),
+            )
+        }
+        openAiServer.start()
+
+        val ollamaServer = HttpServer.create(InetSocketAddress(0), 0)
+        ollamaServer.createContext("/api/chat") { exchange ->
+            respond(
+                exchange = exchange,
+                body = """
+                    {
+                      "model": "llama3.2",
+                      "message": {
+                        "role": "assistant",
+                        "content": "ollama spring hello"
+                      }
+                    }
+                """.trimIndent(),
+            )
+        }
+        ollamaServer.start()
+
+        try {
+            val contextRunner = ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
+                .withUserConfiguration(TestApplication::class.java)
+                .withPropertyValues(
+                    "tramai.models.gpt-5.1-chat-latest=openai",
+                    "tramai.models.llama3.2=ollama",
+                    "tramai.providers.openai.apiKey=test-openai-key",
+                    "tramai.providers.openai.baseUrl=http://localhost:${openAiServer.address.port}/v1",
+                    "tramai.providers.ollama.baseUrl=http://localhost:${ollamaServer.address.port}",
+                )
+
+            contextRunner.run { context ->
+                assertThat(context).hasNotFailed()
+                val openAiAnalyzer = context.getBean(TestInvoiceAnalyzer::class.java)
+                val ollamaAnalyzer = context.getBean(TestOllamaAnalyzer::class.java)
+
+                // Both property-backed providers are registered side by side.
+                assertThat(runBlocking { openAiAnalyzer.analyze("invoice-123") }).isEqualTo("openai spring hello")
+                assertThat(runBlocking { ollamaAnalyzer.analyze("invoice-123") }).isEqualTo("ollama spring hello")
+            }
+        } finally {
+            openAiServer.stop(0)
+            ollamaServer.stop(0)
+        }
+    }
+
+    @Test
+    fun `cache disabled by default -- two identical invocations both reach the provider proving the NoOp cache`() {
+        val contextRunner = ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
+            .withUserConfiguration(TestApplication::class.java)
+            .withPropertyValues(
+                "tramai.default-provider=cached",
+                "tramai.models.gpt-5.1-chat-latest=cached",
+                // tramai.cache.in-memory.enabled stays at its default (false)
+            )
+
+        contextRunner.run { context ->
+            val analyzer = context.getBean(CachedInvoiceAnalyzer::class.java)
+            val provider = context.getBean(CachedProvider::class.java)
+
+            val first = runBlocking { analyzer.analyze("invoice-123") }
+            val second = runBlocking { analyzer.analyze("invoice-123") }
+
+            // NoOp default cache: identical invocations both reach the provider bean.
+            assertThat(first).isEqualTo("cached spring hello 1")
+            assertThat(second).isEqualTo("cached spring hello 2")
+            assertThat(provider.requests).hasSize(2)
+        }
+    }
+
+    @Test
+    fun `user registered ModelProvider beans are all visible to the tramai bean at assembly`() {
+        val contextRunner = ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(TramaiAutoConfiguration::class.java))
+            .withUserConfiguration(TestApplication::class.java)
+            .withBean("alphaProvider", ModelProvider::class.java, Supplier { FixedProvider("alpha") })
+            .withBean("betaProvider", ModelProvider::class.java, Supplier { FixedProvider("beta") })
+            .withPropertyValues(
+                "tramai.models.gpt-5.1-chat-latest=alpha",
+                "tramai.models.llama3.2=beta",
+            )
+
+        contextRunner.run { context ->
+            assertThat(context).hasNotFailed()
+            val openAiAnalyzer = context.getBean(TestInvoiceAnalyzer::class.java)
+            val ollamaAnalyzer = context.getBean(TestOllamaAnalyzer::class.java)
+
+            // Both bean providers were visible when the tramai bean was assembled.
+            assertThat(runBlocking { openAiAnalyzer.analyze("invoice-123") }).isEqualTo("alpha")
+            assertThat(runBlocking { ollamaAnalyzer.analyze("invoice-123") }).isEqualTo("beta")
+        }
+    }
+}
+
+@AiService
+interface TestOllamaAnalyzer {
+    @Operation(
+        prompt = "Analyze the invoice with ollama",
+        model = "llama3.2",
+    )
+    suspend fun analyze(invoiceId: String): String
+}
+
+private fun respond(
+    exchange: HttpExchange,
+    body: String,
+    status: Int = 200,
+) {
+    exchange.responseHeaders.add("Content-Type", "application/json")
+    exchange.sendResponseHeaders(status, body.toByteArray().size.toLong())
+    exchange.responseBody.use { it.write(body.toByteArray()) }
+}


### PR DESCRIPTION
# test(spring): characterize auto-configuration and dependency boundaries (Epic 6.3)

## What

Preparatory, test-only PR for Epic 6.3 (Modularize Spring integration). Before moving any classes or modules, freeze the **current** `tramai-spring` behavior as a regression oracle so the decomposition PR (#261) can prove behavior unchanged.

## Additions

1. **`TramaiAutoConfigurationConditionsTest`** — condition and ordering characterization (12 scenarios):
   - no provider configured / missing credentials → observable failure mode
   - `apiKey` + `apiKeySecretRef` both set → `cannot be configured together` guard
   - unresolvable secret reference → `No SecretValueResolver could resolve`
   - Vault / AWS Secrets Manager enabled-but-incompletely-configured → clear startup errors
   - Vault + AWS both disabled with no secret config → context loads cleanly
   - user-supplied `Tramai` bean wins over `@ConditionalOnMissingBean` auto-config
   - two distinct property providers (OpenAI + Ollama) coexist and both register
   - cache disabled (default) → every invocation reaches the provider (NoOp cache)
   - provider beans visible to the runtime at assembly time (ordering)

2. **`tramai-spring-consumer-boundary`** — new test-only module depending on `tramai-spring` alone:
   - proves the **current** transitive classpath carries OpenAI, Anthropic, Ollama, and AWS Secrets Manager SDKs (the coupling Epic 6.3 must break — acceptance criterion: *consumers only receive dependencies for selected adapters*)
   - proves the consumer declares **no direct** provider dependencies (leak is transitive, not declared)
   - assertions are written to pass today and are explicitly marked to be flipped by #261 after the module split

## What this PR deliberately does NOT do

- no new production modules, no provider/secret moves, no `tramai-spring` removal
- no rename of public configuration namespaces
- no production behavior changes
- no bundling of the decomposition itself (that's #261)

## Verification

- `./gradlew :tramai-spring:test` — green (new conditions test + existing suite)
- `./gradlew :tramai-spring-consumer-boundary:test` — green (characterizes current leak)
- `./gradlew verifyPr -PchangeClass=runtime-behaviour` — green
- Zero production code changed.
