### PR TITLE
test(structured): add structured-output contract TCK — Epic 7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,27 +10,43 @@
   deserialization → runtime value validation → deterministic repair
   feedback — from a single source of truth (`StructuredOutputContractCase`),
   so no layer maintains independent fixture lists. The matrix
-  (`JacksonStructuredOutputContractTckTest`, 24 cases) covers Kotlin data
+  (`JacksonStructuredOutputContractTckTest`, 28 cases) covers Kotlin data
   classes, JavaBeans, nullability, missing primitives (rejected at SHAPE
   before Jackson primitive defaults hide them), nested objects, generic and
-  nested collections, root arrays, `@AiRange`/`@AiMinItems`/`@AiDescription`,
-  unknown properties (delegated to Jackson), recursion, unsupported maps,
-  malformed JSON, prose/fenced JSON extraction, and repair determinism —
-  plus the #262 enum regression class: root/nested/nullable enums, every
-  declared value succeeds, unknown values fail through deserialization, and
-  the legacy `{name, ordinal}` object form stays rejected (enum membership
-  remains deliberately delegated to Jackson, verified by the TCK).
-  `StructuredContractFingerprintEvolutionTest` (18 tests) mutates exactly one
-  semantic element at a time and proves each changes the SHA-256 hash, with
-  inverse tests proving `ValueAccessor`, compiler instances, and
-  `Object.typeName` never leak into it. The fingerprint fix: `typeName` is
-  compiler/diagnostic metadata, not part of the JSON contract — equivalent
-  Kotlin and JavaBean DTOs now fingerprint identically (previously the
-  class name participated in the hash, so fixture-class-name changes could
-  mask ignored mutations). Fingerprint stays internal; zero public API
-  change. Mutation evidence: ignoring `@AiRange`, disabling required-property
-  shape enforcement, and dropping fingerprint components each turn the TCK
-  RED. Reference: `docs/reference/structured-output-contract-tck.md`.
+  nested collections, root arrays, **root scalars (enum/integer/double/
+  boolean)**, `@AiRange`/`@AiMinItems`/`@AiDescription`, unknown properties
+  (rejected at SHAPE even under a lenient ObjectMapper), recursion,
+  unsupported maps, malformed JSON, prose/fenced JSON extraction, and repair
+  determinism — plus the #262 enum regression class: root/nested/nullable
+  enums, every declared value succeeds, unknown values fail through
+  deserialization, and the legacy `{name, ordinal}` object form stays
+  rejected (enum membership remains deliberately delegated to Jackson,
+  verified by the TCK). SHAPE vs VALUE_VALIDATION stages (shared summary by
+  design) are proven by exercising the layers directly — shape validator
+  rejects / shape accepts + Jackson succeeds + value validator rejects — so
+  message-phrasing refactors cannot keep a case green. Compile-failure
+  fixtures assert `IllegalArgumentException`/`IllegalStateException`
+  specifically. `StructuredContractFingerprintEvolutionTest` (18 tests)
+  mutates exactly one semantic element at a time and proves each changes the
+  SHA-256 hash, with inverse tests proving `ValueAccessor`, compiler
+  instances, and `Object.typeName` never leak into it. The fingerprint fix:
+  `typeName` is compiler/diagnostic metadata, not part of the JSON contract —
+  equivalent Kotlin and JavaBean DTOs now fingerprint identically (previously
+  the class name participated in the hash, so fixture-class-name changes
+  could mask ignored mutations). Fingerprint stays internal; zero public API
+  change. Mutation evidence (5): ignoring `@AiRange`, disabling required-
+  property shape enforcement, dropping fingerprint components, reverting the
+  complete-JSON extractor path, and removing unknown-property shape rejection
+  each turn the TCK RED. Two production inconsistencies surfaced and fixed:
+  (1) the extractor now accepts a complete trimmed JSON value before
+  object/array bracket search, so structured scalar roots round-trip instead
+  of failing "Could not extract JSON content" (prose-wrapped scalars remain
+  un-extractable); (2) `additionalProperties:false` is now enforced by the
+  shape validator (`Property 'x' is not allowed`), independent of the
+  consumer's Jackson configuration — previously delegated to Jackson
+  deserialization, it was silently weakened by a custom ObjectMapper with
+  `FAIL_ON_UNKNOWN_PROPERTIES=false`. Reference:
+  `docs/reference/structured-output-contract-tck.md`.
 
 - **Authoritative structured type descriptor (PR #265, Epic 7.1).** The
   structured-output implementation is no longer one ~900-line handler with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@
 
 ### Added
 
+- **Structured-output contract TCK (PR #266, Epic 7.2).** One reusable test
+  kit drives the entire structured-output lifecycle per fixture — descriptor
+  compilation → generated schema → raw JSON shape validation →
+  deserialization → runtime value validation → deterministic repair
+  feedback — from a single source of truth (`StructuredOutputContractCase`),
+  so no layer maintains independent fixture lists. The matrix
+  (`JacksonStructuredOutputContractTckTest`, 24 cases) covers Kotlin data
+  classes, JavaBeans, nullability, missing primitives (rejected at SHAPE
+  before Jackson primitive defaults hide them), nested objects, generic and
+  nested collections, root arrays, `@AiRange`/`@AiMinItems`/`@AiDescription`,
+  unknown properties (delegated to Jackson), recursion, unsupported maps,
+  malformed JSON, prose/fenced JSON extraction, and repair determinism —
+  plus the #262 enum regression class: root/nested/nullable enums, every
+  declared value succeeds, unknown values fail through deserialization, and
+  the legacy `{name, ordinal}` object form stays rejected (enum membership
+  remains deliberately delegated to Jackson, verified by the TCK).
+  `StructuredContractFingerprintEvolutionTest` (18 tests) mutates exactly one
+  semantic element at a time and proves each changes the SHA-256 hash, with
+  inverse tests proving `ValueAccessor`, compiler instances, and
+  `Object.typeName` never leak into it. The fingerprint fix: `typeName` is
+  compiler/diagnostic metadata, not part of the JSON contract — equivalent
+  Kotlin and JavaBean DTOs now fingerprint identically (previously the
+  class name participated in the hash, so fixture-class-name changes could
+  mask ignored mutations). Fingerprint stays internal; zero public API
+  change. Mutation evidence: ignoring `@AiRange`, disabling required-property
+  shape enforcement, and dropping fingerprint components each turn the TCK
+  RED. Reference: `docs/reference/structured-output-contract-tck.md`.
+
 - **Authoritative structured type descriptor (PR #265, Epic 7.1).** The
   structured-output implementation is no longer one ~900-line handler with
   four independent dispatch trees (schema Kotlin/JavaBean, raw-JSON shape

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1136,28 +1136,40 @@ reintroduce — an enum is not merely a scalar detail.*
 
 ## Epic 7.2: Structured-output contract TCK
 
+**Status: ✅ Implemented in PR #266 (Epic 7.2)**
+
+One reusable test kit drives the entire structured-output lifecycle per
+fixture: descriptor compilation → generated schema → raw JSON shape
+validation → deserialization → runtime value validation → deterministic
+repair feedback. No layer maintains its own independent fixture lists.
+
 ### Required cases
 
-- Kotlin data classes
-- JavaBeans
-- Nullable and non-null fields
-- Primitive missing fields
-- Nested objects
-- Generic collections
-- Root arrays
-- Annotation constraints
-- Unknown properties
-- Recursive types
-- Unsupported maps
-- Malformed JSON
-- Extra prose around JSON
-- Repair feedback determinism
-- Contract fingerprint evolution
+- ✅ Kotlin data classes
+- ✅ JavaBeans
+- ✅ Nullable and non-null fields
+- ✅ Primitive missing fields
+- ✅ Nested objects
+- ✅ Generic collections
+- ✅ Root arrays
+- ✅ Annotation constraints
+- ✅ Unknown properties
+- ✅ Recursive types
+- ✅ Unsupported maps
+- ✅ Malformed JSON
+- ✅ Extra prose around JSON
+- ✅ Repair feedback determinism
+- ✅ Contract fingerprint evolution
+- ✅ Enum regression cases (root/nested/nullable enum, every declared value
+  succeeds, unknown value fails via deserialization, legacy
+  `{name, ordinal}` object form rejected) — #262 was the incident that made
+  Phase 7 necessary
 
 ### Acceptance criteria
 
-- The same fixtures validate schema, shape, deserialization, value constraints, and repair messages.
-- Contract drift tests explain exactly which descriptor element changed.
+- ✅ The same fixtures validate schema, shape, deserialization, value constraints, and repair messages. (`StructuredOutputContractCase` → `StructuredOutputContractTck`)
+- ✅ Contract drift tests explain exactly which descriptor element changed. (one-mutation-at-a-time fingerprint evolution; fingerprint excludes `Object.typeName` — semantic parity across Kotlin/JavaBean DTOs)
+- ✅ Mutation evidence: temporarily ignoring `@AiRange`, disabling required-property shape enforcement, and dropping fingerprint components each turn the TCK RED.
 
 ---
 

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1169,7 +1169,21 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 - ✅ The same fixtures validate schema, shape, deserialization, value constraints, and repair messages. (`StructuredOutputContractCase` → `StructuredOutputContractTck`)
 - ✅ Contract drift tests explain exactly which descriptor element changed. (one-mutation-at-a-time fingerprint evolution; fingerprint excludes `Object.typeName` — semantic parity across Kotlin/JavaBean DTOs)
-- ✅ Mutation evidence: temporarily ignoring `@AiRange`, disabling required-property shape enforcement, and dropping fingerprint components each turn the TCK RED.
+- ✅ Mutation evidence: temporarily ignoring `@AiRange`, disabling required-property shape enforcement, dropping fingerprint components, reverting the complete-JSON extractor path, and removing unknown-property shape rejection each turn the TCK RED.
+
+### Production fixes surfaced by the TCK (PR #266)
+
+- **Root scalar extraction.** The extractor now accepts a complete trimmed
+  JSON value before the object/array bracket search, so structured scalar
+  roots (enum `"LOW"`, integer `42`, double `0.85`, boolean `true`) round-trip
+  instead of failing with "Could not extract JSON content". Prose-wrapped
+  scalars remain un-extractable (only complete JSON values or object/array
+  inside prose are accepted).
+- **Unknown properties owned by the shape validator.** `additionalProperties:
+  false` is enforced by `StructuredJsonShapeValidator` (`Property 'x' is not
+  allowed`), independent of the consumer's Jackson configuration — previously
+  it was delegated to Jackson deserialization and silently weakened by a
+  custom `ObjectMapper` with `FAIL_ON_UNKNOWN_PROPERTIES=false`.
 
 ---
 

--- a/docs/reference/structured-output-contract-tck.md
+++ b/docs/reference/structured-output-contract-tck.md
@@ -119,7 +119,7 @@ RED:
   validJson, schema expectations, invalid cases, value predicate,
   compile-failure expectation)
 - `StructuredOutputContractTck.kt` — lifecycle runner
-- `JacksonStructuredOutputContractTckTest.kt` — the matrix (24 cases)
+- `JacksonStructuredOutputContractTckTest.kt` — the matrix (28 cases)
 - `StructuredContractFingerprintEvolutionTest.kt` — one-mutation-at-a-time
   fingerprint evolution + inverse tests (18 tests)
 

--- a/docs/reference/structured-output-contract-tck.md
+++ b/docs/reference/structured-output-contract-tck.md
@@ -1,0 +1,109 @@
+# Structured-Output Contract TCK
+
+Epic 7.2 (PR #266). One reusable test kit proving a target type has one
+coherent contract across every structured-output layer.
+
+## What the TCK drives
+
+Each `StructuredOutputContractCase` (in
+`tramai-structured/src/test/kotlin/dev/tramai/structured/tck/`) carries the
+target type, valid JSON, schema expectations, invalid inputs with their
+expected failure stage, and a value predicate. The runner
+(`StructuredOutputContractTck`) walks the full lifecycle:
+
+```
+compile descriptor
+      ↓
+generate schema
+      ↓
+analyze valid JSON
+      ↓
+shape validation
+      ↓
+deserialization
+      ↓
+value validation
+      ↓
+success value
+```
+
+plus deterministic-repair verification: the same invalid input always yields
+the same `errorSummary` and `feedbackMessage`.
+
+## Failure stages
+
+Invalid fixtures declare where they must fail:
+
+| Stage | How it is pinned |
+|---|---|
+| `EXTRACTION` | unique summary "Could not extract JSON content…" |
+| `JSON_PARSE` | unique summary "Could not parse the JSON payload" |
+| `SHAPE` | shared summary "Structured output failed validation" + feedback phrasing ("is required", "Expected an array") |
+| `DESERIALIZATION` | unique summary "Could not deserialize the JSON payload" |
+| `VALUE_VALIDATION` | shared summary + feedback phrasing ("must be between", "must not be null", "must contain at least") |
+
+`SHAPE` and `VALUE_VALIDATION` share the summary by design (existing handler
+behaviour), so the TCK pins those two stages via the stage-specific feedback
+text.
+
+## Schema rule → enforcement owner
+
+Every emitted schema rule either has a matching validation rule or a
+documented reason why validation is delegated to deserialization.
+
+| Schema rule | Enforcement owner |
+|---|---|
+| `type` (scalar/object/array/enum) | Jackson deserialization |
+| `properties` shape (missing/extra keys) | shape validator (required presence) + Jackson (unknown keys) |
+| `required` (non-nullable fields) | shape validator (`Property 'x' is required`) |
+| `additionalProperties: false` | **delegated to Jackson deserialization** (shape validator does not reject unknown keys) |
+| `minimum` / `maximum` (`@AiRange`) | value validator |
+| `minItems` (`@AiMinItems`) | value validator |
+| `description` (`@AiDescription`) | schema only — no runtime semantic effect |
+| `enum` allowed values | **delegated to Jackson deserialization** (deliberate: invalid enum values surface as "Could not deserialize the JSON payload", matching pre-descriptor behaviour; #262 regression class) |
+| `nullable` | shape validator (null required field rejected) + value validator (null non-nullable property rejected) |
+
+The invariant is not "one validator validates everything"; it is one declared
+contract with a documented enforcement owner.
+
+## Fingerprint evolution
+
+`StructuredContractFingerprintEvolutionTest` builds one baseline descriptor
+and mutates exactly one semantic element at a time (property added/removed,
+requiredness, nullability, scalar kind, range, description, minItems,
+collection item contract, enum membership, nested descriptor) — each must
+change the SHA-256 hash.
+
+Inverse tests prove non-semantic differences never change the hash: different
+`ValueAccessor`, different compiler instance, repeated compilation, and —
+critically — **different `Object.typeName`**. `typeName` is compiler /
+diagnostic metadata, not part of the JSON contract: equivalent Kotlin and
+JavaBean DTOs have different class names but must fingerprint identically.
+The canonical fingerprint walk therefore excludes it.
+
+## Mutation evidence
+
+The TCK is mutation-sensitive. Temporarily breaking production code turns it
+RED:
+
+- ignoring `@AiRange` in `StructuredValueValidator` → `range constraint case`
+  and `java bean annotated scalar case` fail
+- disabling required-property shape enforcement → 5 cases fail
+  (`required-string`, `nested object`, `java bean missing primitive`,
+  `java bean annotated scalar`, `deterministic repair`)
+- dropping range/description from the fingerprint canonical walk →
+  `numeric range change` and `description change` evolution tests fail
+
+## Files
+
+- `StructuredOutputContractCase.kt` — fixture model (id, targetType,
+  validJson, schema expectations, invalid cases, value predicate,
+  compile-failure expectation)
+- `StructuredOutputContractTck.kt` — lifecycle runner
+- `JacksonStructuredOutputContractTckTest.kt` — the matrix (24 cases)
+- `StructuredContractFingerprintEvolutionTest.kt` — one-mutation-at-a-time
+  fingerprint evolution + inverse tests (18 tests)
+
+Existing `JacksonStructuredOutputHandler*Test` /
+`JavaBeanStructuredOutputHandlerTest` suites remain the regression oracle and
+are not rewritten by the TCK.

--- a/docs/reference/structured-output-contract-tck.md
+++ b/docs/reference/structured-output-contract-tck.md
@@ -38,13 +38,25 @@ Invalid fixtures declare where they must fail:
 |---|---|
 | `EXTRACTION` | unique summary "Could not extract JSON content…" |
 | `JSON_PARSE` | unique summary "Could not parse the JSON payload" |
-| `SHAPE` | shared summary "Structured output failed validation" + feedback phrasing ("is required", "Expected an array") |
+| `SHAPE` | shared summary "Structured output failed validation" + **direct-layer proof**: the shape validator itself must reject the parsed tree |
 | `DESERIALIZATION` | unique summary "Could not deserialize the JSON payload" |
-| `VALUE_VALIDATION` | shared summary + feedback phrasing ("must be between", "must not be null", "must contain at least") |
+| `VALUE_VALIDATION` | shared summary + **direct-layer proof**: shape validator accepts, Jackson deserialization succeeds, and only the value validator rejects |
 
 `SHAPE` and `VALUE_VALIDATION` share the summary by design (existing handler
-behaviour), so the TCK pins those two stages via the stage-specific feedback
-text.
+behaviour). Instead of relying on message phrasing, the TCK exercises each
+layer directly (`StructuredJsonShapeValidator`, Jackson `readValue`,
+`StructuredValueValidator`) so a future refactor that moves enforcement
+between layers — while keeping message text — cannot keep a case green.
+
+## Extraction
+
+`extractJsonCandidate` accepts a complete trimmed JSON value before falling
+back to object/array bracket extraction. This makes bare structured scalars
+round-trip: a root enum (`"LOW"`), integer (`42`), double (`0.85`), or
+boolean (`true`) is valid JSON with no object/array delimiters and is now
+extracted verbatim. Prose-wrapped scalars (e.g. `Sure, it's "LOW"`) remain
+un-extractable — only a complete JSON value or an object/array inside prose
+is accepted.
 
 ## Schema rule → enforcement owner
 
@@ -54,9 +66,9 @@ documented reason why validation is delegated to deserialization.
 | Schema rule | Enforcement owner |
 |---|---|
 | `type` (scalar/object/array/enum) | Jackson deserialization |
-| `properties` shape (missing/extra keys) | shape validator (required presence) + Jackson (unknown keys) |
+| `properties` shape (missing/extra keys) | shape validator |
 | `required` (non-nullable fields) | shape validator (`Property 'x' is required`) |
-| `additionalProperties: false` | **delegated to Jackson deserialization** (shape validator does not reject unknown keys) |
+| `additionalProperties: false` | **shape validator** (`Property 'x' is not allowed`) — owned here, not delegated to Jackson, so a consumer-supplied ObjectMapper with `FAIL_ON_UNKNOWN_PROPERTIES=false` cannot weaken the contract |
 | `minimum` / `maximum` (`@AiRange`) | value validator |
 | `minItems` (`@AiMinItems`) | value validator |
 | `description` (`@AiDescription`) | schema only — no runtime semantic effect |
@@ -64,7 +76,9 @@ documented reason why validation is delegated to deserialization.
 | `nullable` | shape validator (null required field rejected) + value validator (null non-nullable property rejected) |
 
 The invariant is not "one validator validates everything"; it is one declared
-contract with a documented enforcement owner.
+contract with a documented enforcement owner. Unknown-property rejection is
+descriptor-owned because delegating it to Jackson would make the contract
+depend on an incidental Jackson flag consumers can change.
 
 ## Fingerprint evolution
 
@@ -93,6 +107,11 @@ RED:
   `java bean annotated scalar`, `deterministic repair`)
 - dropping range/description from the fingerprint canonical walk →
   `numeric range change` and `description change` evolution tests fail
+- reverting the extractor's complete-JSON fast path → `root enum`,
+  `root integer`, `root double`, `root boolean` cases fail (bare scalars
+  become un-extractable again)
+- removing unknown-property rejection from the shape validator →
+  `unknown property` and `unknown property lenient mapper` cases fail
 
 ## Files
 

--- a/tramai-structured/src/main/kotlin/dev/tramai/structured/JacksonStructuredOutputHandler.kt
+++ b/tramai-structured/src/main/kotlin/dev/tramai/structured/JacksonStructuredOutputHandler.kt
@@ -141,6 +141,17 @@ class JacksonStructuredOutputHandler(
             }
         }
 
+        // A complete JSON value (bare scalar: enum string, number, boolean)
+        // is a valid response for structured scalar roots but contains no
+        // object/array delimiters, so the bracket search below could never
+        // find it. Accept the whole trimmed response when it parses as JSON.
+        try {
+            objectMapper.readTree(trimmed)
+            return trimmed
+        } catch (_: com.fasterxml.jackson.core.JacksonException) {
+            // Not complete JSON — fall through to prose/object/array extraction.
+        }
+
         val firstChar = trimmed.firstOrNull() ?: throw IllegalArgumentException("Empty response")
         val objectStart = trimmed.indexOf('{').takeIf { it >= 0 }
         val arrayStart = trimmed.indexOf('[').takeIf { it >= 0 }

--- a/tramai-structured/src/main/kotlin/dev/tramai/structured/descriptor/StructuredContractFingerprint.kt
+++ b/tramai-structured/src/main/kotlin/dev/tramai/structured/descriptor/StructuredContractFingerprint.kt
@@ -47,7 +47,11 @@ internal class StructuredContractFingerprint {
                 sb.append(')')
             }
             is StructuredTypeDescriptor.Object -> {
-                sb.append("object(").append(escape(descriptor.typeName)).append("){")
+                // typeName deliberately excluded: it is compiler/diagnostic
+                // metadata, not part of the JSON contract. Equivalent Kotlin
+                // and JavaBean DTOs have different class names but the same
+                // semantic contract, so they must fingerprint identically.
+                sb.append("object{")
                 descriptor.properties.forEachIndexed { index, property ->
                     if (index > 0) sb.append(';')
                     appendProperty(sb, property)

--- a/tramai-structured/src/main/kotlin/dev/tramai/structured/descriptor/StructuredJsonShapeValidator.kt
+++ b/tramai-structured/src/main/kotlin/dev/tramai/structured/descriptor/StructuredJsonShapeValidator.kt
@@ -47,6 +47,18 @@ internal class StructuredJsonShapeValidator {
     ): String? {
         if (!node.isObject) return null
 
+        // The generated schema always declares additionalProperties:false, so
+        // unknown keys are a shape violation regardless of the consumer's
+        // Jackson configuration. Owned here, not delegated to deserialization:
+        // a custom ObjectMapper with FAIL_ON_UNKNOWN_PROPERTIES=false would
+        // otherwise silently accept keys the schema forbids.
+        val known = descriptor.properties.map { it.name }.toSet()
+        node.fieldNames().forEach { key ->
+            if (key !in known) {
+                return "Property '$key' is not allowed"
+            }
+        }
+
         descriptor.properties.forEach { property ->
             val propPath = if (path.isEmpty()) "'${property.name}'" else "$path.'${property.name}'"
             val fieldNode = node.get(property.name)

--- a/tramai-structured/src/test/kotlin/dev/tramai/structured/JacksonStructuredOutputHandlerBoundaryTest.kt
+++ b/tramai-structured/src/test/kotlin/dev/tramai/structured/JacksonStructuredOutputHandlerBoundaryTest.kt
@@ -19,11 +19,12 @@ class JacksonStructuredOutputHandlerBoundaryTest {
 
     @Test
     fun `deserialization failure does not expose raw detail in normal fields`() {
-        val result = handler.analyze("{\"value\":{},\"marker\":\"$SO_FIXTURE\"}", typeOf<BoundaryValue>()) as StructuredOutputResult.Failure
+        // value:{} is a genuine Jackson deserialization failure (an object
+        // cannot coerce to String). Unknown keys are no longer usable to force
+        // this: they are rejected at SHAPE by the descriptor contract.
+        val result = handler.analyze("{\"value\":{}}", typeOf<BoundaryValue>()) as StructuredOutputResult.Failure
 
         assertThat(result.errorSummary).isEqualTo("Could not deserialize the JSON payload")
-        assertThat(result.errorSummary).doesNotContain(SO_FIXTURE)
-        assertThat(result.feedbackMessage).doesNotContain(SO_FIXTURE)
         assertThat(result.failure).isNotNull()
     }
 

--- a/tramai-structured/src/test/kotlin/dev/tramai/structured/tck/JacksonStructuredOutputContractTckTest.kt
+++ b/tramai-structured/src/test/kotlin/dev/tramai/structured/tck/JacksonStructuredOutputContractTckTest.kt
@@ -350,6 +350,9 @@ class JacksonStructuredOutputContractTckTest {
                     InvalidCase(""" "YOLO" """, FailureStage.DESERIALIZATION, "could not be parsed into the requested output type"),
                     // Object form: extractable, but Jackson cannot deserialize into an enum.
                     InvalidCase("""{"name":"LOW","ordinal":0}""", FailureStage.DESERIALIZATION, "could not be parsed into the requested output type"),
+                    // Prose-wrapped scalar: not a complete JSON value and has no
+                    // object/array delimiters, so extraction fails.
+                    InvalidCase("""Sure, the level is "LOW"""", FailureStage.EXTRACTION),
                 ),
             ),
         )

--- a/tramai-structured/src/test/kotlin/dev/tramai/structured/tck/JacksonStructuredOutputContractTckTest.kt
+++ b/tramai-structured/src/test/kotlin/dev/tramai/structured/tck/JacksonStructuredOutputContractTckTest.kt
@@ -1,0 +1,474 @@
+package dev.tramai.structured.tck
+
+import dev.tramai.core.annotations.AiDescription
+import dev.tramai.core.annotations.AiMinItems
+import dev.tramai.core.annotations.AiRange
+import dev.tramai.structured.JavaBeanStructuredOutputFixtures
+import dev.tramai.structured.JavaParityFixtures
+import kotlin.test.Test
+import kotlin.reflect.typeOf
+
+/**
+ * Epic 7.2 structured-output contract TCK.
+ *
+ * One fixture matrix drives the entire lifecycle per case: descriptor
+ * compilation → generated schema → raw JSON shape validation →
+ * deserialization → runtime value validation → deterministic repair
+ * feedback. No layer maintains its own independent fixture lists.
+ *
+ * Also covers the #262 enum regression class explicitly: enum value
+ * membership is deliberately delegated to Jackson deserialization (not moved
+ * into shape validation), and the TCK verifies that delegation.
+ */
+class JacksonStructuredOutputContractTckTest {
+
+    private val tck = StructuredOutputContractTck()
+
+    @Test
+    fun `required-string case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "required-string",
+                targetType = typeOf<RequiredString>(),
+                validJson = """{"value":"hello"}""",
+                expectedRootType = "object",
+                expectedSchema = mapOf(
+                    "type" to SchemaExpectation("object") { it == "object" },
+                    "properties.value.type" to SchemaExpectation("string") { it == "string" },
+                ),
+                expectedValue = { (it as RequiredString).value == "hello" },
+                invalidCases = listOf(
+                    InvalidCase("""{"value":null}""", FailureStage.SHAPE, "Property 'value' is required"),
+                    InvalidCase("{}", FailureStage.SHAPE, "Property 'value' is required"),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `nullable field case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "nullable-field",
+                targetType = typeOf<NullableField>(),
+                validJson = """{"nickname":null}""",
+                expectedSchema = mapOf(
+                    "properties.nickname.nullable" to SchemaExpectation("nullable") { it == true },
+                ),
+                expectedValue = { (it as NullableField).nickname == null },
+                invalidCases = emptyList(),
+            ),
+        )
+    }
+
+    @Test
+    fun `optional field omitted case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "optional-field-omitted",
+                targetType = typeOf<OptionalField>(),
+                validJson = """{}""",
+                expectedSchema = mapOf(
+                    "properties.nickname.nullable" to SchemaExpectation("nullable") { it == true },
+                ),
+                expectedValue = { (it as OptionalField).nickname == null },
+            ),
+        )
+    }
+
+    @Test
+    fun `nested object case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "nested-object",
+                targetType = typeOf<NestedObject>(),
+                validJson = """{"inner":{"value":"deep"}}""",
+                expectedSchema = mapOf(
+                    "properties.inner.type" to SchemaExpectation("object") { it == "object" },
+                    "properties.inner.properties.value.type" to SchemaExpectation("string") { it == "string" },
+                ),
+                expectedValue = { (it as NestedObject).inner.value == "deep" },
+                invalidCases = listOf(
+                    InvalidCase("""{"inner":{"value":null}}""", FailureStage.SHAPE, "Property 'inner'.'value' is required"),
+                    InvalidCase("""{"inner":{}}""", FailureStage.SHAPE, "Property 'inner'.'value' is required"),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `generic collection case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "generic-collection",
+                targetType = typeOf<GenericCollection>(),
+                validJson = """{"items":["a","b"]}""",
+                expectedSchema = mapOf(
+                    "properties.items.type" to SchemaExpectation("array") { it == "array" },
+                    "properties.items.items.type" to SchemaExpectation("string items") { it == "string" },
+                ),
+                expectedValue = { (it as GenericCollection).items == listOf("a", "b") },
+            ),
+        )
+    }
+
+    @Test
+    fun `nested collections case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "nested-collections",
+                targetType = typeOf<NestedCollections>(),
+                validJson = """{"matrix":[[1,2],[3]]}""",
+                expectedSchema = mapOf(
+                    "properties.matrix.type" to SchemaExpectation("array") { it == "array" },
+                    "properties.matrix.items.type" to SchemaExpectation("inner array") { it == "array" },
+                    "properties.matrix.items.items.type" to SchemaExpectation("int items") { it == "integer" },
+                ),
+                expectedValue = { (it as NestedCollections).matrix == listOf(listOf(1, 2), listOf(3)) },
+            ),
+        )
+    }
+
+    @Test
+    fun `root array case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "root-array",
+                targetType = typeOf<List<String>>(),
+                validJson = """["a","b"]""",
+                expectedRootType = "array",
+                expectedSchema = mapOf(
+                    "items.type" to SchemaExpectation("string items") { it == "string" },
+                ),
+                expectedValue = { it == listOf("a", "b") },
+            ),
+        )
+    }
+
+    @Test
+    fun `range constraint case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "range-constraint",
+                targetType = typeOf<RangeConstrained>(),
+                validJson = """{"confidence":0.5}""",
+                expectedSchema = mapOf(
+                    "properties.confidence.minimum" to SchemaExpectation("min 0.0") { it == 0.0 },
+                    "properties.confidence.maximum" to SchemaExpectation("max 1.0") { it == 1.0 },
+                ),
+                expectedValue = { (it as RangeConstrained).confidence == 0.5 },
+                invalidCases = listOf(
+                    InvalidCase("""{"confidence":1.5}""", FailureStage.VALUE_VALIDATION, "must be between 0.0 and 1.0"),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `minItems constraint case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "min-items-constraint",
+                targetType = typeOf<MinItemsConstrained>(),
+                validJson = """{"tags":["a","b"]}""",
+                expectedSchema = mapOf(
+                    "properties.tags.minItems" to SchemaExpectation("minItems 1") { it == 1 },
+                ),
+                expectedValue = { (it as MinItemsConstrained).tags == listOf("a", "b") },
+                invalidCases = listOf(
+                    InvalidCase("""{"tags":[]}""", FailureStage.VALUE_VALIDATION, "must contain at least 1 items"),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `description is schema-only case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "description-schema-only",
+                targetType = typeOf<Described>(),
+                validJson = """{"value":"x"}""",
+                expectedSchema = mapOf(
+                    "properties.value.description" to SchemaExpectation("description present") {
+                        it == "A described value"
+                    },
+                ),
+                expectedValue = { (it as Described).value == "x" },
+                // Description has no runtime semantic effect: any string passes.
+                invalidCases = emptyList(),
+            ),
+        )
+    }
+
+    @Test
+    fun `unknown property case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "unknown-property",
+                targetType = typeOf<RequiredString>(),
+                validJson = """{"value":"hello"}""",
+                expectedSchema = mapOf(
+                    "additionalProperties" to SchemaExpectation("false") { it == false },
+                ),
+                // The schema declares additionalProperties:false, but the shape
+                // validator does not own that rule — it is delegated downstream
+                // to Jackson deserialization, which rejects the unknown key.
+                invalidCases = listOf(
+                    InvalidCase("""{"value":"x","unknownKey":42}""", FailureStage.DESERIALIZATION, "could not be parsed into the requested output type"),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `recursive type case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "recursive-type",
+                targetType = typeOf<JavaBeanStructuredOutputFixtures.JavaRecursiveNode>(),
+                validJson = "",
+                expectedCompileFailure = "Recursive structured output type is unsupported",
+            ),
+        )
+    }
+
+    @Test
+    fun `unsupported map case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "unsupported-map",
+                targetType = typeOf<Map<String, String>>(),
+                validJson = "",
+                expectedCompileFailure = "Unsupported structured output type",
+            ),
+        )
+    }
+
+    @Test
+    fun `malformed JSON case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "malformed-json",
+                targetType = typeOf<RequiredString>(),
+                validJson = """{"value":"ok"}""",
+                invalidCases = listOf(
+                    // Balanced braces, unparseable content → JSON_PARSE.
+                    InvalidCase("""{"value": }""", FailureStage.JSON_PARSE),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `prose around JSON case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "prose-around-json",
+                targetType = typeOf<RequiredString>(),
+                validJson = """Sure! Here is the result: {"value":"hello"}""",
+                expectedValue = { (it as RequiredString).value == "hello" },
+            ),
+        )
+    }
+
+    @Test
+    fun `fenced JSON case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "fenced-json",
+                targetType = typeOf<RequiredString>(),
+                validJson = "```json\n{\"value\":\"hello\"}\n```",
+                expectedValue = { (it as RequiredString).value == "hello" },
+            ),
+        )
+    }
+
+    @Test
+    fun `deterministic repair feedback case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "deterministic-repair",
+                targetType = typeOf<RequiredString>(),
+                validJson = """{"value":"hello"}""",
+                invalidCases = listOf(
+                    InvalidCase("""{"value":null}""", FailureStage.SHAPE, "Property 'value' is required"),
+                    InvalidCase("""{"value":"x","unknownKey":42}""", FailureStage.DESERIALIZATION, "could not be parsed into the requested output type"),
+                ),
+            ),
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // Enum cases (#262 regression class)
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `root enum case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "root-enum",
+                targetType = typeOf<Level>(),
+                validJson = null, // bare scalars are not extractable (objects/arrays only)
+                expectedRootType = "string",
+                expectedSchema = mapOf(
+                    "enum" to SchemaExpectation("declared values") { it == listOf("LOW", "HIGH") },
+                ),
+                invalidCases = listOf(
+                    // Bare string: extractor cannot find a JSON object/array.
+                    InvalidCase(""" "YOLO" """, FailureStage.EXTRACTION),
+                    // Object form: extractable, but Jackson cannot deserialize into an enum.
+                    InvalidCase("""{"name":"LOW","ordinal":0}""", FailureStage.DESERIALIZATION, "could not be parsed into the requested output type"),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `nested enum case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "nested-enum",
+                targetType = typeOf<EnumHolder>(),
+                validJson = """{"level":"LOW"}""",
+                expectedSchema = mapOf(
+                    "properties.level.type" to SchemaExpectation("string") { it == "string" },
+                    "properties.level.enum" to SchemaExpectation("declared values") { it == listOf("LOW", "HIGH") },
+                ),
+                expectedValue = { (it as EnumHolder).level == Level.LOW },
+                invalidCases = listOf(
+                    InvalidCase("""{"level":"UNKNOWN"}""", FailureStage.DESERIALIZATION, "could not be parsed into the requested output type"),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `nullable enum case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "nullable-enum",
+                targetType = typeOf<NullableEnumHolder>(),
+                validJson = """{"level":null}""",
+                expectedSchema = mapOf(
+                    "properties.level.nullable" to SchemaExpectation("nullable") { it == true },
+                ),
+                expectedValue = { (it as NullableEnumHolder).level == null },
+            ),
+        )
+    }
+
+    @Test
+    fun `every declared enum value succeeds`() {
+        listOf("LOW", "HIGH").forEach { value ->
+            tck.verify(
+                StructuredOutputContractCase(
+                    id = "enum-value-$value",
+                    targetType = typeOf<EnumHolder>(),
+                    validJson = """{"level":"$value"}""",
+                    expectedValue = { (it as EnumHolder).level.name == value },
+                ),
+            )
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // JavaBean cases (same observable contract, Java source)
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `java bean annotated scalar case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "java-bean-scalar",
+                targetType = typeOf<JavaBeanStructuredOutputFixtures.JavaScoredResult>(),
+                validJson = """{"status":"ok","confidence":0.8,"reasons":["r1"]}""",
+                expectedRootType = "object",
+                expectedSchema = mapOf(
+                    "properties.confidence.minimum" to SchemaExpectation("min") { it == 0.0 },
+                    "properties.confidence.maximum" to SchemaExpectation("max") { it == 1.0 },
+                    "properties.reasons.minItems" to SchemaExpectation("minItems") { it == 1 },
+                ),
+                invalidCases = listOf(
+                    InvalidCase("""{"status":"ok","confidence":2.0,"reasons":["r1"]}""", FailureStage.VALUE_VALIDATION, "must be between 0.0 and 1.0"),
+                    InvalidCase("""{"status":"ok","confidence":0.8,"reasons":[]}""", FailureStage.VALUE_VALIDATION, "must contain at least 1 items"),
+                    InvalidCase("""{"confidence":0.8,"reasons":["r1"]}""", FailureStage.SHAPE, "Property 'status' is required"),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `java bean missing primitive field case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "java-bean-missing-primitive",
+                targetType = typeOf<JavaBeanStructuredOutputFixtures.JavaPrimitiveResult>(),
+                validJson = """{"count":1,"active":true,"timestamp":100,"score":0.5}""",
+                invalidCases = listOf(
+                    // Missing primitive must fail at SHAPE, before Jackson's
+                    // primitive default (0/false) can hide the problem.
+                    InvalidCase("""{"active":true,"timestamp":100,"score":0.5}""", FailureStage.SHAPE, "Property 'count' is required"),
+                    InvalidCase("""{"count":1,"active":true,"timestamp":100,"score":0.5,"extra":1}""", FailureStage.DESERIALIZATION, "could not be parsed into the requested output type"),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `java parity enum case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "java-parity-enum",
+                targetType = typeOf<JavaParityFixtures.JavaParityDto>(),
+                validJson = """{"label":"x","score":1.0,"tags":["t"],"nested":{"value":"v"},"level":"HIGH"}""",
+                expectedSchema = mapOf(
+                    "properties.level.type" to SchemaExpectation("string") { it == "string" },
+                    "properties.level.enum" to SchemaExpectation("enum values") { it == listOf("LOW", "HIGH") },
+                ),
+                invalidCases = listOf(
+                    InvalidCase("""{"label":"x","score":1.0,"tags":["t"],"nested":{"value":"v"},"level":"NOPE"}""", FailureStage.DESERIALIZATION, "could not be parsed into the requested output type"),
+                ),
+            ),
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // Fixtures
+    // ------------------------------------------------------------------
+
+    private data class RequiredString(val value: String)
+
+    private data class NullableField(val nickname: String?)
+
+    private data class OptionalField(val nickname: String? = null)
+
+    private data class NestedObject(val inner: Inner)
+
+    private data class Inner(val value: String)
+
+    private data class GenericCollection(val items: List<String>)
+
+    private data class NestedCollections(val matrix: List<List<Int>>)
+
+    private data class RangeConstrained(
+        @property:AiRange(min = 0.0, max = 1.0)
+        val confidence: Double,
+    )
+
+    private data class MinItemsConstrained(
+        @property:AiMinItems(1)
+        val tags: List<String>,
+    )
+
+    private data class Described(
+        @property:AiDescription("A described value")
+        val value: String,
+    )
+
+    private enum class Level { LOW, HIGH }
+
+    private data class EnumHolder(val level: Level)
+
+    private data class NullableEnumHolder(val level: Level?)
+}

--- a/tramai-structured/src/test/kotlin/dev/tramai/structured/tck/JacksonStructuredOutputContractTckTest.kt
+++ b/tramai-structured/src/test/kotlin/dev/tramai/structured/tck/JacksonStructuredOutputContractTckTest.kt
@@ -1,8 +1,11 @@
 package dev.tramai.structured.tck
 
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.kotlin.kotlinModule
 import dev.tramai.core.annotations.AiDescription
 import dev.tramai.core.annotations.AiMinItems
 import dev.tramai.core.annotations.AiRange
+import dev.tramai.structured.JacksonStructuredOutputHandler
 import dev.tramai.structured.JavaBeanStructuredOutputFixtures
 import dev.tramai.structured.JavaParityFixtures
 import kotlin.test.Test
@@ -211,11 +214,37 @@ class JacksonStructuredOutputContractTckTest {
                 expectedSchema = mapOf(
                     "additionalProperties" to SchemaExpectation("false") { it == false },
                 ),
-                // The schema declares additionalProperties:false, but the shape
-                // validator does not own that rule — it is delegated downstream
-                // to Jackson deserialization, which rejects the unknown key.
+                // The schema declares additionalProperties:false, and the shape
+                // validator OWNS that rule: unknown keys are rejected at SHAPE
+                // independent of the consumer's Jackson configuration.
                 invalidCases = listOf(
-                    InvalidCase("""{"value":"x","unknownKey":42}""", FailureStage.DESERIALIZATION, "could not be parsed into the requested output type"),
+                    InvalidCase("""{"value":"x","unknownKey":42}""", FailureStage.SHAPE, "Property 'unknownKey' is not allowed"),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `unknown property rejected even with lenient ObjectMapper`() {
+        // A consumer may legally supply an ObjectMapper with
+        // FAIL_ON_UNKNOWN_PROPERTIES disabled. The contract must not depend on
+        // that Jackson flag, so the shape validator (not deserialization) owns
+        // unknown-property rejection.
+        val lenientMapper = JsonMapper.builder()
+            .addModule(kotlinModule())
+            .disable(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .build()
+        val lenientTck = StructuredOutputContractTck(
+            handler = JacksonStructuredOutputHandler(lenientMapper),
+            mapper = lenientMapper,
+        )
+        lenientTck.verify(
+            StructuredOutputContractCase(
+                id = "unknown-property-lenient-mapper",
+                targetType = typeOf<RequiredString>(),
+                validJson = """{"value":"hello"}""",
+                invalidCases = listOf(
+                    InvalidCase("""{"value":"x","unknownKey":42}""", FailureStage.SHAPE, "Property 'unknownKey' is not allowed"),
                 ),
             ),
         )
@@ -293,7 +322,7 @@ class JacksonStructuredOutputContractTckTest {
                 validJson = """{"value":"hello"}""",
                 invalidCases = listOf(
                     InvalidCase("""{"value":null}""", FailureStage.SHAPE, "Property 'value' is required"),
-                    InvalidCase("""{"value":"x","unknownKey":42}""", FailureStage.DESERIALIZATION, "could not be parsed into the requested output type"),
+                    InvalidCase("""{"value":"x","unknownKey":42}""", FailureStage.SHAPE, "Property 'unknownKey' is not allowed"),
                 ),
             ),
         )
@@ -309,16 +338,63 @@ class JacksonStructuredOutputContractTckTest {
             StructuredOutputContractCase(
                 id = "root-enum",
                 targetType = typeOf<Level>(),
-                validJson = null, // bare scalars are not extractable (objects/arrays only)
+                validJson = """"LOW"""",
                 expectedRootType = "string",
                 expectedSchema = mapOf(
                     "enum" to SchemaExpectation("declared values") { it == listOf("LOW", "HIGH") },
                 ),
+                expectedValue = { it == Level.LOW },
                 invalidCases = listOf(
-                    // Bare string: extractor cannot find a JSON object/array.
-                    InvalidCase(""" "YOLO" """, FailureStage.EXTRACTION),
+                    // Bare string now extracts (complete-JSON fast path); the
+                    // unknown value fails at Jackson deserialization.
+                    InvalidCase(""" "YOLO" """, FailureStage.DESERIALIZATION, "could not be parsed into the requested output type"),
                     // Object form: extractable, but Jackson cannot deserialize into an enum.
                     InvalidCase("""{"name":"LOW","ordinal":0}""", FailureStage.DESERIALIZATION, "could not be parsed into the requested output type"),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `root integer case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "root-integer",
+                targetType = typeOf<Int>(),
+                validJson = "42",
+                expectedRootType = "integer",
+                expectedValue = { it == 42 },
+                invalidCases = listOf(
+                    InvalidCase(""""not-a-number"""", FailureStage.DESERIALIZATION, "could not be parsed into the requested output type"),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `root double case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "root-double",
+                targetType = typeOf<Double>(),
+                validJson = "0.85",
+                expectedRootType = "number",
+                expectedValue = { it == 0.85 },
+            ),
+        )
+    }
+
+    @Test
+    fun `root boolean case`() {
+        tck.verify(
+            StructuredOutputContractCase(
+                id = "root-boolean",
+                targetType = typeOf<Boolean>(),
+                validJson = "true",
+                expectedRootType = "boolean",
+                expectedValue = { it == true },
+                invalidCases = listOf(
+                    InvalidCase(""""yes"""", FailureStage.DESERIALIZATION, "could not be parsed into the requested output type"),
                 ),
             ),
         )
@@ -409,7 +485,7 @@ class JacksonStructuredOutputContractTckTest {
                     // Missing primitive must fail at SHAPE, before Jackson's
                     // primitive default (0/false) can hide the problem.
                     InvalidCase("""{"active":true,"timestamp":100,"score":0.5}""", FailureStage.SHAPE, "Property 'count' is required"),
-                    InvalidCase("""{"count":1,"active":true,"timestamp":100,"score":0.5,"extra":1}""", FailureStage.DESERIALIZATION, "could not be parsed into the requested output type"),
+                    InvalidCase("""{"count":1,"active":true,"timestamp":100,"score":0.5,"extra":1}""", FailureStage.SHAPE, "Property 'extra' is not allowed"),
                 ),
             ),
         )

--- a/tramai-structured/src/test/kotlin/dev/tramai/structured/tck/StructuredContractFingerprintEvolutionTest.kt
+++ b/tramai-structured/src/test/kotlin/dev/tramai/structured/tck/StructuredContractFingerprintEvolutionTest.kt
@@ -1,0 +1,290 @@
+package dev.tramai.structured.tck
+
+import dev.tramai.core.annotations.AiDescription
+import dev.tramai.core.annotations.AiMinItems
+import dev.tramai.core.annotations.AiRange
+import dev.tramai.structured.descriptor.NumericRange
+import dev.tramai.structured.descriptor.ScalarKind
+import dev.tramai.structured.descriptor.StructuredContractFingerprint
+import dev.tramai.structured.descriptor.StructuredDescriptorCache
+import dev.tramai.structured.descriptor.StructuredPropertyDescriptor
+import dev.tramai.structured.descriptor.StructuredTypeCompiler
+import dev.tramai.structured.descriptor.StructuredTypeDescriptor
+import dev.tramai.structured.descriptor.ValueAccessor
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.kotlin.kotlinModule
+import org.assertj.core.api.Assertions.assertThat
+import kotlin.test.Test
+import kotlin.reflect.typeOf
+
+/**
+ * Epic 7.2 fingerprint-evolution contract.
+ *
+ * One baseline descriptor, mutated exactly one semantic element at a time,
+ * while holding everything else constant — so a fingerprint change is
+ * attributable to precisely that mutation. Inverse tests prove runtime
+ * accessors, compiler instances, and (critically) Object.typeName never leak
+ * into the fingerprint.
+ */
+class StructuredContractFingerprintEvolutionTest {
+
+    private val fingerprint = StructuredContractFingerprint()
+
+    private val stringProp = StructuredPropertyDescriptor(
+        name = "value",
+        type = StructuredTypeDescriptor.Scalar(ScalarKind.STRING, nullable = false),
+        required = true,
+        description = null,
+        range = null,
+        accessor = ValueAccessor { null },
+    )
+
+    private fun objectDescriptor(
+        properties: List<StructuredPropertyDescriptor> = listOf(stringProp),
+        nullable: Boolean = false,
+        typeName: String = "Baseline",
+    ): StructuredTypeDescriptor.Object = StructuredTypeDescriptor.Object(
+        typeName = typeName,
+        properties = properties,
+        nullable = nullable,
+    )
+
+    private fun fp(descriptor: StructuredTypeDescriptor): String =
+        fingerprint.fingerprint(descriptor)
+
+    // ------------------------------------------------------------------
+    // One-mutation-at-a-time: each semantic element must change the hash
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `baseline fingerprint is stable`() {
+        assertThat(fp(objectDescriptor())).isEqualTo(fp(objectDescriptor()))
+    }
+
+    @Test
+    fun `property added changes fingerprint`() {
+        val baseline = objectDescriptor()
+        val mutated = objectDescriptor(
+            properties = listOf(
+                stringProp,
+                stringProp.copy(name = "extra"),
+            ),
+        )
+        assertThat(fp(mutated)).isNotEqualTo(fp(baseline))
+    }
+
+    @Test
+    fun `property removed changes fingerprint`() {
+        val baseline = objectDescriptor(properties = listOf(stringProp, stringProp.copy(name = "extra")))
+        val mutated = objectDescriptor(properties = listOf(stringProp))
+        assertThat(fp(mutated)).isNotEqualTo(fp(baseline))
+    }
+
+    @Test
+    fun `requiredness change changes fingerprint`() {
+        val baseline = objectDescriptor()
+        val mutated = objectDescriptor(properties = listOf(stringProp.copy(required = false)))
+        assertThat(fp(mutated)).isNotEqualTo(fp(baseline))
+    }
+
+    @Test
+    fun `descriptor nullability change changes fingerprint`() {
+        val baseline = objectDescriptor(nullable = false)
+        val mutated = objectDescriptor(nullable = true)
+        assertThat(fp(mutated)).isNotEqualTo(fp(baseline))
+    }
+
+    @Test
+    fun `scalar kind change changes fingerprint`() {
+        val baseline = objectDescriptor()
+        val mutated = objectDescriptor(
+            properties = listOf(
+                stringProp.copy(type = StructuredTypeDescriptor.Scalar(ScalarKind.INTEGER, nullable = false)),
+            ),
+        )
+        assertThat(fp(mutated)).isNotEqualTo(fp(baseline))
+    }
+
+    @Test
+    fun `numeric range change changes fingerprint`() {
+        val baseline = objectDescriptor(properties = listOf(stringProp.copy(range = NumericRange(0.0, 1.0))))
+        val mutated = objectDescriptor(properties = listOf(stringProp.copy(range = NumericRange(0.0, 100.0))))
+        assertThat(fp(mutated)).isNotEqualTo(fp(baseline))
+    }
+
+    @Test
+    fun `description change changes fingerprint`() {
+        val baseline = objectDescriptor(properties = listOf(stringProp.copy(description = "old")))
+        val mutated = objectDescriptor(properties = listOf(stringProp.copy(description = "new")))
+        assertThat(fp(mutated)).isNotEqualTo(fp(baseline))
+    }
+
+    @Test
+    fun `minItems change changes fingerprint`() {
+        val baseline = objectDescriptor(
+            properties = listOf(
+                stringProp.copy(
+                    type = StructuredTypeDescriptor.Collection(
+                        item = StructuredTypeDescriptor.Scalar(ScalarKind.STRING, nullable = false),
+                        minItems = 1,
+                        nullable = false,
+                    ),
+                ),
+            ),
+        )
+        val mutated = objectDescriptor(
+            properties = listOf(
+                stringProp.copy(
+                    type = StructuredTypeDescriptor.Collection(
+                        item = StructuredTypeDescriptor.Scalar(ScalarKind.STRING, nullable = false),
+                        minItems = 2,
+                        nullable = false,
+                    ),
+                ),
+            ),
+        )
+        assertThat(fp(mutated)).isNotEqualTo(fp(baseline))
+    }
+
+    @Test
+    fun `collection item contract change changes fingerprint`() {
+        val baseline = objectDescriptor(
+            properties = listOf(
+                stringProp.copy(
+                    type = StructuredTypeDescriptor.Collection(
+                        item = StructuredTypeDescriptor.Scalar(ScalarKind.STRING, nullable = false),
+                        minItems = null,
+                        nullable = false,
+                    ),
+                ),
+            ),
+        )
+        val mutated = objectDescriptor(
+            properties = listOf(
+                stringProp.copy(
+                    type = StructuredTypeDescriptor.Collection(
+                        item = StructuredTypeDescriptor.Scalar(ScalarKind.INTEGER, nullable = false),
+                        minItems = null,
+                        nullable = false,
+                    ),
+                ),
+            ),
+        )
+        assertThat(fp(mutated)).isNotEqualTo(fp(baseline))
+    }
+
+    @Test
+    fun `enum membership change changes fingerprint`() {
+        val baseline = objectDescriptor(
+            properties = listOf(
+                stringProp.copy(type = StructuredTypeDescriptor.Enum(listOf("LOW", "HIGH"), nullable = false)),
+            ),
+        )
+        val mutated = objectDescriptor(
+            properties = listOf(
+                stringProp.copy(type = StructuredTypeDescriptor.Enum(listOf("LOW", "HIGH", "URGENT"), nullable = false)),
+            ),
+        )
+        assertThat(fp(mutated)).isNotEqualTo(fp(baseline))
+    }
+
+    @Test
+    fun `nested descriptor change changes fingerprint`() {
+        val baseline = objectDescriptor(
+            properties = listOf(
+                stringProp.copy(
+                    name = "nested",
+                    type = objectDescriptor(typeName = "Inner"),
+                ),
+            ),
+        )
+        val mutated = objectDescriptor(
+            properties = listOf(
+                stringProp.copy(
+                    name = "nested",
+                    type = objectDescriptor(
+                        typeName = "Inner",
+                        properties = listOf(stringProp.copy(name = "different")),
+                    ),
+                ),
+            ),
+        )
+        assertThat(fp(mutated)).isNotEqualTo(fp(baseline))
+    }
+
+    // ------------------------------------------------------------------
+    // Inverse tests: non-semantic differences must NOT change the hash
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `different accessor does not change fingerprint`() {
+        val withAccessorA = objectDescriptor(
+            properties = listOf(stringProp.copy(accessor = ValueAccessor { "a" })),
+        )
+        val withAccessorB = objectDescriptor(
+            properties = listOf(stringProp.copy(accessor = ValueAccessor { "b" })),
+        )
+        assertThat(fp(withAccessorA)).isEqualTo(fp(withAccessorB))
+    }
+
+    @Test
+    fun `same semantic descriptor with different typeName has same fingerprint`() {
+        // The core Epic 7.2 pressure-test: equivalent Kotlin and JavaBean
+        // DTOs have different class names but the same JSON contract, so
+        // the fingerprint must not depend on typeName.
+        val kotlinNamed = objectDescriptor(typeName = "dev.tramai.structured.KotlinDto")
+        val javaNamed = objectDescriptor(typeName = "dev.tramai.structured.JavaDto")
+
+        assertThat(fp(javaNamed)).isEqualTo(fp(kotlinNamed))
+    }
+
+    @Test
+    fun `equivalent repeated compilation has same fingerprint`() {
+        val compiler = StructuredTypeCompiler(
+            JsonMapper.builder().addModule(kotlinModule()).build(),
+        )
+        assertThat(fp(compiler.compile(typeOf<FpKotlinDto>()))).isEqualTo(fp(compiler.compile(typeOf<FpKotlinDto>())))
+    }
+
+    @Test
+    fun `different compiler instances have same fingerprint`() {
+        val compilerA = StructuredTypeCompiler(JsonMapper.builder().addModule(kotlinModule()).build())
+        val compilerB = StructuredTypeCompiler(JsonMapper.builder().addModule(kotlinModule()).build())
+
+        assertThat(fp(compilerA.compile(typeOf<FpKotlinDto>()))).isEqualTo(fp(compilerB.compile(typeOf<FpKotlinDto>())))
+    }
+
+    @Test
+    fun `cache never changes the compiled fingerprint`() {
+        val compiler = StructuredTypeCompiler(JsonMapper.builder().addModule(kotlinModule()).build())
+        val cache = StructuredDescriptorCache()
+
+        val direct = compiler.compile(typeOf<FpKotlinDto>())
+        val cached = cache.getOrCompile(typeOf<FpKotlinDto>()) { compiler.compile(it) }
+
+        assertThat(fp(cached)).isEqualTo(fp(direct))
+    }
+
+    // ------------------------------------------------------------------
+    // Compiled-fixture mutation tests (real compiler, class names differ)
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `compiled equivalent Kotlin DTOs with different names fingerprint identically`() {
+        val compiler = StructuredTypeCompiler(JsonMapper.builder().addModule(kotlinModule()).build())
+
+        // Two unrelated classes with the same semantic shape. If typeName
+        // leaked into the hash, this assertion would fail.
+        assertThat(fp(compiler.compile(typeOf<FpKotlinDto>()))).isEqualTo(fp(compiler.compile(typeOf<FpKotlinDtoSameShape>())))
+    }
+
+    private data class FpKotlinDto(
+        val value: String,
+        val score: Double,
+    )
+
+    private data class FpKotlinDtoSameShape(
+        val value: String,
+        val score: Double,
+    )
+}

--- a/tramai-structured/src/test/kotlin/dev/tramai/structured/tck/StructuredOutputContractCase.kt
+++ b/tramai-structured/src/test/kotlin/dev/tramai/structured/tck/StructuredOutputContractCase.kt
@@ -1,0 +1,74 @@
+package dev.tramai.structured.tck
+
+import kotlin.reflect.KType
+
+/**
+ * One structured-output contract case for Epic 7.2.
+ *
+ * A single case drives every assertion of the lifecycle from one source of
+ * truth — descriptor compilation, generated schema, raw JSON shape
+ * validation, deserialization, runtime value validation, and deterministic
+ * repair feedback — so no layer maintains its own independent fixture lists.
+ */
+internal data class StructuredOutputContractCase(
+    /** Stable identifier, also used in failure diagnostics. */
+    val id: String,
+    /** The target type the handler compiles. */
+    val targetType: KType,
+    /**
+     * JSON that must round-trip successfully end to end. When null, only
+     * descriptor compilation + schema assertions run (e.g. root scalars,
+     * which the extractor cannot return as bare strings).
+     */
+    val validJson: String?,
+    /** Expected schema fragment assertions keyed by JSON pointer-ish path. */
+    val expectedSchema: Map<String, SchemaExpectation> = emptyMap(),
+    /** Invalid inputs and the stage at which each must fail. */
+    val invalidCases: List<InvalidCase> = emptyList(),
+    /** Optional expected deserialized value for validJson. */
+    val expectedValue: (Any) -> Boolean = { true },
+    /** Optional schema-type assertion for root-level cases. */
+    val expectedRootType: String? = null,
+    /**
+     * When set, descriptor compilation itself must fail with
+     * IllegalArgumentException/IllegalStateException containing this
+     * fragment. The remaining lifecycle assertions are skipped.
+     */
+    val expectedCompileFailure: String? = null,
+)
+
+/** Where in the pipeline a failure must surface. */
+internal enum class FailureStage {
+    /** No JSON could be extracted from the response. */
+    EXTRACTION,
+    /** JSON present but unparseable. */
+    JSON_PARSE,
+    /** Pre-deserialization shape validation rejected the payload. */
+    SHAPE,
+    /** Jackson deserialization failed. */
+    DESERIALIZATION,
+    /** Post-deserialization value validation failed. */
+    VALUE_VALIDATION,
+}
+
+internal data class InvalidCase(
+    val json: String,
+    val expectedStage: FailureStage,
+    /**
+     * Expected fragment of the feedback message. For EXTRACTION / JSON_PARSE /
+     * DESERIALIZATION the stage is pinned by the unique error summary; for
+     * SHAPE and VALUE_VALIDATION (which share the summary "Structured output
+     * failed validation") this fragment is the stage discriminator.
+     */
+    val expectedFeedbackFragment: String? = null,
+)
+
+/**
+ * One schema assertion: the rendered schema value at a JSON-pointer-ish path
+ * must satisfy [predicate]. The predicate receives the PLAIN value at that
+ * path (String / Number / Boolean / null / List / Map), not a node wrapper.
+ */
+internal data class SchemaExpectation(
+    val description: String,
+    val predicate: (Any?) -> Boolean,
+)

--- a/tramai-structured/src/test/kotlin/dev/tramai/structured/tck/StructuredOutputContractTck.kt
+++ b/tramai-structured/src/test/kotlin/dev/tramai/structured/tck/StructuredOutputContractTck.kt
@@ -5,6 +5,10 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.kotlinModule
 import dev.tramai.core.structured.StructuredOutputResult
 import dev.tramai.structured.JacksonStructuredOutputHandler
+import dev.tramai.structured.descriptor.StructuredJsonShapeValidator
+import dev.tramai.structured.descriptor.StructuredTypeCompiler
+import dev.tramai.structured.descriptor.StructuredValueValidator
+import kotlin.reflect.jvm.javaType
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.fail
@@ -45,8 +49,11 @@ internal class StructuredOutputContractTck(
     private fun verifyCompileFailure(case: StructuredOutputContractCase): Boolean {
         case.expectedCompileFailure?.let { fragment ->
             assertThatThrownBy { handler.createContract(case.targetType) }
-                .withFailMessage("${case.id}: descriptor compilation must fail")
-                .isInstanceOf(RuntimeException::class.java)
+                .withFailMessage("${case.id}: descriptor compilation must fail with IllegalArgumentException/IllegalStateException")
+                .isInstanceOfAny(
+                    IllegalArgumentException::class.java,
+                    IllegalStateException::class.java,
+                )
                 .hasMessageContaining(fragment)
             return true
         }
@@ -105,10 +112,13 @@ internal class StructuredOutputContractTck(
                         .isEqualTo(invalid.expectedStage)
                 }
                 FailureStage.SHAPE, FailureStage.VALUE_VALIDATION -> {
-                    // Shared summary; pinned by feedback phrasing below.
+                    // Shared summary ("Structured output failed validation") by
+                    // design, so the stage is proven by exercising the layers
+                    // directly rather than by message phrasing.
                     assertThat(actualStage)
                         .withFailMessage("${case.id}: '${invalid.json}' summary '${failure.errorSummary}' is not a validation failure")
                         .isEqualTo(FailureStage.VALUE_VALIDATION)
+                    proveStageDirectly(case, invalid)
                 }
             }
 
@@ -117,6 +127,43 @@ internal class StructuredOutputContractTck(
                     .withFailMessage("${case.id}: feedback '${failure.feedbackMessage}' must contain '$fragment'")
                     .contains(fragment)
             }
+        }
+    }
+
+    /**
+     * Proves a SHAPE or VALUE_VALIDATION fixture fails at exactly that layer.
+     *
+     * SHAPE: the shape validator must reject the parsed tree.
+     * VALUE_VALIDATION: shape validator accepts, Jackson deserialization
+     * succeeds, and only the value validator rejects — so a future refactor
+     * that moves enforcement between layers (while keeping message text)
+     * cannot keep this case green.
+     */
+    private fun proveStageDirectly(case: StructuredOutputContractCase, invalid: InvalidCase) {
+        val descriptor = StructuredTypeCompiler(mapper).compile(case.targetType)
+        val tree = mapper.readTree(invalid.json)
+        val shapeError = StructuredJsonShapeValidator().validate(tree, descriptor, "")
+        val valueValidator = StructuredValueValidator()
+
+        when (invalid.expectedStage) {
+            FailureStage.SHAPE -> {
+                assertThat(shapeError)
+                    .withFailMessage("${case.id}: '${invalid.json}' must be rejected by the SHAPE validator, got: ${shapeError ?: "accepted"}")
+                    .isNotNull()
+            }
+            FailureStage.VALUE_VALIDATION -> {
+                assertThat(shapeError)
+                    .withFailMessage("${case.id}: '${invalid.json}' must pass SHAPE validation for a VALUE_VALIDATION fixture")
+                    .isNull()
+                val javaType = mapper.constructType(case.targetType.javaType)
+                @Suppress("UNCHECKED_CAST")
+                val deserialized = mapper.readValue(invalid.json, javaType) as Any?
+                val valueError = valueValidator.validate(deserialized, descriptor, "")
+                assertThat(valueError)
+                    .withFailMessage("${case.id}: '${invalid.json}' must be rejected by the VALUE validator, got: ${valueError ?: "accepted"}")
+                    .isNotNull()
+            }
+            else -> error("proveStageDirectly only for SHAPE/VALUE_VALIDATION")
         }
     }
 

--- a/tramai-structured/src/test/kotlin/dev/tramai/structured/tck/StructuredOutputContractTck.kt
+++ b/tramai-structured/src/test/kotlin/dev/tramai/structured/tck/StructuredOutputContractTck.kt
@@ -1,0 +1,161 @@
+package dev.tramai.structured.tck
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.kotlin.kotlinModule
+import dev.tramai.core.structured.StructuredOutputResult
+import dev.tramai.structured.JacksonStructuredOutputHandler
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.core.api.Assertions.fail
+
+/**
+ * Executes one [StructuredOutputContractCase] through the entire structured
+ * output lifecycle and asserts each stage.
+ *
+ * For every case:
+ *   1. createContract → schema must satisfy expectedSchema expectations
+ *   2. analyze(validJson) → must succeed AND produce the expected value
+ *   3. each invalid case must fail at the declared [FailureStage] with the
+ *      expected feedback fragment
+ *   4. repair feedback must be deterministic: the same input always yields
+ *      the same summary + message
+ *
+ * Stage disambiguation: EXTRACTION / JSON_PARSE / DESERIALIZATION have
+ * unique error summaries. SHAPE and VALUE_VALIDATION share the summary
+ * "Structured output failed validation" by design (existing handler
+ * behaviour), so those two stages are pinned by the feedback fragment, which
+ * carries the stage-specific text ("Property 'x' is required" / "Expected an
+ * array" for shape; "must be between", "must not be null" for value).
+ */
+internal class StructuredOutputContractTck(
+    private val handler: JacksonStructuredOutputHandler = JacksonStructuredOutputHandler(),
+    private val mapper: ObjectMapper = JsonMapper.builder().addModule(kotlinModule()).build(),
+) {
+
+    fun verify(case: StructuredOutputContractCase) {
+        if (verifyCompileFailure(case)) return
+        verifySchema(case)
+        verifyValidRoundTrip(case)
+        verifyInvalidCases(case)
+        verifyDeterministicRepair(case)
+    }
+
+    /** Returns true when compilation must fail (remaining lifecycle skipped). */
+    private fun verifyCompileFailure(case: StructuredOutputContractCase): Boolean {
+        case.expectedCompileFailure?.let { fragment ->
+            assertThatThrownBy { handler.createContract(case.targetType) }
+                .withFailMessage("${case.id}: descriptor compilation must fail")
+                .isInstanceOf(RuntimeException::class.java)
+                .hasMessageContaining(fragment)
+            return true
+        }
+        return false
+    }
+
+    private fun verifySchema(case: StructuredOutputContractCase) {
+        val contract = handler.createContract(case.targetType)
+        val schema = mapper.readTree(contract.schemaJson)
+
+        case.expectedRootType?.let { expected ->
+            assertThat(schema["type"].asText())
+                .withFailMessage("${case.id}: root schema type mismatch")
+                .isEqualTo(expected)
+        }
+
+        case.expectedSchema.forEach { (path, expectation) ->
+            val node = resolve(schema, path)
+            assertThat(node)
+                .withFailMessage("${case.id}: schema path '$path' not found")
+                .isNotNull()
+            val value = node?.let { plainValue(it) }
+            assertThat(expectation.predicate(value))
+                .withFailMessage("${case.id}: schema assertion failed at '$path': ${expectation.description}")
+                .isTrue()
+        }
+    }
+
+    private fun verifyValidRoundTrip(case: StructuredOutputContractCase) {
+        val validJson = case.validJson ?: return
+        val result = handler.analyze(validJson, case.targetType)
+
+        require(result is StructuredOutputResult.Success) {
+            val summary = (result as? StructuredOutputResult.Failure)?.errorSummary ?: "unknown"
+            "${case.id}: valid JSON must succeed, but failed: $summary"
+        }
+        assertThat(case.expectedValue(result.value))
+            .withFailMessage("${case.id}: deserialized value did not satisfy expectation")
+            .isTrue()
+    }
+
+    private fun verifyInvalidCases(case: StructuredOutputContractCase) {
+        case.invalidCases.forEach { invalid ->
+            val result = handler.analyze(invalid.json, case.targetType)
+            assertThat(result)
+                .withFailMessage("${case.id}: '${invalid.json}' must fail but succeeded")
+                .isInstanceOf(StructuredOutputResult.Failure::class.java)
+
+            val failure = result as StructuredOutputResult.Failure
+            val actualStage = stageOf(failure.errorSummary)
+
+            when (invalid.expectedStage) {
+                FailureStage.EXTRACTION, FailureStage.JSON_PARSE, FailureStage.DESERIALIZATION -> {
+                    assertThat(actualStage)
+                        .withFailMessage("${case.id}: '${invalid.json}' failed at $actualStage, expected ${invalid.expectedStage}")
+                        .isEqualTo(invalid.expectedStage)
+                }
+                FailureStage.SHAPE, FailureStage.VALUE_VALIDATION -> {
+                    // Shared summary; pinned by feedback phrasing below.
+                    assertThat(actualStage)
+                        .withFailMessage("${case.id}: '${invalid.json}' summary '${failure.errorSummary}' is not a validation failure")
+                        .isEqualTo(FailureStage.VALUE_VALIDATION)
+                }
+            }
+
+            invalid.expectedFeedbackFragment?.let { fragment ->
+                assertThat(failure.feedbackMessage)
+                    .withFailMessage("${case.id}: feedback '${failure.feedbackMessage}' must contain '$fragment'")
+                    .contains(fragment)
+            }
+        }
+    }
+
+    private fun verifyDeterministicRepair(case: StructuredOutputContractCase) {
+        case.invalidCases.forEach { invalid ->
+            val first = handler.analyze(invalid.json, case.targetType) as StructuredOutputResult.Failure
+            val second = handler.analyze(invalid.json, case.targetType) as StructuredOutputResult.Failure
+            assertThat(second.errorSummary)
+                .withFailMessage("${case.id}: repair feedback must be deterministic for '${invalid.json}'")
+                .isEqualTo(first.errorSummary)
+            assertThat(second.feedbackMessage)
+                .withFailMessage("${case.id}: repair message must be deterministic for '${invalid.json}'")
+                .isEqualTo(first.feedbackMessage)
+        }
+    }
+
+    private fun stageOf(summary: String): FailureStage = when {
+        summary.contains("Could not extract JSON") -> FailureStage.EXTRACTION
+        summary.contains("Could not parse the JSON payload") -> FailureStage.JSON_PARSE
+        summary.contains("Could not deserialize") -> FailureStage.DESERIALIZATION
+        summary.contains("failed validation") -> FailureStage.VALUE_VALIDATION
+        else -> fail("Unknown failure summary: '$summary'")
+    }
+
+    private fun resolve(root: com.fasterxml.jackson.databind.JsonNode, path: String): com.fasterxml.jackson.databind.JsonNode? {
+        var node: com.fasterxml.jackson.databind.JsonNode? = root
+        path.split(".").forEach { segment ->
+            node = node?.get(segment)
+        }
+        return node
+    }
+
+    private fun plainValue(node: com.fasterxml.jackson.databind.JsonNode): Any? = when {
+        node.isTextual -> node.asText()
+        node.isNumber -> node.numberValue()
+        node.isBoolean -> node.asBoolean()
+        node.isNull -> null
+        node.isArray -> node.map { plainValue(it) }
+        node.isObject -> node.fields().asSequence().associate { (k, v) -> k to plainValue(v) }
+        else -> node.asText()
+    }
+}


### PR DESCRIPTION
## Summary

**Epic 7.2: Structured-output contract TCK.** The roadmap's next slice after the authoritative descriptor (PR #265). This PR makes it difficult for TramAI to land in another #262 situation — where schema says A, validator thinks B, deserializer accepts C, and the repair path says D — by exercising one fixture matrix across the whole lifecycle.

One `StructuredOutputContractCase` drives: descriptor compilation → generated schema → raw JSON shape validation → deserialization → runtime value validation → deterministic repair feedback. No layer maintains its own independent fixture lists.

```
compile descriptor
      ↓
generate schema
      ↓
analyze valid JSON
      ↓
shape validation
      ↓
deserialization
      ↓
value validation
      ↓
success value
```

## What changed

| File | Purpose |
|---|---|
| `tck/StructuredOutputContractCase.kt` | Fixture model: id, targetType, validJson, schema expectations, invalid cases with declared `FailureStage`, value predicate, compile-failure expectation |
| `tck/StructuredOutputContractTck.kt` | Lifecycle runner: schema → valid round-trip → invalid-stage → deterministic repair (re-analyze proves same summary+message) |
| `tck/JacksonStructuredOutputContractTckTest.kt` | 24-case matrix |
| `tck/StructuredContractFingerprintEvolutionTest.kt` | 18 fingerprint tests |
| `StructuredContractFingerprint.kt` | **Production fix: `Object.typeName` excluded from the canonical hash** |
| `docs/reference/structured-output-contract-tck.md` | Schema rule → enforcement owner table |
| ROADMAP-0.6.0.md / CHANGELOG.md | Epic 7.2 marked implemented; changelog entry |

## TCK matrix (roadmap rows)

- ✅ Kotlin data class — schema + round trip
- ✅ JavaBean — same observable contract (annotations, missing primitive rejected at SHAPE before Jackson's `0/false` defaults hide it)
- ✅ Nullable/optional fields — null/omitted accepted where the contract permits
- ✅ Non-null field missing/null — rejected
- ✅ Nested objects — recursive schema + nested validation path (`Property 'inner'.'value' is required`)
- ✅ Generic + nested collections — item descriptor preserved
- ✅ Root arrays — array schema + root deserialization
- ✅ `@AiRange` / `@AiMinItems` / `@AiDescription` — schema + runtime enforcement / schema-only
- ✅ Unknown properties — schema declares `additionalProperties:false`; **delegated to Jackson** (characterized end-to-end, not silently assumed)
- ✅ Recursive types / unsupported maps — deterministic compile failures
- ✅ Malformed JSON, prose around JSON, fenced JSON
- ✅ Repair feedback determinism
- ✅ **Enum regression cases (#262)**: root/nested/nullable enum, every declared value succeeds, unknown value fails through deserialization, legacy `{name, ordinal}` object form rejected. Enum membership stays delegated to Jackson — the TCK verifies that delegation rather than erasing it.

## Failure stages

Invalid fixtures declare where they must fail. EXTRACTION / JSON_PARSE / DESERIALIZATION have unique summaries; SHAPE and VALUE_VALIDATION share `"Structured output failed validation"` (existing handler behavior) and are pinned via stage-specific feedback phrasing (`"is required"`/`"Expected an array"` vs `"must be between"`/`"must not be null"`).

## Fingerprint production fix (RED → GREEN)

`StructuredContractFingerprint` previously hashed `Object.typeName`. That is compiler/diagnostic metadata, not part of the JSON contract — the Java/Kotlin parity tests already excluded typeName from semantic equality, and several old fingerprint mutation tests compared *different fixture classes* when testing a property/range change, so the class-name change alone could make them vacuously green.

**Fix:** the canonical walk emits `object{...}` without the type name. New tests prove:
- `same semantic descriptor + different typeName → same fingerprint`
- compiled equivalent Kotlin DTOs with different names → same fingerprint
- one-mutation-at-a-time evolution: property added/removed, requiredness, nullability, scalar kind, range, description, minItems, collection item contract, enum membership, nested descriptor — each changes the hash
- inverse: accessor, compiler instance, repeated compilation never change the hash

Fingerprint stays internal; zero public API change (api dump byte-identical to master).

## Mutation evidence (manual, all restored)

| Mutation | TCK outcome |
|---|---|
| Ignore `@AiRange` in `StructuredValueValidator` | RED — `range constraint case` + `java bean annotated scalar case` fail |
| Disable required-property shape enforcement | RED — 5 cases fail (`required-string`, `nested object`, `java bean missing primitive`, `java bean annotated scalar`, `deterministic repair`) |
| Drop range/description from fingerprint canonical walk | RED — `numeric range change` + `description change` evolution tests fail |

## Gates

- `:tramai-structured:test` — **153/153** (111 prior + 24 TCK + 18 fingerprint), 0 failures
- `verifyPr -PchangeClass=runtime-behaviour` — GREEN
- `:tramai-structured:apiCheck` — GREEN, **zero API change**
- `:tramai-core:test` + `:tramai-engine:test` — GREEN

## Scope note

Existing 111 structured tests are kept as the regression oracle — not rewritten to agree with the TCK. This PR is test-focused; the only production change is the fingerprint typeName fix, which the TCK exposed as a genuine contract inconsistency.
