### PR TITLE
refactor(spring): make EnableTramai profile-neutral

### DIFF
--- a/tramai-spring-boot-starter-sovereign/src/main/resources/META-INF/spring/dev.tramai.spring.EnableTramai.imports
+++ b/tramai-spring-boot-starter-sovereign/src/main/resources/META-INF/spring/dev.tramai.spring.EnableTramai.imports
@@ -1,0 +1,2 @@
+dev.tramai.spring.sovereign.SovereignTramaiProfileAutoConfiguration
+dev.tramai.spring.sovereign.SovereignAiServiceProxyAutoConfiguration

--- a/tramai-spring-boot-starter-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/EnableTramaiSovereignProfileTest.kt
+++ b/tramai-spring-boot-starter-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/EnableTramaiSovereignProfileTest.kt
@@ -1,0 +1,37 @@
+package dev.tramai.spring.sovereign
+
+import dev.tramai.spring.sovereign.enablefixture.SovereignEnableTramaiFixture
+import dev.tramai.spring.sovereign.enablefixture.SovereignEnableTramaiService
+import dev.tramai.sovereign.SovereignTramai
+import dev.tramai.standalone.Tramai
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.test.context.support.TestPropertySourceUtils
+
+class EnableTramaiSovereignProfileTest {
+
+    @Test
+    fun `annotation driven context activates sovereign profile and discovers AiService`() {
+        AnnotationConfigApplicationContext().use { context ->
+            TestPropertySourceUtils.addInlinedPropertiesToEnvironment(
+                context,
+                "tramai.profile=sovereign",
+                "tramai.sovereign.allowed-models[0]=local-model",
+                "tramai.sovereign.allowed-providers[0]=local-provider",
+                "tramai.sovereign.provider-zones.local-provider=LOCAL",
+                "tramai.sovereign.models.local-model=local-provider",
+            )
+            context.register(SovereignEnableTramaiFixture::class.java)
+            context.refresh()
+
+            assertNotNull(context.getBean(SovereignTramai::class.java))
+            assertNull(context.getBeanProvider(Tramai::class.java).ifAvailable)
+            val service = context.getBean(SovereignEnableTramaiService::class.java)
+            assertEquals("SOVEREIGN_ENABLE_OK", runBlocking { service.analyze("invoice") })
+        }
+    }
+}

--- a/tramai-spring-boot-starter-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/EnableTramaiSovereignProfileTest.kt
+++ b/tramai-spring-boot-starter-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/EnableTramaiSovereignProfileTest.kt
@@ -9,21 +9,28 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import org.assertj.core.api.Assertions.assertThat
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.test.context.support.TestPropertySourceUtils
 
 class EnableTramaiSovereignProfileTest {
+
+    private val sovereignProperties = arrayOf(
+        "tramai.profile=sovereign",
+        "tramai.sovereign.allowed-models[0]=local-model",
+        "tramai.sovereign.allowed-providers[0]=local-provider",
+        "tramai.sovereign.provider-zones.local-provider=LOCAL",
+        "tramai.sovereign.models.local-model=local-provider",
+    )
 
     @Test
     fun `annotation driven context activates sovereign profile and discovers AiService`() {
         AnnotationConfigApplicationContext().use { context ->
             TestPropertySourceUtils.addInlinedPropertiesToEnvironment(
                 context,
-                "tramai.profile=sovereign",
-                "tramai.sovereign.allowed-models[0]=local-model",
-                "tramai.sovereign.allowed-providers[0]=local-provider",
-                "tramai.sovereign.provider-zones.local-provider=LOCAL",
-                "tramai.sovereign.models.local-model=local-provider",
+                *sovereignProperties,
             )
             context.register(SovereignEnableTramaiFixture::class.java)
             context.refresh()
@@ -33,5 +40,31 @@ class EnableTramaiSovereignProfileTest {
             val service = context.getBean(SovereignEnableTramaiService::class.java)
             assertEquals("SOVEREIGN_ENABLE_OK", runBlocking { service.analyze("invoice") })
         }
+    }
+
+    @Test
+    fun `explicit annotation coexists with mixed classpath boot auto configuration`() {
+        val standardProfileAutoConfiguration =
+            Class.forName("dev.tramai.spring.StandardTramaiProfileAutoConfiguration")
+        val standardProxyAutoConfiguration =
+            Class.forName("dev.tramai.spring.AiServiceProxyAutoConfiguration")
+
+        ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(
+                    standardProfileAutoConfiguration,
+                    standardProxyAutoConfiguration,
+                    SovereignTramaiProfileAutoConfiguration::class.java,
+                    SovereignAiServiceProxyAutoConfiguration::class.java,
+                ),
+            )
+            .withUserConfiguration(SovereignEnableTramaiFixture::class.java)
+            .withPropertyValues(*sovereignProperties)
+            .run { context ->
+                assertThat(context).hasNotFailed()
+                assertThat(context).hasSingleBean(SovereignTramai::class.java)
+                assertThat(context).doesNotHaveBean(Tramai::class.java)
+                assertThat(context).hasSingleBean(SovereignEnableTramaiService::class.java)
+            }
     }
 }

