### PR TITLE
test(persistence): add WorkflowLeaseStore compatibility TCK — Epic 8.1g

### DIFF
--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1191,7 +1191,7 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ## Epic 8.1: Persistence Store TCKs
 
-**Status: 🚧 IN PROGRESS** — Approval store slice done (PR #267), Approval continuation slice done (PR #269), suspended invocation slice done (PR #270), audit store slice done (PR #271), audit outbox slice done (PR #272), workflow checkpoint slice done (PR #273); remaining families pending.
+**Status: 🚧 IN PROGRESS** — Approval store slice done (PR #267), Approval continuation slice done (PR #269), suspended invocation slice done (PR #270), audit store slice done (PR #271), audit outbox slice done (PR #272), workflow checkpoint slice done (PR #273), workflow lease slice done (PR #274); memory family remaining.
 
 **Goal:** Ensure in-memory, file, and JDBC implementations share the same behavioural contract.
 
@@ -1203,7 +1203,7 @@ repair feedback. No layer maintains its own independent fixture lists.
 - Audit store — ✅ PR #271 (shared `AuditStoreTck`, 43 cases × 3 implementations + enrollment guard)
 - Audit outbox store — ✅ PR #272 (shared `SovereignOpsAuditOutboxStoreTck`, 55 cases × 3 implementations + enrollment guard)
 - Workflow checkpoint store — ✅ PR #273 (shared `WorkflowCheckpointStoreTck`, 42 cases × 4 implementations + enrollment guard)
-- Workflow lease store — ⏳
+- Workflow lease store — ✅ PR #274 (shared `WorkflowLeaseStoreTck` 51 cases + `WorkflowLeaseCheckpointFenceTck` 14 cases, × 3 implementations + enrollment guards)
 - Step-attempt store — ✅ PR #218 (shared TCK + restart recovery tests for in-memory, file, and JDBC)
 - Memory store — ⏳
 
@@ -1225,7 +1225,7 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ### Acceptance criteria
 
-- ✅ Every published store implementation passes the relevant TCK (Approval: 3/3 via #267; Approval continuation: 3/3 via #269; suspended invocation: 3/3 via #270; audit: 3/3 via #271; audit outbox: 3/3 via #272; workflow checkpoint: 4/4 via #273; step-attempt: 3/3 via PR #218).
+- ✅ Every published store implementation passes the relevant TCK (Approval: 3/3 via #267; Approval continuation: 3/3 via #269; suspended invocation: 3/3 via #270; audit: 3/3 via #271; audit outbox: 3/3 via #272; workflow checkpoint: 4/4 via #273; workflow lease: 3/3 store + 3/3 fence via #274; step-attempt: 3/3 via PR #218).
 - ✅ Implementation-specific tests cover only storage technology and performance differences (encryption, permissions, corruption, record format for file; SQL schema, JSON mapping, connection cleanup for JDBC).
 - ✅ Contract failures use common typed exceptions or reason codes (`ApprovalStoreConflictException`, `ApprovalStoreNotFoundException`, `ApprovalStoreTokenRejectedException`, `ApprovalStoreNotConsumableException`, `IllegalApprovalTransitionException`; `ApprovalContinuationConflictException`, `ApprovalContinuationNotFoundException`, `ApprovalContinuationNotClaimableException`, `ApprovalContinuationNotCompletableException`; AuditStore: `audit-store-invalid-stream-id`, `audit-store-invalid-event-id`, `audit-stream-id-mismatch`, `audit-sequence-gap`, `audit-hash-chain-broken`, `audit-event-hash-mismatch`, `audit-schema-version-unsupported`, `audit-duplicate-event-id`).
 
@@ -1290,6 +1290,18 @@ repair feedback. No layer maintains its own independent fixture lists.
 - Zero public API change to existing types; no persisted format or schema changes to existing records (legacy records readable + migratable); no existing tests deleted
 - Remaining families: workflow lease, memory
 - Reference: `docs/reference/persistence-store-compatibility-contract.md`; legacy path behavior documented in `docs/guides/orchestration-persistence.md`
+
+### Deliverables (PR #274)
+
+- `tramai-testing/src/testFixtures/.../persistence/lease/` — `WorkflowLeaseStoreTck` (51 cases), `WorkflowLeaseCheckpointFenceTck` (14 cases), `WorkflowLeaseFixtures`, `MutableMillisClock` (thread-safe AtomicLong clock; no system clock, no sleeps)
+- Runners: `InMemoryWorkflowLeaseStoreTckTest`, `FileWorkflowLeaseStoreTckTest`, `JdbcWorkflowLeaseStoreTckTest` (real H2) + the same three stores enrolled in the fence contract (`*WorkflowLeaseStoreCheckpointFenceTckTest`, JDBC lease + checkpoint stores sharing ONE DataSource for the atomic fence transaction); two enrollment guards (`WorkflowLeaseStoreTckEnrollmentArchitectureTest`, `WorkflowLeaseCheckpointFenceTckEnrollmentArchitectureTest`) reusing the #273 scanner
+- Contract: for one (workflowName, workflowId), at any instant at most one active lease token authorizes mutations, and storage technology cannot change that answer. Claim identity, exact expiry boundary (`expiresAt > now` active), renewal from durable state, release semantics (leaseId is the fencing capability — ownerId alone insufficient), stale predecessor can never renew/release/fence, input-domain hardening (IllegalArgumentException outside the boundary), 4 real races × 20 (initial claim, expired takeover, renew-vs-claim at exact expiry, colliding keys in parallel)
+- Companion fence contract: `StaleWorkflowLeaseException` (`"Workflow lease is no longer active"`) distinct from `WorkflowLeaseConflictException`; checkpoint unchanged on stale rejection; **new shared invariant: lease identity must equal checkpoint identity (IllegalArgumentException, fail before touching storage)**; the fence is NOT a renewal API and must not mutate lease metadata
+- Principal production fixes: **File lease identity** — `CollisionFreeWorkflowLeasePathStrategy` (safe segments keep their legacy path; unsafe → `~`+base64url, injective, never collides with legacy paths; legacy leases honored with identity verification, NOT migrated while live — lock namespace unchanged under an active lease); **JDBC renew returns the durable row** (caller's tampered snapshot no longer leaks); **JDBC fence uses SELECT ... FOR UPDATE** instead of the state-mutating UPDATE (checkpointRevision never rewritten as a side effect); shared caller-input validation in all three stores
+- Mutation evidence (17 mutations, each restored): active-claim guard, expiry boundary, fixed leaseId, renew leaseId/owner/expired/revision/expiry, release token, fence key-binding, fence forged-token, input validation, File lossy path, File foreign legacy identity, JDBC caller snapshot, JDBC mutating lock, File lock removal
+- Zero public API change to existing types; `api/` dump regenerated for the additive strategy class; no existing tests deleted
+- Remaining family: memory
+- Reference: `docs/reference/persistence-store-compatibility-contract.md`; lease layout documented in `docs/guides/orchestration-persistence.md`
 
 ---
 

--- a/docs/guides/orchestration-persistence.md
+++ b/docs/guides/orchestration-persistence.md
@@ -132,6 +132,30 @@ file — there are never two authoritative copies of one checkpoint.
 `DefaultWorkflowCheckpointPathStrategy` (the lossy layout) is still
 available for explicit injection and is unchanged for the lease store.
 
+## Lease File Layout
+
+`FileWorkflowLeaseStore` persists one `lease.properties` per workflow under
+the store root. Since version 0.6.0 the path is derived with the minimally
+disruptive `CollisionFreeWorkflowLeasePathStrategy`: identity segments
+already in the legacy-safe raw domain (`[A-Za-z0-9_-]`) keep their existing
+path unchanged (normal UUID/hyphenated workflow IDs do not move); any other
+segment is encoded as `~` + URL-safe Base64 (no padding). `~` is outside
+the legacy-safe domain, so a canonical path can never collide with a legacy
+sanitized path — two logically distinct workflows can never address the
+same lease file, and storage layout cannot redefine who owns a workflow:
+
+```
+<root>/<safe-name-or-~base64url(name)>/<safe-id-or-~base64url(id)>/lease.properties
+```
+
+Leases persisted before this strategy remain readable: a load/claim/renew/
+release first tries the canonical path, then the legacy sanitized path, and
+only accepts a legacy-path lease whose contents identify the requested
+`workflowName`/`workflowId` (a colliding key's lease is never returned as
+yours and never overwritten). A live legacy lease is NOT migrated — the
+filesystem lock namespace must not change under an active lease; after
+release or expiry the next claim uses the canonical path.
+
 ## Safe Failure Boundaries
 
 Built-in persistence stores expose fixed-text public failures. They do not copy filesystem paths, SQL, persisted payloads, or arbitrary storage exception messages into public exceptions, ordinary worker callbacks, or default logs. The original failure is available only through `PersistenceFailureDiagnosticObserver`.

--- a/docs/modules/tramai-orchestration.md
+++ b/docs/modules/tramai-orchestration.md
@@ -306,6 +306,48 @@ val recoveryController = InMemoryWorkflowRecoveryController(
 )
 ```
 
+### Lease stores
+
+Active ownership for one (workflowName, workflowId) is a versioned lease
+token. At any instant at most one active lease can authorize checkpoint
+mutations, and storage technology cannot change that answer — a worker
+owns a workflow only via **logical workflow identity + current active
+leaseId + matching owner + not expired** (`expiresAt > now` is active,
+`expiresAt <= now` is expired). `leaseId` is the fencing capability;
+`ownerId` alone is insufficient — a stale predecessor (even the same
+owner) can never renew, release, or fence after a takeover. All three
+built-in stores (`InMemoryWorkflowLeaseStore`, `FileWorkflowLeaseStore`,
+`JdbcWorkflowLeaseStore`) pass the shared lease TCK (51 cases) and the
+companion fence TCK (14 cases) — the fence is the atomic
+"ownership check + checkpoint mutation" operation, is not a renewal API,
+and never mutates lease metadata.
+
+```kotlin
+val leaseStore = JdbcWorkflowLeaseStore(dataSource) // or InMemory/File
+leaseStore.createTableSql() // execute during application schema setup
+
+val lease = leaseStore.claim(
+    workflowName = "invoice-review",
+    workflowId = "run-001",
+    ownerId = "node-a",
+    checkpointRevision = 3,
+    leaseDurationMillis = 30_000,
+)
+// Fenced checkpoint mutation: lease + checkpoint in one atomic operation.
+leaseStore.saveCheckpointIfLeaseOwner(checkpointStore, checkpoint, 3, lease)
+```
+
+The file store's `CollisionFreeWorkflowLeasePathStrategy` keeps safe
+segments (`[A-Za-z0-9_-]`) on their legacy path and encodes everything else
+as `~`+base64url, so distinct identities can never alias on disk; legacy
+leases are honored on their legacy path and never migrated while live (see
+`docs/guides/orchestration-persistence.md`). Caller-input errors (blank
+identities, nonpositive duration, mismatched fence identity) are
+`IllegalArgumentException`; lease-contention failures are
+`WorkflowLeaseConflictException` (`"Workflow lease conflict"`) and stale
+fencing is `StaleWorkflowLeaseException`
+(`"Workflow lease is no longer active"`).
+
 ### Distributed workers
 
 `TramaiWorker` enables multi-node workflow execution. Workers poll a shared checkpoint catalog, claim workflows via lease fencing, and execute resumes. Each worker is completely determined by the bindings explicitly supplied to it — there is no process-global workflow registration.

--- a/docs/reference/persistence-store-compatibility-contract.md
+++ b/docs/reference/persistence-store-compatibility-contract.md
@@ -827,21 +827,30 @@ fencing operation.
   change under an active lease) — after release or expiry the next claim
   uses the canonical path. `DefaultWorkflowCheckpointPathStrategy` is
   unchanged.
-- **Stable lock namespace across the legacy→canonical migration (P1
-  review finding).** The lease file path is NOT the synchronization
-  identity when the path itself is migratable: locking whichever data path
-  happens to exist before locking let two concurrent claimants of an
-  expired legacy unsafe-key lease both succeed (A locks the legacy path,
-  deletes it, writes canonical; B — resolving after the delete, before the
-  move — locks the canonical path, sees no lease, succeeds). `claim()`
-  therefore locks a **stable `leaseLockPath`** — for the collision-free
-  strategy the immutable legacy-sanitized path (a/b and a?b share a lock:
-  harmless serialization, distinct lease files) — and **re-resolves the
-  effective storage path INSIDE the acquired lock**. A deterministic
-  regression parks claimant A mid-migration via the injectable
-  `AtomicFileWriter.beforeMove` hook while B claims: exactly 1 success, 1
-  conflict, single canonical lease. (M18 mutates this back to
-  lock-the-storage-path → the race turns RED.)
+- **One stable lock namespace for the whole lease state machine (P1,
+  second review finding).** The lease file path is NOT the synchronization
+  identity when the path itself is migratable — and the rule applies to
+  every operation, not just claim: once `claim()` moved to the stable
+  logical lock while `currentLease`/`renew`/`release`/fenced save/fenced
+  delete kept locking the current data path, an unsafe canonical identity
+  had TWO synchronization namespaces. Two concrete breaks: (P1-A) at exact
+  expiry a `currentLease` cleanup holding the canonical lock could delete
+  the successor a concurrent claim had just written under the legacy lock;
+  (P1-B, the serious one) an active fenced checkpoint mutation could
+  overlap a successor takeover — the stale worker's checkpoint save
+  completes after B has taken ownership, exactly the split-brain the fence
+  exists to prevent. The File store now centralizes the rule: every
+  operation that can observe, change, expire, replace, or fence a lease
+  serializes through `withLogicalLeaseLock` / `withLogicalLeaseLockSuspending`
+  — acquire `leaseLockPath` (the stable logical lock), then resolve
+  `effectiveLeasePath` INSIDE the lock. Re-resolution after acquisition is
+  mandatory: an operation that waited on the right lock must never act on
+  pre-lock path state. Deterministic regression: `AtomicFileWriter.beforeMove`
+  parks claimant A mid-migration while B claims → exactly 1 success, 1
+  conflict (M18). Stronger fence-vs-takeover regression: a hooked
+  checkpoint store parks worker A's fenced save after validation; the clock
+  passes expiry; B's claim must NOT complete while A's fenced mutation
+  holds the lease lock, then B takes over after A completes (M19).
 - **JDBC renew returns the durable row** instead of the caller-derived
   snapshot (`lease.copy(...)`): the caller's tampered acquiredAt/expiresAt
   can no longer leak into the returned lease.
@@ -855,7 +864,7 @@ fencing operation.
 - New public class `CollisionFreeWorkflowLeasePathStrategy` is additive;
   `api/` dump regenerated.
 
-### Mutation evidence (18 mutations, each restored)
+### Mutation evidence (19 mutations, each restored)
 
 | Mutation | TCK outcome |
 |---|---|
@@ -877,6 +886,7 @@ fencing operation.
 | JDBC fence mutates checkpoint revision | RED — fence non-mutation case |
 | File claim loses its file lock | RED — claim race |
 | File claim locks the storage path and resolves it before locking | RED — expired-legacy concurrent-takeover race |
+| File fence reverts to the data-path lock | RED — fence-vs-takeover race |
 
 ### Scope
 

--- a/docs/reference/persistence-store-compatibility-contract.md
+++ b/docs/reference/persistence-store-compatibility-contract.md
@@ -3,9 +3,10 @@
 Epic 8.1 (PR #267 ApprovalStore slice, PR #269 ApprovalContinuationStore
 slice, PR #270 SuspendedInvocationStore slice, PR #271 AuditStore slice,
 PR #272 SovereignOpsAuditOutboxStore slice, PR #273 WorkflowCheckpointStore
-slice). Shared behavioral TCKs prove every implementation of a store family
-satisfies exactly the same externally observable contract, regardless of
-storage technology (memory, encrypted files, Markdown, JDBC).
+slice, PR #274 WorkflowLeaseStore slice). Shared behavioral TCKs prove every
+implementation of a store family satisfies exactly the same externally
+observable contract, regardless of storage technology (memory, encrypted
+files, Markdown, JDBC).
 
 ## Epic 8.1 matrix
 
@@ -17,7 +18,7 @@ storage technology (memory, encrypted files, Markdown, JDBC).
 | Audit | ✅ | ✅ | — | ✅ | ✅ #271 |
 | Audit outbox | ✅ | ✅ | — | ✅ | ✅ #272 |
 | Workflow checkpoint | ✅ | ✅ | ✅ | ✅ | ✅ #273 |
-| Workflow lease | … | … | — | … | ⏳ |
+| Workflow lease | ✅ | ✅ | — | ✅ | ✅ #274 |
 | Step attempt | ✅ | ✅ | — | ✅ | ✅ #218 |
 | Memory | … | … | — | … | ⏳ |
 
@@ -723,3 +724,152 @@ higher-level coverage. No existing tests were deleted. `tramai-testing`
 testFixtures gained a dependency on `tramai-orchestration` (test-fixture-only)
 so the shared suite can be written in one place. Legacy path behavior is
 documented in `docs/guides/orchestration-persistence.md`.
+
+## WorkflowLeaseStore TCK (PR #274)
+
+`WorkflowLeaseStoreTck` (tramai-testing testFixtures) runs **51 shared
+behavioral cases** against every `WorkflowLeaseStore` implementation — the
+orchestration module's in-memory store, the properties-file store, and JDBC
+(real H2, not a proxy backend). The companion
+`WorkflowLeaseCheckpointFenceTck` runs **14 shared cases** against every
+`WorkflowLeaseCheckpointFence` implementation (same three stores), because
+the worker depends on the fence and the distributed-execution design
+requires stale-worker checkpoint writes to be rejected by the active lease
+token. Both TCKs are deterministic: a thread-safe `MutableMillisClock`
+(AtomicLong) replaces the system clock; no sleeps, no `Instant.now()`.
+
+The property the contract enforces: **for one (workflowName, workflowId),
+at any instant there is at most one active lease token capable of
+authorizing mutations, and storage technology cannot change that answer.**
+Identity → claim ownership → time-bound validity → renewal/takeover →
+checkpoint fencing. What proves a worker owns a workflow is NOT ownerId,
+filesystem path, checkpoint revision, or a lease object that used to be
+valid — it is logical workflow identity + current active leaseId + matching
+owner + not expired, and the ownership check and mutation form ONE atomic
+fencing operation.
+
+- **Claim / identity (14):** missing → null; claim returns an active lease;
+  exact name/id/owner; nullable checkpoint revision; acquiredAt == now;
+  expiresAt == now + duration; nonblank leaseId; same-name/different-id and
+  same-id/different-name independence; second active claim by another owner
+  → `WorkflowLeaseConflictException` (`"Workflow lease conflict"`, null
+  cause); second active claim by the SAME owner → conflict; rejected claim
+  leaves the original unchanged; **two legacy-colliding identities
+  (`"order/a"` vs `"order?a"`) can own active leases simultaneously** —
+  storage layout cannot redefine who owns a workflow.
+- **Exact expiry semantics (10):** authoritative boundary `expiresAt > now`
+  → active, `expiresAt <= now` → expired. T0+999 → lease; T0+1000 → null;
+  claim at T0+999 → conflict; claim at T0+1000 → succeeds; takeover gets
+  new owner/acquisition time/fresh expiry; stale old lease cannot renew or
+  release the successor; same owner taking over after expiry still receives
+  a NEW fencing token. Implementations may or may not physically delete
+  expired state — only observable behavior is pinned.
+- **Renewal (9):** successful renew preserves workflow identity, leaseId,
+  ownerId, acquiredAt; new checkpointRevision; new expiresAt =
+  renewalNow + duration (never old-expiry + duration); **the caller's lease
+  object is a capability snapshot, not writable metadata — a tampered
+  `acquiredAt=42` snapshot must not leak into the returned lease** (this
+  discriminator exposed the JDBC divergence); renew to/from nullable
+  revision; wrong leaseId → conflict; wrong owner → conflict; missing →
+  conflict; exact-expiry → conflict; rejected renew non-mutating.
+- **Release (7):** active + correct token removed; missing → no-op; expired
+  → no-op; wrong token → conflict; wrong owner → conflict; **stale
+  predecessor (even the same ownerId, different leaseId) cannot release the
+  successor** — leaseId is the fencing capability, not owner name alone.
+- **Input-domain hardening (6):** blank workflowName/workflowId/ownerId,
+  leaseDurationMillis == 0 or < 0, and blank leaseId on renew/release are
+  `IllegalArgumentException` — caller errors OUTSIDE the persistence
+  boundary, mirroring `WorkflowLeasePolicy` runtime invariants. Unicode and
+  punctuation remain legitimate identities (no ASCII/path-safe restriction —
+  that would merely hide the File-store bug).
+- **Concurrency (4 real parallel races, start barrier, 20 iterations
+  each):** initial claim race (8 owners → 1 success, 7 conflicts, 1 active
+  durable lease); expired takeover race (seed expired → exactly 1 takeover);
+  **renewal vs takeover at the exact expiry boundary** (renew → conflict,
+  claim → success, final owner = new); parallel claims of the two
+  legacy-colliding keys (both succeed — turns File RED before its identity
+  fix).
+
+### WorkflowLeaseCheckpointFence TCK (companion, 14 cases)
+
+- **Valid fence:** active lease + checkpoint rev1 → fenced save → rev2,
+  fenced delete → absent, lease still active; works with null
+  checkpointRevision.
+- **Stale fence:** `StaleWorkflowLeaseException` with exactly
+  `"Workflow lease is no longer active"` and null cause for expired lease,
+  replaced lease, wrong leaseId, wrong owner, missing lease — and the
+  checkpoint remains completely unchanged. Semantically distinct from the
+  ordinary `WorkflowLeaseConflictException`.
+- **Identity binding (new shared invariant):** a lease for workflow A must
+  never authorize a mutation of workflow B — `IllegalArgumentException`
+  before touching storage, no checkpoint or lease mutation (save AND
+  delete). This closes a shared weakness in all three fences.
+- **The fence is NOT a renewal API:** fenced saves never extend the lease;
+  and the fence must not write the expected lease's checkpointRevision into
+  the durable lease as a side effect of checking ownership (the
+  discriminator that exposed the JDBC lockLeaseRow UPDATE).
+
+### Production changes (runtime-behaviour)
+
+- **File lease identity fix (the principal one).** The lossy
+  `sanitizePathSegment` collapsed `"order/a"` and `"order?a"` onto one lease
+  file — for leases this is worse than for checkpoints: storage layout could
+  redefine who owns a workflow. The new
+  `CollisionFreeWorkflowLeasePathStrategy` is minimally disruptive: segments
+  already in the legacy-safe raw domain `[A-Za-z0-9_-]` keep their existing
+  path (UUID/hyphenated workflow IDs do not move), any other segment is
+  encoded as `~` + URL-safe Base64 (`~` is outside the legacy-safe domain,
+  so canonical paths can never collide with legacy paths). Legacy leases are
+  honored on their legacy path with identity verification (a colliding
+  key's lease is never returned as yours, never overwritten); a live lease
+  is NOT migrated (the lock namespace must not change under an active
+  lease) — after release or expiry the next claim uses the canonical path.
+  `DefaultWorkflowCheckpointPathStrategy` is unchanged.
+- **JDBC renew returns the durable row** instead of the caller-derived
+  snapshot (`lease.copy(...)`): the caller's tampered acquiredAt/expiresAt
+  can no longer leak into the returned lease.
+- **JDBC fence uses a genuine row lock** (`SELECT ... FOR UPDATE` inside
+  the shared-DataSource checkpoint transaction) instead of the
+  state-mutating `UPDATE ... SET checkpoint_revision = ?` — the fence no
+  longer mutates lease metadata as a side effect.
+- **Shared caller-input validation** (`validateLeaseIdentityInput`,
+  `validateLeaseToken`, `validateFenceIdentity`) added to all three stores
+  outside their persistence boundaries.
+- New public class `CollisionFreeWorkflowLeasePathStrategy` is additive;
+  `api/` dump regenerated.
+
+### Mutation evidence (17 mutations, each restored)
+
+| Mutation | TCK outcome |
+|---|---|
+| active claim guard removed | RED — duplicate-claim cases + claim race |
+| expiry boundary `>=` → `>` | RED — exact-expiry cases + boundary race |
+| claim reuses a fixed lease id | RED — new-token-on-takeover |
+| renew ignores leaseId | RED — wrong-token renew |
+| renew ignores owner | RED — wrong-owner renew |
+| renew accepts expired lease | RED — exact-expiry renew |
+| renew does not update revision | RED — renew identity case |
+| renew expiry based on old expiry | RED — renewal-time case |
+| release ignores token | RED — wrong-token/stale-release cases |
+| fence accepts mismatched checkpoint identity | RED — key-binding save |
+| stale fence accepts forged token | RED — wrong-token/owner fence cases |
+| claim input validation removed | RED — blank/zero/negative-arg cases |
+| File reverts to lossy path | RED — collision discriminator |
+| File accepts foreign colliding legacy identity | RED — File legacy regression |
+| JDBC renew returns caller snapshot | RED — durable-authority case |
+| JDBC fence mutates checkpoint revision | RED — fence non-mutation case |
+| File claim loses its file lock | RED — claim race |
+
+### Scope
+
+The TCK owns cross-technology lease semantics. Implementation-specific
+suites continue owning file format/permissions, JDBC schema internals,
+cancellation, safe-failure diagnostics, worker takeover and renewal-loop
+behavior (`WorkflowLeaseStoreTest`, `LeaseCoordinatorTest`,
+`LeaseRenewalLoopTest`, `TramaiWorkerTest`,
+`FileWorkflowPersistenceCancellationContractTest`,
+`JdbcWorkflowPersistenceCancellationContractTest`,
+`PersistenceSafeFailureBoundaryTest`) — none were deleted or replaced. The
+example smoke suite re-verified (safe-segment lease paths are unchanged, so
+the example's persisted-layout assertions still hold). Lease path behavior
+is documented in `docs/guides/orchestration-persistence.md`.

--- a/docs/reference/persistence-store-compatibility-contract.md
+++ b/docs/reference/persistence-store-compatibility-contract.md
@@ -816,15 +816,32 @@ fencing operation.
   file — for leases this is worse than for checkpoints: storage layout could
   redefine who owns a workflow. The new
   `CollisionFreeWorkflowLeasePathStrategy` is minimally disruptive: segments
-  already in the legacy-safe raw domain `[A-Za-z0-9_-]` keep their existing
-  path (UUID/hyphenated workflow IDs do not move), any other segment is
-  encoded as `~` + URL-safe Base64 (`~` is outside the legacy-safe domain,
-  so canonical paths can never collide with legacy paths). Legacy leases are
-  honored on their legacy path with identity verification (a colliding
-  key's lease is never returned as yours, never overwritten); a live lease
-  is NOT migrated (the lock namespace must not change under an active
-  lease) — after release or expiry the next claim uses the canonical path.
-  `DefaultWorkflowCheckpointPathStrategy` is unchanged.
+  already in the legacy-safe raw domain `[A-Za-z0-9_-]` (ASCII letters,
+  digits, `-`, `_` — enforced by an explicit ASCII predicate) keep their
+  existing path (UUID/hyphenated workflow IDs do not move), any other
+  segment is encoded as `~` + URL-safe Base64 (`~` is outside the
+  legacy-safe domain, so canonical paths can never collide with legacy
+  paths). Legacy leases are honored on their legacy path with identity
+  verification (a colliding key's lease is never returned as yours, never
+  overwritten); a live lease is NOT migrated (the lock namespace must not
+  change under an active lease) — after release or expiry the next claim
+  uses the canonical path. `DefaultWorkflowCheckpointPathStrategy` is
+  unchanged.
+- **Stable lock namespace across the legacy→canonical migration (P1
+  review finding).** The lease file path is NOT the synchronization
+  identity when the path itself is migratable: locking whichever data path
+  happens to exist before locking let two concurrent claimants of an
+  expired legacy unsafe-key lease both succeed (A locks the legacy path,
+  deletes it, writes canonical; B — resolving after the delete, before the
+  move — locks the canonical path, sees no lease, succeeds). `claim()`
+  therefore locks a **stable `leaseLockPath`** — for the collision-free
+  strategy the immutable legacy-sanitized path (a/b and a?b share a lock:
+  harmless serialization, distinct lease files) — and **re-resolves the
+  effective storage path INSIDE the acquired lock**. A deterministic
+  regression parks claimant A mid-migration via the injectable
+  `AtomicFileWriter.beforeMove` hook while B claims: exactly 1 success, 1
+  conflict, single canonical lease. (M18 mutates this back to
+  lock-the-storage-path → the race turns RED.)
 - **JDBC renew returns the durable row** instead of the caller-derived
   snapshot (`lease.copy(...)`): the caller's tampered acquiredAt/expiresAt
   can no longer leak into the returned lease.
@@ -838,7 +855,7 @@ fencing operation.
 - New public class `CollisionFreeWorkflowLeasePathStrategy` is additive;
   `api/` dump regenerated.
 
-### Mutation evidence (17 mutations, each restored)
+### Mutation evidence (18 mutations, each restored)
 
 | Mutation | TCK outcome |
 |---|---|
@@ -859,6 +876,7 @@ fencing operation.
 | JDBC renew returns caller snapshot | RED — durable-authority case |
 | JDBC fence mutates checkpoint revision | RED — fence non-mutation case |
 | File claim loses its file lock | RED — claim race |
+| File claim locks the storage path and resolves it before locking | RED — expired-legacy concurrent-takeover race |
 
 ### Scope
 

--- a/tramai-orchestration/api/tramai-orchestration.api
+++ b/tramai-orchestration/api/tramai-orchestration.api
@@ -69,6 +69,12 @@ public final class dev/tramai/orchestration/CollisionFreeWorkflowCheckpointPathS
 	public fun resolve (Ljava/nio/file/Path;Ljava/lang/String;Ljava/lang/String;)Ljava/nio/file/Path;
 }
 
+public final class dev/tramai/orchestration/CollisionFreeWorkflowLeasePathStrategy : dev/tramai/orchestration/WorkflowCheckpointPathStrategy {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun legacyLeasePath (Ljava/nio/file/Path;Ljava/lang/String;Ljava/lang/String;)Ljava/nio/file/Path;
+	public fun resolve (Ljava/nio/file/Path;Ljava/lang/String;Ljava/lang/String;)Ljava/nio/file/Path;
+}
+
 public final class dev/tramai/orchestration/DefaultInstructionDefense : dev/tramai/core/security/InstructionDefense {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FileWorkflowLeaseStore.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FileWorkflowLeaseStore.kt
@@ -128,11 +128,7 @@ class FileWorkflowLeaseStore private constructor(
     ): WorkflowLease? = persistenceBoundary(
         PersistenceResourceKind.LEASE, PersistenceOperation.LOAD, persistenceFailureDiagnosticObserver,
     ) {
-        val leasePath = effectiveLeasePath(workflowName, workflowId)
-        if (!Files.exists(leasePath)) {
-            return@persistenceBoundary null
-        }
-        withFileLockCancellable(leasePath) {
+        withLogicalLeaseLock(workflowName, workflowId) { leasePath ->
             val existing = readLeaseIfPresent(leasePath)
             when {
                 existing == null -> null
@@ -160,19 +156,7 @@ class FileWorkflowLeaseStore private constructor(
             PersistenceResourceKind.LEASE, PersistenceOperation.CLAIM, persistenceFailureDiagnosticObserver,
         ) {
             val canonical = leasePath(workflowName, workflowId)
-            // The lock namespace is the SYNCHRONIZATION identity and must stay
-            // stable across the legacy -> canonical migration: competing
-            // claimants of one logical workflow always pass through the same
-            // lock, even while the storage path itself moves. For the
-            // collision-free strategy this deliberately resolves to the
-            // legacy-sanitized path (a/b and a?b share a lock — harmless
-            // serialization — while their lease files remain distinct).
-            val lockPath = leaseLockPath(workflowName, workflowId)
-            withFileLockCancellable(lockPath) {
-                // Re-resolve the storage path NOW, inside the acquired lock:
-                // a claimant that resolved the legacy path before waiting must
-                // not act on stale path information after migration.
-                val target = effectiveLeasePath(workflowName, workflowId)
+            withLogicalLeaseLock(workflowName, workflowId) { target ->
                 val existing = readLeaseIfPresent(target)?.takeIf {
                     identityMatches(it, workflowName, workflowId)
                 }
@@ -210,8 +194,7 @@ class FileWorkflowLeaseStore private constructor(
         return persistenceBoundary(
             PersistenceResourceKind.LEASE, PersistenceOperation.RENEW, persistenceFailureDiagnosticObserver,
         ) {
-            val leasePath = effectiveLeasePath(lease.workflowName, lease.workflowId)
-            withFileLockCancellable(leasePath) {
+            withLogicalLeaseLock(lease.workflowName, lease.workflowId) { leasePath ->
                 val existing = readLeaseIfPresent(leasePath)?.takeIf {
                     identityMatches(it, lease.workflowName, lease.workflowId)
                 }
@@ -236,14 +219,13 @@ class FileWorkflowLeaseStore private constructor(
     override suspend fun release(lease: WorkflowLease) {
         validateLeaseToken(lease)
         persistenceBoundary(PersistenceResourceKind.LEASE, PersistenceOperation.RELEASE, persistenceFailureDiagnosticObserver) {
-            val leasePath = effectiveLeasePath(lease.workflowName, lease.workflowId)
-            withFileLockCancellable(leasePath) {
+            withLogicalLeaseLock(lease.workflowName, lease.workflowId) { leasePath ->
                 val existing = readLeaseIfPresent(leasePath)?.takeIf {
                     identityMatches(it, lease.workflowName, lease.workflowId)
-                } ?: return@withFileLockCancellable
+                } ?: return@withLogicalLeaseLock
                 if (isExpired(existing)) {
                     deleteLeaseIfPresent(leasePath)
-                    return@withFileLockCancellable
+                    return@withLogicalLeaseLock
                 }
                 if (existing.leaseId != lease.leaseId || existing.ownerId != lease.ownerId) {
                     throw safePersistenceFailure(PersistenceResourceKind.LEASE, PersistenceOperation.RELEASE, PersistenceFailureCode.CONFLICT)
@@ -263,8 +245,7 @@ class FileWorkflowLeaseStore private constructor(
         return persistenceBoundary(
             PersistenceResourceKind.LEASE, PersistenceOperation.SAVE, persistenceFailureDiagnosticObserver,
         ) {
-            val leasePath = effectiveLeasePath(expectedLease.workflowName, expectedLease.workflowId)
-            withFileLockCancellableSuspending(leasePath) {
+            withLogicalLeaseLockSuspending(expectedLease.workflowName, expectedLease.workflowId) { leasePath ->
                 val current = readLeaseIfPresent(leasePath)
                     ?.takeIf { identityMatches(it, expectedLease.workflowName, expectedLease.workflowId) }
                     ?.takeUnless(::isExpired)
@@ -283,8 +264,7 @@ class FileWorkflowLeaseStore private constructor(
     ) {
         validateFenceIdentity(expectedLease, workflowName, workflowId)
         persistenceBoundary(PersistenceResourceKind.LEASE, PersistenceOperation.DELETE, persistenceFailureDiagnosticObserver) {
-            val leasePath = effectiveLeasePath(expectedLease.workflowName, expectedLease.workflowId)
-            withFileLockCancellableSuspending(leasePath) {
+            withLogicalLeaseLockSuspending(expectedLease.workflowName, expectedLease.workflowId) { leasePath ->
                 val current = readLeaseIfPresent(leasePath)
                     ?.takeIf { identityMatches(it, expectedLease.workflowName, expectedLease.workflowId) }
                     ?.takeUnless(::isExpired)
@@ -304,9 +284,16 @@ class FileWorkflowLeaseStore private constructor(
      * lock file both the legacy and the canonical storage paths coordinate
      * through. For the collision-free strategy that is the legacy-sanitized
      * path — it is immutable across the migration boundary, so every
-     * concurrent claimant of the same logical workflow serializes on the
+     * concurrent operation on the same logical workflow serializes on the
      * same lock regardless of where the lease file currently lives. For any
      * other strategy the storage path is the lock path (no migration).
+     *
+     * This is the ONLY lock the File store uses: every operation that can
+     * observe, change, expire, replace, or fence a lease (currentLease,
+     * claim, renew, release, fenced save, fenced delete) acquires the
+     * logical lease lock and resolves the current data path INSIDE it. The
+     * lease's storage location may change (legacy → canonical migration);
+     * its synchronization identity never does.
      */
     private fun leaseLockPath(
         workflowName: String,
@@ -315,6 +302,36 @@ class FileWorkflowLeaseStore private constructor(
         is CollisionFreeWorkflowLeasePathStrategy ->
             strategy.legacyLeasePath(rootDirectory, workflowName, workflowId)
         else -> leasePath(workflowName, workflowId)
+    }
+
+    /**
+     * Acquires the stable logical lease lock, then resolves the current
+     * storage path INSIDE the lock and runs [block] with it. A caller that
+     * resolved the path before waiting must never act on stale path
+     * information after migration, so re-resolution after acquisition is
+     * mandatory, not an optimization.
+     */
+    private suspend inline fun <T> withLogicalLeaseLock(
+        workflowName: String,
+        workflowId: String,
+        crossinline block: (leasePath: Path) -> T,
+    ): T {
+        val lockPath = leaseLockPath(workflowName, workflowId)
+        return withFileLockCancellable(lockPath) {
+            block(effectiveLeasePath(workflowName, workflowId))
+        }
+    }
+
+    /** Suspending variant for the checkpoint-fence operations. */
+    private suspend inline fun <T> withLogicalLeaseLockSuspending(
+        workflowName: String,
+        workflowId: String,
+        crossinline block: suspend (leasePath: Path) -> T,
+    ): T {
+        val lockPath = leaseLockPath(workflowName, workflowId)
+        return withFileLockCancellableSuspending(lockPath) {
+            block(effectiveLeasePath(workflowName, workflowId))
+        }
     }
 
     /**

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FileWorkflowLeaseStore.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FileWorkflowLeaseStore.kt
@@ -2,17 +2,63 @@ package dev.tramai.orchestration
 
 import dev.tramai.core.coroutines.rethrowIfCancellation
 import java.io.StringWriter
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.Base64
 import java.util.Properties
 import java.util.UUID
+/**
+ * Collision-free lease path strategy with minimal layout disruption.
+ *
+ * A lease file is live coordination state — changing its path also changes
+ * the filesystem lock namespace — so unlike the checkpoint strategy this
+ * does NOT re-encode every segment. Segments already in the legacy-safe
+ * raw domain (`[A-Za-z0-9_-]`) keep their existing path unchanged; any
+ * other segment is encoded as `~` + URL-safe Base64 (no padding). `~` is
+ * outside the legacy-safe domain, so a canonical path can never collide
+ * with a legacy sanitized path, and every distinct identity maps to a
+ * distinct file — storage layout cannot redefine who owns a workflow.
+ */
+class CollisionFreeWorkflowLeasePathStrategy(
+    private val fileName: String,
+) : WorkflowCheckpointPathStrategy {
+    override fun resolve(
+        rootDirectory: Path,
+        workflowName: String,
+        workflowId: String,
+    ): Path = rootDirectory
+        .resolve(encodeSegment(workflowName))
+        .resolve(encodeSegment(workflowId))
+        .resolve(fileName)
+
+    /** The pre-collision-free (lossy sanitized) path this key would have used. */
+    fun legacyLeasePath(
+        rootDirectory: Path,
+        workflowName: String,
+        workflowId: String,
+    ): Path = rootDirectory
+        .resolve(sanitizePathSegment(workflowName))
+        .resolve(sanitizePathSegment(workflowId))
+        .resolve(fileName)
+
+    private fun encodeSegment(input: String): String =
+        if (input.all { it.isLetterOrDigit() || it == '-' || it == '_' }) {
+            input
+        } else {
+            "~" + Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(input.toByteArray(StandardCharsets.UTF_8))
+        }
+}
+
 /**
  * Plain file-backed lease store for local and single-filesystem deployments that still need active ownership.
  */
 class FileWorkflowLeaseStore private constructor(
     private val rootDirectory: Path,
     private val pathStrategy: WorkflowCheckpointPathStrategy =
-        DefaultWorkflowCheckpointPathStrategy("lease.properties"),
+        CollisionFreeWorkflowLeasePathStrategy("lease.properties"),
     private val clockMillis: () -> Long = System::currentTimeMillis,
     private val atomicWriter: AtomicFileWriter = realAtomicFileWriter,
 ) : WorkflowLeaseStore, WorkflowLeaseCheckpointFence {
@@ -23,7 +69,7 @@ class FileWorkflowLeaseStore private constructor(
     constructor(
         rootDirectory: Path,
         pathStrategy: WorkflowCheckpointPathStrategy =
-            DefaultWorkflowCheckpointPathStrategy("lease.properties"),
+            CollisionFreeWorkflowLeasePathStrategy("lease.properties"),
         clockMillis: () -> Long = System::currentTimeMillis,
     ) : this(rootDirectory, pathStrategy, clockMillis, realAtomicFileWriter)
 
@@ -67,19 +113,23 @@ class FileWorkflowLeaseStore private constructor(
     ): WorkflowLease? = persistenceBoundary(
         PersistenceResourceKind.LEASE, PersistenceOperation.LOAD, persistenceFailureDiagnosticObserver,
     ) {
-        val leasePath = leasePath(workflowName, workflowId)
+        val leasePath = effectiveLeasePath(workflowName, workflowId)
         if (!Files.exists(leasePath)) {
             return@persistenceBoundary null
         }
         withFileLockCancellable(leasePath) {
             val existing = readLeaseIfPresent(leasePath)
-            if (existing == null) {
-                null
-            } else if (isExpired(existing)) {
-                deleteLeaseIfPresent(leasePath)
-                null
-            } else {
-                existing
+            when {
+                existing == null -> null
+                // A legacy sanitized path may hold another key's lease after
+                // the collision-free strategy was introduced; only accept it
+                // when it identifies the requested key.
+                !identityMatches(existing, workflowName, workflowId) -> null
+                isExpired(existing) -> {
+                    deleteLeaseIfPresent(leasePath)
+                    null
+                }
+                else -> existing
             }
         }
     }
@@ -89,61 +139,82 @@ class FileWorkflowLeaseStore private constructor(
         ownerId: String,
         checkpointRevision: Long?,
         leaseDurationMillis: Long,
-    ): WorkflowLease = persistenceBoundary(
-        PersistenceResourceKind.LEASE, PersistenceOperation.CLAIM, persistenceFailureDiagnosticObserver,
-    ) {
-        val leasePath = leasePath(workflowName, workflowId)
-        withFileLockCancellable(leasePath) {
-            val existing = readLeaseIfPresent(leasePath)
-            if (existing != null && !isExpired(existing)) {
-                throw safePersistenceFailure(PersistenceResourceKind.LEASE, PersistenceOperation.CLAIM, PersistenceFailureCode.CONFLICT)
+    ): WorkflowLease {
+        validateLeaseIdentityInput(workflowName, workflowId, ownerId, leaseDurationMillis)
+        return persistenceBoundary(
+            PersistenceResourceKind.LEASE, PersistenceOperation.CLAIM, persistenceFailureDiagnosticObserver,
+        ) {
+            val canonical = leasePath(workflowName, workflowId)
+            val target = effectiveLeasePath(workflowName, workflowId)
+            withFileLockCancellable(target) {
+                val existing = readLeaseIfPresent(target)?.takeIf {
+                    identityMatches(it, workflowName, workflowId)
+                }
+                if (existing != null && !isExpired(existing)) {
+                    throw safePersistenceFailure(PersistenceResourceKind.LEASE, PersistenceOperation.CLAIM, PersistenceFailureCode.CONFLICT)
+                }
+                if (existing != null && target != canonical) {
+                    // An expired legacy lease: do not extend it in place —
+                    // operate on the legacy path until release or expiry, then
+                    // the next claim uses the canonical collision-free path.
+                    deleteLeaseIfPresent(target)
+                }
+                val now = clockMillis()
+                val lease = WorkflowLease(
+                    workflowName = workflowName,
+                    workflowId = workflowId,
+                    leaseId = UUID.randomUUID().toString(),
+                    ownerId = ownerId,
+                    checkpointRevision = checkpointRevision,
+                    acquiredAtEpochMillis = now,
+                    expiresAtEpochMillis = now + leaseDurationMillis,
+                )
+                atomicWriter.write(canonical, encodeLease(lease))
+                lease
             }
-            val now = clockMillis()
-            val lease = WorkflowLease(
-                workflowName = workflowName,
-                workflowId = workflowId,
-                leaseId = UUID.randomUUID().toString(),
-                ownerId = ownerId,
-                checkpointRevision = checkpointRevision,
-                acquiredAtEpochMillis = now,
-                expiresAtEpochMillis = now + leaseDurationMillis,
-            )
-            atomicWriter.write(leasePath, encodeLease(lease))
-            lease
         }
     }
     override suspend fun renew(
         lease: WorkflowLease,
         checkpointRevision: Long?,
         leaseDurationMillis: Long,
-    ): WorkflowLease = persistenceBoundary(
-        PersistenceResourceKind.LEASE, PersistenceOperation.RENEW, persistenceFailureDiagnosticObserver,
-    ) {
-        val leasePath = leasePath(lease.workflowName, lease.workflowId)
-        withFileLockCancellable(leasePath) {
-            val existing = readLeaseIfPresent(leasePath)
-                ?: throw safePersistenceFailure(PersistenceResourceKind.LEASE, PersistenceOperation.RENEW, PersistenceFailureCode.CONFLICT)
-            if (isExpired(existing)) {
-                deleteLeaseIfPresent(leasePath)
-                throw safePersistenceFailure(PersistenceResourceKind.LEASE, PersistenceOperation.RENEW, PersistenceFailureCode.CONFLICT)
+    ): WorkflowLease {
+        validateLeaseToken(lease)
+        require(leaseDurationMillis > 0) { "leaseDurationMillis must be greater than zero" }
+        return persistenceBoundary(
+            PersistenceResourceKind.LEASE, PersistenceOperation.RENEW, persistenceFailureDiagnosticObserver,
+        ) {
+            val leasePath = effectiveLeasePath(lease.workflowName, lease.workflowId)
+            withFileLockCancellable(leasePath) {
+                val existing = readLeaseIfPresent(leasePath)?.takeIf {
+                    identityMatches(it, lease.workflowName, lease.workflowId)
+                }
+                    ?: throw safePersistenceFailure(PersistenceResourceKind.LEASE, PersistenceOperation.RENEW, PersistenceFailureCode.CONFLICT)
+                if (isExpired(existing)) {
+                    deleteLeaseIfPresent(leasePath)
+                    throw safePersistenceFailure(PersistenceResourceKind.LEASE, PersistenceOperation.RENEW, PersistenceFailureCode.CONFLICT)
+                }
+                if (existing.leaseId != lease.leaseId || existing.ownerId != lease.ownerId) {
+                    throw safePersistenceFailure(PersistenceResourceKind.LEASE, PersistenceOperation.RENEW, PersistenceFailureCode.CONFLICT)
+                }
+                val now = clockMillis()
+                val renewed = existing.copy(
+                    checkpointRevision = checkpointRevision,
+                    expiresAtEpochMillis = now + leaseDurationMillis,
+                )
+                atomicWriter.write(leasePath, encodeLease(renewed))
+                renewed
             }
-            if (existing.leaseId != lease.leaseId || existing.ownerId != lease.ownerId) {
-                throw safePersistenceFailure(PersistenceResourceKind.LEASE, PersistenceOperation.RENEW, PersistenceFailureCode.CONFLICT)
-            }
-            val now = clockMillis()
-            val renewed = existing.copy(
-                checkpointRevision = checkpointRevision,
-                expiresAtEpochMillis = now + leaseDurationMillis,
-            )
-            atomicWriter.write(leasePath, encodeLease(renewed))
-            renewed
         }
     }
     override suspend fun release(lease: WorkflowLease) {
+        validateLeaseToken(lease)
         persistenceBoundary(PersistenceResourceKind.LEASE, PersistenceOperation.RELEASE, persistenceFailureDiagnosticObserver) {
-            val leasePath = leasePath(lease.workflowName, lease.workflowId)
+            val leasePath = effectiveLeasePath(lease.workflowName, lease.workflowId)
             withFileLockCancellable(leasePath) {
-                val existing = readLeaseIfPresent(leasePath) ?: return@withFileLockCancellable
+                val existing = readLeaseIfPresent(leasePath)?.takeIf {
+                    identityMatches(it, lease.workflowName, lease.workflowId)
+                } ?: return@withFileLockCancellable
                 if (isExpired(existing)) {
                     deleteLeaseIfPresent(leasePath)
                     return@withFileLockCancellable
@@ -161,14 +232,19 @@ class FileWorkflowLeaseStore private constructor(
         checkpoint: WorkflowCheckpoint,
         expectedRevision: Long?,
         expectedLease: WorkflowLease,
-    ): WorkflowCheckpoint = persistenceBoundary(
-        PersistenceResourceKind.LEASE, PersistenceOperation.SAVE, persistenceFailureDiagnosticObserver,
-    ) {
-        val leasePath = leasePath(expectedLease.workflowName, expectedLease.workflowId)
-        withFileLockCancellableSuspending(leasePath) {
-            val current = readLeaseIfPresent(leasePath)?.takeUnless(::isExpired)
-            validateExpectedLease(expectedLease, current)
-            checkpointStore.save(checkpoint, expectedRevision)
+    ): WorkflowCheckpoint {
+        validateFenceIdentity(expectedLease, checkpoint.workflowName, checkpoint.workflowId)
+        return persistenceBoundary(
+            PersistenceResourceKind.LEASE, PersistenceOperation.SAVE, persistenceFailureDiagnosticObserver,
+        ) {
+            val leasePath = effectiveLeasePath(expectedLease.workflowName, expectedLease.workflowId)
+            withFileLockCancellableSuspending(leasePath) {
+                val current = readLeaseIfPresent(leasePath)
+                    ?.takeIf { identityMatches(it, expectedLease.workflowName, expectedLease.workflowId) }
+                    ?.takeUnless(::isExpired)
+                validateExpectedLease(expectedLease, current)
+                checkpointStore.save(checkpoint, expectedRevision)
+            }
         }
     }
 
@@ -179,10 +255,13 @@ class FileWorkflowLeaseStore private constructor(
         expectedRevision: Long?,
         expectedLease: WorkflowLease,
     ) {
+        validateFenceIdentity(expectedLease, workflowName, workflowId)
         persistenceBoundary(PersistenceResourceKind.LEASE, PersistenceOperation.DELETE, persistenceFailureDiagnosticObserver) {
-            val leasePath = leasePath(expectedLease.workflowName, expectedLease.workflowId)
+            val leasePath = effectiveLeasePath(expectedLease.workflowName, expectedLease.workflowId)
             withFileLockCancellableSuspending(leasePath) {
-                val current = readLeaseIfPresent(leasePath)?.takeUnless(::isExpired)
+                val current = readLeaseIfPresent(leasePath)
+                    ?.takeIf { identityMatches(it, expectedLease.workflowName, expectedLease.workflowId) }
+                    ?.takeUnless(::isExpired)
                 validateExpectedLease(expectedLease, current)
                 checkpointStore.delete(workflowName, workflowId, expectedRevision)
             }
@@ -193,6 +272,32 @@ class FileWorkflowLeaseStore private constructor(
         workflowName: String,
         workflowId: String,
     ): Path = pathStrategy.resolve(rootDirectory, workflowName, workflowId)
+
+    /**
+     * The path currently holding this key's lease: the canonical
+     * collision-free path when present, otherwise the legacy sanitized path
+     * (when the strategy supports it and the file exists), otherwise the
+     * canonical path. Callers must still verify the decoded record's
+     * identity — a legacy path may hold a colliding key's lease.
+     */
+    private fun effectiveLeasePath(
+        workflowName: String,
+        workflowId: String,
+    ): Path {
+        val canonical = leasePath(workflowName, workflowId)
+        if (Files.exists(canonical)) return canonical
+        val legacy = (pathStrategy as? CollisionFreeWorkflowLeasePathStrategy)
+            ?.legacyLeasePath(rootDirectory, workflowName, workflowId)
+            ?: return canonical
+        return if (Files.exists(legacy)) legacy else canonical
+    }
+
+    private fun identityMatches(
+        lease: WorkflowLease,
+        workflowName: String,
+        workflowId: String,
+    ): Boolean = lease.workflowName == workflowName && lease.workflowId == workflowId
+
     private fun readLeaseIfPresent(path: Path): WorkflowLease? = try {
         if (Files.exists(path)) {
             decodeLease(Files.readString(path))

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FileWorkflowLeaseStore.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FileWorkflowLeaseStore.kt
@@ -43,13 +43,16 @@ class CollisionFreeWorkflowLeasePathStrategy(
         .resolve(fileName)
 
     private fun encodeSegment(input: String): String =
-        if (input.all { it.isLetterOrDigit() || it == '-' || it == '_' }) {
+        if (input.all { it.isAsciiSafe() }) {
             input
         } else {
             "~" + Base64.getUrlEncoder()
                 .withoutPadding()
                 .encodeToString(input.toByteArray(StandardCharsets.UTF_8))
         }
+
+    private fun Char.isAsciiSafe(): Boolean =
+        this in 'A'..'Z' || this in 'a'..'z' || this in '0'..'9' || this == '-' || this == '_'
 }
 
 /**
@@ -90,6 +93,18 @@ class FileWorkflowLeaseStore private constructor(
         ) = FileWorkflowLeaseStore(
             rootDirectory,
             DefaultWorkflowCheckpointPathStrategy("lease.properties"),
+            clockMillis,
+            atomicWriter,
+        )
+
+        fun forTest(
+            rootDirectory: Path,
+            pathStrategy: WorkflowCheckpointPathStrategy,
+            atomicWriter: AtomicFileWriter,
+            clockMillis: () -> Long = System::currentTimeMillis,
+        ) = FileWorkflowLeaseStore(
+            rootDirectory,
+            pathStrategy,
             clockMillis,
             atomicWriter,
         )
@@ -145,8 +160,19 @@ class FileWorkflowLeaseStore private constructor(
             PersistenceResourceKind.LEASE, PersistenceOperation.CLAIM, persistenceFailureDiagnosticObserver,
         ) {
             val canonical = leasePath(workflowName, workflowId)
-            val target = effectiveLeasePath(workflowName, workflowId)
-            withFileLockCancellable(target) {
+            // The lock namespace is the SYNCHRONIZATION identity and must stay
+            // stable across the legacy -> canonical migration: competing
+            // claimants of one logical workflow always pass through the same
+            // lock, even while the storage path itself moves. For the
+            // collision-free strategy this deliberately resolves to the
+            // legacy-sanitized path (a/b and a?b share a lock — harmless
+            // serialization — while their lease files remain distinct).
+            val lockPath = leaseLockPath(workflowName, workflowId)
+            withFileLockCancellable(lockPath) {
+                // Re-resolve the storage path NOW, inside the acquired lock:
+                // a claimant that resolved the legacy path before waiting must
+                // not act on stale path information after migration.
+                val target = effectiveLeasePath(workflowName, workflowId)
                 val existing = readLeaseIfPresent(target)?.takeIf {
                     identityMatches(it, workflowName, workflowId)
                 }
@@ -272,6 +298,24 @@ class FileWorkflowLeaseStore private constructor(
         workflowName: String,
         workflowId: String,
     ): Path = pathStrategy.resolve(rootDirectory, workflowName, workflowId)
+
+    /**
+     * The stable synchronization identity for one logical workflow: the
+     * lock file both the legacy and the canonical storage paths coordinate
+     * through. For the collision-free strategy that is the legacy-sanitized
+     * path — it is immutable across the migration boundary, so every
+     * concurrent claimant of the same logical workflow serializes on the
+     * same lock regardless of where the lease file currently lives. For any
+     * other strategy the storage path is the lock path (no migration).
+     */
+    private fun leaseLockPath(
+        workflowName: String,
+        workflowId: String,
+    ): Path = when (val strategy = pathStrategy) {
+        is CollisionFreeWorkflowLeasePathStrategy ->
+            strategy.legacyLeasePath(rootDirectory, workflowName, workflowId)
+        else -> leasePath(workflowName, workflowId)
+    }
 
     /**
      * The path currently holding this key's lease: the canonical

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/JdbcWorkflowLeaseStore.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/JdbcWorkflowLeaseStore.kt
@@ -42,61 +42,69 @@ class JdbcWorkflowLeaseStore(
         ownerId: String,
         checkpointRevision: Long?,
         leaseDurationMillis: Long,
-    ): WorkflowLease = persistenceBoundary(
-        PersistenceResourceKind.LEASE, PersistenceOperation.CLAIM, persistenceFailureDiagnosticObserver,
-    ) {
-        val lease = newLease(
-            workflowName = workflowName,
-            workflowId = workflowId,
-            ownerId = ownerId,
-            checkpointRevision = checkpointRevision,
-            leaseDurationMillis = leaseDurationMillis,
-        )
-        val existing = loadLease(workflowName, workflowId)
-        when {
-            existing == null -> insertLease(lease)
-            !isExpired(existing) -> throw activeLeaseConflict()
-            else -> replaceExpiredLease(
-                lease = lease,
-                previous = existing,
+    ): WorkflowLease {
+        validateLeaseIdentityInput(workflowName, workflowId, ownerId, leaseDurationMillis)
+        return persistenceBoundary(
+            PersistenceResourceKind.LEASE, PersistenceOperation.CLAIM, persistenceFailureDiagnosticObserver,
+        ) {
+            val lease = newLease(
+                workflowName = workflowName,
+                workflowId = workflowId,
+                ownerId = ownerId,
+                checkpointRevision = checkpointRevision,
+                leaseDurationMillis = leaseDurationMillis,
             )
+            val existing = loadLease(workflowName, workflowId)
+            when {
+                existing == null -> insertLease(lease)
+                !isExpired(existing) -> throw activeLeaseConflict()
+                else -> replaceExpiredLease(
+                    lease = lease,
+                    previous = existing,
+                )
+            }
         }
     }
     override suspend fun renew(
         lease: WorkflowLease,
         checkpointRevision: Long?,
         leaseDurationMillis: Long,
-    ): WorkflowLease = persistenceBoundary(
-        PersistenceResourceKind.LEASE, PersistenceOperation.RENEW, persistenceFailureDiagnosticObserver,
-    ) {
-        val now = clockMillis()
-        val renewed = lease.copy(
-            checkpointRevision = checkpointRevision,
-            expiresAtEpochMillis = now + leaseDurationMillis,
-        )
-        executeJdbcCancellable(dataSource) { conn ->
-            conn.prepareStatement(renewSql()).use { statement ->
-                if (checkpointRevision == null) {
-                    statement.setNull(1, java.sql.Types.BIGINT)
-                } else {
-                    statement.setLong(1, checkpointRevision)
+    ): WorkflowLease {
+        validateLeaseToken(lease)
+        require(leaseDurationMillis > 0) { "leaseDurationMillis must be greater than zero" }
+        return persistenceBoundary(
+            PersistenceResourceKind.LEASE, PersistenceOperation.RENEW, persistenceFailureDiagnosticObserver,
+        ) {
+            val now = clockMillis()
+            val renewedExpiry = now + leaseDurationMillis
+            executeJdbcCancellable(dataSource) { conn ->
+                conn.prepareStatement(renewSql()).use { statement ->
+                    if (checkpointRevision == null) {
+                        statement.setNull(1, java.sql.Types.BIGINT)
+                    } else {
+                        statement.setLong(1, checkpointRevision)
+                    }
+                    statement.setLong(2, renewedExpiry)
+                    statement.setString(3, lease.workflowName)
+                    statement.setString(4, lease.workflowId)
+                    statement.setString(5, lease.leaseId)
+                    statement.setString(6, lease.ownerId)
+                    statement.setLong(7, now)
+                    val updated = statement.executeUpdate()
+                    if (updated == 0) {
+                        val existing = loadLease(conn, lease.workflowName, lease.workflowId)
+                        throw renewalConflict()
+                    }
                 }
-                statement.setLong(2, renewed.expiresAtEpochMillis)
-                statement.setString(3, lease.workflowName)
-                statement.setString(4, lease.workflowId)
-                statement.setString(5, lease.leaseId)
-                statement.setString(6, lease.ownerId)
-                statement.setLong(7, now)
-                val updated = statement.executeUpdate()
-                if (updated == 0) {
-                    val existing = loadLease(conn, lease.workflowName, lease.workflowId)
-                    throw renewalConflict()
-                }
+                // The durable row is authoritative: the caller's lease object
+                // is a capability snapshot, never writable lease metadata.
+                loadLease(conn, lease.workflowName, lease.workflowId)
+                    ?: throw renewalConflict()
             }
         }
-        renewed
     }
     override suspend fun release(lease: WorkflowLease) {
+        validateLeaseToken(lease)
         persistenceBoundary(PersistenceResourceKind.LEASE, PersistenceOperation.RELEASE, persistenceFailureDiagnosticObserver) { executeJdbcCancellable(dataSource) { conn ->
             conn.prepareStatement(releaseSql()).use { statement ->
                 statement.setString(1, lease.workflowName)
@@ -122,6 +130,7 @@ class JdbcWorkflowLeaseStore(
         expectedRevision: Long?,
         expectedLease: WorkflowLease,
     ): WorkflowCheckpoint {
+        validateFenceIdentity(expectedLease, checkpoint.workflowName, checkpoint.workflowId)
         // Caller/framework preconditions stay OUTSIDE the boundary: a wrong
         // store type or DataSource mismatch is a caller error (IllegalArgumentException),
         // not a persistence failure (the P2-3 finding). Both fences must agree.
@@ -160,6 +169,7 @@ class JdbcWorkflowLeaseStore(
         expectedRevision: Long?,
         expectedLease: WorkflowLease,
     ) {
+        validateFenceIdentity(expectedLease, workflowName, workflowId)
         val jdbcCheckpointStore = checkpointStore as? JdbcWorkflowCheckpointStore
             ?: throw unsupportedFence(checkpointStore)
         require(jdbcCheckpointStore.dataSource === dataSource) {
@@ -297,20 +307,25 @@ class JdbcWorkflowLeaseStore(
         connection: java.sql.Connection,
         expectedLease: WorkflowLease,
     ) {
+        // A genuine row lock, never a state-mutating UPDATE: the fence must
+        // not write expectedLease.checkpointRevision into the durable lease
+        // merely as a side effect of checking ownership.
         connection.prepareStatement(lockLeaseSql()).use { statement ->
-            if (expectedLease.checkpointRevision == null) {
-                statement.setNull(1, java.sql.Types.BIGINT)
-            } else {
-                statement.setLong(1, expectedLease.checkpointRevision)
-            }
-            statement.setString(2, expectedLease.workflowName)
-            statement.setString(3, expectedLease.workflowId)
-            statement.setString(4, expectedLease.leaseId)
-            statement.setString(5, expectedLease.ownerId)
-            statement.setLong(6, clockMillis())
-            val updated = statement.executeUpdate()
-            if (updated == 0) {
-                throw safeStaleWorkflowLeaseFailure()
+            statement.setString(1, expectedLease.workflowName)
+            statement.setString(2, expectedLease.workflowId)
+            statement.executeQuery().use { resultSet ->
+                if (!resultSet.next()) {
+                    throw safeStaleWorkflowLeaseFailure()
+                }
+                val leaseId = resultSet.getString(table.leaseIdColumn)
+                val ownerId = resultSet.getString(table.ownerIdColumn)
+                val expiresAt = resultSet.getLong(table.expiresAtEpochMillisColumn)
+                if (leaseId != expectedLease.leaseId ||
+                    ownerId != expectedLease.ownerId ||
+                    expiresAt <= clockMillis()
+                ) {
+                    throw safeStaleWorkflowLeaseFailure()
+                }
             }
         }
     }
@@ -377,13 +392,14 @@ class JdbcWorkflowLeaseStore(
             AND ${table.expiresAtEpochMillisColumn} > ?
     """.trimIndent()
     private fun lockLeaseSql(): String = """
-        UPDATE ${table.tableName}
-        SET ${table.checkpointRevisionColumn} = ?
+        SELECT
+            ${table.leaseIdColumn},
+            ${table.ownerIdColumn},
+            ${table.expiresAtEpochMillisColumn}
+        FROM ${table.tableName}
         WHERE ${table.workflowNameColumn} = ?
             AND ${table.workflowIdColumn} = ?
-            AND ${table.leaseIdColumn} = ?
-            AND ${table.ownerIdColumn} = ?
-            AND ${table.expiresAtEpochMillisColumn} > ?
+        FOR UPDATE
     """.trimIndent()
     private fun releaseSql(): String = """
         DELETE FROM ${table.tableName}

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowLease.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowLease.kt
@@ -80,6 +80,45 @@ class WorkflowLeaseConflictException(
     var safeFactoryTrusted: Boolean = false
         internal set
 }
+
+/**
+ * Caller-input validation for lease operations, enforced OUTSIDE the
+ * persistence boundary: these are caller errors (IllegalArgumentException),
+ * not persistence failures. Mirrors the WorkflowLeasePolicy runtime
+ * invariants (nonblank ownership, positive duration).
+ */
+internal fun validateLeaseIdentityInput(
+    workflowName: String,
+    workflowId: String,
+    ownerId: String,
+    leaseDurationMillis: Long,
+) {
+    require(workflowName.isNotBlank()) { "workflowName must not be blank" }
+    require(workflowId.isNotBlank()) { "workflowId must not be blank" }
+    require(ownerId.isNotBlank()) { "ownerId must not be blank" }
+    require(leaseDurationMillis > 0) { "leaseDurationMillis must be greater than zero" }
+}
+
+internal fun validateLeaseToken(lease: WorkflowLease) {
+    require(lease.leaseId.isNotBlank()) { "leaseId must not be blank" }
+}
+
+/**
+ * The fence binds the expected lease identity to the checkpoint identity:
+ * a lease for workflow A must never authorize a mutation of workflow B.
+ * Framework/caller misuse — IllegalArgumentException, before touching
+ * storage, with no checkpoint or lease mutation.
+ */
+internal fun validateFenceIdentity(
+    expectedLease: WorkflowLease,
+    workflowName: String,
+    workflowId: String,
+) {
+    require(expectedLease.workflowName == workflowName && expectedLease.workflowId == workflowId) {
+        "Fenced checkpoint identity ($workflowName, $workflowId) must match the lease identity " +
+            "(${expectedLease.workflowName}, ${expectedLease.workflowId})"
+    }
+}
 /**
  * Simple in-memory lease store for tests and lightweight local use.
  */
@@ -119,59 +158,67 @@ class InMemoryWorkflowLeaseStore(
         ownerId: String,
         checkpointRevision: Long?,
         leaseDurationMillis: Long,
-    ): WorkflowLease = persistenceBoundary(
-        PersistenceResourceKind.LEASE, PersistenceOperation.CLAIM, persistenceFailureDiagnosticObserver,
-    ) { leaseMutex.withLock {
-        synchronized(monitor) {
-            val key = LeaseKey(workflowName, workflowId)
-            val existing = leases[key]
-            if (existing != null && !isExpired(existing)) {
-                throw safePersistenceFailure(PersistenceResourceKind.LEASE, PersistenceOperation.CLAIM, PersistenceFailureCode.CONFLICT)
+    ): WorkflowLease {
+        validateLeaseIdentityInput(workflowName, workflowId, ownerId, leaseDurationMillis)
+        return persistenceBoundary(
+            PersistenceResourceKind.LEASE, PersistenceOperation.CLAIM, persistenceFailureDiagnosticObserver,
+        ) { leaseMutex.withLock {
+            synchronized(monitor) {
+                val key = LeaseKey(workflowName, workflowId)
+                val existing = leases[key]
+                if (existing != null && !isExpired(existing)) {
+                    throw safePersistenceFailure(PersistenceResourceKind.LEASE, PersistenceOperation.CLAIM, PersistenceFailureCode.CONFLICT)
+                }
+                val now = clockMillis()
+                val lease = WorkflowLease(
+                    workflowName = workflowName,
+                    workflowId = workflowId,
+                    leaseId = UUID.randomUUID().toString(),
+                    ownerId = ownerId,
+                    checkpointRevision = checkpointRevision,
+                    acquiredAtEpochMillis = now,
+                    expiresAtEpochMillis = now + leaseDurationMillis,
+                )
+                leases[key] = lease
+                lease
             }
-            val now = clockMillis()
-            val lease = WorkflowLease(
-                workflowName = workflowName,
-                workflowId = workflowId,
-                leaseId = UUID.randomUUID().toString(),
-                ownerId = ownerId,
-                checkpointRevision = checkpointRevision,
-                acquiredAtEpochMillis = now,
-                expiresAtEpochMillis = now + leaseDurationMillis,
-            )
-            leases[key] = lease
-            lease
-        }
-    } }
+        } }
+    }
 
     override suspend fun renew(
         lease: WorkflowLease,
         checkpointRevision: Long?,
         leaseDurationMillis: Long,
-    ): WorkflowLease = persistenceBoundary(
-        PersistenceResourceKind.LEASE, PersistenceOperation.RENEW, persistenceFailureDiagnosticObserver,
-    ) { leaseMutex.withLock {
-        synchronized(monitor) {
-            val key = LeaseKey(lease.workflowName, lease.workflowId)
-            val existing = leases[key]
-                ?: throw safePersistenceFailure(PersistenceResourceKind.LEASE, PersistenceOperation.RENEW, PersistenceFailureCode.CONFLICT)
-            if (isExpired(existing)) {
-                leases.remove(key)
-                throw safePersistenceFailure(PersistenceResourceKind.LEASE, PersistenceOperation.RENEW, PersistenceFailureCode.CONFLICT)
+    ): WorkflowLease {
+        validateLeaseToken(lease)
+        require(leaseDurationMillis > 0) { "leaseDurationMillis must be greater than zero" }
+        return persistenceBoundary(
+            PersistenceResourceKind.LEASE, PersistenceOperation.RENEW, persistenceFailureDiagnosticObserver,
+        ) { leaseMutex.withLock {
+            synchronized(monitor) {
+                val key = LeaseKey(lease.workflowName, lease.workflowId)
+                val existing = leases[key]
+                    ?: throw safePersistenceFailure(PersistenceResourceKind.LEASE, PersistenceOperation.RENEW, PersistenceFailureCode.CONFLICT)
+                if (isExpired(existing)) {
+                    leases.remove(key)
+                    throw safePersistenceFailure(PersistenceResourceKind.LEASE, PersistenceOperation.RENEW, PersistenceFailureCode.CONFLICT)
+                }
+                if (existing.leaseId != lease.leaseId || existing.ownerId != lease.ownerId) {
+                    throw safePersistenceFailure(PersistenceResourceKind.LEASE, PersistenceOperation.RENEW, PersistenceFailureCode.CONFLICT)
+                }
+                val now = clockMillis()
+                val renewed = existing.copy(
+                    checkpointRevision = checkpointRevision,
+                    expiresAtEpochMillis = now + leaseDurationMillis,
+                )
+                leases[key] = renewed
+                renewed
             }
-            if (existing.leaseId != lease.leaseId || existing.ownerId != lease.ownerId) {
-                throw safePersistenceFailure(PersistenceResourceKind.LEASE, PersistenceOperation.RENEW, PersistenceFailureCode.CONFLICT)
-            }
-            val now = clockMillis()
-            val renewed = existing.copy(
-                checkpointRevision = checkpointRevision,
-                expiresAtEpochMillis = now + leaseDurationMillis,
-            )
-            leases[key] = renewed
-            renewed
-        }
-    } }
+        } }
+    }
 
     override suspend fun release(lease: WorkflowLease) {
+        validateLeaseToken(lease)
         persistenceBoundary(PersistenceResourceKind.LEASE, PersistenceOperation.RELEASE, persistenceFailureDiagnosticObserver) { leaseMutex.withLock {
             synchronized(monitor) {
                 val key = LeaseKey(lease.workflowName, lease.workflowId)
@@ -193,15 +240,18 @@ class InMemoryWorkflowLeaseStore(
         checkpoint: WorkflowCheckpoint,
         expectedRevision: Long?,
         expectedLease: WorkflowLease,
-    ): WorkflowCheckpoint = persistenceBoundary(
-        PersistenceResourceKind.LEASE, PersistenceOperation.SAVE, persistenceFailureDiagnosticObserver,
-    ) { leaseMutex.withLock {
-        val current = synchronized(monitor) {
-            activeLease(expectedLease.workflowName, expectedLease.workflowId)
-        }
-        validateExpectedLease(expectedLease, current)
-        checkpointStore.save(checkpoint, expectedRevision)
-    } }
+    ): WorkflowCheckpoint {
+        validateFenceIdentity(expectedLease, checkpoint.workflowName, checkpoint.workflowId)
+        return persistenceBoundary(
+            PersistenceResourceKind.LEASE, PersistenceOperation.SAVE, persistenceFailureDiagnosticObserver,
+        ) { leaseMutex.withLock {
+            val current = synchronized(monitor) {
+                activeLease(expectedLease.workflowName, expectedLease.workflowId)
+            }
+            validateExpectedLease(expectedLease, current)
+            checkpointStore.save(checkpoint, expectedRevision)
+        } }
+    }
 
     override suspend fun deleteCheckpointIfLeaseOwner(
         checkpointStore: WorkflowCheckpointStore,
@@ -210,6 +260,7 @@ class InMemoryWorkflowLeaseStore(
         expectedRevision: Long?,
         expectedLease: WorkflowLease,
     ) {
+        validateFenceIdentity(expectedLease, workflowName, workflowId)
         persistenceBoundary(PersistenceResourceKind.LEASE, PersistenceOperation.DELETE, persistenceFailureDiagnosticObserver) { leaseMutex.withLock {
             val current = synchronized(monitor) {
                 activeLease(workflowName, workflowId)

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/FileWorkflowLeaseStoreCheckpointFenceTckTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/FileWorkflowLeaseStoreCheckpointFenceTckTest.kt
@@ -1,0 +1,40 @@
+package dev.tramai.orchestration
+
+import dev.tramai.testing.persistence.lease.MutableMillisClock
+import dev.tramai.testing.persistence.lease.WorkflowLeaseCheckpointFenceTck
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicLong
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.TestInstance
+import kotlin.io.path.exists
+
+/**
+ * Epic 8.1g: FileWorkflowLeaseStore must also satisfy the companion
+ * WorkflowLeaseCheckpointFence compatibility contract (tramai-testing
+ * testFixtures). The runner owns per-case isolation: a fresh temp directory
+ * shared by the lease store and its fenced checkpoint store.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FileWorkflowLeaseStoreCheckpointFenceTckTest : WorkflowLeaseCheckpointFenceTck() {
+
+    private val rootDir: Path = Files.createTempDirectory("tramai-fence-tck-file-").toAbsolutePath()
+    private val caseCounter = AtomicLong(0)
+
+    override fun newHarness(): Harness {
+        val clock = MutableMillisClock()
+        val caseDir = Files.createDirectories(rootDir.resolve("case-${caseCounter.incrementAndGet()}"))
+        val leaseStore = FileWorkflowLeaseStore(caseDir, clockMillis = clock)
+        return Harness(
+            clock = clock,
+            leaseStore = leaseStore,
+            fence = leaseStore,
+            checkpointStore = FileWorkflowCheckpointStore(caseDir),
+        )
+    }
+
+    @AfterAll
+    fun cleanup() {
+        if (rootDir.exists()) rootDir.toFile().deleteRecursively()
+    }
+}

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/FileWorkflowLeaseStoreTckTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/FileWorkflowLeaseStoreTckTest.kt
@@ -1,0 +1,33 @@
+package dev.tramai.orchestration
+
+import dev.tramai.testing.persistence.lease.MutableMillisClock
+import dev.tramai.testing.persistence.lease.WorkflowLeaseStoreTck
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicLong
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.TestInstance
+import kotlin.io.path.exists
+
+/**
+ * Epic 8.1g: FileWorkflowLeaseStore must satisfy the shared lease
+ * compatibility contract (tramai-testing testFixtures). The runner owns the
+ * per-case isolation (unique temp directory + deterministic clock); file
+ * format, permissions and lock mechanics never contaminate the contract.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FileWorkflowLeaseStoreTckTest : WorkflowLeaseStoreTck() {
+
+    private val rootDir: Path = Files.createTempDirectory("tramai-lease-tck-file-").toAbsolutePath()
+    private val caseCounter = AtomicLong(0)
+
+    override fun createStore(clock: MutableMillisClock): WorkflowLeaseStore {
+        val caseDir = Files.createDirectories(rootDir.resolve("case-${caseCounter.incrementAndGet()}"))
+        return FileWorkflowLeaseStore(caseDir, clockMillis = clock)
+    }
+
+    @AfterAll
+    fun cleanup() {
+        if (rootDir.exists()) rootDir.toFile().deleteRecursively()
+    }
+}

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/InMemoryWorkflowLeaseStoreCheckpointFenceTckTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/InMemoryWorkflowLeaseStoreCheckpointFenceTckTest.kt
@@ -1,0 +1,24 @@
+package dev.tramai.orchestration
+
+import dev.tramai.testing.persistence.lease.MutableMillisClock
+import dev.tramai.testing.persistence.lease.WorkflowLeaseCheckpointFenceTck
+
+/**
+ * Epic 8.1g: InMemoryWorkflowLeaseStore must also satisfy the companion
+ * WorkflowLeaseCheckpointFence compatibility contract (tramai-testing
+ * testFixtures): the fence is the worker's ownership check + checkpoint
+ * mutation, one atomic fencing operation.
+ */
+class InMemoryWorkflowLeaseStoreCheckpointFenceTckTest : WorkflowLeaseCheckpointFenceTck() {
+
+    override fun newHarness(): Harness {
+        val clock = MutableMillisClock()
+        val leaseStore = InMemoryWorkflowLeaseStore(clock)
+        return Harness(
+            clock = clock,
+            leaseStore = leaseStore,
+            fence = leaseStore,
+            checkpointStore = InMemoryWorkflowCheckpointStore(),
+        )
+    }
+}

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/InMemoryWorkflowLeaseStoreTckTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/InMemoryWorkflowLeaseStoreTckTest.kt
@@ -1,0 +1,16 @@
+package dev.tramai.orchestration
+
+import dev.tramai.testing.persistence.lease.MutableMillisClock
+import dev.tramai.testing.persistence.lease.WorkflowLeaseStoreTck
+
+/**
+ * Epic 8.1g: InMemoryWorkflowLeaseStore — the orchestration module's default
+ * lease store — must satisfy the shared lease compatibility contract
+ * (tramai-testing testFixtures). A fresh store + deterministic clock per
+ * case; the store itself is the mutation target for the family.
+ */
+class InMemoryWorkflowLeaseStoreTckTest : WorkflowLeaseStoreTck() {
+
+    override fun createStore(clock: MutableMillisClock): WorkflowLeaseStore =
+        InMemoryWorkflowLeaseStore(clock)
+}

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/JdbcWorkflowLeaseStoreCheckpointFenceTckTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/JdbcWorkflowLeaseStoreCheckpointFenceTckTest.kt
@@ -1,0 +1,72 @@
+package dev.tramai.orchestration
+
+import dev.tramai.testing.persistence.lease.MutableMillisClock
+import dev.tramai.testing.persistence.lease.WorkflowLeaseCheckpointFenceTck
+import java.sql.DriverManager
+import javax.sql.DataSource
+import org.h2.jdbcx.JdbcDataSource
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Epic 8.1g: JdbcWorkflowLeaseStore must also satisfy the companion
+ * WorkflowLeaseCheckpointFence compatibility contract (tramai-testing
+ * testFixtures). The lease store and the fenced JdbcWorkflowCheckpointStore
+ * SHARE one DataSource — that is what makes the ownership check + checkpoint
+ * mutation one atomic transaction boundary (FOR UPDATE row lock).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JdbcWorkflowLeaseStoreCheckpointFenceTckTest : WorkflowLeaseCheckpointFenceTck() {
+
+    private lateinit var dataSource: DataSource
+
+    @BeforeAll
+    fun setUpAll() {
+        val ds = JdbcDataSource()
+        ds.setURL("jdbc:h2:mem:fence_tck;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE")
+        ds.user = "sa"
+        ds.password = ""
+        dataSource = ds
+        val leaseStore = JdbcWorkflowLeaseStore(dataSource)
+        val checkpointStore = JdbcWorkflowCheckpointStore(dataSource)
+        DriverManager.getConnection("jdbc:h2:mem:fence_tck;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE", "sa", "")
+            .use { conn ->
+                conn.createStatement().use {
+                    it.execute(leaseStore.createTableSql())
+                    it.execute(checkpointStore.createTableSql())
+                }
+            }
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        runCatching {
+            DriverManager.getConnection("jdbc:h2:mem:fence_tck;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE", "sa", "")
+                .use { conn ->
+                    conn.createStatement().use {
+                        it.execute("DROP TABLE IF EXISTS tramai_workflow_lease")
+                        it.execute("DROP TABLE IF EXISTS tramai_workflow_checkpoint")
+                    }
+                }
+        }
+    }
+
+    override fun newHarness(): Harness {
+        val clock = MutableMillisClock()
+        DriverManager.getConnection("jdbc:h2:mem:fence_tck;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE", "sa", "")
+            .use { conn ->
+                conn.createStatement().use {
+                    it.execute("DELETE FROM tramai_workflow_lease")
+                    it.execute("DELETE FROM tramai_workflow_checkpoint")
+                }
+            }
+        val leaseStore = JdbcWorkflowLeaseStore(dataSource, clockMillis = clock)
+        return Harness(
+            clock = clock,
+            leaseStore = leaseStore,
+            fence = leaseStore,
+            checkpointStore = JdbcWorkflowCheckpointStore(dataSource),
+        )
+    }
+}

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/JdbcWorkflowLeaseStoreTckTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/JdbcWorkflowLeaseStoreTckTest.kt
@@ -1,0 +1,52 @@
+package dev.tramai.orchestration
+
+import dev.tramai.testing.persistence.lease.MutableMillisClock
+import dev.tramai.testing.persistence.lease.WorkflowLeaseStoreTck
+import java.sql.DriverManager
+import javax.sql.DataSource
+import org.h2.jdbcx.JdbcDataSource
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Epic 8.1g: JdbcWorkflowLeaseStore must satisfy the shared lease
+ * compatibility contract (tramai-testing testFixtures) against a REAL
+ * relational engine — H2 — rather than a fake JDBC backend. The lease SPI
+ * is standard SQL (PK insert, conditional update, delete, row lock), so H2
+ * gives stronger contract evidence without Testcontainers. The runner owns
+ * the datasource, schema, and per-case table reset.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JdbcWorkflowLeaseStoreTckTest : WorkflowLeaseStoreTck() {
+
+    private lateinit var dataSource: DataSource
+
+    @BeforeAll
+    fun setUpAll() {
+        val ds = JdbcDataSource()
+        ds.setURL("jdbc:h2:mem:lease_tck;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE")
+        ds.user = "sa"
+        ds.password = ""
+        dataSource = ds
+        val store = JdbcWorkflowLeaseStore(dataSource)
+        DriverManager.getConnection("jdbc:h2:mem:lease_tck;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE", "sa", "")
+            .use { conn -> conn.createStatement().use { it.execute(store.createTableSql()) } }
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        runCatching {
+            DriverManager.getConnection("jdbc:h2:mem:lease_tck;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE", "sa", "")
+                .use { conn -> conn.createStatement().use { it.execute("DROP TABLE IF EXISTS tramai_workflow_lease") } }
+        }
+    }
+
+    override fun createStore(clock: MutableMillisClock): WorkflowLeaseStore {
+        DriverManager.getConnection("jdbc:h2:mem:lease_tck;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE", "sa", "")
+            .use { conn ->
+                conn.createStatement().use { it.execute("DELETE FROM tramai_workflow_lease") }
+            }
+        return JdbcWorkflowLeaseStore(dataSource, clockMillis = clock)
+    }
+}

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowLeaseStoreTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowLeaseStoreTest.kt
@@ -1,5 +1,9 @@
 package dev.tramai.orchestration
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import kotlin.io.path.createTempDirectory
@@ -378,6 +382,74 @@ class WorkflowLeaseStoreTest {
         } finally {
             directory.toFile().deleteRecursively()
         }
+    }
+
+    @Test
+    fun `concurrent takeover of an expired legacy unsafe-key lease yields exactly one winner`() = runBlocking<Unit> {
+        var now = 2_000L
+        val directory = createTempDirectory("tramai-lease-legacy-race")
+        try {
+            // Expired pre-collision-free lease for "order/a" on the legacy
+            // lossy path ("order_a").
+            val legacyLease = WorkflowLease(
+                workflowName = "order",
+                workflowId = "a/b",
+                leaseId = "legacy-token-9",
+                ownerId = "worker-old",
+                checkpointRevision = null,
+                acquiredAtEpochMillis = 500,
+                expiresAtEpochMillis = 1_500,
+            )
+            val legacyPath = DefaultWorkflowCheckpointPathStrategy("lease.properties")
+                .resolve(directory, "order", "a/b")
+            Files.createDirectories(legacyPath.parent)
+            Files.writeString(legacyPath, encodeLease(legacyLease))
+
+            // Deterministically park claimant A INSIDE the migration window:
+            // the legacy file is already deleted, the canonical write is about
+            // to move. B then runs against exactly that transient state.
+            val inMigrationWindow = CompletableDeferred<Unit>()
+            val releaseA = CompletableDeferred<Unit>()
+            val writerA = AtomicFileWriter { _ ->
+                inMigrationWindow.complete(Unit)
+                runBlocking { releaseA.await() }
+            }
+            // B uses a SEPARATE store sharing the same directory with a plain
+            // writer: its outcome must depend only on the lock namespace, not
+            // on the shared hook (which would block B too and mask the race).
+            val strategy = CollisionFreeWorkflowLeasePathStrategy("lease.properties")
+            val storeA = FileWorkflowLeaseStore.forTest(directory, strategy, writerA) { now }
+            val storeB = FileWorkflowLeaseStore.forTest(directory, strategy, AtomicFileWriter()) { now }
+
+            val a = async(Dispatchers.Default) {
+                runCatching { storeA.claim("order", "a/b", "worker-a", checkpointRevision = null, leaseDurationMillis = 1_000) }
+            }
+            inMigrationWindow.await()
+            val b = async(Dispatchers.Default) {
+                runCatching { storeB.claim("order", "a/b", "worker-b", checkpointRevision = null, leaseDurationMillis = 1_000) }
+            }
+            // A is provably parked mid-migration (legacy deleted, canonical
+            // not yet moved) while holding the legacy lock. If B completes
+            // NOW, it must have resolved the stale canonical path and
+            // succeeded — the pre-fix defect. With the stable lock namespace
+            // B blocks on the legacy lock instead and cannot complete.
+            val bCompletedWhileABlocked = withTimeoutOrNull(5_000) { b.await() }
+            releaseA.complete(Unit)
+            val outcomes = listOf(a.await(), bCompletedWhileABlocked ?: b.await())
+
+            assertThat(outcomes.count { it.isSuccess })
+                .withFailMessage("expected exactly one claimant to win the expired legacy takeover, got $outcomes")
+                .isEqualTo(1)
+            assertThat(outcomes.filter { it.isFailure }.map { it.exceptionOrNull()?.javaClass?.name })
+                .containsExactly(WorkflowLeaseConflictException::class.java.name)
+            assertThat(runBlocking { storeA.currentLease("order", "a/b") }).isNotNull
+            // The legacy file is gone; the single authoritative lease is the
+            // canonical one.
+            assertThat(Files.exists(legacyPath)).isFalse()
+        } finally {
+            directory.toFile().deleteRecursively()
+        }
+        Unit
     }
 }
 private data class LeaseResumeState(

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowLeaseStoreTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowLeaseStoreTest.kt
@@ -327,6 +327,58 @@ class WorkflowLeaseStoreTest {
         runBlocking { store.release(renewed) }
         assertThat(runBlocking { store.currentLease("jdbc-lease", "wf-1") }).isNull()
     }
+
+    @Test
+    fun `file store honors an exact legacy lease and never aliases a colliding identity`() {
+        var now = 1_000L
+        val directory = createTempDirectory("tramai-lease-legacy")
+        try {
+            // Pre-collision-free lease for "order/a" written at the legacy
+            // lossy path ("order_a").
+            val legacyLease = WorkflowLease(
+                workflowName = "order",
+                workflowId = "a/b",
+                leaseId = "legacy-token-1",
+                ownerId = "worker-old",
+                checkpointRevision = null,
+                acquiredAtEpochMillis = now,
+                expiresAtEpochMillis = now + 10_000,
+            )
+            val legacyPath = DefaultWorkflowCheckpointPathStrategy("lease.properties")
+                .resolve(directory, "order", "a/b")
+            Files.createDirectories(legacyPath.parent)
+            Files.writeString(legacyPath, encodeLease(legacyLease))
+
+            val store = FileWorkflowLeaseStore(directory, clockMillis = { now })
+            // The exact matching legacy lease is honored (no migration).
+            assertThat(runBlocking { store.currentLease("order", "a/b") }).isEqualTo(legacyLease)
+
+            // The colliding identity must never see A's lease as its own —
+            // even before it has any lease of its own.
+            assertThat(runBlocking { store.currentLease("order", "a?b") }).isNull()
+
+            // ...and can claim its canonical path independently.
+            val b = runBlocking {
+                store.claim("order", "a?b", "worker-new", checkpointRevision = null, leaseDurationMillis = 1_000)
+            }
+            assertThat(runBlocking { store.currentLease("order", "a?b") }).isEqualTo(b)
+            assertThat(runBlocking { store.currentLease("order", "a?b") })
+                .isNotEqualTo(legacyLease)
+            assertThat(runBlocking { store.currentLease("order", "a/b") }).isEqualTo(legacyLease)
+
+            // After expiry, the next claim for "a/b" uses the canonical path
+            // and the legacy file is not authoritative anymore.
+            now += 11_000
+            assertThat(runBlocking { store.currentLease("order", "a/b") }).isNull()
+            val again = runBlocking {
+                store.claim("order", "a/b", "worker-old", checkpointRevision = null, leaseDurationMillis = 1_000)
+            }
+            assertThat(runBlocking { store.currentLease("order", "a/b") }).isEqualTo(again)
+            assertThat(again.leaseId).isNotEqualTo("legacy-token-1")
+        } finally {
+            directory.toFile().deleteRecursively()
+        }
+    }
 }
 private data class LeaseResumeState(
     val value: String,
@@ -545,4 +597,4 @@ private fun defaultLeaseValue(returnType: Class<*>): Any? = when {
     returnType == Float::class.javaPrimitiveType -> 0f
     returnType == Char::class.javaPrimitiveType -> '\u0000'
     else -> null
-}
+    }

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowLeaseStoreTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowLeaseStoreTest.kt
@@ -433,7 +433,7 @@ class WorkflowLeaseStoreTest {
             // NOW, it must have resolved the stale canonical path and
             // succeeded — the pre-fix defect. With the stable lock namespace
             // B blocks on the legacy lock instead and cannot complete.
-            val bCompletedWhileABlocked = withTimeoutOrNull(5_000) { b.await() }
+            val bCompletedWhileABlocked = withTimeoutOrNull(2_000) { b.await() }
             releaseA.complete(Unit)
             val outcomes = listOf(a.await(), bCompletedWhileABlocked ?: b.await())
 
@@ -450,6 +450,66 @@ class WorkflowLeaseStoreTest {
             directory.toFile().deleteRecursively()
         }
         Unit
+    }
+
+    @Test
+    fun `fenced checkpoint mutation cannot overlap a successor takeover on an unsafe key`() = runBlocking<Unit> {
+        var now = 1_000L
+        val directory = createTempDirectory("tramai-lease-fence-takeover")
+        try {
+            val strategy = CollisionFreeWorkflowLeasePathStrategy("lease.properties")
+            val storeA = FileWorkflowLeaseStore.forTest(directory, strategy, AtomicFileWriter()) { now }
+            val storeB = FileWorkflowLeaseStore.forTest(directory, strategy, AtomicFileWriter()) { now }
+
+            val leaseA = storeA.claim("order", "a/b", "worker-a", checkpointRevision = null, leaseDurationMillis = 10_000)
+            val checkpointStore = InMemoryWorkflowCheckpointStore()
+            checkpointStore.save(
+                WorkflowCheckpoint("order", "a/b", nextStepIndex = 1, stepExecutions = 1, lastCompletedStepName = "step-1", statePayload = "s1", revision = 1),
+            )
+            val checkpointV2 = WorkflowCheckpoint("order", "a/b", nextStepIndex = 2, stepExecutions = 2, lastCompletedStepName = "step-2", statePayload = "s2", revision = 2)
+
+            // Hooked checkpoint store: blocks INSIDE the fenced mutation, after
+            // the fence validated worker A's lease and acquired the lease lock.
+            val inFencedMutation = CompletableDeferred<Unit>()
+            val releaseFence = CompletableDeferred<Unit>()
+            val hooked = object : WorkflowCheckpointStore by checkpointStore {
+                override suspend fun save(checkpoint: WorkflowCheckpoint, expectedRevision: Long?): WorkflowCheckpoint {
+                    inFencedMutation.complete(Unit)
+                    // Direct await (no nested runBlocking): this hook must stay
+                    // cancellable so a failing test cannot strand the fence.
+                    releaseFence.await()
+                    return checkpointStore.save(checkpoint, expectedRevision)
+                }
+            }
+            val fence = async(Dispatchers.Default) {
+                runCatching {
+                    storeA.saveCheckpointIfLeaseOwner(hooked, checkpointV2, expectedRevision = 1, expectedLease = leaseA)
+                }
+            }
+            inFencedMutation.await()
+            // Worker A's fence holds the lease lock mid-mutation. A's lease is
+            // still active; now let it expire and start B's takeover.
+            now = 20_000L
+            val b = async(Dispatchers.Default) {
+                runCatching { storeB.claim("order", "a/b", "worker-b", checkpointRevision = null, leaseDurationMillis = 10_000) }
+            }
+            val bCompletedWhileFenced = withTimeoutOrNull(2_000) { b.await() }
+            // B must NOT complete while A's fenced checkpoint mutation holds
+            // the lease lock — otherwise the stale worker A can still commit
+            // state after B has taken ownership (split brain).
+            assertThat(bCompletedWhileFenced)
+                .withFailMessage("claim B succeeded while worker A's fenced checkpoint mutation was in flight: $bCompletedWhileFenced")
+                .isNull()
+            releaseFence.complete(Unit)
+            assertThat(fence.await().isSuccess).isTrue()
+            assertThat(b.await().isSuccess).isTrue()
+            // B owns the lease afterward; A's fence completed before B's claim.
+            assertThat(runBlocking { storeA.currentLease("order", "a/b")!!.ownerId }).isEqualTo("worker-b")
+            assertThat(runBlocking { storeA.currentLease("order", "a/b")!!.leaseId })
+                .isNotEqualTo(leaseA.leaseId)
+        } finally {
+            directory.toFile().deleteRecursively()
+        }
     }
 }
 private data class LeaseResumeState(

--- a/tramai-testing/src/test/kotlin/dev/tramai/testing/WorkflowLeaseCheckpointFenceTckEnrollmentArchitectureTest.kt
+++ b/tramai-testing/src/test/kotlin/dev/tramai/testing/WorkflowLeaseCheckpointFenceTckEnrollmentArchitectureTest.kt
@@ -1,0 +1,85 @@
+package dev.tramai.testing
+
+import java.io.File
+import java.nio.file.Files
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Epic 8.1g architecture guard: every concrete
+ * [dev.tramai.orchestration.WorkflowLeaseCheckpointFence] implementation
+ * must be enrolled in the companion fence compatibility contract
+ * (tramai-testing testFixtures). The fence is a distinct optional SPI the
+ * built-in lease stores implement and the worker depends on — it must never
+ * be weakened silently.
+ */
+class WorkflowLeaseCheckpointFenceTckEnrollmentArchitectureTest {
+
+    private val scanner = StoreEnrollmentScanner("WorkflowLeaseCheckpointFence", "WorkflowLeaseCheckpointFenceTck")
+
+    private val repoRoot: File =
+        generateSequence(File(".").absoluteFile) { it.parentFile }
+            .first { it.resolve("settings.gradle.kts").isFile }
+
+    private val expectedRunners = setOf(
+        "InMemoryWorkflowLeaseStoreCheckpointFenceTckTest",
+        "FileWorkflowLeaseStoreCheckpointFenceTckTest",
+        "JdbcWorkflowLeaseStoreCheckpointFenceTckTest",
+    )
+
+    /** Fence runners follow the `<Store>CheckpointFenceTckTest` convention. */
+    private fun runnerNameFor(storeName: String): String = "${storeName}CheckpointFenceTckTest"
+
+    private fun hasValidRunner(repoRoot: File, module: String, storeName: String): Boolean {
+        val runnerName = runnerNameFor(storeName)
+        val testDir = File(repoRoot, "$module/src/test/kotlin")
+        val runnerFile = testDir.walkTopDown()
+            .firstOrNull { it.isFile && it.name == "$runnerName.kt" } ?: return false
+        return Regex("""(?s)class\s+$runnerName\b[^{]*:\s*WorkflowLeaseCheckpointFenceTck\b""")
+            .containsMatchIn(runnerFile.readText())
+    }
+
+    @Test
+    fun `every roadmap fence implementation ships a TCK runner`() {
+        val missing = expectedRunners.filter { runnerName -> scanner.findRunnerFile(repoRoot, runnerName) == null }
+        assertThat(missing)
+            .withFailMessage(
+                "Pinned WorkflowLeaseCheckpointFence TCK runners missing: $missing",
+            )
+            .isEmpty()
+    }
+
+    @Test
+    fun `every WorkflowLeaseCheckpointFence implementation has a valid TCK runner in its module`() {
+        val unenrolled = scanner.storeModules(repoRoot).flatMap { (module, implementations) ->
+            implementations
+                .filter { storeName -> !hasValidRunner(repoRoot, module, storeName) }
+                .map { store -> "$module/$store" }
+        }
+        assertThat(unenrolled)
+            .withFailMessage(
+                "WorkflowLeaseCheckpointFence implementations without a <Store>TckTest runner " +
+                    "extending WorkflowLeaseCheckpointFenceTck in the same module: $unenrolled",
+            )
+            .isEmpty()
+    }
+
+    @Test
+    fun `private decorator is not a fence family member`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            import dev.tramai.orchestration.WorkflowLeaseCheckpointFence
+            private class FencedLease(private val delegate: WorkflowLeaseCheckpointFence) :
+                WorkflowLeaseCheckpointFence by delegate
+            """.trimIndent(),
+        )
+        assertThat(scanner.implementationsIn(file)).isEmpty()
+    }
+
+    private fun tempSourceFile(content: String): File =
+        Files.createTempFile("fence-enrollment-probe-", ".kt").toFile().apply {
+            writeText(content)
+            deleteOnExit()
+        }
+}

--- a/tramai-testing/src/test/kotlin/dev/tramai/testing/WorkflowLeaseStoreTckEnrollmentArchitectureTest.kt
+++ b/tramai-testing/src/test/kotlin/dev/tramai/testing/WorkflowLeaseStoreTckEnrollmentArchitectureTest.kt
@@ -1,0 +1,98 @@
+package dev.tramai.testing
+
+import java.io.File
+import java.nio.file.Files
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Epic 8.1g architecture guard: every concrete
+ * [dev.tramai.orchestration.WorkflowLeaseStore] implementation must be
+ * enrolled in the shared lease compatibility contract (tramai-testing
+ * testFixtures). A future Redis/workflow lease store cannot merge without
+ * enrollment.
+ */
+class WorkflowLeaseStoreTckEnrollmentArchitectureTest {
+
+    private val scanner = StoreEnrollmentScanner("WorkflowLeaseStore", "WorkflowLeaseStoreTck")
+
+    private val repoRoot: File =
+        generateSequence(File(".").absoluteFile) { it.parentFile }
+            .first { it.resolve("settings.gradle.kts").isFile }
+
+    private val expectedRunners = setOf(
+        "InMemoryWorkflowLeaseStoreTckTest",
+        "FileWorkflowLeaseStoreTckTest",
+        "JdbcWorkflowLeaseStoreTckTest",
+    )
+
+    @Test
+    fun `every roadmap WorkflowLeaseStore ships a TCK runner`() {
+        val missing = expectedRunners.filter { runnerName -> scanner.findRunnerFile(repoRoot, runnerName) == null }
+        assertThat(missing)
+            .withFailMessage(
+                "Pinned WorkflowLeaseStore TCK runners missing. The compatibility contract is " +
+                    "reviewed per runner; deleting a runner silently removes a store from the contract: $missing",
+            )
+            .isEmpty()
+    }
+
+    @Test
+    fun `every WorkflowLeaseStore implementation has a valid TCK runner in its module`() {
+        val unenrolled = scanner.storeModules(repoRoot).flatMap { (module, implementations) ->
+            implementations
+                .filter { storeName -> !scanner.hasValidRunner(repoRoot, module, storeName) }
+                .map { store -> "$module/$store" }
+        }
+        assertThat(unenrolled)
+            .withFailMessage(
+                "WorkflowLeaseStore implementations without a <Store>TckTest runner extending " +
+                    "WorkflowLeaseStoreTck in the same module: $unenrolled. " +
+                    "Adding a WorkflowLeaseStore without enrolling it in the compatibility " +
+                    "contract must make a gate fail.",
+            )
+            .isEmpty()
+    }
+
+    // ── probe tests for the scanner against this family ─────────────
+
+    @Test
+    fun `body-less WorkflowLeaseStore implementation is detected`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            import dev.tramai.orchestration.WorkflowLeaseStore
+            class RedisLeaseStore(private val delegate: WorkflowLeaseStore) :
+                WorkflowLeaseStore by delegate
+            """.trimIndent(),
+        )
+        assertThat(scanner.implementationsIn(file)).containsExactly("RedisLeaseStore")
+    }
+
+    @Test
+    fun `runner file must actually subclass WorkflowLeaseStoreTck`() {
+        val fake = tempSourceFile("class RedisLeaseStoreTckTest")
+        val real = tempSourceFile("class RedisLeaseStoreTckTest : WorkflowLeaseStoreTck() { }")
+        assertThat(scanner.runnerSubclassesTck(fake, "RedisLeaseStore")).isFalse()
+        assertThat(scanner.runnerSubclassesTck(real, "RedisLeaseStore")).isTrue()
+    }
+
+    @Test
+    fun `private decorator is not a family member`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            import dev.tramai.orchestration.WorkflowLeaseStore
+            private class FencedLeaseStore(private val delegate: WorkflowLeaseStore) :
+                WorkflowLeaseStore by delegate
+            """.trimIndent(),
+        )
+        assertThat(scanner.implementationsIn(file)).isEmpty()
+    }
+
+    private fun tempSourceFile(content: String): File =
+        Files.createTempFile("lease-enrollment-probe-", ".kt").toFile().apply {
+            writeText(content)
+            deleteOnExit()
+        }
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/lease/MutableMillisClock.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/lease/MutableMillisClock.kt
@@ -1,0 +1,29 @@
+package dev.tramai.testing.persistence.lease
+
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Thread-safe deterministic millis clock for the lease TCKs: fixed at
+ * construction, advanced/set explicitly by the test. Never
+ * `System.currentTimeMillis()`.
+ *
+ * Fits the built-in stores' `clockMillis: () -> Long` slot. Backed by
+ * [AtomicLong] because the concurrency cases read the clock from parallel
+ * workers.
+ */
+class MutableMillisClock(
+    initial: Long = 1_800_000_000_000L,
+) : () -> Long {
+
+    private val now = AtomicLong(initial)
+
+    override fun invoke(): Long = now.get()
+
+    fun set(millis: Long) {
+        now.set(millis)
+    }
+
+    fun advance(millis: Long) {
+        now.addAndGet(millis)
+    }
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/lease/WorkflowLeaseCheckpointFenceTck.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/lease/WorkflowLeaseCheckpointFenceTck.kt
@@ -1,0 +1,290 @@
+package dev.tramai.testing.persistence.lease
+
+import dev.tramai.orchestration.StaleWorkflowLeaseException
+import dev.tramai.orchestration.WorkflowCheckpoint
+import dev.tramai.orchestration.WorkflowCheckpointStore
+import dev.tramai.orchestration.WorkflowLease
+import dev.tramai.orchestration.WorkflowLeaseCheckpointFence
+import dev.tramai.orchestration.WorkflowLeaseStore
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Epic 8.1g: the companion
+ * [dev.tramai.orchestration.WorkflowLeaseCheckpointFence] compatibility
+ * contract — a distinct optional SPI the built-in lease stores implement
+ * and the worker depends on. The fence establishes "this active lease token
+ * still owns the workflow" and makes the ownership check + checkpoint
+ * mutation one atomic fencing operation. It is NOT a renewal API and must
+ * not mutate lease metadata.
+ *
+ * Stale fencing is `StaleWorkflowLeaseException` with exactly
+ * "Workflow lease is no longer active" — semantically distinct from the
+ * ordinary claim/renew/release conflict.
+ */
+abstract class WorkflowLeaseCheckpointFenceTck {
+
+    /** Fresh isolated lease + checkpoint storage and a deterministic clock per case. */
+    protected abstract fun newHarness(): Harness
+
+    class Harness(
+        val clock: MutableMillisClock,
+        val leaseStore: WorkflowLeaseStore,
+        val fence: WorkflowLeaseCheckpointFence,
+        val checkpointStore: WorkflowCheckpointStore,
+    )
+
+    private fun checkpoint(
+        workflowName: String,
+        workflowId: String,
+        nextStepIndex: Int = 3,
+        revision: Long = 0,
+    ): WorkflowCheckpoint = WorkflowCheckpoint(
+        workflowName = workflowName,
+        workflowId = workflowId,
+        nextStepIndex = nextStepIndex,
+        stepExecutions = 1,
+        lastCompletedStepName = "validate",
+        statePayload = """{"state":"review"}""",
+        revision = revision,
+        metadata = emptyMap(),
+        savedAtEpochMillis = 1_800_000_000_000L,
+    )
+
+    private fun assertStale(thrown: Throwable?) {
+        assertThat(thrown).isInstanceOf(StaleWorkflowLeaseException::class.java)
+        assertThat(thrown?.message).isEqualTo("Workflow lease is no longer active")
+        assertThat(thrown?.cause).isNull()
+    }
+
+    @Test
+    fun `fenced checkpoint save succeeds for the active owner`() = runBlocking<Unit> {
+        val h = newHarness()
+        h.checkpointStore.save(checkpoint("invoice-review", "run-001", revision = 1))
+        val lease = h.leaseStore.claim("invoice-review", "run-001", "worker-7", checkpointRevision = 1, leaseDurationMillis = 1_000)
+        val saved = h.fence.saveCheckpointIfLeaseOwner(
+            checkpointStore = h.checkpointStore,
+            checkpoint = checkpoint("invoice-review", "run-001", revision = 1, nextStepIndex = 4),
+            expectedRevision = 1,
+            expectedLease = lease,
+        )
+        assertThat(saved.revision).isEqualTo(2)
+        assertThat(h.checkpointStore.load("invoice-review", "run-001")?.nextStepIndex).isEqualTo(4)
+        assertThat(h.leaseStore.currentLease("invoice-review", "run-001")).isEqualTo(lease)
+    }
+
+    @Test
+    fun `fenced checkpoint delete succeeds for the active owner`() = runBlocking<Unit> {
+        val h = newHarness()
+        h.checkpointStore.save(checkpoint("invoice-review", "run-001", revision = 1))
+        val lease = h.leaseStore.claim("invoice-review", "run-001", "worker-7", checkpointRevision = 1, leaseDurationMillis = 1_000)
+        h.fence.deleteCheckpointIfLeaseOwner(
+            checkpointStore = h.checkpointStore,
+            workflowName = "invoice-review",
+            workflowId = "run-001",
+            expectedRevision = 1,
+            expectedLease = lease,
+        )
+        assertThat(h.checkpointStore.load("invoice-review", "run-001")).isNull()
+        assertThat(h.leaseStore.currentLease("invoice-review", "run-001")).isEqualTo(lease)
+    }
+
+    @Test
+    fun `fence with an expired lease is stale and leaves the checkpoint unchanged`() = runBlocking<Unit> {
+        val h = newHarness()
+        h.checkpointStore.save(checkpoint("invoice-review", "run-001", revision = 1))
+        val lease = h.leaseStore.claim("invoice-review", "run-001", "worker-7", checkpointRevision = 1, leaseDurationMillis = 1_000)
+        h.clock.advance(2_000)
+        assertStale(runCatching {
+            h.fence.saveCheckpointIfLeaseOwner(
+                checkpointStore = h.checkpointStore,
+                checkpoint = checkpoint("invoice-review", "run-001", revision = 1, nextStepIndex = 9),
+                expectedRevision = 1,
+                expectedLease = lease,
+            )
+        }.exceptionOrNull())
+        assertThat(h.checkpointStore.load("invoice-review", "run-001")?.nextStepIndex).isEqualTo(3)
+    }
+
+    @Test
+    fun `fence with a replaced lease is stale and leaves the checkpoint unchanged`() = runBlocking<Unit> {
+        val h = newHarness()
+        h.checkpointStore.save(checkpoint("invoice-review", "run-001", revision = 1))
+        val old = h.leaseStore.claim("invoice-review", "run-001", "worker-7", checkpointRevision = 1, leaseDurationMillis = 1_000)
+        h.clock.advance(2_000)
+        h.leaseStore.claim("invoice-review", "run-001", "worker-9", checkpointRevision = 1, leaseDurationMillis = 1_000)
+        assertStale(runCatching {
+            h.fence.saveCheckpointIfLeaseOwner(
+                checkpointStore = h.checkpointStore,
+                checkpoint = checkpoint("invoice-review", "run-001", revision = 1, nextStepIndex = 9),
+                expectedRevision = 1,
+                expectedLease = old,
+            )
+        }.exceptionOrNull())
+        assertThat(h.checkpointStore.load("invoice-review", "run-001")?.nextStepIndex).isEqualTo(3)
+    }
+
+    @Test
+    fun `fence with the wrong lease id is stale`() = runBlocking<Unit> {
+        val h = newHarness()
+        h.checkpointStore.save(checkpoint("invoice-review", "run-001", revision = 1))
+        val lease = h.leaseStore.claim("invoice-review", "run-001", "worker-7", checkpointRevision = 1, leaseDurationMillis = 1_000)
+        assertStale(runCatching {
+            h.fence.saveCheckpointIfLeaseOwner(
+                checkpointStore = h.checkpointStore,
+                checkpoint = checkpoint("invoice-review", "run-001", revision = 1),
+                expectedRevision = 1,
+                expectedLease = lease.copy(leaseId = "forged-token"),
+            )
+        }.exceptionOrNull())
+    }
+
+    @Test
+    fun `fence with the wrong owner is stale`() = runBlocking<Unit> {
+        val h = newHarness()
+        h.checkpointStore.save(checkpoint("invoice-review", "run-001", revision = 1))
+        val lease = h.leaseStore.claim("invoice-review", "run-001", "worker-7", checkpointRevision = 1, leaseDurationMillis = 1_000)
+        assertStale(runCatching {
+            h.fence.saveCheckpointIfLeaseOwner(
+                checkpointStore = h.checkpointStore,
+                checkpoint = checkpoint("invoice-review", "run-001", revision = 1),
+                expectedRevision = 1,
+                expectedLease = lease.copy(ownerId = "forged-owner"),
+            )
+        }.exceptionOrNull())
+    }
+
+    @Test
+    fun `fence with a missing lease is stale`() = runBlocking<Unit> {
+        val h = newHarness()
+        h.checkpointStore.save(checkpoint("invoice-review", "run-001", revision = 1))
+        assertStale(runCatching {
+            h.fence.saveCheckpointIfLeaseOwner(
+                checkpointStore = h.checkpointStore,
+                checkpoint = checkpoint("invoice-review", "run-001", revision = 1),
+                expectedRevision = 1,
+                expectedLease = WorkflowLeaseFixtures.lease(),
+            )
+        }.exceptionOrNull())
+        assertThat(h.checkpointStore.load("invoice-review", "run-001")).isNotNull
+    }
+
+    @Test
+    fun `fence binds lease identity to checkpoint identity on save`() = runBlocking<Unit> {
+        val h = newHarness()
+        h.checkpointStore.save(checkpoint("workflow-b", "id-1", revision = 1))
+        val lease = h.leaseStore.claim("workflow-a", "id-1", "worker-7", checkpointRevision = 1, leaseDurationMillis = 1_000)
+        assertThat(runCatching {
+            h.fence.saveCheckpointIfLeaseOwner(
+                checkpointStore = h.checkpointStore,
+                checkpoint = checkpoint("workflow-b", "id-1", revision = 1, nextStepIndex = 9),
+                expectedRevision = 1,
+                expectedLease = lease,
+            )
+        }.exceptionOrNull()).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(h.checkpointStore.load("workflow-b", "id-1")?.nextStepIndex).isEqualTo(3)
+        assertThat(h.leaseStore.currentLease("workflow-a", "id-1")).isEqualTo(lease)
+    }
+
+    @Test
+    fun `fence binds lease identity to checkpoint identity on delete`() = runBlocking<Unit> {
+        val h = newHarness()
+        h.checkpointStore.save(checkpoint("workflow-a", "id-2", revision = 1))
+        val lease = h.leaseStore.claim("workflow-a", "id-1", "worker-7", checkpointRevision = 1, leaseDurationMillis = 1_000)
+        assertThat(runCatching {
+            h.fence.deleteCheckpointIfLeaseOwner(
+                checkpointStore = h.checkpointStore,
+                workflowName = "workflow-a",
+                workflowId = "id-2",
+                expectedRevision = 1,
+                expectedLease = lease,
+            )
+        }.exceptionOrNull()).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(h.checkpointStore.load("workflow-a", "id-2")).isNotNull
+        assertThat(h.leaseStore.currentLease("workflow-a", "id-1")).isEqualTo(lease)
+    }
+
+    @Test
+    fun `fence does not renew or extend the lease`() = runBlocking<Unit> {
+        val h = newHarness()
+        h.checkpointStore.save(checkpoint("invoice-review", "run-001", revision = 1))
+        val lease = h.leaseStore.claim("invoice-review", "run-001", "worker-7", checkpointRevision = 1, leaseDurationMillis = 1_000)
+        h.clock.advance(500)
+        h.fence.saveCheckpointIfLeaseOwner(
+            checkpointStore = h.checkpointStore,
+            checkpoint = checkpoint("invoice-review", "run-001", revision = 1),
+            expectedRevision = 1,
+            expectedLease = lease,
+        )
+        h.clock.advance(500)
+        // Still inside the original window at T0+1000? No: T0+1000 is exact
+        // expiry, so the lease must be gone — the fence never extended it.
+        assertThat(h.leaseStore.currentLease("invoice-review", "run-001")).isNull()
+    }
+
+    @Test
+    fun `fence does not mutate durable lease metadata`() = runBlocking<Unit> {
+        val h = newHarness()
+        h.checkpointStore.save(checkpoint("invoice-review", "run-001", revision = 1))
+        val lease = h.leaseStore.claim("invoice-review", "run-001", "worker-7", checkpointRevision = 3, leaseDurationMillis = 1_000)
+        // The caller's snapshot is a capability token; the fence must not
+        // write its checkpointRevision into the durable lease.
+        val tampered = lease.copy(checkpointRevision = 999)
+        h.fence.saveCheckpointIfLeaseOwner(
+            checkpointStore = h.checkpointStore,
+            checkpoint = checkpoint("invoice-review", "run-001", revision = 1, nextStepIndex = 4),
+            expectedRevision = 1,
+            expectedLease = tampered,
+        )
+        assertThat(h.checkpointStore.load("invoice-review", "run-001")?.nextStepIndex).isEqualTo(4)
+        assertThat(h.leaseStore.currentLease("invoice-review", "run-001")?.checkpointRevision).isEqualTo(3)
+    }
+
+    @Test
+    fun `fence works with a null checkpoint revision lease`() = runBlocking<Unit> {
+        val h = newHarness()
+        h.checkpointStore.save(checkpoint("invoice-review", "run-001", revision = 1))
+        val lease = h.leaseStore.claim("invoice-review", "run-001", "worker-7", checkpointRevision = null, leaseDurationMillis = 1_000)
+        h.fence.saveCheckpointIfLeaseOwner(
+            checkpointStore = h.checkpointStore,
+            checkpoint = checkpoint("invoice-review", "run-001", revision = 1, nextStepIndex = 4),
+            expectedRevision = 1,
+            expectedLease = lease,
+        )
+        assertThat(h.checkpointStore.load("invoice-review", "run-001")?.nextStepIndex).isEqualTo(4)
+    }
+
+    @Test
+    fun `fence delete with stale lease is stale and leaves the checkpoint`() = runBlocking<Unit> {
+        val h = newHarness()
+        h.checkpointStore.save(checkpoint("invoice-review", "run-001", revision = 1))
+        val lease = h.leaseStore.claim("invoice-review", "run-001", "worker-7", checkpointRevision = 1, leaseDurationMillis = 1_000)
+        h.clock.advance(2_000)
+        assertStale(runCatching {
+            h.fence.deleteCheckpointIfLeaseOwner(
+                checkpointStore = h.checkpointStore,
+                workflowName = "invoice-review",
+                workflowId = "run-001",
+                expectedRevision = 1,
+                expectedLease = lease,
+            )
+        }.exceptionOrNull())
+        assertThat(h.checkpointStore.load("invoice-review", "run-001")).isNotNull
+    }
+
+    @Test
+    fun `fence works with a tampered acquiredAt snapshot`() = runBlocking<Unit> {
+        val h = newHarness()
+        h.checkpointStore.save(checkpoint("invoice-review", "run-001", revision = 1))
+        val lease = h.leaseStore.claim("invoice-review", "run-001", "worker-7", checkpointRevision = 1, leaseDurationMillis = 1_000)
+        val tampered = lease.copy(acquiredAtEpochMillis = 42, expiresAtEpochMillis = 43)
+        val saved = h.fence.saveCheckpointIfLeaseOwner(
+            checkpointStore = h.checkpointStore,
+            checkpoint = checkpoint("invoice-review", "run-001", revision = 1),
+            expectedRevision = 1,
+            expectedLease = tampered,
+        )
+        assertThat(saved.revision).isEqualTo(2)
+    }
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/lease/WorkflowLeaseFixtures.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/lease/WorkflowLeaseFixtures.kt
@@ -1,0 +1,41 @@
+package dev.tramai.testing.persistence.lease
+
+import dev.tramai.orchestration.WorkflowLease
+
+/**
+ * Epic 8.1g: fixtures for the shared
+ * [dev.tramai.orchestration.WorkflowLeaseStore] and
+ * [dev.tramai.orchestration.WorkflowLeaseCheckpointFence] compatibility
+ * contracts. Deterministic only — explicit identities, fixed durations and
+ * clock-controlled timestamps. No sleeps, no real clock.
+ */
+object WorkflowLeaseFixtures {
+
+    const val T0: Long = 1_800_000_000_000L
+
+    const val DURATION: Long = 1_000
+
+    const val WORKFLOW_NAME: String = "invoice-review"
+
+    const val WORKFLOW_ID: String = "run-001"
+
+    const val OWNER: String = "worker-7"
+
+    fun lease(
+        workflowName: String = WORKFLOW_NAME,
+        workflowId: String = WORKFLOW_ID,
+        leaseId: String = "lease-1",
+        ownerId: String = OWNER,
+        checkpointRevision: Long? = 3,
+        acquiredAtEpochMillis: Long = T0,
+        expiresAtEpochMillis: Long = T0 + DURATION,
+    ): WorkflowLease = WorkflowLease(
+        workflowName = workflowName,
+        workflowId = workflowId,
+        leaseId = leaseId,
+        ownerId = ownerId,
+        checkpointRevision = checkpointRevision,
+        acquiredAtEpochMillis = acquiredAtEpochMillis,
+        expiresAtEpochMillis = expiresAtEpochMillis,
+    )
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/lease/WorkflowLeaseStoreTck.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/lease/WorkflowLeaseStoreTck.kt
@@ -1,0 +1,630 @@
+package dev.tramai.testing.persistence.lease
+
+import dev.tramai.orchestration.WorkflowLease
+import dev.tramai.orchestration.WorkflowLeaseConflictException
+import dev.tramai.orchestration.WorkflowLeaseStore
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Epic 8.1g: the shared, cross-implementation
+ * [dev.tramai.orchestration.WorkflowLeaseStore] compatibility contract.
+ *
+ * The property the contract enforces: for one (workflowName, workflowId),
+ * at any instant there is at most one active lease token capable of
+ * authorizing mutations, and storage technology cannot change that answer.
+ * Identity → claim ownership → time-bound validity → renewal/takeover.
+ *
+ * Expiry boundary (authoritative): `expiresAt > now` → active;
+ * `expiresAt <= now` → expired. The durable stored lease is authoritative;
+ * the caller's lease object is a capability/token snapshot, never writable
+ * lease metadata.
+ */
+abstract class WorkflowLeaseStoreTck {
+
+    /** Fresh isolated storage + deterministic clock per case; runner owns cleanup. */
+    protected abstract fun createStore(clock: MutableMillisClock): WorkflowLeaseStore
+
+    private fun assertConflict(thrown: Throwable?) {
+        assertThat(thrown).isInstanceOf(WorkflowLeaseConflictException::class.java)
+        assertThat(thrown?.message).isEqualTo("Workflow lease conflict")
+        assertThat(thrown?.cause).isNull()
+    }
+
+    // ── A. Claim / identity ─────────────────────────────────────────
+
+    @Test
+    fun `missing lease loads null`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        assertThat(store.currentLease("no-such", "never")).isNull()
+    }
+
+    @Test
+    fun `claim returns an active lease`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val lease = store.claim("invoice-review", "run-001", "worker-7", checkpointRevision = 3, leaseDurationMillis = 1_000)
+        assertThat(lease).isNotNull
+        assertThat(store.currentLease("invoice-review", "run-001")).isEqualTo(lease)
+    }
+
+    @Test
+    fun `claim preserves exact workflow name and id`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val lease = store.claim("invoice-review", "run-001", "worker-7", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertThat(lease.workflowName).isEqualTo("invoice-review")
+        assertThat(lease.workflowId).isEqualTo("run-001")
+    }
+
+    @Test
+    fun `claim preserves exact owner`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val lease = store.claim("invoice-review", "run-001", "worker-42", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertThat(lease.ownerId).isEqualTo("worker-42")
+    }
+
+    @Test
+    fun `claim preserves nullable checkpoint revision`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val lease = store.claim("invoice-review", "run-001", "worker-7", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertThat(lease.checkpointRevision).isNull()
+        assertThat(store.currentLease("invoice-review", "run-001")?.checkpointRevision).isNull()
+    }
+
+    @Test
+    fun `claim sets acquiredAt to now`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val lease = store.claim("invoice-review", "run-001", "worker-7", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertThat(lease.acquiredAtEpochMillis).isEqualTo(clock())
+    }
+
+    @Test
+    fun `claim sets expiresAt to now plus duration`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val lease = store.claim("invoice-review", "run-001", "worker-7", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertThat(lease.expiresAtEpochMillis).isEqualTo(clock() + 1_000)
+    }
+
+    @Test
+    fun `lease id is nonblank`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val lease = store.claim("invoice-review", "run-001", "worker-7", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertThat(lease.leaseId).isNotBlank()
+    }
+
+    @Test
+    fun `same workflow name different ids stay independent`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val a = store.claim("shared", "id-a", "w-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        val b = store.claim("shared", "id-b", "w-2", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertThat(store.currentLease("shared", "id-a")).isEqualTo(a)
+        assertThat(store.currentLease("shared", "id-b")).isEqualTo(b)
+    }
+
+    @Test
+    fun `same workflow id different names stay independent`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val a = store.claim("name-a", "shared-id", "w-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        val b = store.claim("name-b", "shared-id", "w-2", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertThat(store.currentLease("name-a", "shared-id")).isEqualTo(a)
+        assertThat(store.currentLease("name-b", "shared-id")).isEqualTo(b)
+    }
+
+    @Test
+    fun `second active claim by another owner conflicts`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertConflict(runCatching {
+            store.claim("invoice-review", "run-001", "worker-2", checkpointRevision = null, leaseDurationMillis = 1_000)
+        }.exceptionOrNull())
+    }
+
+    @Test
+    fun `second active claim by the same owner conflicts`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertConflict(runCatching {
+            store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        }.exceptionOrNull())
+    }
+
+    @Test
+    fun `rejected active claim leaves the original unchanged`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val original = store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = 7, leaseDurationMillis = 1_000)
+        runCatching {
+            store.claim("invoice-review", "run-001", "worker-2", checkpointRevision = 9, leaseDurationMillis = 1_000)
+        }
+        assertThat(store.currentLease("invoice-review", "run-001")).isEqualTo(original)
+    }
+
+    @Test
+    fun `legacy-colliding identities can own active leases simultaneously`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        // DefaultWorkflowCheckpointPathStrategy maps both to "order_a".
+        val a = store.claim("order", "a/b", "w-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        val b = store.claim("order", "a?b", "w-2", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertThat(store.currentLease("order", "a/b")).isEqualTo(a)
+        assertThat(store.currentLease("order", "a?b")).isEqualTo(b)
+        assertThat(store.currentLease("order", "a/b")).isNotEqualTo(store.currentLease("order", "a?b"))
+    }
+
+    // ── B. Exact expiry semantics ───────────────────────────────────
+
+    @Test
+    fun `one millisecond before expiry the lease is active`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val lease = store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        clock.advance(999)
+        assertThat(store.currentLease("invoice-review", "run-001")).isEqualTo(lease)
+    }
+
+    @Test
+    fun `at exact expiry the lease is gone`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        clock.advance(1_000)
+        assertThat(store.currentLease("invoice-review", "run-001")).isNull()
+    }
+
+    @Test
+    fun `claim one millisecond before expiry conflicts`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        clock.advance(999)
+        assertConflict(runCatching {
+            store.claim("invoice-review", "run-001", "worker-2", checkpointRevision = null, leaseDurationMillis = 1_000)
+        }.exceptionOrNull())
+    }
+
+    @Test
+    fun `claim at exact expiry succeeds`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        clock.advance(1_000)
+        val takeover = store.claim("invoice-review", "run-001", "worker-2", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertThat(takeover).isNotNull
+        assertThat(store.currentLease("invoice-review", "run-001")).isEqualTo(takeover)
+    }
+
+    @Test
+    fun `takeover gets the new owner`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        clock.advance(2_000)
+        val takeover = store.claim("invoice-review", "run-001", "worker-2", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertThat(takeover.ownerId).isEqualTo("worker-2")
+    }
+
+    @Test
+    fun `takeover gets a new acquisition time`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        clock.advance(2_000)
+        val takeover = store.claim("invoice-review", "run-001", "worker-2", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertThat(takeover.acquiredAtEpochMillis).isEqualTo(clock())
+    }
+
+    @Test
+    fun `takeover gets a fresh expiry`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        clock.advance(2_000)
+        val takeover = store.claim("invoice-review", "run-001", "worker-2", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertThat(takeover.expiresAtEpochMillis).isEqualTo(clock() + 1_000)
+    }
+
+    @Test
+    fun `stale old lease cannot renew after takeover`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val old = store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        clock.advance(2_000)
+        store.claim("invoice-review", "run-001", "worker-2", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertConflict(runCatching {
+            store.renew(old, checkpointRevision = null, leaseDurationMillis = 1_000)
+        }.exceptionOrNull())
+    }
+
+    @Test
+    fun `stale old lease cannot release the new owners lease`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val old = store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        clock.advance(2_000)
+        val takeover = store.claim("invoice-review", "run-001", "worker-2", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertConflict(runCatching { store.release(old) }.exceptionOrNull())
+        assertThat(store.currentLease("invoice-review", "run-001")).isEqualTo(takeover)
+    }
+
+    @Test
+    fun `same owner taking over after expiry receives a new fencing token`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val first = store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        clock.advance(2_000)
+        val second = store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertThat(second.leaseId).isNotEqualTo(first.leaseId)
+    }
+
+    // ── C. Renewal contract ─────────────────────────────────────────
+
+    @Test
+    fun `successful renew preserves identity and updates revision and expiry`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val claimed = store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = 1, leaseDurationMillis = 1_000)
+        clock.advance(250)
+        val renewed = store.renew(claimed, checkpointRevision = 7, leaseDurationMillis = 1_000)
+        assertThat(renewed.workflowName).isEqualTo(claimed.workflowName)
+        assertThat(renewed.workflowId).isEqualTo(claimed.workflowId)
+        assertThat(renewed.leaseId).isEqualTo(claimed.leaseId)
+        assertThat(renewed.ownerId).isEqualTo(claimed.ownerId)
+        assertThat(renewed.acquiredAtEpochMillis).isEqualTo(claimed.acquiredAtEpochMillis)
+        assertThat(renewed.checkpointRevision).isEqualTo(7)
+        assertThat(renewed.expiresAtEpochMillis).isEqualTo(clock() + 1_000)
+        assertThat(store.currentLease("invoice-review", "run-001")).isEqualTo(renewed)
+    }
+
+    @Test
+    fun `renew expiry is based on renewal time not old expiry`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val claimed = store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        clock.advance(500)
+        val renewed = store.renew(claimed, checkpointRevision = null, leaseDurationMillis = 5_000)
+        assertThat(renewed.expiresAtEpochMillis).isEqualTo(clock() + 5_000)
+    }
+
+    @Test
+    fun `caller-tampered acquired and expiry times are not authoritative`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val claimed = store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = 1, leaseDurationMillis = 1_000)
+        val callerSnapshot = claimed.copy(acquiredAtEpochMillis = 42, expiresAtEpochMillis = 43)
+        clock.advance(200)
+        val renewed = store.renew(callerSnapshot, checkpointRevision = 7, leaseDurationMillis = 5_000)
+        assertThat(renewed.acquiredAtEpochMillis).isEqualTo(claimed.acquiredAtEpochMillis)
+        assertThat(renewed).isEqualTo(store.currentLease("invoice-review", "run-001"))
+    }
+
+    @Test
+    fun `renewal can set checkpoint revision to null`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val claimed = store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = 5, leaseDurationMillis = 1_000)
+        val renewed = store.renew(claimed, checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertThat(renewed.checkpointRevision).isNull()
+    }
+
+    @Test
+    fun `renewal can set checkpoint revision from null to a value`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val claimed = store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        val renewed = store.renew(claimed, checkpointRevision = 9, leaseDurationMillis = 1_000)
+        assertThat(renewed.checkpointRevision).isEqualTo(9)
+    }
+
+    @Test
+    fun `renew with wrong lease id conflicts`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val claimed = store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertConflict(runCatching {
+            store.renew(claimed.copy(leaseId = "other-token"), checkpointRevision = null, leaseDurationMillis = 1_000)
+        }.exceptionOrNull())
+    }
+
+    @Test
+    fun `renew with wrong owner conflicts`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val claimed = store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertConflict(runCatching {
+            store.renew(claimed.copy(ownerId = "intruder"), checkpointRevision = null, leaseDurationMillis = 1_000)
+        }.exceptionOrNull())
+    }
+
+    @Test
+    fun `renew of a missing lease conflicts`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        assertConflict(runCatching {
+            store.renew(
+                WorkflowLeaseFixtures.lease(),
+                checkpointRevision = null,
+                leaseDurationMillis = 1_000,
+            )
+        }.exceptionOrNull())
+    }
+
+    @Test
+    fun `renew at exact expiry conflicts`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val claimed = store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        clock.advance(1_000)
+        assertConflict(runCatching {
+            store.renew(claimed, checkpointRevision = null, leaseDurationMillis = 1_000)
+        }.exceptionOrNull())
+    }
+
+    @Test
+    fun `rejected renew is non-mutating`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val claimed = store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = 3, leaseDurationMillis = 1_000)
+        runCatching { store.renew(claimed.copy(leaseId = "wrong"), checkpointRevision = 99, leaseDurationMillis = 1_000) }
+        assertThat(store.currentLease("invoice-review", "run-001")).isEqualTo(claimed)
+    }
+
+    // ── D. Release contract ─────────────────────────────────────────
+
+    @Test
+    fun `release with the active correct token removes the lease`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val claimed = store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        store.release(claimed)
+        assertThat(store.currentLease("invoice-review", "run-001")).isNull()
+    }
+
+    @Test
+    fun `release of a missing lease is a no-op`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        store.release(WorkflowLeaseFixtures.lease())
+        assertThat(store.currentLease("invoice-review", "run-001")).isNull()
+    }
+
+    @Test
+    fun `release of an expired lease is a no-op`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val claimed = store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        clock.advance(2_000)
+        store.release(claimed)
+        assertThat(store.currentLease("invoice-review", "run-001")).isNull()
+    }
+
+    @Test
+    fun `release with the wrong lease token conflicts`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val claimed = store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertConflict(runCatching { store.release(claimed.copy(leaseId = "other-token")) }.exceptionOrNull())
+        assertThat(store.currentLease("invoice-review", "run-001")).isEqualTo(claimed)
+    }
+
+    @Test
+    fun `release with the wrong owner conflicts`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val claimed = store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertConflict(runCatching { store.release(claimed.copy(ownerId = "intruder")) }.exceptionOrNull())
+        assertThat(store.currentLease("invoice-review", "run-001")).isEqualTo(claimed)
+    }
+
+    @Test
+    fun `stale predecessor cannot release the successor`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val old = store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        clock.advance(2_000)
+        val takeover = store.claim("invoice-review", "run-001", "worker-2", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertConflict(runCatching { store.release(old) }.exceptionOrNull())
+        assertThat(store.currentLease("invoice-review", "run-001")).isEqualTo(takeover)
+    }
+
+    @Test
+    fun `same owner stale predecessor cannot release the successor`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val old = store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        clock.advance(2_000)
+        val takeover = store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        assertThat(takeover.leaseId).isNotEqualTo(old.leaseId)
+        assertConflict(runCatching { store.release(old) }.exceptionOrNull())
+        assertThat(store.currentLease("invoice-review", "run-001")).isEqualTo(takeover)
+    }
+
+    // ── E. Input-domain hardening ───────────────────────────────────
+
+    @Test
+    fun `blank workflow name is a caller error`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        assertThat(runCatching {
+            store.claim("   ", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        }.exceptionOrNull()).isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `blank workflow id is a caller error`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        assertThat(runCatching {
+            store.claim("invoice-review", "", "worker-1", checkpointRevision = null, leaseDurationMillis = 1_000)
+        }.exceptionOrNull()).isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `blank owner id is a caller error`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        assertThat(runCatching {
+            store.claim("invoice-review", "run-001", "\t", checkpointRevision = null, leaseDurationMillis = 1_000)
+        }.exceptionOrNull()).isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `zero lease duration is a caller error`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        assertThat(runCatching {
+            store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = 0)
+        }.exceptionOrNull()).isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `negative lease duration is a caller error`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        assertThat(runCatching {
+            store.claim("invoice-review", "run-001", "worker-1", checkpointRevision = null, leaseDurationMillis = -5)
+        }.exceptionOrNull()).isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `blank lease id on renew and release is a caller error`() = runBlocking<Unit> {
+        val clock = MutableMillisClock()
+        val store = createStore(clock)
+        val blank = WorkflowLeaseFixtures.lease(leaseId = " ")
+        assertThat(runCatching {
+            store.renew(blank, checkpointRevision = null, leaseDurationMillis = 1_000)
+        }.exceptionOrNull()).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(runCatching { store.release(blank) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    // ── F. Concurrency ──────────────────────────────────────────────
+
+    @Test
+    fun `initial claim race - exactly one winner`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val clock = MutableMillisClock()
+            val store = createStore(clock)
+            val name = "race-claim-$round"
+            val outcomes = runInParallel(0 until 8) { index ->
+                runCatching {
+                    store.claim(name, "wf", "worker-$index", checkpointRevision = null, leaseDurationMillis = 1_000)
+                }
+            }
+            assertThat(outcomes.count { it.isSuccess }).withFailMessage {
+                "round $round: expected exactly one claim winner, got ${outcomes.count { it.isSuccess }}"
+            }.isEqualTo(1)
+            assertThat(outcomes.filter { it.isFailure }.map { it.exceptionOrNull()?.javaClass?.name }.toSet())
+                .containsExactly(WorkflowLeaseConflictException::class.java.name)
+            assertThat(store.currentLease(name, "wf")).isNotNull
+        }
+    }
+
+    @Test
+    fun `expired takeover race - exactly one takeover`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val clock = MutableMillisClock()
+            val store = createStore(clock)
+            val name = "race-takeover-$round"
+            store.claim(name, "wf", "worker-old", checkpointRevision = null, leaseDurationMillis = 1_000)
+            clock.advance(2_000)
+            val outcomes = runInParallel(0 until 8) { index ->
+                runCatching {
+                    store.claim(name, "wf", "worker-new-$index", checkpointRevision = null, leaseDurationMillis = 1_000)
+                }
+            }
+            assertThat(outcomes.count { it.isSuccess }).withFailMessage {
+                "round $round: expected exactly one takeover, got ${outcomes.count { it.isSuccess }}"
+            }.isEqualTo(1)
+            assertThat(outcomes.filter { it.isFailure }.map { it.exceptionOrNull()?.javaClass?.name }.toSet())
+                .containsExactly(WorkflowLeaseConflictException::class.java.name)
+            val winnerOwner = "worker-new-${outcomes.indexOfFirst { it.isSuccess }}"
+            assertThat(store.currentLease(name, "wf")?.ownerId).isEqualTo(winnerOwner)
+        }
+    }
+
+    @Test
+    fun `renewal versus takeover at exact expiry - takeover wins`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val clock = MutableMillisClock()
+            val store = createStore(clock)
+            val name = "race-boundary-$round"
+            val old = store.claim(name, "wf", "worker-old", checkpointRevision = null, leaseDurationMillis = 1_000)
+            clock.advance(1_000)
+            val outcomes = runInParallel(0 until 2) { index ->
+                if (index == 0) {
+                    runCatching { store.renew(old, checkpointRevision = 5, leaseDurationMillis = 1_000) }
+                } else {
+                    runCatching {
+                        store.claim(name, "wf", "worker-new", checkpointRevision = null, leaseDurationMillis = 1_000)
+                    }
+                }
+            }
+            assertThat(outcomes[0].isFailure).withFailMessage {
+                "round $round: renew at exact expiry must conflict, got $outcomes"
+            }.isTrue
+            assertThat(outcomes[1].isSuccess).withFailMessage {
+                "round $round: claim at exact expiry must succeed, got $outcomes"
+            }.isTrue
+            assertThat(store.currentLease(name, "wf")?.ownerId).isEqualTo("worker-new")
+        }
+    }
+
+    @Test
+    fun `colliding logical keys claim in parallel without interference`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val clock = MutableMillisClock()
+            val store = createStore(clock)
+            val name = "order"
+            val outcomes = runInParallel(listOf("a/b" to "w-1", "a?b" to "w-2")) { (id, owner) ->
+                runCatching { store.claim(name, id, owner, checkpointRevision = null, leaseDurationMillis = 1_000) }
+            }
+            assertThat(outcomes.count { it.isSuccess }).withFailMessage {
+                "round $round: both colliding keys must claim independently, got $outcomes"
+            }.isEqualTo(2)
+            assertThat(store.currentLease(name, "a/b")?.ownerId).isEqualTo("w-1")
+            assertThat(store.currentLease(name, "a?b")?.ownerId).isEqualTo("w-2")
+        }
+    }
+
+    // ── Parallel-race helper (shared pattern from #269-#273) ────────
+
+    private suspend fun <T, R> runInParallel(
+        items: List<T>,
+        block: suspend (T) -> R,
+    ): List<R> = coroutineScope {
+        val ready = Channel<Unit>(items.size)
+        val release = CompletableDeferred<Unit>()
+        val workers = items.map { item ->
+            async(Dispatchers.Default) {
+                ready.send(Unit)
+                release.await()
+                block(item)
+            }
+        }
+        repeat(items.size) { ready.receive() }
+        release.complete(Unit)
+        workers.map { it.await() }
+    }
+
+    private suspend fun <R> runInParallel(
+        range: IntRange,
+        block: suspend (Int) -> R,
+    ): List<R> = runInParallel(range.toList(), block)
+}


### PR DESCRIPTION
## test(persistence): add WorkflowLeaseStore compatibility TCK — Epic 8.1g

**Status:** Epic 8.1 🚧 IN PROGRESS — Approval ✅ (#267), Approval continuation ✅ (#269), Suspended invocation ✅ (#270), Audit ✅ (#271), Audit outbox ✅ (#272), Workflow checkpoint ✅ (#273), **Workflow lease ✅ (this PR)**; memory pending.

### What this PR does

Two shared behavioral contracts in one PR, preserving the SPI distinction:

- **`WorkflowLeaseStoreTck`** (tramai-testing testFixtures) — **51 shared cases**; any future `WorkflowLeaseStore` (Redis, …) must pass it.
- **`WorkflowLeaseCheckpointFenceTck`** — **14 shared cases**; any future fence implementation must additionally pass it. The fence is a separate optional SPI, NOT magically mandatory at the lease level — but the worker depends on it, so it gets its own contract now, not in 8.2.

Both run against the three real implementations — in-memory, properties-file, and **JDBC against real H2** (the lease SPI is standard SQL: PK insert, conditional update, row lock; the orchestration test module already has H2). The JDBC fence runners make the lease and checkpoint stores **share one DataSource** — that is what makes the ownership check + checkpoint mutation one atomic transaction boundary. Deterministic everywhere: thread-safe `MutableMillisClock` (AtomicLong), no `System.currentTimeMillis()`, no sleeps, no `delay()` as synchronization.

The contract enforced: **for one (workflowName, workflowId), at any instant there is at most one active lease token capable of authorizing mutations — and storage technology cannot change that answer.** What proves a worker owns a workflow is NOT ownerId, filesystem path, checkpoint revision, or a lease object that used to be valid — it is logical identity + current active leaseId + matching owner + not expired (`expiresAt > now` active, `expiresAt <= now` expired), and the ownership check + mutation form ONE atomic fencing operation.

- **Claim / identity (14):** missing → null; claim returns an active lease; exact name/id/owner; nullable checkpoint revision; acquiredAt == now; expiresAt == now + duration; nonblank leaseId; same-name/different-id and same-id/different-name independence; second active claim by another owner → `WorkflowLeaseConflictException` (`"Workflow lease conflict"`, null cause); second active claim by the SAME owner → conflict; rejected claim leaves the original unchanged; **two legacy-colliding identities (`"order/a"` vs `"order?a"`) can own active leases simultaneously** — the discriminator that turned the File store RED.
- **Exact expiry semantics (10):** `expiresAt > now` → active; `<= now` → expired. T0+999 → lease, T0+1000 → null; claim at T0+999 → conflict, at T0+1000 → succeeds; takeover gets new owner/acquisition time/fresh expiry; stale old lease cannot renew or release the successor; same owner taking over still receives a NEW fencing token. Physical deletion of expired state is implementation detail — only observable behavior is pinned.
- **Renewal (9):** successful renew preserves identity/leaseId/ownerId/acquiredAt; new checkpointRevision; new expiresAt = renewalNow + duration (never old-expiry + duration); **the caller's lease object is a capability snapshot, not writable metadata — a tampered `acquiredAt=42` snapshot must not leak into the returned lease** (this discriminator exposed the JDBC divergence); renew to/from null revision; wrong leaseId / wrong owner / missing / exact-expiry → conflict; rejected renew non-mutating.
- **Release (7):** active + correct token removed; missing → no-op; expired → no-op; wrong token → conflict; wrong owner → conflict; **stale predecessor — even with the same ownerId, different leaseId — cannot release the successor**; leaseId is the fencing capability, ownerId alone is insufficient.
- **Input-domain hardening (6):** blank workflowName/workflowId/ownerId, `leaseDurationMillis == 0` or `< 0`, blank leaseId on renew/release → `IllegalArgumentException` OUTSIDE the persistence boundary (caller errors, mirroring `WorkflowLeasePolicy` runtime invariants). No ASCII/path-safe restriction — Unicode and punctuation remain legitimate identities (that would merely hide the File-store bug).
- **Concurrency (4 real parallel races, start barrier, 20 iterations each):** initial claim race (8 owners → exactly 1 winner, 7 conflicts, 1 active durable lease); expired takeover race (seed expired → exactly 1 takeover); **renewal vs takeover at the exact expiry boundary** (renew → conflict, claim → success, final owner = new); parallel claims of the two colliding keys (both succeed).

### WorkflowLeaseCheckpointFence TCK (companion, 14 cases)

- **Valid fence:** active lease + checkpoint rev1 → fenced save → rev2; fenced delete → absent; lease remains active; works with null checkpointRevision.
- **Stale fence:** `StaleWorkflowLeaseException` with exactly `"Workflow lease is no longer active"` and null cause — expired lease, replaced lease, wrong leaseId, wrong owner, missing lease; the checkpoint stays completely unchanged. Semantically distinct from `WorkflowLeaseConflictException` (the safe-failure layer already preserves this).
- **Identity binding (new shared invariant):** a lease for workflow A must never authorize a mutation of workflow B — `IllegalArgumentException` before touching storage, no checkpoint or lease mutation (save AND delete). This closes a shared weakness in all three fences.
- **The fence is NOT a renewal API:** fenced saves never extend the lease; and the fence must not write the expected lease's checkpointRevision into the durable lease as a side effect of locking (the discriminator that exposed the JDBC `lockLeaseRow` UPDATE).

### Production changes (runtime-behaviour — genuine fixes, not test-only)

1. **File lease identity (the principal fix).** The lossy `sanitizePathSegment` collapsed `"order/a"` and `"order?a"` onto ONE lease file — for leases this is worse than checkpoints: **storage layout could redefine who owns a workflow.** New `CollisionFreeWorkflowLeasePathStrategy`, minimally disruptive: segments already in the legacy-safe raw domain `[A-Za-z0-9_-]` keep their existing path (normal UUID/hyphenated workflow IDs do NOT move); any other segment is encoded `~` + URL-safe Base64 (`~` is outside the legacy-safe domain, so canonical paths can never collide with legacy paths). Legacy leases are honored on their legacy path with **identity verification** (a colliding key's lease is never returned as yours, never overwritten); a live legacy lease is **NOT migrated** — the filesystem lock namespace must not change under an active lease; after release or expiry the next claim uses the canonical path. Direct File-specific regression: legacy `order/a` active + `currentLease("order","a?b") == null` + `claim(B)` succeeds + A intact + `A.leaseId != B.leaseId`. `DefaultWorkflowCheckpointPathStrategy` unchanged.
2. **JDBC renew returns the durable row** (re-read after the conditional UPDATE) instead of the caller-derived `lease.copy(...)` — a tampered acquiredAt/expiresAt snapshot can no longer leak into the returned lease.
3. **JDBC fence uses a genuine row lock** — `SELECT … FOR UPDATE` inside the shared-DataSource checkpoint transaction — instead of the state-mutating `UPDATE … SET checkpoint_revision = ?`; lease metadata is never rewritten as a side effect of checking ownership.
4. **Shared caller-input validation** (`validateLeaseIdentityInput`, `validateLeaseToken`, `validateFenceIdentity`) added to all three stores, outside their persistence boundaries.
5. `StoreEnrollmentScanner`-based guards ×2 (`WorkflowLeaseStoreTckEnrollmentArchitectureTest`, `WorkflowLeaseCheckpointFenceTckEnrollmentArchitectureTest`): every implementation (including future Redis) must ship a `<Store>TckTest` / `<Store>CheckpointFenceTckTest` runner extending the contract, private decorators excluded. New public class `CollisionFreeWorkflowLeasePathStrategy` is additive; `api/` dump regenerated.

### Mutation evidence — 17 mutations, each baseline GREEN → named TCK case RED → restored GREEN

| Mutation | TCK outcome |
|---|---|
| active claim guard removed | RED — duplicate-claim cases + claim race |
| expiry boundary `>=` → `>` | RED — exact-expiry cases + boundary race |
| claim reuses a fixed lease id | RED — new-token-on-takeover |
| renew ignores leaseId | RED — wrong-token renew |
| renew ignores owner | RED — wrong-owner renew |
| renew accepts expired lease | RED — exact-expiry renew |
| renew does not update revision | RED — renew identity case |
| renew expiry based on old expiry | RED — renewal-time case |
| release ignores token | RED — wrong-token/stale-release cases |
| fence accepts mismatched checkpoint identity | RED — key-binding save |
| stale fence accepts forged token | RED — wrong-token/owner fence cases |
| claim input validation removed | RED — blank/zero/negative-arg cases |
| File reverts to lossy path | RED — collision discriminator |
| File accepts foreign colliding legacy identity | RED — File legacy regression (preflight: anchor must match exactly once) |
| JDBC renew returns caller snapshot | RED — durable-authority case |
| JDBC fence mutates checkpoint revision | RED — fence non-mutation case |
| File claim loses its file lock | RED — claim race |

### Gates

- `verifyPr -PchangeClass=runtime-behaviour`: **BUILD SUCCESSFUL**
- `verifyCancellationSafety` vs master: **BUILD SUCCESSFUL**
- `:tramai-orchestration:apiCheck`: **PASSED** (dump regenerated for the additive strategy)
- 51/51 × 3 store TCK + 14/14 × 3 fence TCK (real H2); 17/17 mutations RED → GREEN
- Existing suites untouched and green: `WorkflowLeaseStoreTest` (+ new File legacy regression), `LeaseCoordinatorTest`, `LeaseRenewalLoopTest`, `TramaiWorkerTest`, `FileWorkflowPersistenceCancellationContractTest`, `JdbcWorkflowPersistenceCancellationContractTest`, `PersistenceSafeFailureBoundaryTest`
- Example consumer suite re-verified: `examples/kotlin-springboot-example test` **BUILD SUCCESSFUL** (safe-segment lease paths are unchanged, so the example's persisted-layout assertions still hold)
- Zero public API change to existing types; no persisted format/schema changes to existing records (legacy leases readable, honored, never migrated while live); no existing tests deleted
