### PR TITLE
fix(structured): generate string enum schemas instead of name/ordinal objects

### DIFF
--- a/tramai-structured/src/main/kotlin/dev/tramai/structured/JacksonStructuredOutputHandler.kt
+++ b/tramai-structured/src/main/kotlin/dev/tramai/structured/JacksonStructuredOutputHandler.kt
@@ -139,7 +139,14 @@ class JacksonStructuredOutputHandler(
             Boolean::class -> scalarSchema("boolean", targetType)
             List::class, MutableList::class -> listSchema(targetType)
             Map::class, MutableMap::class -> error("Unsupported structured output type: $targetType")
-            is KClass<*> -> objectSchema(classifier, targetType)
+            is KClass<*> -> {
+                val klass = classifier as KClass<*>
+                if (klass.java.isEnum) {
+                    enumSchema(klass, targetType)
+                } else {
+                    objectSchema(klass, targetType)
+                }
+            }
             else -> error("Unsupported structured output type: $targetType")
         }
     }
@@ -165,6 +172,24 @@ class JacksonStructuredOutputHandler(
             if (targetType.isMarkedNullable) {
                 schema["nullable"] = true
             }
+        }
+    }
+
+    /**
+     * Kotlin enums are serialized by their [Enum.name] — the same value the
+     * Jackson deserializer accepts. The schema must therefore be a flat string
+     * enum, not an object: any model following an object schema (name/ordinal
+     * properties) can never deserialize.
+     */
+    private fun enumSchema(
+        type: KClass<*>,
+        targetType: KType,
+    ): Map<String, Any?> = linkedMapOf<String, Any?>(
+        "type" to "string",
+        "enum" to type.java.enumConstants.map { (it as Enum<*>).name },
+    ).also { schema ->
+        if (targetType.isMarkedNullable) {
+            schema["nullable"] = true
         }
     }
 

--- a/tramai-structured/src/test/kotlin/dev/tramai/structured/JacksonStructuredOutputHandlerTest.kt
+++ b/tramai-structured/src/test/kotlin/dev/tramai/structured/JacksonStructuredOutputHandlerTest.kt
@@ -93,7 +93,120 @@ class JacksonStructuredOutputHandlerTest {
         }.isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("Unsupported structured output type")
     }
+
+    // -----------------------------------------------------------------------
+    // Enum contract: schema generation, shape validation, and deserialization
+    // must all agree that a Kotlin enum is a flat string (regression: the
+    // schema used to describe enums as name/ordinal objects, which no model
+    // output could satisfy and still deserialize).
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `enum root type generates a string enum schema`() {
+        val schema = handler.generateSchema(typeOf<Risk>())
+            .let { jackson.readTree(it) }
+
+        assertThat(schema.get("type").asText()).isEqualTo("string")
+        assertThat(schema.get("enum").map { it.asText() })
+            .containsExactly("LOW", "HIGH")
+    }
+
+    @Test
+    fun `nested enum property generates a string enum schema`() {
+        val schema = handler.generateSchema(typeOf<Assessment>())
+            .let { jackson.readTree(it) }
+        val riskSchema = schema.get("properties").get("risk")
+
+        assertThat(riskSchema.get("type").asText()).isEqualTo("string")
+        assertThat(riskSchema.get("enum").map { it.asText() })
+            .containsExactly("LOW", "HIGH")
+    }
+
+    @Test
+    fun `flat string enum value passes shape validation and deserializes`() {
+        val result = handler.analyze(
+            rawResponse = """{"risk":"LOW"}""",
+            targetType = typeOf<Assessment>(),
+        )
+
+        assertThat(result).isInstanceOf(StructuredOutputResult.Success::class.java)
+        val success = result as StructuredOutputResult.Success
+        assertThat((success.value as Assessment).risk).isEqualTo(Risk.LOW)
+    }
+
+    @Test
+    fun `invalid enum value is rejected cleanly`() {
+        val result = handler.analyze(
+            rawResponse = """{"risk":"YOLO"}""",
+            targetType = typeOf<Assessment>(),
+        )
+
+        assertThat(result).isInstanceOf(StructuredOutputResult.Failure::class.java)
+        val failure = result as StructuredOutputResult.Failure
+        assertThat(failure.errorSummary).isEqualTo("Could not deserialize the JSON payload")
+    }
+
+    @Test
+    fun `nullable enum keeps nullability semantics in schema and parsing`() {
+        val schema = handler.generateSchema(typeOf<NullableAssessment>())
+            .let { jackson.readTree(it) }
+        val riskSchema = schema.get("properties").get("risk")
+        assertThat(riskSchema.get("type").asText()).isEqualTo("string")
+        assertThat(riskSchema.has("nullable")).isTrue()
+        assertThat(riskSchema.get("nullable").asBoolean()).isTrue()
+
+        val result = handler.analyze(
+            rawResponse = """{"risk":null}""",
+            targetType = typeOf<NullableAssessment>(),
+        )
+        assertThat(result).isInstanceOf(StructuredOutputResult.Success::class.java)
+        assertThat((result as StructuredOutputResult.Success).value as NullableAssessment)
+            .isEqualTo(NullableAssessment(risk = null))
+    }
+
+    @Test
+    fun `schema and parser agree for every declared enum value`() {
+        val schema = handler.generateSchema(typeOf<Assessment>())
+            .let { jackson.readTree(it) }
+        val declaredNames = schema.get("properties").get("risk").get("enum")
+            .map { it.asText() }
+
+        assertThat(declaredNames).containsExactly("LOW", "HIGH")
+        declaredNames.forEach { name ->
+            val result = handler.analyze(
+                rawResponse = """{"risk":"$name"}""",
+                targetType = typeOf<Assessment>(),
+            )
+            assertThat(result).isInstanceOf(StructuredOutputResult.Success::class.java)
+            assertThat(((result as StructuredOutputResult.Success).value as Assessment).risk.name)
+                .isEqualTo(name)
+        }
+    }
+
+    @Test
+    fun `pre-fix object form of an enum is rejected`() {
+        // The historical bug: models followed the object schema and emitted
+        // {"name":"LOW","ordinal":0}, which can never deserialize. This test
+        // pins that the object form stays rejected while the flat string wins.
+        val result = handler.analyze(
+            rawResponse = """{"risk":{"name":"LOW","ordinal":0}}""",
+            targetType = typeOf<Assessment>(),
+        )
+        assertThat(result).isInstanceOf(StructuredOutputResult.Failure::class.java)
+    }
 }
