### PR TITLE
refactor(spring): make AI service creation runtime-neutral

### DIFF
--- a/tramai-spring-core/src/main/kotlin/dev/tramai/spring/AiServiceFactoryBean.kt
+++ b/tramai-spring-core/src/main/kotlin/dev/tramai/spring/AiServiceFactoryBean.kt
@@ -1,12 +1,17 @@
 package dev.tramai.spring
 
-import dev.tramai.standalone.Tramai
 import org.springframework.beans.factory.BeanFactory
 import org.springframework.beans.factory.BeanFactoryAware
 import org.springframework.beans.factory.FactoryBean
 
 /**
- * Spring [FactoryBean] that creates Tramai-backed service proxies.
+ * Spring [FactoryBean] that creates service proxies through the active TramAI
+ * runtime profile.
+ *
+ * The concrete runtime is intentionally resolved through the shared named
+ * [AiServiceCreator] bean rather than by looking up `Tramai` directly. This
+ * keeps `@AiService` bean registration independent of standard vs sovereign
+ * runtime selection.
  */
 class AiServiceFactoryBean<T : Any>(
     private val serviceType: Class<T>,
@@ -18,8 +23,16 @@ class AiServiceFactoryBean<T : Any>(
     }
 
     override fun getObject(): T {
-        val tramai = beanFactory.getBean(Tramai::class.java)
-        return tramai.create(serviceType.kotlin)
+        val creatorBean = beanFactory.getBean(AI_SERVICE_CREATOR_BEAN_NAME)
+        check(creatorBean is Function1<*, *>) {
+            "tramai-ai-service-creator-invalid"
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        val creator = creatorBean as AiServiceCreator
+
+        @Suppress("UNCHECKED_CAST")
+        return creator(serviceType.kotlin) as T
     }
 
     override fun getObjectType(): Class<*> = serviceType

--- a/tramai-spring-core/src/main/kotlin/dev/tramai/spring/AiServiceProxyAutoConfiguration.kt
+++ b/tramai-spring-core/src/main/kotlin/dev/tramai/spring/AiServiceProxyAutoConfiguration.kt
@@ -1,0 +1,33 @@
+package dev.tramai.spring
+
+import dev.tramai.standalone.Tramai
+import kotlin.reflect.KClass
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+
+/** Internal bean name shared by TramAI Spring runtime profiles. */
+internal const val AI_SERVICE_CREATOR_BEAN_NAME: String = "tramaiAiServiceCreator"
+
+/** Runtime-neutral service creation contract used by [AiServiceFactoryBean]. */
+internal typealias AiServiceCreator = (KClass<*>) -> Any
+
+/**
+ * Adapts the standard [Tramai] runtime to Spring's runtime-neutral AI service
+ * registration path.
+ *
+ * Sovereign and future runtime profiles provide the same named creator bean,
+ * allowing `@AiService` discovery to stay independent of the active runtime.
+ */
+@AutoConfiguration(after = [TramaiAutoConfiguration::class])
+internal class AiServiceProxyAutoConfiguration {
+
+    @Bean(name = [AI_SERVICE_CREATOR_BEAN_NAME])
+    @ConditionalOnBean(Tramai::class)
+    @ConditionalOnMissingBean(name = [AI_SERVICE_CREATOR_BEAN_NAME])
+    fun aiServiceCreator(tramai: Tramai): AiServiceCreator = { serviceType ->
+        @Suppress("UNCHECKED_CAST")
+        tramai.create(serviceType as KClass<Any>)
+    }
+}

--- a/tramai-spring-core/src/main/kotlin/dev/tramai/spring/EnableTramai.kt
+++ b/tramai-spring-core/src/main/kotlin/dev/tramai/spring/EnableTramai.kt
@@ -8,5 +8,8 @@ import org.springframework.context.annotation.Import
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented
-@Import(TramaiAutoConfiguration::class)
+@Import(
+    TramaiAutoConfiguration::class,
+    AiServiceProxyAutoConfiguration::class,
+)
 annotation class EnableTramai

--- a/tramai-spring-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/tramai-spring-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,4 @@
 dev.tramai.spring.TramaiSecretResolutionAutoConfiguration
 dev.tramai.spring.TramaiAutoConfiguration
+dev.tramai.spring.AiServiceProxyAutoConfiguration
 dev.tramai.spring.SecurityClassificationAutoConfiguration

--- a/tramai-spring-core/src/test/kotlin/dev/tramai/spring/AiServiceFactoryBeanTest.kt
+++ b/tramai-spring-core/src/test/kotlin/dev/tramai/spring/AiServiceFactoryBeanTest.kt
@@ -1,0 +1,45 @@
+package dev.tramai.spring
+
+import kotlin.reflect.KClass
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import org.springframework.beans.factory.support.DefaultListableBeanFactory
+
+class AiServiceFactoryBeanTest {
+
+    @Test
+    fun `factory delegates service creation to active runtime creator`() {
+        val beanFactory = DefaultListableBeanFactory()
+        var requestedType: KClass<*>? = null
+        val expected = TestAiService()
+        val creator: AiServiceCreator = { serviceType ->
+            requestedType = serviceType
+            expected
+        }
+        beanFactory.registerSingleton(AI_SERVICE_CREATOR_BEAN_NAME, creator)
+
+        val factory = AiServiceFactoryBean(TestAiService::class.java)
+        factory.setBeanFactory(beanFactory)
+
+        assertSame(expected, factory.getObject())
+        assertEquals(TestAiService::class, requestedType)
+    }
+
+    @Test
+    fun `factory fails loudly when runtime creator bean has wrong type`() {
+        val beanFactory = DefaultListableBeanFactory()
+        beanFactory.registerSingleton(AI_SERVICE_CREATOR_BEAN_NAME, "not-a-function")
+
+        val factory = AiServiceFactoryBean(TestAiService::class.java)
+        factory.setBeanFactory(beanFactory)
+
+        val failure = assertFailsWith<IllegalStateException> {
+            factory.getObject()
+        }
+        assertEquals("tramai-ai-service-creator-invalid", failure.message)
+    }
+
+    private class TestAiService
+}


### PR DESCRIPTION
Spring unification track S1.

### What changes
- `AiServiceFactoryBean` no longer looks up `Tramai` directly.
- A runtime-neutral named AI-service creator bean becomes the Spring composition boundary.
- Standard `Tramai` auto-configuration supplies that creator through a small internal auto-configuration.
- `@EnableTramai` imports the companion proxy auto-configuration so its existing behavior is preserved.
- Focused tests pin delegation to the active runtime creator and fail-loud behavior for an invalid creator.

### Why
This is the foundation for making `@AiService` registration identical under standard and sovereign runtime profiles without making the scanner depend on `tramai-sovereign`.

### Scope
- `tramai-spring-core` only.
- No sovereign behavior change yet.
- No public API addition intended; the new wiring contract is internal Spring composition.
- No `master` merge; this PR targets the Spring-track integration branch.