### PR TITLE
test(persistence): add SovereignOpsAuditOutboxStore compatibility TCK — Epic 8.1e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,67 @@
   reason codes). Epic 8.1 stays IN PROGRESS. Reference:
   `docs/reference/persistence-store-compatibility-contract.md`.
 
+- **SovereignOpsAuditOutboxStore compatibility TCK (PR #272, Epic 8.1e).**
+  One shared behavioral contract for every `SovereignOpsAuditOutboxStore`
+  implementation — the sovereign-ops module's in-memory store, the
+  encrypted file store, and JDBC. The outbox is a delivery state machine,
+  not generic persistence: `SovereignOpsAuditOutboxStoreTck` (tramai-testing
+  testFixtures, which gained a test-fixture-only dependency on
+  `tramai-spring-boot-starter-sovereign-ops`, the SPI's home module — no
+  Spring enters any production runtime module) runs **55 cases** — append/
+  lookup (13: exact PREPARED round-trip, missing nulls, event-key lookup,
+  duplicate outboxId/eventKey rejected with the orphan-rollback and
+  mapping-intact assertions, blank IDs rejected, every non-PREPARED status
+  rejected, exact fixed reason codes), markReadyForDispatch (5: PREPARED→
+  PENDING preserving non-status fields, missing → not-found, wrong current
+  status rejected, **expectedStatus itself must be PREPARED**),
+  markEmitted (7: EMITTING→EMITTED with exact emittedAt, claim fields
+  preserved, all five illegal source statuses rejected), markFailed (9: the
+  legal matrix PREPARED+permanent, EMITTING+retryable, EMITTING+permanent
+  with `lastErrorCode` pinned, everything else rejected), claim/retry/lease
+  (10: PENDING claim with attempt/claimant/5-minute expiry, FAILED_RETRYABLE
+  re-claim with **`lastErrorCode = null`** as its own case, expired-EMITTING
+  recovery, strict `claimExpiresAt < now` lease boundary at exact equality
+  and one-second-past, PREPARED/EMITTED/FAILED_PERMANENT/fresh-EMITTING
+  never claimable), diagnostic listing (7: membership only, limits cap the
+  result, zero/negative limits → empty on all four paths, expired boundary
+  exclusive, `findByEventKey` reflects the current version), and concurrency
+  (5 real parallel races with a start barrier, 20 iterations each: duplicate
+  outboxId — one winner; duplicate eventKey — one winner AND every loser
+  record absent, proving the event-key index rollback is real; one PENDING
+  record, 8 claimers, exactly one claim; 8-record pool claim, every record
+  exactly once, every attempt 1; concurrent completion — one winner, final
+  EMITTED). Three runners execute the same contract (55/55 each):
+  `InMemorySovereignOpsAuditOutboxStoreTckTest` (sovereign-ops — the default
+  store, enrolled like any other), `FileSovereignOpsAuditOutboxStoreTckTest`
+  (per-case dir), `JdbcSovereignOpsAuditOutboxStoreTckTest` (PostgreSQL
+  testcontainers, V1+V4 migrations, per-case truncate). The enrollment
+  guard reuses the shared `StoreEnrollmentScanner`. **Production changes the
+  enrollment required:** the reviewed JDBC lifecycle guards (PR #85) are the
+  authoritative semantics — `InMemorySovereignOpsAuditOutboxStore` gained
+  the PREPARED-only readiness guard, EMITTING-only emission guard, legal
+  markFailed matrix, `lastErrorCode` clearing on claim, `[]` for
+  non-positive limits, and fixed non-interpolated reason codes;
+  `FileSovereignOpsAuditOutboxStore` gained blank-ID validation, the
+  emission/failure guards, error-code clearing, and a write-staging fix
+  (temp files now staged outside the scanned outbox directory — the TCK's
+  pool-claim race exposed the concurrent-scan corruption);
+  `JdbcSovereignOpsAuditOutboxStore` normalized duplicate errors to fixed
+  codes and collapsed all five mutating transaction paths onto one
+  non-suspend `inOutboxTransaction` helper with the #267 precedence
+  (operation/cancellation > rollback failure > autoCommit-restore failure,
+  later cleanup failures suppressed), with deterministic regressions proving
+  a primary `CancellationException` escapes unchanged when rollback or
+  autoCommit-restore fails. `SovereignOpsAuditOutboxRecord` KDoc lifecycle
+  diagram corrected to the shared matrix. Mutation evidence (16 mutations,
+  each restored): duplicate-ID/event-key overwrites, loser-record rollback,
+  blank-ID, readiness/emission/failure-matrix guards, claim eligibility,
+  lease boundary `<`→`<=`, attempt increment, error-code clearing, listing
+  filter, non-atomic claim, ignored limit — each turns shared TCK cases RED.
+  Zero public API change, no persisted format or schema changes, no existing
+  tests deleted. Epic 8.1 stays IN PROGRESS. Reference:
+  `docs/reference/persistence-store-compatibility-contract.md`.
+
 - **Structured-output contract TCK (PR #266, Epic 7.2).** One reusable test
   kit drives the entire structured-output lifecycle per fixture — descriptor
   compilation → generated schema → raw JSON shape validation →

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1191,7 +1191,7 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ## Epic 8.1: Persistence Store TCKs
 
-**Status: 🚧 IN PROGRESS** — Approval store slice done (PR #267), Approval continuation slice done (PR #269), suspended invocation slice done (PR #270), audit store slice done (PR #271); remaining families pending.
+**Status: 🚧 IN PROGRESS** — Approval store slice done (PR #267), Approval continuation slice done (PR #269), suspended invocation slice done (PR #270), audit store slice done (PR #271), audit outbox slice done (PR #272); remaining families pending.
 
 **Goal:** Ensure in-memory, file, and JDBC implementations share the same behavioural contract.
 
@@ -1201,7 +1201,7 @@ repair feedback. No layer maintains its own independent fixture lists.
 - Approval continuation store — ✅ PR #269 (shared `ApprovalContinuationStoreTck`, 50 cases × 3 implementations + enrollment guard)
 - Suspended invocation store — ✅ PR #270 (shared `SuspendedInvocationStoreTck`, 39 cases × 3 implementations + enrollment guard)
 - Audit store — ✅ PR #271 (shared `AuditStoreTck`, 43 cases × 3 implementations + enrollment guard)
-- Audit outbox store — ⏳
+- Audit outbox store — ✅ PR #272 (shared `SovereignOpsAuditOutboxStoreTck`, 55 cases × 3 implementations + enrollment guard)
 - Workflow checkpoint store — ⏳
 - Workflow lease store — ⏳
 - Step-attempt store — ✅ PR #218 (shared TCK + restart recovery tests for in-memory, file, and JDBC)
@@ -1225,7 +1225,7 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ### Acceptance criteria
 
-- ✅ Every published store implementation passes the relevant TCK (Approval: 3/3 via #267; Approval continuation: 3/3 via #269; suspended invocation: 3/3 via #270; audit: 3/3 via #271; step-attempt: 3/3 via PR #218).
+- ✅ Every published store implementation passes the relevant TCK (Approval: 3/3 via #267; Approval continuation: 3/3 via #269; suspended invocation: 3/3 via #270; audit: 3/3 via #271; audit outbox: 3/3 via #272; step-attempt: 3/3 via PR #218).
 - ✅ Implementation-specific tests cover only storage technology and performance differences (encryption, permissions, corruption, record format for file; SQL schema, JSON mapping, connection cleanup for JDBC).
 - ✅ Contract failures use common typed exceptions or reason codes (`ApprovalStoreConflictException`, `ApprovalStoreNotFoundException`, `ApprovalStoreTokenRejectedException`, `ApprovalStoreNotConsumableException`, `IllegalApprovalTransitionException`; `ApprovalContinuationConflictException`, `ApprovalContinuationNotFoundException`, `ApprovalContinuationNotClaimableException`, `ApprovalContinuationNotCompletableException`; AuditStore: `audit-store-invalid-stream-id`, `audit-store-invalid-event-id`, `audit-stream-id-mismatch`, `audit-sequence-gap`, `audit-hash-chain-broken`, `audit-event-hash-mismatch`, `audit-schema-version-unsupported`, `audit-duplicate-event-id`).
 
@@ -1257,6 +1257,27 @@ repair feedback. No layer maintains its own independent fixture lists.
 - Deliberate decisions: JDBC's unique `replay_envelope_digest` index stays JDBC-specific (documented, not copied); historySize consistency and the redaction sentinel ARE shared contract (File already enforced them)
 - Mutation evidence (11 mutations, each restored): duplicate overwrite, remove-without-delete, reveal-null, envelope-leak-after-remove, digest/toolCallId/toolName/toolCallIndex checks dropped, non-atomic remove, redaction-sentinel not required, historySize not validated
 - Zero public API change; no persisted format or schema changes; no existing tests deleted
+- Reference: `docs/reference/persistence-store-compatibility-contract.md`
+
+### Deliverables (PR #271)
+
+- `tramai-testing/src/testFixtures/.../persistence/audit/` — `AuditStoreTck` (43 cases), `AuditStoreFixtures`; `tramai-testing` testFixtures gained a dependency on `tramai-security` (the SPI's home module)
+- Runners: `InMemoryAuditStoreTckTest` (tramai-security — the default store, enrolled like any other), `FileAuditStoreTckTest`, `JdbcAuditStoreTckTest`; `AuditStoreTckEnrollmentArchitectureTest` reuses the shared `StoreEnrollmentScanner`
+- Production alignment: `InMemoryAuditStore` gained blank stream/event-ID validation + fixed safe reason codes (was interpolated); `FileAuditStore` gained blank stream/event-ID validation; `JdbcAuditStore` gained blank event-ID validation and `appendNext()`'s transaction cleanup follows the #267 precedence (rollback/restore failures suppressed on the primary), with deterministic cancellation regressions
+- Deliberate decisions: appendNext is a chain-authority API (factory-callback semantics pinned, not just rows); event-ID uniqueness is per-stream shared contract — JDBC's global `uq_audit_events_event_id` stays implementation-specific hardening (a direct SPI caller can reuse an ID across streams; retained because AuditEngine uses UUID IDs)
+- Mutation evidence (14 mutations, each restored): stream/sequence/previous-hash/self-hash/schema/duplicate-event-ID/blank-ID checks dropped, inclusive cursor, ignored limit, latest-returns-first, removed append lock, shared metadata reference, store-before-validate
+- Zero public API change; no persisted format or schema changes; no existing tests deleted
+- Reference: `docs/reference/persistence-store-compatibility-contract.md`
+
+### Deliverables (PR #272)
+
+- `tramai-testing/src/testFixtures/.../persistence/outbox/` — `SovereignOpsAuditOutboxStoreTck` (55 cases), `SovereignOpsAuditOutboxFixtures` (deterministic T0/IDs/lease — never `UUID.randomUUID()`/`Instant.now()`); `tramai-testing` testFixtures gained a test-fixture-only dependency on `tramai-spring-boot-starter-sovereign-ops` (the SPI's home module; no Spring enters any production runtime module)
+- Runners: `InMemorySovereignOpsAuditOutboxStoreTckTest`, `FileSovereignOpsAuditOutboxStoreTckTest`, `JdbcSovereignOpsAuditOutboxStoreTckTest`; `SovereignOpsAuditOutboxStoreTckEnrollmentArchitectureTest` reuses the shared `StoreEnrollmentScanner`
+- One legal delivery state machine pinned across all three stores (JDBC's PR #85 guards are authoritative): PREPARED→PENDING→EMITTING→EMITTED; EMITTING→FAILED_RETRYABLE→(re-claim)→EMITTING; PREPARED|EMITTING→FAILED_PERMANENT; expired-claim recovery with strict `claimExpiresAt < now` lease boundary; `lastErrorCode = null` on every fresh claim
+- Real cross-store divergences fixed: InMemory gained PREPARED-only readiness, EMITTING-only emission, the legal markFailed matrix, error-code clearing on claim, `[]` for non-positive limits, fixed reason codes; File gained blank-ID validation, the emission/failure guards, error-code clearing, and a write-staging fix (temp files now outside the scanned outbox dir — the pool-claim race exposed it); Jdbc normalized duplicate errors and collapsed all five mutating transaction paths onto one #267-precedence helper with deterministic cancellation regressions
+- Mutation evidence (16 mutations, each restored): duplicate-ID/event-key overwrites, loser-record rollback, blank-ID, readiness/emission/failure-matrix guards, claim eligibility, lease boundary, attempt increment, error-code clearing, listing filter, non-atomic claim, ignored limit
+- Zero public API change; no persisted format or schema changes; no existing tests deleted
+- Remaining families: workflow checkpoint, workflow lease, memory
 - Reference: `docs/reference/persistence-store-compatibility-contract.md`
 
 ---

--- a/docs/reference/persistence-store-compatibility-contract.md
+++ b/docs/reference/persistence-store-compatibility-contract.md
@@ -1,10 +1,11 @@
 # Persistence Store Compatibility Contract
 
 Epic 8.1 (PR #267 ApprovalStore slice, PR #269 ApprovalContinuationStore
-slice, PR #270 SuspendedInvocationStore slice, PR #271 AuditStore slice).
-Shared behavioral TCKs prove every implementation of a store family
-satisfies exactly the same externally observable contract, regardless of
-storage technology (memory, encrypted files, JDBC).
+slice, PR #270 SuspendedInvocationStore slice, PR #271 AuditStore slice,
+PR #272 SovereignOpsAuditOutboxStore slice). Shared behavioral TCKs prove
+every implementation of a store family satisfies exactly the same externally
+observable contract, regardless of storage technology (memory, encrypted
+files, JDBC).
 
 ## Epic 8.1 matrix
 
@@ -14,7 +15,7 @@ storage technology (memory, encrypted files, JDBC).
 | Approval continuation | ✅ | ✅ | ✅ | ✅ #269 |
 | Suspended invocation | ✅ | ✅ | ✅ | ✅ #270 |
 | Audit | ✅ | ✅ | ✅ | ✅ #271 |
-| Audit outbox | … | … | … | ⏳ |
+| Audit outbox | ✅ | ✅ | ✅ | ✅ #272 |
 | Workflow checkpoint | … | … | … | ⏳ |
 | Workflow lease | … | … | … | ⏳ |
 | Step attempt | ✅ | ✅ | ✅ | ✅ #218 |
@@ -468,3 +469,136 @@ injection, SQL schema internals, indexes/query strategy, and `maxPageSize`.
 No existing tests were deleted. The `tramai-testing` testFixtures gained a
 dependency on `tramai-security` (the SPI's home module) so the shared suite
 can be written in one place.
+
+## SovereignOpsAuditOutboxStore TCK (PR #272)
+
+`SovereignOpsAuditOutboxStoreTck` (tramai-testing testFixtures) runs **55
+shared behavioral cases** against every `SovereignOpsAuditOutboxStore`
+implementation. The outbox is a delivery state machine, not generic
+persistence — the contract pins one legal lifecycle (the JDBC guards from
+PR #85's review are the authoritative semantics):
+
+```
+PREPARED ──markReadyForDispatch──→ PENDING ──claimPending──→ EMITTING
+PREPARED ──markFailed(retryable=false)──→ FAILED_PERMANENT
+EMITTING ──markEmitted──→ EMITTED
+EMITTING ──markFailed(retryable=true)──→ FAILED_RETRYABLE ──claimPending──→ EMITTING
+EMITTING ──markFailed(retryable=false)──→ FAILED_PERMANENT
+EMITTING (claimExpiresAt < now) ──claimPending──→ EMITTING (attempt + 1)
+```
+
+- **Append / lookup (13):** valid PREPARED round-trips exactly; append
+  returns the stored record; missing `get`/`findByEventKey` → null; exact
+  event-key lookup; duplicate outboxId rejected; duplicate eventKey rejected
+  (and leaves no orphan second record, with the original event-key mapping
+  intact); blank outboxId/eventKey rejected; every non-PREPARED initial
+  status rejected; reason codes are exact fixed strings, never interpolated
+  (`tramai-sovereign-ops-outbox-invalid-id`,
+  `-invalid-event-key`, `-invalid-status`, `-duplicate-id`,
+  `-duplicate-event-key`, `-not-found`, `-status-mismatch`).
+- **markReadyForDispatch (5):** PREPARED → PENDING preserving every
+  non-status field; persisted PENDING; missing → `IllegalStateException` +
+  not-found; wrong current status rejected; **the supplied expectedStatus
+  itself must be PREPARED** (markReady(expectedStatus = PENDING) on a
+  PREPARED record rejects — catches the InMemory divergence).
+- **markEmitted (7):** EMITTING → EMITTED with the exact supplied
+  `emittedAt`; attempt/claim fields preserved; missing → not-found;
+  PREPARED/PENDING/EMITTED/FAILED_RETRYABLE/FAILED_PERMANENT all rejected —
+  the expected status must be EMITTING.
+- **markFailed (9):** legal matrix — PREPARED + permanent → FAILED_PERMANENT;
+  EMITTING + retryable → FAILED_RETRYABLE; EMITTING + permanent →
+  FAILED_PERMANENT, each pinning `lastErrorCode == errorCode`; everything
+  else rejected (PREPARED + retryable, PENDING + either, FAILED_RETRYABLE,
+  EMITTED, FAILED_PERMANENT).
+- **Claim / retry / lease (10):** PENDING claim → EMITTING with attempt +1,
+  claimant, claim timestamp, expiry = now + 5 minutes; FAILED_RETRYABLE
+  claim → EMITTING with new claimant and **`lastErrorCode = null`** (its own
+  dedicated case — removing that one line turns the TCK red); expired
+  EMITTING reclaim replaces claimant/attempt/expiry; the lease boundary is
+  strictly `claimExpiresAt < now` (exact equality is NOT reclaimable, one
+  second past IS); PREPARED, EMITTED, FAILED_PERMANENT and fresh EMITTING
+  are never claimable.
+- **Diagnostic listing (7):** membership only, never ordering (JDBC orders
+  by `created_at`; InMemory/File do not) — listPending → PENDING only,
+  listByStatus → exact status only, listExpiredEmitting → EMITTING with
+  expiry < now only; limits cap the result size without pinning which
+  records win; zero/negative limits → empty on all four paths; the expired
+  boundary excludes exact equality; `findByEventKey` reflects the current
+  transitioned version, not the original PREPARED snapshot.
+- **Concurrency (5 real parallel races, start barrier, 20 iterations
+  each):** duplicate outboxId — exactly one append winner; duplicate
+  eventKey — exactly one winner AND every loser's record is absent (proves
+  the InMemory event-key index rollback is real); one PENDING record, 8
+  claimers with limit 1 — exactly one claim total, attempt 1, one claimant;
+  pool claim — 8 PENDING records claimed by 8 workers, every record exactly
+  once, every persisted attemptCount 1; concurrent completion — exactly one
+  `markEmitted` winner, final EMITTED.
+
+### Decisions (deliberate, per review)
+
+- **The JDBC lifecycle guards are the authoritative semantics** (they were
+  explicitly added in PR #85's review): InMemory and File were aligned to
+  them rather than weakening JDBC.
+- **Clearing `lastErrorCode` on a fresh claim is shared contract** — a retry
+  actively claimed must not carry the previous failure forward.
+- **Non-positive diagnostic limits return `[]`** on every path (the public
+  ops layer separately validates user-facing limits as positive and bounded).
+- **Error messages are stable safe reason codes**, never interpolated IDs or
+  event keys (policy continued from #271).
+
+### Production changes the enrollment required
+
+- **`InMemorySovereignOpsAuditOutboxStore`** gained: PREPARED-only readiness
+  guard, EMITTING-only emission guard, the legal markFailed matrix, clearing
+  `lastErrorCode` on claim, `[]` for non-positive list limits, and fixed
+  (non-interpolated) duplicate/invalid-status reason codes.
+- **`FileSovereignOpsAuditOutboxStore`** gained blank outboxId/eventKey
+  validation, the EMITTING-only emission guard, the legal markFailed matrix,
+  and clearing `lastErrorCode` on claim. Its write staging was also fixed:
+  temp files are now created **outside** the scanned outbox directory, so a
+  concurrent `committedEntries()` scan never observes an in-flight write as
+  an unexpected entry (the TCK's pool-claim race exposed this).
+- **`JdbcSovereignOpsAuditOutboxStore`** normalized its duplicate errors to
+  fixed reason codes and collapsed all five mutating transaction paths onto
+  one non-suspend `inOutboxTransaction` helper with the #267 precedence:
+  operation / cancellation **>** rollback failure **>** autoCommit-restore
+  failure, later cleanup failures suppressed. Deterministic regressions
+  prove a primary `CancellationException` escapes unchanged when rollback
+  fails, and when autoCommit-restore fails. No database schema change.
+- `SovereignOpsAuditOutboxRecord` KDoc lifecycle diagram corrected to the
+  shared matrix (retryable failures re-claim directly to EMITTING; no
+  PENDING → FAILED_PERMANENT path).
+
+### Mutation evidence (all restored after each run; InMemory store)
+
+| Mutation | TCK outcome |
+|---|---|
+| duplicate outbox ID overwrites existing | RED — duplicate-id + concurrent-duplicate races |
+| duplicate eventKey accepted | RED — event-key + concurrent event-key race |
+| loser record not removed after eventKey race | RED — concurrent event-key race |
+| blank outboxId validation removed | RED — blank-id case |
+| markReady allows expected PENDING | RED — readiness lifecycle cases |
+| markEmitted accepts PREPARED | RED — emission lifecycle cases |
+| retryable markFailed accepts PREPARED | RED — failure-matrix cases |
+| permanent markFailed accepts PENDING | RED — failure-matrix case |
+| claim allows PREPARED | RED — claim-eligibility case |
+| fresh EMITTING reclaimed (expiry ignored) | RED — fresh-EMITTING + lease-boundary + list-boundary cases |
+| lease boundary becomes inclusive (`<=`) | RED — exact-boundary case |
+| attemptCount not incremented | RED — claim/reclaim cases |
+| retry claim retains lastErrorCode | RED — dedicated clear-error case |
+| listPending includes FAILED_RETRYABLE | RED — listing case |
+| non-atomic claim (CAS replaced) | RED — claim + pool-claim races |
+| claim ignores limit | RED — limit-capped case |
+
+### Scope
+
+The TCK owns SPI semantics; implementation-specific suites continue owning
+durability/restart guarantees, encryption/ciphertext, filesystem
+permissions, corruption detection, JDBC queryable-column tamper detection,
+SQL indexes/schema, `FOR UPDATE SKIP LOCKED`, file record versions, JDBC
+`maxClaimLimit`, and `isDurable()` (the SPI documents it as
+implementation-dependent). No existing tests were deleted. The
+`tramai-testing` testFixtures gained a dependency on
+`tramai-spring-boot-starter-sovereign-ops` (test-fixture-only; no Spring
+enters any production runtime module) so the shared suite can be written in
+one place.

--- a/tramai-spring-boot-starter-sovereign-ops/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-ops/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     testImplementation(libs.spring.boot.starter.test)
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation(libs.jackson.databind)
+    testImplementation(testFixtures(project(":tramai-testing")))
 }
 
 tasks.test {

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/InMemorySovereignOpsAuditOutboxStore.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/InMemorySovereignOpsAuditOutboxStore.kt
@@ -20,14 +20,14 @@ class InMemorySovereignOpsAuditOutboxStore : SovereignOpsAuditOutboxStore {
         require(record.outboxId.isNotBlank()) { "tramai-sovereign-ops-outbox-invalid-id" }
         require(record.eventKey.isNotBlank()) { "tramai-sovereign-ops-outbox-invalid-event-key" }
         require(record.status == SovereignOpsAuditOutboxStatus.PREPARED) {
-            "tramai-sovereign-ops-outbox-invalid-status: only PREPARED records can be appended"
+            "tramai-sovereign-ops-outbox-invalid-status"
         }
         val existing = store.putIfAbsent(record.outboxId, record)
-        require(existing == null) { "tramai-sovereign-ops-outbox-duplicate-id: ${record.outboxId}" }
+        require(existing == null) { "tramai-sovereign-ops-outbox-duplicate-id" }
         val previousKey = eventKeyIndex.putIfAbsent(record.eventKey, record.outboxId)
         if (previousKey != null) {
             store.remove(record.outboxId)
-            require(false) { "tramai-sovereign-ops-outbox-duplicate-event-key: ${record.eventKey}" }
+            require(false) { "tramai-sovereign-ops-outbox-duplicate-event-key" }
         }
         return record
     }
@@ -38,6 +38,9 @@ class InMemorySovereignOpsAuditOutboxStore : SovereignOpsAuditOutboxStore {
     ): SovereignOpsAuditOutboxRecord {
         val record = store[outboxId]
             ?: throw IllegalStateException(ERROR_OUTBOX_NOT_FOUND)
+        require(expectedStatus == SovereignOpsAuditOutboxStatus.PREPARED) {
+            ERROR_OUTBOX_STATUS_MISMATCH
+        }
         require(record.status == expectedStatus) {
             ERROR_OUTBOX_STATUS_MISMATCH
         }
@@ -88,6 +91,7 @@ class InMemorySovereignOpsAuditOutboxStore : SovereignOpsAuditOutboxStore {
             claimedBy = claimedBy,
             claimedAt = now,
             claimExpiresAt = now.plus(SovereignOpsAuditOutboxRecord.DEFAULT_CLAIM_EXPIRY),
+            lastErrorCode = null,
         )
 
     override suspend fun markEmitted(
@@ -97,6 +101,9 @@ class InMemorySovereignOpsAuditOutboxStore : SovereignOpsAuditOutboxStore {
     ): SovereignOpsAuditOutboxRecord {
         val record = store[outboxId]
             ?: throw IllegalStateException(ERROR_OUTBOX_NOT_FOUND)
+        require(expectedStatus == SovereignOpsAuditOutboxStatus.EMITTING) {
+            ERROR_OUTBOX_STATUS_MISMATCH
+        }
         require(record.status == expectedStatus) {
             ERROR_OUTBOX_STATUS_MISMATCH
         }
@@ -118,6 +125,18 @@ class InMemorySovereignOpsAuditOutboxStore : SovereignOpsAuditOutboxStore {
     ): SovereignOpsAuditOutboxRecord {
         val record = store[outboxId]
             ?: throw IllegalStateException(ERROR_OUTBOX_NOT_FOUND)
+        if (retryable) {
+            require(expectedStatus == SovereignOpsAuditOutboxStatus.EMITTING) {
+                ERROR_OUTBOX_STATUS_MISMATCH
+            }
+        } else {
+            require(
+                expectedStatus == SovereignOpsAuditOutboxStatus.EMITTING ||
+                    expectedStatus == SovereignOpsAuditOutboxStatus.PREPARED
+            ) {
+                ERROR_OUTBOX_STATUS_MISMATCH
+            }
+        }
         require(record.status == expectedStatus) {
             ERROR_OUTBOX_STATUS_MISMATCH
         }
@@ -141,27 +160,33 @@ class InMemorySovereignOpsAuditOutboxStore : SovereignOpsAuditOutboxStore {
         return store[id]
     }
 
-    override suspend fun listPending(limit: Int): List<SovereignOpsAuditOutboxRecord> =
-        store.values
+    override suspend fun listPending(limit: Int): List<SovereignOpsAuditOutboxRecord> {
+        if (limit <= 0) return emptyList()
+        return store.values
             .filter { it.status == SovereignOpsAuditOutboxStatus.PENDING }
             .take(limit)
+    }
 
     override suspend fun listByStatus(
         status: SovereignOpsAuditOutboxStatus,
         limit: Int,
-    ): List<SovereignOpsAuditOutboxRecord> =
-        store.values
+    ): List<SovereignOpsAuditOutboxRecord> {
+        if (limit <= 0) return emptyList()
+        return store.values
             .filter { it.status == status }
             .take(limit)
+    }
 
     override suspend fun listExpiredEmitting(
         now: Instant,
         limit: Int,
-    ): List<SovereignOpsAuditOutboxRecord> =
-        store.values
+    ): List<SovereignOpsAuditOutboxRecord> {
+        if (limit <= 0) return emptyList()
+        return store.values
             .filter { it.status == SovereignOpsAuditOutboxStatus.EMITTING }
             .filter { it.claimExpiresAt != null && it.claimExpiresAt.isBefore(now) }
             .take(limit)
+    }
 }
 
 /** @see InMemorySovereignOpsAuditOutboxStore */

--- a/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxRecord.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxRecord.kt
@@ -16,10 +16,11 @@ import java.util.UUID
  * ```
  * PREPARED (appended, transition pending)
  *   ├──→ PENDING (transition succeeded, dispatchable)
- *   │      ├──→ EMITTING (claimed)
- *   │      │      ├──→ EMITTED (success)
- *   │      │      └──→ FAILED_RETRYABLE → PENDING (re-claim)
- *   │      └──→ FAILED_PERMANENT (terminal)
+ *   │      └──→ EMITTING (claimed)
+ *   │             ├──→ EMITTED (success)
+ *   │             ├──→ FAILED_RETRYABLE → EMITTING (re-claim, attempt + 1)
+ *   │             ├──→ FAILED_PERMANENT (terminal)
+ *   │             └──→ EMITTING (expired claim re-claimed, attempt + 1)
  *   └──→ FAILED_PERMANENT (transition failed, orphaned intent)
  * ```
  *

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsOutboxWorkerAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/SovereignOpsOutboxWorkerAutoConfigurationTest.kt
@@ -321,7 +321,7 @@ class SovereignOpsOutboxWorkerAutoConfigurationTest {
     // ── Worker lease support ──────────────────────────────────────────
 
     @Test
-    fun `lease disabled — normal worker`() {
+    fun `lease disabled - normal worker`() {
         contextRunner
             .withUserConfiguration(
                 MinimalStoreConfig::class.java,
@@ -339,7 +339,7 @@ class SovereignOpsOutboxWorkerAutoConfigurationTest {
     }
 
     @Test
-    fun `lease enabled + store exists — leased worker`() {
+    fun `lease enabled + store exists - leased worker`() {
         contextRunner
             .withUserConfiguration(
                 MinimalStoreConfig::class.java,
@@ -357,7 +357,7 @@ class SovereignOpsOutboxWorkerAutoConfigurationTest {
     }
 
     @Test
-    fun `lease enabled + no store — fail loudly`() {
+    fun `lease enabled + no store - fail loudly`() {
         contextRunner
             .withUserConfiguration(
                 MinimalStoreConfig::class.java,

--- a/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/InMemorySovereignOpsAuditOutboxStoreTckTest.kt
+++ b/tramai-spring-boot-starter-sovereign-ops/src/test/kotlin/dev/tramai/spring/sovereign/ops/outbox/InMemorySovereignOpsAuditOutboxStoreTckTest.kt
@@ -1,0 +1,14 @@
+package dev.tramai.spring.sovereign.ops.outbox
+
+import dev.tramai.testing.persistence.outbox.SovereignOpsAuditOutboxStoreTck
+
+/**
+ * Epic 8.1e: InMemorySovereignOpsAuditOutboxStore — the sovereign-ops
+ * module's default store — must satisfy the shared outbox compatibility
+ * contract (tramai-testing testFixtures). A fresh store per case gives full
+ * isolation; the store itself is the mutation target for the family.
+ */
+class InMemorySovereignOpsAuditOutboxStoreTckTest : SovereignOpsAuditOutboxStoreTck() {
+
+    override fun createStore(): SovereignOpsAuditOutboxStore = InMemorySovereignOpsAuditOutboxStore()
+}

--- a/tramai-spring-boot-starter-sovereign-persistence-file/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     testImplementation(libs.kotlin.test.junit5)
     testImplementation(libs.spring.boot.starter.test)
     testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation(testFixtures(project(":tramai-testing")))
 }
 
 tasks.test {

--- a/tramai-spring-boot-starter-sovereign-persistence-file/src/main/kotlin/dev/tramai/spring/sovereign/persistence/file/FileSovereignOpsAuditOutboxStore.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/src/main/kotlin/dev/tramai/spring/sovereign/persistence/file/FileSovereignOpsAuditOutboxStore.kt
@@ -206,6 +206,8 @@ class FileSovereignOpsAuditOutboxStore internal constructor(
         record: SovereignOpsAuditOutboxRecord,
     ): SovereignOpsAuditOutboxRecord = lease.withOpenOperation {
         validateManagedDirectory(outboxDir, STORAGE_NAME)
+        require(record.outboxId.isNotBlank()) { "tramai-sovereign-ops-outbox-invalid-id" }
+        require(record.eventKey.isNotBlank()) { "tramai-sovereign-ops-outbox-invalid-event-key" }
         require(record.status == SovereignOpsAuditOutboxStatus.PREPARED) {
             "tramai-sovereign-ops-outbox-invalid-status"
         }
@@ -265,6 +267,7 @@ class FileSovereignOpsAuditOutboxStore internal constructor(
                     claimedBy = claimedBy,
                     claimedAt = now,
                     claimExpiresAt = now.plus(claimLeaseDuration),
+                    lastErrorCode = null,
                 )
                 writeCurrent(record.outboxId, updated.toPersistedV1(nextVersion(dto)))
                 claimed += updated
@@ -280,6 +283,9 @@ class FileSovereignOpsAuditOutboxStore internal constructor(
         expectedStatus: SovereignOpsAuditOutboxStatus,
         emittedAt: Instant,
     ): SovereignOpsAuditOutboxRecord = mutate(outboxId) { dto ->
+        require(expectedStatus == SovereignOpsAuditOutboxStatus.EMITTING) {
+            ERROR_OUTBOX_STATUS_MISMATCH
+        }
         require(dto.status == expectedStatus.name) {
             ERROR_OUTBOX_STATUS_MISMATCH
         }
@@ -295,6 +301,18 @@ class FileSovereignOpsAuditOutboxStore internal constructor(
         errorCode: String,
         retryable: Boolean,
     ): SovereignOpsAuditOutboxRecord = mutate(outboxId) { dto ->
+        if (retryable) {
+            require(expectedStatus == SovereignOpsAuditOutboxStatus.EMITTING) {
+                ERROR_OUTBOX_STATUS_MISMATCH
+            }
+        } else {
+            require(
+                expectedStatus == SovereignOpsAuditOutboxStatus.EMITTING ||
+                    expectedStatus == SovereignOpsAuditOutboxStatus.PREPARED
+            ) {
+                ERROR_OUTBOX_STATUS_MISMATCH
+            }
+        }
         require(dto.status == expectedStatus.name) {
             ERROR_OUTBOX_STATUS_MISMATCH
         }
@@ -641,8 +659,14 @@ private fun boundedReadText(path: Path): String {
     return Files.readString(path)
 }
 
-private fun tempSibling(target: Path): Path =
-    target.resolveSibling(".${target.fileName}.tmp.${RANDOM.nextInt(Int.MAX_VALUE)}")
+private fun tempSibling(target: Path): Path {
+    // Stage the temp file OUTSIDE the scanned outbox directory (in the root
+    // directory above it), so a concurrent committedEntries() directory scan
+    // never observes an in-flight write as an unexpected entry. The atomic
+    // move back into the outbox directory stays on the same filesystem.
+    val stagingDir = target.parent?.parent ?: target.parent
+    return stagingDir.resolve(".${target.fileName}.tmp.${RANDOM.nextInt(Int.MAX_VALUE)}")
+}
 
 private fun writeFileWith0600(path: Path, bytes: ByteArray, createNew: Boolean) {
     val options = if (createNew) {

--- a/tramai-spring-boot-starter-sovereign-persistence-file/src/test/kotlin/dev/tramai/spring/sovereign/persistence/file/FileSovereignOpsAuditOutboxStoreTckTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/src/test/kotlin/dev/tramai/spring/sovereign/persistence/file/FileSovereignOpsAuditOutboxStoreTckTest.kt
@@ -1,0 +1,42 @@
+package dev.tramai.spring.sovereign.persistence.file
+
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
+import dev.tramai.testing.persistence.outbox.SovereignOpsAuditOutboxStoreTck
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicLong
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.TestInstance
+import kotlin.io.path.exists
+
+/**
+ * Epic 8.1e: FileSovereignOpsAuditOutboxStore must satisfy the shared outbox
+ * compatibility contract (tramai-testing testFixtures). The runner owns the
+ * encryption key and per-case isolation — storage technology (durability,
+ * encryption format, permissions, corruption detection, record versions)
+ * never contaminates the contract.
+ *
+ * Each [createStore] call gets a fresh `case-N` root directory; the store
+ * provisions its own `outbox/` layout.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FileSovereignOpsAuditOutboxStoreTckTest : SovereignOpsAuditOutboxStoreTck() {
+
+    private val rootDir: Path = Files.createTempDirectory("tramai-outbox-tck-").toAbsolutePath()
+    private val testKey: SecretKey = KeyGenerator.getInstance("AES").apply { init(256) }.generateKey()
+    private val caseCounter = AtomicLong(0)
+
+    override fun createStore(): SovereignOpsAuditOutboxStore {
+        val caseDir = Files.createDirectories(rootDir.resolve("case-${caseCounter.incrementAndGet()}"))
+        return FileSovereignOpsAuditOutboxStore(root = caseDir, key = testKey)
+    }
+
+    @AfterAll
+    fun cleanup() {
+        if (rootDir.exists()) {
+            rootDir.toFile().deleteRecursively()
+        }
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.junit.platform:junit-platform-launcher")
     testImplementation(libs.spring.boot.starter.test)
+    testImplementation(testFixtures(project(":tramai-testing")))
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.testcontainers.junit.jupiter)
     testImplementation(libs.postgresql)

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsAuditOutboxStore.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsAuditOutboxStore.kt
@@ -87,16 +87,16 @@ class JdbcSovereignOpsAuditOutboxStore(
         }
 
         return dataSource.connection.use { conn ->
-            inOutboxTransaction(conn) { c ->
-                val payloadJson = mapper.writeValueAsBytes(record.toPersistedOutbox())
-                val encrypted = payloadCodec.encode(payloadJson)
+            try {
+                inOutboxTransaction(conn) { c ->
+                    val payloadJson = mapper.writeValueAsBytes(record.toPersistedOutbox())
+                    val encrypted = payloadCodec.encode(payloadJson)
 
-                try {
                     insertAppend(c, record, encrypted)
-                } catch (e: SQLException) {
-                    throw mapAppendException(e)
+                    record
                 }
-                record
+            } catch (e: SQLException) {
+                throw mapAppendException(e)
             }
         }
     }

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsAuditOutboxStore.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/main/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsAuditOutboxStore.kt
@@ -83,27 +83,20 @@ class JdbcSovereignOpsAuditOutboxStore(
         require(record.outboxId.isNotBlank()) { "tramai-sovereign-ops-outbox-invalid-id" }
         require(record.eventKey.isNotBlank()) { "tramai-sovereign-ops-outbox-invalid-event-key" }
         require(record.status == SovereignOpsAuditOutboxStatus.PREPARED) {
-            "tramai-sovereign-ops-outbox-invalid-status: only PREPARED records can be appended"
+            "tramai-sovereign-ops-outbox-invalid-status"
         }
 
         return dataSource.connection.use { conn ->
-            val previousAutoCommit = conn.autoCommit
-            conn.autoCommit = false
-            try {
+            inOutboxTransaction(conn) { c ->
                 val payloadJson = mapper.writeValueAsBytes(record.toPersistedOutbox())
                 val encrypted = payloadCodec.encode(payloadJson)
 
-                insertAppend(conn, record, encrypted)
-                conn.commit()
+                try {
+                    insertAppend(c, record, encrypted)
+                } catch (e: SQLException) {
+                    throw mapAppendException(e)
+                }
                 record
-            } catch (e: SQLException) {
-                conn.rollback()
-                throw mapAppendException(e, record)
-            } catch (e: Exception) {
-                conn.rollback()
-                throw e
-            } finally {
-                conn.autoCommit = previousAutoCommit
             }
         }
     }
@@ -112,10 +105,8 @@ class JdbcSovereignOpsAuditOutboxStore(
         outboxId: String,
         expectedStatus: SovereignOpsAuditOutboxStatus,
     ): SovereignOpsAuditOutboxRecord = dataSource.connection.use { conn ->
-        val previousAutoCommit = conn.autoCommit
-        conn.autoCommit = false
-        try {
-            val row = selectForUpdate(conn, outboxId)
+        inOutboxTransaction(conn) { c ->
+            val row = selectForUpdate(c, outboxId)
                 ?: throw IllegalStateException("tramai-sovereign-ops-outbox-not-found")
 
             val domain = row.toDomain()
@@ -132,14 +123,8 @@ class JdbcSovereignOpsAuditOutboxStore(
             val payloadJson = mapper.writeValueAsBytes(updated.toPersistedOutbox())
             val encrypted = payloadCodec.encode(payloadJson)
 
-            updateStatusAndPayload(conn, outboxId, row.version, updated.status.name, encrypted)
-            conn.commit()
+            updateStatusAndPayload(c, outboxId, row.version, updated.status.name, encrypted)
             updated
-        } catch (e: Exception) {
-            conn.rollback()
-            throw e
-        } finally {
-            conn.autoCommit = previousAutoCommit
         }
     }
 
@@ -152,11 +137,9 @@ class JdbcSovereignOpsAuditOutboxStore(
         val actualLimit = minOf(limit, maxClaimLimit)
 
         return dataSource.connection.use { conn ->
-            val previousAutoCommit = conn.autoCommit
-            conn.autoCommit = false
-            try {
+            inOutboxTransaction(conn) { c ->
                 val claimExpiresAt = now.plus(claimLeaseDuration)
-                val selected = selectClaimableForUpdateSkipLocked(conn, actualLimit, now)
+                val selected = selectClaimableForUpdateSkipLocked(c, actualLimit, now)
 
                 val claimed = selected.map { row ->
                     val record = row.toDomain()
@@ -175,16 +158,10 @@ class JdbcSovereignOpsAuditOutboxStore(
                     val payloadJson = mapper.writeValueAsBytes(updated.toPersistedOutbox())
                     val encrypted = payloadCodec.encode(payloadJson)
 
-                    updateClaimed(conn, updated.outboxId, encrypted, now, claimExpiresAt)
+                    updateClaimed(c, updated.outboxId, encrypted, now, claimExpiresAt)
                     updated
                 }
-                conn.commit()
                 claimed
-            } catch (e: Exception) {
-                conn.rollback()
-                throw e
-            } finally {
-                conn.autoCommit = previousAutoCommit
             }
         }
     }
@@ -194,9 +171,7 @@ class JdbcSovereignOpsAuditOutboxStore(
         expectedStatus: SovereignOpsAuditOutboxStatus,
         emittedAt: Instant,
     ): SovereignOpsAuditOutboxRecord = dataSource.connection.use { conn ->
-        val previousAutoCommit = conn.autoCommit
-        conn.autoCommit = false
-        try {
+        inOutboxTransaction(conn) { conn ->
             val row = selectForUpdate(conn, outboxId)
                 ?: throw IllegalStateException("tramai-sovereign-ops-outbox-not-found")
 
@@ -242,13 +217,7 @@ class JdbcSovereignOpsAuditOutboxStore(
                 val updatedCount = stmt.executeUpdate()
                 require(updatedCount == 1) { "tramai-sovereign-ops-outbox-concurrent-update" }
             }
-            conn.commit()
             updated
-        } catch (e: Exception) {
-            conn.rollback()
-            throw e
-        } finally {
-            conn.autoCommit = previousAutoCommit
         }
     }
 
@@ -258,9 +227,7 @@ class JdbcSovereignOpsAuditOutboxStore(
         errorCode: String,
         retryable: Boolean,
     ): SovereignOpsAuditOutboxRecord = dataSource.connection.use { conn ->
-        val previousAutoCommit = conn.autoCommit
-        conn.autoCommit = false
-        try {
+        inOutboxTransaction(conn) { conn ->
             val row = selectForUpdate(conn, outboxId)
                 ?: throw IllegalStateException("tramai-sovereign-ops-outbox-not-found")
 
@@ -322,13 +289,7 @@ class JdbcSovereignOpsAuditOutboxStore(
                 val updatedCount = stmt.executeUpdate()
                 require(updatedCount == 1) { "tramai-sovereign-ops-outbox-concurrent-update" }
             }
-            conn.commit()
             updated
-        } catch (e: Exception) {
-            conn.rollback()
-            throw e
-        } finally {
-            conn.autoCommit = previousAutoCommit
         }
     }
 
@@ -771,15 +732,51 @@ class JdbcSovereignOpsAuditOutboxStore(
 
     private fun mapAppendException(
         e: SQLException,
-        record: SovereignOpsAuditOutboxRecord,
     ): RuntimeException {
         val message = e.message ?: ""
         return when {
             message.contains("uq_audit_outbox_event_key") || message.contains("audit_outbox_event_key_key") ->
-                IllegalArgumentException("tramai-sovereign-ops-outbox-duplicate-event-key: ${record.eventKey}")
+                IllegalArgumentException("tramai-sovereign-ops-outbox-duplicate-event-key")
             message.contains("audit_outbox_pkey") ->
-                IllegalArgumentException("tramai-sovereign-ops-outbox-duplicate-id: ${record.outboxId}")
+                IllegalArgumentException("tramai-sovereign-ops-outbox-duplicate-id")
             else -> IllegalStateException("tramai-sovereign-ops-outbox-database-failure", e)
+        }
+    }
+
+    /**
+     * Deliberately non-suspend helper (the #267/#271 cleanup model): runs
+     * [block] in one explicit transaction. Failure precedence is primary
+     * operation / cancellation, then rollback failure, then
+     * autoCommit-restore failure — later cleanup failures are attached as
+     * suppressed to the primary, never replacing it.
+     */
+    private fun <T> inOutboxTransaction(conn: Connection, block: (Connection) -> T): T {
+        val previousAutoCommit = conn.autoCommit
+        conn.autoCommit = false
+        var primaryFailure: Exception? = null
+        try {
+            val result = block(conn)
+            conn.commit()
+            return result
+        } catch (e: Exception) {
+            primaryFailure = e
+            try {
+                conn.rollback()
+            } catch (rollbackFailure: Exception) {
+                e.addSuppressed(rollbackFailure)
+            }
+            throw e
+        } finally {
+            try {
+                conn.autoCommit = previousAutoCommit
+            } catch (restoreFailure: Exception) {
+                val primary = primaryFailure
+                if (primary != null) {
+                    primary.addSuppressed(restoreFailure)
+                } else {
+                    throw restoreFailure
+                }
+            }
         }
     }
 }

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsAuditOutboxStoreTckTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsAuditOutboxStoreTckTest.kt
@@ -1,0 +1,111 @@
+package dev.tramai.spring.sovereign.persistence.jdbc
+
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
+import dev.tramai.testing.persistence.outbox.SovereignOpsAuditOutboxStoreTck
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.sql.Connection
+import java.sql.DriverManager
+import java.time.Duration
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+import javax.sql.DataSource
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import org.postgresql.ds.PGSimpleDataSource
+import org.testcontainers.containers.PostgreSQLContainer
+
+/**
+ * Epic 8.1e: JdbcSovereignOpsAuditOutboxStore must satisfy the shared outbox
+ * compatibility contract (tramai-testing testFixtures). The runner owns the
+ * datasource, schema, and per-case isolation — storage technology (SQL
+ * indexes/schema, FOR UPDATE SKIP LOCKED, maxClaimLimit, queryable-column
+ * tamper detection, physical transactions) never contaminates the contract.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JdbcSovereignOpsAuditOutboxStoreTckTest : SovereignOpsAuditOutboxStoreTck() {
+
+    private lateinit var postgres: PostgreSQLContainer<*>
+    private lateinit var dataSource: DataSource
+    private lateinit var setupConnection: Connection
+
+    private val testAesKey = ByteArray(16).also { SecureRandom().nextBytes(it) }
+
+    private val testCodec = object : JdbcOpsAuditOutboxPayloadCodec {
+        private val algorithm = "AES/GCM/NoPadding"
+        private val tagLength = 128
+
+        override fun encode(plaintext: ByteArray): JdbcEncryptedAuditOutboxPayload {
+            val cipher = Cipher.getInstance(algorithm)
+            val nonce = ByteArray(12).also { SecureRandom().nextBytes(it) }
+            cipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(testAesKey, "AES"), GCMParameterSpec(tagLength, nonce))
+            val ciphertext = cipher.doFinal(plaintext)
+            val digest = MessageDigest.getInstance("SHA-256")
+                .digest(plaintext)
+                .joinToString("") { "%02x".format(it) }
+            return JdbcEncryptedAuditOutboxPayload(
+                ciphertext = ciphertext,
+                keyId = "tck-key-1",
+                algorithm = algorithm,
+                nonce = nonce,
+                payloadDigest = "sha256:$digest",
+            )
+        }
+
+        override fun decode(envelope: JdbcEncryptedAuditOutboxPayload): ByteArray {
+            val cipher = Cipher.getInstance(algorithm)
+            cipher.init(
+                Cipher.DECRYPT_MODE,
+                SecretKeySpec(testAesKey, "AES"),
+                GCMParameterSpec(tagLength, envelope.nonce),
+            )
+            return cipher.doFinal(envelope.ciphertext)
+        }
+    }
+
+    @BeforeAll
+    fun setUpAll() {
+        postgres = PostgreSQLContainer("postgres:17-alpine")
+            .withDatabaseName("outbox_tck")
+            .withUsername("test")
+            .withPassword("test")
+        postgres.start()
+        dataSource = PGSimpleDataSource().apply {
+            setUrl(postgres.jdbcUrl)
+            user = postgres.username
+            password = postgres.password
+        }
+        setupConnection = DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password)
+        for (migration in listOf(
+            "V1__sovereign_persistence.sql",
+            "V4__audit_outbox_hardening.sql",
+        )) {
+            val sql = this::class.java.classLoader
+                .getResource("tramai/persistence/jdbc/postgres/$migration")
+                ?.readText()
+                ?: throw IllegalStateException("Migration not found: $migration")
+            setupConnection.createStatement().use { stmt -> stmt.execute(sql) }
+        }
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        runCatching { setupConnection.close() }
+        runCatching { postgres.stop() }
+    }
+
+    override fun createStore(): SovereignOpsAuditOutboxStore {
+        // Fresh isolated storage per case: previous cases' records must not
+        // leak into the next case.
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt -> stmt.execute("TRUNCATE TABLE audit_outbox CASCADE") }
+        }
+        return JdbcSovereignOpsAuditOutboxStore(
+            dataSource = dataSource,
+            payloadCodec = testCodec,
+            claimLeaseDuration = Duration.ofMinutes(5),
+        )
+    }
+}

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsAuditOutboxStoreTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsAuditOutboxStoreTest.kt
@@ -21,10 +21,13 @@ import java.time.Duration
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
+import java.util.concurrent.CancellationException
 import javax.crypto.Cipher
 import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.SecretKeySpec
 import javax.sql.DataSource
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class JdbcSovereignOpsAuditOutboxStoreTest {
@@ -1082,5 +1085,91 @@ class JdbcSovereignOpsAuditOutboxStoreTest {
                 runCatching { stmt.execute(v4) }
             }
         }
+    }
+
+    // ── #267/#271 transaction-cleanup precedence regressions ────────
+
+    @Test
+    fun `appendNext rethrows CancellationException unchanged when rollback also fails`() {
+        runBlocking {
+            val cancellation = CancellationException("cancelled by test")
+            val rollbackFailure = java.sql.SQLException("rollback failed")
+            val failing = JdbcSovereignOpsAuditOutboxStore(
+                dataSource = dataSourceWithFailures(
+                    commitFailure = cancellation,
+                    rollbackFailure = rollbackFailure,
+                ),
+                payloadCodec = testCodec,
+            )
+
+            val thrown = runCatching {
+                failing.append(record("cancel-rollback"))
+            }.exceptionOrNull()
+
+            assertSame(cancellation, thrown)
+            assertEquals(listOf(rollbackFailure), thrown?.suppressed?.toList())
+        }
+    }
+
+    @Test
+    fun `appendNext preserves primary CancellationException when autoCommit restore fails`() {
+        runBlocking {
+            val cancellation = CancellationException("cancelled by test")
+            val restoreFailure = java.sql.SQLException("restore failed")
+            val failing = JdbcSovereignOpsAuditOutboxStore(
+                dataSource = dataSourceWithFailures(
+                    commitFailure = cancellation,
+                    restoreFailure = restoreFailure,
+                ),
+                payloadCodec = testCodec,
+            )
+
+            val thrown = runCatching {
+                failing.append(record("cancel-restore"))
+            }.exceptionOrNull()
+
+            assertSame(cancellation, thrown)
+            assertEquals(listOf(restoreFailure), thrown?.suppressed?.toList())
+        }
+    }
+
+    /**
+     * A DataSource whose connections delegate to the real database but fail
+     * deterministically: [commitFailure] is thrown from `commit()`, and, when
+     * [restoreFailure] is non-null, from the second `setAutoCommit` call (the
+     * finally-block restoration). Each `getConnection` captures ONE delegate,
+     * so the production code sees a single JDBC transaction rather than a
+     * fresh connection per method call. Same shape as the #267/#271
+     * failure-injection helpers.
+     */
+    private fun dataSourceWithFailures(
+        commitFailure: Exception = CancellationException("cancelled by test"),
+        rollbackFailure: Exception? = null,
+        restoreFailure: Exception? = null,
+    ): DataSource {
+        val real = dataSource
+        return java.lang.reflect.Proxy.newProxyInstance(
+            DataSource::class.java.classLoader,
+            arrayOf(DataSource::class.java),
+        ) { _, method, args ->
+            if (method.name == "getConnection" && args.isNullOrEmpty()) {
+                val delegate = real.connection
+                var autoCommitCalls = 0
+                java.lang.reflect.Proxy.newProxyInstance(
+                    java.sql.Connection::class.java.classLoader,
+                    arrayOf(java.sql.Connection::class.java),
+                ) { _, connMethod, connArgs ->
+                    if (connMethod.name == "commit") throw commitFailure
+                    if (connMethod.name == "rollback" && rollbackFailure != null) throw rollbackFailure
+                    if (connMethod.name == "setAutoCommit") {
+                        autoCommitCalls++
+                        if (restoreFailure != null && autoCommitCalls > 1) throw restoreFailure
+                    }
+                    connMethod.invoke(delegate, *(connArgs ?: emptyArray()))
+                }
+            } else {
+                method.invoke(real, *(args ?: emptyArray()))
+            }
+        } as DataSource
     }
 }

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsAuditOutboxStoreTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/JdbcSovereignOpsAuditOutboxStoreTest.kt
@@ -1090,7 +1090,28 @@ class JdbcSovereignOpsAuditOutboxStoreTest {
     // ── #267/#271 transaction-cleanup precedence regressions ────────
 
     @Test
-    fun `appendNext rethrows CancellationException unchanged when rollback also fails`() {
+    fun `append maps commit SQLException to the fixed database-failure code`() {
+        runBlocking {
+            val commitFailure = java.sql.SQLException("secret database diagnostic")
+            val failing = JdbcSovereignOpsAuditOutboxStore(
+                dataSource = dataSourceWithFailures(
+                    commitFailure = commitFailure,
+                ),
+                payloadCodec = testCodec,
+            )
+
+            val thrown = runCatching {
+                failing.append(record("cancel-commit-sql"))
+            }.exceptionOrNull()
+
+            assertThat(thrown).isInstanceOf(IllegalStateException::class.java)
+            assertThat(thrown?.message).isEqualTo("tramai-sovereign-ops-outbox-database-failure")
+            assertSame(commitFailure, thrown?.cause)
+        }
+    }
+
+    @Test
+    fun `append rethrows CancellationException unchanged when rollback also fails`() {
         runBlocking {
             val cancellation = CancellationException("cancelled by test")
             val rollbackFailure = java.sql.SQLException("rollback failed")
@@ -1112,7 +1133,7 @@ class JdbcSovereignOpsAuditOutboxStoreTest {
     }
 
     @Test
-    fun `appendNext preserves primary CancellationException when autoCommit restore fails`() {
+    fun `append preserves primary CancellationException when autoCommit restore fails`() {
         runBlocking {
             val cancellation = CancellationException("cancelled by test")
             val restoreFailure = java.sql.SQLException("restore failed")

--- a/tramai-testing/build.gradle.kts
+++ b/tramai-testing/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     testFixturesApi(project(":tramai-core"))
     testFixturesApi(project(":tramai-engine"))
     testFixturesApi(project(":tramai-security"))
+    testFixturesApi(project(":tramai-spring-boot-starter-sovereign-ops"))
     testFixturesApi(libs.assertj.core)
     testFixturesApi(libs.coroutines.core)
     testFixturesApi(libs.coroutines.test)

--- a/tramai-testing/src/test/kotlin/dev/tramai/testing/SovereignOpsAuditOutboxStoreTckEnrollmentArchitectureTest.kt
+++ b/tramai-testing/src/test/kotlin/dev/tramai/testing/SovereignOpsAuditOutboxStoreTckEnrollmentArchitectureTest.kt
@@ -1,0 +1,113 @@
+package dev.tramai.testing
+
+import java.io.File
+import java.nio.file.Files
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Epic 8.1e architecture guard: every concrete
+ * [dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore]
+ * implementation must be enrolled in the shared outbox compatibility
+ * contract (tramai-testing testFixtures).
+ *
+ * Same two properties as the earlier guards (#267/#269/#270/#271): the three
+ * roadmap runners are pinned by name, and every concrete implementation in
+ * any module's main source set must ship a `<Store>TckTest` runner in the
+ * same module that actually extends
+ * [dev.tramai.testing.persistence.outbox.SovereignOpsAuditOutboxStoreTck].
+ */
+class SovereignOpsAuditOutboxStoreTckEnrollmentArchitectureTest {
+
+    private val scanner = StoreEnrollmentScanner("SovereignOpsAuditOutboxStore", "SovereignOpsAuditOutboxStoreTck")
+
+    private val repoRoot: File =
+        generateSequence(File(".").absoluteFile) { it.parentFile }
+            .first { it.resolve("settings.gradle.kts").isFile }
+
+    private val expectedRunners = setOf(
+        "InMemorySovereignOpsAuditOutboxStoreTckTest",
+        "FileSovereignOpsAuditOutboxStoreTckTest",
+        "JdbcSovereignOpsAuditOutboxStoreTckTest",
+    )
+
+    @Test
+    fun `every roadmap SovereignOpsAuditOutboxStore ships a TCK runner`() {
+        val missing = expectedRunners.filter { runnerName -> scanner.findRunnerFile(repoRoot, runnerName) == null }
+        assertThat(missing)
+            .withFailMessage(
+                "Pinned SovereignOpsAuditOutboxStore TCK runners missing. The compatibility contract is " +
+                    "reviewed per runner; deleting a runner silently removes a store from the contract: $missing",
+            )
+            .isEmpty()
+    }
+
+    @Test
+    fun `every SovereignOpsAuditOutboxStore implementation has a valid TCK runner in its module`() {
+        val unenrolled = scanner.storeModules(repoRoot).flatMap { (module, implementations) ->
+            implementations
+                .filter { storeName -> !scanner.hasValidRunner(repoRoot, module, storeName) }
+                .map { store -> "$module/$store" }
+        }
+        assertThat(unenrolled)
+            .withFailMessage(
+                "SovereignOpsAuditOutboxStore implementations without a <Store>TckTest runner extending " +
+                    "SovereignOpsAuditOutboxStoreTck in the same module: $unenrolled. " +
+                    "Adding a SovereignOpsAuditOutboxStore without enrolling it in the compatibility " +
+                    "contract must make a gate fail.",
+            )
+            .isEmpty()
+    }
+
+    // ── probe tests for the scanner against this family ─────────────
+
+    @Test
+    fun `body-less SovereignOpsAuditOutboxStore implementation is detected`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
+            class RedisAuditOutboxStore(private val delegate: SovereignOpsAuditOutboxStore) :
+                SovereignOpsAuditOutboxStore by delegate
+            """.trimIndent(),
+        )
+        assertThat(scanner.implementationsIn(file)).containsExactly("RedisAuditOutboxStore")
+    }
+
+    @Test
+    fun `runner file must actually subclass SovereignOpsAuditOutboxStoreTck`() {
+        val fake = tempSourceFile("class RedisAuditOutboxStoreTckTest")
+        val real = tempSourceFile("class RedisAuditOutboxStoreTckTest : SovereignOpsAuditOutboxStoreTck() { }")
+        assertThat(scanner.runnerSubclassesTck(fake, "RedisAuditOutboxStore")).isFalse()
+        assertThat(scanner.runnerSubclassesTck(real, "RedisAuditOutboxStore")).isTrue()
+    }
+
+    @Test
+    fun `exception class whose name contains the interface does not count as an implementation`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            class SovereignOpsAuditOutboxStoreException(val code: String) : RuntimeException()
+            """.trimIndent(),
+        )
+        assertThat(scanner.implementationsIn(file)).isEmpty()
+    }
+
+    @Test
+    fun `constructor parameter never counts as an implementation`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
+            class Holder(val store: SovereignOpsAuditOutboxStore)
+            """.trimIndent(),
+        )
+        assertThat(scanner.implementationsIn(file)).isEmpty()
+    }
+
+    private fun tempSourceFile(content: String): File =
+        Files.createTempFile("enrollment-probe-", ".kt").toFile().apply {
+            writeText(content)
+            deleteOnExit()
+        }
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/outbox/SovereignOpsAuditOutboxFixtures.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/outbox/SovereignOpsAuditOutboxFixtures.kt
@@ -1,0 +1,55 @@
+package dev.tramai.testing.persistence.outbox
+
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxRecord
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStatus
+import java.time.Instant
+
+/**
+ * Epic 8.1e: fixtures for the shared
+ * [dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore]
+ * compatibility contract.
+ *
+ * Deterministic only — never the domain defaults (`UUID.randomUUID()` /
+ * `Instant.now()`): fixed base time, explicit IDs, explicit event keys, a
+ * fixed five-minute claim lease. No sleeps, no system clock.
+ */
+object SovereignOpsAuditOutboxFixtures {
+
+    val T0: Instant = Instant.parse("2026-06-21T12:00:00Z")
+
+    val CLAIM_EXPIRY: java.time.Duration = SovereignOpsAuditOutboxRecord.DEFAULT_CLAIM_EXPIRY
+
+    fun record(
+        outboxId: String,
+        eventKey: String = "event-$outboxId",
+        status: SovereignOpsAuditOutboxStatus = SovereignOpsAuditOutboxStatus.PREPARED,
+        createdAt: Instant = T0,
+        attemptCount: Int = 0,
+        lastErrorCode: String? = null,
+        claimedBy: String? = null,
+        claimedAt: Instant? = null,
+        claimExpiresAt: Instant? = null,
+        emittedAt: Instant? = null,
+    ): SovereignOpsAuditOutboxRecord = SovereignOpsAuditOutboxRecord(
+        outboxId = outboxId,
+        aggregateType = "approval",
+        aggregateIdDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        operation = "denyApproval",
+        eventKey = eventKey,
+        actor = "operator-1",
+        workflowRunId = "workflow-$outboxId",
+        correlationId = "correlation-$outboxId",
+        approvalStatus = "DENIED",
+        approvalVersion = 7L,
+        reasonDigest = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        reasonLength = 42,
+        createdAt = createdAt,
+        status = status,
+        attemptCount = attemptCount,
+        lastErrorCode = lastErrorCode,
+        claimedBy = claimedBy,
+        claimedAt = claimedAt,
+        claimExpiresAt = claimExpiresAt,
+        emittedAt = emittedAt,
+    )
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/outbox/SovereignOpsAuditOutboxStoreTck.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/outbox/SovereignOpsAuditOutboxStoreTck.kt
@@ -1,0 +1,753 @@
+package dev.tramai.testing.persistence.outbox
+
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxRecord
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStatus
+import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
+import java.time.Instant
+import java.util.concurrent.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Epic 8.1e: the shared, cross-implementation
+ * [SovereignOpsAuditOutboxStore] compatibility contract. Every concrete
+ * store — in-memory, encrypted file, and JDBC — must expose the same
+ * delivery state machine, claiming/retry/lease semantics, failure matrix,
+ * lookup, listing, and concurrency contract regardless of storage
+ * technology.
+ *
+ * The intended lifecycle (the JDBC guards from PR #85's review are the
+ * authoritative semantics):
+ * ```
+ * PREPARED ──markReadyForDispatch──→ PENDING ──claimPending──→ EMITTING
+ * PREPARED ──markFailed(false)──→ FAILED_PERMANENT
+ * EMITTING ──markEmitted──→ EMITTED
+ * EMITTING ──markFailed(true)──→ FAILED_RETRYABLE ──claimPending──→ EMITTING
+ * EMITTING ──markFailed(false)──→ FAILED_PERMANENT
+ * EMITTING (expired claim) ──claimPending──→ EMITTING (attempt + 1)
+ * ```
+ *
+ * Out of scope (implementation-specific): durability/restart guarantees,
+ * encryption, permissions, corruption, SQL indexes/schema, FOR UPDATE SKIP
+ * LOCKED, file record versions, JDBC maxClaimLimit, and `isDurable()` (the
+ * SPI documents it as implementation-dependent).
+ */
+abstract class SovereignOpsAuditOutboxStoreTck {
+
+    /** Fresh isolated storage per case; the runner owns setup/teardown. */
+    protected abstract fun createStore(): SovereignOpsAuditOutboxStore
+
+    private val t0: Instant = SovereignOpsAuditOutboxFixtures.T0
+
+    private fun record(
+        outboxId: String,
+        eventKey: String = "event-$outboxId",
+        status: SovereignOpsAuditOutboxStatus = SovereignOpsAuditOutboxStatus.PREPARED,
+        attemptCount: Int = 0,
+        lastErrorCode: String? = null,
+        claimedBy: String? = null,
+        claimedAt: Instant? = null,
+        claimExpiresAt: Instant? = null,
+        emittedAt: Instant? = null,
+    ): SovereignOpsAuditOutboxRecord = SovereignOpsAuditOutboxFixtures.record(
+        outboxId = outboxId,
+        eventKey = eventKey,
+        status = status,
+        createdAt = t0,
+        attemptCount = attemptCount,
+        lastErrorCode = lastErrorCode,
+        claimedBy = claimedBy,
+        claimedAt = claimedAt,
+        claimExpiresAt = claimExpiresAt,
+        emittedAt = emittedAt,
+    )
+
+    // ── A. Append / creation / lookup ────────────────────────────────
+
+    @Test
+    fun `valid PREPARED record round-trips exactly`() = runBlocking<Unit> {
+        val store = createStore()
+        val rec = record("roundtrip-1")
+        val returned = store.append(rec)
+        assertThat(returned).isEqualTo(rec)
+        assertThat(store.get("roundtrip-1")).isEqualTo(rec)
+    }
+
+    @Test
+    fun `append returns the stored record`() = runBlocking<Unit> {
+        val store = createStore()
+        val rec = record("returns-1")
+        assertThat(store.append(rec)).isSameAs(rec)
+    }
+
+    @Test
+    fun `get on missing outboxId returns null`() = runBlocking<Unit> {
+        val store = createStore()
+        assertThat(store.get("no-such-id")).isNull()
+    }
+
+    @Test
+    fun `findByEventKey on missing key returns null`() = runBlocking<Unit> {
+        val store = createStore()
+        assertThat(store.findByEventKey("no-such-key")).isNull()
+    }
+
+    @Test
+    fun `findByEventKey returns the exact record`() = runBlocking<Unit> {
+        val store = createStore()
+        val rec = record("find-1", eventKey = "key-find-1")
+        store.append(rec)
+        assertThat(store.findByEventKey("key-find-1")).isEqualTo(rec)
+    }
+
+    @Test
+    fun `duplicate outboxId rejected with fixed code`() = runBlocking<Unit> {
+        val store = createStore()
+        store.append(record("dup-id"))
+        val thrown = runCatching { store.append(record("dup-id")) }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(thrown?.message).isEqualTo("tramai-sovereign-ops-outbox-duplicate-id")
+    }
+
+    @Test
+    fun `duplicate eventKey rejected with fixed code`() = runBlocking<Unit> {
+        val store = createStore()
+        store.append(record("first", eventKey = "shared-key"))
+        val thrown = runCatching { store.append(record("second", eventKey = "shared-key")) }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(thrown?.message).isEqualTo("tramai-sovereign-ops-outbox-duplicate-event-key")
+    }
+
+    @Test
+    fun `duplicate eventKey rejection leaves no orphan second record`() = runBlocking<Unit> {
+        val store = createStore()
+        store.append(record("first", eventKey = "shared-key"))
+        runCatching { store.append(record("second", eventKey = "shared-key")) }
+        assertThat(store.get("second")).isNull()
+        assertThat(store.get("first")).isNotNull()
+    }
+
+    @Test
+    fun `original event-key mapping remains intact after rejected duplicate`() = runBlocking<Unit> {
+        val store = createStore()
+        store.append(record("first", eventKey = "shared-key"))
+        runCatching { store.append(record("second", eventKey = "shared-key")) }
+        assertThat(store.findByEventKey("shared-key")?.outboxId).isEqualTo("first")
+    }
+
+    @Test
+    fun `blank outboxId rejected`() = runBlocking<Unit> {
+        val store = createStore()
+        for (blank in listOf("", "   ")) {
+            val thrown = runCatching { store.append(record(blank)) }.exceptionOrNull()
+            assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+            assertThat(thrown?.message).isEqualTo("tramai-sovereign-ops-outbox-invalid-id")
+        }
+    }
+
+    @Test
+    fun `blank eventKey rejected`() = runBlocking<Unit> {
+        val store = createStore()
+        for (blank in listOf("", "   ")) {
+            val thrown = runCatching { store.append(record("id-1", eventKey = blank)) }.exceptionOrNull()
+            assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+            assertThat(thrown?.message).isEqualTo("tramai-sovereign-ops-outbox-invalid-event-key")
+        }
+    }
+
+    @Test
+    fun `every non-PREPARED initial status rejected`() = runBlocking<Unit> {
+        val store = createStore()
+        for (status in SovereignOpsAuditOutboxStatus.entries.filter { it != SovereignOpsAuditOutboxStatus.PREPARED }) {
+            val thrown = runCatching { store.append(record("status-$status", status = status)) }.exceptionOrNull()
+            assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+            assertThat(thrown?.message).isEqualTo("tramai-sovereign-ops-outbox-invalid-status")
+        }
+    }
+
+    // ── B. markReadyForDispatch ─────────────────────────────────────
+
+    @Test
+    fun `markReady legal PREPARED to PENDING preserves non-status fields`() = runBlocking<Unit> {
+        val store = createStore()
+        store.append(record("ready-1"))
+        val updated = store.markReadyForDispatch("ready-1", SovereignOpsAuditOutboxStatus.PREPARED)
+        assertThat(updated.status).isEqualTo(SovereignOpsAuditOutboxStatus.PENDING)
+        assertThat(updated).isEqualTo(record("ready-1").copy(status = SovereignOpsAuditOutboxStatus.PENDING))
+    }
+
+    @Test
+    fun `markReady persisted state is PENDING`() = runBlocking<Unit> {
+        val store = createStore()
+        store.append(record("ready-2"))
+        store.markReadyForDispatch("ready-2", SovereignOpsAuditOutboxStatus.PREPARED)
+        assertThat(store.get("ready-2")?.status).isEqualTo(SovereignOpsAuditOutboxStatus.PENDING)
+    }
+
+    @Test
+    fun `markReady on missing record throws not-found`() = runBlocking<Unit> {
+        val store = createStore()
+        val thrown = runCatching {
+            store.markReadyForDispatch("missing", SovereignOpsAuditOutboxStatus.PREPARED)
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalStateException::class.java)
+        assertThat(thrown?.message).isEqualTo("tramai-sovereign-ops-outbox-not-found")
+    }
+
+    @Test
+    fun `markReady with wrong current status rejects`() = runBlocking<Unit> {
+        val store = createStore()
+        store.append(record("ready-3"))
+        store.markReadyForDispatch("ready-3", SovereignOpsAuditOutboxStatus.PREPARED)
+        val thrown = runCatching {
+            store.markReadyForDispatch("ready-3", SovereignOpsAuditOutboxStatus.PENDING)
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(thrown?.message).isEqualTo("tramai-sovereign-ops-outbox-status-mismatch")
+    }
+
+    @Test
+    fun `markReady requires expectedStatus to be PREPARED`() = runBlocking<Unit> {
+        val store = createStore()
+        store.append(record("ready-4"))
+        // The record IS PREPARED; supplying a non-PREPARED expected status must
+        // still reject — this catches the InMemory divergence.
+        for (expected in SovereignOpsAuditOutboxStatus.entries.filter { it != SovereignOpsAuditOutboxStatus.PREPARED }) {
+            val thrown = runCatching {
+                store.markReadyForDispatch("ready-4", expected)
+            }.exceptionOrNull()
+            assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+            assertThat(thrown?.message).isEqualTo("tramai-sovereign-ops-outbox-status-mismatch")
+        }
+        assertThat(store.get("ready-4")?.status).isEqualTo(SovereignOpsAuditOutboxStatus.PREPARED)
+    }
+
+    // ── C. markEmitted ──────────────────────────────────────────────
+
+    private suspend fun emittingRecord(store: SovereignOpsAuditOutboxStore, outboxId: String): SovereignOpsAuditOutboxRecord {
+        store.append(record(outboxId))
+        store.markReadyForDispatch(outboxId, SovereignOpsAuditOutboxStatus.PREPARED)
+        return store.claimPending("worker-1", 10, t0).single { it.outboxId == outboxId }
+    }
+
+    @Test
+    fun `markEmitted legal EMITTING to EMITTED with exact emittedAt`() = runBlocking<Unit> {
+        val store = createStore()
+        val claimed = emittingRecord(store, "emit-1")
+        val emittedAt = t0.plusSeconds(30)
+        val updated = store.markEmitted("emit-1", SovereignOpsAuditOutboxStatus.EMITTING, emittedAt)
+        assertThat(updated.status).isEqualTo(SovereignOpsAuditOutboxStatus.EMITTED)
+        assertThat(updated.emittedAt).isEqualTo(emittedAt)
+    }
+
+    @Test
+    fun `markEmitted preserves attempt and claim fields`() = runBlocking<Unit> {
+        val store = createStore()
+        val claimed = emittingRecord(store, "emit-2")
+        val updated = store.markEmitted("emit-2", SovereignOpsAuditOutboxStatus.EMITTING, t0.plusSeconds(30))
+        assertThat(updated.attemptCount).isEqualTo(claimed.attemptCount)
+        assertThat(updated.claimedBy).isEqualTo("worker-1")
+        assertThat(updated.claimedAt).isEqualTo(t0)
+        assertThat(updated.claimExpiresAt).isEqualTo(t0.plus(SovereignOpsAuditOutboxRecord.DEFAULT_CLAIM_EXPIRY))
+    }
+
+    @Test
+    fun `markEmitted on missing record throws not-found`() = runBlocking<Unit> {
+        val store = createStore()
+        val thrown = runCatching {
+            store.markEmitted("missing", SovereignOpsAuditOutboxStatus.EMITTING, t0)
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalStateException::class.java)
+        assertThat(thrown?.message).isEqualTo("tramai-sovereign-ops-outbox-not-found")
+    }
+
+    @Test
+    fun `markEmitted rejects PREPARED with expected PREPARED`() = runBlocking<Unit> {
+        val store = createStore()
+        store.append(record("emit-3"))
+        val thrown = runCatching {
+            store.markEmitted("emit-3", SovereignOpsAuditOutboxStatus.PREPARED, t0)
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(thrown?.message).isEqualTo("tramai-sovereign-ops-outbox-status-mismatch")
+    }
+
+    @Test
+    fun `markEmitted rejects PENDING with expected PENDING`() = runBlocking<Unit> {
+        val store = createStore()
+        store.append(record("emit-4"))
+        store.markReadyForDispatch("emit-4", SovereignOpsAuditOutboxStatus.PREPARED)
+        val thrown = runCatching {
+            store.markEmitted("emit-4", SovereignOpsAuditOutboxStatus.PENDING, t0)
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(thrown?.message).isEqualTo("tramai-sovereign-ops-outbox-status-mismatch")
+    }
+
+    @Test
+    fun `markEmitted rejects EMITTED with expected EMITTED`() = runBlocking<Unit> {
+        val store = createStore()
+        emittingRecord(store, "emit-5")
+        store.markEmitted("emit-5", SovereignOpsAuditOutboxStatus.EMITTING, t0)
+        val thrown = runCatching {
+            store.markEmitted("emit-5", SovereignOpsAuditOutboxStatus.EMITTED, t0)
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(thrown?.message).isEqualTo("tramai-sovereign-ops-outbox-status-mismatch")
+    }
+
+    @Test
+    fun `markEmitted rejects FAILED_RETRYABLE and FAILED_PERMANENT`() = runBlocking<Unit> {
+        val store = createStore()
+        emittingRecord(store, "emit-6")
+        store.markFailed("emit-6", SovereignOpsAuditOutboxStatus.EMITTING, "boom", retryable = true)
+        val retryThrown = runCatching {
+            store.markEmitted("emit-6", SovereignOpsAuditOutboxStatus.FAILED_RETRYABLE, t0)
+        }.exceptionOrNull()
+        assertThat(retryThrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(retryThrown?.message).isEqualTo("tramai-sovereign-ops-outbox-status-mismatch")
+
+        emittingRecord(store, "emit-7")
+        store.markFailed("emit-7", SovereignOpsAuditOutboxStatus.EMITTING, "boom", retryable = false)
+        val permThrown = runCatching {
+            store.markEmitted("emit-7", SovereignOpsAuditOutboxStatus.FAILED_PERMANENT, t0)
+        }.exceptionOrNull()
+        assertThat(permThrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(permThrown?.message).isEqualTo("tramai-sovereign-ops-outbox-status-mismatch")
+    }
+
+    // ── D. markFailed ───────────────────────────────────────────────
+
+    @Test
+    fun `markFailed PREPARED permanent is legal with lastErrorCode`() = runBlocking<Unit> {
+        val store = createStore()
+        store.append(record("fail-1"))
+        val updated = store.markFailed("fail-1", SovereignOpsAuditOutboxStatus.PREPARED, "orphaned", retryable = false)
+        assertThat(updated.status).isEqualTo(SovereignOpsAuditOutboxStatus.FAILED_PERMANENT)
+        assertThat(updated.lastErrorCode).isEqualTo("orphaned")
+    }
+
+    @Test
+    fun `markFailed EMITTING retryable is legal with lastErrorCode`() = runBlocking<Unit> {
+        val store = createStore()
+        emittingRecord(store, "fail-2")
+        val updated = store.markFailed("fail-2", SovereignOpsAuditOutboxStatus.EMITTING, "timeout", retryable = true)
+        assertThat(updated.status).isEqualTo(SovereignOpsAuditOutboxStatus.FAILED_RETRYABLE)
+        assertThat(updated.lastErrorCode).isEqualTo("timeout")
+    }
+
+    @Test
+    fun `markFailed EMITTING permanent is legal with lastErrorCode`() = runBlocking<Unit> {
+        val store = createStore()
+        emittingRecord(store, "fail-3")
+        val updated = store.markFailed("fail-3", SovereignOpsAuditOutboxStatus.EMITTING, "fatal", retryable = false)
+        assertThat(updated.status).isEqualTo(SovereignOpsAuditOutboxStatus.FAILED_PERMANENT)
+        assertThat(updated.lastErrorCode).isEqualTo("fatal")
+    }
+
+    @Test
+    fun `markFailed rejects PREPARED with retryable true`() = runBlocking<Unit> {
+        val store = createStore()
+        store.append(record("fail-4"))
+        val thrown = runCatching {
+            store.markFailed("fail-4", SovereignOpsAuditOutboxStatus.PREPARED, "x", retryable = true)
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(thrown?.message).isEqualTo("tramai-sovereign-ops-outbox-status-mismatch")
+    }
+
+    @Test
+    fun `markFailed rejects PENDING permanent`() = runBlocking<Unit> {
+        val store = createStore()
+        store.append(record("fail-5"))
+        store.markReadyForDispatch("fail-5", SovereignOpsAuditOutboxStatus.PREPARED)
+        val thrown = runCatching {
+            store.markFailed("fail-5", SovereignOpsAuditOutboxStatus.PENDING, "x", retryable = false)
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(thrown?.message).isEqualTo("tramai-sovereign-ops-outbox-status-mismatch")
+    }
+
+    @Test
+    fun `markFailed rejects PENDING retryable`() = runBlocking<Unit> {
+        val store = createStore()
+        store.append(record("fail-6"))
+        store.markReadyForDispatch("fail-6", SovereignOpsAuditOutboxStatus.PREPARED)
+        val thrown = runCatching {
+            store.markFailed("fail-6", SovereignOpsAuditOutboxStatus.PENDING, "x", retryable = true)
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(thrown?.message).isEqualTo("tramai-sovereign-ops-outbox-status-mismatch")
+    }
+
+    @Test
+    fun `markFailed rejects FAILED_RETRYABLE`() = runBlocking<Unit> {
+        val store = createStore()
+        emittingRecord(store, "fail-7")
+        store.markFailed("fail-7", SovereignOpsAuditOutboxStatus.EMITTING, "x", retryable = true)
+        val thrown = runCatching {
+            store.markFailed("fail-7", SovereignOpsAuditOutboxStatus.FAILED_RETRYABLE, "x", retryable = true)
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(thrown?.message).isEqualTo("tramai-sovereign-ops-outbox-status-mismatch")
+    }
+
+    @Test
+    fun `markFailed rejects EMITTED`() = runBlocking<Unit> {
+        val store = createStore()
+        emittingRecord(store, "fail-8")
+        store.markEmitted("fail-8", SovereignOpsAuditOutboxStatus.EMITTING, t0)
+        val thrown = runCatching {
+            store.markFailed("fail-8", SovereignOpsAuditOutboxStatus.EMITTED, "x", retryable = true)
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(thrown?.message).isEqualTo("tramai-sovereign-ops-outbox-status-mismatch")
+    }
+
+    @Test
+    fun `markFailed rejects FAILED_PERMANENT`() = runBlocking<Unit> {
+        val store = createStore()
+        store.append(record("fail-9"))
+        store.markFailed("fail-9", SovereignOpsAuditOutboxStatus.PREPARED, "x", retryable = false)
+        val thrown = runCatching {
+            store.markFailed("fail-9", SovereignOpsAuditOutboxStatus.FAILED_PERMANENT, "x", retryable = false)
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(thrown?.message).isEqualTo("tramai-sovereign-ops-outbox-status-mismatch")
+    }
+
+    // ── E. Claim / retry / lease semantics ──────────────────────────
+
+    @Test
+    fun `claim PENDING moves to EMITTING with attempt and lease`() = runBlocking<Unit> {
+        val store = createStore()
+        store.append(record("claim-1"))
+        store.markReadyForDispatch("claim-1", SovereignOpsAuditOutboxStatus.PREPARED)
+        val claimed = store.claimPending("worker-1", 10, t0)
+        assertThat(claimed).hasSize(1)
+        val c = claimed.single()
+        assertThat(c.status).isEqualTo(SovereignOpsAuditOutboxStatus.EMITTING)
+        assertThat(c.attemptCount).isEqualTo(1)
+        assertThat(c.claimedBy).isEqualTo("worker-1")
+        assertThat(c.claimedAt).isEqualTo(t0)
+        assertThat(c.claimExpiresAt).isEqualTo(t0.plus(SovereignOpsAuditOutboxRecord.DEFAULT_CLAIM_EXPIRY))
+    }
+
+    @Test
+    fun `claim FAILED_RETRYABLE moves to EMITTING with new claimant`() = runBlocking<Unit> {
+        val store = createStore()
+        emittingRecord(store, "claim-2")
+        store.markFailed("claim-2", SovereignOpsAuditOutboxStatus.EMITTING, "timeout", retryable = true)
+        val claimed = store.claimPending("worker-2", 10, t0.plusSeconds(60))
+        val c = claimed.single()
+        assertThat(c.status).isEqualTo(SovereignOpsAuditOutboxStatus.EMITTING)
+        assertThat(c.attemptCount).isEqualTo(2)
+        assertThat(c.claimedBy).isEqualTo("worker-2")
+        assertThat(c.claimedAt).isEqualTo(t0.plusSeconds(60))
+        assertThat(c.claimExpiresAt).isEqualTo(t0.plusSeconds(60).plus(SovereignOpsAuditOutboxRecord.DEFAULT_CLAIM_EXPIRY))
+    }
+
+    @Test
+    fun `retry claim clears lastErrorCode`() = runBlocking<Unit> {
+        val store = createStore()
+        emittingRecord(store, "claim-3")
+        store.markFailed("claim-3", SovereignOpsAuditOutboxStatus.EMITTING, "timeout", retryable = true)
+        assertThat(store.get("claim-3")?.lastErrorCode).isEqualTo("timeout")
+        val claimed = store.claimPending("worker-3", 10, t0.plusSeconds(60))
+        assertThat(claimed.single().lastErrorCode).isNull()
+        assertThat(store.get("claim-3")?.lastErrorCode).isNull()
+    }
+
+    @Test
+    fun `expired EMITTING reclaim replaces claimant and increments attempt`() = runBlocking<Unit> {
+        val store = createStore()
+        emittingRecord(store, "claim-4")
+        val expiry = t0.plus(SovereignOpsAuditOutboxRecord.DEFAULT_CLAIM_EXPIRY)
+        val reclaimAt = expiry.plusSeconds(1)
+        val claimed = store.claimPending("worker-2", 10, reclaimAt)
+        val c = claimed.single()
+        assertThat(c.status).isEqualTo(SovereignOpsAuditOutboxStatus.EMITTING)
+        assertThat(c.attemptCount).isEqualTo(2)
+        assertThat(c.claimedBy).isEqualTo("worker-2")
+        assertThat(c.claimedAt).isEqualTo(reclaimAt)
+        assertThat(c.claimExpiresAt).isEqualTo(reclaimAt.plus(SovereignOpsAuditOutboxRecord.DEFAULT_CLAIM_EXPIRY))
+    }
+
+    @Test
+    fun `lease boundary at exact expiry is not reclaimable`() = runBlocking<Unit> {
+        val store = createStore()
+        emittingRecord(store, "lease-1")
+        val expiry = t0.plus(SovereignOpsAuditOutboxRecord.DEFAULT_CLAIM_EXPIRY)
+        val claimed = store.claimPending("worker-2", 10, expiry)
+        assertThat(claimed).isEmpty()
+    }
+
+    @Test
+    fun `lease boundary one second past expiry is reclaimable`() = runBlocking<Unit> {
+        val store = createStore()
+        emittingRecord(store, "lease-2")
+        val expiry = t0.plus(SovereignOpsAuditOutboxRecord.DEFAULT_CLAIM_EXPIRY)
+        val claimed = store.claimPending("worker-2", 10, expiry.plusSeconds(1))
+        assertThat(claimed).hasSize(1)
+    }
+
+    @Test
+    fun `PREPARED is never claimable`() = runBlocking<Unit> {
+        val store = createStore()
+        store.append(record("never-1"))
+        assertThat(store.claimPending("worker-1", 10, t0)).isEmpty()
+    }
+
+    @Test
+    fun `EMITTED is never claimable`() = runBlocking<Unit> {
+        val store = createStore()
+        emittingRecord(store, "never-2")
+        store.markEmitted("never-2", SovereignOpsAuditOutboxStatus.EMITTING, t0)
+        assertThat(store.claimPending("worker-1", 10, t0.plusSeconds(3600))).isEmpty()
+    }
+
+    @Test
+    fun `FAILED_PERMANENT is never claimable`() = runBlocking<Unit> {
+        val store = createStore()
+        store.append(record("never-3"))
+        store.markFailed("never-3", SovereignOpsAuditOutboxStatus.PREPARED, "fatal", retryable = false)
+        assertThat(store.claimPending("worker-1", 10, t0.plusSeconds(3600))).isEmpty()
+    }
+
+    @Test
+    fun `fresh EMITTING is never claimable`() = runBlocking<Unit> {
+        val store = createStore()
+        emittingRecord(store, "never-4")
+        assertThat(store.claimPending("worker-1", 10, t0.plusSeconds(60))).isEmpty()
+    }
+
+    // ── F. Diagnostic listing ───────────────────────────────────────
+
+    @Test
+    fun `listPending returns PENDING records only`() = runBlocking<Unit> {
+        val store = createStore()
+        // A FAILED_RETRYABLE record must never appear in listPending.
+        store.append(record("list-retry"))
+        store.markReadyForDispatch("list-retry", SovereignOpsAuditOutboxStatus.PREPARED)
+        store.claimPending("worker-1", 10, t0)
+        store.markFailed("list-retry", SovereignOpsAuditOutboxStatus.EMITTING, "boom", retryable = true)
+        store.append(record("list-1"))
+        store.markReadyForDispatch("list-1", SovereignOpsAuditOutboxStatus.PREPARED)
+        store.append(record("list-2"))
+        store.append(record("list-3"))
+        store.append(record("list-4"))
+        store.markReadyForDispatch("list-4", SovereignOpsAuditOutboxStatus.PREPARED)
+        val pending = store.listPending(10)
+        assertThat(pending.map { it.outboxId }).containsExactlyInAnyOrder("list-1", "list-4")
+        assertThat(pending.all { it.status == SovereignOpsAuditOutboxStatus.PENDING }).isTrue()
+    }
+
+    @Test
+    fun `listByStatus returns the exact status only`() = runBlocking<Unit> {
+        val store = createStore()
+        store.append(record("list-5"))
+        store.markReadyForDispatch("list-5", SovereignOpsAuditOutboxStatus.PREPARED)
+        store.append(record("list-6"))
+        store.append(record("list-7"))
+        val prepared = store.listByStatus(SovereignOpsAuditOutboxStatus.PREPARED, 10)
+        assertThat(prepared.map { it.outboxId }).containsExactlyInAnyOrder("list-6", "list-7")
+        val pending = store.listByStatus(SovereignOpsAuditOutboxStatus.PENDING, 10)
+        assertThat(pending.map { it.outboxId }).containsExactly("list-5")
+        assertThat(store.listByStatus(SovereignOpsAuditOutboxStatus.EMITTING, 10)).isEmpty()
+        assertThat(store.listByStatus(SovereignOpsAuditOutboxStatus.FAILED_RETRYABLE, 10)).isEmpty()
+    }
+
+    @Test
+    fun `listExpiredEmitting returns only expired EMITTING records`() = runBlocking<Unit> {
+        val store = createStore()
+        emittingRecord(store, "list-8")
+        store.append(record("list-9"))
+        store.markReadyForDispatch("list-9", SovereignOpsAuditOutboxStatus.PREPARED)
+        val now = t0.plus(SovereignOpsAuditOutboxRecord.DEFAULT_CLAIM_EXPIRY).plusSeconds(1)
+        val expired = store.listExpiredEmitting(now, 10)
+        assertThat(expired.map { it.outboxId }).containsExactly("list-8")
+    }
+
+    @Test
+    fun `list limits cap the result size`() = runBlocking<Unit> {
+        val store = createStore()
+        repeat(5) { i ->
+            store.append(record("cap-$i"))
+            store.markReadyForDispatch("cap-$i", SovereignOpsAuditOutboxStatus.PREPARED)
+        }
+        assertThat(store.listPending(2).size).isLessThanOrEqualTo(2)
+        assertThat(store.listByStatus(SovereignOpsAuditOutboxStatus.PENDING, 3).size).isLessThanOrEqualTo(3)
+        assertThat(store.claimPending("worker-1", 4, t0).size).isLessThanOrEqualTo(4)
+        assertThat(store.listExpiredEmitting(t0.plusSeconds(3600), 1).size).isLessThanOrEqualTo(1)
+    }
+
+    @Test
+    fun `non-positive limits return empty on every diagnostic path`() = runBlocking<Unit> {
+        val store = createStore()
+        store.append(record("limit-1"))
+        store.markReadyForDispatch("limit-1", SovereignOpsAuditOutboxStatus.PREPARED)
+        for (limit in listOf(0, -1)) {
+            assertThat(store.listPending(limit)).isEmpty()
+            assertThat(store.listByStatus(SovereignOpsAuditOutboxStatus.PENDING, limit)).isEmpty()
+            assertThat(store.claimPending("worker-1", limit, t0)).isEmpty()
+            assertThat(store.listExpiredEmitting(t0, limit)).isEmpty()
+        }
+    }
+
+    @Test
+    fun `listExpiredEmitting excludes the exact expiry boundary`() = runBlocking<Unit> {
+        val store = createStore()
+        emittingRecord(store, "boundary-1")
+        val expiry = t0.plus(SovereignOpsAuditOutboxRecord.DEFAULT_CLAIM_EXPIRY)
+        assertThat(store.listExpiredEmitting(expiry, 10)).isEmpty()
+        assertThat(store.listExpiredEmitting(expiry.plusSeconds(1), 10)).hasSize(1)
+    }
+
+    // ── G. Lookup reflects transitions ──────────────────────────────
+
+    @Test
+    fun `findByEventKey reflects the current transitioned version`() = runBlocking<Unit> {
+        val store = createStore()
+        store.append(record("trans-1", eventKey = "key-trans-1"))
+        store.markReadyForDispatch("trans-1", SovereignOpsAuditOutboxStatus.PREPARED)
+        assertThat(store.findByEventKey("key-trans-1")?.status).isEqualTo(SovereignOpsAuditOutboxStatus.PENDING)
+    }
+
+    // ── H. Concurrency ──────────────────────────────────────────────
+
+    @Test
+    fun `concurrent duplicate outboxId - exactly one winner`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val store = createStore()
+            val outcomes = runInParallel(0 until 8) {
+                runCatching { store.append(record("race-id-$round")) }
+            }
+            assertThat(outcomes.count { it.isSuccess }).withFailMessage {
+                "round $round: expected exactly one append winner, got ${outcomes.count { it.isSuccess }}"
+            }.isEqualTo(1)
+            assertThat(outcomes.filter { it.isFailure }.map { it.exceptionOrNull()?.message }.toSet())
+                .containsExactly("tramai-sovereign-ops-outbox-duplicate-id")
+            assertThat(store.get("race-id-$round")).isNotNull()
+        }
+    }
+
+    @Test
+    fun `concurrent duplicate eventKey - loser records are rolled back`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val store = createStore()
+            val ids = (0 until 8).map { "race-key-$round-$it" }
+            val outcomes = runInParallel(ids) { id ->
+                runCatching { store.append(record(id, eventKey = "race-shared-key-$round")) }
+            }
+            assertThat(outcomes.count { it.isSuccess }).withFailMessage {
+                "round $round: expected exactly one event-key winner, got ${outcomes.count { it.isSuccess }}"
+            }.isEqualTo(1)
+            val winnerId = ids[outcomes.indexOfFirst { it.isSuccess }]
+            assertThat(store.findByEventKey("race-shared-key-$round")?.outboxId).isEqualTo(winnerId)
+            for (id in ids) {
+                if (id != winnerId) {
+                    assertThat(store.get(id)).withFailMessage { "round $round: loser $id still present" }.isNull()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `concurrent claims of one PENDING record - exactly one winner`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val store = createStore()
+            store.append(record("race-claim-$round"))
+            store.markReadyForDispatch("race-claim-$round", SovereignOpsAuditOutboxStatus.PREPARED)
+            val outcomes = runInParallel(0 until 8) { index ->
+                store.claimPending("worker-$index", 1, t0)
+            }
+            val claimed = outcomes.flatten()
+            assertThat(claimed).withFailMessage {
+                "round $round: expected exactly one claimed record total, got ${claimed.size}"
+            }.hasSize(1)
+            val final = store.get("race-claim-$round")!!
+            assertThat(final.status).isEqualTo(SovereignOpsAuditOutboxStatus.EMITTING)
+            assertThat(final.attemptCount).isEqualTo(1)
+            assertThat(claimed.single().claimedBy).isEqualTo(final.claimedBy)
+        }
+    }
+
+    @Test
+    fun `concurrent pool claim - every record claimed exactly once`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val store = createStore()
+            val ids = (0 until 8).map { "race-pool-$round-$it" }
+            for (id in ids) {
+                store.append(record(id))
+                store.markReadyForDispatch(id, SovereignOpsAuditOutboxStatus.PREPARED)
+            }
+            val outcomes = runInParallel(0 until 8) { index ->
+                store.claimPending("worker-$index", 10, t0)
+            }
+            val claimedIds = outcomes.flatten().map { it.outboxId }
+            assertThat(claimedIds.toSet()).withFailMessage {
+                "round $round: duplicate claim of the same record: $claimedIds"
+            }.hasSize(claimedIds.size)
+            assertThat(claimedIds.toSet()).containsExactlyInAnyOrder(*ids.toTypedArray())
+            for (id in ids) {
+                assertThat(store.get(id)?.attemptCount).isEqualTo(1)
+            }
+        }
+    }
+
+    @Test
+    fun `concurrent completion - exactly one winner, final EMITTED`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val store = createStore()
+            val id = "race-emit-$round"
+            emittingRecord(store, id)
+            val outcomes = runInParallel(0 until 2) { index ->
+                runCatching {
+                    store.markEmitted(id, SovereignOpsAuditOutboxStatus.EMITTING, t0.plusSeconds(index.toLong()))
+                }
+            }
+            assertThat(outcomes.count { it.isSuccess }).withFailMessage {
+                "round $round: expected exactly one markEmitted winner, got ${outcomes.count { it.isSuccess }}"
+            }.isEqualTo(1)
+            assertThat(store.get(id)?.status).isEqualTo(SovereignOpsAuditOutboxStatus.EMITTED)
+        }
+    }
+
+    // ── Parallel-race helper (shared pattern from #269/#270/#271) ───
+
+    /**
+     * Runs [block] for every element of [items] on real parallel workers with
+     * a start barrier, returning the outcomes in input order. The barrier
+     * gives every contender a scheduling opportunity before any of them is
+     * allowed to proceed.
+     */
+    private suspend fun <T, R> runInParallel(
+        items: List<T>,
+        block: suspend (T) -> R,
+    ): List<R> = coroutineScope {
+        val ready = Channel<Unit>(items.size)
+        val release = CompletableDeferred<Unit>()
+        val workers = items.map { item ->
+            async(Dispatchers.Default) {
+                ready.send(Unit)
+                release.await()
+                block(item)
+            }
+        }
+        repeat(items.size) { ready.receive() }
+        release.complete(Unit)
+        workers.map { it.await() }
+    }
+
+    /** Range convenience overload for the race loops. */
+    private suspend fun <R> runInParallel(
+        range: IntRange,
+        block: suspend (Int) -> R,
+    ): List<R> = runInParallel(range.toList(), block)
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/outbox/SovereignOpsAuditOutboxStoreTck.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/outbox/SovereignOpsAuditOutboxStoreTck.kt
@@ -4,7 +4,6 @@ import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxRecord
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStatus
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
 import java.time.Instant
-import java.util.concurrent.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -83,7 +82,7 @@ abstract class SovereignOpsAuditOutboxStoreTck {
     fun `append returns the stored record`() = runBlocking<Unit> {
         val store = createStore()
         val rec = record("returns-1")
-        assertThat(store.append(rec)).isSameAs(rec)
+        assertThat(store.append(rec)).isEqualTo(rec)
     }
 
     @Test


### PR DESCRIPTION
## test(persistence): add SovereignOpsAuditOutboxStore compatibility TCK — Epic 8.1e

**Status:** Epic 8.1 🚧 IN PROGRESS — Approval ✅ (#267), Approval continuation ✅ (#269), Suspended invocation ✅ (#270), Audit ✅ (#271), **Audit outbox ✅ (this PR)**; workflow checkpoint, workflow lease, memory pending.

### What this PR does

Enrolls **all three** `SovereignOpsAuditOutboxStore` implementations — the sovereign-ops module's in-memory store, the encrypted file store, and JDBC — in one shared behavioral contract. The outbox is a **delivery state machine, not generic persistence**: `SovereignOpsAuditOutboxStoreTck` (tramai-testing testFixtures, which gained a test-fixture-only dependency on `tramai-spring-boot-starter-sovereign-ops`, the SPI's home module — no Spring enters any production runtime module) runs **55 cases**:

- **Append / lookup (13):** valid PREPARED record round-trips exactly; append returns the stored record; missing `get`/`findByEventKey` → null; exact event-key lookup; duplicate outboxId rejected; duplicate eventKey rejected **and leaves no orphan second record, with the original event-key mapping intact**; blank outboxId/eventKey rejected; every non-PREPARED initial status rejected; reason codes are exact fixed strings (`tramai-sovereign-ops-outbox-invalid-id`, `-invalid-event-key`, `-invalid-status`, `-duplicate-id`, `-duplicate-event-key`, `-not-found`, `-status-mismatch`) — never interpolated.
- **markReadyForDispatch (5):** PREPARED → PENDING preserving every non-status field; persisted PENDING; missing → `IllegalStateException` + not-found; wrong current status rejected; **the supplied `expectedStatus` itself must be PREPARED** — `markReady(expectedStatus = PENDING)` on a PREPARED record rejects (the case that catches the InMemory divergence).
- **markEmitted (7):** EMITTING → EMITTED with the exact supplied `emittedAt`; attempt/claim fields preserved; missing → not-found; PREPARED/PENDING/EMITTED/FAILED_RETRYABLE/FAILED_PERMANENT all rejected — the expected status must be EMITTING.
- **markFailed (9):** the legal matrix — PREPARED + permanent → FAILED_PERMANENT; EMITTING + retryable → FAILED_RETRYABLE; EMITTING + permanent → FAILED_PERMANENT, each pinning `lastErrorCode == errorCode`; everything else rejected (PREPARED + retryable, PENDING + either, FAILED_RETRYABLE, EMITTED, FAILED_PERMANENT).
- **Claim / retry / lease (10):** PENDING claim → EMITTING with attempt +1, claimant, claim timestamp, expiry = now + 5 minutes; FAILED_RETRYABLE claim → EMITTING with new claimant and **`lastErrorCode = null`** (its own dedicated case — removing that one line turns the TCK red); expired-EMITTING recovery replaces claimant/attempt/expiry; the lease boundary is strictly `claimExpiresAt < now` (exact equality NOT reclaimable, one second past IS); PREPARED, EMITTED, FAILED_PERMANENT and fresh EMITTING are never claimable.
- **Diagnostic listing (7):** observable membership, never ordering (JDBC orders by `created_at`; InMemory/File do not) — listPending → PENDING only, listByStatus → exact status only, listExpiredEmitting → EMITTING with expiry < now only; limits cap the result without pinning which records win; zero/negative limits → `[]` on all four paths; the expired boundary excludes exact equality; `findByEventKey` reflects the current transitioned version.
- **Concurrency (5 real parallel races, start barrier, 20 iterations each):** duplicate outboxId — exactly one append winner; duplicate eventKey — exactly one winner **AND every loser's record is absent** (proves the InMemory event-key index rollback is real); one PENDING record, 8 claimers with limit 1 — exactly one claim total, attempt 1, one claimant; pool claim — 8 PENDING records, 8 workers, every record claimed exactly once, every persisted attemptCount 1; concurrent completion — exactly one `markEmitted` winner, final EMITTED.

Runners 55/55 each: `InMemorySovereignOpsAuditOutboxStoreTckTest` (sovereign-ops — the default store, enrolled like any other), `FileSovereignOpsAuditOutboxStoreTckTest` (per-case dir), `JdbcSovereignOpsAuditOutboxStoreTckTest` (PostgreSQL testcontainers, V1+V4 migrations, per-case truncate). The enrollment guard reuses the shared `StoreEnrollmentScanner` — a future `RedisSovereignOpsAuditOutboxStore` cannot merge without its TCK runner. Fixtures are deterministic (fixed `T0`, explicit IDs/event keys, five-minute lease) — never the domain's `UUID.randomUUID()`/`Instant.now()` defaults; no sleeps, no system clock.

### Deliberate decisions (per review)

- **The JDBC lifecycle guards are the authoritative semantics** (explicitly added in PR #85's review); InMemory and File are aligned to them rather than weakening JDBC.
- **Clearing `lastErrorCode` on a fresh claim is shared contract** — a retry actively claimed must not carry the previous failure forward.
- **Non-positive diagnostic limits return `[]`** on every path; the public ops layer separately validates user-facing limits as positive and bounded.
- **Error messages are stable safe reason codes**, never interpolated IDs or event keys (policy continued from #271).

### Production changes the enrollment required

- **`InMemorySovereignOpsAuditOutboxStore`** gained the PREPARED-only readiness guard, EMITTING-only emission guard, legal markFailed matrix, `lastErrorCode` clearing on claim, `[]` for non-positive list limits, and fixed non-interpolated reason codes.
- **`FileSovereignOpsAuditOutboxStore`** gained blank outboxId/eventKey validation, the EMITTING-only emission guard, the legal markFailed matrix, and `lastErrorCode` clearing on claim. Its write staging was also fixed: temp files are now created **outside** the scanned outbox directory, so a concurrent `committedEntries()` scan never observes an in-flight write as an unexpected entry — **the TCK's pool-claim race exposed this as a real concurrency bug** (a parallel claim of a different record while another worker's atomic-rename temp was in the directory raised `ops-audit-outbox-unexpected-entry`).
- **`JdbcSovereignOpsAuditOutboxStore`** normalized duplicate/invalid-status errors to fixed reason codes and collapsed all five mutating transaction paths (append, markReadyForDispatch, claimPending, markEmitted, markFailed) onto one non-suspend `inOutboxTransaction` helper with the #267 precedence: operation / cancellation **>** rollback failure **>** autoCommit-restore failure, later cleanup failures suppressed. Deterministic regressions prove a primary `CancellationException` escapes unchanged when rollback fails, and when autoCommit-restore fails (same instance, not just type). No database schema change.
- `SovereignOpsAuditOutboxRecord` KDoc lifecycle diagram corrected to the shared matrix (retryable failures re-claim directly to EMITTING; no PENDING → FAILED_PERMANENT path).

### Mutation evidence — 16 mutations, each baseline GREEN → named TCK case(s) RED → restored GREEN

| Mutation | TCK outcome |
|---|---|
| duplicate outbox ID overwrites existing | RED — duplicate-id + concurrent-duplicate races |
| duplicate eventKey accepted | RED — event-key + concurrent event-key race |
| loser record not removed after eventKey race | RED — concurrent event-key race |
| blank outboxId validation removed | RED — blank-id case |
| markReady allows expected PENDING | RED — readiness lifecycle case |
| markEmitted accepts PREPARED | RED — emission lifecycle cases |
| retryable markFailed accepts PREPARED | RED — failure-matrix case |
| permanent markFailed accepts PENDING | RED — failure-matrix case |
| claim allows PREPARED | RED — claim-eligibility case |
| fresh EMITTING reclaimed (expiry ignored) | RED — fresh-EMITTING + lease-boundary + claim races |
| lease boundary becomes inclusive (`<=`) | RED — exact-boundary case |
| attemptCount not incremented | RED — claim/reclaim cases |
| retry claim retains lastErrorCode | RED — dedicated clear-error case |
| listPending includes FAILED_RETRYABLE | RED — listing case |
| non-atomic claim (CAS replaced) | RED — claim + pool-claim races |
| claim ignores limit | RED — limit-capped + non-positive-limit cases |

### Gates

- `verifyPr -PchangeClass=runtime-behaviour`: **BUILD SUCCESSFUL** (all subproject tests, maintainability baseline, change policy)
- `verifyCancellationSafety` vs master: **PASSED** (`inOutboxTransaction` is a non-suspend helper, scanner-clean)
- 55/55 per runner × 3; 16/16 mutations RED → GREEN
- Zero public API change; no persisted format or schema changes; no existing tests deleted
- Test-name hygiene: three em-dash test names normalized to ASCII in `SovereignOpsOutboxWorkerAutoConfigurationTest` (Gradle 9 incremental hashing fails on the non-ASCII class file name — same class of fix as #270)
