### PR TITLE
test(persistence): add WorkflowCheckpointStore compatibility TCK — Epic 8.1f

### DIFF
--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1191,7 +1191,7 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ## Epic 8.1: Persistence Store TCKs
 
-**Status: 🚧 IN PROGRESS** — Approval store slice done (PR #267), Approval continuation slice done (PR #269), suspended invocation slice done (PR #270), audit store slice done (PR #271), audit outbox slice done (PR #272); remaining families pending.
+**Status: 🚧 IN PROGRESS** — Approval store slice done (PR #267), Approval continuation slice done (PR #269), suspended invocation slice done (PR #270), audit store slice done (PR #271), audit outbox slice done (PR #272), workflow checkpoint slice done (PR #273); remaining families pending.
 
 **Goal:** Ensure in-memory, file, and JDBC implementations share the same behavioural contract.
 
@@ -1202,7 +1202,7 @@ repair feedback. No layer maintains its own independent fixture lists.
 - Suspended invocation store — ✅ PR #270 (shared `SuspendedInvocationStoreTck`, 39 cases × 3 implementations + enrollment guard)
 - Audit store — ✅ PR #271 (shared `AuditStoreTck`, 43 cases × 3 implementations + enrollment guard)
 - Audit outbox store — ✅ PR #272 (shared `SovereignOpsAuditOutboxStoreTck`, 55 cases × 3 implementations + enrollment guard)
-- Workflow checkpoint store — ⏳
+- Workflow checkpoint store — ✅ PR #273 (shared `WorkflowCheckpointStoreTck`, 42 cases × 4 implementations + enrollment guard)
 - Workflow lease store — ⏳
 - Step-attempt store — ✅ PR #218 (shared TCK + restart recovery tests for in-memory, file, and JDBC)
 - Memory store — ⏳
@@ -1225,7 +1225,7 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ### Acceptance criteria
 
-- ✅ Every published store implementation passes the relevant TCK (Approval: 3/3 via #267; Approval continuation: 3/3 via #269; suspended invocation: 3/3 via #270; audit: 3/3 via #271; audit outbox: 3/3 via #272; step-attempt: 3/3 via PR #218).
+- ✅ Every published store implementation passes the relevant TCK (Approval: 3/3 via #267; Approval continuation: 3/3 via #269; suspended invocation: 3/3 via #270; audit: 3/3 via #271; audit outbox: 3/3 via #272; workflow checkpoint: 4/4 via #273; step-attempt: 3/3 via PR #218).
 - ✅ Implementation-specific tests cover only storage technology and performance differences (encryption, permissions, corruption, record format for file; SQL schema, JSON mapping, connection cleanup for JDBC).
 - ✅ Contract failures use common typed exceptions or reason codes (`ApprovalStoreConflictException`, `ApprovalStoreNotFoundException`, `ApprovalStoreTokenRejectedException`, `ApprovalStoreNotConsumableException`, `IllegalApprovalTransitionException`; `ApprovalContinuationConflictException`, `ApprovalContinuationNotFoundException`, `ApprovalContinuationNotClaimableException`, `ApprovalContinuationNotCompletableException`; AuditStore: `audit-store-invalid-stream-id`, `audit-store-invalid-event-id`, `audit-stream-id-mismatch`, `audit-sequence-gap`, `audit-hash-chain-broken`, `audit-event-hash-mismatch`, `audit-schema-version-unsupported`, `audit-duplicate-event-id`).
 
@@ -1279,6 +1279,17 @@ repair feedback. No layer maintains its own independent fixture lists.
 - Zero public API change; no persisted format or schema changes; no existing tests deleted
 - Remaining families: workflow checkpoint, workflow lease, memory
 - Reference: `docs/reference/persistence-store-compatibility-contract.md`
+
+### Deliverables (PR #273)
+
+- `tramai-testing/src/testFixtures/.../persistence/checkpoint/` — `WorkflowCheckpointStoreTck` (42 cases), `WorkflowCheckpointFixtures` (deterministic — never the `System.currentTimeMillis()` savedAt default); `tramai-testing` testFixtures gained a test-fixture-only dependency on `tramai-orchestration` (the SPI's home module)
+- Runners: `InMemoryWorkflowCheckpointStoreTckTest`, `FileWorkflowCheckpointStoreTckTest`, `MarkdownWorkflowCheckpointStoreTckTest`, `JdbcWorkflowCheckpointStoreTckTest` (real H2, not a proxy backend); `WorkflowCheckpointStoreTckEnrollmentArchitectureTest` reuses the shared `StoreEnrollmentScanner` (now skipping private declarations — the supervisor's private lease-fencing decorator is not a store family member)
+- One identity/revision/delete/recovery contract across all four stores: checkpoint = versioned logical record keyed by (workflowName, workflowId); store-owned revision progression (1 → 2 → 3); optimistic concurrency via expectedRevision; delete/idempotency (unconditional delete is a no-op on missing, recreate starts at rev 1); recovery-state persistence through the SPI's default load-then-save (proven sufficiently atomic by the competing-requireRecovery race — no override rewritten); `WorkflowCheckpointCatalog` deliberately outside the TCK (distinct optional SPI, Markdown intentionally does not implement it)
+- Principal production fix: **File/Markdown logical-key collision repair** — the lossy `sanitizePathSegment` collapsed `"order/a"` and `"order?a"` onto one file; the checkpoint stores now default to the new collision-free `CollisionFreeWorkflowCheckpointPathStrategy` (URL-safe Base64, injective) with legacy-path fallback, identity verification (never overwrite a colliding key's record), and migrate-on-first-update (never two authoritative copies). `DefaultWorkflowCheckpointPathStrategy` unchanged (lease store depends on it). Additive public API; `api/` dump regenerated
+- Mutation evidence (13 mutations, each restored): duplicate-create overwrite, input-revision trust, revision 0, ignored expected-revision (save + delete), missing+expected create/delete, missing-delete throws, non-atomic save/delete, recovery-state normalization, lossy path regression
+- Zero public API change to existing types; no persisted format or schema changes to existing records (legacy records readable + migratable); no existing tests deleted
+- Remaining families: workflow lease, memory
+- Reference: `docs/reference/persistence-store-compatibility-contract.md`; legacy path behavior documented in `docs/guides/orchestration-persistence.md`
 
 ---
 

--- a/docs/guides/orchestration-persistence.md
+++ b/docs/guides/orchestration-persistence.md
@@ -108,6 +108,30 @@ The important contract detail is revision handling:
 
 That gives database, object-store, and filesystem implementations the same optimistic-concurrency model.
 
+## Checkpoint File Layout
+
+`FileWorkflowCheckpointStore` and `MarkdownWorkflowCheckpointStore` persist
+one file per checkpoint under the store root. Since version 0.6.0 the path
+is derived with the collision-free
+`CollisionFreeWorkflowCheckpointPathStrategy`: each identity segment
+(`workflowName`, `workflowId`) is URL-safe Base64 (no padding), so every
+distinct logical key maps to a distinct file:
+
+```
+<root>/<base64url(workflowName)>/<base64url(workflowId)>/checkpoint.properties
+<root>/<base64url(workflowName)>/<base64url(workflowId)>/checkpoint.md
+```
+
+Records persisted before this strategy (which sanitized segments to
+`[A-Za-z0-9_-]`, lossily collapsing keys like `"order/a"` and `"order?a"`)
+remain readable: a load first tries the canonical path, then the legacy
+sanitized path, and only accepts a legacy-path record whose contents
+identify the requested `workflowName`/`workflowId`. The first legitimate
+update migrates the record to the canonical path and deletes the legacy
+file — there are never two authoritative copies of one checkpoint.
+`DefaultWorkflowCheckpointPathStrategy` (the lossy layout) is still
+available for explicit injection and is unchanged for the lease store.
+
 ## Safe Failure Boundaries
 
 Built-in persistence stores expose fixed-text public failures. They do not copy filesystem paths, SQL, persisted payloads, or arbitrary storage exception messages into public exceptions, ordinary worker callbacks, or default logs. The original failure is available only through `PersistenceFailureDiagnosticObserver`.

--- a/docs/reference/persistence-store-compatibility-contract.md
+++ b/docs/reference/persistence-store-compatibility-contract.md
@@ -2,24 +2,29 @@
 
 Epic 8.1 (PR #267 ApprovalStore slice, PR #269 ApprovalContinuationStore
 slice, PR #270 SuspendedInvocationStore slice, PR #271 AuditStore slice,
-PR #272 SovereignOpsAuditOutboxStore slice). Shared behavioral TCKs prove
-every implementation of a store family satisfies exactly the same externally
-observable contract, regardless of storage technology (memory, encrypted
-files, JDBC).
+PR #272 SovereignOpsAuditOutboxStore slice, PR #273 WorkflowCheckpointStore
+slice). Shared behavioral TCKs prove every implementation of a store family
+satisfies exactly the same externally observable contract, regardless of
+storage technology (memory, encrypted files, Markdown, JDBC).
 
 ## Epic 8.1 matrix
 
-| Store family | In-memory | File | JDBC | Shared TCK |
-|---|---|---|---|---|
-| Approval | ✅ | ✅ | ✅ | ✅ #267 |
-| Approval continuation | ✅ | ✅ | ✅ | ✅ #269 |
-| Suspended invocation | ✅ | ✅ | ✅ | ✅ #270 |
-| Audit | ✅ | ✅ | ✅ | ✅ #271 |
-| Audit outbox | ✅ | ✅ | ✅ | ✅ #272 |
-| Workflow checkpoint | … | … | … | ⏳ |
-| Workflow lease | … | … | … | ⏳ |
-| Step attempt | ✅ | ✅ | ✅ | ✅ #218 |
-| Memory | … | … | … | ⏳ |
+| Store family | In-memory | File | Markdown | JDBC | Shared TCK |
+|---|---|---|---|---|---|
+| Approval | ✅ | ✅ | — | ✅ | ✅ #267 |
+| Approval continuation | ✅ | ✅ | — | ✅ | ✅ #269 |
+| Suspended invocation | ✅ | ✅ | — | ✅ | ✅ #270 |
+| Audit | ✅ | ✅ | — | ✅ | ✅ #271 |
+| Audit outbox | ✅ | ✅ | — | ✅ | ✅ #272 |
+| Workflow checkpoint | ✅ | ✅ | ✅ | ✅ | ✅ #273 |
+| Workflow lease | … | … | — | … | ⏳ |
+| Step attempt | ✅ | ✅ | — | ✅ | ✅ #218 |
+| Memory | … | … | — | … | ⏳ |
+
+Markdown cells: the Markdown checkpoint store implements the
+`WorkflowCheckpointStore` SPI (enrolled in #273) but not the optional
+`WorkflowCheckpointCatalog`/step-attempt families; the remaining families
+have no Markdown implementation.
 
 ## ApprovalStore TCK (PR #267)
 
@@ -602,3 +607,119 @@ implementation-dependent). No existing tests were deleted. The
 `tramai-spring-boot-starter-sovereign-ops` (test-fixture-only; no Spring
 enters any production runtime module) so the shared suite can be written in
 one place.
+
+## WorkflowCheckpointStore TCK (PR #273)
+
+`WorkflowCheckpointStoreTck` (tramai-testing testFixtures, which gained a
+test-fixture-only dependency on `tramai-orchestration`, the SPI's home
+module) runs **42 shared behavioral cases** against every
+`WorkflowCheckpointStore` implementation — the orchestration module's
+in-memory store, the properties-file store, the Markdown store, and JDBC
+(real H2, not a fake backend; the checkpoint SPI is standard SQL). A
+checkpoint is a **versioned logical record identified by (workflowName,
+workflowId)**, never "a file containing state": filesystem-safe naming,
+Markdown formatting and JDBC primary keys are implementation mechanics and
+cannot change what constitutes a unique checkpoint.
+
+- **Creation / read / identity (14):** full round-trip; save returns the
+  persisted value; missing load → null; first revision always 1; the
+  caller-supplied `revision` field is never authoritative; nullable
+  `lastCompletedStepName` preserved; multiline/Unicode/punctuation state
+  payload preserved; metadata exact; `Required` recovery state round-trips;
+  same workflowName/different IDs and same workflowId/different names
+  independent; duplicate create → `WorkflowCheckpointConflictException`
+  with exactly `"Workflow checkpoint conflict"` and null cause; rejected
+  duplicate leaves the original unchanged; **distinct keys whose legacy
+  sanitized paths collide remain distinct** (`"a/b"` vs `"a?b"` — the
+  discriminator that exposed the File/Markdown identity-domain divergence).
+- **Revision / optimistic concurrency (9):** exact expected revision
+  succeeds; update persists new values; stale lower revision conflicts;
+  impossible higher revision conflicts; expected revision on missing record
+  conflicts; expected null on existing record conflicts; failed update is
+  non-mutating; supplied revision 999 never becomes 999/1000; repeated
+  updates advance exactly 1 → 2 → 3.
+- **Delete / idempotency (7):** exact revision deletes; stale revision
+  conflicts; stale delete non-mutating; missing + expected revision
+  conflicts; missing + null expected is a no-op; existing + null expected
+  deletes; recreate after delete starts fresh at revision 1 (deleting a
+  checkpoint deletes its revision history).
+- **Recovery state (8):** `requireRecovery` transitions Normal@1 →
+  Required@2 with the exact `WorkflowRecoveryRecord` (reason, stepName,
+  attemptId, priorWorkerId, detectedAt, nullable idempotencyKey,
+  instructions); unrelated checkpoint fields preserved; stale expected
+  revision conflicts; missing checkpoint conflicts; failed operation
+  non-mutating. `clearRecovery` transitions Required@2 → Normal@3; stale
+  revision conflicts; failed operation non-mutating. The store-level
+  recovery contract deliberately does NOT declare
+  `requireRecovery(Required)`/`clearRecovery(Normal)` illegal — those
+  higher-level lifecycle restrictions belong to `WorkflowRecoveryController`.
+- **Concurrency (4 real parallel races, start barrier, 20 iterations
+  each):** concurrent create — exactly one winner, final revision 1;
+  **competing same-revision updates** — exactly one winner, final revision
+  2 with the winner's payload, all others conflict; update versus delete —
+  exactly one legal winner; **competing requireRecovery** — exactly one
+  winner with the winner's exact record (proves the SPI's default
+  load-then-save implementation is sufficiently atomic through the
+  underlying save CAS — no store override was rewritten).
+
+### Decisions (deliberate, per review)
+
+- **File/Markdown logical-key collision repair (the principal production
+  fix).** The lossy `sanitizePathSegment` mapping collapsed distinct keys
+  onto one file (`"order/a"` and `"order?a"` → `"order_a"`), while
+  InMemory/JDBC distinguished them. The checkpoint stores now default to the
+  new collision-free `CollisionFreeWorkflowCheckpointPathStrategy`
+  (URL-safe Base64 segments, injective and reversible) and read pre-upgrade
+  checkpoints via the legacy sanitized path **with identity verification**
+  (the decoded record must identify the requested key — a legacy path may
+  hold a colliding key's record, and it is never overwritten). The first
+  legitimate update migrates the record to the canonical path and deletes
+  the legacy file — never two authoritative copies.
+  `DefaultWorkflowCheckpointPathStrategy` is unchanged (the lease store and
+  explicit-injection callers depend on it). New public class is additive;
+  `api/` dump regenerated.
+- **`WorkflowCheckpointCatalog` is outside the shared #273 TCK**: it is a
+  distinct optional SPI and Markdown intentionally does not implement it.
+- **The JDBC runner uses real H2** — stronger contract evidence than the
+  proxy backend; no Testcontainers needed for standard-SQL semantics.
+- **Conflict taxonomy pinned:** `WorkflowCheckpointConflictException` with
+  message `"Workflow checkpoint conflict"` and null cause. Raw
+  SQL/filesystem exceptions and corruption behavior stay out of the shared
+  contract.
+- The enrollment scanner now skips `private` declarations (the supervisor's
+  private lease-fencing decorator is an implementation detail, not a store
+  family member).
+
+### Mutation evidence (13 mutations, each restored; InMemory store + strategy)
+
+| Mutation | TCK outcome |
+|---|---|
+| duplicate create overwrites existing | RED — duplicate-create + create race |
+| initial revision trusts supplied revision | RED — first-revision + input-revision cases |
+| initial revision becomes 0 | RED — first-revision case |
+| update ignores expected revision | RED — stale/higher conflicts + update & recovery races |
+| update does not increment revision | RED — exact-revision + 1→2→3 cases |
+| missing + expected becomes create | RED — missing-with-expected conflict |
+| delete ignores expected revision | RED — stale-delete cases |
+| missing + expected delete silently succeeds | RED — missing-with-expected delete conflict |
+| missing unconditional delete throws | RED — missing no-op idempotency |
+| save becomes check-then-write (synchronized removed) | RED — update race + create race |
+| delete becomes check-then-delete (synchronized removed) | RED — update-vs-delete race |
+| save always writes Normal recovery state | RED — Required round-trip case |
+| file path mapping reverts to lossy sanitize | RED — collision discriminator (File + Markdown) |
+
+### Scope
+
+The TCK owns SPI semantics; implementation-specific suites continue owning
+persistence formats (properties/Markdown/JSON), restart durability,
+permissions, corruption injection, JDBC schema internals, and the
+`WorkflowCheckpointCatalog` listing SPI. Existing suites
+(`WorkflowCheckpointStoreTest`, `WorkflowRecoveryContractTest`,
+`DurableWorkflowRecoveryFileTest`/`JdbcTest`,
+`FileWorkflowPersistenceCancellationContractTest`,
+`JdbcWorkflowPersistenceCancellationContractTest`,
+`PersistenceSafeFailureBoundaryTest`) are untouched and keep their
+higher-level coverage. No existing tests were deleted. `tramai-testing`
+testFixtures gained a dependency on `tramai-orchestration` (test-fixture-only)
+so the shared suite can be written in one place. Legacy path behavior is
+documented in `docs/guides/orchestration-persistence.md`.

--- a/examples/kotlin-springboot-example/MANUAL.md
+++ b/examples/kotlin-springboot-example/MANUAL.md
@@ -114,7 +114,15 @@ This shows how TramAI composes with explicit orchestration rather than hiding mu
 After running a workflow, inspect:
 
 ```bash
-cat build/tramai-example/workflows/invoice-review-workflow/<workflowId>/checkpoint.md
+# checkpoint (collision-free layout — each segment is base64url-encoded)
+ls build/tramai-example/workflows/
+cat "build/tramai-example/workflows/$(echo -n invoice-review-workflow | base64 -w0 | tr '+/' '-_' | tr -d '=')/$(echo -n <workflowId> | base64 -w0 | tr '+/' '-_' | tr -d '=')/checkpoint.md"
+```
+
+Or, for the lease file (legacy sanitized layout):
+
+```bash
+cat build/tramai-example/workflows/invoice-review-workflow/<workflowId>/lease.properties
 ```
 
 The saved checkpoint lets you audit:

--- a/examples/kotlin-springboot-example/README.md
+++ b/examples/kotlin-springboot-example/README.md
@@ -117,13 +117,19 @@ For a workflow id like `wf-1042`, the example writes files like:
 
 ```text
 build/tramai-example/workflows/
-└── invoice-review-workflow/
+├── <base64url(invoice-review-workflow)>/       # checkpoint store root
+│   └── <base64url(wf-1042)>/
+│       └── checkpoint.md
+└── invoice-review-workflow/                    # lease store (legacy layout)
     └── wf-1042/
-        ├── checkpoint.md
         └── lease.properties
 ```
 
-The checkpoint is retained after completion. The lease file exists only while a node owns the run.
+The checkpoint store uses the collision-free path strategy (each identity
+segment is URL-safe Base64 without padding, so distinct workflow IDs can
+never alias on disk); the lease store still uses the legacy sanitized
+layout. `checkpoint.md` is retained after completion. The lease file exists
+only while a node owns the run.
 
 ## Native Image Metadata
 

--- a/examples/kotlin-springboot-example/src/main/kotlin/dev/tramai/examples/springboot/workflow/InvoiceWorkflowCoordinator.kt
+++ b/examples/kotlin-springboot-example/src/main/kotlin/dev/tramai/examples/springboot/workflow/InvoiceWorkflowCoordinator.kt
@@ -21,8 +21,11 @@ import kotlinx.coroutines.withContext
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.nio.channels.OverlappingFileLockException
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Instant
+import java.util.Base64
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.io.path.exists
@@ -590,14 +593,28 @@ class InvoiceWorkflowCoordinator(
     }
 
     private fun discoverCheckpointWorkflowIds(): List<String> {
-        val workflowRoot = Path.of(persistenceRoot).resolve(WORKFLOW_NAME)
-        if (!workflowRoot.exists() || !workflowRoot.isDirectory()) {
+        val root = Path.of(persistenceRoot)
+        if (!root.exists() || !root.isDirectory()) {
             return emptyList()
         }
         return runCatching {
-            workflowRoot.listDirectoryEntries()
-                .filter { it.isDirectory() }
-                .map { it.fileName.toString() }
+            Files.walk(root).use { paths ->
+                paths
+                    .toList()
+                    .filter { it.fileName.toString() == "checkpoint.md" }
+                    .mapNotNull { checkpointFile ->
+                        val idSegment = checkpointFile.parent?.fileName?.toString() ?: return@mapNotNull null
+                        // Collision-free layout encodes the id segment as
+                        // base64url; the legacy layout used the raw id. Try
+                        // decoding first, fall back to the raw name.
+                        runCatching {
+                            String(Base64.getUrlDecoder().decode(idSegment), StandardCharsets.UTF_8)
+                        }.getOrElse { idSegment }
+                    }
+                    .distinct()
+                    .sorted()
+                    .toList()
+            }
         }.getOrDefault(emptyList())
     }
 

--- a/examples/kotlin-springboot-example/src/test/kotlin/dev/tramai/examples/springboot/ExampleApplicationTest.kt
+++ b/examples/kotlin-springboot-example/src/test/kotlin/dev/tramai/examples/springboot/ExampleApplicationTest.kt
@@ -194,11 +194,17 @@ class ExampleApplicationTest {
             .andExpect(jsonPath("$.workflowId").value(workflowId))
             .andExpect(jsonPath("$.result.handlingLane").value("ESCALATION"))
 
-        val workflowDirectory = workflowRoot
+        // The checkpoint store resolves paths with the collision-free
+        // strategy (base64url segments); the lease store still uses the
+        // legacy sanitized layout.
+        val checkpointDirectory = dev.tramai.orchestration.CollisionFreeWorkflowCheckpointPathStrategy("checkpoint.md")
+            .resolve(workflowRoot, InvoiceWorkflowCoordinator.WORKFLOW_NAME, workflowId)
+            .parent
+        assertThat(Files.exists(checkpointDirectory.resolve("checkpoint.md"))).isTrue()
+        val legacyDirectory = workflowRoot
             .resolve(InvoiceWorkflowCoordinator.WORKFLOW_NAME)
             .resolve(workflowId)
-        assertThat(Files.exists(workflowDirectory.resolve("checkpoint.md"))).isTrue()
-        assertThat(Files.exists(workflowDirectory.resolve("lease.properties"))).isFalse()
+        assertThat(Files.exists(legacyDirectory.resolve("lease.properties"))).isFalse()
     }
 
     @Test

--- a/tramai-orchestration/api/tramai-orchestration.api
+++ b/tramai-orchestration/api/tramai-orchestration.api
@@ -63,6 +63,12 @@ public final class dev/tramai/orchestration/CodexStepConfig {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class dev/tramai/orchestration/CollisionFreeWorkflowCheckpointPathStrategy : dev/tramai/orchestration/WorkflowCheckpointPathStrategy {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun legacyCheckpointPath (Ljava/nio/file/Path;Ljava/lang/String;Ljava/lang/String;)Ljava/nio/file/Path;
+	public fun resolve (Ljava/nio/file/Path;Ljava/lang/String;Ljava/lang/String;)Ljava/nio/file/Path;
+}
+
 public final class dev/tramai/orchestration/DefaultInstructionDefense : dev/tramai/core/security/InstructionDefense {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V

--- a/tramai-orchestration/build.gradle.kts
+++ b/tramai-orchestration/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
 
     testImplementation(project(":tramai-engine"))
     testImplementation(project(":tramai-testing"))
+    testImplementation(testFixtures(project(":tramai-testing")))
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.assertj.core)
     testImplementation(libs.kotlin.test.junit5)

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FileWorkflowCheckpointStore.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FileWorkflowCheckpointStore.kt
@@ -34,7 +34,7 @@ class FileWorkflowCheckpointStore private constructor(
     constructor(
         rootDirectory: Path,
         pathStrategy: WorkflowCheckpointPathStrategy =
-            DefaultWorkflowCheckpointPathStrategy("checkpoint.properties"),
+            CollisionFreeWorkflowCheckpointPathStrategy("checkpoint.properties"),
     ) : this(rootDirectory, pathStrategy, realAtomicFileWriter)
 
     constructor(
@@ -73,7 +73,7 @@ class FileWorkflowCheckpointStore private constructor(
         PersistenceResourceKind.CHECKPOINT, PersistenceOperation.LOAD, persistenceFailureDiagnosticObserver,
         classify = ::classifyCheckpointFailure,
     ) {
-        val checkpointPath = checkpointPath(workflowName, workflowId)
+        val checkpointPath = effectiveCheckpointPath(workflowName, workflowId)
         if (!Files.exists(checkpointPath)) {
             null
         } else {
@@ -81,7 +81,15 @@ class FileWorkflowCheckpointStore private constructor(
                 if (!Files.exists(checkpointPath)) {
                     null
                 } else {
-                    decodeCheckpoint(Files.readString(checkpointPath))
+                    val decoded = decodeCheckpoint(Files.readString(checkpointPath))
+                    // A legacy sanitized path may hold another key's record
+                    // after the collision-free strategy was introduced; only
+                    // accept it when it identifies the requested key.
+                    if (decoded.workflowName == workflowName && decoded.workflowId == workflowId) {
+                        decoded
+                    } else {
+                        null
+                    }
                 }
             }
         }
@@ -93,23 +101,42 @@ class FileWorkflowCheckpointStore private constructor(
         PersistenceResourceKind.CHECKPOINT, PersistenceOperation.SAVE, persistenceFailureDiagnosticObserver,
         classify = ::classifyCheckpointFailure,
     ) {
-        val checkpointPath = checkpointPath(checkpoint.workflowName, checkpoint.workflowId)
-        withFileLockCancellable(checkpointPath) {
-            val existing = if (Files.exists(checkpointPath)) {
-                decodeCheckpoint(Files.readString(checkpointPath))
+        val workflowName = checkpoint.workflowName
+        val workflowId = checkpoint.workflowId
+        val canonical = checkpointPath(workflowName, workflowId)
+        val target = effectiveCheckpointPath(workflowName, workflowId)
+        withFileLockCancellable(target) {
+            val existing = if (Files.exists(target)) {
+                decodeCheckpoint(Files.readString(target))
             } else {
                 null
             }
+            val identityMatch = existing == null ||
+                (existing.workflowName == workflowName && existing.workflowId == workflowId)
+            if (existing != null && !identityMatch) {
+                // The file at the target path belongs to a different logical
+                // key (legacy collision); never overwrite it.
+                throw safePersistenceFailure(
+                    PersistenceResourceKind.CHECKPOINT,
+                    PersistenceOperation.SAVE,
+                    PersistenceFailureCode.CONFLICT,
+                )
+            }
+            val effectiveExisting = if (identityMatch) existing else null
             validateExpectedRevision(
-                workflowName = checkpoint.workflowName,
-                workflowId = checkpoint.workflowId,
-                existing = existing,
+                workflowName = workflowName,
+                workflowId = workflowId,
+                existing = effectiveExisting,
                 expectedRevision = expectedRevision,
             )
             val persisted = checkpoint.copy(
-                revision = (existing?.revision ?: 0) + 1,
+                revision = (effectiveExisting?.revision ?: 0) + 1,
             )
-            atomicWriter.write(checkpointPath, encodeCheckpoint(persisted))
+            atomicWriter.write(canonical, encodeCheckpoint(persisted))
+            if (target != canonical && existing != null) {
+                // Migrate the legacy-path record to the canonical path.
+                Files.deleteIfExists(target)
+            }
             persisted
         }
     }
@@ -121,20 +148,30 @@ class FileWorkflowCheckpointStore private constructor(
         PersistenceResourceKind.CHECKPOINT, PersistenceOperation.DELETE, persistenceFailureDiagnosticObserver,
         classify = ::classifyCheckpointFailure,
     ) {
-        val checkpointPath = checkpointPath(workflowName, workflowId)
-        withFileLockCancellable(checkpointPath) {
-            val existing = if (Files.exists(checkpointPath)) {
-                decodeCheckpoint(Files.readString(checkpointPath))
+        val canonical = checkpointPath(workflowName, workflowId)
+        val target = effectiveCheckpointPath(workflowName, workflowId)
+        withFileLockCancellable(target) {
+            val existing = if (Files.exists(target)) {
+                decodeCheckpoint(Files.readString(target))
             } else {
                 null
             }
+            val identityMatch = existing == null ||
+                (existing.workflowName == workflowName && existing.workflowId == workflowId)
+            val effectiveExisting = if (identityMatch) existing else null
             validateDeleteExpectedRevision(
                 workflowName = workflowName,
                 workflowId = workflowId,
-                existing = existing,
+                existing = effectiveExisting,
                 expectedRevision = expectedRevision,
             )
-            Files.deleteIfExists(checkpointPath)
+            if (identityMatch && existing != null) {
+                Files.deleteIfExists(target)
+                if (target != canonical) {
+                    // No stale canonical file should exist; clean up defensively.
+                    Files.deleteIfExists(canonical)
+                }
+            }
             Unit
         }
     }
@@ -167,6 +204,25 @@ class FileWorkflowCheckpointStore private constructor(
         workflowName: String,
         workflowId: String,
     ): Path = pathStrategy.resolve(rootDirectory, workflowName, workflowId)
+
+    /**
+     * The path currently holding this checkpoint: the canonical collision-free
+     * path when present, otherwise the legacy sanitized path (when the
+     * strategy supports it and the legacy file exists), otherwise the
+     * canonical path. Callers must still verify the decoded record's identity
+     * — a legacy path may hold a colliding key's record.
+     */
+    private fun effectiveCheckpointPath(
+        workflowName: String,
+        workflowId: String,
+    ): Path {
+        val canonical = checkpointPath(workflowName, workflowId)
+        if (Files.exists(canonical)) return canonical
+        val legacy = (pathStrategy as? CollisionFreeWorkflowCheckpointPathStrategy)
+            ?.legacyCheckpointPath(rootDirectory, workflowName, workflowId)
+            ?: return canonical
+        return if (Files.exists(legacy)) legacy else canonical
+    }
 }
 /**
  * Strategy used by file-based checkpoint stores to choose one file path per checkpoint.
@@ -189,6 +245,50 @@ class DefaultWorkflowCheckpointPathStrategy(
         .resolve(sanitizePathSegment(workflowName))
         .resolve(sanitizePathSegment(workflowId))
         .resolve(fileName)
+}
+
+/**
+ * Collision-free checkpoint path strategy.
+ *
+ * [DefaultWorkflowCheckpointPathStrategy] maps every non-`[A-Za-z0-9_-]`
+ * character to `_`, so logically distinct keys collapse onto one file
+ * (`"order/a"` and `"order?a"` both become `"order_a"`). This strategy
+ * encodes each identity segment with URL-safe Base64 (no padding), which is
+ * reversible and injective: every distinct (workflowName, workflowId) maps
+ * to a distinct path, matching the identity domain of the in-memory and JDBC
+ * stores.
+ *
+ * [legacyCheckpointPath] resolves the historical sanitized path for the same
+ * key so stores can read checkpoints persisted before this strategy was
+ * introduced (verify the decoded record's identity before accepting it, and
+ * migrate on the first legitimate update).
+ */
+class CollisionFreeWorkflowCheckpointPathStrategy(
+    private val fileName: String,
+) : WorkflowCheckpointPathStrategy {
+    override fun resolve(
+        rootDirectory: Path,
+        workflowName: String,
+        workflowId: String,
+    ): Path = rootDirectory
+        .resolve(encodeSegment(workflowName))
+        .resolve(encodeSegment(workflowId))
+        .resolve(fileName)
+
+    /** The pre-collision-free path this key would have used. */
+    fun legacyCheckpointPath(
+        rootDirectory: Path,
+        workflowName: String,
+        workflowId: String,
+    ): Path = rootDirectory
+        .resolve(sanitizePathSegment(workflowName))
+        .resolve(sanitizePathSegment(workflowId))
+        .resolve(fileName)
+
+    private fun encodeSegment(input: String): String =
+        Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(input.toByteArray(StandardCharsets.UTF_8))
 }
 internal fun encodeCheckpoint(checkpoint: WorkflowCheckpoint): String {
     val properties = Properties()

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/MarkdownWorkflowCheckpointStore.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/MarkdownWorkflowCheckpointStore.kt
@@ -8,7 +8,7 @@ import kotlin.math.max
  */
 class MarkdownWorkflowCheckpointStore(
     private val rootDirectory: Path,
-    private val pathStrategy: WorkflowCheckpointPathStrategy = DefaultWorkflowCheckpointPathStrategy("checkpoint.md"),
+    private val pathStrategy: WorkflowCheckpointPathStrategy = CollisionFreeWorkflowCheckpointPathStrategy("checkpoint.md"),
 ) : WorkflowCheckpointStore {
     var persistenceFailureDiagnosticObserver: PersistenceFailureDiagnosticObserver =
         NoOpPersistenceFailureDiagnosticObserver
@@ -28,7 +28,7 @@ class MarkdownWorkflowCheckpointStore(
         PersistenceResourceKind.CHECKPOINT, PersistenceOperation.LOAD, persistenceFailureDiagnosticObserver,
         classify = ::classifyCheckpointFailure,
     ) {
-        val checkpointPath = checkpointPath(workflowName, workflowId)
+        val checkpointPath = effectiveCheckpointPath(workflowName, workflowId)
         if (!Files.exists(checkpointPath)) {
             null
         } else {
@@ -36,7 +36,15 @@ class MarkdownWorkflowCheckpointStore(
                 if (!Files.exists(checkpointPath)) {
                     null
                 } else {
-                    decodeMarkdownCheckpoint(Files.readString(checkpointPath))
+                    val decoded = decodeMarkdownCheckpoint(Files.readString(checkpointPath))
+                    // A legacy sanitized path may hold another key's record
+                    // after the collision-free strategy was introduced; only
+                    // accept it when it identifies the requested key.
+                    if (decoded.workflowName == workflowName && decoded.workflowId == workflowId) {
+                        decoded
+                    } else {
+                        null
+                    }
                 }
             }
         }
@@ -48,21 +56,40 @@ class MarkdownWorkflowCheckpointStore(
         PersistenceResourceKind.CHECKPOINT, PersistenceOperation.SAVE, persistenceFailureDiagnosticObserver,
         classify = ::classifyCheckpointFailure,
     ) {
-        val checkpointPath = checkpointPath(checkpoint.workflowName, checkpoint.workflowId)
-        withFileLockCancellable(checkpointPath) {
-            val existing = if (Files.exists(checkpointPath)) {
-                decodeMarkdownCheckpoint(Files.readString(checkpointPath))
+        val workflowName = checkpoint.workflowName
+        val workflowId = checkpoint.workflowId
+        val canonical = checkpointPath(workflowName, workflowId)
+        val target = effectiveCheckpointPath(workflowName, workflowId)
+        withFileLockCancellable(target) {
+            val existing = if (Files.exists(target)) {
+                decodeMarkdownCheckpoint(Files.readString(target))
             } else {
                 null
             }
+            val identityMatch = existing == null ||
+                (existing.workflowName == workflowName && existing.workflowId == workflowId)
+            if (existing != null && !identityMatch) {
+                // The file at the target path belongs to a different logical
+                // key (legacy collision); never overwrite it.
+                throw safePersistenceFailure(
+                    PersistenceResourceKind.CHECKPOINT,
+                    PersistenceOperation.SAVE,
+                    PersistenceFailureCode.CONFLICT,
+                )
+            }
+            val effectiveExisting = if (identityMatch) existing else null
             validateExpectedRevision(
-                workflowName = checkpoint.workflowName,
-                workflowId = checkpoint.workflowId,
-                existing = existing,
+                workflowName = workflowName,
+                workflowId = workflowId,
+                existing = effectiveExisting,
                 expectedRevision = expectedRevision,
             )
-            val persisted = checkpoint.copy(revision = (existing?.revision ?: 0) + 1)
-            writeStringAtomically(checkpointPath, encodeMarkdownCheckpoint(persisted))
+            val persisted = checkpoint.copy(revision = (effectiveExisting?.revision ?: 0) + 1)
+            writeStringAtomically(canonical, encodeMarkdownCheckpoint(persisted))
+            if (target != canonical && existing != null) {
+                // Migrate the legacy-path record to the canonical path.
+                Files.deleteIfExists(target)
+            }
             persisted
         }
     }
@@ -74,20 +101,30 @@ class MarkdownWorkflowCheckpointStore(
         PersistenceResourceKind.CHECKPOINT, PersistenceOperation.DELETE, persistenceFailureDiagnosticObserver,
         classify = ::classifyCheckpointFailure,
     ) {
-        val checkpointPath = checkpointPath(workflowName, workflowId)
-        withFileLockCancellable(checkpointPath) {
-            val existing = if (Files.exists(checkpointPath)) {
-                decodeMarkdownCheckpoint(Files.readString(checkpointPath))
+        val canonical = checkpointPath(workflowName, workflowId)
+        val target = effectiveCheckpointPath(workflowName, workflowId)
+        withFileLockCancellable(target) {
+            val existing = if (Files.exists(target)) {
+                decodeMarkdownCheckpoint(Files.readString(target))
             } else {
                 null
             }
+            val identityMatch = existing == null ||
+                (existing.workflowName == workflowName && existing.workflowId == workflowId)
+            val effectiveExisting = if (identityMatch) existing else null
             validateDeleteExpectedRevision(
                 workflowName = workflowName,
                 workflowId = workflowId,
-                existing = existing,
+                existing = effectiveExisting,
                 expectedRevision = expectedRevision,
             )
-            Files.deleteIfExists(checkpointPath)
+            if (identityMatch && existing != null) {
+                Files.deleteIfExists(target)
+                if (target != canonical) {
+                    // No stale canonical file should exist; clean up defensively.
+                    Files.deleteIfExists(canonical)
+                }
+            }
             Unit
         }
     }
@@ -95,6 +132,25 @@ class MarkdownWorkflowCheckpointStore(
         workflowName: String,
         workflowId: String,
     ): Path = pathStrategy.resolve(rootDirectory, workflowName, workflowId)
+
+    /**
+     * The path currently holding this checkpoint: the canonical collision-free
+     * path when present, otherwise the legacy sanitized path (when the
+     * strategy supports it and the legacy file exists), otherwise the
+     * canonical path. Callers must still verify the decoded record's identity
+     * — a legacy path may hold a colliding key's record.
+     */
+    private fun effectiveCheckpointPath(
+        workflowName: String,
+        workflowId: String,
+    ): Path {
+        val canonical = checkpointPath(workflowName, workflowId)
+        if (Files.exists(canonical)) return canonical
+        val legacy = (pathStrategy as? CollisionFreeWorkflowCheckpointPathStrategy)
+            ?.legacyCheckpointPath(rootDirectory, workflowName, workflowId)
+            ?: return canonical
+        return if (Files.exists(legacy)) legacy else canonical
+    }
 }
 internal fun encodeMarkdownCheckpoint(checkpoint: WorkflowCheckpoint): String {
     val metadataLines = checkpoint.metadata.entries

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/FileWorkflowCheckpointStoreTckTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/FileWorkflowCheckpointStoreTckTest.kt
@@ -1,0 +1,32 @@
+package dev.tramai.orchestration
+
+import dev.tramai.testing.persistence.checkpoint.WorkflowCheckpointStoreTck
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicLong
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.TestInstance
+import kotlin.io.path.exists
+
+/**
+ * Epic 8.1f: FileWorkflowCheckpointStore must satisfy the shared checkpoint
+ * compatibility contract (tramai-testing testFixtures). The runner owns the
+ * per-case isolation; storage technology (file format, permissions,
+ * corruption) never contaminates the contract.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FileWorkflowCheckpointStoreTckTest : WorkflowCheckpointStoreTck() {
+
+    private val rootDir: Path = Files.createTempDirectory("tramai-checkpoint-tck-file-").toAbsolutePath()
+    private val caseCounter = AtomicLong(0)
+
+    override fun createStore(): WorkflowCheckpointStore {
+        val caseDir = Files.createDirectories(rootDir.resolve("case-${caseCounter.incrementAndGet()}"))
+        return FileWorkflowCheckpointStore(caseDir)
+    }
+
+    @AfterAll
+    fun cleanup() {
+        if (rootDir.exists()) rootDir.toFile().deleteRecursively()
+    }
+}

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/FileWorkflowPersistenceCancellationContractTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/FileWorkflowPersistenceCancellationContractTest.kt
@@ -236,7 +236,7 @@ class FileWorkflowPersistenceCancellationContractTest {
     // ═══ Test 2: JVM mutex released on cancellation ═══
 
     @Test
-    fun `jvm mutex released on cancellation — second coroutine cancelled while waiting`() {
+    fun `jvm mutex released on cancellation - second coroutine cancelled while waiting`() {
         runBlocking {
             val checkpoint = testCheckpoint()
             val registryBefore = pathLockRegistrySize()

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/InMemoryWorkflowCheckpointStoreTckTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/InMemoryWorkflowCheckpointStoreTckTest.kt
@@ -1,0 +1,15 @@
+package dev.tramai.orchestration
+
+import dev.tramai.testing.persistence.checkpoint.WorkflowCheckpointStoreTck
+
+/**
+ * Epic 8.1f: InMemoryWorkflowCheckpointStore — the orchestration module's
+ * default checkpoint store — must satisfy the shared checkpoint
+ * compatibility contract (tramai-testing testFixtures). A fresh store per
+ * case gives full isolation; the store itself is the mutation target for
+ * the family.
+ */
+class InMemoryWorkflowCheckpointStoreTckTest : WorkflowCheckpointStoreTck() {
+
+    override fun createStore(): WorkflowCheckpointStore = InMemoryWorkflowCheckpointStore()
+}

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/JdbcWorkflowCheckpointStoreTckTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/JdbcWorkflowCheckpointStoreTckTest.kt
@@ -1,0 +1,53 @@
+package dev.tramai.orchestration
+
+import dev.tramai.testing.persistence.checkpoint.WorkflowCheckpointStoreTck
+import java.sql.DriverManager
+import javax.sql.DataSource
+import org.h2.jdbcx.JdbcDataSource
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Epic 8.1f: JdbcWorkflowCheckpointStore must satisfy the shared checkpoint
+ * compatibility contract (tramai-testing testFixtures) against a REAL
+ * relational engine — H2 — rather than a fake JDBC backend. The checkpoint
+ * SPI is standard SQL (primary keys, inserts, conditional updates, deletes),
+ * so H2 gives stronger contract evidence without Testcontainers. The runner
+ * owns the datasource, schema, and per-case table reset; SQL mechanics are
+ * never part of the shared contract.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JdbcWorkflowCheckpointStoreTckTest : WorkflowCheckpointStoreTck() {
+
+    private lateinit var dataSource: DataSource
+
+    @BeforeAll
+    fun setUpAll() {
+        val ds = JdbcDataSource()
+        ds.setURL("jdbc:h2:mem:checkpoint_tck;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE")
+        ds.user = "sa"
+        ds.password = ""
+        dataSource = ds
+        val store = JdbcWorkflowCheckpointStore(dataSource)
+        DriverManager.getConnection("jdbc:h2:mem:checkpoint_tck;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE", "sa", "")
+            .use { conn -> conn.createStatement().use { it.execute(store.createTableSql()) } }
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        runCatching {
+            DriverManager.getConnection("jdbc:h2:mem:checkpoint_tck;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE", "sa", "")
+                .use { conn -> conn.createStatement().use { it.execute("DROP TABLE IF EXISTS tramai_workflow_checkpoint") } }
+        }
+    }
+
+    override fun createStore(): WorkflowCheckpointStore {
+        // Fresh isolated storage per case.
+        DriverManager.getConnection("jdbc:h2:mem:checkpoint_tck;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE", "sa", "")
+            .use { conn ->
+                conn.createStatement().use { it.execute("DELETE FROM tramai_workflow_checkpoint") }
+            }
+        return JdbcWorkflowCheckpointStore(dataSource)
+    }
+}

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/MarkdownWorkflowCheckpointStoreTckTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/MarkdownWorkflowCheckpointStoreTckTest.kt
@@ -1,0 +1,32 @@
+package dev.tramai.orchestration
+
+import dev.tramai.testing.persistence.checkpoint.WorkflowCheckpointStoreTck
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicLong
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.TestInstance
+import kotlin.io.path.exists
+
+/**
+ * Epic 8.1f: MarkdownWorkflowCheckpointStore must satisfy the shared
+ * checkpoint compatibility contract (tramai-testing testFixtures). The
+ * runner owns the per-case isolation; the Markdown format and audit-friendly
+ * rendering are implementation mechanics, never contract.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MarkdownWorkflowCheckpointStoreTckTest : WorkflowCheckpointStoreTck() {
+
+    private val rootDir: Path = Files.createTempDirectory("tramai-checkpoint-tck-md-").toAbsolutePath()
+    private val caseCounter = AtomicLong(0)
+
+    override fun createStore(): WorkflowCheckpointStore {
+        val caseDir = Files.createDirectories(rootDir.resolve("case-${caseCounter.incrementAndGet()}"))
+        return MarkdownWorkflowCheckpointStore(caseDir)
+    }
+
+    @AfterAll
+    fun cleanup() {
+        if (rootDir.exists()) rootDir.toFile().deleteRecursively()
+    }
+}

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowCheckpointStoreTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowCheckpointStoreTest.kt
@@ -64,6 +64,51 @@ class WorkflowCheckpointStoreTest {
         }
     }
     @Test
+    fun `file store reads and migrates a legacy sanitized-path checkpoint`() {
+        val directory = createTempDirectory("tramai-file-legacy")
+        try {
+            // Simulate a checkpoint persisted BEFORE the collision-free path
+            // strategy: written directly at the historical lossy path.
+            val legacyCheckpoint = sampleCheckpoint(
+                workflowName = "legacy-workflow",
+                workflowId = "wf-legacy",
+                statePayload = "legacy-state",
+            ).copy(nextStepIndex = 2, revision = 1)
+            val legacyPath = DefaultWorkflowCheckpointPathStrategy("checkpoint.properties")
+                .resolve(directory, "legacy-workflow", "wf-legacy")
+            Files.createDirectories(legacyPath.parent)
+            Files.writeString(legacyPath, encodeCheckpoint(legacyCheckpoint))
+
+            val store = FileWorkflowCheckpointStore(directory)
+            // Old record is still readable through the new store (revision is
+            // whatever was persisted — the store does not rewrite it on load).
+            assertThat(runBlocking { store.load("legacy-workflow", "wf-legacy") })
+                .isEqualTo(legacyCheckpoint)
+
+            // First legitimate update migrates to the canonical path and
+            // removes the legacy file (never two authoritative copies).
+            val updated = runBlocking {
+                store.save(
+                    sampleCheckpoint(
+                        workflowName = "legacy-workflow",
+                        workflowId = "wf-legacy",
+                        statePayload = "legacy-state-2",
+                    ).copy(nextStepIndex = 4),
+                    expectedRevision = 1,
+                )
+            }
+            assertThat(updated.revision).isEqualTo(2)
+            val canonicalPath = CollisionFreeWorkflowCheckpointPathStrategy("checkpoint.properties")
+                .resolve(directory, "legacy-workflow", "wf-legacy")
+            assertThat(Files.exists(canonicalPath)).isTrue()
+            assertThat(Files.exists(legacyPath)).isFalse()
+            assertThat(runBlocking { store.load("legacy-workflow", "wf-legacy")?.nextStepIndex }).isEqualTo(4)
+        } finally {
+            deleteRecursively(directory)
+        }
+    }
+
+    @Test
     fun `markdown checkpoint store writes readable markdown and round trips payload`() {
         val directory = createTempDirectory("tramai-markdown-store")
         try {
@@ -74,10 +119,8 @@ class WorkflowCheckpointStoreTest {
                 statePayload = "line-1\n```json\n{\"ok\":true}\n```",
             )
             val persisted = runBlocking { store.save(checkpoint) }
-            val checkpointPath = directory
-                .resolve("markdown-workflow")
-                .resolve("wf-md")
-                .resolve("checkpoint.md")
+            val checkpointPath = CollisionFreeWorkflowCheckpointPathStrategy("checkpoint.md")
+                .resolve(directory, "markdown-workflow", "wf-md")
             val markdown = Files.readString(checkpointPath)
             val loaded = runBlocking { store.load("markdown-workflow", "wf-md") }
             assertThat(markdown)

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowRecoveryContractTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowRecoveryContractTest.kt
@@ -390,7 +390,7 @@ class WorkflowRecoveryContractTest {
     }
 
     @Test
-    fun `concurrent retry approvals — the approval whose checkpoint clear succeeds is the effective authorization`() {
+    fun `concurrent retry approvals - the approval whose checkpoint clear succeeds is the effective authorization`() {
         runBlocking {
             val delegate = InMemoryWorkflowCheckpointStore()
             val saved = delegate.save(sampleCheckpoint())
@@ -888,7 +888,7 @@ class WorkflowRecoveryContractTest {
     }
 
     @Test
-    fun `Two concurrent requireRecovery calls — first wins`() {
+    fun `Two concurrent requireRecovery calls - first wins`() {
         runBlocking {
             val store = InMemoryWorkflowCheckpointStore()
             val saved = store.save(sampleCheckpoint())

--- a/tramai-testing/build.gradle.kts
+++ b/tramai-testing/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     testFixturesApi(project(":tramai-engine"))
     testFixturesApi(project(":tramai-security"))
     testFixturesApi(project(":tramai-spring-boot-starter-sovereign-ops"))
+    testFixturesApi(project(":tramai-orchestration"))
     testFixturesApi(libs.assertj.core)
     testFixturesApi(libs.coroutines.core)
     testFixturesApi(libs.coroutines.test)

--- a/tramai-testing/src/test/kotlin/dev/tramai/testing/StoreEnrollmentScanner.kt
+++ b/tramai-testing/src/test/kotlin/dev/tramai/testing/StoreEnrollmentScanner.kt
@@ -43,7 +43,10 @@ class StoreEnrollmentScanner(
      * after the first top-level `:` (depth-aware), so a constructor parameter
      * like `class X(val store: ApprovalStore, ...)` never counts as a
      * supertype, while `class X(...) : ApprovalStore` (multi-line or not) is
-     * caught.
+     * caught. `private` declarations are skipped: a private class cannot be a
+     * publishable store-family member (nothing outside its file can
+     * instantiate it or enroll it in a runner), e.g. the supervisor's
+     * private lease-fencing decorator.
      */
     fun implementationsIn(file: File): List<String> {
         val text = file.readText()
@@ -54,10 +57,11 @@ class StoreEnrollmentScanner(
             // containing declaration keywords or a doc comment is such a false
             // positive (e.g. exception classes with implicit bodies).
             val overSpanned = DECLARATION_KEYWORD.containsMatchIn(supertype)
+            val isPrivate = Regex("""(?m)^\s*private\s+(?:class|object)\s+$name\b""").containsMatchIn(text)
             // Word-boundary match on the interface name so a supertype like
             // `ApprovalContinuationStoreException` (whose name merely
             // contains the words) never counts as an implementation.
-            if (!overSpanned && interfaceType.containsMatchIn(supertype)) name else null
+            if (!overSpanned && !isPrivate && interfaceType.containsMatchIn(supertype)) name else null
         }.distinct().toList()
     }
 

--- a/tramai-testing/src/test/kotlin/dev/tramai/testing/WorkflowCheckpointStoreTckEnrollmentArchitectureTest.kt
+++ b/tramai-testing/src/test/kotlin/dev/tramai/testing/WorkflowCheckpointStoreTckEnrollmentArchitectureTest.kt
@@ -1,0 +1,115 @@
+package dev.tramai.testing
+
+import java.io.File
+import java.nio.file.Files
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Epic 8.1f architecture guard: every concrete
+ * [dev.tramai.orchestration.WorkflowCheckpointStore] implementation must be
+ * enrolled in the shared checkpoint compatibility contract (tramai-testing
+ * testFixtures).
+ *
+ * Same two properties as the earlier guards (#267-#272): the four roadmap
+ * runners are pinned by name, and every concrete implementation in any
+ * module's main source set must ship a `<Store>TckTest` runner in the same
+ * module that actually extends
+ * [dev.tramai.testing.persistence.checkpoint.WorkflowCheckpointStoreTck].
+ * A future Redis/workflow-checkpoint store cannot merge without enrollment.
+ */
+class WorkflowCheckpointStoreTckEnrollmentArchitectureTest {
+
+    private val scanner = StoreEnrollmentScanner("WorkflowCheckpointStore", "WorkflowCheckpointStoreTck")
+
+    private val repoRoot: File =
+        generateSequence(File(".").absoluteFile) { it.parentFile }
+            .first { it.resolve("settings.gradle.kts").isFile }
+
+    private val expectedRunners = setOf(
+        "InMemoryWorkflowCheckpointStoreTckTest",
+        "FileWorkflowCheckpointStoreTckTest",
+        "MarkdownWorkflowCheckpointStoreTckTest",
+        "JdbcWorkflowCheckpointStoreTckTest",
+    )
+
+    @Test
+    fun `every roadmap WorkflowCheckpointStore ships a TCK runner`() {
+        val missing = expectedRunners.filter { runnerName -> scanner.findRunnerFile(repoRoot, runnerName) == null }
+        assertThat(missing)
+            .withFailMessage(
+                "Pinned WorkflowCheckpointStore TCK runners missing. The compatibility contract is " +
+                    "reviewed per runner; deleting a runner silently removes a store from the contract: $missing",
+            )
+            .isEmpty()
+    }
+
+    @Test
+    fun `every WorkflowCheckpointStore implementation has a valid TCK runner in its module`() {
+        val unenrolled = scanner.storeModules(repoRoot).flatMap { (module, implementations) ->
+            implementations
+                .filter { storeName -> !scanner.hasValidRunner(repoRoot, module, storeName) }
+                .map { store -> "$module/$store" }
+        }
+        assertThat(unenrolled)
+            .withFailMessage(
+                "WorkflowCheckpointStore implementations without a <Store>TckTest runner extending " +
+                    "WorkflowCheckpointStoreTck in the same module: $unenrolled. " +
+                    "Adding a WorkflowCheckpointStore without enrolling it in the compatibility " +
+                    "contract must make a gate fail.",
+            )
+            .isEmpty()
+    }
+
+    // ── probe tests for the scanner against this family ─────────────
+
+    @Test
+    fun `body-less WorkflowCheckpointStore implementation is detected`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            import dev.tramai.orchestration.WorkflowCheckpointStore
+            class RedisCheckpointStore(private val delegate: WorkflowCheckpointStore) :
+                WorkflowCheckpointStore by delegate
+            """.trimIndent(),
+        )
+        assertThat(scanner.implementationsIn(file)).containsExactly("RedisCheckpointStore")
+    }
+
+    @Test
+    fun `runner file must actually subclass WorkflowCheckpointStoreTck`() {
+        val fake = tempSourceFile("class RedisCheckpointStoreTckTest")
+        val real = tempSourceFile("class RedisCheckpointStoreTckTest : WorkflowCheckpointStoreTck() { }")
+        assertThat(scanner.runnerSubclassesTck(fake, "RedisCheckpointStore")).isFalse()
+        assertThat(scanner.runnerSubclassesTck(real, "RedisCheckpointStore")).isTrue()
+    }
+
+    @Test
+    fun `exception class whose name contains the interface does not count as an implementation`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            class WorkflowCheckpointStoreException(val code: String) : RuntimeException()
+            """.trimIndent(),
+        )
+        assertThat(scanner.implementationsIn(file)).isEmpty()
+    }
+
+    @Test
+    fun `constructor parameter never counts as an implementation`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            import dev.tramai.orchestration.WorkflowCheckpointStore
+            class Holder(val store: WorkflowCheckpointStore)
+            """.trimIndent(),
+        )
+        assertThat(scanner.implementationsIn(file)).isEmpty()
+    }
+
+    private fun tempSourceFile(content: String): File =
+        Files.createTempFile("enrollment-probe-", ".kt").toFile().apply {
+            writeText(content)
+            deleteOnExit()
+        }
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/checkpoint/WorkflowCheckpointFixtures.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/checkpoint/WorkflowCheckpointFixtures.kt
@@ -1,0 +1,67 @@
+package dev.tramai.testing.persistence.checkpoint
+
+import dev.tramai.orchestration.WorkflowCheckpoint
+import dev.tramai.orchestration.WorkflowRecoveryReason
+import dev.tramai.orchestration.WorkflowRecoveryRecord
+import dev.tramai.orchestration.WorkflowRecoveryState
+
+/**
+ * Epic 8.1f: fixtures for the shared
+ * [dev.tramai.orchestration.WorkflowCheckpointStore] compatibility contract.
+ *
+ * Deterministic only — never the domain defaults (`savedAtEpochMillis =
+ * System.currentTimeMillis()`): fixed timestamps, explicit names/IDs,
+ * explicit payloads and metadata. No sleeps, no system clock.
+ */
+object WorkflowCheckpointFixtures {
+
+    val SAVED_AT_EPOCH_MILLIS: Long = 1_800_000_000_000L
+
+    val DETECTED_AT_EPOCH_MILLIS: Long = 1_800_000_000_042L
+
+    fun checkpoint(
+        workflowName: String,
+        workflowId: String,
+        nextStepIndex: Int = 3,
+        stepExecutions: Int = 5,
+        lastCompletedStepName: String? = "validate",
+        statePayload: String = """{"state":"review"}""",
+        revision: Long = 0,
+        metadata: Map<String, String> = mapOf("region" to "eu-west", "tenant" to "acme"),
+        savedAtEpochMillis: Long = SAVED_AT_EPOCH_MILLIS,
+        recoveryState: WorkflowRecoveryState = WorkflowRecoveryState.Normal,
+    ): WorkflowCheckpoint = WorkflowCheckpoint(
+        workflowName = workflowName,
+        workflowId = workflowId,
+        nextStepIndex = nextStepIndex,
+        stepExecutions = stepExecutions,
+        lastCompletedStepName = lastCompletedStepName,
+        statePayload = statePayload,
+        revision = revision,
+        metadata = metadata,
+        savedAtEpochMillis = savedAtEpochMillis,
+        recoveryState = recoveryState,
+    )
+
+    fun recoveryRecord(
+        reason: WorkflowRecoveryReason = WorkflowRecoveryReason.NON_REPLAYABLE_OUTCOME_UNKNOWN,
+        stepName: String = "sendInvoice",
+        attemptId: String = "attempt-42",
+        priorWorkerId: String = "worker-7",
+        detectedAtEpochMillis: Long = DETECTED_AT_EPOCH_MILLIS,
+        idempotencyKey: String? = "idem-xyz",
+        instructions: String? = "manual confirmation required",
+    ): WorkflowRecoveryRecord = WorkflowRecoveryRecord(
+        reason = reason,
+        stepName = stepName,
+        attemptId = attemptId,
+        priorWorkerId = priorWorkerId,
+        detectedAtEpochMillis = detectedAtEpochMillis,
+        idempotencyKey = idempotencyKey,
+        instructions = instructions,
+    )
+
+    fun required(
+        record: WorkflowRecoveryRecord = recoveryRecord(),
+    ): WorkflowRecoveryState.Required = WorkflowRecoveryState.Required(record)
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/checkpoint/WorkflowCheckpointStoreTck.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/checkpoint/WorkflowCheckpointStoreTck.kt
@@ -1,0 +1,558 @@
+package dev.tramai.testing.persistence.checkpoint
+
+import dev.tramai.orchestration.WorkflowCheckpoint
+import dev.tramai.orchestration.WorkflowCheckpointConflictException
+import dev.tramai.orchestration.WorkflowCheckpointStore
+import dev.tramai.orchestration.WorkflowRecoveryRecord
+import dev.tramai.orchestration.WorkflowRecoveryState
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Epic 8.1f: the shared, cross-implementation
+ * [dev.tramai.orchestration.WorkflowCheckpointStore] compatibility contract.
+ * Every concrete store — in-memory, properties-file, Markdown, and JDBC —
+ * must treat a checkpoint as a versioned logical record identified by
+ * (workflowName, workflowId), with store-owned revision progression,
+ * optimistic concurrency, delete/idempotency semantics, and recovery-state
+ * persistence.
+ *
+ * A checkpoint is NOT "a file containing state": filesystem-safe naming,
+ * Markdown formatting and JDBC primary keys are implementation mechanics and
+ * must not change what constitutes a unique checkpoint. [WorkflowCheckpointCatalog]
+ * is a distinct optional SPI (Markdown intentionally does not implement it)
+ * and is outside this contract.
+ */
+abstract class WorkflowCheckpointStoreTck {
+
+    /** Fresh isolated storage per case; the runner owns setup/teardown. */
+    protected abstract fun createStore(): WorkflowCheckpointStore
+
+    private val savedAt = WorkflowCheckpointFixtures.SAVED_AT_EPOCH_MILLIS
+
+    private fun checkpoint(
+        workflowName: String,
+        workflowId: String,
+        nextStepIndex: Int = 3,
+        stepExecutions: Int = 5,
+        lastCompletedStepName: String? = "validate",
+        statePayload: String = """{"state":"review"}""",
+        revision: Long = 0,
+        metadata: Map<String, String> = mapOf("region" to "eu-west", "tenant" to "acme"),
+        recoveryState: WorkflowRecoveryState = WorkflowRecoveryState.Normal,
+    ): WorkflowCheckpoint = WorkflowCheckpointFixtures.checkpoint(
+        workflowName = workflowName,
+        workflowId = workflowId,
+        nextStepIndex = nextStepIndex,
+        stepExecutions = stepExecutions,
+        lastCompletedStepName = lastCompletedStepName,
+        statePayload = statePayload,
+        revision = revision,
+        metadata = metadata,
+        savedAtEpochMillis = savedAt,
+        recoveryState = recoveryState,
+    )
+
+    private fun recoveryRecord(
+        reason: dev.tramai.orchestration.WorkflowRecoveryReason = dev.tramai.orchestration.WorkflowRecoveryReason.NON_REPLAYABLE_OUTCOME_UNKNOWN,
+        stepName: String = "sendInvoice",
+        attemptId: String = "attempt-42",
+        priorWorkerId: String = "worker-7",
+        idempotencyKey: String? = "idem-xyz",
+        instructions: String? = "manual confirmation required",
+    ): WorkflowRecoveryRecord = WorkflowCheckpointFixtures.recoveryRecord(
+        reason = reason,
+        stepName = stepName,
+        attemptId = attemptId,
+        priorWorkerId = priorWorkerId,
+        idempotencyKey = idempotencyKey,
+        instructions = instructions,
+    )
+
+    // ── A. Creation / read / identity ───────────────────────────────
+
+    @Test
+    fun `full checkpoint round-trips exactly`() = runBlocking<Unit> {
+        val store = createStore()
+        val rec = checkpoint("invoice-review", "run-001")
+        store.save(rec)
+        assertThat(store.load("invoice-review", "run-001")).isEqualTo(rec.copy(revision = 1))
+    }
+
+    @Test
+    fun `save returns the persisted value`() = runBlocking<Unit> {
+        val store = createStore()
+        val persisted = store.save(checkpoint("invoice-review", "run-002"))
+        assertThat(persisted).isEqualTo(checkpoint("invoice-review", "run-002").copy(revision = 1))
+        assertThat(store.load("invoice-review", "run-002")).isEqualTo(persisted)
+    }
+
+    @Test
+    fun `missing checkpoint loads null`() = runBlocking<Unit> {
+        val store = createStore()
+        assertThat(store.load("no-such", "never")).isNull()
+    }
+
+    @Test
+    fun `first revision is always 1`() = runBlocking<Unit> {
+        val store = createStore()
+        val persisted = store.save(checkpoint("rev", "first"))
+        assertThat(persisted.revision).isEqualTo(1)
+        assertThat(store.load("rev", "first")?.revision).isEqualTo(1)
+    }
+
+    @Test
+    fun `caller-supplied revision is not authoritative`() = runBlocking<Unit> {
+        val store = createStore()
+        val persisted = store.save(checkpoint("rev", "ignored-input", revision = 999))
+        assertThat(persisted.revision).isEqualTo(1)
+    }
+
+    @Test
+    fun `nullable lastCompletedStepName is preserved`() = runBlocking<Unit> {
+        val store = createStore()
+        store.save(checkpoint("nullable", "null-step", lastCompletedStepName = null))
+        assertThat(store.load("nullable", "null-step")?.lastCompletedStepName).isNull()
+    }
+
+    @Test
+    fun `state payload with multiline unicode and punctuation is preserved`() = runBlocking<Unit> {
+        val store = createStore()
+        val payload = "line-1\nline-2 🚀 \"quoted\" `code` {json:true} café — done"
+        store.save(checkpoint("payload", "rich", statePayload = payload))
+        assertThat(store.load("payload", "rich")?.statePayload).isEqualTo(payload)
+    }
+
+    @Test
+    fun `metadata exact keys and values preserved`() = runBlocking<Unit> {
+        val store = createStore()
+        val metadata = mapOf("region" to "eu-west", "tenant" to "acme", "empty" to "")
+        store.save(checkpoint("meta", "exact", metadata = metadata))
+        assertThat(store.load("meta", "exact")?.metadata).isEqualTo(metadata)
+    }
+
+    @Test
+    fun `Required recovery state round-trips exactly`() = runBlocking<Unit> {
+        val store = createStore()
+        val required = WorkflowCheckpointFixtures.required(recoveryRecord())
+        store.save(checkpoint("rec", "required", recoveryState = required))
+        assertThat(store.load("rec", "required")?.recoveryState).isEqualTo(required)
+    }
+
+    @Test
+    fun `same workflowName different IDs are independent`() = runBlocking<Unit> {
+        val store = createStore()
+        store.save(checkpoint("shared", "id-a", nextStepIndex = 1))
+        store.save(checkpoint("shared", "id-b", nextStepIndex = 9))
+        assertThat(store.load("shared", "id-a")?.nextStepIndex).isEqualTo(1)
+        assertThat(store.load("shared", "id-b")?.nextStepIndex).isEqualTo(9)
+    }
+
+    @Test
+    fun `same workflowId different names are independent`() = runBlocking<Unit> {
+        val store = createStore()
+        store.save(checkpoint("name-a", "shared-id", stepExecutions = 1))
+        store.save(checkpoint("name-b", "shared-id", stepExecutions = 7))
+        assertThat(store.load("name-a", "shared-id")?.stepExecutions).isEqualTo(1)
+        assertThat(store.load("name-b", "shared-id")?.stepExecutions).isEqualTo(7)
+    }
+
+    @Test
+    fun `duplicate create raises typed conflict with fixed message`() = runBlocking<Unit> {
+        val store = createStore()
+        store.save(checkpoint("dup", "create"))
+        val thrown = runCatching { store.save(checkpoint("dup", "create")) }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(WorkflowCheckpointConflictException::class.java)
+        assertThat(thrown?.message).isEqualTo("Workflow checkpoint conflict")
+        assertThat(thrown?.cause).isNull()
+    }
+
+    @Test
+    fun `rejected duplicate leaves the original unchanged`() = runBlocking<Unit> {
+        val store = createStore()
+        val original = store.save(checkpoint("dup", "unchanged", nextStepIndex = 3))
+        runCatching { store.save(checkpoint("dup", "unchanged", nextStepIndex = 99)) }
+        assertThat(store.load("dup", "unchanged")).isEqualTo(original)
+    }
+
+    @Test
+    fun `distinct keys whose legacy sanitized paths collide remain distinct`() = runBlocking<Unit> {
+        val store = createStore()
+        // DefaultWorkflowCheckpointPathStrategy maps both to "order_a".
+        store.save(checkpoint("order", "a/b", nextStepIndex = 1))
+        store.save(checkpoint("order", "a?b", nextStepIndex = 2))
+        assertThat(store.load("order", "a/b")?.nextStepIndex).isEqualTo(1)
+        assertThat(store.load("order", "a?b")?.nextStepIndex).isEqualTo(2)
+        assertThat(store.load("order", "a/b")).isNotEqualTo(store.load("order", "a?b"))
+    }
+
+    // ── B. Revision / optimistic concurrency ────────────────────────
+
+    @Test
+    fun `exact expected revision update succeeds and increments`() = runBlocking<Unit> {
+        val store = createStore()
+        store.save(checkpoint("rev", "exact"))
+        val updated = store.save(checkpoint("rev", "exact", nextStepIndex = 4), expectedRevision = 1)
+        assertThat(updated.revision).isEqualTo(2)
+        assertThat(updated.nextStepIndex).isEqualTo(4)
+    }
+
+    @Test
+    fun `update changes fields and persists new values`() = runBlocking<Unit> {
+        val store = createStore()
+        store.save(checkpoint("rev", "fields", statePayload = "before"))
+        store.save(checkpoint("rev", "fields", statePayload = "after"), expectedRevision = 1)
+        assertThat(store.load("rev", "fields")?.statePayload).isEqualTo("after")
+    }
+
+    @Test
+    fun `stale lower revision conflicts`() = runBlocking<Unit> {
+        val store = createStore()
+        store.save(checkpoint("rev", "stale"))
+        store.save(checkpoint("rev", "stale", nextStepIndex = 4), expectedRevision = 1)
+        val thrown = runCatching {
+            store.save(checkpoint("rev", "stale", nextStepIndex = 5), expectedRevision = 1)
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(WorkflowCheckpointConflictException::class.java)
+        assertThat(thrown?.message).isEqualTo("Workflow checkpoint conflict")
+    }
+
+    @Test
+    fun `impossible higher revision conflicts`() = runBlocking<Unit> {
+        val store = createStore()
+        store.save(checkpoint("rev", "higher"))
+        val thrown = runCatching {
+            store.save(checkpoint("rev", "higher", nextStepIndex = 5), expectedRevision = 99)
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(WorkflowCheckpointConflictException::class.java)
+    }
+
+    @Test
+    fun `expected revision on missing record conflicts`() = runBlocking<Unit> {
+        val store = createStore()
+        val thrown = runCatching {
+            store.save(checkpoint("rev", "missing"), expectedRevision = 1)
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(WorkflowCheckpointConflictException::class.java)
+    }
+
+    @Test
+    fun `expected null on existing record conflicts`() = runBlocking<Unit> {
+        val store = createStore()
+        store.save(checkpoint("rev", "exists"))
+        val thrown = runCatching { store.save(checkpoint("rev", "exists", nextStepIndex = 9)) }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(WorkflowCheckpointConflictException::class.java)
+    }
+
+    @Test
+    fun `failed update leaves the record unchanged`() = runBlocking<Unit> {
+        val store = createStore()
+        val original = store.save(checkpoint("rev", "noop", nextStepIndex = 3))
+        runCatching { store.save(checkpoint("rev", "noop", nextStepIndex = 8), expectedRevision = 42) }
+        assertThat(store.load("rev", "noop")).isEqualTo(original)
+    }
+
+    @Test
+    fun `supplied revision 999 does not become 999 or 1000`() = runBlocking<Unit> {
+        val store = createStore()
+        store.save(checkpoint("rev", "chain", revision = 999))
+        val updated = store.save(checkpoint("rev", "chain", revision = 999), expectedRevision = 1)
+        assertThat(updated.revision).isEqualTo(2)
+    }
+
+    @Test
+    fun `repeated updates advance revision 1 2 3`() = runBlocking<Unit> {
+        val store = createStore()
+        store.save(checkpoint("rev", "chain3"))
+        val second = store.save(checkpoint("rev", "chain3", nextStepIndex = 4), expectedRevision = 1)
+        val third = store.save(checkpoint("rev", "chain3", nextStepIndex = 5), expectedRevision = 2)
+        assertThat(second.revision).isEqualTo(2)
+        assertThat(third.revision).isEqualTo(3)
+        assertThat(store.load("rev", "chain3")?.revision).isEqualTo(3)
+    }
+
+    // ── C. Delete / idempotency ─────────────────────────────────────
+
+    @Test
+    fun `exact revision deletes`() = runBlocking<Unit> {
+        val store = createStore()
+        store.save(checkpoint("del", "exact"))
+        store.delete("del", "exact", expectedRevision = 1)
+        assertThat(store.load("del", "exact")).isNull()
+    }
+
+    @Test
+    fun `stale revision delete conflicts`() = runBlocking<Unit> {
+        val store = createStore()
+        store.save(checkpoint("del", "stale"))
+        store.save(checkpoint("del", "stale", nextStepIndex = 4), expectedRevision = 1)
+        val thrown = runCatching { store.delete("del", "stale", expectedRevision = 1) }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(WorkflowCheckpointConflictException::class.java)
+    }
+
+    @Test
+    fun `stale delete leaves the record unchanged`() = runBlocking<Unit> {
+        val store = createStore()
+        val original = store.save(checkpoint("del", "kept", nextStepIndex = 3))
+        runCatching { store.delete("del", "kept", expectedRevision = 42) }
+        assertThat(store.load("del", "kept")).isEqualTo(original)
+    }
+
+    @Test
+    fun `missing record with expected revision delete conflicts`() = runBlocking<Unit> {
+        val store = createStore()
+        val thrown = runCatching { store.delete("del", "missing", expectedRevision = 1) }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(WorkflowCheckpointConflictException::class.java)
+    }
+
+    @Test
+    fun `missing record with no expected revision delete is a no-op`() = runBlocking<Unit> {
+        val store = createStore()
+        store.delete("del", "noop")
+        assertThat(store.load("del", "noop")).isNull()
+    }
+
+    @Test
+    fun `existing record with no expected revision deletes`() = runBlocking<Unit> {
+        val store = createStore()
+        store.save(checkpoint("del", "unconditional"))
+        store.delete("del", "unconditional")
+        assertThat(store.load("del", "unconditional")).isNull()
+    }
+
+    @Test
+    fun `recreate after delete starts at revision 1`() = runBlocking<Unit> {
+        val store = createStore()
+        store.save(checkpoint("del", "recreate"))
+        store.save(checkpoint("del", "recreate", nextStepIndex = 4), expectedRevision = 1)
+        store.delete("del", "recreate", expectedRevision = 2)
+        val recreated = store.save(checkpoint("del", "recreate", nextStepIndex = 1))
+        assertThat(recreated.revision).isEqualTo(1)
+        assertThat(store.load("del", "recreate")?.nextStepIndex).isEqualTo(1)
+    }
+
+    // ── D. Recovery state ───────────────────────────────────────────
+
+    @Test
+    fun `requireRecovery transitions Normal to Required with exact record`() = runBlocking<Unit> {
+        val store = createStore()
+        store.save(checkpoint("rec", "require"))
+        val record = recoveryRecord()
+        val updated = store.requireRecovery("rec", "require", expectedRevision = 1, record = record)
+        assertThat(updated.revision).isEqualTo(2)
+        assertThat(updated.recoveryState).isEqualTo(WorkflowRecoveryState.Required(record))
+        assertThat(store.load("rec", "require")?.recoveryState).isEqualTo(WorkflowRecoveryState.Required(record))
+    }
+
+    @Test
+    fun `requireRecovery preserves unrelated checkpoint fields`() = runBlocking<Unit> {
+        val store = createStore()
+        store.save(
+            checkpoint(
+                "rec", "preserve", nextStepIndex = 3, stepExecutions = 5,
+                lastCompletedStepName = "validate", statePayload = """{"state":"review"}""",
+                metadata = mapOf("region" to "eu-west"),
+            ),
+        )
+        val record = recoveryRecord()
+        store.requireRecovery("rec", "preserve", expectedRevision = 1, record = record)
+        val loaded = store.load("rec", "preserve")!!
+        assertThat(loaded.nextStepIndex).isEqualTo(3)
+        assertThat(loaded.stepExecutions).isEqualTo(5)
+        assertThat(loaded.lastCompletedStepName).isEqualTo("validate")
+        assertThat(loaded.statePayload).isEqualTo("""{"state":"review"}""")
+        assertThat(loaded.metadata).isEqualTo(mapOf("region" to "eu-west"))
+        assertThat(loaded.savedAtEpochMillis).isEqualTo(savedAt)
+    }
+
+    @Test
+    fun `requireRecovery with stale revision conflicts`() = runBlocking<Unit> {
+        val store = createStore()
+        store.save(checkpoint("rec", "stale"))
+        store.save(checkpoint("rec", "stale", nextStepIndex = 4), expectedRevision = 1)
+        val thrown = runCatching {
+            store.requireRecovery("rec", "stale", expectedRevision = 1, record = recoveryRecord())
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(WorkflowCheckpointConflictException::class.java)
+    }
+
+    @Test
+    fun `requireRecovery on missing checkpoint conflicts`() = runBlocking<Unit> {
+        val store = createStore()
+        val thrown = runCatching {
+            store.requireRecovery("rec", "missing", expectedRevision = 1, record = recoveryRecord())
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(WorkflowCheckpointConflictException::class.java)
+    }
+
+    @Test
+    fun `failed requireRecovery leaves state unchanged`() = runBlocking<Unit> {
+        val store = createStore()
+        val original = store.save(checkpoint("rec", "noop"))
+        runCatching {
+            store.requireRecovery("rec", "noop", expectedRevision = 99, record = recoveryRecord())
+        }
+        assertThat(store.load("rec", "noop")).isEqualTo(original)
+    }
+
+    @Test
+    fun `clearRecovery transitions Required to Normal at revision plus one`() = runBlocking<Unit> {
+        val store = createStore()
+        store.save(checkpoint("rec", "clear"))
+        val record = recoveryRecord()
+        store.requireRecovery("rec", "clear", expectedRevision = 1, record = record)
+        val cleared = store.clearRecovery("rec", "clear", expectedRevision = 2)
+        assertThat(cleared.revision).isEqualTo(3)
+        assertThat(cleared.recoveryState).isEqualTo(WorkflowRecoveryState.Normal)
+        assertThat(store.load("rec", "clear")?.recoveryState).isEqualTo(WorkflowRecoveryState.Normal)
+    }
+
+    @Test
+    fun `clearRecovery with stale revision conflicts`() = runBlocking<Unit> {
+        val store = createStore()
+        store.save(checkpoint("rec", "clear-stale"))
+        store.requireRecovery("rec", "clear-stale", expectedRevision = 1, record = recoveryRecord())
+        val thrown = runCatching {
+            store.clearRecovery("rec", "clear-stale", expectedRevision = 1)
+        }.exceptionOrNull()
+        assertThat(thrown).isInstanceOf(WorkflowCheckpointConflictException::class.java)
+    }
+
+    @Test
+    fun `failed clearRecovery is non-mutating`() = runBlocking<Unit> {
+        val store = createStore()
+        store.save(checkpoint("rec", "clear-noop"))
+        val record = recoveryRecord()
+        val required = store.requireRecovery("rec", "clear-noop", expectedRevision = 1, record = record)
+        runCatching { store.clearRecovery("rec", "clear-noop", expectedRevision = 99) }
+        assertThat(store.load("rec", "clear-noop")).isEqualTo(required)
+    }
+
+    // ── E. Concurrency ──────────────────────────────────────────────
+
+    @Test
+    fun `concurrent create - exactly one winner at revision 1`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val store = createStore()
+            val outcomes = runInParallel(0 until 8) {
+                runCatching { store.save(checkpoint("race-create-$round", "wf")) }
+            }
+            assertThat(outcomes.count { it.isSuccess }).withFailMessage {
+                "round $round: expected exactly one create winner, got ${outcomes.count { it.isSuccess }}"
+            }.isEqualTo(1)
+            assertThat(outcomes.filter { it.isFailure }.map { it.exceptionOrNull()?.javaClass?.name }.toSet())
+                .containsExactly(WorkflowCheckpointConflictException::class.java.name)
+            assertThat(store.load("race-create-$round", "wf")?.revision).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `competing same-revision updates - exactly one winner`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val store = createStore()
+            val name = "race-update-$round"
+            store.save(checkpoint(name, "wf"))
+            val payloads = (0 until 8).map { "payload-$round-$it" }
+            val outcomes = runInParallel(payloads) { payload ->
+                runCatching {
+                    store.save(checkpoint(name, "wf", statePayload = payload), expectedRevision = 1)
+                }
+            }
+            assertThat(outcomes.count { it.isSuccess }).withFailMessage {
+                "round $round: expected exactly one update winner, got ${outcomes.count { it.isSuccess }}"
+            }.isEqualTo(1)
+            assertThat(outcomes.filter { it.isFailure }.map { it.exceptionOrNull()?.javaClass?.name }.toSet())
+                .containsExactly(WorkflowCheckpointConflictException::class.java.name)
+            val winnerPayload = payloads[outcomes.indexOfFirst { it.isSuccess }]
+            assertThat(store.load(name, "wf")?.revision).isEqualTo(2)
+            assertThat(store.load(name, "wf")?.statePayload).isEqualTo(winnerPayload)
+        }
+    }
+
+    @Test
+    fun `concurrent update versus delete - exactly one legal winner`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val store = createStore()
+            val name = "race-del-$round"
+            store.save(checkpoint(name, "wf"))
+            val outcomes = runInParallel(0 until 2) { index ->
+                if (index == 0) {
+                    runCatching { store.save(checkpoint(name, "wf", nextStepIndex = 9), expectedRevision = 1) }
+                } else {
+                    runCatching { store.delete(name, "wf", expectedRevision = 1) }
+                }
+            }
+            val successes = outcomes.count { it.isSuccess }
+            assertThat(successes).withFailMessage {
+                "round $round: expected exactly one legal winner, got $successes (outcomes: $outcomes)"
+            }.isEqualTo(1)
+            val final = store.load(name, "wf")
+            if (outcomes[0].isSuccess) {
+                assertThat(final?.revision).isEqualTo(2)
+                assertThat(final?.nextStepIndex).isEqualTo(9)
+            } else {
+                assertThat(final).isNull()
+            }
+        }
+    }
+
+    @Test
+    fun `competing requireRecovery - exactly one winner with exact record`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val store = createStore()
+            val name = "race-rec-$round"
+            store.save(checkpoint(name, "wf"))
+            val records = (0 until 8).map { index ->
+                recoveryRecord(attemptId = "attempt-$round-$index", priorWorkerId = "worker-$index")
+            }
+            val outcomes = runInParallel(records) { record ->
+                runCatching { store.requireRecovery(name, "wf", expectedRevision = 1, record = record) }
+            }
+            assertThat(outcomes.count { it.isSuccess }).withFailMessage {
+                "round $round: expected exactly one recovery winner, got ${outcomes.count { it.isSuccess }}"
+            }.isEqualTo(1)
+            assertThat(outcomes.filter { it.isFailure }.map { it.exceptionOrNull()?.javaClass?.name }.toSet())
+                .containsExactly(WorkflowCheckpointConflictException::class.java.name)
+            val winnerRecord = records[outcomes.indexOfFirst { it.isSuccess }]
+            val final = store.load(name, "wf")!!
+            assertThat(final.revision).isEqualTo(2)
+            assertThat(final.recoveryState).isEqualTo(WorkflowRecoveryState.Required(winnerRecord))
+        }
+    }
+
+    // ── Parallel-race helper (shared pattern from #269-#272) ────────
+
+    /**
+     * Runs [block] for every element of [items] on real parallel workers with
+     * a start barrier, returning the outcomes in input order.
+     */
+    private suspend fun <T, R> runInParallel(
+        items: List<T>,
+        block: suspend (T) -> R,
+    ): List<R> = coroutineScope {
+        val ready = Channel<Unit>(items.size)
+        val release = CompletableDeferred<Unit>()
+        val workers = items.map { item ->
+            async(Dispatchers.Default) {
+                ready.send(Unit)
+                release.await()
+                block(item)
+            }
+        }
+        repeat(items.size) { ready.receive() }
+        release.complete(Unit)
+        workers.map { it.await() }
+    }
+
+    /** Range convenience overload for the race loops. */
+    private suspend fun <R> runInParallel(
+        range: IntRange,
+        block: suspend (Int) -> R,
+    ): List<R> = runInParallel(range.toList(), block)
+}


### PR DESCRIPTION
## test(persistence): add WorkflowCheckpointStore compatibility TCK — Epic 8.1f

**Status:** Epic 8.1 🚧 IN PROGRESS — Approval ✅ (#267), Approval continuation ✅ (#269), Suspended invocation ✅ (#270), Audit ✅ (#271), Audit outbox ✅ (#272), **Workflow checkpoint ✅ (this PR)**; workflow lease, memory pending.

### What this PR does

Enrolls **all four** `WorkflowCheckpointStore` implementations — the orchestration module's in-memory store, the properties-file store, the Markdown store, and JDBC — in one shared behavioral contract. `WorkflowCheckpointStoreTck` (tramai-testing testFixtures, which gained a test-fixture-only dependency on `tramai-orchestration`, the SPI's home module) runs **42 cases**. A checkpoint is a **versioned logical record identified by (workflowName, workflowId)** — never "a file containing state": filesystem-safe naming, Markdown formatting and JDBC primary keys are implementation mechanics and cannot change what constitutes a unique checkpoint.

- **Creation / read / identity (14):** full round-trip; save returns the persisted value; missing load → null; first revision always 1; the caller-supplied `revision` field is never authoritative (rev 999 stays rev 1); nullable `lastCompletedStepName` preserved; multiline/Unicode/punctuation payload preserved; metadata exact; `Required` recovery state round-trips; same-name/different-ID and same-ID/different-name independence; duplicate create → `WorkflowCheckpointConflictException` with exactly `"Workflow checkpoint conflict"` and null cause; rejected duplicate leaves the original unchanged; **distinct keys whose legacy sanitized paths collide remain distinct** (`"order/a"` vs `"order?a"` — the discriminator that exposed the File/Markdown identity-domain divergence).
- **Revision / optimistic concurrency (9):** exact expected revision succeeds; update persists new values; stale lower revision conflicts; impossible higher revision conflicts; expected revision on missing record conflicts; expected null on existing record conflicts; failed update non-mutating; revision 999 never becomes 999/1000; repeated updates advance exactly 1 → 2 → 3.
- **Delete / idempotency (7):** exact revision deletes; stale revision conflicts; stale delete non-mutating; missing + expected revision conflicts; missing + null expected is a no-op; existing + null expected deletes; recreate after delete starts fresh at revision 1 (deleting a checkpoint deletes its revision history).
- **Recovery state (8):** `requireRecovery` transitions Normal@1 → Required@2 with the exact `WorkflowRecoveryRecord` (reason, stepName, attemptId, priorWorkerId, detectedAt, nullable idempotencyKey, instructions); unrelated checkpoint fields preserved; stale expected revision conflicts; missing checkpoint conflicts; failed operation non-mutating. `clearRecovery` Required@2 → Normal@3; stale conflict; failed non-mutating. The store-level contract deliberately does NOT declare `requireRecovery(Required)`/`clearRecovery(Normal)` illegal — those higher-level lifecycle restrictions belong to `WorkflowRecoveryController`.
- **Concurrency (4 real parallel races, start barrier, 20 iterations each):** concurrent create — exactly one winner, final revision 1; **competing same-revision updates** — exactly one winner, final revision 2 with the winner's payload; update versus delete — exactly one legal winner; **competing requireRecovery** — exactly one winner with the winner's exact record (proves the SPI's default load-then-save is sufficiently atomic through the underlying save CAS — **no store override was rewritten**).

Runners 42/42 each: `InMemoryWorkflowCheckpointStoreTckTest`, `FileWorkflowCheckpointStoreTckTest` (per-case dir), `MarkdownWorkflowCheckpointStoreTckTest` (per-case dir), `JdbcWorkflowCheckpointStoreTckTest` (**real H2** — the checkpoint SPI is standard SQL; stronger evidence than the proxy backend, no Testcontainers). Enrollment guard reuses `StoreEnrollmentScanner` (now skipping `private` declarations — the supervisor's private lease-fencing decorator is not a store-family member). Fixtures are deterministic (fixed `savedAtEpochMillis` — never the `System.currentTimeMillis()` default — explicit IDs/payloads/metadata); no sleeps, no system clock.

### Deliberate decisions (per review)

- **`WorkflowCheckpointCatalog` is outside the shared #273 TCK** — it is a distinct optional SPI and Markdown intentionally does not implement it.
- **Conflict taxonomy pinned:** `WorkflowCheckpointConflictException` with message `"Workflow checkpoint conflict"` and null cause; raw SQL/filesystem exceptions and corruption stay implementation-specific.
- **The JDBC lifecycle guards / revision semantics are already aligned across the four stores** — the TCK's value here was proving that alignment and finding the path-identity divergence, not manufacturing production changes.

### Production changes the enrollment required

- **File/Markdown logical-key collision repair (the principal production fix).** The lossy `sanitizePathSegment` collapsed distinct keys onto one file (`"order/a"` and `"order?a"` → `"order_a"`), while InMemory/JDBC distinguished them. The checkpoint stores now default to the new **`CollisionFreeWorkflowCheckpointPathStrategy`** (URL-safe Base64 segments, injective and reversible) and read pre-upgrade checkpoints via the legacy sanitized path **with identity verification** — a legacy path may hold a colliding key's record, and it is never overwritten (conflict instead of data loss). The first legitimate update migrates the record to the canonical path and deletes the legacy file — **never two authoritative copies**. `DefaultWorkflowCheckpointPathStrategy` is unchanged (the lease store and explicit-injection callers depend on it). New public class is additive; `api/` dump regenerated.
- `StoreEnrollmentScanner` skips `private` declarations (implementation detail decorators can't be enrolled).
- Test-name hygiene: three em-dash test names normalized to ASCII (Gradle 9 incremental hashing fails on non-ASCII class file names).

### Mutation evidence — 14 mutations, each baseline GREEN → named TCK case(s) RED → restored GREEN

| Mutation | TCK outcome |
|---|---|
| duplicate create overwrites existing | RED — duplicate-create + create race |
| initial revision trusts supplied revision | RED — input-revision + 999 cases |
| initial revision becomes 0 | RED — first-revision case |
| update ignores expected revision | RED — stale/higher conflicts + update & recovery races |
| update does not increment revision | RED — exact-revision + 1→2→3 cases |
| missing + expected becomes create | RED — missing-with-expected conflict |
| delete ignores expected revision | RED — stale-delete cases |
| missing + expected delete silently succeeds | RED — missing-with-expected delete conflict |
| missing unconditional delete throws | RED — missing no-op idempotency |
| save becomes check-then-write (synchronized removed) | RED — update race + create race |
| delete becomes check-then-delete (synchronized removed) | RED — update-vs-delete race |
| save always writes Normal recovery state | RED — Required round-trip + recovery cases |
| File path mapping reverts to lossy sanitize | RED — collision discriminator |
| Markdown path mapping reverts to lossy sanitize | RED — collision discriminator |

### Gates

- `verifyPr -PchangeClass=runtime-behaviour`: **BUILD SUCCESSFUL** (all subproject tests, maintainability baseline, change policy)
- `verifyCancellationSafety` vs master: **PASSED**
- `:tramai-orchestration:apiCheck`: **PASSED** (regenerated dump for the additive strategy class)
- 42/42 per runner × 4; 14/14 mutations RED → GREEN
- Existing suites untouched and green: `WorkflowCheckpointStoreTest` (+ new legacy-migration regression), `WorkflowRecoveryContractTest`, `DurableWorkflowRecoveryFileTest`/`JdbcTest`, `FileWorkflowPersistenceCancellationContractTest`, `JdbcWorkflowPersistenceCancellationContractTest`, `PersistenceSafeFailureBoundaryTest`
- Zero public API change to existing types; no persisted format or schema changes to existing records (legacy records readable + migratable); no existing tests deleted
