### PR TITLE
feat(spring): sovereign @AiTool parity with governed metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- **Governed `@AiTool` parity for the sovereign runtime (Spring track S4).** `@AiTool` gains opt-in governance metadata (`permission`, `risk`, `approval`, `managedNetworkEgress`, `audit`) with conservative defaults (HIGH risk, HUMAN_REQUIRED approval, DENY egress, FULL audit). Empty `permission` preserves the legacy contract — no `ToolSecurityMetadata` is produced and standard Spring behavior is unchanged; the sovereign runtime continues to reject such legacy tools (`tool-metadata-missing`). `AiToolScanner` maps governed annotations to strict `ToolSecurityMetadata` and rejects blank/padded permissions. The sovereign starter now discovers `@AiTool` methods alongside explicit `TramaiTool` beans, with the engine remaining the single fail-loud authority for duplicate tool identities.
+
 - **ApprovalStore compatibility TCK (PR #267, Epic 8.1a).** One shared
   behavioral contract for every `ApprovalStore` implementation, in
   tramai-testing testFixtures: `ApprovalStoreTck` runs **37 cases** —

--- a/docs/reference/annotations.md
+++ b/docs/reference/annotations.md
@@ -181,7 +181,7 @@ This should explain what the tool does, not how it is implemented.
 
 #### `idempotent`
 
-Whether the tool is safe to retry after transient failure.
+Whether repeating execution with the same logical input is safe. This describes repetition safety, not whether TramAI should retry the tool after a failure.
 
 Default: `false`
 
@@ -215,17 +215,19 @@ Default: `ApprovalMode.HUMAN_REQUIRED`
 
 #### `managedNetworkEgress`
 
-Managed network-egress policy used by secure policy profiles when `permission` is set.
+Managed network-egress metadata for TramAI-managed destinations when `permission` is set.
 
 Default: `ManagedNetworkEgress.DENY`
 
+This does not sandbox arbitrary networking performed inside the annotated method. Infrastructure controls remain required for code paths that bypass TramAI-managed transports.
+
 #### `audit`
 
-Audit detail requested for governed execution when `permission` is set.
+Audit detail metadata requested for governed execution when `permission` is set.
 
 Default: `AuditDetail.FULL`
 
-The governance defaults are deliberately conservative (high risk, human approval, denied egress, full audit) so that opting into governance never silently weakens policy.
+The governance defaults are deliberately conservative (high risk, human approval, denied managed egress, full audit metadata) so that opting into governance never silently weakens the declared policy posture.
 
 ## Structured Output Property Annotations
 

--- a/docs/reference/annotations.md
+++ b/docs/reference/annotations.md
@@ -193,6 +193,40 @@ Default: `UNKNOWN`
 
 Use it to describe whether the tool reads data, writes data, or has stronger external effects.
 
+#### `permission`
+
+Permission required to expose and execute the tool under secure policy profiles.
+
+Default: empty string.
+
+Empty preserves the legacy annotation contract: no `ToolSecurityMetadata` is produced and the standard runtime exposes the tool as before. Secure profiles such as sovereign TramAI reject tools without security metadata (`tool-metadata-missing`). Setting a non-empty permission makes the annotation produce strict `ToolSecurityMetadata` using `risk`, `approval`, `managedNetworkEgress`, and `audit`.
+
+#### `risk`
+
+Risk classification used by secure policy profiles when `permission` is set.
+
+Default: `RiskLevel.HIGH`
+
+#### `approval`
+
+Approval mode used by secure policy profiles when `permission` is set.
+
+Default: `ApprovalMode.HUMAN_REQUIRED`
+
+#### `managedNetworkEgress`
+
+Managed network-egress policy used by secure policy profiles when `permission` is set.
+
+Default: `ManagedNetworkEgress.DENY`
+
+#### `audit`
+
+Audit detail requested for governed execution when `permission` is set.
+
+Default: `AuditDetail.FULL`
+
+The governance defaults are deliberately conservative (high risk, human approval, denied egress, full audit) so that opting into governance never silently weakens policy.
+
 ## Structured Output Property Annotations
 
 These annotations affect structured schema generation and validation for non-`String` return types.

--- a/tramai-core/api/tramai-core.api
+++ b/tramai-core/api/tramai-core.api
@@ -15,9 +15,14 @@ public abstract interface annotation class dev/tramai/core/annotations/AiService
 }
 
 public abstract interface annotation class dev/tramai/core/annotations/AiTool : java/lang/annotation/Annotation {
+	public abstract fun approval ()Ldev/tramai/core/policy/ApprovalMode;
+	public abstract fun audit ()Ldev/tramai/core/policy/AuditDetail;
 	public abstract fun description ()Ljava/lang/String;
 	public abstract fun idempotent ()Z
+	public abstract fun managedNetworkEgress ()Ldev/tramai/core/policy/ManagedNetworkEgress;
 	public abstract fun name ()Ljava/lang/String;
+	public abstract fun permission ()Ljava/lang/String;
+	public abstract fun risk ()Ldev/tramai/core/policy/RiskLevel;
 	public abstract fun sideEffectLevel ()Ldev/tramai/core/model/SideEffectLevel;
 }
 

