### PR TITLE
fix(spring): unify provider resolution and runtime authority across profiles

### DIFF
--- a/examples/sovereign-runtime-consumer-smoke/src/main/kotlin/dev/tramai/examples/sovereign/consumersmoke/SmokeApplication.kt
+++ b/examples/sovereign-runtime-consumer-smoke/src/main/kotlin/dev/tramai/examples/sovereign/consumersmoke/SmokeApplication.kt
@@ -1,10 +1,28 @@
 package dev.tramai.examples.sovereign.consumersmoke
 
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.provider.ModelProvider
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Bean
 
 @SpringBootApplication
-open class SmokeApplication
+open class SmokeApplication {
+
+    /**
+     * H1 contract: a selected sovereign profile requires at least one model
+     * provider. The smoke app performs no real AI calls, so a stub provider
+     * satisfies the runtime without external network.
+     */
+    @Bean
+    fun smokeProvider(): ModelProvider = object : ModelProvider {
+        override fun providerId(): String = "local-provider"
+
+        override suspend fun complete(request: ModelRequest): ModelResponse =
+            ModelResponse(content = "smoke")
+    }
+}
 
 fun main(args: Array<String>) {
     runApplication<SmokeApplication>(*args)

--- a/tramai-spring-boot-starter-sovereign-persistence-file/src/test/kotlin/dev/tramai/spring/sovereign/persistence/file/SovereignFilePersistenceAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/src/test/kotlin/dev/tramai/spring/sovereign/persistence/file/SovereignFilePersistenceAutoConfigurationTest.kt
@@ -311,12 +311,13 @@ class SovereignFilePersistenceAutoConfigurationTest {
                     dev.tramai.spring.sovereign.SovereignTramaiAutoConfiguration::class.java,
                 ),
             )
+            .withUserConfiguration(MinimalProviderConfig::class.java)
             .withPropertyValues(
                 "tramai.sovereign.enabled=true",
                 "tramai.sovereign.allowed-models[0]=local-model",
-                "tramai.sovereign.allowed-providers[0]=local-provider",
-                "tramai.sovereign.provider-zones.local-provider=LOCAL",
-                "tramai.sovereign.models.local-model=local-provider",
+                "tramai.sovereign.allowed-providers[0]=test-provider",
+                "tramai.sovereign.provider-zones.test-provider=LOCAL",
+                "tramai.sovereign.models.local-model=test-provider",
                 "tramai.sovereign.persistence.type=file",
                 "tramai.sovereign.persistence.base-dir=${dir.toAbsolutePath()}",
                 "tramai.sovereign.persistence.encryption.key-file=${keyFile.toAbsolutePath()}",

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/SovereignJdbcPersistenceAutoConfigurationTest.kt
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/kotlin/dev/tramai/spring/sovereign/persistence/jdbc/SovereignJdbcPersistenceAutoConfigurationTest.kt
@@ -401,7 +401,10 @@ class SovereignJdbcPersistenceAutoConfigurationTest {
                     dev.tramai.spring.sovereign.SovereignTramaiAutoConfiguration::class.java,
                 ),
             )
