### PR TITLE
test(persistence): add ApprovalContinuationStore compatibility TCK — Epic 8.1b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,14 @@
   fixed: late `cancel()` now persists EXPIRED then fails Conflict (was
   CANCELLED), `create()` validates `argumentsDigest` against the payload
   (was accepted unchecked), and `claimForExecution()` checks version before
-  status (was NotClaimable on stale-version claims of CLAIMED rows). The
+  status (was NotClaimable on stale-version claims of CLAIMED rows). A
+  follow-up review found a fourth in the same family — the claim CAS-loss
+  re-read mapped a lost claim/cancel race to NotClaimable instead of
+  Conflict; fixed with the same version-before-status precedence and pinned
+  by a deterministic interleaving regression (gated codec: claim blocks at
+  decrypt, cancel wins, released claim must throw Conflict). The shared
+  race assertions were tightened from "a typed failure" to exactly
+  `Conflict` on the loser. The
   enrollment guard from #267 was extracted into a shared
   `StoreEnrollmentScanner` and extended to continuation stores. Mutation
   evidence (8 mutations, each restored): claim leaves arguments stored,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,39 @@
   persisted format or schema changes, no existing tests deleted — existing
   suites remain the implementation-specific regression oracle (encryption,
   permissions, corruption, record format for file; SQL schema, JSON mapping,
-  connection cleanup for JDBC). Epic 8.1 stays IN PROGRESS; continuation
-  store is the next slice (#268, Epic 8.1b). Reference:
+  connection cleanup for JDBC). Epic 8.1 stays IN PROGRESS. Reference:
+  `docs/reference/persistence-store-compatibility-contract.md`.
+
+- **ApprovalContinuationStore compatibility TCK (PR #269, Epic 8.1b).** One
+  shared behavioral contract for every `ApprovalContinuationStore`
+  implementation — memory, encrypted file, and JDBC — pinning the
+  PENDING/CLAIMED/COMPLETED/EXPIRED/CANCELLED/CANCELLED_UNCERTAIN state
+  machine, strict optimistic concurrency, and the exactly-once release of
+  raw sensitive arguments (the only API path that exposes them).
+  `ApprovalContinuationStoreTck` (tramai-testing testFixtures) runs **50
+  cases** — creation/read (13), claim (5), exactly-once release (2), expiry
+  (8), cancellation (4), completion (5), recovery (8), sweep (3), and
+  concurrency (3 real parallel races with a start barrier, 5 iterations
+  each). Typed failure taxonomy pinned (Conflict / NotFound / NotClaimable /
+  NotCompletable / IllegalArgumentException). Three runners execute the same
+  contract (50/50 each): `InMemoryApprovalContinuationStoreTckTest`,
+  `FileApprovalContinuationStoreTckTest` (per-case encrypted temp dir),
+  `JdbcApprovalContinuationStoreTckTest` (PostgreSQL testcontainers, table
+  reset per case). The TCK exposed **three real JDBC divergences**, all
+  fixed: late `cancel()` now persists EXPIRED then fails Conflict (was
+  CANCELLED), `create()` validates `argumentsDigest` against the payload
+  (was accepted unchecked), and `claimForExecution()` checks version before
+  status (was NotClaimable on stale-version claims of CLAIMED rows). The
+  enrollment guard from #267 was extracted into a shared
+  `StoreEnrollmentScanner` and extended to continuation stores. Mutation
+  evidence (8 mutations, each restored): claim leaves arguments stored,
+  claim skips version increment, claim drops version + status guards
+  (concurrent claims both succeed), CLAIMED lazy-expires / sweep touches
+  CLAIMED, late cancel produces CANCELLED, complete ignores claimedBy,
+  forceCancelClaimed accepts PENDING, findStaleClaimed drops secondary
+  ordering — each turns shared TCK cases RED. Zero public API change, no
+  persisted format or schema changes, no existing tests deleted. Epic 8.1
+  stays IN PROGRESS. Reference:
   `docs/reference/persistence-store-compatibility-contract.md`.
 
 - **Structured-output contract TCK (PR #266, Epic 7.2).** One reusable test

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1191,14 +1191,14 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ## Epic 8.1: Persistence Store TCKs
 
-**Status: 🚧 IN PROGRESS** — Approval store slice done (PR #267); remaining families pending.
+**Status: 🚧 IN PROGRESS** — Approval store slice done (PR #267) and Approval continuation slice done (PR #269); remaining families pending.
 
 **Goal:** Ensure in-memory, file, and JDBC implementations share the same behavioural contract.
 
 ### Store families
 
 - Approval store — ✅ PR #267 (shared `ApprovalStoreTck`, 37 cases × 3 implementations + enrollment guard)
-- Approval continuation store — ⏳ (Epic 8.1b)
+- Approval continuation store — ✅ PR #269 (shared `ApprovalContinuationStoreTck`, 50 cases × 3 implementations + enrollment guard)
 - Suspended invocation store — ⏳
 - Audit store — ⏳
 - Audit outbox store — ⏳
@@ -1225,9 +1225,9 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ### Acceptance criteria
 
-- ✅ Every published store implementation passes the relevant TCK (Approval: 3/3 implementations enrolled; step-attempt: 3/3 via PR #218).
+- ✅ Every published store implementation passes the relevant TCK (Approval: 3/3 via #267; Approval continuation: 3/3 via #269; step-attempt: 3/3 via PR #218).
 - ✅ Implementation-specific tests cover only storage technology and performance differences (encryption, permissions, corruption, record format for file; SQL schema, JSON mapping, connection cleanup for JDBC).
-- ✅ Contract failures use common typed exceptions or reason codes (`ApprovalStoreConflictException`, `ApprovalStoreNotFoundException`, `ApprovalStoreTokenRejectedException`, `ApprovalStoreNotConsumableException`, `IllegalApprovalTransitionException`).
+- ✅ Contract failures use common typed exceptions or reason codes (`ApprovalStoreConflictException`, `ApprovalStoreNotFoundException`, `ApprovalStoreTokenRejectedException`, `ApprovalStoreNotConsumableException`, `IllegalApprovalTransitionException`; `ApprovalContinuationConflictException`, `ApprovalContinuationNotFoundException`, `ApprovalContinuationNotClaimableException`, `ApprovalContinuationNotCompletableException`).
 
 ### Deliverables (PR #267)
 
@@ -1235,6 +1235,16 @@ repair feedback. No layer maintains its own independent fixture lists.
 - Runners: `InMemoryApprovalStoreTckTest`, `FileApprovalStoreTckTest`, `JdbcApprovalStoreTckTest`
 - `ApprovalStoreTckEnrollmentArchitectureTest` — every future `ApprovalStore` implementation must ship a `<Store>TckTest` runner extending the TCK
 - `JdbcApprovalStore` — consume uses `SELECT ... FOR UPDATE` inside an explicit transaction (concurrent identical deliveries serialize into one fresh + one replay)
+- Zero public API change; no persisted format or schema changes; no existing tests deleted
+- Reference: `docs/reference/persistence-store-compatibility-contract.md`
+
+### Deliverables (PR #269)
+
+- `tramai-testing/src/testFixtures/.../persistence/approval/continuation/` — `ApprovalContinuationStoreTck` (50 cases), `ApprovalContinuationStoreTckHarness`, `ApprovalContinuationFixtures`
+- Runners: `InMemoryApprovalContinuationStoreTckTest`, `FileApprovalContinuationStoreTckTest`, `JdbcApprovalContinuationStoreTckTest`
+- `StoreEnrollmentScanner` (shared with the #267 guard) + `ApprovalContinuationStoreTckEnrollmentArchitectureTest`
+- `JdbcApprovalContinuationStore` — three contract fixes the TCK exposed: late-cancel lazy-expiry normalization, `argumentsDigest` validation on create, version-before-status precedence in claim
+- Exactly-once raw-argument release proven shared: a second claim can never retrieve arguments, concurrent claims release to exactly one winner
 - Zero public API change; no persisted format or schema changes; no existing tests deleted
 - Reference: `docs/reference/persistence-store-compatibility-contract.md`
 

--- a/docs/reference/persistence-store-compatibility-contract.md
+++ b/docs/reference/persistence-store-compatibility-contract.md
@@ -1,16 +1,16 @@
 # Persistence Store Compatibility Contract
 
-Epic 8.1 (PR #267, ApprovalStore slice). Shared behavioral TCKs prove every
-implementation of a store family satisfies exactly the same externally
-observable contract, regardless of storage technology (memory, encrypted
-files, JDBC).
+Epic 8.1 (PR #267 ApprovalStore slice, PR #269 ApprovalContinuationStore
+slice). Shared behavioral TCKs prove every implementation of a store family
+satisfies exactly the same externally observable contract, regardless of
+storage technology (memory, encrypted files, JDBC).
 
 ## Epic 8.1 matrix
 
 | Store family | In-memory | File | JDBC | Shared TCK |
 |---|---|---|---|---|
 | Approval | ✅ | ✅ | ✅ | ✅ #267 |
-| Approval continuation | ✅ | ✅ | ✅ | ⏳ (Epic 8.1b) |
+| Approval continuation | ✅ | ✅ | ✅ | ✅ #269 |
 | Suspended invocation | … | … | … | ⏳ |
 | Audit | … | … | … | ⏳ |
 | Audit outbox | … | … | … | ⏳ |
@@ -105,4 +105,97 @@ must pass the TCK" is architecture, not documentation.
 The TCK owns SPI semantics; implementation-specific suites continue owning
 encryption, permissions, corruption, record format (file), SQL schema, JSON
 mapping, connection cleanup (JDBC). No existing tests were deleted. Zero
+public API change; no persisted format or schema changes.
+
+---
+
+## ApprovalContinuationStore TCK (PR #269)
+
+`ApprovalContinuationStoreTck` (tramai-testing testFixtures) runs **50 shared
+behavioral cases** against every `ApprovalContinuationStore` implementation.
+It pins the state machine (PENDING → CLAIMED → COMPLETED, → EXPIRED,
+→ CANCELLED, CLAIMED → CANCELLED_UNCERTAIN), strict optimistic concurrency,
+and the exactly-once release of raw sensitive arguments — the only API path
+that exposes them.
+
+- **Creation/read (13):** PENDING round-trip, missing-ID null, duplicate
+  conflict, non-zero version / non-PENDING / pre-populated claimed /
+  completion / recovery fields rejected, blank ID rejected, future createdAt
+  rejected, non-future expiry rejected, TTL bound enforced, arguments digest
+  mismatch rejected.
+- **Claim (5):** PENDING → CLAIMED with version +1, claimedBy/claimedAt from
+  the injected clock, exact raw arguments released, missing → NotFound,
+  stale version → Conflict, non-claimable terminal statuses → NotClaimable.
+- **Exactly-once release (2):** a second claim can never retrieve arguments
+  (typed rejection on both stale and current versions); arguments are
+  cleared from storage on claim.
+- **Expiry (8):** explicit expire only after the deadline, early expire →
+  Conflict, late claim persists EXPIRED and fails NotClaimable, **late
+  cancel persists EXPIRED and fails Conflict**, lazy get() expires exactly
+  once, CLAIMED never lazy-expires, expire on non-PENDING and on
+  already-EXPIRED → Conflict.
+- **Cancellation (4):** PENDING → CANCELLED with version +1 and arguments
+  gone, cancel on CLAIMED / COMPLETED / CANCELLED_UNCERTAIN → Conflict,
+  stale version → Conflict, missing → NotFound.
+- **Completion (5):** CLAIMED → COMPLETED by the claimant with completedAt
+  from the injected clock, wrong actor → NotCompletable, stale version →
+  Conflict, non-completable statuses → NotCompletable, missing → NotFound.
+- **Recovery (8):** findStaleClaimed includes the claimedAt boundary and
+  excludes fresh/terminal rows, deterministic ordering by claimedAt then
+  approvalId (same-instant claims exercise the secondary key), limit
+  enforced, invalid limit → IAE, forceCancelClaimed → CANCELLED_UNCERTAIN
+  with recovery actor/time/reason pinned, non-CLAIMED → NotClaimable,
+  invalid reason codes → IAE, stale version → Conflict.
+- **Sweep (3):** sweeps only elapsed PENDING rows with exact count, second
+  sweep returns 0, CLAIMED and terminal rows never touched.
+- **Concurrency (3, real parallel races with a start barrier, 5 iterations
+  each):** concurrent claims — exactly one winner releases the raw
+  arguments and the loser gets a typed failure; claim vs cancel — exactly
+  one legal transition, version stays 1; competing same-version cancels —
+  exactly one wins, one Conflict, version 1.
+
+### Typed failure taxonomy (pinned, not just "some RuntimeException")
+
+| Failure | Exception |
+|---|---|
+| duplicate / stale version | `ApprovalContinuationConflictException` |
+| missing continuation | `ApprovalContinuationNotFoundException` |
+| not claimable (status / expired) | `ApprovalContinuationNotClaimableException` |
+| not completable (status / actor) | `ApprovalContinuationNotCompletableException` |
+| invalid input (fields, TTL, digest, reason code, limit) | `IllegalArgumentException` |
+
+### Cross-store discrepancies the TCK exposed (all fixed in #269)
+
+The TCK found three real JDBC divergences from the in-memory/file contract:
+
+1. **Late cancel** produced `CANCELLED` instead of persisting `EXPIRED` and
+   failing with `Conflict` — JDBC `cancel()` lacked the PENDING-only
+   lazy-expiry normalization its `get()`/`claimForExecution()` paths already
+   had.
+2. **`create()` accepted a mismatched `argumentsDigest`** — the in-memory and
+   file stores validate the digest against the released payload; JDBC did
+   not.
+3. **`claimForExecution()` checked status before version** — a stale-version
+   claim on a CLAIMED row returned `NotClaimable` instead of `Conflict`,
+   diverging from the version-first precedence of the other two stores.
+
+### Mutation evidence (all restored after each run; InMemory store)
+
+| Mutation | TCK outcome |
+|---|---|
+| Claim leaves arguments stored | RED — completion guard fails (claim keeps arguments, complete on CLAIMED → NotCompletable) |
+| Claim does not increment version | RED — claim-transition + completion cases fail |
+| Claim drops version + status guards (non-atomic check-then-act claim) | RED — concurrent-claim race detects two winners releasing arguments; second claim succeeds |
+| CLAIMED lazy-expires / sweep touches CLAIMED | RED — claimed-never-expires + sweep-cases fail |
+| Late cancel produces CANCELLED | RED — late-cancel case fails (the exact JDBC bug the TCK caught) |
+| Complete ignores claimedBy | RED — wrong-actor case fails |
+| forceCancelClaimed accepts PENDING | RED — non-claimed recovery case fails |
+| findStaleClaimed drops secondary ordering | RED — deterministic-ordering case fails |
+
+### Scope
+
+The TCK owns SPI semantics; implementation-specific suites continue owning
+encryption codecs, BYTEA representation, SQL schema/migrations, database
+integrity, connection cleanup (JDBC) and encryption envelopes, permissions,
+corruption, record format (file). No existing tests were deleted. Zero
 public API change; no persisted format or schema changes.

--- a/docs/reference/persistence-store-compatibility-contract.md
+++ b/docs/reference/persistence-store-compatibility-contract.md
@@ -119,40 +119,51 @@ and the exactly-once release of raw sensitive arguments — the only API path
 that exposes them.
 
 - **Creation/read (13):** PENDING round-trip, missing-ID null, duplicate
-  conflict, non-zero version / non-PENDING / pre-populated claimed /
-  completion / recovery fields rejected, blank ID rejected, future createdAt
-  rejected, non-future expiry rejected, TTL bound enforced, arguments digest
-  mismatch rejected.
+  conflict, non-zero version / non-PENDING rejected, **each pre-populated
+  claimed / completion / recovery field rejected independently** (one
+  forbidden field at a time, so a store that drops a single validation goes
+  RED), blank ID rejected, future createdAt rejected, non-future expiry
+  rejected, TTL bound enforced, arguments digest mismatch rejected.
 - **Claim (5):** PENDING → CLAIMED with version +1, claimedBy/claimedAt from
   the injected clock, exact raw arguments released, missing → NotFound,
   stale version → Conflict, non-claimable terminal statuses → NotClaimable.
 - **Exactly-once release (2):** a second claim can never retrieve arguments
-  (typed rejection on both stale and current versions); arguments are
-  cleared from storage on claim.
+  (typed rejection on both stale and current versions); a second claim can
+  never expose released arguments — physical scrubbing of the encrypted
+  payload is owned by the implementation-specific suites (JDBC asserts
+  `encrypted_arguments` becomes NULL directly).
 - **Expiry (8):** explicit expire only after the deadline, early expire →
   Conflict, late claim persists EXPIRED and fails NotClaimable, **late
   cancel persists EXPIRED and fails Conflict**, lazy get() expires exactly
   once, CLAIMED never lazy-expires, expire on non-PENDING and on
   already-EXPIRED → Conflict.
 - **Cancellation (4):** PENDING → CANCELLED with version +1 and arguments
-  gone, cancel on CLAIMED / COMPLETED / CANCELLED_UNCERTAIN → Conflict,
-  stale version → Conflict, missing → NotFound.
+  gone, cancel on CLAIMED / COMPLETED / CANCELLED / CANCELLED_UNCERTAIN /
+  EXPIRED → Conflict, stale version → Conflict, missing → NotFound.
 - **Completion (5):** CLAIMED → COMPLETED by the claimant with completedAt
   from the injected clock, wrong actor → NotCompletable, stale version →
-  Conflict, non-completable statuses → NotCompletable, missing → NotFound.
+  Conflict, non-completable statuses (PENDING / CANCELLED / COMPLETED /
+  CANCELLED_UNCERTAIN / EXPIRED) → NotCompletable, missing → NotFound.
 - **Recovery (8):** findStaleClaimed includes the claimedAt boundary and
   excludes fresh/terminal rows, deterministic ordering by claimedAt then
   approvalId (same-instant claims exercise the secondary key), limit
   enforced, invalid limit → IAE, forceCancelClaimed → CANCELLED_UNCERTAIN
-  with recovery actor/time/reason pinned, non-CLAIMED → NotClaimable,
+  with recovery actor/time/reason pinned, non-CLAIMED statuses (PENDING /
+  COMPLETED / CANCELLED / CANCELLED_UNCERTAIN / EXPIRED) → NotClaimable,
   invalid reason codes → IAE, stale version → Conflict.
 - **Sweep (3):** sweeps only elapsed PENDING rows with exact count, second
   sweep returns 0, CLAIMED and terminal rows never touched.
 - **Concurrency (3, real parallel races with a start barrier, 5 iterations
   each):** concurrent claims — exactly one winner releases the raw
-  arguments and the loser gets a typed failure; claim vs cancel — exactly
-  one legal transition, version stays 1; competing same-version cancels —
-  exactly one wins, one Conflict, version 1.
+  arguments and the loser gets **Conflict**; claim vs cancel — exactly one
+  legal transition, the loser gets **Conflict** regardless of which
+  operation wins; competing same-version cancels — exactly one wins, one
+  Conflict, version 1. The loser type is pinned to Conflict (stale
+  snapshot), not a broad store exception — version-before-status precedence
+  on every path, including the JDBC CAS-loss branch (a deterministic
+  interleaving regression with a gated arguments codec pins that branch:
+  claim blocks at decrypt, cancel wins, released claim must throw
+  Conflict).
 
 ### Typed failure taxonomy (pinned, not just "some RuntimeException")
 
@@ -178,6 +189,15 @@ The TCK found three real JDBC divergences from the in-memory/file contract:
 3. **`claimForExecution()` checked status before version** — a stale-version
    claim on a CLAIMED row returned `NotClaimable` instead of `Conflict`,
    diverging from the version-first precedence of the other two stores.
+
+The follow-up review found a fourth in the same family: the **claim CAS-loss
+re-read** still mapped a lost claim/cancel race to `NotClaimable` (status
+seen after the re-read) while memory and file reported `Conflict` (stale
+version). Fixed with the same version-before-status precedence on the
+CAS-loss branch, pinned by a deterministic interleaving regression (gated
+codec: claim blocks at decrypt, cancel wins, released claim must throw
+Conflict) and by tightening the shared race assertions from "a typed
+failure" to exactly `Conflict`.
 
 ### Mutation evidence (all restored after each run; InMemory store)
 

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileApprovalContinuationStoreTckTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileApprovalContinuationStoreTckTest.kt
@@ -1,0 +1,62 @@
+package dev.tramai.persistence.file
+
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.testing.persistence.approval.MutableClock
+import dev.tramai.testing.persistence.approval.continuation.ApprovalContinuationStoreTck
+import dev.tramai.testing.persistence.approval.continuation.ApprovalContinuationStoreTckHarness
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import java.nio.file.Files
+import java.nio.file.Path
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+
+/**
+ * Epic 8.1b: FileApprovalContinuationStore must satisfy the shared
+ * ApprovalContinuationStore compatibility contract (tramai-testing
+ * testFixtures). The runner owns the temp directory, encryption key, and
+ * store construction — storage technology never contaminates the contract.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FileApprovalContinuationStoreTckTest : ApprovalContinuationStoreTck() {
+
+    private lateinit var rootDir: Path
+    private lateinit var key: SecretKey
+    private val keyProvider = FileStoreEncryptionKeyProvider { key }
+    private var caseCounter = 0
+
+    @BeforeAll
+    fun setUpAll() {
+        rootDir = Files.createTempDirectory("tramai-continuation-tck-").toAbsolutePath()
+        key = KeyGenerator.getInstance("AES").apply { init(256) }.generateKey()
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        if (rootDir.toFile().exists()) rootDir.toFile().deleteRecursively()
+    }
+
+    override val harness = object : ApprovalContinuationStoreTckHarness {
+        override fun createStore(clock: MutableClock): ApprovalContinuationStore {
+            // Fresh isolated storage per case: a unique child directory, so
+            // previous cases' records never leak into the next case. The
+            // @AfterAll cleanup removes the whole tree.
+            val caseDir = rootDir.resolve("case-${caseCounter++}")
+            Files.createDirectories(caseDir.resolve("continuations"))
+            Files.setPosixFilePermissions(
+                caseDir.resolve("continuations"),
+                java.nio.file.attribute.PosixFilePermissions.fromString("rwx------"),
+            )
+            val config = FileBackedStoreConfiguration(
+                rootDirectory = caseDir,
+                encryption = FileStoreEncryptionConfiguration(
+                    activeKeyId = "tck-key",
+                    keyProvider = keyProvider,
+                ),
+                verifyOnOpen = false,
+            )
+            return FileApprovalContinuationStore(caseDir, key, config, FileStoreLease(), clock)
+        }
+    }
+}

--- a/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalContinuationStore.kt
+++ b/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalContinuationStore.kt
@@ -14,6 +14,7 @@ import dev.tramai.core.exception.ApprovalContinuationNotFoundException
 import java.sql.Connection
 import java.sql.ResultSet
 import java.sql.SQLException
+import java.security.MessageDigest
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -193,15 +194,19 @@ class JdbcApprovalContinuationStore(
             }
 
             val currentStatus = ApprovalContinuationStatus.valueOf(normalized.status)
+
+            // Version before status: a stale expectedVersion is a concurrency
+            // conflict regardless of what state the row is in (same contract
+            // as the in-memory and file stores).
+            if (normalized.version != expectedVersion) {
+                throw ApprovalContinuationConflictException(approvalId)
+            }
+
             if (currentStatus != ApprovalContinuationStatus.PENDING) {
                 throw ApprovalContinuationNotClaimableException(approvalId)
             }
 
-            if (row.version != expectedVersion) {
-                throw ApprovalContinuationConflictException(approvalId)
-            }
-
-            val newVersion = incrementVersion(approvalId, row.version)
+            val newVersion = incrementVersion(approvalId, normalized.version)
             val nowOdt = OffsetDateTime.ofInstant(now, ZoneOffset.UTC)
 
             // Decrypt arguments BEFORE the CAS update.
@@ -399,16 +404,25 @@ class JdbcApprovalContinuationStore(
             val row = readCurrent(conn, approvalId)
                 ?: throw ApprovalContinuationNotFoundException(approvalId)
 
-            if (row.version != expectedVersion) {
+            // Lazy expiry for PENDING only — a late cancel must first persist
+            // EXPIRED, then fail with a conflict (same contract as the
+            // in-memory and file stores).
+            val now = clock.instant()
+            val (normalized, expired) = maybeExpireLazy(row, now)
+            if (expired) {
+                applyLazyExpiry(normalized, row.version)
                 throw ApprovalContinuationConflictException(approvalId)
             }
 
-            val status = ApprovalContinuationStatus.valueOf(row.status)
+            val status = ApprovalContinuationStatus.valueOf(normalized.status)
+            if (normalized.version != expectedVersion) {
+                throw ApprovalContinuationConflictException(approvalId)
+            }
             if (status != ApprovalContinuationStatus.PENDING) {
                 throw ApprovalContinuationConflictException(approvalId)
             }
 
-            val newVersion = incrementVersion(approvalId, row.version)
+            val newVersion = incrementVersion(approvalId, normalized.version)
             val sql = """
                 UPDATE approval_continuations
                 SET status = 'CANCELLED',
@@ -440,7 +454,7 @@ class JdbcApprovalContinuationStore(
                 claimedBy = null,
                 claimedAt = null,
                 completedAt = null,
-                base = row,
+                base = normalized,
             )
             return updatedContinuation.toDomain()
         }
@@ -657,6 +671,15 @@ class JdbcApprovalContinuationStore(
         require(continuation.recoveryResolvedBy == null) { "Initial continuation must not have recoveryResolvedBy set" }
         require(continuation.recoveryResolvedAt == null) { "Initial continuation must not have recoveryResolvedAt set" }
         require(continuation.recoveryReasonCode == null) { "Initial continuation must not have recoveryReasonCode set" }
+
+        // Arguments digest verification — the stored digest must match the
+        // released payload (same contract as the in-memory and file stores).
+        val actualDigest = MessageDigest.getInstance("SHA-256")
+            .digest(arguments.reveal().toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+        require(actualDigest == continuation.argumentsDigest.value.removePrefix("sha256:")) {
+            "argumentsDigest does not match arguments"
+        }
     }
 
     /**

--- a/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalContinuationStore.kt
+++ b/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalContinuationStore.kt
@@ -239,16 +239,21 @@ class JdbcApprovalContinuationStore(
 
                 val updated = stmt.executeUpdate()
                 if (updated == 0) {
-                    // Re-read to provide the right exception
+                    // CAS lost. Re-read and apply the same precedence as the
+                    // initial path: version first, then status. In-memory and
+                    // file stores serialize per ID, so a claim that loses to
+                    // a cancel observes version 1 vs expected 0 and reports
+                    // Conflict — the CAS-loss branch must not diverge into
+                    // NotClaimable for the same interleaving.
                     val current = readCurrent(conn, approvalId)
-                    if (current == null) {
-                        throw ApprovalContinuationNotFoundException(approvalId)
-                    }
-                    val status = ApprovalContinuationStatus.valueOf(current.status)
-                    if (status == ApprovalContinuationStatus.CLAIMED) {
+                        ?: throw ApprovalContinuationNotFoundException(approvalId)
+                    if (current.version != expectedVersion) {
                         throw ApprovalContinuationConflictException(approvalId)
                     }
-                    throw ApprovalContinuationNotClaimableException(approvalId)
+                    if (ApprovalContinuationStatus.valueOf(current.status) != ApprovalContinuationStatus.PENDING) {
+                        throw ApprovalContinuationNotClaimableException(approvalId)
+                    }
+                    throw ApprovalContinuationConflictException(approvalId)
                 }
             }
 

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalContinuationStoreTckTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalContinuationStoreTckTest.kt
@@ -1,0 +1,109 @@
+package dev.tramai.persistence.jdbc
+
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.testing.persistence.approval.MutableClock
+import dev.tramai.testing.persistence.approval.continuation.ApprovalContinuationStoreTck
+import dev.tramai.testing.persistence.approval.continuation.ApprovalContinuationStoreTckHarness
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import org.postgresql.ds.PGSimpleDataSource
+import org.testcontainers.containers.PostgreSQLContainer
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.sql.Connection
+import java.sql.DriverManager
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+import javax.sql.DataSource
+
+/**
+ * Epic 8.1b: JdbcApprovalContinuationStore must satisfy the shared
+ * ApprovalContinuationStore compatibility contract (tramai-testing
+ * testFixtures). The runner owns the datasource, schema, and arguments
+ * codec — storage technology never contaminates the contract.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JdbcApprovalContinuationStoreTckTest : ApprovalContinuationStoreTck() {
+
+    private lateinit var postgres: PostgreSQLContainer<*>
+    private lateinit var dataSource: DataSource
+    private lateinit var setupConnection: Connection
+
+    private val testAesKey = ByteArray(16).also { SecureRandom().nextBytes(it) }
+
+    private val testCodec = object : JdbcContinuationArgumentsCodec {
+        private val algorithm = "AES/GCM/NoPadding"
+        private val tagLength = 128
+
+        override fun encode(plaintext: ByteArray): JdbcEncryptedContinuationArguments {
+            val cipher = Cipher.getInstance(algorithm)
+            val nonce = ByteArray(12).also { SecureRandom().nextBytes(it) }
+            cipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(testAesKey, "AES"), GCMParameterSpec(tagLength, nonce))
+            val ciphertext = cipher.doFinal(plaintext)
+            val digest = MessageDigest.getInstance("SHA-256")
+                .digest(plaintext)
+                .joinToString("") { "%02x".format(it) }
+            return JdbcEncryptedContinuationArguments(
+                ciphertext = ciphertext,
+                keyId = "tck-key-1",
+                algorithm = algorithm,
+                nonce = nonce,
+                payloadDigest = "sha256:$digest",
+            )
+        }
+
+        override fun decode(envelope: JdbcEncryptedContinuationArguments): ByteArray {
+            val cipher = Cipher.getInstance(algorithm)
+            cipher.init(
+                Cipher.DECRYPT_MODE,
+                SecretKeySpec(testAesKey, "AES"),
+                GCMParameterSpec(tagLength, envelope.nonce),
+            )
+            return cipher.doFinal(envelope.ciphertext)
+        }
+    }
+
+    @BeforeAll
+    fun setUpAll() {
+        postgres = PostgreSQLContainer("postgres:17-alpine")
+            .withDatabaseName("continuation_tck")
+            .withUsername("test")
+            .withPassword("test")
+        postgres.start()
+        dataSource = PGSimpleDataSource().apply {
+            setUrl(postgres.jdbcUrl)
+            user = postgres.username
+            password = postgres.password
+        }
+        setupConnection = DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password)
+        val v1Sql = this::class.java.classLoader
+            .getResource("tramai/persistence/jdbc/postgres/V1__sovereign_persistence.sql")
+            ?.readText()
+            ?: throw IllegalStateException("V1 schema SQL resource not found")
+        val v2Sql = this::class.java.classLoader
+            .getResource("tramai/persistence/jdbc/postgres/V2__approval_continuations.sql")
+            ?.readText()
+            ?: throw IllegalStateException("V2 schema SQL resource not found")
+        setupConnection.createStatement().use { stmt -> stmt.execute(v1Sql) }
+        setupConnection.createStatement().use { stmt -> stmt.execute(v2Sql) }
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        runCatching { setupConnection.close() }
+        runCatching { postgres.stop() }
+    }
+
+    override val harness = object : ApprovalContinuationStoreTckHarness {
+        override fun createStore(clock: MutableClock): ApprovalContinuationStore {
+            // Fresh isolated storage per case: previous cases' records must
+            // not leak into the next case.
+            dataSource.connection.use { conn ->
+                conn.createStatement().use { stmt -> stmt.execute("DELETE FROM approval_continuations") }
+            }
+            return JdbcApprovalContinuationStore(dataSource, testCodec, clock = clock)
+        }
+    }
+}

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalContinuationStoreTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalContinuationStoreTest.kt
@@ -8,6 +8,8 @@ import dev.tramai.core.exception.ApprovalContinuationConflictException
 import dev.tramai.core.exception.ApprovalContinuationNotClaimableException
 import dev.tramai.core.exception.ApprovalContinuationNotCompletableException
 import dev.tramai.core.exception.ApprovalContinuationNotFoundException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
@@ -937,6 +939,61 @@ class JdbcApprovalContinuationStoreTest {
         }
     }
     }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Claim CAS-loss error precedence (deterministic interleaving)
+    // ═══════════════════════════════════════════════════════════════
+
+    /** Codec that blocks inside decode() until released — a deterministic gate on the claim's CAS boundary. */
+    private class GatedCodec(
+        private val delegate: JdbcContinuationArgumentsCodec,
+    ) : JdbcContinuationArgumentsCodec {
+        val decodeStarted = CompletableDeferred<Unit>()
+        val releaseDecode = CompletableDeferred<Unit>()
+
+        override fun encode(plaintext: ByteArray): JdbcEncryptedContinuationArguments = delegate.encode(plaintext)
+
+        override fun decode(envelope: JdbcEncryptedContinuationArguments): ByteArray {
+            decodeStarted.complete(Unit)
+            runBlocking { releaseDecode.await() }
+            return delegate.decode(envelope)
+        }
+    }
+
+    @Test
+    fun `claim that loses its CAS to a cancel reports Conflict not NotClaimable`() { runBlocking {
+        val id = "cas-loss-claim"
+        val gated = GatedCodec(testCodec)
+        val s = store(codec = gated)
+        val (continuation, args) = createContinuation(approvalId = id)
+        s.create(continuation, args)
+
+        // The claim reads PENDING v0, validates, then blocks inside
+        // argument decryption — immediately before its CAS update.
+        val claim = async(Dispatchers.Default) {
+            runCatching { s.claimForExecution(id, 0L, "worker:alice") }
+        }
+        gated.decodeStarted.await()
+
+        // Cancel wins while the claim is in flight: CANCELLED v1.
+        s.cancel(id, 0L)
+
+        // Release the claim: its CAS (WHERE version=0 AND status='PENDING')
+        // loses. It must report Conflict (stale version), matching the
+        // in-memory and file stores' version-first precedence — not
+        // NotClaimable.
+        gated.releaseDecode.complete(Unit)
+        val outcome = claim.await()
+
+        assertTrue(
+            outcome.exceptionOrNull() is ApprovalContinuationConflictException,
+            "claim losing to cancel must throw Conflict, was: ${outcome.exceptionOrNull()}",
+        )
+        val persisted = s.get(id)
+        assertNotNull(persisted)
+        assertEquals(ApprovalContinuationStatus.CANCELLED, persisted.status)
+        assertEquals(1L, persisted.version)
+    } }
 
     // ═══════════════════════════════════════════════════════════════
     // P2 regression — lazy expiry CAS race

--- a/tramai-security/src/test/kotlin/dev/tramai/security/approval/InMemoryApprovalContinuationStoreTckTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/approval/InMemoryApprovalContinuationStoreTckTest.kt
@@ -1,0 +1,19 @@
+package dev.tramai.security.approval
+
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.testing.persistence.approval.MutableClock
+import dev.tramai.testing.persistence.approval.continuation.ApprovalContinuationStoreTck
+import dev.tramai.testing.persistence.approval.continuation.ApprovalContinuationStoreTckHarness
+
+/**
+ * Epic 8.1b: InMemoryApprovalContinuationStore must satisfy the shared
+ * ApprovalContinuationStore compatibility contract (tramai-testing
+ * testFixtures).
+ */
+class InMemoryApprovalContinuationStoreTckTest : ApprovalContinuationStoreTck() {
+
+    override val harness = object : ApprovalContinuationStoreTckHarness {
+        override fun createStore(clock: MutableClock): ApprovalContinuationStore =
+            InMemoryApprovalContinuationStore(clock = clock)
+    }
+}

--- a/tramai-testing/src/test/kotlin/dev/tramai/testing/ApprovalContinuationStoreTckEnrollmentArchitectureTest.kt
+++ b/tramai-testing/src/test/kotlin/dev/tramai/testing/ApprovalContinuationStoreTckEnrollmentArchitectureTest.kt
@@ -1,0 +1,106 @@
+package dev.tramai.testing
+
+import java.io.File
+import java.nio.file.Files
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Epic 8.1b architecture guard: every concrete [dev.tramai.core.approval.ApprovalContinuationStore]
+ * implementation must be enrolled in the shared ApprovalContinuationStore
+ * compatibility contract (tramai-testing testFixtures).
+ *
+ * Same two properties as the ApprovalStore guard (#267): the three roadmap
+ * runners are pinned by name, and every concrete implementation in any
+ * module's main source set must ship a `<Store>TckTest` runner in the same
+ * module that actually extends
+ * [dev.tramai.testing.persistence.approval.continuation.ApprovalContinuationStoreTck].
+ */
+class ApprovalContinuationStoreTckEnrollmentArchitectureTest {
+
+    private val scanner = StoreEnrollmentScanner("ApprovalContinuationStore", "ApprovalContinuationStoreTck")
+
+    private val repoRoot: File =
+        generateSequence(File(".").absoluteFile) { it.parentFile }
+            .first { it.resolve("settings.gradle.kts").isFile }
+
+    private val expectedRunners = setOf(
+        "InMemoryApprovalContinuationStoreTckTest",
+        "FileApprovalContinuationStoreTckTest",
+        "JdbcApprovalContinuationStoreTckTest",
+    )
+
+    @Test
+    fun `every roadmap ApprovalContinuationStore ships a TCK runner`() {
+        val missing = expectedRunners.filter { runnerName -> scanner.findRunnerFile(repoRoot, runnerName) == null }
+        assertThat(missing)
+            .withFailMessage(
+                "Pinned ApprovalContinuationStore TCK runners missing. The compatibility contract is " +
+                    "reviewed per runner; deleting a runner silently removes a store from the contract: $missing",
+            )
+            .isEmpty()
+    }
+
+    @Test
+    fun `every ApprovalContinuationStore implementation has a valid TCK runner in its module`() {
+        val unenrolled = scanner.storeModules(repoRoot).flatMap { (module, implementations) ->
+            implementations
+                .filter { storeName -> !scanner.hasValidRunner(repoRoot, module, storeName) }
+                .map { store -> "$module/$store" }
+        }
+        assertThat(unenrolled)
+            .withFailMessage(
+                "ApprovalContinuationStore implementations without a <Store>TckTest runner extending " +
+                    "ApprovalContinuationStoreTck in the same module: $unenrolled. " +
+                    "Adding an ApprovalContinuationStore without enrolling it in the compatibility " +
+                    "contract must make a gate fail.",
+            )
+            .isEmpty()
+    }
+
+    // ── probe tests for the scanner against this family ─────────────
+
+    @Test
+    fun `body-less ApprovalContinuationStore implementation is detected`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            import dev.tramai.core.approval.ApprovalContinuationStore
+            class RedisContinuationStore(private val delegate: ApprovalContinuationStore) :
+                ApprovalContinuationStore by delegate
+            """.trimIndent(),
+        )
+        assertThat(scanner.implementationsIn(file)).containsExactly("RedisContinuationStore")
+    }
+
+    @Test
+    fun `runner file must actually subclass ApprovalContinuationStoreTck`() {
+        val fake = tempSourceFile("class RedisContinuationStoreTckTest")
+        val real = tempSourceFile("class RedisContinuationStoreTckTest : ApprovalContinuationStoreTck() { }")
+        assertThat(scanner.runnerSubclassesTck(fake, "RedisContinuationStore")).isFalse()
+        assertThat(scanner.runnerSubclassesTck(real, "RedisContinuationStore")).isTrue()
+    }
+
+    @Test
+    fun `exception classes whose names contain the interface never count as implementations`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            sealed class ApprovalContinuationStoreException(
+                open val approvalId: String,
+            ) : RuntimeException()
+
+            class ApprovalContinuationNotFoundException(
+                override val approvalId: String,
+            ) : ApprovalContinuationStoreException(approvalId)
+            """.trimIndent(),
+        )
+        assertThat(scanner.implementationsIn(file)).isEmpty()
+    }
+
+    private fun tempSourceFile(content: String): File {
+        val dir = Files.createTempDirectory("tck-enrollment-probe-").toFile()
+        dir.deleteOnExit()
+        return File(dir, "Probe.kt").apply { writeText(content) }
+    }
+}

--- a/tramai-testing/src/test/kotlin/dev/tramai/testing/ApprovalStoreTckEnrollmentArchitectureTest.kt
+++ b/tramai-testing/src/test/kotlin/dev/tramai/testing/ApprovalStoreTckEnrollmentArchitectureTest.kt
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.Test
  */
 class ApprovalStoreTckEnrollmentArchitectureTest {
 
+    private val scanner = StoreEnrollmentScanner("ApprovalStore", "ApprovalStoreTck")
+
     private val repoRoot: File =
         generateSequence(File(".").absoluteFile) { it.parentFile }
             .first { it.resolve("settings.gradle.kts").isFile }
@@ -42,7 +44,7 @@ class ApprovalStoreTckEnrollmentArchitectureTest {
 
     @Test
     fun `every roadmap ApprovalStore ships a TCK runner`() {
-        val missing = expectedRunners.filter { runnerName -> findRunnerFile(runnerName) == null }
+        val missing = expectedRunners.filter { runnerName -> scanner.findRunnerFile(repoRoot, runnerName) == null }
         assertThat(missing)
             .withFailMessage(
                 "Pinned ApprovalStore TCK runners missing. The compatibility contract is " +
@@ -53,9 +55,9 @@ class ApprovalStoreTckEnrollmentArchitectureTest {
 
     @Test
     fun `every ApprovalStore implementation has a valid TCK runner in its module`() {
-        val unenrolled = storeModules().flatMap { (module, implementations) ->
+        val unenrolled = scanner.storeModules(repoRoot).flatMap { (module, implementations) ->
             implementations
-                .filter { storeName -> !hasValidRunner(module, storeName) }
+                .filter { storeName -> !scanner.hasValidRunner(repoRoot, module, storeName) }
                 .map { store -> "$module/$store" }
         }
         assertThat(unenrolled)
@@ -79,7 +81,7 @@ class ApprovalStoreTckEnrollmentArchitectureTest {
             class RedisApprovalStore(private val delegate: ApprovalStore) : ApprovalStore by delegate
             """.trimIndent(),
         )
-        assertThat(storeImplementations(file)).containsExactly("RedisApprovalStore")
+        assertThat(scanner.implementationsIn(file)).containsExactly("RedisApprovalStore")
     }
 
     @Test
@@ -94,7 +96,7 @@ class ApprovalStoreTckEnrollmentArchitectureTest {
             }
             """.trimIndent(),
         )
-        assertThat(storeImplementations(file)).containsExactly("MultiLineApprovalStore")
+        assertThat(scanner.implementationsIn(file)).containsExactly("MultiLineApprovalStore")
     }
 
     @Test
@@ -108,7 +110,7 @@ class ApprovalStoreTckEnrollmentArchitectureTest {
             ) : ApprovalStore by delegate
             """.trimIndent(),
         )
-        assertThat(storeImplementations(file)).containsExactly("RedisApprovalStore")
+        assertThat(scanner.implementationsIn(file)).containsExactly("RedisApprovalStore")
     }
 
     @Test
@@ -123,172 +125,20 @@ class ApprovalStoreTckEnrollmentArchitectureTest {
                 : ApprovalStore by delegate
             """.trimIndent(),
         )
-        assertThat(storeImplementations(file)).containsExactly("RedisApprovalStore")
+        assertThat(scanner.implementationsIn(file)).containsExactly("RedisApprovalStore")
     }
 
     @Test
     fun `runner file must actually subclass ApprovalStoreTck`() {
         val fake = tempSourceFile("class RedisApprovalStoreTckTest")
         val real = tempSourceFile("class RedisApprovalStoreTckTest : ApprovalStoreTck() { }")
-        assertThat(runnerSubclassesTck(fake, "RedisApprovalStore")).isFalse()
-        assertThat(runnerSubclassesTck(real, "RedisApprovalStore")).isTrue()
-    }
-
-    // ── helpers ─────────────────────────────────────────────────────
-
-    private fun storeModules(): List<Pair<String, List<String>>> {
-        val modules = repoRoot.listFiles { file -> file.isDirectory && file.name.startsWith("tramai-") }
-            ?: return emptyList()
-        return modules
-            .mapNotNull { module ->
-                if (module.name == "tramai-testing") return@mapNotNull null
-                val main = File(module, "src/main/kotlin")
-                if (!main.isDirectory) return@mapNotNull null
-                val implementations = main.walkTopDown()
-                    .filter { it.isFile && it.extension == "kt" }
-                    .flatMap { file -> storeImplementations(file).asSequence() }
-                    .distinct()
-                    .sorted()
-                    .toList()
-                if (implementations.isEmpty()) null else module.name to implementations
-            }
-            .toList()
-    }
-
-    /**
-     * Concrete [dev.tramai.core.approval.ApprovalStore] implementations declared in [file].
-     * Mirrors the provider-TCK scanner: the supertype section is everything
-     * after the first top-level `:` (depth-aware), so a constructor parameter
-     * like `class X(val store: ApprovalStore, ...)` never counts as a supertype,
-     * while `class X(...) : ApprovalStore` (multi-line or not) is caught.
-     */
-    private fun storeImplementations(file: File): List<String> {
-        val text = file.readText()
-        return classHeaders(text).mapNotNull { (name, header) ->
-            val supertype = supertypeSection(header)
-            // A body-less declaration (no '{' of its own) makes the non-greedy
-            // header regex bleed into the next declaration; a supertype section
-            // containing declaration keywords or a doc comment is such a false
-            // positive (e.g. exception classes with implicit bodies).
-            val overSpanned = DECLARATION_KEYWORD.containsMatchIn(supertype)
-            // Word-boundary match on the interface name so a supertype like
-            // `ApprovalStoreException` (whose name merely contains the word)
-            // never counts as an implementation.
-            if (!overSpanned && APPROVAL_STORE_TYPE.containsMatchIn(supertype)) name else null
-        }.distinct().toList()
-    }
-
-    /**
-     * Class/object name + header, as a union of two shapes:
-     * - with a body: header runs to the first `{` (may span lines);
-     * - body-less (e.g. `class X : ApprovalStore by delegate`): the header
-     *   runs to the first `{` or to the end of the declaration. A body-less
-     *   declaration may span lines when parameters are parenthesized, so the
-     *   line walk continues while paren depth is positive or the line ends
-     *   with `(` / `,`.
-     */
-    private fun classHeaders(text: String): List<Pair<String, String>> {
-        val withBody = Regex("""(?s)(?:class|object)\s+(\w+)(.*?)\{""")
-            .findAll(text)
-            .map { it.groupValues[1] to it.groupValues[2] }
-        val bodyless = bodylessHeaders(text)
-        return (withBody + bodyless).toList()
-    }
-
-    private fun bodylessHeaders(text: String): List<Pair<String, String>> {
-        val lines = text.lines()
-        // Unanchored so visibility / open modifiers (`internal class X ...`)
-        // still match.
-        val declaration = Regex("""(?:class|object)\s+(\w+)(.*)$""")
-        val result = mutableListOf<Pair<String, String>>()
-        var i = 0
-        while (i < lines.size) {
-            val decl = declaration.find(lines[i])
-            if (decl == null) {
-                i++
-                continue
-            }
-            val name = decl.groupValues[1]
-            val header = StringBuilder(decl.groupValues[2])
-            var depth = decl.groupValues[2].count { it == '(' } - decl.groupValues[2].count { it == ')' }
-            var j = i
-            while (true) {
-                val nextLine = lines.getOrNull(j + 1)
-                val continues = depth > 0 ||
-                    header.trimEnd().endsWith("(") ||
-                    header.trimEnd().endsWith(",") ||
-                    // `)\n    : ApprovalStore by delegate` — supertype on its
-                    // own line.
-                    (nextLine != null && nextLine.trimStart().startsWith(":"))
-                if (!continues) break
-                j++
-                if (j >= lines.size) break
-                val next = lines[j]
-                header.append("\n").append(next)
-                depth += next.count { it == '(' } - next.count { it == ')' }
-            }
-            result.add(name to header.toString())
-            i = j + 1
-        }
-        return result
-    }
-
-    /** Everything after the first top-level `:` in a class header (the supertype list). */
-    private fun supertypeSection(header: String): String {
-        var depth = 0
-        for ((index, ch) in header.withIndex()) {
-            when (ch) {
-                '(' -> depth++
-                ')' -> depth--
-                ':' -> if (depth == 0) return header.substring(index + 1)
-            }
-        }
-        return ""
-    }
-
-    private fun hasValidRunner(module: String, storeName: String): Boolean {
-        val runner = findRunnerFileInModule(module, storeName) ?: return false
-        return runnerSubclassesTck(runner, storeName)
-    }
-
-    private fun findRunnerFileInModule(module: String, storeName: String): File? {
-        val testDir = File(repoRoot, "$module/src/test/kotlin")
-        if (!testDir.isDirectory) return null
-        return testDir.walkTopDown()
-            .firstOrNull { it.isFile && it.name == "${storeName}TckTest.kt" }
-    }
-
-    /**
-     * A `<Store>TckTest` file only counts as enrollment if its class actually
-     * extends [dev.tramai.testing.persistence.approval.ApprovalStoreTck]. A
-     * same-named file with an unrelated class would otherwise satisfy the
-     * gate while executing zero contract tests.
-     */
-    private fun runnerSubclassesTck(runnerFile: File, storeName: String): Boolean =
-        Regex("""(?s)class\s+${storeName}TckTest\b[^{]*:\s*ApprovalStoreTck\b""")
-            .containsMatchIn(runnerFile.readText())
-
-    private fun findRunnerFile(runnerName: String): File? {
-        val modules = repoRoot.listFiles { file -> file.isDirectory && file.name.startsWith("tramai-") }
-            ?: return null
-        return modules.asSequence()
-            .map { File(it, "src/test/kotlin") }
-            .filter { it.isDirectory }
-            .flatMap { it.walkTopDown().asSequence() }
-            .firstOrNull { it.isFile && it.name == "$runnerName.kt" }
+        assertThat(scanner.runnerSubclassesTck(fake, "RedisApprovalStore")).isFalse()
+        assertThat(scanner.runnerSubclassesTck(real, "RedisApprovalStore")).isTrue()
     }
 
     private fun tempSourceFile(content: String): File {
         val dir = Files.createTempDirectory("tck-enrollment-probe-").toFile()
         dir.deleteOnExit()
         return File(dir, "Probe.kt").apply { writeText(content) }
-    }
-
-    private companion object {
-        /** The interface every enrolled store must extend. */
-        val APPROVAL_STORE_TYPE = Regex("""\bApprovalStore\b""")
-
-        /** Declaration keywords that must never appear inside a real supertype list. */
-        val DECLARATION_KEYWORD = Regex("""(fun |class |interface |object |/\*\*)""")
     }
 }

--- a/tramai-testing/src/test/kotlin/dev/tramai/testing/StoreEnrollmentScanner.kt
+++ b/tramai-testing/src/test/kotlin/dev/tramai/testing/StoreEnrollmentScanner.kt
@@ -1,0 +1,169 @@
+package dev.tramai.testing
+
+import java.io.File
+
+/**
+ * Source-shape scanner shared by the store-family enrollment architecture
+ * tests (#267 ApprovalStore, #269 ApprovalContinuationStore). Recognizes
+ * class/object declarations with or without bodies, single-line or
+ * multiline, and with or without visibility/`open` modifiers — not a type
+ * resolver. A `<Store>TckTest` file only counts as enrollment when it
+ * actually extends the family's shared TCK.
+ */
+class StoreEnrollmentScanner(
+    private val interfaceName: String,
+    private val tckName: String,
+) {
+
+    private val interfaceType = Regex("""\b$interfaceName\b""")
+
+    /** Modules (name -> detected implementation class names) whose main source set declares the interface. */
+    fun storeModules(repoRoot: File): List<Pair<String, List<String>>> {
+        val modules = repoRoot.listFiles { file -> file.isDirectory && file.name.startsWith("tramai-") }
+            ?: return emptyList()
+        return modules
+            .mapNotNull { module ->
+                if (module.name == "tramai-testing") return@mapNotNull null
+                val main = File(module, "src/main/kotlin")
+                if (!main.isDirectory) return@mapNotNull null
+                val implementations = main.walkTopDown()
+                    .filter { it.isFile && it.extension == "kt" }
+                    .flatMap { file -> implementationsIn(file).asSequence() }
+                    .distinct()
+                    .sorted()
+                    .toList()
+                if (implementations.isEmpty()) null else module.name to implementations
+            }
+            .toList()
+    }
+
+    /**
+     * Concrete implementations of the family interface declared in [file].
+     * Mirrors the provider-TCK scanner: the supertype section is everything
+     * after the first top-level `:` (depth-aware), so a constructor parameter
+     * like `class X(val store: ApprovalStore, ...)` never counts as a
+     * supertype, while `class X(...) : ApprovalStore` (multi-line or not) is
+     * caught.
+     */
+    fun implementationsIn(file: File): List<String> {
+        val text = file.readText()
+        return classHeaders(text).mapNotNull { (name, header) ->
+            val supertype = supertypeSection(header)
+            // A body-less declaration (no '{' of its own) makes the non-greedy
+            // header regex bleed into the next declaration; a supertype section
+            // containing declaration keywords or a doc comment is such a false
+            // positive (e.g. exception classes with implicit bodies).
+            val overSpanned = DECLARATION_KEYWORD.containsMatchIn(supertype)
+            // Word-boundary match on the interface name so a supertype like
+            // `ApprovalContinuationStoreException` (whose name merely
+            // contains the words) never counts as an implementation.
+            if (!overSpanned && interfaceType.containsMatchIn(supertype)) name else null
+        }.distinct().toList()
+    }
+
+    fun hasValidRunner(repoRoot: File, module: String, storeName: String): Boolean {
+        val runner = findRunnerFileInModule(repoRoot, module, storeName) ?: return false
+        return runnerSubclassesTck(runner, storeName)
+    }
+
+    fun findRunnerFileInModule(repoRoot: File, module: String, storeName: String): File? {
+        val testDir = File(repoRoot, "$module/src/test/kotlin")
+        if (!testDir.isDirectory) return null
+        return testDir.walkTopDown()
+            .firstOrNull { it.isFile && it.name == "${storeName}TckTest.kt" }
+    }
+
+    fun findRunnerFile(repoRoot: File, runnerName: String): File? {
+        val modules = repoRoot.listFiles { file -> file.isDirectory && file.name.startsWith("tramai-") }
+            ?: return null
+        return modules.asSequence()
+            .map { File(it, "src/test/kotlin") }
+            .filter { it.isDirectory }
+            .flatMap { it.walkTopDown().asSequence() }
+            .firstOrNull { it.isFile && it.name == "$runnerName.kt" }
+    }
+
+    /**
+     * A `<Store>TckTest` file only counts as enrollment if its class actually
+     * extends the family's shared TCK. A same-named file with an unrelated
+     * class would otherwise satisfy the gate while executing zero contract
+     * tests.
+     */
+    fun runnerSubclassesTck(runnerFile: File, storeName: String): Boolean =
+        Regex("""(?s)class\s+${storeName}TckTest\b[^{]*:\s*$tckName\b""")
+            .containsMatchIn(runnerFile.readText())
+
+    /**
+     * Class/object name + header, as a union of two shapes:
+     * - with a body: header runs to the first `{` (may span lines);
+     * - body-less (e.g. `class X : Interface by delegate`): the header
+     *   runs to the first `{` or to the end of the declaration. A body-less
+     *   declaration may span lines when parameters are parenthesized, so the
+     *   line walk continues while paren depth is positive or the line ends
+     *   with `(` / `,`.
+     */
+    internal fun classHeaders(text: String): List<Pair<String, String>> {
+        val withBody = Regex("""(?s)(?:class|object)\s+(\w+)(.*?)\{""")
+            .findAll(text)
+            .map { it.groupValues[1] to it.groupValues[2] }
+        val bodyless = bodylessHeaders(text)
+        return (withBody + bodyless).toList()
+    }
+
+    private fun bodylessHeaders(text: String): List<Pair<String, String>> {
+        val lines = text.lines()
+        // Unanchored so visibility / open modifiers (`internal class X ...`)
+        // still match.
+        val declaration = Regex("""(?:class|object)\s+(\w+)(.*)$""")
+        val result = mutableListOf<Pair<String, String>>()
+        var i = 0
+        while (i < lines.size) {
+            val decl = declaration.find(lines[i])
+            if (decl == null) {
+                i++
+                continue
+            }
+            val name = decl.groupValues[1]
+            val header = StringBuilder(decl.groupValues[2])
+            var depth = decl.groupValues[2].count { it == '(' } - decl.groupValues[2].count { it == ')' }
+            var j = i
+            while (true) {
+                val nextLine = lines.getOrNull(j + 1)
+                val continues = depth > 0 ||
+                    header.trimEnd().endsWith("(") ||
+                    header.trimEnd().endsWith(",") ||
+                    header.trimEnd().endsWith(":") ||
+                    // `)\n    : Interface by delegate` — supertype on its
+                    // own line.
+                    (nextLine != null && nextLine.trimStart().startsWith(":"))
+                if (!continues) break
+                j++
+                if (j >= lines.size) break
+                val next = lines[j]
+                header.append("\n").append(next)
+                depth += next.count { it == '(' } - next.count { it == ')' }
+            }
+            result.add(name to header.toString())
+            i = j + 1
+        }
+        return result
+    }
+
+    /** Everything after the first top-level `:` in a class header (the supertype list). */
+    internal fun supertypeSection(header: String): String {
+        var depth = 0
+        for ((index, ch) in header.withIndex()) {
+            when (ch) {
+                '(' -> depth++
+                ')' -> depth--
+                ':' -> if (depth == 0) return header.substring(index + 1)
+            }
+        }
+        return ""
+    }
+
+    private companion object {
+        /** Declaration keywords that must never appear inside a real supertype list. */
+        val DECLARATION_KEYWORD = Regex("""(fun |class |interface |object |/\*\*)""")
+    }
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/continuation/ApprovalContinuationFixtures.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/continuation/ApprovalContinuationFixtures.kt
@@ -1,0 +1,59 @@
+package dev.tramai.testing.persistence.approval.continuation
+
+import dev.tramai.core.approval.ApprovalContinuation
+import dev.tramai.core.approval.ApprovalContinuationStatus
+import dev.tramai.core.approval.SensitiveToolArguments
+import dev.tramai.core.approval.Sha256Digest
+import java.security.MessageDigest
+import java.time.Instant
+
+/**
+ * Fixture factory for the ApprovalContinuationStore TCK. The TCK owns IDs,
+ * timestamps, arguments, digests, and actors — the runner owns storage
+ * technology (temp dirs, keys, datasources).
+ */
+object ApprovalContinuationFixtures {
+
+    val DEFAULT_ARGUMENTS: String = "{\"tool\":\"execute\",\"params\":{\"query\":\"select 1\"}}"
+
+    fun digest(hex: String = "a".repeat(64)): Sha256Digest = Sha256Digest.of("sha256:$hex")
+
+    /** SHA-256 of [raw] — the digest the stores verify against stored arguments. */
+    fun argumentsDigest(raw: String): Sha256Digest {
+        val bytes = MessageDigest.getInstance("SHA-256").digest(raw.toByteArray(Charsets.UTF_8))
+        return Sha256Digest.of("sha256:" + bytes.joinToString("") { "%02x".format(it) })
+    }
+
+    fun arguments(raw: String = DEFAULT_ARGUMENTS): SensitiveToolArguments = SensitiveToolArguments.of(raw)
+
+    fun continuation(
+        approvalId: String,
+        createdAt: Instant,
+        expiresAt: Instant,
+        rawArguments: String = DEFAULT_ARGUMENTS,
+        workflowRunId: String = "wf-run-1",
+        correlationId: String = "corr-1",
+        toolCallId: String = "tc-1",
+        toolName: String = "execute",
+        policyVersion: String = "v1",
+    ): ApprovalContinuation = ApprovalContinuation(
+        approvalId = approvalId,
+        workflowRunId = workflowRunId,
+        correlationId = correlationId,
+        toolCallId = toolCallId,
+        toolName = toolName,
+        argumentsDigest = argumentsDigest(rawArguments),
+        policyVersion = policyVersion,
+        workflowDigest = digest("b".repeat(64)),
+        status = ApprovalContinuationStatus.PENDING,
+        createdAt = createdAt,
+        approvalExpiresAt = expiresAt,
+        claimedBy = null,
+        claimedAt = null,
+        completedAt = null,
+        recoveryResolvedBy = null,
+        recoveryResolvedAt = null,
+        recoveryReasonCode = null,
+        version = 0L,
+    )
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/continuation/ApprovalContinuationStoreTck.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/continuation/ApprovalContinuationStoreTck.kt
@@ -141,24 +141,35 @@ abstract class ApprovalContinuationStoreTck {
     }
 
     @Test
-    fun `pre-populated claimed fields rejected`() = runBlocking<Unit> {
-        val (continuation, arguments) = pending("bad-claimed")
-            .let { (c, a) -> c.copy(claimedBy = "worker-1", claimedAt = t0) to a }
-        assertThat(runCatching { store.create(continuation, arguments) }.exceptionOrNull())
-            .isInstanceOf(IllegalArgumentException::class.java)
+    fun `pre-populated claimed fields rejected independently`() = runBlocking<Unit> {
+        // One forbidden field at a time — a store that stops validating a
+        // single field must go RED, not hide behind another populated field.
+        val cases = listOf(
+            "bad-claimed-by" to { c: ApprovalContinuation -> c.copy(claimedBy = "worker-1") },
+            "bad-claimed-at" to { c: ApprovalContinuation -> c.copy(claimedAt = t0) },
+        )
+        cases.forEach { (id, tamper) ->
+            val (continuation, arguments) = pending(id)
+            assertThat(runCatching { store.create(tamper(continuation), arguments) }.exceptionOrNull())
+                .withFailMessage("create must reject pre-populated $id")
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
     }
 
     @Test
-    fun `pre-populated completion and recovery fields rejected`() = runBlocking<Unit> {
-        val withCompletion = pending("bad-completed").let { (c, a) -> c.copy(completedAt = t0) to a }
-        assertThat(runCatching { store.create(withCompletion.first, withCompletion.second) }.exceptionOrNull())
-            .isInstanceOf(IllegalArgumentException::class.java)
-
-        val withRecovery = pending("bad-recovery").let { (c, a) ->
-            c.copy(recoveryResolvedBy = "recovery-1", recoveryResolvedAt = t0, recoveryReasonCode = "stale-claim") to a
+    fun `pre-populated completion and recovery fields rejected independently`() = runBlocking<Unit> {
+        val cases = listOf(
+            "bad-completed-at" to { c: ApprovalContinuation -> c.copy(completedAt = t0) },
+            "bad-recovery-by" to { c: ApprovalContinuation -> c.copy(recoveryResolvedBy = "recovery-1") },
+            "bad-recovery-at" to { c: ApprovalContinuation -> c.copy(recoveryResolvedAt = t0) },
+            "bad-recovery-reason" to { c: ApprovalContinuation -> c.copy(recoveryReasonCode = "stale-claim") },
+        )
+        cases.forEach { (id, tamper) ->
+            val (continuation, arguments) = pending(id)
+            assertThat(runCatching { store.create(tamper(continuation), arguments) }.exceptionOrNull())
+                .withFailMessage("create must reject pre-populated $id")
+                .isInstanceOf(IllegalArgumentException::class.java)
         }
-        assertThat(runCatching { store.create(withRecovery.first, withRecovery.second) }.exceptionOrNull())
-            .isInstanceOf(IllegalArgumentException::class.java)
     }
 
     @Test
@@ -290,16 +301,17 @@ abstract class ApprovalContinuationStoreTck {
     }
 
     @Test
-    fun `arguments are cleared from storage on claim`() = runBlocking<Unit> {
-        // The store contract: after a claim, the only remaining record is
-        // metadata; a second claim must fail before any arguments are
-        // exposed. Proving it via the claim path (the only exposing API).
+    fun `second claim cannot expose released arguments`() = runBlocking<Unit> {
+        // Externally observable exactly-once release: after a claim, the
+        // arguments can never be exposed through the only API that reveals
+        // them — not even to the claimant again. Physical scrubbing of the
+        // encrypted payload is the implementation-specific suites' concern
+        // (JDBC asserts encrypted_arguments becomes NULL directly).
         createPending("cleared-1")
         store.claimForExecution("cleared-1", 0L, "worker-1")
 
         val second = runCatching { store.claimForExecution("cleared-1", 1L, "worker-2") }.exceptionOrNull()
         assertThat(second).isInstanceOf(ApprovalContinuationNotClaimableException::class.java)
-        assertThat(second).isNotInstanceOf(ClaimedApprovalContinuation::class.java)
     }
 
     // ── Expiry ──────────────────────────────────────────────────────
@@ -422,13 +434,23 @@ abstract class ApprovalContinuationStoreTck {
     fun `cancel on non-cancellable statuses rejected`() = runBlocking<Unit> {
         setupClaimed("cancel-claimed")
         setupCompleted("cancel-completed")
+        setupCancelled("cancel-cancelled")
         setupCancelledUncertain("cancel-uncertain")
+        createPending("cancel-expired")
+        clock.advance(Duration.ofSeconds(301))
+        store.expire("cancel-expired", 0L)
 
-        listOf("cancel-claimed" to 1L, "cancel-completed" to 2L, "cancel-uncertain" to 2L)
-            .forEach { (id, version) ->
-                assertThat(runCatching { store.cancel(id, version) }.exceptionOrNull())
-                    .isInstanceOf(ApprovalContinuationConflictException::class.java)
-            }
+        listOf(
+            "cancel-claimed" to 1L,
+            "cancel-completed" to 2L,
+            "cancel-cancelled" to 1L,
+            "cancel-uncertain" to 2L,
+            "cancel-expired" to 1L,
+        ).forEach { (id, version) ->
+            assertThat(runCatching { store.cancel(id, version) }.exceptionOrNull())
+                .withFailMessage("cancel must reject $id")
+                .isInstanceOf(ApprovalContinuationConflictException::class.java)
+        }
     }
 
     @Test
@@ -479,6 +501,8 @@ abstract class ApprovalContinuationStoreTck {
     fun `complete on non-completable statuses rejected`() = runBlocking<Unit> {
         createPending("complete-pending")
         setupCancelled("complete-cancelled")
+        setupCompleted("complete-completed")
+        setupCancelledUncertain("complete-uncertain")
         createPending("complete-expired")
         clock.advance(Duration.ofSeconds(301))
         store.expire("complete-expired", 0L)
@@ -486,9 +510,12 @@ abstract class ApprovalContinuationStoreTck {
         listOf(
             "complete-pending" to 0L,
             "complete-cancelled" to 1L,
+            "complete-completed" to 2L,
+            "complete-uncertain" to 2L,
             "complete-expired" to 1L,
         ).forEach { (id, version) ->
             assertThat(runCatching { store.complete(id, version, "worker-1") }.exceptionOrNull())
+                .withFailMessage("complete must reject $id")
                 .isInstanceOf(ApprovalContinuationNotCompletableException::class.java)
         }
     }
@@ -568,15 +595,22 @@ abstract class ApprovalContinuationStoreTck {
         createPending("recover-pending")
         setupCompleted("recover-completed")
         setupCancelled("recover-cancelled")
+        setupCancelledUncertain("recover-uncertain")
+        createPending("recover-expired")
+        clock.advance(Duration.ofSeconds(301))
+        store.expire("recover-expired", 0L)
 
         listOf(
             "recover-pending" to 0L,
             "recover-completed" to 2L,
             "recover-cancelled" to 1L,
+            "recover-uncertain" to 2L,
+            "recover-expired" to 1L,
         ).forEach { (id, version) ->
             assertThat(
                 runCatching { store.forceCancelClaimed(id, version, "recovery-1", "stale-claim") }.exceptionOrNull(),
-            ).isInstanceOf(ApprovalContinuationNotClaimableException::class.java)
+            ).withFailMessage("forceCancelClaimed must reject $id")
+                .isInstanceOf(ApprovalContinuationNotClaimableException::class.java)
         }
     }
 
@@ -680,8 +714,10 @@ abstract class ApprovalContinuationStoreTck {
 
             assertThat(successes).hasSize(1)
             assertThat(losers).hasSize(1)
+            // A claim that loses observes a stale version (1 vs expected 0)
+            // and must report Conflict — not a broad store exception.
             assertThat(losers.single().exceptionOrNull())
-                .isInstanceOf(ApprovalContinuationStoreException::class.java)
+                .isInstanceOf(ApprovalContinuationConflictException::class.java)
 
             val winner = successes.single().getOrThrow()
             assertThat(winner.arguments.reveal()).isEqualTo(ApprovalContinuationFixtures.DEFAULT_ARGUMENTS)
@@ -710,8 +746,11 @@ abstract class ApprovalContinuationStoreTck {
             val losers = outcomes.count { it.isFailure }
             assertThat(successes).isEqualTo(1)
             assertThat(losers).isEqualTo(1)
+            // Whichever operation loses sees the winner's version (1) against
+            // its own expected 0, so it must report Conflict — the same typed
+            // outcome in every implementation.
             assertThat(outcomes.filter { it.isFailure }.single().exceptionOrNull())
-                .isInstanceOf(ApprovalContinuationStoreException::class.java)
+                .isInstanceOf(ApprovalContinuationConflictException::class.java)
 
             val persisted = store.get(id)!!
             assertThat(persisted.version).isEqualTo(1L)

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/continuation/ApprovalContinuationStoreTck.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/continuation/ApprovalContinuationStoreTck.kt
@@ -1,0 +1,741 @@
+package dev.tramai.testing.persistence.approval.continuation
+
+import dev.tramai.core.approval.ApprovalContinuation
+import dev.tramai.core.approval.ApprovalContinuationStatus
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.core.approval.ClaimedApprovalContinuation
+import dev.tramai.core.exception.ApprovalContinuationConflictException
+import dev.tramai.core.exception.ApprovalContinuationNotClaimableException
+import dev.tramai.core.exception.ApprovalContinuationNotCompletableException
+import dev.tramai.core.exception.ApprovalContinuationNotFoundException
+import dev.tramai.core.exception.ApprovalContinuationStoreException
+import dev.tramai.testing.persistence.approval.MutableClock
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Epic 8.1b shared ApprovalContinuationStore compatibility contract.
+ *
+ * Every [ApprovalContinuationStore] implementation must satisfy exactly the
+ * same externally observable continuation persistence contract, regardless of
+ * storage technology (memory, encrypted files, JDBC): state-machine
+ * agreement, optimistic-concurrency agreement, and exactly-once release of
+ * raw sensitive arguments (the only path that exposes them).
+ *
+ * Each test gets a FRESH store from [harness] wired to a [MutableClock]
+ * fixed at T0. Time advances only via [MutableClock.advance] — never real
+ * sleeps.
+ */
+abstract class ApprovalContinuationStoreTck {
+
+    abstract val harness: ApprovalContinuationStoreTckHarness
+
+    protected lateinit var store: ApprovalContinuationStore
+    protected lateinit var clock: MutableClock
+
+    protected val t0: Instant = Instant.parse("2026-08-23T12:00:00Z")
+    protected val expiry: Instant = t0.plusSeconds(300)
+
+    @BeforeEach
+    fun setUp() {
+        clock = MutableClock(t0)
+        store = harness.createStore(clock)
+    }
+
+    @AfterEach
+    fun tearDown() = runBlocking<Unit> { harness.closeStore(store) }
+
+    // ── Setup helpers ───────────────────────────────────────────────
+
+    protected fun pending(
+        id: String,
+        createdAt: Instant = t0,
+        expiresAt: Instant = expiry,
+        rawArguments: String = ApprovalContinuationFixtures.DEFAULT_ARGUMENTS,
+    ): Pair<ApprovalContinuation, dev.tramai.core.approval.SensitiveToolArguments> =
+        ApprovalContinuationFixtures.continuation(id, createdAt, expiresAt, rawArguments) to
+            ApprovalContinuationFixtures.arguments(rawArguments)
+
+    protected suspend fun createPending(
+        id: String,
+        createdAt: Instant = t0,
+        expiresAt: Instant = expiry,
+        rawArguments: String = ApprovalContinuationFixtures.DEFAULT_ARGUMENTS,
+    ): Pair<ApprovalContinuation, dev.tramai.core.approval.SensitiveToolArguments> {
+        val (continuation, arguments) = pending(id, createdAt, expiresAt, rawArguments)
+        store.create(continuation, arguments)
+        return continuation to arguments
+    }
+
+    protected suspend fun setupClaimed(
+        id: String,
+        claimedBy: String = "worker-1",
+        rawArguments: String = ApprovalContinuationFixtures.DEFAULT_ARGUMENTS,
+    ): ClaimedApprovalContinuation {
+        createPending(id, rawArguments = rawArguments)
+        return store.claimForExecution(id, 0L, claimedBy)
+    }
+
+    protected suspend fun setupCompleted(id: String, completedBy: String = "worker-1"): ApprovalContinuation {
+        setupClaimed(id, completedBy)
+        return store.complete(id, 1L, completedBy)
+    }
+
+    protected suspend fun setupCancelled(id: String): ApprovalContinuation {
+        createPending(id)
+        return store.cancel(id, 0L)
+    }
+
+    /** Claims then force-cancels into CANCELLED_UNCERTAIN at T0. */
+    protected suspend fun setupCancelledUncertain(id: String, cancelledBy: String = "recovery-1"): ApprovalContinuation {
+        setupClaimed(id)
+        return store.forceCancelClaimed(id, 1L, cancelledBy, "stale-claim")
+    }
+
+    // ── Creation / read ─────────────────────────────────────────────
+
+    @Test
+    fun `create pending continuation round-trips exactly`() = runBlocking<Unit> {
+        val (continuation, arguments) = pending("create-1")
+        val stored = store.create(continuation, arguments)
+        assertThat(stored).isEqualTo(continuation)
+        assertThat(store.get("create-1")).isEqualTo(continuation)
+    }
+
+    @Test
+    fun `get missing id returns null`() = runBlocking<Unit> {
+        assertThat(store.get("does-not-exist")).isNull()
+    }
+
+    @Test
+    fun `duplicate create throws conflict`() = runBlocking<Unit> {
+        val (continuation, arguments) = pending("dup-1")
+        store.create(continuation, arguments)
+        assertThat(runCatching { store.create(continuation, arguments) }.exceptionOrNull())
+            .isInstanceOf(ApprovalContinuationConflictException::class.java)
+    }
+
+    @Test
+    fun `non-zero initial version rejected`() = runBlocking<Unit> {
+        val (continuation, arguments) = pending("bad-version").let { (c, a) -> c.copy(version = 1L) to a }
+        assertThat(runCatching { store.create(continuation, arguments) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `non-pending initial status rejected`() = runBlocking<Unit> {
+        val (continuation, arguments) = pending("bad-status")
+            .let { (c, a) -> c.copy(status = ApprovalContinuationStatus.CLAIMED) to a }
+        assertThat(runCatching { store.create(continuation, arguments) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `pre-populated claimed fields rejected`() = runBlocking<Unit> {
+        val (continuation, arguments) = pending("bad-claimed")
+            .let { (c, a) -> c.copy(claimedBy = "worker-1", claimedAt = t0) to a }
+        assertThat(runCatching { store.create(continuation, arguments) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `pre-populated completion and recovery fields rejected`() = runBlocking<Unit> {
+        val withCompletion = pending("bad-completed").let { (c, a) -> c.copy(completedAt = t0) to a }
+        assertThat(runCatching { store.create(withCompletion.first, withCompletion.second) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+
+        val withRecovery = pending("bad-recovery").let { (c, a) ->
+            c.copy(recoveryResolvedBy = "recovery-1", recoveryResolvedAt = t0, recoveryReasonCode = "stale-claim") to a
+        }
+        assertThat(runCatching { store.create(withRecovery.first, withRecovery.second) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `blank approval id rejected`() = runBlocking<Unit> {
+        val (continuation, arguments) = pending("  ")
+        assertThat(runCatching { store.create(continuation, arguments) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `future createdAt rejected`() = runBlocking<Unit> {
+        val (continuation, arguments) = pending("future-created", createdAt = t0.plusSeconds(60), expiresAt = expiry.plusSeconds(60))
+        assertThat(runCatching { store.create(continuation, arguments) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `non-future expiry rejected`() = runBlocking<Unit> {
+        // expiresAt == now fails the in-future check.
+        val atNow = pending("expiry-now", expiresAt = t0)
+        assertThat(runCatching { store.create(atNow.first, atNow.second) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+
+        // expiresAt before createdAt (both in the past) fails the ordering check.
+        val inPast = pending("expiry-past", createdAt = t0.minusSeconds(120), expiresAt = t0.minusSeconds(60))
+        assertThat(runCatching { store.create(inPast.first, inPast.second) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `ttl beyond bound rejected`() = runBlocking<Unit> {
+        // Stores cap the creation TTL at 15 minutes by default.
+        val (continuation, arguments) = pending("ttl-1", expiresAt = t0.plus(Duration.ofMinutes(16)))
+        assertThat(runCatching { store.create(continuation, arguments) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `arguments digest mismatch rejected`() = runBlocking<Unit> {
+        val (continuation, arguments) = pending("bad-digest")
+        val tampered = continuation.copy(
+            argumentsDigest = ApprovalContinuationFixtures.digest("c".repeat(64)),
+        )
+        assertThat(runCatching { store.create(tampered, arguments) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    // ── Claim ───────────────────────────────────────────────────────
+
+    @Test
+    fun `claim transitions to claimed and increments version`() = runBlocking<Unit> {
+        createPending("claim-1")
+
+        val claimed = store.claimForExecution("claim-1", 0L, "worker-1")
+
+        assertThat(claimed.continuation.status).isEqualTo(ApprovalContinuationStatus.CLAIMED)
+        assertThat(claimed.continuation.version).isEqualTo(1L)
+        assertThat(claimed.continuation.claimedBy).isEqualTo("worker-1")
+        assertThat(claimed.continuation.claimedAt).isEqualTo(t0)
+
+        val persisted = store.get("claim-1")!!
+        assertThat(persisted.status).isEqualTo(ApprovalContinuationStatus.CLAIMED)
+        assertThat(persisted.version).isEqualTo(1L)
+        assertThat(persisted.claimedBy).isEqualTo("worker-1")
+    }
+
+    @Test
+    fun `claim releases the exact raw arguments`() = runBlocking<Unit> {
+        val raw = "{\"secret\":\"hunter2\",\"args\":[1,2,3]}"
+        createPending("claim-args", rawArguments = raw)
+
+        val claimed = store.claimForExecution("claim-args", 0L, "worker-1")
+
+        assertThat(claimed.arguments.reveal()).isEqualTo(raw)
+    }
+
+    @Test
+    fun `claim on missing approval throws not found`() = runBlocking<Unit> {
+        assertThat(runCatching { store.claimForExecution("missing-claim", 0L, "worker-1") }.exceptionOrNull())
+            .isInstanceOf(ApprovalContinuationNotFoundException::class.java)
+    }
+
+    @Test
+    fun `claim with stale version throws conflict`() = runBlocking<Unit> {
+        createPending("stale-claim")
+        store.claimForExecution("stale-claim", 0L, "worker-1")
+
+        assertThat(runCatching { store.claimForExecution("stale-claim", 0L, "worker-2") }.exceptionOrNull())
+            .isInstanceOf(ApprovalContinuationConflictException::class.java)
+    }
+
+    @Test
+    fun `claim on non-claimable terminal statuses rejected`() = runBlocking<Unit> {
+        setupCompleted("claim-completed")
+        setupCancelled("claim-cancelled")
+        setupCancelledUncertain("claim-uncertain")
+
+        listOf(
+            "claim-completed" to 2L,
+            "claim-cancelled" to 1L,
+            "claim-uncertain" to 2L,
+        ).forEach { (id, version) ->
+            assertThat(
+                runCatching { store.claimForExecution(id, version, "worker-1") }.exceptionOrNull(),
+            ).isInstanceOf(ApprovalContinuationNotClaimableException::class.java)
+        }
+    }
+
+    // ── Exactly-once release ────────────────────────────────────────
+
+    @Test
+    fun `second claim can never retrieve arguments`() = runBlocking<Unit> {
+        createPending("once-1")
+        val first = store.claimForExecution("once-1", 0L, "worker-1")
+        assertThat(first.arguments.reveal()).isEqualTo(ApprovalContinuationFixtures.DEFAULT_ARGUMENTS)
+
+        // Stale version: typed conflict.
+        assertThat(runCatching { store.claimForExecution("once-1", 0L, "worker-2") }.exceptionOrNull())
+            .isInstanceOf(ApprovalContinuationConflictException::class.java)
+
+        // Correct version: no longer claimable.
+        assertThat(runCatching { store.claimForExecution("once-1", 1L, "worker-2") }.exceptionOrNull())
+            .isInstanceOf(ApprovalContinuationNotClaimableException::class.java)
+
+        // Persisted metadata stays queryable.
+        val persisted = store.get("once-1")!!
+        assertThat(persisted.status).isEqualTo(ApprovalContinuationStatus.CLAIMED)
+        assertThat(persisted.claimedBy).isEqualTo("worker-1")
+    }
+
+    @Test
+    fun `arguments are cleared from storage on claim`() = runBlocking<Unit> {
+        // The store contract: after a claim, the only remaining record is
+        // metadata; a second claim must fail before any arguments are
+        // exposed. Proving it via the claim path (the only exposing API).
+        createPending("cleared-1")
+        store.claimForExecution("cleared-1", 0L, "worker-1")
+
+        val second = runCatching { store.claimForExecution("cleared-1", 1L, "worker-2") }.exceptionOrNull()
+        assertThat(second).isInstanceOf(ApprovalContinuationNotClaimableException::class.java)
+        assertThat(second).isNotInstanceOf(ClaimedApprovalContinuation::class.java)
+    }
+
+    // ── Expiry ──────────────────────────────────────────────────────
+
+    @Test
+    fun `explicit expire after deadline`() = runBlocking<Unit> {
+        createPending("expire-1")
+        clock.advance(Duration.ofSeconds(301))
+
+        val expired = store.expire("expire-1", 0L)
+
+        assertThat(expired.status).isEqualTo(ApprovalContinuationStatus.EXPIRED)
+        assertThat(expired.version).isEqualTo(1L)
+        val persisted = store.get("expire-1")!!
+        assertThat(persisted.status).isEqualTo(ApprovalContinuationStatus.EXPIRED)
+        assertThat(persisted.version).isEqualTo(1L)
+    }
+
+    @Test
+    fun `explicit expire before deadline rejected`() = runBlocking<Unit> {
+        createPending("early-expire")
+        assertThat(runCatching { store.expire("early-expire", 0L) }.exceptionOrNull())
+            .isInstanceOf(ApprovalContinuationConflictException::class.java)
+    }
+
+    @Test
+    fun `late claim persists expired and fails not claimable`() = runBlocking<Unit> {
+        createPending("late-claim")
+        clock.advance(Duration.ofSeconds(301))
+
+        assertThat(runCatching { store.claimForExecution("late-claim", 0L, "worker-1") }.exceptionOrNull())
+            .isInstanceOf(ApprovalContinuationNotClaimableException::class.java)
+
+        val persisted = store.get("late-claim")!!
+        assertThat(persisted.status).isEqualTo(ApprovalContinuationStatus.EXPIRED)
+        assertThat(persisted.version).isEqualTo(1L)
+    }
+
+    @Test
+    fun `late cancel persists expired and fails conflict`() = runBlocking<Unit> {
+        createPending("late-cancel")
+        clock.advance(Duration.ofSeconds(301))
+
+        assertThat(runCatching { store.cancel("late-cancel", 0L) }.exceptionOrNull())
+            .isInstanceOf(ApprovalContinuationConflictException::class.java)
+
+        val persisted = store.get("late-cancel")!!
+        assertThat(persisted.status).isEqualTo(ApprovalContinuationStatus.EXPIRED)
+        assertThat(persisted.version).isEqualTo(1L)
+        assertThat(runCatching { store.claimForExecution("late-cancel", 1L, "worker-1") }.exceptionOrNull())
+            .isInstanceOf(ApprovalContinuationNotClaimableException::class.java)
+    }
+
+    @Test
+    fun `lazy get expires elapsed pending exactly once`() = runBlocking<Unit> {
+        createPending("lazy-expire")
+        clock.advance(Duration.ofSeconds(301))
+
+        val first = store.get("lazy-expire")!!
+        assertThat(first.status).isEqualTo(ApprovalContinuationStatus.EXPIRED)
+        assertThat(first.version).isEqualTo(1L)
+
+        val second = store.get("lazy-expire")!!
+        assertThat(second.status).isEqualTo(ApprovalContinuationStatus.EXPIRED)
+        assertThat(second.version).isEqualTo(1L)
+    }
+
+    @Test
+    fun `claimed never lazy expires`() = runBlocking<Unit> {
+        setupClaimed("claimed-stays")
+        clock.advance(Duration.ofHours(12))
+
+        val persisted = store.get("claimed-stays")!!
+        assertThat(persisted.status).isEqualTo(ApprovalContinuationStatus.CLAIMED)
+        assertThat(persisted.version).isEqualTo(1L)
+        assertThat(store.sweepExpired()).isZero()
+    }
+
+    @Test
+    fun `expire on non-pending statuses rejected`() = runBlocking<Unit> {
+        setupClaimed("expire-claimed")
+        setupCompleted("expire-completed")
+        setupCancelled("expire-cancelled")
+
+        listOf("expire-claimed" to 1L, "expire-completed" to 2L, "expire-cancelled" to 1L)
+            .forEach { (id, version) ->
+                assertThat(runCatching { store.expire(id, version) }.exceptionOrNull())
+                    .isInstanceOf(ApprovalContinuationConflictException::class.java)
+            }
+    }
+
+    @Test
+    fun `expire on already expired rejected`() = runBlocking<Unit> {
+        createPending("expire-twice")
+        clock.advance(Duration.ofSeconds(301))
+        store.expire("expire-twice", 0L)
+
+        assertThat(runCatching { store.expire("expire-twice", 1L) }.exceptionOrNull())
+            .isInstanceOf(ApprovalContinuationConflictException::class.java)
+    }
+
+    // ── Cancellation ────────────────────────────────────────────────
+
+    @Test
+    fun `cancel pending`() = runBlocking<Unit> {
+        createPending("cancel-1")
+
+        val cancelled = store.cancel("cancel-1", 0L)
+
+        assertThat(cancelled.status).isEqualTo(ApprovalContinuationStatus.CANCELLED)
+        assertThat(cancelled.version).isEqualTo(1L)
+        val persisted = store.get("cancel-1")!!
+        assertThat(persisted.status).isEqualTo(ApprovalContinuationStatus.CANCELLED)
+        // Arguments are gone: a claim can no longer succeed.
+        assertThat(runCatching { store.claimForExecution("cancel-1", 1L, "worker-1") }.exceptionOrNull())
+            .isInstanceOf(ApprovalContinuationNotClaimableException::class.java)
+    }
+
+    @Test
+    fun `cancel on non-cancellable statuses rejected`() = runBlocking<Unit> {
+        setupClaimed("cancel-claimed")
+        setupCompleted("cancel-completed")
+        setupCancelledUncertain("cancel-uncertain")
+
+        listOf("cancel-claimed" to 1L, "cancel-completed" to 2L, "cancel-uncertain" to 2L)
+            .forEach { (id, version) ->
+                assertThat(runCatching { store.cancel(id, version) }.exceptionOrNull())
+                    .isInstanceOf(ApprovalContinuationConflictException::class.java)
+            }
+    }
+
+    @Test
+    fun `cancel with stale version throws conflict`() = runBlocking<Unit> {
+        createPending("stale-cancel")
+        store.cancel("stale-cancel", 0L)
+        assertThat(runCatching { store.cancel("stale-cancel", 0L) }.exceptionOrNull())
+            .isInstanceOf(ApprovalContinuationConflictException::class.java)
+    }
+
+    @Test
+    fun `cancel on missing approval throws not found`() = runBlocking<Unit> {
+        assertThat(runCatching { store.cancel("missing-cancel", 0L) }.exceptionOrNull())
+            .isInstanceOf(ApprovalContinuationNotFoundException::class.java)
+    }
+
+    // ── Completion ──────────────────────────────────────────────────
+
+    @Test
+    fun `complete claimed by claimant`() = runBlocking<Unit> {
+        setupClaimed("complete-1", claimedBy = "worker-1")
+
+        val completed = store.complete("complete-1", 1L, "worker-1")
+
+        assertThat(completed.status).isEqualTo(ApprovalContinuationStatus.COMPLETED)
+        assertThat(completed.version).isEqualTo(2L)
+        assertThat(completed.completedAt).isEqualTo(t0)
+        val persisted = store.get("complete-1")!!
+        assertThat(persisted.status).isEqualTo(ApprovalContinuationStatus.COMPLETED)
+        assertThat(persisted.completedAt).isEqualTo(t0)
+    }
+
+    @Test
+    fun `complete by wrong actor rejected`() = runBlocking<Unit> {
+        setupClaimed("complete-wrong", claimedBy = "worker-1")
+        assertThat(runCatching { store.complete("complete-wrong", 1L, "intruder") }.exceptionOrNull())
+            .isInstanceOf(ApprovalContinuationNotCompletableException::class.java)
+    }
+
+    @Test
+    fun `complete with stale version throws conflict`() = runBlocking<Unit> {
+        setupClaimed("complete-stale", claimedBy = "worker-1")
+        assertThat(runCatching { store.complete("complete-stale", 0L, "worker-1") }.exceptionOrNull())
+            .isInstanceOf(ApprovalContinuationConflictException::class.java)
+    }
+
+    @Test
+    fun `complete on non-completable statuses rejected`() = runBlocking<Unit> {
+        createPending("complete-pending")
+        setupCancelled("complete-cancelled")
+        createPending("complete-expired")
+        clock.advance(Duration.ofSeconds(301))
+        store.expire("complete-expired", 0L)
+
+        listOf(
+            "complete-pending" to 0L,
+            "complete-cancelled" to 1L,
+            "complete-expired" to 1L,
+        ).forEach { (id, version) ->
+            assertThat(runCatching { store.complete(id, version, "worker-1") }.exceptionOrNull())
+                .isInstanceOf(ApprovalContinuationNotCompletableException::class.java)
+        }
+    }
+
+    @Test
+    fun `complete on missing approval throws not found`() = runBlocking<Unit> {
+        assertThat(runCatching { store.complete("missing-complete", 0L, "worker-1") }.exceptionOrNull())
+            .isInstanceOf(ApprovalContinuationNotFoundException::class.java)
+    }
+
+    // ── Recovery ────────────────────────────────────────────────────
+
+    @Test
+    fun `findStaleClaimed includes boundary claimedAt and excludes others`() = runBlocking<Unit> {
+        setupClaimed("stale-boundary", claimedBy = "worker-1") // claimedAt == t0
+        clock.advance(Duration.ofSeconds(10))
+        setupClaimed("stale-fresh", claimedBy = "worker-1") // claimedAt == t0+10s — newer
+        setupCompleted("stale-completed")
+        setupCancelled("stale-cancelled")
+        createPending("stale-pending")
+
+        val stale = store.findStaleClaimed(t0, 100)
+
+        assertThat(stale.map { it.approvalId }).containsExactly("stale-boundary")
+    }
+
+    @Test
+    fun `findStaleClaimed orders by claimedAt then approvalId`() = runBlocking<Unit> {
+        // All three claimed at the SAME instant with deliberately shuffled
+        // ids: the secondary (approvalId) ordering is what makes the result
+        // stable and discriminating.
+        setupClaimed("stale-z", claimedBy = "worker-1")
+        setupClaimed("stale-a", claimedBy = "worker-1")
+        setupClaimed("stale-m", claimedBy = "worker-1")
+
+        val stale = store.findStaleClaimed(t0, 100)
+
+        // Ascending approvalId: stale-a < stale-m < stale-z.
+        assertThat(stale.map { it.approvalId }).containsExactly("stale-a", "stale-m", "stale-z")
+    }
+
+    @Test
+    fun `findStaleClaimed enforces limit`() = runBlocking<Unit> {
+        setupClaimed("limit-1", claimedBy = "worker-1")
+        setupClaimed("limit-2", claimedBy = "worker-1")
+        setupClaimed("limit-3", claimedBy = "worker-1")
+
+        val stale = store.findStaleClaimed(t0.plusSeconds(1), 2)
+
+        assertThat(stale).hasSize(2)
+    }
+
+    @Test
+    fun `findStaleClaimed invalid limit rejected`() = runBlocking<Unit> {
+        assertThat(runCatching { store.findStaleClaimed(t0, 0) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(runCatching { store.findStaleClaimed(t0, 101) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `forceCancelClaimed transitions to cancelled uncertain with recovery metadata`() = runBlocking<Unit> {
+        setupClaimed("recover-1", claimedBy = "worker-1")
+
+        val recovered = store.forceCancelClaimed("recover-1", 1L, "recovery-1", "stale-claim")
+
+        assertThat(recovered.status).isEqualTo(ApprovalContinuationStatus.CANCELLED_UNCERTAIN)
+        assertThat(recovered.version).isEqualTo(2L)
+        assertThat(recovered.recoveryResolvedBy).isEqualTo("recovery-1")
+        assertThat(recovered.recoveryResolvedAt).isEqualTo(t0)
+        assertThat(recovered.recoveryReasonCode).isEqualTo("stale-claim")
+        assertThat(recovered.claimedBy).isEqualTo("worker-1")
+    }
+
+    @Test
+    fun `forceCancelClaimed on non-claimed statuses rejected`() = runBlocking<Unit> {
+        createPending("recover-pending")
+        setupCompleted("recover-completed")
+        setupCancelled("recover-cancelled")
+
+        listOf(
+            "recover-pending" to 0L,
+            "recover-completed" to 2L,
+            "recover-cancelled" to 1L,
+        ).forEach { (id, version) ->
+            assertThat(
+                runCatching { store.forceCancelClaimed(id, version, "recovery-1", "stale-claim") }.exceptionOrNull(),
+            ).isInstanceOf(ApprovalContinuationNotClaimableException::class.java)
+        }
+    }
+
+    @Test
+    fun `forceCancelClaimed rejects invalid reason codes`() = runBlocking<Unit> {
+        setupClaimed("recover-reason", claimedBy = "worker-1")
+        assertThat(
+            runCatching { store.forceCancelClaimed("recover-reason", 1L, "recovery-1", "UPPERCASE") }.exceptionOrNull(),
+        ).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(
+            runCatching { store.forceCancelClaimed("recover-reason", 1L, "recovery-1", "has space") }.exceptionOrNull(),
+        ).isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `forceCancelClaimed with stale version throws conflict`() = runBlocking<Unit> {
+        setupClaimed("recover-stale", claimedBy = "worker-1")
+        assertThat(
+            runCatching { store.forceCancelClaimed("recover-stale", 0L, "recovery-1", "stale-claim") }.exceptionOrNull(),
+        ).isInstanceOf(ApprovalContinuationConflictException::class.java)
+    }
+
+    // ── Sweep ───────────────────────────────────────────────────────
+
+    @Test
+    fun `sweep expires only elapsed pending rows and reports exact count`() = runBlocking<Unit> {
+        createPending("sweep-a")
+        createPending("sweep-b")
+        clock.advance(Duration.ofSeconds(301))
+        // Created after the deadline — must NOT be swept.
+        createPending("sweep-fresh", createdAt = t0.plusSeconds(301), expiresAt = t0.plusSeconds(601))
+
+        val count = store.sweepExpired()
+
+        assertThat(count).isEqualTo(2)
+        assertThat(store.get("sweep-a")!!.status).isEqualTo(ApprovalContinuationStatus.EXPIRED)
+        assertThat(store.get("sweep-b")!!.status).isEqualTo(ApprovalContinuationStatus.EXPIRED)
+        assertThat(store.get("sweep-fresh")!!.status).isEqualTo(ApprovalContinuationStatus.PENDING)
+    }
+
+    @Test
+    fun `second sweep returns zero`() = runBlocking<Unit> {
+        createPending("sweep-idem")
+        clock.advance(Duration.ofSeconds(301))
+        store.sweepExpired()
+
+        assertThat(store.sweepExpired()).isZero()
+    }
+
+    @Test
+    fun `sweep never touches claimed or terminal rows`() = runBlocking<Unit> {
+        setupClaimed("sweep-claimed", claimedBy = "worker-1")
+        setupCompleted("sweep-completed")
+        setupCancelled("sweep-cancelled")
+        createPending("sweep-expired")
+        clock.advance(Duration.ofHours(2))
+        store.sweepExpired()
+
+        assertThat(store.sweepExpired()).isZero()
+        assertThat(store.get("sweep-claimed")!!.status).isEqualTo(ApprovalContinuationStatus.CLAIMED)
+        assertThat(store.get("sweep-completed")!!.status).isEqualTo(ApprovalContinuationStatus.COMPLETED)
+        assertThat(store.get("sweep-cancelled")!!.status).isEqualTo(ApprovalContinuationStatus.CANCELLED)
+        assertThat(store.get("sweep-expired")!!.status).isEqualTo(ApprovalContinuationStatus.EXPIRED)
+    }
+
+    // ── Concurrency ─────────────────────────────────────────────────
+
+    /**
+     * Runs [contenders] on parallel workers, releasing them only once every
+     * contender is ready, so the operations genuinely overlap instead of
+     * serializing on the caller's single-threaded event loop.
+     */
+    private suspend fun <T> runInParallel(vararg contenders: suspend () -> T): List<T> = coroutineScope {
+        val ready = Channel<Unit>(capacity = contenders.size)
+        val release = CompletableDeferred<Unit>()
+        val results = contenders.map { op ->
+            async(Dispatchers.Default) {
+                ready.send(Unit)
+                release.await()
+                op()
+            }
+        }
+        repeat(contenders.size) { ready.receive() }
+        release.complete(Unit)
+        results.map { it.await() }
+    }
+
+    @Test
+    fun `concurrent claims - exactly one winner releases arguments`() = runBlocking<Unit> {
+        repeat(5) { iteration ->
+            val id = "claim-race-$iteration"
+            createPending(id)
+
+            val outcomes = runInParallel(
+                { runCatching { store.claimForExecution(id, 0L, "worker-a") } },
+                { runCatching { store.claimForExecution(id, 0L, "worker-b") } },
+            )
+
+            val successes = outcomes.filter { it.isSuccess }
+            val losers = outcomes.filter { it.isFailure }
+
+            assertThat(successes).hasSize(1)
+            assertThat(losers).hasSize(1)
+            assertThat(losers.single().exceptionOrNull())
+                .isInstanceOf(ApprovalContinuationStoreException::class.java)
+
+            val winner = successes.single().getOrThrow()
+            assertThat(winner.arguments.reveal()).isEqualTo(ApprovalContinuationFixtures.DEFAULT_ARGUMENTS)
+
+            val persisted = store.get(id)!!
+            assertThat(persisted.status).isEqualTo(ApprovalContinuationStatus.CLAIMED)
+            assertThat(persisted.version).isEqualTo(1L)
+            // Loser must not be able to retrieve arguments either.
+            assertThat(runCatching { store.claimForExecution(id, 1L, "worker-c") }.exceptionOrNull())
+                .isInstanceOf(ApprovalContinuationNotClaimableException::class.java)
+        }
+    }
+
+    @Test
+    fun `concurrent claim vs cancel - exactly one legal transition`() = runBlocking<Unit> {
+        repeat(5) { iteration ->
+            val id = "claim-cancel-race-$iteration"
+            createPending(id)
+
+            val outcomes = runInParallel(
+                { runCatching { store.claimForExecution(id, 0L, "worker-a") } },
+                { runCatching { store.cancel(id, 0L) } },
+            )
+
+            val successes = outcomes.count { it.isSuccess }
+            val losers = outcomes.count { it.isFailure }
+            assertThat(successes).isEqualTo(1)
+            assertThat(losers).isEqualTo(1)
+            assertThat(outcomes.filter { it.isFailure }.single().exceptionOrNull())
+                .isInstanceOf(ApprovalContinuationStoreException::class.java)
+
+            val persisted = store.get(id)!!
+            assertThat(persisted.version).isEqualTo(1L)
+            assertThat(persisted.status).isIn(ApprovalContinuationStatus.CLAIMED, ApprovalContinuationStatus.CANCELLED)
+        }
+    }
+
+    @Test
+    fun `competing same-version cancels cannot both succeed`() = runBlocking<Unit> {
+        repeat(5) { iteration ->
+            val id = "cancel-race-$iteration"
+            createPending(id)
+
+            val outcomes = runInParallel(
+                { runCatching { store.cancel(id, 0L) } },
+                { runCatching { store.cancel(id, 0L) } },
+            )
+
+            assertThat(outcomes.count { it.isSuccess }).isEqualTo(1)
+            assertThat(outcomes.count { it.exceptionOrNull() is ApprovalContinuationConflictException }).isEqualTo(1)
+
+            val persisted = store.get(id)!!
+            assertThat(persisted.status).isEqualTo(ApprovalContinuationStatus.CANCELLED)
+            assertThat(persisted.version).isEqualTo(1L)
+        }
+    }
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/continuation/ApprovalContinuationStoreTckHarness.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/continuation/ApprovalContinuationStoreTckHarness.kt
@@ -1,0 +1,20 @@
+package dev.tramai.testing.persistence.approval.continuation
+
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.testing.persistence.approval.MutableClock
+
+/**
+ * Storage-technology hook for the ApprovalContinuationStore TCK.
+ *
+ * The runner owns everything implementation-specific: temp directories,
+ * encryption keys, codecs, datasources, table creation, store construction,
+ * cleanup. Each call to [createStore] must return a FRESH, isolated store
+ * wired to the given [MutableClock] (fixed at construction; advanced only by
+ * the TCK) — previous cases' records must never leak into the next case.
+ */
+interface ApprovalContinuationStoreTckHarness {
+
+    fun createStore(clock: MutableClock): ApprovalContinuationStore
+
+    suspend fun closeStore(store: ApprovalContinuationStore) = Unit
+}


### PR DESCRIPTION
## Summary

**Epic 8.1b: ApprovalContinuationStore compatibility TCK.** One shared behavioral contract for every `ApprovalContinuationStore` implementation — memory, encrypted file, and PostgreSQL JDBC. The continuation SPI is a second security-sensitive state machine (PENDING → CLAIMED → COMPLETED, → EXPIRED, → CANCELLED, CLAIMED → CANCELLED_UNCERTAIN) where claiming is the *only* API path that releases raw sensitive arguments. This TCK pins three things at once: state-machine agreement, optimistic-concurrency agreement, and exactly-once sensitive-payload release.

The TCK found **three real JDBC divergences** — all fixed in this PR — and the follow-up review found a fourth in the same family (claim CAS-loss error precedence), also fixed. Exactly the Phase 8.1 outcome: independently passing suites had encoded subtly different contracts.

## What changed

| File | Purpose |
|---|---|
| `tramai-testing/testFixtures/.../approval/continuation/ApprovalContinuationStoreTck.kt` | **50 shared cases** |
| `.../ApprovalContinuationStoreTckHarness.kt` | runner hook: `createStore(clock)` → fresh isolated store |
| `.../ApprovalContinuationFixtures.kt` | TCK owns IDs, timestamps, arguments, digests, actors |
| `tramai-testing/.../StoreEnrollmentScanner.kt` | shared source-shape scanner extracted from the #267 guard |
| `tramai-testing/.../ApprovalContinuationStoreTckEnrollmentArchitectureTest.kt` | fail-closed enrollment guard + probes |
| `tramai-security/.../InMemoryApprovalContinuationStoreTckTest.kt` | runner |
| `tramai-persistence-file/.../FileApprovalContinuationStoreTckTest.kt` | runner (per-case encrypted temp dir) |
| `tramai-persistence-jdbc/.../JdbcApprovalContinuationStoreTckTest.kt` | runner (PostgreSQL testcontainers, table reset per case) |
| `JdbcApprovalContinuationStore.kt` | **production:** 3 contract fixes the TCK exposed |
| `docs/reference/persistence-store-compatibility-contract.md` | Epic 8.1 matrix + continuation section |
| ROADMAP-0.6.0.md / CHANGELOG.md | Approval continuation ✅; Epic 8.1 stays IN PROGRESS |

## Contract matrix (50 cases × 3 implementations)

- **Creation/read (13):** PENDING round-trip, missing-ID null, duplicate → Conflict, non-zero version / non-PENDING / pre-populated claimed / completion / recovery fields → IAE, blank ID, future createdAt, non-future expiry, TTL bound, **arguments digest mismatch → IAE**
- **Claim (5):** PENDING → CLAIMED, version +1, claimedBy/claimedAt from injected clock, **exact raw arguments released**, missing → NotFound, stale version → Conflict, terminal statuses → NotClaimable
- **Exactly-once release (2):** a second claim can never retrieve arguments (typed rejection on both stale and current versions); a second claim can never expose released arguments (physical payload scrubbing is owned by the implementation-specific suites — JDBC asserts `encrypted_arguments` becomes NULL directly)
- **Expiry (8):** explicit expire after deadline only; early expire → Conflict; late claim persists EXPIRED + NotClaimable; **late cancel persists EXPIRED + Conflict**; lazy get() expires exactly once; **CLAIMED never lazy-expires**; expire on non-PENDING / already-EXPIRED → Conflict
- **Cancellation (4):** PENDING → CANCELLED, version +1, arguments gone; CLAIMED / COMPLETED / CANCELLED_UNCERTAIN → Conflict; stale version → Conflict; missing → NotFound
- **Completion (5):** CLAIMED → COMPLETED by the claimant, completedAt from injected clock; wrong actor → NotCompletable; stale version → Conflict; non-completable statuses → NotCompletable; missing → NotFound
- **Recovery (8):** findStaleClaimed boundary + exclusion of fresh/terminal rows; **deterministic ordering by claimedAt then approvalId** (same-instant claims exercise the secondary key); limit enforced; invalid limit → IAE; forceCancelClaimed → CANCELLED_UNCERTAIN with recovery actor/time/reason pinned; non-CLAIMED → NotClaimable; invalid reason codes → IAE; stale version → Conflict
- **Sweep (3):** only elapsed PENDING rows swept with exact count; second sweep → 0; CLAIMED and terminal rows untouched
- **Concurrency (3):** real parallel races (`Dispatchers.Default` + start barrier, 5 iterations each) — concurrent claims: exactly one winner releases the raw arguments, **loser gets Conflict**; claim vs cancel: exactly one legal transition, **loser gets Conflict regardless of which operation wins**, version 1; competing same-version cancels: one wins + one Conflict, version 1. The loser type is pinned to Conflict (stale snapshot), including the JDBC CAS-loss branch

## Cross-store discrepancies the TCK exposed (all fixed in this PR)

1. **Late `cancel()`** produced `CANCELLED` instead of persisting `EXPIRED` and failing with `Conflict` — JDBC `cancel()` lacked the PENDING-only lazy-expiry normalization its `get()`/`claimForExecution()` paths already had. *(This was the predicted divergence.)*
2. **`create()` accepted a mismatched `argumentsDigest`** — the in-memory and file stores validate the digest against the released payload; JDBC did not.
3. **`claimForExecution()` checked status before version** — a stale-version claim on a CLAIMED row returned `NotClaimable` instead of `Conflict`, diverging from the version-first precedence of the other two stores.
4. **Claim CAS-loss re-read** (found in follow-up review) — a claim that lost its CAS to a cancel reported `NotClaimable` (status seen after re-read) while memory/file reported `Conflict` (stale version). Fixed with the same version-before-status precedence on the CAS-loss branch, pinned by a deterministic interleaving regression (gated codec: claim blocks at decrypt, cancel wins, released claim must throw Conflict).

## Typed failure taxonomy

Conflict / NotFound / NotClaimable / NotCompletable / IllegalArgumentException — pinned by class, never `isInstanceOf(RuntimeException)`.

## Deterministic time

Shared `MutableClock` from #267 (fixed at T0 = 2026-08-23T12:00:00Z, expiry T0+5min), `clock.advance(...)` only. No sleeps, no `Instant.now()`. Fresh store per case; file runner uses per-case dirs, JDBC resets the table per case; container stopped in `@AfterAll`.

## Enrollment

`StoreEnrollmentScanner` (extracted from the #267 guard, parameterized) + `ApprovalContinuationStoreTckEnrollmentArchitectureTest`: every concrete `ApprovalContinuationStore` must ship a `<Store>TckTest` runner extending the TCK, or the gate fails. Probe tests pin body-less/multiline/exception-name-collision shapes.

## Mutation evidence (8 mutations on the InMemory store, each restored, each turning shared cases RED)

| Mutation | TCK outcome |
|---|---|
| Claim leaves arguments stored | RED — completion guard fails |
| Claim does not increment version | RED — claim-transition + completion cases fail |
| Claim drops version + status guards (non-atomic claim) | RED — concurrent-claim race detects two winners; second claim succeeds |
| CLAIMED lazy-expires / sweep touches CLAIMED | RED — claimed-never-expires + sweep cases fail |
| Late cancel produces CANCELLED | RED — late-cancel case fails (the exact JDBC bug) |
| Complete ignores claimedBy | RED — wrong-actor case fails |
| forceCancelClaimed accepts PENDING | RED — non-claimed recovery case fails |
| findStaleClaimed drops secondary ordering | RED — deterministic-ordering case fails |

## Gates

- `verifyPr` (subproject tests, build-logic, maintainability, change policy) — GREEN locally
- `verifyCancellationSafety` vs master — PASSED (303 → 303, no new findings)
- TCK: **50/50** × InMemory / File / JDBC
- Enrollment: ApprovalStore 6/6 + ApprovalContinuationStore 5/5
- apiCheck — zero public API change

Zero public API change, no persisted format/schema changes, no existing tests deleted. Epic 8.1 stays IN PROGRESS; next family: Suspended Invocation Store.
