### PR TITLE
test(orchestration): fix flaky concurrent worker claim test

### DIFF
--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TramaiWorkerTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TramaiWorkerTest.kt
@@ -42,6 +42,13 @@ class TramaiWorkerTest {
 
         val worker0 = worker("worker-0", leaseStore, checkpointStore, workflow, workerCount = 2, partitionEnabled = true)
         val worker1 = worker("worker-1", leaseStore, checkpointStore, workflow, workerCount = 2, partitionEnabled = true)
+        // Pre-register both workers so the first poll already sees the full
+        // pool. Without this, whichever worker polls before the other has
+        // registered legitimately owns both partitions (ModHashPartitionStrategy
+        // partitions over the live active set) and the strict per-worker
+        // ownership assertions below become racy.
+        leaseStore.registerWorker("worker-0", "tests", "v1", setOf(), "host-0")
+        leaseStore.registerWorker("worker-1", "tests", "v1", setOf(), "host-1")
         worker0.start()
         worker1.start()
         try {


### PR DESCRIPTION
## Summary

Fixes a pre-existing flaky test in `tramai-orchestration`: `TramaiWorkerTest > two workers claim different workflows concurrently()`.

### Root cause

`ModHashPartitionStrategy.ownsPartition` assigns workflows to workers by hashing the workflow ID against the **live active worker set** (`listActiveWorkers()`). `TramaiWorker.start()` registers the worker, then immediately launches the poll loop. In the test, both workers are started back-to-back and work is seeded **before** either worker has necessarily registered:

- If `worker-0`'s first poll runs before `worker-1` has registered, the active set is `[worker-0]` — one worker, one partition — so `worker-0` legitimately owns **both** runs, claims both, and executes both.
- The test then asserts `worker1Attempt.workerId == "worker-1"` and fails with `expected: "worker-1" but was: "worker-0"`.

The production behavior is **correct**: a solo worker must claim everything, otherwise work would stall until a second worker appears. The test's premise — strict per-worker partition ownership — requires the full pool to be visible before claiming starts.

Observed on CI: failed 3× consecutively on PR #263's head (14:41/14:45/14:49) and previously on master CI (2026-08-21 run `32525287636`). Same code passed this gate at 13:50 the same day — timing-dependent race.

### Fix

Pre-register both workers in the lease store **before** starting either, so the first poll already sees the full pool:

```kotlin
leaseStore.registerWorker("worker-0", "tests", "v1", setOf(), "host-0")
leaseStore.registerWorker("worker-1", "tests", "v1", setOf(), "host-1")
worker0.start()
worker1.start()
```

This mirrors what the sibling test `partition pinning distributes workflows by stable hash` already does (it waits for both registrations before seeding work). No production code changed; no assertion weakened.

## What

- `tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TramaiWorkerTest.kt` (+7): registration barrier in the concurrent-claim test.

## Verification

- `./gradlew :tramai-orchestration:test --tests "dev.tramai.orchestration.TramaiWorkerTest" --rerun-tasks` — **20 consecutive GREEN runs** (the previously flaky test).

## Non-claims

- Does NOT change partition-assignment semantics. A worker that starts alone still claims everything (correct production behavior).
- Does NOT address other pre-existing flakiness elsewhere in the repo.

This PR needs review before merge.
