### PR TITLE
fix(spring): invoke AiTool methods through Spring proxies

### DIFF
--- a/tramai-spring-core/src/main/kotlin/dev/tramai/spring/AiToolScanner.kt
+++ b/tramai-spring-core/src/main/kotlin/dev/tramai/spring/AiToolScanner.kt
@@ -51,8 +51,15 @@ object AiToolScanner {
 
             val targetClass: KClass<*> = org.springframework.util.ClassUtils.getUserClass(beanType).kotlin
 
+            // A JDK interface proxy resolves its bean type to the $Proxy class,
+            // whose synthesized methods carry no annotations; the @AiTool may
+            // live on an interface the proxy implements. Check both the target
+            // class and the declared interfaces before deciding to scan.
             val hasTool = try {
-                targetClass.functions.any { it.findAnnotation<AiTool>() != null }
+                targetClass.functions.any { it.findAnnotation<AiTool>() != null } ||
+                    beanType.interfaces.any { interfaceType ->
+                        interfaceType.kotlin.functions.any { it.findAnnotation<AiTool>() != null }
+                    }
             } catch (e: Throwable) {
                 false
             }
@@ -91,7 +98,9 @@ object AiToolScanner {
         bean: Any,
         function: KFunction<*>,
     ): TramaiTool<*, *>? {
-        val annotation = try { function.findAnnotation<AiTool>() } catch (e: Exception) { null } ?: return null
+        val annotation = try { function.findAnnotation<AiTool>() } catch (e: Exception) { null }
+            ?: findInterfaceAnnotation(bean, function)
+            ?: return null
 
         val parameters = function.valueParameters
         check(parameters.size == 1) {
@@ -118,6 +127,24 @@ object AiToolScanner {
             sideEffectLevel = annotation.sideEffectLevel,
             security = security,
         )
+    }
+
+    /**
+     * Falls back to an interface-declared [AiTool] when the implementation
+     * method carries no annotation (annotations on overrides are not inherited).
+     * The interface's Kotlin function also preserves suspend metadata, which is
+     * what [MethodBackedTramaiTool] dispatches through for proxied beans.
+     */
+    private fun findInterfaceAnnotation(bean: Any, function: KFunction<*>): AiTool? {
+        val declaredInterfaces = bean::class.java.interfaces
+        if (declaredInterfaces.isEmpty()) return null
+        return declaredInterfaces.asSequence()
+            .flatMap { it.kotlin.functions.asSequence() }
+            .firstOrNull { candidate ->
+                candidate.name == function.name &&
+                    candidate.valueParameters.size == function.valueParameters.size
+            }
+            ?.findAnnotation<AiTool>()
     }
 
     private fun resolveSecurityMetadata(
@@ -159,11 +186,36 @@ object AiToolScanner {
     ) : TramaiTool<I, Any> {
 
         override suspend fun execute(input: I, context: ToolExecutionContext): Any {
-            return if (function.isSuspend) {
-                function.callSuspend(bean, input) ?: Unit
+            val invocable = resolveInvocableFunction()
+            return if (invocable.isSuspend) {
+                invocable.callSuspend(bean, input) ?: Unit
             } else {
-                function.call(bean, input) ?: Unit
+                invocable.call(bean, input) ?: Unit
             }
+        }
+
+        /**
+         * The discovered [function] belongs to the tool's target class. For a
+         * JDK interface proxy the bean is NOT an instance of that target class,
+         * so invoking the target-class function on the proxy receiver throws a
+         * receiver-type mismatch. Resolve the same method against an interface
+         * the bean actually implements (Kotlin metadata is preserved there, so
+         * suspend functions stay suspend) — invocation then dispatches through
+         * the proxy and Spring AOP advice runs. Plain objects and CGLIB proxies
+         * fall back to the discovered target-class function.
+         */
+        private fun resolveInvocableFunction(): KFunction<*> {
+            val declaredInterfaces = bean::class.java.interfaces
+            if (declaredInterfaces.isNotEmpty()) {
+                for (interfaceType in declaredInterfaces) {
+                    val match = interfaceType.kotlin.functions.firstOrNull { candidate ->
+                        candidate.name == function.name &&
+                            candidate.valueParameters.size == function.valueParameters.size
+                    }
+                    if (match != null) return match
+                }
+            }
+            return function
         }
     }
 }

--- a/tramai-spring-core/src/main/kotlin/dev/tramai/spring/AiToolScanner.kt
+++ b/tramai-spring-core/src/main/kotlin/dev/tramai/spring/AiToolScanner.kt
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.ListableBeanFactory
 import org.springframework.context.ApplicationContext
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
+import kotlin.reflect.KType
 import kotlin.reflect.full.callSuspend
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.functions
@@ -130,6 +131,31 @@ object AiToolScanner {
     }
 
     /**
+     * Exact overload-safe signature match. Name + arity alone is not enough:
+     * `fun lookup(InvoiceInput)` and `fun lookup(CustomerInput)` share both.
+     * Compare name, suspend-ness, and the full parameter type shapes.
+     */
+    private fun KFunction<*>.sameSignatureAs(other: KFunction<*>): Boolean =
+        name == other.name &&
+            isSuspend == other.isSuspend &&
+            valueParameters.size == other.valueParameters.size &&
+            valueParameters.zip(other.valueParameters).all { (a, b) -> a.type.sameShape(b.type) }
+
+    /** Structural type comparison: classifier + nullability + type arguments. */
+    private fun KType.sameShape(other: KType): Boolean {
+        if (classifier != other.classifier || isMarkedNullable != other.isMarkedNullable) return false
+        if (arguments.size != other.arguments.size) return false
+        return arguments.zip(other.arguments).all { (a, b) ->
+            a.variance == b.variance &&
+                when {
+                    a.type == null && b.type == null -> true
+                    a.type != null && b.type != null -> a.type!!.sameShape(b.type!!)
+                    else -> false
+                }
+        }
+    }
+
+    /**
      * Falls back to an interface-declared [AiTool] when the implementation
      * method carries no annotation (annotations on overrides are not inherited).
      * The interface's Kotlin function also preserves suspend metadata, which is
@@ -140,10 +166,7 @@ object AiToolScanner {
         if (declaredInterfaces.isEmpty()) return null
         return declaredInterfaces.asSequence()
             .flatMap { it.kotlin.functions.asSequence() }
-            .firstOrNull { candidate ->
-                candidate.name == function.name &&
-                    candidate.valueParameters.size == function.valueParameters.size
-            }
+            .firstOrNull { candidate -> candidate.sameSignatureAs(function) }
             ?.findAnnotation<AiTool>()
     }
 
@@ -185,37 +208,37 @@ object AiToolScanner {
         override val security: ToolSecurityMetadata?,
     ) : TramaiTool<I, Any> {
 
+        /**
+         * The discovered [function] belongs to the tool's target class. For a
+         * JDK interface proxy the bean is NOT an instance of that target class,
+         * so invoking the target-class function on the proxy receiver throws a
+         * receiver-type mismatch. Resolve the same signature against an
+         * interface the bean actually implements (Kotlin metadata is preserved
+         * there, so suspend functions stay suspend) — invocation then
+         * dispatches through the proxy and Spring AOP advice runs. Plain
+         * objects and CGLIB proxies fall back to the discovered target-class
+         * function. The proxy/function relationship is immutable for the
+         * lifetime of the tool, so the resolution is done once.
+         */
+        private val invocable: KFunction<*> = run {
+            val declaredInterfaces = bean::class.java.interfaces
+            if (declaredInterfaces.isNotEmpty()) {
+                for (interfaceType in declaredInterfaces) {
+                    val match = interfaceType.kotlin.functions.firstOrNull { candidate ->
+                        candidate.sameSignatureAs(function)
+                    }
+                    if (match != null) return@run match
+                }
+            }
+            function
+        }
+
         override suspend fun execute(input: I, context: ToolExecutionContext): Any {
-            val invocable = resolveInvocableFunction()
             return if (invocable.isSuspend) {
                 invocable.callSuspend(bean, input) ?: Unit
             } else {
                 invocable.call(bean, input) ?: Unit
             }
-        }
-
-        /**
-         * The discovered [function] belongs to the tool's target class. For a
-         * JDK interface proxy the bean is NOT an instance of that target class,
-         * so invoking the target-class function on the proxy receiver throws a
-         * receiver-type mismatch. Resolve the same method against an interface
-         * the bean actually implements (Kotlin metadata is preserved there, so
-         * suspend functions stay suspend) — invocation then dispatches through
-         * the proxy and Spring AOP advice runs. Plain objects and CGLIB proxies
-         * fall back to the discovered target-class function.
-         */
-        private fun resolveInvocableFunction(): KFunction<*> {
-            val declaredInterfaces = bean::class.java.interfaces
-            if (declaredInterfaces.isNotEmpty()) {
-                for (interfaceType in declaredInterfaces) {
-                    val match = interfaceType.kotlin.functions.firstOrNull { candidate ->
-                        candidate.name == function.name &&
-                            candidate.valueParameters.size == function.valueParameters.size
-                    }
-                    if (match != null) return match
-                }
-            }
-            return function
         }
     }
 }

--- a/tramai-spring-core/src/test/kotlin/dev/tramai/spring/AiToolScannerTest.kt
+++ b/tramai-spring-core/src/test/kotlin/dev/tramai/spring/AiToolScannerTest.kt
@@ -2,10 +2,13 @@ package dev.tramai.spring
 
 import dev.tramai.core.annotations.AiTool
 import dev.tramai.core.model.SideEffectLevel
+import dev.tramai.core.model.ToolExecutionContext
+import dev.tramai.core.model.TramaiTool
 import dev.tramai.core.policy.ApprovalMode
 import dev.tramai.core.policy.AuditDetail
 import dev.tramai.core.policy.ManagedNetworkEgress
 import dev.tramai.core.policy.RiskLevel
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
@@ -157,7 +160,6 @@ class AiToolScannerTest {
     @Test
     fun `jdk dynamic proxy bean is scanned correctly`() {
         val context = GenericApplicationContext().apply {
-            beanFactory.registerSingleton("toolServiceTarget", ToolServiceImpl())
             registerBeanDefinition("jdkProxyToolBean", RootBeanDefinition(ToolServiceImpl::class.java))
             beanFactory.addBeanPostProcessor(
                 object : BeanPostProcessor {
@@ -180,6 +182,98 @@ class AiToolScannerTest {
 
         assertEquals(listOf("lookupInvoice"), toolNames)
     }
+
+    @Test
+    fun `jdk proxied blocking tool executes through the proxy and preserves advice`() {
+        val advice = RecordingMethodInterceptor()
+        val context = GenericApplicationContext().apply {
+            registerBeanDefinition("jdkProxyToolBean", RootBeanDefinition(ToolServiceImpl::class.java))
+            beanFactory.addBeanPostProcessor(
+                object : BeanPostProcessor {
+                    override fun postProcessAfterInitialization(bean: Any, beanName: String): Any {
+                        if (beanName != "jdkProxyToolBean") {
+                            return bean
+                        }
+
+                        return ProxyFactory(bean).apply {
+                            setInterfaces(ToolService::class.java)
+                            isProxyTargetClass = false
+                            addAdvice(advice)
+                        }.proxy
+                    }
+                },
+            )
+            refresh()
+        }
+
+        val tool = AiToolScanner.fromApplicationContext(context).single()
+        val result = runBlocking {
+            (tool as TramaiTool<ToolInput, Any>).execute(ToolInput("inv-1"), toolExecutionContext())
+        }
+
+        assertEquals("inv-1", result)
+        assertEquals(listOf("lookupInvoice"), advice.invocations)
+    }
+
+    @Test
+    fun `jdk proxied suspend tool executes through the proxy and preserves advice`() {
+        val advice = RecordingMethodInterceptor()
+        val context = GenericApplicationContext().apply {
+            registerBeanDefinition("jdkSuspendProxyToolBean", RootBeanDefinition(SuspendToolServiceImpl::class.java))
+            beanFactory.addBeanPostProcessor(
+                object : BeanPostProcessor {
+                    override fun postProcessAfterInitialization(bean: Any, beanName: String): Any {
+                        if (beanName != "jdkSuspendProxyToolBean") {
+                            return bean
+                        }
+
+                        return ProxyFactory(bean).apply {
+                            setInterfaces(SuspendToolService::class.java)
+                            isProxyTargetClass = false
+                            addAdvice(advice)
+                        }.proxy
+                    }
+                },
+            )
+            refresh()
+        }
+
+        val tool = AiToolScanner.fromApplicationContext(context).single()
+        val result = runBlocking {
+            (tool as TramaiTool<ToolInput, Any>).execute(ToolInput("inv-2"), toolExecutionContext())
+        }
+
+        assertEquals("inv-2", result)
+        assertEquals(listOf("lookupInvoice"), advice.invocations)
+    }
+
+    @Test
+    fun `cglib proxied tool executes through the proxy and preserves advice`() {
+        val advice = RecordingMethodInterceptor()
+        val proxiedBean = ProxyFactory(ToolBean()).apply {
+            isProxyTargetClass = true
+            addAdvice(advice)
+        }.getProxy()
+        val context = GenericApplicationContext().apply {
+            beanFactory.registerSingleton("cglibProxiedToolBean", proxiedBean)
+            refresh()
+        }
+
+        val tool = AiToolScanner.fromApplicationContext(context).single()
+        val result = runBlocking {
+            (tool as TramaiTool<ToolInput, Any>).execute(ToolInput("inv-3"), toolExecutionContext())
+        }
+
+        assertEquals("inv-3", result)
+        assertEquals(listOf("lookupInvoice"), advice.invocations)
+    }
+
+    private fun toolExecutionContext() = ToolExecutionContext(
+        operationName = "test",
+        modelName = "local-model",
+        attemptNumber = 1,
+        timeout = java.time.Duration.ofSeconds(10),
+    )
 
     data class ToolInput(val invoiceId: String)
 
@@ -251,5 +345,24 @@ class AiToolScannerTest {
     open class ToolServiceImpl : ToolService {
         @AiTool(description = "Looks up an invoice", sideEffectLevel = SideEffectLevel.READ_ONLY)
         override fun lookupInvoice(input: ToolInput): String = input.invoiceId
+    }
+
+    interface SuspendToolService {
+        @AiTool(description = "Looks up an invoice", sideEffectLevel = SideEffectLevel.READ_ONLY)
+        suspend fun lookupInvoice(input: ToolInput): String
+    }
+
+    open class SuspendToolServiceImpl : SuspendToolService {
+        @AiTool(description = "Looks up an invoice", sideEffectLevel = SideEffectLevel.READ_ONLY)
+        override suspend fun lookupInvoice(input: ToolInput): String = input.invoiceId
+    }
+
+    class RecordingMethodInterceptor : org.aopalliance.intercept.MethodInterceptor {
+        val invocations = mutableListOf<String>()
+
+        override fun invoke(invocation: org.aopalliance.intercept.MethodInvocation): Any {
+            invocations += invocation.method.name
+            return invocation.proceed() ?: Unit
+        }
     }
 }

--- a/tramai-spring-core/src/test/kotlin/dev/tramai/spring/AiToolScannerTest.kt
+++ b/tramai-spring-core/src/test/kotlin/dev/tramai/spring/AiToolScannerTest.kt
@@ -268,6 +268,59 @@ class AiToolScannerTest {
         assertEquals(listOf("lookupInvoice"), advice.invocations)
     }
 
+    @Test
+    fun `jdk proxied overloaded tools select the exact signature and metadata`() {
+        val advice = RecordingMethodInterceptor()
+        val context = GenericApplicationContext().apply {
+            registerBeanDefinition("jdkOverloadedToolBean", RootBeanDefinition(OverloadedToolServiceImpl::class.java))
+            beanFactory.addBeanPostProcessor(
+                object : BeanPostProcessor {
+                    override fun postProcessAfterInitialization(bean: Any, beanName: String): Any {
+                        if (beanName != "jdkOverloadedToolBean") {
+                            return bean
+                        }
+
+                        return ProxyFactory(bean).apply {
+                            setInterfaces(OverloadedToolService::class.java)
+                            isProxyTargetClass = false
+                            addAdvice(advice)
+                        }.proxy
+                    }
+                },
+            )
+            refresh()
+        }
+
+        val tools = AiToolScanner.fromApplicationContext(context)
+            .sortedBy { it.name }
+            .map { tool ->
+                tool to requireNotNull(tool.security).permission
+            }
+
+        // 1 + 2: both overloads discovered with their OWN interface annotation
+        // (name + permission come from the exact signature, not name/arity).
+        assertEquals(
+            listOf("lookupCustomer" to "customer.read", "lookupInvoice" to "invoice.read"),
+            tools.map { it.first.name to it.second },
+        )
+
+        // 3 + 4: each dispatches through the proxy to the correct impl overload,
+        // with Spring AOP advice running for both.
+        val byName = tools.associate { it.first.name to it.first }
+        val customerResult = runBlocking {
+            (byName.getValue("lookupCustomer") as TramaiTool<CustomerInput, Any>)
+                .execute(CustomerInput("c-1"), toolExecutionContext())
+        }
+        val invoiceResult = runBlocking {
+            (byName.getValue("lookupInvoice") as TramaiTool<InvoiceInput, Any>)
+                .execute(InvoiceInput("inv-1"), toolExecutionContext())
+        }
+
+        assertEquals("customer:c-1", customerResult)
+        assertEquals("invoice:inv-1", invoiceResult)
+        assertEquals(listOf("lookup", "lookup"), advice.invocations)
+    }
+
     private fun toolExecutionContext() = ToolExecutionContext(
         operationName = "test",
         modelName = "local-model",
@@ -276,6 +329,10 @@ class AiToolScannerTest {
     )
 
     data class ToolInput(val invoiceId: String)
+
+    data class InvoiceInput(val invoiceId: String)
+
+    data class CustomerInput(val customerId: String)
 
     open class ToolBean {
         @AiTool(description = "Looks up an invoice", sideEffectLevel = SideEffectLevel.READ_ONLY)
@@ -355,6 +412,35 @@ class AiToolScannerTest {
     open class SuspendToolServiceImpl : SuspendToolService {
         @AiTool(description = "Looks up an invoice", sideEffectLevel = SideEffectLevel.READ_ONLY)
         override suspend fun lookupInvoice(input: ToolInput): String = input.invoiceId
+    }
+
+    interface OverloadedToolService {
+        @AiTool(
+            name = "lookupInvoice",
+            description = "Looks up an invoice",
+            sideEffectLevel = SideEffectLevel.READ_ONLY,
+            permission = "invoice.read",
+        )
+        fun lookup(input: InvoiceInput): String
+
+        @AiTool(
+            name = "lookupCustomer",
+            description = "Looks up a customer",
+            sideEffectLevel = SideEffectLevel.READ_ONLY,
+            permission = "customer.read",
+        )
+        fun lookup(input: CustomerInput): String
+    }
+
+    /**
+     * Same-name, same-arity overloads with NO annotations on the impl methods
+     * (annotations on overrides are not inherited) — this forces the interface
+     * fallback to resolve by exact signature, not name/arity.
+     */
+    open class OverloadedToolServiceImpl : OverloadedToolService {
+        override fun lookup(input: InvoiceInput): String = "invoice:${input.invoiceId}"
+
+        override fun lookup(input: CustomerInput): String = "customer:${input.customerId}"
     }
 
     class RecordingMethodInterceptor : org.aopalliance.intercept.MethodInterceptor {


### PR DESCRIPTION
## H2 — fix(spring): invoke AiTool methods through Spring proxies

Integration-review fix (final track review finding 2). Branch from `04942322` (track head). The review correctly identified that JDK-proxied `@AiTool` beans were *discovered but structurally broken* — investigation found the defect was actually two layers deep.

### Root cause (deeper than reported)

1. **Discovery was silently skipping JDK proxies entirely.** `findAnnotatedBeans` resolves the bean type via `getType(beanName)`; for a JDK-proxied bean this returns the `$Proxy` class, whose synthesized methods carry no annotations — so the `hasTool` check returned false and the bean was never scanned. The pre-existing `jdk dynamic proxy bean is scanned correctly` test only passed because a **raw target singleton** was also registered in the same context; the proxy bean itself was never the subject.
2. **Invocation was receiver-broken.** `MethodBackedTramaiTool` kept the Spring bean (the proxy) as receiver but invoked the target-class `KFunction` — `KFunction.call(proxy, …)` throws a receiver-type mismatch because a JDK proxy is not an instance of the concrete class. (CGLIB proxies survive via subclassing.)

### Fix
- `hasTool` now also checks `@AiTool` declared on interfaces the bean type implements; `validateAndCreateTool` falls back to the interface function's annotation (method annotations are not inherited on overrides).
- `MethodBackedTramaiTool` resolves the invocable function against an interface the bean actually implements (Kotlin metadata preserved — suspend stays suspend) and dispatches **through the proxy**, so Spring AOP advice runs. Plain objects and CGLIB proxies fall back to the discovered target-class function.
- No unwrapping, no AOP bypass, no global CGLIB forcing — per the review's criteria.

### Regression tests (AiToolScannerTest)
- JDK-proxied **blocking** tool executes through the proxy; `RecordingMethodInterceptor` proves advice runs.
- JDK-proxied **suspend** tool executes through the proxy; advice runs.
- CGLIB-proxied tool executes through the proxy; advice runs.
- The old discovery test now tests the proxy bean alone (raw singleton removed — it was masking the bug).

### Validation
- `:tramai-spring-core:test --rerun-tasks` ✅
- `verifyPr -PchangeClass=runtime-behaviour` ✅ (no api dump change — scanner internals only)
