### PR TITLE
feat(build): replace boilerplate module rationales (Epic 9.1d)

### DIFF
--- a/config/quality/module-catalog.yml
+++ b/config/quality/module-catalog.yml
@@ -107,6 +107,7 @@ modules:
     layer: operations-observability
     publishability: internal
     apiStability: internal
+    rationale: "Optional Vue 3 admin dashboard packaged as runtime-served static assets for operational inspection."
 
   - path: ":tramai-deepseek"
     <<: *provider
@@ -139,6 +140,7 @@ modules:
   - path: ":tramai-mcp"
     <<: *internal
     layer: operations-observability
+    rationale: "MCP server adapter exposing TramAI workflows as tools over stdio and SSE."
     publishability: internal
     apiStability: internal
 
@@ -152,6 +154,7 @@ modules:
   - path: ":tramai-memory-store"
     <<: *internal
     layer: higher-capabilities
+    rationale: "Durable memory-store implementations (JDBC, Redis) and supporting persistence SPI for the memory capability."
     publishability: internal
     apiStability: internal
 
@@ -228,6 +231,7 @@ modules:
   - path: ":tramai-server"
     <<: *internal
     layer: operations-observability
+    rationale: "HTTP API surface (workflow registry, workers, audit) with webhooks, OpenAPI and SSE endpoints."
     publishability: internal
     apiStability: internal
 
@@ -240,7 +244,7 @@ modules:
 
   - path: ":tramai-spring"
     <<: *framework
-    rationale: "Spring Boot auto-configuration and bean wiring for TramAI services."
+    rationale: "Legacy Spring facade over tramai-spring-core retained for back-compatibility; not the onboarding entry point."
     layer: framework-integrations
     publishability: published
     apiStability: preview
@@ -297,12 +301,14 @@ modules:
   - path: ":tramai-spring-consumer-boundary"
     <<: *internalTesting
     layer: testing-support
+    rationale: "Consumer-facing classpath boundary test verifying published Spring artifacts expose no unintended classes."
     publishability: internal
     apiStability: internal
 
   - path: ":tramai-spring-consumer-selective"
     <<: *internalTesting
     layer: testing-support
+    rationale: "Consumer-facing selective-dependency test verifying Spring consumers compile with minimal TramAI dependencies."
     publishability: internal
     apiStability: internal
 

--- a/config/quality/module-catalog.yml
+++ b/config/quality/module-catalog.yml
@@ -104,10 +104,10 @@ modules:
 
   - path: ":tramai-dashboard"
     <<: *internal
+    rationale: "Optional Vue 3 admin dashboard packaged as runtime-served static assets for operational inspection."
     layer: operations-observability
     publishability: internal
     apiStability: internal
-    rationale: "Optional Vue 3 admin dashboard packaged as runtime-served static assets for operational inspection."
 
   - path: ":tramai-deepseek"
     <<: *provider
@@ -139,8 +139,8 @@ modules:
 
   - path: ":tramai-mcp"
     <<: *internal
-    layer: operations-observability
     rationale: "MCP server adapter exposing TramAI workflows as tools over stdio and SSE."
+    layer: operations-observability
     publishability: internal
     apiStability: internal
 
@@ -153,8 +153,8 @@ modules:
 
   - path: ":tramai-memory-store"
     <<: *internal
-    layer: higher-capabilities
     rationale: "Durable memory-store implementations (JDBC, Redis) and supporting persistence SPI for the memory capability."
+    layer: higher-capabilities
     publishability: internal
     apiStability: internal
 
@@ -230,8 +230,8 @@ modules:
 
   - path: ":tramai-server"
     <<: *internal
-    layer: operations-observability
     rationale: "HTTP API surface (workflow registry, workers, audit) with webhooks, OpenAPI and SSE endpoints."
+    layer: operations-observability
     publishability: internal
     apiStability: internal
 
@@ -244,7 +244,7 @@ modules:
 
   - path: ":tramai-spring"
     <<: *framework
-    rationale: "Legacy Spring facade over tramai-spring-core retained for back-compatibility; not the onboarding entry point."
+    rationale: "Legacy Spring facade over :tramai-spring-core retained for back-compatibility; not the onboarding entry point."
     layer: framework-integrations
     publishability: published
     apiStability: preview
@@ -300,15 +300,15 @@ modules:
 
   - path: ":tramai-spring-consumer-boundary"
     <<: *internalTesting
-    layer: testing-support
     rationale: "Consumer-facing classpath boundary test verifying published Spring artifacts expose no unintended classes."
