### PR TITLE
test(spring): lock unified profile compatibility contract

### DIFF
--- a/docs/guides/sovereign-runtime-quickstart.md
+++ b/docs/guides/sovereign-runtime-quickstart.md
@@ -62,6 +62,8 @@ dependencies {
 
 ## Minimal configuration
 
+Sovereignty is **configuration, not code**: use the same unified starter as standard applications, then select the sovereign runtime with `tramai.profile: sovereign`. The application code (`@AiService` interfaces, constructor injection, `@AiTool` methods) does not change between profiles.
+
 Enable the Sovereign Runtime and its subsystems in `application.yml`:
 
 ```yaml

--- a/docs/guides/spring-boot.md
+++ b/docs/guides/spring-boot.md
@@ -1,17 +1,17 @@
 # Spring Boot Integration
 
-Use `tramai-spring` when you want Tramai service interfaces injected as Spring beans.
+Use `tramai-spring-boot-starter` when you want Tramai service interfaces injected as Spring beans. One starter covers both runtime profiles — standard and sovereign; the profile is selected with `tramai.profile`, never with a different dependency or annotation.
 
 ## Quick Start
 
-Add the module to your app and configure at least one provider.
+Add the starter to your app and configure at least one provider.
 
 ### Gradle
 
 ```kotlin
 dependencies {
     implementation(platform("dev.tramai:tramai-bom:0.5.0"))
-    implementation("dev.tramai:tramai-spring")
+    implementation("dev.tramai:tramai-spring-boot-starter")
     implementation("dev.tramai:tramai-openai")
 }
 ```
@@ -34,7 +34,7 @@ dependencies {
 <dependencies>
   <dependency>
     <groupId>dev.tramai</groupId>
-    <artifactId>tramai-spring</artifactId>
+    <artifactId>tramai-spring-boot-starter</artifactId>
   </dependency>
   <dependency>
     <groupId>dev.tramai</groupId>
@@ -78,11 +78,84 @@ tramai:
 
 That is the core Spring model:
 
-1. add `tramai-spring`
+1. add `tramai-spring-boot-starter`
 2. add one provider module
 3. define an `@AiService`
 4. configure `tramai.*`
 5. inject the interface like a normal bean
+
+## Runtime profiles
+
+`tramai.profile` selects the runtime; the application code is identical for both profiles.
+
+| `tramai.profile` | Runtime | Guarantees |
+|---|---|---|
+| *(missing)* | standard | configurable/general runtime behavior |
+| `standard` / `STANDARD` | standard | configurable/general runtime behavior |
+| `sovereign` / `SOVEREIGN` | sovereign | fail-closed governed execution, provider/model constraints, tool metadata enforcement |
+
+- Missing profile defaults to **standard**. There is no implicit sovereign selection.
+- Values are case-insensitive; any other value fails loudly at startup (e.g. `tramai.profile=soveriegn`).
+- Exactly one runtime authority is ever active — never both.
+
+### Sovereign
+
+```yaml
+tramai:
+  profile: sovereign
+  sovereign:
+    allowed-models:
+      - local-model
+    allowed-providers:
+      - local-provider
+    provider-zones:
+      local-provider: LOCAL
+    models:
+      local-model: local-provider
+```
+
+Your business code does not need a sovereign version. Sovereignty is selected at the runtime boundary — the same `@AiService` interfaces, the same constructor injection, the same `@AiTool` methods. Governance becomes stricter, the programming model does not change. See the [Sovereign Runtime Quickstart](sovereign-runtime-quickstart.md).
+
+### `@EnableTramai`
+
+- Under Spring Boot, `@EnableTramai` is **normally unnecessary** — auto-configuration discovers Tramai automatically.
+- In annotation-driven / non-Boot Spring contexts it is a useful explicit opt-in.
+- It selects the Spring programming model, **not** the runtime profile. The runtime profile is always `tramai.profile`. Explicit `@EnableTramai` coexists with Boot auto-configuration without duplicate beans.
+
+## Module responsibilities
+
+| Artifact | Purpose | Typical direct dependency? |
+|---|---|---|
+| `tramai-spring-boot-starter` | Canonical Boot starter for both profiles | **Yes** |
+| `tramai-spring-core` | Shared/standard Spring integration | Usually transitive |
+| `tramai-spring-sovereign` | Sovereign Spring runtime integration | Usually transitive |
+
+Depend on `tramai-spring-boot-starter`. Do not manually compose core + sovereign unless you have an advanced reason.
+
+## Migrating from `tramai-spring-boot-starter-sovereign`
+
+The standalone sovereign starter was removed in 0.6.0. To migrate:
+
+```kotlin
+// Before
+implementation("dev.tramai:tramai-spring-boot-starter-sovereign:<version>")
+
+// After
+implementation("dev.tramai:tramai-spring-boot-starter:<version>")
+```
+
+plus:
+
+```yaml
+tramai:
+  profile: sovereign
+```
+
+What changed:
+
+- **Implicit sovereign selection was removed** — `tramai.profile=sovereign` is now explicit; without it the app runs standard.
+- Packages/classes in `dev.tramai.spring.sovereign` remain the sovereign integration; no application code rewrite is needed for ordinary `@AiService` / `@AiTool` usage.
+- No compatibility code is provided — the unified starter is the single canonical path.
 
 ## YAML Configuration
 

--- a/docs/guides/spring-boot.md
+++ b/docs/guides/spring-boot.md
@@ -10,7 +10,7 @@ Add the starter to your app and configure at least one provider.
 
 ```kotlin
 dependencies {
-    implementation(platform("dev.tramai:tramai-bom:0.5.0"))
+    implementation(platform("dev.tramai:tramai-bom:0.6.0"))
     implementation("dev.tramai:tramai-spring-boot-starter")
     implementation("dev.tramai:tramai-openai")
 }
@@ -24,7 +24,7 @@ dependencies {
     <dependency>
       <groupId>dev.tramai</groupId>
       <artifactId>tramai-bom</artifactId>
-      <version>0.5.0</version>
+      <version>0.6.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/docs/guides/spring-boot.md
+++ b/docs/guides/spring-boot.md
@@ -10,7 +10,7 @@ Add the starter to your app and configure at least one provider.
 
 ```kotlin
 dependencies {
-    implementation(platform("dev.tramai:tramai-bom:0.6.0"))
+    implementation(platform("dev.tramai:tramai-bom:<version>"))
     implementation("dev.tramai:tramai-spring-boot-starter")
     implementation("dev.tramai:tramai-openai")
 }
@@ -24,7 +24,7 @@ dependencies {
     <dependency>
       <groupId>dev.tramai</groupId>
       <artifactId>tramai-bom</artifactId>
-      <version>0.6.0</version>
+      <version><version></version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/docs/guides/spring-boot.md
+++ b/docs/guides/spring-boot.md
@@ -24,7 +24,7 @@ dependencies {
     <dependency>
       <groupId>dev.tramai</groupId>
       <artifactId>tramai-bom</artifactId>
-      <version><version></version>
+      <version>TRAMAI_VERSION</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/docs/module-guide.md
+++ b/docs/module-guide.md
@@ -155,7 +155,8 @@ dependencies {
 | Module | Purpose | When to use |
 |--------|---------|-------------|
 | `tramai-standalone` | Framework-free entry point via `Tramai.builder()`. | CLI tools, library code, Ktor, http4k, plain Kotlin. |
-| `tramai-spring` | Spring Boot auto-configuration (`@EnableTramai`). | Spring Boot 3.x applications. |
+| `tramai-spring-boot-starter` | Canonical Spring Boot starter: one programming model, two runtime profiles (`tramai.profile`). | Spring Boot 3.x applications — standard or sovereign. |
+| `tramai-spring` | Legacy Spring facade over `tramai-spring-core` (pre-0.6.0 coordinate). | Existing 0.5.x Spring applications; new apps should use the unified starter. |
 
 ### Platform Modules
 

--- a/docs/modules/tramai-spring.md
+++ b/docs/modules/tramai-spring.md
@@ -13,7 +13,9 @@
 
 ### What
 
-`tramai-spring` is a thin Spring Boot `@AutoConfiguration` that takes the same `Tramai` runtime you'd build manually with `tramai-standalone` and makes it available through Spring's DI container. Add the dependency, annotate your application class with `@EnableTramai`, define an `@AiService` interface, and it becomes an injectable bean — no `@Bean` factory methods, no manual `Tramai.builder()` chains.
+`tramai-spring` is the 0.6.0 compatibility facade over `tramai-spring-core`. New applications should depend on the canonical [`tramai-spring-boot-starter`](sovereign-runtime-module-matrix.md) instead — one starter for both runtime profiles, profile selected via `tramai.profile`.
+
+`tramai-spring` is a thin Spring Boot `@AutoConfiguration` that takes the same `Tramai` runtime you'd build manually with `tramai-standalone` and makes it available through Spring's DI container. Add the dependency, define an `@AiService` interface, and it becomes an injectable bean — no `@Bean` factory methods, no manual `Tramai.builder()` chains. Under Spring Boot, `@EnableTramai` is normally unnecessary; in annotation-driven/non-Boot Spring contexts it is the explicit opt-in.
 
 ### Why
 
@@ -109,7 +111,6 @@ dependencies {
 
 ```kotlin
 @SpringBootApplication
-@EnableTramai
 class InvoiceApplication
 
 fun main() = runApplication<InvoiceApplication>()
@@ -284,7 +285,7 @@ The module is activated by either:
 1. `@EnableTramai` — a meta-annotation that `@Import(TramaiAutoConfiguration::class)`, allowing explicit opt-in
 2. Spring Boot's automatic `@AutoConfiguration` discovery via `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`
 
-`@EnableTramai` exists as an explicit signal — even though Spring Boot would auto-discover the configuration class — to make the dependency visible in code, matching the principle of explicitness over magic.
+`@EnableTramai` selects the Spring programming model, **not** the runtime profile. The runtime profile is always selected via `tramai.profile` (missing → standard, `sovereign` → sovereign). Under Spring Boot the annotation is normally unnecessary — auto-discovery already activates the module; it remains useful in annotation-driven/non-Boot Spring contexts as an explicit signal, matching the principle of explicitness over magic.
 
 ### Bean registration flow
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -18,6 +18,7 @@ tramai:
 
 Top-level keys:
 
+- `profile`
 - `default-provider`
 - `models`
 - `fallbacks`
@@ -26,6 +27,20 @@ Top-level keys:
 - `cache`
 - `secrets`
 - `providers`
+
+### `tramai.profile`
+
+Selects the active runtime profile.
+
+| Value | Runtime |
+|---|---|
+| *(missing)* | standard (default) |
+| `standard` / `STANDARD` | standard |
+| `sovereign` / `SOVEREIGN` | sovereign |
+
+- Values are case-insensitive.
+- Any other value fails loudly at startup — there is never a silent fallback to a runtime.
+- Exactly one runtime authority is active; `standard` and `sovereign` never coexist.
 
 Runtime and platform modules add their own namespaces:
 

--- a/tramai-spring-boot-starter/src/test/kotlin/dev/tramai/spring/compatibility/SpringRuntimeProfileCompatibilityContract.kt
+++ b/tramai-spring-boot-starter/src/test/kotlin/dev/tramai/spring/compatibility/SpringRuntimeProfileCompatibilityContract.kt
@@ -1,0 +1,150 @@
+package dev.tramai.spring.compatibility
+
+import dev.tramai.spring.compatibilityfixture.TckAiService
+import dev.tramai.spring.compatibilityfixture.TckCompatibilityFixture
+import dev.tramai.spring.compatibilityfixture.TckConsumer
+import dev.tramai.spring.compatibilityfixture.TckEnableTramaiFixture
+import dev.tramai.spring.AiToolScanner
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.springframework.beans.factory.support.BeanDefinitionRegistry
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.ConfigurableApplicationContext
+
+/**
+ * One runtime profile's view of the compatibility contract: which authority
+ * beans must/must not exist and which runtime configuration to apply.
+ */
+internal data class RuntimeProfileHarness(
+    val displayName: String,
+    val profileProperty: String,
+    val runtimeType: Class<*>,
+    val forbiddenRuntimeType: Class<*>,
+    val sovereignRuntimeType: Class<*>?,
+    val properties: Array<String>,
+)
+
+/**
+ * Reusable S7 compatibility contract: proves that the standard and sovereign
+ * runtime profiles expose the SAME application-facing Spring programming
+ * model.
+ *
+ * One application fixture ([TckCompatibilityFixture]) runs under each profile
+ * harness; only `tramai.profile` and runtime configuration change.
+ *
+ * The contract is profile-NEUTRAL. It does NOT assert equal security
+ * outcomes — sovereign intentionally enforces stricter guarantees. Profile-
+ * specific governance enforcement stays in the sovereign module tests
+ * (e.g. SovereignAiToolScanningTest).
+ *
+ * Follows the repository TCK convention (StructuredOutputContractTck):
+ * an internal contract class executed by a thin JUnit driver per
+ * implementation — here, per runtime profile.
+ */
+internal class SpringRuntimeProfileCompatibilityContract(
+    private val harness: RuntimeProfileHarness,
+) {
+
+    private val unifiedAutoConfigurations = AutoConfigurations.of(
+        Class.forName("dev.tramai.spring.StandardTramaiProfileAutoConfiguration"),
+        Class.forName("dev.tramai.spring.AiServiceProxyAutoConfiguration"),
+        Class.forName("dev.tramai.spring.sovereign.SovereignTramaiProfileAutoConfiguration"),
+        Class.forName("dev.tramai.spring.sovereign.SovereignAiServiceProxyAutoConfiguration"),
+    )
+
+    fun verify() {
+        verifyPlainBootFixture()
+        verifyExplicitEnableTramaiFixture()
+    }
+
+    /** Canonical Boot experience: @SpringBootApplication-equivalent fixture, no @EnableTramai. */
+    private fun verifyPlainBootFixture() {
+        ApplicationContextRunner()
+            .withConfiguration(unifiedAutoConfigurations)
+            .withUserConfiguration(TckCompatibilityFixture::class.java)
+            .withInitializer(::registerFixturePackage)
+            .withPropertyValues(harness.profileProperty, *harness.properties)
+            .run { context ->
+                assertThat(context).hasNotFailed()
+
+                // Runtime authority: exactly one, never both.
+                verifyRuntimeAuthority(context)
+
+                // @AiService discovery + injection + invocation.
+                assertThat(context).hasSingleBean(TckAiService::class.java)
+                val service = context.getBean(TckAiService::class.java)
+                assertThat(runBlocking { service.analyze("invoice") }).isEqualTo("TCK_OK")
+
+                // Named AiService creator: present and functional.
+                assertThat(context.getBeanFactory().containsBean("tramaiAiServiceCreator")).isTrue()
+                assertThat(context.getBean("tramaiAiServiceCreator")).isNotNull()
+
+                // Constructor injection into application code under both profiles.
+                val consumer = context.getBean(TckConsumer::class.java)
+                assertThat(consumer.invokeAi("invoice")).isEqualTo("TCK_OK")
+
+                // @AiTool discovery parity at the programming-model level.
+                verifyToolDiscovery(context)
+            }
+    }
+
+    /** Explicit @EnableTramai must coexist with Boot auto-config without duplicates. */
+    private fun verifyExplicitEnableTramaiFixture() {
+        ApplicationContextRunner()
+            .withConfiguration(unifiedAutoConfigurations)
+            .withUserConfiguration(TckEnableTramaiFixture::class.java)
+            .withInitializer(::registerFixturePackage)
+            .withPropertyValues(harness.profileProperty, *harness.properties)
+            .run { context ->
+                assertThat(context).hasNotFailed()
+                verifyRuntimeAuthority(context)
+                assertThat(context).hasSingleBean(TckAiService::class.java)
+                // A duplicate creator bean name would fail context startup;
+                // the named creator contract therefore holds iff startup succeeds
+                // and the bean is resolvable.
+                assertThat(context.getBeanFactory().containsBean("tramaiAiServiceCreator")).isTrue()
+                assertThat(context.getBean("tramaiAiServiceCreator")).isNotNull()
+            }
+    }
+
+    private fun verifyRuntimeAuthority(context: AssertableApplicationContext) {
+        assertThat(context).hasSingleBean(harness.runtimeType)
+        assertThat(context).doesNotHaveBean(harness.forbiddenRuntimeType)
+        harness.sovereignRuntimeType?.let { sovereignRuntimeType ->
+            assertThat(context).hasSingleBean(sovereignRuntimeType)
+        }
+    }
+
+    /**
+     * Both runtimes wire the SAME shared [AiToolScanner] at startup; asserting
+     * scanner output against the started context pins identical discovery and
+     * identical governed-metadata mapping under both profiles.
+     */
+    private fun verifyToolDiscovery(context: AssertableApplicationContext) {
+        val tools = AiToolScanner.fromApplicationContext(context)
+
+        val governed = tools.single { it.name == "tck-schedule-payment" }
+        val security = governed.security
+        assertThat(security).isNotNull()
+        security!!.let {
+            assertThat(it.permission).isEqualTo("payment.schedule")
+            assertThat(it.risk).isEqualTo(dev.tramai.core.policy.RiskLevel.LOW)
+            assertThat(it.approval).isEqualTo(dev.tramai.core.policy.ApprovalMode.AUTO)
+            assertThat(it.managedNetworkEgress).isEqualTo(dev.tramai.core.policy.ManagedNetworkEgress.DENY)
+            assertThat(it.audit).isEqualTo(dev.tramai.core.policy.AuditDetail.FULL)
+        }
+
+        val legacy = tools.single { it.name == "tck-legacy-payment" }
+        assertThat(legacy.security).isNull()
+    }
+
+    private fun registerFixturePackage(context: ConfigurableApplicationContext) {
+        AutoConfigurationPackages.register(
+            context.beanFactory as BeanDefinitionRegistry,
+            "dev.tramai.spring.compatibilityfixture",
+        )
+    }
+}

--- a/tramai-spring-boot-starter/src/test/kotlin/dev/tramai/spring/compatibility/SpringRuntimeProfileCompatibilityContract.kt
+++ b/tramai-spring-boot-starter/src/test/kotlin/dev/tramai/spring/compatibility/SpringRuntimeProfileCompatibilityContract.kt
@@ -15,15 +15,21 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.ConfigurableApplicationContext
 
 /**
- * One runtime profile's view of the compatibility contract: which authority
- * beans must/must not exist and which runtime configuration to apply.
+ * One runtime profile's view of the compatibility contract.
+ *
+ * The authority invariant is modeled explicitly for every profile:
+ * [runtimeType] must exist exactly once, every [forbiddenRuntimeTypes] must
+ * not exist at all, and every [auxiliaryRuntimeTypes] (the sovereign runtime
+ * pairing) must exist exactly once. The standard harness therefore also
+ * asserts zero `SovereignTramaiRuntime` — a regression that creates the
+ * auxiliary runtime without its authority fails the contract.
  */
 internal data class RuntimeProfileHarness(
     val displayName: String,
     val profileProperty: String,
     val runtimeType: Class<*>,
-    val forbiddenRuntimeType: Class<*>,
-    val sovereignRuntimeType: Class<*>?,
+    val forbiddenRuntimeTypes: List<Class<*>>,
+    val auxiliaryRuntimeTypes: List<Class<*>>,
     val properties: Array<String>,
 )
 
@@ -112,9 +118,11 @@ internal class SpringRuntimeProfileCompatibilityContract(
 
     private fun verifyRuntimeAuthority(context: AssertableApplicationContext) {
         assertThat(context).hasSingleBean(harness.runtimeType)
-        assertThat(context).doesNotHaveBean(harness.forbiddenRuntimeType)
-        harness.sovereignRuntimeType?.let { sovereignRuntimeType ->
-            assertThat(context).hasSingleBean(sovereignRuntimeType)
+        harness.forbiddenRuntimeTypes.forEach { forbidden ->
+            assertThat(context).doesNotHaveBean(forbidden)
+        }
+        harness.auxiliaryRuntimeTypes.forEach { auxiliary ->
+            assertThat(context).hasSingleBean(auxiliary)
         }
     }
 

--- a/tramai-spring-boot-starter/src/test/kotlin/dev/tramai/spring/compatibility/SpringRuntimeProfileCompatibilityTckTest.kt
+++ b/tramai-spring-boot-starter/src/test/kotlin/dev/tramai/spring/compatibility/SpringRuntimeProfileCompatibilityTckTest.kt
@@ -1,0 +1,54 @@
+package dev.tramai.spring.compatibility
+
+import dev.tramai.sovereign.SovereignTramai
+import dev.tramai.sovereign.SovereignTramaiRuntime
+import dev.tramai.standalone.Tramai
+import org.junit.jupiter.api.Test
+
+/**
+ * Runs the S7 profile compatibility contract against both runtime profiles.
+ *
+ * The SAME application fixture (TckCompatibilityFixture) is executed twice;
+ * the only semantic selection difference between the two runs is
+ * `tramai.profile` plus profile-specific runtime configuration. This is the
+ * key S0–S6 compatibility proof: one programming model, two runtime
+ * profiles, different guarantees.
+ */
+class SpringRuntimeProfileCompatibilityTckTest {
+
+    @Test
+    fun `standard profile conforms to the Spring compatibility contract`() {
+        SpringRuntimeProfileCompatibilityContract(
+            RuntimeProfileHarness(
+                displayName = "standard",
+                profileProperty = "tramai.profile=standard",
+                runtimeType = Tramai::class.java,
+                forbiddenRuntimeType = SovereignTramai::class.java,
+                sovereignRuntimeType = null,
+                properties = arrayOf(
+                    "tramai.models.local-model=local-provider",
+                    "tramai.default-provider=local-provider",
+                ),
+            ),
+        ).verify()
+    }
+
+    @Test
+    fun `sovereign profile conforms to the Spring compatibility contract`() {
+        SpringRuntimeProfileCompatibilityContract(
+            RuntimeProfileHarness(
+                displayName = "sovereign",
+                profileProperty = "tramai.profile=sovereign",
+                runtimeType = SovereignTramai::class.java,
+                forbiddenRuntimeType = Tramai::class.java,
+                sovereignRuntimeType = SovereignTramaiRuntime::class.java,
+                properties = arrayOf(
+                    "tramai.sovereign.allowed-models[0]=local-model",
+                    "tramai.sovereign.allowed-providers[0]=local-provider",
+                    "tramai.sovereign.provider-zones.local-provider=LOCAL",
+                    "tramai.sovereign.models.local-model=local-provider",
+                ),
+            ),
+        ).verify()
+    }
+}

--- a/tramai-spring-boot-starter/src/test/kotlin/dev/tramai/spring/compatibility/SpringRuntimeProfileCompatibilityTckTest.kt
+++ b/tramai-spring-boot-starter/src/test/kotlin/dev/tramai/spring/compatibility/SpringRuntimeProfileCompatibilityTckTest.kt
@@ -23,8 +23,11 @@ class SpringRuntimeProfileCompatibilityTckTest {
                 displayName = "standard",
                 profileProperty = "tramai.profile=standard",
                 runtimeType = Tramai::class.java,
-                forbiddenRuntimeType = SovereignTramai::class.java,
-                sovereignRuntimeType = null,
+                forbiddenRuntimeTypes = listOf(
+                    SovereignTramai::class.java,
+                    SovereignTramaiRuntime::class.java,
+                ),
+                auxiliaryRuntimeTypes = emptyList(),
                 properties = arrayOf(
                     "tramai.models.local-model=local-provider",
                     "tramai.default-provider=local-provider",
@@ -40,8 +43,8 @@ class SpringRuntimeProfileCompatibilityTckTest {
                 displayName = "sovereign",
                 profileProperty = "tramai.profile=sovereign",
                 runtimeType = SovereignTramai::class.java,
-                forbiddenRuntimeType = Tramai::class.java,
-                sovereignRuntimeType = SovereignTramaiRuntime::class.java,
+                forbiddenRuntimeTypes = listOf(Tramai::class.java),
+                auxiliaryRuntimeTypes = listOf(SovereignTramaiRuntime::class.java),
                 properties = arrayOf(
                     "tramai.sovereign.allowed-models[0]=local-model",
                     "tramai.sovereign.allowed-providers[0]=local-provider",

--- a/tramai-spring-boot-starter/src/test/kotlin/dev/tramai/spring/compatibilityfixture/TckCompatibilityFixture.kt
+++ b/tramai-spring-boot-starter/src/test/kotlin/dev/tramai/spring/compatibilityfixture/TckCompatibilityFixture.kt
@@ -1,0 +1,105 @@
+package dev.tramai.spring.compatibilityfixture
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.AiTool
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.model.SideEffectLevel
+import dev.tramai.core.policy.ApprovalMode
+import dev.tramai.core.policy.AuditDetail
+import dev.tramai.core.policy.ManagedNetworkEgress
+import dev.tramai.core.policy.RiskLevel
+import dev.tramai.core.provider.ModelProvider
+import dev.tramai.spring.EnableTramai
+import kotlinx.coroutines.runBlocking
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.stereotype.Service
+
+/**
+ * THE single application fixture for the S7 profile compatibility TCK.
+ *
+ * The same classes run under `tramai.profile=standard` and
+ * `tramai.profile=sovereign`. The fixture contains no profile-specific
+ * types, no `if (sovereign)` branches, no manual `runtime.create(...)` —
+ * only configuration changes between the two contexts.
+ */
+@Configuration(proxyBeanMethods = false)
+class TckCompatibilityFixture {
+
+    @Bean
+    fun tckProvider(): ModelProvider = object : ModelProvider {
+        override fun providerId(): String = "local-provider"
+
+        override suspend fun complete(request: ModelRequest): ModelResponse =
+            ModelResponse(content = "TCK_OK")
+    }
+
+    @Bean
+    fun tckPaymentTool(): TckPaymentTool = TckPaymentTool()
+
+    @Bean
+    fun tckLegacyPaymentTool(): TckLegacyPaymentTool = TckLegacyPaymentTool()
+
+    /** Constructor-style injection of the [TckAiService] into application code. */
+    @Bean
+    fun tckConsumer(ai: TckAiService): TckConsumer = TckConsumer(ai)
+}
+
+/** Same-fixture variant that additionally opts into the annotation-driven model. */
+@Configuration(proxyBeanMethods = false)
+@EnableTramai
+@Import(TckCompatibilityFixture::class)
+class TckEnableTramaiFixture
+
+@AiService
+interface TckAiService {
+    @Operation(
+        model = "local-model",
+        prompt = "Return the TCK result.",
+    )
+    suspend fun analyze(input: String): String
+}
+
+@Service
+class TckConsumer(private val ai: TckAiService) {
+    fun invokeAi(input: String): String = runBlocking { ai.analyze(input) }
+}
+
+data class TckPaymentInput(val invoiceId: String)
+
+/** Governed tool: identical discovery + metadata mapping under both profiles. */
+open class TckPaymentTool {
+    @AiTool(
+        name = "tck-schedule-payment",
+        description = "Schedules a payment for an invoice",
+        idempotent = true,
+        sideEffectLevel = SideEffectLevel.WRITE,
+        permission = "payment.schedule",
+        risk = RiskLevel.LOW,
+        approval = ApprovalMode.AUTO,
+        managedNetworkEgress = ManagedNetworkEgress.DENY,
+        audit = AuditDetail.FULL,
+    )
+    open suspend fun schedulePayment(input: TckPaymentInput): String =
+        "PAID-${input.invoiceId}"
+}
+
+/**
+ * Legacy metadata-less tool: discovered identically at the programming-model
+ * level under both profiles. Enforcement differs by design — standard allows
+ * it, sovereign fail-closes with `tool-metadata-missing` (covered by
+ * SovereignAiToolScanningTest; this TCK pins discovery parity only).
+ */
+open class TckLegacyPaymentTool {
+    @AiTool(
+        name = "tck-legacy-payment",
+        description = "Legacy annotation without governance metadata",
+        idempotent = true,
+        sideEffectLevel = SideEffectLevel.WRITE,
+    )
+    open suspend fun schedulePayment(input: TckPaymentInput): String =
+        "PAID-${input.invoiceId}"
+}

--- a/tramai-spring-core/src/main/kotlin/dev/tramai/spring/EnableTramai.kt
+++ b/tramai-spring-core/src/main/kotlin/dev/tramai/spring/EnableTramai.kt
@@ -14,7 +14,9 @@ import org.springframework.context.annotation.Import
  * The annotation does not select a runtime profile. `tramai.profile` remains the
  * authority: missing or `standard` yields the standard runtime, `sovereign`
  * yields the sovereign runtime. There is no implicit sovereign default — the
- * unified starter behaves identically under both profiles.
+ * unified starter exposes the same Spring programming model under both
+ * profiles; the selected runtime profile determines the execution and
+ * governance guarantees.
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)

--- a/tramai-spring-core/src/main/kotlin/dev/tramai/spring/EnableTramai.kt
+++ b/tramai-spring-core/src/main/kotlin/dev/tramai/spring/EnableTramai.kt
@@ -12,9 +12,9 @@ import org.springframework.context.annotation.Import
  * the TramAI profile configurations contributed by modules on the classpath.
  *
  * The annotation does not select a runtime profile. `tramai.profile` remains the
- * authority: standard is the compatibility default, while the sovereign starter
- * supplies its own Boot default and can also participate in annotation-driven
- * contexts when `tramai.profile=sovereign` is set explicitly.
+ * authority: missing or `standard` yields the standard runtime, `sovereign`
+ * yields the sovereign runtime. There is no implicit sovereign default — the
+ * unified starter behaves identically under both profiles.
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)

--- a/tramai-spring-core/src/main/kotlin/dev/tramai/spring/StandardTramaiProfileAutoConfiguration.kt
+++ b/tramai-spring-core/src/main/kotlin/dev/tramai/spring/StandardTramaiProfileAutoConfiguration.kt
@@ -8,9 +8,9 @@ import org.springframework.context.annotation.Import
  * Selects the standard TramAI runtime for Spring Boot applications.
  *
  * `standard` remains the default when no explicit profile is provided, preserving
- * existing `tramai-spring` behavior. The sovereign starter contributes a low-
- * precedence default of `tramai.profile=sovereign`, so adding that starter cannot
- * accidentally activate both runtimes.
+ * existing `tramai-spring` behavior. There is no implicit sovereign default:
+ * the sovereign runtime activates only when `tramai.profile=sovereign` is set
+ * explicitly, so the two runtime authorities can never both activate.
  */
 @AutoConfiguration
 @ConditionalOnProperty(


### PR DESCRIPTION
## S7 — Spring compatibility TCK + migration/docs

### What this PR is

The final slice of the 0.6.0 Spring unification track. It locks the S0–S6 contract into a reusable, profile-neutral compatibility TCK and makes the public documentation tell one coherent story about the unified Spring experience. **Zero production behavior change** — the only production-file edits are two KDoc corrections (comment-only).

### 1. Runtime profile compatibility TCK

`tramai-spring-boot-starter` gains a reusable contract following the repository TCK convention (StructuredOutputContractTck: internal contract class + thin JUnit driver):

- `SpringRuntimeProfileCompatibilityContract` — profile-neutral contract, parameterized by a `RuntimeProfileHarness`
- `SpringRuntimeProfileCompatibilityTckTest` — the key proof: **one fixture, two contexts**, the only semantic difference being `tramai.profile` + runtime configuration
- `TckCompatibilityFixture` — the single application fixture: no `if (sovereign)`, no profile-specific annotations, no manual `runtime.create(...)`

Contract matrix pinned:

| # | Contract | Assertion |
|---|---|---|
| 1 | `@AiService` discovery | single bean, injectable, callable — both profiles |
| 2 | Constructor injection | `@Service`-style consumer wired via constructor, invokes the same injected AiService — both profiles |
| 3 | Explicit `@EnableTramai` | coexists with Boot auto-config, no duplicate beans — both profiles |
| 4 | Boot without `@EnableTramai` | plain fixture sufficient — both profiles |
| 5 | Runtime authority | standard: 1×`Tramai`, 0×`SovereignTramai`; sovereign: 0×`Tramai`, 1×`SovereignTramai` + 1×`SovereignTramaiRuntime`; context fails if both appear |
| 6 | Named creator | `tramaiAiServiceCreator` present + resolvable; a duplicate name fails startup |
| 7 | `@AiTool` discovery | same tool discovered at programming-model level — both profiles |
| 8 | Governed `@AiTool` | identical identity + metadata mapping (`permission`/`risk`/`approval`/`managedNetworkEgress`/`audit`) — both profiles |
| 9 | Legacy metadata-less `@AiTool` | discovery parity only; sovereign fail-closed enforcement (`tool-metadata-missing`) stays covered in `SovereignAiToolScanningTest` — **programming-model parity ≠ policy parity** |
| 10 | Duplicate tool identity | not duplicated here — already proven by S4 engine/sovereign tests (startup `Duplicate tool name registered`) |
| 11 | Explicit `runtime.create(...)` | still available (`Tramai.create` / `SovereignTramai.create`); docs do not claim removal |

Profile values matrix, invalid-profile failure, and same-fixture switching were already pinned by `UnifiedSpringBootStarterTest` (S6) — not duplicated; the TCK's per-profile runs plus those tests cover the full matrix.

### 2. Documentation

- **`docs/guides/spring-boot.md`** — leads with the canonical `tramai-spring-boot-starter`; new sections: runtime profiles (`tramai.profile` semantics), sovereign (config, not code), `@EnableTramai` precision, module responsibility table, and a **migration guide** from the removed `tramai-spring-boot-starter-sovereign`.
- **`docs/reference/configuration.md`** — `tramai.profile` contract added.
- **`docs/guides/sovereign-runtime-quickstart.md`** — states sovereignty is configuration, not code; application code unchanged.
- **`docs/modules/tramai-spring.md`** — marks `tramai-spring` as the legacy facade, canonical starter is the unified one; `@EnableTramai` precision (selects the programming model, not the profile).
- **`docs/module-guide.md`** — module table lists the unified starter as canonical.
- **Production KDoc (comment-only)** — `EnableTramai.kt` + `StandardTramaiProfileAutoConfiguration.kt` still described the pre-S6 implicit sovereign default; corrected to the canonical contract.

### Scope guards honored

- No release lists, SBOM, module boundaries, RC workflow, or publication config touched.
- No quality deviations added; canonical baseline untouched; no suppression.
- Examples audit: both Spring examples already use the unified starter + explicit `tramai.profile: sovereign` (S6); left untouched.
- `tramai-spring-boot-starter-sovereign-ops*` / `-persistence-*` names intentionally unchanged (S6 naming decision, out of S7 scope).
- Stale-reference audit: the removed coordinate survives only in the immutable baseline + CHANGELOG/history.

### Validation

- `:tramai-spring-core:test :tramai-spring-sovereign:test :tramai-spring-boot-starter:test --rerun-tasks` ✅
- TCK focused runs ×3 ✅
- `verifyPr -PchangeClass=runtime-behaviour` ✅ (change policy, maintainability baseline, all subproject tests)
