### PR TITLE
build(quality): add unified 0.6.0 architecture gate (Epic 10.4, Track B2)

### DIFF
--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/ArchitectureReport.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/ArchitectureReport.kt
@@ -1,0 +1,108 @@
+package dev.tramai.build.quality
+
+import java.io.File
+
+enum class ArchitectureCheckStatus { PASS, FAIL }
+
+data class ArchitectureCheckResult(
+    val id: String,
+    val status: ArchitectureCheckStatus,
+    val diagnostics: List<VerificationDiagnostic>,
+)
+
+data class ArchitectureVerificationSummary(
+    val checks: Int,
+    val passed: Int,
+    val failed: Int,
+)
+
+data class ArchitectureVerificationReport(
+    val schemaVersion: String = "1",
+    val status: ArchitectureCheckStatus,
+    val checks: List<ArchitectureCheckResult>,
+    val summary: ArchitectureVerificationSummary,
+)
+
+object ArchitectureReportAggregator {
+    val checkIds: Set<String> = setOf(
+        "module-manifest",
+        "publishing-topology",
+        "dependency-boundaries",
+        "dependency-cycles",
+        "global-state",
+        "api-architecture",
+        "protocol-catalog",
+        "cancellation-safety",
+        "provider-contracts",
+        "store-contracts",
+    )
+
+    fun aggregate(checkDiagnostics: Map<String, List<VerificationDiagnostic>>): ArchitectureVerificationReport {
+        val checks = checkDiagnostics
+            .map { (id, diagnostics) ->
+                val sortedDiagnostics = diagnostics.sortedWith(
+                    compareBy<VerificationDiagnostic> { it.code.name }
+                        .thenBy { it.severity.name }
+                        .thenBy { it.message }
+                        .thenBy { it.modulePath.orEmpty() }
+                        .thenBy { it.findingId.orEmpty() }
+                        .thenBy { it.deviationId.orEmpty() }
+                )
+                ArchitectureCheckResult(
+                    id = id,
+                    status = if (sortedDiagnostics.any { it.severity == DiagnosticSeverity.FAILURE }) {
+                        ArchitectureCheckStatus.FAIL
+                    } else {
+                        ArchitectureCheckStatus.PASS
+                    },
+                    diagnostics = sortedDiagnostics,
+                )
+            }
+            .sortedBy { it.id }
+        val failed = checks.count { it.status == ArchitectureCheckStatus.FAIL }
+        return ArchitectureVerificationReport(
+            status = if (failed == 0) ArchitectureCheckStatus.PASS else ArchitectureCheckStatus.FAIL,
+            checks = checks,
+            summary = ArchitectureVerificationSummary(
+                checks = checks.size,
+                passed = checks.size - failed,
+                failed = failed,
+            ),
+        )
+    }
+}
+
+object ArchitectureReportJson {
+    fun write(report: ArchitectureVerificationReport, outputFile: File) {
+        ReportNormalizer.writeJson(toJsonValue(report), outputFile)
+    }
+
+    fun toJson(report: ArchitectureVerificationReport): String =
+        ReportNormalizer.toJson(toJsonValue(report))
+
+    private fun toJsonValue(report: ArchitectureVerificationReport): Map<String, Any> = mapOf(
+        "schemaVersion" to report.schemaVersion,
+        "status" to report.status.name,
+        "checks" to report.checks.map { check ->
+            mapOf(
+                "id" to check.id,
+                "status" to check.status.name,
+                "diagnostics" to check.diagnostics.map(::diagnosticJson),
+            )
+        },
+        "summary" to mapOf(
+            "checks" to report.summary.checks,
+            "passed" to report.summary.passed,
+            "failed" to report.summary.failed,
+        ),
+    )
+
+    private fun diagnosticJson(diagnostic: VerificationDiagnostic): Map<String, String> = buildMap {
+        put("code", diagnostic.code.name)
+        put("severity", diagnostic.severity.name)
+        put("message", diagnostic.message)
+        diagnostic.modulePath?.let { put("modulePath", it) }
+        diagnostic.findingId?.let { put("findingId", it) }
+        diagnostic.deviationId?.let { put("deviationId", it) }
+    }
+}

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/ArchitectureReport.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/ArchitectureReport.kt
@@ -38,6 +38,10 @@ object ArchitectureReportAggregator {
     )
 
     fun aggregate(checkDiagnostics: Map<String, List<VerificationDiagnostic>>): ArchitectureVerificationReport {
+        require(checkDiagnostics.keys == checkIds) {
+            "Architecture aggregator contract: expected exactly ${checkIds.size} stable check ids " +
+                "${checkIds.sorted()}, but received ${checkDiagnostics.keys.sorted()}"
+        }
         val checks = checkDiagnostics
             .map { (id, diagnostics) ->
                 val sortedDiagnostics = diagnostics.sortedWith(
@@ -104,5 +108,77 @@ object ArchitectureReportJson {
         diagnostic.modulePath?.let { put("modulePath", it) }
         diagnostic.findingId?.let { put("findingId", it) }
         diagnostic.deviationId?.let { put("deviationId", it) }
+        diagnostic.baselineValue?.let { put("baselineValue", it) }
+        diagnostic.currentValue?.let { put("currentValue", it) }
     }
+}
+
+/**
+ * Fail-closed evidence collection for the architecture gate: an exception in an
+ * evidence source becomes FAILURE diagnostics on the affected checks instead of
+ * aborting before the report is written. The final report write must happen
+ * after all collectEvidence calls and before the terminal exception.
+ */
+internal fun collectEvidence(
+    label: String,
+    affectedChecks: Set<String>,
+    target: Map<String, MutableList<VerificationDiagnostic>>,
+    evidence: () -> Unit,
+) {
+    try {
+        evidence()
+    } catch (exception: Exception) {
+        affectedChecks.forEach { checkId ->
+            target.getValue(checkId) += VerificationDiagnostic.failure(
+                DiagnosticCode.EMPTY_SECTION,
+                "$label could not complete: ${exception.message ?: exception.javaClass.name}",
+            )
+        }
+    }
+}
+
+/**
+ * Pinned identities of every enrollment architecture guard the 0.6.0 gate
+ * requires. Discovery is by exact class identity, not by count: deleting or
+ * renaming one of these classes must fail the gate even if the others still run.
+ */
+internal val enrollmentArchitectureTestClasses: Set<String> = setOf(
+    "dev.tramai.testing.ProviderTckEnrollmentArchitectureTest",
+    "dev.tramai.testing.ApprovalContinuationStoreTckEnrollmentArchitectureTest",
+    "dev.tramai.testing.ApprovalStoreTckEnrollmentArchitectureTest",
+    "dev.tramai.testing.AuditStoreTckEnrollmentArchitectureTest",
+    "dev.tramai.testing.ChatMemoryStoreTckEnrollmentArchitectureTest",
+    "dev.tramai.testing.SovereignOpsAuditOutboxStoreTckEnrollmentArchitectureTest",
+    "dev.tramai.testing.SuspendedInvocationStoreTckEnrollmentArchitectureTest",
+    "dev.tramai.testing.WorkflowCheckpointStoreTckEnrollmentArchitectureTest",
+    "dev.tramai.testing.WorkflowLeaseCheckpointFenceTckEnrollmentArchitectureTest",
+    "dev.tramai.testing.WorkflowLeaseStoreTckEnrollmentArchitectureTest",
+)
+
+/**
+ * Compares discovered enrollment test classes against the pinned identities.
+ * Returns check-id → FAILURE diagnostics for missing (deleted/renamed) guards
+ * and for unexpected discovered classes (identity drift).
+ */
+internal fun enrollmentGuardDiagnostics(discoveredClasses: Set<String>): Map<String, List<VerificationDiagnostic>> {
+    val providerClass = "dev.tramai.testing.ProviderTckEnrollmentArchitectureTest"
+    fun route(className: String): String = if (className == providerClass) "provider-contracts" else "store-contracts"
+    val result = mutableMapOf<String, MutableList<VerificationDiagnostic>>()
+    (enrollmentArchitectureTestClasses - discoveredClasses).forEach { className ->
+        result.getOrPut(route(className)) { mutableListOf() }.add(
+            VerificationDiagnostic.failure(
+                DiagnosticCode.EMPTY_SECTION,
+                "Expected enrollment architecture test $className was not discovered — its guard may have been deleted or renamed",
+            ),
+        )
+    }
+    (discoveredClasses - enrollmentArchitectureTestClasses).forEach { className ->
+        result.getOrPut(route(className)) { mutableListOf() }.add(
+            VerificationDiagnostic.failure(
+                DiagnosticCode.EMPTY_SECTION,
+                "Unexpected enrollment architecture test $className was discovered — guard identity drifted",
+            ),
+        )
+    }
+    return result
 }

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/ArchitectureReport.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/ArchitectureReport.kt
@@ -77,21 +77,21 @@ object ArchitectureReportAggregator {
 }
 
 object ArchitectureReportJson {
-    fun write(report: ArchitectureVerificationReport, outputFile: File) {
-        ReportNormalizer.writeJson(toJsonValue(report), outputFile)
+    fun write(report: ArchitectureVerificationReport, outputFile: File, repoRoot: File) {
+        ReportNormalizer.writeJson(toJsonValue(report, repoRoot), outputFile)
     }
 
-    fun toJson(report: ArchitectureVerificationReport): String =
-        ReportNormalizer.toJson(toJsonValue(report))
+    fun toJson(report: ArchitectureVerificationReport, repoRoot: File): String =
+        ReportNormalizer.toJson(toJsonValue(report, repoRoot))
 
-    private fun toJsonValue(report: ArchitectureVerificationReport): Map<String, Any> = mapOf(
+    private fun toJsonValue(report: ArchitectureVerificationReport, repoRoot: File): Map<String, Any> = mapOf(
         "schemaVersion" to report.schemaVersion,
         "status" to report.status.name,
         "checks" to report.checks.map { check ->
             mapOf(
                 "id" to check.id,
                 "status" to check.status.name,
-                "diagnostics" to check.diagnostics.map(::diagnosticJson),
+                "diagnostics" to check.diagnostics.map { diagnosticJson(it, repoRoot) },
             )
         },
         "summary" to mapOf(
@@ -101,15 +101,96 @@ object ArchitectureReportJson {
         ),
     )
 
-    private fun diagnosticJson(diagnostic: VerificationDiagnostic): Map<String, String> = buildMap {
+    private fun diagnosticJson(diagnostic: VerificationDiagnostic, repoRoot: File): Map<String, String> = buildMap {
         put("code", diagnostic.code.name)
         put("severity", diagnostic.severity.name)
-        put("message", diagnostic.message)
+        put("message", sanitizePaths(diagnostic.message, repoRoot))
         diagnostic.modulePath?.let { put("modulePath", it) }
-        diagnostic.findingId?.let { put("findingId", it) }
+        diagnostic.findingId?.let { put("findingId", sanitizePaths(it, repoRoot)) }
         diagnostic.deviationId?.let { put("deviationId", it) }
-        diagnostic.baselineValue?.let { put("baselineValue", it) }
-        diagnostic.currentValue?.let { put("currentValue", it) }
+        diagnostic.baselineValue?.let { put("baselineValue", sanitizePaths(it, repoRoot)) }
+        diagnostic.currentValue?.let { put("currentValue", sanitizePaths(it, repoRoot)) }
+    }
+
+    /** Replaces the repository checkout root with a portable placeholder so failure
+     *  reports are path-independent across machines. */
+    private fun sanitizePaths(value: String, repoRoot: File): String {
+        val root = repoRoot.absolutePath
+        return value.replace(root, "<repo-root>")
+            .replace(root.replace(File.separatorChar, '/'), "<repo-root>")
+            .replace(root.replace('/', File.separatorChar), "<repo-root>")
+    }
+}
+
+/**
+ * Reads per-project fail-soft dependency probe outputs for the architecture
+ * gate. A probe that hit a resolution failure writes a typed marker instead of
+ * throwing, so the gate can fail closed with evidence rather than the task
+ * graph aborting before the report is written.
+ */
+internal data class DependencyProbeEvidence(
+    val resolvedRecords: List<ResolvedDependency>,
+    val failures: List<String>,
+)
+
+internal fun readDependencyProbeEvidence(probeFiles: List<File>): DependencyProbeEvidence {
+    val resolvedRecords = mutableListOf<ResolvedDependency>()
+    val failures = mutableListOf<String>()
+    probeFiles.forEach { file ->
+        if (!file.isFile) {
+            failures += "Missing dependency probe output: ${file.path}"
+            return@forEach
+        }
+        try {
+            val raw = ReportNormalizer.readJson(file, Array<Any>::class.java).toList()
+            val failed = raw.firstOrNull { (it as? Map<*, *>)?.get("resolutionFailed") == true }
+            if (failed != null) {
+                failures += (failed as Map<*, *>)["message"]?.toString() ?: "unknown dependency resolution failure"
+            } else {
+                resolvedRecords += ReportNormalizer.readJson(file, Array<ResolvedDependency>::class.java).toList()
+            }
+        } catch (exception: Exception) {
+            failures += "Invalid dependency probe output ${file.path}: ${exception.message}"
+        }
+    }
+    return DependencyProbeEvidence(resolvedRecords, failures)
+}
+
+/**
+ * Codes whose FAILURE presence means the baseline verifier could not establish
+ * its mandatory evidence (it early-returns without running the architecture
+ * checks). These must fail EVERY baseline-backed check: the gate cannot claim
+ * a check passed when its evidence was never produced.
+ */
+internal val baselineEvidenceFailureCodes: Set<DiagnosticCode> = setOf(
+    DiagnosticCode.EMPTY_SECTION,
+    DiagnosticCode.DEPENDENCY_RESOLUTION_FAILED,
+)
+
+/**
+ * Routes baseline diagnostics into the architecture gate. If the baseline
+ * verifier early-returned with evidence-unavailable FAILURE diagnostics
+ * ([baselineEvidenceFailureCodes]), every baseline-backed check fails closed.
+ * Otherwise diagnostics are routed through [classify] (the exhaustive
+ * DiagnosticCode → check-id mapping).
+ */
+internal fun routeBaselineDiagnostics(
+    diagnostics: List<VerificationDiagnostic>,
+    target: Map<String, MutableList<VerificationDiagnostic>>,
+    baselineCheckIds: Set<String>,
+    classify: (DiagnosticCode) -> String?,
+) {
+    val evidenceFailures = diagnostics.filter {
+        it.severity == DiagnosticSeverity.FAILURE && it.code in baselineEvidenceFailureCodes
+    }
+    if (evidenceFailures.isNotEmpty()) {
+        baselineCheckIds.forEach { checkId ->
+            target.getValue(checkId) += evidenceFailures
+        }
+    } else {
+        diagnostics.forEach { diagnostic ->
+            classify(diagnostic.code)?.let { target.getValue(it) += diagnostic }
+        }
     }
 }
 

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/DependencyResolutionTasks.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/DependencyResolutionTasks.kt
@@ -1,6 +1,7 @@
 package dev.tramai.build.quality
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.Project
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
@@ -12,7 +13,6 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.GradleException
 import java.io.File
-import javax.inject.Inject
 
 abstract class GenerateResolvedDependencyBaselineTask : DefaultTask() {
 
@@ -25,92 +25,139 @@ abstract class GenerateResolvedDependencyBaselineTask : DefaultTask() {
 
     @TaskAction
     fun collect() {
-        val records = mutableListOf<ResolvedDependency>()
-
-        // Only resolve configurations owned by THIS project (Gradle 9 lock rule)
-        listOf("compileClasspath", "runtimeClasspath").forEach { configName ->
-            val config = project.configurations.findByName(configName)
-            if (config == null || !config.isCanBeResolved) return@forEach
-
-            val resolutionResult = config.incoming.resolutionResult
-            val root = resolutionResult.rootComponent.get()
-
-            traverseDependencyTree(
-                consumer = project.path,
-                configuration = configName,
-                component = root,
-                path = listOf(project.path),
-                depth = 0,
-                ancestry = mutableSetOf(root.id.displayName),
-                records = records
-            )
-        }
-
-        val normalized = DependencyEdgeNormalizer.normalize(records)
+        val normalized = DependencyEdgeNormalizer.normalize(collectResolvedDependencies(project))
         outputFile.get().asFile.let { file ->
             file.parentFile.mkdirs()
             ReportNormalizer.writeJson(normalized, file)
         }
     }
+}
 
-    private fun traverseDependencyTree(
-        consumer: String,
-        configuration: String,
-        component: ResolvedComponentResult,
-        path: List<String>,
-        depth: Int,
-        ancestry: MutableSet<String>,
-        records: MutableList<ResolvedDependency>
-    ) {
-        component.dependencies.toList().sortedBy { it.requested.displayName }.forEach { dep ->
-            if (dep is UnresolvedDependencyResult) {
-                throw GradleException(
-                    "Failed to resolve $consumer:$configuration dependency " +
-                        "${dep.requested.displayName}: ${dep.failure.message}"
+/**
+ * Resolves [project]'s compile/runtime classpath and returns raw dependency
+ * records. Shared by [GenerateResolvedDependencyBaselineTask] (per-project
+ * probe files) and the architecture gate (in-process aggregate generation).
+ * Throws [GradleException] on an unresolved dependency — callers decide whether
+ * that aborts the build (probe task) or becomes fail-closed evidence (gate).
+ */
+internal fun collectResolvedDependencies(project: Project): List<ResolvedDependency> {
+    val records = mutableListOf<ResolvedDependency>()
+
+    // Only resolve configurations owned by THIS project (Gradle 9 lock rule)
+    listOf("compileClasspath", "runtimeClasspath").forEach { configName ->
+        val config = project.configurations.findByName(configName)
+        if (config == null || !config.isCanBeResolved) return@forEach
+
+        val resolutionResult = config.incoming.resolutionResult
+        val root = resolutionResult.rootComponent.get()
+
+        traverseDependencyTree(
+            consumer = project.path,
+            configuration = configName,
+            component = root,
+            path = listOf(project.path),
+            depth = 0,
+            ancestry = mutableSetOf(root.id.displayName),
+            records = records
+        )
+    }
+    return records
+}
+
+/**
+ * Fail-soft per-project dependency probe for the architecture gate. Unlike
+ * [GenerateResolvedDependencyBaselineTask] it NEVER throws on unresolved
+ * dependencies: a resolution failure is written into the output file as a
+ * typed marker, so the gate can report fail-closed evidence instead of the
+ * task graph aborting before the report is written.
+ */
+abstract class ArchitectureDependencyProbeTask : DefaultTask() {
+
+    init {
+        outputs.upToDateWhen { false }
+    }
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun collect() {
+        val file = outputFile.get().asFile
+        file.parentFile.mkdirs()
+        try {
+            val normalized = DependencyEdgeNormalizer.normalize(collectResolvedDependencies(project))
+            ReportNormalizer.writeJson(normalized, file)
+        } catch (exception: Exception) {
+            ReportNormalizer.writeJson(
+                listOf(
+                    mapOf(
+                        "resolutionFailed" to true,
+                        "message" to (exception.message ?: exception.javaClass.name),
+                    ),
+                ),
+                file,
+            )
+        }
+    }
+}
+
+private fun traverseDependencyTree(
+    consumer: String,
+    configuration: String,
+    component: ResolvedComponentResult,
+    path: List<String>,
+    depth: Int,
+    ancestry: MutableSet<String>,
+    records: MutableList<ResolvedDependency>
+) {
+    component.dependencies.toList().sortedBy { it.requested.displayName }.forEach { dep ->
+        if (dep is UnresolvedDependencyResult) {
+            throw GradleException(
+                "Failed to resolve $consumer:$configuration dependency " +
+                    "${dep.requested.displayName}: ${dep.failure.message}"
+            )
+        }
+        if (dep is ResolvedDependencyResult) {
+            val selected = dep.selected
+            val selectedId = selected.id
+            val pathElement = when (selectedId) {
+                is ModuleComponentIdentifier -> "${selectedId.group}:${selectedId.module}:${selectedId.version}"
+                is ProjectComponentIdentifier -> selectedId.projectPath
+                else -> selectedId.displayName
+            }
+            val nextPath = path + pathElement
+
+            if (selectedId is ModuleComponentIdentifier) {
+                val requested = (dep.requested as? ModuleComponentSelector)?.version
+                records.add(
+                    ResolvedDependency(
+                        group = selectedId.group,
+                        artifact = selectedId.module,
+                        selectedVersion = selectedId.version,
+                        requestedVersion = requested,
+                        direct = depth == 0,
+                        configuration = configuration,
+                        selectionReason = selected.selectionReason.descriptions
+                            .map { it.description }
+                            .sorted()
+                            .joinToString("; "),
+                        dependencyPath = nextPath,
+                        consumers = listOf(consumer)
+                    )
                 )
             }
-            if (dep is ResolvedDependencyResult) {
-                val selected = dep.selected
-                val selectedId = selected.id
-                val pathElement = when (selectedId) {
-                    is ModuleComponentIdentifier -> "${selectedId.group}:${selectedId.module}:${selectedId.version}"
-                    is ProjectComponentIdentifier -> selectedId.projectPath
-                    else -> selectedId.displayName
-                }
-                val nextPath = path + pathElement
 
-                if (selectedId is ModuleComponentIdentifier) {
-                    val requested = (dep.requested as? ModuleComponentSelector)?.version
-                    records.add(
-                        ResolvedDependency(
-                            group = selectedId.group,
-                            artifact = selectedId.module,
-                            selectedVersion = selectedId.version,
-                            requestedVersion = requested,
-                            direct = depth == 0,
-                            configuration = configuration,
-                            selectionReason = selected.selectionReason.descriptions
-                                .map { it.description }
-                                .sorted()
-                                .joinToString("; "),
-                            dependencyPath = nextPath,
-                            consumers = listOf(consumer)
-                        )
-                    )
-                }
-
-                if (selectedId.displayName !in ancestry) {
-                    ancestry.add(selectedId.displayName)
-                    traverseDependencyTree(
-                        consumer = consumer,
-                        configuration = configuration,
-                        component = selected,
-                        path = nextPath,
-                        depth = depth + 1,
-                        ancestry = ancestry,
-                        records = records
-                    )
-                }
+            if (selectedId.displayName !in ancestry) {
+                ancestry.add(selectedId.displayName)
+                traverseDependencyTree(
+                    consumer = consumer,
+                    configuration = configuration,
+                    component = selected,
+                    path = nextPath,
+                    depth = depth + 1,
+                    ancestry = ancestry,
+                    records = records
+                )
             }
         }
     }

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
@@ -906,58 +906,58 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
         project.tasks.register("verify060Architecture") {
             group = "verification"
             description = "build(quality): add unified 0.6.0 architecture gate"
+            dependsOn("generateResolvedDependencyBaseline")
             dependsOn(enrollmentTest)
             doLast {
                 val architectureDiagnostics = ArchitectureReportAggregator.checkIds
                     .associateWith { mutableListOf<VerificationDiagnostic>() }
+                val context = MeasurementContext.fromProject(project)
                 val verificationReport = File(reportDir, "verification-report.json")
-                try {
-                    BaselineVerifier(BaselineGenerator(MeasurementContext.fromProject(project)),
-                        MeasurementContext.fromProject(project), reportDir).verify()
+
+                collectEvidence("baseline verification", baselineCheckIds, architectureDiagnostics) {
+                    BaselineVerifier(BaselineGenerator(context), context, reportDir).verify()
                     addBaselineDiagnostics(readBaselineDiagnostics(verificationReport), architectureDiagnostics)
-                } catch (exception: Exception) {
-                    baselineCheckIds.forEach { checkId ->
-                        architectureDiagnostics.getValue(checkId) += VerificationDiagnostic.failure(
-                            DiagnosticCode.EMPTY_SECTION,
-                            "Baseline verification could not complete: ${exception.message ?: exception.javaClass.name}",
-                        )
-                    }
                 }
 
-                val catalog = ModuleManifest.catalog(project.rootDir)
-                val actualProjects = project.allprojects
-                    .filter { it != project && it.buildFile.exists() }
-                    .map { it.path }
-                    .toSet()
-                val actualPublished = (project.extensions.extraProperties.properties["tramai.publishableModulePaths"] as? Collection<*>)
-                    ?.map { it.toString() }?.toSet().orEmpty()
-                val bomProject = project.allprojects.firstOrNull { it.name == "tramai-bom" }
-                val actualBom = bomProject
-                    ?.configurations
-                    ?.findByName("api")
-                    ?.dependencyConstraints
-                    .orEmpty()
-                    .mapNotNull { constraint ->
-                        constraint.name.takeIf { it.startsWith("tramai-") || it.startsWith("examples:") }?.let { ":$it" }
-                    }
-                    .toSet()
-                addManifestDiagnostics(
-                    ModuleManifestVerifier.verify(catalog.modules, actualProjects, actualPublished, actualBom),
-                    architectureDiagnostics,
-                )
-                addEnrollmentDiagnostics(
-                    File(project.project(":tramai-testing").buildDir, "test-results/architectureContractEnrollmentTest"),
-                    architectureDiagnostics,
-                )
+                collectEvidence("module manifest verification", setOf("module-manifest", "publishing-topology"), architectureDiagnostics) {
+                    val catalog = ModuleManifest.catalog(project.rootDir)
+                    val actualProjects = project.allprojects
+                        .filter { it != project && it.buildFile.exists() }
+                        .map { it.path }
+                        .toSet()
+                    val actualPublished = (project.extensions.extraProperties.properties["tramai.publishableModulePaths"] as? Collection<*>)
+                        ?.map { it.toString() }?.toSet().orEmpty()
+                    val bomProject = project.allprojects.firstOrNull { it.name == "tramai-bom" }
+                    val actualBom = bomProject
+                        ?.configurations
+                        ?.findByName("api")
+                        ?.dependencyConstraints
+                        .orEmpty()
+                        .mapNotNull { constraint ->
+                            constraint.name.takeIf { it.startsWith("tramai-") || it.startsWith("examples:") }?.let { ":$it" }
+                        }
+                        .toSet()
+                    addManifestDiagnostics(
+                        ModuleManifestVerifier.verify(catalog.modules, actualProjects, actualPublished, actualBom),
+                        architectureDiagnostics,
+                    )
+                }
+
+                collectEvidence("enrollment contract verification", setOf("provider-contracts", "store-contracts"), architectureDiagnostics) {
+                    addEnrollmentDiagnostics(
+                        File(project.project(":tramai-testing").buildDir, "test-results/architectureContractEnrollmentTest"),
+                        architectureDiagnostics,
+                    )
+                }
 
                 val report = ArchitectureReportAggregator.aggregate(architectureDiagnostics)
-                ArchitectureReportJson.write(
-                    report,
-                    File(project.layout.buildDirectory.get().asFile, "reports/tramai/architecture/architecture-report.json"),
-                )
+                val reportFile = File(project.layout.buildDirectory.get().asFile, "reports/tramai/architecture/architecture-report.json")
+                // Report is written BEFORE the terminal exception — failure must produce evidence.
+                ArchitectureReportJson.write(report, reportFile)
                 if (report.status == ArchitectureCheckStatus.FAIL) {
                     throw GradleException("0.6.0 architecture verification FAILED: " +
-                        report.checks.filter { it.status == ArchitectureCheckStatus.FAIL }.joinToString { it.id })
+                        report.checks.filter { it.status == ArchitectureCheckStatus.FAIL }.joinToString { it.id } +
+                        " — see ${reportFile.path}")
                 }
             }
         }
@@ -1210,15 +1210,110 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
         }
     }
 
-    private fun baselineCheckFor(code: DiagnosticCode): String? = when {
-        code.name.startsWith("MODULE_CATALOG_") && code !in publishingTopologyCodes -> "module-manifest"
-        code in setOf(DiagnosticCode.FORBIDDEN_LAYER_EDGE, DiagnosticCode.SELF_DEPENDENCY) -> "dependency-boundaries"
-        code == DiagnosticCode.NEW_DEPENDENCY_CYCLE -> "dependency-cycles"
-        code == DiagnosticCode.NEW_GLOBAL_STATE_FINDING -> "global-state"
-        code.name.startsWith("API_") -> "api-architecture"
-        code == DiagnosticCode.STABLE_PROTOCOL_CONTRACT_REMOVED -> "protocol-catalog"
-        code in setOf(DiagnosticCode.NEW_CANCELLATION_FINDING, DiagnosticCode.CANCELLATION_RISK_WORSENED) -> "cancellation-safety"
-        else -> null
+    /**
+     * Exhaustive classification of every DiagnosticCode. No else branch: adding a
+     * new DiagnosticCode forces a decision at compile time — either it belongs to
+     * an architecture check here, or it is explicitly excluded.
+     */
+    private fun baselineCheckFor(code: DiagnosticCode): String? = when (code) {
+        // Module catalogue (all codes except BOM/publishing drift, which are publishing-topology)
+        DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY,
+        DiagnosticCode.MODULE_CATALOG_UNKNOWN_ENTRY,
+        DiagnosticCode.MODULE_CATALOG_DUPLICATE_PATH,
+        DiagnosticCode.MODULE_CATALOG_INVALID_LAYER,
+        DiagnosticCode.MODULE_CATALOG_MISSING_API_STABILITY,
+        DiagnosticCode.MODULE_CATALOG_EXAMPLE_PUBLISHABLE,
+        DiagnosticCode.MODULE_CATALOG_DISAGREEMENT,
+        DiagnosticCode.MODULE_CATALOG_INVALID_SCHEMA,
+        DiagnosticCode.MODULE_CATALOG_INVALID_MATURITY,
+        DiagnosticCode.MODULE_CATALOG_INVALID_PUBLISHABILITY,
+        DiagnosticCode.MODULE_CATALOG_INVALID_VISIBILITY,
+        DiagnosticCode.MODULE_CATALOG_INVALID_RELEASE_INCLUSION,
+        DiagnosticCode.MODULE_CATALOG_INVALID_POLICY,
+        DiagnosticCode.MODULE_CATALOG_BLANK_OWNER,
+        DiagnosticCode.MODULE_CATALOG_BLANK_RATIONALE,
+        DiagnosticCode.MODULE_CATALOG_INVALID_COMBINATION,
+        -> "module-manifest"
+
+        DiagnosticCode.MODULE_CATALOG_BOM_DRIFT,
+        DiagnosticCode.MODULE_CATALOG_PUBLISHING_DRIFT,
+        -> "publishing-topology"
+
+        DiagnosticCode.FORBIDDEN_LAYER_EDGE,
+        DiagnosticCode.SELF_DEPENDENCY,
+        -> "dependency-boundaries"
+
+        DiagnosticCode.NEW_DEPENDENCY_CYCLE,
+        -> "dependency-cycles"
+
+        DiagnosticCode.NEW_GLOBAL_STATE_FINDING,
+        -> "global-state"
+
+        DiagnosticCode.API_BASELINE_EMPTY,
+        DiagnosticCode.API_DUMP_MISSING,
+        DiagnosticCode.API_DUMP_DUPLICATE,
+        DiagnosticCode.API_MODULE_UNCLASSIFIED,
+        DiagnosticCode.API_VALIDATION_NOT_CONFIGURED,
+        DiagnosticCode.API_COMPATIBILITY_FAILED,
+        DiagnosticCode.API_HASH_CHANGED,
+        DiagnosticCode.API_DUMP_NONDETERMINISTIC,
+        -> "api-architecture"
+
+        DiagnosticCode.STABLE_PROTOCOL_CONTRACT_REMOVED,
+        -> "protocol-catalog"
+
+        DiagnosticCode.NEW_CANCELLATION_FINDING,
+        DiagnosticCode.CANCELLATION_RISK_WORSENED,
+        -> "cancellation-safety"
+
+        // Explicitly outside the 0.6.0 architecture gate.
+        DiagnosticCode.BASELINE_IDENTITY_MISMATCH,
+        DiagnosticCode.ANALYZER_COMMIT_NOT_ANCESTOR,
+        DiagnosticCode.MEASURED_TREE_MISMATCH,
+        DiagnosticCode.TAG_COMMIT_MISMATCH,
+        DiagnosticCode.TAG_TREE_MISMATCH,
+        DiagnosticCode.DIRTY_WORKTREE,
+        DiagnosticCode.DEPENDENCY_BASELINE_EMPTY,
+        DiagnosticCode.DEPENDENCY_RESOLUTION_FAILED,
+        DiagnosticCode.DYNAMIC_DEPENDENCY_VERSION,
+        DiagnosticCode.SNAPSHOT_DEPENDENCY,
+        DiagnosticCode.DEPENDENCY_CONVERGENCE_FAILURE,
+        DiagnosticCode.DEPENDENCY_ADDED,
+        DiagnosticCode.DEPENDENCY_REMOVED,
+        DiagnosticCode.DEPENDENCY_VERSION_CHANGED,
+        DiagnosticCode.TEST_QUALITY_CONFIGURATION_INVALID,
+        DiagnosticCode.COVERAGE_REPORT_MISSING,
+        DiagnosticCode.COVERAGE_REPORT_MALFORMED,
+        DiagnosticCode.COVERAGE_COUNTER_MISSING,
+        DiagnosticCode.COVERAGE_PATH_LEAK,
+        DiagnosticCode.COVERAGE_REGRESSION,
+        DiagnosticCode.COVERAGE_FAMILY_EMPTY,
+        DiagnosticCode.COVERAGE_EXCLUSION_UNDOCUMENTED,
+        DiagnosticCode.MUTATION_REPORT_MISSING,
+        DiagnosticCode.MUTATION_REPORT_MALFORMED,
+        DiagnosticCode.MUTATION_TARGET_EMPTY,
+        DiagnosticCode.MUTATION_REGRESSION,
+        DiagnosticCode.MUTATION_SURVIVOR_UNCLASSIFIED,
+        DiagnosticCode.MUTATION_MISSING_TEST_UNTRACKED,
+        DiagnosticCode.TEST_REPORT_MISSING,
+        DiagnosticCode.TEST_PERFORMANCE_REGRESSION,
+        DiagnosticCode.CRITICAL_TEST_REGRESSION,
+        DiagnosticCode.CRITICAL_TEST_NEWLY_SKIPPED,
+        DiagnosticCode.TEST_QUALITY_STATUS_PENDING,
+        DiagnosticCode.NEW_NONDETERMINISM_FINDING,
+        DiagnosticCode.HOTSPOT_REGRESSION,
+        DiagnosticCode.NEW_TOP_FIVE_HOTSPOT,
+        DiagnosticCode.FILE_GROWTH_EXCEEDED,
+        DiagnosticCode.INVALID_DEVIATION_SCOPE,
+        DiagnosticCode.ORPHANED_DEVIATION,
+        DiagnosticCode.EXPIRED_DEVIATION,
+        DiagnosticCode.DUPLICATE_DEVIATION,
+        DiagnosticCode.MALFORMED_DEVIATION,
+        DiagnosticCode.DEVIATION_BASELINE_MISMATCH,
+        DiagnosticCode.DEVIATION_COVERAGE_EXCEEDED,
+        DiagnosticCode.GENERATED_DOCUMENT_DRIFT,
+        DiagnosticCode.EMPTY_SECTION,
+        -> null
     }
 
     private fun addManifestDiagnostics(
@@ -1248,10 +1343,22 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             return
         }
 
-        val foundChecks = mutableSetOf<String>()
+        val discoveredClasses = mutableSetOf<String>()
         reports.forEach { report ->
+            val className = report.name.removePrefix("TEST-").removeSuffix(".xml")
+            discoveredClasses += className
+            val check = when {
+                className == "dev.tramai.testing.ProviderTckEnrollmentArchitectureTest" -> "provider-contracts"
+                className.endsWith("EnrollmentArchitectureTest") -> "store-contracts"
+                else -> null
+            } ?: return@forEach
             val factory = DocumentBuilderFactory.newInstance().apply {
                 setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+                setFeature("http://xml.org/sax/features/external-general-entities", false)
+                setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+                setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+                setAttribute("http://javax.xml.XMLConstants/property/accessExternalDTD", "")
+                setAttribute("http://javax.xml.XMLConstants/property/accessExternalSchema", "")
                 isXIncludeAware = false
                 isExpandEntityReferences = false
             }
@@ -1259,13 +1366,6 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             val cases = document.getElementsByTagName("testcase")
             for (index in 0 until cases.length) {
                 val testCase = cases.item(index) as org.w3c.dom.Element
-                val className = testCase.getAttribute("classname")
-                val check = when {
-                    className.contains("ProviderTckEnrollmentArchitectureTest") -> "provider-contracts"
-                    className.endsWith("EnrollmentArchitectureTest") -> "store-contracts"
-                    else -> null
-                } ?: continue
-                foundChecks += check
                 for (childIndex in 0 until testCase.childNodes.length) {
                     val child = testCase.childNodes.item(childIndex)
                     if (child.nodeName !in setOf("failure", "error")) continue
@@ -1278,11 +1378,11 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                 }
             }
         }
-        (setOf("provider-contracts", "store-contracts") - foundChecks).forEach { check ->
-            checks.getValue(check) += VerificationDiagnostic.failure(
-                DiagnosticCode.EMPTY_SECTION,
-                "No $check enrollment architecture test result was found in ${resultsDir.path}",
-            )
+
+        // Pin guard identities: deleting/renaming one enrollment class must FAIL
+        // even if the others still run. Discovery by identity, not by count.
+        enrollmentGuardDiagnostics(discoveredClasses).forEach { (check, diagnostics) ->
+            checks.getValue(check) += diagnostics
         }
     }
 

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
@@ -135,6 +135,23 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             }
         }
 
+        // Fail-soft per-project dependency probes for the architecture gate.
+        // Unlike the tasks above they never throw on unresolved dependencies;
+        // the gate reads their outputs and converts resolution failure into
+        // typed fail-closed evidence, so the report is always written.
+        val architectureProbeTasks = mutableListOf<String>()
+        project.allprojects.filter { it != project && it.buildFile.exists() }.forEach { sub ->
+            val probe = sub.tasks.register("architectureDependencyProbe", ArchitectureDependencyProbeTask::class.java)
+            probe.configure {
+                group = "verification"
+                description = "Resolves external dependencies for ${sub.path} (fail-soft, architecture gate)"
+                outputFile.set(
+                    sub.layout.buildDirectory.file("reports/maintainability/architecture-dependencies.json")
+                )
+            }
+            architectureProbeTasks.add("${sub.path}:architectureDependencyProbe")
+        }
+
         project.tasks.register("generateModuleDependencyGraph") {
             group = "maintainability"
             description = "Generates the module dependency graph (JSON, DOT, Mermaid)"
@@ -906,7 +923,7 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
         project.tasks.register("verify060Architecture") {
             group = "verification"
             description = "build(quality): add unified 0.6.0 architecture gate"
-            dependsOn("generateResolvedDependencyBaseline")
+            dependsOn(*architectureProbeTasks.toTypedArray())
             dependsOn(enrollmentTest)
             doLast {
                 val architectureDiagnostics = ArchitectureReportAggregator.checkIds
@@ -915,8 +932,39 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                 val verificationReport = File(reportDir, "verification-report.json")
 
                 collectEvidence("baseline verification", baselineCheckIds, architectureDiagnostics) {
-                    BaselineVerifier(BaselineGenerator(context), context, reportDir).verify()
-                    addBaselineDiagnostics(readBaselineDiagnostics(verificationReport), architectureDiagnostics)
+                    // Read the fail-soft per-project dependency probes. Resolution
+                    // failure reaches the gate as typed evidence (the probe tasks
+                    // never abort the task graph), so the report is always written.
+                    val probeFiles = project.allprojects
+                        .filter { it != project && it.buildFile.exists() }
+                        .sortedBy { it.path }
+                        .map { sub ->
+                            File(sub.layout.buildDirectory.get().asFile, "reports/maintainability/architecture-dependencies.json")
+                        }
+                    val evidence = readDependencyProbeEvidence(probeFiles)
+                    if (evidence.failures.isNotEmpty()) {
+                        val message = "Dependency evidence unavailable: ${evidence.failures.joinToString("; ")}"
+                        baselineCheckIds.forEach { checkId ->
+                            architectureDiagnostics.getValue(checkId) += VerificationDiagnostic.failure(
+                                DiagnosticCode.DEPENDENCY_RESOLUTION_FAILED,
+                                message,
+                            )
+                        }
+                    } else {
+                        val resolvedDependenciesFile = File(reportDir, "resolved-dependencies.json")
+                        reportDir.mkdirs()
+                        ReportNormalizer.writeJson(
+                            BaselineGenerator.sortResolvedDependencies(evidence.resolvedRecords),
+                            resolvedDependenciesFile,
+                        )
+                        BaselineVerifier(BaselineGenerator(context), context, reportDir).verify()
+                        routeBaselineDiagnostics(
+                            readBaselineDiagnostics(verificationReport),
+                            architectureDiagnostics,
+                            baselineCheckIds,
+                            ::baselineCheckFor,
+                        )
+                    }
                 }
 
                 collectEvidence("module manifest verification", setOf("module-manifest", "publishing-topology"), architectureDiagnostics) {
@@ -953,7 +1001,7 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                 val report = ArchitectureReportAggregator.aggregate(architectureDiagnostics)
                 val reportFile = File(project.layout.buildDirectory.get().asFile, "reports/tramai/architecture/architecture-report.json")
                 // Report is written BEFORE the terminal exception — failure must produce evidence.
-                ArchitectureReportJson.write(report, reportFile)
+                ArchitectureReportJson.write(report, reportFile, project.rootDir)
                 if (report.status == ArchitectureCheckStatus.FAIL) {
                     throw GradleException("0.6.0 architecture verification FAILED: " +
                         report.checks.filter { it.status == ArchitectureCheckStatus.FAIL }.joinToString { it.id } +
@@ -1198,15 +1246,6 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                 baselineValue = entry["baselineValue"]?.toString(),
                 currentValue = entry["currentValue"]?.toString(),
             )
-        }
-    }
-
-    private fun addBaselineDiagnostics(
-        diagnostics: List<VerificationDiagnostic>,
-        checks: Map<String, MutableList<VerificationDiagnostic>>,
-    ) {
-        diagnostics.forEach { diagnostic ->
-            baselineCheckFor(diagnostic.code)?.let { checks.getValue(it) += diagnostic }
         }
     }
 

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
@@ -4,9 +4,11 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.GradleException
 import org.gradle.api.Action
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.testing.Test
 import org.gradle.testing.jacoco.tasks.JacocoReport
 import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
 
 /**
  * Gradle plugin that registers all maintainability baseline generation and verification tasks.
@@ -876,6 +878,90 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             }
         }
 
+        val enrollmentTest = project.tasks.register("architectureContractEnrollmentTest", Test::class.java) {
+            group = "verification"
+            description = "Runs provider and store enrollment architecture contracts"
+            val testingProject = project.project(":tramai-testing")
+            val testSourceSet = testingProject.extensions
+                .getByType(JavaPluginExtension::class.java)
+                .sourceSets
+                .getByName("test")
+            dependsOn(testingProject.tasks.named("testClasses"))
+            testClassesDirs = testSourceSet.output.classesDirs
+            classpath = testSourceSet.runtimeClasspath
+            useJUnitPlatform()
+            filter.includeTestsMatching("dev.tramai.testing.*EnrollmentArchitectureTest")
+            ignoreFailures = true
+            binaryResultsDirectory.set(
+                testingProject.layout.buildDirectory.dir("test-results/architectureContractEnrollmentTest/binary")
+            )
+            reports.junitXml.outputLocation.set(
+                testingProject.layout.buildDirectory.dir("test-results/architectureContractEnrollmentTest")
+            )
+            reports.html.outputLocation.set(
+                testingProject.layout.buildDirectory.dir("reports/tests/architectureContractEnrollmentTest")
+            )
+        }
+
+        project.tasks.register("verify060Architecture") {
+            group = "verification"
+            description = "build(quality): add unified 0.6.0 architecture gate"
+            dependsOn(enrollmentTest)
+            doLast {
+                val architectureDiagnostics = ArchitectureReportAggregator.checkIds
+                    .associateWith { mutableListOf<VerificationDiagnostic>() }
+                val verificationReport = File(reportDir, "verification-report.json")
+                try {
+                    BaselineVerifier(BaselineGenerator(MeasurementContext.fromProject(project)),
+                        MeasurementContext.fromProject(project), reportDir).verify()
+                    addBaselineDiagnostics(readBaselineDiagnostics(verificationReport), architectureDiagnostics)
+                } catch (exception: Exception) {
+                    baselineCheckIds.forEach { checkId ->
+                        architectureDiagnostics.getValue(checkId) += VerificationDiagnostic.failure(
+                            DiagnosticCode.EMPTY_SECTION,
+                            "Baseline verification could not complete: ${exception.message ?: exception.javaClass.name}",
+                        )
+                    }
+                }
+
+                val catalog = ModuleManifest.catalog(project.rootDir)
+                val actualProjects = project.allprojects
+                    .filter { it != project && it.buildFile.exists() }
+                    .map { it.path }
+                    .toSet()
+                val actualPublished = (project.extensions.extraProperties.properties["tramai.publishableModulePaths"] as? Collection<*>)
+                    ?.map { it.toString() }?.toSet().orEmpty()
+                val bomProject = project.allprojects.firstOrNull { it.name == "tramai-bom" }
+                val actualBom = bomProject
+                    ?.configurations
+                    ?.findByName("api")
+                    ?.dependencyConstraints
+                    .orEmpty()
+                    .mapNotNull { constraint ->
+                        constraint.name.takeIf { it.startsWith("tramai-") || it.startsWith("examples:") }?.let { ":$it" }
+                    }
+                    .toSet()
+                addManifestDiagnostics(
+                    ModuleManifestVerifier.verify(catalog.modules, actualProjects, actualPublished, actualBom),
+                    architectureDiagnostics,
+                )
+                addEnrollmentDiagnostics(
+                    File(project.project(":tramai-testing").buildDir, "test-results/architectureContractEnrollmentTest"),
+                    architectureDiagnostics,
+                )
+
+                val report = ArchitectureReportAggregator.aggregate(architectureDiagnostics)
+                ArchitectureReportJson.write(
+                    report,
+                    File(project.layout.buildDirectory.get().asFile, "reports/tramai/architecture/architecture-report.json"),
+                )
+                if (report.status == ArchitectureCheckStatus.FAIL) {
+                    throw GradleException("0.6.0 architecture verification FAILED: " +
+                        report.checks.filter { it.status == ArchitectureCheckStatus.FAIL }.joinToString { it.id })
+                }
+            }
+        }
+
         // ---- PR Verification (primary local check gate) ----
 
         val verifyPr = project.tasks.register("verifyPr") {
@@ -1092,4 +1178,127 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
 
     private fun groovyString(value: String): String =
         value.replace("\\", "\\\\").replace("'", "\\'")
+
+    private fun readBaselineDiagnostics(reportFile: File): List<VerificationDiagnostic> {
+        if (!reportFile.isFile) {
+            throw GradleException("Baseline verifier did not produce ${reportFile.path}")
+        }
+        val report = ReportNormalizer.readJson(reportFile, Map::class.java)
+        val diagnostics = report["diagnostics"] as? List<*>
+            ?: throw GradleException("Baseline verification report has no diagnostics array")
+        return diagnostics.map { raw ->
+            val entry = raw as? Map<*, *> ?: throw GradleException("Malformed baseline diagnostic")
+            VerificationDiagnostic(
+                code = DiagnosticCode.valueOf(entry["code"]?.toString() ?: error("Baseline diagnostic code missing")),
+                severity = DiagnosticSeverity.valueOf(entry["severity"]?.toString() ?: error("Baseline diagnostic severity missing")),
+                message = entry["message"]?.toString() ?: error("Baseline diagnostic message missing"),
+                modulePath = entry["modulePath"]?.toString(),
+                findingId = entry["findingId"]?.toString(),
+                deviationId = entry["deviationId"]?.toString(),
+                baselineValue = entry["baselineValue"]?.toString(),
+                currentValue = entry["currentValue"]?.toString(),
+            )
+        }
+    }
+
+    private fun addBaselineDiagnostics(
+        diagnostics: List<VerificationDiagnostic>,
+        checks: Map<String, MutableList<VerificationDiagnostic>>,
+    ) {
+        diagnostics.forEach { diagnostic ->
+            baselineCheckFor(diagnostic.code)?.let { checks.getValue(it) += diagnostic }
+        }
+    }
+
+    private fun baselineCheckFor(code: DiagnosticCode): String? = when {
+        code.name.startsWith("MODULE_CATALOG_") && code !in publishingTopologyCodes -> "module-manifest"
+        code in setOf(DiagnosticCode.FORBIDDEN_LAYER_EDGE, DiagnosticCode.SELF_DEPENDENCY) -> "dependency-boundaries"
+        code == DiagnosticCode.NEW_DEPENDENCY_CYCLE -> "dependency-cycles"
+        code == DiagnosticCode.NEW_GLOBAL_STATE_FINDING -> "global-state"
+        code.name.startsWith("API_") -> "api-architecture"
+        code == DiagnosticCode.STABLE_PROTOCOL_CONTRACT_REMOVED -> "protocol-catalog"
+        code in setOf(DiagnosticCode.NEW_CANCELLATION_FINDING, DiagnosticCode.CANCELLATION_RISK_WORSENED) -> "cancellation-safety"
+        else -> null
+    }
+
+    private fun addManifestDiagnostics(
+        diagnostics: List<VerificationDiagnostic>,
+        checks: Map<String, MutableList<VerificationDiagnostic>>,
+    ) {
+        diagnostics.forEach { diagnostic ->
+            val check = if (diagnostic.code in publishingTopologyCodes) "publishing-topology" else "module-manifest"
+            checks.getValue(check) += diagnostic
+        }
+    }
+
+    private fun addEnrollmentDiagnostics(
+        resultsDir: File,
+        checks: Map<String, MutableList<VerificationDiagnostic>>,
+    ) {
+        val reports = resultsDir.listFiles { file -> file.isFile && file.name.startsWith("TEST-") && file.extension == "xml" }
+            ?.sortedBy { it.name }
+            .orEmpty()
+        if (reports.isEmpty()) {
+            listOf("provider-contracts", "store-contracts").forEach { check ->
+                checks.getValue(check) += VerificationDiagnostic.failure(
+                    DiagnosticCode.EMPTY_SECTION,
+                    "Enrollment architecture test results are missing from ${resultsDir.path}",
+                )
+            }
+            return
+        }
+
+        val foundChecks = mutableSetOf<String>()
+        reports.forEach { report ->
+            val factory = DocumentBuilderFactory.newInstance().apply {
+                setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+                isXIncludeAware = false
+                isExpandEntityReferences = false
+            }
+            val document = factory.newDocumentBuilder().parse(report)
+            val cases = document.getElementsByTagName("testcase")
+            for (index in 0 until cases.length) {
+                val testCase = cases.item(index) as org.w3c.dom.Element
+                val className = testCase.getAttribute("classname")
+                val check = when {
+                    className.contains("ProviderTckEnrollmentArchitectureTest") -> "provider-contracts"
+                    className.endsWith("EnrollmentArchitectureTest") -> "store-contracts"
+                    else -> null
+                } ?: continue
+                foundChecks += check
+                for (childIndex in 0 until testCase.childNodes.length) {
+                    val child = testCase.childNodes.item(childIndex)
+                    if (child.nodeName !in setOf("failure", "error")) continue
+                    val failure = child as org.w3c.dom.Element
+                    val message = failure.getAttribute("message").ifBlank { failure.textContent.trim() }
+                    checks.getValue(check) += VerificationDiagnostic.failure(
+                        DiagnosticCode.EMPTY_SECTION,
+                        "$className failed: $message",
+                    )
+                }
+            }
+        }
+        (setOf("provider-contracts", "store-contracts") - foundChecks).forEach { check ->
+            checks.getValue(check) += VerificationDiagnostic.failure(
+                DiagnosticCode.EMPTY_SECTION,
+                "No $check enrollment architecture test result was found in ${resultsDir.path}",
+            )
+        }
+    }
+
+    private companion object {
+        val publishingTopologyCodes = setOf(
+            DiagnosticCode.MODULE_CATALOG_BOM_DRIFT,
+            DiagnosticCode.MODULE_CATALOG_PUBLISHING_DRIFT,
+        )
+        val baselineCheckIds = setOf(
+            "module-manifest",
+            "dependency-boundaries",
+            "dependency-cycles",
+            "global-state",
+            "api-architecture",
+            "protocol-catalog",
+            "cancellation-safety",
+        )
+    }
 }

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/ArchitectureReportAggregatorTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/ArchitectureReportAggregatorTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -108,7 +109,7 @@ class ArchitectureReportAggregatorTest {
         assertEquals(10, first.summary.passed)
         assertEquals(0, first.summary.failed)
         assertTrue(first.checks.all { it.diagnostics.isEmpty() })
-        assertEquals(ArchitectureReportJson.toJson(first), ArchitectureReportJson.toJson(second))
+        assertEquals(ArchitectureReportJson.toJson(first, tempDir), ArchitectureReportJson.toJson(second, tempDir))
     }
 
     @Test
@@ -130,11 +131,129 @@ class ArchitectureReportAggregatorTest {
         )
         // Report must be written even when evidence collection fails.
         val reportFile = File(tempDir, "architecture-report.json")
-        ArchitectureReportJson.write(report, reportFile)
+        ArchitectureReportJson.write(report, reportFile, tempDir)
         assertTrue(reportFile.isFile)
         val written = ReportNormalizer.readJson(reportFile, Map::class.java)
         assertEquals("FAIL", written["status"])
         assertEquals(2, (written["summary"] as Map<*, *>)["failed"].let { it as Number }.toInt())
+    }
+
+    @Test
+    fun `A12 baseline evidence unavailable fails every baseline-backed check`() {
+        val target = emptyChecks()
+        routeBaselineDiagnostics(
+            diagnostics = listOf(
+                VerificationDiagnostic.failure(
+                    DiagnosticCode.EMPTY_SECTION,
+                    "Committed baseline not found: ${tempDir.absolutePath}/config/quality/0.6.0-baseline.json",
+                ),
+            ),
+            target = target,
+            baselineCheckIds = setOf(
+                "module-manifest", "dependency-boundaries", "dependency-cycles",
+                "global-state", "api-architecture", "protocol-catalog", "cancellation-safety",
+            ),
+            classify = { null },
+        )
+        val report = ArchitectureReportAggregator.aggregate(target)
+
+        assertEquals(ArchitectureCheckStatus.FAIL, report.status)
+        assertEquals(7, report.summary.failed)
+        // Every baseline-backed check fails; the three non-baseline checks stay PASS.
+        val baselineIds = setOf(
+            "module-manifest", "dependency-boundaries", "dependency-cycles",
+            "global-state", "api-architecture", "protocol-catalog", "cancellation-safety",
+        )
+        assertTrue(report.checks.filter { it.id in baselineIds }.all { it.status == ArchitectureCheckStatus.FAIL })
+        assertTrue(report.checks.filter { it.id !in baselineIds }.all { it.status == ArchitectureCheckStatus.PASS })
+        // Every baseline-backed check carries the evidence-failure diagnostic.
+        assertTrue(
+            report.checks.filter { it.id in baselineIds }.all { check ->
+                check.diagnostics.any { it.code == DiagnosticCode.EMPTY_SECTION }
+            },
+        )
+        // A failing report with an absolute path must sanitize it.
+        val reportFile = File(tempDir, "architecture-report.json")
+        ArchitectureReportJson.write(report, reportFile, tempDir)
+        val json = reportFile.readText()
+        assertTrue(json.contains("<repo-root>"))
+        assertFalse(json.contains(tempDir.absolutePath))
+    }
+
+    @Test
+    fun `A13 dependency evidence unavailable fails every baseline-backed check`() {
+        val target = emptyChecks()
+        routeBaselineDiagnostics(
+            diagnostics = listOf(
+                VerificationDiagnostic.failure(
+                    DiagnosticCode.DEPENDENCY_RESOLUTION_FAILED,
+                    "Failed to resolve current production dependencies: broken",
+                ),
+            ),
+            target = target,
+            baselineCheckIds = setOf(
+                "module-manifest", "dependency-boundaries", "dependency-cycles",
+                "global-state", "api-architecture", "protocol-catalog", "cancellation-safety",
+            ),
+            classify = { null },
+        )
+        val report = ArchitectureReportAggregator.aggregate(target)
+
+        assertEquals(ArchitectureCheckStatus.FAIL, report.status)
+        assertEquals(7, report.summary.failed)
+        val baselineIds = setOf(
+            "module-manifest", "dependency-boundaries", "dependency-cycles",
+            "global-state", "api-architecture", "protocol-catalog", "cancellation-safety",
+        )
+        assertTrue(
+            report.checks.filter { it.id in baselineIds }.all { check ->
+                check.diagnostics.any { it.code == DiagnosticCode.DEPENDENCY_RESOLUTION_FAILED }
+            },
+        )
+    }
+
+    @Test
+    fun `A14 failure report never leaks repository root path`() {
+        val root = File(tempDir, "repo").apply { mkdirs() }
+        val target = emptyChecks()
+        collectEvidence("baseline verification", setOf("module-manifest"), target) {
+            target.getValue("module-manifest") += VerificationDiagnostic.failure(
+                DiagnosticCode.EMPTY_SECTION,
+                "Committed baseline not found: ${root.absolutePath}/config/quality/0.6.0-baseline.json",
+            )
+        }
+        val report = ArchitectureReportAggregator.aggregate(target)
+        val json = ArchitectureReportJson.toJson(report, root)
+
+        assertFalse(json.contains(root.absolutePath))
+        assertTrue(json.contains("<repo-root>"))
+    }
+
+    @Test
+    fun `A15 fail-soft dependency probe marker becomes typed evidence`() {
+        val probeDir = File(tempDir, "probes").apply { mkdirs() }
+        val okProbe = File(probeDir, "ok.json").apply {
+            writeText(
+                """[{"group":"dev.tramai","artifact":"tramai-core","selectedVersion":"1.0","requestedVersion":"1.0","direct":true,"configuration":"compileClasspath","selectionReason":"","dependencyPath":[":tramai-core"],"consumers":[":tramai-core"]}]""",
+            )
+        }
+        val failedProbe = File(probeDir, "failed.json").apply {
+            writeText(
+                """[{"resolutionFailed":true,"message":"Failed to resolve :tramai-core:compileClasspath dependency org.example:missing:1.0: not found"}]""",
+            )
+        }
+
+        val okEvidence = readDependencyProbeEvidence(listOf(okProbe))
+        assertTrue(okEvidence.failures.isEmpty())
+        assertEquals(1, okEvidence.resolvedRecords.size)
+
+        val failedEvidence = readDependencyProbeEvidence(listOf(okProbe, failedProbe))
+        assertEquals(1, failedEvidence.failures.size)
+        assertTrue(failedEvidence.failures.single().contains("org.example:missing"))
+
+        val missingEvidence = readDependencyProbeEvidence(listOf(File(probeDir, "absent.json")))
+        assertEquals(1, missingEvidence.failures.size)
+        assertTrue(missingEvidence.failures.single().contains("Missing dependency probe output"))
     }
 
     @Test

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/ArchitectureReportAggregatorTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/ArchitectureReportAggregatorTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -108,6 +109,69 @@ class ArchitectureReportAggregatorTest {
         assertEquals(0, first.summary.failed)
         assertTrue(first.checks.all { it.diagnostics.isEmpty() })
         assertEquals(ArchitectureReportJson.toJson(first), ArchitectureReportJson.toJson(second))
+    }
+
+    @Test
+    fun `A9 evidence source exception fails its checks and report is still writable`() {
+        val target = emptyChecks()
+        collectEvidence("baseline verification", setOf("module-manifest", "dependency-boundaries"), target) {
+            throw IllegalStateException("catalog exploded")
+        }
+        val report = ArchitectureReportAggregator.aggregate(target)
+
+        assertEquals(ArchitectureCheckStatus.FAIL, report.status)
+        assertEquals(
+            ArchitectureCheckStatus.FAIL,
+            report.checks.single { it.id == "module-manifest" }.status,
+        )
+        assertEquals(
+            ArchitectureCheckStatus.FAIL,
+            report.checks.single { it.id == "dependency-boundaries" }.status,
+        )
+        // Report must be written even when evidence collection fails.
+        val reportFile = File(tempDir, "architecture-report.json")
+        ArchitectureReportJson.write(report, reportFile)
+        assertTrue(reportFile.isFile)
+        val written = ReportNormalizer.readJson(reportFile, Map::class.java)
+        assertEquals("FAIL", written["status"])
+        assertEquals(2, (written["summary"] as Map<*, *>)["failed"].let { it as Number }.toInt())
+    }
+
+    @Test
+    fun `A10 deleted enrollment guard class fails store contracts by identity`() {
+        val discovered = enrollmentArchitectureTestClasses - "dev.tramai.testing.ApprovalStoreTckEnrollmentArchitectureTest"
+        val diagnostics = enrollmentGuardDiagnostics(discovered)
+
+        val storeDiagnostics = diagnostics["store-contracts"].orEmpty()
+        assertTrue(storeDiagnostics.any { it.message.contains("ApprovalStoreTckEnrollmentArchitectureTest") })
+        assertTrue(diagnostics["provider-contracts"].orEmpty().isEmpty())
+    }
+
+    @Test
+    fun `A10b renamed enrollment guard class fails by identity in both directions`() {
+        val discovered = (enrollmentArchitectureTestClasses - "dev.tramai.testing.AuditStoreTckEnrollmentArchitectureTest") +
+            "dev.tramai.testing.RenamedAuditStoreTckEnrollmentArchitectureTest"
+        val diagnostics = enrollmentGuardDiagnostics(discovered)
+
+        val storeDiagnostics = diagnostics["store-contracts"].orEmpty()
+        assertTrue(storeDiagnostics.any { it.message.contains("AuditStoreTckEnrollmentArchitectureTest was not discovered") })
+        assertTrue(storeDiagnostics.any { it.message.contains("RenamedAuditStoreTckEnrollmentArchitectureTest was discovered") })
+    }
+
+    @Test
+    fun `A10c missing provider guard fails provider contracts`() {
+        val discovered = enrollmentArchitectureTestClasses - "dev.tramai.testing.ProviderTckEnrollmentArchitectureTest"
+        val diagnostics = enrollmentGuardDiagnostics(discovered)
+
+        assertTrue(diagnostics["provider-contracts"].orEmpty().isNotEmpty())
+    }
+
+    @Test
+    fun `A11 aggregator rejects unexpected check id set`() {
+        val wrong = emptyChecks().toMutableMap().apply { remove("global-state") }
+        assertFailsWith<IllegalArgumentException> {
+            ArchitectureReportAggregator.aggregate(wrong)
+        }
     }
 
     private fun assertFailed(checkId: String, diagnostic: VerificationDiagnostic) {

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/ArchitectureReportAggregatorTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/ArchitectureReportAggregatorTest.kt
@@ -1,0 +1,133 @@
+package dev.tramai.build.quality
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ArchitectureReportAggregatorTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    @Test
+    fun `A1 forbidden edge fails dependency boundaries`() {
+        fixtureDir()
+        val catalog = ModuleCatalog(tempDir)
+        assertTrue(catalog.parse().errors.isEmpty())
+        val boundaries = ModuleBoundaries(tempDir).fromResult(ModuleBoundaries(tempDir).parse())
+        val diagnostic = assertNotNull(boundaries.checkEdge(":tramai-core", ":tramai-openai", catalog))
+        assertEquals(DiagnosticCode.FORBIDDEN_LAYER_EDGE, diagnostic.code)
+
+        assertFailed("dependency-boundaries", diagnostic)
+    }
+
+    @Test
+    fun `A2 dependency cycle fails dependency cycles`() {
+        val cycles = ModuleGraphAnalyzer(
+            MeasurementContext.fromDirectory(tempDir, ModuleCatalog(tempDir))
+        ).findCycles(
+            nodes = listOf(":a", ":b"),
+            edges = listOf(
+                DependencyEdge(":a", ":b", "api"),
+                DependencyEdge(":b", ":a", "api"),
+            ),
+        )
+        assertTrue(cycles.isNotEmpty())
+
+        assertFailed(
+            "dependency-cycles",
+            VerificationDiagnostic.failure(DiagnosticCode.NEW_DEPENDENCY_CYCLE, "A -> B -> A"),
+        )
+    }
+
+    @Test
+    fun `A3 manifest drift fails module manifest`() {
+        fixtureDir()
+        val catalog = ModuleCatalog(tempDir).parse()
+        val diagnostics = ModuleManifestVerifier.verify(
+            catalogModules = catalog.modules,
+            projectPaths = catalog.modules.keys - ":tramai-core",
+            publishedPaths = ModuleManifest.publishableModulePaths(catalog.modules.values).toSet(),
+            bomPaths = ModuleManifest.bomModulePaths(catalog.modules.values).toSet(),
+        )
+        val diagnostic = assertNotNull(diagnostics.firstOrNull { it.code == DiagnosticCode.MODULE_CATALOG_UNKNOWN_ENTRY })
+
+        assertFailed("module-manifest", diagnostic)
+    }
+
+    @Test
+    fun `A4 bom drift fails publishing topology`() {
+        fixtureDir()
+        val catalog = ModuleCatalog(tempDir).parse()
+        val diagnostics = ModuleManifestVerifier.verify(
+            catalogModules = catalog.modules,
+            projectPaths = catalog.modules.keys,
+            publishedPaths = ModuleManifest.publishableModulePaths(catalog.modules.values).toSet(),
+            bomPaths = ModuleManifest.bomModulePaths(catalog.modules.values).toSet() - ":tramai-core",
+        )
+        val diagnostic = assertNotNull(diagnostics.firstOrNull { it.code == DiagnosticCode.MODULE_CATALOG_BOM_DRIFT })
+
+        assertFailed("publishing-topology", diagnostic)
+    }
+
+    @Test
+    fun `A5 api failure fails api architecture`() {
+        assertFailed(
+            "api-architecture",
+            VerificationDiagnostic.failure(DiagnosticCode.API_COMPATIBILITY_FAILED, "API compatibility failed"),
+        )
+    }
+
+    @Test
+    fun `A6 global state failure fails global state`() {
+        assertFailed(
+            "global-state",
+            VerificationDiagnostic.failure(DiagnosticCode.NEW_GLOBAL_STATE_FINDING, "New global state"),
+        )
+    }
+
+    @Test
+    fun `A7 cancellation failure fails cancellation safety`() {
+        assertFailed(
+            "cancellation-safety",
+            VerificationDiagnostic.failure(DiagnosticCode.NEW_CANCELLATION_FINDING, "New cancellation finding"),
+        )
+    }
+
+    @Test
+    fun `A8 empty diagnostics pass all ten checks deterministically`() {
+        val first = ArchitectureReportAggregator.aggregate(emptyChecks())
+        val second = ArchitectureReportAggregator.aggregate(emptyChecks())
+
+        assertEquals(ArchitectureCheckStatus.PASS, first.status)
+        assertEquals(10, first.summary.checks)
+        assertEquals(10, first.summary.passed)
+        assertEquals(0, first.summary.failed)
+        assertTrue(first.checks.all { it.diagnostics.isEmpty() })
+        assertEquals(ArchitectureReportJson.toJson(first), ArchitectureReportJson.toJson(second))
+    }
+
+    private fun assertFailed(checkId: String, diagnostic: VerificationDiagnostic) {
+        val report = ArchitectureReportAggregator.aggregate(emptyChecks().also { it.getValue(checkId) += diagnostic })
+        assertEquals(ArchitectureCheckStatus.FAIL, report.status)
+        assertEquals(ArchitectureCheckStatus.FAIL, report.checks.single { it.id == checkId }.status)
+    }
+
+    private fun emptyChecks(): MutableMap<String, MutableList<VerificationDiagnostic>> =
+        ArchitectureReportAggregator.checkIds
+            .associateWith { mutableListOf<VerificationDiagnostic>() }
+            .toMutableMap()
+
+    private fun fixtureDir() {
+        val config = File(tempDir, "config/quality").apply { mkdirs() }
+        File(config, "module-catalog.yml").writeText(File(repoRoot(), "config/quality/module-catalog.yml").readText())
+        File(config, "module-boundaries.yml").writeText(File(repoRoot(), "config/quality/module-boundaries.yml").readText())
+    }
+
+    private fun repoRoot(): File = System.getProperty("tramai.repositoryRoot")
+        ?.let(::File)
+        ?: error("tramai.repositoryRoot system property not set")
+}

--- a/docs/EPIC-10.4-architecture-gate.md
+++ b/docs/EPIC-10.4-architecture-gate.md
@@ -124,34 +124,54 @@ Diagnostic JSON shape (mirror `BaselineVerifier.writeVerificationReport`):
 Register in `MaintainabilityBaselinePlugin.kt`:
 
 1. **`verify060Architecture`** (group `verification`, description as PR title):
-   - `dependsOn("generateResolvedDependencyBaseline")` — the baseline verifier
-     requires `build/reports/maintainability/resolved-dependencies.json`; the
-     gate must run standalone on a clean workspace, not only after
-     `verifyPr`/`verifyMaintainabilityBaseline` have created the artifact.
-   - `dependsOn` the enrollment Test task below.
+   - `dependsOn` the fail-soft dependency probes below AND the enrollment Test
+     task. The probes never throw, so the gate's `doLast` always runs and the
+     report is always written — a dependency-resolution failure reaches the
+     gate as typed evidence, it does not abort the task graph.
    - Orchestrates **fail-closed** evidence collection so the report is ALWAYS
      written before any terminal exception:
-     1. Run `BaselineVerifier(...).verify()` (same construction as
-        `verifyMaintainabilityBaseline`), catch exceptions → convert to a
-        failure diagnostic for the affected checks.
-     2. Read the typed diagnostics from the `verification-report.json` the
-        verifier wrote (`build/reports/maintainability/verification-report.json`).
-     3. Call `ModuleManifestVerifier.verify(...)` directly (parse catalog +
+     1. Read the fail-soft per-project dependency probe outputs
+        (`architecture-dependencies.json` per project). If any probe recorded a
+        resolution failure, fail every baseline-backed check with
+        `DEPENDENCY_RESOLUTION_FAILED` and skip the baseline verifier (its
+        evidence is unavailable).
+     2. Otherwise aggregate the probe records into
+        `build/reports/maintainability/resolved-dependencies.json` and run
+        `BaselineVerifier(...).verify()` (same construction as
+        `verifyMaintainabilityBaseline`).
+     3. Read the typed diagnostics from the `verification-report.json` the
+        verifier wrote. If it contains evidence-unavailable FAILURE diagnostics
+        (`EMPTY_SECTION` / `DEPENDENCY_RESOLUTION_FAILED` — the verifier's
+        early-return paths for missing/unreadable baseline or failed current
+        generation), EVERY baseline-backed check fails closed: the gate cannot
+        claim a check passed when its evidence was never produced. Otherwise
+        route diagnostics through the exhaustive classification.
+     4. Call `ModuleManifestVerifier.verify(...)` directly (parse catalog +
         project model + published extra + BOM constraints) → typed diagnostics;
         catch exceptions → failure diagnostics for module-manifest +
         publishing-topology.
-     4. Read the JUnit XML produced by the enrollment Test task (see 2) →
+     5. Read the JUnit XML produced by the enrollment Test task (see 2) →
         provider-contracts / store-contracts outcomes; catch exceptions →
         failure diagnostics for both enrollment checks.
-     5. Partition by check id (§3), call `ArchitectureReportAggregator.aggregate`.
-     6. Write `build/reports/tramai/architecture/architecture-report.json` —
+     6. Partition by check id (§3), call `ArchitectureReportAggregator.aggregate`.
+     7. Write `build/reports/tramai/architecture/architecture-report.json` —
         BEFORE the terminal exception, so a failing run leaves evidence.
-     7. If `status == FAIL`, throw `GradleException` listing failed checks and
+        Diagnostic messages are sanitized (repository root replaced with
+        `<repo-root>`) so failure reports are path-independent.
+     8. If `status == FAIL`, throw `GradleException` listing failed checks and
         the report path.
    - Do NOT wire into `verifyPr`/`check` in this PR (CI lane redesign is a
      non-goal, Epic 10.5); keep it standalone. Running it in the PR's
      verification is the evidence.
-2. **`architectureContractEnrollmentTest`** — thin Test task (root project):
+2. **`architectureDependencyProbe`** — fail-soft per-project dependency probe
+   (new task type `ArchitectureDependencyProbeTask`, root project registers one
+   per subproject): resolves the project's compile/runtime classpath; on success
+   writes normalized records; on ANY resolution exception writes a typed marker
+   (`[{"resolutionFailed": true, "message": "..."}]`) and never throws. This is
+   what makes the gate's "report always written" guarantee hold even when
+   dependency resolution fails — the throwing task-graph prerequisite is
+   replaced by fail-soft evidence acquisition.
+3. **`architectureContractEnrollmentTest`** — thin Test task (root project):
    - `testClassesDirs`/`classpath` from the `:tramai-testing` test source set
      (⚠️ custom Test tasks need explicit wiring or they run zero tests)
    - `useJUnitPlatform { includeTestsMatching("dev.tramai.testing.*EnrollmentArchitectureTest") }`
@@ -170,7 +190,7 @@ Register in `MaintainabilityBaselinePlugin.kt`:
    `store-contracts`/`provider-contracts` even when the other guards still run.
    Discovery is by identity, not by count.
 
-## 7. Discriminator / mutation proof (A1–A11)
+## 7. Discriminator / mutation proof (A1–A15)
 
 New build-logic test file `ArchitectureReportAggregatorTest.kt`. Each test
 feeds the aggregator a real failure diagnostic (constructed with the EXACT
@@ -189,23 +209,29 @@ diagnostic via the real verifier on a fixture instead of constructing it:
 - **A9 evidence-source exception (review round 1, P1)**: `collectEvidence` with a throwing evidence lambda → affected checks FAIL with `EMPTY_SECTION`, and `ArchitectureReportJson.write` still produces a file with `status: FAIL` — proves the report survives evidence-source failures
 - **A10 enrollment identity pinning (review round 1, P1)**: deleting one pinned store class from the discovered set → `store-contracts` FAIL naming that class; renaming → FAIL in both directions (missing + unexpected); deleting the provider class → `provider-contracts` FAIL
 - **A11 aggregator rejects unexpected id set (review round 1, P2)**: `aggregate` with a map missing one of the 10 stable ids throws `IllegalArgumentException` — no 9/11-check reports
+- **A12 baseline evidence unavailable (review round 2, P1)**: `routeBaselineDiagnostics` with an `EMPTY_SECTION` FAILURE diagnostic → EVERY baseline-backed check FAIL (7), the three non-baseline checks stay PASS, and the written report sanitizes the absolute path to `<repo-root>`
+- **A13 dependency evidence unavailable (review round 2, P1)**: `routeBaselineDiagnostics` with a `DEPENDENCY_RESOLUTION_FAILED` FAILURE diagnostic → every baseline-backed check FAIL with that code
+- **A14 path sanitization (review round 2, P2)**: a failure diagnostic containing the repository root path serializes with `<repo-root>` and never leaks the absolute path
+- **A15 fail-soft probe marker (review round 2, P1/P2)**: `readDependencyProbeEvidence` turns a `resolutionFailed` probe marker into a typed failure and a valid probe into records; a missing probe file is also a failure
 
 The essential property: **an underlying verifier failing means
 `verify060Architecture` must fail and record that exact failure** — the
-aggregator maps every code the real verifiers emit to a FAIL bucket, and the
+aggregator maps every code the real verifiers emit to a FAIL bucket, the
 exhaustive `when (code)` classification in `baselineCheckFor` has NO else
-branch, so a new `DiagnosticCode` forces an explicit in-gate/out-of-gate
-decision at compile time.
+branch (a new `DiagnosticCode` forces an explicit in-gate/out-of-gate decision
+at compile time), and evidence-unavailable diagnostics fail closed rather than
+being silently discarded.
 
 ## 8. Files
 
 ### Create
-- `build-logic/src/main/kotlin/dev/tramai/build/quality/ArchitectureReport.kt` — model + `ArchitectureReportAggregator` (pure) + `collectEvidence` (fail-closed) + pinned `enrollmentArchitectureTestClasses` + `enrollmentGuardDiagnostics`
-- `build-logic/src/test/kotlin/dev/tramai/build/quality/ArchitectureReportAggregatorTest.kt` — A1–A11
+- `build-logic/src/main/kotlin/dev/tramai/build/quality/ArchitectureReport.kt` — model + `ArchitectureReportAggregator` (pure) + `collectEvidence` (fail-closed) + `routeBaselineDiagnostics` (evidence-failure fan-out) + pinned `enrollmentArchitectureTestClasses` + `enrollmentGuardDiagnostics` + `readDependencyProbeEvidence` + path sanitization
+- `build-logic/src/main/kotlin/dev/tramai/build/quality/DependencyResolutionTasks.kt` — extract `collectResolvedDependencies` (shared); add fail-soft `ArchitectureDependencyProbeTask`
+- `build-logic/src/test/kotlin/dev/tramai/build/quality/ArchitectureReportAggregatorTest.kt` — A1–A15
 - `docs/EPIC-10.4-architecture-gate.md` — this spec (committed first)
 
 ### Modify
-- `build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt` — register `verify060Architecture` + `architectureContractEnrollmentTest`
+- `build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt` — register `verify060Architecture` + `architectureContractEnrollmentTest` + per-project `architectureDependencyProbe`
 
 ### Do NOT touch
 - Any `tramai-*/src/main/kotlin/**` file (zero runtime production changes)

--- a/docs/EPIC-10.4-architecture-gate.md
+++ b/docs/EPIC-10.4-architecture-gate.md
@@ -124,21 +124,30 @@ Diagnostic JSON shape (mirror `BaselineVerifier.writeVerificationReport`):
 Register in `MaintainabilityBaselinePlugin.kt`:
 
 1. **`verify060Architecture`** (group `verification`, description as PR title):
-   - does NOT `dependsOn` the throwing baseline task — it orchestrates
-     in-process so the report is always written:
+   - `dependsOn("generateResolvedDependencyBaseline")` — the baseline verifier
+     requires `build/reports/maintainability/resolved-dependencies.json`; the
+     gate must run standalone on a clean workspace, not only after
+     `verifyPr`/`verifyMaintainabilityBaseline` have created the artifact.
+   - `dependsOn` the enrollment Test task below.
+   - Orchestrates **fail-closed** evidence collection so the report is ALWAYS
+     written before any terminal exception:
      1. Run `BaselineVerifier(...).verify()` (same construction as
         `verifyMaintainabilityBaseline`), catch exceptions → convert to a
         failure diagnostic for the affected checks.
      2. Read the typed diagnostics from the `verification-report.json` the
         verifier wrote (`build/reports/maintainability/verification-report.json`).
      3. Call `ModuleManifestVerifier.verify(...)` directly (parse catalog +
-        project model + published extra + BOM constraints) → typed diagnostics.
-     4. Read the JUnit XML produced by the enrollment Test tasks (see 2) →
-        provider-contracts / store-contracts outcomes.
+        project model + published extra + BOM constraints) → typed diagnostics;
+        catch exceptions → failure diagnostics for module-manifest +
+        publishing-topology.
+     4. Read the JUnit XML produced by the enrollment Test task (see 2) →
+        provider-contracts / store-contracts outcomes; catch exceptions →
+        failure diagnostics for both enrollment checks.
      5. Partition by check id (§3), call `ArchitectureReportAggregator.aggregate`.
-     6. Write `build/reports/tramai/architecture/architecture-report.json`.
-     7. If `status == FAIL`, throw `GradleException` listing failed checks.
-   - `dependsOn` the enrollment Test tasks below.
+     6. Write `build/reports/tramai/architecture/architecture-report.json` —
+        BEFORE the terminal exception, so a failing run leaves evidence.
+     7. If `status == FAIL`, throw `GradleException` listing failed checks and
+        the report path.
    - Do NOT wire into `verifyPr`/`check` in this PR (CI lane redesign is a
      non-goal, Epic 10.5); keep it standalone. Running it in the PR's
      verification is the evidence.
@@ -154,7 +163,14 @@ Register in `MaintainabilityBaselinePlugin.kt`:
    XML by test class name (`ProviderTckEnrollmentArchitectureTest` →
    provider-contracts; any other enrollment test → store-contracts).
 
-## 7. Discriminator / mutation proof (A1–A8)
+   **Enrollment guard identities are pinned** (review round 1, P1): the gate
+   holds the exact set of the 10 expected enrollment architecture test classes
+   (`enrollmentArchitectureTestClasses`). The façade compares discovered XML
+   classes against the pinned set — deleting or renaming ANY guard class fails
+   `store-contracts`/`provider-contracts` even when the other guards still run.
+   Discovery is by identity, not by count.
+
+## 7. Discriminator / mutation proof (A1–A11)
 
 New build-logic test file `ArchitectureReportAggregatorTest.kt`. Each test
 feeds the aggregator a real failure diagnostic (constructed with the EXACT
@@ -170,16 +186,22 @@ diagnostic via the real verifier on a fixture instead of constructing it:
 - **A6 global mutable state**: `VerificationDiagnostic.failure(NEW_GLOBAL_STATE_FINDING, ...)` → `global-state` FAIL
 - **A7 cancellation**: `VerificationDiagnostic.failure(NEW_CANCELLATION_FINDING, ...)` → `cancellation-safety` FAIL
 - **A8 all valid**: empty diagnostics for every check → PASS, zero failed, summary counts correct
+- **A9 evidence-source exception (review round 1, P1)**: `collectEvidence` with a throwing evidence lambda → affected checks FAIL with `EMPTY_SECTION`, and `ArchitectureReportJson.write` still produces a file with `status: FAIL` — proves the report survives evidence-source failures
+- **A10 enrollment identity pinning (review round 1, P1)**: deleting one pinned store class from the discovered set → `store-contracts` FAIL naming that class; renaming → FAIL in both directions (missing + unexpected); deleting the provider class → `provider-contracts` FAIL
+- **A11 aggregator rejects unexpected id set (review round 1, P2)**: `aggregate` with a map missing one of the 10 stable ids throws `IllegalArgumentException` — no 9/11-check reports
 
 The essential property: **an underlying verifier failing means
 `verify060Architecture` must fail and record that exact failure** — the
-aggregator maps every code the real verifiers emit to a FAIL bucket.
+aggregator maps every code the real verifiers emit to a FAIL bucket, and the
+exhaustive `when (code)` classification in `baselineCheckFor` has NO else
+branch, so a new `DiagnosticCode` forces an explicit in-gate/out-of-gate
+decision at compile time.
 
 ## 8. Files
 
 ### Create
-- `build-logic/src/main/kotlin/dev/tramai/build/quality/ArchitectureReport.kt` — model + `ArchitectureReportAggregator` (pure)
-- `build-logic/src/test/kotlin/dev/tramai/build/quality/ArchitectureReportAggregatorTest.kt` — A1–A8
+- `build-logic/src/main/kotlin/dev/tramai/build/quality/ArchitectureReport.kt` — model + `ArchitectureReportAggregator` (pure) + `collectEvidence` (fail-closed) + pinned `enrollmentArchitectureTestClasses` + `enrollmentGuardDiagnostics`
+- `build-logic/src/test/kotlin/dev/tramai/build/quality/ArchitectureReportAggregatorTest.kt` — A1–A11
 - `docs/EPIC-10.4-architecture-gate.md` — this spec (committed first)
 
 ### Modify

--- a/docs/EPIC-10.4-architecture-gate.md
+++ b/docs/EPIC-10.4-architecture-gate.md
@@ -1,0 +1,250 @@
+# Epic 10.4 — Unified 0.6.0 Architecture Gate (Track B2)
+
+**Branch:** `build/0.6.0-architecture-gate`
+**Base:** `master @ 8705c5bd` (merged B1 / PR #298)
+**PR title:** `build(quality): add unified 0.6.0 architecture gate`
+
+## 1. Objective
+
+Create one authoritative release-facing command:
+
+```bash
+./gradlew verify060Architecture
+```
+
+that aggregates **existing** architectural contracts (never reimplements them)
+and emits:
+
+```text
+build/reports/tramai/architecture/architecture-report.json
+```
+
+It answers: *"Does the current repository satisfy the architectural
+invariants required for TramAI 0.6.0?"*
+
+## 2. Critical design rule
+
+The façade owns **orchestration, normalization, aggregation, reporting,
+final PASS/FAIL** — nothing else. It must NOT become another source of
+architectural truth.
+
+- Where an existing verifier returns typed diagnostics, **consume that
+  directly**.
+- Where an existing Gradle task is the only boundary, use a **minimal
+  adapter** (read its typed artifact; never parse console output).
+- Do NOT copy logic from `BaselineVerifier`, cancellation checks, TCKs, etc.
+
+## 3. Check registry (stable IDs → evidence source)
+
+| id | Evidence source | Typed codes consumed |
+|----|-----------------|----------------------|
+| `module-manifest` | `ModuleManifestVerifier.verify(...)` (B1, direct call) + baseline report catalog codes | `MODULE_CATALOG_*` (except drift codes below) |
+| `publishing-topology` | `ModuleManifestVerifier.verify(...)` (B1) | `MODULE_CATALOG_BOM_DRIFT`, `MODULE_CATALOG_PUBLISHING_DRIFT` |
+| `dependency-boundaries` | `BaselineVerifier.verify()` → `verification-report.json` | `FORBIDDEN_LAYER_EDGE`, `SELF_DEPENDENCY`, `MODULE_CATALOG_DISAGREEMENT` |
+| `dependency-cycles` | same | `NEW_DEPENDENCY_CYCLE` |
+| `global-state` | same | `NEW_GLOBAL_STATE_FINDING` |
+| `api-architecture` | same | `API_*` |
+| `protocol-catalog` | same | `STABLE_PROTOCOL_CONTRACT_REMOVED` |
+| `cancellation-safety` | same | `NEW_CANCELLATION_FINDING`, `CANCELLATION_RISK_WORSENED` |
+| `provider-contracts` | thin Test task running `ProviderTckEnrollmentArchitectureTest` (existing), JUnit XML adapter | n/a (test outcome) |
+| `store-contracts` | thin Test task running the 9 existing `*StoreTckEnrollmentArchitectureTest` classes, JUnit XML adapter | n/a (test outcome) |
+
+The `dependency-boundaries` check additionally reflects the B1 dependency
+policy verification (already inside `BaselineVerifier.verify()` via
+`verifyDependencyPolicies`, which emits `FORBIDDEN_LAYER_EDGE`).
+
+## 4. Internal model (build-logic, not published API)
+
+```kotlin
+enum class ArchitectureCheckStatus { PASS, FAIL }
+
+data class ArchitectureCheckResult(
+    val id: String,
+    val status: ArchitectureCheckStatus,
+    val diagnostics: List<VerificationDiagnostic>,
+)
+
+data class ArchitectureVerificationSummary(
+    val checks: Int,
+    val passed: Int,
+    val failed: Int,
+)
+
+data class ArchitectureVerificationReport(
+    val schemaVersion: String,      // "1"
+    val status: ArchitectureCheckStatus,
+    val checks: List<ArchitectureCheckResult>,
+    val summary: ArchitectureVerificationSummary,
+)
+```
+
+Put this in a new build-logic file `ArchitectureReport.kt` together with the
+**pure aggregation function**:
+
+```kotlin
+object ArchitectureReportAggregator {
+    fun aggregate(checkDiagnostics: Map<String, List<VerificationDiagnostic>>): ArchitectureVerificationReport
+}
+```
+
+- status = FAIL iff any check has a FAILURE-severity diagnostic (or the
+  check's source reported failure).
+- summary = derived counts; deterministic ordering (checks sorted by id).
+
+## 5. Report contract (`architecture-report.json`)
+
+```json
+{
+  "schemaVersion": "1",
+  "status": "PASS",
+  "checks": [
+    { "id": "module-manifest", "status": "PASS", "diagnostics": [] },
+    { "id": "dependency-boundaries", "status": "PASS", "diagnostics": [] }
+  ],
+  "summary": { "checks": 10, "passed": 10, "failed": 0 }
+}
+```
+
+Requirements:
+- deterministic — no timestamps, no absolute paths, no `Instant.now()`; keys
+  sorted (use the same deterministic JSON writer style as
+  `ReportNormalizer.writeJson` / `ApiBaselineVerifier.deterministicJson`)
+- machine-readable
+- stable check IDs (the table in §3)
+- typed diagnostic codes where available (`DiagnosticCode.name` + severity)
+- no console-output parsing anywhere
+- **the report is still written when the gate fails** — the task writes the
+  JSON first, then throws `GradleException` if status == FAIL
+
+Diagnostic JSON shape (mirror `BaselineVerifier.writeVerificationReport`):
+`code`, `severity`, `message`, `modulePath`, `findingId`, `deviationId` (omit nulls).
+
+## 6. Task wiring
+
+Register in `MaintainabilityBaselinePlugin.kt`:
+
+1. **`verify060Architecture`** (group `verification`, description as PR title):
+   - does NOT `dependsOn` the throwing baseline task — it orchestrates
+     in-process so the report is always written:
+     1. Run `BaselineVerifier(...).verify()` (same construction as
+        `verifyMaintainabilityBaseline`), catch exceptions → convert to a
+        failure diagnostic for the affected checks.
+     2. Read the typed diagnostics from the `verification-report.json` the
+        verifier wrote (`build/reports/maintainability/verification-report.json`).
+     3. Call `ModuleManifestVerifier.verify(...)` directly (parse catalog +
+        project model + published extra + BOM constraints) → typed diagnostics.
+     4. Read the JUnit XML produced by the enrollment Test tasks (see 2) →
+        provider-contracts / store-contracts outcomes.
+     5. Partition by check id (§3), call `ArchitectureReportAggregator.aggregate`.
+     6. Write `build/reports/tramai/architecture/architecture-report.json`.
+     7. If `status == FAIL`, throw `GradleException` listing failed checks.
+   - `dependsOn` the enrollment Test tasks below.
+   - Do NOT wire into `verifyPr`/`check` in this PR (CI lane redesign is a
+     non-goal, Epic 10.5); keep it standalone. Running it in the PR's
+     verification is the evidence.
+2. **`architectureContractEnrollmentTest`** — thin Test task (root project):
+   - `testClassesDirs`/`classpath` from the `:tramai-testing` test source set
+     (⚠️ custom Test tasks need explicit wiring or they run zero tests)
+   - `useJUnitPlatform { includeTestsMatching("dev.tramai.testing.*EnrollmentArchitectureTest") }`
+   - `ignoreFailures = true` (the façade reads the XML and decides; the test
+     task must not throw before the report is written)
+   - results land in `tramai-testing/build/test-results/architectureContractEnrollmentTest/`
+
+   Do NOT create provider/store separate tasks — one task, the façade splits
+   XML by test class name (`ProviderTckEnrollmentArchitectureTest` →
+   provider-contracts; any other enrollment test → store-contracts).
+
+## 7. Discriminator / mutation proof (A1–A8)
+
+New build-logic test file `ArchitectureReportAggregatorTest.kt`. Each test
+feeds the aggregator a real failure diagnostic (constructed with the EXACT
+`DiagnosticCode` the underlying verifier emits) and asserts the report is FAIL
+with the failing check id; A8 asserts PASS. Where cheap, produce the
+diagnostic via the real verifier on a fixture instead of constructing it:
+
+- **A1 forbidden edge**: `ModuleBoundaries.checkEdge(":tramai-core", ":tramai-openai", catalog)` on the committed fixture → `FORBIDDEN_LAYER_EDGE` → `dependency-boundaries` FAIL
+- **A2 dependency cycle**: `ModuleGraphAnalyzer.findCycles(A→B→A)` → `dependency-cycles` FAIL (aggregator maps `NEW_DEPENDENCY_CYCLE`; assert via constructing that code if the analyzer returns raw cycles — the aggregator consumes typed diagnostics, so construct `VerificationDiagnostic.failure(NEW_DEPENDENCY_CYCLE, ...)` and assert the bucket)
+- **A3 manifest/settings drift**: `ModuleManifestVerifier.verify` with ghost/missing project path → `MODULE_CATALOG_UNKNOWN_ENTRY`/`MODULE_CATALOG_MISSING_ENTRY` → `module-manifest` FAIL
+- **A4 BOM drift**: `ModuleManifestVerifier.verify` with stale bomPaths → `MODULE_CATALOG_BOM_DRIFT` → `publishing-topology` FAIL
+- **A5 API classification**: `VerificationDiagnostic.failure(API_COMPATIBILITY_FAILED, ...)` → `api-architecture` FAIL
+- **A6 global mutable state**: `VerificationDiagnostic.failure(NEW_GLOBAL_STATE_FINDING, ...)` → `global-state` FAIL
+- **A7 cancellation**: `VerificationDiagnostic.failure(NEW_CANCELLATION_FINDING, ...)` → `cancellation-safety` FAIL
+- **A8 all valid**: empty diagnostics for every check → PASS, zero failed, summary counts correct
+
+The essential property: **an underlying verifier failing means
+`verify060Architecture` must fail and record that exact failure** — the
+aggregator maps every code the real verifiers emit to a FAIL bucket.
+
+## 8. Files
+
+### Create
+- `build-logic/src/main/kotlin/dev/tramai/build/quality/ArchitectureReport.kt` — model + `ArchitectureReportAggregator` (pure)
+- `build-logic/src/test/kotlin/dev/tramai/build/quality/ArchitectureReportAggregatorTest.kt` — A1–A8
+- `docs/EPIC-10.4-architecture-gate.md` — this spec (committed first)
+
+### Modify
+- `build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt` — register `verify060Architecture` + `architectureContractEnrollmentTest`
+
+### Do NOT touch
+- Any `tramai-*/src/main/kotlin/**` file (zero runtime production changes)
+- `config/quality/0.6.0-baseline.json`, `maintainability-deviations.yml`, `mutation-classifications.yml`, `test-quality.yml`
+- `tramai-testing/src/**` (the enrollment tests already exist; no new TCK semantics)
+- `BaselineVerifier.kt`, `ModuleCatalog.kt`, `ModuleManifest.kt`, `ModuleManifestVerifier.kt` (B1 code is consumed, not modified — only add new files + plugin registration)
+- `build.gradle.kts` monolith unless the Test task wiring requires it (prefer plugin registration; the Test task needs `:tramai-testing`'s source set — if the plugin can't reach it cleanly, register the Test task in the root build.gradle.kts with the exact wiring and note why)
+- `.github/workflows/**` (CI lane redesign is Epic 10.5, non-goal)
+
+## 9. Verification (all must pass)
+
+```bash
+cd ~/Development/aurora-b2
+export PATH="$HOME/.sdkman/candidates/gradle/8.5/bin:$PATH"   # CanonicalProbeFunctionalTest needs literal gradle
+git status --short                                            # no .hermes/, no stray files
+JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ./gradlew :build-logic:test --no-build-cache
+JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ./gradlew verify060Architecture
+JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ./gradlew verify060Architecture   # 2nd run: byte-identical report
+JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ./gradlew verifyPr --no-build-cache
+```
+
+- `:build-logic:test` — 250+ existing + A1–A8 suite PASS
+- `verify060Architecture` — PASS, `architecture-report.json` written with 10
+  checks, status PASS
+- second `verify060Architecture` — report byte-identical (determinism proof)
+- `verifyPr` — green (existing gates unaffected)
+
+## 10. Acceptance criteria (checklist)
+
+- [ ] `./gradlew verify060Architecture` exists
+- [ ] One machine-readable `architecture-report.json` always produced (also on failure)
+- [ ] Existing verifiers reused, not duplicated (only aggregation code is new)
+- [ ] Stable IDs for every architectural check (§3)
+- [ ] Typed diagnostics preserved (`DiagnosticCode.name` + severity in JSON)
+- [ ] Failure of any mandatory check makes aggregate FAIL
+- [ ] Manifest/settings topology included
+- [ ] Publishing/BOM topology included
+- [ ] Dependency direction included
+- [ ] Dependency cycles included
+- [ ] Core/examples boundary rules included
+- [ ] Global-state architecture included
+- [ ] API architecture included (existing baseline infrastructure)
+- [ ] Protocol/event catalogue checks included
+- [ ] Cancellation safety included
+- [ ] Provider TCK aggregate included (enrollment tests, not full TCK execution)
+- [ ] Store TCK aggregate included (enrollment tests)
+- [ ] Aggregate has mutation/discriminator proof (A1–A8)
+- [ ] Existing `verifyPr` remains green
+- [ ] No runtime production behaviour changes
+- [ ] No baseline/deviation edits
+
+## 11. Non-goals (this PR)
+
+- No new Detekt/formatting policy (Epic 10.1)
+- No new API compatibility semantics (Track B3 / Epic 10.2)
+- No coverage/mutation infrastructure (Epic 10.3)
+- No CI lane redesign (Epic 10.5) — `verify060Architecture` stays standalone
+- No moving Gradle code into additional convention plugins (Epic 9.2)
+- No runtime/provider fixes (Track A)
+- No new TCK semantics — the enrollment tests are the existing boundary; full
+  provider/store TCK execution stays in the normal test tasks
+
+If B2 discovers a missing architecture invariant belonging to another epic,
+report the gap in the PR body rather than absorbing the epic.


### PR DESCRIPTION
## Summary

Track B2 / Epic 10.4: one authoritative release-facing architecture gate.

```bash
./gradlew verify060Architecture
```

aggregates the **existing** architectural contracts — it reuses, never
reimplements — and emits a deterministic, machine-readable
`build/reports/tramai/architecture/architecture-report.json` (also written on
failure).

Zero runtime production changes. No baseline/deviation edits. B1 verifier code
(`BaselineVerifier`, `ModuleManifestVerifier`, `ModuleCatalog`, etc.) is
consumed as-is, not modified. `verify060Architecture` stays standalone (CI lane
redesign is Epic 10.5, a non-goal).

## What

**Internal model** (`ArchitectureReport.kt`, build-logic, not published API):
- `ArchitectureCheckStatus { PASS, FAIL }`, `ArchitectureCheckResult(id, status, diagnostics)`,
  `ArchitectureVerificationSummary(checks, passed, failed)`, `ArchitectureVerificationReport`
- `ArchitectureReportAggregator.aggregate(checkDiagnostics)` — pure: FAIL iff
  any check carries a FAILURE-severity diagnostic; checks sorted by id;
  diagnostics sorted deterministically; summary derived
- `ArchitectureReportJson` — deterministic JSON via the existing
  `ReportNormalizer` writer (sorted keys, no timestamps, no absolute paths)

**Check registry — 10 stable IDs, all sourced from existing verifiers:**

| id | Evidence source |
|----|-----------------|
| `module-manifest` | `ModuleManifestVerifier.verify(...)` (B1) + baseline `MODULE_CATALOG_*` codes |
| `publishing-topology` | `ModuleManifestVerifier.verify(...)` — `MODULE_CATALOG_BOM_DRIFT` / `PUBLISHING_DRIFT` |
| `dependency-boundaries` | baseline `FORBIDDEN_LAYER_EDGE` / `SELF_DEPENDENCY` / `MODULE_CATALOG_DISAGREEMENT` (incl. B1 dependency-policy verification) |
| `dependency-cycles` | baseline `NEW_DEPENDENCY_CYCLE` |
| `global-state` | baseline `NEW_GLOBAL_STATE_FINDING` |
| `api-architecture` | baseline `API_*` codes |
| `protocol-catalog` | baseline `STABLE_PROTOCOL_CONTRACT_REMOVED` |
| `cancellation-safety` | baseline `NEW_CANCELLATION_FINDING` / `CANCELLATION_RISK_WORSENED` |
| `provider-contracts` | thin Test task running the existing `ProviderTckEnrollmentArchitectureTest` → JUnit XML adapter |
| `store-contracts` | thin Test task running the 9 existing `*StoreTckEnrollmentArchitectureTest` classes → JUnit XML adapter |

**Orchestration** (`verify060Architecture` task, in `MaintainabilityBaselinePlugin`):
1. Runs the existing `BaselineVerifier.verify()` in-process (try/catch — a
   verifier failure becomes diagnostics, never aborts before the report)
2. Reads typed diagnostics from the `verification-report.json` the verifier
   writes (no console parsing, no re-derivation)
3. Calls `ModuleManifestVerifier.verify(...)` directly with the same
   independent signals as B1 (`verifyModuleManifest`)
4. Reads the enrollment Test task's JUnit XML (secure parser:
   `disallow-doctype-decl`, no XInclude, no entity expansion)
5. Partitions by check id → `ArchitectureReportAggregator.aggregate`
6. Writes `architecture-report.json` **before** throwing — the report exists
   even when the gate fails
7. Throws `GradleException` listing failed check ids if status == FAIL

**Thin enrollment Test task** (`architectureContractEnrollmentTest`):
- explicit `testClassesDirs` + `classpath` from `:tramai-testing` test source
  set (⚠️ custom Test tasks silently run zero tests without this — verified:
  10 XML files, real testcases)
- `includeTestsMatching("dev.tramai.testing.*EnrollmentArchitectureTest")`,
  `ignoreFailures = true` (façade reads XML and decides; the task must not
  abort before the report is written)
- one task; the façade splits provider vs store by test class name

**Discriminator suite** (`ArchitectureReportAggregatorTest`, A1–A8):
- A1 forbidden edge: real `ModuleBoundaries.checkEdge(core→openai)` →
  `FORBIDDEN_LAYER_EDGE` → `dependency-boundaries` FAIL
- A2 cycle: real `ModuleGraphAnalyzer.findCycles(A→B→A)` +
  `NEW_DEPENDENCY_CYCLE` → `dependency-cycles` FAIL
- A3 manifest drift: `ModuleManifestVerifier.verify` with ghost project path →
  `MODULE_CATALOG_UNKNOWN_ENTRY` → `module-manifest` FAIL
- A4 BOM drift: stale `bomPaths` → `MODULE_CATALOG_BOM_DRIFT` →
  `publishing-topology` FAIL
- A5 `API_COMPATIBILITY_FAILED` → `api-architecture` FAIL
- A6 `NEW_GLOBAL_STATE_FINDING` → `global-state` FAIL
- A7 `NEW_CANCELLATION_FINDING` → `cancellation-safety` FAIL
- A8 empty diagnostics → PASS, summary(10, 10, 0), deterministic JSON across
  two aggregations

## Files

- `build-logic/.../ArchitectureReport.kt` — NEW (model + aggregator + JSON writer)
- `build-logic/.../MaintainabilityBaselinePlugin.kt` — `verify060Architecture` +
  `architectureContractEnrollmentTest` registrations (+ XML/diagnostic helpers)
- `build-logic/src/test/.../ArchitectureReportAggregatorTest.kt` — NEW A1–A8
- `docs/EPIC-10.4-architecture-gate.md` — committed spec

## Verification

All run locally with `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64` (and
sdkman Gradle 8.5 on PATH for CanonicalProbeFunctionalTest — environment, not
code; CI has Gradle):

- `:build-logic:test` — **PASS** (250+ tests incl. A1–A8)
- `verify060Architecture` — **PASS**; report written with 10 checks, status
  PASS, all typed diagnostics empty
- `verify060Architecture` (2nd run) — report **byte-identical** (`diff` clean) → determinism proven
- `verifyPr` — **PASS** (320 tasks; subproject tests + build-logic tests + maintainability baseline + change policy + B1 manifest gates)

Report head (generated):

```json
{ "schemaVersion": "1", "status": "PASS",
  "checks": [ { "id": "api-architecture", "status": "PASS", "diagnostics": [] }, ... ],
  "summary": { "checks": 10, "passed": 10, "failed": 0 } }
```

## Non-claims

- Does NOT reimplement any existing verifier — only aggregation/orchestration/reporting is new.
- Does NOT execute full provider/store TCK suites in the gate (only the fast
  enrollment architecture tests; full TCK execution stays in normal test tasks).
- Does NOT wire `verify060Architecture` into `verifyPr`/`check` (CI lane
  redesign = Epic 10.5, non-goal).
- Does NOT add Detekt/formatting (10.1), API compatibility semantics (10.2/B3),
  coverage/mutation infra (10.3), convention-plugin moves (9.2), or Track A
  runtime fixes.
- Does NOT edit `config/quality/0.6.0-baseline.json` or any deviation file.

This PR needs review before merge.



---

## Review round 1 — REQUEST CHANGES → resolved (commit `c1f479c4`)

All reviewer findings fixed structurally; each proven by a real run.

**P1 — gate not standalone on clean workspace** → `verify060Architecture` now
`dependsOn("generateResolvedDependencyBaseline")`. Proven: deleted root
`build/` + `tramai-testing/build/`, ran the gate alone → PASS (prerequisite
generated the required `resolved-dependencies.json`).

**P1 — "report always written on failure" not guaranteed** → all three
evidence sources (baseline, manifest, enrollment) now run through
`collectEvidence(...)`, a fail-closed wrapper: any exception becomes FAILURE
diagnostics on the affected checks; the report write happens after collection
and before the terminal `GradleException`. New discriminator **A9** proves a
throwing evidence lambda still yields a written `status: FAIL` report.

**P1 — enrollment coverage can silently disappear** → the 10 expected
enrollment guard classes are now **pinned by identity**
(`enrollmentArchitectureTestClasses`); discovered XML classes are compared
set-to-set, both directions (missing → FAIL naming the class; unexpected →
FAIL). Proven end-to-end: temporarily deleted
`ApprovalStoreTckEnrollmentArchitectureTest.kt`, ran the gate → FAIL with
`store-contracts` + diagnostic naming the exact class; restored → PASS. New
discriminators **A10/A10b/A10c**.

**P1/P2 — unmapped baseline codes silently dropped** → `baselineCheckFor` is
now an exhaustive `when (code)` over every `DiagnosticCode` with **no else
branch**; adding a new code forces an explicit in-gate/out-of-gate decision at
compile time.

**Smaller fixes**:
- single `MeasurementContext.fromProject(project)` (was constructed twice)
- aggregator enforces exactly the 10 stable ids (`require(keys == checkIds)`) — new discriminator **A11**
- XML hardening completed: external general/parameter entities, `load-external-dtd`,
  `ACCESS_EXTERNAL_DTD`/`ACCESS_EXTERNAL_SCHEMA` (plus the existing doctype/XInclude locks)
- `baselineValue`/`currentValue` preserved in `architecture-report.json`
- spec updated to match (A1–A11, task wiring, fail-closed flow)

**Verification (all real runs)**: `:build-logic:test` PASS (264 tests, 13 A-tests);
`verify060Architecture` PASS standalone on a clean build dir; report byte-identical
across two runs (determinism); guard-deletion e2e FAIL + report written; full
`verifyPr` PASS (320 tasks).



---

## Review round 2 — REQUEST CHANGES → resolved (commit `a8b9a37f`)

All three findings fixed structurally; each verified by real runs and new discriminators.

**P1 — BaselineVerifier early-return false-PASS** → new `routeBaselineDiagnostics`
replaces the plain routing: if the baseline report contains FAILURE-severity
evidence-unavailable diagnostics (`EMPTY_SECTION` / `DEPENDENCY_RESOLUTION_FAILED`
— the verifier's early-return paths for missing/unreadable committed baseline,
failed current generation, or failed dependency resolution), **every**
baseline-backed check fails closed. The gate can no longer claim a check passed
when its evidence was never produced. Proven end-to-end: temporarily removed
`config/quality/0.6.0-baseline.json`, ran the gate → FAIL with all 7
baseline-backed checks + report written. New discriminators **A12** (EMPTY_SECTION
fan-out), **A13** (DEPENDENCY_RESOLUTION_FAILED fan-out).

**P1/P2 — prerequisite failure could bypass report generation** → the throwing
`dependsOn("generateResolvedDependencyBaseline")` is gone. The gate now depends on
**fail-soft per-project dependency probes** (`ArchitectureDependencyProbeTask`,
one per subproject): on any resolution exception they write a typed marker
(`[{"resolutionFailed": true, "message": "..."}]`) and never throw, so the gate's
`doLast` always runs and the report is always written. The gate reads the probes
via `readDependencyProbeEvidence`; a marker fails every baseline-backed check
with `DEPENDENCY_RESOLUTION_FAILED`; success aggregates the records into
`resolved-dependencies.json` and proceeds with the baseline verifier. New
discriminator **A15** (marker → typed failure; valid probe → records; missing
file → failure). The dependency-collection logic was extracted to a shared
`collectResolvedDependencies(project)` used by both the existing throwing task
and the new fail-soft task.

**P2 — failure reports could leak absolute paths** → `ArchitectureReportJson`
now sanitizes every serialized string field (message, findingId, baselineValue,
currentValue) replacing the repository root with `<repo-root>`, on all three
separator forms. Proven: the baseline-missing failure report contains
`Committed baseline not found: <repo-root>/config/quality/...` and zero absolute
paths; the PASS report diff is still byte-identical. New discriminator **A14**.

**Verification (all real runs)**: `:build-logic:test` PASS (268 tests, 15 A-tests);
`verify060Architecture` PASS standalone on a clean build dir; FAIL with report
written + sanitized path when committed baseline missing; report byte-identical
across two runs; full `verifyPr` PASS (320 tasks). No runtime production,
baseline, deviation, or CI files touched.
