### PR TITLE
test(approval): add approval lifecycle state-machine properties — Epic 8.2a

### DIFF
--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1307,11 +1307,13 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ## Epic 8.2: State-machine and property-based tests
 
+**Status: 🚧 IN PROGRESS** — Approval lifecycle done (PR #277); remaining targets pending.
+
 **Goal:** Test lifecycle logic through transitions rather than isolated examples.
 
 ### Targets
 
-- Approval lifecycle
+- Approval lifecycle — ✅ PR #277 (5 model-based properties × 3 implementations added to `ApprovalStoreTck`: 42 shared cases total; pure `ApprovalLifecycleModel` oracle, 32-seed × 32-action deterministic corpus with guaranteed wrong-version-while-pending coverage, per-step invariants, wrong-version decision matrix + 3 concurrency properties ×20, coverage guard, 16-mutation evidence; zero production changes)
 - Continuation lifecycle
 - Worker lifecycle
 - Lease lifecycle
@@ -1327,6 +1329,15 @@ repair feedback. No layer maintains its own independent fixture lists.
 3. Assert invariants after every transition.
 4. Add concurrency tests for claims, versions, leases, duplicate decisions, and takeover.
 5. Add deterministic schedulers/clocks for timing-sensitive tests.
+
+### Deliverables (PR #277)
+
+- `tramai-testing/src/testFixtures/.../persistence/approval/` — `ApprovalLifecycleModel` (pure oracle + action alphabet + outcome kinds + invariants), `ApprovalLifecycleActionGenerator` (deterministic, state-aware)
+- `ApprovalStoreTck` augmented with 5 properties: generated lifecycle sequences (32 seeds × 32 actions, whole-record equality after every action, seed/step/prefix failure diagnostics), wrong-version decision matrix (Approve/Deny/Timeout × before/exact/after-expiry → CONFLICT + zero mutation), duplicate concurrent decisions (8 → 1 win/7 conflict), identical consumption (8 → 1 fresh + 7 replays, same durable record), competing consumers (8 → exactly one durable consumer identity)
+- `tramai-testing/src/test/.../persistence/approval/` — `ApprovalLifecycleActionGeneratorTest` coverage guard (16 semantic categories incl. reachable wrong-version-while-pending + determinism + full status lattice)
+- Model aligned to cross-store token-first precedence on the wrong-token path (SPI KDoc leaves check order unpinned)
+- Zero production changes; no public API/schema/persisted-format changes; no existing tests deleted
+- Reference: `docs/reference/state-machine-property-testing-contract.md`
 
 ---
 

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1313,7 +1313,7 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ### Targets
 
-- Approval lifecycle — ✅ PR #278 (5 model-based properties × 3 implementations added to `ApprovalStoreTck`: 42 shared cases total; pure `ApprovalLifecycleModel` oracle, 32-seed × 32-action deterministic corpus with guaranteed wrong-version-while-pending coverage, per-step invariants, wrong-version decision matrix + 3 concurrency properties ×20, coverage guard, 16-mutation evidence; zero production changes)
+- Approval lifecycle — ✅ PR #278 (5 model-based properties × 3 implementations added to `ApprovalStoreTck`: 42 shared cases total; pure `ApprovalLifecycleModel` oracle, 32-seed × 32-action deterministic corpus with guaranteed wrong-version-while-pending coverage, per-step invariants, wrong-version decision matrix + 3 concurrency properties ×20, coverage guard, 18-mutation evidence; zero production changes)
 - Continuation lifecycle
 - Worker lifecycle
 - Lease lifecycle

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1307,13 +1307,13 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ## Epic 8.2: State-machine and property-based tests
 
-**Status: 🚧 IN PROGRESS** — Approval lifecycle done (PR #277); remaining targets pending.
+**Status: 🚧 IN PROGRESS** — Approval lifecycle done (PR #278); remaining targets pending.
 
 **Goal:** Test lifecycle logic through transitions rather than isolated examples.
 
 ### Targets
 
-- Approval lifecycle — ✅ PR #277 (5 model-based properties × 3 implementations added to `ApprovalStoreTck`: 42 shared cases total; pure `ApprovalLifecycleModel` oracle, 32-seed × 32-action deterministic corpus with guaranteed wrong-version-while-pending coverage, per-step invariants, wrong-version decision matrix + 3 concurrency properties ×20, coverage guard, 16-mutation evidence; zero production changes)
+- Approval lifecycle — ✅ PR #278 (5 model-based properties × 3 implementations added to `ApprovalStoreTck`: 42 shared cases total; pure `ApprovalLifecycleModel` oracle, 32-seed × 32-action deterministic corpus with guaranteed wrong-version-while-pending coverage, per-step invariants, wrong-version decision matrix + 3 concurrency properties ×20, coverage guard, 16-mutation evidence; zero production changes)
 - Continuation lifecycle
 - Worker lifecycle
 - Lease lifecycle
@@ -1330,7 +1330,7 @@ repair feedback. No layer maintains its own independent fixture lists.
 4. Add concurrency tests for claims, versions, leases, duplicate decisions, and takeover.
 5. Add deterministic schedulers/clocks for timing-sensitive tests.
 
-### Deliverables (PR #277)
+### Deliverables (PR #278)
 
 - `tramai-testing/src/testFixtures/.../persistence/approval/` — `ApprovalLifecycleModel` (pure oracle + action alphabet + outcome kinds + invariants), `ApprovalLifecycleActionGenerator` (deterministic, state-aware)
 - `ApprovalStoreTck` augmented with 5 properties: generated lifecycle sequences (32 seeds × 32 actions, whole-record equality after every action, seed/step/prefix failure diagnostics), wrong-version decision matrix (Approve/Deny/Timeout × before/exact/after-expiry → CONFLICT + zero mutation), duplicate concurrent decisions (8 → 1 win/7 conflict), identical consumption (8 → 1 fresh + 7 replays, same durable record), competing consumers (8 → exactly one durable consumer identity)

--- a/docs/reference/persistence-store-compatibility-contract.md
+++ b/docs/reference/persistence-store-compatibility-contract.md
@@ -117,6 +117,16 @@ encryption, permissions, corruption, record format (file), SQL schema, JSON
 mapping, connection cleanup (JDBC). No existing tests were deleted. Zero
 public API change; no persisted format or schema changes.
 
+### Epic 8.2a augmentation (PR #277)
+
+`ApprovalStoreTck` was augmented with model-based lifecycle properties — 5
+new shared cases (37 → 42): generated lifecycle sequences against a pure
+`ApprovalLifecycleModel` oracle (32 seeds × 32 actions, whole-record
+equality + invariants after every action), a wrong-version decision matrix,
+duplicate concurrent decisions, identical consumption, and competing
+consumers. See
+`docs/reference/state-machine-property-testing-contract.md`.
+
 ---
 
 ## ApprovalContinuationStore TCK (PR #269)

--- a/docs/reference/persistence-store-compatibility-contract.md
+++ b/docs/reference/persistence-store-compatibility-contract.md
@@ -117,7 +117,7 @@ encryption, permissions, corruption, record format (file), SQL schema, JSON
 mapping, connection cleanup (JDBC). No existing tests were deleted. Zero
 public API change; no persisted format or schema changes.
 
-### Epic 8.2a augmentation (PR #277)
+### Epic 8.2a augmentation (PR #278)
 
 `ApprovalStoreTck` was augmented with model-based lifecycle properties — 5
 new shared cases (37 → 42): generated lifecycle sequences against a pure

--- a/docs/reference/state-machine-property-testing-contract.md
+++ b/docs/reference/state-machine-property-testing-contract.md
@@ -1,0 +1,209 @@
+# State-Machine and Property-Based Testing Contract
+
+Epic 8.2 replaces "specific scenario → expected result" with
+"model state → generated action → predicted transition → execute real
+store → compare → assert all invariants → repeat" for the lifecycle-heavy
+components of TramAI.
+
+## Epic 8.2 matrix
+
+| Target | Status |
+|---|---|
+| Approval lifecycle | ✅ #277 |
+| Continuation lifecycle | ⏳ |
+| Worker lifecycle | ⏳ |
+| Lease lifecycle | ⏳ |
+| Outbox lifecycle | ⏳ |
+| Workflow checkpoint/resume lifecycle | ⏳ |
+| Circuit breaker states | ⏳ |
+| Provider retry/fallback | ⏳ |
+
+## Method
+
+Every 8.2 slice follows the same shape:
+
+1. **Independent pure model.** The oracle is a standalone state machine
+   encoded from the DOCUMENTED contract (KDoc + prior example TCKs) — never
+   derived from production helpers such as `resolveNextStatus(...)` or
+   `consumeFreshApproval(...)`. Otherwise the suite only proves production
+   agrees with itself.
+2. **State-aware action alphabet.** Actions carry everything needed to
+   execute against the real component (actors, workers, versions, tokens);
+   the model decides legality for the current state. Illegal actions are
+   first-class corpus members — rejection is part of the contract.
+3. **Deterministic corpus.** Explicit seeds, no property-testing framework
+   yet (no Kotest/jqwik/QuickCheck). `32 seeds × 32 actions` per
+   implementation. Same seed → same trace, pinned by a coverage guard.
+4. **Exact predicted outcome per action.** Success → exactly the
+   model-predicted state (whole-record comparison); rejection → exactly the
+   model-predicted failure category AND zero durable mutation.
+5. **Invariants after EVERY action.** Not only the field touched by the
+   latest action — status monotonicity, version discipline, field
+   pairing/immutability, and full-record equality with the model.
+6. **Concurrency properties.** Real parallel workers (start barrier, one-way
+   release), 20 iterations: the result must correspond to one legal
+   serialization of the concurrent operations.
+7. **Coverage guard.** A pure test proves the fixed corpus reaches every
+   important category, so future generator edits cannot silently delete
+   behavioral coverage.
+8. **Mutation evidence.** Every mutation must turn a NEW 8.2 property RED on
+   its own — it does not count if only an older example test detects it.
+
+## Failure diagnostics
+
+Every generated-sequence property failure prints:
+
+```
+seed=<seed>
+step=<step>
+action=<action>
+prefix:
+  0 <action>
+  1 <action>
+  ...
+modelBefore=<model state>
+expected=<predicted outcome>
+actual=<actual outcome>
+```
+
+Because invariants are checked after every action, the failing prefix is
+already a useful minimal reproduction.
+
+---
+
+## Approval lifecycle — #277 (Epic 8.2a)
+
+`ApprovalStoreTck` (tramai-testing testFixtures) gained **5 model-based
+properties** on top of its 37 example-based cases — 42 shared cases × 3
+implementations (InMemory, File, JDBC). No new runner family: the existing
+harness (fresh store + deterministic `MutableClock` per case) already
+provides everything.
+
+### Model states
+
+```
+PENDING@v0
+   │
+   ├── approve ──────> APPROVED/UNCONSUMED@v1
+   │                          │
+   │                          └── consume ──> APPROVED/CONSUMED@v2
+   │                                             │
+   │                                             └── exact replay → unchanged @v2
+   │
+   ├── deny ─────────> DENIED@v1
+   │
+   └── timeout ──────> TIMED_OUT@v1
+```
+
+`ApprovalLifecycleModel` carries status, version, now, decidedBy/decidedAt/
+decisionComment, consumedBy/consumedAt. The immutable request fields
+(approvalId, binding, requestedBy, requestedAt, expiresAt) are pinned
+separately; after every action the expected `ApprovalRequest` is
+reconstructed and compared to `store.get(id)` **exactly**.
+
+### Action alphabet
+
+```
+AdvanceToBeforeExpiry / AdvanceToExactExpiry / AdvancePastExpiry
+ApproveCurrentVersion / ApproveWrongVersion
+DenyCurrentVersion / DenyWrongVersion
+TimeoutCurrentVersion / TimeoutWrongVersion
+ConsumeValid(worker) / ConsumeWrongVersion / ConsumeWrongToken
+```
+
+`ConsumeValid(workerB)` legality depends on state: unconsumed → fresh;
+consumed by workerA → exact replay; consumed by workerA but caller workerB →
+rejected.
+
+### Expiry boundary (pinned)
+
+`now < expiresAt` → decisions legal, fresh consume legal.
+`now >= expiresAt` → timeout legal (while PENDING), decisions illegal, fresh
+consume illegal, exact replay of an already-consumed approval remains legal.
+This matches the implementation's `now >= expiresAt` boundary in all three
+stores.
+
+### Per-step invariants
+
+Status monotonicity (PENDING leaves once, terminal never changes); version
+never decreases or jumps (max lifecycle version v2); binding/identity
+immutable; PENDING carries no decision/consumption fields; DENIED/TIMED_OUT
+never acquire consumption fields; APPROVED consumption fields both-null or
+both-set; decision and consumption metadata immutable after being set;
+rejected action → durable record byte-identical before/after.
+
+### Generated corpus
+
+32 seeds × 32 actions = 1,024 lifecycle actions per implementation × 3 =
+3,072 model-checked operations. Every seed opens with a GUARANTEED
+wrong-version decision evaluated against the PENDING pre-state (the only
+state where the transition version guard is the discriminator) — the corpus
+must never depend on luck for a primary optimistic-concurrency invariant.
+`ApprovalLifecycleActionGeneratorTest` pins: same seed → same trace, all 16
+semantic categories present (valid approve/deny/timeout, early-timeout
+rejection, approve/deny-after-expiry rejection, wrong-version conflict,
+wrong-version-while-pending, post-terminal rejection, fresh consume, expired
+fresh-consume rejection, wrong-token rejection, exact replay, replay after
+expiry, wrong-actor/wrong-version replay rejections), and all four statuses
+reached.
+
+### Concurrency properties (×20 iterations, start barrier)
+
+- **Wrong-version decisions (deterministic matrix):** for every
+  Approve/Deny/Timeout with `expectedVersion = durable + 1`, at t0 / exact
+  expiry / after expiry → `ApprovalStoreConflictException` and the durable
+  record exactly unchanged. Pins optimistic versioning on DECISION
+  transitions including failure precedence: version is checked before the
+  expiry window, so a stale-version decision at/after expiry is a CONFLICT,
+  not an IllegalApprovalTransition.
+- **Duplicate decisions:** 8 contenders (Approve/Deny alternating,
+  expectedVersion 0) → exactly 1 success, 7 conflicts, durable v1 with the
+  winner's status/decidedBy; no second decision can overwrite the winner.
+- **Identical consumption:** 8 identical consumers (same version, token,
+  worker) → 1 fresh receipt + 7 exact replays, all returning the SAME
+  durable v2 record with identical consumedAt.
+- **Competing consumers:** 8 unique actors → exactly one fresh winner,
+  durable v2 with the winner's consumedBy; no second actor ever obtains a
+  successful receipt (replay requires the durable consumer identity to match
+  the caller); losers may surface any of the typed non-success outcomes
+  (check precedence is not pinned after the winner commits).
+
+### Contract precedence discovered
+
+The model originally checked the expiry window before the token on the
+wrong-token path; all three stores uniformly check the token FIRST (an
+expired-but-unconsumed approval with a wrong token is
+`ApprovalStoreTokenRejectedException`, not `NotConsumable`). The SPI KDoc
+does not pin check order — the model was aligned to the cross-store
+behavior (token-first) rather than weakening either side.
+
+### Mutation evidence (16 mutations, each restored)
+
+Each mutation makes a NEW 8.2 property RED (generated-sequence and/or
+identical-consumption); none rely on an old #267 example test:
+
+| Mutation | Discriminator |
+|---|---|
+| terminal decision guard removed | generated sequence |
+| expiry boundary `>=` → `>` | generated sequence |
+| early timeout allowed | generated sequence |
+| approve after expiry allowed | generated sequence |
+| deny after expiry allowed | generated sequence |
+| transition version check removed | generated sequence + wrong-version matrix |
+| decision version increment removed | generated sequence |
+| decidedAt not updated | generated sequence |
+| decidedBy dropped | generated sequence |
+| fresh consume version check removed | generated sequence |
+| fresh consume expiry check removed | generated sequence |
+| fresh consume version increment removed | generated sequence |
+| replay changes the durable record | generated sequence + identical consumption |
+| replay accepts a different consumer | generated sequence |
+| token check removed | generated sequence |
+| exact replay disabled | generated sequence + identical consumption |
+
+### Production changes
+
+None. Zero production code, zero public API, zero schema, zero persisted
+format. The model exposed one genuine cross-store behavior (token-first
+precedence) which the SPI KDoc leaves unpinned; the model was aligned, not
+the stores.

--- a/docs/reference/state-machine-property-testing-contract.md
+++ b/docs/reference/state-machine-property-testing-contract.md
@@ -130,7 +130,9 @@ never decreases or jumps (max lifecycle version v2); binding/identity
 immutable; PENDING carries no decision/consumption fields; DENIED/TIMED_OUT
 never acquire consumption fields; APPROVED consumption fields both-null or
 both-set; decision and consumption metadata immutable after being set;
-rejected action → durable record byte-identical before/after.
+rejected action → durable record value-identical before/after (externally
+observable domain equality — `store.get(id)` equals the pre-action record;
+not a claim about persisted bytes).
 
 ### Generated corpus
 
@@ -139,23 +141,36 @@ rejected action → durable record byte-identical before/after.
 wrong-version decision evaluated against the PENDING pre-state (the only
 state where the transition version guard is the discriminator) — the corpus
 must never depend on luck for a primary optimistic-concurrency invariant.
-`ApprovalLifecycleActionGeneratorTest` pins: same seed → same trace, all 16
+`ApprovalLifecycleActionGeneratorTest` pins: same seed → same trace, all 18
 semantic categories present (valid approve/deny/timeout, early-timeout
-rejection, approve/deny-after-expiry rejection, wrong-version conflict,
-wrong-version-while-pending, post-terminal rejection, fresh consume, expired
-fresh-consume rejection, wrong-token rejection, exact replay, replay after
+rejection, approve/deny-after-expiry rejection, exact-expiry boundary,
+wrong-version conflict, wrong-version-while-pending, post-terminal
+rejection, fresh consume, expired fresh-consume rejection, fresh-consume
+wrong-version rejection, wrong-token rejection, exact replay, replay after
 expiry, wrong-actor/wrong-version replay rejections), and all four statuses
-reached.
+reached. Categories are recorded from the MODEL WALK (reachable pre-state
+semantics), not from action-enum presence: e.g. `exact-expiry-boundary`
+requires a PENDING pre-state at exactly `now == expiresAt` (not just
+`now > expiresAt`), and `fresh-consume-wrong-version-rejection` requires
+APPROVED + unconsumed — a future generator edit that silently loses these
+discriminators fails the guard.
+
+Note on time actions: the `Advance*` actions SET the clock absolutely and
+may move it backwards (e.g. past-expiry then before-expiry). Clock reversal
+is part of the tested model — deterministic time control for boundary
+pinning, not wall-clock monotonicity. Epic 8.3 owns time abstractions.
+
+### Wrong-version decision matrix (deterministic, not a race)
+
+For every Approve/Deny/Timeout with `expectedVersion = durable + 1`, at
+t0 / exact expiry / after expiry → `ApprovalStoreConflictException` and the
+durable record exactly unchanged. Pins optimistic versioning on DECISION
+transitions including failure precedence: version is checked before the
+expiry window, so a stale-version decision at/after expiry is a CONFLICT,
+not an IllegalApprovalTransition.
 
 ### Concurrency properties (×20 iterations, start barrier)
 
-- **Wrong-version decisions (deterministic matrix):** for every
-  Approve/Deny/Timeout with `expectedVersion = durable + 1`, at t0 / exact
-  expiry / after expiry → `ApprovalStoreConflictException` and the durable
-  record exactly unchanged. Pins optimistic versioning on DECISION
-  transitions including failure precedence: version is checked before the
-  expiry window, so a stale-version decision at/after expiry is a CONFLICT,
-  not an IllegalApprovalTransition.
 - **Duplicate decisions:** 8 contenders (Approve/Deny alternating,
   expectedVersion 0) → exactly 1 success, 7 conflicts, durable v1 with the
   winner's status/decidedBy; no second decision can overwrite the winner.
@@ -164,9 +179,15 @@ reached.
   durable v2 record with identical consumedAt.
 - **Competing consumers:** 8 unique actors → exactly one fresh winner,
   durable v2 with the winner's consumedBy; no second actor ever obtains a
-  successful receipt (replay requires the durable consumer identity to match
-  the caller); losers may surface any of the typed non-success outcomes
-  (check precedence is not pinned after the winner commits).
+  successful receipt. Every loser deterministically surfaces
+  `ApprovalStoreNotConsumableException`: whole-consume atomicity (InMemory
+  CAS, File per-record lock, JDBC `FOR UPDATE` row-lock) serializes each
+  loser AFTER the winner, so the loser reads the consumed record, takes the
+  replay path with the valid predecessor version (1) and matching token,
+  and fails only on the actor check. Conflict or TokenRejected are NOT
+  legal serialized loser outcomes — a loser leaking Conflict would mean an
+  implementation that lost a race without re-reading the winning state
+  (the exact false confidence this suite exists to remove).
 
 ### Contract precedence discovered
 
@@ -174,13 +195,17 @@ The model originally checked the expiry window before the token on the
 wrong-token path; all three stores uniformly check the token FIRST (an
 expired-but-unconsumed approval with a wrong token is
 `ApprovalStoreTokenRejectedException`, not `NotConsumable`). The SPI KDoc
-does not pin check order — the model was aligned to the cross-store
-behavior (token-first) rather than weakening either side.
+does not pin check order. This PR makes an explicit decision: **token-first
+is promoted to an intentional cross-store contract**, pinned by the model
+and verified on all three implementations. If a future implementation ever
+wants a different precedence, it must first change the SPI KDoc — the
+shared TCK will reject the divergence.
 
-### Mutation evidence (16 mutations, each restored)
+### Mutation evidence (18 mutations, each restored)
 
-Each mutation makes a NEW 8.2 property RED (generated-sequence and/or
-identical-consumption); none rely on an old #267 example test:
+Each mutation makes a NEW 8.2 property RED (generated-sequence, identical-
+consumption and/or competing-consumers); none rely on an old #267 example
+test:
 
 | Mutation | Discriminator |
 |---|---|
@@ -200,6 +225,8 @@ identical-consumption); none rely on an old #267 example test:
 | replay accepts a different consumer | generated sequence |
 | token check removed | generated sequence |
 | exact replay disabled | generated sequence + identical consumption |
+| replay accepts expectedVersion == durableVersion | generated sequence |
+| replay loser leaks Conflict instead of NotConsumable | competing consumers + generated sequence |
 
 ### Production changes
 

--- a/docs/reference/state-machine-property-testing-contract.md
+++ b/docs/reference/state-machine-property-testing-contract.md
@@ -9,7 +9,7 @@ components of TramAI.
 
 | Target | Status |
 |---|---|
-| Approval lifecycle | ✅ #277 |
+| Approval lifecycle | ✅ #278 |
 | Continuation lifecycle | ⏳ |
 | Worker lifecycle | ⏳ |
 | Lease lifecycle | ⏳ |
@@ -71,7 +71,7 @@ already a useful minimal reproduction.
 
 ---
 
-## Approval lifecycle — #277 (Epic 8.2a)
+## Approval lifecycle — #278 (Epic 8.2a)
 
 `ApprovalStoreTck` (tramai-testing testFixtures) gained **5 model-based
 properties** on top of its 37 example-based cases — 42 shared cases × 3

--- a/tramai-testing/src/test/kotlin/dev/tramai/testing/persistence/approval/ApprovalLifecycleActionGeneratorTest.kt
+++ b/tramai-testing/src/test/kotlin/dev/tramai/testing/persistence/approval/ApprovalLifecycleActionGeneratorTest.kt
@@ -71,14 +71,14 @@ class ApprovalLifecycleActionGeneratorTest {
             "exact-replay-after-expiry",
             "wrong-actor-replay-rejection",
             "wrong-version-replay-rejection",
+            "fresh-consume-wrong-version-rejection",
+            "exact-expiry-boundary",
         )
         val missing = expectedCategories.filterNot { it in categories }
         assertThat(missing)
             .withFailMessage {
-                val sample = events.filter { it.category in missing }.take(3).joinToString("\n") {
-                    "  seed=${it.seed} step=${it.step} action=${it.action.describe()}"
-                }
-                "corpus missing categories: $missing\nfirst occurrences:\n$sample\n" +
+                val available = categories.sorted().joinToString(", ")
+                "corpus missing categories: $missing\navailable: $available\n" +
                     "total events: ${events.size}, seeds: ${ApprovalLifecycleActionGenerator.SEED_COUNT}"
             }
             .isEmpty()
@@ -121,7 +121,12 @@ class ApprovalLifecycleActionGeneratorTest {
         fun add(category: String) = events.add(RecordedEvent(category, seed, step, action, outcome))
         when (action) {
             is ApprovalLifecycleAction.ApproveCurrentVersion -> when (outcome) {
-                is ApprovalLifecycleOutcome.Success -> add("valid-approve")
+                is ApprovalLifecycleOutcome.Success -> {
+                    add("valid-approve")
+                    if (before.status == dev.tramai.core.approval.ApprovalStatus.PENDING && before.now == expiry) {
+                        add("exact-expiry-boundary")
+                    }
+                }
                 is ApprovalLifecycleOutcome.Failure -> {
                     // Genuine after-expiry rejection requires the PENDING
                     // pre-state: a decision on a terminal status is a
@@ -129,20 +134,42 @@ class ApprovalLifecycleActionGeneratorTest {
                     if (before.status == dev.tramai.core.approval.ApprovalStatus.PENDING && before.now >= expiry) {
                         add("approve-after-expiry-rejection")
                     }
+                    // Exact-equality (now == expiresAt) must be reached, not
+                    // just now > expiresAt — a future generator edit that
+                    // silently loses exact-equality would make the M2
+                    // boundary mutation weak again.
+                    if (before.status == dev.tramai.core.approval.ApprovalStatus.PENDING && before.now == expiry) {
+                        add("exact-expiry-boundary")
+                    }
                     if (before.status != dev.tramai.core.approval.ApprovalStatus.PENDING) add("post-terminal-rejection")
                 }
             }
             is ApprovalLifecycleAction.DenyCurrentVersion -> when (outcome) {
-                is ApprovalLifecycleOutcome.Success -> add("valid-deny")
+                is ApprovalLifecycleOutcome.Success -> {
+                    add("valid-deny")
+                    if (before.status == dev.tramai.core.approval.ApprovalStatus.PENDING && before.now == expiry) {
+                        add("exact-expiry-boundary")
+                    }
+                }
                 is ApprovalLifecycleOutcome.Failure -> {
                     if (before.status == dev.tramai.core.approval.ApprovalStatus.PENDING && before.now >= expiry) {
                         add("deny-after-expiry-rejection")
+                    }
+                    if (before.status == dev.tramai.core.approval.ApprovalStatus.PENDING && before.now == expiry) {
+                        add("exact-expiry-boundary")
                     }
                     if (before.status != dev.tramai.core.approval.ApprovalStatus.PENDING) add("post-terminal-rejection")
                 }
             }
             is ApprovalLifecycleAction.TimeoutCurrentVersion -> when (outcome) {
-                is ApprovalLifecycleOutcome.Success -> add("valid-timeout")
+                is ApprovalLifecycleOutcome.Success -> {
+                    add("valid-timeout")
+                    // Timeout is legal at exact expiry (now == expiresAt) —
+                    // the boundary where the M2 `>=` vs `>` mutation differs.
+                    if (before.status == dev.tramai.core.approval.ApprovalStatus.PENDING && before.now == expiry) {
+                        add("exact-expiry-boundary")
+                    }
+                }
                 is ApprovalLifecycleOutcome.Failure -> {
                     if (before.status == dev.tramai.core.approval.ApprovalStatus.PENDING && before.now < expiry) {
                         add("early-timeout-rejection")
@@ -191,6 +218,13 @@ class ApprovalLifecycleActionGeneratorTest {
                 is ApprovalLifecycleOutcome.Failure -> {
                     add("wrong-version-conflict")
                     if (before.consumedAt != null) add("wrong-version-replay-rejection")
+                    // Fresh-consumption version guard (M10): APPROVED +
+                    // unconsumed + wrong expected version -> CONFLICT. Not
+                    // implied by wrong-version-conflict (decisions) nor by
+                    // wrong-version-replay-rejection (consumed state).
+                    if (before.status == dev.tramai.core.approval.ApprovalStatus.APPROVED && before.consumedAt == null) {
+                        add("fresh-consume-wrong-version-rejection")
+                    }
                 }
                 is ApprovalLifecycleOutcome.Success -> Unit
             }

--- a/tramai-testing/src/test/kotlin/dev/tramai/testing/persistence/approval/ApprovalLifecycleActionGeneratorTest.kt
+++ b/tramai-testing/src/test/kotlin/dev/tramai/testing/persistence/approval/ApprovalLifecycleActionGeneratorTest.kt
@@ -1,0 +1,205 @@
+package dev.tramai.testing.persistence.approval
+
+import java.time.Instant
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Epic 8.2a coverage guard for the deterministic action corpus.
+ *
+ * Randomized-looking property suites are worthless if the fixed seed corpus
+ * never reaches difficult states. This test executes the exact 32-seed
+ * corpus and proves it contains every important lifecycle category, and that
+ * the same seed always yields the same action trace — so future generator
+ * edits cannot silently delete behavioral coverage.
+ */
+class ApprovalLifecycleActionGeneratorTest {
+
+    private val t0: Instant = Instant.parse("2026-08-22T12:00:00Z")
+    private val expiry: Instant = t0.plusSeconds(600)
+
+    private data class RecordedEvent(
+        val category: String,
+        val seed: Long,
+        val step: Int,
+        val action: ApprovalLifecycleAction,
+        val outcome: ApprovalLifecycleOutcome,
+    )
+
+    @Test
+    fun `same seed produces exactly the same action trace`() {
+        for (seed in 0L until ApprovalLifecycleActionGenerator.SEED_COUNT) {
+            val first = ApprovalLifecycleActionGenerator.generate(seed, initialNow = t0, expiresAt = expiry)
+            val second = ApprovalLifecycleActionGenerator.generate(seed, initialNow = t0, expiresAt = expiry)
+            assertThat(first.map { it.describe() })
+                .withFailMessage("seed $seed must be deterministic")
+                .isEqualTo(second.map { it.describe() })
+        }
+    }
+
+    @Test
+    fun `fixed seed corpus covers every lifecycle category`() {
+        val events = ArrayList<RecordedEvent>()
+        for (seed in 0L until ApprovalLifecycleActionGenerator.SEED_COUNT) {
+            var model = ApprovalLifecycleModel.pending(t0)
+            val actions = ApprovalLifecycleActionGenerator.generate(seed, initialNow = t0, expiresAt = expiry)
+            actions.forEachIndexed { step, action ->
+                val before = model
+                val outcome = model.apply(action, expiry)
+                record(events, seed, step, action, before, outcome)
+                if (outcome is ApprovalLifecycleOutcome.Success) {
+                    model = outcome.next
+                }
+            }
+        }
+
+        val categories = events.map { it.category }.toSet()
+        val expectedCategories = listOf(
+            "valid-approve",
+            "valid-deny",
+            "valid-timeout",
+            "early-timeout-rejection",
+            "approve-after-expiry-rejection",
+            "deny-after-expiry-rejection",
+            "wrong-version-conflict",
+            "transition-wrong-version-while-pending",
+            "post-terminal-rejection",
+            "fresh-consume",
+            "expired-fresh-consume-rejection",
+            "wrong-token-rejection",
+            "exact-replay",
+            "exact-replay-after-expiry",
+            "wrong-actor-replay-rejection",
+            "wrong-version-replay-rejection",
+        )
+        val missing = expectedCategories.filterNot { it in categories }
+        assertThat(missing)
+            .withFailMessage {
+                val sample = events.filter { it.category in missing }.take(3).joinToString("\n") {
+                    "  seed=${it.seed} step=${it.step} action=${it.action.describe()}"
+                }
+                "corpus missing categories: $missing\nfirst occurrences:\n$sample\n" +
+                    "total events: ${events.size}, seeds: ${ApprovalLifecycleActionGenerator.SEED_COUNT}"
+            }
+            .isEmpty()
+    }
+
+    @Test
+    fun `corpus contains both terminal outcomes and the full decision lattice`() {
+        val statuses = HashSet<dev.tramai.core.approval.ApprovalStatus>()
+        for (seed in 0L until ApprovalLifecycleActionGenerator.SEED_COUNT) {
+            var model = ApprovalLifecycleModel.pending(t0)
+            val actions = ApprovalLifecycleActionGenerator.generate(seed, initialNow = t0, expiresAt = expiry)
+            actions.forEachIndexed { step, action ->
+                val outcome = model.apply(action, expiry)
+                if (outcome is ApprovalLifecycleOutcome.Success) {
+                    model = outcome.next
+                    statuses += outcome.next.status
+                }
+            }
+        }
+        assertThat(statuses)
+            .withFailMessage("corpus must reach every lifecycle status; found=$statuses")
+            .containsExactlyInAnyOrder(
+                dev.tramai.core.approval.ApprovalStatus.PENDING,
+                dev.tramai.core.approval.ApprovalStatus.APPROVED,
+                dev.tramai.core.approval.ApprovalStatus.DENIED,
+                dev.tramai.core.approval.ApprovalStatus.TIMED_OUT,
+            )
+    }
+
+    // ── category recording ───────────────────────────────────────────
+
+    private fun record(
+        events: MutableList<RecordedEvent>,
+        seed: Long,
+        step: Int,
+        action: ApprovalLifecycleAction,
+        before: ApprovalLifecycleModel,
+        outcome: ApprovalLifecycleOutcome,
+    ) {
+        fun add(category: String) = events.add(RecordedEvent(category, seed, step, action, outcome))
+        when (action) {
+            is ApprovalLifecycleAction.ApproveCurrentVersion -> when (outcome) {
+                is ApprovalLifecycleOutcome.Success -> add("valid-approve")
+                is ApprovalLifecycleOutcome.Failure -> {
+                    // Genuine after-expiry rejection requires the PENDING
+                    // pre-state: a decision on a terminal status is a
+                    // post-terminal rejection, not an expiry rejection.
+                    if (before.status == dev.tramai.core.approval.ApprovalStatus.PENDING && before.now >= expiry) {
+                        add("approve-after-expiry-rejection")
+                    }
+                    if (before.status != dev.tramai.core.approval.ApprovalStatus.PENDING) add("post-terminal-rejection")
+                }
+            }
+            is ApprovalLifecycleAction.DenyCurrentVersion -> when (outcome) {
+                is ApprovalLifecycleOutcome.Success -> add("valid-deny")
+                is ApprovalLifecycleOutcome.Failure -> {
+                    if (before.status == dev.tramai.core.approval.ApprovalStatus.PENDING && before.now >= expiry) {
+                        add("deny-after-expiry-rejection")
+                    }
+                    if (before.status != dev.tramai.core.approval.ApprovalStatus.PENDING) add("post-terminal-rejection")
+                }
+            }
+            is ApprovalLifecycleAction.TimeoutCurrentVersion -> when (outcome) {
+                is ApprovalLifecycleOutcome.Success -> add("valid-timeout")
+                is ApprovalLifecycleOutcome.Failure -> {
+                    if (before.status == dev.tramai.core.approval.ApprovalStatus.PENDING && before.now < expiry) {
+                        add("early-timeout-rejection")
+                    }
+                    if (before.status != dev.tramai.core.approval.ApprovalStatus.PENDING) add("post-terminal-rejection")
+                }
+            }
+            is ApprovalLifecycleAction.ApproveWrongVersion,
+            is ApprovalLifecycleAction.DenyWrongVersion,
+            is ApprovalLifecycleAction.TimeoutWrongVersion,
+            -> {
+                if (outcome is ApprovalLifecycleOutcome.Failure && outcome.kind == ApprovalLifecycleFailureKind.CONFLICT) {
+                    add("wrong-version-conflict")
+                }
+                if (before.status == dev.tramai.core.approval.ApprovalStatus.PENDING) {
+                    // Semantic category: a wrong-version DECISION actually
+                    // evaluated against the PENDING pre-state — the only
+                    // state where the transition version guard is the
+                    // discriminator. Syntactic presence of the action enum is
+                    // not sufficient evidence.
+                    add("transition-wrong-version-while-pending")
+                }
+            }
+            is ApprovalLifecycleAction.ConsumeValid -> when (outcome) {
+                is ApprovalLifecycleOutcome.Success -> {
+                    if (outcome.replayed) {
+                        add("exact-replay")
+                        if (before.now >= expiry) add("exact-replay-after-expiry")
+                    } else {
+                        add("fresh-consume")
+                    }
+                }
+                is ApprovalLifecycleOutcome.Failure -> {
+                    if (before.consumedAt != null && before.consumedBy != action.worker) add("wrong-actor-replay-rejection")
+                    // Genuine expired-fresh rejection requires the APPROVED
+                    // pre-state: a consume on TIMED_OUT/DENIED is a status
+                    // rejection, not an expiry rejection.
+                    if (before.status == dev.tramai.core.approval.ApprovalStatus.APPROVED &&
+                        before.consumedAt == null && before.now >= expiry
+                    ) {
+                        add("expired-fresh-consume-rejection")
+                    }
+                }
+            }
+            is ApprovalLifecycleAction.ConsumeWrongVersion -> when (outcome) {
+                is ApprovalLifecycleOutcome.Failure -> {
+                    add("wrong-version-conflict")
+                    if (before.consumedAt != null) add("wrong-version-replay-rejection")
+                }
+                is ApprovalLifecycleOutcome.Success -> Unit
+            }
+            is ApprovalLifecycleAction.ConsumeWrongToken -> if (outcome is ApprovalLifecycleOutcome.Failure &&
+                outcome.kind == ApprovalLifecycleFailureKind.TOKEN_REJECTED
+            ) {
+                add("wrong-token-rejection")
+            }
+            else -> Unit // advances
+        }
+    }
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/ApprovalLifecycleActionGenerator.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/ApprovalLifecycleActionGenerator.kt
@@ -1,0 +1,180 @@
+package dev.tramai.testing.persistence.approval
+
+import java.time.Instant
+import kotlin.random.Random
+
+/**
+ * Epic 8.2a: deterministic, state-aware generator for the approval lifecycle
+ * property corpus.
+ *
+ * [generate] is a pure function of (seed, count, initialNow, expiresAt):
+ * the same seed always yields the same action trace, and the trace is
+ * simulated against the pure model so the choices stay state-aware (legal
+ * and illegal actions interleave deliberately — the corpus is not
+ * malformed-input fuzzing). The TCK replays the same actions through the
+ * same model against the real stores.
+ *
+ * Coverage is pinned by `ApprovalLifecycleActionGeneratorTest`: across the
+ * 32-seed corpus every required category (valid approve/deny/timeout, early
+ * timeout, after-expiry rejections, wrong-version conflicts, post-terminal
+ * rejection, fresh consume, expired fresh-consume rejection, wrong-token,
+ * exact replay, replay after expiry, wrong-actor/wrong-version replay
+ * rejections) must occur at least once.
+ */
+internal object ApprovalLifecycleActionGenerator {
+
+    const val SEED_COUNT: Long = 32L
+    const val ACTIONS_PER_SEQUENCE: Int = 32
+
+    private val actors = listOf("approver-a", "approver-b")
+    private val workers = listOf("worker-a", "worker-b")
+
+    fun generate(
+        seed: Long,
+        count: Int = ACTIONS_PER_SEQUENCE,
+        initialNow: Instant,
+        expiresAt: Instant,
+    ): List<ApprovalLifecycleAction> {
+        val rng = Random(seed)
+        var model = ApprovalLifecycleModel.pending(initialNow)
+        var wrongVersionEmitted = false
+        // Odd seeds force the APPROVED→unconsumed→expired path so a fresh
+        // consume is guaranteed to be evaluated against an EXPIRED APPROVED
+        // pre-state (the expiry guard's discriminator) — never left to luck.
+        val forceExpiredFresh = seed % 2L == 1L
+        var advanceToExpiryEmitted = false
+        var expiredFreshEmitted = false
+        return buildList {
+            repeat(count) {
+                val action = when {
+                    !wrongVersionEmitted && model.status == dev.tramai.core.approval.ApprovalStatus.PENDING && model.now < expiresAt -> {
+                        // GUARANTEED reachable wrong-version decision against the
+                        // PENDING pre-state (the only state where the transition
+                        // version guard is the discriminator). Every seed opens
+                        // with one — the corpus must never depend on luck for a
+                        // primary optimistic-concurrency invariant.
+                        wrongVersionEmitted = true
+                        if (seed % 2L == 0L) {
+                            ApprovalLifecycleAction.ApproveWrongVersion(actors[rng.nextInt(actors.size)])
+                        } else {
+                            ApprovalLifecycleAction.DenyWrongVersion(actors[rng.nextInt(actors.size)])
+                        }
+                    }
+                    forceExpiredFresh && !advanceToExpiryEmitted &&
+                        model.status == dev.tramai.core.approval.ApprovalStatus.APPROVED &&
+                        model.consumedAt == null && model.now < expiresAt -> {
+                        advanceToExpiryEmitted = true
+                        ApprovalLifecycleAction.AdvancePastExpiry
+                    }
+                    forceExpiredFresh && !expiredFreshEmitted &&
+                        model.status == dev.tramai.core.approval.ApprovalStatus.APPROVED &&
+                        model.consumedAt == null && model.now >= expiresAt -> {
+                        expiredFreshEmitted = true
+                        ApprovalLifecycleAction.ConsumeValid(workers[rng.nextInt(workers.size)])
+                    }
+                    else -> pick(rng, model, expiresAt)
+                }
+                add(action)
+                val outcome = model.apply(action, expiresAt)
+                if (outcome is ApprovalLifecycleOutcome.Success) {
+                    model = outcome.next
+                }
+            }
+        }
+    }
+
+    // ── state-aware picking ─────────────────────────────────────────
+
+    private fun pick(rng: Random, model: ApprovalLifecycleModel, expiresAt: Instant): ApprovalLifecycleAction =
+        when (model.status) {
+            dev.tramai.core.approval.ApprovalStatus.PENDING -> pickPending(rng, model, expiresAt)
+            dev.tramai.core.approval.ApprovalStatus.APPROVED -> pickApproved(rng, model, expiresAt)
+            else -> pickTerminal(rng, model, expiresAt)
+        }
+
+    private fun pickPending(rng: Random, model: ApprovalLifecycleModel, expiresAt: Instant): ApprovalLifecycleAction {
+        val expired = model.now >= expiresAt
+        val r = rng.nextInt(100)
+        return when {
+            r < 22 -> pickAdvance(rng)
+            // Decision exploration, biased toward making a decision so the
+            // corpus reaches consumption and replay phases.
+            r < 34 -> ApprovalLifecycleAction.ApproveCurrentVersion(pickActor(rng))
+            r < 46 -> ApprovalLifecycleAction.DenyCurrentVersion(pickActor(rng))
+            r < 56 -> ApprovalLifecycleAction.TimeoutCurrentVersion
+            r < 68 -> if (expired) {
+                // After expiry the only legal decision is timeout; approve/deny
+                // are rejections. Wrong-version is avoided here (version-vs-
+                // expiry precedence is not contractually pinned).
+                when (rng.nextInt(4)) {
+                    0 -> ApprovalLifecycleAction.ApproveCurrentVersion(pickActor(rng))
+                    1 -> ApprovalLifecycleAction.DenyCurrentVersion(pickActor(rng))
+                    else -> ApprovalLifecycleAction.TimeoutCurrentVersion
+                }
+            } else {
+                // Before expiry approve/deny are legal, timeout is illegal,
+                // wrong-version is a clean CONFLICT.
+                when (rng.nextInt(5)) {
+                    0 -> ApprovalLifecycleAction.ApproveCurrentVersion(pickActor(rng))
+                    1 -> ApprovalLifecycleAction.DenyCurrentVersion(pickActor(rng))
+                    2 -> ApprovalLifecycleAction.TimeoutCurrentVersion
+                    3 -> ApprovalLifecycleAction.ApproveWrongVersion(pickActor(rng))
+                    else -> ApprovalLifecycleAction.DenyWrongVersion(pickActor(rng))
+                }
+            }
+            r < 80 -> ApprovalLifecycleAction.ApproveCurrentVersion(pickActor(rng))
+            r < 88 -> ApprovalLifecycleAction.DenyCurrentVersion(pickActor(rng))
+            r < 94 -> ApprovalLifecycleAction.TimeoutCurrentVersion
+            else -> pickAdvance(rng)
+        }
+    }
+
+    private fun pickApproved(rng: Random, model: ApprovalLifecycleModel, expiresAt: Instant): ApprovalLifecycleAction {
+        val unconsumed = model.consumedAt == null
+        val expired = model.now >= expiresAt
+        val r = rng.nextInt(100)
+        if (unconsumed) {
+            return when {
+                r < 42 -> ApprovalLifecycleAction.ConsumeValid(pickWorker(rng))
+                r < 56 -> ApprovalLifecycleAction.ConsumeWrongVersion(pickWorker(rng))
+                r < 70 -> ApprovalLifecycleAction.ConsumeWrongToken(pickWorker(rng))
+                r < 78 -> if (expired) ApprovalLifecycleAction.ConsumeValid(pickWorker(rng)) else ApprovalLifecycleAction.ApproveCurrentVersion(pickActor(rng))
+                r < 88 -> ApprovalLifecycleAction.ApproveCurrentVersion(pickActor(rng))
+                r < 94 -> ApprovalLifecycleAction.DenyCurrentVersion(pickActor(rng))
+                else -> pickAdvance(rng)
+            }
+        }
+        // Consumed — replay phase: exact replay, wrong-actor/wrong-version/
+        // wrong-token rejections, post-terminal rejections.
+        val sameWorker = model.consumedBy ?: pickWorker(rng)
+        val otherWorker = workers.first { it != sameWorker }
+        return when {
+            r < 40 -> ApprovalLifecycleAction.ConsumeValid(sameWorker)
+            r < 54 -> ApprovalLifecycleAction.ConsumeValid(otherWorker)
+            r < 66 -> ApprovalLifecycleAction.ConsumeWrongVersion(sameWorker)
+            r < 76 -> ApprovalLifecycleAction.ConsumeWrongToken(sameWorker)
+            r < 86 -> ApprovalLifecycleAction.ApproveCurrentVersion(pickActor(rng))
+            r < 93 -> ApprovalLifecycleAction.DenyCurrentVersion(pickActor(rng))
+            else -> pickAdvance(rng)
+        }
+    }
+
+    private fun pickTerminal(rng: Random, model: ApprovalLifecycleModel, expiresAt: Instant): ApprovalLifecycleAction =
+        when (rng.nextInt(10)) {
+            0, 1, 2, 3 -> ApprovalLifecycleAction.ApproveCurrentVersion(pickActor(rng))
+            4, 5, 6 -> ApprovalLifecycleAction.DenyCurrentVersion(pickActor(rng))
+            7, 8 -> ApprovalLifecycleAction.TimeoutCurrentVersion
+            else -> ApprovalLifecycleAction.ConsumeValid(pickWorker(rng))
+        }
+
+    private fun pickAdvance(rng: Random): ApprovalLifecycleAction =
+        when (rng.nextInt(10)) {
+            0, 1, 2, 3, 4, 5 -> ApprovalLifecycleAction.AdvanceToBeforeExpiry
+            6, 7 -> ApprovalLifecycleAction.AdvanceToExactExpiry
+            else -> ApprovalLifecycleAction.AdvancePastExpiry
+        }
+
+    private fun pickActor(rng: Random): String = actors[rng.nextInt(actors.size)]
+
+    private fun pickWorker(rng: Random): String = workers[rng.nextInt(workers.size)]
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/ApprovalLifecycleModel.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/ApprovalLifecycleModel.kt
@@ -151,11 +151,11 @@ internal data class ApprovalLifecycleModel(
 
     private fun applyConsumeWrongToken(worker: String, expiresAt: Instant): ApprovalLifecycleOutcome {
         if (status != ApprovalStatus.APPROVED) return notConsumable()
-        if (consumedAt != null && consumedBy != worker) return notConsumable()
-        // The token is checked before the expiry window on the wrong-token
-        // path (uniform across InMemory/File/JDBC; the SPI KDoc does not pin
-        // check order): an expired-but-unconsumed approval with a wrong token
-        // is TOKEN_REJECTED, not NOT_CONSUMABLE.
+        // Token check is unconditional on an APPROVED record (checked before
+        // the actor/replay logic and before the expiry window — uniform across
+        // InMemory/File/JDBC; the SPI KDoc does not pin check order): a wrong
+        // token is TOKEN_REJECTED even for a consumed-by-other record and even
+        // when expired.
         return ApprovalLifecycleOutcome.Failure(ApprovalLifecycleFailureKind.TOKEN_REJECTED)
     }
 
@@ -282,6 +282,8 @@ internal sealed interface ApprovalLifecycleAction {
 
     data object TimeoutCurrentVersion : ApprovalLifecycleAction
     data object TimeoutWrongVersion : ApprovalLifecycleAction
+    // NOTE: TimeoutWrongVersion is never emitted by the generator — it is
+    // exercised only by the wrong-version decision matrix in ApprovalStoreTck.
 
     data class ConsumeValid(val worker: String) : ApprovalLifecycleAction
     data class ConsumeWrongVersion(val worker: String) : ApprovalLifecycleAction

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/ApprovalLifecycleModel.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/ApprovalLifecycleModel.kt
@@ -1,0 +1,307 @@
+package dev.tramai.testing.persistence.approval
+
+import dev.tramai.core.approval.ApprovalRequest
+import dev.tramai.core.approval.ApprovalStatus
+import java.time.Instant
+
+/**
+ * Epic 8.2a: PURE, independent lifecycle oracle for the ApprovalStore
+ * compatibility contract.
+ *
+ * This is deliberately NOT derived from the production stores or their
+ * helpers — it encodes the documented lifecycle (ApprovalRequest KDoc +
+ * ApprovalStore SPI KDoc + the #267 contract) as a standalone state machine,
+ * so the property suite proves "the store agrees with the documented model"
+ * rather than "the store agrees with itself".
+ *
+ * State: status/version/now plus every mutable decision and consumption
+ * field. The immutable request fields (approvalId, binding, requestedBy,
+ * requestedAt, expiresAt) are pinned separately by the caller and merged via
+ * [toRequest] for whole-record comparison.
+ *
+ * Expiry boundary (documented and implemented everywhere):
+ *   now < expiresAt  → decision legal, fresh consume legal
+ *   now >= expiresAt → timeout legal (while PENDING), decision illegal,
+ *                      fresh consume illegal, exact replay still legal
+ *
+ * Invariants enforced structurally by the transition rules and re-checked
+ * explicitly via [invariants] after every generated action.
+ */
+internal data class ApprovalLifecycleModel(
+    val status: ApprovalStatus,
+    val version: Long,
+    val now: Instant,
+    val decidedBy: String?,
+    val decidedAt: Instant?,
+    val decisionComment: String?,
+    val consumedBy: String?,
+    val consumedAt: Instant?,
+) {
+
+    companion object {
+        fun from(request: ApprovalRequest, now: Instant): ApprovalLifecycleModel = ApprovalLifecycleModel(
+            status = request.status,
+            version = request.version,
+            now = now,
+            decidedBy = request.decidedBy,
+            decidedAt = request.decidedAt,
+            decisionComment = request.decisionComment,
+            consumedBy = request.consumedBy,
+            consumedAt = request.consumedAt,
+        )
+
+        fun pending(now: Instant): ApprovalLifecycleModel = ApprovalLifecycleModel(
+            status = ApprovalStatus.PENDING,
+            version = 0L,
+            now = now,
+            decidedBy = null,
+            decidedAt = null,
+            decisionComment = null,
+            consumedBy = null,
+            consumedAt = null,
+        )
+    }
+
+    /** Reconstructs the complete expected durable record from a base request. */
+    fun toRequest(base: ApprovalRequest): ApprovalRequest = base.copy(
+        status = status,
+        version = version,
+        decidedBy = decidedBy,
+        decidedAt = decidedAt,
+        decisionComment = decisionComment,
+        consumedBy = consumedBy,
+        consumedAt = consumedAt,
+    )
+
+    /**
+     * Applies [action] to the model and returns the predicted outcome. A
+     * [ApprovalLifecycleOutcome.Success] carries the next model state; a
+     * [ApprovalLifecycleOutcome.Failure] leaves the model unchanged. The
+     * model never throws production exceptions.
+     */
+    fun apply(action: ApprovalLifecycleAction, expiresAt: Instant): ApprovalLifecycleOutcome = when (action) {
+        is ApprovalLifecycleAction.AdvanceToBeforeExpiry -> success(now = expiresAt.minusSeconds(1))
+        is ApprovalLifecycleAction.AdvanceToExactExpiry -> success(now = expiresAt)
+        is ApprovalLifecycleAction.AdvancePastExpiry -> success(now = expiresAt.plusSeconds(1))
+        is ApprovalLifecycleAction.ApproveCurrentVersion -> applyDecision(action.actor, action.comment, ApprovalStatus.APPROVED, expiresAt)
+        is ApprovalLifecycleAction.ApproveWrongVersion -> ApprovalLifecycleOutcome.Failure(ApprovalLifecycleFailureKind.CONFLICT)
+        is ApprovalLifecycleAction.DenyCurrentVersion -> applyDecision(action.actor, action.comment, ApprovalStatus.DENIED, expiresAt)
+        is ApprovalLifecycleAction.DenyWrongVersion -> ApprovalLifecycleOutcome.Failure(ApprovalLifecycleFailureKind.CONFLICT)
+        is ApprovalLifecycleAction.TimeoutCurrentVersion -> applyTimeout(expiresAt)
+        is ApprovalLifecycleAction.TimeoutWrongVersion -> ApprovalLifecycleOutcome.Failure(ApprovalLifecycleFailureKind.CONFLICT)
+        is ApprovalLifecycleAction.ConsumeValid -> applyConsumeValid(action.worker, expiresAt)
+        is ApprovalLifecycleAction.ConsumeWrongVersion -> applyConsumeWrongVersion(expiresAt)
+        is ApprovalLifecycleAction.ConsumeWrongToken -> applyConsumeWrongToken(action.worker, expiresAt)
+    }
+
+    // ── decision path ────────────────────────────────────────────────
+
+    private fun applyDecision(
+        actor: String,
+        comment: String?,
+        target: ApprovalStatus,
+        expiresAt: Instant,
+    ): ApprovalLifecycleOutcome {
+        if (status != ApprovalStatus.PENDING) return illegalTransition()
+        if (now >= expiresAt) return illegalTransition()
+        return success(
+            status = target,
+            version = version + 1,
+            decidedBy = actor,
+            decidedAt = now,
+            decisionComment = comment,
+        )
+    }
+
+    private fun applyTimeout(expiresAt: Instant): ApprovalLifecycleOutcome {
+        if (status != ApprovalStatus.PENDING) return illegalTransition()
+        if (now < expiresAt) return illegalTransition()
+        return success(
+            status = ApprovalStatus.TIMED_OUT,
+            version = version + 1,
+            decidedBy = null,
+            decidedAt = now,
+            decisionComment = null,
+        )
+    }
+
+    // ── consumption path ─────────────────────────────────────────────
+
+    private fun applyConsumeValid(worker: String, expiresAt: Instant): ApprovalLifecycleOutcome {
+        if (status != ApprovalStatus.APPROVED) return notConsumable()
+        if (consumedAt == null) {
+            // Fresh path: unexpired, version/token match (the action is the
+            // "valid" shape), unconsumed → fresh consumption.
+            if (now >= expiresAt) return notConsumable()
+            return success(consumedBy = worker, consumedAt = now, version = version + 1)
+        }
+        // Consumed path: exact replay requires the same actor; replay stays
+        // legal after expiry and never changes the durable record.
+        return if (consumedBy == worker) {
+            ApprovalLifecycleOutcome.Success(next = this, replayed = true)
+        } else {
+            notConsumable()
+        }
+    }
+
+    private fun applyConsumeWrongVersion(expiresAt: Instant): ApprovalLifecycleOutcome {
+        if (status != ApprovalStatus.APPROVED) return notConsumable()
+        return ApprovalLifecycleOutcome.Failure(ApprovalLifecycleFailureKind.CONFLICT)
+    }
+
+    private fun applyConsumeWrongToken(worker: String, expiresAt: Instant): ApprovalLifecycleOutcome {
+        if (status != ApprovalStatus.APPROVED) return notConsumable()
+        if (consumedAt != null && consumedBy != worker) return notConsumable()
+        // The token is checked before the expiry window on the wrong-token
+        // path (uniform across InMemory/File/JDBC; the SPI KDoc does not pin
+        // check order): an expired-but-unconsumed approval with a wrong token
+        // is TOKEN_REJECTED, not NOT_CONSUMABLE.
+        return ApprovalLifecycleOutcome.Failure(ApprovalLifecycleFailureKind.TOKEN_REJECTED)
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────
+
+    private fun success(
+        status: ApprovalStatus = this.status,
+        version: Long = this.version,
+        now: Instant = this.now,
+        decidedBy: String? = this.decidedBy,
+        decidedAt: Instant? = this.decidedAt,
+        decisionComment: String? = this.decisionComment,
+        consumedBy: String? = this.consumedBy,
+        consumedAt: Instant? = this.consumedAt,
+    ): ApprovalLifecycleOutcome.Success = ApprovalLifecycleOutcome.Success(
+        next = copy(
+            status = status,
+            version = version,
+            now = now,
+            decidedBy = decidedBy,
+            decidedAt = decidedAt,
+            decisionComment = decisionComment,
+            consumedBy = consumedBy,
+            consumedAt = consumedAt,
+        ),
+        replayed = false,
+    )
+
+    private fun illegalTransition(): ApprovalLifecycleOutcome.Failure =
+        ApprovalLifecycleOutcome.Failure(ApprovalLifecycleFailureKind.ILLEGAL_TRANSITION)
+
+    private fun notConsumable(): ApprovalLifecycleOutcome.Failure =
+        ApprovalLifecycleOutcome.Failure(ApprovalLifecycleFailureKind.NOT_CONSUMABLE)
+
+    /**
+     * Explicit per-step invariant audit (the table from the Epic 8.2a brief).
+     * Returns every violated invariant; empty means the model state is legal.
+     */
+    fun invariants(): List<String> {
+        val violations = ArrayList<String>()
+        if (version < 0) violations += "version $version < 0"
+        if (status == ApprovalStatus.PENDING) {
+            if (decidedBy != null || decidedAt != null || decisionComment != null) {
+                violations += "PENDING must not carry decision fields"
+            }
+            if (consumedBy != null || consumedAt != null) {
+                violations += "PENDING must not carry consumption fields"
+            }
+        }
+        if (status == ApprovalStatus.DENIED || status == ApprovalStatus.TIMED_OUT) {
+            if (consumedBy != null || consumedAt != null) {
+                violations += "$status must never acquire consumption fields"
+            }
+        }
+        if (status == ApprovalStatus.APPROVED) {
+            if (decidedBy == null || decidedAt == null) violations += "APPROVED must carry decision fields"
+            if (consumedBy == null != (consumedAt == null)) {
+                violations += "APPROVED consumption fields must be both null or both set"
+            }
+        }
+        if (status == ApprovalStatus.DENIED && (decidedBy == null || decidedAt == null)) {
+            violations += "DENIED must carry decision fields"
+        }
+        if (status == ApprovalStatus.TIMED_OUT && (decidedBy != null || decisionComment != null)) {
+            violations += "TIMED_OUT must not carry decidedBy or decisionComment"
+        }
+        if (consumedBy != null && consumedAt == null) violations += "consumedBy set without consumedAt"
+        return violations
+    }
+
+    fun describe(): String =
+        "$status(v=$version, decidedBy=$decidedBy, decidedAt=$decidedAt, comment=$decisionComment, consumedBy=$consumedBy, consumedAt=$consumedAt)"
+}
+
+/**
+ * Test-side failure categories, mapped to the public typed exceptions ONLY
+ * when comparing with the real store. The model itself never throws.
+ */
+internal enum class ApprovalLifecycleFailureKind {
+    CONFLICT,
+    ILLEGAL_TRANSITION,
+    NOT_CONSUMABLE,
+    TOKEN_REJECTED,
+    ;
+
+    fun exceptionClass(): Class<out Exception> = when (this) {
+        CONFLICT -> dev.tramai.core.exception.ApprovalStoreConflictException::class.java
+        ILLEGAL_TRANSITION -> dev.tramai.core.exception.IllegalApprovalTransitionException::class.java
+        NOT_CONSUMABLE -> dev.tramai.core.exception.ApprovalStoreNotConsumableException::class.java
+        TOKEN_REJECTED -> dev.tramai.core.exception.ApprovalStoreTokenRejectedException::class.java
+    }
+}
+
+internal sealed interface ApprovalLifecycleOutcome {
+    data class Success(
+        val next: ApprovalLifecycleModel,
+        val replayed: Boolean,
+    ) : ApprovalLifecycleOutcome
+
+    data class Failure(
+        val kind: ApprovalLifecycleFailureKind,
+    ) : ApprovalLifecycleOutcome
+
+    val nextModelOrCurrent: ApprovalLifecycleModel
+        get() = if (this is Success) next else error("no next model for a failure")
+}
+
+/**
+ * State-aware action alphabet for the generated lifecycle corpus. Each action
+ * carries everything needed to EXECUTE it against the real store; the model
+ * decides whether it is legal for the current state.
+ */
+internal sealed interface ApprovalLifecycleAction {
+
+    data object AdvanceToBeforeExpiry : ApprovalLifecycleAction
+    data object AdvanceToExactExpiry : ApprovalLifecycleAction
+    data object AdvancePastExpiry : ApprovalLifecycleAction
+
+    data class ApproveCurrentVersion(val actor: String, val comment: String? = null) : ApprovalLifecycleAction
+    data class ApproveWrongVersion(val actor: String) : ApprovalLifecycleAction
+
+    data class DenyCurrentVersion(val actor: String, val comment: String? = null) : ApprovalLifecycleAction
+    data class DenyWrongVersion(val actor: String) : ApprovalLifecycleAction
+
+    data object TimeoutCurrentVersion : ApprovalLifecycleAction
+    data object TimeoutWrongVersion : ApprovalLifecycleAction
+
+    data class ConsumeValid(val worker: String) : ApprovalLifecycleAction
+    data class ConsumeWrongVersion(val worker: String) : ApprovalLifecycleAction
+    data class ConsumeWrongToken(val worker: String) : ApprovalLifecycleAction
+
+    val isAdvance: Boolean
+        get() = this is AdvanceToBeforeExpiry || this is AdvanceToExactExpiry || this is AdvancePastExpiry
+
+    fun describe(): String = when (this) {
+        AdvanceToBeforeExpiry -> "AdvanceToBeforeExpiry"
+        AdvanceToExactExpiry -> "AdvanceToExactExpiry"
+        AdvancePastExpiry -> "AdvancePastExpiry"
+        is ApproveCurrentVersion -> "ApproveCurrentVersion($actor)"
+        is ApproveWrongVersion -> "ApproveWrongVersion($actor)"
+        is DenyCurrentVersion -> "DenyCurrentVersion($actor)"
+        is DenyWrongVersion -> "DenyWrongVersion($actor)"
+        TimeoutCurrentVersion -> "TimeoutCurrentVersion"
+        TimeoutWrongVersion -> "TimeoutWrongVersion"
+        is ConsumeValid -> "ConsumeValid($worker)"
+        is ConsumeWrongVersion -> "ConsumeWrongVersion($worker)"
+        is ConsumeWrongToken -> "ConsumeWrongToken($worker)"
+    }
+}

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/ApprovalStoreTck.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/ApprovalStoreTck.kt
@@ -1,5 +1,7 @@
 package dev.tramai.testing.persistence.approval
 
+import dev.tramai.core.approval.ApprovalConsumptionReceipt
+import dev.tramai.core.approval.ApprovalRequest
 import dev.tramai.core.approval.ApprovalStatus
 import dev.tramai.core.approval.ApprovalStore
 import dev.tramai.core.approval.ApprovalTransition
@@ -516,5 +518,338 @@ abstract class ApprovalStoreTck {
             assertThat(receipts[0].request.version).isEqualTo(2L)
             assertThat(store.get(id)?.version).isEqualTo(2L)
         }
+    }
+
+    // ── Epic 8.2a: model-based lifecycle properties ────────────────
+    //
+    // The four properties below replace "specific scenario → expected
+    // result" with "model state → generated action → predicted transition →
+    // execute real store → compare → assert all invariants → repeat". The
+    // oracle is ApprovalLifecycleModel — a PURE, independent encoding of the
+    // documented lifecycle, deliberately not derived from the production
+    // stores or their helpers.
+
+    @Test
+    fun `generated approval lifecycle sequences match the independent model after every action`() = runBlocking<Unit> {
+        for (seed in 0L until ApprovalLifecycleActionGenerator.SEED_COUNT) {
+            clock.set(t0)
+            val id = "state-machine-$seed"
+            val initial = ApprovalStoreFixtures.pending(id, t0, expiry)
+            store.create(initial)
+            var model = ApprovalLifecycleModel.from(initial, t0)
+            val actions = ApprovalLifecycleActionGenerator.generate(seed, initialNow = t0, expiresAt = expiry)
+
+            actions.forEachIndexed { step, action ->
+                clock.set(model.now)
+                val before = store.get(id)!!
+                val expected = model.apply(action, expiry)
+                val actual = executeLifecycleAction(action, model, store, id)
+
+                assertLifecycleOutcome(expected, actual, seed, step, action, actions, model)
+
+                model = when (expected) {
+                    is ApprovalLifecycleOutcome.Success -> expected.next
+                    is ApprovalLifecycleOutcome.Failure -> model
+                }
+                clock.set(model.now)
+
+                val modelViolations = model.invariants()
+                assertThat(modelViolations).withFailMessage {
+                    "seed=$seed step=$step action=${action.describe()}: model invariants violated: $modelViolations"
+                }.isEmpty()
+
+                val expectedRecord = model.toRequest(initial)
+                val persisted = store.get(id)!!
+                assertThat(persisted).withFailMessage {
+                    lifecycleFailureMessage(seed, step, action, actions, model, expected, actual)
+                }.isEqualTo(expectedRecord)
+
+                if (expected is ApprovalLifecycleOutcome.Failure) {
+                    assertThat(persisted).withFailMessage {
+                        "seed=$seed step=$step action=${action.describe()}: rejected action must not mutate the durable record"
+                    }.isEqualTo(before)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `wrong-version decisions always conflict without changing durable state`() = runBlocking<Unit> {
+        // Pins optimistic versioning on DECISION transitions, including
+        // failure precedence: version is checked before the expiry window,
+        // so a stale-version decision at/after expiry is a CONFLICT, not an
+        // IllegalApprovalTransition. Same model machinery as the generated
+        // property — nothing duplicated by hand.
+        val transitions = listOf(
+            ApprovalLifecycleAction.ApproveWrongVersion("approver"),
+            ApprovalLifecycleAction.DenyWrongVersion("denier"),
+            ApprovalLifecycleAction.TimeoutWrongVersion,
+        )
+        val times = listOf(t0, expiry, expiry.plusSeconds(1))
+        times.forEachIndexed { timeIndex, now ->
+            transitions.forEachIndexed { transitionIndex, action ->
+                val id = "wrong-version-decision-$timeIndex-$transitionIndex"
+                clock.set(t0)
+                val initial = ApprovalStoreFixtures.pending(id, t0, expiry)
+                store.create(initial)
+                val model = ApprovalLifecycleModel.from(initial, t0).copy(now = now)
+                clock.set(now)
+                val before = store.get(id)!!
+
+                val expected = model.apply(action, expiry)
+                val actual = executeLifecycleAction(action, model, store, id)
+
+                assertLifecycleOutcome(expected, actual, 0L, 0, action, listOf(action), model)
+                assertThat(store.get(id)).withFailMessage {
+                    "wrong-version $action at $now must not mutate the durable record"
+                }.isEqualTo(before)
+            }
+        }
+    }
+
+    @Test
+    fun `duplicate concurrent decisions - exactly one winner and seven conflicts`() = runBlocking<Unit> {
+        repeat(20) { iteration ->
+            val id = "decision-race-$iteration"
+            val request = ApprovalStoreFixtures.pending(id, t0, expiry)
+            store.create(request)
+
+            val contenders = Array<suspend () -> Result<ApprovalRequest>>(8) { index ->
+                val approve = index % 2 == 0
+                {
+                    runCatching {
+                        if (approve) {
+                            store.transition(id, 0L, ApprovalTransition.Approve("approver-$index"))
+                        } else {
+                            store.transition(id, 0L, ApprovalTransition.Deny("denier-$index"))
+                        }
+                    }
+                }
+            }
+            val outcomes = runInParallel(*contenders)
+
+            assertThat(outcomes.count { it.isSuccess })
+                .withFailMessage("iteration $iteration: exactly one decision must win")
+                .isEqualTo(1)
+            assertThat(outcomes.count { it.exceptionOrNull() is ApprovalStoreConflictException })
+                .withFailMessage("iteration $iteration: the seven losers must all conflict")
+                .isEqualTo(7)
+
+            val winner = outcomes.indexOfFirst { it.isSuccess }
+            val persisted = store.get(id)!!
+            assertThat(persisted.version).isEqualTo(1L)
+            assertThat(persisted.status)
+                .isEqualTo(if (winner % 2 == 0) ApprovalStatus.APPROVED else ApprovalStatus.DENIED)
+            assertThat(persisted.decidedBy)
+                .isEqualTo(if (winner % 2 == 0) "approver-$winner" else "denier-$winner")
+        }
+    }
+
+    @Test
+    fun `eight identical consumers - one fresh receipt and seven exact replays of the same durable record`() = runBlocking<Unit> {
+        repeat(20) { iteration ->
+            val id = "identical-consume-$iteration"
+            approveAndConsumeSetup(id)
+
+            val contenders = Array<suspend () -> ApprovalConsumptionReceipt>(8) {
+                { store.consumeApprovedOrReplay(id, 1L, ApprovalStoreFixtures.validTokenDigest(), "worker-a") }
+            }
+            val receipts = runInParallel(*contenders)
+
+            assertThat(receipts.count { !it.replayed })
+                .withFailMessage("iteration $iteration: exactly one fresh receipt expected")
+                .isEqualTo(1)
+            assertThat(receipts.count { it.replayed })
+                .withFailMessage("iteration $iteration: exactly seven exact replays expected")
+                .isEqualTo(7)
+
+            val durable = store.get(id)!!
+            assertThat(durable.version).isEqualTo(2L)
+            assertThat(durable.consumedBy).isEqualTo("worker-a")
+            receipts.forEach { receipt ->
+                assertThat(receipt.request).isEqualTo(durable)
+            }
+        }
+    }
+
+    @Test
+    fun `eight competing consumers - exactly one durable consumer identity`() = runBlocking<Unit> {
+        repeat(20) { iteration ->
+            val id = "competing-consume-$iteration"
+            approveAndConsumeSetup(id)
+
+            val contenders = Array<suspend () -> Result<ApprovalConsumptionReceipt>>(8) { index ->
+                { runCatching { store.consumeApprovedOrReplay(id, 1L, ApprovalStoreFixtures.validTokenDigest(), "worker-$index") } }
+            }
+            val outcomes = runInParallel(*contenders)
+
+            val freshWinners = outcomes.filter { it.isSuccess && !it.getOrThrow().replayed }
+            assertThat(freshWinners.size)
+                .withFailMessage("iteration $iteration: exactly one fresh consumption winner expected")
+                .isEqualTo(1)
+            // No loser may ever obtain a successful receipt: replay requires
+            // the durable consumedBy to equal the caller, and the winner is a
+            // different actor than every loser.
+            assertThat(outcomes.filter { it.isSuccess && it.getOrThrow().replayed }).isEmpty()
+
+            val durable = store.get(id)!!
+            assertThat(durable.version).isEqualTo(2L)
+            val winnerIndex = outcomes.indexOfFirst { it.isSuccess && it.getOrThrow().replayed == false }
+            assertThat(durable.consumedBy).isEqualTo("worker-$winnerIndex")
+
+            // Losers fail with one of the typed non-success outcomes; which
+            // one depends on the store's check precedence after the winner
+            // committed — only the absence of a second success is pinned.
+            val loserFailures = outcomes.filter { it.isFailure }.map { it.exceptionOrNull() }
+            assertThat(loserFailures.size).isEqualTo(7)
+            assertThat(loserFailures.map { it?.javaClass }).allMatch { failureClass ->
+                failureClass == ApprovalStoreConflictException::class.java ||
+                    failureClass == ApprovalStoreNotConsumableException::class.java ||
+                    failureClass == ApprovalStoreTokenRejectedException::class.java
+            }
+        }
+    }
+
+    // ── Epic 8.2a helpers ───────────────────────────────────────────
+
+    private sealed interface LifecycleExecutionResult {
+        data class Success(
+            val replayed: Boolean,
+        ) : LifecycleExecutionResult
+
+        data class Failure(
+            val exceptionClass: Class<out Exception>,
+        ) : LifecycleExecutionResult
+
+        fun describe(): String = when (this) {
+            is Success -> "Success(replayed=$replayed)"
+            is Failure -> "Failure(${exceptionClass.simpleName})"
+        }
+    }
+
+    private suspend fun executeLifecycleAction(
+        action: ApprovalLifecycleAction,
+        model: ApprovalLifecycleModel,
+        store: ApprovalStore,
+        id: String,
+    ): LifecycleExecutionResult {
+        if (action.isAdvance) return LifecycleExecutionResult.Success(replayed = false)
+
+        val expectedVersion = when (action) {
+            is ApprovalLifecycleAction.ApproveCurrentVersion,
+            is ApprovalLifecycleAction.DenyCurrentVersion,
+            ApprovalLifecycleAction.TimeoutCurrentVersion,
+            -> model.version
+            is ApprovalLifecycleAction.ApproveWrongVersion,
+            is ApprovalLifecycleAction.DenyWrongVersion,
+            ApprovalLifecycleAction.TimeoutWrongVersion,
+            is ApprovalLifecycleAction.ConsumeWrongVersion,
+            -> model.version + 1
+            is ApprovalLifecycleAction.ConsumeValid,
+            is ApprovalLifecycleAction.ConsumeWrongToken,
+            -> if (model.consumedAt == null) model.version else model.version - 1
+            else -> model.version
+        }
+
+        return when (action) {
+            is ApprovalLifecycleAction.ApproveCurrentVersion -> runCatching {
+                store.transition(id, expectedVersion, ApprovalTransition.Approve(action.actor, action.comment))
+            }.toLifecycleResult()
+            is ApprovalLifecycleAction.ApproveWrongVersion -> runCatching {
+                store.transition(id, expectedVersion, ApprovalTransition.Approve(action.actor, null))
+            }.toLifecycleResult()
+            is ApprovalLifecycleAction.DenyCurrentVersion -> runCatching {
+                store.transition(id, expectedVersion, ApprovalTransition.Deny(action.actor, action.comment))
+            }.toLifecycleResult()
+            is ApprovalLifecycleAction.DenyWrongVersion -> runCatching {
+                store.transition(id, expectedVersion, ApprovalTransition.Deny(action.actor, null))
+            }.toLifecycleResult()
+            ApprovalLifecycleAction.TimeoutCurrentVersion,
+            ApprovalLifecycleAction.TimeoutWrongVersion,
+            -> runCatching {
+                store.transition(id, expectedVersion, ApprovalTransition.Timeout)
+            }.toLifecycleResult()
+            is ApprovalLifecycleAction.ConsumeValid -> runCatching {
+                store.consumeApprovedOrReplay(id, expectedVersion, ApprovalStoreFixtures.validTokenDigest(), action.worker)
+            }.let { result ->
+                result.fold(
+                    onSuccess = { LifecycleExecutionResult.Success(replayed = it.replayed) },
+                    onFailure = { LifecycleExecutionResult.Failure(it::class.java as Class<out Exception>) },
+                )
+            }
+            is ApprovalLifecycleAction.ConsumeWrongVersion -> runCatching {
+                store.consumeApprovedOrReplay(id, expectedVersion, ApprovalStoreFixtures.validTokenDigest(), action.worker)
+            }.let { result ->
+                result.fold(
+                    onSuccess = { LifecycleExecutionResult.Success(replayed = it.replayed) },
+                    onFailure = { LifecycleExecutionResult.Failure(it::class.java as Class<out Exception>) },
+                )
+            }
+            is ApprovalLifecycleAction.ConsumeWrongToken -> runCatching {
+                store.consumeApprovedOrReplay(id, expectedVersion, ApprovalStoreFixtures.wrongTokenDigest(), action.worker)
+            }.let { result ->
+                result.fold(
+                    onSuccess = { LifecycleExecutionResult.Success(replayed = it.replayed) },
+                    onFailure = { LifecycleExecutionResult.Failure(it::class.java as Class<out Exception>) },
+                )
+            }
+            else -> LifecycleExecutionResult.Success(replayed = false) // advances handled above
+        }
+    }
+
+    private fun Result<*>.toLifecycleResult(): LifecycleExecutionResult = fold(
+        onSuccess = { LifecycleExecutionResult.Success(replayed = false) },
+        onFailure = { LifecycleExecutionResult.Failure(it::class.java as Class<out Exception>) },
+    )
+
+    private fun assertLifecycleOutcome(
+        expected: ApprovalLifecycleOutcome,
+        actual: LifecycleExecutionResult,
+        seed: Long,
+        step: Int,
+        action: ApprovalLifecycleAction,
+        actions: List<ApprovalLifecycleAction>,
+        model: ApprovalLifecycleModel,
+    ) {
+        when (expected) {
+            is ApprovalLifecycleOutcome.Success -> {
+                assertThat(actual).withFailMessage {
+                    lifecycleFailureMessage(seed, step, action, actions, model, expected, actual)
+                }.isInstanceOf(LifecycleExecutionResult.Success::class.java)
+                val success = actual as LifecycleExecutionResult.Success
+                assertThat(success.replayed).withFailMessage {
+                    lifecycleFailureMessage(seed, step, action, actions, model, expected, actual)
+                }.isEqualTo(expected.replayed)
+            }
+            is ApprovalLifecycleOutcome.Failure -> {
+                assertThat(actual).withFailMessage {
+                    lifecycleFailureMessage(seed, step, action, actions, model, expected, actual)
+                }.isInstanceOf(LifecycleExecutionResult.Failure::class.java)
+                val failure = actual as LifecycleExecutionResult.Failure
+                assertThat(failure.exceptionClass).withFailMessage {
+                    lifecycleFailureMessage(seed, step, action, actions, model, expected, actual)
+                }.isEqualTo(expected.kind.exceptionClass())
+            }
+        }
+    }
+
+    private fun lifecycleFailureMessage(
+        seed: Long,
+        step: Int,
+        action: ApprovalLifecycleAction,
+        actions: List<ApprovalLifecycleAction>,
+        model: ApprovalLifecycleModel,
+        expected: ApprovalLifecycleOutcome,
+        actual: LifecycleExecutionResult,
+    ): String = buildString {
+        appendLine("Approval lifecycle property failed")
+        appendLine("seed=$seed")
+        appendLine("step=$step")
+        appendLine("action=${action.describe()}")
+        appendLine("prefix:")
+        actions.take(step).forEachIndexed { index, prior -> appendLine("  $index ${prior.describe()}") }
+        appendLine("modelBefore=${model.describe()}")
+        appendLine("expected=$expected")
+        appendLine("actual=${actual.describe()}")
     }
 }

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/ApprovalStoreTck.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/ApprovalStoreTck.kt
@@ -522,7 +522,7 @@ abstract class ApprovalStoreTck {
 
     // ── Epic 8.2a: model-based lifecycle properties ────────────────
     //
-    // The four properties below replace "specific scenario → expected
+    // The properties below replace "specific scenario → expected
     // result" with "model state → generated action → predicted transition →
     // execute real store → compare → assert all invariants → repeat". The
     // oracle is ApprovalLifecycleModel — a PURE, independent encoding of the
@@ -697,15 +697,19 @@ abstract class ApprovalStoreTck {
             val winnerIndex = outcomes.indexOfFirst { it.isSuccess && it.getOrThrow().replayed == false }
             assertThat(durable.consumedBy).isEqualTo("worker-$winnerIndex")
 
-            // Losers fail with one of the typed non-success outcomes; which
-            // one depends on the store's check precedence after the winner
-            // committed — only the absence of a second success is pinned.
+            // After the winner commits, every backend's whole-consume atomicity
+            // (InMemory CAS, File per-record lock, JDBC FOR UPDATE row-lock)
+            // serializes each loser AFTER the winner: the loser reads the
+            // consumed record, dispatches to the replay path with the valid
+            // predecessor version (1) and matching token, and fails only on
+            // the actor check. Conflict or TokenRejected are NOT legal
+            // serialized loser outcomes — a loser leaking Conflict would mean
+            // an implementation that lost a race without re-reading the
+            // winning state (exactly the false confidence Epic 8.2 removes).
             val loserFailures = outcomes.filter { it.isFailure }.map { it.exceptionOrNull() }
             assertThat(loserFailures.size).isEqualTo(7)
-            assertThat(loserFailures.map { it?.javaClass }).allMatch { failureClass ->
-                failureClass == ApprovalStoreConflictException::class.java ||
-                    failureClass == ApprovalStoreNotConsumableException::class.java ||
-                    failureClass == ApprovalStoreTokenRejectedException::class.java
+            assertThat(loserFailures.map { it?.javaClass }).allMatch {
+                it == ApprovalStoreNotConsumableException::class.java
             }
         }
     }
@@ -743,8 +747,15 @@ abstract class ApprovalStoreTck {
             is ApprovalLifecycleAction.ApproveWrongVersion,
             is ApprovalLifecycleAction.DenyWrongVersion,
             ApprovalLifecycleAction.TimeoutWrongVersion,
-            is ApprovalLifecycleAction.ConsumeWrongVersion,
             -> model.version + 1
+            is ApprovalLifecycleAction.ConsumeWrongVersion ->
+                // The dangerous wrong expected-version is the one ADJACENT to
+                // the valid expected version, not durable+1: fresh consume
+                // valid expected = durable (v1) -> wrong = v2; replay valid
+                // expected = durable-1 (v1) -> wrong = v2 (an implementation
+                // accepting expectedVersion == durableVersion would pass a
+                // durable+1 probe but must fail here).
+                if (model.consumedAt == null) model.version + 1 else model.version
             is ApprovalLifecycleAction.ConsumeValid,
             is ApprovalLifecycleAction.ConsumeWrongToken,
             -> if (model.consumedAt == null) model.version else model.version - 1


### PR DESCRIPTION
# Approval lifecycle state-machine properties — Epic 8.2a

## What this PR does

Adds the first slice of **Epic 8.2 (state-machine and property-based tests)**: model-based lifecycle properties for the ApprovalStore family, layered onto the existing `ApprovalStoreTck` rather than a new runner family.

**37 → 42 shared cases × 3 implementations** (InMemory, File, JDBC).

The new dimension vs. #267 (example-based):

```
model state → generated action → predicted transition → execute real store
→ compare → assert all invariants → repeat
```

## Files

- `tramai-testing/src/testFixtures/.../persistence/approval/ApprovalLifecycleModel.kt` — **pure independent oracle**: status/version/now/decision/consumption fields, transition rules, 13 per-step invariants, outcome kinds (CONFLICT / ILLEGAL_TRANSITION / NOT_CONSUMABLE / TOKEN_REJECTED) mapped to the public typed exceptions. Deliberately NOT derived from production helpers (`resolveNextStatus`, `consumeFreshApproval`, `consumeReplayApproval` are never called).
- `tramai-testing/src/testFixtures/.../persistence/approval/ApprovalLifecycleActionGenerator.kt` — deterministic 32-seed × 32-action corpus (same seed → same trace), state-aware alphabet. **Guaranteed reachability**, not luck: every seed opens with a wrong-version decision evaluated against the PENDING pre-state; odd seeds force the APPROVED→unconsumed→expired fresh-consume path; both the wrong-version and expired-fresh discriminators are structurally present.
- `ApprovalStoreTck.kt` — 5 new properties:
  1. **Generated lifecycle sequences match the independent model after every action** — 1,024 actions × 3 stores = 3,072 model-checked operations; whole-record equality after every action; rejected actions leave the durable record value-identical; seed/step/prefix failure diagnostics.
  2. **Wrong-version decisions always conflict without changing durable state** — deterministic matrix: Approve/Deny/Timeout × (before / exact / after expiry) with `expectedVersion = durable + 1` → `ApprovalStoreConflictException` + zero mutation. Pins failure precedence: version checked before the expiry window.
  3. **Duplicate concurrent decisions** (×20) — 8 contenders (Approve/Deny alternating, expectedVersion 0) → exactly 1 success, 7 conflicts, durable v1 with the winner's status/decidedBy.
  4. **Identical consumption** (×20) — 8 identical consumers → 1 fresh receipt + 7 exact replays, all returning the SAME durable v2 record with identical consumedAt.
  5. **Competing consumers** (×20) — 8 unique actors → exactly one durable consumer identity; **all 7 losers deterministically surface `ApprovalStoreNotConsumableException`** (whole-consume atomicity serializes each loser after the winner; Conflict/TokenRejected are NOT legal serialized loser outcomes).
- `tramai-testing/src/test/.../ApprovalLifecycleActionGeneratorTest.kt` — coverage guard: same seed → same trace; **18 semantic categories** (reachable pre-state, not syntactic action presence) incl. `transition-wrong-version-while-pending`, `exact-expiry-boundary` (PENDING at exactly `now == expiresAt`), `fresh-consume-wrong-version-rejection` (APPROVED + unconsumed), genuine `expired-fresh-consume-rejection` (APPROVED pre-state), genuine after-expiry approve/deny rejections (PENDING pre-state); full status lattice.
- Docs: new `docs/reference/state-machine-property-testing-contract.md` (Epic 8.2 umbrella); ROADMAP Epic 8.2 🚧 IN PROGRESS + deliverables; persistence contract doc: "Epic 8.2a augmentation (PR #278)" note.

## Contract finding (documented, no production change)

The model originally checked the expiry window before the token on the wrong-token path; **all three stores uniformly check the token first** (expired-but-unconsumed + wrong token → `ApprovalStoreTokenRejectedException`, not `NotConsumable`). The SPI KDoc does not pin check order — the model was aligned to the cross-store behavior rather than weakening either side.

## Mutation evidence — 18/18 RED → GREEN, 0 weak

Each mutation makes a NEW #278 property RED on its own (never an old #267 example test). Log: `/tmp/approval-mutation-evidence.log` (each mutation: baseline GREEN → exactly-one-replacement preflight → mutated → RED → restored → GREEN). The final campaign adds M17 (replay accepts `expectedVersion == durableVersion` → generated-sequence RED) and M18 (replay loser leaks Conflict instead of NotConsumable → competing-consumers RED), and re-verifies M2/M10 under the two new semantic coverage categories (`exact-expiry-boundary`, `fresh-consume-wrong-version-rejection`).

| # | Mutation | Discriminator |
|---|---|---|
| M1 | terminal decision guard removed | generated sequence |
| M2 | expiry boundary `>=` → `>` | generated sequence |
| M3 | early timeout allowed | generated sequence |
| M4 | approve after expiry allowed | generated sequence |
| M5 | deny after expiry allowed | generated sequence |
| M6 | transition version check removed | generated sequence + wrong-version matrix |
| M7 | decision version increment removed | generated sequence |
| M8 | decidedAt not updated | generated sequence |
| M9 | decidedBy dropped | generated sequence |
| M10 | fresh consume version check removed | generated sequence |
| M11 | fresh consume expiry check removed | generated sequence |
| M12 | fresh consume version increment removed | generated sequence |
| M13 | replay changes the durable record | generated sequence + identical consumption |
| M14 | replay accepts a different consumer | generated sequence |
| M15 | token check removed | generated sequence |
| M16 | exact replay disabled | generated sequence + identical consumption |
| M17 | replay accepts expectedVersion == durableVersion | generated sequence |
| M18 | replay loser leaks Conflict instead of NotConsumable | competing consumers + generated sequence |

**M5, M6, M11 note:** the first campaign runs surfaced three corpus holes (mutation invisible because the fixed corpus never reached the discriminating pre-state). Each was fixed in the TEST SUITE — semantic coverage categories + guaranteed generator reachability — not by weakening or replacing the mutation. M6's final state is RED on both the generated sequence and the deterministic wrong-version matrix. **Review round:** M17/M18 added per deep review — replay wrong-version now probes the dangerous adjacent `expectedVersion == durableVersion` (executor derives wrong versions relative to the VALID expected version, not durable+1), and the competing-consumer property now asserts all 7 losers surface `ApprovalStoreNotConsumableException`; two new semantic coverage categories (`exact-expiry-boundary`, `fresh-consume-wrong-version-rejection`) pin the M2/M10 discriminators.

## Gates

- 3 runners: **42/42 each** (37 existing + 5 new)
- `verifyJUnitTestSignatures` ✅ · `verifyCancellationSafety` ✅ · `apiCheck` ✅ (no API dump change) · `verifyPr -PchangeClass=runtime-behaviour` ✅
- (Pre-existing `TramaiWorkerTest` flake observed once in a full verifyPr run; proven standalone-green, same flake as #274.)

## Production changes

**None.** Zero production code, zero public API, zero schema, zero persisted format. No baseline/deviation/config changes.
