### PR TITLE
test(persistence): add SuspendedInvocationStore compatibility TCK — Epic 8.1c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,35 +98,46 @@
   implementation — the engine's default in-memory store, the encrypted file
   store, and JDBC. `SuspendedInvocationStoreTck` (tramai-testing
   testFixtures; the module gained a testFixtures dependency on
-  `tramai-engine`, the SPI's home module) runs **33 cases** — creation/read
+  `tramai-engine`, the SPI's home module) runs **39 cases** — creation/read
   (13: full-metadata round-trip incl. token budget and tool security,
   missing null, duplicate approvalId rejected, blank/control/whitespace/
   oversized ID fields rejected on every operation), sensitive release (6:
   reveal returns equal messages, missing null, get() never exposes the
   messages, envelope `toString` is `[REDACTED]`, reveal does not consume,
-  repeated reveals equal), digest + envelope binding (6: digest mismatch,
+  repeated reveals equal), digest + envelope binding (8: digest mismatch,
   tampered envelope, no assistant tool-call batch, toolCallId absent,
-  toolCallIndex out of bounds, toolName mismatch — all rejected), remove
-  (5: returns metadata, then get/reveal null, missing null, create after
-  remove succeeds), and concurrency (3 real parallel races with a start
-  barrier, 20 iterations each: concurrent create — exactly one winner;
-  concurrent remove — exactly one winner; reveal while remove — no crashes,
-  exactly one remove winner). Three runners execute the same contract
-  (33/33 each): `InMemorySuspendedInvocationStoreTckTest` (tramai-engine —
-  the engine's default store is enrolled like any other, not exempt),
-  `FileSuspendedInvocationStoreTckTest` (per-case encrypted temp dir),
-  `JdbcSuspendedInvocationStoreTckTest` (PostgreSQL testcontainers, table
-  reset per case). The enrollment guard reuses the shared
-  `StoreEnrollmentScanner`. **Production changes the enrollment required:**
-  `InMemorySuspendedInvocationStore` gained the shared validations it lacked
-  (ID-field validation on every operation, envelope binding, canonical
-  replay-envelope digest check) — it previously accepted records the file
-  and JDBC stores reject; the SPI KDoc durability claim was corrected
-  ("not persist beyond the JVM lifecycle" → durability is
-  implementation-specific: in-memory is process-local, file/JDBC may
-  survive restart); engine test doubles that built invalid envelopes now
-  build valid ones (the real suspension path always produces valid
-  records). **Deliberate decision — replay-digest uniqueness stays
+  toolCallIndex out of bounds, toolName mismatch — all rejected),
+  redaction invariants (6: correctly-digested RAW selected arguments
+  rejected, duplicate selected toolCallId rejected, extra/misplaced
+  sentinel rejected, selected call outside the latest assistant batch
+  rejected, negative historySize and envelope-smaller-than-historySize
+  rejected), remove (5: returns metadata, then get/reveal null, missing
+  null, create after remove succeeds), and concurrency (3 real parallel
+  races with a start barrier, 20 iterations each: concurrent create —
+  exactly one winner; concurrent remove — exactly one winner; reveal while
+  remove — no crashes, exactly one remove winner). Three runners execute
+  the same contract (39/39 each): `InMemorySuspendedInvocationStoreTckTest`
+  (tramai-engine — the engine's default store is enrolled like any other,
+  not exempt), `FileSuspendedInvocationStoreTckTest` (per-case encrypted
+  temp dir), `JdbcSuspendedInvocationStoreTckTest` (PostgreSQL
+  testcontainers, table reset per case). The enrollment guard reuses the
+  shared `StoreEnrollmentScanner`. **Production changes the enrollment
+  required:** `InMemorySuspendedInvocationStore` gained the shared
+  validations it lacked, delegated to a shared `ReplayEnvelopeValidator`
+  (ID fields, envelope binding, canonical digest, and the **redaction
+  invariants** — history-size consistency, globally unique selected
+  toolCallId, latest-assistant-batch slot, exactly one redaction sentinel
+  at the selected slot); `JdbcSuspendedInvocationStore` now enforces the
+  same redaction invariants (mirrored inline, pinned by the TCK) — it
+  previously accepted and encrypted a correctly-digested unredacted
+  envelope, violating the SPEC-016 boundary that raw tool arguments live
+  only behind the ApprovalContinuationStore; the SPI KDoc durability claim
+  was corrected ("not persist beyond the JVM lifecycle" → durability is
+  implementation-specific); engine test doubles that built invalid
+  envelopes now build valid ones (redacted sentinel + canonical digest),
+  and the JDBC raw-in-DB test now asserts the API boundary rejects
+  raw-args envelopes while the valid envelope's sensitive content stays
+  encrypted at rest. **Deliberate decision — replay-digest uniqueness stays
   JDBC-specific:** the JDBC unique index on `replay_envelope_digest`
   (double-suspension hardening) is NOT copied to the in-memory/file stores
   and is NOT pinned by the TCK, because the engine's suspension flow
@@ -134,11 +145,14 @@
   documented in the contract reference so future implementations know the
   divergence is deliberate. Implementation-specific concerns (restart
   durability, encryption format, permissions, corruption, schema versions,
-  SQL locking) stay out of the shared TCK. Mutation evidence (9 mutations,
+  SQL locking) stay out of the shared TCK. Mutation evidence (11 mutations,
   each restored): duplicate create overwrites existing, remove becomes
   get-without-delete, reveal returns null, remove leaves the envelope
   reachable, digest/toolCallId/toolName/toolCallIndex checks dropped,
-  non-atomic check-then-act remove — each turns shared TCK cases RED. Zero
+  non-atomic check-then-act remove, redaction sentinel not required,
+  historySize consistency not validated — each turns shared TCK cases RED
+  (the duplicate-id case passes via `single()`'s incidental IAE under the
+  toolCallId mutation — documented in the contract reference). Zero
   public API change, no persisted format or schema changes, no existing
   tests deleted. Epic 8.1 stays IN PROGRESS. Reference:
   `docs/reference/persistence-store-compatibility-contract.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,56 @@
   stays IN PROGRESS. Reference:
   `docs/reference/persistence-store-compatibility-contract.md`.
 
+- **SuspendedInvocationStore compatibility TCK (PR #270, Epic 8.1c).** One
+  shared behavioral contract for every `SuspendedInvocationStore`
+  implementation — the engine's default in-memory store, the encrypted file
+  store, and JDBC. `SuspendedInvocationStoreTck` (tramai-testing
+  testFixtures; the module gained a testFixtures dependency on
+  `tramai-engine`, the SPI's home module) runs **33 cases** — creation/read
+  (13: full-metadata round-trip incl. token budget and tool security,
+  missing null, duplicate approvalId rejected, blank/control/whitespace/
+  oversized ID fields rejected on every operation), sensitive release (6:
+  reveal returns equal messages, missing null, get() never exposes the
+  messages, envelope `toString` is `[REDACTED]`, reveal does not consume,
+  repeated reveals equal), digest + envelope binding (6: digest mismatch,
+  tampered envelope, no assistant tool-call batch, toolCallId absent,
+  toolCallIndex out of bounds, toolName mismatch — all rejected), remove
+  (5: returns metadata, then get/reveal null, missing null, create after
+  remove succeeds), and concurrency (3 real parallel races with a start
+  barrier, 20 iterations each: concurrent create — exactly one winner;
+  concurrent remove — exactly one winner; reveal while remove — no crashes,
+  exactly one remove winner). Three runners execute the same contract
+  (33/33 each): `InMemorySuspendedInvocationStoreTckTest` (tramai-engine —
+  the engine's default store is enrolled like any other, not exempt),
+  `FileSuspendedInvocationStoreTckTest` (per-case encrypted temp dir),
+  `JdbcSuspendedInvocationStoreTckTest` (PostgreSQL testcontainers, table
+  reset per case). The enrollment guard reuses the shared
+  `StoreEnrollmentScanner`. **Production changes the enrollment required:**
+  `InMemorySuspendedInvocationStore` gained the shared validations it lacked
+  (ID-field validation on every operation, envelope binding, canonical
+  replay-envelope digest check) — it previously accepted records the file
+  and JDBC stores reject; the SPI KDoc durability claim was corrected
+  ("not persist beyond the JVM lifecycle" → durability is
+  implementation-specific: in-memory is process-local, file/JDBC may
+  survive restart); engine test doubles that built invalid envelopes now
+  build valid ones (the real suspension path always produces valid
+  records). **Deliberate decision — replay-digest uniqueness stays
+  JDBC-specific:** the JDBC unique index on `replay_envelope_digest`
+  (double-suspension hardening) is NOT copied to the in-memory/file stores
+  and is NOT pinned by the TCK, because the engine's suspension flow
+  already rejects duplicate approvalIds via the continuation store;
+  documented in the contract reference so future implementations know the
+  divergence is deliberate. Implementation-specific concerns (restart
+  durability, encryption format, permissions, corruption, schema versions,
+  SQL locking) stay out of the shared TCK. Mutation evidence (9 mutations,
+  each restored): duplicate create overwrites existing, remove becomes
+  get-without-delete, reveal returns null, remove leaves the envelope
+  reachable, digest/toolCallId/toolName/toolCallIndex checks dropped,
+  non-atomic check-then-act remove — each turns shared TCK cases RED. Zero
+  public API change, no persisted format or schema changes, no existing
+  tests deleted. Epic 8.1 stays IN PROGRESS. Reference:
+  `docs/reference/persistence-store-compatibility-contract.md`.
+
 - **Structured-output contract TCK (PR #266, Epic 7.2).** One reusable test
   kit drives the entire structured-output lifecycle per fixture — descriptor
   compilation → generated schema → raw JSON shape validation →

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1199,7 +1199,7 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 - Approval store — ✅ PR #267 (shared `ApprovalStoreTck`, 37 cases × 3 implementations + enrollment guard)
 - Approval continuation store — ✅ PR #269 (shared `ApprovalContinuationStoreTck`, 50 cases × 3 implementations + enrollment guard)
-- Suspended invocation store — ✅ PR #270 (shared `SuspendedInvocationStoreTck`, 33 cases × 3 implementations + enrollment guard)
+- Suspended invocation store — ✅ PR #270 (shared `SuspendedInvocationStoreTck`, 39 cases × 3 implementations + enrollment guard)
 - Audit store — ⏳
 - Audit outbox store — ⏳
 - Workflow checkpoint store — ⏳
@@ -1250,12 +1250,12 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ### Deliverables (PR #270)
 
-- `tramai-testing/src/testFixtures/.../persistence/engine/` — `SuspendedInvocationStoreTck` (33 cases), `SuspendedInvocationFixtures`; `tramai-testing` testFixtures gained a dependency on `tramai-engine` (the SPI's home module)
+- `tramai-testing/src/testFixtures/.../persistence/engine/` — `SuspendedInvocationStoreTck` (39 cases), `SuspendedInvocationFixtures`; `tramai-testing` testFixtures gained a dependency on `tramai-engine` (the SPI's home module)
 - Runners: `InMemorySuspendedInvocationStoreTckTest` (tramai-engine — the engine's default store, enrolled like any other), `FileSuspendedInvocationStoreTckTest`, `JdbcSuspendedInvocationStoreTckTest`
 - `SuspendedInvocationStoreTckEnrollmentArchitectureTest` — reuses the shared `StoreEnrollmentScanner`
-- `InMemorySuspendedInvocationStore` gained the shared validations it lacked (ID fields, envelope binding, canonical digest); SPI KDoc durability claim corrected to implementation-specific
-- Deliberate decision: JDBC's unique `replay_envelope_digest` index stays JDBC-specific (engine never double-suspends; continuation store already rejects duplicate approvalId) — documented, not copied to the other stores
-- Mutation evidence (9 mutations, each restored): duplicate overwrite, remove-without-delete, reveal-null, envelope-leak-after-remove, digest/toolCallId/toolName/toolCallIndex checks dropped, non-atomic remove
+- `InMemorySuspendedInvocationStore` gained the shared validations it lacked (ID fields, envelope binding, canonical digest, redaction invariants via shared `ReplayEnvelopeValidator`); `JdbcSuspendedInvocationStore` now enforces the same redaction invariants (rejects correctly-digested unredacted envelopes); SPI KDoc durability claim corrected to implementation-specific
+- Deliberate decisions: JDBC's unique `replay_envelope_digest` index stays JDBC-specific (documented, not copied); historySize consistency and the redaction sentinel ARE shared contract (File already enforced them)
+- Mutation evidence (11 mutations, each restored): duplicate overwrite, remove-without-delete, reveal-null, envelope-leak-after-remove, digest/toolCallId/toolName/toolCallIndex checks dropped, non-atomic remove, redaction-sentinel not required, historySize not validated
 - Zero public API change; no persisted format or schema changes; no existing tests deleted
 - Reference: `docs/reference/persistence-store-compatibility-contract.md`
 

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1191,7 +1191,7 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ## Epic 8.1: Persistence Store TCKs
 
-**Status: 🚧 IN PROGRESS** — Approval store slice done (PR #267) and Approval continuation slice done (PR #269); remaining families pending.
+**Status: 🚧 IN PROGRESS** — Approval store slice done (PR #267), Approval continuation slice done (PR #269), suspended invocation slice done (PR #270); remaining families pending.
 
 **Goal:** Ensure in-memory, file, and JDBC implementations share the same behavioural contract.
 
@@ -1199,7 +1199,7 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 - Approval store — ✅ PR #267 (shared `ApprovalStoreTck`, 37 cases × 3 implementations + enrollment guard)
 - Approval continuation store — ✅ PR #269 (shared `ApprovalContinuationStoreTck`, 50 cases × 3 implementations + enrollment guard)
-- Suspended invocation store — ⏳
+- Suspended invocation store — ✅ PR #270 (shared `SuspendedInvocationStoreTck`, 33 cases × 3 implementations + enrollment guard)
 - Audit store — ⏳
 - Audit outbox store — ⏳
 - Workflow checkpoint store — ⏳
@@ -1225,7 +1225,7 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ### Acceptance criteria
 
-- ✅ Every published store implementation passes the relevant TCK (Approval: 3/3 via #267; Approval continuation: 3/3 via #269; step-attempt: 3/3 via PR #218).
+- ✅ Every published store implementation passes the relevant TCK (Approval: 3/3 via #267; Approval continuation: 3/3 via #269; suspended invocation: 3/3 via #270; step-attempt: 3/3 via PR #218).
 - ✅ Implementation-specific tests cover only storage technology and performance differences (encryption, permissions, corruption, record format for file; SQL schema, JSON mapping, connection cleanup for JDBC).
 - ✅ Contract failures use common typed exceptions or reason codes (`ApprovalStoreConflictException`, `ApprovalStoreNotFoundException`, `ApprovalStoreTokenRejectedException`, `ApprovalStoreNotConsumableException`, `IllegalApprovalTransitionException`; `ApprovalContinuationConflictException`, `ApprovalContinuationNotFoundException`, `ApprovalContinuationNotClaimableException`, `ApprovalContinuationNotCompletableException`).
 
@@ -1245,6 +1245,17 @@ repair feedback. No layer maintains its own independent fixture lists.
 - `StoreEnrollmentScanner` (shared with the #267 guard) + `ApprovalContinuationStoreTckEnrollmentArchitectureTest`
 - `JdbcApprovalContinuationStore` — three contract fixes the TCK exposed: late-cancel lazy-expiry normalization, `argumentsDigest` validation on create, version-before-status precedence in claim
 - Exactly-once raw-argument release proven shared: a second claim can never retrieve arguments, concurrent claims release to exactly one winner
+- Zero public API change; no persisted format or schema changes; no existing tests deleted
+- Reference: `docs/reference/persistence-store-compatibility-contract.md`
+
+### Deliverables (PR #270)
+
+- `tramai-testing/src/testFixtures/.../persistence/engine/` — `SuspendedInvocationStoreTck` (33 cases), `SuspendedInvocationFixtures`; `tramai-testing` testFixtures gained a dependency on `tramai-engine` (the SPI's home module)
+- Runners: `InMemorySuspendedInvocationStoreTckTest` (tramai-engine — the engine's default store, enrolled like any other), `FileSuspendedInvocationStoreTckTest`, `JdbcSuspendedInvocationStoreTckTest`
+- `SuspendedInvocationStoreTckEnrollmentArchitectureTest` — reuses the shared `StoreEnrollmentScanner`
+- `InMemorySuspendedInvocationStore` gained the shared validations it lacked (ID fields, envelope binding, canonical digest); SPI KDoc durability claim corrected to implementation-specific
+- Deliberate decision: JDBC's unique `replay_envelope_digest` index stays JDBC-specific (engine never double-suspends; continuation store already rejects duplicate approvalId) — documented, not copied to the other stores
+- Mutation evidence (9 mutations, each restored): duplicate overwrite, remove-without-delete, reveal-null, envelope-leak-after-remove, digest/toolCallId/toolName/toolCallIndex checks dropped, non-atomic remove
 - Zero public API change; no persisted format or schema changes; no existing tests deleted
 - Reference: `docs/reference/persistence-store-compatibility-contract.md`
 

--- a/docs/reference/persistence-store-compatibility-contract.md
+++ b/docs/reference/persistence-store-compatibility-contract.md
@@ -224,7 +224,7 @@ public API change; no persisted format or schema changes.
 
 ## SuspendedInvocationStore TCK (PR #270)
 
-`SuspendedInvocationStoreTck` (tramai-testing testFixtures) runs **33 shared
+`SuspendedInvocationStoreTck` (tramai-testing testFixtures) runs **39 shared
 behavioral cases** against every `SuspendedInvocationStore` implementation:
 the engine's default in-memory store (`InMemorySuspendedInvocationStore`,
 `tramai-engine`), the encrypted file store (`tramai-persistence-file`), and
@@ -251,6 +251,14 @@ JDBC-only unique replay-envelope-digest constraint (see below).
   (wrong digest and tampered envelope both), an envelope without an assistant
   tool-call message, a toolCallId absent from the envelope, a toolCallIndex
   out of bounds, and a toolName that does not match the envelope.
+- **Redaction invariants (6):** the replay envelope must already be redacted
+  — a correctly-digested envelope whose selected tool call carries RAW
+  arguments is rejected (the digest is recomputed over the invalid envelope,
+  so only the redaction check can fire); a duplicate selected toolCallId
+  across the envelope is rejected; an extra or misplaced redaction sentinel
+  is rejected; a selected call outside the latest assistant tool-call batch
+  is rejected; negative historySize and an envelope smaller than its
+  historySize are rejected.
 - **Remove (5):** remove returns the created metadata, remove then get →
   null, remove then reveal → null, missing → null, create after remove
   succeeds with the same approvalId.
@@ -281,18 +289,30 @@ does not pin it:
 ### Production changes the enrollment required
 
 - **`InMemorySuspendedInvocationStore` gained the shared validations** it
-  lacked: ID-field validation on every operation, envelope binding
-  (assistant tool-call batch, toolCallId/name/index match), and the
-  canonical replay-envelope digest check. It previously accepted records the
-  file and JDBC stores rejected — the exact drift Epic 8.1 exists to remove.
-  The engine's own test doubles that built invalid envelopes were corrected
-  to build valid ones (the engine's real suspension path always produces
-  valid records).
+  lacked, delegated to a shared `ReplayEnvelopeValidator` (tramai-engine,
+  internal): ID-field validation on every operation, envelope binding, the
+  canonical replay-envelope digest check, and the **redaction invariants** —
+  history-size consistency, globally unique selected toolCallId, selected
+  slot in the latest assistant batch, and exactly one redaction sentinel at
+  the selected slot. It previously accepted records the file store rejected.
+- **`JdbcSuspendedInvocationStore` now enforces the same redaction
+  invariants** (mirrored inline — cross-module copy of the engine validator,
+  pinned by the TCK so the copies cannot drift). It previously accepted and
+  encrypted a correctly-digested unredacted envelope, which violated the
+  architecture invariant that raw tool arguments live only behind the
+  ApprovalContinuationStore boundary (SPEC-016).
 - **SPI KDoc fixed**: the interface claimed stores "do not persist beyond
   the JVM lifecycle"; durability is implementation-specific (in-memory is
   process-local, file/JDBC may survive restart).
+- Engine test doubles that built invalid envelopes now build valid ones
+  (redacted sentinel + canonical digest): the testFixtures
+  `TestApprovalGatewayPersistenceRequestBuilder`, `DefaultApprovalGatewayTest`,
+  and the JDBC implementation-specific fixtures. The JDBC
+  `raw replay envelope is not visible in the database` test was rewritten:
+  raw-args envelopes are now rejected at the API boundary, and the valid
+  (redacted) envelope's sensitive message content is still encrypted at rest.
 
-### Mutation evidence (all restored after each run; InMemory store)
+### Mutation evidence (all restored after each run; InMemory store + validator)
 
 | Mutation | TCK outcome |
 |---|---|
@@ -301,10 +321,12 @@ does not pin it:
 | Reveal returns null despite existing entry | RED — reveal round-trip + non-consuming reveal cases fail |
 | Remove leaves replay envelope reachable | RED — remove-then-reveal case fails |
 | Digest mismatch accepted | RED — digest-mismatch + tampered-envelope cases fail |
-| toolCallId mismatch accepted | RED — toolCallId-binding case fails |
+| toolCallId mismatch accepted | RED — toolCallId-binding case fails (the duplicate-id case passes via `single()`'s incidental IAE — documented) |
 | toolName mismatch accepted | RED — toolName-binding case fails |
-| toolCallIndex mismatch accepted | RED — toolCallIndex-binding case fails |
+| toolCallIndex checks dropped | RED — toolCallIndex-binding case fails |
 | Concurrent remove check-then-act (two winners) | RED — concurrent-remove race fails |
+| Redaction sentinel not required | RED — not-redacted + extra-sentinel cases fail |
+| historySize consistency not validated | RED — negative-historySize + too-small-envelope cases fail |
 
 ### Scope
 

--- a/docs/reference/persistence-store-compatibility-contract.md
+++ b/docs/reference/persistence-store-compatibility-contract.md
@@ -219,3 +219,99 @@ encryption codecs, BYTEA representation, SQL schema/migrations, database
 integrity, connection cleanup (JDBC) and encryption envelopes, permissions,
 corruption, record format (file). No existing tests were deleted. Zero
 public API change; no persisted format or schema changes.
+
+---
+
+## SuspendedInvocationStore TCK (PR #270)
+
+`SuspendedInvocationStoreTck` (tramai-testing testFixtures) runs **33 shared
+behavioral cases** against every `SuspendedInvocationStore` implementation:
+the engine's default in-memory store (`InMemorySuspendedInvocationStore`,
+`tramai-engine`), the encrypted file store (`tramai-persistence-file`), and
+the JDBC store (`tramai-persistence-jdbc`).
+
+The contract covers safe metadata CRUD, the sensitive replay-envelope release
+path, the digest + envelope-binding invariants, ID validation, and real
+parallel races. It deliberately does NOT pin implementation-specific
+concerns: restart durability, encryption format, file permissions, corruption
+handling, schema-version decoding, SQL locking/resource behavior, or the
+JDBC-only unique replay-envelope-digest constraint (see below).
+
+- **Creation/read (13):** full-metadata round-trip (incl. token budget and
+  tool security), missing → null, duplicate approvalId → IAE, blank /
+  control-character / whitespace-padded / oversized approvalId → IAE, blank
+  toolCallId / toolName / correlationId / conversationId → IAE, blank
+  approvalId on get/reveal/remove → IAE.
+- **Sensitive release (6):** reveal returns an envelope whose messages equal
+  the originals, missing → null, get() never exposes the messages (safe
+  metadata shape only), envelope `toString` is `[REDACTED]`, reveal does not
+  consume (record survives until remove), repeated reveals return equal
+  content.
+- **Digest + binding (6):** create rejects a canonical-digest mismatch
+  (wrong digest and tampered envelope both), an envelope without an assistant
+  tool-call message, a toolCallId absent from the envelope, a toolCallIndex
+  out of bounds, and a toolName that does not match the envelope.
+- **Remove (5):** remove returns the created metadata, remove then get →
+  null, remove then reveal → null, missing → null, create after remove
+  succeeds with the same approvalId.
+- **Concurrency (3, real parallel races with a start barrier, 20 iterations
+  each):** concurrent create — exactly one winner, seven `IllegalArgumentException`
+  losers; concurrent remove — exactly one winner returns metadata; concurrent
+  reveal while remove — no crashes and exactly one remove winner (reveals may
+  observe the entry or the empty state, both valid).
+
+### Deliberate cross-store decision: replay-digest uniqueness
+
+`JdbcSuspendedInvocationStore` keeps a unique index on
+`replay_envelope_digest` and maps a collision to
+`suspended-invocation-replay-envelope-digest-already-exists`, so the same
+replay payload can never be suspended under two different approval IDs.
+The in-memory and file stores do NOT enforce this, and the TCK deliberately
+does not pin it:
+
+- The engine's suspension flow (`ApprovalSuspensionCoordinator`) creates the
+  `ApprovalContinuationStore` entry first, and that store already rejects a
+  duplicate approvalId — the engine never suspends the same invocation twice.
+- Digest uniqueness across different approval IDs is therefore defensive
+  hardening specific to the JDBC store, not a shared contract invariant.
+- It is documented here so a future implementation knows the divergence is
+  deliberate; if double-suspension protection ever becomes a shared
+  requirement, it belongs in the TCK and all three stores must conform.
+
+### Production changes the enrollment required
+
+- **`InMemorySuspendedInvocationStore` gained the shared validations** it
+  lacked: ID-field validation on every operation, envelope binding
+  (assistant tool-call batch, toolCallId/name/index match), and the
+  canonical replay-envelope digest check. It previously accepted records the
+  file and JDBC stores rejected — the exact drift Epic 8.1 exists to remove.
+  The engine's own test doubles that built invalid envelopes were corrected
+  to build valid ones (the engine's real suspension path always produces
+  valid records).
+- **SPI KDoc fixed**: the interface claimed stores "do not persist beyond
+  the JVM lifecycle"; durability is implementation-specific (in-memory is
+  process-local, file/JDBC may survive restart).
+
+### Mutation evidence (all restored after each run; InMemory store)
+
+| Mutation | TCK outcome |
+|---|---|
+| Duplicate create overwrites existing | RED — duplicate-create case fails |
+| Remove becomes get-without-delete | RED — remove-then-get / remove-then-reveal / create-after-remove / concurrent-remove cases fail |
+| Reveal returns null despite existing entry | RED — reveal round-trip + non-consuming reveal cases fail |
+| Remove leaves replay envelope reachable | RED — remove-then-reveal case fails |
+| Digest mismatch accepted | RED — digest-mismatch + tampered-envelope cases fail |
+| toolCallId mismatch accepted | RED — toolCallId-binding case fails |
+| toolName mismatch accepted | RED — toolName-binding case fails |
+| toolCallIndex mismatch accepted | RED — toolCallIndex-binding case fails |
+| Concurrent remove check-then-act (two winners) | RED — concurrent-remove race fails |
+
+### Scope
+
+The TCK owns SPI semantics; implementation-specific suites continue owning
+restart durability (`FileSuspendedInvocationStoreRestartTest`), encryption
+envelopes, permissions, corruption handling, record format (file), SQL
+schema/JSON mapping/connection cleanup (JDBC). No existing tests were
+deleted. The `tramai-testing` testFixtures gained a dependency on
+`tramai-engine` (the SPI's home module) so the shared suite can be written
+once and run against all three implementations.

--- a/tramai-engine/build.gradle.kts
+++ b/tramai-engine/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     testImplementation(libs.assertj.core)
     testImplementation(libs.kotlin.test.junit5)
     testImplementation(project(":tramai-structured"))
+    testImplementation(testFixtures(project(":tramai-testing")))
     testImplementation(libs.coroutines.test)
     testImplementation(libs.jackson.databind)
 }

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/InMemorySuspendedInvocationStore.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/InMemorySuspendedInvocationStore.kt
@@ -1,7 +1,5 @@
 package dev.tramai.engine
 
-import dev.tramai.core.model.Message
-import dev.tramai.core.model.MessageRole
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -68,26 +66,11 @@ internal class InMemorySuspendedInvocationStore : SuspendedInvocationStore {
         metadata.conversationId?.let { validateIdField(it, "conversationId") }
 
         val messages = replayEnvelope.revealForResume().messages
-        validateEnvelopeBinding(metadata, messages)
+        ReplayEnvelopeValidator.validate(metadata, messages)
         val canonical = ReplayEnvelopeDigestHelper.compute(metadata.operationReference, messages)
         require(canonical == metadata.replayEnvelopeDigest) {
             "replay-envelope-digest-mismatch: canonical=$canonical, provided=${metadata.replayEnvelopeDigest}"
         }
-    }
-
-    private fun validateEnvelopeBinding(
-        metadata: SuspendedInvocationMetadata,
-        messages: List<Message>,
-    ) {
-        val assistantMsg = messages.lastOrNull { it.role == MessageRole.ASSISTANT && !it.toolCalls.isNullOrEmpty() }
-            ?: throw IllegalArgumentException("replay-envelope-no-assistant-tool-calls")
-        val toolCalls = checkNotNull(assistantMsg.toolCalls)
-        require(metadata.toolCallIndex in toolCalls.indices) {
-            "replay-envelope-tool-call-index-out-of-bounds"
-        }
-        val selectedCall = toolCalls[metadata.toolCallIndex]
-        require(selectedCall.id == metadata.toolCallId) { "replay-envelope-tool-call-id-mismatch" }
-        require(selectedCall.name == metadata.toolName) { "replay-envelope-tool-call-name-mismatch" }
     }
 
     private fun validateIdField(value: String, fieldName: String) {

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/InMemorySuspendedInvocationStore.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/InMemorySuspendedInvocationStore.kt
@@ -1,12 +1,23 @@
 package dev.tramai.engine
 
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
 import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Thread-safe in-memory implementation of [SuspendedInvocationStore].
  *
  * Stores both safe metadata and replay envelope in a single [ConcurrentHashMap] keyed by [approvalId].
- * Does NOT persist beyond the JVM lifecycle.
+ * Does NOT persist beyond the JVM lifecycle (process-local, per the SPI contract:
+ * durability is implementation-specific).
+ *
+ * Enforces the shared contract validations (matching the file and JDBC stores):
+ * - ID fields must be non-blank, free of control characters, ≤ 256 chars, and
+ *   without surrounding whitespace on every operation.
+ * - [create] rejects a replay envelope that does not bind to the metadata
+ *   (no assistant tool-call batch, toolCallIndex out of bounds, toolCallId /
+ *   toolName mismatch) and a [SuspendedInvocationMetadata.replayEnvelopeDigest]
+ *   that does not match the canonical digest of the envelope messages.
  */
 internal class InMemorySuspendedInvocationStore : SuspendedInvocationStore {
 
@@ -21,6 +32,7 @@ internal class InMemorySuspendedInvocationStore : SuspendedInvocationStore {
         metadata: SuspendedInvocationMetadata,
         replayEnvelope: SensitiveReplayEnvelope,
     ) {
+        validateCreateInput(metadata, replayEnvelope)
         val existing = invocations.putIfAbsent(
             metadata.approvalId,
             StoredSuspendedInvocation(metadata = metadata, replayEnvelope = replayEnvelope),
@@ -30,14 +42,60 @@ internal class InMemorySuspendedInvocationStore : SuspendedInvocationStore {
         }
     }
 
-    override suspend fun get(approvalId: String): SuspendedInvocationMetadata? =
-        invocations[approvalId]?.metadata
+    override suspend fun get(approvalId: String): SuspendedInvocationMetadata? {
+        validateIdField(approvalId, "approvalId")
+        return invocations[approvalId]?.metadata
+    }
 
-    override suspend fun revealReplayEnvelope(approvalId: String): SensitiveReplayEnvelope? =
-        invocations[approvalId]?.replayEnvelope
+    override suspend fun revealReplayEnvelope(approvalId: String): SensitiveReplayEnvelope? {
+        validateIdField(approvalId, "approvalId")
+        return invocations[approvalId]?.replayEnvelope
+    }
 
-    override suspend fun remove(approvalId: String): SuspendedInvocationMetadata? =
-        invocations.remove(approvalId)?.metadata
+    override suspend fun remove(approvalId: String): SuspendedInvocationMetadata? {
+        validateIdField(approvalId, "approvalId")
+        return invocations.remove(approvalId)?.metadata
+    }
+
+    private fun validateCreateInput(
+        metadata: SuspendedInvocationMetadata,
+        replayEnvelope: SensitiveReplayEnvelope,
+    ) {
+        validateIdField(metadata.approvalId, "approvalId")
+        validateIdField(metadata.toolCallId, "toolCallId")
+        validateIdField(metadata.toolName, "toolName")
+        validateIdField(metadata.correlationId, "correlationId")
+        metadata.conversationId?.let { validateIdField(it, "conversationId") }
+
+        val messages = replayEnvelope.revealForResume().messages
+        validateEnvelopeBinding(metadata, messages)
+        val canonical = ReplayEnvelopeDigestHelper.compute(metadata.operationReference, messages)
+        require(canonical == metadata.replayEnvelopeDigest) {
+            "replay-envelope-digest-mismatch: canonical=$canonical, provided=${metadata.replayEnvelopeDigest}"
+        }
+    }
+
+    private fun validateEnvelopeBinding(
+        metadata: SuspendedInvocationMetadata,
+        messages: List<Message>,
+    ) {
+        val assistantMsg = messages.lastOrNull { it.role == MessageRole.ASSISTANT && !it.toolCalls.isNullOrEmpty() }
+            ?: throw IllegalArgumentException("replay-envelope-no-assistant-tool-calls")
+        val toolCalls = checkNotNull(assistantMsg.toolCalls)
+        require(metadata.toolCallIndex in toolCalls.indices) {
+            "replay-envelope-tool-call-index-out-of-bounds"
+        }
+        val selectedCall = toolCalls[metadata.toolCallIndex]
+        require(selectedCall.id == metadata.toolCallId) { "replay-envelope-tool-call-id-mismatch" }
+        require(selectedCall.name == metadata.toolName) { "replay-envelope-tool-call-name-mismatch" }
+    }
+
+    private fun validateIdField(value: String, fieldName: String) {
+        require(value.isNotBlank()) { "$fieldName must not be blank" }
+        require(value.none { it.isISOControl() }) { "$fieldName must not contain control characters" }
+        require(value.length <= 256) { "$fieldName exceeds maximum length of 256" }
+        require(value == value.trim()) { "$fieldName must not contain surrounding whitespace" }
+    }
 }
 
 fun inMemorySuspendedInvocationStore(): SuspendedInvocationStore =

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/ReplayEnvelopeValidator.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/ReplayEnvelopeValidator.kt
@@ -1,0 +1,72 @@
+package dev.tramai.engine
+
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
+import dev.tramai.core.model.ToolCall
+
+/**
+ * Shared replay-envelope invariant validation (Epic 8.1c).
+ *
+ * Mirrors the semantics [ReplayEnvelopeFactory.prepareForSuspension]
+ * guarantees at suspension time and that the file store re-validates before
+ * persistence: the selected suspended tool call must be globally unique,
+ * sit in the latest assistant tool-call batch at the metadata index, carry
+ * the redaction sentinel in its arguments (exactly one sentinel, at the
+ * selected slot), and the envelope must be consistent with the metadata
+ * history size. Raw selected tool arguments never belong in a replay
+ * envelope — they live behind the ApprovalContinuationStore boundary.
+ *
+ * Internal to the engine module; the JDBC store mirrors these checks inline
+ * (cross-module), and the shared TCK pins the behavior so the copies cannot
+ * drift.
+ */
+internal object ReplayEnvelopeValidator {
+
+    fun validate(metadata: SuspendedInvocationMetadata, messages: List<Message>) {
+        require(metadata.historySize >= 0) { "suspended-replay-envelope-history-size-negative" }
+        require(messages.size > metadata.historySize) { "suspended-replay-envelope-history-size-mismatch" }
+
+        val allSlots = messages.flatMapIndexed { messageIndex, message ->
+            message.toolCalls.orEmpty().mapIndexed { toolCallIndex, call ->
+                ReplayToolCallSlot(messageIndex, toolCallIndex, call)
+            }
+        }
+        val matchingSlots = allSlots.filter { it.call.id == metadata.toolCallId }
+        require(matchingSlots.size == 1) { "suspended-replay-envelope-tool-call-id-mismatch" }
+
+        val selectedSlot = matchingSlots.single()
+        require(metadata.toolCallIndex >= 0) { "suspended-replay-envelope-tool-call-index-out-of-bounds" }
+        require(selectedSlot.toolCallIndex == metadata.toolCallIndex) {
+            "suspended-replay-envelope-tool-call-index-mismatch"
+        }
+        require(selectedSlot.call.name == metadata.toolName) {
+            "suspended-replay-envelope-tool-call-name-mismatch"
+        }
+
+        val latestAssistantIdx = messages.indexOfLast {
+            it.role == MessageRole.ASSISTANT && !it.toolCalls.isNullOrEmpty()
+        }
+        require(latestAssistantIdx >= 0) { "suspended-replay-envelope-assistant-batch-not-found" }
+        require(selectedSlot.messageIndex == latestAssistantIdx) {
+            "suspended-replay-envelope-tool-call-slot-mismatch"
+        }
+
+        val sentinelSlots = allSlots.filter {
+            it.call.argumentsJson == REDACTED_APPROVAL_CONTINUATION_ARGUMENTS
+        }
+        require(sentinelSlots.size == 1) { "suspended-replay-envelope-redaction-count-mismatch" }
+        val sentinelSlot = sentinelSlots.single()
+        require(
+            sentinelSlot.messageIndex == selectedSlot.messageIndex &&
+                sentinelSlot.toolCallIndex == selectedSlot.toolCallIndex,
+        ) {
+            "suspended-replay-envelope-redaction-count-mismatch"
+        }
+    }
+
+    private data class ReplayToolCallSlot(
+        val messageIndex: Int,
+        val toolCallIndex: Int,
+        val call: ToolCall,
+    )
+}

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/SuspendedInvocationStore.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/SuspendedInvocationStore.kt
@@ -138,7 +138,8 @@ data class ResumeContext(
  * Implementations must:
  * - NOT expose raw tool arguments, approval tokens, or sensitive tool payloads via [get]
  * - Be thread-safe (concurrent create/get/remove)
- * - Not persist beyond the JVM lifecycle (resume after restart is out of scope for v1)
+ * - Durability is implementation-specific: the in-memory store is
+ *   process-local, while the file and JDBC stores may survive a restart.
  *
  * ⚠️ Expiry / sweep is a legitimate lifecycle concern but is deferred.
  *    Entries created here have no automatic TTL — they must be explicitly

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/InMemorySuspendedInvocationStoreTckTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/InMemorySuspendedInvocationStoreTckTest.kt
@@ -1,0 +1,14 @@
+package dev.tramai.engine
+
+import dev.tramai.testing.persistence.engine.SuspendedInvocationStoreTck
+
+/**
+ * Epic 8.1c: the engine's default in-memory store must satisfy the shared
+ * SuspendedInvocationStore compatibility contract (tramai-testing
+ * testFixtures). It is a production implementation — TramaiEngine defaults
+ * every constructor to it — so it is enrolled like any other store, and it
+ * doubles as the mutation target for the contract's mutation evidence.
+ */
+class InMemorySuspendedInvocationStoreTckTest : SuspendedInvocationStoreTck() {
+    override fun createStore(): SuspendedInvocationStore = inMemorySuspendedInvocationStore()
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/PolicyEnforcementTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/PolicyEnforcementTest.kt
@@ -1882,7 +1882,7 @@ class PolicyEnforcementTest {
     // -- Cold streaming Flow enforcement (ITEM 3) ------------------------------
 
     @Test
-    fun `cold Flow — policy changed after Flow creation blocks collection`() { runBlocking {
+    fun `cold Flow - policy changed after Flow creation blocks collection`() { runBlocking {
         var currentPolicy: PolicyDecision = PolicyDecision.Allow
         val sProvider = streamingProvider()
 
@@ -1913,7 +1913,7 @@ class PolicyEnforcementTest {
     }
 
     @Test
-    fun `cold Flow — each collection evaluates policy independently`() { runBlocking {
+    fun `cold Flow - each collection evaluates policy independently`() { runBlocking {
         val enforceCount = AtomicInteger(0)
         val sProvider = streamingProvider()
 
@@ -1944,7 +1944,7 @@ class PolicyEnforcementTest {
     }
 
     @Test
-    fun `streaming fallback — BEFORE_RESPONSE_RETURN denies fallback route with providerId and modelName`() { runBlocking {
+    fun `streaming fallback - BEFORE_RESPONSE_RETURN denies fallback route with providerId and modelName`() { runBlocking {
         val primaryStreamProvider = object : ModelProvider, StreamCapable {
             val callCount = AtomicInteger(0)
             override fun providerId() = "primary-stream"
@@ -2032,7 +2032,7 @@ class PolicyEnforcementTest {
     // -- Fallback transition enforcement (ITEM 4) ------------------------------
 
     @Test
-    fun `circuit breaker open — BEFORE_FALLBACK fires and deny blocks fallback`() { runBlocking {
+    fun `circuit breaker open - BEFORE_FALLBACK fires and deny blocks fallback`() { runBlocking {
         val fallbackCallCount = AtomicInteger(0)
         val primaryCallCount = AtomicInteger(0)
         val failOnceProvider = object : ModelProvider {
@@ -2096,7 +2096,7 @@ class PolicyEnforcementTest {
     }
 
     @Test
-    fun `provider failure — BEFORE_FALLBACK fires and allow proceeds to secondary`() { runBlocking {
+    fun `provider failure before fallback fires and allow proceeds to secondary`() { runBlocking {
         val fallbackCalled = AtomicInteger(0)
         var fallbackEnforced = false
         val failOnceProvider = object : ModelProvider {

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/PolicyEnforcementTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/PolicyEnforcementTest.kt
@@ -2096,7 +2096,7 @@ class PolicyEnforcementTest {
     }
 
     @Test
-    fun `provider failure before fallback fires and allow proceeds to secondary`() { runBlocking {
+    fun `provider failure - BEFORE_FALLBACK fires and allow proceeds to secondary`() { runBlocking {
         val fallbackCalled = AtomicInteger(0)
         var fallbackEnforced = false
         val failOnceProvider = object : ModelProvider {

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/approval/DefaultApprovalGatewayTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/approval/DefaultApprovalGatewayTest.kt
@@ -23,6 +23,10 @@ import dev.tramai.engine.EngineExecutionIdentity
 import dev.tramai.engine.ExecutionSecurityContext
 import dev.tramai.engine.ResumeOperationReference
 import dev.tramai.engine.ResumeToolReference
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
+import dev.tramai.core.model.ToolCall
+import dev.tramai.engine.ReplayEnvelopeDigestHelper
 import dev.tramai.engine.SensitiveReplayEnvelope
 import dev.tramai.engine.SuspendedInvocationMetadata
 import dev.tramai.engine.SuspendedInvocationStore
@@ -606,6 +610,24 @@ internal class FakeApprovalGatewayRequestFactory(
             version = 0L,
         )
 
+        val operationReference = ResumeOperationReference(
+            serviceInterface = "dev.tramai.test.TestService",
+            methodName = "testMethod",
+            jvmMethodDescriptor = "(Ltest/Input;)Ltest/Output;",
+            resumeDefinitionDigest = zeroDigest,
+        )
+        // The envelope must bind to the metadata (assistant tool-call message
+        // with matching id/name/index) and carry the canonical digest, per the
+        // shared SuspendedInvocationStore contract.
+        val envelopeMessages = listOf(
+            Message(
+                role = MessageRole.ASSISTANT,
+                content = "",
+                toolCalls = listOf(ToolCall(id = "tc-1", name = "test-tool", argumentsJson = "{}")),
+            ),
+        )
+        val envelopeDigest = ReplayEnvelopeDigestHelper.compute(operationReference, envelopeMessages)
+
         val suspendedInvocationMetadata = SuspendedInvocationMetadata(
             approvalId = defaultApprovalId,
             toolCallId = "tc-1",
@@ -620,20 +642,15 @@ internal class FakeApprovalGatewayRequestFactory(
                 actorId = defaultRequestedBy,
             ),
             securityContext = ExecutionSecurityContext(),
-            operationReference = ResumeOperationReference(
-                serviceInterface = "dev.tramai.test.TestService",
-                methodName = "testMethod",
-                jvmMethodDescriptor = "(Ltest/Input;)Ltest/Output;",
-                resumeDefinitionDigest = zeroDigest,
-            ),
-            replayEnvelopeDigest = zeroDigest,
+            operationReference = operationReference,
+            replayEnvelopeDigest = envelopeDigest,
             toolReference = ResumeToolReference(
                 toolName = "test-tool",
                 declarationDigest = zeroDigest,
             ),
         )
 
-        val replayEnvelope = SensitiveReplayEnvelope.of(emptyList())
+        val replayEnvelope = SensitiveReplayEnvelope.of(envelopeMessages)
 
         return ApprovalGatewayPersistenceRequest(
             approvalRequest = approvalRequest,

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/approval/DefaultApprovalGatewayTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/approval/DefaultApprovalGatewayTest.kt
@@ -617,13 +617,20 @@ internal class FakeApprovalGatewayRequestFactory(
             resumeDefinitionDigest = zeroDigest,
         )
         // The envelope must bind to the metadata (assistant tool-call message
-        // with matching id/name/index) and carry the canonical digest, per the
+        // with matching id/name/index), carry the canonical digest, and have
+        // the selected arguments replaced by the redaction sentinel — per the
         // shared SuspendedInvocationStore contract.
         val envelopeMessages = listOf(
             Message(
                 role = MessageRole.ASSISTANT,
                 content = "",
-                toolCalls = listOf(ToolCall(id = "tc-1", name = "test-tool", argumentsJson = "{}")),
+                toolCalls = listOf(
+                    ToolCall(
+                        id = "tc-1",
+                        name = "test-tool",
+                        argumentsJson = "__redacted_approval_continuation_args__",
+                    ),
+                ),
             ),
         )
         val envelopeDigest = ReplayEnvelopeDigestHelper.compute(operationReference, envelopeMessages)

--- a/tramai-engine/src/testFixtures/kotlin/dev/tramai/engine/approval/testing/TestApprovalGatewayPersistenceRequestBuilder.kt
+++ b/tramai-engine/src/testFixtures/kotlin/dev/tramai/engine/approval/testing/TestApprovalGatewayPersistenceRequestBuilder.kt
@@ -141,7 +141,10 @@ class TestApprovalGatewayPersistenceRequestBuilder(
                     ToolCall(
                         id = toolCallId,
                         name = toolName,
-                        argumentsJson = argsJson,
+                        // Selected arguments are redacted in the replay
+                        // envelope — raw arguments live behind the
+                        // ApprovalContinuationStore boundary.
+                        argumentsJson = "__redacted_approval_continuation_args__",
                     ),
                 ),
             ),

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStoreTckTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileSuspendedInvocationStoreTckTest.kt
@@ -1,0 +1,60 @@
+package dev.tramai.persistence.file
+
+import dev.tramai.engine.SuspendedInvocationStore
+import dev.tramai.testing.persistence.engine.SuspendedInvocationStoreTck
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermissions
+import java.util.concurrent.atomic.AtomicLong
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.TestInstance
+import kotlin.io.path.exists
+
+/**
+ * Epic 8.1c: FileSuspendedInvocationStore must satisfy the shared
+ * SuspendedInvocationStore compatibility contract (tramai-testing
+ * testFixtures). The runner owns the encryption key, directory layout, and
+ * per-case isolation — storage technology never contaminates the contract.
+ *
+ * Each [createStore] call gets a fresh `case-N/suspended` directory so
+ * previous cases' records cannot leak into the next case.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FileSuspendedInvocationStoreTckTest : SuspendedInvocationStoreTck() {
+
+    private val rootDir: Path = Files.createTempDirectory("tramai-suspended-tck-").toAbsolutePath()
+    private val testKey: SecretKey = KeyGenerator.getInstance("AES").apply { init(256) }.generateKey()
+    private val keyProvider = FileStoreEncryptionKeyProvider { testKey }
+    private val caseCounter = AtomicLong(0)
+
+    override fun createStore(): SuspendedInvocationStore {
+        val caseDir = Files.createDirectories(rootDir.resolve("case-${caseCounter.incrementAndGet()}"))
+        Files.createDirectories(caseDir.resolve("suspended"))
+        Files.setPosixFilePermissions(
+            caseDir.resolve("suspended"),
+            PosixFilePermissions.fromString("rwx------"),
+        )
+        return FileSuspendedInvocationStore(
+            root = caseDir,
+            key = testKey,
+            configuration = FileBackedStoreConfiguration(
+                rootDirectory = caseDir,
+                encryption = FileStoreEncryptionConfiguration(
+                    activeKeyId = "tck-key-1",
+                    keyProvider = keyProvider,
+                ),
+                verifyOnOpen = false,
+            ),
+            lease = FileStoreLease(),
+        )
+    }
+
+    @AfterAll
+    fun cleanup() {
+        if (rootDir.exists()) {
+            rootDir.toFile().deleteRecursively()
+        }
+    }
+}

--- a/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcSuspendedInvocationStore.kt
+++ b/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcSuspendedInvocationStore.kt
@@ -75,6 +75,9 @@ class JdbcSuspendedInvocationStore(
      * No default typing — only used for safe primitive/String fields.
      */
     companion object {
+        private const val REDACTED_APPROVAL_CONTINUATION_ARGUMENTS =
+            "__redacted_approval_continuation_args__"
+
         private val mapper: ObjectMapper = ObjectMapper()
             .registerKotlinModule()
             .registerModule(JavaTimeModule())
@@ -271,25 +274,69 @@ class JdbcSuspendedInvocationStore(
     // ── Internal helpers ──────────────────────────────────────────
 
     /**
-     * Validates invariants between the [SuspendedInvocationMetadata] and the
-     * replay envelope [Message]s that will be persisted:
-     * - Tool call ID, name, and index in the messages must match metadata.
+     * Validates the shared replay-envelope invariants between the
+     * [SuspendedInvocationMetadata] and the replay envelope [Message]s that
+     * will be persisted — mirroring the engine's [dev.tramai.engine.ReplayEnvelopeValidator]
+     * (cross-module copy; the shared TCK pins the behavior so the copies
+     * cannot drift):
+     * - history-size consistency;
+     * - the selected toolCallId is globally unique;
+     * - the selected call sits at the metadata index/name in the latest
+     *   assistant tool-call batch;
+     * - the selected call's arguments are the redaction sentinel (exactly one
+     *   sentinel, at the selected slot) — raw selected tool arguments never
+     *   belong in a replay envelope.
      */
     private fun validateReplayEnvelopeInvariants(
         metadata: SuspendedInvocationMetadata,
         messages: List<Message>,
     ) {
-        // Find the matching assistant message with tool calls
-        val assistantMsg = messages.lastOrNull { it.role == MessageRole.ASSISTANT && !it.toolCalls.isNullOrEmpty() }
-            ?: throw IllegalArgumentException("replay-envelope-no-assistant-tool-calls")
+        require(metadata.historySize >= 0) { "suspended-replay-envelope-history-size-negative" }
+        require(messages.size > metadata.historySize) { "suspended-replay-envelope-history-size-mismatch" }
 
-        val tc = checkNotNull(assistantMsg.toolCalls)
+        val allSlots = messages.flatMapIndexed { messageIndex, message ->
+            message.toolCalls.orEmpty().mapIndexed { toolCallIndex, call ->
+                ReplayToolCallSlot(messageIndex, toolCallIndex, call)
+            }
+        }
+        val matchingSlots = allSlots.filter { it.call.id == metadata.toolCallId }
+        require(matchingSlots.size == 1) { "suspended-replay-envelope-tool-call-id-mismatch" }
+        val selectedSlot = matchingSlots.single()
 
-        require(metadata.toolCallIndex in tc.indices) { "replay-envelope-tool-call-index-out-of-bounds" }
-        val selectedCall = tc[metadata.toolCallIndex]
-        require(selectedCall.id == metadata.toolCallId) { "replay-envelope-tool-call-id-mismatch" }
-        require(selectedCall.name == metadata.toolName) { "replay-envelope-tool-call-name-mismatch" }
+        require(metadata.toolCallIndex >= 0) { "suspended-replay-envelope-tool-call-index-out-of-bounds" }
+        require(selectedSlot.toolCallIndex == metadata.toolCallIndex) {
+            "suspended-replay-envelope-tool-call-index-mismatch"
+        }
+        require(selectedSlot.call.name == metadata.toolName) {
+            "suspended-replay-envelope-tool-call-name-mismatch"
+        }
+
+        val latestAssistantIdx = messages.indexOfLast {
+            it.role == MessageRole.ASSISTANT && !it.toolCalls.isNullOrEmpty()
+        }
+        require(latestAssistantIdx >= 0) { "suspended-replay-envelope-assistant-batch-not-found" }
+        require(selectedSlot.messageIndex == latestAssistantIdx) {
+            "suspended-replay-envelope-tool-call-slot-mismatch"
+        }
+
+        val sentinelSlots = allSlots.filter {
+            it.call.argumentsJson == REDACTED_APPROVAL_CONTINUATION_ARGUMENTS
+        }
+        require(sentinelSlots.size == 1) { "suspended-replay-envelope-redaction-count-mismatch" }
+        val sentinelSlot = sentinelSlots.single()
+        require(
+            sentinelSlot.messageIndex == selectedSlot.messageIndex &&
+                sentinelSlot.toolCallIndex == selectedSlot.toolCallIndex,
+        ) {
+            "suspended-replay-envelope-redaction-count-mismatch"
+        }
     }
+
+    private data class ReplayToolCallSlot(
+        val messageIndex: Int,
+        val toolCallIndex: Int,
+        val call: ToolCall,
+    )
 
     /**
      * Extracts the constraint name from a [SQLException] message text.

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcSuspendedInvocationStoreTckTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcSuspendedInvocationStoreTckTest.kt
@@ -1,0 +1,109 @@
+package dev.tramai.persistence.jdbc
+
+import dev.tramai.engine.SuspendedInvocationStore
+import dev.tramai.testing.persistence.engine.SuspendedInvocationStoreTck
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.sql.Connection
+import java.sql.DriverManager
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+import javax.sql.DataSource
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import org.postgresql.ds.PGSimpleDataSource
+import org.testcontainers.containers.PostgreSQLContainer
+
+/**
+ * Epic 8.1c: JdbcSuspendedInvocationStore must satisfy the shared
+ * SuspendedInvocationStore compatibility contract (tramai-testing
+ * testFixtures). The runner owns the datasource, schema, replay-envelope
+ * codec, and per-case isolation — storage technology never contaminates the
+ * contract.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JdbcSuspendedInvocationStoreTckTest : SuspendedInvocationStoreTck() {
+
+    private lateinit var postgres: PostgreSQLContainer<*>
+    private lateinit var dataSource: DataSource
+    private lateinit var setupConnection: Connection
+
+    private val testAesKey = ByteArray(16).also { SecureRandom().nextBytes(it) }
+
+    private val testCodec = object : JdbcReplayEnvelopeCodec {
+        private val algorithm = "AES/GCM/NoPadding"
+        private val tagLength = 128
+
+        override fun encode(plaintext: ByteArray): JdbcEncryptedReplayEnvelope {
+            val cipher = Cipher.getInstance(algorithm)
+            val nonce = ByteArray(12).also { SecureRandom().nextBytes(it) }
+            cipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(testAesKey, "AES"), GCMParameterSpec(tagLength, nonce))
+            val ciphertext = cipher.doFinal(plaintext)
+            val digest = MessageDigest.getInstance("SHA-256")
+                .digest(plaintext)
+                .joinToString("") { "%02x".format(it) }
+            return JdbcEncryptedReplayEnvelope(
+                ciphertext = ciphertext,
+                keyId = "tck-key-1",
+                algorithm = algorithm,
+                nonce = nonce,
+                payloadDigest = "sha256:$digest",
+            )
+        }
+
+        override fun decode(envelope: JdbcEncryptedReplayEnvelope): ByteArray {
+            val cipher = Cipher.getInstance(algorithm)
+            cipher.init(
+                Cipher.DECRYPT_MODE,
+                SecretKeySpec(testAesKey, "AES"),
+                GCMParameterSpec(tagLength, envelope.nonce),
+            )
+            return cipher.doFinal(envelope.ciphertext)
+        }
+    }
+
+    private val fixedClock = Clock.fixed(
+        Instant.parse("2026-06-21T12:00:00Z"),
+        ZoneId.of("UTC"),
+    )
+
+    @BeforeAll
+    fun setUpAll() {
+        postgres = PostgreSQLContainer("postgres:17-alpine")
+            .withDatabaseName("suspended_tck")
+            .withUsername("test")
+            .withPassword("test")
+        postgres.start()
+        dataSource = PGSimpleDataSource().apply {
+            setUrl(postgres.jdbcUrl)
+            user = postgres.username
+            password = postgres.password
+        }
+        setupConnection = DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password)
+        val v1Sql = this::class.java.classLoader
+            .getResource("tramai/persistence/jdbc/postgres/V1__sovereign_persistence.sql")
+            ?.readText()
+            ?: throw IllegalStateException("V1 schema SQL resource not found")
+        setupConnection.createStatement().use { stmt -> stmt.execute(v1Sql) }
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        runCatching { setupConnection.close() }
+        runCatching { postgres.stop() }
+    }
+
+    override fun createStore(): SuspendedInvocationStore {
+        // Fresh isolated storage per case: previous cases' records must not
+        // leak into the next case.
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt -> stmt.execute("DELETE FROM suspended_invocations") }
+        }
+        return JdbcSuspendedInvocationStore(dataSource, testCodec, clock = fixedClock)
+    }
+}

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcSuspendedInvocationStoreTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcSuspendedInvocationStoreTest.kt
@@ -202,7 +202,7 @@ class JdbcSuspendedInvocationStoreTest {
         ),
         replayEnvelopeDigest = digest,
         conversationId = "conv-1",
-        historySize = 5,
+        historySize = 1,
         tokenBudgetSnapshot = TokenBudgetSnapshot(
             totalInputTokens = 100,
             totalOutputTokens = 50,
@@ -229,7 +229,7 @@ class JdbcSuspendedInvocationStoreTest {
                 ToolCall(
                     id = "tc-1",
                     name = "test_tool",
-                    argumentsJson = """{"key":"value"}""",
+                    argumentsJson = "__redacted_approval_continuation_args__",
                 ),
             ),
         ),
@@ -261,7 +261,7 @@ class JdbcSuspendedInvocationStoreTest {
             Message(MessageRole.USER, "Hello B"),
             Message(
                 MessageRole.ASSISTANT, "",
-                toolCalls = listOf(ToolCall("tc-2", "other_tool", """{"key":"value"}""")),
+                toolCalls = listOf(ToolCall("tc-2", "other_tool", "__redacted_approval_continuation_args__")),
             ),
         )
         val digestB = ReplayEnvelopeDigestHelper.compute(
@@ -445,9 +445,11 @@ class JdbcSuspendedInvocationStoreTest {
     }
 
     @Test
-    fun `raw replay envelope is not visible in the database`() { runBlocking {
+    fun `raw replay envelope is rejected before reaching the database`() { runBlocking {
         val s = store()
-        // Create with some sensitive content
+        // Raw selected tool arguments never reach the store: the shared
+        // contract rejects a correctly-digested unredacted envelope, so the
+        // encryption boundary never sees them.
         val messages = listOf(
             Message(MessageRole.USER, "Sensitive query: password=secret123"),
             Message(
@@ -464,9 +466,34 @@ class JdbcSuspendedInvocationStoreTest {
             ),
             messages = messages,
         )
+        assertFailsWith<IllegalArgumentException> {
+            s.create(
+                sampleMetadata("si-no-raw", digest = rawDigest).copy(toolCallId = "tc-x"),
+                sampleEnvelope(messages),
+            )
+        }
+
+        // And a valid (redacted) envelope's sensitive message content is still
+        // encrypted at rest — never visible as plaintext in the DB.
+        val validMessages = listOf(
+            Message(MessageRole.USER, "Sensitive query: password=secret123"),
+            Message(
+                MessageRole.ASSISTANT, "",
+                toolCalls = listOf(ToolCall("tc-x", "test_tool", "__redacted_approval_continuation_args__")),
+            ),
+        )
+        val validDigest = ReplayEnvelopeDigestHelper.compute(
+            operationReference = ResumeOperationReference(
+                serviceInterface = "com.example.TestService",
+                methodName = "execute",
+                jvmMethodDescriptor = "(Ljava/lang/String;)V",
+                resumeDefinitionDigest = operationDigest,
+            ),
+            messages = validMessages,
+        )
         s.create(
-            sampleMetadata("si-no-raw", digest = rawDigest).copy(toolCallId = "tc-x"),
-            sampleEnvelope(messages),
+            sampleMetadata("si-no-raw", digest = validDigest).copy(toolCallId = "tc-x"),
+            sampleEnvelope(validMessages),
         )
 
         val conn: Connection = DriverManager.getConnection(
@@ -481,7 +508,6 @@ class JdbcSuspendedInvocationStoreTest {
                     val text = ciphertext.toString(StandardCharsets.UTF_8)
                     // Verify ciphertext does not contain the plaintext strings
                     assertTrue(text.contains("secret123").not(), "Raw content visible in DB")
-                    assertTrue(text.contains("top-secret").not(), "Raw tool args visible in DB")
                     assertTrue(text.contains("password").not(), "Raw password visible in DB")
                 }
             }
@@ -713,7 +739,7 @@ class JdbcSuspendedInvocationStoreTest {
         assertEquals(operationDigest, loaded.operationReference.resumeDefinitionDigest)
         assertEquals(fixedDigest, loaded.replayEnvelopeDigest)
         assertEquals("conv-1", loaded.conversationId)
-        assertEquals(5, loaded.historySize)
+        assertEquals(1, loaded.historySize)
         assertEquals(100L, loaded.tokenBudgetSnapshot?.totalInputTokens)
         assertEquals(50L, loaded.tokenBudgetSnapshot?.totalOutputTokens)
         assertEquals(0.01, loaded.tokenBudgetSnapshot!!.totalInputCost, 0.001)

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsApprovalRequestMutationStoreTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsApprovalRequestMutationStoreTest.kt
@@ -558,7 +558,7 @@ class JdbcSovereignOpsApprovalRequestMutationStoreTest {
                     ToolCall(
                         id = "tool-call-$approvalId",
                         name = "tool-$approvalId",
-                        argumentsJson = "{}",
+                        argumentsJson = "__redacted_approval_continuation_args__",
                     ),
                 ),
             ),

--- a/tramai-testing/build.gradle.kts
+++ b/tramai-testing/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation(libs.assertj.core)
 
     testFixturesApi(project(":tramai-core"))
+    testFixturesApi(project(":tramai-engine"))
     testFixturesApi(libs.assertj.core)
     testFixturesApi(libs.coroutines.core)
     testFixturesApi(libs.coroutines.test)

--- a/tramai-testing/src/test/kotlin/dev/tramai/testing/SuspendedInvocationStoreTckEnrollmentArchitectureTest.kt
+++ b/tramai-testing/src/test/kotlin/dev/tramai/testing/SuspendedInvocationStoreTckEnrollmentArchitectureTest.kt
@@ -104,12 +104,9 @@ class SuspendedInvocationStoreTckEnrollmentArchitectureTest {
         assertThat(scanner.implementationsIn(file)).isEmpty()
     }
 
-    private fun tempSourceFile(content: String): File {
-        val dir = Files.createTempDirectory("enrollment-probe-")
-        val file = dir.resolve("Probe.kt").toFile()
-        file.writeText(content)
-        file.deleteOnExit()
-        dir.toFile().deleteOnExit()
-        return file
-    }
+    private fun tempSourceFile(content: String): File =
+        Files.createTempFile("enrollment-probe-", ".kt").toFile().apply {
+            writeText(content)
+            deleteOnExit()
+        }
 }

--- a/tramai-testing/src/test/kotlin/dev/tramai/testing/SuspendedInvocationStoreTckEnrollmentArchitectureTest.kt
+++ b/tramai-testing/src/test/kotlin/dev/tramai/testing/SuspendedInvocationStoreTckEnrollmentArchitectureTest.kt
@@ -1,0 +1,115 @@
+package dev.tramai.testing
+
+import java.io.File
+import java.nio.file.Files
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Epic 8.1c architecture guard: every concrete [dev.tramai.engine.SuspendedInvocationStore]
+ * implementation must be enrolled in the shared SuspendedInvocationStore
+ * compatibility contract (tramai-testing testFixtures).
+ *
+ * Same two properties as the Approval guards (#267/#269): the three roadmap
+ * runners are pinned by name, and every concrete implementation in any
+ * module's main source set must ship a `<Store>TckTest` runner in the same
+ * module that actually extends
+ * [dev.tramai.testing.persistence.engine.SuspendedInvocationStoreTck].
+ */
+class SuspendedInvocationStoreTckEnrollmentArchitectureTest {
+
+    private val scanner = StoreEnrollmentScanner("SuspendedInvocationStore", "SuspendedInvocationStoreTck")
+
+    private val repoRoot: File =
+        generateSequence(File(".").absoluteFile) { it.parentFile }
+            .first { it.resolve("settings.gradle.kts").isFile }
+
+    private val expectedRunners = setOf(
+        "InMemorySuspendedInvocationStoreTckTest",
+        "FileSuspendedInvocationStoreTckTest",
+        "JdbcSuspendedInvocationStoreTckTest",
+    )
+
+    @Test
+    fun `every roadmap SuspendedInvocationStore ships a TCK runner`() {
+        val missing = expectedRunners.filter { runnerName -> scanner.findRunnerFile(repoRoot, runnerName) == null }
+        assertThat(missing)
+            .withFailMessage(
+                "Pinned SuspendedInvocationStore TCK runners missing. The compatibility contract is " +
+                    "reviewed per runner; deleting a runner silently removes a store from the contract: $missing",
+            )
+            .isEmpty()
+    }
+
+    @Test
+    fun `every SuspendedInvocationStore implementation has a valid TCK runner in its module`() {
+        val unenrolled = scanner.storeModules(repoRoot).flatMap { (module, implementations) ->
+            implementations
+                .filter { storeName -> !scanner.hasValidRunner(repoRoot, module, storeName) }
+                .map { store -> "$module/$store" }
+        }
+        assertThat(unenrolled)
+            .withFailMessage(
+                "SuspendedInvocationStore implementations without a <Store>TckTest runner extending " +
+                    "SuspendedInvocationStoreTck in the same module: $unenrolled. " +
+                    "Adding a SuspendedInvocationStore without enrolling it in the compatibility " +
+                    "contract must make a gate fail.",
+            )
+            .isEmpty()
+    }
+
+    // ── probe tests for the scanner against this family ─────────────
+
+    @Test
+    fun `body-less SuspendedInvocationStore implementation is detected`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            import dev.tramai.engine.SuspendedInvocationStore
+            class RedisSuspendedStore(private val delegate: SuspendedInvocationStore) :
+                SuspendedInvocationStore by delegate
+            """.trimIndent(),
+        )
+        assertThat(scanner.implementationsIn(file)).containsExactly("RedisSuspendedStore")
+    }
+
+    @Test
+    fun `runner file must actually subclass SuspendedInvocationStoreTck`() {
+        val fake = tempSourceFile("class RedisSuspendedStoreTckTest")
+        val real = tempSourceFile("class RedisSuspendedStoreTckTest : SuspendedInvocationStoreTck() { }")
+        assertThat(scanner.runnerSubclassesTck(fake, "RedisSuspendedStore")).isFalse()
+        assertThat(scanner.runnerSubclassesTck(real, "RedisSuspendedStore")).isTrue()
+    }
+
+    @Test
+    fun `exception class whose name contains the interface does not count as an implementation`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            class SuspendedInvocationStoreException(val code: String) : RuntimeException()
+            """.trimIndent(),
+        )
+        assertThat(scanner.implementationsIn(file)).isEmpty()
+    }
+
+    @Test
+    fun `constructor parameter never counts as an implementation`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            import dev.tramai.engine.SuspendedInvocationStore
+            class Holder(val store: SuspendedInvocationStore)
+            """.trimIndent(),
+        )
+        assertThat(scanner.implementationsIn(file)).isEmpty()
+    }
+
+    private fun tempSourceFile(content: String): File {
+        val dir = Files.createTempDirectory("enrollment-probe-")
+        val file = dir.resolve("Probe.kt").toFile()
+        file.writeText(content)
+        file.deleteOnExit()
+        dir.toFile().deleteOnExit()
+        return file
+    }
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/engine/SuspendedInvocationFixtures.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/engine/SuspendedInvocationFixtures.kt
@@ -85,6 +85,75 @@ object SuspendedInvocationFixtures {
         ),
     )
 
+    /**
+     * Envelope whose selected tool call carries RAW arguments — the exact
+     * violation the redaction invariant must reject. Digest computed over
+     * these messages stays canonical, so only the redaction check can fire.
+     */
+    fun messagesWithRawSelectedArguments(
+        rawArguments: String = """{"customerSecret":"abc"}""",
+    ): List<Message> = listOf(
+        Message(role = MessageRole.USER, content = "review-sensitive-prompt"),
+        Message(
+            role = MessageRole.ASSISTANT,
+            content = "",
+            toolCalls = listOf(
+                ToolCall(id = TOOL_CALL_ID, name = TOOL_NAME, argumentsJson = rawArguments),
+            ),
+        ),
+    )
+
+    /** Envelope whose selected toolCallId appears in TWO assistant batches. */
+    fun messagesWithDuplicateSelectedId(): List<Message> = listOf(
+        Message(role = MessageRole.USER, content = "review-sensitive-prompt"),
+        Message(
+            role = MessageRole.ASSISTANT,
+            content = "",
+            toolCalls = listOf(
+                ToolCall(id = TOOL_CALL_ID, name = TOOL_NAME, argumentsJson = REDACTED_ARGUMENTS),
+            ),
+        ),
+        Message(
+            role = MessageRole.ASSISTANT,
+            content = "",
+            toolCalls = listOf(
+                ToolCall(id = TOOL_CALL_ID, name = TOOL_NAME, argumentsJson = """{"x":1}"""),
+            ),
+        ),
+    )
+
+    /** Envelope with the selected slot redacted PLUS a stray extra sentinel. */
+    fun messagesWithExtraSentinel(): List<Message> = listOf(
+        Message(role = MessageRole.USER, content = "review-sensitive-prompt"),
+        Message(
+            role = MessageRole.ASSISTANT,
+            content = "",
+            toolCalls = listOf(
+                ToolCall(id = TOOL_CALL_ID, name = TOOL_NAME, argumentsJson = REDACTED_ARGUMENTS),
+                ToolCall(id = "other-call", name = "other_tool", argumentsJson = REDACTED_ARGUMENTS),
+            ),
+        ),
+    )
+
+    /** Envelope whose selected call sits in an EARLIER assistant batch. */
+    fun messagesWithSelectedCallInEarlierBatch(): List<Message> = listOf(
+        Message(role = MessageRole.USER, content = "review-sensitive-prompt"),
+        Message(
+            role = MessageRole.ASSISTANT,
+            content = "",
+            toolCalls = listOf(
+                ToolCall(id = TOOL_CALL_ID, name = TOOL_NAME, argumentsJson = REDACTED_ARGUMENTS),
+            ),
+        ),
+        Message(
+            role = MessageRole.ASSISTANT,
+            content = "",
+            toolCalls = listOf(
+                ToolCall(id = "later-call", name = "later_tool", argumentsJson = """{"x":1}"""),
+            ),
+        ),
+    )
+
     /** Envelope wrapping [messages], with a defensive copy like the engine's. */
     fun envelope(messages: List<Message> = messages()): SensitiveReplayEnvelope =
         SensitiveReplayEnvelope.of(messages)
@@ -155,7 +224,9 @@ object SuspendedInvocationFixtures {
         conversationId = conversationId,
         historySize = historySize,
         tokenBudgetSnapshot = TOKEN_BUDGET,
-        toolReference = TOOL_REFERENCE,
+        // toolReference must stay internally consistent with toolName so a
+        // negative fixture mutates exactly one relationship at a time.
+        toolReference = TOOL_REFERENCE.copy(toolName = toolName),
         toolSecurity = TOOL_SECURITY,
     )
 }

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/engine/SuspendedInvocationFixtures.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/engine/SuspendedInvocationFixtures.kt
@@ -1,0 +1,161 @@
+package dev.tramai.testing.persistence.engine
+
+import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
+import dev.tramai.core.model.ToolCall
+import dev.tramai.core.policy.ToolSecurityMetadata
+import dev.tramai.engine.EngineExecutionIdentity
+import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.ReplayEnvelopeDigestHelper
+import dev.tramai.engine.ResumeOperationReference
+import dev.tramai.engine.ResumeToolReference
+import dev.tramai.engine.SensitiveReplayEnvelope
+import dev.tramai.engine.SuspendedInvocationMetadata
+import dev.tramai.engine.TokenBudgetSnapshot
+import dev.tramai.core.policy.DataClassification
+import dev.tramai.core.policy.ClassificationSource
+
+/**
+ * Shared fixture builders for the [SuspendedInvocationStoreTck].
+ *
+ * Every record built here satisfies the *intersection* of the three stores'
+ * create-time validations, so a single fixture set runs against all of them:
+ * the selected tool call lives in the latest assistant message with tool
+ * calls, carries the engine's redaction sentinel in its arguments, and the
+ * metadata digest is the canonical digest of the envelope messages.
+ */
+object SuspendedInvocationFixtures {
+
+    const val TOOL_NAME = "sensitive_lookup"
+    const val TOOL_CALL_ID = "tool-call-1"
+    const val REDACTED_ARGUMENTS = "__redacted_approval_continuation_args__"
+
+    val OPERATION_DIGEST = Sha256Digest.of(
+        "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    )
+
+    val WORKFLOW_DIGEST = Sha256Digest.of(
+        "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+    )
+
+    val OPERATION_REFERENCE = ResumeOperationReference(
+        serviceInterface = "dev.tramai.testing.SuspendedTestService",
+        methodName = "resume",
+        jvmMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/String;",
+        resumeDefinitionDigest = OPERATION_DIGEST,
+    )
+
+    val TOOL_REFERENCE = ResumeToolReference(
+        toolName = TOOL_NAME,
+        declarationDigest = OPERATION_DIGEST,
+    )
+
+    val TOKEN_BUDGET = TokenBudgetSnapshot(
+        totalInputTokens = 1_024L,
+        totalOutputTokens = 512L,
+        totalInputCost = 0.01,
+        totalOutputCost = 0.02,
+        warnIfExceeded = true,
+    )
+
+    val TOOL_SECURITY = ToolSecurityMetadata.legacyPermissive()
+
+    /** The canonical messages used by every fixture: user + assistant-with-tool-call. */
+    fun messages(
+        toolCallId: String = TOOL_CALL_ID,
+        toolName: String = TOOL_NAME,
+        toolCallIndex: Int = 0,
+        toolCalls: List<ToolCall>? = null,
+    ): List<Message> = listOf(
+        Message(
+            role = MessageRole.USER,
+            content = "review-sensitive-prompt workflow=workflow-run-1 correlation=correlation-1",
+        ),
+        Message(
+            role = MessageRole.ASSISTANT,
+            content = "",
+            toolCalls = toolCalls ?: listOf(
+                ToolCall(
+                    id = toolCallId,
+                    name = toolName,
+                    argumentsJson = if (toolCallIndex == 0) REDACTED_ARGUMENTS else "{}",
+                ),
+            ),
+        ),
+    )
+
+    /** Envelope wrapping [messages], with a defensive copy like the engine's. */
+    fun envelope(messages: List<Message> = messages()): SensitiveReplayEnvelope =
+        SensitiveReplayEnvelope.of(messages)
+
+    /** Computes the canonical digest the engine would attach to [messages]. */
+    fun digest(messages: List<Message> = messages()): Sha256Digest =
+        ReplayEnvelopeDigestHelper.compute(OPERATION_REFERENCE, messages)
+
+    /**
+     * A valid metadata+envelope pair for [approvalId].
+     *
+     * [digestOverride] and [messageOverride] let tests tamper with exactly one
+     * binding at a time while keeping the rest canonical.
+     */
+    fun record(
+        approvalId: String = "si-1",
+        toolCallId: String = TOOL_CALL_ID,
+        toolName: String = TOOL_NAME,
+        toolCallIndex: Int = 0,
+        correlationId: String = "correlation-1",
+        conversationId: String? = "conversation-1",
+        historySize: Int = 1,
+        digestOverride: Sha256Digest? = null,
+        messageOverride: List<Message>? = null,
+    ): Pair<SuspendedInvocationMetadata, SensitiveReplayEnvelope> {
+        val messages = messageOverride ?: messages(toolCallId, toolName, toolCallIndex)
+        val metadata = metadata(
+            approvalId = approvalId,
+            toolCallId = toolCallId,
+            toolName = toolName,
+            toolCallIndex = toolCallIndex,
+            correlationId = correlationId,
+            conversationId = conversationId,
+            historySize = historySize,
+            replayEnvelopeDigest = digestOverride ?: digest(messages),
+        )
+        return metadata to envelope(messages)
+    }
+
+    fun metadata(
+        approvalId: String = "si-1",
+        toolCallId: String = TOOL_CALL_ID,
+        toolName: String = TOOL_NAME,
+        toolCallIndex: Int = 0,
+        correlationId: String = "correlation-1",
+        conversationId: String? = "conversation-1",
+        historySize: Int = 1,
+        replayEnvelopeDigest: Sha256Digest = digest(),
+    ): SuspendedInvocationMetadata = SuspendedInvocationMetadata(
+        approvalId = approvalId,
+        toolCallId = toolCallId,
+        toolName = toolName,
+        toolCallIndex = toolCallIndex,
+        correlationId = correlationId,
+        identity = EngineExecutionIdentity(
+            workflowRunId = "workflow-run-1",
+            correlationId = correlationId,
+            workflowDigest = WORKFLOW_DIGEST,
+            policyVersion = "policy-v1",
+            actorId = "actor-1",
+        ),
+        securityContext = ExecutionSecurityContext(
+            dataClassification = DataClassification.CONFIDENTIAL,
+            classificationSource = ClassificationSource.RULE_BASED,
+        ),
+        operationReference = OPERATION_REFERENCE,
+        replayEnvelopeDigest = replayEnvelopeDigest,
+        conversationId = conversationId,
+        historySize = historySize,
+        tokenBudgetSnapshot = TOKEN_BUDGET,
+        toolReference = TOOL_REFERENCE,
+        toolSecurity = TOOL_SECURITY,
+    )
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/engine/SuspendedInvocationStoreTck.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/engine/SuspendedInvocationStoreTck.kt
@@ -1,0 +1,424 @@
+package dev.tramai.testing.persistence.engine
+
+import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
+import dev.tramai.engine.SensitiveReplayEnvelope
+import dev.tramai.engine.SuspendedInvocationMetadata
+import dev.tramai.engine.SuspendedInvocationStore
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFailsWith
+
+/**
+ * Shared compatibility contract for every [SuspendedInvocationStore]
+ * implementation (Epic 8.1c). Runners in each owning module extend this class
+ * and provide a fresh [createStore] per test.
+ *
+ * The contract covers CRUD, the sensitive-replay-envelope release path, the
+ * digest + envelope-binding invariants, ID validation, and real parallel
+ * races. It deliberately does NOT pin implementation-specific concerns:
+ * restart durability, encryption format, file permissions, corruption
+ * handling, schema versions, SQL resource/locking behavior, or the JDBC-only
+ * unique replay-envelope-digest constraint.
+ */
+abstract class SuspendedInvocationStoreTck {
+
+    protected abstract fun createStore(): SuspendedInvocationStore
+
+    // ── Creation / read ────────────────────────────────────────────
+
+    @Test
+    fun `create then get round-trips every metadata field`() = runBlocking<Unit> {
+        val store = createStore()
+        val (metadata, envelope) = SuspendedInvocationFixtures.record()
+
+        store.create(metadata, envelope)
+
+        val retrieved = store.get(metadata.approvalId)
+        assertThat(retrieved).isNotNull
+        assertThat(retrieved).isEqualTo(metadata)
+        assertThat(retrieved!!.tokenBudgetSnapshot).isEqualTo(SuspendedInvocationFixtures.TOKEN_BUDGET)
+        assertThat(retrieved.toolSecurity).isEqualTo(SuspendedInvocationFixtures.TOOL_SECURITY)
+        assertThat(retrieved.replayEnvelopeDigest).isEqualTo(metadata.replayEnvelopeDigest)
+    }
+
+    @Test
+    fun `get on missing approvalId returns null`() = runBlocking<Unit> {
+        val store = createStore()
+        assertThat(store.get("missing-id")).isNull()
+    }
+
+    @Test
+    fun `duplicate create with same approvalId fails`() = runBlocking<Unit> {
+        val store = createStore()
+        val (metadata, envelope) = SuspendedInvocationFixtures.record("dup-1")
+        store.create(metadata, envelope)
+
+        assertFailsWith<IllegalArgumentException> {
+            store.create(metadata, envelope)
+        }
+    }
+
+    @Test
+    fun `create rejects blank approvalId`() = runBlocking<Unit> {
+        val store = createStore()
+        val (metadata, envelope) = SuspendedInvocationFixtures.record(approvalId = "  ")
+        assertFailsWith<IllegalArgumentException> { store.create(metadata, envelope) }
+    }
+
+    @Test
+    fun `create rejects control characters in approvalId`() = runBlocking<Unit> {
+        val store = createStore()
+        val (metadata, envelope) = SuspendedInvocationFixtures.record(approvalId = "bad\nid")
+        assertFailsWith<IllegalArgumentException> { store.create(metadata, envelope) }
+    }
+
+    @Test
+    fun `create rejects approvalId with surrounding whitespace`() = runBlocking<Unit> {
+        val store = createStore()
+        val (metadata, envelope) = SuspendedInvocationFixtures.record(approvalId = "  padded-id  ")
+        assertFailsWith<IllegalArgumentException> { store.create(metadata, envelope) }
+    }
+
+    @Test
+    fun `create rejects oversized approvalId`() = runBlocking<Unit> {
+        val store = createStore()
+        val (metadata, envelope) = SuspendedInvocationFixtures.record(approvalId = "x".repeat(257))
+        assertFailsWith<IllegalArgumentException> { store.create(metadata, envelope) }
+    }
+
+    @Test
+    fun `create rejects blank toolCallId`() = runBlocking<Unit> {
+        val store = createStore()
+        val (metadata, envelope) = SuspendedInvocationFixtures.record(toolCallId = "")
+        assertFailsWith<IllegalArgumentException> { store.create(metadata, envelope) }
+    }
+
+    @Test
+    fun `create rejects blank toolName`() = runBlocking<Unit> {
+        val store = createStore()
+        val (metadata, envelope) = SuspendedInvocationFixtures.record(toolName = "")
+        assertFailsWith<IllegalArgumentException> { store.create(metadata, envelope) }
+    }
+
+    @Test
+    fun `create rejects blank correlationId`() = runBlocking<Unit> {
+        val store = createStore()
+        val (metadata, envelope) = SuspendedInvocationFixtures.record(correlationId = "")
+        assertFailsWith<IllegalArgumentException> { store.create(metadata, envelope) }
+    }
+
+    @Test
+    fun `create rejects blank conversationId when present`() = runBlocking<Unit> {
+        val store = createStore()
+        val (metadata, envelope) = SuspendedInvocationFixtures.record(conversationId = " ")
+        assertFailsWith<IllegalArgumentException> { store.create(metadata, envelope) }
+    }
+
+    @Test
+    fun `get with blank approvalId fails`() = runBlocking<Unit> {
+        val store = createStore()
+        assertFailsWith<IllegalArgumentException> { store.get("") }
+        assertFailsWith<IllegalArgumentException> { store.get("  x  ") }
+    }
+
+    @Test
+    fun `reveal and remove with blank approvalId fail`() = runBlocking<Unit> {
+        val store = createStore()
+        assertFailsWith<IllegalArgumentException> { store.revealReplayEnvelope("") }
+        assertFailsWith<IllegalArgumentException> { store.remove("") }
+    }
+
+    // ── Sensitive release path ─────────────────────────────────────
+
+    @Test
+    fun `reveal returns envelope whose messages equal the originals`() = runBlocking<Unit> {
+        val store = createStore()
+        val (metadata, envelope) = SuspendedInvocationFixtures.record()
+        val originalMessages = envelope.revealForResume().messages
+
+        store.create(metadata, envelope)
+        val revealed = store.revealReplayEnvelope(metadata.approvalId)
+
+        assertThat(revealed).isNotNull
+        assertThat(revealed!!.revealForResume().messages).isEqualTo(originalMessages)
+    }
+
+    @Test
+    fun `reveal on missing approvalId returns null`() = runBlocking<Unit> {
+        val store = createStore()
+        assertThat(store.revealReplayEnvelope("missing-id")).isNull()
+    }
+
+    @Test
+    fun `get never exposes the replay messages`() = runBlocking<Unit> {
+        val store = createStore()
+        val (metadata, envelope) = SuspendedInvocationFixtures.record()
+        store.create(metadata, envelope)
+
+        // The only message-bearing access is revealReplayEnvelope; get() must
+        // surface the safe metadata shape and nothing else.
+        val retrieved = store.get(metadata.approvalId)!!
+        assertThat(retrieved::class.java).isEqualTo(SuspendedInvocationMetadata::class.java)
+        assertThat(retrieved.toolCallId).isEqualTo(metadata.toolCallId)
+        assertThat(retrieved.toolName).isEqualTo(metadata.toolName)
+        assertThat(retrieved.replayEnvelopeDigest).isEqualTo(metadata.replayEnvelopeDigest)
+    }
+
+    @Test
+    fun `replay envelope toString is redacted`() = runBlocking<Unit> {
+        val envelope = SuspendedInvocationFixtures.envelope(
+            listOf(Message(role = MessageRole.USER, content = "secret-prompt")),
+        )
+        assertThat(envelope.toString()).isEqualTo("[REDACTED]")
+        assertThat(envelope.toString()).doesNotContain("secret-prompt")
+    }
+
+    @Test
+    fun `reveal does not remove the invocation`() = runBlocking<Unit> {
+        val store = createStore()
+        val (metadata, envelope) = SuspendedInvocationFixtures.record()
+        store.create(metadata, envelope)
+
+        store.revealReplayEnvelope(metadata.approvalId)
+
+        // The sensitive release path is not a consume: the record survives
+        // until an explicit remove.
+        assertThat(store.get(metadata.approvalId)).isEqualTo(metadata)
+        assertThat(store.revealReplayEnvelope(metadata.approvalId)).isNotNull
+    }
+
+    @Test
+    fun `multiple reveals return equal content without consuming`() = runBlocking<Unit> {
+        val store = createStore()
+        val (metadata, envelope) = SuspendedInvocationFixtures.record()
+        store.create(metadata, envelope)
+
+        val first = store.revealReplayEnvelope(metadata.approvalId)!!
+        val second = store.revealReplayEnvelope(metadata.approvalId)!!
+        assertThat(second.revealForResume().messages).isEqualTo(first.revealForResume().messages)
+    }
+
+    // ── Digest + envelope binding ──────────────────────────────────
+
+    @Test
+    fun `create rejects replay envelope digest mismatch`() = runBlocking<Unit> {
+        val store = createStore()
+        val (metadata, envelope) = SuspendedInvocationFixtures.record(
+            digestOverride = Sha256Digest.of(
+                "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+            ),
+        )
+        assertFailsWith<IllegalArgumentException> { store.create(metadata, envelope) }
+    }
+
+    @Test
+    fun `create rejects tampered envelope messages`() = runBlocking<Unit> {
+        val store = createStore()
+        // Envelope messages changed after the canonical digest was computed
+        // over the original set — metadata digest must not match them.
+        val tamperedMessages = SuspendedInvocationFixtures.messages().mapIndexed { index, message ->
+            if (index == 0) message.copy(content = "tampered-prompt") else message
+        }
+        val metadata = SuspendedInvocationFixtures.metadata(replayEnvelopeDigest = SuspendedInvocationFixtures.digest())
+        val envelope = SuspendedInvocationFixtures.envelope(tamperedMessages)
+        assertFailsWith<IllegalArgumentException> { store.create(metadata, envelope) }
+    }
+
+    @Test
+    fun `create rejects envelope without assistant tool calls`() = runBlocking<Unit> {
+        val store = createStore()
+        val metadata = SuspendedInvocationFixtures.metadata(replayEnvelopeDigest = SuspendedInvocationFixtures.digest())
+        val envelope = SuspendedInvocationFixtures.envelope(
+            listOf(Message(role = MessageRole.USER, content = "no tool calls")),
+        )
+        assertFailsWith<IllegalArgumentException> { store.create(metadata, envelope) }
+    }
+
+    @Test
+    fun `create rejects toolCallId that does not exist in the envelope`() = runBlocking<Unit> {
+        val store = createStore()
+        // Metadata names a tool call that the (digest-valid) envelope does not contain.
+        val metadata = SuspendedInvocationFixtures.metadata(
+            toolCallId = "different-tool-call",
+            replayEnvelopeDigest = SuspendedInvocationFixtures.digest(),
+        )
+        val envelope = SuspendedInvocationFixtures.envelope()
+        assertFailsWith<IllegalArgumentException> { store.create(metadata, envelope) }
+    }
+
+    @Test
+    fun `create rejects toolCallIndex out of bounds`() = runBlocking<Unit> {
+        val store = createStore()
+        val metadata = SuspendedInvocationFixtures.metadata(
+            toolCallIndex = 3,
+            replayEnvelopeDigest = SuspendedInvocationFixtures.digest(),
+        )
+        val envelope = SuspendedInvocationFixtures.envelope()
+        assertFailsWith<IllegalArgumentException> { store.create(metadata, envelope) }
+    }
+
+    @Test
+    fun `create rejects toolName that does not match the envelope`() = runBlocking<Unit> {
+        val store = createStore()
+        val metadata = SuspendedInvocationFixtures.metadata(
+            toolName = "other_tool",
+            replayEnvelopeDigest = SuspendedInvocationFixtures.digest(),
+        )
+        val envelope = SuspendedInvocationFixtures.envelope()
+        assertFailsWith<IllegalArgumentException> { store.create(metadata, envelope) }
+    }
+
+    // ── Remove ─────────────────────────────────────────────────────
+
+    @Test
+    fun `remove returns the created metadata`() = runBlocking<Unit> {
+        val store = createStore()
+        val (metadata, envelope) = SuspendedInvocationFixtures.record()
+        store.create(metadata, envelope)
+
+        val removed = store.remove(metadata.approvalId)
+        assertThat(removed).isEqualTo(metadata)
+    }
+
+    @Test
+    fun `remove then get returns null`() = runBlocking<Unit> {
+        val store = createStore()
+        val (metadata, envelope) = SuspendedInvocationFixtures.record()
+        store.create(metadata, envelope)
+        store.remove(metadata.approvalId)
+        assertThat(store.get(metadata.approvalId)).isNull()
+    }
+
+    @Test
+    fun `remove then reveal returns null`() = runBlocking<Unit> {
+        val store = createStore()
+        val (metadata, envelope) = SuspendedInvocationFixtures.record()
+        store.create(metadata, envelope)
+        store.remove(metadata.approvalId)
+        assertThat(store.revealReplayEnvelope(metadata.approvalId)).isNull()
+    }
+
+    @Test
+    fun `remove on missing approvalId returns null`() = runBlocking<Unit> {
+        val store = createStore()
+        assertThat(store.remove("missing-id")).isNull()
+    }
+
+    @Test
+    fun `create after remove succeeds with the same approvalId`() = runBlocking<Unit> {
+        val store = createStore()
+        val (metadata, envelope) = SuspendedInvocationFixtures.record("recreate-1")
+        store.create(metadata, envelope)
+        store.remove(metadata.approvalId)
+
+        val (metadata2, envelope2) = SuspendedInvocationFixtures.record("recreate-1", correlationId = "correlation-2")
+        store.create(metadata2, envelope2)
+        assertThat(store.get("recreate-1")).isEqualTo(metadata2)
+    }
+
+    // ── Concurrency ────────────────────────────────────────────────
+
+    @Test
+    fun `concurrent create with same approvalId - exactly one winner`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val store = createStore()
+            val id = "race-create-$round"
+            val records = (0 until 8).map { index ->
+                val (metadata, envelope) = SuspendedInvocationFixtures.record(
+                    approvalId = id,
+                    correlationId = "corr-$index",
+                )
+                metadata to envelope
+            }
+
+            val outcomes = runInParallel(records) { (metadata, envelope) ->
+                runCatching { store.create(metadata, envelope) }
+            }
+
+            assertThat(outcomes.count { it.isSuccess }).isEqualTo(1)
+            assertThat(outcomes.count { it.isFailure }).isEqualTo(7)
+            assertThat(outcomes.filter { it.isFailure }.map { it.exceptionOrNull() })
+                .allMatch { it is IllegalArgumentException }
+        }
+    }
+
+    @Test
+    fun `concurrent remove - exactly one winner returns metadata`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val store = createStore()
+            val id = "race-remove-$round"
+            val (metadata, envelope) = SuspendedInvocationFixtures.record(id)
+            store.create(metadata, envelope)
+
+            val outcomes = runInParallel(1..8) {
+                runCatching { store.remove(id) }
+            }
+
+            assertThat(outcomes.count { it.isSuccess && it.getOrNull() != null }).isEqualTo(1)
+            assertThat(outcomes.count { it.isSuccess && it.getOrNull() == null }).isEqualTo(7)
+        }
+    }
+
+    @Test
+    fun `concurrent reveal while remove - valid outcomes only`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val store = createStore()
+            val id = "race-reveal-$round"
+            val (metadata, envelope) = SuspendedInvocationFixtures.record(id)
+            store.create(metadata, envelope)
+
+            val outcomes = runInParallel(1..8) {
+                if (it % 2 == 0) {
+                    runCatching { store.revealReplayEnvelope(id) }.map { saw -> "reveal:$saw" }
+                } else {
+                    runCatching { store.remove(id) }.map { found -> "remove:${found != null}" }
+                }
+            }
+
+            // No crashes, and exactly one remove wins (reveals may observe the
+            // entry before the delete or the empty state after it — both valid).
+            assertThat(outcomes.filter { it.isFailure }).isEmpty()
+            assertThat(outcomes.filter { it.isSuccess && it.getOrNull() == "remove:true" }).hasSize(1)
+        }
+    }
+
+    // ── Parallel-race helper ───────────────────────────────────────
+
+    /**
+     * Runs [block] for every element of [items] on real parallel workers with
+     * a start barrier, returning the outcomes in input order. The barrier
+     * gives every contender a scheduling opportunity before any of them is
+     * allowed to proceed.
+     */
+    private suspend fun <T, R> runInParallel(
+        items: List<T>,
+        block: suspend (T) -> R,
+    ): List<R> = coroutineScope {
+        val ready = Channel<Unit>(items.size)
+        val release = CompletableDeferred<Unit>()
+        val workers = items.map { item ->
+            async(Dispatchers.Default) {
+                ready.send(Unit)
+                release.await()
+                block(item)
+            }
+        }
+        repeat(items.size) { ready.receive() }
+        release.complete(Unit)
+        workers.map { it.await() }
+    }
+
+    /** Range convenience overload for the race loops. */
+    private suspend fun <R> runInParallel(
+        range: IntRange,
+        block: suspend (Int) -> R,
+    ): List<R> = runInParallel(range.toList(), block)
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/engine/SuspendedInvocationStoreTck.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/engine/SuspendedInvocationStoreTck.kt
@@ -276,6 +276,69 @@ abstract class SuspendedInvocationStoreTck {
         assertFailsWith<IllegalArgumentException> { store.create(metadata, envelope) }
     }
 
+    // ── Redaction invariants (raw selected arguments never reach a store) ──
+
+    @Test
+    fun `create rejects selected tool call that is not redacted`() = runBlocking<Unit> {
+        val store = createStore()
+        // Raw selected arguments with a canonical digest over THAT envelope:
+        // only the redaction invariant can reject it, not the digest check.
+        val rawMessages = SuspendedInvocationFixtures.messagesWithRawSelectedArguments()
+        val metadata = SuspendedInvocationFixtures.metadata(
+            replayEnvelopeDigest = SuspendedInvocationFixtures.digest(rawMessages),
+        )
+        val envelope = SuspendedInvocationFixtures.envelope(rawMessages)
+        assertFailsWith<IllegalArgumentException> { store.create(metadata, envelope) }
+    }
+
+    @Test
+    fun `create rejects duplicate selected toolCallId across the envelope`() = runBlocking<Unit> {
+        val store = createStore()
+        val duplicateMessages = SuspendedInvocationFixtures.messagesWithDuplicateSelectedId()
+        val metadata = SuspendedInvocationFixtures.metadata(
+            replayEnvelopeDigest = SuspendedInvocationFixtures.digest(duplicateMessages),
+        )
+        val envelope = SuspendedInvocationFixtures.envelope(duplicateMessages)
+        assertFailsWith<IllegalArgumentException> { store.create(metadata, envelope) }
+    }
+
+    @Test
+    fun `create rejects extra or misplaced redaction sentinel`() = runBlocking<Unit> {
+        val store = createStore()
+        val extraSentinelMessages = SuspendedInvocationFixtures.messagesWithExtraSentinel()
+        val metadata = SuspendedInvocationFixtures.metadata(
+            replayEnvelopeDigest = SuspendedInvocationFixtures.digest(extraSentinelMessages),
+        )
+        val envelope = SuspendedInvocationFixtures.envelope(extraSentinelMessages)
+        assertFailsWith<IllegalArgumentException> { store.create(metadata, envelope) }
+    }
+
+    @Test
+    fun `create rejects selected tool call outside the latest assistant batch`() = runBlocking<Unit> {
+        val store = createStore()
+        val earlierBatchMessages = SuspendedInvocationFixtures.messagesWithSelectedCallInEarlierBatch()
+        val metadata = SuspendedInvocationFixtures.metadata(
+            replayEnvelopeDigest = SuspendedInvocationFixtures.digest(earlierBatchMessages),
+        )
+        val envelope = SuspendedInvocationFixtures.envelope(earlierBatchMessages)
+        assertFailsWith<IllegalArgumentException> { store.create(metadata, envelope) }
+    }
+
+    @Test
+    fun `create rejects negative historySize`() = runBlocking<Unit> {
+        val store = createStore()
+        val (metadata, envelope) = SuspendedInvocationFixtures.record(historySize = -1)
+        assertFailsWith<IllegalArgumentException> { store.create(metadata, envelope) }
+    }
+
+    @Test
+    fun `create rejects envelope smaller than its historySize`() = runBlocking<Unit> {
+        val store = createStore()
+        // Two messages cannot account for five history entries.
+        val (metadata, envelope) = SuspendedInvocationFixtures.record(historySize = 5)
+        assertFailsWith<IllegalArgumentException> { store.create(metadata, envelope) }
+    }
+
     // ── Remove ─────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## test(persistence): add SuspendedInvocationStore compatibility TCK — Epic 8.1c

**Status:** Epic 8.1 🚧 IN PROGRESS — Approval ✅ (#267), Approval continuation ✅ (#269), **Suspended invocation ✅ (this PR, review round 1 closed)**; audit, audit outbox, workflow checkpoint, workflow lease, memory pending.

### What this PR does

Enrolls **all three** `SuspendedInvocationStore` implementations — the engine's **default in-memory store**, the encrypted file store, and JDBC — in one shared compatibility contract. `SuspendedInvocationStoreTck` (tramai-testing testFixtures) runs **39 cases**:

- **Creation/read (13):** full-metadata round-trip (incl. token budget + tool security), missing → null, duplicate approvalId → IAE, blank/control/whitespace/oversized ID fields rejected on every operation.
- **Sensitive release (6):** reveal returns equal messages, missing → null, `get()` never exposes the messages, envelope `toString` is `[REDACTED]`, reveal does not consume, repeated reveals equal.
- **Digest + binding (6):** digest mismatch, tampered envelope, no assistant tool-call batch, toolCallId absent, toolCallIndex out of bounds, toolName mismatch — all rejected.
- **Redaction invariants (6):** a correctly-digested envelope whose selected tool call carries **RAW** arguments is rejected (digest recomputed over that envelope, so only the redaction check can fire); duplicate selected toolCallId rejected; extra/misplaced sentinel rejected; selected call outside the latest assistant batch rejected; negative historySize and envelope-smaller-than-historySize rejected.
- **Remove (5):** returns metadata, then get/reveal → null, missing → null, create-after-remove succeeds.
- **Concurrency (3 real parallel races, start barrier, 20 iterations each):** concurrent create — exactly one winner; concurrent remove — exactly one winner; reveal while remove — no crashes, exactly one remove winner.

Runners: `InMemorySuspendedInvocationStoreTckTest` (tramai-engine — the engine's default store is enrolled like any other, not exempt), `FileSuspendedInvocationStoreTckTest` (per-case encrypted temp dir), `JdbcSuspendedInvocationStoreTckTest` (PostgreSQL testcontainers, table reset per case). Enrollment guard reuses the shared `StoreEnrollmentScanner`.

### Review round 1 (P2) — redaction invariants pinned as shared contract

The round-1 gap: `SensitiveReplayEnvelope.of(messages)` defensively copies arbitrary messages, so a caller could construct a **correctly-digested envelope with raw selected tool arguments** and get store-dependent behavior — File rejected it, InMemory/JDBC accepted (JDBC encrypted it). The TCK now pins the redaction invariants and **InMemory and JDBC agree with File**:

- New `ReplayEnvelopeValidator` (tramai-engine, internal): history-size consistency, globally unique selected toolCallId, selected slot in the **latest assistant tool-call batch**, exactly **one redaction sentinel at the selected slot**. `InMemorySuspendedInvocationStore` delegates to it; `JdbcSuspendedInvocationStore` mirrors it inline (cross-module copy, TCK-pinned so the copies cannot drift).
- historySize consistency is shared contract (File already enforced it).
- Test doubles that built invalid envelopes now build valid ones (redacted sentinel + canonical digest): engine testFixtures `TestApprovalGatewayPersistenceRequestBuilder`, `DefaultApprovalGatewayTest`, `JdbcSuspendedInvocationStoreTest` (incl. a latent `historySize=5` vs 2-message-envelope fixture), and `JdbcSovereignOpsApprovalRequestMutationStoreTest` (sovereign module, caught by `verifyPr`). The JDBC "raw not visible in DB" test was rewritten: raw-args envelopes are rejected at the API boundary; a valid envelope's sensitive message content stays encrypted at rest.

### Scope discipline (per review)

- **Outside the shared TCK** (implementation-specific): restart durability, encryption format, file permissions, corruption handling, schema-version decoding, SQL locking/resource behavior.
- **Deliberate decision — replay-digest uniqueness stays JDBC-specific:** the JDBC unique index on `replay_envelope_digest` (double-suspension hardening) is **not** copied to the in-memory/file stores and **not** pinned by the TCK. The engine's suspension flow creates the continuation entry first, and the continuation store already rejects a duplicate approvalId — the engine never suspends the same invocation twice. Documented in the contract reference so future implementations know the divergence is deliberate.

### Production changes the enrollment required

- **`InMemorySuspendedInvocationStore` gained the shared validations** it lacked (ID fields, envelope binding, canonical digest, redaction invariants) — it previously accepted records the file store rejects. **`JdbcSuspendedInvocationStore` now enforces the same redaction invariants** — it previously accepted and encrypted raw-args envelopes, violating the SPEC-016 boundary that raw tool arguments live only behind the ApprovalContinuationStore.
- **SPI KDoc fixed:** durability is implementation-specific (in-memory process-local; file/JDBC may survive restart).

### P3 fixes

- `SuspendedInvocationFixtures.metadata(toolName=...)` keeps `toolReference` internally consistent — one invalid fixture mutates exactly one relationship.
- Enrollment probe temp cleanup: single `createTempFile` + `deleteOnExit` (no reverse-order directory trap).
- Fifth em-dash rename restored to the `foo - BEFORE_FALLBACK` symmetry (non-blocking nit).

### Mutation evidence — 11 mutations, each baseline GREEN → named TCK case(s) RED → restored GREEN

| Mutation | TCK outcome |
|---|---|
| Duplicate create overwrites existing | RED — duplicate-create + concurrent-create cases |
| Remove becomes get-without-delete | RED — remove-then-get / remove-then-reveal / create-after-remove / both remove races |
| Reveal returns null despite existing entry | RED — reveal round-trip + non-consuming reveal cases |
| Remove leaves replay envelope reachable | RED — remove-then-reveal case |
| Digest mismatch accepted | RED — digest-mismatch + tampered-envelope cases |
| toolCallId mismatch accepted | RED — toolCallId-binding case (duplicate-id case passes via `single()`'s incidental IAE — documented in the contract reference) |
| toolName mismatch accepted | RED — toolName-binding case |
| toolCallIndex checks dropped | RED — toolCallIndex-binding case |
| Concurrent remove check-then-act (two winners) | RED — concurrent-remove race (20-iteration race) |
| Redaction sentinel not required | RED — not-redacted + extra-sentinel cases |
| historySize consistency not validated | RED — negative-historySize + too-small-envelope cases |

### Build reproducibility fix (separate commit)

`PolicyEnforcementTest` had **five test names with an em dash (—)**; Kotlin embeds test names into generated anonymous-class filenames, and Gradle 9's incremental output hashing fails on the resulting path, breaking reproducible `--rerun-tasks` verification — including the mutation-verification procedure required for this PR. Replaced with ASCII hyphens; verified GREEN → GREEN on two consecutive `--rerun-tasks` runs without cleaning.

### Gates

- `verifyPr -PchangeClass=runtime-behaviour` (all subproject tests incl. sovereign modules, build-logic, maintainability baseline, change policy): **BUILD SUCCESSFUL**
- `verifyCancellationSafety` vs master: **PASSED**
- 39/39 per runner × 3; 11/11 mutations RED → GREEN
- Zero public API change; no persisted format or schema changes; no existing tests deleted
