### PR TITLE
test(persistence): add ChatMemoryStore compatibility TCK — Epic 8.1h

### DIFF
--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1191,7 +1191,7 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ## Epic 8.1: Persistence Store TCKs
 
-**Status: 🚧 IN PROGRESS** — Approval store slice done (PR #267), Approval continuation slice done (PR #269), suspended invocation slice done (PR #270), audit store slice done (PR #271), audit outbox slice done (PR #272), workflow checkpoint slice done (PR #273), workflow lease slice done (PR #274); memory family remaining.
+**Status: ✅ DONE** — Approval store slice done (PR #267), Approval continuation slice done (PR #269), suspended invocation slice done (PR #270), audit store slice done (PR #271), audit outbox slice done (PR #272), workflow checkpoint slice done (PR #273), workflow lease slice done (PR #274), memory slice done (PR #275).
 
 **Goal:** Ensure in-memory, file, and JDBC implementations share the same behavioural contract.
 
@@ -1205,7 +1205,7 @@ repair feedback. No layer maintains its own independent fixture lists.
 - Workflow checkpoint store — ✅ PR #273 (shared `WorkflowCheckpointStoreTck`, 42 cases × 4 implementations + enrollment guard)
 - Workflow lease store — ✅ PR #274 (shared `WorkflowLeaseStoreTck` 51 cases + `WorkflowLeaseCheckpointFenceTck` 14 cases, × 3 implementations + enrollment guards)
 - Step-attempt store — ✅ PR #218 (shared TCK + restart recovery tests for in-memory, file, and JDBC)
-- Memory store — ⏳
+- Memory store — ✅ PR #275 (shared `ChatMemoryStoreTck`, 50 cases × 2 implementations (JDBC + Redis) + enrollment guard; Redis activity-index + atomic batch appends + JDBC ordinal-retry production changes)
 
 ### Contract areas
 

--- a/docs/modules/tramai-memory-store.md
+++ b/docs/modules/tramai-memory-store.md
@@ -19,10 +19,36 @@ interface ChatMemoryStore {
     fun getMessages(conversationId: String): List<Message>
     fun appendMessages(conversationId: String, messages: List<Message>)
     fun deleteConversation(conversationId: String)
+    fun listConversations(limit: Int, offset: Int): List<String>
 }
 ```
 
-Implementations of this interface can be bound to Postgres, Redis, MongoDB, or even the local filesystem. They plug directly into `PersistentChatMemory` found in the `tramai-memory` module.
+The SPI promises: implementations are thread-safe; conversation IDs are
+nonblank; missing conversations return `emptyList()`; reads are snapshots;
+listing is ordered by most recent append/activity descending and paginated.
+A successful `appendMessages()` adds its complete batch exactly once and
+contiguously — concurrent appends never interleave mid-batch.
+
+Bundled implementations (both enrolled in the shared
+`ChatMemoryStoreTck` compatibility contract, Epic 8.1h):
+
+- `JdbcChatMemoryStore` — generic JDBC, ordinal-per-message rows, optimistic
+  whole-transaction retry on the `(conversation_id, ordinal)` uniqueness race
+  (SQLState 23505) so concurrent valid appends never fail on ordinal
+  allocation.
+- `RedisChatMemoryStore` — Redis Lists per conversation plus a sorted-set
+  activity index at the exact key prefix; every append is one atomic
+  `MULTI` (single `RPUSH` of the whole batch + `ZADD`), every delete is
+  `MULTI` (`DEL` + `ZREM`); pre-index legacy lists stay readable and
+  discoverable and are enrolled on their next append. Deployment note: the
+  key at the exact prefix must be a Redis sorted set (the store creates it
+  on first append) — a pre-existing key of another type at the prefix makes
+  appends/deletes fail loudly with `JedisDataException` (WRONGTYPE), never
+  silently degrade.
+
+Implementations of this interface can be bound to Postgres, Redis, MongoDB,
+or even the local filesystem. They plug directly into `PersistentChatMemory`
+found in the `tramai-memory` module.
 
 ## Dependencies
 

--- a/docs/reference/persistence-store-compatibility-contract.md
+++ b/docs/reference/persistence-store-compatibility-contract.md
@@ -10,22 +10,24 @@ files, Markdown, JDBC).
 
 ## Epic 8.1 matrix
 
-| Store family | In-memory | File | Markdown | JDBC | Shared TCK |
-|---|---|---|---|---|---|
-| Approval | ✅ | ✅ | — | ✅ | ✅ #267 |
-| Approval continuation | ✅ | ✅ | — | ✅ | ✅ #269 |
-| Suspended invocation | ✅ | ✅ | — | ✅ | ✅ #270 |
-| Audit | ✅ | ✅ | — | ✅ | ✅ #271 |
-| Audit outbox | ✅ | ✅ | — | ✅ | ✅ #272 |
-| Workflow checkpoint | ✅ | ✅ | ✅ | ✅ | ✅ #273 |
-| Workflow lease | ✅ | ✅ | — | ✅ | ✅ #274 |
-| Step attempt | ✅ | ✅ | — | ✅ | ✅ #218 |
-| Memory | … | … | — | … | ⏳ |
+| Store family | In-memory | File | Markdown | JDBC | Redis | Shared TCK |
+|---|---|---|---|---|---|---|
+| Approval | ✅ | ✅ | — | ✅ | — | ✅ #267 |
+| Approval continuation | ✅ | ✅ | — | ✅ | — | ✅ #269 |
+| Suspended invocation | ✅ | ✅ | — | ✅ | — | ✅ #270 |
+| Audit | ✅ | ✅ | — | ✅ | — | ✅ #271 |
+| Audit outbox | ✅ | ✅ | — | ✅ | — | ✅ #272 |
+| Workflow checkpoint | ✅ | ✅ | ✅ | ✅ | — | ✅ #273 |
+| Workflow lease | ✅ | ✅ | — | ✅ | — | ✅ #274 |
+| Step attempt | ✅ | ✅ | — | ✅ | — | ✅ #218 |
+| Memory | — | — | — | ✅ | ✅ | ✅ #275 |
 
 Markdown cells: the Markdown checkpoint store implements the
 `WorkflowCheckpointStore` SPI (enrolled in #273) but not the optional
 `WorkflowCheckpointCatalog`/step-attempt families; the remaining families
-have no Markdown implementation.
+have no Markdown implementation. The Memory family has exactly two concrete
+implementations — JDBC and Redis — and no in-memory/file variants; the
+shared TCK runs against both (real H2 and a real Redis Testcontainer).
 
 ## ApprovalStore TCK (PR #267)
 
@@ -901,3 +903,160 @@ behavior (`WorkflowLeaseStoreTest`, `LeaseCoordinatorTest`,
 example smoke suite re-verified (safe-segment lease paths are unchanged, so
 the example's persisted-layout assertions still hold). Lease path behavior
 is documented in `docs/guides/orchestration-persistence.md`.
+## ChatMemoryStore TCK (PR #275)
+
+`ChatMemoryStoreTck` (tramai-testing testFixtures) runs **50 shared
+behavioral cases** against every `ChatMemoryStore` implementation —
+`JdbcChatMemoryStore` (real H2) and `RedisChatMemoryStore` (real Redis 7.4
+Testcontainer, two independent JedisPools per case). The contract:
+
+> A conversation is one ordered logical message history. A successful
+> appendMessages() adds its complete batch exactly once and contiguously;
+> reads preserve the complete Message value; deletion removes the
+> conversation; listing reflects most-recent conversation activity
+> deterministically; and those answers cannot depend on whether the backend
+> is JDBC or Redis.
+
+Every test drives a `ChatMemoryStoreTckHarness` exposing TWO distinct store
+objects ([primary] and [peer]) over the same physical backend — a per-instance
+mutex inside one store object is not evidence for multi-node JDBC/Redis, so
+the concurrency cases prove coordination at the backend level. Deterministic
+throughout: `MutableMillisClock` (AtomicLong) drives both stores; no sleeps,
+no real clock.
+
+- **Read / append / identity (10):** unknown conversation → empty list;
+  single append round-trips; multi-message batch preserves exact order;
+  second append extends (never replaces); repeated append concatenates
+  exactly; empty append on missing/existing conversation does nothing;
+  conversations isolated; Unicode/punctuation/colon/space conversation IDs
+  work (conversationId is a LOGICAL ID — no SQL/Redis-key-safe subset is
+  imposed); caller-provided order is authoritative.
+- **Full Message fidelity (14):** SYSTEM/USER/ASSISTANT/TOOL roles;
+  multiline Unicode content; TextPart; ImagePart (exact mimeType + bytes);
+  ImageUrlContent with url AND mimeType (the discriminator that exposed the
+  serializer dropping `mimeType`); ImageUrlContent with null mimeType;
+  single/multiple ASSISTANT tool calls with JSON arguments; null vs empty
+  contentParts; null vs empty toolCalls; mixed roles round-trip as one
+  history.
+- **Snapshot semantics (2):** reads are snapshots — mutating the returned
+  list (legal: unmodifiable or independent copy) never changes the store;
+  a previously returned snapshot is not mutated by a later append.
+- **Delete (5):** existing deleted → empty; missing delete is a no-op;
+  deleting A never touches B; append after delete starts a fresh history;
+  deleted conversation disappears from listConversations (no tombstone
+  semantics in the shared contract).
+- **Input validation (4):** blank (`""`, `"   "`, `"\t"`) conversation IDs
+  rejected as `IllegalArgumentException` on getMessages/appendMessages/
+  deleteConversation; limit == 0, limit < 0, offset < 0 rejected on
+  listConversations. Raw backend failures stay implementation-specific.
+- **listConversations contract (10):** empty → []; single conversation;
+  multiple ordered by most recent activity descending; appending to an
+  older conversation moves it first; multiple messages → one ID; limit
+  caps; offset skips exactly N; final partial page; offset beyond end →
+  empty; delete + recreate gets NEW activity. Ties are NOT pinned (JDBC
+  breaks by conversation ID; Redis by its own deterministic ZSET tie
+  order). The SPI KDoc was corrected from "creation time descending" to
+  "most recent append/activity descending" — the chat-UX semantics the
+  JDBC store already implemented.
+- **Empty append is not activity (1):** appending an empty batch to an
+  older conversation does NOT move it up the listing.
+- **Concurrency — linearizable batch append (4 real races, start barrier,
+  20 iterations each, primary + peer):** (1) 8 concurrent single appends —
+  all succeed, 8 messages, each exactly once; (2) two concurrent 3-message
+  batches — legal outcomes are A1A2A3B1B2B3 or B1B2B3A1A2A3, NEVER
+  interleaved, neither append fails (turns both stores RED: Redis via
+  per-message RPUSH, JDBC via missing ordinal retry); (3) concurrent batch
+  append vs delete — final history is [] or the full batch, never partial,
+  and listConversations membership agrees with the final history; (4)
+  concurrent batches in independent conversations — both exact histories
+  survive (no global ordinal/list/index contamination).
+
+### Production changes (runtime-behaviour)
+
+- **Redis activity index (new).** Conversation lists keep the existing
+  `{keyPrefix}:{conversationId}` keys; a sorted-set index at the EXACT
+  `{keyPrefix}` key maps conversationId → last append epoch millis. The
+  index key is structurally disjoint from every conversation key (conversation
+  keys always contain the separator), so no conversation ID can collide with
+  the index. `listConversations` = `ZREVRANGE` (deterministic, paginated) —
+  the old SCAN-order collect/stop/drop-take could not satisfy ordered
+  pagination. Writes are fail-loud: a queued command that fails inside
+  MULTI (e.g. a wrong-type key at the index prefix) surfaces as a
+  `JedisDataException` instead of a silent partial transition. Reads are
+  per-command point-in-time snapshots — a conversation deleted between the
+  index read and the legacy SCAN can still appear on that one listing call,
+  but can never persist in the index.
+- **Redis append is ONE atomic transition:** `MULTI` → one `RPUSH` carrying
+  the whole batch (never one RPUSH per message — another writer must not
+  interleave between the messages of one logical append) + activity `ZADD`
+  → `EXEC`. Delete is `MULTI` → `DEL` + `ZREM` → `EXEC`, so
+  listConversations can never expose an ID whose history is gone. A
+  `MULTI`-atomicity race with the hook-free design is the M19 discriminator.
+- **Redis legacy backward compatibility.** Pre-index deployments
+  (conversation lists with no ZSET member) stay readable (getMessages
+  unchanged) and discoverable: listConversations falls back to SCAN for
+  unindexed keys and lists them deterministically (conversationId
+  ascending) AFTER indexed conversations. Reads never mutate the index. The
+  next append to a legacy conversation enrolls it via the same atomic
+  transaction (old history preserved). Direct regressions: legacy readable,
+  legacy discoverable, legacy append enrolls + orders, legacy delete leaves
+  no residue, legacy-only listing deterministic.
+- **Redis internal clock seam:** `internal var clockMillis` — the public
+  constructor ABI is unchanged; the runner wires `MutableMillisClock`.
+- **JDBC bounded optimistic whole-transaction retry.** `SELECT MAX(ordinal)
+  + 1` then INSERT inside one transaction can let two writers both compute
+  nextOrdinal = 4; one wins the (conversation_id, ordinal) PK, the other
+  must NOT fail merely because another valid append won ordinal allocation.
+  The whole batch transaction now retries on exactly SQLState 23505 (walked
+  through `JdbcBatchUpdateException.nextException`, since H2 wraps batch PK
+  violations) from a fresh durable MAX — never remaining messages, never a
+  partial commit, never arbitrary SQL errors, bounded (20 attempts). No
+  per-instance/static mutex — that does not fix multi-node persistence.
+- **JDBC transaction cleanup discipline (established #267/#269/#271
+  pattern preserved):** primary operation failure > rollback failure >
+  autoCommit-restore failure; later cleanup errors become suppressed — the
+  retry loop cannot swallow a rollback error, retry after an unknown
+  failure, or replace the primary exception with autoCommit restoration.
+- **StoredMessage `ImageUrlContent.mimeType` round-trip.** The serializer
+  stored `text = url` and reconstruction ignored the MIME type. Now
+  `StoredContentPart(type="image_url", text=url, mimeType=…)` and
+  reconstruction `ImageUrlContent(url, mimeType)` — backward compatible
+  with old JSON where `mimeType == null`. No public API change.
+- Core change: `ChatMemoryStore.listConversations` KDoc — "ordered by most
+  recent append/activity descending". KDoc only, no API dump change.
+
+### Mutation evidence (20 mutations, each restored)
+
+| Mutation | TCK outcome |
+|---|---|
+| ImageUrlContent.mimeType dropped in serializer | RED — url-image fidelity |
+| ImagePart mimeType flattened | RED — image round-trip |
+| TextPart content lost | RED — text-part round-trip |
+| TOOL toolCallId dropped | RED — tool round-trip |
+| ASSISTANT toolCalls dropped | RED — tool-call round-trip |
+| JDBC getMessages always returns empty | RED — single-append round-trip |
+| JDBC append resets ordinals (replaces history) | RED — second-append-extends |
+| JDBC batch reversed | RED — batch order |
+| JDBC batch drops first message | RED — single-append round-trip |
+| blank-ID validation removed | RED — blank getMessages |
+| conversation IDs share one key (JDBC WHERE / Redis key) | RED — isolation |
+| delete becomes no-op | RED — delete-removes |
+| Redis delete leaves index member | RED — delete/list consistency |
+| list ignores limit (JDBC LIMIT / Redis take) | RED — limit caps |
+| list ignores offset (JDBC OFFSET / Redis drop) | RED — offset skips |
+| activity update disabled (JDBC ASC / Redis const score) | RED — recency move |
+| Redis ZSET order replaced by SCAN | RED — recency listing |
+| Redis empty append registers activity | RED — empty-append no-op |
+| Redis batch back to per-message RPUSH | RED — concurrent-batch race |
+| JDBC ordinal retry removed | RED — concurrent-batch race |
+
+### Scope
+
+The TCK owns cross-technology chat-memory semantics. Direct suites continue
+owning implementation internals: `JdbcChatMemoryStoreTest` (schema SQL,
+custom table, raw behavior), `PersistentChatMemoryTest` (the consumer:
+simple delegation + optional cache), and the new `RedisChatMemoryStoreTest`
+(legacy unindexed data, key-prefix isolation, transaction data/index
+consistency) — none were deleted or replaced. The example smoke suite
+re-verified (the example does not depend on Redis or the memory store's
+list ordering).

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,7 @@ jedis = { module = "redis.clients:jedis", version.ref = "jedis" }
 h2database = { module = "com.h2database:h2", version = "2.3.232" }
 postgresql = { module = "org.postgresql:postgresql", version = "42.7.5" }
 testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version.ref = "testcontainers" }
+testcontainers-core = { module = "org.testcontainers:testcontainers" }
 testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql" }
 testcontainers-junit-jupiter = { module = "org.testcontainers:testcontainers-junit-jupiter" }
 pgvector = { module = "com.pgvector:pgvector", version = "0.1.6" }

--- a/tramai-core/src/main/kotlin/dev/tramai/core/memory/ChatMemoryStore.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/memory/ChatMemoryStore.kt
@@ -46,7 +46,7 @@ interface ChatMemoryStore {
      *
      * @param limit the maximum number of identifiers to return (must be >= 1)
      * @param offset the number of identifiers to skip before returning results (must be >= 0)
-     * @return a list of conversation identifiers, ordered by creation time descending
+     * @return a list of conversation identifiers, ordered by most recent append/activity descending
      * @throws IllegalArgumentException if [limit] is less than 1 or [offset] is negative
      */
     fun listConversations(limit: Int, offset: Int): List<String>

--- a/tramai-memory-store/build.gradle.kts
+++ b/tramai-memory-store/build.gradle.kts
@@ -26,10 +26,15 @@ dependencies {
     implementation(libs.jackson.module.kotlin)
     implementation(libs.jedis)
 
+    testImplementation(project(":tramai-testing"))
+    testImplementation(testFixtures(project(":tramai-testing")))
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.assertj.core)
     testImplementation(libs.h2database)
     testImplementation(libs.kotlin.test.junit5)
+    testImplementation(platform(libs.testcontainers.bom))
+    testImplementation(libs.testcontainers.core)
+    testImplementation(libs.testcontainers.junit.jupiter)
 }
 
 tasks.test {

--- a/tramai-memory-store/src/main/kotlin/dev/tramai/memory/store/JdbcChatMemoryStore.kt
+++ b/tramai-memory-store/src/main/kotlin/dev/tramai/memory/store/JdbcChatMemoryStore.kt
@@ -39,27 +39,96 @@ class JdbcChatMemoryStore(
         require(conversationId.isNotBlank()) { VALIDATION_CONVERSATION_ID_BLANK }
         if (messages.isEmpty()) return
 
-        dataSource.connection.use { connection ->
-            val originalAutoCommit = connection.autoCommit
-            try {
-                connection.autoCommit = false
-                val nextOrdinal = loadNextOrdinal(connection, conversationId)
-                connection.prepareStatement(insertMessageSql()).use { statement ->
-                    messages.forEachIndexed { index, message ->
-                        statement.setString(1, conversationId)
-                        statement.setInt(2, nextOrdinal + index)
-                        statement.setString(3, serializeMessage(message))
-                        statement.setLong(4, clockMillis())
-                        statement.addBatch()
-                    }
-                    statement.executeBatch()
+        // Optimistic whole-transaction retry: two concurrent writers can both
+        // read nextOrdinal = N; one commits N..N+k, the other loses on the
+        // (conversation_id, ordinal) PK. A valid concurrent append must not
+        // fail merely because another valid append won ordinal allocation —
+        // retry the ENTIRE batch from a fresh durable MAX, never remaining
+        // messages, never a partial commit. Only the known ordinal-uniqueness
+        // race (SQLState 23505) is retried; other failures keep ordinary JDBC
+        // semantics.
+        var attempt = 0
+        while (true) {
+            attempt++
+            val failure = appendBatchOnce(conversationId, messages)
+            if (failure == null) return
+            if (isOrdinalConflict(failure) && attempt < MAX_APPEND_ATTEMPTS) {
+                continue
+            }
+            throw failure
+        }
+    }
+
+    /**
+     * True when [failure] is (or wraps) the ordinal-uniqueness race. H2
+     * surfaces batch PK violations as a JdbcBatchUpdateException whose
+     * underlying SQLException (SQLState 23505) sits on `nextException` —
+     * walk the whole SQLException chain instead of trusting the top frame.
+     */
+    private fun isOrdinalConflict(failure: Throwable?): Boolean {
+        var current: Throwable? = failure
+        while (current != null) {
+            if (current is java.sql.SQLException && current.sqlState == ORDINAL_UNIQUE_SQL_STATE) return true
+            if (current is java.sql.SQLException && current.nextException != null && current.nextException !== current) {
+                current = current.nextException
+            } else {
+                current = current.cause
+            }
+        }
+        return false
+    }
+
+    private fun appendBatchOnce(
+        conversationId: String,
+        messages: List<Message>,
+    ): Exception? = dataSource.connection.use { connection ->
+        val originalAutoCommit = connection.autoCommit
+        var primaryFailure: Exception? = null
+        var rollbackFailed = false
+        try {
+            connection.autoCommit = false
+            val nextOrdinal = loadNextOrdinal(connection, conversationId)
+            connection.prepareStatement(insertMessageSql()).use { statement ->
+                messages.forEachIndexed { index, message ->
+                    statement.setString(1, conversationId)
+                    statement.setInt(2, nextOrdinal + index)
+                    statement.setString(3, serializeMessage(message))
+                    statement.setLong(4, clockMillis())
+                    statement.addBatch()
                 }
-                connection.commit()
-            } catch (error: Exception) {
+                statement.executeBatch()
+            }
+            connection.commit()
+            null
+        } catch (error: Exception) {
+            primaryFailure = error
+            try {
                 connection.rollback()
-                throw error
-            } finally {
-                connection.autoCommit = originalAutoCommit
+            } catch (rollbackFailure: Exception) {
+                primaryFailure.addSuppressed(rollbackFailure)
+                rollbackFailed = true
+            }
+            // A failed rollback may have left the partial batch in the OPEN
+            // transaction: retrying the batch would duplicate those rows.
+            // Surface as a non-retryable failure and skip the autoCommit
+            // restore (which would COMMIT the partial batch) — closing the
+            // connection rolls it back instead.
+            if (rollbackFailed) {
+                IllegalStateException("append failed and rollback failed; not retrying", primaryFailure)
+            } else {
+                error
+            }
+        } finally {
+            if (!rollbackFailed) {
+                try {
+                    connection.autoCommit = originalAutoCommit
+                } catch (restoreFailure: Exception) {
+                    if (primaryFailure != null) {
+                        primaryFailure.addSuppressed(restoreFailure)
+                    } else {
+                        throw restoreFailure
+                    }
+                }
             }
         }
     }
@@ -182,4 +251,15 @@ data class JdbcChatMemoryTable(
 
 /** @see JdbcChatMemoryStore */
 private const val VALIDATION_CONVERSATION_ID_BLANK = "conversationId must not be blank"
+
+/** SQLState for a unique-constraint violation (the (conversation_id, ordinal) PK race). */
+private const val ORDINAL_UNIQUE_SQL_STATE = "23505"
+
+/**
+ * Bounded retries for the ordinal-allocation race; after this the race
+ * failure is surfaced. Each attempt resolves at most one contention level
+ * (one writer wins per ordinal), so the bound must comfortably exceed the
+ * maximum expected concurrent writers.
+ */
+private const val MAX_APPEND_ATTEMPTS = 20
 

--- a/tramai-memory-store/src/main/kotlin/dev/tramai/memory/store/RedisChatMemoryStore.kt
+++ b/tramai-memory-store/src/main/kotlin/dev/tramai/memory/store/RedisChatMemoryStore.kt
@@ -6,15 +6,32 @@ import dev.tramai.core.memory.ChatMemoryStore
 import dev.tramai.core.model.Message
 import dev.tramai.core.model.MessageRole
 import redis.clients.jedis.JedisPool
+import redis.clients.jedis.exceptions.JedisDataException
 import redis.clients.jedis.params.ScanParams
 import redis.clients.jedis.resps.ScanResult
-import java.nio.charset.StandardCharsets
 
 /**
  * Redis-backed [ChatMemoryStore] for persistent conversation history.
  *
- * Messages per conversation are stored as a Redis List with key format `{keyPrefix}:{conversationId}`.
- * Uses [JedisPool] for connection pooling.
+ * Messages per conversation are stored as a Redis List with key format
+ * `{keyPrefix}:{conversationId}`. A sorted-set activity index at the exact
+ * `{keyPrefix}` key maps conversationId → last append epoch millis, which
+ * makes [listConversations] deterministic (ZREVRANGE) instead of
+ * SCAN-order. The index key is structurally disjoint from every
+ * conversation key (conversation keys always contain the separator), so no
+ * conversation ID can collide with the index.
+ *
+ * Every append is one atomic MULTI/EXEC transition: a single RPUSH carrying
+ * the whole batch (never one RPUSH per message — another writer must not be
+ * able to interleave between the messages of one logical append), plus the
+ * activity-index ZADD in the same transaction. Deletes remove the
+ * conversation list and the index member atomically.
+ *
+ * Existing pre-index deployments (lists without a ZSET member) stay
+ * readable and discoverable: [listConversations] falls back to SCAN for
+ * unindexed keys and lists them deterministically after indexed
+ * conversations. The next append to a legacy conversation enrolls it in
+ * the index as part of the same atomic append.
  *
  * @param jedisPool the Redis connection pool
  * @param keyPrefix prefix for Redis keys (default: "chat")
@@ -25,6 +42,12 @@ class RedisChatMemoryStore(
     private val keyPrefix: String = "chat",
     private val objectMapper: ObjectMapper = jacksonObjectMapper().findAndRegisterModules(),
 ) : ChatMemoryStore {
+
+    /**
+     * Internal deterministic-clock seam for the TCK: the published
+     * constructor ABI stays unchanged; tests wire a MutableMillisClock here.
+     */
+    internal var clockMillis: () -> Long = System::currentTimeMillis
 
     override fun getMessages(conversationId: String): List<Message> {
         require(conversationId.isNotBlank()) { VALIDATION_CONVERSATION_ID_BLANK }
@@ -40,9 +63,20 @@ class RedisChatMemoryStore(
         require(conversationId.isNotBlank()) { VALIDATION_CONVERSATION_ID_BLANK }
         if (messages.isEmpty()) return
         val key = conversationKey(conversationId)
+        val serialized = messages.map(::serializeMessage).toTypedArray()
+        val activityTime = clockMillis().toDouble()
         jedisPool.resource.use { jedis ->
-            messages.forEach { message ->
-                jedis.rpush(key, serializeMessage(message))
+            val transaction = jedis.multi()
+            try {
+                // One logical append transition: the whole batch in a single
+                // RPUSH (contiguous — another writer cannot interleave
+                // between messages) and the activity-index update in the
+                // same Redis transaction.
+                transaction.rpush(key, *serialized)
+                transaction.zadd(activityIndexKey(), activityTime, conversationId)
+                throwIfTransactionFailed(transaction.exec())
+            } finally {
+                transaction.close()
             }
         }
     }
@@ -51,31 +85,59 @@ class RedisChatMemoryStore(
         require(conversationId.isNotBlank()) { VALIDATION_CONVERSATION_ID_BLANK }
         val key = conversationKey(conversationId)
         jedisPool.resource.use { jedis ->
-            jedis.del(key)
+            val transaction = jedis.multi()
+            try {
+                // Remove data and activity membership atomically: otherwise
+                // listConversations could expose an ID whose history is gone.
+                transaction.del(key)
+                transaction.zrem(activityIndexKey(), conversationId)
+                throwIfTransactionFailed(transaction.exec())
+            } finally {
+                transaction.close()
+            }
         }
     }
 
     override fun listConversations(limit: Int, offset: Int): List<String> {
         require(limit >= 1) { "limit must be at least 1" }
         require(offset >= 0) { "offset must be at least 0" }
-        val pattern = "$keyPrefix:*"
-        val scanParams = ScanParams().match(pattern).count(100)
-        val result = mutableListOf<String>()
-        var cursor = ScanParams.SCAN_POINTER_START
-
-        jedisPool.resource.use { jedis ->
+        val indexKey = activityIndexKey()
+        return jedisPool.resource.use { jedis ->
+            val indexed = jedis.zrevrange(indexKey, 0, -1) ?: emptyList()
+            if (indexed.size >= offset + limit) {
+                return@use indexed.drop(offset).take(limit)
+            }
+            // Legacy conversations (pre-index lists with no ZSET member) are
+            // not in the activity index; discover them by SCAN and list them
+            // deterministically (conversationId ascending) AFTER indexed
+            // conversations.
+            val indexedIds = indexed.toHashSet()
+            val legacy = ArrayList<String>()
+            var cursor = ScanParams.SCAN_POINTER_START
+            val scanParams = ScanParams().match("$keyPrefix:*").count(100)
             do {
-                val scanResult: ScanResult<ByteArray> = jedis.scan(cursor.toByteArray(StandardCharsets.UTF_8), scanParams)
+                val scanResult: ScanResult<String> = jedis.scan(cursor, scanParams)
                 cursor = scanResult.cursor
-                for (keyBytes in scanResult.result) {
-                    val key = String(keyBytes, StandardCharsets.UTF_8)
-                    val conversationId = extractConversationId(key) ?: continue
-                    result.add(conversationId)
+                for (key in scanResult.result) {
+                    val id = extractConversationId(key) ?: continue
+                    if (id !in indexedIds) legacy.add(id)
                 }
-            } while (cursor != ScanParams.SCAN_POINTER_START && result.size < offset + limit)
+            } while (cursor != ScanParams.SCAN_POINTER_START)
+            (indexed + legacy.distinct().sorted()).drop(offset).take(limit)
         }
+    }
 
-        return result.drop(offset).take(limit)
+    /** The activity index lives at the exact key prefix, disjoint from every conversation key. */
+    private fun activityIndexKey(): String = keyPrefix
+
+    /**
+     * Jedis 6 does NOT throw from `exec()` when a queued command fails — the
+     * error is returned as a [JedisDataException] element of the result list.
+     * A partial transition (e.g. WRONGTYPE on the index key) must fail
+     * loudly, never report success with half the transition applied.
+     */
+    private fun throwIfTransactionFailed(results: List<Any?>?) {
+        results?.firstOrNull { it is JedisDataException }?.let { throw it as JedisDataException }
     }
 
     private fun conversationKey(conversationId: String): String = "$keyPrefix:$conversationId"

--- a/tramai-memory-store/src/main/kotlin/dev/tramai/memory/store/StoredMessage.kt
+++ b/tramai-memory-store/src/main/kotlin/dev/tramai/memory/store/StoredMessage.kt
@@ -47,6 +47,7 @@ internal fun toStoredContentPart(part: ContentPart): StoredContentPart = when (p
     is ContentPart.ImageUrlContent -> StoredContentPart(
         type = "image_url",
         text = part.url,
+        mimeType = part.mimeType,
     )
 }
 
@@ -60,7 +61,10 @@ internal fun toContentPart(part: StoredContentPart): ContentPart = when (part.ty
             data = Base64.getDecoder().decode(data),
         )
     }
-    "image_url" -> ContentPart.ImageUrlContent(part.text ?: "")
+    "image_url" -> ContentPart.ImageUrlContent(
+        url = part.text ?: "",
+        mimeType = part.mimeType,
+    )
     else -> throw IllegalArgumentException("Unsupported stored content part type '${part.type}'")
 }
 

--- a/tramai-memory-store/src/test/kotlin/dev/tramai/memory/store/JdbcChatMemoryStoreTckTest.kt
+++ b/tramai-memory-store/src/test/kotlin/dev/tramai/memory/store/JdbcChatMemoryStoreTckTest.kt
@@ -1,0 +1,57 @@
+package dev.tramai.memory.store
+
+import dev.tramai.core.memory.ChatMemoryStore
+import dev.tramai.testing.persistence.memory.ChatMemoryStoreTck
+import dev.tramai.testing.persistence.memory.ChatMemoryStoreTckHarness
+import dev.tramai.testing.persistence.memory.MutableMillisClock
+import javax.sql.DataSource
+import org.h2.jdbcx.JdbcDataSource
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Epic 8.1h: JdbcChatMemoryStore must satisfy the shared chat-memory
+ * compatibility contract (tramai-testing testFixtures) against a REAL
+ * relational engine — H2. The SPI is standard SQL, so H2 gives stronger
+ * contract evidence without Testcontainers. The runner owns the
+ * datasource, schema, and per-case reset, and exposes TWO distinct store
+ * objects over the SAME DataSource so the concurrency cases prove
+ * backend-level coordination.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JdbcChatMemoryStoreTckTest : ChatMemoryStoreTck() {
+
+    private lateinit var dataSource: DataSource
+
+    @BeforeAll
+    fun setUpAll() {
+        val ds = JdbcDataSource()
+        ds.setURL("jdbc:h2:mem:chat_memory_tck;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE")
+        ds.user = "sa"
+        ds.password = ""
+        dataSource = ds
+        dataSource.connection.use { connection ->
+            connection.createStatement().use { it.execute(JdbcChatMemoryStore(dataSource).createTableSql()) }
+        }
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        runCatching {
+            dataSource.connection.use { connection ->
+                connection.createStatement().use { it.execute("DROP TABLE IF EXISTS chat_memory") }
+            }
+        }
+    }
+
+    override fun createHarness(clock: MutableMillisClock): ChatMemoryStoreTckHarness {
+        dataSource.connection.use { connection ->
+            connection.createStatement().use { it.execute("DELETE FROM chat_memory") }
+        }
+        return object : ChatMemoryStoreTckHarness {
+            override val primary: ChatMemoryStore = JdbcChatMemoryStore(dataSource, clockMillis = clock)
+            override val peer: ChatMemoryStore = JdbcChatMemoryStore(dataSource, clockMillis = clock)
+        }
+    }
+}

--- a/tramai-memory-store/src/test/kotlin/dev/tramai/memory/store/RedisChatMemoryStoreTckTest.kt
+++ b/tramai-memory-store/src/test/kotlin/dev/tramai/memory/store/RedisChatMemoryStoreTckTest.kt
@@ -1,0 +1,64 @@
+package dev.tramai.memory.store
+
+import dev.tramai.core.memory.ChatMemoryStore
+import dev.tramai.testing.persistence.memory.ChatMemoryStoreTck
+import dev.tramai.testing.persistence.memory.ChatMemoryStoreTckHarness
+import dev.tramai.testing.persistence.memory.MutableMillisClock
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import redis.clients.jedis.JedisPool
+
+/**
+ * Epic 8.1h: RedisChatMemoryStore must satisfy the shared chat-memory
+ * compatibility contract against a REAL Redis server (Testcontainer, not a
+ * mocked Jedis). One container per class; each TCK case gets a unique
+ * keyPrefix and TWO independent JedisPools/two store objects over the same
+ * server, so the concurrency cases prove backend-level coordination.
+ */
+@Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RedisChatMemoryStoreTckTest : ChatMemoryStoreTck() {
+
+    companion object {
+        @Container
+        val redis: GenericContainer<*> = GenericContainer("redis:7.4-alpine")
+            .withExposedPorts(6379)
+
+        private val prefixCounter = AtomicInteger(0)
+    }
+
+    private lateinit var redisUrl: String
+
+    @BeforeAll
+    fun setUpAll() {
+        redisUrl = "redis://${redis.host}:${redis.getMappedPort(6379)}"
+    }
+
+    override fun createHarness(clock: MutableMillisClock): ChatMemoryStoreTckHarness {
+        val prefix = "tck-${prefixCounter.incrementAndGet()}"
+        val poolA = JedisPool(redisUrl)
+        val poolB = JedisPool(redisUrl)
+        return object : ChatMemoryStoreTckHarness {
+            override val primary: ChatMemoryStore =
+                RedisChatMemoryStore(poolA, keyPrefix = prefix).also { it.clockMillis = clock }
+            override val peer: ChatMemoryStore =
+                RedisChatMemoryStore(poolB, keyPrefix = prefix).also { it.clockMillis = clock }
+
+            override fun close() {
+                runCatching {
+                    poolA.resource.use { jedis ->
+                        val conversationKeys = jedis.keys("$prefix:*")
+                        if (conversationKeys.isNotEmpty()) jedis.del(*conversationKeys.toTypedArray())
+                        jedis.del(prefix)
+                    }
+                }
+                poolA.close()
+                poolB.close()
+            }
+        }
+    }
+}

--- a/tramai-memory-store/src/test/kotlin/dev/tramai/memory/store/RedisChatMemoryStoreTest.kt
+++ b/tramai-memory-store/src/test/kotlin/dev/tramai/memory/store/RedisChatMemoryStoreTest.kt
@@ -1,0 +1,185 @@
+package dev.tramai.memory.store
+
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import redis.clients.jedis.Jedis
+import redis.clients.jedis.JedisPool
+import redis.clients.jedis.exceptions.JedisDataException
+
+/**
+ * Epic 8.1h: Redis-specific regressions the shared TCK intentionally does
+ * not own — pre-activity-index legacy lists, key-prefix isolation, and
+ * transaction data/index consistency. Real Redis (Testcontainer), not a
+ * mocked Jedis.
+ */
+@Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RedisChatMemoryStoreTest {
+
+    companion object {
+        @Container
+        val redis: GenericContainer<*> = GenericContainer("redis:7.4-alpine")
+            .withExposedPorts(6379)
+    }
+
+    private lateinit var pool: JedisPool
+
+    @BeforeAll
+    fun setUpAll() {
+        pool = JedisPool("redis://${redis.host}:${redis.getMappedPort(6379)}")
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        pool.close()
+    }
+
+    private fun store(prefix: String = "redis-specific"): RedisChatMemoryStore =
+        RedisChatMemoryStore(pool, keyPrefix = prefix)
+
+    private fun rawLegacyList(prefix: String, conversationId: String, contents: List<String>) {
+        pool.resource.use { jedis ->
+            jedis.rpush("$prefix:$conversationId", *contents.toTypedArray())
+        }
+    }
+
+    private fun userMessage(content: String): Message = Message(role = MessageRole.USER, content = content)
+
+    private fun rawJson(content: String): String =
+        """{"role":"USER","content":"$content","contentParts":null,"toolCallId":null,"toolCalls":null}"""
+
+    // ── legacy unindexed data (pre-activity-index deployments) ───────
+
+    @Test
+    fun `legacy list without index member remains readable`() {
+        rawLegacyList("legacy-read", "conv-1", listOf(rawJson("old-1"), rawJson("old-2")))
+        assertThat(store("legacy-read").getMessages("conv-1"))
+            .containsExactly(userMessage("old-1"), userMessage("old-2"))
+    }
+
+    @Test
+    fun `legacy list remains discoverable in listConversations`() {
+        rawLegacyList("legacy-list", "conv-legacy", listOf(rawJson("old")))
+        assertThat(store("legacy-list").listConversations(100, 0)).contains("conv-legacy")
+    }
+
+    @Test
+    fun `legacy append preserves old history and enrolls activity ordering`() {
+        rawLegacyList("legacy-enroll", "conv-enroll", listOf(rawJson("old")))
+        val s = store("legacy-enroll")
+        s.appendMessages("conv-enroll", listOf(userMessage("new")))
+        assertThat(s.getMessages("conv-enroll").map { it.content }).containsExactly("old", "new")
+        // Enrolled in the activity index: listed and ordered by activity.
+        assertThat(s.listConversations(100, 0)).containsExactly("conv-enroll")
+        pool.resource.use { jedis ->
+            assertThat(jedis.zscore("legacy-enroll", "conv-enroll")).isNotNull
+        }
+    }
+
+    @Test
+    fun `legacy delete removes data without leaving index residue`() {
+        rawLegacyList("legacy-del", "conv-del", listOf(rawJson("old")))
+        val s = store("legacy-del")
+        s.deleteConversation("conv-del")
+        assertThat(s.getMessages("conv-del")).isEmpty()
+        assertThat(s.listConversations(100, 0)).doesNotContain("conv-del")
+        pool.resource.use { jedis ->
+            assertThat(jedis.exists("legacy-del:conv-del")).isFalse()
+            val score: Double? = jedis.zscore("legacy-del", "conv-del")
+            assertThat(score).isNull()
+        }
+    }
+
+    @Test
+    fun `legacy only conversations list deterministically by id ascending`() {
+        rawLegacyList("legacy-order", "zzz", listOf(rawJson("z")))
+        rawLegacyList("legacy-order", "aaa", listOf(rawJson("a")))
+        assertThat(store("legacy-order").listConversations(100, 0)).containsExactly("aaa", "zzz")
+    }
+
+    // ── key-prefix isolation ─────────────────────────────────────────
+
+    @Test
+    fun `stores with distinct key prefixes never share data or index`() {
+        val storeA = store("prefix-a")
+        val storeB = store("prefix-b")
+        storeA.appendMessages("shared-id", listOf(userMessage("from-A")))
+        storeB.appendMessages("shared-id", listOf(userMessage("from-B")))
+        assertThat(storeA.getMessages("shared-id").map { it.content }).containsExactly("from-A")
+        assertThat(storeB.getMessages("shared-id").map { it.content }).containsExactly("from-B")
+        assertThat(storeA.listConversations(100, 0)).containsExactly("shared-id")
+        assertThat(storeB.listConversations(100, 0)).containsExactly("shared-id")
+    }
+
+    // ── transaction data/index consistency ──────────────────────────
+
+    @Test
+    fun `append writes conversation data and index member atomically`() {
+        val s = store("txn-append")
+        s.appendMessages("conv-tx", listOf(userMessage("a"), userMessage("b")))
+        pool.resource.use { jedis ->
+            assertThat(jedis.llen("txn-append:conv-tx")).isEqualTo(2)
+            assertThat(jedis.zscore("txn-append", "conv-tx")).isNotNull
+        }
+    }
+
+    @Test
+    fun `delete removes conversation data and index member atomically`() {
+        val s = store("txn-delete")
+        s.appendMessages("conv-tx", listOf(userMessage("a")))
+        s.deleteConversation("conv-tx")
+        pool.resource.use { jedis ->
+            assertThat(jedis.exists("txn-delete:conv-tx")).isFalse()
+            val score: Double? = jedis.zscore("txn-delete", "conv-tx")
+            assertThat(score).isNull()
+        }
+    }
+
+    @Test
+    fun `conversation id containing the separator never collides with the index`() {
+        val s = store("txn-colon")
+        s.appendMessages("a:b", listOf(userMessage("x")))
+        pool.resource.use { jedis ->
+            // The list key is "txn-colon:a:b" — still a conversation key, never the index.
+            assertThat(jedis.type("txn-colon")).isEqualTo("zset")
+            assertThat(jedis.llen("txn-colon:a:b")).isEqualTo(1)
+            assertThat(jedis.zscore("txn-colon", "a:b")).isNotNull
+        }
+        assertThat(s.getMessages("a:b").map { it.content }).containsExactly("x")
+        assertThat(s.listConversations(100, 0)).containsExactly("a:b")
+    }
+
+    // ── failed queued commands must fail loudly (Jedis 6 exec() returns
+    //    the error as a result element instead of throwing) ───────────
+
+    @Test
+    fun `append fails loudly when the activity index key has the wrong type`() {
+        val s = store("txn-wrongtype-append")
+        pool.resource.use { jedis -> jedis.set("txn-wrongtype-append", "not-a-zset") }
+        org.assertj.core.api.Assertions.assertThatThrownBy {
+            s.appendMessages("conv-1", listOf(userMessage("x")))
+        }.isInstanceOf(JedisDataException::class.java)
+        // Redis MULTI does NOT roll back a failed queued command: the RPUSH
+        // may already be applied, leaving a readable-but-unindexed (legacy)
+        // conversation. The contract is the loud exception, not rollback.
+        assertThat(s.getMessages("conv-1").map { it.content }).containsExactly("x")
+    }
+
+    @Test
+    fun `delete fails loudly when the activity index key has the wrong type`() {
+        val s = store("txn-wrongtype-delete")
+        s.appendMessages("conv-1", listOf(userMessage("x")))
+        pool.resource.use { jedis -> jedis.set("txn-wrongtype-delete", "not-a-zset") }
+        org.assertj.core.api.Assertions.assertThatThrownBy {
+            s.deleteConversation("conv-1")
+        }.isInstanceOf(JedisDataException::class.java)
+    }
+}

--- a/tramai-testing/src/test/kotlin/dev/tramai/testing/ChatMemoryStoreTckEnrollmentArchitectureTest.kt
+++ b/tramai-testing/src/test/kotlin/dev/tramai/testing/ChatMemoryStoreTckEnrollmentArchitectureTest.kt
@@ -1,0 +1,97 @@
+package dev.tramai.testing
+
+import java.io.File
+import java.nio.file.Files
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Epic 8.1h architecture guard: every concrete
+ * [dev.tramai.core.memory.ChatMemoryStore] implementation must be enrolled
+ * in the shared chat-memory compatibility contract (tramai-testing
+ * testFixtures). A future File/Mongo/Dynamo chat-memory store cannot merge
+ * without enrollment.
+ */
+class ChatMemoryStoreTckEnrollmentArchitectureTest {
+
+    private val scanner = StoreEnrollmentScanner("ChatMemoryStore", "ChatMemoryStoreTck")
+
+    private val repoRoot: File =
+        generateSequence(File(".").absoluteFile) { it.parentFile }
+            .first { it.resolve("settings.gradle.kts").isFile }
+
+    private val expectedRunners = setOf(
+        "JdbcChatMemoryStoreTckTest",
+        "RedisChatMemoryStoreTckTest",
+    )
+
+    @Test
+    fun `every roadmap ChatMemoryStore ships a TCK runner`() {
+        val missing = expectedRunners.filter { runnerName -> scanner.findRunnerFile(repoRoot, runnerName) == null }
+        assertThat(missing)
+            .withFailMessage(
+                "Pinned ChatMemoryStore TCK runners missing. The compatibility contract is " +
+                    "reviewed per runner; deleting a runner silently removes a store from the contract: $missing",
+            )
+            .isEmpty()
+    }
+
+    @Test
+    fun `every ChatMemoryStore implementation has a valid TCK runner in its module`() {
+        val unenrolled = scanner.storeModules(repoRoot).flatMap { (module, implementations) ->
+            implementations
+                .filter { storeName -> !scanner.hasValidRunner(repoRoot, module, storeName) }
+                .map { store -> "$module/$store" }
+        }
+        assertThat(unenrolled)
+            .withFailMessage(
+                "ChatMemoryStore implementations without a <Store>TckTest runner extending " +
+                    "ChatMemoryStoreTck in the same module: $unenrolled. " +
+                    "Adding a ChatMemoryStore without enrolling it in the compatibility " +
+                    "contract must make a gate fail.",
+            )
+            .isEmpty()
+    }
+
+    // ── probe tests for the scanner against this family ─────────────
+
+    @Test
+    fun `body-less ChatMemoryStore implementation is detected`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            import dev.tramai.core.memory.ChatMemoryStore
+            class FileChatMemoryStore(private val delegate: ChatMemoryStore) :
+                ChatMemoryStore by delegate
+            """.trimIndent(),
+        )
+        assertThat(scanner.implementationsIn(file)).containsExactly("FileChatMemoryStore")
+    }
+
+    @Test
+    fun `runner file must actually subclass ChatMemoryStoreTck`() {
+        val fake = tempSourceFile("class MongoChatMemoryStoreTckTest")
+        val real = tempSourceFile("class MongoChatMemoryStoreTckTest : ChatMemoryStoreTck() { }")
+        assertThat(scanner.runnerSubclassesTck(fake, "MongoChatMemoryStore")).isFalse()
+        assertThat(scanner.runnerSubclassesTck(real, "MongoChatMemoryStore")).isTrue()
+    }
+
+    @Test
+    fun `private decorator is not a family member`() {
+        val file = tempSourceFile(
+            """
+            package probe
+            import dev.tramai.core.memory.ChatMemoryStore
+            private class FencedChatMemoryStore(private val delegate: ChatMemoryStore) :
+                ChatMemoryStore by delegate
+            """.trimIndent(),
+        )
+        assertThat(scanner.implementationsIn(file)).isEmpty()
+    }
+
+    private fun tempSourceFile(content: String): File =
+        Files.createTempFile("chat-memory-enrollment-probe-", ".kt").toFile().apply {
+            writeText(content)
+            deleteOnExit()
+        }
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/memory/ChatMemoryStoreFixtures.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/memory/ChatMemoryStoreFixtures.kt
@@ -1,0 +1,51 @@
+package dev.tramai.testing.persistence.memory
+
+import dev.tramai.core.model.ContentPart
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
+import dev.tramai.core.model.ToolCall
+
+/**
+ * Epic 8.1h: fixtures for the shared
+ * [dev.tramai.core.memory.ChatMemoryStore] compatibility contract.
+ * Deterministic only — explicit identities and clock-controlled
+ * timestamps. No sleeps, no real clock.
+ *
+ * Message construction respects the core invariant: `content` OR
+ * `contentParts`, never both.
+ */
+object ChatMemoryStoreFixtures {
+
+    const val T0: Long = 1_800_000_000_000L
+
+    const val CONVERSATION: String = "conversation-1"
+
+    fun text(content: String, role: MessageRole = MessageRole.USER): Message =
+        Message(role = role, content = content)
+
+    fun system(content: String): Message = Message(role = MessageRole.SYSTEM, content = content)
+
+    fun user(content: String): Message = Message(role = MessageRole.USER, content = content)
+
+    fun assistant(content: String): Message = Message(role = MessageRole.ASSISTANT, content = content)
+
+    fun tool(toolCallId: String, content: String): Message =
+        Message(role = MessageRole.TOOL, content = content, toolCallId = toolCallId)
+
+    /** Rich message carrying content parts (content must stay blank). */
+    fun rich(parts: List<ContentPart>): Message =
+        Message(role = MessageRole.USER, content = "", contentParts = parts)
+
+    /** Assistant message carrying tool calls (content must stay blank). */
+    fun assistantToolCalls(calls: List<ToolCall>): Message =
+        Message(role = MessageRole.ASSISTANT, content = "", toolCalls = calls)
+
+    fun toolCall(id: String, name: String, argumentsJson: String): ToolCall =
+        ToolCall(id = id, name = name, argumentsJson = argumentsJson)
+
+    /** The full-fidelity discriminator: URL image with a MIME type hint. */
+    fun urlImageMessage(
+        url: String = "https://example.test/image.webp",
+        mimeType: String? = "image/webp",
+    ): Message = rich(listOf(ContentPart.ImageUrlContent(url = url, mimeType = mimeType)))
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/memory/ChatMemoryStoreTck.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/memory/ChatMemoryStoreTck.kt
@@ -1,0 +1,754 @@
+package dev.tramai.testing.persistence.memory
+
+import dev.tramai.core.model.ContentPart
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Epic 8.1h: shared cross-implementation compatibility contract for
+ * [dev.tramai.core.memory.ChatMemoryStore].
+ *
+ * The contract:
+ * > A conversation is one ordered logical message history. A successful
+ * > appendMessages() adds its complete batch exactly once and contiguously;
+ * > reads preserve the complete Message value; deletion removes the
+ * > conversation; listing reflects most-recent conversation activity
+ * > deterministically; and those answers cannot depend on whether the
+ * > backend is JDBC or Redis.
+ *
+ * Every test drives the runner-provided harness: [ChatMemoryStoreTckHarness]
+ * exposes two distinct store objects ([primary] and [peer]) over the same
+ * physical backend, so the concurrency cases prove backend-level
+ * coordination, not a per-instance mutex.
+ */
+abstract class ChatMemoryStoreTck {
+
+    /** Fresh isolated backend + deterministic clock per test; runner owns cleanup. */
+    protected abstract fun createHarness(clock: MutableMillisClock): ChatMemoryStoreTckHarness
+
+    // ── C1. Read / append / identity ────────────────────────────────
+
+    @Test
+    fun `unknown conversation returns an empty list`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            assertThat(harness.primary.getMessages("never-seen")).isEmpty()
+            assertThat(harness.peer.getMessages("never-seen")).isEmpty()
+        }
+    }
+
+    @Test
+    fun `single append round trips`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.appendMessages("conv-single", listOf(ChatMemoryStoreFixtures.user("hello")))
+            assertThat(harness.primary.getMessages("conv-single")).containsExactly(ChatMemoryStoreFixtures.user("hello"))
+        }
+    }
+
+    @Test
+    fun `multi message append preserves exact order`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            val batch = listOf(
+                ChatMemoryStoreFixtures.system("sys"),
+                ChatMemoryStoreFixtures.user("u1"),
+                ChatMemoryStoreFixtures.assistant("a1"),
+            )
+            harness.primary.appendMessages("conv-order", batch)
+            assertThat(harness.primary.getMessages("conv-order")).containsExactlyElementsOf(batch)
+        }
+    }
+
+    @Test
+    fun `second append extends rather than replaces`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.appendMessages("conv-extend", listOf(ChatMemoryStoreFixtures.user("first")))
+            harness.peer.appendMessages("conv-extend", listOf(ChatMemoryStoreFixtures.user("second")))
+            assertThat(harness.primary.getMessages("conv-extend").map { it.content })
+                .containsExactly("first", "second")
+        }
+    }
+
+    @Test
+    fun `repeated append yields exact concatenation`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.appendMessages("conv-concat", listOf(ChatMemoryStoreFixtures.user("a"), ChatMemoryStoreFixtures.user("b")))
+            harness.peer.appendMessages("conv-concat", listOf(ChatMemoryStoreFixtures.user("c")))
+            harness.primary.appendMessages("conv-concat", listOf(ChatMemoryStoreFixtures.user("d"), ChatMemoryStoreFixtures.user("e")))
+            assertThat(harness.primary.getMessages("conv-concat").map { it.content })
+                .containsExactly("a", "b", "c", "d", "e")
+        }
+    }
+
+    @Test
+    fun `empty append on a missing conversation does nothing`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.appendMessages("conv-empty-missing", emptyList())
+            assertThat(harness.primary.getMessages("conv-empty-missing")).isEmpty()
+            assertThat(harness.primary.listConversations(10, 0)).doesNotContain("conv-empty-missing")
+        }
+    }
+
+    @Test
+    fun `empty append on an existing conversation leaves it unchanged`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.appendMessages("conv-empty-existing", listOf(ChatMemoryStoreFixtures.user("only")))
+            harness.peer.appendMessages("conv-empty-existing", emptyList())
+            assertThat(harness.primary.getMessages("conv-empty-existing").map { it.content }).containsExactly("only")
+        }
+    }
+
+    @Test
+    fun `conversations are isolated`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.appendMessages("conv-iso-a", listOf(ChatMemoryStoreFixtures.user("A")))
+            harness.peer.appendMessages("conv-iso-b", listOf(ChatMemoryStoreFixtures.user("B"), ChatMemoryStoreFixtures.user("B2")))
+            assertThat(harness.primary.getMessages("conv-iso-a").map { it.content }).containsExactly("A")
+            assertThat(harness.primary.getMessages("conv-iso-b").map { it.content }).containsExactly("B", "B2")
+        }
+    }
+
+    @Test
+    fun `nonblank conversation ids with unicode punctuation colon and spaces work`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            val ids = listOf(
+                "日本語セッション",
+                "order:123:detail",
+                "conv with spaces",
+                "a/b?c=d&e",
+                "emoji-😀-session",
+            )
+            ids.forEachIndexed { index, id ->
+                harness.primary.appendMessages(id, listOf(ChatMemoryStoreFixtures.user("m$index")))
+            }
+            ids.forEachIndexed { index, id ->
+                assertThat(harness.primary.getMessages(id).map { it.content }).containsExactly("m$index")
+            }
+            // All distinct logical conversations, never collapsed onto one key.
+            assertThat(harness.primary.listConversations(100, 0)).containsAll(ids)
+        }
+    }
+
+    @Test
+    fun `caller provided message order is authoritative`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            val batch = listOf(
+                ChatMemoryStoreFixtures.user("z-last-intent"),
+                ChatMemoryStoreFixtures.user("a-first-intent"),
+                ChatMemoryStoreFixtures.user("m-middle-intent"),
+            )
+            harness.primary.appendMessages("conv-order-authoritative", batch)
+            assertThat(harness.primary.getMessages("conv-order-authoritative").map { it.content })
+                .containsExactly("z-last-intent", "a-first-intent", "m-middle-intent")
+        }
+    }
+
+    // ── C2. Full Message fidelity ───────────────────────────────────
+
+    @Test
+    fun `system role round trips exactly`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            val message = ChatMemoryStoreFixtures.system("You are a helpful assistant.")
+            harness.primary.appendMessages("fid-system", listOf(message))
+            assertThat(harness.primary.getMessages("fid-system")).containsExactly(message)
+        }
+    }
+
+    @Test
+    fun `user role round trips exactly`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            val message = ChatMemoryStoreFixtures.user("What is the capital of France?")
+            harness.primary.appendMessages("fid-user", listOf(message))
+            assertThat(harness.primary.getMessages("fid-user")).containsExactly(message)
+        }
+    }
+
+    @Test
+    fun `assistant role round trips exactly`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            val message = ChatMemoryStoreFixtures.assistant("The capital is Paris.")
+            harness.primary.appendMessages("fid-assistant", listOf(message))
+            assertThat(harness.primary.getMessages("fid-assistant")).containsExactly(message)
+        }
+    }
+
+    @Test
+    fun `tool role with toolCallId round trips exactly`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            val message = ChatMemoryStoreFixtures.tool("call_abc123", """{"result": "ok"}""")
+            harness.primary.appendMessages("fid-tool", listOf(message))
+            assertThat(harness.primary.getMessages("fid-tool")).containsExactly(message)
+        }
+    }
+
+    @Test
+    fun `multiline unicode content round trips exactly`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            val content = "line one\nline two\n日本語のテキスト\nemoji: 🚀🎉\n\ttabbed"
+            val message = ChatMemoryStoreFixtures.user(content)
+            harness.primary.appendMessages("fid-unicode", listOf(message))
+            assertThat(harness.primary.getMessages("fid-unicode")).containsExactly(message)
+        }
+    }
+
+    @Test
+    fun `text content part round trips exactly`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            val message = ChatMemoryStoreFixtures.rich(listOf(ContentPart.TextPart("rich text fragment")))
+            harness.primary.appendMessages("fid-textpart", listOf(message))
+            assertThat(harness.primary.getMessages("fid-textpart")).containsExactly(message)
+        }
+    }
+
+    @Test
+    fun `image content part round trips exact mime type and bytes`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            val bytes = byteArrayOf(0x01, 0x02, 0x03, 0x00, 0x7F, 0x0A)
+            val message = ChatMemoryStoreFixtures.rich(
+                listOf(ContentPart.ImagePart(mimeType = "image/png", data = bytes)),
+            )
+            harness.primary.appendMessages("fid-image", listOf(message))
+            assertThat(harness.primary.getMessages("fid-image")).containsExactly(message)
+        }
+    }
+
+    @Test
+    fun `url image content round trips exact url and mime type`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            val message = ChatMemoryStoreFixtures.urlImageMessage(
+                url = "https://example.test/image.webp",
+                mimeType = "image/webp",
+            )
+            harness.primary.appendMessages("fid-imageurl", listOf(message))
+            assertThat(harness.primary.getMessages("fid-imageurl")).containsExactly(message)
+        }
+    }
+
+    @Test
+    fun `url image content without mime type round trips with null mime type`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            val message = ChatMemoryStoreFixtures.urlImageMessage(mimeType = null)
+            harness.primary.appendMessages("fid-imageurl-null", listOf(message))
+            assertThat(harness.primary.getMessages("fid-imageurl-null")).containsExactly(message)
+        }
+    }
+
+    @Test
+    fun `assistant single tool call with json arguments round trips exactly`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            val message = ChatMemoryStoreFixtures.assistantToolCalls(
+                listOf(
+                    ChatMemoryStoreFixtures.toolCall(
+                        id = "call_1",
+                        name = "search_web",
+                        argumentsJson = """{"query": "tramai", "limit": 5, "flags": [true, null, "x"]}""",
+                    ),
+                ),
+            )
+            harness.primary.appendMessages("fid-toolcall-1", listOf(message))
+            assertThat(harness.primary.getMessages("fid-toolcall-1")).containsExactly(message)
+        }
+    }
+
+    @Test
+    fun `assistant multiple tool calls round trip exactly in order`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            val message = ChatMemoryStoreFixtures.assistantToolCalls(
+                listOf(
+                    ChatMemoryStoreFixtures.toolCall("call_a", "tool_a", """{"arg": 1}"""),
+                    ChatMemoryStoreFixtures.toolCall("call_b", "tool_b", """{"arg": 2}"""),
+                    ChatMemoryStoreFixtures.toolCall("call_c", "tool_c", """{"arg": 3}"""),
+                ),
+            )
+            harness.primary.appendMessages("fid-toolcall-n", listOf(message))
+            assertThat(harness.primary.getMessages("fid-toolcall-n")).containsExactly(message)
+        }
+    }
+
+    @Test
+    fun `null versus empty contentParts round trip distinctly`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            val withNull = ChatMemoryStoreFixtures.text("plain text")
+            val withEmpty = ChatMemoryStoreFixtures.rich(emptyList())
+            harness.primary.appendMessages("fid-parts-null", listOf(withNull))
+            harness.peer.appendMessages("fid-parts-empty", listOf(withEmpty))
+            assertThat(harness.primary.getMessages("fid-parts-null")).containsExactly(withNull)
+            assertThat(harness.primary.getMessages("fid-parts-empty")).containsExactly(withEmpty)
+        }
+    }
+
+    @Test
+    fun `null versus empty toolCalls round trip distinctly`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            val withNull = ChatMemoryStoreFixtures.assistant("plain assistant text")
+            val withEmpty = ChatMemoryStoreFixtures.assistantToolCalls(emptyList())
+            harness.primary.appendMessages("fid-calls-null", listOf(withNull))
+            harness.peer.appendMessages("fid-calls-empty", listOf(withEmpty))
+            assertThat(harness.primary.getMessages("fid-calls-null")).containsExactly(withNull)
+            assertThat(harness.primary.getMessages("fid-calls-empty")).containsExactly(withEmpty)
+        }
+    }
+
+    @Test
+    fun `mixed roles and content kinds round trip as one history`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            val history = listOf(
+                ChatMemoryStoreFixtures.system("rules"),
+                ChatMemoryStoreFixtures.user("question"),
+                ChatMemoryStoreFixtures.assistantToolCalls(
+                    listOf(ChatMemoryStoreFixtures.toolCall("c1", "lookup", """{"k": "v"}""")),
+                ),
+                ChatMemoryStoreFixtures.tool("c1", "the answer"),
+                ChatMemoryStoreFixtures.rich(
+                    listOf(ContentPart.TextPart("final"), ContentPart.ImageUrlContent("https://x.test/i.png", "image/png")),
+                ),
+            )
+            harness.primary.appendMessages("fid-mixed", history)
+            assertThat(harness.primary.getMessages("fid-mixed")).containsExactlyElementsOf(history)
+            assertThat(harness.peer.getMessages("fid-mixed")).containsExactlyElementsOf(history)
+        }
+    }
+
+    // ── C3. Snapshot semantics ──────────────────────────────────────
+
+    @Test
+    fun `read returns a snapshot immune to mutation of the returned list`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.appendMessages("snap-mutate", listOf(ChatMemoryStoreFixtures.user("a"), ChatMemoryStoreFixtures.user("b")))
+            val snapshot = harness.primary.getMessages("snap-mutate")
+            runCatching { (snapshot as MutableList<Message>).clear() } // legal: unmodifiable (throws) or independent copy
+            assertThat(harness.primary.getMessages("snap-mutate").map { it.content }).containsExactly("a", "b")
+        }
+    }
+
+    @Test
+    fun `previous snapshot is not mutated by a later append`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.appendMessages("snap-append", listOf(ChatMemoryStoreFixtures.user("A")))
+            val snapshot = harness.primary.getMessages("snap-append")
+            harness.peer.appendMessages("snap-append", listOf(ChatMemoryStoreFixtures.user("B")))
+            assertThat(snapshot.map { it.content }).containsExactly("A")
+            assertThat(harness.primary.getMessages("snap-append").map { it.content }).containsExactly("A", "B")
+        }
+    }
+
+    // ── C4. Delete semantics ────────────────────────────────────────
+
+    @Test
+    fun `delete removes an existing conversation`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.appendMessages("del-existing", listOf(ChatMemoryStoreFixtures.user("x")))
+            harness.peer.deleteConversation("del-existing")
+            assertThat(harness.primary.getMessages("del-existing")).isEmpty()
+        }
+    }
+
+    @Test
+    fun `delete of a missing conversation is an idempotent no-op`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.deleteConversation("del-missing")
+            harness.peer.deleteConversation("del-missing")
+            assertThat(harness.primary.getMessages("del-missing")).isEmpty()
+        }
+    }
+
+    @Test
+    fun `deleting one conversation does not modify another`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.appendMessages("del-a", listOf(ChatMemoryStoreFixtures.user("A")))
+            harness.peer.appendMessages("del-b", listOf(ChatMemoryStoreFixtures.user("B")))
+            harness.primary.deleteConversation("del-a")
+            assertThat(harness.primary.getMessages("del-a")).isEmpty()
+            assertThat(harness.primary.getMessages("del-b").map { it.content }).containsExactly("B")
+        }
+    }
+
+    @Test
+    fun `append after delete starts a fresh history`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.appendMessages("del-recreate", listOf(ChatMemoryStoreFixtures.user("old")))
+            harness.peer.deleteConversation("del-recreate")
+            harness.primary.appendMessages("del-recreate", listOf(ChatMemoryStoreFixtures.user("new")))
+            assertThat(harness.primary.getMessages("del-recreate").map { it.content }).containsExactly("new")
+        }
+    }
+
+    @Test
+    fun `deleted conversation disappears from listConversations`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.appendMessages("del-listed", listOf(ChatMemoryStoreFixtures.user("x")))
+            assertThat(harness.primary.listConversations(100, 0)).contains("del-listed")
+            harness.peer.deleteConversation("del-listed")
+            assertThat(harness.primary.listConversations(100, 0)).doesNotContain("del-listed")
+        }
+    }
+
+    // ── C5. Input validation ────────────────────────────────────────
+
+    @Test
+    fun `blank conversation id on getMessages is a caller error`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            for (blank in listOf("", "   ", "\t")) {
+                assertThat(runCatching { harness.primary.getMessages(blank) }.exceptionOrNull())
+                    .withFailMessage("getMessages(\"$blank\") must reject blank identity")
+                    .isInstanceOf(IllegalArgumentException::class.java)
+            }
+        }
+    }
+
+    @Test
+    fun `blank conversation id on appendMessages is a caller error`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            for (blank in listOf("", "   ", "\t")) {
+                assertThat(runCatching { harness.primary.appendMessages(blank, listOf(ChatMemoryStoreFixtures.user("x"))) }.exceptionOrNull())
+                    .withFailMessage("appendMessages(\"$blank\") must reject blank identity")
+                    .isInstanceOf(IllegalArgumentException::class.java)
+            }
+        }
+    }
+
+    @Test
+    fun `blank conversation id on deleteConversation is a caller error`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            for (blank in listOf("", "   ", "\t")) {
+                assertThat(runCatching { harness.primary.deleteConversation(blank) }.exceptionOrNull())
+                    .withFailMessage("deleteConversation(\"$blank\") must reject blank identity")
+                    .isInstanceOf(IllegalArgumentException::class.java)
+            }
+        }
+    }
+
+    @Test
+    fun `invalid pagination arguments are caller errors`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            assertThat(runCatching { harness.primary.listConversations(0, 0) }.exceptionOrNull())
+                .isInstanceOf(IllegalArgumentException::class.java)
+            assertThat(runCatching { harness.primary.listConversations(-1, 0) }.exceptionOrNull())
+                .isInstanceOf(IllegalArgumentException::class.java)
+            assertThat(runCatching { harness.primary.listConversations(10, -1) }.exceptionOrNull())
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    // ── C6. listConversations contract ──────────────────────────────
+
+    @Test
+    fun `empty store lists no conversations`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            assertThat(harness.primary.listConversations(100, 0)).isEmpty()
+        }
+    }
+
+    @Test
+    fun `single conversation is listed once`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.appendMessages("list-single", listOf(ChatMemoryStoreFixtures.user("x")))
+            assertThat(harness.primary.listConversations(100, 0)).containsExactly("list-single")
+        }
+    }
+
+    @Test
+    fun `multiple conversations order by most recent activity descending`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.appendMessages("list-old", listOf(ChatMemoryStoreFixtures.user("a"))) // t0
+            clock.advance(1)
+            harness.peer.appendMessages("list-new", listOf(ChatMemoryStoreFixtures.user("b"))) // t0+1
+            clock.advance(1)
+            harness.primary.appendMessages("list-newer", listOf(ChatMemoryStoreFixtures.user("c"))) // t0+2
+            assertThat(harness.primary.listConversations(100, 0))
+                .containsExactly("list-newer", "list-new", "list-old")
+        }
+    }
+
+    @Test
+    fun `appending to an older conversation moves it to first`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.appendMessages("list-move-a", listOf(ChatMemoryStoreFixtures.user("a"))) // t0
+            clock.advance(1)
+            harness.peer.appendMessages("list-move-b", listOf(ChatMemoryStoreFixtures.user("b"))) // t0+1
+            assertThat(harness.primary.listConversations(100, 0)).containsExactly("list-move-b", "list-move-a")
+            clock.advance(1)
+            harness.primary.appendMessages("list-move-a", listOf(ChatMemoryStoreFixtures.user("a2"))) // t0+2
+            assertThat(harness.primary.listConversations(100, 0)).containsExactly("list-move-a", "list-move-b")
+        }
+    }
+
+    @Test
+    fun `multiple messages in one conversation produce one listing id`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.appendMessages("list-one-id", listOf(ChatMemoryStoreFixtures.user("1"), ChatMemoryStoreFixtures.user("2")))
+            clock.advance(1)
+            harness.peer.appendMessages("list-one-id", listOf(ChatMemoryStoreFixtures.user("3")))
+            assertThat(harness.primary.listConversations(100, 0)).containsExactly("list-one-id")
+        }
+    }
+
+    @Test
+    fun `limit caps results`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.appendMessages("list-limit-1", listOf(ChatMemoryStoreFixtures.user("a")))
+            clock.advance(1)
+            harness.peer.appendMessages("list-limit-2", listOf(ChatMemoryStoreFixtures.user("b")))
+            clock.advance(1)
+            harness.primary.appendMessages("list-limit-3", listOf(ChatMemoryStoreFixtures.user("c")))
+            assertThat(harness.primary.listConversations(2, 0)).containsExactly("list-limit-3", "list-limit-2")
+        }
+    }
+
+    @Test
+    fun `offset skips exactly n results`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.appendMessages("list-off-1", listOf(ChatMemoryStoreFixtures.user("a")))
+            clock.advance(1)
+            harness.peer.appendMessages("list-off-2", listOf(ChatMemoryStoreFixtures.user("b")))
+            clock.advance(1)
+            harness.primary.appendMessages("list-off-3", listOf(ChatMemoryStoreFixtures.user("c")))
+            assertThat(harness.primary.listConversations(100, 1)).containsExactly("list-off-2", "list-off-1")
+            assertThat(harness.primary.listConversations(1, 2)).containsExactly("list-off-1")
+        }
+    }
+
+    @Test
+    fun `final partial page is returned`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.appendMessages("list-page-1", listOf(ChatMemoryStoreFixtures.user("a")))
+            clock.advance(1)
+            harness.peer.appendMessages("list-page-2", listOf(ChatMemoryStoreFixtures.user("b")))
+            clock.advance(1)
+            harness.primary.appendMessages("list-page-3", listOf(ChatMemoryStoreFixtures.user("c")))
+            clock.advance(1)
+            harness.peer.appendMessages("list-page-4", listOf(ChatMemoryStoreFixtures.user("d")))
+            assertThat(harness.primary.listConversations(3, 2)).containsExactly("list-page-2", "list-page-1")
+        }
+    }
+
+    @Test
+    fun `offset beyond end returns empty`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.appendMessages("list-beyond", listOf(ChatMemoryStoreFixtures.user("x")))
+            assertThat(harness.primary.listConversations(100, 5)).isEmpty()
+        }
+    }
+
+    @Test
+    fun `delete and recreate gives that conversation new activity`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.appendMessages("list-recreate", listOf(ChatMemoryStoreFixtures.user("first"))) // t0
+            clock.advance(1)
+            harness.peer.appendMessages("list-other", listOf(ChatMemoryStoreFixtures.user("o"))) // t0+1
+            assertThat(harness.primary.listConversations(100, 0)).containsExactly("list-other", "list-recreate")
+            harness.primary.deleteConversation("list-recreate")
+            assertThat(harness.primary.listConversations(100, 0)).containsExactly("list-other")
+            clock.advance(1)
+            harness.peer.appendMessages("list-recreate", listOf(ChatMemoryStoreFixtures.user("second"))) // t0+2
+            assertThat(harness.primary.listConversations(100, 0)).containsExactly("list-recreate", "list-other")
+        }
+    }
+
+    // ── C7. Empty append is not activity ────────────────────────────
+
+    @Test
+    fun `empty append does not count as conversation activity`() {
+        val clock = MutableMillisClock()
+        createHarness(clock).use { harness ->
+            harness.primary.appendMessages("act-a", listOf(ChatMemoryStoreFixtures.user("a"))) // t0
+            clock.advance(1)
+            harness.peer.appendMessages("act-b", listOf(ChatMemoryStoreFixtures.user("b"))) // t0+1
+            assertThat(harness.primary.listConversations(100, 0)).containsExactly("act-b", "act-a")
+            clock.advance(1)
+            harness.primary.appendMessages("act-a", emptyList()) // must NOT move act-a first
+            assertThat(harness.primary.listConversations(100, 0)).containsExactly("act-b", "act-a")
+        }
+    }
+
+    // ── C8. Concurrency: linearizable batch append ──────────────────
+
+    @Test
+    fun `concurrent single appends all succeed exactly once`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val clock = MutableMillisClock()
+            createHarness(clock).use { harness ->
+                val conversation = "race-single-$round"
+                val outcomes = runInParallel(0 until 8) { index ->
+                    val store = if (index % 2 == 0) harness.primary else harness.peer
+                    runCatching { store.appendMessages(conversation, listOf(ChatMemoryStoreFixtures.user("M$index"))) }
+                }
+                assertThat(outcomes.count { it.isSuccess }).withFailMessage {
+                    "round $round: all 8 concurrent single appends must succeed, got $outcomes"
+                }.isEqualTo(8)
+                val history = harness.primary.getMessages(conversation)
+                assertThat(history).hasSize(8)
+                assertThat(history.map { it.content }.toSet())
+                    .withFailMessage("round $round: each unique message must appear exactly once")
+                    .isEqualTo((0 until 8).map { "M$it" }.toSet())
+            }
+        }
+    }
+
+    @Test
+    fun `concurrent batch appends are atomic and contiguous`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val clock = MutableMillisClock()
+            createHarness(clock).use { harness ->
+                val conversation = "race-batch-$round"
+                val a = listOf("A1", "A2", "A3").map { ChatMemoryStoreFixtures.user(it) }
+                val b = listOf("B1", "B2", "B3").map { ChatMemoryStoreFixtures.user(it) }
+                val outcomes = runInParallel(0 until 2) { index ->
+                    if (index == 0) {
+                        runCatching { harness.primary.appendMessages(conversation, a) }
+                    } else {
+                        runCatching { harness.peer.appendMessages(conversation, b) }
+                    }
+                }
+                assertThat(outcomes.count { it.isSuccess }).withFailMessage {
+                    "round $round: both concurrent batch appends must succeed, got $outcomes"
+                }.isEqualTo(2)
+                val history = harness.primary.getMessages(conversation).map { it.content }
+                assertThat(history).withFailMessage {
+                    "round $round: batches must be contiguous, never interleaved: $history"
+                }.isIn(
+                    listOf("A1", "A2", "A3", "B1", "B2", "B3"),
+                    listOf("B1", "B2", "B3", "A1", "A2", "A3"),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `concurrent append versus delete never leaves partial history`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val clock = MutableMillisClock()
+            createHarness(clock).use { harness ->
+                val conversation = "race-delete-$round"
+                val outcomes = runInParallel(0 until 2) { index ->
+                    if (index == 0) {
+                        runCatching {
+                            harness.primary.appendMessages(conversation, listOf("X1", "X2", "X3").map { ChatMemoryStoreFixtures.user(it) })
+                        }
+                    } else {
+                        runCatching { harness.peer.deleteConversation(conversation) }
+                    }
+                }
+                assertThat(outcomes.count { it.isSuccess }).withFailMessage {
+                    "round $round: both operations must succeed, got $outcomes"
+                }.isEqualTo(2)
+                val history = harness.primary.getMessages(conversation).map { it.content }
+                assertThat(history).withFailMessage {
+                    "round $round: append vs delete must never leave partial history: $history"
+                }.isIn(emptyList<String>(), listOf("X1", "X2", "X3"))
+                // Listing membership must agree with the final history.
+                val listed = harness.peer.listConversations(100, 0).contains(conversation)
+                assertThat(listed).withFailMessage {
+                    "round $round: listing membership must agree with final history $history"
+                }.isEqualTo(history.isNotEmpty())
+            }
+        }
+    }
+
+    @Test
+    fun `concurrent batches in independent conversations both survive exactly`() = runBlocking<Unit> {
+        repeat(20) { round ->
+            val clock = MutableMillisClock()
+            createHarness(clock).use { harness ->
+                val conversationA = "race-ind-a-$round"
+                val conversationB = "race-ind-b-$round"
+                val outcomes = runInParallel(0 until 2) { index ->
+                    if (index == 0) {
+                        runCatching {
+                            harness.primary.appendMessages(conversationA, listOf("A1", "A2", "A3").map { ChatMemoryStoreFixtures.user(it) })
+                        }
+                    } else {
+                        runCatching {
+                            harness.peer.appendMessages(conversationB, listOf("B1", "B2", "B3").map { ChatMemoryStoreFixtures.user(it) })
+                        }
+                    }
+                }
+                assertThat(outcomes.count { it.isSuccess }).withFailMessage {
+                    "round $round: both independent appends must succeed, got $outcomes"
+                }.isEqualTo(2)
+                assertThat(harness.primary.getMessages(conversationA).map { it.content })
+                    .withFailMessage("round $round: conversation A history must survive exactly")
+                    .containsExactly("A1", "A2", "A3")
+                assertThat(harness.primary.getMessages(conversationB).map { it.content })
+                    .withFailMessage("round $round: conversation B history must survive exactly")
+                    .containsExactly("B1", "B2", "B3")
+            }
+        }
+    }
+
+    // ── Parallel-race helper (shared pattern from #269-#274) ─────────
+
+    private suspend fun <T, R> runInParallel(
+        items: List<T>,
+        block: suspend (T) -> R,
+    ): List<R> = coroutineScope {
+        val ready = Channel<Unit>(items.size)
+        val release = CompletableDeferred<Unit>()
+        val workers = items.map { item ->
+            async(Dispatchers.Default) {
+                ready.send(Unit)
+                release.await()
+                block(item)
+            }
+        }
+        repeat(items.size) { ready.receive() }
+        release.complete(Unit)
+        workers.map { it.await() }
+    }
+
+    private suspend fun <R> runInParallel(
+        range: IntRange,
+        block: suspend (Int) -> R,
+    ): List<R> = runInParallel(range.toList(), block)
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/memory/ChatMemoryStoreTckHarness.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/memory/ChatMemoryStoreTckHarness.kt
@@ -1,0 +1,23 @@
+package dev.tramai.testing.persistence.memory
+
+import dev.tramai.core.memory.ChatMemoryStore
+
+/**
+ * Epic 8.1h: per-test backend harness for the
+ * [dev.tramai.core.memory.ChatMemoryStore] compatibility contract.
+ *
+ * [primary] and [peer] are DISTINCT store objects over the SAME physical
+ * backend. A single in-memory mutex inside one store object is not evidence
+ * for JDBC/Redis shared by multiple application nodes — the concurrency
+ * contract must prove coordination at the backend level.
+ */
+interface ChatMemoryStoreTckHarness : AutoCloseable {
+
+    /** First store instance. */
+    val primary: ChatMemoryStore
+
+    /** Second store instance over the same physical backend. */
+    val peer: ChatMemoryStore
+
+    override fun close() {}
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/memory/MutableMillisClock.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/memory/MutableMillisClock.kt
@@ -1,0 +1,28 @@
+package dev.tramai.testing.persistence.memory
+
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Thread-safe deterministic millis clock for the chat-memory TCKs: fixed at
+ * construction, advanced/set explicitly by the test. Never
+ * `System.currentTimeMillis()`.
+ *
+ * Backed by [AtomicLong] because the concurrency cases read the clock from
+ * parallel workers.
+ */
+class MutableMillisClock(
+    initial: Long = 1_800_000_000_000L,
+) : () -> Long {
+
+    private val now = AtomicLong(initial)
+
+    override fun invoke(): Long = now.get()
+
+    fun set(millis: Long) {
+        now.set(millis)
+    }
+
+    fun advance(millis: Long) {
+        now.addAndGet(millis)
+    }
+}


### PR DESCRIPTION
# test(persistence): add ChatMemoryStore compatibility TCK — Epic 8.1h

Closes the **final store-family slice of Epic 8.1** (memory). The compatibility matrix now has every published store family in the tramai/aurora monorepo passing one shared cross-implementation TCK in `tramai-testing` testFixtures.

## Shared contract

`ChatMemoryStoreTck` (tramai-testing testFixtures) runs **50 shared cases × 2 implementations** (`JdbcChatMemoryStore` on real H2, `RedisChatMemoryStore` on a real Redis 7.4 Testcontainer with two independent JedisPools per case):

> A conversation is one ordered logical message history. A successful `appendMessages()` adds its complete batch exactly once and contiguously; reads preserve the complete `Message` value; deletion removes the conversation; listing reflects most-recent conversation activity deterministically; and those answers cannot depend on whether the backend is JDBC or Redis.

- **Harness:** `ChatMemoryStoreTckHarness` exposes `primary` + `peer` — two DISTINCT store objects over the same physical backend, so the concurrency cases prove backend-level coordination, not a per-instance mutex.
- **Deterministic:** `MutableMillisClock` (AtomicLong) drives both stores; zero sleeps, zero real-clock reads.
- **50 cases:** read/append/identity (10) · full Message fidelity incl. the `ImageUrlContent.mimeType` discriminator (14) · snapshot semantics (2) · delete (5) · input validation incl. blank IDs + pagination args (4) · `listConversations` contract — most-recent-activity descending, recency move, pagination (10) · empty append is not activity (1) · 4 real parallel races × 20 iterations (single appends, atomic batch append, append-vs-delete, independent conversations).
- **Enrollment guard:** `ChatMemoryStoreTckEnrollmentArchitectureTest` — a future File/Mongo/Dynamo `ChatMemoryStore` cannot merge without enrollment.

## Deliberate production changes (runtime-behaviour)

1. **Redis activity index.** New sorted-set at the exact `{keyPrefix}` key (structurally disjoint from every conversation key): conversationId → last append epoch millis. `listConversations` = `ZREVRANGE` (deterministic, paginated) instead of SCAN-order collect/stop/drop-take. Legacy pre-index lists stay readable + discoverable (SCAN fallback, deterministic ordering after indexed conversations) and are enrolled atomically on their next append.
2. **Redis atomic batch append / delete.** `MULTI` → one `RPUSH` of the WHOLE batch + activity `ZADD` → `EXEC`; `MULTI` → `DEL` + `ZREM` → `EXEC`. A concurrent append can no longer interleave between the messages of another append; the listing index can never expose an ID whose history is gone.
3. **JDBC optimistic whole-transaction retry.** Concurrent writers can both read `MAX(ordinal)+1`; one wins the `(conversation_id, ordinal)` PK. The losing writer now retries the ENTIRE batch from a fresh durable MAX on exactly SQLState 23505 (walked through `JdbcBatchUpdateException.nextException`), bounded (20), never partial, never arbitrary SQL errors. Preserves the repo's primary > rollback > autoCommit-restore cleanup discipline (suppressed).
4. **StoredMessage `ImageUrlContent.mimeType` round-trip** (backward compatible; old JSON with null mimeType still reads). No public API change.
5. **Core KDoc only:** `ChatMemoryStore.listConversations` — "ordered by most recent append/activity descending" (the chat-UX semantics the JDBC store already implemented).

## Mutation evidence — 20/20 RED → GREEN, 0 weak

Named discriminator per mutation; every mutation restored after its run. Full table in the contract doc (`docs/reference/persistence-store-compatibility-contract.md`, `ChatMemoryStore TCK (PR #275)`): serializer fidelity (5), read/append identity (4), validation (1), key isolation (1), delete (2), listing limit/offset/recency/order (4), empty-append activity (1), Redis per-message RPUSH race (1), JDBC ordinal-retry race (1).

## Gates

- `tramai-memory-store` tests: **115/115** (50 JDBC TCK + 50 Redis TCK + 11 Redis-specific legacy/index/consistency/wrong-type + 4 direct JDBC)
- `tramai-testing` tests: green (enrollment guard 5/5)
- `apiCheck` ✅ (no API dump change — internal clock seam, private helpers)
- `verifyPr` ✅ (`-PchangeClass=runtime-behaviour`, maintainability baseline + change policy included)
- `verifyCancellationSafety` ✅ · `publishToMavenLocal` + example smoke suite ✅
- Docs: contract matrix (Memory row ✅ + Redis column), roadmap Epic 8.1 ✅ DONE, `tramai-memory-store` module doc synced to the real SPI.


## Review round 1 (independent agent review, all findings addressed)

| Finding | Resolution |
|---------|-----------|
| P1: Redis `exec()` result never inspected — Jedis 6 returns failed queued commands as result elements, so a WRONGTYPE index key silently degraded to legacy/zombie state | `throwIfTransactionFailed()` on both MULTI paths — a failed queued command surfaces as `JedisDataException`; 2 Redis-specific wrong-type regressions added (MULTI does not roll back — the RPUSH may be applied, the conversation stays readable/unindexed, the contract is the loud exception) |
| P2: JDBC retry could duplicate rows after a failed rollback (autoCommit restore would COMMIT the open partial batch) | failed rollback → non-retryable wrapper + skip the autoCommit restore so close() rolls the open transaction back |
| P3: 23505 retry not scoped to the ordinal PK | accepted — bounded (20), surfaces loudly; constraint-name matching is over-engineering |
| P3: listConversations stale-read window (index read vs legacy SCAN) | accepted + doc softened to per-command point-in-time snapshots |
| P3: listing O(N) / cosmetic edge assertions / two-pass campaign | accepted — documented; 20/20 discriminators RED→GREEN with the log kept honest |

Write-path mutations (M12/M13/M19/M20) re-verified RED→GREEN on the fixed code.
