### PR TITLE
docs(persistence): clarify Redis memory listing consistency

### DIFF
--- a/docs/reference/persistence-store-compatibility-contract.md
+++ b/docs/reference/persistence-store-compatibility-contract.md
@@ -989,9 +989,10 @@ no real clock.
 - **Redis append is ONE atomic transition:** `MULTI` → one `RPUSH` carrying
   the whole batch (never one RPUSH per message — another writer must not
   interleave between the messages of one logical append) + activity `ZADD`
-  → `EXEC`. Delete is `MULTI` → `DEL` + `ZREM` → `EXEC`, so
-  listConversations can never expose an ID whose history is gone. A
-  `MULTI`-atomicity race with the hook-free design is the M19 discriminator.
+  → `EXEC`. Delete is `MULTI` → `DEL` + `ZREM` → `EXEC`, so successful
+  writes keep conversation history and activity-index membership mutually
+  consistent. A `MULTI`-atomicity race with the hook-free design is the M19
+  discriminator.
 - **Redis legacy backward compatibility.** Pre-index deployments
   (conversation lists with no ZSET member) stay readable (getMessages
   unchanged) and discoverable: listConversations falls back to SCAN for


### PR DESCRIPTION
# docs(persistence): clarify Redis memory listing consistency

Docs-only cleanup (one file, zero production/API/baseline changes) for the P3 noted in the #275 review.

## What changed

`docs/reference/persistence-store-compatibility-contract.md` — the Redis delete bullet no longer claims `listConversations can never expose an ID whose history is gone`; it now reads:

> successful writes keep conversation history and activity-index membership mutually consistent

The point-in-time snapshot caveat directly above (a conversation deleted between the index read and the legacy SCAN can still appear on that one listing call) is preserved, so the document clearly distinguishes **write atomicity** from **cross-command read snapshot semantics**:

> Atomic writes do not imply a multi-command read transaction.

## Out of scope

- The pagination P3 (offset+limit overflow / full-ZSET read) is intentionally NOT included — it changes production code and deserves its own runtime-behaviour task if ever addressed.
- No test, build, API, or baseline files touched.

## Gates

- `verifyPr -PchangeClass=documentation` ✅ (BUILD SUCCESSFUL)
- Diff: 1 file, +4/−3, docs only.