--- a/tramai-spring-boot-starter-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/enablefixture/SovereignEnableTramaiFixture.kt
+++ b/tramai-spring-boot-starter-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/enablefixture/SovereignEnableTramaiFixture.kt
@@ -1,0 +1,32 @@
+package dev.tramai.spring.sovereign.enablefixture
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.provider.ModelProvider
+import dev.tramai.spring.EnableTramai
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration(proxyBeanMethods = false)
+@EnableTramai
+class SovereignEnableTramaiFixture {
+
+    @Bean
+    fun sovereignEnableProvider(): ModelProvider = object : ModelProvider {
+        override fun providerId(): String = "local-provider"
+
+        override suspend fun complete(request: ModelRequest): ModelResponse =
+            ModelResponse(content = "SOVEREIGN_ENABLE_OK")
+    }
+}
+
+@AiService
+interface SovereignEnableTramaiService {
+    @Operation(
+        model = "local-model",
+        prompt = "Return the sovereign profile test result.",
+    )
+    suspend fun analyze(input: String): String
+}

--- a/tramai-spring-core/src/main/kotlin/dev/tramai/spring/EnableTramai.kt
+++ b/tramai-spring-core/src/main/kotlin/dev/tramai/spring/EnableTramai.kt
@@ -1,21 +1,24 @@
 package dev.tramai.spring
 
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage
 import org.springframework.context.annotation.Import
 
 /**
- * Enables TramAI Spring integration for the standard runtime profile.
+ * Enables TramAI's Spring programming model for the active runtime profile.
  *
- * In Spring Boot applications the starter auto-configuration is normally
- * sufficient; this annotation remains an explicit opt-in for applications that
- * prefer annotation-driven configuration. It routes through the standard
- * profile gate only — sovereign `@AiService` registration requires the
- * sovereign starter's auto-configuration.
+ * In Spring Boot applications TramAI auto-configuration is normally sufficient,
+ * so this annotation is optional. In an annotation-driven Spring context it
+ * establishes the application package used for `@AiService` discovery and loads
+ * the TramAI profile configurations contributed by modules on the classpath.
+ *
+ * The annotation does not select a runtime profile. `tramai.profile` remains the
+ * authority: standard is the compatibility default, while the sovereign starter
+ * supplies its own Boot default and can also participate in annotation-driven
+ * contexts when `tramai.profile=sovereign` is set explicitly.
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented
-@Import(
-    StandardTramaiProfileAutoConfiguration::class,
-    AiServiceProxyAutoConfiguration::class,
-)
+@AutoConfigurationPackage
+@Import(TramaiEnableImportSelector::class)
 annotation class EnableTramai

--- a/tramai-spring-core/src/main/kotlin/dev/tramai/spring/TramaiEnableImportSelector.kt
+++ b/tramai-spring-core/src/main/kotlin/dev/tramai/spring/TramaiEnableImportSelector.kt
@@ -1,0 +1,32 @@
+package dev.tramai.spring
+
+import org.springframework.beans.factory.BeanClassLoaderAware
+import org.springframework.boot.context.annotation.ImportCandidates
+import org.springframework.context.annotation.ImportSelector
+import org.springframework.core.type.AnnotationMetadata
+
+/**
+ * Loads the TramAI configurations contributed to [EnableTramai] by modules on
+ * the application classpath.
+ *
+ * Contributions use Spring Boot's imports convention under
+ * `META-INF/spring/dev.tramai.spring.EnableTramai.imports`. This keeps the
+ * annotation profile-neutral: spring-core contributes the standard profile,
+ * while optional modules such as the sovereign starter contribute their own
+ * profile configuration without creating a compile-time dependency back into
+ * spring-core.
+ */
+internal class TramaiEnableImportSelector : ImportSelector, BeanClassLoaderAware {
+
+    private lateinit var beanClassLoader: ClassLoader
+
+    override fun setBeanClassLoader(classLoader: ClassLoader) {
+        beanClassLoader = classLoader
+    }
+
+    override fun selectImports(importingClassMetadata: AnnotationMetadata): Array<String> =
+        ImportCandidates.load(EnableTramai::class.java, beanClassLoader)
+            .candidates
+            .distinct()
+            .toTypedArray()
+}

