### PR TITLE
test(persistence): add AuditStore compatibility TCK — Epic 8.1d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,9 +197,11 @@
   primary `CancellationException` escapes unchanged when rollback or
   autoCommit-restore fails. **Deliberate decision — event-ID uniqueness is
   per-stream shared contract; JDBC's global `uq_audit_events_event_id`
-  index is kept as implementation-specific hardening** (the store never
-  sees a cross-stream duplicate through the SPI), documented in the
-  contract reference. Implementation-specific concerns (restart
+  index is kept as implementation-specific hardening** — a direct SPI caller
+  can reuse an event ID across streams (InMemory/File accept it); JDBC
+  rejects it, retained because normal AuditEngine generation uses UUID IDs
+  and there is no architecture requirement to reuse an ID across streams —
+  documented in the contract reference. Implementation-specific concerns (restart
   durability, encryption format, permissions, corruption, SQL schema/
   indexes, `maxPageSize`) stay out of the shared TCK. Mutation evidence
   (14 mutations, each restored): stream/sequence/previous-hash/self-hash/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@
   oversized ID fields rejected on every operation), sensitive release (6:
   reveal returns equal messages, missing null, get() never exposes the
   messages, envelope `toString` is `[REDACTED]`, reveal does not consume,
-  repeated reveals equal), digest + envelope binding (8: digest mismatch,
+  repeated reveals equal), digest + envelope binding (6: digest mismatch,
   tampered envelope, no assistant tool-call batch, toolCallId absent,
   toolCallIndex out of bounds, toolName mismatch — all rejected),
   redaction invariants (6: correctly-digested RAW selected arguments
@@ -155,6 +155,60 @@
   toolCallId mutation — documented in the contract reference). Zero
   public API change, no persisted format or schema changes, no existing
   tests deleted. Epic 8.1 stays IN PROGRESS. Reference:
