### PR TITLE
docs: add authoritative repository architecture map (Epic 11.2a)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,17 @@ That means:
 
 If a reviewer cannot tell from the tests what a feature guarantees, the test suite is not strong enough yet.
 
+## Repository Navigation
+
+Before editing a subsystem:
+
+1. Read [ARCHITECTURE.md](./ARCHITECTURE.md).
+2. Follow its ownership pointer to the relevant module.
+3. Read the applicable guide under `docs/architecture/change-guides/` when one exists.
+4. Run the contract/TCK identified by the architecture documentation.
+
+The architecture map is authoritative for navigation; do not duplicate it here.
+
 ## Mandatory Execution Protocol
 
 ### Before editing

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,9 +11,9 @@ This is the authoritative navigation map for the TramAI repository. It tells you
 | Module classification / ownership / maturity / publishability / API stability / release inclusion | [`config/quality/module-catalog.yml`](./config/quality/module-catalog.yml) |
 | Module dependency exceptions / forbidden layer edges | [`config/quality/module-boundaries.yml`](./config/quality/module-boundaries.yml) |
 | Generated module overview (matrix) | [`docs/reference/module-matrix.md`](./docs/reference/module-matrix.md) — generated from the catalog, do not edit |
-| Dependency topology (graph) | [`docs/architecture/module-dependency-graph.md`](./docs/architecture/module-dependency-graph.md) |
+| Dependency topology (graph) | [`docs/architecture/module-dependency-graph.md`](./docs/architecture/module-dependency-graph.md) — **v0.5.0 baseline snapshot** (48 modules); current topology derives from the manifest + module-boundaries |
 | Public API compatibility | `api/*.api` dumps per module (binary-compatibility-validator) |
-| Runtime events / reason codes | [`docs/reference/runtime-event-catalogue.md`](./docs/reference/runtime-event-catalogue.md) |
+| Runtime events / reason codes | [`RuntimeEventCatalogue.kt`](./tramai-core/src/main/kotlin/dev/tramai/core/observation/event/RuntimeEventCatalogue.kt) (authoritative); [`docs/reference/runtime-event-catalogue.md`](./docs/reference/runtime-event-catalogue.md) is its generated view |
 | Provider routing | [`ProviderRegistry`](./tramai-core/src/main/kotlin/dev/tramai/core/provider/ProviderRegistry.kt) + provider routing contracts in `tramai-engine` |
 | Structured output contract | compiled structured descriptor (`StructuredTypeDescriptor`, `StructuredContractFingerprint` in `tramai-structured`) |
 | Persistence behavior | Store TCKs under [`tramai-testing`](./tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/) (e.g. `ApprovalStoreTck`) |
@@ -22,7 +22,7 @@ This is the authoritative navigation map for the TramAI repository. It tells you
 
 ## 2. Module layers
 