--- a/tramai-spring-core/src/main/kotlin/dev/tramai/spring/TramaiEnableImportSelector.kt
+++ b/tramai-spring-core/src/main/kotlin/dev/tramai/spring/TramaiEnableImportSelector.kt
@@ -3,7 +3,7 @@ package dev.tramai.spring
 import org.springframework.beans.factory.BeanClassLoaderAware
 import org.springframework.boot.context.annotation.ImportCandidates
 import org.springframework.context.EnvironmentAware
-import org.springframework.context.annotation.ImportSelector
+import org.springframework.context.annotation.DeferredImportSelector
 import org.springframework.core.env.Environment
 import org.springframework.core.type.AnnotationMetadata
 
@@ -17,9 +17,14 @@ import org.springframework.core.type.AnnotationMetadata
  * while optional modules such as the sovereign starter contribute their own
  * profile configuration without creating a compile-time dependency back into
  * spring-core.
+ *
+ * Imports are deferred so application `@Bean` definitions are registered before
+ * TramAI auto-configuration conditions are evaluated. This preserves the same
+ * lifecycle assumption as Spring Boot auto-configuration (for example,
+ * sovereign runtime creation is conditional on an application ModelProvider).
  */
 internal class TramaiEnableImportSelector :
-    ImportSelector,
+    DeferredImportSelector,
     BeanClassLoaderAware,
     EnvironmentAware {
 

--- a/tramai-spring-core/src/main/kotlin/dev/tramai/spring/TramaiEnableImportSelector.kt
+++ b/tramai-spring-core/src/main/kotlin/dev/tramai/spring/TramaiEnableImportSelector.kt
@@ -2,7 +2,9 @@ package dev.tramai.spring
 
 import org.springframework.beans.factory.BeanClassLoaderAware
 import org.springframework.boot.context.annotation.ImportCandidates
+import org.springframework.context.EnvironmentAware
 import org.springframework.context.annotation.ImportSelector
+import org.springframework.core.env.Environment
 import org.springframework.core.type.AnnotationMetadata
 
 /**
@@ -16,17 +18,30 @@ import org.springframework.core.type.AnnotationMetadata
  * profile configuration without creating a compile-time dependency back into
  * spring-core.
  */
-internal class TramaiEnableImportSelector : ImportSelector, BeanClassLoaderAware {
+internal class TramaiEnableImportSelector :
+    ImportSelector,
+    BeanClassLoaderAware,
+    EnvironmentAware {
 
     private lateinit var beanClassLoader: ClassLoader
+    private lateinit var environment: Environment
 
     override fun setBeanClassLoader(classLoader: ClassLoader) {
         beanClassLoader = classLoader
     }
 
-    override fun selectImports(importingClassMetadata: AnnotationMetadata): Array<String> =
-        ImportCandidates.load(EnableTramai::class.java, beanClassLoader)
+    override fun setEnvironment(environment: Environment) {
+        this.environment = environment
+    }
+
+    override fun selectImports(importingClassMetadata: AnnotationMetadata): Array<String> {
+        TramaiRuntimeProfileSupport.validate(
+            environment.getProperty(TramaiRuntimeProfileSupport.PROPERTY_NAME),
+        )
+
+        return ImportCandidates.load(EnableTramai::class.java, beanClassLoader)
             .candidates
             .distinct()
             .toTypedArray()
+    }
 }

--- a/tramai-spring-core/src/main/kotlin/dev/tramai/spring/TramaiRuntimeProfileEnvironmentPostProcessor.kt
+++ b/tramai-spring-core/src/main/kotlin/dev/tramai/spring/TramaiRuntimeProfileEnvironmentPostProcessor.kt
@@ -1,0 +1,27 @@
+package dev.tramai.spring
+
+import org.springframework.boot.SpringApplication
+import org.springframework.boot.env.EnvironmentPostProcessor
+import org.springframework.core.Ordered
+import org.springframework.core.env.ConfigurableEnvironment
+
+/**
+ * Fails Spring Boot startup early when `tramai.profile` contains an unsupported
+ * value. Missing profile remains valid because profile modules own their
+ * compatibility defaults.
+ */
+internal class TramaiRuntimeProfileEnvironmentPostProcessor :
+    EnvironmentPostProcessor,
+    Ordered {
+
+    override fun postProcessEnvironment(
+        environment: ConfigurableEnvironment,
+        application: SpringApplication,
+    ) {
+        TramaiRuntimeProfileSupport.validate(
+            environment.getProperty(TramaiRuntimeProfileSupport.PROPERTY_NAME),
+        )
+    }
+
+    override fun getOrder(): Int = Ordered.LOWEST_PRECEDENCE
+}

--- a/tramai-spring-core/src/main/kotlin/dev/tramai/spring/TramaiRuntimeProfileSupport.kt
+++ b/tramai-spring-core/src/main/kotlin/dev/tramai/spring/TramaiRuntimeProfileSupport.kt
@@ -9,7 +9,7 @@ internal object TramaiRuntimeProfileSupport {
         if (configuredProfile == null) {
             return
         }
-        require(configuredProfile in supportedProfiles) {
+        require(configuredProfile.lowercase() in supportedProfiles) {
             "Unsupported tramai.profile '$configuredProfile'. Supported values: ${supportedProfiles.joinToString(", ")}."
         }
     }

--- a/tramai-spring-core/src/main/kotlin/dev/tramai/spring/TramaiRuntimeProfileSupport.kt
+++ b/tramai-spring-core/src/main/kotlin/dev/tramai/spring/TramaiRuntimeProfileSupport.kt
@@ -1,0 +1,16 @@
+package dev.tramai.spring
+
+internal object TramaiRuntimeProfileSupport {
+    const val PROPERTY_NAME: String = "tramai.profile"
+
+    private val supportedProfiles = linkedSetOf("standard", "sovereign")
+
+    fun validate(configuredProfile: String?) {
+        if (configuredProfile == null) {
+            return
+        }
+        require(configuredProfile in supportedProfiles) {
+            "Unsupported tramai.profile '$configuredProfile'. Supported values: ${supportedProfiles.joinToString(", ")}."
+        }
+    }
+}

--- a/tramai-spring-core/src/main/resources/META-INF/spring.factories
+++ b/tramai-spring-core/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.env.EnvironmentPostProcessor=\
+dev.tramai.spring.TramaiRuntimeProfileEnvironmentPostProcessor

--- a/tramai-spring-core/src/main/resources/META-INF/spring/dev.tramai.spring.EnableTramai.imports
+++ b/tramai-spring-core/src/main/resources/META-INF/spring/dev.tramai.spring.EnableTramai.imports
@@ -1,0 +1,2 @@
+dev.tramai.spring.StandardTramaiProfileAutoConfiguration
+dev.tramai.spring.AiServiceProxyAutoConfiguration

--- a/tramai-spring-core/src/test/kotlin/dev/tramai/spring/EnableTramaiProfileNeutralTest.kt
+++ b/tramai-spring-core/src/test/kotlin/dev/tramai/spring/EnableTramaiProfileNeutralTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.test.context.support.TestPropertySourceUtils
 
@@ -27,5 +28,23 @@ class EnableTramaiProfileNeutralTest {
             val service = context.getBean(StandardEnableTramaiService::class.java)
             assertEquals("STANDARD_ENABLE_OK", runBlocking { service.analyze("invoice") })
         }
+    }
+
+    @Test
+    fun `annotation driven context rejects unsupported runtime profile`() {
+        assertThatThrownBy {
+            AnnotationConfigApplicationContext().use { context ->
+                TestPropertySourceUtils.addInlinedPropertiesToEnvironment(
+                    context,
+                    "tramai.profile=soveriegn",
+                )
+                context.register(StandardEnableTramaiFixture::class.java)
+                context.refresh()
+            }
+        }
+            .hasRootCauseInstanceOf(IllegalArgumentException::class.java)
+            .hasRootCauseMessage(
+                "Unsupported tramai.profile 'soveriegn'. Supported values: standard, sovereign.",
+            )
     }
 }

--- a/tramai-spring-core/src/test/kotlin/dev/tramai/spring/EnableTramaiProfileNeutralTest.kt
+++ b/tramai-spring-core/src/test/kotlin/dev/tramai/spring/EnableTramaiProfileNeutralTest.kt
@@ -7,7 +7,10 @@ import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.test.context.support.TestPropertySourceUtils
 
@@ -28,6 +31,27 @@ class EnableTramaiProfileNeutralTest {
             val service = context.getBean(StandardEnableTramaiService::class.java)
             assertEquals("STANDARD_ENABLE_OK", runBlocking { service.analyze("invoice") })
         }
+    }
+
+    @Test
+    fun `explicit annotation coexists with boot auto configuration`() {
+        ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(
+                    StandardTramaiProfileAutoConfiguration::class.java,
+                    AiServiceProxyAutoConfiguration::class.java,
+                ),
+            )
+            .withUserConfiguration(StandardEnableTramaiFixture::class.java)
+            .withPropertyValues(
+                "tramai.models.local-model=local-provider",
+                "tramai.default-provider=local-provider",
+            )
+            .run { context ->
+                assertThat(context).hasNotFailed()
+                assertThat(context).hasSingleBean(Tramai::class.java)
+                assertThat(context).hasSingleBean(StandardEnableTramaiService::class.java)
+            }
     }
 
     @Test