+  `docs/reference/persistence-store-compatibility-contract.md`.
+
+- **AuditStore compatibility TCK (PR #271, Epic 8.1d).** One shared
+  behavioral contract for every `AuditStore` implementation — the security
+  module's in-memory store, the encrypted file store, and JDBC.
+  `AuditStoreTck` (tramai-testing testFixtures; the module gained a
+  testFixtures dependency on `tramai-security`, the SPI's home module) runs
+  **43 cases** — append/chain semantics (19: first append factory receives
+  `latest == null`, sequence 1, `previousEventHash == null`, second factory
+  receives the exact latest, every field round-trips, wrong stream/sequence/
+  previous-hash/self-hash/schema/duplicate-event-ID all rejected with the
+  fixed safe reason codes, blank stream/event IDs rejected, rejected append
+  leaves the stream unchanged, factory invoked exactly once, factory
+  exception and `CancellationException` propagate unchanged and append
+  nothing), read/latest (8: missing stream → empty/null, ascending order,
+  exact equality, latest equals final, independent streams never bleed,
+  metadata defensively isolated from source and returned mutation), pagination
+  (12: exclusive cursor, limit respected as a maximum, partial page, cursor
+  at final → empty, zero/negative limit and negative cursor rejected, page
+  equals the readStream slice), hash-chain integrity (1: sequence/previous-
+  hash/self-hash invariants + `AuditChainVerifier` valid), and concurrency
+  (3 real parallel races with a start barrier, 20 iterations each: 8
+  same-stream appends all succeed with sequences exactly 1..8 and an
+  uninterrupted chain; concurrent duplicate event ID — exactly one winner;
+  concurrent independent streams both start at sequence 1). Three runners
+  execute the same contract (43/43 each): `InMemoryAuditStoreTckTest`
+  (tramai-security — the default store is enrolled like any other, not
+  exempt), `FileAuditStoreTckTest` (per-case dir with 0700 `audit/`), and
+  `JdbcAuditStoreTckTest` (PostgreSQL testcontainers, V1+V3 migrations,
+  per-case table reset). The enrollment guard reuses the shared
+  `StoreEnrollmentScanner`. **Production changes the enrollment required:**
+  `InMemoryAuditStore` gained blank stream/event-ID validation and replaced
+  its interpolated validation messages with the fixed safe reason codes
+  already used by File/JDBC; `FileAuditStore` gained the same blank
+  stream/event-ID validation before filesystem work; `JdbcAuditStore`
+  gained the blank event-ID check and `appendNext()`'s transaction cleanup
+  now follows the #267 primary-exception-precedence pattern (operation /
+  cancellation > rollback failure > autoCommit-restore failure, later
+  cleanup failures suppressed) with deterministic regressions proving a
+  primary `CancellationException` escapes unchanged when rollback or
+  autoCommit-restore fails. **Deliberate decision — event-ID uniqueness is
+  per-stream shared contract; JDBC's global `uq_audit_events_event_id`
+  index is kept as implementation-specific hardening** (the store never
+  sees a cross-stream duplicate through the SPI), documented in the
+  contract reference. Implementation-specific concerns (restart
+  durability, encryption format, permissions, corruption, SQL schema/
+  indexes, `maxPageSize`) stay out of the shared TCK. Mutation evidence
+  (14 mutations, each restored): stream/sequence/previous-hash/self-hash/
+  schema/duplicate-event-ID/blank-ID checks dropped, inclusive cursor,
+  ignored limit, latest-returns-first, removed append lock, shared metadata
+  reference, store-before-validate — each turns shared TCK cases RED. Zero
+  public API change, no persisted format or schema changes, no existing
+  tests deleted (6 `AuditEngineTest` message assertions updated to the fixed
+  reason codes). Epic 8.1 stays IN PROGRESS. Reference:
   `docs/reference/persistence-store-compatibility-contract.md`.
 
 - **Structured-output contract TCK (PR #266, Epic 7.2).** One reusable test

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1227,7 +1227,7 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 - ✅ Every published store implementation passes the relevant TCK (Approval: 3/3 via #267; Approval continuation: 3/3 via #269; suspended invocation: 3/3 via #270; audit: 3/3 via #271; step-attempt: 3/3 via PR #218).
 - ✅ Implementation-specific tests cover only storage technology and performance differences (encryption, permissions, corruption, record format for file; SQL schema, JSON mapping, connection cleanup for JDBC).
-- ✅ Contract failures use common typed exceptions or reason codes (`ApprovalStoreConflictException`, `ApprovalStoreNotFoundException`, `ApprovalStoreTokenRejectedException`, `ApprovalStoreNotConsumableException`, `IllegalApprovalTransitionException`; `ApprovalContinuationConflictException`, `ApprovalContinuationNotFoundException`, `ApprovalContinuationNotClaimableException`, `ApprovalContinuationNotCompletableException`).
+- ✅ Contract failures use common typed exceptions or reason codes (`ApprovalStoreConflictException`, `ApprovalStoreNotFoundException`, `ApprovalStoreTokenRejectedException`, `ApprovalStoreNotConsumableException`, `IllegalApprovalTransitionException`; `ApprovalContinuationConflictException`, `ApprovalContinuationNotFoundException`, `ApprovalContinuationNotClaimableException`, `ApprovalContinuationNotCompletableException`; AuditStore: `audit-store-invalid-stream-id`, `audit-store-invalid-event-id`, `audit-stream-id-mismatch`, `audit-sequence-gap`, `audit-hash-chain-broken`, `audit-event-hash-mismatch`, `audit-schema-version-unsupported`, `audit-duplicate-event-id`).
 
 ### Deliverables (PR #267)
 

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1191,7 +1191,7 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ## Epic 8.1: Persistence Store TCKs
 
-**Status: 🚧 IN PROGRESS** — Approval store slice done (PR #267), Approval continuation slice done (PR #269), suspended invocation slice done (PR #270); remaining families pending.
+**Status: 🚧 IN PROGRESS** — Approval store slice done (PR #267), Approval continuation slice done (PR #269), suspended invocation slice done (PR #270), audit store slice done (PR #271); remaining families pending.
 
 **Goal:** Ensure in-memory, file, and JDBC implementations share the same behavioural contract.
 
@@ -1200,7 +1200,7 @@ repair feedback. No layer maintains its own independent fixture lists.
 - Approval store — ✅ PR #267 (shared `ApprovalStoreTck`, 37 cases × 3 implementations + enrollment guard)
 - Approval continuation store — ✅ PR #269 (shared `ApprovalContinuationStoreTck`, 50 cases × 3 implementations + enrollment guard)
 - Suspended invocation store — ✅ PR #270 (shared `SuspendedInvocationStoreTck`, 39 cases × 3 implementations + enrollment guard)
-- Audit store — ⏳
+- Audit store — ✅ PR #271 (shared `AuditStoreTck`, 43 cases × 3 implementations + enrollment guard)
 - Audit outbox store — ⏳
 - Workflow checkpoint store — ⏳
 - Workflow lease store — ⏳
@@ -1225,7 +1225,7 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ### Acceptance criteria
 
-- ✅ Every published store implementation passes the relevant TCK (Approval: 3/3 via #267; Approval continuation: 3/3 via #269; suspended invocation: 3/3 via #270; step-attempt: 3/3 via PR #218).
+- ✅ Every published store implementation passes the relevant TCK (Approval: 3/3 via #267; Approval continuation: 3/3 via #269; suspended invocation: 3/3 via #270; audit: 3/3 via #271; step-attempt: 3/3 via PR #218).
 - ✅ Implementation-specific tests cover only storage technology and performance differences (encryption, permissions, corruption, record format for file; SQL schema, JSON mapping, connection cleanup for JDBC).
 - ✅ Contract failures use common typed exceptions or reason codes (`ApprovalStoreConflictException`, `ApprovalStoreNotFoundException`, `ApprovalStoreTokenRejectedException`, `ApprovalStoreNotConsumableException`, `IllegalApprovalTransitionException`; `ApprovalContinuationConflictException`, `ApprovalContinuationNotFoundException`, `ApprovalContinuationNotClaimableException`, `ApprovalContinuationNotCompletableException`).
 

--- a/docs/reference/persistence-store-compatibility-contract.md
+++ b/docs/reference/persistence-store-compatibility-contract.md
@@ -1,7 +1,8 @@
 # Persistence Store Compatibility Contract
 
 Epic 8.1 (PR #267 ApprovalStore slice, PR #269 ApprovalContinuationStore
-slice). Shared behavioral TCKs prove every implementation of a store family
+slice, PR #270 SuspendedInvocationStore slice, PR #271 AuditStore slice).
+Shared behavioral TCKs prove every implementation of a store family
 satisfies exactly the same externally observable contract, regardless of
 storage technology (memory, encrypted files, JDBC).
 
@@ -11,8 +12,8 @@ storage technology (memory, encrypted files, JDBC).
 |---|---|---|---|---|
 | Approval | ✅ | ✅ | ✅ | ✅ #267 |
 | Approval continuation | ✅ | ✅ | ✅ | ✅ #269 |
-| Suspended invocation | … | … | … | ⏳ |
-| Audit | … | … | … | ⏳ |
+| Suspended invocation | ✅ | ✅ | ✅ | ✅ #270 |
+| Audit | ✅ | ✅ | ✅ | ✅ #271 |
 | Audit outbox | … | … | … | ⏳ |
 | Workflow checkpoint | … | … | … | ⏳ |
 | Workflow lease | … | … | … | ⏳ |
@@ -337,3 +338,128 @@ schema/JSON mapping/connection cleanup (JDBC). No existing tests were
 deleted. The `tramai-testing` testFixtures gained a dependency on
 `tramai-engine` (the SPI's home module) so the shared suite can be written
 once and run against all three implementations.
+
+## AuditStore TCK (PR #271)
+
+`AuditStoreTck` (tramai-testing testFixtures) runs **43 shared behavioral
+cases** against every `AuditStore` implementation. Audit is not ordinary
+CRUD: the store is the chain authority — it serializes access to the
+authoritative latest event, hands it to the factory, validates the returned
+event's chain position, and appends atomically. The TCK therefore tests the
+factory-callback semantics themselves, not just resulting rows.
+
+- **Append / chain semantics (19):** first append's factory receives
+  `latest == null`; first event has sequence 1 and `previousEventHash ==
+  null`; the second append's factory receives the exact latest event;
+  second event has sequence 2 and `previousEventHash == first.eventHash`;
+  every metadata field round-trips; wrong auditStreamId rejected
+  (`audit-stream-id-mismatch`); wrong sequence rejected (`audit-sequence-gap`);
+  wrong previous hash rejected (`audit-hash-chain-broken`); invalid
+  self-hash rejected (`audit-event-hash-mismatch`); unsupported schema
+  version rejected (`audit-schema-version-unsupported`); duplicate event ID
+  in the same stream rejected (`audit-duplicate-event-id`); blank audit
+  stream ID rejected (`audit-store-invalid-stream-id`); blank event ID
+  rejected (`audit-store-invalid-event-id`); a rejected append leaves the
+  stream unchanged; the event factory is invoked exactly once per append;
+  a factory exception propagates unchanged and appends nothing;
+  `CancellationException` propagates as the same instance and appends
+  nothing. Malformed fixtures compute their digest over the malformed event,
+  so exactly one invariant is violated per case.
+- **Read / latest semantics (8):** missing stream → `emptyList()`/`null`;
+  ascending sequence order; exact field equality; `latestEvent()` equals the
+  final event; independent streams never bleed; metadata is defensively
+  isolated — mutating the source map after append cannot mutate stored
+  evidence, and mutating returned metadata cannot modify the persisted
+  event (storage isolation is the observable rule, not whether every
+  returned map throws `UnsupportedOperationException`).
+- **Pagination (12):** the SPI cursor is exclusive and the limit is a
+  maximum — `null`/`0` cursor starts at sequence 1; cursor N returns events
+  starting at N+1; limit respected; partial page at the end; cursor at the
+  final event → empty; missing stream → empty; zero/negative limit rejected;
+  negative cursor rejected; ascending order preserved; page contents equal
+  the corresponding slice of `readStream`. The contract never demands
+  "exactly limit" because JDBC deliberately supports a configured
+  `maxPageSize`.
+- **Hash-chain integrity (1):** for a valid multi-event stream —
+  `events[i].sequenceNumber == events[i-1].sequenceNumber + 1`,
+  `events[i].previousEventHash == events[i-1].eventHash`,
+  `events[i].eventHash == calculateHash()` — and `AuditChainVerifier.verify`
+  reports valid.
+- **Concurrency (3 real parallel races, start barrier, 20 iterations
+  each):** 8 concurrent same-stream appends — all succeed, sequences
+  exactly 1..8, unique event IDs, valid uninterrupted chain; concurrent
+  duplicate event ID — exactly one winner, losers rejected with
+  `audit-duplicate-event-id`, stored once, chain valid; concurrent
+  independent streams — both start at sequence 1 independently, both chains
+  valid.
+
+### Decisions (deliberate, per review)
+
+- **Event-ID uniqueness is per-stream shared contract; cross-stream reuse is
+  NOT.** JDBC's global unique index `uq_audit_events_event_id` is kept and
+  documented as implementation-specific defensive hardening (same rationale
+  as the replay-digest uniqueness in #270): the store never sees a
+  cross-stream duplicate through the SPI, so making it a shared requirement
+  would force a schema/design change without an architecture reason.
+- **`appendNext` is a chain-authority API, not a plain append:** the TCK
+  pins the factory-callback contract (invoked exactly once, receives the
+  authoritative latest, exception/cancellation propagate unchanged with
+  nothing appended).
+- **Validation errors are stable safe reason codes**, not interpolated
+  messages: File and JDBC already used the fixed codes; `InMemoryAuditStore`
+  was normalized to them so storage technology never changes the error
+  surface.
+
+### Production changes the enrollment required
+
+- **`InMemoryAuditStore`** gained the shared input validation it lacked
+  (blank audit stream ID on every operation, blank event ID on append) and
+  replaced its interpolated human-readable validation messages with the
+  fixed safe reason codes used by File/JDBC. Its Mutex-per-stream atomic
+  append, snapshot-based defensive metadata copies, and chain validation
+  were already conformant.
+- **`FileAuditStore`** gained the same shared blank stream/event ID
+  validation before any filesystem work (it previously hashed whatever
+  string it received). No append-chain change: File is the strictest
+  implementation (full-chain validation on every read).
+- **`JdbcAuditStore`** gained the shared blank event-ID validation, and
+  `appendNext()`'s transaction cleanup now follows the #267
+  primary-exception-precedence pattern: operation / cancellation **>**
+  rollback failure **>** autoCommit-restore failure, with later cleanup
+  failures attached as `suppressed` to the primary — a rollback or restore
+  failure can no longer mask the primary exception or cancellation. No
+  database schema change.
+- Deterministic JDBC regressions added: primary `CancellationException` +
+  rollback failure → same cancellation escapes, rollback failure suppressed;
+  primary `CancellationException` + autoCommit-restore failure → same
+  cancellation escapes, restore failure suppressed.
+- Existing `AuditEngineTest` assertions on the old interpolated InMemory
+  messages were updated to the fixed reason codes (6 tests).
+
+### Mutation evidence (all restored after each run; InMemory store)
+
+| Mutation | TCK outcome |
+|---|---|
+| append skips stream-ID check | RED — wrong-stream case fails |
+| append accepts wrong sequence | RED — wrong-sequence case fails |
+| append ignores previous hash | RED — chain-link case fails |
+| append ignores event hash self-hash | RED — self-hash case fails |
+| append accepts unsupported schema | RED — schema-version case fails |
+| duplicate eventId accepted | RED — duplicate + concurrent-duplicate cases fail |
+| blank stream-ID check removed | RED — blank-stream case fails |
+| blank event-ID check removed | RED — blank-event case fails |
+| page cursor becomes inclusive (`>=`) | RED — exclusive-cursor + final-cursor cases fail |
+| page ignores limit | RED — limit case fails |
+| latestEvent returns first instead of last | RED — latest-equals-final case fails |
+| same-stream append lock removed (non-atomic) | RED — both same-stream races fail |
+| shared metadata reference retained | RED — source-mutation isolation case fails |
+| rejected factory result still stored (add before validation) | RED — rejected-append-leaves-stream-unchanged (and every other append case) fails |
+
+### Scope
+
+The TCK owns SPI semantics; implementation-specific suites continue owning
+restart durability, encryption format, file permissions, corruption
+injection, SQL schema internals, indexes/query strategy, and `maxPageSize`.
+No existing tests were deleted. The `tramai-testing` testFixtures gained a
+dependency on `tramai-security` (the SPI's home module) so the shared suite
+can be written in one place.

--- a/docs/reference/persistence-store-compatibility-contract.md
+++ b/docs/reference/persistence-store-compatibility-contract.md
@@ -377,9 +377,11 @@ factory-callback semantics themselves, not just resulting rows.
   starting at N+1; limit respected; partial page at the end; cursor at the
   final event → empty; missing stream → empty; zero/negative limit rejected;
   negative cursor rejected; ascending order preserved; page contents equal
-  the corresponding slice of `readStream`. The contract never demands
-  "exactly limit" because JDBC deliberately supports a configured
-  `maxPageSize`.
+  the corresponding slice of `readStream`. The contract expects the
+  requested limit when enough events are available within the
+  implementation's supported page cap, but does not require a request
+  larger than an implementation-specific maximum such as JDBC's
+  `maxPageSize` to return the entire requested count.
 - **Hash-chain integrity (1):** for a valid multi-event stream —
   `events[i].sequenceNumber == events[i-1].sequenceNumber + 1`,
   `events[i].previousEventHash == events[i-1].eventHash`,
@@ -396,11 +398,14 @@ factory-callback semantics themselves, not just resulting rows.
 ### Decisions (deliberate, per review)
 
 - **Event-ID uniqueness is per-stream shared contract; cross-stream reuse is
-  NOT.** JDBC's global unique index `uq_audit_events_event_id` is kept and
-  documented as implementation-specific defensive hardening (same rationale
-  as the replay-digest uniqueness in #270): the store never sees a
-  cross-stream duplicate through the SPI, so making it a shared requirement
-  would force a schema/design change without an architecture reason.
+  NOT.** Cross-stream event-ID reuse is intentionally outside the shared
+  AuditStore contract — a direct SPI caller can reuse an ID across streams
+  and InMemory/File accept it. JDBC additionally enforces global event-ID
+  uniqueness as implementation-specific hardening, retained because normal
+  AuditEngine generation uses UUID event IDs and there is no architecture
+  requirement to reuse an ID across streams (same rationale as the
+  replay-digest uniqueness in #270). Documented so future implementations
+  know the divergence is deliberate.
 - **`appendNext` is a chain-authority API, not a plain append:** the TCK
   pins the factory-callback contract (invoked exactly once, receives the
   authoritative latest, exception/cancellation propagate unchanged with

--- a/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/FileAuditStore.kt
+++ b/tramai-persistence-file/src/main/kotlin/dev/tramai/persistence/file/FileAuditStore.kt
@@ -184,6 +184,7 @@ class FileAuditStore internal constructor(
         previousEvent: AuditEvent?,
         existingEventDigests: Set<String>,
     ) {
+        require(event.eventId.isNotBlank()) { "audit-store-invalid-event-id" }
         require(event.auditStreamId == expectedAuditStreamId) { "audit-stream-id-mismatch" }
         require(event.schemaVersion == CURRENT_AUDIT_SCHEMA_VERSION) { "audit-schema-version-unsupported" }
 
@@ -212,6 +213,7 @@ class FileAuditStore internal constructor(
         auditStreamId: String,
         eventFactory: (latest: AuditEvent?) -> AuditEvent,
     ): AuditEvent = lease.withOpenOperation {
+        require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
         val sDigest = streamDigest(auditStreamId)
         val lock = streamLocks.computeIfAbsent(sDigest) { FileStoreUtil.perKeyLock() }
         lock.lock()
@@ -260,6 +262,7 @@ class FileAuditStore internal constructor(
     }
 
     override suspend fun readStream(auditStreamId: String): List<AuditEvent> = lease.withOpenOperation {
+        require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
         val entries = scanStreamEntries(auditStreamId)
         if (entries.isEmpty()) return@withOpenOperation emptyList()
 
@@ -276,6 +279,7 @@ class FileAuditStore internal constructor(
         afterSequenceNumber: Long?,
         limit: Int,
     ): List<AuditEvent> = lease.withOpenOperation {
+        require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
         require(limit > 0) { "audit-store-invalid-limit" }
         require(afterSequenceNumber == null || afterSequenceNumber >= 0) {
             "audit-store-invalid-cursor"
@@ -308,6 +312,7 @@ class FileAuditStore internal constructor(
     }
 
     override suspend fun latestEvent(auditStreamId: String): AuditEvent? = lease.withOpenOperation {
+        require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
         val entries = scanStreamEntries(auditStreamId)
         if (entries.isEmpty()) return@withOpenOperation null
 

--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileAuditStoreTckTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileAuditStoreTckTest.kt
@@ -1,0 +1,60 @@
+package dev.tramai.persistence.file
+
+import dev.tramai.security.audit.AuditStore
+import dev.tramai.testing.persistence.audit.AuditStoreTck
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermissions
+import java.util.concurrent.atomic.AtomicLong
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.TestInstance
+import kotlin.io.path.exists
+
+/**
+ * Epic 8.1d: FileAuditStore must satisfy the shared AuditStore compatibility
+ * contract (tramai-testing testFixtures). The runner owns the encryption key
+ * and per-case isolation — storage technology (encryption, permissions,
+ * corruption handling) never contaminates the contract.
+ *
+ * Each [createStore] call gets a fresh `case-N` root directory; the store
+ * provisions its own `audit/` layout.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FileAuditStoreTckTest : AuditStoreTck() {
+
+    private val rootDir: Path = Files.createTempDirectory("tramai-audit-tck-").toAbsolutePath()
+    private val testKey: SecretKey = KeyGenerator.getInstance("AES").apply { init(256) }.generateKey()
+    private val keyProvider = FileStoreEncryptionKeyProvider { testKey }
+    private val caseCounter = AtomicLong(0)
+
+    override fun createStore(): AuditStore {
+        val caseDir = Files.createDirectories(rootDir.resolve("case-${caseCounter.incrementAndGet()}"))
+        // The store expects a pre-provisioned managed audit/ directory with
+        // 0700 permissions (the runner owns storage layout; the contract
+        // never tests it).
+        val auditDir = Files.createDirectories(caseDir.resolve("audit"))
+        Files.setPosixFilePermissions(auditDir, PosixFilePermissions.fromString("rwx------"))
+        return FileAuditStore(
+            caseDir,
+            testKey,
+            FileBackedStoreConfiguration(
+                rootDirectory = caseDir,
+                encryption = FileStoreEncryptionConfiguration(
+                    activeKeyId = "tck-key-1",
+                    keyProvider = keyProvider,
+                ),
+                verifyOnOpen = false,
+            ),
+            FileStoreLease(),
+        )
+    }
+
+    @AfterAll
+    fun cleanup() {
+        if (rootDir.exists()) {
+            rootDir.toFile().deleteRecursively()
+        }
+    }
+}

--- a/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcAuditStore.kt
+++ b/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcAuditStore.kt
@@ -10,7 +10,7 @@ import dev.tramai.security.audit.AuditHashAlgorithm
 import dev.tramai.security.audit.AuditStore
 import dev.tramai.security.audit.CURRENT_AUDIT_SCHEMA_VERSION
 import dev.tramai.security.audit.calculateHash
-import dev.tramai.core.coroutines.rethrowIfCancellation
+import java.util.concurrent.CancellationException
 import java.sql.Connection
 import java.sql.ResultSet
 import java.sql.SQLException
@@ -102,6 +102,7 @@ class JdbcAuditStore(
         dataSource.connection.use { conn ->
             val previousAutoCommit = conn.autoCommit
             conn.autoCommit = false
+            var primaryFailure: Exception? = null
             try {
                 // Ensure stream head row exists (idempotent)
                 ensureStreamHead(conn, auditStreamId)
@@ -155,11 +156,52 @@ class JdbcAuditStore(
                 conn.commit()
                 return event
             } catch (e: Exception) {
-                conn.rollback()
-                e.rethrowIfCancellation()
+                if (e is CancellationException) {
+                    primaryFailure = e
+                    rollbackSuppressing(conn, e)
+                    throw e
+                }
+                primaryFailure = e
+                rollbackSuppressing(conn, e)
                 throw e
             } finally {
-                conn.autoCommit = previousAutoCommit
+                restoreAutoCommitSuppressing(conn, previousAutoCommit, primaryFailure)
+            }
+        }
+    }
+
+    /**
+     * Deliberately non-suspend helper (the #267 cleanup model): rolls back,
+     * attaching a rollback failure as suppressed to [primary] so cleanup can
+     * never mask the primary exception or cancellation. Runs for
+     * cancellations too — a cancelled append leaves no partial stream head.
+     */
+    private fun rollbackSuppressing(conn: Connection, primary: Exception) {
+        try {
+            conn.rollback()
+        } catch (rollbackFailure: Exception) {
+            primary.addSuppressed(rollbackFailure)
+        }
+    }
+
+    /**
+     * Deliberately non-suspend helper (the #267 cleanup model): restores the
+     * connection's autoCommit state, attaching the restore failure as
+     * suppressed to the primary when one exists (otherwise the restore
+     * failure is the only failure and propagates).
+     */
+    private fun restoreAutoCommitSuppressing(
+        conn: Connection,
+        previousAutoCommit: Boolean,
+        primary: Exception?,
+    ) {
+        try {
+            conn.autoCommit = previousAutoCommit
+        } catch (restoreFailure: Exception) {
+            if (primary != null) {
+                primary.addSuppressed(restoreFailure)
+            } else {
+                throw restoreFailure
             }
         }
     }
@@ -370,6 +412,7 @@ class JdbcAuditStore(
         previousEvent: AuditEvent?,
         head: StreamHead,
     ) {
+        require(event.eventId.isNotBlank()) { "audit-store-invalid-event-id" }
         require(event.auditStreamId == expectedAuditStreamId) { "audit-stream-id-mismatch" }
         require(event.schemaVersion == CURRENT_AUDIT_SCHEMA_VERSION) {
             "audit-schema-version-unsupported"

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcAuditStoreTckTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcAuditStoreTckTest.kt
@@ -1,0 +1,116 @@
+package dev.tramai.persistence.jdbc
+
+import dev.tramai.security.audit.AuditStore
+import dev.tramai.testing.persistence.audit.AuditStoreTck
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.sql.Connection
+import java.sql.DriverManager
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+import javax.sql.DataSource
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import org.postgresql.ds.PGSimpleDataSource
+import org.testcontainers.containers.PostgreSQLContainer
+
+/**
+ * Epic 8.1d: JdbcAuditStore must satisfy the shared AuditStore compatibility
+ * contract (tramai-testing testFixtures). The runner owns the datasource,
+ * schema, and per-case isolation — storage technology (SQL schema, indexes,
+ * encryption at rest, query strategy) never contaminates the contract.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JdbcAuditStoreTckTest : AuditStoreTck() {
+
+    private lateinit var postgres: PostgreSQLContainer<*>
+    private lateinit var dataSource: DataSource
+    private lateinit var setupConnection: Connection
+
+    private val testAesKey = ByteArray(16).also { SecureRandom().nextBytes(it) }
+
+    private val testCodec = object : JdbcAuditPayloadCodec {
+        private val algorithm = "AES/GCM/NoPadding"
+        private val tagLength = 128
+
+        override fun encode(plaintext: ByteArray): JdbcEncryptedAuditPayload {
+            val cipher = Cipher.getInstance(algorithm)
+            val nonce = ByteArray(12).also { SecureRandom().nextBytes(it) }
+            cipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(testAesKey, "AES"), GCMParameterSpec(tagLength, nonce))
+            val ciphertext = cipher.doFinal(plaintext)
+            val digest = MessageDigest.getInstance("SHA-256")
+                .digest(plaintext)
+                .joinToString("") { "%02x".format(it) }
+            return JdbcEncryptedAuditPayload(
+                ciphertext = ciphertext,
+                keyId = "tck-key-1",
+                algorithm = algorithm,
+                nonce = nonce,
+                payloadDigest = "sha256:$digest",
+            )
+        }
+
+        override fun decode(envelope: JdbcEncryptedAuditPayload): ByteArray {
+            val cipher = Cipher.getInstance(algorithm)
+            cipher.init(
+                Cipher.DECRYPT_MODE,
+                SecretKeySpec(testAesKey, "AES"),
+                GCMParameterSpec(tagLength, envelope.nonce),
+            )
+            return cipher.doFinal(envelope.ciphertext)
+        }
+    }
+
+    private val fixedClock = Clock.fixed(
+        Instant.parse("2026-06-21T12:00:00Z"),
+        ZoneId.of("UTC"),
+    )
+
+    @BeforeAll
+    fun setUpAll() {
+        postgres = PostgreSQLContainer("postgres:17-alpine")
+            .withDatabaseName("audit_tck")
+            .withUsername("test")
+            .withPassword("test")
+        postgres.start()
+        dataSource = PGSimpleDataSource().apply {
+            setUrl(postgres.jdbcUrl)
+            user = postgres.username
+            password = postgres.password
+        }
+        setupConnection = DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password)
+        for (migration in listOf(
+            "V1__sovereign_persistence.sql",
+            "V3__audit_events_hardening.sql",
+        )) {
+            val sql = this::class.java.classLoader
+                .getResource("tramai/persistence/jdbc/postgres/$migration")
+                ?.readText()
+                ?: throw IllegalStateException("Migration not found: $migration")
+            setupConnection.createStatement().use { stmt -> stmt.execute(sql) }
+        }
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        runCatching { setupConnection.close() }
+        runCatching { postgres.stop() }
+    }
+
+    override fun createStore(): AuditStore {
+        // Fresh isolated storage per case: previous cases' streams must not
+        // leak into the next case.
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.execute("DELETE FROM audit_events")
+                stmt.execute("DELETE FROM audit_stream_heads")
+            }
+        }
+        return JdbcAuditStore(dataSource, testCodec, clock = fixedClock)
+    }
+}

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcAuditStoreTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcAuditStoreTest.kt
@@ -21,6 +21,8 @@ import java.sql.DriverManager
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
+import java.lang.reflect.Proxy
+import java.util.concurrent.CancellationException
 import javax.crypto.Cipher
 import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.SecretKeySpec
@@ -29,6 +31,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -975,5 +978,73 @@ class JdbcAuditStoreTest {
             s.appendNext("stream-1", eventFactory("stream-1"))
         }
     }
+    }
+
+    @Test
+    fun `appendNext rethrows CancellationException unchanged when rollback also fails`() { runBlocking {
+        val cancellation = CancellationException("cancelled by test")
+        val rollbackFailure = java.sql.SQLException("rollback failed")
+        val failing = JdbcAuditStore(dataSourceWithFailures(rollbackFailure = rollbackFailure), testCodec, fixedClock)
+
+        val thrown = runCatching {
+            failing.appendNext("stream-1") { throw cancellation }
+        }.exceptionOrNull()
+
+        assertSame(cancellation, thrown)
+        assertEquals(listOf(rollbackFailure), thrown?.suppressed?.toList())
+    }
+    }
+
+    @Test
+    fun `appendNext preserves primary CancellationException when autoCommit restore fails`() { runBlocking {
+        val cancellation = CancellationException("cancelled by test")
+        val restoreFailure = java.sql.SQLException("restore failed")
+        val failing = JdbcAuditStore(dataSourceWithFailures(restoreFailure = restoreFailure), testCodec, fixedClock)
+
+        val thrown = runCatching {
+            failing.appendNext("stream-1") { throw cancellation }
+        }.exceptionOrNull()
+
+        assertSame(cancellation, thrown)
+        assertEquals(listOf(restoreFailure), thrown?.suppressed?.toList())
+    }
+    }
+
+    /**
+     * A DataSource whose connections delegate to the real database but fail
+     * deterministically: [rollbackFailure] is thrown from `rollback()`, and,
+     * when [restoreFailure] is non-null, from the second `setAutoCommit` call
+     * (the finally-block restoration). Each `getConnection` captures ONE
+     * delegate, so the production code sees a single JDBC transaction rather
+     * than a fresh connection per method call. Same shape as the #267
+     * ApprovalStore failure-injection helper.
+     */
+    private fun dataSourceWithFailures(
+        rollbackFailure: Exception? = null,
+        restoreFailure: Exception? = null,
+    ): DataSource {
+        val real = createDataSource()
+        return Proxy.newProxyInstance(
+            DataSource::class.java.classLoader,
+            arrayOf(DataSource::class.java),
+        ) { _, method, args ->
+            if (method.name == "getConnection" && args.isNullOrEmpty()) {
+                val delegate = real.connection
+                var autoCommitCalls = 0
+                Proxy.newProxyInstance(
+                    Connection::class.java.classLoader,
+                    arrayOf(Connection::class.java),
+                ) { _, connMethod, connArgs ->
+                    if (connMethod.name == "rollback" && rollbackFailure != null) throw rollbackFailure
+                    if (connMethod.name == "setAutoCommit") {
+                        autoCommitCalls++
+                        if (restoreFailure != null && autoCommitCalls > 1) throw restoreFailure
+                    }
+                    connMethod.invoke(delegate, *(connArgs ?: emptyArray()))
+                }
+            } else {
+                method.invoke(real, *(args ?: emptyArray()))
+            }
+        } as DataSource
     }
 }

--- a/tramai-security/src/main/kotlin/dev/tramai/security/audit/InMemoryAuditStore.kt
+++ b/tramai-security/src/main/kotlin/dev/tramai/security/audit/InMemoryAuditStore.kt
@@ -22,6 +22,7 @@ class InMemoryAuditStore : AuditStore {
         auditStreamId: String,
         eventFactory: (latest: AuditEvent?) -> AuditEvent,
     ): AuditEvent {
+        require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
         val state = streams.computeIfAbsent(auditStreamId) { StreamState() }
         return state.lock.withLock {
             val latest = state.events.lastOrNull()
@@ -30,35 +31,37 @@ class InMemoryAuditStore : AuditStore {
             val rawEvent = eventFactory(latest?.snapshot())
             val snapshot = rawEvent.snapshot()
 
+            require(snapshot.eventId.isNotBlank()) { "audit-store-invalid-event-id" }
+
             // auditStreamId must match
             require(snapshot.auditStreamId == auditStreamId) {
-                "event auditStreamId '${snapshot.auditStreamId}' does not match expected '$auditStreamId'"
+                "audit-stream-id-mismatch"
             }
 
             // sequence must be exactly 1 more than latest
             val expectedSequence = (latest?.sequenceNumber ?: 0L) + 1L
             require(snapshot.sequenceNumber == expectedSequence) {
-                "Expected sequenceNumber $expectedSequence for stream '$auditStreamId' but got ${snapshot.sequenceNumber}"
+                "audit-sequence-gap"
             }
 
             // previousEventHash must match latest eventHash
             require(snapshot.previousEventHash == latest?.eventHash) {
-                "previousEventHash does not match latest eventHash"
+                "audit-hash-chain-broken"
             }
 
             // eventHash must equal calculated hash
             require(snapshot.eventHash == snapshot.copy(eventHash = "").calculateHash()) {
-                "eventHash does not match calculated hash"
+                "audit-event-hash-mismatch"
             }
 
             // schemaVersion must be current
             require(snapshot.schemaVersion == CURRENT_AUDIT_SCHEMA_VERSION) {
-                "Unsupported audit schema version ${snapshot.schemaVersion}"
+                "audit-schema-version-unsupported"
             }
 
             // no duplicate eventId in stream
             require(state.events.none { it.eventId == snapshot.eventId }) {
-                "Duplicate eventId '${snapshot.eventId}' in stream '$auditStreamId'"
+                "audit-duplicate-event-id"
             }
 
             state.events.add(snapshot)
@@ -67,6 +70,7 @@ class InMemoryAuditStore : AuditStore {
     }
 
     override suspend fun readStream(auditStreamId: String): List<AuditEvent> {
+        require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
         val state = streams[auditStreamId] ?: return emptyList()
         return state.lock.withLock {
             state.events.map { it.snapshot() }
@@ -78,6 +82,7 @@ class InMemoryAuditStore : AuditStore {
         afterSequenceNumber: Long?,
         limit: Int,
     ): List<AuditEvent> {
+        require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
         require(limit > 0) { "audit-store-invalid-limit" }
         require(afterSequenceNumber == null || afterSequenceNumber >= 0) {
             "audit-store-invalid-cursor"
@@ -95,6 +100,7 @@ class InMemoryAuditStore : AuditStore {
     }
 
     override suspend fun latestEvent(auditStreamId: String): AuditEvent? {
+        require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
         val state = streams[auditStreamId] ?: return null
         return state.lock.withLock {
             state.events.lastOrNull()?.snapshot()

--- a/tramai-security/src/test/kotlin/dev/tramai/security/audit/AuditEngineTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/audit/AuditEngineTest.kt
@@ -411,7 +411,7 @@ class AuditEngineTest {
                 ).copy(eventHash = "placeholder")
             }
         }
-        assertTrue(exception.message?.contains("auditStreamId") == true)
+        assertTrue(exception.message?.contains("audit-stream-id-mismatch") == true)
     }
     }
 
@@ -443,7 +443,7 @@ class AuditEngineTest {
                 ).copy(eventHash = "placeholder")
             }
         }
-        assertTrue(exception.message?.contains("sequenceNumber") == true)
+        assertTrue(exception.message?.contains("audit-sequence-gap") == true)
     }
     }
 
@@ -475,7 +475,10 @@ class AuditEngineTest {
                 ).copy(eventHash = "placeholder")
             }
         }
-        assertTrue(exception.message?.contains("previousEventHash") == true || exception.message?.contains("eventHash") == true)
+        assertTrue(
+            exception.message?.contains("audit-hash-chain-broken") == true ||
+                exception.message?.contains("audit-event-hash-mismatch") == true,
+        )
     }
     }
 
@@ -505,7 +508,7 @@ class AuditEngineTest {
                 )
             }
         }
-        assertTrue(exception.message?.contains("eventHash") == true)
+        assertTrue(exception.message?.contains("audit-event-hash-mismatch") == true)
     }
     }
 
@@ -556,7 +559,7 @@ class AuditEngineTest {
                 )
             }
         }
-        assertTrue(exception.message?.contains("Duplicate") == true || exception.message?.contains("eventId") == true)
+        assertTrue(exception.message?.contains("audit-duplicate-event-id") == true)
     }
     }
 
@@ -946,7 +949,7 @@ class AuditEngineTest {
                 ).let { it.copy(eventHash = it.copy(eventHash = "").calculateHash()) }
             }
         }
-        assertTrue(exception.message?.contains("Unsupported") == true)
+        assertTrue(exception.message?.contains("audit-schema-version-unsupported") == true)
     }
     }
 

--- a/tramai-security/src/test/kotlin/dev/tramai/security/audit/InMemoryAuditStoreTckTest.kt
+++ b/tramai-security/src/test/kotlin/dev/tramai/security/audit/InMemoryAuditStoreTckTest.kt
@@ -1,0 +1,14 @@
+package dev.tramai.security.audit
+
+import dev.tramai.testing.persistence.audit.AuditStoreTck
+
+/**
+ * Epic 8.1d: InMemoryAuditStore — the security module's default store — must
+ * satisfy the shared AuditStore compatibility contract (tramai-testing
+ * testFixtures). A fresh store per case gives full isolation; the store
+ * itself is the reference implementation and mutation target for the family.
+ */
+class InMemoryAuditStoreTckTest : AuditStoreTck() {
+
+    override fun createStore(): AuditStore = InMemoryAuditStore()
+}

--- a/tramai-testing/build.gradle.kts
+++ b/tramai-testing/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
 
     testFixturesApi(project(":tramai-core"))
     testFixturesApi(project(":tramai-engine"))
+    testFixturesApi(project(":tramai-security"))
     testFixturesApi(libs.assertj.core)
     testFixturesApi(libs.coroutines.core)
     testFixturesApi(libs.coroutines.test)

--- a/tramai-testing/src/test/kotlin/dev/tramai/testing/AuditStoreTckEnrollmentArchitectureTest.kt
+++ b/tramai-testing/src/test/kotlin/dev/tramai/testing/AuditStoreTckEnrollmentArchitectureTest.kt
@@ -1,0 +1,111 @@
+package dev.tramai.testing
+
+import java.io.File
+import java.nio.file.Files
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Epic 8.1d architecture guard: every concrete [dev.tramai.security.audit.AuditStore]
+ * implementation must be enrolled in the shared AuditStore compatibility
+ * contract (tramai-testing testFixtures).
+ *
+ * Same two properties as the earlier guards (#267/#269/#270): the three
+ * roadmap runners are pinned by name, and every concrete implementation in
+ * any module's main source set must ship a `<Store>TckTest` runner in the
+ * same module that actually extends [dev.tramai.testing.persistence.audit.AuditStoreTck].
+ */
+class AuditStoreTckEnrollmentArchitectureTest {
+
+    private val scanner = StoreEnrollmentScanner("AuditStore", "AuditStoreTck")
+
+    private val repoRoot: File =
+        generateSequence(File(".").absoluteFile) { it.parentFile }
+            .first { it.resolve("settings.gradle.kts").isFile }
+
+    private val expectedRunners = setOf(
+        "InMemoryAuditStoreTckTest",
+        "FileAuditStoreTckTest",
+        "JdbcAuditStoreTckTest",
+    )
+
+    @Test
+    fun `every roadmap AuditStore ships a TCK runner`() {
+        val missing = expectedRunners.filter { runnerName -> scanner.findRunnerFile(repoRoot, runnerName) == null }
+        assertThat(missing)
+            .withFailMessage(
+                "Pinned AuditStore TCK runners missing. The compatibility contract is " +
+                    "reviewed per runner; deleting a runner silently removes a store from the contract: $missing",
+            )
+            .isEmpty()
+    }
+
+    @Test
+    fun `every AuditStore implementation has a valid TCK runner in its module`() {
+        val unenrolled = scanner.storeModules(repoRoot).flatMap { (module, implementations) ->
+            implementations
+                .filter { storeName -> !scanner.hasValidRunner(repoRoot, module, storeName) }
+                .map { store -> "$module/$store" }
+        }
+        assertThat(unenrolled)
+            .withFailMessage(
+                "AuditStore implementations without a <Store>TckTest runner extending " +
+                    "AuditStoreTck in the same module: $unenrolled. " +
+                    "Adding an AuditStore without enrolling it in the compatibility " +
+                    "contract must make a gate fail.",
+            )
+            .isEmpty()
+    }
+
+    // ── probe tests for the scanner against this family ─────────────
+
+    @Test
+    fun `body-less AuditStore implementation is detected`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            import dev.tramai.security.audit.AuditStore
+            class RedisAuditStore(private val delegate: AuditStore) :
+                AuditStore by delegate
+            """.trimIndent(),
+        )
+        assertThat(scanner.implementationsIn(file)).containsExactly("RedisAuditStore")
+    }
+
+    @Test
+    fun `runner file must actually subclass AuditStoreTck`() {
+        val fake = tempSourceFile("class RedisAuditStoreTckTest")
+        val real = tempSourceFile("class RedisAuditStoreTckTest : AuditStoreTck() { }")
+        assertThat(scanner.runnerSubclassesTck(fake, "RedisAuditStore")).isFalse()
+        assertThat(scanner.runnerSubclassesTck(real, "RedisAuditStore")).isTrue()
+    }
+
+    @Test
+    fun `exception class whose name contains the interface does not count as an implementation`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            class AuditStoreException(val code: String) : RuntimeException()
+            """.trimIndent(),
+        )
+        assertThat(scanner.implementationsIn(file)).isEmpty()
+    }
+
+    @Test
+    fun `constructor parameter never counts as an implementation`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            import dev.tramai.security.audit.AuditStore
+            class Holder(val store: AuditStore)
+            """.trimIndent(),
+        )
+        assertThat(scanner.implementationsIn(file)).isEmpty()
+    }
+
+    private fun tempSourceFile(content: String): File =
+        Files.createTempFile("enrollment-probe-", ".kt").toFile().apply {
+            writeText(content)
+            deleteOnExit()
+        }
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/audit/AuditStoreFixtures.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/audit/AuditStoreFixtures.kt
@@ -1,0 +1,79 @@
+package dev.tramai.testing.persistence.audit
+
+import dev.tramai.security.audit.AuditEvent
+import dev.tramai.security.audit.AuditHashAlgorithm
+import dev.tramai.security.audit.CURRENT_AUDIT_SCHEMA_VERSION
+import dev.tramai.security.audit.calculateHash
+import java.time.Instant
+
+/**
+ * Epic 8.1d: fixtures for the shared [dev.tramai.security.audit.AuditStore]
+ * compatibility contract.
+ *
+ * The factory produces a fully valid event for the given stream/latest pair —
+ * correct sequence, linked previous hash, and a self-hash computed over that
+ * exact event — unless the caller explicitly overrides one relationship. That
+ * way a negative fixture mutates exactly one invariant at a time (the
+ * #269/#270 lesson: no fixture may accidentally violate several contracts).
+ */
+object AuditStoreFixtures {
+
+    val BASE_TIME: Instant = Instant.parse("2026-06-21T12:00:00Z")
+
+    /**
+     * Builds the next valid [AuditEvent] for [latest].
+     *
+     * @param auditStreamId the stream the event will be appended to
+     * @param eventId the event's unique ID
+     * @param latest the authoritative latest event (null for a first append)
+     * @param sequenceNumber explicit sequence override (null = latest + 1)
+     * @param previousEventHash explicit previous-hash override (null = latest's hash)
+     * @param eventHash explicit self-hash override (null = computed over the event)
+     * @param schemaVersion explicit schema override (default = current)
+     * @param auditStreamIdOverride event-side stream ID override (null = [auditStreamId])
+     */
+    fun event(
+        auditStreamId: String,
+        eventId: String,
+        latest: AuditEvent?,
+        sequenceNumber: Long? = null,
+        previousEventHash: String? = null,
+        eventHash: String? = null,
+        schemaVersion: Int = CURRENT_AUDIT_SCHEMA_VERSION,
+        auditStreamIdOverride: String? = null,
+        timestamp: Instant = BASE_TIME,
+        metadata: Map<String, String> = emptyMap(),
+        decision: String = "APPROVED",
+    ): AuditEvent {
+        val raw = AuditEvent(
+            schemaVersion = schemaVersion,
+            hashAlgorithm = AuditHashAlgorithm.SHA_256,
+            auditStreamId = auditStreamIdOverride ?: auditStreamId,
+            eventId = eventId,
+            sequenceNumber = sequenceNumber ?: (latest?.sequenceNumber ?: 0L) + 1L,
+            workflowRunId = "wf-1",
+            correlationId = "corr-1",
+            actor = "user:alice",
+            enforcementPoint = "test-gate",
+            decision = decision,
+            policyVersion = "v1",
+            workflowDigest = "sha256:0001",
+            previousEventHash = previousEventHash ?: latest?.eventHash,
+            eventHash = "",
+            timestamp = timestamp,
+            reasonCode = "reason-1",
+            metadata = metadata,
+        )
+        return raw.copy(eventHash = eventHash ?: raw.copy(eventHash = "").calculateHash())
+    }
+
+    /** An append factory producing a valid next event with the given [eventId]. */
+    fun factory(
+        auditStreamId: String,
+        eventId: String,
+        timestamp: Instant = BASE_TIME,
+        metadata: Map<String, String> = emptyMap(),
+    ): (AuditEvent?) -> AuditEvent = { latest ->
+        event(auditStreamId, eventId, latest, timestamp = timestamp, metadata = metadata)
+    }
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/audit/AuditStoreTck.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/audit/AuditStoreTck.kt
@@ -37,14 +37,16 @@ abstract class AuditStoreTck {
     /** Fresh isolated storage per case; the runner owns setup/teardown. */
     protected abstract fun createStore(): AuditStore
 
-    private fun appendValid(
+    private suspend fun appendValid(
         store: AuditStore,
         streamId: String,
         eventId: String,
         metadata: Map<String, String> = emptyMap(),
-    ): AuditEvent = runBlocking {
-        store.appendNext(streamId, AuditStoreFixtures.factory(streamId, eventId, metadata = metadata))
-    }
+    ): AuditEvent =
+        store.appendNext(
+            streamId,
+            AuditStoreFixtures.factory(streamId, eventId, metadata = metadata),
+        )
 
     // ── Append / chain semantics ────────────────────────────────────
 

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/audit/AuditStoreTck.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/audit/AuditStoreTck.kt
@@ -1,0 +1,623 @@
+package dev.tramai.testing.persistence.audit
+
+import dev.tramai.security.audit.AuditChainVerifier
+import dev.tramai.security.audit.AuditEvent
+import dev.tramai.security.audit.AuditHashAlgorithm
+import dev.tramai.security.audit.AuditStore
+import dev.tramai.security.audit.CURRENT_AUDIT_SCHEMA_VERSION
+import dev.tramai.security.audit.calculateHash
+import java.util.concurrent.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.channels.Channel
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Epic 8.1d: the shared, cross-implementation [AuditStore] compatibility
+ * contract. Every concrete store — the engine's in-memory default, the
+ * encrypted file store, and JDBC — must obey the same externally observable
+ * append, hash-chain, pagination, isolation, validation, failure, and
+ * concurrency semantics regardless of whether storage is memory, encrypted
+ * files, or PostgreSQL.
+ *
+ * Out of scope (implementation-specific, covered by each store's own tests):
+ * restart durability, encryption format, file permissions, corruption
+ * handling, SQL schema internals, indexes, and query strategy.
+ *
+ * Concurrency uses real parallel workers with a start barrier and a deferred
+ * release — no sleeps, no `Instant.now` (timestamps come from the fixed
+ * fixture clock).
+ */
+abstract class AuditStoreTck {
+
+    /** Fresh isolated storage per case; the runner owns setup/teardown. */
+    protected abstract fun createStore(): AuditStore
+
+    private fun appendValid(
+        store: AuditStore,
+        streamId: String,
+        eventId: String,
+        metadata: Map<String, String> = emptyMap(),
+    ): AuditEvent = runBlocking {
+        store.appendNext(streamId, AuditStoreFixtures.factory(streamId, eventId, metadata = metadata))
+    }
+
+    // ── Append / chain semantics ────────────────────────────────────
+
+    @Test
+    fun `first append receives latest null`() = runBlocking<Unit> {
+        val store = createStore()
+        var observed: AuditEvent? = AuditEvent(
+            schemaVersion = CURRENT_AUDIT_SCHEMA_VERSION,
+            hashAlgorithm = AuditHashAlgorithm.SHA_256,
+            auditStreamId = "sentinel",
+            eventId = "sentinel",
+            sequenceNumber = 99,
+            workflowRunId = null,
+            correlationId = null,
+            actor = null,
+            enforcementPoint = "sentinel",
+            decision = "sentinel",
+            policyVersion = null,
+            workflowDigest = null,
+            previousEventHash = null,
+            eventHash = "sentinel",
+            timestamp = AuditStoreFixtures.BASE_TIME,
+            reasonCode = null,
+        )
+        store.appendNext("stream-a", { latest ->
+            observed = latest
+            AuditStoreFixtures.event("stream-a", "evt-1", latest)
+        })
+        assertThat(observed).isNull()
+    }
+
+    @Test
+    fun `first event has sequence 1`() = runBlocking<Unit> {
+        val store = createStore()
+        val first = appendValid(store, "stream-a", "evt-1")
+        assertThat(first.sequenceNumber).isEqualTo(1L)
+    }
+
+    @Test
+    fun `first event previousEventHash is null`() = runBlocking<Unit> {
+        val store = createStore()
+        val first = appendValid(store, "stream-a", "evt-1")
+        assertThat(first.previousEventHash).isNull()
+    }
+
+    @Test
+    fun `second append factory receives the exact latest event`() = runBlocking<Unit> {
+        val store = createStore()
+        val first = appendValid(store, "stream-a", "evt-1")
+        var observed: AuditEvent? = null
+        store.appendNext("stream-a", { latest ->
+            observed = latest
+            AuditStoreFixtures.event("stream-a", "evt-2", latest)
+        })
+        assertThat(observed).isEqualTo(first)
+    }
+
+    @Test
+    fun `second event has sequence 2`() = runBlocking<Unit> {
+        val store = createStore()
+        appendValid(store, "stream-a", "evt-1")
+        val second = appendValid(store, "stream-a", "evt-2")
+        assertThat(second.sequenceNumber).isEqualTo(2L)
+    }
+
+    @Test
+    fun `second event previousEventHash equals first eventHash`() = runBlocking<Unit> {
+        val store = createStore()
+        val first = appendValid(store, "stream-a", "evt-1")
+        val second = appendValid(store, "stream-a", "evt-2")
+        assertThat(second.previousEventHash).isEqualTo(first.eventHash)
+    }
+
+    @Test
+    fun `every metadata field round-trips`() = runBlocking<Unit> {
+        val store = createStore()
+        val metadata = mapOf(
+            "decision.actor" to "user:alice",
+            "enforcement.point" to "test-gate",
+            "policy.version" to "v1",
+            "workflow.digest" to "sha256:0001",
+            "arbitrary" to "value",
+        )
+        val appended = store.appendNext("stream-a") { latest ->
+            AuditStoreFixtures.event(
+                auditStreamId = "stream-a",
+                eventId = "evt-roundtrip",
+                latest = latest,
+                timestamp = AuditStoreFixtures.BASE_TIME.plusSeconds(1),
+                metadata = metadata,
+                decision = "DENIED",
+            )
+        }
+        val read = store.readStream("stream-a").single()
+        assertThat(read).isEqualTo(appended)
+        assertThat(read.sequenceNumber).isEqualTo(1L)
+        assertThat(read.eventId).isEqualTo("evt-roundtrip")
+        assertThat(read.auditStreamId).isEqualTo("stream-a")
+        assertThat(read.schemaVersion).isEqualTo(CURRENT_AUDIT_SCHEMA_VERSION)
+        assertThat(read.workflowRunId).isEqualTo("wf-1")
+        assertThat(read.correlationId).isEqualTo("corr-1")
+        assertThat(read.actor).isEqualTo("user:alice")
+        assertThat(read.enforcementPoint).isEqualTo("test-gate")
+        assertThat(read.decision).isEqualTo("DENIED")
+        assertThat(read.policyVersion).isEqualTo("v1")
+        assertThat(read.workflowDigest).isEqualTo("sha256:0001")
+        assertThat(read.timestamp).isEqualTo(AuditStoreFixtures.BASE_TIME.plusSeconds(1))
+        assertThat(read.reasonCode).isEqualTo("reason-1")
+        assertThat(read.metadata).isEqualTo(metadata)
+    }
+
+    @Test
+    fun `append rejects wrong auditStreamId`() = runBlocking<Unit> {
+        val store = createStore()
+        val thrown = runCatching {
+            store.appendNext("stream-a") { latest ->
+                AuditStoreFixtures.event("stream-a", "evt-wrong-stream", latest, auditStreamIdOverride = "other-stream")
+            }
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(thrown?.message).isEqualTo("audit-stream-id-mismatch")
+    }
+
+    @Test
+    fun `append rejects wrong sequence`() = runBlocking<Unit> {
+        val store = createStore()
+        appendValid(store, "stream-a", "evt-1")
+        val thrown = runCatching {
+            store.appendNext("stream-a") { latest ->
+                AuditStoreFixtures.event("stream-a", "evt-wrong-seq", latest, sequenceNumber = 5L)
+            }
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(thrown?.message).isEqualTo("audit-sequence-gap")
+    }
+
+    @Test
+    fun `append rejects wrong previousEventHash`() = runBlocking<Unit> {
+        val store = createStore()
+        appendValid(store, "stream-a", "evt-1")
+        val thrown = runCatching {
+            store.appendNext("stream-a") { latest ->
+                AuditStoreFixtures.event(
+                    "stream-a", "evt-wrong-prev", latest,
+                    previousEventHash = "0000000000000000000000000000000000000000000000000000000000000000",
+                )
+            }
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(thrown?.message).isEqualTo("audit-hash-chain-broken")
+    }
+
+    @Test
+    fun `append rejects invalid eventHash`() = runBlocking<Unit> {
+        val store = createStore()
+        val thrown = runCatching {
+            store.appendNext("stream-a") { latest ->
+                AuditStoreFixtures.event("stream-a", "evt-wrong-hash", latest, eventHash = "deadbeef")
+            }
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(thrown?.message).isEqualTo("audit-event-hash-mismatch")
+    }
+
+    @Test
+    fun `append rejects unsupported schema version`() = runBlocking<Unit> {
+        val store = createStore()
+        val thrown = runCatching {
+            store.appendNext("stream-a") { latest ->
+                AuditStoreFixtures.event("stream-a", "evt-old-schema", latest, schemaVersion = 2)
+            }
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(thrown?.message).isEqualTo("audit-schema-version-unsupported")
+    }
+
+    @Test
+    fun `append rejects duplicate event ID in the same stream`() = runBlocking<Unit> {
+        val store = createStore()
+        appendValid(store, "stream-a", "evt-dup")
+        val thrown = runCatching {
+            store.appendNext("stream-a") { latest ->
+                AuditStoreFixtures.event("stream-a", "evt-dup", latest)
+            }
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(thrown?.message).isEqualTo("audit-duplicate-event-id")
+    }
+
+    @Test
+    fun `append rejects blank audit stream ID`() = runBlocking<Unit> {
+        val store = createStore()
+        for (blank in listOf("", "   ")) {
+            val thrown = runCatching {
+                store.appendNext(blank) { latest ->
+                    AuditStoreFixtures.event(blank, "evt-blank-stream", latest)
+                }
+            }.exceptionOrNull()
+            assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+            assertThat(thrown?.message).isEqualTo("audit-store-invalid-stream-id")
+        }
+    }
+
+    @Test
+    fun `append rejects blank event ID`() = runBlocking<Unit> {
+        val store = createStore()
+        for (blank in listOf("", "   ")) {
+            val thrown = runCatching {
+                store.appendNext("stream-a") { latest ->
+                    AuditStoreFixtures.event("stream-a", blank, latest)
+                }
+            }.exceptionOrNull()
+            assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+            assertThat(thrown?.message).isEqualTo("audit-store-invalid-event-id")
+        }
+    }
+
+    @Test
+    fun `rejected append leaves the stream unchanged`() = runBlocking<Unit> {
+        val store = createStore()
+        val rejected = runCatching {
+            store.appendNext("stream-a") { latest ->
+                AuditStoreFixtures.event("stream-a", "evt-bad", latest, sequenceNumber = 42L)
+            }
+        }
+        assertThat(rejected.isFailure).isTrue()
+        assertThat(store.readStream("stream-a")).isEmpty()
+        assertThat(store.latestEvent("stream-a")).isNull()
+        // a subsequent valid append still starts at sequence 1
+        val first = appendValid(store, "stream-a", "evt-ok")
+        assertThat(first.sequenceNumber).isEqualTo(1L)
+    }
+
+    @Test
+    fun `event factory is invoked exactly once per append`() = runBlocking<Unit> {
+        val store = createStore()
+        var invocations = 0
+        store.appendNext("stream-a") { latest ->
+            invocations++
+            AuditStoreFixtures.event("stream-a", "evt-once", latest)
+        }
+        assertThat(invocations).isEqualTo(1)
+    }
+
+    @Test
+    fun `factory exception propagates unchanged and appends nothing`() = runBlocking<Unit> {
+        val store = createStore()
+        val boom = IllegalStateException("factory exploded")
+        val thrown = runCatching {
+            store.appendNext("stream-a") { boom.let { throw it } }
+        }.exceptionOrNull()
+        assertThat(thrown).isSameAs(boom)
+        assertThat(store.readStream("stream-a")).isEmpty()
+        assertThat(store.latestEvent("stream-a")).isNull()
+    }
+
+    @Test
+    fun `CancellationException propagates as the same instance and appends nothing`() = runBlocking<Unit> {
+        val store = createStore()
+        val cancellation = CancellationException("cancelled by test")
+        val thrown = runCatching {
+            store.appendNext("stream-a") { cancellation.let { throw it } }
+        }.exceptionOrNull()
+        assertThat(thrown).isSameAs(cancellation)
+        assertThat(store.readStream("stream-a")).isEmpty()
+        assertThat(store.latestEvent("stream-a")).isNull()
+    }
+
+    // ── Read / latest semantics ─────────────────────────────────────
+
+    @Test
+    fun `missing stream readStream returns emptyList`() = runBlocking<Unit> {
+        val store = createStore()
+        assertThat(store.readStream("no-such-stream")).isEmpty()
+    }
+
+    @Test
+    fun `missing stream latestEvent returns null`() = runBlocking<Unit> {
+        val store = createStore()
+        assertThat(store.latestEvent("no-such-stream")).isNull()
+    }
+
+    @Test
+    fun `readStream returns events in ascending sequence order`() = runBlocking<Unit> {
+        val store = createStore()
+        appendValid(store, "stream-a", "evt-1")
+        appendValid(store, "stream-a", "evt-2")
+        appendValid(store, "stream-a", "evt-3")
+        val read = store.readStream("stream-a")
+        assertThat(read.map { it.sequenceNumber }).containsExactly(1L, 2L, 3L)
+        assertThat(read.map { it.eventId }).containsExactly("evt-1", "evt-2", "evt-3")
+    }
+
+    @Test
+    fun `latestEvent equals the final event`() = runBlocking<Unit> {
+        val store = createStore()
+        appendValid(store, "stream-a", "evt-1")
+        val second = appendValid(store, "stream-a", "evt-2")
+        assertThat(store.latestEvent("stream-a")).isEqualTo(second)
+    }
+
+    @Test
+    fun `independent streams never bleed into one another`() = runBlocking<Unit> {
+        val store = createStore()
+        appendValid(store, "stream-a", "a-1")
+        appendValid(store, "stream-a", "a-2")
+        appendValid(store, "stream-b", "b-1")
+        assertThat(store.readStream("stream-a").map { it.eventId }).containsExactly("a-1", "a-2")
+        assertThat(store.readStream("stream-b").map { it.eventId }).containsExactly("b-1")
+        assertThat(store.latestEvent("stream-a")?.eventId).isEqualTo("a-2")
+        assertThat(store.latestEvent("stream-b")?.eventId).isEqualTo("b-1")
+        assertThat(store.readStream("stream-a").all { it.auditStreamId == "stream-a" }).isTrue()
+    }
+
+    @Test
+    fun `mutating the source metadata map after append cannot mutate stored evidence`() = runBlocking<Unit> {
+        val store = createStore()
+        val source = mutableMapOf("key" to "value")
+        store.appendNext("stream-a") { latest ->
+            AuditStoreFixtures.event("stream-a", "evt-isolated", latest, metadata = source)
+        }
+        source["key"] = "mutated"
+        assertThat(store.readStream("stream-a").single().metadata).isEqualTo(mapOf("key" to "value"))
+    }
+
+    @Test
+    fun `mutating returned metadata cannot modify the persisted event`() = runBlocking<Unit> {
+        val store = createStore()
+        val appended = appendValid(store, "stream-a", "evt-immutable", metadata = mapOf("key" to "value"))
+        runCatching { (appended.metadata as MutableMap<String, String>)["key"] = "mutated" }
+        assertThat(store.readStream("stream-a").single().metadata).isEqualTo(mapOf("key" to "value"))
+    }
+
+    // ── Pagination semantics ────────────────────────────────────────
+
+    private suspend fun seedFive(store: AuditStore) {
+        repeat(5) { i ->
+            store.appendNext("stream-a", AuditStoreFixtures.factory("stream-a", "evt-${i + 1}"))
+        }
+    }
+
+    @Test
+    fun `page with null cursor starts from sequence 1`() = runBlocking<Unit> {
+        val store = createStore()
+        seedFive(store)
+        val page = store.readStreamPage("stream-a", afterSequenceNumber = null, limit = 10)
+        assertThat(page.map { it.sequenceNumber }).containsExactly(1L, 2L, 3L, 4L, 5L)
+    }
+
+    @Test
+    fun `page with cursor 0 starts from sequence 1`() = runBlocking<Unit> {
+        val store = createStore()
+        seedFive(store)
+        val page = store.readStreamPage("stream-a", afterSequenceNumber = 0L, limit = 10)
+        assertThat(page.map { it.sequenceNumber }).containsExactly(1L, 2L, 3L, 4L, 5L)
+    }
+
+    @Test
+    fun `page cursor N returns events starting at N+1`() = runBlocking<Unit> {
+        val store = createStore()
+        seedFive(store)
+        val page = store.readStreamPage("stream-a", afterSequenceNumber = 2L, limit = 10)
+        assertThat(page.map { it.sequenceNumber }).containsExactly(3L, 4L, 5L)
+    }
+
+    @Test
+    fun `page respects the limit`() = runBlocking<Unit> {
+        val store = createStore()
+        seedFive(store)
+        val page = store.readStreamPage("stream-a", afterSequenceNumber = null, limit = 2)
+        assertThat(page.map { it.sequenceNumber }).containsExactly(1L, 2L)
+    }
+
+    @Test
+    fun `page returns a partial page at the end of the stream`() = runBlocking<Unit> {
+        val store = createStore()
+        seedFive(store)
+        val page = store.readStreamPage("stream-a", afterSequenceNumber = 2L, limit = 10)
+        assertThat(page.map { it.sequenceNumber }).containsExactly(3L, 4L, 5L)
+    }
+
+    @Test
+    fun `page with cursor at the final event returns empty`() = runBlocking<Unit> {
+        val store = createStore()
+        seedFive(store)
+        val page = store.readStreamPage("stream-a", afterSequenceNumber = 5L, limit = 10)
+        assertThat(page).isEmpty()
+    }
+
+    @Test
+    fun `page on a missing stream returns empty`() = runBlocking<Unit> {
+        val store = createStore()
+        assertThat(store.readStreamPage("no-such-stream", afterSequenceNumber = null, limit = 10)).isEmpty()
+    }
+
+    @Test
+    fun `page rejects zero limit`() = runBlocking<Unit> {
+        val store = createStore()
+        val thrown = runCatching { store.readStreamPage("stream-a", afterSequenceNumber = null, limit = 0) }
+            .exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(thrown?.message).isEqualTo("audit-store-invalid-limit")
+    }
+
+    @Test
+    fun `page rejects negative limit`() = runBlocking<Unit> {
+        val store = createStore()
+        val thrown = runCatching { store.readStreamPage("stream-a", afterSequenceNumber = null, limit = -1) }
+            .exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(thrown?.message).isEqualTo("audit-store-invalid-limit")
+    }
+
+    @Test
+    fun `page rejects negative cursor`() = runBlocking<Unit> {
+        val store = createStore()
+        val thrown = runCatching { store.readStreamPage("stream-a", afterSequenceNumber = -1L, limit = 10) }
+            .exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(thrown?.message).isEqualTo("audit-store-invalid-cursor")
+    }
+
+    @Test
+    fun `page preserves ascending order`() = runBlocking<Unit> {
+        val store = createStore()
+        seedFive(store)
+        val page = store.readStreamPage("stream-a", afterSequenceNumber = 1L, limit = 3)
+        assertThat(page.map { it.sequenceNumber }).containsExactly(2L, 3L, 4L)
+    }
+
+    @Test
+    fun `page contents equal the corresponding slice of readStream`() = runBlocking<Unit> {
+        val store = createStore()
+        seedFive(store)
+        val page = store.readStreamPage("stream-a", afterSequenceNumber = 1L, limit = 2)
+        assertThat(page).isEqualTo(store.readStream("stream-a").filter { it.sequenceNumber > 1L }.take(2))
+    }
+
+    @Test
+    fun `read paths reject blank audit stream ID`() = runBlocking<Unit> {
+        val store = createStore()
+        for (blank in listOf("", "   ")) {
+            val ops = listOf<suspend () -> Any?>(
+                { store.readStream(blank) },
+                { store.readStreamPage(blank, afterSequenceNumber = null, limit = 10) },
+                { store.latestEvent(blank) },
+            )
+            for (op in ops) {
+                val thrown = runCatching { op() }.exceptionOrNull()
+                assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+                assertThat(thrown?.message).isEqualTo("audit-store-invalid-stream-id")
+            }
+        }
+    }
+
+    // ── Hash-chain integrity ────────────────────────────────────────
+
+    @Test
+    fun `valid multi-event stream satisfies chain invariants and verifier`() = runBlocking<Unit> {
+        val store = createStore()
+        val events = mutableListOf<AuditEvent>()
+        repeat(4) { i ->
+            events.add(appendValid(store, "stream-a", "evt-chain-${i + 1}"))
+        }
+        for (i in 1 until events.size) {
+            assertThat(events[i].sequenceNumber).isEqualTo(events[i - 1].sequenceNumber + 1L)
+            assertThat(events[i].previousEventHash).isEqualTo(events[i - 1].eventHash)
+        }
+        for (event in events) {
+            assertThat(event.eventHash).isEqualTo(event.copy(eventHash = "").calculateHash())
+        }
+        val result = AuditChainVerifier.verify(events)
+        assertThat(result.isValid).withFailMessage { result.errors.joinToString { it.message } }.isTrue()
+    }
+
+    // ── Concurrency ─────────────────────────────────────────────────
+
+    @Test
+    fun `concurrent same-stream appends all succeed with an uninterrupted chain`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val store = createStore()
+            val outcomes = runInParallel(0 until 8) { index ->
+                runCatching {
+                    store.appendNext("stream-a") { latest ->
+                        AuditStoreFixtures.event("stream-a", "evt-$round-$index", latest)
+                    }
+                }
+            }
+            assertThat(outcomes.count { it.isSuccess }).withFailMessage {
+                "round $round: expected 8 successes, got ${outcomes.count { it.isSuccess }}"
+            }.isEqualTo(8)
+            val events = store.readStream("stream-a")
+            assertThat(events.map { it.sequenceNumber }).containsExactly(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L)
+            assertThat(events.map { it.eventId }.toSet()).hasSize(8)
+            val result = AuditChainVerifier.verify(events)
+            assertThat(result.isValid).withFailMessage { result.errors.joinToString { it.message } }.isTrue()
+        }
+    }
+
+    @Test
+    fun `concurrent duplicate event ID - exactly one winner`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val store = createStore()
+            val outcomes = runInParallel(0 until 8) {
+                runCatching {
+                    store.appendNext("stream-a") { latest ->
+                        AuditStoreFixtures.event("stream-a", "evt-dup-$round", latest)
+                    }
+                }
+            }
+            assertThat(outcomes.count { it.isSuccess }).withFailMessage {
+                "round $round: expected exactly one winner, got ${outcomes.count { it.isSuccess }}"
+            }.isEqualTo(1)
+            assertThat(outcomes.filter { it.isFailure }.map { it.exceptionOrNull() })
+                .allMatch { it is IllegalArgumentException && it.message == "audit-duplicate-event-id" }
+            val events = store.readStream("stream-a")
+            assertThat(events.map { it.eventId }).containsExactly("evt-dup-$round")
+            val result = AuditChainVerifier.verify(events)
+            assertThat(result.isValid).withFailMessage { result.errors.joinToString { it.message } }.isTrue()
+        }
+    }
+
+    @Test
+    fun `concurrent independent streams both start at sequence 1`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val store = createStore()
+            val outcomes = runInParallel(0 until 8) { index ->
+                val stream = if (index % 2 == 0) "stream-a" else "stream-b"
+                runCatching {
+                    store.appendNext(stream) { latest ->
+                        AuditStoreFixtures.event(stream, "evt-$round-$index", latest)
+                    }
+                }
+            }
+            assertThat(outcomes.count { it.isSuccess }).isEqualTo(8)
+            val a = store.readStream("stream-a")
+            val b = store.readStream("stream-b")
+            assertThat(a.map { it.sequenceNumber }).containsExactly(1L, 2L, 3L, 4L)
+            assertThat(b.map { it.sequenceNumber }).containsExactly(1L, 2L, 3L, 4L)
+            assertThat(AuditChainVerifier.verify(a).isValid).isTrue()
+            assertThat(AuditChainVerifier.verify(b).isValid).isTrue()
+        }
+    }
+
+    // ── Parallel-race helper (shared pattern from #269/#270) ────────
+
+    /**
+     * Runs [block] for every element of [items] on real parallel workers with
+     * a start barrier, returning the outcomes in input order. The barrier
+     * gives every contender a scheduling opportunity before any of them is
+     * allowed to proceed.
+     */
+    private suspend fun <T, R> runInParallel(
+        items: List<T>,
+        block: suspend (T) -> R,
+    ): List<R> = coroutineScope {
+        val ready = Channel<Unit>(items.size)
+        val release = CompletableDeferred<Unit>()
+        val workers = items.map { item ->
+            async(Dispatchers.Default) {
+                ready.send(Unit)
+                release.await()
+                block(item)
+            }
+        }
+        repeat(items.size) { ready.receive() }
+        release.complete(Unit)
+        workers.map { it.await() }
+    }
+
+    /** Range convenience overload for the race loops. */
+    private suspend fun <R> runInParallel(
+        range: IntRange,
+        block: suspend (Int) -> R,
+    ): List<R> = runInParallel(range.toList(), block)
+}


### PR DESCRIPTION
## test(persistence): add AuditStore compatibility TCK — Epic 8.1d

**Status:** Epic 8.1 🚧 IN PROGRESS — Approval ✅ (#267), Approval continuation ✅ (#269), Suspended invocation ✅ (#270), **Audit ✅ (this PR)**; audit outbox, workflow checkpoint, workflow lease, memory pending.

### What this PR does

Enrolls **all three** `AuditStore` implementations — the security module's default in-memory store, the encrypted file store, and JDBC — in one shared behavioral contract. `AuditStoreTck` (tramai-testing testFixtures, which gained a testFixtures dependency on `tramai-security`, the SPI's home module) runs **43 cases**:

- **Append / chain semantics (19):** the first append's factory receives `latest == null`; first event has sequence 1 and `previousEventHash == null`; the second append's factory receives the exact latest event; second event has sequence 2 and `previousEventHash == first.eventHash`; every metadata field round-trips; wrong auditStreamId / sequence / previous-hash / self-hash / schema version / duplicate event-ID all rejected with the fixed safe reason codes; blank stream and event IDs rejected; a rejected append leaves the stream unchanged; the factory is invoked exactly once; a factory exception and a `CancellationException` propagate unchanged and append nothing. Malformed fixtures compute their digest over the malformed event, so **exactly one invariant is violated per case** (the #269/#270 lesson).
- **Read / latest semantics (8):** missing stream → `emptyList()`/`null`; ascending order; exact field equality; `latestEvent()` equals the final event; independent streams never bleed; metadata is defensively isolated — mutating the source map after append cannot mutate stored evidence, and mutating returned metadata cannot modify the persisted event.
- **Pagination (12):** exclusive cursor (null/0 → start at 1; N → first event N+1); limit respected as a maximum — the contract expects the requested limit when enough events are available within the implementation's supported page cap, but does not require a request larger than an implementation-specific maximum such as JDBC's `maxPageSize` to return the entire requested count; partial page; cursor at final → empty; zero/negative limit and negative cursor rejected; page contents equal the corresponding `readStream` slice.
- **Hash-chain integrity (1):** sequence/previous-hash/self-hash invariants plus `AuditChainVerifier.verify` valid.
- **Concurrency (3 real parallel races, start barrier, 20 iterations each):** 8 concurrent same-stream appends all succeed with sequences exactly 1..8 and an uninterrupted chain; concurrent duplicate event ID — exactly one winner; concurrent independent streams both start at sequence 1.

Runners 43/43 each: `InMemoryAuditStoreTckTest` (tramai-security — the default store enrolled like any other, not exempt), `FileAuditStoreTckTest` (per-case dir with 0700 `audit/`), `JdbcAuditStoreTckTest` (PostgreSQL testcontainers, V1+V3 migrations, per-case table reset). The enrollment guard reuses the shared `StoreEnrollmentScanner` with the fixed single-temp-file probe.

### Deliberate decisions (per review)

- **Event-ID uniqueness is per-stream shared contract; cross-stream reuse is NOT.** Cross-stream event-ID reuse is intentionally outside the shared AuditStore contract — a direct SPI caller can reuse an ID across streams and InMemory/File accept it. JDBC additionally enforces global event-ID uniqueness (`uq_audit_events_event_id`) as implementation-specific hardening, retained because normal AuditEngine generation uses UUID event IDs and there is no architecture requirement to reuse an ID across streams — same rationale as the replay-digest uniqueness in #270. Documented so future implementations know the divergence is deliberate.
- **`appendNext` is a chain-authority API, not a plain append:** the store serializes access to the authoritative latest, hands it to the factory, validates the returned event's chain position, and appends atomically — so the TCK pins the factory-callback semantics themselves (exactly-once invocation, authoritative latest, unchanged exception/cancellation propagation, nothing appended on failure).
- **Validation errors are stable safe reason codes** (`audit-stream-id-mismatch`, `audit-sequence-gap`, `audit-hash-chain-broken`, `audit-event-hash-mismatch`, `audit-schema-version-unsupported`, `audit-duplicate-event-id`, `audit-store-invalid-stream-id`, `audit-store-invalid-event-id`), never interpolated values.

### Production changes the enrollment required

- **`InMemoryAuditStore`** gained blank stream-ID (every operation) and blank event-ID (append) validation and replaced its interpolated human-readable validation messages with the fixed reason codes already used by File/JDBC. Its Mutex-per-stream atomic append, snapshot-based defensive metadata copies, and chain validation were already conformant.
- **`FileAuditStore`** gained the same blank stream/event-ID validation before any filesystem work (it previously hashed whatever string it received). No append-chain change — File is the strictest implementation (full-chain validation on every read).
- **`JdbcAuditStore`** gained the blank event-ID check, and `appendNext()`'s transaction cleanup now follows the **#267 primary-exception-precedence pattern**: operation / cancellation **>** rollback failure **>** autoCommit-restore failure, later cleanup failures attached as `suppressed` to the primary. Deterministic regressions prove a primary `CancellationException` escapes unchanged when rollback fails, and when autoCommit-restore fails, with the cleanup failure suppressed. No database schema change.
- 6 `AuditEngineTest` assertions updated from the old interpolated InMemory messages to the fixed reason codes.

### Mutation evidence — 14 mutations, each baseline GREEN → named TCK case(s) RED → restored GREEN

| Mutation | TCK outcome |
|---|---|
| append skips stream-ID check | RED — wrong-stream case |
| append accepts wrong sequence | RED — wrong-sequence case |
| append ignores previous hash | RED — chain-link case |
| append ignores event hash self-hash | RED — self-hash case |
| append accepts unsupported schema | RED — schema-version case |
| duplicate eventId accepted | RED — duplicate + concurrent-duplicate cases |
| blank stream-ID check removed | RED — blank-stream case |
| blank event-ID check removed | RED — blank-event case |
| page cursor becomes inclusive (`>=`) | RED — exclusive-cursor + final-cursor cases |
| page ignores limit | RED — limit case |
| latestEvent returns first instead of last | RED — latest-equals-final case |
| same-stream append lock removed (non-atomic) | RED — both same-stream races |
| shared metadata reference retained | RED — source-mutation isolation case |
| rejected factory result still stored (add before validation) | RED — rejected-append-leaves-stream-unchanged (and every other append case) |

### Gates

- `verifyPr -PchangeClass=runtime-behaviour`: **BUILD SUCCESSFUL** (all subproject tests, maintainability baseline, change policy)
- `verifyCancellationSafety` vs master: **PASSED** (the #267-pattern cleanup is scanner-clean: if-is-CancellationException rethrow in suspend scope, cleanup in deliberately non-suspend helpers)
- 43/43 per runner × 3; 14/14 mutations RED → GREEN
- Zero public API change; no persisted format or schema changes; no existing tests deleted