+    layer: testing-support
     publishability: internal
     apiStability: internal
 
   - path: ":tramai-spring-consumer-selective"
     <<: *internalTesting
-    layer: testing-support
     rationale: "Consumer-facing selective-dependency test verifying Spring consumers compile with minimal TramAI dependencies."
+    layer: testing-support
     publishability: internal
     apiStability: internal
 

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1401,6 +1401,15 @@ repair feedback. No layer maintains its own independent fixture lists.
 - Every module has a documented reason to exist.
 - CI rejects dependency cycles and forbidden layer edges.
 
+### Status: ✅ Complete
+
+- **AC1** (publishability not via hand-written lists) — ✅ PR #298 (manifest-derived publishing/BOM, `verifyModuleManifest` in `verifyPr`).
+- **AC2** (documented reason to exist) — ✅ PRs #298, #304 (specific rationale for all 58 modules).
+- **AC3** (cycles + forbidden edges rejected in CI) — ✅ PR #298 (M1–M8 mutation suite).
+- **Tasks 1–4** — ✅ PR #298.
+- **Task 5** (overlap review) — ✅ PR #300: 58/58 modules reviewed, 49 KEEP / 9 CLARIFY / 0 CONSOLIDATE.
+- **Task 6** (consolidation) — ✅ PR #300: reviewed; no consolidation improves ownership/dependency clarity sufficiently to justify compatibility and churn costs. The 9 CLARIFY findings were resolved without consolidation: JDBC release-surface correction (PR #303) + rationale clarity (PR #304).
+
 ---
 
 ## Epic 9.2: Move build logic into `build-logic`


### PR DESCRIPTION
## Summary

Epic 9.1d — module rationale quality closure **+ Epic 9.1 formal closure** (final PR of the 9.1 sequence).

8 modules in the authoritative `config/quality/module-catalog.yml` had generic or misleading rationale. Per 9.1b this is an **architecture-metadata change** (the catalog is the machine-readable module manifest), not docs-only. Note: the diff changes **7** rationale fields in this PR — the eighth (JDBC) is handled separately by #303.

## What

`config/quality/module-catalog.yml` — rationale replacements only (no publishability, layer, maturity, or boundary changes):

- `tramai-spring` — legacy Spring facade over `:tramai-spring-core` retained for back-compatibility; not the onboarding entry point.
- `tramai-server` — HTTP API surface (workflow registry, workers, audit) with webhooks, OpenAPI, SSE.
- `tramai-mcp` — MCP server adapter exposing workflows as tools over stdio and SSE.
- `tramai-dashboard` — optional Vue 3 admin dashboard as runtime-served static assets.
- `tramai-memory-store` — durable memory-store implementations (JDBC, Redis) and supporting persistence SPI.
- `tramai-spring-consumer-boundary` — consumer-facing classpath boundary test for published Spring artifacts.
- `tramai-spring-consumer-selective` — consumer-facing selective-dependency test.

(JDBC rationale handled in #303.)

## Epic 9.1 closure (this PR)

`docs/ROADMAP-0.6.0.md` — Epic 9.1 marked **✅ Complete**:

- AC1 (manifest-derived publishability) — #298
- AC2 (documented reason to exist) — #298, #304
- AC3 (cycles + forbidden edges) — #298 (M1–M8)
- Tasks 1–4 — #298
- Task 5 (overlap review) — #300: 58/58 modules, 49 KEEP / 9 CLARIFY / 0 CONSOLIDATE
- Task 6 (consolidation) — #300: reviewed, no consolidation justified; 9 CLARIFY resolved via #303 (JDBC release surface) + #304 (rationales)

## Review fixes applied

- Rebased onto post-#303 master; JDBC published classification + rationale verified surviving.
- 8 → 7 modules in description (JDBC handled by #303).
- All rationale fields placed immediately after their YAML anchor (catalog key-ordering convention).
- `tramai-spring-core` → canonical `:tramai-spring-core` module path.

## Verification

- YAML parses: 58 modules, zero blank/short rationales.
- `verifyModuleManifest` — PASS (part of verifyPr).
- `verifyPr` — BUILD SUCCESSFUL (320 tasks), incl. `verifyModuleMatrixDrift`, `verifyChangePolicy`, maintainability baseline.
- Matrix unaffected (rationale not rendered).

## Non-claims

- No module publishability/layer/boundary changes.
- No production code, no build-logic change, no baseline change.
- No consolidation.

This PR needs review before merge.