-The 10-layer model is defined by the manifest (`config/quality/module-catalog.yml`); this section explains the layers and their dependency direction. **Module membership is derived, not duplicated here** — see the [module matrix](./docs/reference/module-matrix.md).
+The 10-layer model is defined by the manifest (`config/quality/module-catalog.yml`); this section is **conceptual orientation, not a strict enforced hierarchy** — exact dependency policy lives in the manifest's per-module `dependencyPolicy` fields and `module-boundaries.yml`. **Module membership is derived, not duplicated here** — see the [module matrix](./docs/reference/module-matrix.md).
 
 ```
 core-contracts
@@ -51,7 +51,7 @@ testing-support → supports contracts without entering the runtime dependency f
 - **applications-examples** — executable examples (excluded from release).
 - **testing-support** — TCKs, fakes, consumer boundary tests.
 
-Dependency direction is enforced by `module-boundaries.yml` + the maintainability baseline (`verifyForbiddenEdges` / `verifyDependencyCycles`).
+Dependency direction is enforced by `module-boundaries.yml` + the maintainability baseline (`verifyForbiddenEdges` / `verifyDependencyCycles`), and aggregated by the unified architecture gate `./gradlew verify060Architecture`.
 
 ## 3. Where does X live?
 
@@ -81,7 +81,7 @@ Dependency direction is enforced by `module-boundaries.yml` + the maintainabilit
 | Adding a Spring provider integration | Do NOT add Spring dependencies to `tramai-core` / `tramai-engine` / `tramai-structured`. Spring integration lives in `tramai-spring-core` / starter modules. |
 | Adding a persistence backend | Do NOT copy an existing store's behavior as the specification. Implement the SPI and enroll in the shared TCK. |
 | Changing structured validation | Do NOT independently modify schema generation and post-parse validation. Start from the compiled structured contract (`StructuredTypeDescriptor`). |
-| Adding an event / reason code | Do NOT introduce another string literal beside the authoritative catalogue (`docs/reference/runtime-event-catalogue.md`). |
+| Adding an event / reason code | Do NOT introduce another string literal beside the authoritative `RuntimeEventCatalogue.kt` (`docs/reference/runtime-event-catalogue.md` is its generated view). |
 | Adding a workflow step | Do NOT add new concrete-type dispatch to a central orchestrator god object. Extend the step abstraction in `tramai-orchestration`. |
 
 ## 5. Execution ownership

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,7 +11,7 @@ This is the authoritative navigation map for the TramAI repository. It tells you
 | Module classification / ownership / maturity / publishability / API stability / release inclusion | [`config/quality/module-catalog.yml`](./config/quality/module-catalog.yml) |
 | Module dependency exceptions / forbidden layer edges | [`config/quality/module-boundaries.yml`](./config/quality/module-boundaries.yml) |
 | Generated module overview (matrix) | [`docs/reference/module-matrix.md`](./docs/reference/module-matrix.md) — generated from the catalog, do not edit |
-| Dependency topology (graph) | [`docs/architecture/module-dependency-graph.md`](./docs/architecture/module-dependency-graph.md) — **v0.5.0 baseline snapshot** (48 modules); current topology derives from the manifest + module-boundaries |
+| Dependency topology (graph) | [`docs/architecture/module-dependency-graph.md`](./docs/architecture/module-dependency-graph.md) — **v0.5.0 baseline snapshot** (48 modules). Current dependency policy is defined by `module-catalog.yml` and `module-boundaries.yml`; current resolved dependency edges are verified by `./gradlew verify060Architecture` |
 | Public API compatibility | `api/*.api` dumps per module (binary-compatibility-validator) |
 | Runtime events / reason codes | [`RuntimeEventCatalogue.kt`](./tramai-core/src/main/kotlin/dev/tramai/core/observation/event/RuntimeEventCatalogue.kt) (authoritative); [`docs/reference/runtime-event-catalogue.md`](./docs/reference/runtime-event-catalogue.md) is its generated view |
 | Provider routing | [`ProviderRegistry`](./tramai-core/src/main/kotlin/dev/tramai/core/provider/ProviderRegistry.kt) + provider routing contracts in `tramai-engine` |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,109 @@
+# TramAI Architecture Map
+
+This is the authoritative navigation map for the TramAI repository. It tells you **where a responsibility lives, what is authoritative, and where to start reading** — it does not reproduce the authoritative models themselves.
+
+> **Rule:** this document points to authoritative sources; it does not duplicate them. If a fact is owned by a manifest, catalog, dump, or TCK, link to it. Do not maintain parallel truth here.
+
+## 1. Sources of truth
+
+| Concept | Authoritative source |
+|---------|----------------------|
+| Module classification / ownership / maturity / publishability / API stability / release inclusion | [`config/quality/module-catalog.yml`](./config/quality/module-catalog.yml) |
+| Module dependency exceptions / forbidden layer edges | [`config/quality/module-boundaries.yml`](./config/quality/module-boundaries.yml) |
+| Generated module overview (matrix) | [`docs/reference/module-matrix.md`](./docs/reference/module-matrix.md) — generated from the catalog, do not edit |
+| Dependency topology (graph) | [`docs/architecture/module-dependency-graph.md`](./docs/architecture/module-dependency-graph.md) |
+| Public API compatibility | `api/*.api` dumps per module (binary-compatibility-validator) |
+| Runtime events / reason codes | [`docs/reference/runtime-event-catalogue.md`](./docs/reference/runtime-event-catalogue.md) |
+| Provider routing | [`ProviderRegistry`](./tramai-core/src/main/kotlin/dev/tramai/core/provider/ProviderRegistry.kt) + provider routing contracts in `tramai-engine` |
+| Structured output contract | compiled structured descriptor (`StructuredTypeDescriptor`, `StructuredContractFingerprint` in `tramai-structured`) |
+| Persistence behavior | Store TCKs under [`tramai-testing`](./tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/) (e.g. `ApprovalStoreTck`) |
+| Provider behavior | [`ProviderTck`](./tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/provider/ProviderTck.kt) |
+| Architectural decisions | [`docs/adr/`](./docs/adr/) |
+
+## 2. Module layers
+
+The 10-layer model is defined by the manifest (`config/quality/module-catalog.yml`); this section explains the layers and their dependency direction. **Module membership is derived, not duplicated here** — see the [module matrix](./docs/reference/module-matrix.md).
+
+```
+core-contracts
+      ↓
+runtime-execution
+      ↓
+governance-security / persistence / provider-adapters
+      ↓
+framework-integrations
+      ↓
+operations-observability / higher-capabilities
+      ↓
+applications-examples
+
+testing-support → supports contracts without entering the runtime dependency flow
+```
+
+- **core-contracts** — annotations, shared contracts, request/response models, exceptions. Near zero-dependency.
+- **runtime-execution** — engine, structured output, orchestration, standalone.
+- **governance-security** — policy, approval, audit, evidence, sovereign runtime.
+- **persistence** — storage implementations (file, JDBC).
+- **provider-adapters** — vendor providers via the provider SPI.
+- **framework-integrations** — Spring core/starter/sovereign, provider starters, secrets.
+- **operations-observability** — OTel, platform wiring, server/MCP/dashboard surfaces.
+- **higher-capabilities** — memory, RAG, embeddings, scheduler, vector stores.
+- **applications-examples** — executable examples (excluded from release).
+- **testing-support** — TCKs, fakes, consumer boundary tests.
+
+Dependency direction is enforced by `module-boundaries.yml` + the maintainability baseline (`verifyForbiddenEdges` / `verifyDependencyCycles`).
+
+## 3. Where does X live?
+
+| Responsibility | Start here | Contract / tests |
+|----------------|-----------|------------------|
+| Typed AI service API | `tramai-core` (`@AiService`, annotations) | API dumps + core tests |
+| Engine invocation | `tramai-engine` (`TramaiEngine`, `InvocationExecutionCoordinator`, `TramaiInvocationHandler`) | engine behavioral tests |
+| Provider routing | `tramai-engine` (`ProviderExecutionCoordinator`, `ProviderRegistry` in core) | provider TCK |
+| Provider implementation | the provider module (`tramai-openai`, `tramai-ollama`, …) | [`ProviderTck`](./tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/provider/ProviderTck.kt) |
+| Structured output | `tramai-structured` (`StructuredTypeCompiler`, `JacksonStructuredOutputHandler`) | structured contract TCK / descriptor tests |
+| Tools | `tramai-core` (`Tool`, `AiTool`) + `tramai-engine/tool` | tool contract tests |
+| Policy / DLP | `tramai-security` (`DefaultPolicyEngine`, `RuleBasedDlpInterceptor`) + `tramai-engine` (`PolicyEnforcementHelper`) | policy tests |
+| Approval lifecycle | `tramai-security/approval` + `tramai-core/approval` contracts | [`ApprovalStoreTck`](./tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/ApprovalStoreTck.kt) |
+| Workflow execution | `tramai-orchestration` (`WorkflowExecutionSupervisor`, `TramaiWorker`) | workflow tests |
+| Worker lifecycle | `tramai-orchestration` (`WorkerLifecycleController`, `WorkerShutdownCoordinator`) | lifecycle state-machine tests |
+| Persistence | relevant persistence module (`tramai-persistence-file`, `tramai-persistence-jdbc`) | store TCK |
+| Audit / evidence | `tramai-security` (`audit/`, `evidence/`) | audit/evidence contracts |
+| Spring integration | `tramai-spring-core` (`AiServiceProxyAutoConfiguration`, `EnableTramai`) + starters | compatibility TCK |
+| Observability | `tramai-observability` (`OpenTelemetryOperationObserver`) | observability contract tests |
+| RAG / vector stores | `tramai-rag`, `tramai-vectorstore-*` (SPI in `tramai-vectorstore-spi`) | SPI tests |
+
+## 4. Do not start here
+
+| Task | Do NOT |
+|------|--------|
+| Adding a provider | Do NOT add provider-specific branches to the central engine coordinator (`TramaiEngine`, `InvocationExecutionCoordinator`). Providers implement the SPI; the engine owns routing/retry/fallback. |
+| Adding a Spring provider integration | Do NOT add Spring dependencies to `tramai-core` / `tramai-engine` / `tramai-structured`. Spring integration lives in `tramai-spring-core` / starter modules. |
+| Adding a persistence backend | Do NOT copy an existing store's behavior as the specification. Implement the SPI and enroll in the shared TCK. |
+| Changing structured validation | Do NOT independently modify schema generation and post-parse validation. Start from the compiled structured contract (`StructuredTypeDescriptor`). |
+| Adding an event / reason code | Do NOT introduce another string literal beside the authoritative catalogue (`docs/reference/runtime-event-catalogue.md`). |
+| Adding a workflow step | Do NOT add new concrete-type dispatch to a central orchestrator god object. Extend the step abstraction in `tramai-orchestration`. |
+
+## 5. Execution ownership
+
+The runtime execution seams are described in detail in [`docs/architecture/execution-sequence.md`](./docs/architecture/execution-sequence.md).
+
+Stable ownership statements (current):
+
+- Provider admission and completion are owned by the engine's provider-execution boundary (`ProviderExecutionCoordinator` / `ProviderAttemptExecutor`); retries/fallbacks must not be implemented inside provider adapters.
+- Structured output handling is owned by `tramai-structured`; the engine consumes its contracts.
+- Workflow execution, worker lifecycle, and persistence fencing are owned by `tramai-orchestration` (`WorkflowExecutionSupervisor`, `WorkerLifecycleController`, `WorkerShutdownCoordinator`).
+- Spring integration is a thin adapter over the engine via `tramai-spring-core`.
+
+> Circuit-breaker OPEN/HALF_OPEN generation semantics are intentionally not frozen here while the 8.2g circuit-breaker lifecycle work is in flight. The ownership seam above is stable.
+
+## 6. Navigation protocol for contributors and agents
+
+Before editing a subsystem:
+
+1. Read this map.
+2. Follow its ownership pointer to the responsible module.
+3. Read the relevant change guide under `docs/architecture/change-guides/` (added in Epic 11.2c).
+4. Run the contract/TCK named by that guide.
+
+Automated coding agents must also follow [`AGENTS.md`](./AGENTS.md) for the execution protocol.

--- a/docs/architecture/execution-sequence.md
+++ b/docs/architecture/execution-sequence.md
@@ -32,8 +32,8 @@ Key seams:
 
 Ownership: `tramai-engine/streaming` (`StreamingExecutionCoordinator`).
 
-- Diverges from the invocation flow at provider admission: the admitted attempt streams tokens instead of returning a full response.
-- Rejoins at structured/output processing and observation: streamed content is validated, sanitized, and audited before the caller sees it.
+- Diverges from the invocation flow at provider admission: the admitted attempt streams tokens instead of returning a full response. Token chunks are forwarded to the caller as they arrive (`StreamChunk.Token` → `onToken`); only the terminal assembled response passes through the response-interceptor path (`interceptResponse` on `StreamChunk.Complete`). Per-token validation/sanitization/audit before caller visibility is NOT claimed.
+- Rejoins at structured/output processing and observation on the terminal chunk: the completed response is intercepted, observed, token-budget-enforced, and emitted before the stream finishes.
 - Streaming models: `StreamingExecutionModels` in the same package.
 
 ## C. Tool invocation
@@ -55,7 +55,7 @@ The engine owns tool lifecycle; tools must not bypass policy or return unsanitiz
 
 Ownership: `tramai-engine/approval` (`ApprovalSuspensionCoordinator`, `ApprovalResumeCoordinator`, `DefaultApprovalGateway`, `ReplayAuthorizationService`, `ContinuationClaimService`); durable contracts in `tramai-core/approval`; store semantics under `tramai-security/approval` + store TCKs.
 
-- Suspension: an invocation that requires approval is suspended with a durable `ApprovalContinuation`; state transitions are governed by the approval lifecycle model (`ApprovalStoreTck` / `ApprovalLifecycleModel` in `tramai-testing`).
+- Suspension: an invocation that requires approval is suspended with a durable `ApprovalContinuation`; state transitions are governed by the **approval-continuation** lifecycle model — `ApprovalContinuationStoreTck` + `ApprovalContinuationLifecycleModel` in `tramai-testing` (distinct from `ApprovalStoreTck`, which covers the approval store itself).
 - Replay: incoming replays are validated (`ReplayEnvelopeFactory` / `ReplayEnvelopeValidator`) and deduplicated; claimed resumes route through `ClaimedResumeExecutor`.
 - Authority: `DefaultApprovalGateway` composes approval/suspension/continuation stores; audit decisions flow through `AuditEngineApprovalLifecycleAuditEmitter`.
 

--- a/docs/architecture/execution-sequence.md
+++ b/docs/architecture/execution-sequence.md
@@ -1,0 +1,75 @@
+# Execution Sequence — Runtime Ownership Map
+
+This document describes the runtime execution flows at the **ownership/seam level**: which component owns each stage, where the authoritative contracts live, and where flows diverge and rejoin. It is not a private-call trace.
+
+## A. Typed service invocation
+
+Ownership: `tramai-engine` (`TramaiEngine`, `InvocationExecutionCoordinator`); contracts in `tramai-core`.
+
+```
+caller
+  → @AiService interface method (tramai-core annotations)
+  → JDK dynamic proxy (TramaiInvocationHandler, tramai-engine/invocation)
+  → operation planning (OperationDefinitionCompiler → OperationExecutionPlan, tramai-engine/planning)
+  → governance / input processing (PolicyEnforcementHelper, tramai-engine)
+  → provider routing (ProviderRegistry, tramai-core/provider + ProviderExecutionCoordinator, tramai-engine/provider)
+  → admitted provider attempt (ProviderAttemptExecutor)
+  → provider transport (provider adapter module, e.g. tramai-openai)
+  → structured / raw processing (StructuredResponseCoordinator + tramai-structured handler)
+  → governance / output processing (PolicyEnforcementHelper, before-response-return)
+  → observation / audit / evidence (EngineEventObserver, AuditEngine, evidence)
+  → caller
+```
+
+Key seams:
+
+- **Invocation:** `TramaiInvocationHandler` (proxy) → `InvocationExecutionCoordinator` (governance enforcement points: before-provider-resolution, before-provider-invocation, before-response-return).
+- **Provider execution:** `ProviderExecutionCoordinator` owns routing/retry/fallback; `ProviderAttemptExecutor` owns a single admitted attempt. Provider adapters own transport/vendor translation **only**.
+- **Structured output:** `StructuredResponseCoordinator` (engine) consumes `StructuredOutputHandler` (tramai-structured, e.g. `JacksonStructuredOutputHandler`); the compiled descriptor is authoritative.
+- **Observation:** `EngineEventObserver` / `FailureIsolatingEngineEventObserver`; OTel via `tramai-observability` (`OpenTelemetryOperationObserver`).
+
+## B. Streaming
+
+Ownership: `tramai-engine/streaming` (`StreamingExecutionCoordinator`).
+
+- Diverges from the invocation flow at provider admission: the admitted attempt streams tokens instead of returning a full response.
+- Rejoins at structured/output processing and observation: streamed content is validated, sanitized, and audited before the caller sees it.
+- Streaming models: `StreamingExecutionModels` in the same package.
+
+## C. Tool invocation
+
+Ownership: `tramai-engine/tool` (`ToolExposureCoordinator`, `ToolAuthorizationCoordinator`, `ToolInvocationExecutor`); contracts in `tramai-core` (`Tool`, `AiTool`, `ToolResult`, `ModelVisibleToolMessage`).
+
+```
+model tool request (tool call in provider response)
+  → tool resolution (ToolExposureCoordinator; registry-based, tramai-core)
+  → policy / governance (ToolAuthorizationCoordinator + PolicyEnforcementHelper)
+  → execution (ToolInvocationExecutor)
+  → safe model-visible result (ModelVisibleToolMessage — DLP-sanitized)
+  → evidence / observation (audit + evidence emitters)
+```
+
+The engine owns tool lifecycle; tools must not bypass policy or return unsanitized content to the model.
+
+## D. Approval / replay
+
+Ownership: `tramai-engine/approval` (`ApprovalSuspensionCoordinator`, `ApprovalResumeCoordinator`, `DefaultApprovalGateway`, `ReplayAuthorizationService`, `ContinuationClaimService`); durable contracts in `tramai-core/approval`; store semantics under `tramai-security/approval` + store TCKs.
+
+- Suspension: an invocation that requires approval is suspended with a durable `ApprovalContinuation`; state transitions are governed by the approval lifecycle model (`ApprovalStoreTck` / `ApprovalLifecycleModel` in `tramai-testing`).
+- Replay: incoming replays are validated (`ReplayEnvelopeFactory` / `ReplayEnvelopeValidator`) and deduplicated; claimed resumes route through `ClaimedResumeExecutor`.
+- Authority: `DefaultApprovalGateway` composes approval/suspension/continuation stores; audit decisions flow through `AuditEngineApprovalLifecycleAuditEmitter`.
+
+## E. Workflow / worker
+
+Ownership: `tramai-orchestration`.
+
+- **Supervision:** `WorkflowExecutionSupervisor` owns workflow execution; `WorkerLifecycleController` owns worker lifecycle state; `WorkerShutdownCoordinator` owns coordinated shutdown.
+- **Recovery/fencing:** `WorkflowRecoveryCoordinator` + lease-aware execution (`LeaseCoordinator`, `LeaseRenewalLoop`); persistence seams via checkpoint/lease/step-attempt stores (file, JDBC, Markdown variants).
+- **Workers:** `TramaiWorker` + observers (`FailureIsolatingTramaiWorkerObserver`, `LoggingTramaiWorkerObserver`); OTel via `OpenTelemetryTramaiWorkerObserver`.
+- **Persistence contracts:** `JdbcWorkflowCheckpointStore`, `FileWorkflowCheckpointStore`, step-attempt record stores — behavior enforced by store TCKs, not by copying.
+
+## Stable ownership statements
+
+- Provider admission and completion are owned by the engine's provider-execution boundary; retries/fallbacks must not be implemented inside provider adapters.
+- Structured output validation is owned by `tramai-structured`; the engine consumes its contracts.
+- Circuit-breaker OPEN/HALF_OPEN generation semantics are intentionally not frozen while 8.2g is in flight; the ownership seam above is stable.

--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -1,67 +1,72 @@
-# Module Overview
+# Module Layers
 
-These are the current repository modules and their intended boundaries.
+> **Navigation:** the authoritative module list, classification (layer, maturity, publishability, API stability, owner, release inclusion) and dependency direction live in the machine-readable manifest. This page explains the layer philosophy only; it does not maintain a second module list.
 
-The important distinction is not just module name, but module tier:
+## Sources
 
-- stable consumer modules: normal application dependencies with the clearest compatibility expectations
-- runtime/platform modules: operational surfaces that exist in the repo but evolve faster
+- Module classification / ownership / maturity / publishability: [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml)
+- Forbidden / allowed dependency edges: [`config/quality/module-boundaries.yml`](../../config/quality/module-boundaries.yml)
+- Generated module matrix (all 58 modules with layer/maturity/api/published/owner/release): [`docs/reference/module-matrix.md`](../reference/module-matrix.md)
+- Dependency topology graph: [`docs/architecture/module-dependency-graph.md`](./module-dependency-graph.md)
 
-## Published Consumer Modules
+## Layer Philosophy
 
-- `tramai-core`: annotations, shared contracts, request and response models, common exceptions
-- `tramai-engine`: proxy generation, method dispatch, operation execution, retry and error handling
-- `tramai-structured`: schema generation, response parsing, validation integration, structured retry feedback
-- `tramai-observability`: OpenTelemetry integration and semantic convention mapping
-- `tramai-orchestration`: typed workflow composition, checkpoint/resume coordination, and optional lease-aware execution
-- `tramai-anthropic`: Anthropic provider implementation
-- `tramai-ollama`: Ollama provider implementation
-- `tramai-openai`: OpenAI and OpenAI-compatible provider implementation
-- `tramai-standalone`: minimal framework-free entry point and builder APIs
-- `tramai-spring-boot-starter`: unified Spring Boot starter composing `tramai-spring-core` (standard) and `tramai-spring-sovereign` (sovereign); `tramai.profile` selects the runtime
-- `tramai-spring`: legacy Spring facade over `tramai-spring-core`; not the onboarding entry point
-- `tramai-testing`: mock providers, assertion helpers, and test support
-- `tramai-bom`: BOM for consumer dependency management
-- `tramai-memory`: bounded conversation memory implementations
-- `tramai-embedding`: embedding SPI and provider integrations
-- `tramai-rag`: RAG pipeline and retrieval helpers
-- `tramai-vectorstore-spi`: vector store abstractions
-- `tramai-vectorstore-chroma`: Chroma adapter
-- `tramai-vectorstore-pgvector`: pgvector adapter
+The manifest defines 10 layers with a strict dependency direction (enforced by the maintainability baseline):
 
-## Runtime And Platform Modules
+```
+core-contracts
+      ↓
+runtime-execution
+      ↓
+governance-security / persistence / provider-adapters
+      ↓
+framework-integrations
+      ↓
+operations-observability / higher-capabilities
+      ↓
+applications-examples
 
-- `tramai-memory-store`: durable memory-store implementations and supporting persistence SPI
-- `tramai-scheduler`: cron scheduling, delay-step timing, and durable schedule stores
-- `tramai-server`: HTTP API surface, webhooks, run persistence views, OpenAPI, and SSE endpoints
-- `tramai-mcp`: MCP server adapter that exposes workflows as tools
-- `tramai-platform`: tenancy, API keys, rate limiting, plugin registry, and audit logging
-- `tramai-dashboard`: optional Vue 3 admin UI packaged as runtime-served static assets
+testing-support → supports contracts without entering the runtime dependency flow
+```
 
-## Dependency Direction
+- **core-contracts** — annotations, shared contracts, request/response models, exceptions. Near zero-dependency.
+- **runtime-execution** — engine, structured output, orchestration, standalone.
+- **governance-security** — policy, approval, audit, evidence, sovereign runtime.
+- **persistence** — storage implementations (file, JDBC).
+- **provider-adapters** — vendor providers via the provider SPI.
+- **framework-integrations** — Spring core/starter/sovereign, provider starters, secrets.
+- **operations-observability** — OTel, platform wiring, server/MCP/dashboard surfaces.
+- **higher-capabilities** — memory, RAG, embeddings, scheduler, vector stores.
+- **applications-examples** — executable examples (excluded from release).
+- **testing-support** — TCKs, fakes, consumer boundary tests.
 
-- `tramai-core` should remain as close to zero-dependency as practical.
-- `tramai-engine` depends on `tramai-core`.
-- `tramai-structured` depends on `tramai-core` and integrates with the engine's execution flow.
-- `tramai-observability` is optional and should remain decoupled from the core happy path when OpenTelemetry is absent.
-- Provider modules depend on shared request and response contracts and plug into the engine through the provider interface.
-- `tramai-standalone` composes the minimal runtime for non-framework users: `tramai-core`, `tramai-engine`, and `tramai-structured`.
-- Observability should be added by depending on `tramai-observability`, not by making `tramai-standalone` transitively heavier.
-- Framework adapters such as `tramai-spring` should be thin integration layers, not alternate runtimes.
+## Key Boundaries
+
+The following rules are enforced by `module-boundaries.yml` and verified by the maintainability baseline (new cycles and forbidden edges fail CI):
+
+- `tramai-core` must remain as close to zero-dependency as practical.
+- `tramai-engine` depends on `tramai-core`; it owns orchestration and retry policy.
+- `tramai-structured` owns schema generation, extraction, deserialization, and structured failure analysis.
+- `tramai-observability` is optional and must remain decoupled from the core happy path.
+- Provider modules plug into the engine through the provider interface; they must not implement retry/fallback/circuit logic.
+- `tramai-standalone` composes the minimal runtime for non-framework users.
+- Framework adapters such as `tramai-spring-core` are thin integration layers, not alternate runtimes.
 - `tramai-orchestration` owns workflow execution semantics and persistence boundaries.
-- `tramai-scheduler` sits above orchestration and should not backflow scheduling concerns into the engine.
-- `tramai-server` sits above orchestration and scheduler, exposing operational APIs rather than redefining workflow semantics.
-- `tramai-mcp` sits above server/orchestration concerns and should remain an adapter, not a second orchestration engine.
+- `tramai-scheduler` sits above orchestration and must not backflow scheduling concerns into the engine.
+- `tramai-server` sits above orchestration/scheduler, exposing operational APIs rather than redefining workflow semantics.
+- `tramai-mcp` is an adapter, not a second orchestration engine.
 - `tramai-platform` owns tenancy, governance, and plugin/runtime policy concerns above the server layer.
 - `tramai-dashboard` is a UI packaging module and must remain optional at runtime.
 
 ## Design Constraint
 
-The same core operation semantics should apply everywhere:
+The same core operation semantics apply everywhere:
 
 - standalone applications
 - Spring Boot applications
 - future framework adapters
 - tests using mock providers
 
-That same rule extends upward: the operational modules should compose the core runtime, not fork it.
+That same rule extends upward: the operational modules compose the core runtime, they do not fork it.
+
+For per-module navigation cards (responsibility, entry points, extension points, lifecycle, thread-safety, failure semantics, contract tests), see `docs/architecture/modules/` (added in Epic 11.2b).

--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -7,7 +7,7 @@
 - Module classification / ownership / maturity / publishability: [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml)
 - Forbidden / allowed dependency edges: [`config/quality/module-boundaries.yml`](../../config/quality/module-boundaries.yml)
 - Generated module matrix (all 58 modules with layer/maturity/api/published/owner/release): [`docs/reference/module-matrix.md`](../reference/module-matrix.md)
-- Dependency topology graph (v0.5.0 baseline snapshot): [`docs/architecture/module-dependency-graph.md`](./module-dependency-graph.md) — current topology derives from the manifest + module-boundaries
+- Dependency topology graph (v0.5.0 baseline snapshot): [`docs/architecture/module-dependency-graph.md`](./module-dependency-graph.md). Current dependency policy is defined by `module-catalog.yml` and `module-boundaries.yml`; current resolved dependency edges are verified by `./gradlew verify060Architecture`
 
 ## Layer Philosophy
 
@@ -69,4 +69,4 @@ The same core operation semantics apply everywhere:
 
 That same rule extends upward: the operational modules compose the core runtime, they do not fork it.
 
-For per-module navigation cards (responsibility, entry points, extension points, lifecycle, thread-safety, failure semantics, contract tests), see `docs/modules/` (per-module cards, completed in Epic 11.2b).
+For existing per-module documentation, see `docs/modules/`. Epic 11.2b normalizes and completes these cards against the authoritative 58-module manifest.

--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -7,11 +7,11 @@
 - Module classification / ownership / maturity / publishability: [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml)
 - Forbidden / allowed dependency edges: [`config/quality/module-boundaries.yml`](../../config/quality/module-boundaries.yml)
 - Generated module matrix (all 58 modules with layer/maturity/api/published/owner/release): [`docs/reference/module-matrix.md`](../reference/module-matrix.md)
-- Dependency topology graph: [`docs/architecture/module-dependency-graph.md`](./module-dependency-graph.md)
+- Dependency topology graph (v0.5.0 baseline snapshot): [`docs/architecture/module-dependency-graph.md`](./module-dependency-graph.md) — current topology derives from the manifest + module-boundaries
 
 ## Layer Philosophy
 
-The manifest defines 10 layers with a strict dependency direction (enforced by the maintainability baseline):
+The manifest defines 10 layers with a conceptual dependency direction (**orientation, not a strict enforced hierarchy** — exact policy lives in each module's `dependencyPolicy` and in `module-boundaries.yml`, verified by the maintainability baseline):
 
 ```
 core-contracts
@@ -69,4 +69,4 @@ The same core operation semantics apply everywhere:
 
 That same rule extends upward: the operational modules compose the core runtime, they do not fork it.
 
-For per-module navigation cards (responsibility, entry points, extension points, lifecycle, thread-safety, failure semantics, contract tests), see `docs/architecture/modules/` (added in Epic 11.2b).
+For per-module navigation cards (responsibility, entry points, extension points, lifecycle, thread-safety, failure semantics, contract tests), see `docs/modules/` (per-module cards, completed in Epic 11.2b).

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,5 +1,7 @@
 # Architecture Overview
 
+> **Navigation:** for the authoritative module map, layers, ownership pointers, and sources of truth, start at [`ARCHITECTURE.md`](../../ARCHITECTURE.md). This page covers deeper runtime concepts that the map intentionally does not repeat.
+
 TramAI is a Kotlin-first JVM runtime for governed AI workflows. The core product goal is to let application code interact with AI through typed interface methods while runtime layers handle structured output, provider dispatch, policy enforcement, routing, replay safety, and auditability — not through framework-specific chains, agents, or scattered prompt orchestration.
 
 ## Core Flow
@@ -14,6 +16,8 @@ TramAI is a Kotlin-first JVM runtime for governed AI workflows. The core product
 8. The provider returns raw model output plus metadata.
 9. TramAI either returns raw text, streams chunks, or parses and validates structured output.
 10. Parse failures enter a retry loop with validation feedback.
+
+Ownership of each stage and the current type names live in [`execution-sequence.md`](./execution-sequence.md).
 
 ### Structured Output Retry
 
@@ -33,26 +37,15 @@ If the retry limit is exhausted, TramAI throws `StructuredOutputException` with 
 
 TramAI uses standard JDK dynamic proxies through `java.lang.reflect.Proxy` to implement `@AiService` interfaces at runtime.
 
-`TramaiInvocationHandler` intercepts interface method calls and converts `@Operation`, `@System`, and `@User` annotations into a `ModelRequest` for the engine.
+`TramaiInvocationHandler` intercepts interface method calls and converts `@Operation`, `@System`, and `@User` annotations into a model request for the engine.
 
 Suspend functions are detected from the JVM method signature by checking for a trailing `Continuation` parameter. Those calls are dispatched through `invokeSuspend()`, which launches a coroutine with the continuation's context.
 
 Non-suspend methods are wrapped in `runBlocking { execute(...) }`, so synchronous Java and Kotlin calls still use the same execution pipeline.
 
-The current runtime uses JDK dynamic proxies through `java.lang.reflect.Proxy`. KSP-based compile-time generation and broader GraalVM native-image support remain possible future work; they are not part of the current 0.5.0 release commitment.
+The current runtime uses JDK dynamic proxies through `java.lang.reflect.Proxy`. KSP-based compile-time generation and broader GraalVM native-image support remain possible future work.
 
-## Major Layers
-
-- Application layer: consumer-defined `@AiService` interfaces
-- Proxy layer: runtime-generated implementations that intercept method calls
-- Operation engine: prompt rendering, provider dispatch, streaming, tool calling, parsing, retry, and error handling
-- Observability layer: OpenTelemetry spans, metrics, and semantic attributes
-- Provider layer: Anthropic, Ollama, OpenAI, and OpenAI-compatible providers
-- Optional orchestration layer: typed workflow coordination above `tramai-engine`
-- Optional retrieval and memory layer: RAG, embeddings, vector stores, and bounded chat memory
-- Optional runtime/platform layer: scheduling, HTTP APIs, MCP exposure, tenancy, and dashboard operations
-
-### Operation Interceptor/Observer SPI
+## Operation Interceptor/Observer SPI
 
 The operation engine exposes two opt-in extension points for cross-cutting behavior.
 
@@ -62,7 +55,7 @@ The operation engine exposes two opt-in extension points for cross-cutting behav
 
 Both default to `NoOp` implementations and are enabled explicitly via `Tramai.builder()`.
 
-### Provider Resolution
+## Provider Resolution
 
 `ProviderRegistry` maps model names to provider routes and can define explicit fallback chains for each route.
 
@@ -72,9 +65,9 @@ Resolution order is:
 2. model-to-provider mapping
 3. default provider
 
-Each provider attempt is wrapped with circuit-breaker and retry policy logic. When the primary route fails, fallback routes are tried in order.
+Each provider attempt is wrapped with retry/fallback policy logic. When the primary route fails, fallback routes are tried in order. Provider admission and completion are owned by the engine's provider-execution boundary; provider adapters must not implement retries or fallbacks themselves.
 
-### Observability
+## Observability
 
 When OpenTelemetry is available, TramAI records spans and metrics using GenAI-oriented attributes such as `gen_ai.system`, `gen_ai.request.model`, `gen_ai.response.model`, `gen_ai.usage.input_tokens`, and `gen_ai.usage.output_tokens`.
 
@@ -104,3 +97,5 @@ The core `@AiService` runtime deliberately does not turn application code into a
 - fine-tuning workflows
 
 Those concerns, where they exist in this repository, live in optional modules above the core library surface. The design goal is composability: application teams can use typed AI services alone, or add memory, RAG, orchestration, scheduling, server, MCP, or platform layers without changing the core execution model.
+
+For module membership and dependency direction, see the [module matrix](../reference/module-matrix.md) and [module layers](../../ARCHITECTURE.md#2-module-layers).


### PR DESCRIPTION
## Summary

Epic 11.2a — authoritative repository architecture entry point. First slice of C2 (AI-readable architecture map). Rebased onto post-#301 master (includes the unified architecture gate).

A contributor or coding agent opening the repository can now answer "where does this responsibility live, what is authoritative, where should I start reading?" without repository-wide discovery.

## What (5 files)

- **`ARCHITECTURE.md`** (new, root) — navigation contract: sources-of-truth table (points to module-catalog.yml, module-boundaries.yml, module-matrix.md, RuntimeEventCatalogue.kt, API dumps, TCKs, ADRs — never reproduces them), 10-layer conceptual orientation, "Where does X live?" table, "Do not start here" negative routing, execution ownership, navigation protocol.
- **`docs/architecture/execution-sequence.md`** (new) — ownership-level flow map: typed invocation, streaming divergence/rejoin, tool invocation, approval/replay, workflow/worker. Stable seam statements; circuit-breaker OPEN/HALF_OPEN semantics intentionally NOT frozen while 8.2g is in flight.
- **`docs/architecture/overview.md`** (converged) — keeps deeper runtime concepts (structured retry, proxy dispatch, observer SPI, provider resolution, observability metrics), drops stale "0.5.0 release commitment" language and duplicated layer lists.
- **`docs/architecture/modules.md`** (converged) — layer philosophy only; membership derived from module-catalog.yml / module-matrix.md. No hand-maintained second module list.
- **`AGENTS.md`** — 5-line repository-navigation pointer (read ARCHITECTURE.md, follow ownership pointer, read change guide, run named TCK). Architecture map stays authoritative; not duplicated.

## Review corrections applied (round 1)

1. module-dependency-graph.md labeled as v0.5.0 baseline snapshot (48 modules), not current topology. Dependency policy (module-catalog.yml + module-boundaries.yml) separated from resolved edges (verified by ./gradlew verify060Architecture).
2. 10-layer arrow diagram reframed as conceptual orientation; exact policy lives in manifest `dependencyPolicy` + module-boundaries.yml.
3. Streaming semantics corrected: token chunks forwarded as they arrive (`StreamChunk.Token` → `onToken`); only terminal assembled response passes the interceptor path (`interceptResponse` on `StreamChunk.Complete`). No per-token validation claim.
4. ApprovalContinuation references `ApprovalContinuationStoreTck` + `ApprovalContinuationLifecycleModel`, distinguished from `ApprovalStoreTck`.
5. C2b pointer reuses existing `docs/modules/` (31 cards already there); no new `docs/architecture/modules/` introduced.
6. RuntimeEventCatalogue.kt named authoritative; runtime-event-catalogue.md is its generated view.
7. `./gradlew verify060Architecture` referenced as the unified architecture gate (now on master via #301).
8. PR scope updated: 5 files incl. AGENTS.md.

## Verification

- `verifyPr` — BUILD SUCCESSFUL (320 tasks).
- `verify060Architecture` — PASS (unified architecture gate, available after #301).
- Machine-checked: all markdown links resolve (relative-path aware); all named class/interface/object types exist in source; no stale 0.5.0 claims; no duplicated module lists; diff is docs/instruction-only (5 files).

## Non-claims

- No production code, build logic, or module-catalog changes.
- Does NOT freeze circuit-breaker HALF_OPEN generation semantics (8.2g in flight).

This PR needs review before merge.