+
+private val jackson = com.fasterxml.jackson.databind.ObjectMapper()
+
+private enum class Risk { LOW, HIGH }
+
+private data class Assessment(
+    val risk: Risk,
+)
+
+private data class NullableAssessment(
+    val risk: Risk?,
+)
 
 private data class SpendAnalysis(
     @property:AiDescription("Total spend in USD, always positive")


### PR DESCRIPTION
## Problem

Kotlin enums in structured-output return types were routed into object-schema
generation, producing `{"type":"object","properties":{"name","ordinal"}}`
schemas. Jackson deserializes enums from flat strings, so **no model output
could satisfy both** the schema and the parser:

- any model following the schema emitted `{"name":"LOW","ordinal":0}` → rejected at deserialization
- any model emitting the flat string `"LOW"` violated the schema it was shown

Verified empirically with three real models (gemma-4-12b-it:q5_k_m and
gemma4:e4b via Ollama, deepseek-chat): all three followed the generated schema
and emitted name/ordinal objects, then were rejected. The models were correct;
the schema was wrong. Discovered by the KTConf 2026 demo repo consuming
TramAI as an external library (issue #261).

## Fix

`schemaForType` now handles enum KClasses before the generic object branch,
emitting `{"type":"string","enum":["LOW","HIGH"]}` (nullability mirrored from
`scalarSchema`).

Shape validation already accepts flat strings for enum properties
(`validateKotlinJsonShape` returns no constraint for non-object nodes), so the
string path passes all three layers: schema → shape validation → Jackson.

## Tests (7 new)

1. enum root type → string enum schema
2. nested enum property → string enum schema
3. flat string round trip → shape validation + deserialization
4. invalid enum value (`"YOLO"`) → clean rejection
5. nullable enum → nullability preserved in schema and parsing
6. schema ↔ parser agreement for every declared enum value
7. pre-fix object form stays rejected (regression pin)

## Verification

- `:tramai-structured:test`: 12 tests, 0 failures (5 pre-existing + 7 new)
- Local `verifyPr` blocked by a **pre-existing** tramai-engine full-suite
  failure on this machine ("Could not write XML test results",
  NoClassDefFoundError wave) — reproduced with this change stashed on clean
  master, so unrelated to this PR. CI runs the authoritative full gate.