--- a/tramai-core/src/main/kotlin/dev/tramai/core/annotations/AiTool.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/annotations/AiTool.kt
@@ -22,7 +22,10 @@ annotation class AiTool(
     val name: String = "",
     /** Tool description injected into model tool definitions. */
     val description: String,
-    /** Whether the tool is safe to retry on transient failure. */
+    /**
+     * Whether repeating execution with the same logical input is safe.
+     * This describes repetition/idempotency semantics, not whether TramAI should retry the tool after a failure.
+     */
     val idempotent: Boolean = false,
     /** Side-effect classification for the tool. */
     val sideEffectLevel: SideEffectLevel = SideEffectLevel.UNKNOWN,
@@ -38,8 +41,11 @@ annotation class AiTool(
     val risk: RiskLevel = RiskLevel.HIGH,
     /** Approval mode used by secure policy profiles when [permission] is set. */
     val approval: ApprovalMode = ApprovalMode.HUMAN_REQUIRED,
-    /** Managed network-egress policy when [permission] is set. */
+    /**
+     * Managed network-egress policy metadata when [permission] is set.
+     * This applies only to TramAI-managed egress and does not sandbox arbitrary networking performed inside the method.
+     */
     val managedNetworkEgress: ManagedNetworkEgress = ManagedNetworkEgress.DENY,
-    /** Audit detail requested for governed execution when [permission] is set. */
+    /** Audit detail metadata requested for governed execution when [permission] is set. */
     val audit: AuditDetail = AuditDetail.FULL,
 )

--- a/tramai-core/src/main/kotlin/dev/tramai/core/annotations/AiTool.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/annotations/AiTool.kt
@@ -1,9 +1,18 @@
 package dev.tramai.core.annotations
 
 import dev.tramai.core.model.SideEffectLevel
+import dev.tramai.core.policy.ApprovalMode
+import dev.tramai.core.policy.AuditDetail
+import dev.tramai.core.policy.ManagedNetworkEgress
+import dev.tramai.core.policy.RiskLevel
 
 /**
  * Marks a method for discovery as a portable tool by framework adapters.
+ *
+ * Governance metadata is opt-in for backward compatibility. Setting a non-empty
+ * [permission] makes the annotation produce strict tool security metadata; secure
+ * runtime profiles such as sovereign TramAI require that metadata and reject
+ * legacy annotation-driven tools that leave [permission] empty.
  */
 @MustBeDocumented
 @Retention(AnnotationRetention.RUNTIME)
@@ -17,4 +26,20 @@ annotation class AiTool(
     val idempotent: Boolean = false,
     /** Side-effect classification for the tool. */
     val sideEffectLevel: SideEffectLevel = SideEffectLevel.UNKNOWN,
+    /**
+     * Permission required to expose and execute this tool.
+     *
+     * Empty preserves the legacy annotation contract and produces no
+     * [dev.tramai.core.policy.ToolSecurityMetadata]. Secure profiles reject
+     * tools without security metadata.
+     */
+    val permission: String = "",
+    /** Risk classification used by secure policy profiles when [permission] is set. */
+    val risk: RiskLevel = RiskLevel.HIGH,
+    /** Approval mode used by secure policy profiles when [permission] is set. */
+    val approval: ApprovalMode = ApprovalMode.HUMAN_REQUIRED,
+    /** Managed network-egress policy when [permission] is set. */
+    val managedNetworkEgress: ManagedNetworkEgress = ManagedNetworkEgress.DENY,
+    /** Audit detail requested for governed execution when [permission] is set. */
+    val audit: AuditDetail = AuditDetail.FULL,
 )

--- a/tramai-spring-boot-starter-sovereign/src/main/kotlin/dev/tramai/spring/sovereign/SovereignTramaiAutoConfiguration.kt
+++ b/tramai-spring-boot-starter-sovereign/src/main/kotlin/dev/tramai/spring/sovereign/SovereignTramaiAutoConfiguration.kt
@@ -23,13 +23,16 @@ import dev.tramai.security.model.InMemoryModelRegistry
 import dev.tramai.sovereign.SovereignProfileConfiguration
 import dev.tramai.sovereign.SovereignTramai
 import dev.tramai.sovereign.SovereignTramaiRuntime
+import dev.tramai.spring.AiToolScanner
 import java.time.Clock
 import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 
 /**
@@ -54,6 +57,9 @@ import org.springframework.context.annotation.Bean
     matchIfMissing = true,
 )
 class SovereignTramaiAutoConfiguration {
+
+    @field:Autowired
+    private lateinit var applicationContext: ApplicationContext
 
     companion object {
         private const val DEFAULT_REVISION = "0.0.1"
@@ -209,12 +215,13 @@ class SovereignTramaiAutoConfiguration {
             builder.provider(provider, name = provider.providerId())
         }
 
-        // Register TramaiTool beans from the application context.
-        // Users provide TramaiTool Spring beans and the starter wires
-        // them into the governed runtime. Duplicate tool names are rejected
-        // by the engine at build time — collection keeps that fail-loud
-        // behavior instead of silently deduplicating.
-        builder.tools(toolProviders.orderedStream().toList())
+        // Preserve explicit TramaiTool beans and add the same @AiTool method
+        // discovery used by the standard Spring runtime. Duplicate names are
+        // intentionally passed through so the engine remains the single
+        // fail-loud authority for tool identity collisions.
+        val explicitTools = toolProviders.orderedStream().toList()
+        val annotatedTools = AiToolScanner.fromApplicationContext(applicationContext)
+        builder.tools(explicitTools + annotatedTools)
 
         // Register model routes from properties.
         for ((modelName, providerName) in properties.models) {

--- a/tramai-spring-boot-starter-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/SovereignAiToolScanningTest.kt
+++ b/tramai-spring-boot-starter-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/SovereignAiToolScanningTest.kt
@@ -1,0 +1,139 @@
+package dev.tramai.spring.sovereign
+
+import dev.tramai.core.annotations.AiTool
+import dev.tramai.core.exception.PolicyViolationException
+import dev.tramai.core.model.SideEffectLevel
+import dev.tramai.core.policy.ApprovalMode
+import dev.tramai.core.policy.AuditDetail
+import dev.tramai.core.policy.ManagedNetworkEgress
+import dev.tramai.core.policy.RiskLevel
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.catchThrowable
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+
+class SovereignAiToolScanningTest {
+
+    private val governedToolProperties = arrayOf(
+        "tramai.sovereign.allowed-models[0]=local-invoice-model",
+        "tramai.sovereign.allowed-providers[0]=local-provider",
+        "tramai.sovereign.provider-zones.local-provider=LOCAL",
+        "tramai.sovereign.models.local-invoice-model=local-provider",
+        "tramai.sovereign.allowed-tools[0]=schedule-payment",
+        "tramai.sovereign.allowed-permissions[0]=payment.schedule",
+    )
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(SovereignTramaiAutoConfiguration::class.java))
+
+    @Test
+    fun `governed AiTool method is discovered and callable through sovereign runtime`() {
+        contextRunner
+            .withUserConfiguration(
+                ProviderConfiguration::class.java,
+                GovernedAnnotatedToolConfiguration::class.java,
+            )
+            .withPropertyValues(*governedToolProperties)
+            .run { context ->
+                val runtime = context.getBean(dev.tramai.sovereign.SovereignTramaiRuntime::class.java)
+                val service = runtime.create(SingleToolInvoiceAi::class)
+
+                val result = runBlocking { service.analyze("inv-101") }
+
+                assertThat(result).isEqualTo("FINAL_OK")
+                val toolBean = context.getBean(GovernedAnnotatedPaymentTool::class.java)
+                assertThat(toolBean.executions)
+                    .containsExactly(SchedulePaymentInput("inv-101", 100))
+            }
+    }
+
+    @Test
+    fun `legacy AiTool without governance metadata remains denied by sovereign policy`() {
+        contextRunner
+            .withUserConfiguration(
+                ProviderConfiguration::class.java,
+                LegacyAnnotatedToolConfiguration::class.java,
+            )
+            .withPropertyValues(*governedToolProperties)
+            .run { context ->
+                val runtime = context.getBean(dev.tramai.sovereign.SovereignTramaiRuntime::class.java)
+                val service = runtime.create(SingleToolInvoiceAi::class)
+
+                val thrown = catchThrowable {
+                    runBlocking { service.analyze("inv-102") }
+                }
+
+                assertThat(thrown).isInstanceOf(PolicyViolationException::class.java)
+                val violation = thrown as PolicyViolationException
+                assertThat(violation.decision.reasonCode).isEqualTo("tool-metadata-missing")
+                assertThat(context.getBean(LegacyAnnotatedPaymentTool::class.java).executions).isEmpty()
+            }
+    }
+
+    @Test
+    fun `explicit and annotated tools with the same name fail loudly`() {
+        contextRunner
+            .withUserConfiguration(
+                ProviderConfiguration::class.java,
+                SingleToolConfiguration::class.java,
+                GovernedAnnotatedToolConfiguration::class.java,
+            )
+            .withPropertyValues(*governedToolProperties)
+            .run { context ->
+                assertThat(context).hasFailed()
+                assertThat(requireNotNull(context.startupFailure))
+                    .hasMessageContaining("Duplicate tool name registered")
+                    .hasMessageContaining("schedule-payment")
+            }
+    }
+}
+
+open class GovernedAnnotatedToolConfiguration {
+    @Bean
+    open fun governedAnnotatedPaymentTool(): GovernedAnnotatedPaymentTool =
+        GovernedAnnotatedPaymentTool()
+}
+
+open class GovernedAnnotatedPaymentTool {
+    val executions = mutableListOf<SchedulePaymentInput>()
+
+    @AiTool(
+        name = "schedule-payment",
+        description = "Schedules a payment for an invoice",
+        idempotent = true,
+        sideEffectLevel = SideEffectLevel.WRITE,
+        permission = "payment.schedule",
+        risk = RiskLevel.LOW,
+        approval = ApprovalMode.AUTO,
+        managedNetworkEgress = ManagedNetworkEgress.DENY,
+        audit = AuditDetail.FULL,
+    )
+    open suspend fun schedulePayment(input: SchedulePaymentInput): String {
+        executions += input
+        return "PAID-${input.invoiceId}"
+    }
+}
+
+open class LegacyAnnotatedToolConfiguration {
+    @Bean
+    open fun legacyAnnotatedPaymentTool(): LegacyAnnotatedPaymentTool =
+        LegacyAnnotatedPaymentTool()
+}
+
+open class LegacyAnnotatedPaymentTool {
+    val executions = mutableListOf<SchedulePaymentInput>()
+
+    @AiTool(
+        name = "schedule-payment",
+        description = "Legacy annotation without governance metadata",
+        idempotent = true,
+        sideEffectLevel = SideEffectLevel.WRITE,
+    )
+    open suspend fun schedulePayment(input: SchedulePaymentInput): String {
+        executions += input
+        return "PAID-${input.invoiceId}"
+    }
+}

--- a/tramai-spring-core/src/main/kotlin/dev/tramai/spring/AiToolScanner.kt
+++ b/tramai-spring-core/src/main/kotlin/dev/tramai/spring/AiToolScanner.kt
@@ -1,9 +1,10 @@
 package dev.tramai.spring
 
 import dev.tramai.core.annotations.AiTool
-import dev.tramai.core.model.TramaiTool
 import dev.tramai.core.model.SideEffectLevel
 import dev.tramai.core.model.ToolExecutionContext
+import dev.tramai.core.model.TramaiTool
+import dev.tramai.core.policy.ToolSecurityMetadata
 import org.springframework.aop.support.AopUtils
 import org.springframework.beans.factory.ListableBeanFactory
 import org.springframework.context.ApplicationContext
@@ -105,6 +106,7 @@ object AiToolScanner {
         }
 
         val toolName = annotation.name.takeIf { it.isNotBlank() } ?: function.name
+        val security = resolveSecurityMetadata(beanName, function.name, annotation)
 
         return MethodBackedTramaiTool(
             bean = bean,
@@ -113,7 +115,34 @@ object AiToolScanner {
             description = annotation.description,
             inputType = inputType,
             idempotent = annotation.idempotent,
-            sideEffectLevel = annotation.sideEffectLevel
+            sideEffectLevel = annotation.sideEffectLevel,
+            security = security,
+        )
+    }
+
+    private fun resolveSecurityMetadata(
+        beanName: String,
+        functionName: String,
+        annotation: AiTool,
+    ): ToolSecurityMetadata? {
+        val permission = annotation.permission
+        if (permission.isEmpty()) {
+            return null
+        }
+
+        check(permission.isNotBlank()) {
+            "Tool method $functionName in bean $beanName declares a blank permission"
+        }
+        check(permission == permission.trim()) {
+            "Tool method $functionName in bean $beanName permission must not have surrounding whitespace"
+        }
+
+        return ToolSecurityMetadata(
+            permission = permission,
+            risk = annotation.risk,
+            approval = annotation.approval,
+            managedNetworkEgress = annotation.managedNetworkEgress,
+            audit = annotation.audit,
         )
     }
 
@@ -124,7 +153,8 @@ object AiToolScanner {
         override val description: String,
         override val inputType: KClass<I>,
         override val idempotent: Boolean,
-        override val sideEffectLevel: SideEffectLevel
+        override val sideEffectLevel: SideEffectLevel,
+        override val security: ToolSecurityMetadata?,
     ) : TramaiTool<I, Any> {
 
         override suspend fun execute(input: I, context: ToolExecutionContext): Any {

--- a/tramai-spring-core/src/main/kotlin/dev/tramai/spring/AiToolScanner.kt
+++ b/tramai-spring-core/src/main/kotlin/dev/tramai/spring/AiToolScanner.kt
@@ -106,7 +106,7 @@ object AiToolScanner {
         }
 
         val toolName = annotation.name.takeIf { it.isNotBlank() } ?: function.name
-        val security = resolveSecurityMetadata(beanName, function.name, annotation)
+        val security = resolveSecurityMetadata(beanName, function.name, toolName, annotation)
 
         return MethodBackedTramaiTool(
             bean = bean,
@@ -123,6 +123,7 @@ object AiToolScanner {
     private fun resolveSecurityMetadata(
         beanName: String,
         functionName: String,
+        toolName: String,
         annotation: AiTool,
     ): ToolSecurityMetadata? {
         val permission = annotation.permission
@@ -131,10 +132,10 @@ object AiToolScanner {
         }
 
         check(permission.isNotBlank()) {
-            "Tool method $functionName in bean $beanName declares a blank permission"
+            "Tool '$toolName' (method $functionName in bean $beanName) declares a blank permission"
         }
         check(permission == permission.trim()) {
-            "Tool method $functionName in bean $beanName permission must not have surrounding whitespace"
+            "Tool '$toolName' (method $functionName in bean $beanName) permission must not have surrounding whitespace"
         }
 
         return ToolSecurityMetadata(

--- a/tramai-spring-core/src/test/kotlin/dev/tramai/spring/AiToolScannerTest.kt
+++ b/tramai-spring-core/src/test/kotlin/dev/tramai/spring/AiToolScannerTest.kt
@@ -2,7 +2,12 @@ package dev.tramai.spring
 
 import dev.tramai.core.annotations.AiTool
 import dev.tramai.core.model.SideEffectLevel
+import dev.tramai.core.policy.ApprovalMode
+import dev.tramai.core.policy.AuditDetail
+import dev.tramai.core.policy.ManagedNetworkEgress
+import dev.tramai.core.policy.RiskLevel
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.springframework.aop.framework.ProxyFactory
@@ -22,6 +27,54 @@ class AiToolScannerTest {
         val toolNames = AiToolScanner.fromApplicationContext(context).map { it.name }.distinct()
 
         assertEquals(listOf("lookupInvoice"), toolNames)
+    }
+
+    @Test
+    fun `legacy ai tool annotation keeps security metadata absent`() {
+        val context = GenericApplicationContext().apply {
+            beanFactory.registerSingleton("toolBean", ToolBean())
+            refresh()
+        }
+
+        val tool = AiToolScanner.fromApplicationContext(context).single()
+
+        assertNull(tool.security)
+    }
+
+    @Test
+    fun `governed ai tool annotation maps strict security metadata`() {
+        val context = GenericApplicationContext().apply {
+            beanFactory.registerSingleton("governedToolBean", GovernedToolBean())
+            refresh()
+        }
+
+        val tool = AiToolScanner.fromApplicationContext(context).single()
+        val security = requireNotNull(tool.security)
+
+        assertEquals("invoice.read", security.permission)
+        assertEquals(RiskLevel.LOW, security.risk)
+        assertEquals(ApprovalMode.AUTO, security.approval)
+        assertEquals(ManagedNetworkEgress.DENY, security.managedNetworkEgress)
+        assertEquals(AuditDetail.FULL, security.audit)
+    }
+
+    @Test
+    fun `declared permission must not be blank or padded`() {
+        val blankContext = GenericApplicationContext().apply {
+            beanFactory.registerSingleton("blankPermissionToolBean", BlankPermissionToolBean())
+            refresh()
+        }
+        val paddedContext = GenericApplicationContext().apply {
+            beanFactory.registerSingleton("paddedPermissionToolBean", PaddedPermissionToolBean())
+            refresh()
+        }
+
+        assertThrows(IllegalStateException::class.java) {
+            AiToolScanner.fromApplicationContext(blankContext)
+        }
+        assertThrows(IllegalStateException::class.java) {
+            AiToolScanner.fromApplicationContext(paddedContext)
+        }
     }
 
     @Test
@@ -130,6 +183,29 @@ class AiToolScannerTest {
 
     open class ToolBean {
         @AiTool(description = "Looks up an invoice", sideEffectLevel = SideEffectLevel.READ_ONLY)
+        open fun lookupInvoice(input: ToolInput): String = input.invoiceId
+    }
+
+    open class GovernedToolBean {
+        @AiTool(
+            description = "Looks up a governed invoice",
+            sideEffectLevel = SideEffectLevel.READ_ONLY,
+            permission = "invoice.read",
+            risk = RiskLevel.LOW,
+            approval = ApprovalMode.AUTO,
+            managedNetworkEgress = ManagedNetworkEgress.DENY,
+            audit = AuditDetail.FULL,
+        )
+        open fun lookupInvoice(input: ToolInput): String = input.invoiceId
+    }
+
+    open class BlankPermissionToolBean {
+        @AiTool(description = "Invalid blank permission", permission = "   ")
+        open fun lookupInvoice(input: ToolInput): String = input.invoiceId
+    }
+
+    open class PaddedPermissionToolBean {
+        @AiTool(description = "Invalid padded permission", permission = " invoice.read ")
         open fun lookupInvoice(input: ToolInput): String = input.invoiceId
     }
 

--- a/tramai-spring-core/src/test/kotlin/dev/tramai/spring/AiToolScannerTest.kt
+++ b/tramai-spring-core/src/test/kotlin/dev/tramai/spring/AiToolScannerTest.kt
@@ -9,6 +9,7 @@ import dev.tramai.core.policy.RiskLevel
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.aop.framework.ProxyFactory
 import org.springframework.beans.factory.config.BeanPostProcessor
@@ -72,9 +73,10 @@ class AiToolScannerTest {
         assertThrows(IllegalStateException::class.java) {
             AiToolScanner.fromApplicationContext(blankContext)
         }
-        assertThrows(IllegalStateException::class.java) {
+        val paddedFailure = assertThrows(IllegalStateException::class.java) {
             AiToolScanner.fromApplicationContext(paddedContext)
         }
+        assertTrue(paddedFailure.message.orEmpty().contains("customPaddedTool"))
     }
 
     @Test
@@ -205,7 +207,11 @@ class AiToolScannerTest {
     }
 
     open class PaddedPermissionToolBean {
-        @AiTool(description = "Invalid padded permission", permission = " invoice.read ")
+        @AiTool(
+            name = "customPaddedTool",
+            description = "Invalid padded permission",
+            permission = " invoice.read ",
+        )
         open fun lookupInvoice(input: ToolInput): String = input.invoiceId
     }
 


### PR DESCRIPTION
Spring unification track S4 — `@AiTool` parity for the sovereign runtime.

### Summary
The sovereign runtime can now discover `@AiTool` methods, matching standard Spring discovery — but with the governance metadata sovereign policy already requires. Simply reusing the scanner would have produced fake parity: sovereign rejects `TramaiTool(security = null)` (`tool-metadata-missing`), so legacy annotation-driven tools would be discovered but denied at execution. `@AiTool` therefore gains opt-in governance metadata; empty `permission` keeps the legacy contract intact.

### What changes
- `@AiTool` (tramai-core): optional `permission`, `risk`, `approval`, `managedNetworkEgress`, `audit` with conservative defaults (`HIGH` / `HUMAN_REQUIRED` / `DENY` / `FULL`). `permission=""` produces no `ToolSecurityMetadata` — backward compatible.
- `AiToolScanner` (tramai-spring-core): maps governed annotations into strict `ToolSecurityMetadata`; rejects blank or padded permissions; retains `security = null` for legacy annotations.
- Sovereign starter: combines explicit `TramaiTool` beans with scanned `@AiTool` methods (`builder.tools(explicit + annotated)`), no Spring-side deduplication — the engine remains the single fail-loud authority for duplicate tool identities.
- Canonical `tramai-core` API dump regenerated; annotation reference and CHANGELOG updated.

### Invariants proven
- Sovereign: governed `@AiTool` discovered, executed, and routed through sovereign policy.
- Sovereign: legacy `@AiTool` without metadata still denied (`tool-metadata-missing`) — no silent acceptance.
- Sovereign: explicit `TramaiTool` + annotated tool with the same name fail loudly at the engine boundary.
- Scanner: governed metadata mapping; malformed permissions rejected; legacy behavior unchanged (existing scanner suite still green).

### Verification
- `:tramai-core:test` `:tramai-core:apiCheck` — PASSED
- `:tramai-spring-core:test` (incl. `AiToolScannerTest`) — PASSED
- `:tramai-spring-boot-starter-sovereign:test` (incl. `SovereignAiToolScanningTest`) — PASSED
- `verifyPr` — PASSED (subproject tests, build-logic tests, maintainability baseline, change policy)

### Non-claims
- No Spring-side tool deduplication is added; engine-boundary duplicate rejection is the contract.
- Standard Spring `@AiTool` runtime behavior is unchanged (empty permission remains the default).
- No `AiServiceRuntimeAdapter` SPI is introduced; the internal bean-name seam remains duplicated between spring-core and the sovereign starter by design.

This PR needs review before merge.
