### PR TITLE
test(persistence): add ApprovalStore compatibility TCK — Epic 8.1a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@
 
 ### Added
 
+- **ApprovalStore compatibility TCK (PR #267, Epic 8.1a).** One shared
+  behavioral contract for every `ApprovalStore` implementation, in
+  tramai-testing testFixtures: `ApprovalStoreTck` runs **33 cases** —
+  creation/read (10: PENDING round-trip, missing-ID null, duplicate
+  conflict, non-zero version / non-PENDING / pre-populated decision /
+  consumption fields / blank ID / future requestedAt / invalid expiry all
+  rejected), transitions (10: APPROVED/DENIED with decided fields + version
+  1, expired→TIMED_OUT, timeout-before-expiry and approve/deny-after-expiry
+  rejected, terminal re-transition rejected, stale-version conflict,
+  missing-approval not-found, version increments exactly once),
+  consumption/replay (10: fresh consumption with replayed=false + consumed
+  fields + version 2, wrong token / wrong consumedBy / stale version /
+  PENDING / DENIED / TIMED_OUT / expired-unconsumed rejected, exact replay
+  returns the same durable record with no write and stays valid after
+  expiry, rejected consumption is non-mutating), and concurrency (3:
+  concurrent transition race — exactly one wins and one conflicts with
+  version 1; concurrent identical consumption — one fresh + one replay
+  receipt referencing the same durable record). Deterministic `MutableClock`
+  owned by the TCK (no sleeps, no `Instant.now()`); typed failure taxonomy
+  pinned (Conflict / NotFound / TokenRejected / NotConsumable /
+  IllegalTransition / IllegalArgumentException). Three runners execute the
+  same contract: `InMemoryApprovalStoreTckTest` (tramai-security),
+  `FileApprovalStoreTckTest` (tramai-persistence-file, encrypted temp-dir
+  harness), `JdbcApprovalStoreTckTest` (tramai-persistence-jdbc, PostgreSQL
+  testcontainers) — 33/33 each. `ApprovalStoreTckEnrollmentArchitectureTest`
+  scans every module's main source set for concrete `ApprovalStore`
+  implementations and requires a `<Store>TckTest` runner in the same module,
+  so a future `RedisApprovalStore` cannot merge unenrolled. Mutation
+  evidence (5, each restored): removing the expectedVersion check, allowing
+  terminal-state re-transitions, incrementing version during exact replay,
+  replacing consumedAt during exact replay, and allowing expired fresh
+  consumption each turn TCK cases RED. Zero production code changes (the
+  three stores already agree on the contract), zero public API change, no
+  persisted format or schema changes, no existing tests deleted — existing
+  suites remain the implementation-specific regression oracle (encryption,
+  permissions, corruption, record format for file; SQL schema, JSON mapping,
+  connection cleanup for JDBC). Epic 8.1 stays IN PROGRESS; continuation
+  store is the next slice (#268, Epic 8.1b). Reference:
+  `docs/reference/persistence-store-compatibility-contract.md`.
+
 - **Structured-output contract TCK (PR #266, Epic 7.2).** One reusable test
   kit drives the entire structured-output lifecycle per fixture — descriptor
   compilation → generated schema → raw JSON shape validation →

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,37 +6,48 @@
 
 - **ApprovalStore compatibility TCK (PR #267, Epic 8.1a).** One shared
   behavioral contract for every `ApprovalStore` implementation, in
-  tramai-testing testFixtures: `ApprovalStoreTck` runs **33 cases** —
+  tramai-testing testFixtures: `ApprovalStoreTck` runs **37 cases** —
   creation/read (10: PENDING round-trip, missing-ID null, duplicate
   conflict, non-zero version / non-PENDING / pre-populated decision /
   consumption fields / blank ID / future requestedAt / invalid expiry all
   rejected), transitions (10: APPROVED/DENIED with decided fields + version
   1, expired→TIMED_OUT, timeout-before-expiry and approve/deny-after-expiry
-  rejected, terminal re-transition rejected, stale-version conflict,
-  missing-approval not-found, version increments exactly once),
-  consumption/replay (10: fresh consumption with replayed=false + consumed
+  rejected, terminal re-transition rejected for every terminal status,
+  stale-version conflict, missing-approval not-found, version increments
+  exactly once),
+  consumption/replay (15: fresh consumption with replayed=false + consumed
   fields + version 2, wrong token / wrong consumedBy / stale version /
   PENDING / DENIED / TIMED_OUT / expired-unconsumed rejected, exact replay
   returns the same durable record with no write and stays valid after
-  expiry, rejected consumption is non-mutating), and concurrency (3:
-  concurrent transition race — exactly one wins and one conflicts with
-  version 1; concurrent identical consumption — one fresh + one replay
-  receipt referencing the same durable record). Deterministic `MutableClock`
-  owned by the TCK (no sleeps, no `Instant.now()`); typed failure taxonomy
-  pinned (Conflict / NotFound / TokenRejected / NotConsumable /
-  IllegalTransition / IllegalArgumentException). Three runners execute the
-  same contract: `InMemoryApprovalStoreTckTest` (tramai-security),
-  `FileApprovalStoreTckTest` (tramai-persistence-file, encrypted temp-dir
-  harness), `JdbcApprovalStoreTckTest` (tramai-persistence-jdbc, PostgreSQL
-  testcontainers) — 33/33 each. `ApprovalStoreTckEnrollmentArchitectureTest`
+  expiry, replay with stale version and wrong token rejected on the replay
+  path, consume on missing approval not-found, fresh consumption records
+  the advanced clock instant, rejected consumption is non-mutating), and
+  concurrency (2: concurrent transition race — exactly one wins and one
+  conflicts with version 1; concurrent identical consumption — one fresh +
+  one replay receipt referencing the same durable record). Both race cases
+  run on parallel workers with a start barrier, so they genuinely overlap
+  rather than serializing on the test event loop. Deterministic
+  `MutableClock` owned by the TCK (no sleeps, no `Instant.now()`); typed
+  failure taxonomy pinned (Conflict / NotFound / TokenRejected /
+  NotConsumable / IllegalTransition / IllegalArgumentException). Three
+  runners execute the same contract: `InMemoryApprovalStoreTckTest`
+  (tramai-security), `FileApprovalStoreTckTest` (tramai-persistence-file,
+  encrypted per-case temp-dir harness), `JdbcApprovalStoreTckTest`
+  (tramai-persistence-jdbc, PostgreSQL testcontainers, table reset per
+  case) — 37/37 each. `ApprovalStoreTckEnrollmentArchitectureTest`
   scans every module's main source set for concrete `ApprovalStore`
-  implementations and requires a `<Store>TckTest` runner in the same module,
+  implementations (including body-less declarations) and requires a
+  `<Store>TckTest` runner in the same module that actually extends the TCK,
   so a future `RedisApprovalStore` cannot merge unenrolled. Mutation
-  evidence (5, each restored): removing the expectedVersion check, allowing
+  evidence (each restored): removing the expectedVersion check, allowing
   terminal-state re-transitions, incrementing version during exact replay,
-  replacing consumedAt during exact replay, and allowing expired fresh
-  consumption each turn TCK cases RED. Zero production code changes (the
-  three stores already agree on the contract), zero public API change, no
+  replacing consumedAt during exact replay, allowing expired fresh
+  consumption, and splitting the consume into check-then-act without
+  atomicity each turn TCK cases RED. One production change: the JDBC
+  consume path now takes a `FOR UPDATE` row lock inside an explicit
+  transaction so concurrent identical deliveries serialize into one fresh +
+  one replay (previously the loser could fail the conditional UPDATE).
+  Zero public API change, no
   persisted format or schema changes, no existing tests deleted — existing
   suites remain the implementation-specific regression oracle (encryption,
   permissions, corruption, record format for file; SQL schema, JSON mapping,

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1197,7 +1197,7 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ### Store families
 
-- Approval store — ✅ PR #267 (shared `ApprovalStoreTck`, 33 cases × 3 implementations + enrollment guard)
+- Approval store — ✅ PR #267 (shared `ApprovalStoreTck`, 37 cases × 3 implementations + enrollment guard)
 - Approval continuation store — ⏳ (Epic 8.1b)
 - Suspended invocation store — ⏳
 - Audit store — ⏳

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1191,19 +1191,21 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ## Epic 8.1: Persistence Store TCKs
 
+**Status: 🚧 IN PROGRESS** — Approval store slice done (PR #267); remaining families pending.
+
 **Goal:** Ensure in-memory, file, and JDBC implementations share the same behavioural contract.
 
 ### Store families
 
-- Approval store
-- Approval continuation store
-- Suspended invocation store
-- Audit store
-- Audit outbox store
-- Workflow checkpoint store
-- Workflow lease store
-- Step-attempt store — done for in-memory, file, and JDBC through the shared PR #218 TCK and restart recovery tests
-- Memory store
+- Approval store — ✅ PR #267 (shared `ApprovalStoreTck`, 33 cases × 3 implementations + enrollment guard)
+- Approval continuation store — ⏳ (Epic 8.1b)
+- Suspended invocation store — ⏳
+- Audit store — ⏳
+- Audit outbox store — ⏳
+- Workflow checkpoint store — ⏳
+- Workflow lease store — ⏳
+- Step-attempt store — ✅ PR #218 (shared TCK + restart recovery tests for in-memory, file, and JDBC)
+- Memory store — ⏳
 
 ### Contract areas
 
@@ -1223,9 +1225,17 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ### Acceptance criteria
 
-- Every published store implementation passes the relevant TCK.
-- Implementation-specific tests cover only storage technology and performance differences.
-- Contract failures use common typed exceptions or reason codes.
+- ✅ Every published store implementation passes the relevant TCK (Approval: 3/3 implementations enrolled; step-attempt: 3/3 via PR #218).
+- ✅ Implementation-specific tests cover only storage technology and performance differences (encryption, permissions, corruption, record format for file; SQL schema, JSON mapping, connection cleanup for JDBC).
+- ✅ Contract failures use common typed exceptions or reason codes (`ApprovalStoreConflictException`, `ApprovalStoreNotFoundException`, `ApprovalStoreTokenRejectedException`, `ApprovalStoreNotConsumableException`, `IllegalApprovalTransitionException`).
+
+### Deliverables (PR #267 — test infrastructure only)
+
+- `tramai-testing/src/testFixtures/.../persistence/approval/` — `ApprovalStoreTck` (33 cases), `ApprovalStoreTckHarness`, `ApprovalStoreFixtures`, `MutableClock`
+- Runners: `InMemoryApprovalStoreTckTest`, `FileApprovalStoreTckTest`, `JdbcApprovalStoreTckTest`
+- `ApprovalStoreTckEnrollmentArchitectureTest` — every future `ApprovalStore` implementation must ship a `<Store>TckTest` runner
+- Zero public API change; no persisted format or schema changes; no existing tests deleted
+- Reference: `docs/reference/persistence-store-compatibility-contract.md`
 
 ---
 

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1229,11 +1229,12 @@ repair feedback. No layer maintains its own independent fixture lists.
 - ✅ Implementation-specific tests cover only storage technology and performance differences (encryption, permissions, corruption, record format for file; SQL schema, JSON mapping, connection cleanup for JDBC).
 - ✅ Contract failures use common typed exceptions or reason codes (`ApprovalStoreConflictException`, `ApprovalStoreNotFoundException`, `ApprovalStoreTokenRejectedException`, `ApprovalStoreNotConsumableException`, `IllegalApprovalTransitionException`).
 
-### Deliverables (PR #267 — test infrastructure only)
+### Deliverables (PR #267)
 
-- `tramai-testing/src/testFixtures/.../persistence/approval/` — `ApprovalStoreTck` (33 cases), `ApprovalStoreTckHarness`, `ApprovalStoreFixtures`, `MutableClock`
+- `tramai-testing/src/testFixtures/.../persistence/approval/` — `ApprovalStoreTck` (37 cases), `ApprovalStoreTckHarness`, `ApprovalStoreFixtures`, `MutableClock`
 - Runners: `InMemoryApprovalStoreTckTest`, `FileApprovalStoreTckTest`, `JdbcApprovalStoreTckTest`
-- `ApprovalStoreTckEnrollmentArchitectureTest` — every future `ApprovalStore` implementation must ship a `<Store>TckTest` runner
+- `ApprovalStoreTckEnrollmentArchitectureTest` — every future `ApprovalStore` implementation must ship a `<Store>TckTest` runner extending the TCK
+- `JdbcApprovalStore` — consume uses `SELECT ... FOR UPDATE` inside an explicit transaction (concurrent identical deliveries serialize into one fresh + one replay)
 - Zero public API change; no persisted format or schema changes; no existing tests deleted
 - Reference: `docs/reference/persistence-store-compatibility-contract.md`
 

--- a/docs/reference/persistence-store-compatibility-contract.md
+++ b/docs/reference/persistence-store-compatibility-contract.md
@@ -76,11 +76,14 @@ child directory per case, the JDBC runner resets the table per case.
 ### Enrollment guard
 
 `ApprovalStoreTckEnrollmentArchitectureTest` scans every module's main
-source set for concrete `ApprovalStore` implementations (including body-less
-declarations such as `class X : ApprovalStore by delegate`) and requires a
+source set for concrete `ApprovalStore` implementations and requires a
 `<Store>TckTest` runner in the same module that actually extends
 `ApprovalStoreTck` — a same-named file with an unrelated class does not
-count. A future `RedisApprovalStore` cannot merge without
+count. The scanner recognizes class/object declarations with or without
+bodies, single-line or multiline, and with or without visibility/`open`
+modifiers (including delegated body-less declarations such as
+`class X : ApprovalStore by delegate`); it is a source-shape scanner, not a
+type resolver. A future `RedisApprovalStore` cannot merge without
 `RedisApprovalStoreTckTest` extending the TCK — the phrase "future stores
 must pass the TCK" is architecture, not documentation.
 

--- a/docs/reference/persistence-store-compatibility-contract.md
+++ b/docs/reference/persistence-store-compatibility-contract.md
@@ -21,7 +21,7 @@ files, JDBC).
 
 ## ApprovalStore TCK (PR #267)
 
-`ApprovalStoreTck` (tramai-testing testFixtures) runs **33 shared behavioral
+`ApprovalStoreTck` (tramai-testing testFixtures) runs **37 shared behavioral
 cases** against every `ApprovalStore` implementation:
 
 - **Creation/read (10):** PENDING round-trip, missing-ID null, duplicate
@@ -30,18 +30,24 @@ cases** against every `ApprovalStore` implementation:
   requestedAt rejected, invalid expiry rejected.
 - **Transitions (10):** APPROVED/DENIED with decided fields + version 1,
   expired→TIMED_OUT, timeout-before-expiry rejected, approve/deny-after-
-  expiry rejected, terminal-state re-transition rejected, stale version
-  conflict, missing-approval not-found, version increments exactly once.
-- **Consumption/replay (10):** fresh consumption (replayed=false, consumed
+  expiry rejected, terminal-state re-transition rejected for every terminal
+  status (APPROVED, DENIED, TIMED_OUT), stale version conflict,
+  missing-approval not-found, version increments exactly once.
+- **Consumption/replay (15):** fresh consumption (replayed=false, consumed
   fields, version 2), wrong token rejected, wrong consumedBy on replay
   rejected, stale version rejected, PENDING/DENIED/TIMED_OUT not consumable,
   expired unconsumed not consumable, exact replay returns the same durable
-  record with no write, replay valid after expiry, rejected consumption is
-  non-mutating.
-- **Concurrency (3):** concurrent transition race — exactly one wins, one
+  record with no write, replay valid after expiry, replay with stale
+  expected version rejected (Conflict), wrong token rejected on the replay
+  path, consume on missing approval not-found, fresh consumption records the
+  advanced clock instant, rejected consumption is non-mutating.
+- **Concurrency (2):** concurrent transition race — exactly one wins, one
   conflict, version 1; concurrent identical consumption — one fresh + one
   replay receipt referencing the same durable record, version 2, identical
-  consumedAt.
+  consumedAt. Both cases run on parallel workers (`Dispatchers.Default`) with
+  a start barrier, so the operations genuinely overlap instead of
+  serializing on the test event loop; a non-atomic check-then-act store
+  fails them.
 
 ### Typed failure taxonomy (pinned, not just "some RuntimeException")
 
@@ -63,25 +69,33 @@ advance time via `clock.advance(...)`. No `Thread.sleep`, no `Instant.now()`.
 
 `ApprovalStoreTckHarness.createStore(clock)` returns a fresh store wired to
 the given clock. Runners own storage technology (temp dirs, encryption keys,
-datasources, schema), so technology never contaminates the contract.
+datasources, schema), so technology never contaminates the contract — and
+each case runs against isolated storage: the file runner provisions a unique
+child directory per case, the JDBC runner resets the table per case.
 
 ### Enrollment guard
 
 `ApprovalStoreTckEnrollmentArchitectureTest` scans every module's main
-source set for concrete `ApprovalStore` implementations and requires a
-`<Store>TckTest` runner in the same module. A future `RedisApprovalStore`
-cannot merge without `RedisApprovalStoreTckTest` — the phrase "future stores
+source set for concrete `ApprovalStore` implementations (including body-less
+declarations such as `class X : ApprovalStore by delegate`) and requires a
+`<Store>TckTest` runner in the same module that actually extends
+`ApprovalStoreTck` — a same-named file with an unrelated class does not
+count. A future `RedisApprovalStore` cannot merge without
+`RedisApprovalStoreTckTest` extending the TCK — the phrase "future stores
 must pass the TCK" is architecture, not documentation.
 
 ### Mutation evidence (all restored after each run)
 
 | Mutation | TCK outcome |
 |---|---|
-| Remove expectedVersion check in transition | RED — stale-version + concurrent-race cases fail |
+| Remove expectedVersion check in transition | RED — stale-version cases fail |
+| Check-then-act consume without atomicity (read version, yield, write) | RED — concurrent-race cases detect two winners / a conflict instead of one fresh + one replay |
 | Allow terminal APPROVED to transition again | RED — terminal re-transition case fails |
 | Increment version during exact replay | RED — replay-identity + concurrent-consumption cases fail |
 | Replace consumedAt during exact replay | RED — replay-after-expiry case fails |
 | Allow expired fresh consumption | RED — expired-unconsumed case fails |
+| Skip version check on the replay branch | RED — replay-with-stale-version case fails |
+| Skip token check on the replay branch | RED — wrong-token-on-replay case fails |
 
 ### Scope
 

--- a/docs/reference/persistence-store-compatibility-contract.md
+++ b/docs/reference/persistence-store-compatibility-contract.md
@@ -1,0 +1,91 @@
+# Persistence Store Compatibility Contract
+
+Epic 8.1 (PR #267, ApprovalStore slice). Shared behavioral TCKs prove every
+implementation of a store family satisfies exactly the same externally
+observable contract, regardless of storage technology (memory, encrypted
+files, JDBC).
+
+## Epic 8.1 matrix
+
+| Store family | In-memory | File | JDBC | Shared TCK |
+|---|---|---|---|---|
+| Approval | ✅ | ✅ | ✅ | ✅ #267 |
+| Approval continuation | ✅ | ✅ | ✅ | ⏳ (Epic 8.1b) |
+| Suspended invocation | … | … | … | ⏳ |
+| Audit | … | … | … | ⏳ |
+| Audit outbox | … | … | … | ⏳ |
+| Workflow checkpoint | … | … | … | ⏳ |
+| Workflow lease | … | … | … | ⏳ |
+| Step attempt | ✅ | ✅ | ✅ | ✅ #218 |
+| Memory | … | … | … | ⏳ |
+
+## ApprovalStore TCK (PR #267)
+
+`ApprovalStoreTck` (tramai-testing testFixtures) runs **33 shared behavioral
+cases** against every `ApprovalStore` implementation:
+
+- **Creation/read (10):** PENDING round-trip, missing-ID null, duplicate
+  conflict, non-zero version rejected, non-PENDING rejected, pre-populated
+  decision/consumption fields rejected, blank ID rejected, future
+  requestedAt rejected, invalid expiry rejected.
+- **Transitions (10):** APPROVED/DENIED with decided fields + version 1,
+  expired→TIMED_OUT, timeout-before-expiry rejected, approve/deny-after-
+  expiry rejected, terminal-state re-transition rejected, stale version
+  conflict, missing-approval not-found, version increments exactly once.
+- **Consumption/replay (10):** fresh consumption (replayed=false, consumed
+  fields, version 2), wrong token rejected, wrong consumedBy on replay
+  rejected, stale version rejected, PENDING/DENIED/TIMED_OUT not consumable,
+  expired unconsumed not consumable, exact replay returns the same durable
+  record with no write, replay valid after expiry, rejected consumption is
+  non-mutating.
+- **Concurrency (3):** concurrent transition race — exactly one wins, one
+  conflict, version 1; concurrent identical consumption — one fresh + one
+  replay receipt referencing the same durable record, version 2, identical
+  consumedAt.
+
+### Typed failure taxonomy (pinned, not just "some RuntimeException")
+
+| Failure | Exception |
+|---|---|
+| duplicate / stale version | `ApprovalStoreConflictException` |
+| missing approval | `ApprovalStoreNotFoundException` |
+| wrong token | `ApprovalStoreTokenRejectedException` |
+| not consumable (status/expiry/already consumed) | `ApprovalStoreNotConsumableException` |
+| illegal transition | `IllegalApprovalTransitionException` |
+| invalid input | `IllegalArgumentException` |
+
+### Deterministic time
+
+The TCK owns a `MutableClock` fixed at T0; expiry is T0 + 10 min; tests
+advance time via `clock.advance(...)`. No `Thread.sleep`, no `Instant.now()`.
+
+### Harness
+
+`ApprovalStoreTckHarness.createStore(clock)` returns a fresh store wired to
+the given clock. Runners own storage technology (temp dirs, encryption keys,
+datasources, schema), so technology never contaminates the contract.
+
+### Enrollment guard
+
+`ApprovalStoreTckEnrollmentArchitectureTest` scans every module's main
+source set for concrete `ApprovalStore` implementations and requires a
+`<Store>TckTest` runner in the same module. A future `RedisApprovalStore`
+cannot merge without `RedisApprovalStoreTckTest` — the phrase "future stores
+must pass the TCK" is architecture, not documentation.
+
+### Mutation evidence (all restored after each run)
+
+| Mutation | TCK outcome |
+|---|---|
+| Remove expectedVersion check in transition | RED — stale-version + concurrent-race cases fail |
+| Allow terminal APPROVED to transition again | RED — terminal re-transition case fails |
+| Increment version during exact replay | RED — replay-identity + concurrent-consumption cases fail |
+| Replace consumedAt during exact replay | RED — replay-after-expiry case fails |
+| Allow expired fresh consumption | RED — expired-unconsumed case fails |
+
+### Scope
+
+The TCK owns SPI semantics; implementation-specific suites continue owning
+encryption, permissions, corruption, record format (file), SQL schema, JSON
+mapping, connection cleanup (JDBC). No existing tests were deleted. Zero
+public API change; no persisted format or schema changes.

--- a/tramai-persistence-file/build.gradle.kts
+++ b/tramai-persistence-file/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation(libs.jackson.databind)
     implementation(libs.jackson.module.kotlin)
 
+    testImplementation(testFixtures(project(":tramai-testing")))
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.assertj.core)
     testImplementation(libs.coroutines.test)

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileApprovalStoreTckTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileApprovalStoreTckTest.kt
@@ -1,0 +1,57 @@
+package dev.tramai.persistence.file
+
+import dev.tramai.core.approval.ApprovalStore
+import dev.tramai.testing.persistence.approval.ApprovalStoreTck
+import dev.tramai.testing.persistence.approval.ApprovalStoreTckHarness
+import dev.tramai.testing.persistence.approval.MutableClock
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import java.nio.file.Files
+import java.nio.file.Path
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+
+/**
+ * Epic 8.1a: FileApprovalStore must satisfy the shared ApprovalStore
+ * compatibility contract (tramai-testing testFixtures). The runner owns the
+ * temp directory, encryption key, and store construction — storage
+ * technology never contaminates the contract.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FileApprovalStoreTckTest : ApprovalStoreTck() {
+
+    private lateinit var rootDir: Path
+    private lateinit var key: SecretKey
+    private val keyProvider = FileStoreEncryptionKeyProvider { key }
+
+    @BeforeAll
+    fun setUpAll() {
+        rootDir = Files.createTempDirectory("tramai-approval-tck-").toAbsolutePath()
+        Files.createDirectories(rootDir.resolve("approvals"))
+        Files.setPosixFilePermissions(
+            rootDir.resolve("approvals"),
+            java.nio.file.attribute.PosixFilePermissions.fromString("rwx------"),
+        )
+        key = KeyGenerator.getInstance("AES").apply { init(256) }.generateKey()
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        if (rootDir.toFile().exists()) rootDir.toFile().deleteRecursively()
+    }
+
+    private fun createConfig() = FileBackedStoreConfiguration(
+        rootDirectory = rootDir,
+        encryption = FileStoreEncryptionConfiguration(
+            activeKeyId = "tck-key",
+            keyProvider = keyProvider,
+        ),
+        verifyOnOpen = false,
+    )
+
+    override val harness = object : ApprovalStoreTckHarness {
+        override fun createStore(clock: MutableClock): ApprovalStore =
+            FileApprovalStore(rootDir, key, createConfig(), FileStoreLease(), clock)
+    }
+}

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileApprovalStoreTckTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileApprovalStoreTckTest.kt
@@ -24,15 +24,11 @@ class FileApprovalStoreTckTest : ApprovalStoreTck() {
     private lateinit var rootDir: Path
     private lateinit var key: SecretKey
     private val keyProvider = FileStoreEncryptionKeyProvider { key }
+    private var caseCounter = 0
 
     @BeforeAll
     fun setUpAll() {
         rootDir = Files.createTempDirectory("tramai-approval-tck-").toAbsolutePath()
-        Files.createDirectories(rootDir.resolve("approvals"))
-        Files.setPosixFilePermissions(
-            rootDir.resolve("approvals"),
-            java.nio.file.attribute.PosixFilePermissions.fromString("rwx------"),
-        )
         key = KeyGenerator.getInstance("AES").apply { init(256) }.generateKey()
     }
 
@@ -41,17 +37,26 @@ class FileApprovalStoreTckTest : ApprovalStoreTck() {
         if (rootDir.toFile().exists()) rootDir.toFile().deleteRecursively()
     }
 
-    private fun createConfig() = FileBackedStoreConfiguration(
-        rootDirectory = rootDir,
-        encryption = FileStoreEncryptionConfiguration(
-            activeKeyId = "tck-key",
-            keyProvider = keyProvider,
-        ),
-        verifyOnOpen = false,
-    )
-
     override val harness = object : ApprovalStoreTckHarness {
-        override fun createStore(clock: MutableClock): ApprovalStore =
-            FileApprovalStore(rootDir, key, createConfig(), FileStoreLease(), clock)
+        override fun createStore(clock: MutableClock): ApprovalStore {
+            // Fresh isolated storage per case: a unique child directory, so
+            // previous cases' records never leak into the next case. The
+            // @AfterAll cleanup removes the whole tree.
+            val caseDir = rootDir.resolve("case-${caseCounter++}")
+            Files.createDirectories(caseDir.resolve("approvals"))
+            Files.setPosixFilePermissions(
+                caseDir.resolve("approvals"),
+                java.nio.file.attribute.PosixFilePermissions.fromString("rwx------"),
+            )
+            val config = FileBackedStoreConfiguration(
+                rootDirectory = caseDir,
+                encryption = FileStoreEncryptionConfiguration(
+                    activeKeyId = "tck-key",
+                    keyProvider = keyProvider,
+                ),
+                verifyOnOpen = false,
+            )
+            return FileApprovalStore(caseDir, key, config, FileStoreLease(), clock)
+        }
     }
 }

--- a/tramai-persistence-jdbc/build.gradle.kts
+++ b/tramai-persistence-jdbc/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     implementation(libs.jackson.module.kotlin)
     implementation(libs.jackson.datatype.jsr310)
 
+    testImplementation(testFixtures(project(":tramai-testing")))
     testImplementation(platform(libs.junit.bom))
     testImplementation(platform(libs.testcontainers.bom))
     testImplementation(libs.assertj.core)

--- a/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStore.kt
+++ b/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStore.kt
@@ -229,20 +229,40 @@ class JdbcApprovalStore(
         SafeActorIdPolicy.validateActorId(consumedBy, "consumedBy")
 
         dataSource.connection.use { conn ->
-            val current = readCurrent(conn, approvalId) ?: throw ApprovalStoreNotFoundException(approvalId)
-            val req = mapToApprovalRequest(current)
+            val previousAutoCommit = conn.autoCommit
+            try {
+                // Row lock + explicit transaction so concurrent identical
+                // deliveries serialize: the loser blocks on FOR UPDATE, then
+                // reads the winner's committed state and takes the replay path
+                // instead of failing the conditional UPDATE with a conflict.
+                // In autocommit mode the lock would be released at the end of
+                // the SELECT statement, so the read-modify-write must be one
+                // transaction.
+                conn.autoCommit = false
+                val current = readCurrent(conn, approvalId, forUpdate = true)
+                    ?: throw ApprovalStoreNotFoundException(approvalId)
+                val req = mapToApprovalRequest(current)
 
-            if (req.status != ApprovalStatus.APPROVED) throw ApprovalStoreNotConsumableException(approvalId)
+                if (req.status != ApprovalStatus.APPROVED) throw ApprovalStoreNotConsumableException(approvalId)
 
-            if (!tokenDigestsMatch(presentedTokenDigest, req.binding.approvalTokenDigest)) {
-                throw ApprovalStoreTokenRejectedException(approvalId)
+                if (!tokenDigestsMatch(presentedTokenDigest, req.binding.approvalTokenDigest)) {
+                    throw ApprovalStoreTokenRejectedException(approvalId)
+                }
+
+                val receipt =
+                    if (req.consumedAt == null && req.consumedBy == null) {
+                        consumeFreshApproval(conn, current, req, expectedVersion, consumedBy)
+                    } else {
+                        consumeReplayApproval(approvalId, expectedVersion, consumedBy, req)
+                    }
+                conn.commit()
+                return receipt
+            } catch (e: Throwable) {
+                runCatching { conn.rollback() }
+                throw e
+            } finally {
+                runCatching { conn.autoCommit = previousAutoCommit }
             }
-
-            if (req.consumedAt == null && req.consumedBy == null) {
-                return consumeFreshApproval(conn, current, req, expectedVersion, consumedBy)
-            }
-
-            return consumeReplayApproval(approvalId, expectedVersion, consumedBy, req)
         }
     }
 
@@ -483,13 +503,17 @@ class JdbcApprovalStore(
         }
     }
 
-    private fun readCurrent(conn: java.sql.Connection, approvalId: String): ApprovalRow? {
+    private fun readCurrent(
+        conn: java.sql.Connection,
+        approvalId: String,
+        forUpdate: Boolean = false,
+    ): ApprovalRow? {
         val sql = """
             SELECT approval_id, status, created_at, decided_at, decision_actor_hash, decision_type,
                    sanitized_metadata, version
             FROM approvals
             WHERE approval_id = ?
-        """.trimIndent()
+        """.trimIndent() + if (forUpdate) " FOR UPDATE" else ""
         conn.prepareStatement(sql).use { stmt ->
             stmt.setString(1, approvalId)
             stmt.executeQuery().use { rs ->

--- a/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStore.kt
+++ b/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStore.kt
@@ -242,9 +242,10 @@ class JdbcApprovalStore(
      * read-modify-write must be one transaction.
      *
      * Deliberately non-suspend: there are no coroutine suspension points in
-     * the read-modify-write, and the original exception (including a
-     * CancellationException) is always rethrown as the same instance; a
-     * rollback failure is attached as suppressed rather than replacing it.
+     * the read-modify-write. Failure precedence is primary operation /
+     * cancellation exception, then rollback failure, then connection-state
+     * restoration failure — later cleanup failures are attached as
+     * suppressed to the primary, never replacing it.
      */
     private fun consumeApprovedInTransaction(
         conn: Connection,
@@ -255,11 +256,13 @@ class JdbcApprovalStore(
     ): ApprovalConsumptionReceipt {
         val previousAutoCommit = conn.autoCommit
         conn.autoCommit = false
+        var primaryFailure: Exception? = null
         try {
             val receipt = consumeApprovedLocked(conn, approvalId, expectedVersion, presentedTokenDigest, consumedBy)
             conn.commit()
             return receipt
         } catch (e: Exception) {
+            primaryFailure = e
             try {
                 conn.rollback()
             } catch (rollbackFailure: Exception) {
@@ -267,7 +270,16 @@ class JdbcApprovalStore(
             }
             throw e
         } finally {
-            conn.autoCommit = previousAutoCommit
+            try {
+                conn.autoCommit = previousAutoCommit
+            } catch (restoreFailure: Exception) {
+                val primary = primaryFailure
+                if (primary != null) {
+                    primary.addSuppressed(restoreFailure)
+                } else {
+                    throw restoreFailure
+                }
+            }
         }
     }
 

--- a/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStore.kt
+++ b/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStore.kt
@@ -228,41 +228,70 @@ class JdbcApprovalStore(
         validateIdField(consumedBy, "consumedBy", maxIdLength)
         SafeActorIdPolicy.validateActorId(consumedBy, "consumedBy")
 
-        dataSource.connection.use { conn ->
-            val previousAutoCommit = conn.autoCommit
+        return dataSource.connection.use { conn ->
+            consumeApprovedInTransaction(conn, approvalId, expectedVersion, presentedTokenDigest, consumedBy)
+        }
+    }
+
+    /**
+     * Row lock + explicit transaction so concurrent identical deliveries
+     * serialize: the loser blocks on FOR UPDATE, then reads the winner's
+     * committed state and takes the replay path instead of failing the
+     * conditional UPDATE with a conflict. In autocommit mode the lock would
+     * be released at the end of the SELECT statement, so the
+     * read-modify-write must be one transaction.
+     *
+     * Deliberately non-suspend: there are no coroutine suspension points in
+     * the read-modify-write, and the original exception (including a
+     * CancellationException) is always rethrown as the same instance; a
+     * rollback failure is attached as suppressed rather than replacing it.
+     */
+    private fun consumeApprovedInTransaction(
+        conn: Connection,
+        approvalId: String,
+        expectedVersion: Long,
+        presentedTokenDigest: Sha256Digest,
+        consumedBy: String,
+    ): ApprovalConsumptionReceipt {
+        val previousAutoCommit = conn.autoCommit
+        conn.autoCommit = false
+        try {
+            val receipt = consumeApprovedLocked(conn, approvalId, expectedVersion, presentedTokenDigest, consumedBy)
+            conn.commit()
+            return receipt
+        } catch (e: Exception) {
             try {
-                // Row lock + explicit transaction so concurrent identical
-                // deliveries serialize: the loser blocks on FOR UPDATE, then
-                // reads the winner's committed state and takes the replay path
-                // instead of failing the conditional UPDATE with a conflict.
-                // In autocommit mode the lock would be released at the end of
-                // the SELECT statement, so the read-modify-write must be one
-                // transaction.
-                conn.autoCommit = false
-                val current = readCurrent(conn, approvalId, forUpdate = true)
-                    ?: throw ApprovalStoreNotFoundException(approvalId)
-                val req = mapToApprovalRequest(current)
-
-                if (req.status != ApprovalStatus.APPROVED) throw ApprovalStoreNotConsumableException(approvalId)
-
-                if (!tokenDigestsMatch(presentedTokenDigest, req.binding.approvalTokenDigest)) {
-                    throw ApprovalStoreTokenRejectedException(approvalId)
-                }
-
-                val receipt =
-                    if (req.consumedAt == null && req.consumedBy == null) {
-                        consumeFreshApproval(conn, current, req, expectedVersion, consumedBy)
-                    } else {
-                        consumeReplayApproval(approvalId, expectedVersion, consumedBy, req)
-                    }
-                conn.commit()
-                return receipt
-            } catch (e: Throwable) {
-                runCatching { conn.rollback() }
-                throw e
-            } finally {
-                runCatching { conn.autoCommit = previousAutoCommit }
+                conn.rollback()
+            } catch (rollbackFailure: Exception) {
+                e.addSuppressed(rollbackFailure)
             }
+            throw e
+        } finally {
+            conn.autoCommit = previousAutoCommit
+        }
+    }
+
+    private fun consumeApprovedLocked(
+        conn: Connection,
+        approvalId: String,
+        expectedVersion: Long,
+        presentedTokenDigest: Sha256Digest,
+        consumedBy: String,
+    ): ApprovalConsumptionReceipt {
+        val current = readCurrent(conn, approvalId, forUpdate = true)
+            ?: throw ApprovalStoreNotFoundException(approvalId)
+        val req = mapToApprovalRequest(current)
+
+        if (req.status != ApprovalStatus.APPROVED) throw ApprovalStoreNotConsumableException(approvalId)
+
+        if (!tokenDigestsMatch(presentedTokenDigest, req.binding.approvalTokenDigest)) {
+            throw ApprovalStoreTokenRejectedException(approvalId)
+        }
+
+        return if (req.consumedAt == null && req.consumedBy == null) {
+            consumeFreshApproval(conn, current, req, expectedVersion, consumedBy)
+        } else {
+            consumeReplayApproval(approvalId, expectedVersion, consumedBy, req)
         }
     }
 

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStoreTckTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStoreTckTest.kt
@@ -21,12 +21,13 @@ import javax.sql.DataSource
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class JdbcApprovalStoreTckTest : ApprovalStoreTck() {
 
+    private lateinit var postgres: PostgreSQLContainer<*>
     private lateinit var dataSource: DataSource
     private lateinit var setupConnection: Connection
 
     @BeforeAll
     fun setUpAll() {
-        val postgres = PostgreSQLContainer("postgres:17-alpine")
+        postgres = PostgreSQLContainer("postgres:17-alpine")
             .withDatabaseName("approval_tck")
             .withUsername("test")
             .withPassword("test")
@@ -51,10 +52,17 @@ class JdbcApprovalStoreTckTest : ApprovalStoreTck() {
     @AfterAll
     fun tearDownAll() {
         runCatching { setupConnection.close() }
+        runCatching { postgres.stop() }
     }
 
     override val harness = object : ApprovalStoreTckHarness {
-        override fun createStore(clock: MutableClock): ApprovalStore =
-            JdbcApprovalStore(dataSource, clock = clock)
+        override fun createStore(clock: MutableClock): ApprovalStore {
+            // Fresh isolated storage per case: previous cases' records must
+            // not leak into the next case.
+            dataSource.connection.use { conn ->
+                conn.createStatement().use { stmt -> stmt.execute("DELETE FROM approvals") }
+            }
+            return JdbcApprovalStore(dataSource, clock = clock)
+        }
     }
 }

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStoreTckTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStoreTckTest.kt
@@ -1,0 +1,60 @@
+package dev.tramai.persistence.jdbc
+
+import dev.tramai.core.approval.ApprovalStore
+import dev.tramai.testing.persistence.approval.ApprovalStoreTck
+import dev.tramai.testing.persistence.approval.ApprovalStoreTckHarness
+import dev.tramai.testing.persistence.approval.MutableClock
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import org.postgresql.ds.PGSimpleDataSource
+import org.testcontainers.containers.PostgreSQLContainer
+import java.sql.Connection
+import java.sql.DriverManager
+import javax.sql.DataSource
+
+/**
+ * Epic 8.1a: JdbcApprovalStore must satisfy the shared ApprovalStore
+ * compatibility contract (tramai-testing testFixtures). The runner owns the
+ * datasource + schema — storage technology never contaminates the contract.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JdbcApprovalStoreTckTest : ApprovalStoreTck() {
+
+    private lateinit var dataSource: DataSource
+    private lateinit var setupConnection: Connection
+
+    @BeforeAll
+    fun setUpAll() {
+        val postgres = PostgreSQLContainer("postgres:17-alpine")
+            .withDatabaseName("approval_tck")
+            .withUsername("test")
+            .withPassword("test")
+        postgres.start()
+        dataSource = PGSimpleDataSource().apply {
+            setUrl(postgres.jdbcUrl)
+            user = postgres.username
+            password = postgres.password
+        }
+        setupConnection = DriverManager.getConnection(
+            postgres.jdbcUrl,
+            postgres.username,
+            postgres.password,
+        )
+        val schemaSql = this::class.java.classLoader
+            .getResource("tramai/persistence/jdbc/postgres/V1__sovereign_persistence.sql")
+            ?.readText()
+            ?: throw IllegalStateException("Schema SQL resource not found")
+        setupConnection.createStatement().use { stmt -> stmt.execute(schemaSql) }
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        runCatching { setupConnection.close() }
+    }
+
+    override val harness = object : ApprovalStoreTckHarness {
+        override fun createStore(clock: MutableClock): ApprovalStore =
+            JdbcApprovalStore(dataSource, clock = clock)
+    }
+}

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStoreTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStoreTest.kt
@@ -23,6 +23,7 @@ import org.testcontainers.containers.PostgreSQLContainer
 import java.lang.reflect.Proxy
 import java.sql.Connection
 import java.sql.DriverManager
+import java.sql.SQLException
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -98,23 +99,32 @@ class JdbcApprovalStoreTest {
         JdbcApprovalStore(dataSource, clock)
 
     /**
-     * A DataSource whose connections delegate to the real database but throw
-     * [failure] from `commit()`, so the consume transaction's cleanup path
-     * can be exercised deterministically.
+     * A DataSource whose connections delegate to the real database but fail
+     * deterministically: [commitFailure] is thrown from `commit()`, and, when
+     * [restoreFailure] is non-null, from the second `setAutoCommit` call (the
+     * finally-block restoration). Each `getConnection` captures ONE delegate,
+     * so the production code sees a single JDBC transaction rather than a
+     * fresh connection per method call.
      */
-    private fun dataSourceWithCommitFailure(failure: Exception): DataSource {
+    private fun dataSourceWithFailures(commitFailure: Exception, restoreFailure: Exception? = null): DataSource {
         val real = dataSource
         return Proxy.newProxyInstance(
             DataSource::class.java.classLoader,
             arrayOf(DataSource::class.java),
         ) { _, method, args ->
             if (method.name == "getConnection" && args.isNullOrEmpty()) {
+                val delegate = real.connection
+                var autoCommitCalls = 0
                 Proxy.newProxyInstance(
                     Connection::class.java.classLoader,
                     arrayOf(Connection::class.java),
                 ) { _, connMethod, connArgs ->
-                    if (connMethod.name == "commit") throw failure
-                    connMethod.invoke(real.connection, *(connArgs ?: emptyArray()))
+                    if (connMethod.name == "commit") throw commitFailure
+                    if (connMethod.name == "setAutoCommit") {
+                        autoCommitCalls++
+                        if (restoreFailure != null && autoCommitCalls > 1) throw restoreFailure
+                    }
+                    connMethod.invoke(delegate, *(connArgs ?: emptyArray()))
                 }
             } else {
                 method.invoke(real, *(args ?: emptyArray()))
@@ -337,7 +347,7 @@ class JdbcApprovalStoreTest {
         normal.transition(id, 0, ApprovalTransition.Approve("user:bob"))
 
         val cancellation = CancellationException("cancelled by test")
-        val failing = JdbcApprovalStore(dataSourceWithCommitFailure(cancellation), fixedClock)
+        val failing = JdbcApprovalStore(dataSourceWithFailures(cancellation), fixedClock)
 
         val thrown = runCatching {
             failing.consumeApprovedOrReplay(
@@ -348,6 +358,30 @@ class JdbcApprovalStoreTest {
         }.exceptionOrNull()
 
         assertSame(cancellation, thrown)
+    }
+    }
+
+    @Test
+    fun `consumeApprovedOrReplay preserves primary exception when autoCommit restore fails`() { runBlocking {
+        val id = "cancel-restore"
+        val normal = store()
+        normal.create(approvalRequest(id = id))
+        normal.transition(id, 0, ApprovalTransition.Approve("user:bob"))
+
+        val cancellation = CancellationException("cancelled by test")
+        val restoreFailure = SQLException("restore failed")
+        val failing = JdbcApprovalStore(dataSourceWithFailures(cancellation, restoreFailure), fixedClock)
+
+        val thrown = runCatching {
+            failing.consumeApprovedOrReplay(
+                id, 1,
+                Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+                "worker:executor",
+            )
+        }.exceptionOrNull()
+
+        assertSame(cancellation, thrown)
+        assertEquals(listOf(restoreFailure), thrown?.suppressed?.toList())
     }
     }
 

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStoreTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStoreTest.kt
@@ -20,17 +20,20 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.postgresql.ds.PGSimpleDataSource
 import org.testcontainers.containers.PostgreSQLContainer
+import java.lang.reflect.Proxy
 import java.sql.Connection
 import java.sql.DriverManager
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
+import java.util.concurrent.CancellationException
 import javax.sql.DataSource
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -93,6 +96,31 @@ class JdbcApprovalStoreTest {
 
     private fun store(clock: Clock = fixedClock): JdbcApprovalStore =
         JdbcApprovalStore(dataSource, clock)
+
+    /**
+     * A DataSource whose connections delegate to the real database but throw
+     * [failure] from `commit()`, so the consume transaction's cleanup path
+     * can be exercised deterministically.
+     */
+    private fun dataSourceWithCommitFailure(failure: Exception): DataSource {
+        val real = dataSource
+        return Proxy.newProxyInstance(
+            DataSource::class.java.classLoader,
+            arrayOf(DataSource::class.java),
+        ) { _, method, args ->
+            if (method.name == "getConnection" && args.isNullOrEmpty()) {
+                Proxy.newProxyInstance(
+                    Connection::class.java.classLoader,
+                    arrayOf(Connection::class.java),
+                ) { _, connMethod, connArgs ->
+                    if (connMethod.name == "commit") throw failure
+                    connMethod.invoke(real.connection, *(connArgs ?: emptyArray()))
+                }
+            } else {
+                method.invoke(real, *(args ?: emptyArray()))
+            }
+        } as DataSource
+    }
 
     private fun approvalRequest(
         id: String = "test-approval-1",
@@ -298,6 +326,28 @@ class JdbcApprovalStoreTest {
         assertNotNull(receipt.request.consumedAt)
         assertEquals(2, receipt.request.version)
         assertEquals(false, receipt.replayed)
+    }
+    }
+
+    @Test
+    fun `consumeApprovedOrReplay rethrows CancellationException unchanged from transaction cleanup`() { runBlocking {
+        val id = "cancel-consume"
+        val normal = store()
+        normal.create(approvalRequest(id = id))
+        normal.transition(id, 0, ApprovalTransition.Approve("user:bob"))
+
+        val cancellation = CancellationException("cancelled by test")
+        val failing = JdbcApprovalStore(dataSourceWithCommitFailure(cancellation), fixedClock)
+
+        val thrown = runCatching {
+            failing.consumeApprovedOrReplay(
+                id, 1,
+                Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+                "worker:executor",
+            )
+        }.exceptionOrNull()
+
+        assertSame(cancellation, thrown)
     }
     }
 

--- a/tramai-security/build.gradle.kts
+++ b/tramai-security/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
 
     implementation(libs.coroutines.core)
 
+    testImplementation(testFixtures(project(":tramai-testing")))
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.assertj.core)
     testImplementation(libs.coroutines.test)

--- a/tramai-security/src/test/kotlin/dev/tramai/security/approval/InMemoryApprovalStoreTckTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/approval/InMemoryApprovalStoreTckTest.kt
@@ -1,0 +1,18 @@
+package dev.tramai.security.approval
+
+import dev.tramai.core.approval.ApprovalStore
+import dev.tramai.testing.persistence.approval.ApprovalStoreTck
+import dev.tramai.testing.persistence.approval.ApprovalStoreTckHarness
+import dev.tramai.testing.persistence.approval.MutableClock
+
+/**
+ * Epic 8.1a: InMemoryApprovalStore must satisfy the shared ApprovalStore
+ * compatibility contract (tramai-testing testFixtures).
+ */
+class InMemoryApprovalStoreTckTest : ApprovalStoreTck() {
+
+    override val harness = object : ApprovalStoreTckHarness {
+        override fun createStore(clock: MutableClock): ApprovalStore =
+            InMemoryApprovalStore(clock = clock)
+    }
+}

--- a/tramai-security/src/test/kotlin/dev/tramai/security/approval/InMemoryApprovalStoreTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/approval/InMemoryApprovalStoreTest.kt
@@ -11,6 +11,7 @@ import dev.tramai.core.exception.ApprovalStoreNotFoundException
 import dev.tramai.core.exception.ApprovalStoreTokenRejectedException
 import dev.tramai.core.exception.IllegalApprovalTransitionException
 import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.testing.persistence.approval.MutableClock
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -24,22 +25,6 @@ import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-
-/**
- * A test clock whose instant can be advanced programmatically.
- * Used to test time-dependent behavior without reflection.
- */
-class MutableClock(
-    @Volatile private var now: Instant,
-    private val zone: ZoneId = ZoneId.of("UTC"),
-) : Clock() {
-    override fun instant(): Instant = now
-    override fun withZone(zone: ZoneId): Clock = Clock.fixed(now, zone)
-    override fun getZone(): ZoneId = zone
-
-    fun advance(amount: java.time.Duration) { now = now.plus(amount) }
-    fun set(newNow: Instant) { now = newNow }
-}
 
 class InMemoryApprovalStoreTest {
 

--- a/tramai-testing/src/test/kotlin/dev/tramai/testing/ApprovalStoreTckEnrollmentArchitectureTest.kt
+++ b/tramai-testing/src/test/kotlin/dev/tramai/testing/ApprovalStoreTckEnrollmentArchitectureTest.kt
@@ -1,0 +1,145 @@
+package dev.tramai.testing
+
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Epic 8.1a architecture guard: every concrete [dev.tramai.core.approval.ApprovalStore]
+ * implementation must be enrolled in the shared ApprovalStore compatibility
+ * contract (tramai-testing testFixtures).
+ *
+ * Two properties hold:
+ *
+ * 1. The three roadmap implementations (pinned allowlist) must each ship a
+ *    `<Implementation>TckTest` runner. Deleting or renaming a runner breaks
+ *    the gate.
+ * 2. **Every concrete `ApprovalStore` implementation** in any module's main
+ *    source set must have a runner named after it (`<Store>TckTest`), in the
+ *    same module. Adding a store without a runner fails the gate — the phrase
+ *    "future stores must pass the TCK" is otherwise documentation, not
+ *    architecture.
+ *
+ * The runner file IS the reviewed contract matrix: it wires the store to the
+ * shared [dev.tramai.testing.persistence.approval.ApprovalStoreTck].
+ */
+class ApprovalStoreTckEnrollmentArchitectureTest {
+
+    private val repoRoot: File =
+        generateSequence(File(".").absoluteFile) { it.parentFile }
+            .first { it.resolve("settings.gradle.kts").isFile }
+
+    private val expectedRunners = setOf(
+        "InMemoryApprovalStoreTckTest",
+        "FileApprovalStoreTckTest",
+        "JdbcApprovalStoreTckTest",
+    )
+
+    @Test
+    fun `every roadmap ApprovalStore ships a TCK runner`() {
+        val missing = expectedRunners.filter { runnerName -> findRunnerFile(runnerName) == null }
+        assertThat(missing)
+            .withFailMessage(
+                "Pinned ApprovalStore TCK runners missing. The compatibility contract is " +
+                    "reviewed per runner; deleting a runner silently removes a store from the contract: $missing",
+            )
+            .isEmpty()
+    }
+
+    @Test
+    fun `every ApprovalStore implementation has a runner named after it in its module`() {
+        val unenrolled = storeModules().flatMap { (module, implementations) ->
+            implementations
+                .filter { storeName -> !hasRunner(module, storeName) }
+                .map { store -> "$module/$store" }
+        }
+        assertThat(unenrolled)
+            .withFailMessage(
+                "ApprovalStore implementations without a <Store>TckTest runner in the same module: $unenrolled. " +
+                    "Adding an ApprovalStore without enrolling it in the compatibility contract " +
+                    "must make a gate fail.",
+            )
+            .isEmpty()
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────
+
+    private fun storeModules(): List<Pair<String, List<String>>> {
+        val modules = repoRoot.listFiles { file -> file.isDirectory && file.name.startsWith("tramai-") }
+            ?: return emptyList()
+        return modules
+            .mapNotNull { module ->
+                if (module.name == "tramai-testing") return@mapNotNull null
+                val main = File(module, "src/main/kotlin")
+                if (!main.isDirectory) return@mapNotNull null
+                val implementations = main.walkTopDown()
+                    .filter { it.isFile && it.extension == "kt" }
+                    .flatMap { file -> storeImplementations(file).asSequence() }
+                    .distinct()
+                    .sorted()
+                    .toList()
+                if (implementations.isEmpty()) null else module.name to implementations
+            }
+            .toList()
+    }
+
+    /**
+     * Concrete [dev.tramai.core.approval.ApprovalStore] implementations declared in [file].
+     * Mirrors the provider-TCK scanner: the supertype section is everything
+     * after the first top-level `:` (depth-aware), so a constructor parameter
+     * like `class X(val store: ApprovalStore, ...)` never counts as a supertype,
+     * while `class X(...) : ApprovalStore` (multi-line or not) is caught.
+     */
+    private fun storeImplementations(file: File): List<String> {
+        val text = file.readText()
+        return CLASS_HEADER.findAll(text).mapNotNull { match ->
+            val name = match.groupValues[1]
+            val header = match.groupValues[2]
+            val supertype = supertypeSection(header)
+            // A body-less declaration (no '{' of its own) makes the non-greedy
+            // header regex bleed into the next declaration; a supertype section
+            // containing declaration keywords or a doc comment is such a false
+            // positive (e.g. exception classes with implicit bodies).
+            val overSpanned = DECLARATION_KEYWORD.containsMatchIn(supertype)
+            if (!overSpanned && supertype.contains("ApprovalStore")) name else null
+        }.toList()
+    }
+
+    /** Everything after the first top-level `:` in a class header (the supertype list). */
+    private fun supertypeSection(header: String): String {
+        var depth = 0
+        for ((index, ch) in header.withIndex()) {
+            when (ch) {
+                '(' -> depth++
+                ')' -> depth--
+                ':' -> if (depth == 0) return header.substring(index + 1)
+            }
+        }
+        return ""
+    }
+
+    private fun hasRunner(module: String, storeName: String): Boolean {
+        val testDir = File(repoRoot, "$module/src/test/kotlin")
+        if (!testDir.isDirectory) return false
+        return testDir.walkTopDown()
+            .any { it.isFile && it.name == "${storeName}TckTest.kt" }
+    }
+
+    private fun findRunnerFile(runnerName: String): File? {
+        val modules = repoRoot.listFiles { file -> file.isDirectory && file.name.startsWith("tramai-") }
+            ?: return null
+        return modules.asSequence()
+            .map { File(it, "src/test/kotlin") }
+            .filter { it.isDirectory }
+            .flatMap { it.walkTopDown().asSequence() }
+            .firstOrNull { it.isFile && it.name == "$runnerName.kt" }
+    }
+
+    private companion object {
+        /** Class/object name + header up to the first `{`, spanning newlines. */
+        val CLASS_HEADER = Regex("""(?s)(?:class|object)\s+(\w+)(.*?)\{""")
+
+        /** Declaration keywords that must never appear inside a real supertype list. */
+        val DECLARATION_KEYWORD = Regex("""(fun |class |interface |object |/\*\*)""")
+    }
+}

--- a/tramai-testing/src/test/kotlin/dev/tramai/testing/ApprovalStoreTckEnrollmentArchitectureTest.kt
+++ b/tramai-testing/src/test/kotlin/dev/tramai/testing/ApprovalStoreTckEnrollmentArchitectureTest.kt
@@ -1,6 +1,7 @@
 package dev.tramai.testing
 
 import java.io.File
+import java.nio.file.Files
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -16,9 +17,11 @@ import org.junit.jupiter.api.Test
  *    the gate.
  * 2. **Every concrete `ApprovalStore` implementation** in any module's main
  *    source set must have a runner named after it (`<Store>TckTest`), in the
- *    same module. Adding a store without a runner fails the gate — the phrase
+ *    same module, that actually extends [dev.tramai.testing.persistence.approval.ApprovalStoreTck].
+ *    Adding a store without a runner fails the gate — the phrase
  *    "future stores must pass the TCK" is otherwise documentation, not
- *    architecture.
+ *    architecture. A file named `<Store>TckTest.kt` that does not subclass
+ *    the TCK does not count.
  *
  * The runner file IS the reviewed contract matrix: it wires the store to the
  * shared [dev.tramai.testing.persistence.approval.ApprovalStoreTck].
@@ -47,19 +50,57 @@ class ApprovalStoreTckEnrollmentArchitectureTest {
     }
 
     @Test
-    fun `every ApprovalStore implementation has a runner named after it in its module`() {
+    fun `every ApprovalStore implementation has a valid TCK runner in its module`() {
         val unenrolled = storeModules().flatMap { (module, implementations) ->
             implementations
-                .filter { storeName -> !hasRunner(module, storeName) }
+                .filter { storeName -> !hasValidRunner(module, storeName) }
                 .map { store -> "$module/$store" }
         }
         assertThat(unenrolled)
             .withFailMessage(
-                "ApprovalStore implementations without a <Store>TckTest runner in the same module: $unenrolled. " +
+                "ApprovalStore implementations without a <Store>TckTest runner extending " +
+                    "ApprovalStoreTck in the same module: $unenrolled. " +
                     "Adding an ApprovalStore without enrolling it in the compatibility contract " +
                     "must make a gate fail.",
             )
             .isEmpty()
+    }
+
+    // ── probe tests for the scanner itself ──────────────────────────
+
+    @Test
+    fun `body-less ApprovalStore implementation is detected`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            import dev.tramai.core.approval.ApprovalStore
+            class RedisApprovalStore(private val delegate: ApprovalStore) : ApprovalStore by delegate
+            """.trimIndent(),
+        )
+        assertThat(storeImplementations(file)).containsExactly("RedisApprovalStore")
+    }
+
+    @Test
+    fun `multiline ApprovalStore implementation is detected`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            class MultiLineApprovalStore(
+                private val clock: java.time.Clock,
+            ) : ApprovalStore {
+                override suspend fun create(request: ApprovalRequest): ApprovalRequest = request
+            }
+            """.trimIndent(),
+        )
+        assertThat(storeImplementations(file)).containsExactly("MultiLineApprovalStore")
+    }
+
+    @Test
+    fun `runner file must actually subclass ApprovalStoreTck`() {
+        val fake = tempSourceFile("class RedisApprovalStoreTckTest")
+        val real = tempSourceFile("class RedisApprovalStoreTckTest : ApprovalStoreTck() { }")
+        assertThat(runnerSubclassesTck(fake, "RedisApprovalStore")).isFalse()
+        assertThat(runnerSubclassesTck(real, "RedisApprovalStore")).isTrue()
     }
 
     // ── helpers ─────────────────────────────────────────────────────
@@ -92,9 +133,7 @@ class ApprovalStoreTckEnrollmentArchitectureTest {
      */
     private fun storeImplementations(file: File): List<String> {
         val text = file.readText()
-        return CLASS_HEADER.findAll(text).mapNotNull { match ->
-            val name = match.groupValues[1]
-            val header = match.groupValues[2]
+        return classHeaders(text).mapNotNull { (name, header) ->
             val supertype = supertypeSection(header)
             // A body-less declaration (no '{' of its own) makes the non-greedy
             // header regex bleed into the next declaration; a supertype section
@@ -103,6 +142,22 @@ class ApprovalStoreTckEnrollmentArchitectureTest {
             val overSpanned = DECLARATION_KEYWORD.containsMatchIn(supertype)
             if (!overSpanned && supertype.contains("ApprovalStore")) name else null
         }.toList()
+    }
+
+    /**
+     * Class/object name + header, as a union of two shapes:
+     * - with a body: header runs to the first `{` (may span lines);
+     * - body-less (e.g. `class X : ApprovalStore by delegate`): single-line
+     *   declaration, header runs to end of line.
+     */
+    private fun classHeaders(text: String): List<Pair<String, String>> {
+        val withBody = Regex("""(?s)(?:class|object)\s+(\w+)(.*?)\{""")
+            .findAll(text)
+            .map { it.groupValues[1] to it.groupValues[2] }
+        val bodyless = Regex("""(?m)^\s*(?:class|object)\s+(\w+)([^\n{]*)$""")
+            .findAll(text)
+            .map { it.groupValues[1] to it.groupValues[2] }
+        return (withBody + bodyless).toList()
     }
 
     /** Everything after the first top-level `:` in a class header (the supertype list). */
@@ -118,12 +173,27 @@ class ApprovalStoreTckEnrollmentArchitectureTest {
         return ""
     }
 
-    private fun hasRunner(module: String, storeName: String): Boolean {
-        val testDir = File(repoRoot, "$module/src/test/kotlin")
-        if (!testDir.isDirectory) return false
-        return testDir.walkTopDown()
-            .any { it.isFile && it.name == "${storeName}TckTest.kt" }
+    private fun hasValidRunner(module: String, storeName: String): Boolean {
+        val runner = findRunnerFileInModule(module, storeName) ?: return false
+        return runnerSubclassesTck(runner, storeName)
     }
+
+    private fun findRunnerFileInModule(module: String, storeName: String): File? {
+        val testDir = File(repoRoot, "$module/src/test/kotlin")
+        if (!testDir.isDirectory) return null
+        return testDir.walkTopDown()
+            .firstOrNull { it.isFile && it.name == "${storeName}TckTest.kt" }
+    }
+
+    /**
+     * A `<Store>TckTest` file only counts as enrollment if its class actually
+     * extends [dev.tramai.testing.persistence.approval.ApprovalStoreTck]. A
+     * same-named file with an unrelated class would otherwise satisfy the
+     * gate while executing zero contract tests.
+     */
+    private fun runnerSubclassesTck(runnerFile: File, storeName: String): Boolean =
+        Regex("""(?s)class\s+${storeName}TckTest\b[^{]*:\s*ApprovalStoreTck\b""")
+            .containsMatchIn(runnerFile.readText())
 
     private fun findRunnerFile(runnerName: String): File? {
         val modules = repoRoot.listFiles { file -> file.isDirectory && file.name.startsWith("tramai-") }
@@ -135,10 +205,13 @@ class ApprovalStoreTckEnrollmentArchitectureTest {
             .firstOrNull { it.isFile && it.name == "$runnerName.kt" }
     }
 
-    private companion object {
-        /** Class/object name + header up to the first `{`, spanning newlines. */
-        val CLASS_HEADER = Regex("""(?s)(?:class|object)\s+(\w+)(.*?)\{""")
+    private fun tempSourceFile(content: String): File {
+        val dir = Files.createTempDirectory("tck-enrollment-probe-").toFile()
+        dir.deleteOnExit()
+        return File(dir, "Probe.kt").apply { writeText(content) }
+    }
 
+    private companion object {
         /** Declaration keywords that must never appear inside a real supertype list. */
         val DECLARATION_KEYWORD = Regex("""(fun |class |interface |object |/\*\*)""")
     }

--- a/tramai-testing/src/test/kotlin/dev/tramai/testing/ApprovalStoreTckEnrollmentArchitectureTest.kt
+++ b/tramai-testing/src/test/kotlin/dev/tramai/testing/ApprovalStoreTckEnrollmentArchitectureTest.kt
@@ -21,7 +21,9 @@ import org.junit.jupiter.api.Test
  *    Adding a store without a runner fails the gate — the phrase
  *    "future stores must pass the TCK" is otherwise documentation, not
  *    architecture. A file named `<Store>TckTest.kt` that does not subclass
- *    the TCK does not count.
+ *    the TCK does not count. The scanner is source-shape based (class/object
+ *    declarations with or without bodies, single-line or multiline, with or
+ *    without visibility/`open` modifiers) — not a type resolver.
  *
  * The runner file IS the reviewed contract matrix: it wires the store to the
  * shared [dev.tramai.testing.persistence.approval.ApprovalStoreTck].
@@ -110,6 +112,21 @@ class ApprovalStoreTckEnrollmentArchitectureTest {
     }
 
     @Test
+    fun `modifier-prefixed and colon-continued body-less implementations are detected`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            import dev.tramai.core.approval.ApprovalStore
+            internal class RedisApprovalStore(
+                private val delegate: ApprovalStore,
+            )
+                : ApprovalStore by delegate
+            """.trimIndent(),
+        )
+        assertThat(storeImplementations(file)).containsExactly("RedisApprovalStore")
+    }
+
+    @Test
     fun `runner file must actually subclass ApprovalStoreTck`() {
         val fake = tempSourceFile("class RedisApprovalStoreTckTest")
         val real = tempSourceFile("class RedisApprovalStoreTckTest : ApprovalStoreTck() { }")
@@ -180,7 +197,9 @@ class ApprovalStoreTckEnrollmentArchitectureTest {
 
     private fun bodylessHeaders(text: String): List<Pair<String, String>> {
         val lines = text.lines()
-        val declaration = Regex("""^\s*(?:class|object)\s+(\w+)(.*)$""")
+        // Unanchored so visibility / open modifiers (`internal class X ...`)
+        // still match.
+        val declaration = Regex("""(?:class|object)\s+(\w+)(.*)$""")
         val result = mutableListOf<Pair<String, String>>()
         var i = 0
         while (i < lines.size) {
@@ -193,7 +212,15 @@ class ApprovalStoreTckEnrollmentArchitectureTest {
             val header = StringBuilder(decl.groupValues[2])
             var depth = decl.groupValues[2].count { it == '(' } - decl.groupValues[2].count { it == ')' }
             var j = i
-            while (depth > 0 || header.trimEnd().endsWith("(") || header.trimEnd().endsWith(",")) {
+            while (true) {
+                val nextLine = lines.getOrNull(j + 1)
+                val continues = depth > 0 ||
+                    header.trimEnd().endsWith("(") ||
+                    header.trimEnd().endsWith(",") ||
+                    // `)\n    : ApprovalStore by delegate` — supertype on its
+                    // own line.
+                    (nextLine != null && nextLine.trimStart().startsWith(":"))
+                if (!continues) break
                 j++
                 if (j >= lines.size) break
                 val next = lines[j]

--- a/tramai-testing/src/test/kotlin/dev/tramai/testing/ApprovalStoreTckEnrollmentArchitectureTest.kt
+++ b/tramai-testing/src/test/kotlin/dev/tramai/testing/ApprovalStoreTckEnrollmentArchitectureTest.kt
@@ -96,6 +96,20 @@ class ApprovalStoreTckEnrollmentArchitectureTest {
     }
 
     @Test
+    fun `multiline body-less ApprovalStore implementation is detected`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            import dev.tramai.core.approval.ApprovalStore
+            class RedisApprovalStore(
+                private val delegate: ApprovalStore,
+            ) : ApprovalStore by delegate
+            """.trimIndent(),
+        )
+        assertThat(storeImplementations(file)).containsExactly("RedisApprovalStore")
+    }
+
+    @Test
     fun `runner file must actually subclass ApprovalStoreTck`() {
         val fake = tempSourceFile("class RedisApprovalStoreTckTest")
         val real = tempSourceFile("class RedisApprovalStoreTckTest : ApprovalStoreTck() { }")
@@ -140,24 +154,56 @@ class ApprovalStoreTckEnrollmentArchitectureTest {
             // containing declaration keywords or a doc comment is such a false
             // positive (e.g. exception classes with implicit bodies).
             val overSpanned = DECLARATION_KEYWORD.containsMatchIn(supertype)
-            if (!overSpanned && supertype.contains("ApprovalStore")) name else null
-        }.toList()
+            // Word-boundary match on the interface name so a supertype like
+            // `ApprovalStoreException` (whose name merely contains the word)
+            // never counts as an implementation.
+            if (!overSpanned && APPROVAL_STORE_TYPE.containsMatchIn(supertype)) name else null
+        }.distinct().toList()
     }
 
     /**
      * Class/object name + header, as a union of two shapes:
      * - with a body: header runs to the first `{` (may span lines);
-     * - body-less (e.g. `class X : ApprovalStore by delegate`): single-line
-     *   declaration, header runs to end of line.
+     * - body-less (e.g. `class X : ApprovalStore by delegate`): the header
+     *   runs to the first `{` or to the end of the declaration. A body-less
+     *   declaration may span lines when parameters are parenthesized, so the
+     *   line walk continues while paren depth is positive or the line ends
+     *   with `(` / `,`.
      */
     private fun classHeaders(text: String): List<Pair<String, String>> {
         val withBody = Regex("""(?s)(?:class|object)\s+(\w+)(.*?)\{""")
             .findAll(text)
             .map { it.groupValues[1] to it.groupValues[2] }
-        val bodyless = Regex("""(?m)^\s*(?:class|object)\s+(\w+)([^\n{]*)$""")
-            .findAll(text)
-            .map { it.groupValues[1] to it.groupValues[2] }
+        val bodyless = bodylessHeaders(text)
         return (withBody + bodyless).toList()
+    }
+
+    private fun bodylessHeaders(text: String): List<Pair<String, String>> {
+        val lines = text.lines()
+        val declaration = Regex("""^\s*(?:class|object)\s+(\w+)(.*)$""")
+        val result = mutableListOf<Pair<String, String>>()
+        var i = 0
+        while (i < lines.size) {
+            val decl = declaration.find(lines[i])
+            if (decl == null) {
+                i++
+                continue
+            }
+            val name = decl.groupValues[1]
+            val header = StringBuilder(decl.groupValues[2])
+            var depth = decl.groupValues[2].count { it == '(' } - decl.groupValues[2].count { it == ')' }
+            var j = i
+            while (depth > 0 || header.trimEnd().endsWith("(") || header.trimEnd().endsWith(",")) {
+                j++
+                if (j >= lines.size) break
+                val next = lines[j]
+                header.append("\n").append(next)
+                depth += next.count { it == '(' } - next.count { it == ')' }
+            }
+            result.add(name to header.toString())
+            i = j + 1
+        }
+        return result
     }
 
     /** Everything after the first top-level `:` in a class header (the supertype list). */
@@ -212,6 +258,9 @@ class ApprovalStoreTckEnrollmentArchitectureTest {
     }
 
     private companion object {
+        /** The interface every enrolled store must extend. */
+        val APPROVAL_STORE_TYPE = Regex("""\bApprovalStore\b""")
+
         /** Declaration keywords that must never appear inside a real supertype list. */
         val DECLARATION_KEYWORD = Regex("""(fun |class |interface |object |/\*\*)""")
     }

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/ApprovalStoreFixtures.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/ApprovalStoreFixtures.kt
@@ -1,0 +1,61 @@
+package dev.tramai.testing.persistence.approval
+
+import dev.tramai.core.approval.ApprovalBinding
+import dev.tramai.core.approval.ApprovalRequest
+import dev.tramai.core.approval.ApprovalStatus
+import dev.tramai.core.approval.Sha256Digest
+import java.time.Instant
+
+/**
+ * Fixture factory for the ApprovalStore TCK. The TCK owns approval IDs,
+ * timestamps, token digests, actors, and expected state transitions — the
+ * runner owns storage technology (temp dirs, keys, datasources).
+ */
+object ApprovalStoreFixtures {
+
+    /** Fixed digest: sha256:<64 x 'a'> — valid but NOT the stored token digest. */
+    fun digest(hex: String = "a".repeat(64)): Sha256Digest = Sha256Digest.of("sha256:$hex")
+
+    /** The digest the store will verify against: sha256:<64 x 'f'>. */
+    fun validTokenDigest(): Sha256Digest = digest("f".repeat(64))
+
+    /** A digest guaranteed to mismatch [validTokenDigest]. */
+    fun wrongTokenDigest(): Sha256Digest = digest("e".repeat(64))
+
+    fun binding(
+        workflowRunId: String = "wf-run-1",
+        toolName: String = "execute",
+        argumentsDigest: Sha256Digest = digest("b".repeat(64)),
+        policyVersion: String = "v1",
+        workflowDigest: Sha256Digest = digest("c".repeat(64)),
+        approvalTokenDigest: Sha256Digest = validTokenDigest(),
+    ): ApprovalBinding = ApprovalBinding(
+        workflowRunId = workflowRunId,
+        toolName = toolName,
+        argumentsDigest = argumentsDigest,
+        policyVersion = policyVersion,
+        workflowDigest = workflowDigest,
+        approvalTokenDigest = approvalTokenDigest,
+    )
+
+    fun pending(
+        approvalId: String,
+        requestedAt: Instant,
+        expiresAt: Instant,
+        requestedBy: String = "requester-1",
+        binding: ApprovalBinding = binding(),
+    ): ApprovalRequest = ApprovalRequest(
+        approvalId = approvalId,
+        binding = binding,
+        status = ApprovalStatus.PENDING,
+        requestedBy = requestedBy,
+        requestedAt = requestedAt,
+        expiresAt = expiresAt,
+        decidedBy = null,
+        decidedAt = null,
+        decisionComment = null,
+        consumedBy = null,
+        consumedAt = null,
+        version = 0L,
+    )
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/ApprovalStoreTck.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/ApprovalStoreTck.kt
@@ -8,7 +8,10 @@ import dev.tramai.core.exception.ApprovalStoreNotConsumableException
 import dev.tramai.core.exception.ApprovalStoreNotFoundException
 import dev.tramai.core.exception.ApprovalStoreTokenRejectedException
 import dev.tramai.core.exception.IllegalApprovalTransitionException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
@@ -195,13 +198,31 @@ abstract class ApprovalStoreTck {
     }
 
     @Test
-    fun `terminal state rejects any further transition`() = runBlocking<Unit> {
-        val request = ApprovalStoreFixtures.pending("terminal-1", t0, expiry)
-        store.create(request)
-        store.transition("terminal-1", 0L, ApprovalTransition.Approve("approver-1"))
+    fun `terminal states reject any further transition`() = runBlocking<Unit> {
+        // APPROVED is terminal
+        val approved = ApprovalStoreFixtures.pending("terminal-approved", t0, expiry)
+        store.create(approved)
+        store.transition("terminal-approved", 0L, ApprovalTransition.Approve("approver-1"))
+        assertThat(
+            runCatching { store.transition("terminal-approved", 1L, ApprovalTransition.Deny("denier-1")) }.exceptionOrNull(),
+        ).isInstanceOf(IllegalApprovalTransitionException::class.java)
 
-        assertThat(runCatching { store.transition("terminal-1", 1L, ApprovalTransition.Deny("denier-1")) }.exceptionOrNull())
-            .isInstanceOf(IllegalApprovalTransitionException::class.java)
+        // DENIED is terminal
+        val denied = ApprovalStoreFixtures.pending("terminal-denied", t0, expiry)
+        store.create(denied)
+        store.transition("terminal-denied", 0L, ApprovalTransition.Deny("denier-1"))
+        assertThat(
+            runCatching { store.transition("terminal-denied", 1L, ApprovalTransition.Approve("approver-1")) }.exceptionOrNull(),
+        ).isInstanceOf(IllegalApprovalTransitionException::class.java)
+
+        // TIMED_OUT is terminal
+        val timedOut = ApprovalStoreFixtures.pending("terminal-timedout", t0, expiry)
+        store.create(timedOut)
+        clock.advance(Duration.ofSeconds(601))
+        store.transition("terminal-timedout", 0L, ApprovalTransition.Timeout)
+        assertThat(
+            runCatching { store.transition("terminal-timedout", 1L, ApprovalTransition.Approve("approver-1")) }.exceptionOrNull(),
+        ).isInstanceOf(IllegalApprovalTransitionException::class.java)
     }
 
     @Test
@@ -379,50 +400,121 @@ abstract class ApprovalStoreTck {
         assertThat(store.get("non-mutating")?.version).isEqualTo(1L)
     }
 
+    @Test
+    fun `replay with stale expected version rejected`() = runBlocking<Unit> {
+        approveAndConsumeSetup("replay-stale")
+        store.consumeApprovedOrReplay("replay-stale", 1L, ApprovalStoreFixtures.validTokenDigest(), "worker-1")
+
+        assertThat(
+            runCatching {
+                store.consumeApprovedOrReplay("replay-stale", 0L, ApprovalStoreFixtures.validTokenDigest(), "worker-1")
+            }.exceptionOrNull(),
+        ).isInstanceOf(ApprovalStoreConflictException::class.java)
+    }
+
+    @Test
+    fun `wrong token on replay rejected`() = runBlocking<Unit> {
+        approveAndConsumeSetup("replay-bad-token")
+        store.consumeApprovedOrReplay("replay-bad-token", 1L, ApprovalStoreFixtures.validTokenDigest(), "worker-1")
+
+        assertThat(
+            runCatching {
+                store.consumeApprovedOrReplay("replay-bad-token", 1L, ApprovalStoreFixtures.wrongTokenDigest(), "worker-1")
+            }.exceptionOrNull(),
+        ).isInstanceOf(ApprovalStoreTokenRejectedException::class.java)
+    }
+
+    @Test
+    fun `consume on missing approval throws not found`() = runBlocking<Unit> {
+        assertThat(
+            runCatching {
+                store.consumeApprovedOrReplay("missing-consume", 0L, ApprovalStoreFixtures.validTokenDigest(), "worker-1")
+            }.exceptionOrNull(),
+        ).isInstanceOf(ApprovalStoreNotFoundException::class.java)
+    }
+
+    @Test
+    fun `fresh consumption records the advanced clock instant`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("consume-advanced", t0, expiry)
+        store.create(request)
+        store.transition("consume-advanced", 0L, ApprovalTransition.Approve("approver-1"))
+        clock.advance(Duration.ofSeconds(10))
+
+        val receipt = store.consumeApprovedOrReplay(
+            "consume-advanced", 1L, ApprovalStoreFixtures.validTokenDigest(), "worker-1",
+        )
+
+        assertThat(receipt.request.consumedAt).isEqualTo(t0.plusSeconds(10))
+    }
+
     // ── Concurrency ─────────────────────────────────────────────────
+
+    /**
+     * Runs [contenders] on parallel workers, releasing them only once every
+     * contender is ready, so the operations genuinely overlap instead of
+     * serializing on the caller's single-threaded event loop. A non-atomic
+     * store (check-then-act without a lock/row-lock) must fail the race
+     * assertions below.
+     */
+    private suspend fun <T> runInParallel(vararg contenders: suspend () -> T): List<T> = coroutineScope {
+        val ready = Channel<Unit>(capacity = contenders.size)
+        val release = CompletableDeferred<Unit>()
+        val results = contenders.map { op ->
+            async(Dispatchers.Default) {
+                ready.send(Unit)
+                release.await()
+                op()
+            }
+        }
+        repeat(contenders.size) { ready.receive() }
+        release.complete(Unit)
+        results.map { it.await() }
+    }
 
     @Test
     fun `concurrent transition race - exactly one wins`() = runBlocking<Unit> {
-        val request = ApprovalStoreFixtures.pending("race-1", t0, expiry)
-        store.create(request)
+        // Several scheduling opportunities: one run per id, each on a fresh
+        // approval, so a store that only wins by luck once still fails.
+        repeat(5) { iteration ->
+            val id = "race-$iteration"
+            val request = ApprovalStoreFixtures.pending(id, t0, expiry)
+            store.create(request)
 
-        val outcomes = coroutineScope {
-            val approve = async { runCatching { store.transition("race-1", 0L, ApprovalTransition.Approve("a")) } }
-            val deny = async { runCatching { store.transition("race-1", 0L, ApprovalTransition.Deny("b")) } }
-            listOf(approve.await(), deny.await())
+            val outcomes = runInParallel(
+                { runCatching { store.transition(id, 0L, ApprovalTransition.Approve("a")) } },
+                { runCatching { store.transition(id, 0L, ApprovalTransition.Deny("b")) } },
+            )
+
+            val successes = outcomes.count { it.isSuccess }
+            val conflicts = outcomes.count { it.exceptionOrNull() is ApprovalStoreConflictException }
+            assertThat(successes).isEqualTo(1)
+            assertThat(conflicts).isEqualTo(1)
+
+            val persisted = store.get(id)!!
+            assertThat(persisted.version).isEqualTo(1L)
+            assertThat(persisted.status).isIn(ApprovalStatus.APPROVED, ApprovalStatus.DENIED)
+            val winner = outcomes.first { it.isSuccess }.getOrThrow()
+            assertThat(persisted.status).isEqualTo(winner.status)
         }
-
-        val successes = outcomes.count { it.isSuccess }
-        val conflicts = outcomes.count { it.exceptionOrNull() is ApprovalStoreConflictException }
-        assertThat(successes).isEqualTo(1)
-        assertThat(conflicts).isEqualTo(1)
-
-        val persisted = store.get("race-1")!!
-        assertThat(persisted.version).isEqualTo(1L)
-        assertThat(persisted.status).isIn(ApprovalStatus.APPROVED, ApprovalStatus.DENIED)
-        val winner = outcomes.first { it.isSuccess }.getOrThrow()
-        assertThat(persisted.status).isEqualTo(winner.status)
     }
 
     @Test
     fun `concurrent identical consumption - one fresh one replay, same durable record`() = runBlocking<Unit> {
-        approveAndConsumeSetup("consume-race")
+        repeat(5) { iteration ->
+            val id = "consume-race-$iteration"
+            approveAndConsumeSetup(id)
 
-        val receipts = coroutineScope {
-            val first = async {
-                store.consumeApprovedOrReplay("consume-race", 1L, ApprovalStoreFixtures.validTokenDigest(), "worker-1")
-            }
-            val second = async {
-                store.consumeApprovedOrReplay("consume-race", 1L, ApprovalStoreFixtures.validTokenDigest(), "worker-1")
-            }
-            listOf(first.await(), second.await())
+            val receipts = runInParallel(
+                { store.consumeApprovedOrReplay(id, 1L, ApprovalStoreFixtures.validTokenDigest(), "worker-1") },
+                { store.consumeApprovedOrReplay(id, 1L, ApprovalStoreFixtures.validTokenDigest(), "worker-1") },
+            )
+
+            assertThat(receipts.count { !it.replayed }).isEqualTo(1)
+            assertThat(receipts.count { it.replayed }).isEqualTo(1)
+            assertThat(receipts[0].request).isEqualTo(receipts[1].request)
+            assertThat(receipts[0].request.consumedAt).isEqualTo(receipts[1].request.consumedAt)
+            assertThat(receipts[0].request.version).isEqualTo(2L)
+            assertThat(store.get(id)?.version).isEqualTo(2L)
         }
-
-        assertThat(receipts.count { !it.replayed }).isEqualTo(1)
-        assertThat(receipts.count { it.replayed }).isEqualTo(1)
-        assertThat(receipts[0].request).isEqualTo(receipts[1].request)
-        assertThat(receipts[0].request.consumedAt).isEqualTo(receipts[1].request.consumedAt)
-        assertThat(receipts[0].request.version).isEqualTo(2L)
-        assertThat(store.get("consume-race")?.version).isEqualTo(2L)
     }
 }

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/ApprovalStoreTck.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/ApprovalStoreTck.kt
@@ -1,0 +1,428 @@
+package dev.tramai.testing.persistence.approval
+
+import dev.tramai.core.approval.ApprovalStatus
+import dev.tramai.core.approval.ApprovalStore
+import dev.tramai.core.approval.ApprovalTransition
+import dev.tramai.core.exception.ApprovalStoreConflictException
+import dev.tramai.core.exception.ApprovalStoreNotConsumableException
+import dev.tramai.core.exception.ApprovalStoreNotFoundException
+import dev.tramai.core.exception.ApprovalStoreTokenRejectedException
+import dev.tramai.core.exception.IllegalApprovalTransitionException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Epic 8.1a shared ApprovalStore compatibility contract.
+ *
+ * Every [ApprovalStore] implementation must satisfy exactly the same
+ * externally observable approval persistence contract, regardless of storage
+ * technology (memory, encrypted files, JDBC). This TCK tests the SPI, not
+ * implementation internals.
+ *
+ * Each test gets a FRESH store from [harness] wired to a [MutableClock] fixed
+ * at T0. Time advances only via [MutableClock.advance] — never real sleeps.
+ */
+abstract class ApprovalStoreTck {
+
+    abstract val harness: ApprovalStoreTckHarness
+
+    protected lateinit var store: ApprovalStore
+    protected lateinit var clock: MutableClock
+
+    protected val t0: Instant = Instant.parse("2026-08-22T12:00:00Z")
+    protected val expiry: Instant = t0.plusSeconds(600)
+
+    @BeforeEach
+    fun setUp() {
+        clock = MutableClock(t0)
+        store = harness.createStore(clock)
+    }
+
+    @AfterEach
+    fun tearDown() = runBlocking<Unit> { harness.closeStore(store) }
+
+    // ── Creation / read ─────────────────────────────────────────────
+
+    @Test
+    fun `create pending round-trips exactly`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("create-1", t0, expiry)
+        val stored = store.create(request)
+        assertThat(stored).isEqualTo(request)
+        assertThat(store.get("create-1")).isEqualTo(request)
+    }
+
+    @Test
+    fun `get missing id returns null`() = runBlocking<Unit> {
+        assertThat(store.get("does-not-exist")).isNull()
+    }
+
+    @Test
+    fun `duplicate create throws conflict`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("dup-1", t0, expiry)
+        store.create(request)
+        assertThat(
+            runCatching { store.create(request) }.exceptionOrNull(),
+        ).isInstanceOf(ApprovalStoreConflictException::class.java)
+    }
+
+    @Test
+    fun `non-zero initial version rejected`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("bad-version", t0, expiry).copy(version = 1L)
+        assertThat(runCatching { store.create(request) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `non-pending initial state rejected`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("bad-status", t0, expiry).copy(status = ApprovalStatus.APPROVED)
+        assertThat(runCatching { store.create(request) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `pre-populated decision fields rejected`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("bad-decided", t0, expiry)
+            .copy(decidedBy = "someone", decidedAt = t0)
+        assertThat(runCatching { store.create(request) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `pre-populated consumption fields rejected`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("bad-consumed", t0, expiry)
+            .copy(consumedBy = "someone", consumedAt = t0)
+        assertThat(runCatching { store.create(request) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `blank approval id rejected`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("  ", t0, expiry)
+        assertThat(runCatching { store.create(request) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `requestedAt in future rejected`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("future-req", t0.plusSeconds(60), expiry)
+        assertThat(runCatching { store.create(request) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `expiresAt before requestedAt rejected`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("bad-expiry", t0, t0.minusSeconds(60))
+        assertThat(runCatching { store.create(request) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    // ── State transitions ───────────────────────────────────────────
+
+    @Test
+    fun `pending to approved sets decision fields and increments version`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("approve-1", t0, expiry)
+        store.create(request)
+
+        val updated = store.transition("approve-1", 0L, ApprovalTransition.Approve("approver-1", "looks good"))
+
+        assertThat(updated.status).isEqualTo(ApprovalStatus.APPROVED)
+        assertThat(updated.version).isEqualTo(1L)
+        assertThat(updated.decidedBy).isEqualTo("approver-1")
+        assertThat(updated.decidedAt).isEqualTo(t0)
+        assertThat(updated.decisionComment).isEqualTo("looks good")
+    }
+
+    @Test
+    fun `pending to denied sets decision fields and increments version`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("deny-1", t0, expiry)
+        store.create(request)
+
+        val updated = store.transition("deny-1", 0L, ApprovalTransition.Deny("denier-1"))
+
+        assertThat(updated.status).isEqualTo(ApprovalStatus.DENIED)
+        assertThat(updated.version).isEqualTo(1L)
+        assertThat(updated.decidedBy).isEqualTo("denier-1")
+        assertThat(updated.decidedAt).isEqualTo(t0)
+    }
+
+    @Test
+    fun `expired pending can time out`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("timeout-1", t0, expiry)
+        store.create(request)
+        clock.advance(Duration.ofSeconds(601))
+
+        val updated = store.transition("timeout-1", 0L, ApprovalTransition.Timeout)
+
+        assertThat(updated.status).isEqualTo(ApprovalStatus.TIMED_OUT)
+        assertThat(updated.version).isEqualTo(1L)
+        assertThat(updated.decidedAt).isEqualTo(t0.plusSeconds(601))
+    }
+
+    @Test
+    fun `timeout before expiry rejected`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("early-timeout", t0, expiry)
+        store.create(request)
+
+        assertThat(runCatching { store.transition("early-timeout", 0L, ApprovalTransition.Timeout) }.exceptionOrNull())
+            .isInstanceOf(IllegalApprovalTransitionException::class.java)
+    }
+
+    @Test
+    fun `approve after expiry rejected`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("late-approve", t0, expiry)
+        store.create(request)
+        clock.advance(Duration.ofSeconds(601))
+
+        assertThat(runCatching { store.transition("late-approve", 0L, ApprovalTransition.Approve("approver-1")) }.exceptionOrNull())
+            .isInstanceOf(IllegalApprovalTransitionException::class.java)
+    }
+
+    @Test
+    fun `deny after expiry rejected`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("late-deny", t0, expiry)
+        store.create(request)
+        clock.advance(Duration.ofSeconds(601))
+
+        assertThat(runCatching { store.transition("late-deny", 0L, ApprovalTransition.Deny("denier-1")) }.exceptionOrNull())
+            .isInstanceOf(IllegalApprovalTransitionException::class.java)
+    }
+
+    @Test
+    fun `terminal state rejects any further transition`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("terminal-1", t0, expiry)
+        store.create(request)
+        store.transition("terminal-1", 0L, ApprovalTransition.Approve("approver-1"))
+
+        assertThat(runCatching { store.transition("terminal-1", 1L, ApprovalTransition.Deny("denier-1")) }.exceptionOrNull())
+            .isInstanceOf(IllegalApprovalTransitionException::class.java)
+    }
+
+    @Test
+    fun `stale expected version throws conflict`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("stale-1", t0, expiry)
+        store.create(request)
+        store.transition("stale-1", 0L, ApprovalTransition.Approve("approver-1"))
+
+        assertThat(runCatching { store.transition("stale-1", 0L, ApprovalTransition.Deny("denier-1")) }.exceptionOrNull())
+            .isInstanceOf(ApprovalStoreConflictException::class.java)
+    }
+
+    @Test
+    fun `transition on missing approval throws not found`() = runBlocking<Unit> {
+        assertThat(runCatching { store.transition("missing-1", 0L, ApprovalTransition.Approve("approver-1")) }.exceptionOrNull())
+            .isInstanceOf(ApprovalStoreNotFoundException::class.java)
+    }
+
+    @Test
+    fun `every successful transition increments version exactly once`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("incr-1", t0, expiry)
+        store.create(request)
+
+        val first = store.transition("incr-1", 0L, ApprovalTransition.Approve("approver-1"))
+        assertThat(first.version).isEqualTo(1L)
+        val persisted = store.get("incr-1")
+        assertThat(persisted?.version).isEqualTo(1L)
+    }
+
+    // ── Consumption / exact replay ──────────────────────────────────
+
+    private suspend fun approveAndConsumeSetup(id: String) {
+        val request = ApprovalStoreFixtures.pending(id, t0, expiry)
+        store.create(request)
+        store.transition(id, 0L, ApprovalTransition.Approve("approver-1"))
+    }
+
+    @Test
+    fun `fresh consumption succeeds`() = runBlocking<Unit> {
+        approveAndConsumeSetup("consume-1")
+
+        val receipt = store.consumeApprovedOrReplay(
+            "consume-1", 1L, ApprovalStoreFixtures.validTokenDigest(), "worker-1",
+        )
+
+        assertThat(receipt.replayed).isFalse()
+        assertThat(receipt.request.status).isEqualTo(ApprovalStatus.APPROVED)
+        assertThat(receipt.request.consumedBy).isEqualTo("worker-1")
+        assertThat(receipt.request.consumedAt).isEqualTo(t0)
+        assertThat(receipt.request.version).isEqualTo(2L)
+    }
+
+    @Test
+    fun `wrong token rejected`() = runBlocking<Unit> {
+        approveAndConsumeSetup("bad-token")
+
+        assertThat(
+            runCatching {
+                store.consumeApprovedOrReplay("bad-token", 1L, ApprovalStoreFixtures.wrongTokenDigest(), "worker-1")
+            }.exceptionOrNull(),
+        ).isInstanceOf(ApprovalStoreTokenRejectedException::class.java)
+    }
+
+    @Test
+    fun `wrong consumedBy on replay rejected`() = runBlocking<Unit> {
+        approveAndConsumeSetup("bad-replayer")
+        store.consumeApprovedOrReplay("bad-replayer", 1L, ApprovalStoreFixtures.validTokenDigest(), "worker-1")
+
+        assertThat(
+            runCatching {
+                store.consumeApprovedOrReplay("bad-replayer", 1L, ApprovalStoreFixtures.validTokenDigest(), "intruder")
+            }.exceptionOrNull(),
+        ).isInstanceOf(ApprovalStoreNotConsumableException::class.java)
+    }
+
+    @Test
+    fun `stale expected version on consume rejected`() = runBlocking<Unit> {
+        approveAndConsumeSetup("stale-consume")
+
+        assertThat(
+            runCatching {
+                store.consumeApprovedOrReplay("stale-consume", 0L, ApprovalStoreFixtures.validTokenDigest(), "worker-1")
+            }.exceptionOrNull(),
+        ).isInstanceOf(ApprovalStoreConflictException::class.java)
+    }
+
+    @Test
+    fun `pending cannot be consumed`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("pending-consume", t0, expiry)
+        store.create(request)
+
+        assertThat(
+            runCatching {
+                store.consumeApprovedOrReplay("pending-consume", 0L, ApprovalStoreFixtures.validTokenDigest(), "worker-1")
+            }.exceptionOrNull(),
+        ).isInstanceOf(ApprovalStoreNotConsumableException::class.java)
+    }
+
+    @Test
+    fun `denied cannot be consumed`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("denied-consume", t0, expiry)
+        store.create(request)
+        store.transition("denied-consume", 0L, ApprovalTransition.Deny("denier-1"))
+
+        assertThat(
+            runCatching {
+                store.consumeApprovedOrReplay("denied-consume", 1L, ApprovalStoreFixtures.validTokenDigest(), "worker-1")
+            }.exceptionOrNull(),
+        ).isInstanceOf(ApprovalStoreNotConsumableException::class.java)
+    }
+
+    @Test
+    fun `timed out cannot be consumed`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("timeout-consume", t0, expiry)
+        store.create(request)
+        clock.advance(Duration.ofSeconds(601))
+        store.transition("timeout-consume", 0L, ApprovalTransition.Timeout)
+
+        assertThat(
+            runCatching {
+                store.consumeApprovedOrReplay("timeout-consume", 1L, ApprovalStoreFixtures.validTokenDigest(), "worker-1")
+            }.exceptionOrNull(),
+        ).isInstanceOf(ApprovalStoreNotConsumableException::class.java)
+    }
+
+    @Test
+    fun `expired unconsumed approval cannot be consumed`() = runBlocking<Unit> {
+        approveAndConsumeSetup("expired-consume")
+        clock.advance(Duration.ofSeconds(601))
+
+        assertThat(
+            runCatching {
+                store.consumeApprovedOrReplay("expired-consume", 1L, ApprovalStoreFixtures.validTokenDigest(), "worker-1")
+            }.exceptionOrNull(),
+        ).isInstanceOf(ApprovalStoreNotConsumableException::class.java)
+    }
+
+    @Test
+    fun `exact replay returns same durable record without writing`() = runBlocking<Unit> {
+        approveAndConsumeSetup("replay-1")
+        val first = store.consumeApprovedOrReplay("replay-1", 1L, ApprovalStoreFixtures.validTokenDigest(), "worker-1")
+
+        val replay = store.consumeApprovedOrReplay("replay-1", 1L, ApprovalStoreFixtures.validTokenDigest(), "worker-1")
+
+        assertThat(replay.replayed).isTrue()
+        assertThat(replay.request).isEqualTo(first.request)
+        assertThat(replay.request.consumedAt).isEqualTo(first.request.consumedAt)
+        assertThat(replay.request.version).isEqualTo(2L)
+        assertThat(store.get("replay-1")?.version).isEqualTo(2L)
+    }
+
+    @Test
+    fun `exact replay remains valid after expiry`() = runBlocking<Unit> {
+        approveAndConsumeSetup("replay-expired")
+        store.consumeApprovedOrReplay("replay-expired", 1L, ApprovalStoreFixtures.validTokenDigest(), "worker-1")
+        clock.advance(Duration.ofHours(1))
+
+        val replay = store.consumeApprovedOrReplay("replay-expired", 1L, ApprovalStoreFixtures.validTokenDigest(), "worker-1")
+
+        assertThat(replay.replayed).isTrue()
+        assertThat(replay.request.consumedAt).isEqualTo(t0)
+    }
+
+    @Test
+    fun `rejected consumption leaves stored record unchanged`() = runBlocking<Unit> {
+        approveAndConsumeSetup("non-mutating")
+        val before = store.get("non-mutating")!!
+
+        runCatching {
+            store.consumeApprovedOrReplay("non-mutating", 1L, ApprovalStoreFixtures.wrongTokenDigest(), "worker-1")
+        }
+
+        assertThat(store.get("non-mutating")).isEqualTo(before)
+        assertThat(store.get("non-mutating")?.consumedBy).isNull()
+        assertThat(store.get("non-mutating")?.version).isEqualTo(1L)
+    }
+
+    // ── Concurrency ─────────────────────────────────────────────────
+
+    @Test
+    fun `concurrent transition race - exactly one wins`() = runBlocking<Unit> {
+        val request = ApprovalStoreFixtures.pending("race-1", t0, expiry)
+        store.create(request)
+
+        val outcomes = coroutineScope {
+            val approve = async { runCatching { store.transition("race-1", 0L, ApprovalTransition.Approve("a")) } }
+            val deny = async { runCatching { store.transition("race-1", 0L, ApprovalTransition.Deny("b")) } }
+            listOf(approve.await(), deny.await())
+        }
+
+        val successes = outcomes.count { it.isSuccess }
+        val conflicts = outcomes.count { it.exceptionOrNull() is ApprovalStoreConflictException }
+        assertThat(successes).isEqualTo(1)
+        assertThat(conflicts).isEqualTo(1)
+
+        val persisted = store.get("race-1")!!
+        assertThat(persisted.version).isEqualTo(1L)
+        assertThat(persisted.status).isIn(ApprovalStatus.APPROVED, ApprovalStatus.DENIED)
+        val winner = outcomes.first { it.isSuccess }.getOrThrow()
+        assertThat(persisted.status).isEqualTo(winner.status)
+    }
+
+    @Test
+    fun `concurrent identical consumption - one fresh one replay, same durable record`() = runBlocking<Unit> {
+        approveAndConsumeSetup("consume-race")
+
+        val receipts = coroutineScope {
+            val first = async {
+                store.consumeApprovedOrReplay("consume-race", 1L, ApprovalStoreFixtures.validTokenDigest(), "worker-1")
+            }
+            val second = async {
+                store.consumeApprovedOrReplay("consume-race", 1L, ApprovalStoreFixtures.validTokenDigest(), "worker-1")
+            }
+            listOf(first.await(), second.await())
+        }
+
+        assertThat(receipts.count { !it.replayed }).isEqualTo(1)
+        assertThat(receipts.count { it.replayed }).isEqualTo(1)
+        assertThat(receipts[0].request).isEqualTo(receipts[1].request)
+        assertThat(receipts[0].request.consumedAt).isEqualTo(receipts[1].request.consumedAt)
+        assertThat(receipts[0].request.version).isEqualTo(2L)
+        assertThat(store.get("consume-race")?.version).isEqualTo(2L)
+    }
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/ApprovalStoreTckHarness.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/ApprovalStoreTckHarness.kt
@@ -1,0 +1,18 @@
+package dev.tramai.testing.persistence.approval
+
+import dev.tramai.core.approval.ApprovalStore
+
+/**
+ * Storage-technology hook for the ApprovalStore TCK.
+ *
+ * The runner owns everything implementation-specific: temp directories,
+ * encryption keys, datasources, table creation, store construction, cleanup.
+ * Each call to [createStore] must return a FRESH, isolated store wired to the
+ * given [MutableClock] (fixed at construction; advanced only by the TCK).
+ */
+interface ApprovalStoreTckHarness {
+
+    fun createStore(clock: MutableClock): ApprovalStore
+
+    suspend fun closeStore(store: ApprovalStore) = Unit
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/MutableClock.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/MutableClock.kt
@@ -1,0 +1,26 @@
+package dev.tramai.testing.persistence.approval
+
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+/**
+ * Deterministic [Clock] for the ApprovalStore TCK: fixed at construction,
+ * advanced explicitly by the test. Never `Instant.now()` or real sleeps.
+ */
+class MutableClock(initial: Instant) : Clock() {
+
+    private var now: Instant = initial
+
+    override fun getZone(): ZoneId = ZoneOffset.UTC
+
+    override fun withZone(zone: ZoneId): Clock = this
+
+    override fun instant(): Instant = now
+
+    fun advance(duration: Duration) {
+        now = now.plus(duration)
+    }
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/MutableClock.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/MutableClock.kt
@@ -9,18 +9,29 @@ import java.time.ZoneOffset
 /**
  * Deterministic [Clock] for the ApprovalStore TCK: fixed at construction,
  * advanced explicitly by the test. Never `Instant.now()` or real sleeps.
+ *
+ * Thread-safe: the instant is [Volatile] because the TCK concurrency cases
+ * read the clock from parallel workers.
  */
-class MutableClock(initial: Instant) : Clock() {
+class MutableClock(
+    initial: Instant,
+    private val zone: ZoneId = ZoneOffset.UTC,
+) : Clock() {
 
+    @Volatile
     private var now: Instant = initial
 
-    override fun getZone(): ZoneId = ZoneOffset.UTC
+    override fun getZone(): ZoneId = zone
 
-    override fun withZone(zone: ZoneId): Clock = this
+    override fun withZone(zone: ZoneId): Clock = Clock.fixed(now, zone)
 
     override fun instant(): Instant = now
 
     fun advance(duration: Duration) {
         now = now.plus(duration)
+    }
+
+    fun set(newNow: Instant) {
+        now = newNow
     }
 }


### PR DESCRIPTION
## Summary

**Epic 8.1a: ApprovalStore compatibility TCK.** One shared behavioral contract for every `ApprovalStore` implementation — memory, encrypted file, and JDBC. Three independent test suites can all be green while describing three slightly different contracts; this PR makes `ApprovalStore → one behavioral specification → memory / file / JDBC` architectural reality.

The review rounds found real gaps and they were fixed in this PR (see below). One **production change** is included and deliberate: the JDBC consume path now takes a `FOR UPDATE` row lock inside an explicit transaction, so concurrent identical deliveries serialize into one fresh + one replay. This is a necessary consequence of making the concurrency TCK truthful — the previous autocommit read-then-CAS path could not satisfy the "one fresh + one replay" contract under genuine parallelism. Zero public API change, no persisted format/schema changes, no existing tests deleted.

## What changed

| File | Purpose |
|---|---|
| `tramai-testing/testFixtures/.../persistence/approval/ApprovalStoreTck.kt` | **37 shared cases** |
| `.../ApprovalStoreTckHarness.kt` | runner hook: `createStore(clock)` → fresh store; runner owns storage tech |
| `.../ApprovalStoreFixtures.kt` | TCK owns IDs, timestamps, token digests, actors |
| `.../MutableClock.kt` | deterministic time (`@Volatile`, correct `withZone`), advanced only explicitly |
| `tramai-testing/.../ApprovalStoreTckEnrollmentArchitectureTest.kt` | fail-closed enrollment guard + probe tests |
| `InMemoryApprovalStoreTckTest.kt` (security) | runner |
| `FileApprovalStoreTckTest.kt` (persistence-file) | runner (encrypted per-case temp-dir harness) |
| `JdbcApprovalStoreTckTest.kt` (persistence-jdbc) | runner (PostgreSQL testcontainers, table reset per case, container stopped in `@AfterAll`) |
| `JdbcApprovalStore.kt` (persistence-jdbc) | **production:** consume uses `SELECT ... FOR UPDATE` inside an explicit transaction |
| 3 × `build.gradle.kts` | `testImplementation(testFixtures(project(":tramai-testing")))` |
| `docs/reference/persistence-store-compatibility-contract.md` | Epic 8.1 matrix |
| ROADMAP-0.6.0.md / CHANGELOG.md | Epic 8.1 IN PROGRESS; changelog |

## Contract matrix (37 cases × 3 implementations)

- **Creation/read (10):** PENDING round-trip; missing-ID → null; duplicate → Conflict; non-zero version, non-PENDING, pre-populated decision/consumption fields, blank ID, future requestedAt, invalid expiry → IAE
- **Transitions (10):** APPROVED/DENIED set decided fields + version 1; expired → TIMED_OUT; timeout-before-expiry, approve/deny-after-expiry rejected; **terminal re-transition rejected for every terminal status (APPROVED/DENIED/TIMED_OUT)**; stale version → Conflict; missing → NotFound; version increments exactly once
- **Consumption/replay (15):** fresh consumption (replayed=false, consumed fields, version 2); wrong token → TokenRejected; wrong consumedBy on replay → NotConsumable; stale version → Conflict; PENDING/DENIED/TIMED_OUT/expired-unconsumed → NotConsumable; **exact replay returns the same durable record with no write, stays valid after expiry**; **replay with stale version → Conflict; wrong token on replay → TokenRejected; consume on missing → NotFound; fresh consumption records the advanced clock instant**; rejected consumption is non-mutating
- **Concurrency (2):** concurrent transition race — exactly one wins + one Conflict, version 1; concurrent identical consumption — one fresh + one replay receipt referencing the same durable record, version 2, identical consumedAt. **Both run on parallel workers (`Dispatchers.Default`) with a start barrier, 5 iterations each** — they genuinely overlap instead of serializing on the test event loop.

## Review-fix rounds

- **Round 1 (review):** concurrency tests serialized on `runBlocking`'s single-threaded event loop → now real parallel races with a barrier; enrollment guard had bypasses (body-less classes, fake runner files) → now detects body-less + multiline declarations and requires the runner to actually extend `ApprovalStoreTck`; file/JDBC runners shared storage across cases → per-case isolation; JDBC testcontainer leaked → stopped in `@AfterAll`; terminal-state matrix only pinned APPROVED → all three terminal statuses; `MutableClock` had wrong `withZone`/visibility → consolidated (`@Volatile`, correct semantics).
- **Round 2 (review):** the new parallel consume-race exposed that JDBC's autocommit read-then-CAS could not satisfy one-fresh-one-replay → **`FOR UPDATE` + explicit transaction** in `consumeApprovedOrReplay`. The transaction cleanup was then flagged by `verifyCancellationSafety` (catch(Throwable)/runCatching in a suspend function) → cleanup moved into a **non-suspend helper** that rethrows the original exception (CancellationException unchanged) and attaches rollback failures as suppressed; regression test proves a CancellationException from `commit()` escapes unchanged.

## Typed failure taxonomy

Conflict / NotFound / TokenRejected / NotConsumable / IllegalTransition / IllegalArgumentException — pinned by class, never `isInstanceOf(RuntimeException)`.

## Deterministic time

TCK-owned `MutableClock` fixed at T0 (2026-08-22T12:00:00Z), expiry T0+10min, `clock.advance(...)`. No sleeps, no `Instant.now()` — moves naturally toward Epic 8.3.

## Enrollment guard

`ApprovalStoreTckEnrollmentArchitectureTest` scans every module's main source set for concrete `ApprovalStore` implementations — including body-less (`class X : ApprovalStore by delegate`) and multiline declarations — and requires a `<Store>TckTest` in the same module that **actually extends `ApprovalStoreTck`**. A future `RedisApprovalStore` cannot merge without `RedisApprovalStoreTckTest` extending the TCK. Probe tests pin the scanner's own behavior (body-less, multiline, multiline body-less, fake runner).

## Mutation evidence (each restored after proving RED)

| Mutation | TCK outcome |
|---|---|
| Remove expectedVersion check in transition | RED — stale-version cases fail |
| Check-then-act consume without atomicity | RED — concurrent-race cases detect two winners / conflict instead of fresh+replay |
| Allow terminal re-transitions | RED — terminal matrix fails |
| Increment version during exact replay | RED — replay-identity + concurrent-consumption fail |
| Replace consumedAt during exact replay | RED — replay-after-expiry fails |
| Allow expired fresh consumption | RED — expired-unconsumed fails |
| Skip version/token check on replay branch | RED — replay negatives fail |

## Gates

- `verifyPr` (subproject tests, build-logic, maintainability, change policy) — GREEN locally
- `:tramai-testing:test` — GREEN (incl. enrollment guard probes)
- `:tramai-security:test` — GREEN, TCK **37/37**
- `:tramai-persistence-file:test` — GREEN, TCK **37/37**
- `:tramai-persistence-jdbc:test` — GREEN, TCK **37/37** (PostgreSQL testcontainers) incl. real parallel consume-race + cancellation regression
- `verifyCancellationSafety` — GREEN (no new critical/high findings vs PR base)
- apiCheck — zero public API change
