### PR TITLE
feat(spring): add sovereign AiService proxy parity

### DIFF
--- a/tramai-spring-boot-starter-sovereign/src/main/kotlin/dev/tramai/spring/sovereign/SovereignAiServiceProxyAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign/src/main/kotlin/dev/tramai/spring/sovereign/SovereignAiServiceProxyAutoConfiguration.kt
@@ -1,0 +1,57 @@
+package dev.tramai.spring.sovereign
+
+import dev.tramai.sovereign.SovereignTramai
+import dev.tramai.spring.AiServiceBeanDefinitionRegistrar
+import kotlin.reflect.KClass
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+
+/**
+ * Adapts the sovereign runtime to the shared Spring `@AiService` proxy path.
+ *
+ * The bean name intentionally matches the runtime-neutral lookup performed by
+ * `AiServiceFactoryBean` in `tramai-spring-core`. Keeping this adapter in the
+ * sovereign starter preserves the dependency direction: Spring core knows
+ * nothing about sovereign runtime types.
+ */
+@AutoConfiguration(after = [SovereignTramaiProfileAutoConfiguration::class])
+@ConditionalOnProperty(
+    prefix = "tramai",
+    name = ["profile"],
+    havingValue = "sovereign",
+)
+internal class SovereignAiServiceProxyAutoConfiguration {
+
+    @Bean(name = [AI_SERVICE_CREATOR_BEAN_NAME])
+    @ConditionalOnBean(SovereignTramai::class)
+    @ConditionalOnMissingBean(name = [AI_SERVICE_CREATOR_BEAN_NAME])
+    fun sovereignAiServiceCreator(
+        sovereignTramai: SovereignTramai,
+    ): (KClass<*>) -> Any = { serviceType ->
+        @Suppress("UNCHECKED_CAST")
+        sovereignTramai.create(serviceType as KClass<Any>)
+    }
+
+    /**
+     * Registers the shared scanner for sovereign applications as well.
+     *
+     * This is deliberately not conditional on the creator bean: discovered
+     * `@AiService` definitions must not silently disappear when sovereign
+     * runtime construction is unavailable. Resolving such a service then fails
+     * loudly through the runtime-neutral factory rather than falling back to a
+     * weaker runtime.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    fun sovereignAiServiceBeanDefinitionRegistrar(
+        beanFactory: ConfigurableListableBeanFactory,
+    ): AiServiceBeanDefinitionRegistrar = AiServiceBeanDefinitionRegistrar(beanFactory)
+
+    private companion object {
+        const val AI_SERVICE_CREATOR_BEAN_NAME = "tramaiAiServiceCreator"
+    }
+}

--- a/tramai-spring-boot-starter-sovereign/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/tramai-spring-boot-starter-sovereign/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 dev.tramai.spring.sovereign.SovereignTramaiProfileAutoConfiguration
+dev.tramai.spring.sovereign.SovereignAiServiceProxyAutoConfiguration

--- a/tramai-spring-boot-starter-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/SovereignAiServiceProxyAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/SovereignAiServiceProxyAutoConfigurationTest.kt
@@ -1,0 +1,98 @@
+package dev.tramai.spring.sovereign
+
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.provider.ModelProvider
+import dev.tramai.sovereign.SovereignTramai
+import dev.tramai.sovereign.SovereignTramaiRuntime
+import dev.tramai.spring.AiServiceBeanDefinitionRegistrar
+import dev.tramai.spring.sovereign.aiservicefixture.SovereignScannedAiService
+import dev.tramai.standalone.Tramai
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.NoSuchBeanDefinitionException
+import org.springframework.beans.factory.support.BeanDefinitionRegistry
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+class SovereignAiServiceProxyAutoConfigurationTest {
+
+    private val sovereignProperties = arrayOf(
+        "tramai.profile=sovereign",
+        "tramai.sovereign.allowed-models[0]=local-model",
+        "tramai.sovereign.allowed-providers[0]=local-provider",
+        "tramai.sovereign.provider-zones.local-provider=LOCAL",
+        "tramai.sovereign.models.local-model=local-provider",
+    )
+
+    private val runner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                SovereignTramaiProfileAutoConfiguration::class.java,
+                SovereignAiServiceProxyAutoConfiguration::class.java,
+            ),
+        )
+        .withInitializer { context ->
+            AutoConfigurationPackages.register(
+                context.beanFactory as BeanDefinitionRegistry,
+                "dev.tramai.spring.sovereign.aiservicefixture",
+            )
+        }
+
+    @Test
+    fun `scanned AiService is created and executed by the sovereign runtime`() {
+        runner
+            .withBean(ModelProvider::class.java, { SovereignAiServiceProvider() })
+            .withPropertyValues(*sovereignProperties)
+            .run { context ->
+                assertThat(context).hasSingleBean(SovereignTramai::class.java)
+                assertThat(context).hasSingleBean(SovereignTramaiRuntime::class.java)
+                assertThat(context).doesNotHaveBean(Tramai::class.java)
+                assertThat(context).hasBean("tramaiAiServiceCreator")
+                assertThat(context).hasSingleBean(AiServiceBeanDefinitionRegistrar::class.java)
+
+                val service = context.getBean(SovereignScannedAiService::class.java)
+                val result = runBlocking { service.answer("hello") }
+
+                assertThat(result).isEqualTo("SOVEREIGN_OK")
+            }
+    }
+
+    @Test
+    fun `standard profile does not activate the sovereign AiService adapter`() {
+        runner
+            .withPropertyValues("tramai.profile=standard")
+            .run { context ->
+                assertThat(context).doesNotHaveBean("tramaiAiServiceCreator")
+                assertThat(context).doesNotHaveBean(AiServiceBeanDefinitionRegistrar::class.java)
+                assertThat(context).doesNotHaveBean(SovereignTramai::class.java)
+                assertThat(context).doesNotHaveBean(Tramai::class.java)
+            }
+    }
+
+    @Test
+    fun `missing sovereign creator fails loudly and cannot fall back to standard runtime`() {
+        runner
+            .withPropertyValues(*sovereignProperties)
+            .run { context ->
+                assertThat(context).doesNotHaveBean(SovereignTramai::class.java)
+                assertThat(context).doesNotHaveBean(Tramai::class.java)
+                assertThat(context).doesNotHaveBean("tramaiAiServiceCreator")
+                assertThat(context).hasSingleBean(AiServiceBeanDefinitionRegistrar::class.java)
+
+                assertThatThrownBy {
+                    context.getBean(SovereignScannedAiService::class.java)
+                }.hasRootCauseInstanceOf(NoSuchBeanDefinitionException::class.java)
+            }
+    }
+
+    private class SovereignAiServiceProvider : ModelProvider {
+        override fun providerId(): String = "local-provider"
+
+        override suspend fun complete(request: ModelRequest): ModelResponse =
+            ModelResponse(content = "SOVEREIGN_OK")
+    }
+}

--- a/tramai-spring-boot-starter-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/SovereignAiServiceProxyAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/SovereignAiServiceProxyAutoConfigurationTest.kt
@@ -20,6 +20,12 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner
 
 class SovereignAiServiceProxyAutoConfigurationTest {
 
+    private val standardProfileAutoConfiguration: Class<*> =
+        Class.forName("dev.tramai.spring.StandardTramaiProfileAutoConfiguration")
+
+    private val standardAiServiceProxyAutoConfiguration: Class<*> =
+        Class.forName("dev.tramai.spring.AiServiceProxyAutoConfiguration")
+
     private val sovereignProperties = arrayOf(
         "tramai.profile=sovereign",
         "tramai.sovereign.allowed-models[0]=local-model",
@@ -35,17 +41,23 @@ class SovereignAiServiceProxyAutoConfigurationTest {
                 SovereignAiServiceProxyAutoConfiguration::class.java,
             ),
         )
-        .withInitializer { context ->
-            AutoConfigurationPackages.register(
-                context.beanFactory as BeanDefinitionRegistry,
-                "dev.tramai.spring.sovereign.aiservicefixture",
-            )
-        }
+        .withInitializer(::registerAiServiceFixturePackage)
+
+    private val mixedProfileRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                standardProfileAutoConfiguration,
+                standardAiServiceProxyAutoConfiguration,
+                SovereignTramaiProfileAutoConfiguration::class.java,
+                SovereignAiServiceProxyAutoConfiguration::class.java,
+            ),
+        )
+        .withInitializer(::registerAiServiceFixturePackage)
 
     @Test
     fun `scanned AiService is created and executed by the sovereign runtime`() {
         runner
-            .withBean(ModelProvider::class.java, { SovereignAiServiceProvider() })
+            .withBean(ModelProvider::class.java, { DeterministicAiServiceProvider("SOVEREIGN_OK") })
             .withPropertyValues(*sovereignProperties)
             .run { context ->
                 assertThat(context).hasSingleBean(SovereignTramai::class.java)
@@ -62,14 +74,25 @@ class SovereignAiServiceProxyAutoConfigurationTest {
     }
 
     @Test
-    fun `standard profile does not activate the sovereign AiService adapter`() {
-        runner
-            .withPropertyValues("tramai.profile=standard")
+    fun `standard profile keeps standard AiService wiring active on a mixed classpath`() {
+        mixedProfileRunner
+            .withBean(ModelProvider::class.java, { DeterministicAiServiceProvider("STANDARD_OK") })
+            .withPropertyValues(
+                "tramai.profile=standard",
+                "tramai.models.local-model=local-provider",
+                "tramai.default-provider=local-provider",
+            )
             .run { context ->
-                assertThat(context).doesNotHaveBean("tramaiAiServiceCreator")
-                assertThat(context).doesNotHaveBean(AiServiceBeanDefinitionRegistrar::class.java)
+                assertThat(context).hasSingleBean(Tramai::class.java)
                 assertThat(context).doesNotHaveBean(SovereignTramai::class.java)
-                assertThat(context).doesNotHaveBean(Tramai::class.java)
+                assertThat(context).doesNotHaveBean(SovereignTramaiRuntime::class.java)
+                assertThat(context).hasBean("tramaiAiServiceCreator")
+                assertThat(context).hasSingleBean(AiServiceBeanDefinitionRegistrar::class.java)
+
+                val service = context.getBean(SovereignScannedAiService::class.java)
+                val result = runBlocking { service.answer("hello") }
+
+                assertThat(result).isEqualTo("STANDARD_OK")
             }
     }
 
@@ -89,10 +112,19 @@ class SovereignAiServiceProxyAutoConfigurationTest {
             }
     }
 
-    private class SovereignAiServiceProvider : ModelProvider {
+    private fun registerAiServiceFixturePackage(context: org.springframework.context.ConfigurableApplicationContext) {
+        AutoConfigurationPackages.register(
+            context.beanFactory as BeanDefinitionRegistry,
+            "dev.tramai.spring.sovereign.aiservicefixture",
+        )
+    }
+
+    private class DeterministicAiServiceProvider(
+        private val response: String,
+    ) : ModelProvider {
         override fun providerId(): String = "local-provider"
 
         override suspend fun complete(request: ModelRequest): ModelResponse =
-            ModelResponse(content = "SOVEREIGN_OK")
+            ModelResponse(content = response)
     }
 }

--- a/tramai-spring-boot-starter-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/aiservicefixture/SovereignScannedAiService.kt
+++ b/tramai-spring-boot-starter-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/aiservicefixture/SovereignScannedAiService.kt
@@ -1,0 +1,13 @@
+package dev.tramai.spring.sovereign.aiservicefixture
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+
+@AiService
+interface SovereignScannedAiService {
+    @Operation(
+        prompt = "Return a deterministic sovereign response for {{input}}.",
+        model = "local-model",
+    )
+    suspend fun answer(input: String): String
+}


### PR DESCRIPTION
Spring unification track S3 — sovereign `@AiService` proxy registration parity.

### Goal
Make scanned `@AiService` interfaces bind to the active `SovereignTramai` runtime exactly as the standard Spring profile binds them to `Tramai`, without introducing a `tramai-spring-core -> tramai-sovereign` dependency.

### What changes
- Adds `SovereignAiServiceProxyAutoConfiguration`, active only for `tramai.profile=sovereign` and ordered after the sovereign profile gate.
- Publishes the same named `tramaiAiServiceCreator` function bean expected by `AiServiceFactoryBean`, backed by `SovereignTramai.create(...)`.
- Registers the shared `AiServiceBeanDefinitionRegistrar` for sovereign applications so auto-configuration package scanning discovers `@AiService` interfaces.
- Keeps the registrar independent of creator availability: scanned services do not silently disappear if sovereign runtime construction is unavailable; resolving them fails loudly and cannot fall back to a plain runtime because S2 guarantees there is no `Tramai` bean in sovereign mode.
- Adds a dedicated scanned test fixture and parity tests.

### Invariants pinned by tests
- `profile=sovereign` + valid provider configuration => one `SovereignTramai`, no plain `Tramai`, creator bean present, scanned `@AiService` resolves and executes successfully.
- Full mixed Spring classpath + `profile=standard` => one standard `Tramai`, no sovereign runtime, standard creator/registrar present, and the same scanned `@AiService` resolves and executes through the standard runtime.
- sovereign profile with no sovereign runtime => no creator and no plain `Tramai`; resolving a scanned service fails loudly rather than downgrading.
- no dependency from `tramai-spring-core` to sovereign runtime types.

### Scope
This PR does not yet add `@AiTool` scanning parity. That is S4 after this slice is merged into `track/0.6.0-spring-unification`.