### PR TITLE
test(persistence): fix probabilistic corrupted-record corruption

### DIFF
--- a/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileBackedSovereignStoresTest.kt
+++ b/tramai-persistence-file/src/test/kotlin/dev/tramai/persistence/file/FileBackedSovereignStoresTest.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.assertThrows
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.attribute.PosixFilePermissions
+import java.util.Base64
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
 import kotlin.io.path.*
@@ -223,9 +224,19 @@ class FileBackedSovereignStoresTest {
 
         val path = suspendedRecordPath(approvalId)
         val encrypted = EncryptedFileEnvelopeV1.fromJson(path.readText())
+        // Flip one byte of the ciphertext+tag so the corruption is guaranteed to
+        // change the decrypted content. String-level mutations are unreliable:
+        // depending on the trailing Base64 padding, some character replacements
+        // decode to the same significant bits (e.g. 'X' -> 'Y' under '==' padding
+        // keeps the top 2 bits), making the corruption a silent no-op. A byte
+        // flip always changes the decoded ciphertext, so GCM auth always fails.
+        val corruptedCiphertext = Base64.getDecoder().decode(encrypted.ciphertextBase64)
+            .also { it[0] = (it[0].toInt() xor 0x01).toByte() }
         Files.writeString(
             path,
-            encrypted.copy(ciphertextBase64 = encrypted.ciphertextBase64.dropLast(1) + "X").toJson(),
+            encrypted.copy(
+                ciphertextBase64 = Base64.getEncoder().encodeToString(corruptedCiphertext),
+            ).toJson(),
         )
 
         assertThrows<FileStoreCorruptionException> {


### PR DESCRIPTION
Test-only determinism fix for a pre-existing probabilistic flake in `tramai-persistence-file`.

### Summary
`FileBackedSovereignStoresTest.corrupted suspended record fails startup verification` corrupts a record via `ciphertextBase64.dropLast(1) + "X"`. When the base64 already ends with `'X'` (random key + IV per run ⇒ ~1/64 probability), the "corruption" is a byte-identical no-op: `open()` succeeds, `assertThrows<FileStoreCorruptionException>` fails with `AssertionFailedError`. This surfaced as a real RC workflow failure on PR #285 (run #518, `:tramai-persistence-file:test`, 297 tests, 1 failed) — a module S4 does not touch.

### Fix
Decode the ciphertext and flip one byte (`ciphertext[0] xor 0x01`), then re-encode. Any changed byte in ciphertext+tag makes GCM auth fail deterministically.

An initial string-level fix (flip the last base64 char, `'X'` → `'Y'`) proved insufficient: under trailing Base64 padding, some character replacements decode to the same significant bits (`'X'` and `'Y'` share the top 2 bits used with `==` padding), leaving a residual no-op — a 100-iteration fresh-key loop caught 3/100 failures. The byte-level flip has no such collision.

### Verification
- Original flake: reproduced as the RC CI failure (exact test, `AssertionFailedError` at the `assertThrows` line) and confirmed by the deterministic no-op condition in the code.
- String-level guard insufficiency: 3/100 failures in a fresh-key loop (the reason this PR uses byte-level corruption instead).
- Fixed test: 100-iteration fresh-key loop — 0 failures.
- Full module suite: `:tramai-persistence-file:test` — PASSED.

### Non-claims
- No production code change; no encryption/decryption behavior touched.
- No other corruption tests in this class share the buggy pattern (verified by grep).

This PR needs review before merge.