--- a/tramai-spring-core/src/test/kotlin/dev/tramai/spring/EnableTramaiProfileNeutralTest.kt
+++ b/tramai-spring-core/src/test/kotlin/dev/tramai/spring/EnableTramaiProfileNeutralTest.kt
@@ -66,8 +66,8 @@ class EnableTramaiProfileNeutralTest {
                 context.refresh()
             }
         }
-            .hasRootCauseInstanceOf(IllegalArgumentException::class.java)
-            .hasRootCauseMessage(
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage(
                 "Unsupported tramai.profile 'soveriegn'. Supported values: standard, sovereign.",
             )
     }

--- a/tramai-spring-core/src/test/kotlin/dev/tramai/spring/EnableTramaiProfileNeutralTest.kt
+++ b/tramai-spring-core/src/test/kotlin/dev/tramai/spring/EnableTramaiProfileNeutralTest.kt
@@ -1,0 +1,31 @@
+package dev.tramai.spring
+
+import dev.tramai.spring.enablefixture.StandardEnableTramaiFixture
+import dev.tramai.spring.enablefixture.StandardEnableTramaiService
+import dev.tramai.standalone.Tramai
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.test.context.support.TestPropertySourceUtils
+
+class EnableTramaiProfileNeutralTest {
+
+    @Test
+    fun `annotation driven context defaults to standard and discovers AiService`() {
+        AnnotationConfigApplicationContext().use { context ->
+            TestPropertySourceUtils.addInlinedPropertiesToEnvironment(
+                context,
+                "tramai.models.local-model=local-provider",
+                "tramai.default-provider=local-provider",
+            )
+            context.register(StandardEnableTramaiFixture::class.java)
+            context.refresh()
+
+            assertNotNull(context.getBean(Tramai::class.java))
+            val service = context.getBean(StandardEnableTramaiService::class.java)
+            assertEquals("STANDARD_ENABLE_OK", runBlocking { service.analyze("invoice") })
+        }
+    }
+}

