### PR TITLE
docs: normalize critical module architecture cards (Epic 11.2b1)

### DIFF
--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -9,7 +9,9 @@ Per-module architecture and navigation cards for TramAI. The authoritative modul
 
 ## Card contract
 
-Each module card starts with an `## Architecture` section using these headings:
+Cards normalized under Epic 11.2b conform to the following architecture contract. C2b1 currently has **11 conforming cards**; remaining cards are migrated in subsequent slices.
+
+Each conforming card starts with an `## Architecture` section using these headings:
 
 1. Responsibility
 2. Public entry points
@@ -28,10 +30,14 @@ Below the architecture section, cards may carry long-form usage/design content (
 
 Coverage is computed against the 58-module authoritative manifest (`module-catalog.yml`). `sovereign-runtime-module-matrix.md` is a reference document, not a module card, and is not counted.
 
-| Slice | Cards added | Total cards | Remaining |
-|-------|-------------|-------------|-----------|
-| Baseline (pre-11.2b) | — | 30 | 28 |
-| 11.2b1 (core/governance/persistence/observability/testing) | 2 | **32** | 26 |
+| Metric | Count |
+|--------|-------|
+| Manifest modules | 58 |
+| Module cards | 32 |
+| Conforming cards (C2b1) | 11 |
+| Existing non-conforming | 21 |
+| Missing cards | 26 |
+| Orphans | 0 |
 
 ### Cards (32)
 

--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -1,0 +1,84 @@
+# Module Cards
+
+Per-module architecture and navigation cards for TramAI. The authoritative module list, classification (layer, maturity, publishability, API stability, owner, release inclusion), and dependency policy live in the machine-readable manifest — cards link to it, they do not duplicate it.
+
+- Classification / ownership: [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml)
+- Dependency boundaries: [`config/quality/module-boundaries.yml`](../../config/quality/module-boundaries.yml)
+- Generated module matrix (all 58 modules): [`docs/reference/module-matrix.md`](../reference/module-matrix.md)
+- Root navigation map: [`ARCHITECTURE.md`](../../ARCHITECTURE.md)
+
+## Card contract
+
+Each module card starts with an `## Architecture` section using these headings:
+
+1. Responsibility
+2. Public entry points
+3. Internal extension points
+4. Significant dependencies
+5. Lifecycle ownership
+6. Thread-safety and concurrency
+7. Failure semantics
+8. Contract tests / TCKs
+9. Do not
+10. Related architecture
+
+Below the architecture section, cards may carry long-form usage/design content (quick start, configuration reference, threat model, etc.) — that content is preserved, not replaced.
+
+## Coverage
+
+Coverage is computed against the 58-module authoritative manifest (`module-catalog.yml`). `sovereign-runtime-module-matrix.md` is a reference document, not a module card, and is not counted.
+
+| Slice | Cards added | Total cards | Remaining |
+|-------|-------------|-------------|-----------|
+| Baseline (pre-11.2b) | — | 30 | 28 |
+| 11.2b1 (core/governance/persistence/observability/testing) | 2 | **32** | 26 |
+
+### Cards (32)
+
+- tramai-bom
+- tramai-core
+- tramai-engine
+- tramai-structured
+- tramai-standalone
+- tramai-orchestration
+- tramai-sovereign
+- tramai-security
+- tramai-persistence-file
+- tramai-persistence-jdbc
+- tramai-observability
+- tramai-testing
+- tramai-anthropic
+- tramai-azure-openai
+- tramai-bedrock
+- tramai-deepseek
+- tramai-gemini
+- tramai-ollama
+- tramai-openai
+- tramai-embedding
+- tramai-memory
+- tramai-memory-store
+- tramai-rag
+- tramai-scheduler
+- tramai-vectorstore-spi
+- tramai-vectorstore-chroma
+- tramai-vectorstore-pgvector
+- tramai-platform
+- tramai-server
+- tramai-mcp
+- tramai-dashboard
+- tramai-spring
+
+### Missing (26, next slices)
+
+- tramai-spring-core
+- tramai-spring-sovereign
+- tramai-spring-boot-starter
+- tramai-spring-boot-starter-local-provider-openai
+- tramai-spring-boot-starter-sovereign-ops (+ actuator, micrometer, observability, rest)
+- tramai-spring-boot-starter-sovereign-persistence-file
+- tramai-spring-boot-starter-sovereign-persistence-jdbc
+- tramai-spring-provider-anthropic / ollama / openai
+- tramai-spring-secrets-aws / file / vault
+- tramai-spring-consumer-boundary
+- tramai-spring-consumer-selective
+- examples (approval-resume, governed-workflow, sovereign-document-intelligence, sovereign-offline-verification, spring-sovereign-starter, support-agent, tool-governance)

--- a/docs/modules/tramai-core.md
+++ b/docs/modules/tramai-core.md
@@ -2,27 +2,26 @@
 
 > **One-liner:** Annotations, data models, provider SPI, structured-output contracts, and exceptions for the Tramai AI library.
 > **Module type:** `core`
-> **Group:** `dev.tramai`, **Version:** `0.3.1`
-> **Source files:** 26 (across 12 packages), **LOC:** 1,074
 
 ---
-
 
 ## Architecture
 
 ### Responsibility
 
-Zero- to near-zero-dependency contracts and SPI surface: `@AiService`/`@Operation`/tool annotations, request/response models, provider SPI (`ModelProvider`, `ProviderRegistry`, `ProviderTransport`), structured-output contracts, policy contracts (`PolicyEngine`, `EnforcementPoint`), approval contracts (`ApprovalStore`, `ApprovalContinuationStore`, `ApprovalGateway`), memory contracts, observation contracts and the authoritative runtime event catalogue.
+Zero- to near-zero-dependency contracts and SPI surface: `@AiService`/`@Operation`/tool annotations, request/response models, provider SPI, structured-output contracts, policy contracts, approval contracts, memory contracts, observation contracts and the authoritative runtime event catalogue.
 
 ### Public entry points
 
 - Annotations: `AiService`, `Operation`, `System`, `User`, `SystemPrompt`, `ConversationId`, `AiTool`, `AiDescription`, `AiRange`, `AiMinItems`
 - Provider SPI: `ModelProvider`, `ProviderRegistry`, `ProviderTransport`, `StreamCapable`
-- Structured output contracts: `StructuredOutputHandler`, `StructuredOutputResult`, `StructuredOutputContract`
+- Structured output contracts: `StructuredOutputHandler`, `StructuredOutputResult`
 - Policy: `PolicyEngine`, `EnforcementPoint`, `PolicyDecision`
 - Approval: `ApprovalStore`, `ApprovalContinuationStore`, `ApprovalGateway`, `ApprovalToken`
 - Events: `RuntimeEventCatalogue` (authoritative event/reason-code catalogue)
 - Exceptions: `TramaiException` hierarchy
+
+Verify the full public surface against `tramai-core/api/tramai-core.api`.
 
 ### Internal extension points
 
@@ -32,15 +31,15 @@ Zero- to near-zero-dependency contracts and SPI surface: `@AiService`/`@Operatio
 
 ### Significant dependencies
 
-- None beyond the JDK — `tramai-core` is the dependency root of the repository (see [module-catalog.yml](../../config/quality/module-catalog.yml))
+- `api(kotlinx-coroutines-core)` — coroutine contracts; otherwise JDK-only. `tramai-core` is the dependency root of the repository (see [module-catalog.yml](../../config/quality/module-catalog.yml))
 
 ### Lifecycle ownership
 
-- No runtime state of its own; lifecycle is owned by `tramai-engine` / `tramai-standalone` / framework adapters
+- `tramai-core` owns no process/runtime resource lifecycle. Lifecycle is owned by `tramai-engine` / `tramai-standalone` / framework adapters. If none is applicable, "none" is the correct answer for a given contract.
 
 ### Thread-safety and concurrency
 
-- Contracts are immutable value types; thread-safety of implementations is owned by the implementing module
+- No blanket guarantee applies to all core contracts: `tramai-core` owns no execution lifecycle. Concurrency guarantees belong to each contract and its implementing module. Value types (messages, decisions) are immutable; registries/observers/stores make their own guarantees.
 
 ### Failure semantics
 
@@ -59,7 +58,6 @@ Zero- to near-zero-dependency contracts and SPI surface: `@AiService`/`@Operatio
 
 - [ARCHITECTURE.md](../../ARCHITECTURE.md) — core-contracts layer
 - `docs/adr/` — core design decisions
-
 ---
 
 ## L1: Quick Start (30-second read)
@@ -82,7 +80,7 @@ Without `tramai-core`, no two Tramai modules could communicate. It provides:
 
 ### When to use
 
-- **Always** — every Tramai application depends on `tramai-core`, either directly or transitively through `tramai-engine`, `tramai-standalone`, or `tramai-spring`.
+- **Always** — every Tramai application depends on `tramai-core`, either directly or transitively through `tramai-engine`, `tramai-standalone`, or `tramai-spring-core` (`tramai-spring` is the legacy facade).
 - **Directly** — when writing custom `ModelProvider` implementations, custom `SecretValueResolver` strategies, custom `OperationInterceptor` implementations, or custom tool implementations via `TramaiTool`.
 - **Never alone** — `tramai-core` has no execution engine. Pair it with `tramai-engine` for proxy-based invocation, `tramai-structured` for typed outputs, and a provider module (`tramai-openai`, `tramai-anthropic`, `tramai-ollama`) for actual model calls.
 
@@ -92,7 +90,7 @@ Without `tramai-core`, no two Tramai modules could communicate. It provides:
 
 ```kotlin
 dependencies {
-    implementation("dev.tramai:tramai-core:0.5.0")
+    implementation("dev.tramai:tramai-core")  // version from the TramAI BOM
 }
 ```
 
@@ -102,7 +100,7 @@ dependencies {
 <dependency>
     <groupId>dev.tramai</groupId>
     <artifactId>tramai-core</artifactId>
-    <version>0.5.0</version>
+    <version>${tramai.version}</version>
 </dependency>
 ```
 
@@ -116,7 +114,7 @@ dependencies {
 | Call Anthropic models | `tramai-anthropic` |
 | Call Ollama models | `tramai-ollama` |
 | Get a framework-free entry point | `tramai-standalone` |
-| Use Spring Boot auto-configuration | `tramai-spring` |
+| Use Spring Boot auto-configuration | `tramai-spring-core` (or the unified `tramai-spring-boot-starter`); `tramai-spring` is the legacy facade |
 | Write tests with mock providers | `tramai-testing` |
 
 ---
@@ -500,7 +498,7 @@ The module carries **zero runtime dependencies** beyond `kotlinx-coroutines-core
 - No JSON parsing or schema generation — that lives in `tramai-structured`
 - No workflow/orchestration — that lives in `tramai-orchestration`
 - No observability runtime — that lives in `tramai-observability`
-- No framework integration — that lives in `tramai-spring` / `tramai-standalone`
+- No framework integration — that lives in `tramai-spring-core` / `tramai-standalone` (`tramai-spring` is the legacy facade)
 
 ### Dependency graph
 

--- a/docs/modules/tramai-core.md
+++ b/docs/modules/tramai-core.md
@@ -25,9 +25,7 @@ Verify the full public surface against `tramai-core/api/tramai-core.api`.
 
 ### Internal extension points
 
-- `StructuredOutputHandler` implementation slot (implemented by `tramai-structured`)
-
-Note: public extension SPIs such as `OperationInterceptor`, `OperationObserver`, `DlpInterceptor`, `SecretValueResolver`, and `ConversationIdProvider` are consumer-facing contracts (present in `tramai-core/api/tramai-core.api`), not internal seams — consumers implement them directly.
+- Implementation slot of the public structured-output SPI (implemented by `tramai-structured`)
 
 ### Significant dependencies
 

--- a/docs/modules/tramai-core.md
+++ b/docs/modules/tramai-core.md
@@ -1,7 +1,7 @@
 # Module: `tramai-core`
 
 > **One-liner:** Annotations, data models, provider SPI, structured-output contracts, and exceptions for the Tramai AI library.
-> **Module type:** `core`
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
 
 ---
 
@@ -25,9 +25,9 @@ Verify the full public surface against `tramai-core/api/tramai-core.api`.
 
 ### Internal extension points
 
-- `OperationInterceptor` / `OperationObserver` (observation SPI)
-- `DlpInterceptor` (security), `SecretValueResolver` (secrets), `ConversationIdProvider` (memory)
 - `StructuredOutputHandler` implementation slot (implemented by `tramai-structured`)
+
+Note: public extension SPIs such as `OperationInterceptor`, `OperationObserver`, `DlpInterceptor`, `SecretValueResolver`, and `ConversationIdProvider` are consumer-facing contracts (present in `tramai-core/api/tramai-core.api`), not internal seams — consumers implement them directly.
 
 ### Significant dependencies
 

--- a/docs/modules/tramai-core.md
+++ b/docs/modules/tramai-core.md
@@ -7,6 +7,61 @@
 
 ---
 
+
+## Architecture
+
+### Responsibility
+
+Zero- to near-zero-dependency contracts and SPI surface: `@AiService`/`@Operation`/tool annotations, request/response models, provider SPI (`ModelProvider`, `ProviderRegistry`, `ProviderTransport`), structured-output contracts, policy contracts (`PolicyEngine`, `EnforcementPoint`), approval contracts (`ApprovalStore`, `ApprovalContinuationStore`, `ApprovalGateway`), memory contracts, observation contracts and the authoritative runtime event catalogue.
+
+### Public entry points
+
+- Annotations: `AiService`, `Operation`, `System`, `User`, `SystemPrompt`, `ConversationId`, `AiTool`, `AiDescription`, `AiRange`, `AiMinItems`
+- Provider SPI: `ModelProvider`, `ProviderRegistry`, `ProviderTransport`, `StreamCapable`
+- Structured output contracts: `StructuredOutputHandler`, `StructuredOutputResult`, `StructuredOutputContract`
+- Policy: `PolicyEngine`, `EnforcementPoint`, `PolicyDecision`
+- Approval: `ApprovalStore`, `ApprovalContinuationStore`, `ApprovalGateway`, `ApprovalToken`
+- Events: `RuntimeEventCatalogue` (authoritative event/reason-code catalogue)
+- Exceptions: `TramaiException` hierarchy
+
+### Internal extension points
+
+- `OperationInterceptor` / `OperationObserver` (observation SPI)
+- `DlpInterceptor` (security), `SecretValueResolver` (secrets), `ConversationIdProvider` (memory)
+- `StructuredOutputHandler` implementation slot (implemented by `tramai-structured`)
+
+### Significant dependencies
+
+- None beyond the JDK — `tramai-core` is the dependency root of the repository (see [module-catalog.yml](../../config/quality/module-catalog.yml))
+
+### Lifecycle ownership
+
+- No runtime state of its own; lifecycle is owned by `tramai-engine` / `tramai-standalone` / framework adapters
+
+### Thread-safety and concurrency
+
+- Contracts are immutable value types; thread-safety of implementations is owned by the implementing module
+
+### Failure semantics
+
+- Typed exception hierarchy rooted at `TramaiException`; policy violations as `PolicyViolationException`; approval gating as `ApprovalRequiredException`/`ApprovalSuspendedException`
+
+### Contract tests / TCKs
+
+- Core contract tests in `tramai-core/src/test`; TCK fixtures under `tramai-testing` (provider, store, lifecycle models)
+
+### Do not
+
+- Do not add provider/vendor, Spring, or framework dependencies here
+- Do not add new runtime event/reason-code string literals outside `RuntimeEventCatalogue`
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — core-contracts layer
+- `docs/adr/` — core design decisions
+
+---
+
 ## L1: Quick Start (30-second read)
 
 ### What

--- a/docs/modules/tramai-engine.md
+++ b/docs/modules/tramai-engine.md
@@ -1,7 +1,7 @@
 # Module: `tramai-engine`
 
 > **One-liner:** Runtime engine that turns annotated service interfaces into AI-backed proxies with retry, circuit-breaking, caching, and token budgeting.
-> **Module type:** `core`
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
 
 ---
 
@@ -107,7 +107,8 @@ dependencies {
 **Bill of Materials:**
 
 ```kotlin
-implementation(platform("dev.tramai:tramai-bom"))  // version managed via the BOM
+// Version from the canonical tramaiVersion Gradle property (see gradle.properties)
+implementation(platform("dev.tramai:tramai-bom:${tramaiVersion}"))
 implementation("dev.tramai:tramai-engine")
 ```
 
@@ -117,11 +118,11 @@ implementation("dev.tramai:tramai-engine")
 |-------|------|
 | Quickstart with all modules | `docs/guides/getting-started.md` |
 | Framework-free standalone setup | `docs/modules/tramai-standalone.md` |
-| Spring Boot auto-configuration | `docs/modules/tramai-spring-core.md` (`tramai-spring` is the legacy facade) |
+| Spring Boot auto-configuration | `docs/architecture/modules.md` (framework-integrations layer; `tramai-spring-core` card lands in a later 11.2b slice, `tramai-spring` is the legacy facade) |
 | Defining tools for the engine | `docs/modules/tramai-testing.md` |
-| Spec — Engine & Core design | `docs/specs/spec-001.md` |
-| Spec — Production hardening | `docs/specs/spec-011.md` |
-| Spec — Tool calling | `docs/specs/spec-010.md` |
+| Spec — Engine & Core design | `docs/specs/spec-001-core-engine.md` |
+| Spec — Production hardening | `docs/specs/spec-011-production-hardening.md` |
+| Spec — Tool calling | `docs/specs/spec-010-tool-calling.md` |
 
 ---
 

--- a/docs/modules/tramai-engine.md
+++ b/docs/modules/tramai-engine.md
@@ -17,6 +17,7 @@ Runtime execution core: turns `@AiService` interfaces into provider-backed proxi
 - `EngineEventObserver` — engine observation hook
 - `DefaultApprovalGateway` — approval gateway integration point
 - Public settings/SPI surfaces intended for consumers (retry, circuit-breaker, token-budget settings; cache SPI `OperationResponseCache`)
+- Core extension SPIs consumed by the engine: `OperationInterceptor`, `OperationObserver` (contracts in `tramai-core`)
 
 Verify the full public surface against `tramai-engine/api/tramai-engine.api`.
 
@@ -29,7 +30,6 @@ Verify the full public surface against `tramai-engine/api/tramai-engine.api`.
 - `StructuredResponseCoordinator` — structured-output integration (internal)
 - `ToolExposureCoordinator` / `ToolAuthorizationCoordinator` / `ToolInvocationExecutor` — tool flow (internal)
 - `ApprovalSuspensionCoordinator` / `ApprovalResumeCoordinator` — approval flow (internal)
-- `OperationInterceptor` / `OperationObserver` — cross-cutting request/response hooks
 
 ### Significant dependencies
 
@@ -107,8 +107,9 @@ dependencies {
 **Bill of Materials:**
 
 ```kotlin
-// Version from the canonical tramaiVersion Gradle property (see gradle.properties)
-implementation(platform("dev.tramai:tramai-bom:${tramaiVersion}"))
+// tramaiVersion is the canonical version property (see gradle.properties)
+val tramaiVersion: String by project
+implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
 implementation("dev.tramai:tramai-engine")
 ```
 

--- a/docs/modules/tramai-engine.md
+++ b/docs/modules/tramai-engine.md
@@ -5,7 +5,6 @@
 
 ---
 
-
 ## Architecture
 
 ### Responsibility
@@ -15,23 +14,28 @@ Runtime execution core: turns `@AiService` interfaces into provider-backed proxi
 ### Public entry points
 
 - `TramaiEngine` — engine entry point; `create<T>()` proxy factory
-- `InvocationExecutionCoordinator` — governed invocation pipeline
-- `TramaiInvocationHandler` — JDK proxy dispatch for `@AiService`
-- `ProviderExecutionCoordinator` / `ProviderAttemptExecutor` — provider routing and admitted-attempt execution
-- `StreamingExecutionCoordinator` — streaming flow
-- `StructuredResponseCoordinator` — structured-output integration
-- `ToolExposureCoordinator` / `ToolAuthorizationCoordinator` / `ToolInvocationExecutor` — tool flow
-- `ApprovalSuspensionCoordinator` / `ApprovalResumeCoordinator` / `DefaultApprovalGateway` — approval flow
-- `EngineEventObserver` / `FailureIsolatingEngineEventObserver` — observation
+- `EngineEventObserver` — engine observation hook
+- `DefaultApprovalGateway` — approval gateway integration point
+- Public settings/SPI surfaces intended for consumers (retry, circuit-breaker, token-budget settings; cache SPI `OperationResponseCache`)
+
+Verify the full public surface against `tramai-engine/api/tramai-engine.api`.
 
 ### Internal extension points
 
-- `OperationInterceptor` / `OperationObserver` (cross-cutting request/response hooks)
-- `OperationResponseCache` (cache SPI), `ChatMemory` (memory injection), `StructuredOutputHandler` (consumed from `tramai-structured`)
+- `InvocationExecutionCoordinator` — governed invocation pipeline (internal)
+- `TramaiInvocationHandler` — JDK proxy dispatch (internal)
+- `ProviderExecutionCoordinator` / `ProviderAttemptExecutor` — provider routing and admitted-attempt execution (internal)
+- `StreamingExecutionCoordinator` — streaming flow (internal)
+- `StructuredResponseCoordinator` — structured-output integration (internal)
+- `ToolExposureCoordinator` / `ToolAuthorizationCoordinator` / `ToolInvocationExecutor` — tool flow (internal)
+- `ApprovalSuspensionCoordinator` / `ApprovalResumeCoordinator` — approval flow (internal)
+- `OperationInterceptor` / `OperationObserver` — cross-cutting request/response hooks
 
 ### Significant dependencies
 
-- `api(tramai-core)`; optional integration with `tramai-structured`, `tramai-security`, `tramai-observability` (see [module-catalog.yml](../../config/quality/module-catalog.yml))
+- `api(tramai-core)`; `implementation(tramai-security)` — a real production edge (engine → security)
+- `implementation(kotlinx-coroutines-core)`, `implementation(kotlin-reflect)`
+- `tramai-structured` is test-only; `tramai-observability` is not a production dependency — structured output is consumed contract/injection-based (see [module-catalog.yml](../../config/quality/module-catalog.yml))
 
 ### Lifecycle ownership
 
@@ -39,7 +43,7 @@ Runtime execution core: turns `@AiService` interfaces into provider-backed proxi
 
 ### Thread-safety and concurrency
 
-- Concurrent invocation-safe; per-operation coroutine scopes; cancellation propagation via kotlinx.coroutines (`Cancellation` contracts in core)
+- Concurrent invocation-safe. Invocation bridge uses the engine lifecycle job/scope and a synchronized active-invocation registry; suspend calls launch on the engine lifecycle scope, not a per-operation scope. Cancellation propagation per kotlinx.coroutines contracts in core.
 
 ### Failure semantics
 
@@ -59,7 +63,6 @@ Runtime execution core: turns `@AiService` interfaces into provider-backed proxi
 - [ARCHITECTURE.md](../../ARCHITECTURE.md) — runtime-execution layer
 - [execution-sequence.md](../architecture/execution-sequence.md) — flow ownership
 - `docs/adr/` — engine design decisions
-
 ---
 
 ## L1: Quick Start (30-second read)
@@ -77,7 +80,7 @@ Without `tramai-engine`, you have only the raw SPI contracts in `tramai-core`. T
 Always. `tramai-engine` is the mandatory runtime for any Tramai-based application. It is automatically included by:
 
 - `tramai-standalone` (framework-free entry point)
-- `tramai-spring` (Spring Boot auto-configuration)
+- `tramai-spring-core` / `tramai-spring-boot-starter` (Spring Boot auto-configuration; `tramai-spring` is the legacy facade)
 
 You only interact with it directly if you are building a custom integration or need to configure engine-level settings (cache, circuit breaker, retry policy, token budgets).
 
@@ -87,7 +90,7 @@ You only interact with it directly if you are building a custom integration or n
 
 ```kotlin
 dependencies {
-    implementation("dev.tramai:tramai-engine:0.5.0")
+    implementation("dev.tramai:tramai-engine")  // version from the TramAI BOM
 }
 ```
 
@@ -97,14 +100,14 @@ dependencies {
 <dependency>
     <groupId>dev.tramai</groupId>
     <artifactId>tramai-engine</artifactId>
-    <version>0.5.0</version>
+    <version>${tramai.version}</version>
 </dependency>
 ```
 
 **Bill of Materials:**
 
 ```kotlin
-implementation(platform("dev.tramai:tramai-bom:0.5.0"))
+implementation(platform("dev.tramai:tramai-bom"))  // version managed via the BOM
 implementation("dev.tramai:tramai-engine")
 ```
 
@@ -114,7 +117,7 @@ implementation("dev.tramai:tramai-engine")
 |-------|------|
 | Quickstart with all modules | `docs/guides/getting-started.md` |
 | Framework-free standalone setup | `docs/modules/tramai-standalone.md` |
-| Spring Boot auto-configuration | `docs/modules/tramai-spring.md` |
+| Spring Boot auto-configuration | `docs/modules/tramai-spring-core.md` (`tramai-spring` is the legacy facade) |
 | Defining tools for the engine | `docs/modules/tramai-testing.md` |
 | Spec — Engine & Core design | `docs/specs/spec-001.md` |
 | Spec — Production hardening | `docs/specs/spec-011.md` |
@@ -206,20 +209,7 @@ suspend fun analyze(id: String): String
 
 #### Circuit breaker
 
-Enable the circuit breaker to skip unhealthy provider routes for a cooldown period.
-
-```kotlin
-val engine = TramaiEngine(
-    provider = provider,
-    circuitBreakerSettings = CircuitBreakerSettings(
-        enabled = true,
-        failureThreshold = 3,         // 3 consecutive failures opens the circuit
-        openDurationMillis = 30_000,  // stay open for 30 seconds
-    ),
-)
-```
-
-When the circuit is open, the engine automatically falls through to the next configured route (see provider routing below) or throws `CircuitBreakerOpenException` if no fallback exists.
+Circuit-breaker admission and recovery are engine-owned. `CircuitBreakerSettings` exposes stable configuration knobs (enable, failure threshold, open duration); detailed OPEN/recovery probe semantics are being hardened under 8.2g and are intentionally not restated in this navigation card.
 
 #### Response cache
 
@@ -490,7 +480,7 @@ Requires adding `tramai-memory` to your dependencies:
 
 ```kotlin
 dependencies {
-    implementation("dev.tramai:tramai-memory:0.5.0")
+    implementation("dev.tramai:tramai-memory")  // version from the TramAI BOM
 }
 ```
 
@@ -599,7 +589,7 @@ The engine is **stateless** with respect to business logic: all state is either 
 - Model provider implementations — owned by provider modules (`tramai-openai`, `tramai-anthropic`, `tramai-ollama`)
 - Structured output schema/parsing — owned by `tramai-structured`
 - Multi-step workflows — owned by `tramai-orchestration`
-- Framework integration — owned by adapters (`tramai-spring`, `tramai-standalone`)
+- Framework integration — owned by adapters (`tramai-spring-core`, `tramai-standalone`; `tramai-spring` is the legacy facade)
 - Memory implementations — owned by `tramai-memory` (e.g., `MessageWindowChatMemory`, `MemoryInterceptor`)
 
 ### Dependency graph
@@ -725,16 +715,7 @@ All exceptions are in `dev.tramai.core.exception`:
 | `StructuredOutputException` | Structured parse failure after exhausting retries | No |
 | `ProviderCapabilityException` | Streaming requested but provider doesn't support it | No |
 
-**Circuit breaker state machine:**
-
-```
-CLOSED ──(consecutive failures >= threshold)──→ OPEN
-OPEN ──(openDurationMillis elapsed)──→ HALF_OPEN (next call probes)
-HALF_OPEN ──(success)──→ CLOSED
-HALF_OPEN ──(failure)──→ OPEN
-```
-
-The circuit breaker is per-provider (keyed by `providerId`), not per-model. On success, the circuit state is removed entirely. On failure, a counter increments until the threshold, then the circuit opens for `openDurationMillis`.
+**Circuit breaker state machine:** admission and recovery are engine-owned; detailed OPEN/HALF_OPEN generation and probe semantics are being hardened under 8.2g and are intentionally not restated here. The breaker is per-provider (keyed by `providerId`), not per-model.
 
 #### Testing strategy
 

--- a/docs/modules/tramai-engine.md
+++ b/docs/modules/tramai-engine.md
@@ -5,6 +5,63 @@
 
 ---
 
+
+## Architecture
+
+### Responsibility
+
+Runtime execution core: turns `@AiService` interfaces into provider-backed proxies and owns the full invocation pipeline — operation planning, governance enforcement, provider routing/retry/fallback, structured-output processing, streaming, tool-call orchestration, approval suspension/resume, caching, token budgets and observation.
+
+### Public entry points
+
+- `TramaiEngine` — engine entry point; `create<T>()` proxy factory
+- `InvocationExecutionCoordinator` — governed invocation pipeline
+- `TramaiInvocationHandler` — JDK proxy dispatch for `@AiService`
+- `ProviderExecutionCoordinator` / `ProviderAttemptExecutor` — provider routing and admitted-attempt execution
+- `StreamingExecutionCoordinator` — streaming flow
+- `StructuredResponseCoordinator` — structured-output integration
+- `ToolExposureCoordinator` / `ToolAuthorizationCoordinator` / `ToolInvocationExecutor` — tool flow
+- `ApprovalSuspensionCoordinator` / `ApprovalResumeCoordinator` / `DefaultApprovalGateway` — approval flow
+- `EngineEventObserver` / `FailureIsolatingEngineEventObserver` — observation
+
+### Internal extension points
+
+- `OperationInterceptor` / `OperationObserver` (cross-cutting request/response hooks)
+- `OperationResponseCache` (cache SPI), `ChatMemory` (memory injection), `StructuredOutputHandler` (consumed from `tramai-structured`)
+
+### Significant dependencies
+
+- `api(tramai-core)`; optional integration with `tramai-structured`, `tramai-security`, `tramai-observability` (see [module-catalog.yml](../../config/quality/module-catalog.yml))
+
+### Lifecycle ownership
+
+- Engine owns proxy lifecycle, provider route state, circuit/retry state, cache lifecycle, approval coordination; `close()` semantics per `AutoCloseable`
+
+### Thread-safety and concurrency
+
+- Concurrent invocation-safe; per-operation coroutine scopes; cancellation propagation via kotlinx.coroutines (`Cancellation` contracts in core)
+
+### Failure semantics
+
+- Provider failures normalized to `ProviderException`; retry/fallback driven by typed failure codes; structured failures as `StructuredOutputException`; approval gating as `ApprovalRequiredException`/`ApprovalSuspendedException`
+
+### Contract tests / TCKs
+
+- Engine behavioral tests in `tramai-engine/src/test`; provider TCK via `tramai-testing` (`ProviderTck`)
+
+### Do not
+
+- Do not implement provider-specific logic in the engine
+- Do not add Spring dependencies here
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — runtime-execution layer
+- [execution-sequence.md](../architecture/execution-sequence.md) — flow ownership
+- `docs/adr/` — engine design decisions
+
+---
+
 ## L1: Quick Start (30-second read)
 
 ### What

--- a/docs/modules/tramai-observability.md
+++ b/docs/modules/tramai-observability.md
@@ -1,7 +1,7 @@
 # Module: `tramai-observability`
 
 > **One-liner:** Optional, opt-in OpenTelemetry integration — traces, metrics, and events for operations and workflows.
-> **Module type:** `observability`
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
 
 ---
 
@@ -16,9 +16,7 @@ Optional, opt-in OpenTelemetry integration: spans, metrics and events for operat
 - `OpenTelemetryOperationObserver` — operation/engine observation
 - `OpenTelemetryTramaiWorkerObserver` — worker observation
 - `OpenTelemetryWorkflowObserver` — workflow observation
-- `OpenTelemetryAttributes` — semantic attribute constants
-
-Verify the full public surface against `tramai-observability/api/tramai-observability.api`.
+Verify the full public surface against `tramai-observability/api/tramai-observability.api` (`OpenTelemetryAttributes` is internal).
 
 ### Internal extension points
 

--- a/docs/modules/tramai-observability.md
+++ b/docs/modules/tramai-observability.md
@@ -7,6 +7,54 @@
 
 ---
 
+
+## Architecture
+
+### Responsibility
+
+Optional, opt-in OpenTelemetry integration: spans, metrics and events for operations, workers and workflows.
+
+### Public entry points
+
+- `OpenTelemetryOperationObserver` — operation/engine observation (implements core observation SPI)
+- `OpenTelemetryTramaiWorkerObserver` — worker observation
+- `OpenTelemetryWorkflowObserver` — workflow observation
+- `OpenTelemetryAttributes` — semantic attribute constants
+
+### Internal extension points
+
+- Operation/worker/workflow observer implementations over the core observation SPI
+
+### Significant dependencies
+
+- `api(tramai-core)`; orchestration in implementation scope (see [module-catalog.yml](../../config/quality/module-catalog.yml))
+
+### Lifecycle ownership
+
+- Observer lifecycle follows the OpenTelemetry SDK; no engine state ownership
+
+### Thread-safety and concurrency
+
+- Observers must be safe for concurrent callbacks from the engine
+
+### Failure semantics
+
+- Observability must not break the happy path (failure-isolated observers); OTel absence degrades gracefully
+
+### Contract tests / TCKs
+
+- Span/attribute tests in `tramai-observability/src/test`
+
+### Do not
+
+- Do not make observability a hard dependency of core/runtime modules
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — operations-observability layer
+
+---
+
 ## L1: Quick Start (30-second read)
 
 ### What

--- a/docs/modules/tramai-observability.md
+++ b/docs/modules/tramai-observability.md
@@ -2,11 +2,8 @@
 
 > **One-liner:** Optional, opt-in OpenTelemetry integration — traces, metrics, and events for operations and workflows.
 > **Module type:** `observability`
-> **Group:** `dev.tramai`, **Version:** `0.3.1`
-> **Source files:** 3 (all in `dev.tramai.observability`), **LOC:** ~280
 
 ---
-
 
 ## Architecture
 
@@ -16,10 +13,12 @@ Optional, opt-in OpenTelemetry integration: spans, metrics and events for operat
 
 ### Public entry points
 
-- `OpenTelemetryOperationObserver` — operation/engine observation (implements core observation SPI)
+- `OpenTelemetryOperationObserver` — operation/engine observation
 - `OpenTelemetryTramaiWorkerObserver` — worker observation
 - `OpenTelemetryWorkflowObserver` — workflow observation
 - `OpenTelemetryAttributes` — semantic attribute constants
+
+Verify the full public surface against `tramai-observability/api/tramai-observability.api`.
 
 ### Internal extension points
 
@@ -27,7 +26,7 @@ Optional, opt-in OpenTelemetry integration: spans, metrics and events for operat
 
 ### Significant dependencies
 
-- `api(tramai-core)`; orchestration in implementation scope (see [module-catalog.yml](../../config/quality/module-catalog.yml))
+- `api(tramai-core)`; `implementation(tramai-orchestration)`, `implementation(opentelemetry-api)` (see [module-catalog.yml](../../config/quality/module-catalog.yml))
 
 ### Lifecycle ownership
 
@@ -52,7 +51,6 @@ Optional, opt-in OpenTelemetry integration: spans, metrics and events for operat
 ### Related architecture
 
 - [ARCHITECTURE.md](../../ARCHITECTURE.md) — operations-observability layer
-
 ---
 
 ## L1: Quick Start (30-second read)
@@ -87,7 +85,7 @@ Without this module, Tramai runs with no-op observers — operations and workflo
 
 ```kotlin
 dependencies {
-    implementation("dev.tramai:tramai-observability:0.5.0")
+    implementation("dev.tramai:tramai-observability")  // version from the TramAI BOM
     // You also need an OpenTelemetry SDK + exporter runtime dependency:
     runtimeOnly("io.opentelemetry:opentelemetry-exporter-otlp:...")
     runtimeOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:...")
@@ -100,7 +98,7 @@ dependencies {
 <dependency>
     <groupId>dev.tramai</groupId>
     <artifactId>tramai-observability</artifactId>
-    <version>0.5.0</version>
+    <version>${tramai.version}</version>
 </dependency>
 ```
 
@@ -386,6 +384,6 @@ onWorkflowStarted(name, context)
 ### What `tramai-observability` does NOT include
 
 - **No OpenTelemetry SDK or exporter** — the module depends only on `opentelemetry-api`. SDK, exporters, and auto-configuration are the application's responsibility.
-- **No Spring Boot auto-configuration** — that lives in `tramai-spring`.
+- **No Spring Boot auto-configuration** — that lives in `tramai-spring-core` (`tramai-spring` is the legacy facade).
 - **No logging integration** — spans and metrics are the delivery mechanism, not log statements.
 - **No workflow span nesting** — operation spans (from the engine) and workflow spans (from orchestration) are independent. Workflow steps that make AI calls produce their own `ai.*` spans under the workflow step's context if propagation is configured.

--- a/docs/modules/tramai-orchestration.md
+++ b/docs/modules/tramai-orchestration.md
@@ -8,6 +8,59 @@
 
 ---
 
+
+## Architecture
+
+### Responsibility
+
+Multi-step workflow execution: workflow definitions, execution supervision, worker lifecycle, checkpoints/leases/fencing, step execution (HTTP, shell, Codex, Hermes, MCP), replay policy and recovery.
+
+### Public entry points
+
+- `WorkflowExecutionSupervisor` — workflow execution ownership
+- `WorkerLifecycleController` / `WorkerShutdownCoordinator` — worker lifecycle and coordinated shutdown
+- `TramaiWorker` — worker entry point; observers (`FailureIsolatingTramaiWorkerObserver`, `LoggingTramaiWorkerObserver`)
+- `WorkflowRecoveryCoordinator` / `WorkflowRecoveryController` — recovery
+- `LeaseCoordinator` / `LeaseRenewalLoop` — lease/fencing
+- Step types: `HttpStep`, `ShellStep`, `CodexStep`, `HermesStep`, `McpStep`
+- Persistence: `WorkflowPersistenceSession`, `FileWorkflowCheckpointStore`, `JdbcWorkflowCheckpointStore`, `FileWorkflowLeaseStore`, `JdbcWorkflowLeaseStore`, step-attempt record stores
+
+### Internal extension points
+
+- Workflow observers (`WorkflowObservation`), step executor SPI (`WorkflowStepExecutor`), persistence session SPI, partition strategy (`PartitionAssignmentStrategy`)
+
+### Significant dependencies
+
+- `api(tramai-core)`; engine/testing in test scope (see [module-catalog.yml](../../config/quality/module-catalog.yml))
+
+### Lifecycle ownership
+
+- Owns workflow/worker lifecycle, lease renewal, checkpoint and step-attempt persistence
+
+### Thread-safety and concurrency
+
+- Lease-based fencing prevents concurrent execution of the same lease; worker observers are failure-isolated
+
+### Failure semantics
+
+- Typed persistence failures (`PersistenceFailures`), step failures (`WorkflowStepFailures`, `WorkflowErrors`); replay decision policy governs resume
+
+### Contract tests / TCKs
+
+- Workflow/worker tests in `tramai-orchestration/src/test`; store TCKs via `tramai-testing` (checkpoint/lease/step-attempt)
+
+### Do not
+
+- Do not add new concrete-step dispatch to a central orchestrator god object — extend the step abstraction
+- Do not add provider or Spring dependencies here
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — runtime-execution layer
+- [execution-sequence.md](../architecture/execution-sequence.md) — workflow/worker flow
+
+---
+
 ## L1: Quick Start (30-second read)
 
 ### What

--- a/docs/modules/tramai-orchestration.md
+++ b/docs/modules/tramai-orchestration.md
@@ -2,12 +2,9 @@
 
 > **One-liner:** Multi-step workflow engine with checkpoint/resume, distributed worker support, and a declarative DSL for composing AI, local, gate, branch, parallel, and delay steps.
 > **Module type:** `optional`
-> **Group:** `dev.tramai`, **Version:** `0.3.1`
-> **Source files:** 18, **LOC:** 6,143
 > **Dependencies:** `tramai-core`
 
 ---
-
 
 ## Architecture
 
@@ -17,21 +14,24 @@ Multi-step workflow execution: workflow definitions, execution supervision, work
 
 ### Public entry points
 
-- `WorkflowExecutionSupervisor` — workflow execution ownership
-- `WorkerLifecycleController` / `WorkerShutdownCoordinator` — worker lifecycle and coordinated shutdown
-- `TramaiWorker` — worker entry point; observers (`FailureIsolatingTramaiWorkerObserver`, `LoggingTramaiWorkerObserver`)
-- `WorkflowRecoveryCoordinator` / `WorkflowRecoveryController` — recovery
-- `LeaseCoordinator` / `LeaseRenewalLoop` — lease/fencing
-- Step types: `HttpStep`, `ShellStep`, `CodexStep`, `HermesStep`, `McpStep`
-- Persistence: `WorkflowPersistenceSession`, `FileWorkflowCheckpointStore`, `JdbcWorkflowCheckpointStore`, `FileWorkflowLeaseStore`, `JdbcWorkflowLeaseStore`, step-attempt record stores
+- `TramaiWorker` — worker entry point
+- Workflow definition/builder API (`Workflow`, `WorkflowBuilder`, `WorkflowBindingRegistry`)
+
+Verify the full public surface against `tramai-orchestration/api/tramai-orchestration.api` — the supervision/lifecycle coordinators below are internal.
 
 ### Internal extension points
 
+- `WorkflowExecutionSupervisor` — workflow execution ownership (internal)
+- `WorkerLifecycleController` / `WorkerShutdownCoordinator` — worker lifecycle and coordinated shutdown (internal)
+- `WorkflowRecoveryCoordinator` / `WorkflowRecoveryController` — recovery (internal)
+- `LeaseCoordinator` / `LeaseRenewalLoop` — lease/fencing (internal)
 - Workflow observers (`WorkflowObservation`), step executor SPI (`WorkflowStepExecutor`), persistence session SPI, partition strategy (`PartitionAssignmentStrategy`)
+- Step types: `HttpStep`, `ShellStep`, `CodexStep`, `HermesStep`, `McpStep`
+- Persistence: `WorkflowPersistenceSession`, file/JDBC checkpoint/lease/step-attempt stores
 
 ### Significant dependencies
 
-- `api(tramai-core)`; engine/testing in test scope (see [module-catalog.yml](../../config/quality/module-catalog.yml))
+- `api(tramai-core)`; `implementation(kotlinx-coroutines-core)`, `implementation(mcp-sdk-client)`; engine/testing in test scope (see [module-catalog.yml](../../config/quality/module-catalog.yml))
 
 ### Lifecycle ownership
 
@@ -39,7 +39,7 @@ Multi-step workflow execution: workflow definitions, execution supervision, work
 
 ### Thread-safety and concurrency
 
-- Lease-based fencing prevents concurrent execution of the same lease; worker observers are failure-isolated
+- Lease/fencing prevents a stale owner from committing state after ownership changes; the local active-execution map prevents duplicate local registration (`putIfAbsent`). Those are distinct mechanisms: fencing is for distributed ownership, the local map is for in-process duplicates.
 
 ### Failure semantics
 
@@ -58,7 +58,6 @@ Multi-step workflow execution: workflow definitions, execution supervision, work
 
 - [ARCHITECTURE.md](../../ARCHITECTURE.md) — runtime-execution layer
 - [execution-sequence.md](../architecture/execution-sequence.md) — workflow/worker flow
-
 ---
 
 ## L1: Quick Start (30-second read)
@@ -97,7 +96,7 @@ Do **not** use it for single-turn AI calls — `tramai-engine` with an `@AiServi
 
 ```kotlin
 dependencies {
-    implementation("dev.tramai:tramai-orchestration:0.5.0")
+    implementation("dev.tramai:tramai-orchestration")  // version from the TramAI BOM
 }
 ```
 
@@ -107,14 +106,14 @@ dependencies {
 <dependency>
     <groupId>dev.tramai</groupId>
     <artifactId>tramai-orchestration</artifactId>
-    <version>0.5.0</version>
+    <version>${tramai.version}</version>
 </dependency>
 ```
 
 **Bill of Materials:**
 
 ```kotlin
-implementation(platform("dev.tramai:tramai-bom:0.5.0"))
+implementation(platform("dev.tramai:tramai-bom"))  // version managed via the BOM
 implementation("dev.tramai:tramai-orchestration")
 ```
 
@@ -634,7 +633,7 @@ tramai-orchestration
 **Does not own:**
 - AI provider execution — the `aiStep` builder receives its `invoke` lambda from the caller (typically backed by `tramai-engine` + a provider)
 - Annotations / provider SPIs — owned by `tramai-core`
-- Framework integration — owned by adapters (`tramai-spring`, `tramai-standalone`)
+- Framework integration — owned by adapters (`tramai-spring-core`, `tramai-standalone`; `tramai-spring` is the legacy facade)
 
 ### Dependency graph
 
@@ -644,7 +643,7 @@ tramai-orchestration
         └── kotlinx-coroutines-core
 
 tramai-standalone ─── tramai-orchestration (optional, for agent workflows)
-tramai-spring     ─── tramai-orchestration (optional, for agent workflows)
+tramai-spring-core ─── tramai-orchestration (optional, for agent workflows)
 ```
 
 ### Inner mechanics

--- a/docs/modules/tramai-orchestration.md
+++ b/docs/modules/tramai-orchestration.md
@@ -17,6 +17,9 @@ Multi-step workflow execution: workflow definitions, execution supervision, work
 - `TramaiWorker` — worker entry point
 - `WorkflowRecoveryController` — recovery entry point (public per `tramai-orchestration/api/tramai-orchestration.api`)
 - Workflow definition/builder API (`Workflow`, `WorkflowBuilder`, `WorkflowBindingRegistry`)
+- Step types: `HttpStep`, `ShellStep`, `CodexStep`, `HermesStep`, `McpStep`
+- Persistence stores: `FileWorkflowCheckpointStore`, `JdbcWorkflowCheckpointStore`, `FileWorkflowLeaseStore`, `JdbcWorkflowLeaseStore`, `FileStepAttemptRecordStore`
+- `PartitionAssignmentStrategy` — partition strategy SPI
 
 Verify the full public surface against `tramai-orchestration/api/tramai-orchestration.api` — the supervision/lifecycle coordinators below are internal.
 
@@ -24,11 +27,9 @@ Verify the full public surface against `tramai-orchestration/api/tramai-orchestr
 
 - `WorkflowExecutionSupervisor` — workflow execution ownership (internal)
 - `WorkerLifecycleController` / `WorkerShutdownCoordinator` — worker lifecycle and coordinated shutdown (internal)
-- `WorkflowRecoveryCoordinator` — recovery coordination (internal; `WorkflowRecoveryController` is the public face)
+- `WorkflowRecoveryCoordinator` — recovery coordination (internal)
 - `LeaseCoordinator` / `LeaseRenewalLoop` — lease/fencing (internal)
-- Workflow observers (`WorkflowObservation`), step executor SPI (`WorkflowStepExecutor`), persistence session SPI, partition strategy (`PartitionAssignmentStrategy`)
-- Step types: `HttpStep`, `ShellStep`, `CodexStep`, `HermesStep`, `McpStep`
-- Persistence: `WorkflowPersistenceSession`, file/JDBC checkpoint/lease/step-attempt stores
+- Workflow observers (`WorkflowObservation`), step executor SPI (`WorkflowStepExecutor`), persistence session SPI (`WorkflowPersistenceSession`)
 
 ### Significant dependencies
 
@@ -114,8 +115,9 @@ dependencies {
 **Bill of Materials:**
 
 ```kotlin
-// Version from the canonical tramaiVersion Gradle property (see gradle.properties)
-implementation(platform("dev.tramai:tramai-bom:${tramaiVersion}"))
+// tramaiVersion is the canonical version property (see gradle.properties)
+val tramaiVersion: String by project
+implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
 implementation("dev.tramai:tramai-orchestration")
 ```
 
@@ -124,8 +126,8 @@ implementation("dev.tramai:tramai-orchestration")
 | Topic | Link |
 |-------|------|
 | Quickstart with all modules | `docs/guides/getting-started.md` |
-| Understanding workflow basics | `docs/specs/spec-005-standalone-java-api.md` |
-| Agent CLI step types (Hermes, Codex, MCP, Shell) | `docs/specs/spec-009-streaming-responses.md` |
+| Understanding workflow basics | `docs/specs/spec-012-orchestration-and-coordination.md` |
+| Agent CLI step types (Hermes, Codex, MCP, Shell) | `docs/specs/spec-015-agent-steps.md` |
 | Governed workflow quickstart | `docs/guides/governed-workflow-quickstart.md` |
 
 ---

--- a/docs/modules/tramai-orchestration.md
+++ b/docs/modules/tramai-orchestration.md
@@ -1,7 +1,7 @@
 # Module: `tramai-orchestration`
 
 > **One-liner:** Multi-step workflow engine with checkpoint/resume, distributed worker support, and a declarative DSL for composing AI, local, gate, branch, parallel, and delay steps.
-> **Module type:** `optional`
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
 > **Dependencies:** `tramai-core`
 
 ---
@@ -15,6 +15,7 @@ Multi-step workflow execution: workflow definitions, execution supervision, work
 ### Public entry points
 
 - `TramaiWorker` — worker entry point
+- `WorkflowRecoveryController` — recovery entry point (public per `tramai-orchestration/api/tramai-orchestration.api`)
 - Workflow definition/builder API (`Workflow`, `WorkflowBuilder`, `WorkflowBindingRegistry`)
 
 Verify the full public surface against `tramai-orchestration/api/tramai-orchestration.api` — the supervision/lifecycle coordinators below are internal.
@@ -23,7 +24,7 @@ Verify the full public surface against `tramai-orchestration/api/tramai-orchestr
 
 - `WorkflowExecutionSupervisor` — workflow execution ownership (internal)
 - `WorkerLifecycleController` / `WorkerShutdownCoordinator` — worker lifecycle and coordinated shutdown (internal)
-- `WorkflowRecoveryCoordinator` / `WorkflowRecoveryController` — recovery (internal)
+- `WorkflowRecoveryCoordinator` — recovery coordination (internal; `WorkflowRecoveryController` is the public face)
 - `LeaseCoordinator` / `LeaseRenewalLoop` — lease/fencing (internal)
 - Workflow observers (`WorkflowObservation`), step executor SPI (`WorkflowStepExecutor`), persistence session SPI, partition strategy (`PartitionAssignmentStrategy`)
 - Step types: `HttpStep`, `ShellStep`, `CodexStep`, `HermesStep`, `McpStep`
@@ -113,7 +114,8 @@ dependencies {
 **Bill of Materials:**
 
 ```kotlin
-implementation(platform("dev.tramai:tramai-bom"))  // version managed via the BOM
+// Version from the canonical tramaiVersion Gradle property (see gradle.properties)
+implementation(platform("dev.tramai:tramai-bom:${tramaiVersion}"))
 implementation("dev.tramai:tramai-orchestration")
 ```
 
@@ -122,8 +124,8 @@ implementation("dev.tramai:tramai-orchestration")
 | Topic | Link |
 |-------|------|
 | Quickstart with all modules | `docs/guides/getting-started.md` |
-| Understanding workflow basics | `docs/specs/spec-005.md` |
-| Agent CLI step types (Hermes, Codex, MCP, Shell) | `docs/specs/spec-009.md` |
+| Understanding workflow basics | `docs/specs/spec-005-standalone-java-api.md` |
+| Agent CLI step types (Hermes, Codex, MCP, Shell) | `docs/specs/spec-009-streaming-responses.md` |
 | Governed workflow quickstart | `docs/guides/governed-workflow-quickstart.md` |
 
 ---
@@ -284,7 +286,7 @@ Each item runs in a `coroutineScope { async { ... } }`. The `StopPolicy.maxParal
 
 ### Checkpoint stores
 
-`tramai-orchestration` ships with three `WorkflowCheckpointStore` implementations:
+`tramai-orchestration` ships with four `WorkflowCheckpointStore` implementations:
 
 | Store | Backend | Features |
 |-------|---------|----------|

--- a/docs/modules/tramai-persistence-file.md
+++ b/docs/modules/tramai-persistence-file.md
@@ -1,7 +1,7 @@
 # Module: `tramai-persistence-file`
 
 > **One-liner:** Encrypted-at-rest, single-node file persistence for TramAI sovereign state — `FileApprovalStore`, `FileApprovalContinuationStore`, `FileSuspendedInvocationStore`, and `FileAuditStore` backed by AES-256-GCM encrypted files on a POSIX filesystem.
-> **Module type:** `persistence` + `storage`
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
 > **Dependencies:** `tramai-core`, `tramai-engine`, `tramai-security`
 
 ## Architecture

--- a/docs/modules/tramai-persistence-file.md
+++ b/docs/modules/tramai-persistence-file.md
@@ -3,14 +3,14 @@
 > **One-liner:** Encrypted-at-rest, single-node file persistence for TramAI sovereign state — `FileApprovalStore`, `FileApprovalContinuationStore`, `FileSuspendedInvocationStore`, and `FileAuditStore` backed by AES-256-GCM encrypted files on a POSIX filesystem.
 > **Module type:** `persistence` + `storage`
 > **Dependencies:** `tramai-core`, `tramai-engine`, `tramai-security`
-> **Source files:** 15 files + new files
-
 
 ## Architecture
 
 ### Responsibility
 
 Encrypted-at-rest, single-node file persistence for sovereign stores: `FileApprovalStore`, `FileApprovalContinuationStore`, `FileSuspendedInvocationStore`, `FileAuditStore` backed by AES-256-GCM encrypted files on a POSIX filesystem.
+
+Classification / maturity / publishability / release: see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md).
 
 ### Public entry points
 
@@ -19,17 +19,19 @@ Encrypted-at-rest, single-node file persistence for sovereign stores: `FileAppro
 - `FileApprovalStore`, `FileApprovalContinuationStore`, `FileAuditStore`, suspended-invocation store
 - `FileStoreException` hierarchy (configuration, lock-unavailable, permission, corruption, unsupported-format)
 
+Verify the full public surface against `tramai-persistence-file/api/tramai-persistence-file.api`.
+
 ### Internal extension points
 
 - Store SPI implementations (approval / continuation / audit / suspended invocation)
 
 ### Significant dependencies
 
-- `tramai-core`, `tramai-engine`, `tramai-security` (see [module-catalog.yml](../../config/quality/module-catalog.yml))
+- `api(tramai-core)`, `api(tramai-engine)`, `api(tramai-security)`; Jackson + coroutines (implementation scope) (see [module-catalog.yml](../../config/quality/module-catalog.yml))
 
 ### Lifecycle ownership
 
-- Store open/close with exclusive POSIX file lock; exactly-once continuation claim semantics
+- Store open/close with exclusive POSIX file lock; the store root directory is owned by the store while open. Exactly-once continuation claim semantics are behavioral, not resource lifecycle.
 
 ### Thread-safety and concurrency
 
@@ -52,7 +54,6 @@ Encrypted-at-rest, single-node file persistence for sovereign stores: `FileAppro
 
 - [ARCHITECTURE.md](../../ARCHITECTURE.md) — persistence layer
 - `docs/adr/` — file persistence decisions
-
 ---
 
 ## Purpose

--- a/docs/modules/tramai-persistence-file.md
+++ b/docs/modules/tramai-persistence-file.md
@@ -5,6 +5,56 @@
 > **Dependencies:** `tramai-core`, `tramai-engine`, `tramai-security`
 > **Source files:** 15 files + new files
 
+
+## Architecture
+
+### Responsibility
+
+Encrypted-at-rest, single-node file persistence for sovereign stores: `FileApprovalStore`, `FileApprovalContinuationStore`, `FileSuspendedInvocationStore`, `FileAuditStore` backed by AES-256-GCM encrypted files on a POSIX filesystem.
+
+### Public entry points
+
+- `FileBackedSovereignStores.open(...)` — composition root
+- `FileBackedStoreConfiguration`, `FileStoreEncryptionConfiguration`, `FileStoreEncryptionKeyProvider`
+- `FileApprovalStore`, `FileApprovalContinuationStore`, `FileAuditStore`, suspended-invocation store
+- `FileStoreException` hierarchy (configuration, lock-unavailable, permission, corruption, unsupported-format)
+
+### Internal extension points
+
+- Store SPI implementations (approval / continuation / audit / suspended invocation)
+
+### Significant dependencies
+
+- `tramai-core`, `tramai-engine`, `tramai-security` (see [module-catalog.yml](../../config/quality/module-catalog.yml))
+
+### Lifecycle ownership
+
+- Store open/close with exclusive POSIX file lock; exactly-once continuation claim semantics
+
+### Thread-safety and concurrency
+
+- Per-record and per-stream `ReentrantLock`; exclusive cross-process lock on the store root. Do not invent guarantees beyond the store documentation.
+
+### Failure semantics
+
+- Atomic writes with `ATOMIC_MOVE` (CREATE_NEW for immutable audit events); corruption/tampering detected via GCM tags and hash chains; safe reason-code-only exception messages
+
+### Contract tests / TCKs
+
+- `FileApprovalStoreTckTest`, `FileApprovalContinuationStoreTckTest`, `FileAuditStoreTckTest` — enrolled in the shared TCKs
+
+### Do not
+
+- Do not copy another store's behavior as the spec — the TCKs are authoritative
+- Do not add Spring dependencies here
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — persistence layer
+- `docs/adr/` — file persistence decisions
+
+---
+
 ## Purpose
 
 `tramai-persistence-file` provides durable, encrypted-at-rest storage for the three sovereign store SPIs — `ApprovalStore`, `ApprovalContinuationStore`, and `AuditStore` — using the local filesystem. It is designed for single-node sovereign TramAI deployments that need persistent state without a database or cloud service dependency.

--- a/docs/modules/tramai-persistence-jdbc.md
+++ b/docs/modules/tramai-persistence-jdbc.md
@@ -1,0 +1,50 @@
+# Module: `tramai-persistence-jdbc`
+
+> **One-liner:** JDBC-backed persistence stores for sovereign approvals, audit and workflow state.
+> **Classification:** persistence · published (preview API, release-included) — see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Implements the sovereign store SPIs on PostgreSQL/JDBC: approval stores, continuation stores, audit store, suspended-invocation store, replay envelope codecs. Published as of Epic 9.1c (#303); consumed directly or via `tramai-spring-boot-starter-sovereign-persistence-jdbc`.
+
+### Public entry points
+
+- `dev.tramai.persistence.jdbc.JdbcApprovalStore`, `JdbcApprovalContinuationStore`, `JdbcAuditStore`, `JdbcSuspendedInvocationStore`
+- `JdbcReplayEnvelopeCodec`, `JdbcAuditPayloadCodec`, `JdbcContinuationArgumentsCodec`
+- `SovereignJdbcPersistence` — composition root
+
+### Internal extension points
+
+- Store SPI implementations (approval / continuation / audit / suspended invocation)
+
+### Significant dependencies
+
+- `api(tramai-core)`, `api(tramai-engine)`, `api(tramai-security)`; Jackson codecs (implementation scope)
+
+### Lifecycle ownership
+
+- Exactly-once continuation claim semantics; lazy expiry on pending continuations
+
+### Thread-safety and concurrency
+
+- JDBC-backed stores rely on transaction isolation; connection management is store-scoped. Do not invent guarantees beyond what the store's own documentation states.
+
+### Failure semantics
+
+- Transaction failures propagate as typed store exceptions; no silent partial writes
+
+### Contract tests / TCKs
+
+- `JdbcApprovalStoreTckTest`, `JdbcApprovalContinuationStoreTckTest`, `JdbcAuditStoreTckTest`, `JdbcSuspendedInvocationStoreTckTest` — enrolled in the shared TCKs
+
+### Do not
+
+- Do not copy file-store behavior as the spec; the TCKs are authoritative
+- Do not add Spring dependencies here
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — persistence layer
+- `docs/architecture/sovereign-jdbc-persistence-design.md`

--- a/docs/modules/tramai-persistence-jdbc.md
+++ b/docs/modules/tramai-persistence-jdbc.md
@@ -1,35 +1,37 @@
 # Module: `tramai-persistence-jdbc`
 
 > **One-liner:** JDBC-backed persistence stores for sovereign approvals, audit and workflow state.
-> **Classification:** persistence · published (preview API, release-included) — see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+> **Classification / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
 
 ## Architecture
 
 ### Responsibility
 
-Implements the sovereign store SPIs on PostgreSQL/JDBC: approval stores, continuation stores, audit store, suspended-invocation store, replay envelope codecs. Published as of Epic 9.1c (#303); consumed directly or via `tramai-spring-boot-starter-sovereign-persistence-jdbc`.
+Implements the sovereign store SPIs on PostgreSQL/JDBC: approval stores, continuation stores, audit store, suspended-invocation store, replay envelope codecs. Consumed directly or via `tramai-spring-boot-starter-sovereign-persistence-jdbc`.
 
 ### Public entry points
 
 - `dev.tramai.persistence.jdbc.JdbcApprovalStore`, `JdbcApprovalContinuationStore`, `JdbcAuditStore`, `JdbcSuspendedInvocationStore`
 - `JdbcReplayEnvelopeCodec`, `JdbcAuditPayloadCodec`, `JdbcContinuationArgumentsCodec`
-- `SovereignJdbcPersistence` — composition root
+
+Verify the full public surface against `tramai-persistence-jdbc/api/tramai-persistence-jdbc.api` (`SovereignJdbcPersistence` is internal).
 
 ### Internal extension points
 
+- `SovereignJdbcPersistence` — composition root (internal)
 - Store SPI implementations (approval / continuation / audit / suspended invocation)
 
 ### Significant dependencies
 
-- `api(tramai-core)`, `api(tramai-engine)`, `api(tramai-security)`; Jackson codecs (implementation scope)
+- `api(tramai-core)`, `api(tramai-engine)`, `api(tramai-security)`; Jackson codecs (implementation scope) (see [module-catalog.yml](../../config/quality/module-catalog.yml))
 
 ### Lifecycle ownership
 
-- Exactly-once continuation claim semantics; lazy expiry on pending continuations
+- No process/runtime resource lifecycle owned by this module. Stores borrow the supplied `DataSource`/connection; ownership remains with the caller/composition layer. Exactly-once continuation claim and lazy expiry are behavioral contracts, not resource lifecycle.
 
 ### Thread-safety and concurrency
 
-- JDBC-backed stores rely on transaction isolation; connection management is store-scoped. Do not invent guarantees beyond what the store's own documentation states.
+- JDBC-backed stores rely on transaction isolation; connection management is store-scoped. Do not invent guarantees beyond the store's own documentation.
 
 ### Failure semantics
 

--- a/docs/modules/tramai-security.md
+++ b/docs/modules/tramai-security.md
@@ -1,7 +1,7 @@
 # Module: `tramai-security`
 
 > **One-liner:** Policy enforcement, approval gates, audit and evidence for governed AI invocations.
-> **Classification:** governance-security · published · preview API — see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+> **Classification / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
 
 ## Architecture
 
@@ -13,9 +13,11 @@ Owns governance semantics: policy decision points (`DefaultPolicyEngine`, `RuleB
 
 - `DefaultPolicyEngine` — policy evaluation for governed invocations
 - `RuleBasedDlpInterceptor` — DLP redaction for provider I/O
-- `dev.tramai.security.approval.*` — approval gate coordination, in-memory store implementations (`InMemoryApprovalStore`, `InMemoryApprovalContinuationStore`)
 - `dev.tramai.security.audit.*` — `AuditEngine`, `AuditStore`, hash-chain validation
+- `dev.tramai.security.approval.*` — approval gate coordination, in-memory store implementations (`InMemoryApprovalStore`, `InMemoryApprovalContinuationStore`)
 - `dev.tramai.security.evidence.*` — evidence records
+
+Verify the full public surface against `tramai-security/api/tramai-security.api`.
 
 ### Internal extension points
 
@@ -23,15 +25,15 @@ Owns governance semantics: policy decision points (`DefaultPolicyEngine`, `RuleB
 
 ### Significant dependencies
 
-- `api(tramai-core)` only — governance sits above the engine contract and does not depend on runtime internals
+- `api(tramai-core)`; `implementation(kotlinx-coroutines-core)`, `implementation(jackson-databind)` (see [module-catalog.yml](../../config/quality/module-catalog.yml))
 
 ### Lifecycle ownership
 
-- Approval and continuation state machines; recovery coordination (`ApprovalRecoveryCoordinator`)
+- No process/runtime resource lifecycle owned by this module. Stores borrow caller-supplied resources where applicable; ownership remains with the caller/composition layer. Approval/continuation state machines are behavioral contracts, not resource lifecycle.
 
 ### Thread-safety and concurrency
 
-- Store implementations manage per-record locking; in-memory stores are synchronized. Do not invent guarantees beyond what the store's own documentation states.
+- Store implementations manage per-record locking; in-memory stores are synchronized. No blanket guarantee applies beyond each store's documentation.
 
 ### Failure semantics
 

--- a/docs/modules/tramai-security.md
+++ b/docs/modules/tramai-security.md
@@ -1,0 +1,53 @@
+# Module: `tramai-security`
+
+> **One-liner:** Policy enforcement, approval gates, audit and evidence for governed AI invocations.
+> **Classification:** governance-security · published · preview API — see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Owns governance semantics: policy decision points (`DefaultPolicyEngine`, `RuleBasedDlpInterceptor`), approval lifecycle coordination, audit trail and evidence records for governed AI invocations.
+
+### Public entry points
+
+- `DefaultPolicyEngine` — policy evaluation for governed invocations
+- `RuleBasedDlpInterceptor` — DLP redaction for provider I/O
+- `dev.tramai.security.approval.*` — approval gate coordination, in-memory store implementations (`InMemoryApprovalStore`, `InMemoryApprovalContinuationStore`)
+- `dev.tramai.security.audit.*` — `AuditEngine`, `AuditStore`, hash-chain validation
+- `dev.tramai.security.evidence.*` — evidence records
+
+### Internal extension points
+
+- Store SPIs (`ApprovalStore`, `ApprovalContinuationStore`, `AuditStore`) — implemented by `tramai-persistence-file` / `tramai-persistence-jdbc`
+
+### Significant dependencies
+
+- `api(tramai-core)` only — governance sits above the engine contract and does not depend on runtime internals
+
+### Lifecycle ownership
+
+- Approval and continuation state machines; recovery coordination (`ApprovalRecoveryCoordinator`)
+
+### Thread-safety and concurrency
+
+- Store implementations manage per-record locking; in-memory stores are synchronized. Do not invent guarantees beyond what the store's own documentation states.
+
+### Failure semantics
+
+- Policy violations fail loudly with typed decisions; audit failures surface as evidence gaps rather than silent skips
+
+### Contract tests / TCKs
+
+- `InMemoryApprovalStoreTckTest`, `InMemoryApprovalContinuationStoreTckTest` — enrolled in `ApprovalStoreTck` / `ApprovalContinuationStoreTck` (tramai-testing)
+- `DefaultPolicyEngineTest`, `RuleBasedDlpInterceptorTest`
+
+### Do not
+
+- Do not add Spring/framework dependencies here
+- Do not bypass the policy decision points from engine code
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — governance-security layer
+- `docs/adr/` — governance and approval decisions

--- a/docs/modules/tramai-security.md
+++ b/docs/modules/tramai-security.md
@@ -16,12 +16,13 @@ Owns governance semantics: policy decision points (`DefaultPolicyEngine`, `RuleB
 - `dev.tramai.security.audit.*` — `AuditEngine`, `AuditStore`, hash-chain validation
 - `dev.tramai.security.approval.*` — approval gate coordination, in-memory store implementations (`InMemoryApprovalStore`, `InMemoryApprovalContinuationStore`)
 - `dev.tramai.security.evidence.*` — evidence records
+- Public store contracts (implemented by `tramai-persistence-file` / `tramai-persistence-jdbc`): `ApprovalStore` / `ApprovalContinuationStore` (in `tramai-core` API), `AuditStore` (in `tramai-security` API)
 
 Verify the full public surface against `tramai-security/api/tramai-security.api`.
 
 ### Internal extension points
 
-- Store SPIs (`ApprovalStore`, `ApprovalContinuationStore`, `AuditStore`) — implemented by `tramai-persistence-file` / `tramai-persistence-jdbc`
+- Internal approval/audit coordinators and recovery machinery (implementation details, not consumer seams)
 
 ### Significant dependencies
 

--- a/docs/modules/tramai-sovereign.md
+++ b/docs/modules/tramai-sovereign.md
@@ -4,6 +4,53 @@
 > **Module type:** `composition` + `secure profile`
 > **Source files:** 3 files — `SovereignTramai.kt`, `SovereignProfileConfiguration.kt`, `SovereignDeploymentMode.kt`
 
+
+## Architecture
+
+### Responsibility
+
+Sovereign runtime: sealed, governed, offline-capable execution boundary composing `tramai-standalone` with deny-by-default policy, approval gating, and evidence generation (attestation, audit chain, zero-egress, release bundle).
+
+### Public entry points
+
+- `SovereignTramai` — sovereign runtime entry point
+- `SovereignProfileConfiguration`, `SovereignDeploymentMode`, `SovereignRoutingValidationPolicy` — profile configuration
+- `dev.tramai.sovereign.evidence.*` — evidence models and generators (`SovereignEvidencePackGenerator`, `SovereignEvidencePackWriter`, `ReleaseBundleEvidenceLoader`, evidence V1 types)
+
+### Internal extension points
+
+- Evidence pack generator/writer seams; routing validation policy
+
+### Significant dependencies
+
+- `api(tramai-standalone)`, `api(tramai-security)` (see [module-catalog.yml](../../config/quality/module-catalog.yml))
+
+### Lifecycle ownership
+
+- Sovereign runtime lifecycle; evidence pack generation tied to release/attestation lifecycle
+
+### Thread-safety and concurrency
+
+- Delegates to standalone/engine concurrency; evidence generation is deterministic per input
+
+### Failure semantics
+
+- Sealed-runtime failures surface as typed violations; evidence gaps are not silently skipped
+
+### Contract tests / TCKs
+
+- `tramai-sovereign/src/test`; sovereign E2E fixtures in `tramai-testing`
+
+### Do not
+
+- Do not bypass the sealed-runtime boundary or weaken deny-by-default policy
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — governance-security layer
+
+---
+
 ## Purpose
 
 `tramai-sovereign` is the dependency aggregator and secure embedded runtime profile for sovereign TramAI deployments.

--- a/docs/modules/tramai-sovereign.md
+++ b/docs/modules/tramai-sovereign.md
@@ -2,8 +2,6 @@
 
 > **One-liner:** Secure embedded runtime profile that wires deny-by-default policy enforcement, approved-model registry enforcement, classification-aware provider routing, offline deployment validation, artifact-byte verification, and hash-chained policy-decision audit emission without requiring the SaaS platform.
 > **Module type:** `composition` + `secure profile`
-> **Source files:** 3 files — `SovereignTramai.kt`, `SovereignProfileConfiguration.kt`, `SovereignDeploymentMode.kt`
-
 
 ## Architecture
 
@@ -15,7 +13,9 @@ Sovereign runtime: sealed, governed, offline-capable execution boundary composin
 
 - `SovereignTramai` — sovereign runtime entry point
 - `SovereignProfileConfiguration`, `SovereignDeploymentMode`, `SovereignRoutingValidationPolicy` — profile configuration
-- `dev.tramai.sovereign.evidence.*` — evidence models and generators (`SovereignEvidencePackGenerator`, `SovereignEvidencePackWriter`, `ReleaseBundleEvidenceLoader`, evidence V1 types)
+- `dev.tramai.sovereign.evidence.*` — evidence models and generators
+
+Verify the full public surface against `tramai-sovereign/api/tramai-sovereign.api`.
 
 ### Internal extension points
 
@@ -48,7 +48,6 @@ Sovereign runtime: sealed, governed, offline-capable execution boundary composin
 ### Related architecture
 
 - [ARCHITECTURE.md](../../ARCHITECTURE.md) — governance-security layer
-
 ---
 
 ## Purpose

--- a/docs/modules/tramai-sovereign.md
+++ b/docs/modules/tramai-sovereign.md
@@ -1,7 +1,7 @@
 # Module: `tramai-sovereign`
 
 > **One-liner:** Secure embedded runtime profile that wires deny-by-default policy enforcement, approved-model registry enforcement, classification-aware provider routing, offline deployment validation, artifact-byte verification, and hash-chained policy-decision audit emission without requiring the SaaS platform.
-> **Module type:** `composition` + `secure profile`
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
 
 ## Architecture
 

--- a/docs/modules/tramai-standalone.md
+++ b/docs/modules/tramai-standalone.md
@@ -1,7 +1,7 @@
 # Module: `tramai-standalone`
 
 > **One-liner:** Minimal framework-free entry point that wires core, engine, and structured output into a single `Tramai.create<T>()` call.
-> **Module type:** `composition`
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
 
 ---
 
@@ -14,12 +14,13 @@ Framework-free entry point composing core, engine and structured output into a m
 ### Public entry points
 
 - `Tramai` — builder-style entry point for framework-free usage
+- `TramaiRuntime` — assembled runtime with lifecycle (public per `tramai-standalone/api/tramai-standalone.api`)
 
-Verify the full public surface against `tramai-standalone/api/tramai-standalone.api` (`TramaiRuntime` is internal).
+Verify the full public surface against `tramai-standalone/api/tramai-standalone.api`.
 
 ### Internal extension points
 
-- `TramaiRuntime` — assembled runtime (internal); engine/structured/provider wiring knobs through the `Tramai` builder
+- Engine/structured/provider wiring knobs through the `Tramai` builder
 
 ### Significant dependencies
 
@@ -305,10 +306,7 @@ tramai-standalone
 
   Depended on by:
     - Application code (end-user entry point)
-
-  Not depended on by:
-    - tramai-spring-core (profile-neutral auto-configuration; `tramai-spring` is the legacy facade)
-    - Any other Tramai module
+    - tramai-spring-core (api dependency — `api(project(":tramai-standalone"))`)
 ```
 
 ### What `create<T>()` does end-to-end
@@ -369,6 +367,6 @@ Package: dev.tramai.standalone
 
 ### Testing strategy
 
-- `tramai-standalone` has no tests of its own — it is a thin composition layer
+- `tramai-standalone` is a thin composition layer; its own tests cover runtime assembly (`Tramai` / `TramaiRuntime` wiring)
 - Correctness is verified through `tramai-engine` tests (proxy dispatch, routing, retry) and `tramai-structured` tests (schema generation, parsing, validation)
 - Integration tests in provider modules (`tramai-ollama`, `tramai-openai`, `tramai-anthropic`) cover the full `Tramai.builder()...create<T>()` path

--- a/docs/modules/tramai-standalone.md
+++ b/docs/modules/tramai-standalone.md
@@ -7,6 +7,52 @@
 
 ---
 
+
+## Architecture
+
+### Responsibility
+
+Framework-free entry point composing core, engine and structured output into a minimal runtime (`Tramai`, `TramaiRuntime`).
+
+### Public entry points
+
+- `Tramai` — builder-style entry point for framework-free usage
+- `TramaiRuntime` — assembled runtime with lifecycle
+
+### Internal extension points
+
+- Engine/structured/provider wiring knobs exposed through the `Tramai` builder
+
+### Significant dependencies
+
+- `api(tramai-core)`, `api(tramai-engine)`, `api(tramai-structured)` (see [module-catalog.yml](../../config/quality/module-catalog.yml))
+
+### Lifecycle ownership
+
+- Owns the assembled runtime lifecycle (`close()`)
+
+### Thread-safety and concurrency
+
+- Runtime is concurrent-safe; delegates to engine coroutine scopes
+
+### Failure semantics
+
+- Surfaces engine/structured failures directly to callers
+
+### Contract tests / TCKs
+
+- `tramai-standalone/src/test`; consumed by framework adapters (e.g. `tramai-spring-core` depends on it)
+
+### Do not
+
+- Do not add provider or Spring dependencies here
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — runtime-execution layer
+
+---
+
 ## L1: Quick Start (30-second read)
 
 ### What

--- a/docs/modules/tramai-standalone.md
+++ b/docs/modules/tramai-standalone.md
@@ -2,11 +2,8 @@
 
 > **One-liner:** Minimal framework-free entry point that wires core, engine, and structured output into a single `Tramai.create<T>()` call.
 > **Module type:** `composition`
-> **Source files:** 1 file — `Tramai.kt` (241 LOC)
-> **Build:** `dev.tramai:tramai-standalone:0.5.0`
 
 ---
-
 
 ## Architecture
 
@@ -17,15 +14,16 @@ Framework-free entry point composing core, engine and structured output into a m
 ### Public entry points
 
 - `Tramai` — builder-style entry point for framework-free usage
-- `TramaiRuntime` — assembled runtime with lifecycle
+
+Verify the full public surface against `tramai-standalone/api/tramai-standalone.api` (`TramaiRuntime` is internal).
 
 ### Internal extension points
 
-- Engine/structured/provider wiring knobs exposed through the `Tramai` builder
+- `TramaiRuntime` — assembled runtime (internal); engine/structured/provider wiring knobs through the `Tramai` builder
 
 ### Significant dependencies
 
-- `api(tramai-core)`, `api(tramai-engine)`, `api(tramai-structured)` (see [module-catalog.yml](../../config/quality/module-catalog.yml))
+- `api(tramai-core)`, `api(tramai-engine)`, `api(tramai-structured)`, `api(kotlin-reflect)` (see [module-catalog.yml](../../config/quality/module-catalog.yml))
 
 ### Lifecycle ownership
 
@@ -50,7 +48,6 @@ Framework-free entry point composing core, engine and structured output into a m
 ### Related architecture
 
 - [ARCHITECTURE.md](../../ARCHITECTURE.md) — runtime-execution layer
-
 ---
 
 ## L1: Quick Start (30-second read)
@@ -79,9 +76,9 @@ Use this module when:
 - You want to understand exactly how core + engine + structured wire together
 
 Don't use this module when:
-- You need Spring Boot auto-configuration (use tramai-spring)
+- You need Spring Boot auto-configuration (use `tramai-spring-core` / `tramai-spring-boot-starter`; `tramai-spring` is the legacy facade)
 - You need the orchestration DSL with @AiService scanning (use tramai-orchestration)
-- You want DI-managed provider beans (use tramai-spring)
+- You want DI-managed provider beans (use `tramai-spring-core` / provider starters)
 ```
 
 ### How to add
@@ -89,8 +86,8 @@ Don't use this module when:
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("dev.tramai:tramai-standalone:0.5.0")
-    implementation("dev.tramai:tramai-ollama:0.5.0") // or tramai-openai, tramai-anthropic
+    implementation("dev.tramai:tramai-standalone")  // version from the TramAI BOM
+    implementation("dev.tramai:tramai-ollama")  // version from the TramAI BOM // or tramai-openai, tramai-anthropic
 }
 ```
 
@@ -99,7 +96,7 @@ dependencies {
 <dependency>
     <groupId>dev.tramai</groupId>
     <artifactId>tramai-standalone</artifactId>
-    <version>0.5.0</version>
+    <version>${tramai.version}</version>
 </dependency>
 ```
 
@@ -110,7 +107,7 @@ dependencies {
 - [tramai-engine](./tramai-engine.md) — Orchestration, retry, routing internals
 - [tramai-structured](./tramai-structured.md) — How typed outputs are handled
 - [tramai-ollama](./tramai-ollama.md), [tramai-openai](./tramai-openai.md), [tramai-anthropic](./tramai-anthropic.md) — Provider modules
-- [tramai-spring](./tramai-spring.md) — Spring Boot alternative
+- `tramai-spring-core` — Spring Boot alternative (`tramai-spring` is the legacy facade; card lands in a later 11.2b slice)
 
 ---
 
@@ -310,7 +307,7 @@ tramai-standalone
     - Application code (end-user entry point)
 
   Not depended on by:
-    - tramai-spring (uses its own auto-configuration)
+    - tramai-spring-core (profile-neutral auto-configuration; `tramai-spring` is the legacy facade)
     - Any other Tramai module
 ```
 

--- a/docs/modules/tramai-standalone.md
+++ b/docs/modules/tramai-standalone.md
@@ -20,7 +20,7 @@ Verify the full public surface against `tramai-standalone/api/tramai-standalone.
 
 ### Internal extension points
 
-- Engine/structured/provider wiring knobs through the `Tramai` builder
+- Engine/structured/provider wiring knobs exposed by the builder (the public builder/runtime API is listed under Public entry points)
 
 ### Significant dependencies
 

--- a/docs/modules/tramai-structured.md
+++ b/docs/modules/tramai-structured.md
@@ -2,10 +2,8 @@
 
 > **One-liner:** Generates JSON schemas from Kotlin types, extracts and validates structured objects from LLM responses.
 > **Module type:** `core`
-> **Build coordinates:** `dev.tramai:tramai-structured:0.5.0`
 
 ---
-
 
 ## Architecture
 
@@ -15,25 +13,27 @@ Structured output: compiles Kotlin/Java types into JSON schema descriptors, extr
 
 ### Public entry points
 
-- `JacksonStructuredOutputHandler` — `StructuredOutputHandler` implementation (engine integration point)
-- Descriptor compilers: `KotlinStructuredTypeCompiler`, `JacksonJavaBeanStructuredTypeCompiler`
-- Contracts: `StructuredTypeDescriptor`, `StructuredContractFingerprint`, `StructuredJsonShapeValidator`, `StructuredValueValidator`, `StructuredSchemaRenderer`, `StructuredDescriptorCache`
+- `JacksonStructuredOutputHandler` — the module's public `StructuredOutputHandler` implementation (engine integration point)
+
+Verify the full public surface against `tramai-structured/api/tramai-structured.api` — the descriptor compiler/cache types below are internal.
 
 ### Internal extension points
 
-- `StructuredTypeCompiler` — pluggable compiler per type kind
+- `StructuredTypeCompiler` — pluggable compiler per type kind (internal)
+- `KotlinStructuredTypeCompiler`, `JacksonJavaBeanStructuredTypeCompiler` (internal)
+- Descriptor machinery: `StructuredTypeDescriptor`, `StructuredContractFingerprint`, `StructuredJsonShapeValidator`, `StructuredValueValidator`, `StructuredSchemaRenderer`, `StructuredDescriptorCache` (all internal)
 
 ### Significant dependencies
 
-- `api(tramai-core)` only (see [module-catalog.yml](../../config/quality/module-catalog.yml)); Jackson for JSON codec
+- `api(tramai-core)`; `implementation(jackson-databind)`, `implementation(jackson-module-kotlin)`, `implementation(kotlin-reflect)` (see [module-catalog.yml](../../config/quality/module-catalog.yml))
 
 ### Lifecycle ownership
 
-- Stateless compilers; descriptor cache owns compiled-descriptor lifecycle
+- No process/runtime resource lifecycle owned by this module; compilers are stateless and the descriptor cache owns compiled-descriptor caching only.
 
 ### Thread-safety and concurrency
 
-- Compilers/handlers are immutable and safe for concurrent use; descriptor cache is synchronized
+- No blanket immutability contract is declared: the handler owns instance state and the descriptor cache uses concurrent maps. Treat compiler/handler instances as thread-confined unless the concrete type documents otherwise.
 
 ### Failure semantics
 
@@ -52,7 +52,6 @@ Structured output: compiles Kotlin/Java types into JSON schema descriptors, extr
 
 - [ARCHITECTURE.md](../../ARCHITECTURE.md) — runtime-execution layer
 - `docs/adr/` — structured-output decisions
-
 ---
 
 ## L1: Quick Start (30-second read)
@@ -93,7 +92,7 @@ Without this module, every consumer would reimplement JSON extraction, schema ge
 **Gradle (Kotlin DSL):**
 
 ```kotlin
-implementation("dev.tramai:tramai-structured:0.5.0")
+implementation("dev.tramai:tramai-structured")  // version from the TramAI BOM
 ```
 
 **Maven:**
@@ -102,7 +101,7 @@ implementation("dev.tramai:tramai-structured:0.5.0")
 <dependency>
     <groupId>dev.tramai</groupId>
     <artifactId>tramai-structured</artifactId>
-    <version>0.5.0</version>
+    <version>${tramai.version}</version>
 </dependency>
 ```
 
@@ -421,7 +420,7 @@ tramai-structured
 `tramai-structured` is consumed by:
 - `tramai-engine` — invokes `createContract()` and `analyze()` during operation execution
 - `tramai-standalone` — transitively via engine
-- `tramai-spring` — transitively via engine
+- `tramai-spring-core` — transitively via engine (`tramai-spring` is the legacy facade)
 - `tramai-mcp` — for structured output in MCP tool responses
 
 ### Inner mechanics

--- a/docs/modules/tramai-structured.md
+++ b/docs/modules/tramai-structured.md
@@ -1,7 +1,7 @@
 # Module: `tramai-structured`
 
 > **One-liner:** Generates JSON schemas from Kotlin types, extracts and validates structured objects from LLM responses.
-> **Module type:** `core`
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
 
 ---
 
@@ -122,7 +122,7 @@ The module pulls in:
 
 ### Quick usage
 
-The `JacksonStructuredOutputHandler` is the single implementation of `StructuredOutputHandler`. It is automatically wired by `TramaiEngine` when `tramai-structured` is on the classpath. You typically do not instantiate it directly — but here is how it works end to end.
+The `JacksonStructuredOutputHandler` is the single implementation of `StructuredOutputHandler`. The engine consumes the core `StructuredOutputHandler` SPI; `tramai-standalone` composes the Jackson handler directly when constructing its runtime. Here is how it works end to end.
 
 **1. Define a data class with annotations:**
 
@@ -419,8 +419,8 @@ tramai-structured
 
 `tramai-structured` is consumed by:
 - `tramai-engine` — invokes `createContract()` and `analyze()` during operation execution
-- `tramai-standalone` — transitively via engine
-- `tramai-spring-core` — transitively via engine (`tramai-spring` is the legacy facade)
+- `tramai-standalone` — direct dependency (`api(project(":tramai-structured"))`)
+- `tramai-spring-core` — transitively via `tramai-standalone` (`tramai-spring` is the legacy facade)
 - `tramai-mcp` — for structured output in MCP tool responses
 
 ### Inner mechanics

--- a/docs/modules/tramai-structured.md
+++ b/docs/modules/tramai-structured.md
@@ -6,6 +6,55 @@
 
 ---
 
+
+## Architecture
+
+### Responsibility
+
+Structured output: compiles Kotlin/Java types into JSON schema descriptors, extracts and validates structured objects, renders schemas, and produces failure diagnostics with retry feedback.
+
+### Public entry points
+
+- `JacksonStructuredOutputHandler` — `StructuredOutputHandler` implementation (engine integration point)
+- Descriptor compilers: `KotlinStructuredTypeCompiler`, `JacksonJavaBeanStructuredTypeCompiler`
+- Contracts: `StructuredTypeDescriptor`, `StructuredContractFingerprint`, `StructuredJsonShapeValidator`, `StructuredValueValidator`, `StructuredSchemaRenderer`, `StructuredDescriptorCache`
+
+### Internal extension points
+
+- `StructuredTypeCompiler` — pluggable compiler per type kind
+
+### Significant dependencies
+
+- `api(tramai-core)` only (see [module-catalog.yml](../../config/quality/module-catalog.yml)); Jackson for JSON codec
+
+### Lifecycle ownership
+
+- Stateless compilers; descriptor cache owns compiled-descriptor lifecycle
+
+### Thread-safety and concurrency
+
+- Compilers/handlers are immutable and safe for concurrent use; descriptor cache is synchronized
+
+### Failure semantics
+
+- Parse/validation failures produce `StructuredOutputResult.Failure` with `feedbackMessage` for retry; terminal failure as `StructuredOutputException`
+
+### Contract tests / TCKs
+
+- Descriptor + handler tests in `tramai-structured/src/test`; structured contract TCK in `tramai-testing`
+
+### Do not
+
+- Do not change schema generation and post-parse validation independently — the compiled descriptor is authoritative
+- Do not add provider or Spring dependencies here
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — runtime-execution layer
+- `docs/adr/` — structured-output decisions
+
+---
+
 ## L1: Quick Start (30-second read)
 
 ### What

--- a/docs/modules/tramai-testing.md
+++ b/docs/modules/tramai-testing.md
@@ -2,12 +2,9 @@
 
 > **One-liner:** Mock providers, recording observers, and fluent assertions for deterministic Tramai integration tests.
 > **Module type:** `tooling`
-> **Group:** `dev.tramai`, **Version:** `0.3.1`
-> **Source files:** 6, **LOC:** 448
 > **Dependency:** `tramai-core` (api), AssertJ (implementation)
 
 ---
-
 
 ## Architecture
 
@@ -23,13 +20,15 @@ Testing support: mock providers, recording observers, simulated failures, fluent
 - `MockTool` — tool fake
 - TCK fixtures: provider (`ProviderTck`, `ProviderTckHarness`), store TCKs (`ApprovalStoreTck`, `ApprovalContinuationStoreTck`, lifecycle models), Spring consumer tests
 
+Verify the full public surface against `tramai-testing/api/tramai-testing.api` and `tramai-testing/src/testFixtures`.
+
 ### Internal extension points
 
 - TCK harnesses for provider/store behavior; testFixtures surface for consumers
 
 ### Significant dependencies
 
-- `api(tramai-core)`; testFixtures surface across engine/security/orchestration/Spring starters (see [module-catalog.yml](../../config/quality/module-catalog.yml))
+- `api(tramai-core)`; `implementation(assertj)`; testFixtures surface across engine/security/orchestration/Spring starters (see [module-catalog.yml](../../config/quality/module-catalog.yml))
 
 ### Lifecycle ownership
 
@@ -55,7 +54,6 @@ Testing support: mock providers, recording observers, simulated failures, fluent
 ### Related architecture
 
 - [ARCHITECTURE.md](../../ARCHITECTURE.md) — testing-support layer
-
 ---
 
 ## L1: Quick Start (30-second read)
@@ -101,7 +99,7 @@ Use `tramai-testing` **whenever you write integration tests for Tramai `@AiServi
 
 ```kotlin
 dependencies {
-    testImplementation("dev.tramai:tramai-testing:0.5.0")
+    testImplementation("dev.tramai:tramai-testing")  // version from the TramAI BOM
 }
 ```
 
@@ -111,7 +109,7 @@ dependencies {
 <dependency>
     <groupId>dev.tramai</groupId>
     <artifactId>tramai-testing</artifactId>
-    <version>0.5.0</version>
+    <version>${tramai.version}</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -419,7 +417,7 @@ fun `tool calls are captured and asserted`() {
 
 **What `tramai-testing` does NOT include:**
 - No test runner integration — use your framework of choice (JUnit 5, Kotlin Test)
-- No Spring Boot test slices — pair with `tramai-spring`'s `@EnableTramai` if needed
+- No Spring Boot test slices — pair with `tramai-spring-core`'s `@EnableTramai` if needed (`tramai-spring` is the legacy facade)
 - No HTTP mocking — Tramai's test model replaces the provider entirely, so no need for MockWebServer or WireMock
 
 ### Dependency graph

--- a/docs/modules/tramai-testing.md
+++ b/docs/modules/tramai-testing.md
@@ -1,7 +1,7 @@
 # Module: `tramai-testing`
 
 > **One-liner:** Mock providers, recording observers, and fluent assertions for deterministic Tramai integration tests.
-> **Module type:** `tooling`
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
 > **Dependency:** `tramai-core` (api), AssertJ (implementation)
 
 ---

--- a/docs/modules/tramai-testing.md
+++ b/docs/modules/tramai-testing.md
@@ -8,6 +8,56 @@
 
 ---
 
+
+## Architecture
+
+### Responsibility
+
+Testing support: mock providers, recording observers, simulated failures, fluent assertions, and TCK fixtures for deterministic TramAI tests and consumer-facing compatibility verification.
+
+### Public entry points
+
+- `MockAiProvider`, `SimulatedFailureProvider`, `RecordedRequestProvider` — provider fakes
+- `RecordingOperationObserver` — observation capture
+- `TramaiAssertions` — fluent assertions
+- `MockTool` — tool fake
+- TCK fixtures: provider (`ProviderTck`, `ProviderTckHarness`), store TCKs (`ApprovalStoreTck`, `ApprovalContinuationStoreTck`, lifecycle models), Spring consumer tests
+
+### Internal extension points
+
+- TCK harnesses for provider/store behavior; testFixtures surface for consumers
+
+### Significant dependencies
+
+- `api(tramai-core)`; testFixtures surface across engine/security/orchestration/Spring starters (see [module-catalog.yml](../../config/quality/module-catalog.yml))
+
+### Lifecycle ownership
+
+- Test-scoped; no production runtime ownership
+
+### Thread-safety and concurrency
+
+- Fakes are test-scoped; TCK execution is per-implementation
+
+### Failure semantics
+
+- Assertion failures surface with diagnostic context; TCKs fail on behavioral contract violations
+
+### Contract tests / TCKs
+
+- The TCKs themselves are the contract; enrolled implementations run them in their own modules
+
+### Do not
+
+- Do not put production behavior in test fixtures
+- Do not treat consumer-boundary tests as a substitute for store/provider TCKs
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — testing-support layer
+
+---
+
 ## L1: Quick Start (30-second read)
 
 ### What


### PR DESCRIPTION
## Summary

Epic 11.2b1 — normalize critical module architecture cards. Establishes one predictable per-module architecture/navigation contract and applies it to the 11 modules owning TramAI's core execution, governance, persistence, observability, and testing boundaries.

## What (12 files, docs only)

- **`docs/modules/README.md`** (new) — navigation/coverage index: card contract (10 required architecture headings), honest migration-state table.
- **Normalized** (architecture section prepended, useful long-form preserved): `tramai-core`, `tramai-engine`, `tramai-structured`, `tramai-standalone`, `tramai-orchestration`, `tramai-sovereign`, `tramai-persistence-file`, `tramai-observability`, `tramai-testing`.
- **Created**: `tramai-security`, `tramai-persistence-jdbc`.

Every conforming card has exactly the 10 required headings: Responsibility / Public entry points / Internal extension points / Significant dependencies / Lifecycle ownership / Thread-safety and concurrency / Failure semantics / Contract tests / TCKs / Do not / Related architecture.

## Review round 2 fixes (all P0 items)

1. **Public entry points = consumer-visible API**, verified against `api/*.api` dumps + Kotlin visibility. Internal coordinators/descriptors moved to Internal extension points:
   - structured: only `JacksonStructuredOutputHandler` public; descriptor compiler/cache/validator types are internal
   - engine: `TramaiEngine`, `EngineEventObserver`, `DefaultApprovalGateway` + settings/SPI public; `InvocationExecutionCoordinator`, `TramaiInvocationHandler`, `ProviderExecutionCoordinator`, `ProviderAttemptExecutor`, `StreamingExecutionCoordinator`, `StructuredResponseCoordinator`, tool/approval coordinators internal
   - orchestration: `TramaiWorker` + workflow builder public; `WorkflowExecutionSupervisor`, `WorkerLifecycleController`, `WorkerShutdownCoordinator`, `WorkflowRecoveryCoordinator` internal
2. **Significant dependencies** checked against each module's build.gradle.kts: core has `api(kotlinx-coroutines-core)`; engine has `api(core)` + `implementation(security)` with structured test-only and observability absent.
3. **Stale long-form cleaned** in the 9 existing cards: 0.3.1 metadata, 0.5.0 hard-coded coordinates → BOM/catalog placeholders, source-file/LOC counts, old `tramai-spring` onboarding → `tramai-spring-core` with legacy-facade note. (Preserved useful content; removed known falsehoods.)
4. **Circuit-breaker lifecycle semantics unfrozen** in tramai-engine.md: detailed CLOSED/OPEN/HALF_OPEN machine + threshold examples replaced with stable ownership statement + 8.2g note. Stable configuration shape (settings defaults) kept.
5. **Thread-safety re-audited**: structured no longer claims blanket immutability; core no longer claims all contracts immutable; engine uses the actual lifecycle-scope invocation contract; orchestration distinguishes local duplicate prevention from lease fencing.
6. **Manifest classification linked, not duplicated** in security/JDBC cards; JDBC drops the "Published as of Epic 9.1c" note.
7. **README reports honest migration state**: 58 manifest / 32 cards / **11 conforming** / 21 existing non-conforming / 26 missing / 0 orphans.
8. **Lifecycle ownership** describes resource/runtime lifecycle; "no lifecycle owned / stores borrow caller-supplied resources" where accurate.

## Verification

- 11/11 cards have all 10 required headings.
- Public-entry types validated against API dumps + visibility (0 internal types in public sections).
- Significant dependencies match build.gradle.kts for all 11.
- Zero `0.5.0` / `0.3.1` / `Source files:` / `LOC:` / old-Spring claims in touched cards (full-content grep).
- All links resolve; all named types exist in source.
- `verifyPr` — BUILD SUCCESSFUL (320 tasks).
- `verify060Architecture` — BUILD SUCCESSFUL (92 tasks).
- Copilot structured-output thread resolved.

## Non-claims

- No production/build/catalog/baseline changes.
- Not all 58 modules conform yet: 21 existing cards remain non-conforming and 26 cards are missing — later 11.2b slices.
- This PR does not modify module classifications or boundaries.

## Review round 3 fixes (final narrow cleanup)

1. **Bidirectional visibility validation**: every Public-entry type verified present in its api dump; every type labelled internal verified absent. TramaiRuntime and WorkflowRecoveryController moved to Public (both in their api dumps); OpenTelemetryAttributes marked internal (not in dump); core extension SPIs (OperationInterceptor, OperationObserver, DlpInterceptor, SecretValueResolver, ConversationIdProvider) no longer described as internal seams.
2. **Legacy 'Module type:' metadata removed** from all 9 normalized existing cards — classification now points to module-catalog.yml / module-matrix.md.
3. **Semantic stale-content cleanup**: standalone spring-core dependency + tests claims corrected; structured engine auto-wire claim corrected (engine consumes core SPI, standalone composes Jackson handler directly); structured standalone dependency is direct, not transitive; orchestration checkpoint-store count 3 → 4.
4. **BOM examples fixed** to the canonical tramaiVersion Gradle property (no versionless platform()).
5. **No not-yet-existing card references**: tramai-spring-core.md routed to docs/architecture/modules.md until C2b3; stale spec links corrected.

Verification: verifyPr (320) + verify060Architecture (92) green; bidirectional visibility clean; zero Module type lines; all links + inline repo paths resolve; coverage unchanged 58/32/11/26/0.

## Review round 4 fixes (final)

1. **Whole-section public/internal audit**: public SPIs removed from 'Internal extension points' by section membership, not just labels — engine (OperationInterceptor/Observer), security (ApprovalStore/ApprovalContinuationStore/AuditStore), orchestration (step types, persistence stores, PartitionAssignmentStrategy), core and standalone cross-refs cleaned.
2. **Orchestration spec links by meaning**: workflow → spec-012-orchestration-and-coordination.md; Agent CLI steps → spec-015-agent-steps.md.
3. **BOM examples self-contained**: `val tramaiVersion: String by project` + `platform(dev.tramai:tramai-bom:$tramaiVersion)` (versionless platform() removed).

Verification: whole-section audit clean (0 public types in Internal sections); 11/11 headings; links resolve; coverage unchanged 58/32/11/26/0; verifyPr (320) + verify060Architecture (92) green.

This PR needs review before merge.