-            .withUserConfiguration(TestDataSourceConfig::class.java)
+            .withUserConfiguration(
+                TestDataSourceConfig::class.java,
+                MinimalProviderConfig::class.java,
+            )
             .withPropertyValues(
                 "tramai.sovereign.enabled=true",
                 "tramai.sovereign.allowed-models[0]=local-model",
@@ -637,6 +640,11 @@ open class TestDataSourceConfig {
     open fun testDataSource(): DataSource = NoOpDataSource()
 }
 
+open class MinimalProviderConfig {
+    @Bean
+    open fun stubModelProvider(): StubModelProvider = StubModelProvider()
+}
+
 open class CustomAuditStoreConfig {
     @Bean
     @Primary
@@ -846,4 +854,13 @@ class CustomLeaseStore : SovereignOpsWorkerLeaseStore {
 
     override suspend fun get(leaseName: String) =
         throw UnsupportedOperationException("custom stub")
+}
+
+class StubModelProvider : dev.tramai.core.provider.ModelProvider {
+    override fun providerId(): String = "local-provider"
+
+    override suspend fun complete(
+        request: dev.tramai.core.model.ModelRequest,
+    ): dev.tramai.core.model.ModelResponse =
+        dev.tramai.core.model.ModelResponse(content = "stub response")
 }

--- a/tramai-spring-boot-starter/build.gradle.kts
+++ b/tramai-spring-boot-starter/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     testImplementation(libs.coroutines.core)
     testImplementation(libs.kotlin.test.junit5)
     testImplementation(libs.spring.boot.starter.test)
+    testImplementation(project(":tramai-spring-provider-openai"))
     testImplementation("org.junit.jupiter:junit-jupiter")
 }
 

--- a/tramai-spring-boot-starter/src/test/kotlin/dev/tramai/spring/SpringProviderAdapterCrossProfileTest.kt
+++ b/tramai-spring-boot-starter/src/test/kotlin/dev/tramai/spring/SpringProviderAdapterCrossProfileTest.kt
@@ -1,0 +1,65 @@
+package dev.tramai.spring
+
+import dev.tramai.sovereign.SovereignTramai
+import dev.tramai.sovereign.SovereignTramaiRuntime
+import dev.tramai.standalone.Tramai
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+/**
+ * Cross-profile regression for the property-driven provider seam (H1).
+ *
+ * Uses a REAL provider adapter ([dev.tramai.spring.OpenAiProviderAutoConfiguration])
+ * that contributes a [SpringConfiguredModelProvider] descriptor — not a
+ * handcrafted raw [ModelProvider] fixture. Under both profiles the runtime
+ * must be assembled from the adapter's descriptor with identical semantics.
+ */
+class SpringProviderAdapterCrossProfileTest {
+
+    private val adapterAutoConfigurations = AutoConfigurations.of(
+        Class.forName("dev.tramai.spring.StandardTramaiProfileAutoConfiguration"),
+        Class.forName("dev.tramai.spring.AiServiceProxyAutoConfiguration"),
+        Class.forName("dev.tramai.spring.sovereign.SovereignTramaiProfileAutoConfiguration"),
+        Class.forName("dev.tramai.spring.sovereign.SovereignAiServiceProxyAutoConfiguration"),
+        Class.forName("dev.tramai.spring.TramaiSecretResolutionAutoConfiguration"),
+        Class.forName("dev.tramai.spring.OpenAiProviderAutoConfiguration"),
+    )
+
+    @Test
+    fun `openai property adapter registers the standard runtime`() {
+        ApplicationContextRunner()
+            .withConfiguration(adapterAutoConfigurations)
+            .withPropertyValues(
+                "tramai.profile=standard",
+                "tramai.providers.openai.api-key=fake-key-for-construction-only",
+            )
+            .run { context ->
+                assertThat(context).hasNotFailed()
+                assertThat(context).hasSingleBean(Tramai::class.java)
+                assertThat(context).doesNotHaveBean(SovereignTramai::class.java)
+                assertThat(context).doesNotHaveBean(SovereignTramaiRuntime::class.java)
+            }
+    }
+
+    @Test
+    fun `openai property adapter registers the sovereign runtime`() {
+        ApplicationContextRunner()
+            .withConfiguration(adapterAutoConfigurations)
+            .withPropertyValues(
+                "tramai.profile=sovereign",
+                "tramai.sovereign.allowed-models[0]=gpt-4o",
+                "tramai.sovereign.allowed-providers[0]=openai",
+                "tramai.sovereign.provider-zones.openai=GLOBAL_CLOUD",
+                "tramai.sovereign.models.gpt-4o=openai",
+                "tramai.providers.openai.api-key=fake-key-for-construction-only",
+            )
+            .run { context ->
+                assertThat(context).hasNotFailed()
+                assertThat(context).doesNotHaveBean(Tramai::class.java)
+                assertThat(context).hasSingleBean(SovereignTramai::class.java)
+                assertThat(context).hasSingleBean(SovereignTramaiRuntime::class.java)
+            }
+    }
+}

--- a/tramai-spring-core/api/tramai-spring-core.api
+++ b/tramai-spring-core/api/tramai-spring-core.api
@@ -49,6 +49,11 @@ public final class dev/tramai/spring/SpringConfiguredModelProvider {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class dev/tramai/spring/SpringProviderResolution {
+	public static final field INSTANCE Ldev/tramai/spring/SpringProviderResolution;
+	public final fun resolve (Lorg/springframework/beans/factory/ObjectProvider;Lorg/springframework/beans/factory/ObjectProvider;)Ljava/util/List;
+}
+
 public final class dev/tramai/spring/SpringSecretChain {
 	public fun <init> (Ldev/tramai/core/secret/SecretValueResolver;)V
 	public final fun getResolver ()Ldev/tramai/core/secret/SecretValueResolver;

--- a/tramai-spring-core/src/main/kotlin/dev/tramai/spring/SpringProviderResolution.kt
+++ b/tramai-spring-core/src/main/kotlin/dev/tramai/spring/SpringProviderResolution.kt
@@ -1,0 +1,52 @@
+package dev.tramai.spring
+
+import dev.tramai.core.provider.ModelProvider
+import org.springframework.beans.factory.ObjectProvider
+
+/**
+ * Shared provider-resolution seam for both runtime profiles.
+ *
+ * Collects property-generated providers ([SpringConfiguredModelProvider]
+ * descriptors contributed by `tramai-spring-provider-*` adapter modules) and
+ * explicit user [ModelProvider] beans with identical semantics for standard
+ * and sovereign: unique beans override property-backed providers, and genuine
+ * duplicates are passed through so the canonical runtime builder rejects
+ * them deterministically.
+ *
+ * Lives in Spring core so no runtime profile knows a concrete provider type.
+ * Public because it crosses the module boundary to the sovereign integration;
+ * it is a composition seam, not an application-facing API.
+ */
+object SpringProviderResolution {
+
+    /**
+     * Returns providers as (providerId, provider) pairs in registration order:
+     * unique property providers, unique bean providers (bean-over-property
+     * precedence), then duplicates of each kind unchanged.
+     */
+    fun resolve(
+        springConfiguredProviders: ObjectProvider<SpringConfiguredModelProvider>,
+        beanProviders: ObjectProvider<ModelProvider>,
+    ): List<Pair<String, ModelProvider>> {
+        val propertyProviders: List<Pair<String, ModelProvider>> =
+            springConfiguredProviders.orderedStream()
+                .map { it.providerId to it.provider }
+                .toList()
+
+        val beanProviderList = beanProviders.orderedStream().toList()
+        val beanProviderCounts = beanProviderList.groupingBy { it.providerId() }.eachCount()
+        val uniqueBeanProviders = beanProviderList.filter { beanProviderCounts.getValue(it.providerId()) == 1 }
+        val duplicateBeanProviders = beanProviderList.filter { beanProviderCounts.getValue(it.providerId()) > 1 }
+
+        val propertyProviderCounts = propertyProviders.groupingBy { it.first }.eachCount()
+        val duplicatePropertyProviders = propertyProviders.filter { propertyProviderCounts.getValue(it.first) > 1 }
+        val uniquePropertyProviders = propertyProviders.filter { propertyProviderCounts.getValue(it.first) == 1 }
+
+        val providersById = uniquePropertyProviders.toMap() + uniqueBeanProviders.associate { it.providerId() to it }
+        return buildList {
+            providersById.forEach { (providerId, provider) -> add(providerId to provider) }
+            duplicatePropertyProviders.forEach { add(it) }
+            duplicateBeanProviders.forEach { add(it.providerId() to it) }
+        }
+    }
+}

--- a/tramai-spring-core/src/main/kotlin/dev/tramai/spring/TramaiAutoConfiguration.kt
+++ b/tramai-spring-core/src/main/kotlin/dev/tramai/spring/TramaiAutoConfiguration.kt
@@ -115,35 +115,15 @@ class TramaiAutoConfiguration {
 
         // Property-generated providers are contributed by adapter modules as
         // SpringConfiguredModelProvider beans; core no longer knows any
-        // concrete provider type.
-        val propertyProviders: List<Pair<String, ModelProvider>> =
-            dependencies.springConfiguredProviders.orderedStream()
-                .map { it.providerId to it.provider }
-                .toList()
-
-        val beanProviders = dependencies.modelProviders.orderedStream().toList()
-        val beanProviderCounts = beanProviders.groupingBy { it.providerId() }.eachCount()
-        // Unique beans override property-backed providers; genuine user duplicates are
-        // registered as-is so the canonical plan builder rejects them deterministically.
-        val uniqueBeanProviders = beanProviders.filter { beanProviderCounts.getValue(it.providerId()) == 1 }
-        val duplicateBeanProviders = beanProviders.filter { beanProviderCounts.getValue(it.providerId()) > 1 }
-
-        // Only bean-over-property precedence is intentional. A property-vs-property
-        // duplicate (e.g. OpenAI plus an openai-compatible provider explicitly named
-        // "openai") must NOT be silently collapsed — pass both through so the canonical
-        // plan builder rejects the collision deterministically.
-        val propertyProviderCounts = propertyProviders.groupingBy { it.first }.eachCount()
-        val duplicatePropertyProviders = propertyProviders.filter { propertyProviderCounts.getValue(it.first) > 1 }
-        val uniquePropertyProviders = propertyProviders.filter { propertyProviderCounts.getValue(it.first) == 1 }
-
-        val providersById = uniquePropertyProviders.toMap() + uniqueBeanProviders.associate { it.providerId() to it }
-        providersById.forEach { (providerId, provider) ->
+        // concrete provider type. Same resolution semantics as the sovereign
+        // profile: beans override property providers, duplicates pass through
+        // for the canonical plan builder to reject.
+        SpringProviderResolution.resolve(
+            springConfiguredProviders = dependencies.springConfiguredProviders,
+            beanProviders = dependencies.modelProviders,
+        ).forEach { (providerId, provider) ->
             builder.provider(provider, name = providerId)
         }
-        duplicatePropertyProviders.forEach { (providerId, provider) ->
-            builder.provider(provider, name = providerId)
-        }
-        duplicateBeanProviders.forEach { provider -> builder.provider(provider, name = provider.providerId()) }
 
         properties.models.forEach { (model, providerName) ->
             builder.model(model, providerName)

--- a/tramai-spring-sovereign/src/main/kotlin/dev/tramai/spring/sovereign/SovereignTramaiAutoConfiguration.kt
+++ b/tramai-spring-sovereign/src/main/kotlin/dev/tramai/spring/sovereign/SovereignTramaiAutoConfiguration.kt
@@ -24,13 +24,15 @@ import dev.tramai.sovereign.SovereignProfileConfiguration
 import dev.tramai.sovereign.SovereignTramai
 import dev.tramai.sovereign.SovereignTramaiRuntime
 import dev.tramai.spring.AiToolScanner
+import dev.tramai.spring.SpringConfiguredModelProvider
+import dev.tramai.spring.SpringProviderResolution
+import dev.tramai.standalone.Tramai
 import java.time.Clock
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
@@ -46,16 +48,15 @@ import org.springframework.context.annotation.Bean
  * - [SovereignTramai] and [SovereignTramaiRuntime]
  *
  * All beans are [ConditionalOnMissingBean] so users can override any default.
- * Set `tramai.sovereign.enabled=false` to disable all sovereign auto-configuration.
+ *
+ * `tramai.profile` is the sole runtime selector; this configuration activates
+ * through [SovereignTramaiProfileAutoConfiguration]. The legacy
+ * `tramai.sovereign.enabled=false` switch is rejected by property validation
+ * rather than silently suppressing the runtime (see
+ * [SovereignTramaiProperties]).
  */
 @AutoConfiguration
 @EnableConfigurationProperties(SovereignTramaiProperties::class)
-@ConditionalOnProperty(
-    prefix = "tramai.sovereign",
-    name = ["enabled"],
-    havingValue = "true",
-    matchIfMissing = true,
-)
 class SovereignTramaiAutoConfiguration {
 
     @field:Autowired
@@ -188,16 +189,26 @@ class SovereignTramaiAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnBean(ModelProvider::class)
     fun sovereignTramai(
         profile: SovereignProfileConfiguration,
         modelRegistry: ModelRegistry,
         auditStore: AuditStore,
         modelProviders: ObjectProvider<ModelProvider>,
+        springConfiguredProviders: ObjectProvider<SpringConfiguredModelProvider>,
         toolProviders: ObjectProvider<TramaiTool<*, *>>,
         properties: SovereignTramaiProperties,
         infrastructure: SovereignTramaiInfrastructure,
     ): SovereignTramai {
+        // Exactly one runtime authority: selecting the sovereign profile while a
+        // plain Tramai bean exists (user-supplied, since standard auto-config is
+        // profile-exclusive) is an ambiguous configuration and must fail loudly.
+        val manualTramaiBeans = applicationContext.getBeanNamesForType(Tramai::class.java, false, false)
+        check(manualTramaiBeans.isEmpty()) {
+            "tramai.profile=sovereign is incompatible with a plain Tramai bean " +
+                "(found: ${manualTramaiBeans.joinToString()}). tramai.profile is the sole runtime " +
+                "selector and exactly one runtime authority is allowed."
+        }
+
         val builder = SovereignTramai.builder()
             .profile(profile)
             .modelRegistry(modelRegistry)
@@ -209,10 +220,20 @@ class SovereignTramaiAutoConfiguration {
         infrastructure.suspendedInvocationStore?.let { builder.suspendedInvocationStore(it) }
         infrastructure.toolArgumentsDigester?.let { builder.toolArgumentsDigester(it) }
 
-        // Register provider beans from the application context.
-        // Users provide ModelProvider beans and the starter wires them in.
-        modelProviders.orderedStream().forEach { provider ->
-            builder.provider(provider, name = provider.providerId())
+        // Same provider-resolution semantics as the standard profile: adapter
+        // modules contribute SpringConfiguredModelProvider descriptors and
+        // explicit ModelProvider beans override property-backed providers.
+        // A selected profile must never produce a runtime with zero providers.
+        val resolvedProviders = SpringProviderResolution.resolve(
+            springConfiguredProviders = springConfiguredProviders,
+            beanProviders = modelProviders,
+        )
+        check(resolvedProviders.isNotEmpty()) {
+            "tramai.profile=sovereign requires at least one model provider: add a " +
+                "tramai-spring-provider-* adapter with its properties or a ModelProvider bean."
+        }
+        resolvedProviders.forEach { (providerId, provider) ->
+            builder.provider(provider, name = providerId)
         }
 
         // Preserve explicit TramaiTool beans and add the same @AiTool method

--- a/tramai-spring-sovereign/src/main/kotlin/dev/tramai/spring/sovereign/SovereignTramaiAutoConfiguration.kt
+++ b/tramai-spring-sovereign/src/main/kotlin/dev/tramai/spring/sovereign/SovereignTramaiAutoConfiguration.kt
@@ -202,7 +202,9 @@ class SovereignTramaiAutoConfiguration {
         // Exactly one runtime authority: selecting the sovereign profile while a
         // plain Tramai bean exists (user-supplied, since standard auto-config is
         // profile-exclusive) is an ambiguous configuration and must fail loudly.
-        val manualTramaiBeans = applicationContext.getBeanNamesForType(Tramai::class.java, false, false)
+        // includeNonSingletons = true: a prototype-scoped Tramai bean is still an
+        // authority; only eager initialization is avoided.
+        val manualTramaiBeans = applicationContext.getBeanNamesForType(Tramai::class.java, true, false)
         check(manualTramaiBeans.isEmpty()) {
             "tramai.profile=sovereign is incompatible with a plain Tramai bean " +
                 "(found: ${manualTramaiBeans.joinToString()}). tramai.profile is the sole runtime " +

--- a/tramai-spring-sovereign/src/main/kotlin/dev/tramai/spring/sovereign/SovereignTramaiProperties.kt
+++ b/tramai-spring-sovereign/src/main/kotlin/dev/tramai/spring/sovereign/SovereignTramaiProperties.kt
@@ -28,8 +28,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = "tramai.sovereign")
 data class SovereignTramaiProperties(
     /**
-     * Enables sovereign profile auto-configuration. When false, no sovereign
-     * beans are created (respects [ConditionalOnProperty] semantics).
+     * Compatibility switch retained for existing configurations.
+     *
+     * `tramai.profile` is the sole runtime selector. Setting this to `false`
+     * is rejected with a deterministic startup failure ([resolveProviderTrustZones]).
      */
     var enabled: Boolean = true,
 
@@ -69,6 +71,12 @@ data class SovereignTramaiProperties(
 ) {
     /** Validates this configuration and returns a resolved [ProviderTrustZone] map. */
     internal fun resolveProviderTrustZones(): Map<String, ProviderTrustZone> {
+        check(enabled) {
+            "tramai.sovereign.enabled=false is not supported: tramai.profile is the sole runtime " +
+                "selector. Remove tramai.sovereign.enabled or set it to true; to run the standard " +
+                "runtime select tramai.profile=standard (or omit it)."
+        }
+
         val zones = providerZones.mapValues { (_, zone) ->
             try {
                 ProviderTrustZone.valueOf(zone.uppercase())

--- a/tramai-spring-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/SovereignAiServiceProxyAutoConfigurationTest.kt
+++ b/tramai-spring-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/SovereignAiServiceProxyAutoConfigurationTest.kt
@@ -97,18 +97,17 @@ class SovereignAiServiceProxyAutoConfigurationTest {
     }
 
     @Test
-    fun `missing sovereign creator fails loudly and cannot fall back to standard runtime`() {
+    fun `missing provider under sovereign profile fails loudly and never falls back to standard`() {
         runner
             .withPropertyValues(*sovereignProperties)
             .run { context ->
-                assertThat(context).doesNotHaveBean(SovereignTramai::class.java)
-                assertThat(context).doesNotHaveBean(Tramai::class.java)
-                assertThat(context).doesNotHaveBean("tramaiAiServiceCreator")
-                assertThat(context).hasSingleBean(AiServiceBeanDefinitionRegistrar::class.java)
-
-                assertThatThrownBy {
-                    context.getBean(SovereignScannedAiService::class.java)
-                }.hasRootCauseInstanceOf(NoSuchBeanDefinitionException::class.java)
+                // H1 contract: selecting sovereign without any provider is a
+                // deterministic startup failure, not a silent zero-runtime state.
+                assertThat(context).hasFailed()
+                val failure = requireNotNull(context.startupFailure)
+                assertThat(failure)
+                    .hasMessageContaining("requires at least one model provider")
+                    .hasMessageContaining("tramai-spring-provider-*")
             }
     }
 

--- a/tramai-spring-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/SovereignTramaiAutoConfigurationTest.kt
+++ b/tramai-spring-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/SovereignTramaiAutoConfigurationTest.kt
@@ -44,6 +44,7 @@ class SovereignTramaiAutoConfigurationTest {
     @Test
     fun `creates SovereignProfileConfiguration from valid properties`() {
         contextRunner
+            .withUserConfiguration(MinimalProviderConfiguration::class.java)
             .withPropertyValues(*minimalProperties.entries.map { "${it.key}=${it.value}" }.toTypedArray())
             .run { context ->
                 assertThat(context).hasSingleBean(SovereignProfileConfiguration::class.java)
@@ -57,6 +58,7 @@ class SovereignTramaiAutoConfigurationTest {
     @Test
     fun `model registry is derived from properties dot models`() {
         contextRunner
+            .withUserConfiguration(MinimalProviderConfiguration::class.java)
             .withPropertyValues(*minimalProperties.entries.map { "${it.key}=${it.value}" }.toTypedArray())
             .run { context ->
                 assertThat(context).hasSingleBean(ModelRegistry::class.java)
@@ -93,16 +95,50 @@ class SovereignTramaiAutoConfigurationTest {
             }
     }
 
-    // ── enabled=false ────────────────────────────────────────────────────
+    // ── enabled=false (legacy dual selector) ─────────────────────────────
 
     @Test
-    fun `sovereign profile beans are not created when enabled is false`() {
+    fun `enabled false is rejected when the sovereign profile is selected`() {
         contextRunner
             .withPropertyValues("tramai.sovereign.enabled=false")
             .run { context ->
-                assertThat(context).doesNotHaveBean(SovereignProfileConfiguration::class.java)
-                assertThat(context).doesNotHaveBean(SovereignTramai::class.java)
-                assertThat(context).doesNotHaveBean(SovereignTramaiRuntime::class.java)
+                assertThat(context).hasFailed()
+                val failure = requireNotNull(context.startupFailure)
+                assertThat(failure)
+                    .hasMessageContaining("tramai.sovereign.enabled=false is not supported")
+                    .hasMessageContaining("tramai.profile is the sole runtime selector")
+            }
+    }
+
+    // ── Zero-provider / authority guards ─────────────────────────────────
+
+    @Test
+    fun `sovereign profile without any provider fails loudly`() {
+        contextRunner
+            .withPropertyValues(*minimalProperties.entries.map { "${it.key}=${it.value}" }.toTypedArray())
+            .run { context ->
+                assertThat(context).hasFailed()
+                val failure = requireNotNull(context.startupFailure)
+                assertThat(failure)
+                    .hasMessageContaining("requires at least one model provider")
+                    .hasMessageContaining("tramai-spring-provider-*")
+            }
+    }
+
+    @Test
+    fun `manual Tramai bean under sovereign profile fails loudly`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalProviderConfiguration::class.java,
+                ManualTramaiConfiguration::class.java,
+            )
+            .withPropertyValues(*minimalProperties.entries.map { "${it.key}=${it.value}" }.toTypedArray())
+            .run { context ->
+                assertThat(context).hasFailed()
+                val failure = requireNotNull(context.startupFailure)
+                assertThat(failure)
+                    .hasMessageContaining("tramai.profile=sovereign is incompatible with a plain Tramai bean")
+                    .hasMessageContaining("exactly one runtime authority is allowed")
             }
     }
 
@@ -266,6 +302,11 @@ interface TestInvoiceAi {
 open class MinimalProviderConfiguration {
     @Bean
     open fun stubModelProvider(): StubModelProvider = StubModelProvider()
+}
+
+open class ManualTramaiConfiguration {
+    @Bean
+    open fun manualTramai(): dev.tramai.standalone.Tramai = dev.tramai.standalone.Tramai.builder().build()
 }
 
 open class ModelRegistrySupplierConfiguration {

--- a/tramai-spring-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/SovereignTramaiAutoConfigurationTest.kt
+++ b/tramai-spring-sovereign/src/test/kotlin/dev/tramai/spring/sovereign/SovereignTramaiAutoConfigurationTest.kt
@@ -18,11 +18,13 @@ import java.time.Instant
 import java.time.ZoneId
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Scope
 import kotlin.test.Test
 
 class SovereignTramaiAutoConfigurationTest {
@@ -131,6 +133,23 @@ class SovereignTramaiAutoConfigurationTest {
             .withUserConfiguration(
                 MinimalProviderConfiguration::class.java,
                 ManualTramaiConfiguration::class.java,
+            )
+            .withPropertyValues(*minimalProperties.entries.map { "${it.key}=${it.value}" }.toTypedArray())
+            .run { context ->
+                assertThat(context).hasFailed()
+                val failure = requireNotNull(context.startupFailure)
+                assertThat(failure)
+                    .hasMessageContaining("tramai.profile=sovereign is incompatible with a plain Tramai bean")
+                    .hasMessageContaining("exactly one runtime authority is allowed")
+            }
+    }
+
+    @Test
+    fun `prototype scoped Tramai bean under sovereign profile fails loudly`() {
+        contextRunner
+            .withUserConfiguration(
+                MinimalProviderConfiguration::class.java,
+                PrototypeTramaiConfiguration::class.java,
             )
             .withPropertyValues(*minimalProperties.entries.map { "${it.key}=${it.value}" }.toTypedArray())
             .run { context ->
@@ -307,6 +326,12 @@ open class MinimalProviderConfiguration {
 open class ManualTramaiConfiguration {
     @Bean
     open fun manualTramai(): dev.tramai.standalone.Tramai = dev.tramai.standalone.Tramai.builder().build()
+}
+
+open class PrototypeTramaiConfiguration {
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    open fun prototypeTramai(): dev.tramai.standalone.Tramai = dev.tramai.standalone.Tramai.builder().build()
 }
 
 open class ModelRegistrySupplierConfiguration {


### PR DESCRIPTION
## H1 — fix(spring): unify provider resolution and runtime authority across profiles

Integration-review fix (final track review findings 1, 3, 7). Branch from `04942322` (track head). No architecture redesign — the S0–S7 design stands; this closes the cross-profile seams the slice-level tests did not exercise.

### P1 — Spring provider parity (finding 1)

The sovereign runtime previously consumed only raw `ModelProvider` beans and gated its runtime bean on `@ConditionalOnBean(ModelProvider)`. A normal app using the unified starter + `tramai-spring-provider-openai` (property-driven `SpringConfiguredModelProvider` descriptors) produced **zero sovereign runtime** — silently.

Fix:
- New shared seam in `tramai-spring-core`: `SpringProviderResolution` collects `SpringConfiguredModelProvider` descriptors + explicit `ModelProvider` beans with the exact precedence/duplicate semantics the standard profile already used (unique beans override property providers; genuine duplicates pass through for the canonical builder to reject). `TramaiAutoConfiguration` refactored onto it (behavior identical).
- `SovereignTramaiAutoConfiguration` now injects both `ObjectProvider`s, resolves via the seam, and fails **loudly** when a selected profile yields zero providers: `tramai.profile=sovereign requires at least one model provider: add a tramai-spring-provider-* adapter with its properties or a ModelProvider bean.`
- Regression: `SpringProviderAdapterCrossProfileTest` runs the **real** `tramai-spring-provider-openai` adapter under both profiles (not a handcrafted provider fixture) and asserts the runtime is assembled in both.

### P1/P2 — `tramai.profile` is the sole runtime selector (finding 3)

The dual selector `tramai.sovereign.enabled` is removed:
- The `@ConditionalOnProperty(tramai.sovereign.enabled)` gate on `SovereignTramaiAutoConfiguration` is gone — the profile wrapper (`tramai.profile=sovereign`) is the only gate.
- `tramai.sovereign.enabled=false` is rejected by property validation with a deterministic error naming `tramai.profile` as the sole selector (compat switch retained, contradiction now impossible instead of silently producing zero runtime).

### P2 — ambiguous manual authority fails (finding 7)

Selecting `tramai.profile=sovereign` while a plain `Tramai` bean exists (user-supplied) now fails startup: `tramai.profile=sovereign is incompatible with a plain Tramai bean (...) exactly one runtime authority is allowed.`

Scope note: the guard lives in the sovereign integration (where both runtime types are visible). The inverse case (manual `SovereignTramai` under standard) cannot be observed from `tramai-spring-core` without a sovereign type reference; the auto-config paths themselves remain mutually exclusive by construction.

### Tests
- `SovereignTramaiAutoConfigurationTest`: enabled=false → deterministic failure; zero-provider → failure; manual `Tramai` + sovereign → failure.
- `SovereignAiServiceProxyAutoConfigurationTest`: "missing provider under sovereign profile fails loudly and never falls back to standard" replaces the old silent zero-runtime assertion (test asserted behavior intentionally removed).
- Persistence starter tests (file/JDBC): now supply a provider to the sovereign context (they previously relied on the silent skip).
- New `SpringProviderAdapterCrossProfileTest` (unified starter test, `testImplementation` of the real OpenAI adapter).

### Validation
- `:tramai-spring-core:test :tramai-spring-sovereign:test :tramai-spring-boot-starter:test --rerun-tasks` ✅
- `verifyPr -PchangeClass=runtime-behaviour` ✅ (incl. module boundaries — the new starter→adapter test edge is accepted)
- `:tramai-spring-core:apiDump` updated (+5 lines: the shared resolution seam)