--- a/tramai-spring-core/src/test/kotlin/dev/tramai/spring/TramaiRuntimeProfileEnvironmentPostProcessorTest.kt
+++ b/tramai-spring-core/src/test/kotlin/dev/tramai/spring/TramaiRuntimeProfileEnvironmentPostProcessorTest.kt
@@ -16,8 +16,8 @@ class TramaiRuntimeProfileEnvironmentPostProcessorTest {
     }
 
     @Test
-    fun `supported profiles remain valid`() {
-        listOf("standard", "sovereign").forEach { profile ->
+    fun `supported profiles remain valid with Boot case insensitive semantics`() {
+        listOf("standard", "sovereign", "STANDARD", "SOVEREIGN").forEach { profile ->
             val environment = StandardEnvironment().apply {
                 propertySources.addFirst(
                     MapPropertySource("test", mapOf("tramai.profile" to profile)),

--- a/tramai-spring-core/src/test/kotlin/dev/tramai/spring/TramaiRuntimeProfileEnvironmentPostProcessorTest.kt
+++ b/tramai-spring-core/src/test/kotlin/dev/tramai/spring/TramaiRuntimeProfileEnvironmentPostProcessorTest.kt
@@ -1,0 +1,43 @@
+package dev.tramai.spring
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import org.springframework.boot.SpringApplication
+import org.springframework.core.env.MapPropertySource
+import org.springframework.core.env.StandardEnvironment
+
+class TramaiRuntimeProfileEnvironmentPostProcessorTest {
+
+    private val postProcessor = TramaiRuntimeProfileEnvironmentPostProcessor()
+
+    @Test
+    fun `missing profile remains valid`() {
+        postProcessor.postProcessEnvironment(StandardEnvironment(), SpringApplication())
+    }
+
+    @Test
+    fun `supported profiles remain valid`() {
+        listOf("standard", "sovereign").forEach { profile ->
+            val environment = StandardEnvironment().apply {
+                propertySources.addFirst(
+                    MapPropertySource("test", mapOf("tramai.profile" to profile)),
+                )
+            }
+
+            postProcessor.postProcessEnvironment(environment, SpringApplication())
+        }
+    }
+
+    @Test
+    fun `unsupported profile fails boot environment processing`() {
+        val environment = StandardEnvironment().apply {
+            propertySources.addFirst(
+                MapPropertySource("test", mapOf("tramai.profile" to "soveriegn")),
+            )
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            postProcessor.postProcessEnvironment(environment, SpringApplication())
+        }
+    }
+}

--- a/tramai-spring-core/src/test/kotlin/dev/tramai/spring/enablefixture/StandardEnableTramaiFixture.kt
+++ b/tramai-spring-core/src/test/kotlin/dev/tramai/spring/enablefixture/StandardEnableTramaiFixture.kt
@@ -1,0 +1,32 @@
+package dev.tramai.spring.enablefixture
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.provider.ModelProvider
+import dev.tramai.spring.EnableTramai
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration(proxyBeanMethods = false)
+@EnableTramai
+class StandardEnableTramaiFixture {
+
+    @Bean
+    fun standardEnableProvider(): ModelProvider = object : ModelProvider {
+        override fun providerId(): String = "local-provider"
+
+        override suspend fun complete(request: ModelRequest): ModelResponse =
+            ModelResponse(content = "STANDARD_ENABLE_OK")
+    }
+}
+
+@AiService
+interface StandardEnableTramaiService {
+    @Operation(
+        model = "local-model",
+        prompt = "Return the standard profile test result.",
+    )
+    suspend fun analyze(input: String): String
+}


### PR DESCRIPTION
Spring unification track S5 — `@EnableTramai` / Spring UX cleanup.

### Problem
After S2-S4 the Boot auto-configuration path is profile-safe, but `@EnableTramai` still imports the standard profile directly and annotation-only Spring contexts have no `AutoConfigurationPackages` scan root. As a result the annotation is semantically standard-biased and cannot provide the same `@AiService` programming model for the sovereign starter outside Boot. Explicit invalid `tramai.profile` values can also make all profile gates back off without an early configuration error.

### What changes
- `@EnableTramai` becomes profile-neutral and uses a classpath-contributed import selector rather than importing standard configuration directly.
- `@AutoConfigurationPackage` establishes the annotated application's package as the `@AiService` scan root in annotation-driven Spring contexts.
- `tramai-spring-core` contributes the standard profile + proxy via `META-INF/spring/dev.tramai.spring.EnableTramai.imports`.
- the sovereign starter contributes its sovereign profile + proxy through the same imports resource, preserving spring-core → sovereign dependency isolation.
- explicit unsupported `tramai.profile` values fail early. Boot validates through an `EnvironmentPostProcessor`; annotation-only contexts validate through the import selector. Missing profile remains valid and existing compatibility defaults are unchanged.

### Invariants covered
- annotation-only, missing profile → standard `Tramai`, scanned/injectable `@AiService`.
- annotation-only + sovereign starter + `tramai.profile=sovereign` → `SovereignTramai`, no plain `Tramai`, same scanned/injectable `@AiService`.
- explicit `@EnableTramai` coexists with Boot auto-configuration without duplicate runtime/service registration in both standard and mixed sovereign classpaths.
- unsupported profile values fail instead of silently producing no runtime.
- spring-core has no compile-time dependency on sovereign types.

### Compatibility
- Spring Boot still does not require `@EnableTramai`; normal auto-configuration remains the preferred happy path.
- missing profile remains standard for generic Spring integration.
- the sovereign starter's existing Boot `EnvironmentPostProcessor` still supplies the low-precedence sovereign default.
- annotation-only non-Boot sovereign usage requires explicit `tramai.profile=sovereign` because Boot environment post-processors are not part of that lifecycle.

### Non-claims
- no unified starter/module graph change; that is S6.
- no runtime policy, `@AiTool`, or `@AiService` proxy semantics change.
- no new public runtime SPI.

This PR targets `track/0.6.0-spring-unification` and must pass review + fresh CI/RC before merge.