### PR TITLE
docs: normalize non-Spring module architecture cards (Epic 11.2b2)

### DIFF
--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -9,7 +9,7 @@ Per-module architecture and navigation cards for TramAI. The authoritative modul
 
 ## Card contract
 
-Cards normalized under Epic 11.2b conform to the following architecture contract. C2b1 currently has **11 conforming cards**; remaining cards are migrated in subsequent slices.
+Cards normalized under Epic 11.2b conform to the following architecture contract. C2b1 normalized 11 core/governance/persistence/observability/testing cards; **C2b2 normalized 20 non-Spring cards** (provider adapters, higher capabilities, vector stores, operations/observability, BOM). Remaining cards are migrated in subsequent slices.
 
 Each conforming card starts with an `## Architecture` section using these headings:
 
@@ -34,8 +34,8 @@ Coverage is computed against the 58-module authoritative manifest (`module-catal
 |--------|-------|
 | Manifest modules | 58 |
 | Module cards | 32 |
-| Conforming cards (C2b1) | 11 |
-| Existing non-conforming | 21 |
+| Conforming cards (C2b1 + C2b2) | 31 |
+| Existing non-conforming | 1 (`tramai-spring`, Spring slice) |
 | Missing cards | 26 |
 | Orphans | 0 |
 

--- a/docs/modules/tramai-anthropic.md
+++ b/docs/modules/tramai-anthropic.md
@@ -228,26 +228,19 @@ Cancellation propagates: because the stream is a `kotlinx.coroutines.flow.Flow`,
 
 #### HTTP error responses
 
-Non-2xx status codes are handled by `providerHttpFailureObserved()`:
+Non-2xx status codes are handled by `rejectedProviderHttpResponse(...)` (from `dev.tramai.core.provider.transport`):
 
 ```kotlin
-logProviderHttpFailureDebug(
-    logger = providerLogger,
-    providerName = "anthropic",
-    statusCode = response.statusCode(),
-    body = errorBody.text,
-)
-throw providerHttpFailureObserved(
-    providerId = "anthropic",
-    statusCode = response.statusCode(),
-    body = errorBody.text,
-    bodyTruncated = errorBody.truncated,
-    retryAfterHeader = response.headers().firstValue("Retry-After").orElse(null),
+throw rejectedProviderHttpResponse(
+    providerId = PROVIDER_ID,
+    providerAlias = null,
+    response = response,
     observer = providerFailureDiagnosticObserver,
+    logger = providerLogger,
 )
 ```
 
-Non-2xx bodies are read via `readErrorBodyPreview()` (at most 8 KiB plus one sentinel byte); only the retained bytes are decoded.
+The helper reads the response body (preview capped at 8 KiB plus one sentinel byte), logs trusted metadata only (never the body, headers, credentials, or cause), and raises the `ProviderException`. The same helper is used for the streaming path's `handleHttpError`.
 
 This produces a `ProviderException` with:
 

--- a/docs/modules/tramai-anthropic.md
+++ b/docs/modules/tramai-anthropic.md
@@ -188,7 +188,7 @@ The response is parsed from the JSON body:
 }
 ```
 
-If the response contains no `type: "text"` content block (e.g., only `tool_use` blocks), a `ProviderException` is thrown with a clear message: *"Anthropic response did not contain a text content block"*.
+If the response contains neither `text` nor `tool_use` content blocks, a `ProviderException` is thrown with a clear message: *"Anthropic response did not contain a text or tool_use content block"*. A `tool_use`-only response is valid — tool calls are returned via `ModelResponse.toolCalls`.
 
 Stop reason mapping:
 
@@ -275,7 +275,7 @@ Transport-layer failures are caught and mapped by `providerTransportFailureObser
 
 #### Response parsing errors
 
-If the API returns a successful HTTP status but the content array contains no `type: "text"` block (for example, a `tool_use`-only response), the provider throws a `ProviderException` with message *"Anthropic response did not contain a text content block"* and `retryable = false`.
+If the API returns a successful HTTP status but the content array contains neither `text` nor `tool_use` blocks, the provider throws a `ProviderException` with message *"Anthropic response did not contain a text or tool_use content block"* and `retryable = false`. A `tool_use`-only response is valid and surfaces its calls through `ModelResponse.toolCalls`.
 
 #### Streaming error propagation
 

--- a/docs/modules/tramai-anthropic.md
+++ b/docs/modules/tramai-anthropic.md
@@ -26,7 +26,7 @@ Provider adapter for Anthropic's Messages API (Claude models): `ModelProvider` i
 
 ### Lifecycle ownership
 
-- Provider owns its HTTP client lifecycle; no engine state ownership
+- Provider retains an injected/default `HttpClient` (constructor default `HttpClient.newHttpClient()`) and exposes no close contract; no engine state ownership
 
 ### Thread-safety and concurrency
 

--- a/docs/modules/tramai-anthropic.md
+++ b/docs/modules/tramai-anthropic.md
@@ -1,12 +1,54 @@
 # Module: `tramai-anthropic`
 
 > **One-liner:** Provider for Anthropic's Messages API (Claude models).
-> **Module type:** `provider`
-> **Source files:** 1 — `AnthropicProvider.kt` (192 LOC)
-> **Test files:** 1
-> **Group:** `dev.tramai`, **Version:** `0.3.1`
 
 ---
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Provider adapter for Anthropic's Messages API (Claude models): `ModelProvider` implementation, request/response mapping, streaming, token accounting.
+
+### Public entry points
+
+- `AnthropicProvider` — `ModelProvider` implementation (verify against `tramai-anthropic/api/tramai-anthropic.api`)
+
+### Internal extension points
+
+- Provider transport internals (HTTP client, JSON mapping) — not consumer seams
+
+### Significant dependencies
+
+- `api(tramai-core)`; coroutines + Jackson (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Provider owns its HTTP client lifecycle; no engine state ownership
+
+### Thread-safety and concurrency
+
+- Provider must be safe for concurrent invocation by the engine
+
+### Failure semantics
+
+- Provider failures normalized to `ProviderException` per core contracts
+
+### Contract tests / TCKs
+
+- `AnthropicProviderTckTest` — enrolled in the provider TCK (tramai-testing)
+
+### Do not
+
+- Do not implement retry/fallback/circuit logic here — the engine owns that
+- Do not add Spring dependencies here
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — provider-adapters layer
+- [modules.md](../architecture/modules.md) — provider-adapters layer policy
 
 ## L1: Quick Start (30-second read)
 

--- a/docs/modules/tramai-azure-openai.md
+++ b/docs/modules/tramai-azure-openai.md
@@ -1,12 +1,55 @@
 # Module: `tramai-azure-openai`
 
 > **One-liner:** Provider for Azure OpenAI — deployment-based endpoints with dual API key / Entra ID authentication.
-> **Module type:** `provider`
-> **Source files:** 1 — `AzureOpenAiProvider.kt` (401 LOC)
-> **Test files:** 1 — `AzureOpenAiProviderTest.kt` (206 LOC)
-> **Group:** `dev.tramai`, **Version:** `0.3.1`
 
 ---
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Provider adapter for Azure OpenAI: `ModelProvider` implementation with Entra ID token support (static token, token source).
+
+### Public entry points
+
+- `AzureOpenAiProvider` — `ModelProvider` implementation
+- `StaticAzureEntraAccessTokenSource` — access-token source implementation
+
+Verify against `tramai-azure-openai/api/tramai-azure-openai.api`.
+
+### Internal extension points
+
+- Access-token source seam for Entra ID authentication
+
+### Significant dependencies
+
+- `api(tramai-core)`; coroutines + Jackson (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Provider owns its HTTP client lifecycle; no engine state ownership
+
+### Thread-safety and concurrency
+
+- Provider must be safe for concurrent invocation by the engine
+
+### Failure semantics
+
+- Provider failures normalized to `ProviderException` per core contracts
+
+### Contract tests / TCKs
+
+- `AzureOpenAiProviderTckTest` — enrolled in the provider TCK
+
+### Do not
+
+- Do not implement retry/fallback/circuit logic here — the engine owns that
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — provider-adapters layer
 
 ## L1: Quick Start (30-second read)
 
@@ -30,14 +73,14 @@ Azure OpenAI is the primary AI platform for organizations operating in Microsoft
 
 ```kotlin
 dependencies {
-    implementation("dev.tramai:tramai-azure-openai:0.5.0")
+    implementation("dev.tramai:tramai-azure-openai")  // version from the TramAI BOM
 }
 ```
 
 **Bill of Materials:**
 
 ```kotlin
-implementation(platform("dev.tramai:tramai-bom:0.5.0"))
+implementation(platform("dev.tramai:tramai-bom"))  // version from the BOM
 implementation("dev.tramai:tramai-azure-openai")
 ```
 

--- a/docs/modules/tramai-azure-openai.md
+++ b/docs/modules/tramai-azure-openai.md
@@ -29,7 +29,7 @@ Verify against `tramai-azure-openai/api/tramai-azure-openai.api`.
 
 ### Lifecycle ownership
 
-- Provider owns its HTTP client lifecycle; no engine state ownership
+- Provider retains an injected/default `HttpClient` (constructor default `HttpClient.newHttpClient()`) and exposes no close contract; no engine state ownership
 
 ### Thread-safety and concurrency
 
@@ -80,7 +80,8 @@ dependencies {
 **Bill of Materials:**
 
 ```kotlin
-implementation(platform("dev.tramai:tramai-bom"))  // version from the BOM
+val tramaiVersion: String by project
+    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
 implementation("dev.tramai:tramai-azure-openai")
 ```
 

--- a/docs/modules/tramai-azure-openai.md
+++ b/docs/modules/tramai-azure-openai.md
@@ -81,8 +81,11 @@ dependencies {
 
 ```kotlin
 val tramaiVersion: String by project
+
+dependencies {
     implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
-implementation("dev.tramai:tramai-azure-openai")
+    implementation("dev.tramai:tramai-azure-openai")
+}
 ```
 
 ### Where to go next

--- a/docs/modules/tramai-azure-openai.md
+++ b/docs/modules/tramai-azure-openai.md
@@ -69,14 +69,6 @@ Azure OpenAI is the primary AI platform for organizations operating in Microsoft
 
 ### How to add
 
-**Gradle (Kotlin DSL):**
-
-```kotlin
-dependencies {
-    implementation("dev.tramai:tramai-azure-openai")  // version from the TramAI BOM
-}
-```
-
 **Bill of Materials:**
 
 ```kotlin

--- a/docs/modules/tramai-bedrock.md
+++ b/docs/modules/tramai-bedrock.md
@@ -26,7 +26,7 @@ Provider adapter for AWS Bedrock: `ModelProvider` implementation using the Bedro
 
 ### Lifecycle ownership
 
-- Provider owns its SDK client lifecycle; no engine state ownership
+- Provider creates a Bedrock SDK client per call (via the injected `BedrockRuntimeClientFactory`) and closes it in a `finally` block; no long-lived client or engine state ownership
 
 ### Thread-safety and concurrency
 
@@ -77,7 +77,8 @@ dependencies {
 **Bill of Materials:**
 
 ```kotlin
-implementation(platform("dev.tramai:tramai-bom"))  // version from the BOM
+val tramaiVersion: String by project
+    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
 implementation("dev.tramai:tramai-bedrock")
 ```
 

--- a/docs/modules/tramai-bedrock.md
+++ b/docs/modules/tramai-bedrock.md
@@ -1,12 +1,52 @@
 # Module: `tramai-bedrock`
 
 > **One-liner:** Provider for Amazon Bedrock using the InvokeModel API — translates TramAI's unified message model to the Claude (Anthropic) format.
-> **Module type:** `provider`
-> **Source files:** 1 — `BedrockProvider.kt` (323 LOC)
-> **Test files:** 1 — `BedrockProviderTest.kt` (121 LOC)
-> **Group:** `dev.tramai`, **Version:** `0.3.1`
 
 ---
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Provider adapter for AWS Bedrock: `ModelProvider` implementation using the Bedrock Runtime SDK (AWS SDK auth/regions).
+
+### Public entry points
+
+- `BedrockProvider` — `ModelProvider` implementation (verify against `tramai-bedrock/api/tramai-bedrock.api`)
+
+### Internal extension points
+
+- AWS SDK credential/auth wiring — not consumer seams
+
+### Significant dependencies
+
+- `api(tramai-core)`; AWS SDK (bedrock-runtime, auth, regions) + Jackson + coroutines (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Provider owns its SDK client lifecycle; no engine state ownership
+
+### Thread-safety and concurrency
+
+- Provider must be safe for concurrent invocation by the engine
+
+### Failure semantics
+
+- Provider failures normalized to `ProviderException` per core contracts
+
+### Contract tests / TCKs
+
+- `BedrockProviderTckTest` — enrolled in the provider TCK
+
+### Do not
+
+- Do not implement retry/fallback/circuit logic here — the engine owns that
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — provider-adapters layer
 
 ## L1: Quick Start (30-second read)
 
@@ -30,14 +70,14 @@ Amazon Bedrock is AWS's managed AI service, providing access to Claude, Llama, a
 
 ```kotlin
 dependencies {
-    implementation("dev.tramai:tramai-bedrock:0.5.0")
+    implementation("dev.tramai:tramai-bedrock")  // version from the TramAI BOM
 }
 ```
 
 **Bill of Materials:**
 
 ```kotlin
-implementation(platform("dev.tramai:tramai-bom:0.5.0"))
+implementation(platform("dev.tramai:tramai-bom"))  // version from the BOM
 implementation("dev.tramai:tramai-bedrock")
 ```
 

--- a/docs/modules/tramai-bedrock.md
+++ b/docs/modules/tramai-bedrock.md
@@ -1,6 +1,6 @@
 # Module: `tramai-bedrock`
 
-> **One-liner:** Provider for Amazon Bedrock using the InvokeModel API — translates TramAI's unified message model to the Claude (Anthropic) format.
+> **One-liner:** Provider for Amazon Bedrock — translates TramAI's unified message model to the Claude (Anthropic) format and streams via the Bedrock Runtime SDK.
 
 ---
 
@@ -52,7 +52,7 @@ Provider adapter for AWS Bedrock: `ModelProvider` implementation using the Bedro
 
 ### What
 
-`tramai-bedrock` is a `ModelProvider` + `StreamCapable` implementation that connects Tramai to Amazon Bedrock via the `InvokeModel` API. It translates TramAI's unified message model into the Claude Messages format (Anthropic) and back.
+`tramai-bedrock` is a `ModelProvider` + `StreamCapable` implementation that connects Tramai to Amazon Bedrock. Non-streaming calls use the synchronous `invokeModel` API; streaming uses the async `invokeModelWithResponseStream` API. It translates TramAI's unified message model into the Claude Messages format (Anthropic) and back.
 
 ### Why
 
@@ -78,8 +78,11 @@ dependencies {
 
 ```kotlin
 val tramaiVersion: String by project
+
+dependencies {
     implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
-implementation("dev.tramai:tramai-bedrock")
+    implementation("dev.tramai:tramai-bedrock")
+}
 ```
 
 ### Where to go next
@@ -87,7 +90,7 @@ implementation("dev.tramai:tramai-bedrock")
 | If you want to... | Go here |
 |---|---|
 | Wire a provider into a working app | `docs/modules/tramai-standalone.md` |
-| Use Spring Boot auto-configuration | `docs/modules/tramai-spring.md` |
+| Use Spring Boot auto-configuration | `docs/architecture/modules.md` (framework-integrations layer; `tramai-spring-core` / unified starter, `tramai-spring` is the legacy facade) |
 | Understand the Anthropic message format | `docs/modules/tramai-anthropic.md` (L3) |
 
 ---
@@ -154,7 +157,7 @@ interface StreamingService {
 }
 ```
 
-For Bedrock, streaming uses the same `InvokeModel` endpoint — the response body is read and emitted as tokens through a `Flow`.
+For Bedrock, streaming uses `invokeModelWithResponseStream` on the async SDK client. Incremental `content_block_delta` events (`text_delta`) are emitted as `StreamChunk.Token(...)` deltas through a `Flow` as they arrive — not a single whole-body read.
 
 ### Tool calling
 
@@ -187,7 +190,7 @@ The provider supports image inputs via `ContentPart.ImagePart` and `ContentPart.
 
 ### Design philosophy
 
-`tramai-bedrock` is a **standalone provider** — it implements its own transport layer using the AWS SDK (`BedrockRuntimeClient`) rather than delegating to `OpenAiCompatibleProvider`. This is necessary because Bedrock uses the `InvokeModel` API with model-specific payloads, not the OpenAI `/chat/completions` format.
+`tramai-bedrock` is a **standalone provider** — it implements its own transport layer using the AWS Bedrock Runtime SDK (`BedrockRuntimeAsyncClient`) rather than delegating to `OpenAiCompatibleProvider`. This is necessary because Bedrock uses model-specific payloads with AWS Signature V4 auth, not the OpenAI `/chat/completions` format.
 
 ### Payload translation
 
@@ -204,24 +207,28 @@ The provider translates TramAI's unified message model to the Claude Messages fo
 
 ### Inner mechanics
 
-**Non-streaming flow:**
+**Non-streaming flow:** (uses the synchronous `invokeModel` API)
 
 ```
 1. Build Claude payload: { anthropic_version, max_tokens, messages, system?, tools?, temperature? }
 2. Wrap in InvokeModelRequest with modelId and contentType: "application/json"
-3. Call bedrockRuntimeClient.invokeModel()
+3. Call client.invokeModel() (BedrockRuntimeAsyncClient, suspend/awaitCancellable)
 4. Parse response body: content[] → extract text blocks and tool_use blocks
 5. Map stop_reason → FinishReason (end_turn→STOP, max_tokens→LENGTH, tool_use→STOP, content_filtered→CONTENT_FILTER)
 6. Return ModelResponse with usage (input_tokens, output_tokens)
 ```
 
-**Streaming flow:**
+**Streaming flow:** (uses `invokeModelWithResponseStream` on `BedrockRuntimeAsyncClient`)
 
 ```
 1. Build same Claude payload
-2. InvokeModel — read entire response body
-3. Extract text from content[] blocks
-4. Emit StreamChunk.Token(fullText) followed by StreamChunk.Complete
+2. InvokeModelWithResponseStreamRequest with modelId + payload
+3. BedrockRuntimeAsyncClient.invokeModelWithResponseStream(...) → SdkPublisher<ResponseStream>
+4. Subscribe; onNext(PayloadPart) parses each JSON event:
+     - message_start          → capture input_tokens (usage)
+     - content_block_delta    → text_delta → emit StreamChunk.Token(text) as it arrives
+     - message_delta          → capture final output_tokens
+5. Complete emitted once the invoke future resolves
 ```
 
 ### Authentication model
@@ -244,8 +251,10 @@ Authentication uses AWS Signature V4 via the `AwsCredentialsProvider` interface.
 ```
 BedrockProvider (final)     ← implements ModelProvider, StreamCapable
     │
-    └── uses BedrockRuntimeClient (AWS SDK)
-        └── authenticated via AwsCredentialsProvider
+    ├── uses BedrockRuntimeAsyncClient (AWS SDK, per-call via BedrockRuntimeClientFactory)
+    │     ├── invokeModel()                        (non-streaming)
+    │     └── invokeModelWithResponseStream()      (streaming, SdkPublisher<ResponseStream>)
+    └── authenticated via AwsCredentialsProvider
 ```
 
 ### Dependency graph
@@ -255,13 +264,13 @@ tramai-bedrock
   Depends on:
     - tramai-core (api)        — ModelProvider, ModelRequest, ModelResponse,
                                  StreamCapable, ProviderCapability
-    - aws-bedrockruntime (impl) — InvokeModel API
+    - aws-bedrockruntime (impl) — invokeModel / invokeModelWithResponseStream APIs
     - aws-auth (impl)          — credentials chain
     - jackson-databind (impl)  — JSON payload construction
 
   Depended on by:
     - tramai-standalone        — wired via Tramai.builder().provider()
-    - tramai-spring            — auto-configuration discovers BedrockProvider beans
+    - tramai-spring-core       — auto-configuration discovers BedrockProvider beans (`tramai-spring` is the legacy facade)
 ```
 
 ### Capabilities

--- a/docs/modules/tramai-bedrock.md
+++ b/docs/modules/tramai-bedrock.md
@@ -66,14 +66,6 @@ Amazon Bedrock is AWS's managed AI service, providing access to Claude, Llama, a
 
 ### How to add
 
-**Gradle (Kotlin DSL):**
-
-```kotlin
-dependencies {
-    implementation("dev.tramai:tramai-bedrock")  // version from the TramAI BOM
-}
-```
-
 **Bill of Materials:**
 
 ```kotlin

--- a/docs/modules/tramai-bedrock.md
+++ b/docs/modules/tramai-bedrock.md
@@ -52,7 +52,7 @@ Provider adapter for AWS Bedrock: `ModelProvider` implementation using the Bedro
 
 ### What
 
-`tramai-bedrock` is a `ModelProvider` + `StreamCapable` implementation that connects Tramai to Amazon Bedrock. Non-streaming calls use the synchronous `invokeModel` API; streaming uses the async `invokeModelWithResponseStream` API. It translates TramAI's unified message model into the Claude Messages format (Anthropic) and back.
+`tramai-bedrock` is a `ModelProvider` + `StreamCapable` implementation that connects Tramai to Amazon Bedrock. Non-streaming calls use the non-streaming `invokeModel` operation; streaming uses `invokeModelWithResponseStream` — both on the async `BedrockRuntimeAsyncClient`. It translates TramAI's unified message model into the Claude Messages format (Anthropic) and back.
 
 ### Why
 
@@ -207,7 +207,7 @@ The provider translates TramAI's unified message model to the Claude Messages fo
 
 ### Inner mechanics
 
-**Non-streaming flow:** (uses the synchronous `invokeModel` API)
+**Non-streaming flow:** (uses the non-streaming `invokeModel` operation on the async client)
 
 ```
 1. Build Claude payload: { anthropic_version, max_tokens, messages, system?, tools?, temperature? }

--- a/docs/modules/tramai-bom.md
+++ b/docs/modules/tramai-bom.md
@@ -107,7 +107,7 @@ Gradle's `platform()` notation activates the version constraints from the BOM. A
 To **override** a single module version (e.g., to test a snapshot), declare an explicit version on the module coordinate — the explicit version wins over the BOM constraint:
 
 ```kotlin
-implementation("dev.tramai:tramai-openai:0.6.0-SNAPSHOT")
+implementation("dev.tramai:tramai-openai:0.5.0")  // explicit version wins
 ```
 
 ### Maven

--- a/docs/modules/tramai-bom.md
+++ b/docs/modules/tramai-bom.md
@@ -1,11 +1,53 @@
 # Module: `tramai-bom`
 
 > **One-liner:** Bill of materials — a single-import Maven BOM (Gradle `java-platform`) that aligns versions of all Tramai publishable modules so consumers never worry about cross-module version mismatches.
-> **Module type:** `platform`
-> **Group:** `dev.tramai`, **Version:** `0.3.1`
-> **Module file:** `build.gradle.kts` (23 lines)
 
 ---
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Bill of materials — a `java-platform`/Maven BOM aligning versions of all Tramai publishable modules so consumers never worry about cross-module version mismatches.
+
+### Public entry points
+
+- BOM artifact only (`dev.tramai:tramai-bom`) — no code API
+
+### Internal extension points
+
+- None — publication-only module
+
+### Significant dependencies
+
+- `api()` of every publishable project (platform constraints) — see [module-catalog.yml](../../config/quality/module-catalog.yml) and [module-matrix.md](../../docs/reference/module-matrix.md)
+
+### Lifecycle ownership
+
+- No runtime resource lifecycle; publication artifact only
+
+### Thread-safety and concurrency
+
+- N/A — no runtime code
+
+### Failure semantics
+
+- N/A — no runtime code; BOM drift is caught by the module-manifest verifier
+
+### Contract tests / TCKs
+
+- BOM consistency verified by build-time platform checks (dependencyManagement completeness)
+
+### Do not
+
+- Do not add implementation code here — constraints only
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — core-contracts layer
+- [module-matrix.md](../../docs/reference/module-matrix.md)
 
 ## L1: Quick Start (30-second read)
 
@@ -23,7 +65,7 @@ Tramai has **11 publishable modules** (`tramai-core`, `tramai-engine`, `tramai-s
 - `tramai-spring` depends on several modules
 - `tramai-testing` depends on `tramai-core` and `tramai-engine`
 
-Without a BOM, a consumer who mixes versions (e.g., `tramai-core:0.5.0` with `tramai-engine:0.5.0`) risks `NoSuchMethodError`, binary-incompatible SPI types, or broken annotation processing at runtime. The BOM eliminates this category of error entirely.
+Without a BOM, a consumer who mixes versions (e.g., `tramai-core` with `tramai-engine` (stale version example)`) risks `NoSuchMethodError`, binary-incompatible SPI types, or broken annotation processing at runtime. The BOM eliminates this category of error entirely.
 
 ### When to use the BOM
 
@@ -40,7 +82,7 @@ Without a BOM, a consumer who mixes versions (e.g., `tramai-core:0.5.0` with `tr
 ```kotlin
 dependencies {
     // 1. Import the BOM
-    implementation(platform("dev.tramai:tramai-bom:0.5.0"))
+    implementation(platform("dev.tramai:tramai-bom"))  // version from the BOM
 
     // 2. Declare Tramai modules without versions
     implementation("dev.tramai:tramai-orchestration")
@@ -49,12 +91,12 @@ dependencies {
 }
 ```
 
-Gradle's `platform()` notation activates the version constraints from the BOM. All three modules resolve to `0.3.1` — the version declared in the BOM for each.
+Gradle's `platform()` notation activates the version constraints from the BOM. All three modules resolve to the version declared in the BOM for each.
 
 To **override** a single module version (e.g., to test a snapshot):
 
 ```kotlin
-implementation("dev.tramai:tramai-openai:0.5.0") // explicit version wins
+implementation("dev.tramai:tramai-openai")  // version from the TramAI BOM // explicit version wins
 ```
 
 ### Maven
@@ -65,7 +107,7 @@ implementation("dev.tramai:tramai-openai:0.5.0") // explicit version wins
         <dependency>
             <groupId>dev.tramai</groupId>
             <artifactId>tramai-bom</artifactId>
-            <version>0.5.0</version>
+            <version>${tramai.version}</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -119,7 +161,7 @@ dependencies {
 }
 ```
 
-When published, Gradle resolves each `project()` reference to the **current project version** (`tramaiVersion`, default `0.3.1`). The resulting POM contains a `<dependencyManagement>` block that lists every module with its resolved version.
+When published, Gradle resolves each `project()` reference to the **current project version** (`tramaiVersion`, see `gradle.properties`). The resulting POM contains a `<dependencyManagement>` block that lists every module with its resolved version.
 
 ### Versions it pins
 

--- a/docs/modules/tramai-bom.md
+++ b/docs/modules/tramai-bom.md
@@ -48,24 +48,32 @@ Bill of materials — a `java-platform`/Maven BOM aligning versions of all Trama
 
 - [ARCHITECTURE.md](../../ARCHITECTURE.md) — core-contracts layer
 - [module-matrix.md](../../docs/reference/module-matrix.md)
-
 ## L1: Quick Start (30-second read)
 
 ### What
 
-`tramai-bom` is a **Gradle `java-platform`** (published as a Maven BOM with `packaging=pom`) that declares version constraints for every Tramai module that ships a JAR. It contains no source code — only a single `dependencies.constraints` block that pins each module to the current project version.
+`tramai-bom` is a **Gradle `java-platform`** (published as a Maven BOM with `packaging=pom`) that declares version constraints for every Tramai module that ships a JAR. It contains no source code — only a constraints block that pins each module to the current project version.
 
 When a consumer imports the BOM, all Tramai dependencies resolve to the same version without the consumer needing to specify individual versions.
 
+### Membership is manifest-derived
+
+BOM membership is **not hand-maintained**. It is computed from the authoritative manifest by `ModuleManifest.bomModulePaths(...)` in `build-logic/src/main/kotlin/dev/tramai/build/quality/ModuleManifest.kt`:
+
+```kotlin
+fun bomModulePaths(entries: Collection<ModuleCatalog.ModuleEntry>): List<String> =
+    entries.filter {
+        it.path != ":tramai-bom" &&
+            it.publishability == ModulePublishability.PUBLISHED &&
+            it.releaseInclusion == ReleaseInclusion.INCLUDED
+    }.map { it.path }.sorted()
+```
+
+Every module whose manifest entry is `publishability: published` and `releaseInclusion: included` (excluding `tramai-bom` itself) is a BOM member — the same filter that drives the generated [module matrix](../../docs/reference/module-matrix.md). Adding or removing a module from the BOM is done by editing `module-catalog.yml`, never by editing this card or the constraints block by hand.
+
 ### Why
 
-Tramai has **11 publishable modules** (`tramai-core`, `tramai-engine`, `tramai-structured`, `tramai-anthropic`, `tramai-openai`, `tramai-ollama`, `tramai-observability`, `tramai-orchestration`, `tramai-standalone`, `tramai-spring`, `tramai-testing`). These modules have deep internal dependencies:
-
-- `tramai-orchestration` depends on `tramai-engine` and `tramai-structured`
-- `tramai-spring` depends on several modules
-- `tramai-testing` depends on `tramai-core` and `tramai-engine`
-
-Without a BOM, a consumer who mixes versions (e.g., `tramai-core` with `tramai-engine` (stale version example)`) risks `NoSuchMethodError`, binary-incompatible SPI types, or broken annotation processing at runtime. The BOM eliminates this category of error entirely.
+Tramai modules have deep internal dependencies. Without a BOM, a consumer who mixes versions risks `NoSuchMethodError`, binary-incompatible SPI types, or broken annotation processing at runtime. The BOM eliminates this category of error entirely.
 
 ### When to use the BOM
 
@@ -80,9 +88,12 @@ Without a BOM, a consumer who mixes versions (e.g., `tramai-core` with `tramai-e
 ### Gradle (Kotlin DSL)
 
 ```kotlin
+// tramaiVersion is the canonical version property (see gradle.properties)
+val tramaiVersion: String by project
+
 dependencies {
     // 1. Import the BOM
-    implementation(platform("dev.tramai:tramai-bom"))  // version from the BOM
+    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
 
     // 2. Declare Tramai modules without versions
     implementation("dev.tramai:tramai-orchestration")
@@ -91,12 +102,12 @@ dependencies {
 }
 ```
 
-Gradle's `platform()` notation activates the version constraints from the BOM. All three modules resolve to the version declared in the BOM for each.
+Gradle's `platform()` notation activates the version constraints from the BOM. All declared modules resolve to the version declared in the BOM.
 
-To **override** a single module version (e.g., to test a snapshot):
+To **override** a single module version (e.g., to test a snapshot), declare an explicit version on the module coordinate — the explicit version wins over the BOM constraint:
 
 ```kotlin
-implementation("dev.tramai:tramai-openai")  // version from the TramAI BOM // explicit version wins
+implementation("dev.tramai:tramai-openai:0.6.0-SNAPSHOT")
 ```
 
 ### Maven
@@ -131,62 +142,22 @@ The BOM's `packaging=pom` is verified at publication time — the CI pipeline ch
 
 ### How it works
 
-`tramai-bom` uses Gradle's **`java-platform`** plugin, which produces a Maven BOM POM with a `<dependencyManagement>` section.
-
-The `build.gradle.kts` is straightforward:
-
-```kotlin
-plugins {
-    `java-platform`
-}
-
-javaPlatform {
-    allowDependencies()  // permits the platform itself to have dependencies if needed
-}
-
-dependencies {
-    constraints {
-        api(project(":tramai-core"))
-        api(project(":tramai-engine"))
-        api(project(":tramai-structured"))
-        api(project(":tramai-anthropic"))
-        api(project(":tramai-openai"))
-        api(project(":tramai-ollama"))
-        api(project(":tramai-observability"))
-        api(project(":tramai-orchestration"))
-        api(project(":tramai-standalone"))
-        api(project(":tramai-spring"))
-        api(project(":tramai-testing"))
-    }
-}
-```
+`tramai-bom` uses Gradle's **`java-platform`** plugin, which produces a Maven BOM POM with a `<dependencyManagement>` section. The constraints block is generated from the manifest-derived membership (see above), not copied by hand.
 
 When published, Gradle resolves each `project()` reference to the **current project version** (`tramaiVersion`, see `gradle.properties`). The resulting POM contains a `<dependencyManagement>` block that lists every module with its resolved version.
 
-### Versions it pins
+### What it pins
 
-The BOM pins **all JAR-publishing Tramai modules** — that is, every publishable project except `tramai-bom` itself:
-
-- **`tramai-core`** — core: annotations, SPI, data models, exceptions
-- **`tramai-engine`** — orchestration: proxy dispatch, retry, provider resolution
-- **`tramai-structured`** — structured output: schema gen, extraction, deserialization, failure analysis
-- **`tramai-anthropic`** — provider: Anthropic Claude model provider
-- **`tramai-openai`** — provider: OpenAI / Azure OpenAI model provider
-- **`tramai-ollama`** — provider: Ollama local model provider
-- **`tramai-observability`** — observability: OpenTelemetry hooks (optional plugin)
-- **`tramai-orchestration`** — workflow: `@AiService` / `@Operation` / `@AiTool` DSL
-- **`tramai-standalone`** — runtime: minimal framework-free entry point
-- **`tramai-spring`** — adapter: Spring Boot auto-configuration
-- **`tramai-testing`** — testing: deterministic test utilities, mock providers
+The BOM pins every manifest entry with `publishability: published` and `releaseInclusion: included`, except `tramai-bom` itself. For the authoritative current list, see the generated [module matrix](../../docs/reference/module-matrix.md) — do not maintain a module list in this card.
 
 External (third-party) dependencies like OkHttp, Jackson, or OpenTelemetry SDK are **not** pinned by `tramai-bom` — those are managed by each module's own dependency declarations and the consumer's own platform constraints.
 
 ### Verification
 
-The root `build.gradle.kts` includes a **`verifyPublicationMetadata`** task that enforces:
+Build-time checks enforce:
 
 - The BOM POM has `packaging=pom`
-- The `<dependencyManagement>` section exists and contains exactly one `<dependency>` entry for each publishable JAR module
-- The set of managed artifact IDs matches `jarPublishingProjectNames` (all publishable modules minus `tramai-bom`)
+- The `<dependencyManagement>` section exists and contains exactly one `<dependency>` entry for each manifest-derived BOM member
+- The set of managed artifact IDs matches the publishable, release-included module set (minus `tramai-bom`)
 
 This prevents accidental omissions or extra entries during development. The BOM is also excluded from JAR/sources/javadoc publication — no `-sources.jar` or `-javadoc.jar` is emitted for it.

--- a/docs/modules/tramai-bom.md
+++ b/docs/modules/tramai-bom.md
@@ -22,7 +22,7 @@ Bill of materials — a `java-platform`/Maven BOM aligning versions of all Trama
 
 ### Significant dependencies
 
-- `api()` of every publishable project (platform constraints) — see [module-catalog.yml](../../config/quality/module-catalog.yml) and [module-matrix.md](../../docs/reference/module-matrix.md)
+- `api()` of the manifest-derived BOM member set (published + release-included, excluding `tramai-bom` itself) — see [module-catalog.yml](../../config/quality/module-catalog.yml) and [module-matrix.md](../../docs/reference/module-matrix.md)
 
 ### Lifecycle ownership
 
@@ -58,7 +58,7 @@ When a consumer imports the BOM, all Tramai dependencies resolve to the same ver
 
 ### Membership is manifest-derived
 
-BOM membership is **not hand-maintained**. It is computed from the authoritative manifest by `ModuleManifest.bomModulePaths(...)` in `build-logic/src/main/kotlin/dev/tramai/build/quality/ModuleManifest.kt`:
+BOM membership is derived from the same authoritative manifest represented by the generated module matrix. The matrix contains **all** manifest modules; BOM membership is the **published + release-included subset, excluding `tramai-bom`** — computed by `ModuleManifest.bomModulePaths(...)` in `build-logic/src/main/kotlin/dev/tramai/build/quality/ModuleManifest.kt`:
 
 ```kotlin
 fun bomModulePaths(entries: Collection<ModuleCatalog.ModuleEntry>): List<String> =
@@ -69,7 +69,7 @@ fun bomModulePaths(entries: Collection<ModuleCatalog.ModuleEntry>): List<String>
     }.map { it.path }.sorted()
 ```
 
-Every module whose manifest entry is `publishability: published` and `releaseInclusion: included` (excluding `tramai-bom` itself) is a BOM member — the same filter that drives the generated [module matrix](../../docs/reference/module-matrix.md). Adding or removing a module from the BOM is done by editing `module-catalog.yml`, never by editing this card or the constraints block by hand.
+Every module whose manifest entry is `publishability: published` and `releaseInclusion: included` (excluding `tramai-bom` itself) is a BOM member. Adding or removing a module from the BOM is done by editing `module-catalog.yml`, never by editing this card or the constraints block by hand. (Note: the generated module matrix renders *all* manifest modules; BOM membership is the published + release-included subset.)
 
 ### Why
 

--- a/docs/modules/tramai-dashboard.md
+++ b/docs/modules/tramai-dashboard.md
@@ -72,13 +72,9 @@ Don't use this module when:
 - You have your own monitoring solution (Grafana, Datadog, etc.)
 ```
 
-### How to add
-```kotlin
-// build.gradle.kts
-dependencies {
-    implementation("dev.tramai:tramai-dashboard")  // version from the TramAI BOM
-}
-```
+### How to include (repository-internal)
+
+`tramai-dashboard` is **not published** — it is composed inside the TramAI monorepo as a Gradle project dependency (e.g. by `tramai-server`/deployment packaging). There is no external Maven coordinate and the BOM does not manage it.
 
 ### Where to go next
 - [tramai-server](./tramai-server.md) — The REST API the dashboard consumes

--- a/docs/modules/tramai-dashboard.md
+++ b/docs/modules/tramai-dashboard.md
@@ -14,7 +14,9 @@ Spring Boot dashboard module: settings UI/controller for runtime configuration s
 
 ### Public entry points
 
-- `DashboardAutoConfiguration`, `DashboardSettingsController`, `DashboardMarker` (verify against `tramai-dashboard/api/tramai-dashboard.api`)
+This module is **internal** (manifest: `publishability: internal`, `apiStability: internal`, `releaseInclusion: internal_only`) — there is **no published consumer API**. The following are repository-facing JVM-public entry points only (visible in `tramai-dashboard/api/tramai-dashboard.api`, not for external consumption):
+
+- `DashboardAutoConfiguration`, `DashboardSettingsController`, `DashboardMarker`
 
 ### Internal extension points
 

--- a/docs/modules/tramai-dashboard.md
+++ b/docs/modules/tramai-dashboard.md
@@ -1,12 +1,52 @@
 # Module: `tramai-dashboard`
 
 > **One-liner:** Vue 3 admin UI for managing TramAI workflows, schedules, and workers.
-> **Module type:** `platform`
-> **Source files:** 3 — `DashboardAutoConfiguration.kt`, `DashboardMarker.kt`, `DashboardSettingsController.kt` (124 LOC)
-> **Test files:** 0
-> **Build:** `dev.tramai:tramai-dashboard:0.5.0`
 
 ---
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Spring Boot dashboard module: settings UI/controller for runtime configuration surfaces (`DashboardAutoConfiguration`, `DashboardSettingsController`).
+
+### Public entry points
+
+- `DashboardAutoConfiguration`, `DashboardSettingsController`, `DashboardMarker` (verify against `tramai-dashboard/api/tramai-dashboard.api`)
+
+### Internal extension points
+
+- Dashboard settings/controller wiring (Spring beans)
+
+### Significant dependencies
+
+- `spring-boot-starter-web` (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Spring context lifecycle
+
+### Thread-safety and concurrency
+
+- Spring singletons; controller must be safe for concurrent HTTP requests
+
+### Failure semantics
+
+- Controller errors surface as HTTP error responses
+
+### Contract tests / TCKs
+
+- Covered via server/dashboard integration tests
+
+### Do not
+
+- Do not add engine/provider logic here — this is a presentation/ops surface
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — operations-observability layer
 
 ## L1: Quick Start (30-second read)
 
@@ -34,7 +74,7 @@ Don't use this module when:
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("dev.tramai:tramai-dashboard:0.5.0")
+    implementation("dev.tramai:tramai-dashboard")  // version from the TramAI BOM
 }
 ```
 

--- a/docs/modules/tramai-dashboard.md
+++ b/docs/modules/tramai-dashboard.md
@@ -14,7 +14,7 @@ Spring Boot dashboard module: settings UI/controller for runtime configuration s
 
 ### Public entry points
 
-This module is **internal** (manifest: `publishability: internal`, `apiStability: internal`, `releaseInclusion: internal_only`) — there is **no published consumer API**. The following are repository-facing JVM-public entry points only (visible in `tramai-dashboard/api/tramai-dashboard.api`, not for external consumption):
+This module is **not published for external consumption** — there is **no published consumer API**. Authoritative classification (layer, maturity, publishability, release) is in `module-catalog.yml` / the module matrix. The following are repository-facing JVM-public entry points only (visible in `tramai-dashboard/api/tramai-dashboard.api`, not for external consumption):
 
 - `DashboardAutoConfiguration`, `DashboardSettingsController`, `DashboardMarker`
 

--- a/docs/modules/tramai-deepseek.md
+++ b/docs/modules/tramai-deepseek.md
@@ -26,7 +26,7 @@ Provider adapter for DeepSeek's OpenAI-compatible API: `ModelProvider` implement
 
 ### Lifecycle ownership
 
-- Provider owns its HTTP client lifecycle; no engine state ownership
+- Provider retains an injected/default `HttpClient` (constructor default `HttpClient.newHttpClient()`) and exposes no close contract; no engine state ownership
 
 ### Thread-safety and concurrency
 
@@ -77,7 +77,8 @@ dependencies {
 **Bill of Materials:**
 
 ```kotlin
-implementation(platform("dev.tramai:tramai-bom"))  // version from the BOM
+val tramaiVersion: String by project
+    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
 implementation("dev.tramai:tramai-deepseek")
 ```
 

--- a/docs/modules/tramai-deepseek.md
+++ b/docs/modules/tramai-deepseek.md
@@ -66,14 +66,6 @@ DeepSeek offers competitive pricing and strong performance on coding and reasoni
 
 ### How to add
 
-**Gradle (Kotlin DSL):**
-
-```kotlin
-dependencies {
-    implementation("dev.tramai:tramai-deepseek")  // version from the TramAI BOM
-}
-```
-
 **Bill of Materials:**
 
 ```kotlin

--- a/docs/modules/tramai-deepseek.md
+++ b/docs/modules/tramai-deepseek.md
@@ -1,12 +1,52 @@
 # Module: `tramai-deepseek`
 
 > **One-liner:** Provider for DeepSeek's OpenAI-compatible chat completion API — a thin wrapper around `OpenAiCompatibleProvider`.
-> **Module type:** `provider`
-> **Source files:** 1 — `DeepSeekProvider.kt` (63 LOC)
-> **Test files:** none (tested via `tramai-openai` coverage since the provider delegates entirely to `OpenAiCompatibleProvider`)
-> **Group:** `dev.tramai`, **Version:** `0.3.1`
 
 ---
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Provider adapter for DeepSeek's OpenAI-compatible API: `ModelProvider` implementation.
+
+### Public entry points
+
+- `DeepSeekProvider` — `ModelProvider` implementation (verify against `tramai-deepseek/api/tramai-deepseek.api`)
+
+### Internal extension points
+
+- OpenAI-compatible transport internals (reuses `tramai-openai` infrastructure)
+
+### Significant dependencies
+
+- `api(tramai-core)`, `api(tramai-openai)` (compatibility base); coroutines + Jackson (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Provider owns its HTTP client lifecycle; no engine state ownership
+
+### Thread-safety and concurrency
+
+- Provider must be safe for concurrent invocation by the engine
+
+### Failure semantics
+
+- Provider failures normalized to `ProviderException` per core contracts
+
+### Contract tests / TCKs
+
+- `DeepSeekProviderTckTest` — enrolled in the provider TCK
+
+### Do not
+
+- Do not fork OpenAI transport logic — reuse `tramai-openai`
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — provider-adapters layer
 
 ## L1: Quick Start (30-second read)
 
@@ -30,14 +70,14 @@ DeepSeek offers competitive pricing and strong performance on coding and reasoni
 
 ```kotlin
 dependencies {
-    implementation("dev.tramai:tramai-deepseek:0.5.0")
+    implementation("dev.tramai:tramai-deepseek")  // version from the TramAI BOM
 }
 ```
 
 **Bill of Materials:**
 
 ```kotlin
-implementation(platform("dev.tramai:tramai-bom:0.5.0"))
+implementation(platform("dev.tramai:tramai-bom"))  // version from the BOM
 implementation("dev.tramai:tramai-deepseek")
 ```
 

--- a/docs/modules/tramai-deepseek.md
+++ b/docs/modules/tramai-deepseek.md
@@ -78,8 +78,11 @@ dependencies {
 
 ```kotlin
 val tramaiVersion: String by project
+
+dependencies {
     implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
-implementation("dev.tramai:tramai-deepseek")
+    implementation("dev.tramai:tramai-deepseek")
+}
 ```
 
 ### Where to go next

--- a/docs/modules/tramai-embedding.md
+++ b/docs/modules/tramai-embedding.md
@@ -67,8 +67,12 @@ This module bundles standard integrations natively:
 
 ```kotlin
 // build.gradle.kts
+// tramaiVersion is the canonical version property (see gradle.properties)
+val tramaiVersion: String by project
+
 dependencies {
-    implementation("dev.tramai:tramai-embedding")  // version from the TramAI BOM
+    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
+    implementation("dev.tramai:tramai-embedding")
 }
 ```
 

--- a/docs/modules/tramai-embedding.md
+++ b/docs/modules/tramai-embedding.md
@@ -1,7 +1,5 @@
 # tramai-embedding
 
-**Status:** Stable  
-**Role:** Text embedding generation.
 
 > **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
 
@@ -33,7 +31,7 @@ Verify against `tramai-embedding/api/tramai-embedding.api`.
 
 ### Thread-safety and concurrency
 
-- Registry and models are safe for concurrent use (stateless beyond configuration)
+- The `EmbeddingModelRegistry` is immutable after build; concurrent reads are safe. Individual `EmbeddingModel` implementations have no blanket concurrency contract — check each model's documentation before sharing across threads.
 
 ### Failure semantics
 

--- a/docs/modules/tramai-embedding.md
+++ b/docs/modules/tramai-embedding.md
@@ -1,8 +1,55 @@
 # tramai-embedding
 
-**Version:** 0.3.1  
 **Status:** Stable  
 **Role:** Text embedding generation.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Embedding model integration: `EmbeddingModelRegistry`, `EmbeddingModel` SPI, concrete Ollama and OpenAI embedding models.
+
+### Public entry points
+
+- `EmbeddingModelRegistry` (+ builder), `EmbeddingModel` SPI
+- `OllamaEmbeddingModel`, `OpenAiEmbeddingModel`
+- `EmbeddingConfig`, `EmbeddingException`
+
+Verify against `tramai-embedding/api/tramai-embedding.api`.
+
+### Internal extension points
+
+- New embedding-provider implementations (the public model SPI is listed under Public entry points)
+
+### Significant dependencies
+
+- No project deps beyond coroutines + Jackson (implementation) — models use direct HTTP. See [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Registry/model instances are caller-owned; no process lifecycle owned here
+
+### Thread-safety and concurrency
+
+- Registry and models are safe for concurrent use (stateless beyond configuration)
+
+### Failure semantics
+
+- Embedding failures as `EmbeddingException` with context
+
+### Contract tests / TCKs
+
+- `EmbeddingModelRegistryTest`
+
+### Do not
+
+- Do not couple embedding models to the chat-provider SPI — this is a separate capability
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — higher-capabilities layer
 
 ## Purpose
 
@@ -23,7 +70,7 @@ This module bundles standard integrations natively:
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("dev.tramai:tramai-embedding:0.5.0")
+    implementation("dev.tramai:tramai-embedding")  // version from the TramAI BOM
 }
 ```
 

--- a/docs/modules/tramai-engine.md
+++ b/docs/modules/tramai-engine.md
@@ -109,8 +109,11 @@ dependencies {
 ```kotlin
 // tramaiVersion is the canonical version property (see gradle.properties)
 val tramaiVersion: String by project
-implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
-implementation("dev.tramai:tramai-engine")
+
+dependencies {
+    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
+    implementation("dev.tramai:tramai-engine")
+}
 ```
 
 ### Where to go next

--- a/docs/modules/tramai-gemini.md
+++ b/docs/modules/tramai-gemini.md
@@ -26,7 +26,7 @@ Provider adapter for Google Gemini API: `ModelProvider` implementation.
 
 ### Lifecycle ownership
 
-- Provider owns its HTTP client lifecycle; no engine state ownership
+- Provider retains an injected/default `HttpClient` (constructor default `HttpClient.newHttpClient()`) and exposes no close contract; no engine state ownership
 
 ### Thread-safety and concurrency
 
@@ -78,7 +78,8 @@ dependencies {
 **Bill of Materials:**
 
 ```kotlin
-implementation(platform("dev.tramai:tramai-bom"))  // version from the BOM
+val tramaiVersion: String by project
+    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
 implementation("dev.tramai:tramai-gemini")
 ```
 

--- a/docs/modules/tramai-gemini.md
+++ b/docs/modules/tramai-gemini.md
@@ -67,14 +67,6 @@ Gemini offers competitive pricing, a generous free tier, large context windows, 
 
 ### How to add
 
-**Gradle (Kotlin DSL):**
-
-```kotlin
-dependencies {
-    implementation("dev.tramai:tramai-gemini")  // version from the TramAI BOM
-}
-```
-
 **Bill of Materials:**
 
 ```kotlin

--- a/docs/modules/tramai-gemini.md
+++ b/docs/modules/tramai-gemini.md
@@ -1,12 +1,52 @@
 # Module: `tramai-gemini`
 
 > **One-liner:** Provider for Google Gemini API — translates TramAI's unified message model to Gemini's `generateContent` / `streamGenerateContent` endpoints.
-> **Module type:** `provider`
-> **Source files:** 1 — `GeminiProvider.kt` (406 LOC)
-> **Test files:** 1 — `GeminiProviderTest.kt` (426 LOC)
-> **Group:** `dev.tramai`, **Version:** `0.3.1`
 
 ---
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Provider adapter for Google Gemini API: `ModelProvider` implementation.
+
+### Public entry points
+
+- `GeminiProvider` — `ModelProvider` implementation (verify against `tramai-gemini/api/tramai-gemini.api`)
+
+### Internal extension points
+
+- Provider transport internals (HTTP client, JSON mapping)
+
+### Significant dependencies
+
+- `api(tramai-core)`; coroutines + Jackson (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Provider owns its HTTP client lifecycle; no engine state ownership
+
+### Thread-safety and concurrency
+
+- Provider must be safe for concurrent invocation by the engine
+
+### Failure semantics
+
+- Provider failures normalized to `ProviderException` per core contracts
+
+### Contract tests / TCKs
+
+- `GeminiProviderTckTest` — enrolled in the provider TCK
+
+### Do not
+
+- Do not implement retry/fallback/circuit logic here — the engine owns that
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — provider-adapters layer
 
 ## L1: Quick Start (30-second read)
 
@@ -31,14 +71,14 @@ Gemini offers competitive pricing, a generous free tier, large context windows, 
 
 ```kotlin
 dependencies {
-    implementation("dev.tramai:tramai-gemini:0.5.0")
+    implementation("dev.tramai:tramai-gemini")  // version from the TramAI BOM
 }
 ```
 
 **Bill of Materials:**
 
 ```kotlin
-implementation(platform("dev.tramai:tramai-bom:0.5.0"))
+implementation(platform("dev.tramai:tramai-bom"))  // version from the BOM
 implementation("dev.tramai:tramai-gemini")
 ```
 

--- a/docs/modules/tramai-gemini.md
+++ b/docs/modules/tramai-gemini.md
@@ -79,8 +79,11 @@ dependencies {
 
 ```kotlin
 val tramaiVersion: String by project
+
+dependencies {
     implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
-implementation("dev.tramai:tramai-gemini")
+    implementation("dev.tramai:tramai-gemini")
+}
 ```
 
 ### Where to go next

--- a/docs/modules/tramai-mcp.md
+++ b/docs/modules/tramai-mcp.md
@@ -1,13 +1,58 @@
 # Module: `tramai-mcp`
 
 > **One-liner:** Exposes registered Tramai workflows as MCP (Model Context Protocol) tools — `list_workflows`, `run_workflow`, `resume_workflow`, `get_workflow_status` — over stdio or SSE transport, so AI agents can discover and invoke workflows through the standard MCP contract.
-> **Module type:** `adapter`
-> **Source files:** 3 — `TramaiMcpServer.kt`, `McpToolHandlers.kt`, `TramaiMcpAutoConfiguration.kt`
-> **Test files:** 1 — `TramaiMcpServerTest.kt`
-> **Build:** `dev.tramai:tramai-mcp:0.5.0`
 > **Depends on:** `tramai-server` (required), `tramai-structured` (required), `spring-boot-autoconfigure`, `spring-context`, MCP Kotlin SDK, Ktor CIO
 
 ---
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+MCP (Model Context Protocol) integration: expose TramAI tools via MCP and host an MCP server (stdio/SSE) backed by `tramai-server`.
+
+### Public entry points
+
+- `TramaiMcpServer` — MCP server entry point
+- `TramaiMcpAutoConfiguration`, `TramaiMcpProperties` (Stdio/Sse) — Spring auto-configuration
+- `McpToolHandlers` — tool-to-MCP handler mapping
+- `ToolExecutionException`
+
+Verify against `tramai-mcp/api/tramai-mcp.api`.
+
+### Internal extension points
+
+- MCP transport selection (stdio/SSE) via properties
+
+### Significant dependencies
+
+- `api(tramai-server)`; `implementation(tramai-structured)`; MCP SDK server, Ktor CIO, Spring autoconfigure/context, Okio (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Server lifecycle (start/stop) owned by the host; Spring beans by the context
+
+### Thread-safety and concurrency
+
+- MCP server must handle concurrent tool invocations
+
+### Failure semantics
+
+- Tool failures surface as `ToolExecutionException` mapped to MCP error responses
+
+### Contract tests / TCKs
+
+- `TramaiMcpServerTest`
+
+### Do not
+
+- Do not add provider adapters here — MCP is a protocol surface, not a provider
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — operations-observability layer
 
 ## L1: Quick Start (30-second read)
 
@@ -53,7 +98,7 @@ Don't use this module when:
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation(platform("dev.tramai:tramai-bom:0.5.0"))
+    implementation(platform("dev.tramai:tramai-bom"))  // version from the BOM
     implementation("dev.tramai:tramai-server")  // required dependency
     implementation("dev.tramai:tramai-mcp")
 }
@@ -66,7 +111,7 @@ dependencies {
     <dependency>
       <groupId>dev.tramai</groupId>
       <artifactId>tramai-bom</artifactId>
-      <version>0.5.0</version>
+      <version>${tramai.version}</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>
@@ -259,7 +304,7 @@ class TramaiMcpServer(
 ```
 
 **Server construction (init block):** Creates an MCP SDK `Server` with:
-- `serverInfo` — name `"tramai-mcp"`, version `"0.3.1"`
+- `serverInfo` — name `"tramai-mcp"`, version (module version)
 - `capabilities` — tools support (`listChanged = false`)
 - Four `addTool(...)` registrations, each wiring a tool definition to its handler via `handleCall { ... }`
 

--- a/docs/modules/tramai-mcp.md
+++ b/docs/modules/tramai-mcp.md
@@ -15,7 +15,7 @@ MCP (Model Context Protocol) integration: expose TramAI tools via MCP and host a
 
 ### Public entry points
 
-This module is **internal** (manifest: `publishability: internal`, `apiStability: internal`, `releaseInclusion: internal_only`) — there is **no published consumer API**. The following are repository-facing JVM-public entry points only (visible in `tramai-mcp/api/tramai-mcp.api`, not for external consumption):
+This module is **not published for external consumption** — there is **no published consumer API**. Authoritative classification (layer, maturity, publishability, release) is in `module-catalog.yml` / the module matrix. The following are repository-facing JVM-public entry points only (visible in `tramai-mcp/api/tramai-mcp.api`, not for external consumption):
 
 - `TramaiMcpServer` — MCP server entry point
 - `TramaiMcpAutoConfiguration`, `TramaiMcpProperties` (Stdio/Sse) — Spring auto-configuration

--- a/docs/modules/tramai-mcp.md
+++ b/docs/modules/tramai-mcp.md
@@ -104,18 +104,6 @@ dependencies {
 }
 ```
 
-<dependencies>
-  <dependency>
-    <groupId>dev.tramai</groupId>
-    <artifactId>tramai-server</artifactId>
-  </dependency>
-  <dependency>
-    <groupId>dev.tramai</groupId>
-    <artifactId>tramai-mcp</artifactId>
-  </dependency>
-</dependencies>
-```
-
 ### Configuration
 
 The adapter activates automatically via Spring Boot auto-configuration when the workflow server beans (`WorkflowRegistry`, `WorkflowRunStore`, `WorkflowController`) are present. It binds under the `tramai.mcp.*` namespace:
@@ -260,7 +248,7 @@ tramai-mcp
   ├── api: tramai-server
   │     └── WorkflowRegistry, WorkflowRunStore, WorkflowController
   │
-  ├── api: tramai-structured
+  ├── impl: tramai-structured
   │     └── JacksonStructuredOutputHandler (schema generation)
   │
   ├── impl: MCP Kotlin SDK (io.modelcontextprotocol:kotlin-sdk-server:0.11.1)

--- a/docs/modules/tramai-mcp.md
+++ b/docs/modules/tramai-mcp.md
@@ -93,31 +93,16 @@ Don't use this module when:
 - You want to avoid the MCP SDK dependency
 ```
 
-### How to add
+### How to include (repository-internal)
+
+`tramai-mcp` is **not published** — it is composed inside the TramAI monorepo as a Gradle project dependency (it depends on `tramai-server`). There is no external Maven coordinate and the BOM does not manage it:
 
 ```kotlin
-// build.gradle.kts
+// within the TramAI monorepo (build.gradle.kts of an MCP host)
 dependencies {
-    val tramaiVersion: String by project
-    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
-    implementation("dev.tramai:tramai-server")  // required dependency
-    implementation("dev.tramai:tramai-mcp")
+    implementation(project(":tramai-mcp"))
 }
 ```
-
-```xml
-<!-- pom.xml -->
-<dependencyManagement>
-  <dependencies>
-    <dependency>
-      <groupId>dev.tramai</groupId>
-      <artifactId>tramai-bom</artifactId>
-      <version>${tramai.version}</version>
-      <type>pom</type>
-      <scope>import</scope>
-    </dependency>
-  </dependencies>
-</dependencyManagement>
 
 <dependencies>
   <dependency>

--- a/docs/modules/tramai-mcp.md
+++ b/docs/modules/tramai-mcp.md
@@ -15,12 +15,12 @@ MCP (Model Context Protocol) integration: expose TramAI tools via MCP and host a
 
 ### Public entry points
 
+This module is **internal** (manifest: `publishability: internal`, `apiStability: internal`, `releaseInclusion: internal_only`) — there is **no published consumer API**. The following are repository-facing JVM-public entry points only (visible in `tramai-mcp/api/tramai-mcp.api`, not for external consumption):
+
 - `TramaiMcpServer` — MCP server entry point
 - `TramaiMcpAutoConfiguration`, `TramaiMcpProperties` (Stdio/Sse) — Spring auto-configuration
 - `McpToolHandlers` — tool-to-MCP handler mapping
 - `ToolExecutionException`
-
-Verify against `tramai-mcp/api/tramai-mcp.api`.
 
 ### Internal extension points
 
@@ -98,7 +98,8 @@ Don't use this module when:
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation(platform("dev.tramai:tramai-bom"))  // version from the BOM
+    val tramaiVersion: String by project
+    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
     implementation("dev.tramai:tramai-server")  // required dependency
     implementation("dev.tramai:tramai-mcp")
 }

--- a/docs/modules/tramai-memory-store.md
+++ b/docs/modules/tramai-memory-store.md
@@ -1,7 +1,5 @@
 # tramai-memory-store
 
-**Status:** Stable  
-**Role:** Service Provider Interface (SPI) for persistent chat history.
 
 > **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
 
@@ -9,14 +7,14 @@
 
 ### Responsibility
 
-Persistent chat-memory stores: `JdbcChatMemoryStore`, `RedisChatMemoryStore` implementing the core memory-store contract.
+Durable memory-store implementations: `JdbcChatMemoryStore`, `RedisChatMemoryStore` implementing the `ChatMemoryStore` contract (the SPI lives in `tramai-core`; this module provides implementations, not the interface).
 
 ### Public entry points
 
+This module is **internal** (manifest: `publishability: internal`, `apiStability: internal`, `releaseInclusion: internal_only`) — there is **no published consumer API**. The following are repository-facing JVM-public entry points only (visible in `tramai-memory-store/api/tramai-memory-store.api`, not for external consumption):
+
 - `JdbcChatMemoryStore`, `RedisChatMemoryStore` — `ChatMemoryStore` implementations
 - `JdbcChatMemoryTable` (schema)
-
-Verify against `tramai-memory-store/api/tramai-memory-store.api`.
 
 ### Internal extension points
 

--- a/docs/modules/tramai-memory-store.md
+++ b/docs/modules/tramai-memory-store.md
@@ -1,8 +1,54 @@
 # tramai-memory-store
 
-**Version:** 0.3.1  
 **Status:** Stable  
 **Role:** Service Provider Interface (SPI) for persistent chat history.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Persistent chat-memory stores: `JdbcChatMemoryStore`, `RedisChatMemoryStore` implementing the core memory-store contract.
+
+### Public entry points
+
+- `JdbcChatMemoryStore`, `RedisChatMemoryStore` — `ChatMemoryStore` implementations
+- `JdbcChatMemoryTable` (schema)
+
+Verify against `tramai-memory-store/api/tramai-memory-store.api`.
+
+### Internal extension points
+
+- New memory-store implementations (the public core memory-store SPI is listed under Public entry points)
+
+### Significant dependencies
+
+- `api(tramai-core)`; Jedis, Jackson (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Stores borrow caller-supplied connections/pools; ownership remains with the caller
+
+### Thread-safety and concurrency
+
+- Stores must be safe for concurrent access; JDBC/Redis connection handling is store-scoped
+
+### Failure semantics
+
+- Store failures surface as typed errors; no silent partial writes
+
+### Contract tests / TCKs
+
+- `JdbcChatMemoryStoreTckTest`, `RedisChatMemoryStoreTckTest` — enrolled in the memory-store TCK
+
+### Do not
+
+- Do not add engine/Spring dependencies here
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — higher-capabilities layer
 
 ## Purpose
 
@@ -55,7 +101,7 @@ found in the `tramai-memory` module.
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("dev.tramai:tramai-memory-store:0.5.0")
+    implementation("dev.tramai:tramai-memory-store")  // version from the TramAI BOM
 }
 ```
 

--- a/docs/modules/tramai-memory-store.md
+++ b/docs/modules/tramai-memory-store.md
@@ -11,14 +11,14 @@ Durable memory-store implementations: `JdbcChatMemoryStore`, `RedisChatMemorySto
 
 ### Public entry points
 
-This module is **internal** (manifest: `publishability: internal`, `apiStability: internal`, `releaseInclusion: internal_only`) — there is **no published consumer API**. The following are repository-facing JVM-public entry points only (visible in `tramai-memory-store/api/tramai-memory-store.api`, not for external consumption):
+This module is **not published for external consumption** — there is **no published consumer API**. Authoritative classification (layer, maturity, publishability, release) is in `module-catalog.yml` / the module matrix. The following are repository-facing JVM-public entry points only (visible in `tramai-memory-store/api/tramai-memory-store.api`, not for external consumption):
 
 - `JdbcChatMemoryStore`, `RedisChatMemoryStore` — `ChatMemoryStore` implementations
 - `JdbcChatMemoryTable` (schema)
 
 ### Internal extension points
 
-- New memory-store implementations (the public core memory-store SPI is listed under Public entry points)
+- New memory-store implementations; the `ChatMemoryStore` contract itself lives in `tramai-core` (not this module's public surface)
 
 ### Significant dependencies
 

--- a/docs/modules/tramai-memory-store.md
+++ b/docs/modules/tramai-memory-store.md
@@ -96,12 +96,7 @@ found in the `tramai-memory` module.
 
 ## Dependencies
 
-```kotlin
-// build.gradle.kts
-dependencies {
-    implementation("dev.tramai:tramai-memory-store")  // version from the TramAI BOM
-}
-```
+`tramai-memory-store` is **not published** — the implementations are composed inside the TramAI monorepo (e.g. by deployment packaging or example applications) as Gradle project dependencies. There is no external Maven coordinate and the BOM does not manage it.
 
 ## Quick Start: Using a Store
 

--- a/docs/modules/tramai-memory.md
+++ b/docs/modules/tramai-memory.md
@@ -1,8 +1,54 @@
 # tramai-memory
 
-**Version:** 0.3.1  
 **Status:** Stable  
 **Role:** In-memory context and token-aware multi-turn conversational chat persistence.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Conversational memory: chat-memory implementations (`MessageWindowChatMemory`, `PersistentChatMemory`, `TokenAwareChatMemory`) and the `MemoryInterceptor` engine hook.
+
+### Public entry points
+
+- `MessageWindowChatMemory`, `PersistentChatMemory`, `TokenAwareChatMemory` — `ChatMemory` implementations
+- `MemoryInterceptor` — engine observation hook wiring memory
+
+Verify against `tramai-memory/api/tramai-memory.api`.
+
+### Internal extension points
+
+- New memory implementations (the public core memory SPI is listed under Public entry points)
+
+### Significant dependencies
+
+- `api(tramai-core)` only — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Memory instances are caller-owned; no process lifecycle owned here
+
+### Thread-safety and concurrency
+
+- Memory implementations must be safe for concurrent engine access
+
+### Failure semantics
+
+- Memory persistence failures surface as typed errors; injection must not break the happy path
+
+### Contract tests / TCKs
+
+- `MemoryInterceptorTest`, `MessageWindowChatMemoryTest`, `PersistentChatMemoryTest`, `TokenAwareChatMemoryTest`
+
+### Do not
+
+- Do not add provider/Spring dependencies here
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — higher-capabilities layer
 
 ## Purpose
 
@@ -30,9 +76,9 @@ Connects a `ChatMemoryStore` (database) with an optional in-memory cache (`Messa
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("dev.tramai:tramai-memory:0.5.0")
+    implementation("dev.tramai:tramai-memory")  // version from the TramAI BOM
     // If you need durable storage (Postgres, Redis, File):
-    implementation("dev.tramai:tramai-memory-store:0.5.0")
+    implementation("dev.tramai:tramai-memory-store")  // version from the TramAI BOM
 }
 ```
 

--- a/docs/modules/tramai-memory.md
+++ b/docs/modules/tramai-memory.md
@@ -73,10 +73,14 @@ Connects a `ChatMemoryStore` (database) with an optional in-memory cache (`Messa
 
 ```kotlin
 // build.gradle.kts
+// tramaiVersion is the canonical version property (see gradle.properties)
+val tramaiVersion: String by project
+
 dependencies {
-    implementation("dev.tramai:tramai-memory")  // version from the TramAI BOM
-    // If you need durable storage (Postgres, Redis, File):
-    implementation("dev.tramai:tramai-memory-store")  // version from the TramAI BOM
+    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
+    implementation("dev.tramai:tramai-memory")
+    // For durable storage (Postgres, Redis): also add tramai-memory-store
+    implementation("dev.tramai:tramai-memory-store")
 }
 ```
 

--- a/docs/modules/tramai-memory.md
+++ b/docs/modules/tramai-memory.md
@@ -1,7 +1,5 @@
 # tramai-memory
 
-**Status:** Stable  
-**Role:** In-memory context and token-aware multi-turn conversational chat persistence.
 
 > **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
 

--- a/docs/modules/tramai-ollama.md
+++ b/docs/modules/tramai-ollama.md
@@ -1,12 +1,52 @@
 # Module: `tramai-ollama`
 
 > **One-liner:** Provider for locally-hosted Ollama models via the Ollama chat API.
-> **Module type:** `provider`
-> **Source files:** 1 file — `OllamaProvider.kt` (156 LOC)
-> **Test files:** 2 — `OllamaProviderTest.kt`, `NativeImageSmokeTest.kt`
-> **Build:** `dev.tramai:tramai-ollama:0.5.0`
 
 ---
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Provider adapter for Ollama (local models): `ModelProvider` implementation.
+
+### Public entry points
+
+- `OllamaProvider` — `ModelProvider` implementation (verify against `tramai-ollama/api/tramai-ollama.api`)
+
+### Internal extension points
+
+- Provider transport internals (HTTP client, JSON mapping)
+
+### Significant dependencies
+
+- `api(tramai-core)`; coroutines + Jackson (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Provider owns its HTTP client lifecycle; no engine state ownership
+
+### Thread-safety and concurrency
+
+- Provider must be safe for concurrent invocation by the engine
+
+### Failure semantics
+
+- Provider failures normalized to `ProviderException` per core contracts
+
+### Contract tests / TCKs
+
+- `OllamaProviderTckTest` — enrolled in the provider TCK
+
+### Do not
+
+- Do not implement retry/fallback/circuit logic here — the engine owns that
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — provider-adapters layer
 
 ## L1: Quick Start (30-second read)
 
@@ -36,7 +76,7 @@ Don't use this module when:
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("dev.tramai:tramai-ollama:0.5.0")
+    implementation("dev.tramai:tramai-ollama")  // version from the TramAI BOM
 }
 ```
 
@@ -45,7 +85,7 @@ dependencies {
 <dependency>
     <groupId>dev.tramai</groupId>
     <artifactId>tramai-ollama</artifactId>
-    <version>0.5.0</version>
+    <version>${tramai.version}</version>
 </dependency>
 ```
 

--- a/docs/modules/tramai-ollama.md
+++ b/docs/modules/tramai-ollama.md
@@ -26,7 +26,7 @@ Provider adapter for Ollama (local models): `ModelProvider` implementation.
 
 ### Lifecycle ownership
 
-- Provider owns its HTTP client lifecycle; no engine state ownership
+- Provider retains an injected/default `HttpClient` (constructor default `HttpClient.newHttpClient()`) and exposes no close contract; no engine state ownership
 
 ### Thread-safety and concurrency
 

--- a/docs/modules/tramai-ollama.md
+++ b/docs/modules/tramai-ollama.md
@@ -72,11 +72,16 @@ Don't use this module when:
 - Ollama is not installed on your machine or network
 ```
 
-### How to add
+## Dependencies
+
 ```kotlin
 // build.gradle.kts
+// tramaiVersion is the canonical version property (see gradle.properties)
+val tramaiVersion: String by project
+
 dependencies {
-    implementation("dev.tramai:tramai-ollama")  // version from the TramAI BOM
+    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
+    implementation("dev.tramai:tramai-ollama")
 }
 ```
 

--- a/docs/modules/tramai-openai.md
+++ b/docs/modules/tramai-openai.md
@@ -98,8 +98,11 @@ dependencies {
 
 ```kotlin
 val tramaiVersion: String by project
+
+dependencies {
     implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
-implementation("dev.tramai:tramai-openai")
+    implementation("dev.tramai:tramai-openai")
+}
 ```
 
 ### Where to go next

--- a/docs/modules/tramai-openai.md
+++ b/docs/modules/tramai-openai.md
@@ -1,12 +1,56 @@
 # Module: `tramai-openai`
 
 > **One-liner:** OpenAI-compatible model provider with support for OpenAI API, Together AI, Groq, vLLM, and any `/chat/completions` endpoint.
-> **Module type:** `provider`
-> **Source files:** 2 — `OpenAiProvider.kt` (430 LOC) + `ExperimentalCodexAuth.kt`
-> **Test files:** 2 — `OpenAiProviderTest.kt`, `OpenAiProviderIntegrationTest.kt`
-> **Build:** `dev.tramai:tramai-openai:0.5.0`
 
 ---
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Provider adapter for OpenAI and OpenAI-compatible APIs: `OpenAiProvider`, `OpenAiCompatibleProvider`, access-token sources (static, Codex auth file).
+
+### Public entry points
+
+- `OpenAiProvider`, `OpenAiCompatibleProvider` — `ModelProvider` implementations
+- `StaticOpenAiAccessTokenSource`, `CodexAuthFileTokenSource` — access-token sources
+- `ExperimentalCodexAuth` annotation
+
+Verify against `tramai-openai/api/tramai-openai.api`.
+
+### Internal extension points
+
+- Access-token source seam; OpenAI-compatible base transport (reused by `tramai-deepseek`)
+
+### Significant dependencies
+
+- `api(tramai-core)`; coroutines + Jackson (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Provider owns its HTTP client lifecycle; no engine state ownership
+
+### Thread-safety and concurrency
+
+- Provider must be safe for concurrent invocation by the engine
+
+### Failure semantics
+
+- Provider failures normalized to `ProviderException` per core contracts
+
+### Contract tests / TCKs
+
+- `OpenAiProviderTckTest`, `OpenAiCompatibleProviderTckTest`, `OpenAiStreamingTest` — enrolled in the provider TCK
+
+### Do not
+
+- Do not implement retry/fallback/circuit logic here — the engine owns that
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — provider-adapters layer
 
 ## L1: Quick Start (30-second read)
 
@@ -36,7 +80,7 @@ Don't use this module when you need a non-OpenAI-compatible provider — use `tr
 
 ```kotlin
 dependencies {
-    implementation("dev.tramai:tramai-openai:0.5.0")
+    implementation("dev.tramai:tramai-openai")  // version from the TramAI BOM
 }
 ```
 
@@ -46,14 +90,14 @@ dependencies {
 <dependency>
     <groupId>dev.tramai</groupId>
     <artifactId>tramai-openai</artifactId>
-    <version>0.5.0</version>
+    <version>${tramai.version}</version>
 </dependency>
 ```
 
 **Bill of Materials:**
 
 ```kotlin
-implementation(platform("dev.tramai:tramai-bom:0.5.0"))
+implementation(platform("dev.tramai:tramai-bom"))  // version from the BOM
 implementation("dev.tramai:tramai-openai")
 ```
 
@@ -65,7 +109,7 @@ implementation("dev.tramai:tramai-openai")
 | Use Spring Boot auto-configuration | `docs/modules/tramai-spring.md` |
 | Understand the provider SPI contract | `docs/modules/tramai-core.md` (L3: ModelProvider) |
 | Learn about streaming in general | `docs/modules/tramai-engine.md` (L2: Streaming) |
-| See the full OpenAI-compatible wire format spec | `docs/specs/spec-003.md` |
+| See the full OpenAI-compatible wire format spec | `docs/specs/spec-003-provider-integration.md` |
 
 ---
 

--- a/docs/modules/tramai-openai.md
+++ b/docs/modules/tramai-openai.md
@@ -76,14 +76,6 @@ Don't use this module when you need a non-OpenAI-compatible provider — use `tr
 
 ### How to add
 
-**Gradle (Kotlin DSL):**
-
-```kotlin
-dependencies {
-    implementation("dev.tramai:tramai-openai")  // version from the TramAI BOM
-}
-```
-
 **Maven:**
 
 ```xml

--- a/docs/modules/tramai-openai.md
+++ b/docs/modules/tramai-openai.md
@@ -30,7 +30,7 @@ Verify against `tramai-openai/api/tramai-openai.api`.
 
 ### Lifecycle ownership
 
-- Provider owns its HTTP client lifecycle; no engine state ownership
+- Provider retains an injected/default `HttpClient` (constructor default `HttpClient.newHttpClient()`) and exposes no close contract; no engine state ownership
 
 ### Thread-safety and concurrency
 
@@ -97,7 +97,8 @@ dependencies {
 **Bill of Materials:**
 
 ```kotlin
-implementation(platform("dev.tramai:tramai-bom"))  // version from the BOM
+val tramaiVersion: String by project
+    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
 implementation("dev.tramai:tramai-openai")
 ```
 
@@ -106,7 +107,7 @@ implementation("dev.tramai:tramai-openai")
 | If you want to... | Go here |
 |---|---|
 | Wire a provider into a working app | `docs/modules/tramai-standalone.md` |
-| Use Spring Boot auto-configuration | `docs/modules/tramai-spring.md` |
+| Use Spring Boot auto-configuration | `docs/architecture/modules.md` (framework-integrations layer; `tramai-spring-core` / unified starter, `tramai-spring` is the legacy facade) |
 | Understand the provider SPI contract | `docs/modules/tramai-core.md` (L3: ModelProvider) |
 | Learn about streaming in general | `docs/modules/tramai-engine.md` (L2: Streaming) |
 | See the full OpenAI-compatible wire format spec | `docs/specs/spec-003-provider-integration.md` |
@@ -434,7 +435,7 @@ tramai-openai
 
   Depended on by:
     - tramai-standalone        — wired via Tramai.builder().provider()
-    - tramai-spring            — auto-configuration discovers OpenAiProvider beans
+    - tramai-spring-core     — auto-configuration discovers OpenAiProvider beans (`tramai-spring` is the legacy facade)
 ```
 
 ### Inner mechanics

--- a/docs/modules/tramai-orchestration.md
+++ b/docs/modules/tramai-orchestration.md
@@ -117,8 +117,11 @@ dependencies {
 ```kotlin
 // tramaiVersion is the canonical version property (see gradle.properties)
 val tramaiVersion: String by project
-implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
-implementation("dev.tramai:tramai-orchestration")
+
+dependencies {
+    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
+    implementation("dev.tramai:tramai-orchestration")
+}
 ```
 
 ### Where to go next

--- a/docs/modules/tramai-platform.md
+++ b/docs/modules/tramai-platform.md
@@ -96,7 +96,8 @@ dependencies {
 **Bill of Materials:**
 
 ```kotlin
-implementation(platform("dev.tramai:tramai-bom"))  // version from the BOM
+val tramaiVersion: String by project
+    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
 implementation("dev.tramai:tramai-platform")
 ```
 

--- a/docs/modules/tramai-platform.md
+++ b/docs/modules/tramai-platform.md
@@ -1,12 +1,56 @@
 # Module: `tramai-platform`
 
 > **One-liner:** Multi-tenant operational layer above the workflow server with API key authentication, token-bucket rate limiting, JDBC audit logging, and a runtime plugin system.
-> **Module type:** `application` (Spring Boot)
-> **Group:** `dev.tramai`, **Version:** `0.3.1`
-> **Source files:** 9, **LOC:** 1,469
-> **Dependencies:** `tramai-orchestration`, `tramai-server`, `spring-boot-starter-web`, `spring-boot-starter-security`
 
 ---
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Platform services: API-key auth/rate limiting, audit log, plugin manager, workflow services — the control plane layered over `tramai-server`/`tramai-orchestration`.
+
+### Public entry points
+
+- `ApiKeyService` / `ApiKeyAuthenticator` / `ApiKeyRateLimiter` / `ApiKeyRepository` — API-key auth and rate limiting
+- `AuditLogService` / `AuditLogRepository` / `AuditLogEntry` — audit
+- `PlatformConfiguration`, `PlatformController`, `PlatformWorkflowService`, `PluginManager`
+
+Verify against `tramai-platform/api/tramai-platform.api`.
+
+### Internal extension points
+
+- Repository implementations (JDBC); plugin lifecycle internals behind the public plugin manager
+
+### Significant dependencies
+
+- `api(tramai-orchestration)`; `implementation(tramai-server)`; Spring JDBC/web/security-crypto, Flyway, Jackson, coroutines (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Spring context lifecycle; plugin lifecycle via `PluginManager`
+
+### Thread-safety and concurrency
+
+- Spring singletons; controllers must be safe for concurrent HTTP requests
+
+### Failure semantics
+
+- Auth/rate-limit failures surface as typed HTTP responses; audit failures are not silent
+
+### Contract tests / TCKs
+
+- `PlatformControllerTest`, `SecurityTest`, `PluginStateRepositoryTest`, `PluginWorkflowStartupValidatorTest`
+
+### Do not
+
+- Do not add provider adapters here — platform is a control plane
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — operations-observability layer
 
 ## L1: Quick Start (30-second read)
 
@@ -45,14 +89,14 @@ Do **not** use it for library-embedded usage (a single process calling workflows
 
 ```kotlin
 dependencies {
-    implementation("dev.tramai:tramai-platform:0.5.0")
+    implementation("dev.tramai:tramai-platform")  // version from the TramAI BOM
 }
 ```
 
 **Bill of Materials:**
 
 ```kotlin
-implementation(platform("dev.tramai:tramai-bom:0.5.0"))
+implementation(platform("dev.tramai:tramai-bom"))  // version from the BOM
 implementation("dev.tramai:tramai-platform")
 ```
 

--- a/docs/modules/tramai-platform.md
+++ b/docs/modules/tramai-platform.md
@@ -97,8 +97,11 @@ dependencies {
 
 ```kotlin
 val tramaiVersion: String by project
+
+dependencies {
     implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
-implementation("dev.tramai:tramai-platform")
+    implementation("dev.tramai:tramai-platform")
+}
 ```
 
 `tramai-platform` is a Spring Boot application (`@SpringBootApplication` on `TramaiPlatformApplication`). It auto-configures all beans via `PlatformConfiguration` — see the [configuration reference](../reference/configuration.md) for property overrides.

--- a/docs/modules/tramai-platform.md
+++ b/docs/modules/tramai-platform.md
@@ -85,14 +85,6 @@ Do **not** use it for library-embedded usage (a single process calling workflows
 
 ### How to add
 
-**Gradle (Kotlin DSL):**
-
-```kotlin
-dependencies {
-    implementation("dev.tramai:tramai-platform")  // version from the TramAI BOM
-}
-```
-
 **Bill of Materials:**
 
 ```kotlin

--- a/docs/modules/tramai-rag.md
+++ b/docs/modules/tramai-rag.md
@@ -71,12 +71,15 @@ The `tramai-rag` module provides a comprehensive pipeline for injecting internal
 
 ```kotlin
 // build.gradle.kts
+// tramaiVersion is the canonical version property (see gradle.properties)
+val tramaiVersion: String by project
+
 dependencies {
-    implementation("dev.tramai:tramai-rag")  // version from the TramAI BOM
-    
+    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
+    implementation("dev.tramai:tramai-rag")
     // RAG pipelines usually require embedding and a vector store
-    implementation("dev.tramai:tramai-embedding")  // version from the TramAI BOM
-    implementation("dev.tramai:tramai-vectorstore-chroma")  // version from the TramAI BOM // Or pgvector
+    implementation("dev.tramai:tramai-embedding")
+    implementation("dev.tramai:tramai-vectorstore-chroma") // or pgvector
 }
 ```
 

--- a/docs/modules/tramai-rag.md
+++ b/docs/modules/tramai-rag.md
@@ -1,7 +1,5 @@
 # tramai-rag
 
-**Status:** Stable  
-**Role:** Retrieval-Augmented Generation context pipeline.
 
 > **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
 

--- a/docs/modules/tramai-rag.md
+++ b/docs/modules/tramai-rag.md
@@ -1,8 +1,56 @@
 # tramai-rag
 
-**Version:** 0.3.1  
 **Status:** Stable  
 **Role:** Retrieval-Augmented Generation context pipeline.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+RAG pipeline: chunking, document loading, retrieval, context injection — composing embeddings + vector stores.
+
+### Public entry points
+
+- `RagPipeline`, `RagRetriever`, `ContextInjector`, `Document`
+- Chunkers: `FixedSizeChunker`, `RecursiveCharacterChunker`, `TokenAwareChunker`
+- Loaders: `FileDocumentLoader`, `UrlDocumentLoader`
+- `RagPipelineException`
+
+Verify against `tramai-rag/api/tramai-rag.api`.
+
+### Internal extension points
+
+- New chunker/document-loader implementations (the public chunking / loading SPIs are listed under Public entry points)
+
+### Significant dependencies
+
+- `api(tramai-core)`, `api(tramai-embedding)`, `api(tramai-vectorstore-spi)`; coroutines (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Pipeline/retriever instances are caller-owned; no process lifecycle owned here
+
+### Thread-safety and concurrency
+
+- Components are safe for concurrent use (stateless beyond configuration)
+
+### Failure semantics
+
+- Pipeline failures as `RagPipelineException` with context
+
+### Contract tests / TCKs
+
+- `ChunkersTest`, `ContextInjectorTest`, `RagPipelineTest`, `RagRetrieverTest`
+
+### Do not
+
+- Do not couple RAG to a specific vector store/provider — use the SPIs
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — higher-capabilities layer
 
 ## Purpose
 
@@ -26,11 +74,11 @@ The `tramai-rag` module provides a comprehensive pipeline for injecting internal
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("dev.tramai:tramai-rag:0.5.0")
+    implementation("dev.tramai:tramai-rag")  // version from the TramAI BOM
     
     // RAG pipelines usually require embedding and a vector store
-    implementation("dev.tramai:tramai-embedding:0.5.0")
-    implementation("dev.tramai:tramai-vectorstore-chroma:0.5.0") // Or pgvector
+    implementation("dev.tramai:tramai-embedding")  // version from the TramAI BOM
+    implementation("dev.tramai:tramai-vectorstore-chroma")  // version from the TramAI BOM // Or pgvector
 }
 ```
 

--- a/docs/modules/tramai-scheduler.md
+++ b/docs/modules/tramai-scheduler.md
@@ -113,8 +113,11 @@ dependencies {
 
 ```kotlin
 val tramaiVersion: String by project
+
+dependencies {
     implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
-implementation("dev.tramai:tramai-scheduler")
+    implementation("dev.tramai:tramai-scheduler")
+}
 ```
 
 ### Where to go next

--- a/docs/modules/tramai-scheduler.md
+++ b/docs/modules/tramai-scheduler.md
@@ -1,12 +1,57 @@
 # Module: `tramai-scheduler`
 
 > **One-liner:** Time-based workflow triggers with cron expressions, delay wakeups, and a durable tick-claiming scheduler loop — backed by in-memory or JDBC stores.
-> **Module type:** `optional`
-> **Group:** `dev.tramai`
-> **Source files:** 5, **LOC:** 2,560
-> **Dependencies:** `tramai-orchestration`, `kotlinx-coroutines-core`, `HikariCP`
 
 ---
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Workflow scheduling: cron/calendar rules, scheduled-workflow timer, workflow scheduler stores (in-memory, JDBC).
+
+### Public entry points
+
+- `CronSchedule` (+ builder), `CalendarRule` — schedule definitions
+- `ScheduledWorkflowTimer` — timer entry point
+- `InMemoryWorkflowSchedulerStore`, `JdbcWorkflowSchedulerStore` — scheduler stores
+- `ScheduleRecord`, `ScheduleStatusView`, `ClaimedScheduledTick`, `ClaimedDelayWakeup`
+
+Verify against `tramai-scheduler/api/tramai-scheduler.api`.
+
+### Internal extension points
+
+- New scheduler-store implementations (the public scheduler-store SPI is listed under Public entry points)
+
+### Significant dependencies
+
+- `api(tramai-orchestration)`; HikariCP, coroutines (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Timer lifecycle (start/stop) owned by the host; scheduler stores borrow caller resources
+
+### Thread-safety and concurrency
+
+- Timer must be safe for concurrent tick dispatch; stores manage their own locking
+
+### Failure semantics
+
+- Scheduling failures surface as typed errors; missed/claimed ticks are recoverable
+
+### Contract tests / TCKs
+
+- `SchedulerTest`, `JdbcSchedulerTest`, `SchedulerIsolationTest`
+
+### Do not
+
+- Do not add workflow-execution logic here — scheduling hands off to orchestration
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — higher-capabilities layer
 
 ## L1: Quick Start (30-second read)
 
@@ -50,7 +95,7 @@ Do **not** use it for:
 
 ```kotlin
 dependencies {
-    implementation("dev.tramai:tramai-scheduler:0.5.0")
+    implementation("dev.tramai:tramai-scheduler")  // version from the TramAI BOM
 }
 ```
 
@@ -60,14 +105,14 @@ dependencies {
 <dependency>
     <groupId>dev.tramai</groupId>
     <artifactId>tramai-scheduler</artifactId>
-    <version>0.5.0</version>
+    <version>${tramai.version}</version>
 </dependency>
 ```
 
 **Bill of Materials:**
 
 ```kotlin
-implementation(platform("dev.tramai:tramai-bom:0.5.0"))
+implementation(platform("dev.tramai:tramai-bom"))  // version from the BOM
 implementation("dev.tramai:tramai-scheduler")
 ```
 
@@ -75,8 +120,8 @@ implementation("dev.tramai:tramai-scheduler")
 
 | Topic | Link |
 |-------|------|
-| Workflow basics with checkpoints and delays | `docs/specs/spec-005.md` |
-| Agent CLI step types | `docs/specs/spec-009.md` |
+| Workflow basics with checkpoints and delays | `docs/specs/spec-012-orchestration-and-coordination.md` |
+| Agent CLI step types | `docs/specs/spec-015-agent-steps.md` |
 
 ---
 

--- a/docs/modules/tramai-scheduler.md
+++ b/docs/modules/tramai-scheduler.md
@@ -91,14 +91,6 @@ Do **not** use it for:
 
 ### How to add
 
-**Gradle (Kotlin DSL):**
-
-```kotlin
-dependencies {
-    implementation("dev.tramai:tramai-scheduler")  // version from the TramAI BOM
-}
-```
-
 **Maven:**
 
 ```xml

--- a/docs/modules/tramai-scheduler.md
+++ b/docs/modules/tramai-scheduler.md
@@ -112,7 +112,8 @@ dependencies {
 **Bill of Materials:**
 
 ```kotlin
-implementation(platform("dev.tramai:tramai-bom"))  // version from the BOM
+val tramaiVersion: String by project
+    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
 implementation("dev.tramai:tramai-scheduler")
 ```
 

--- a/docs/modules/tramai-server.md
+++ b/docs/modules/tramai-server.md
@@ -14,13 +14,13 @@ Spring Boot server: workflow/worker/audit/schedule HTTP endpoints, webhook verif
 
 ### Public entry points
 
+This module is **internal** (manifest: `publishability: internal`, `apiStability: internal`, `releaseInclusion: internal_only`) — there is **no published consumer API**. The following are repository-facing JVM-public entry points only (visible in `tramai-server/api/tramai-server.api`, not for external consumption):
+
 - `TramaiServerApplication` — server entry point
 - Controllers: `WorkflowController`, `WorkerController`, `AuditController`, `ScheduleController`
 - `GitHubWebhookSignatureVerifier`, `RequestBodySizeLimitFilter`, `ReplayCache`
 - Stores: `InMemoryAuditLogStore`, `InMemoryWorkerRegistry`
 - Exceptions: `BadWorkflowRequestException`, `InvalidWebhookSignatureException`, `RequestBodyTooLargeException`
-
-Verify against `tramai-server/api/tramai-server.api`.
 
 ### Internal extension points
 
@@ -109,7 +109,9 @@ dependencies {
 **Bill of Materials:**
 
 ```kotlin
-implementation(platform("dev.tramai:tramai-bom"))  // version from the BOM
+// tramaiVersion is the canonical version property (see gradle.properties)
+val tramaiVersion: String by project
+implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
 implementation("dev.tramai:tramai-server")
 ```
 
@@ -121,7 +123,8 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("dev.tramai:tramai-bom"))  // version from the BOM
+    val tramaiVersion: String by project
+    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
     implementation("dev.tramai:tramai-server")
     implementation("dev.tramai:tramai-orchestration")
     // your workflow definitions

--- a/docs/modules/tramai-server.md
+++ b/docs/modules/tramai-server.md
@@ -96,40 +96,15 @@ Workflows defined with `tramai-orchestration` run inside a JVM process. Without 
 | View schedule status | ✅ `GET /schedules`, `GET /schedules/events` (SSE) |
 | Audit API operations | ✅ `GET /audit` |
 
-### How to add
+### How to include (repository-internal)
 
-**Gradle (Kotlin DSL):**
-
-```kotlin
-dependencies {
-    implementation("dev.tramai:tramai-server")  // version from the TramAI BOM
-}
-```
-
-**Bill of Materials:**
+`tramai-server` is **not published** — it is composed inside the TramAI monorepo as a Gradle project dependency (e.g. by `tramai-mcp`, `tramai-platform`, deployment packaging, and example applications). There is no external Maven coordinate and the BOM does not manage it. In-repo Spring Boot composition looks like:
 
 ```kotlin
-// tramaiVersion is the canonical version property (see gradle.properties)
-val tramaiVersion: String by project
-
+// within the TramAI monorepo (build.gradle.kts of a server host)
 dependencies {
-    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
-    implementation("dev.tramai:tramai-server")
-}
-```
-
-**Using the BOM with Spring Boot:**
-
-```kotlin
-plugins {
-    id("org.springframework.boot")
-}
-
-dependencies {
-    val tramaiVersion: String by project
-    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
-    implementation("dev.tramai:tramai-server")
-    implementation("dev.tramai:tramai-orchestration")
+    implementation(project(":tramai-server"))
+    implementation(project(":tramai-orchestration"))
     // your workflow definitions
 }
 ```

--- a/docs/modules/tramai-server.md
+++ b/docs/modules/tramai-server.md
@@ -14,7 +14,7 @@ Spring Boot server: workflow/worker/audit/schedule HTTP endpoints, webhook verif
 
 ### Public entry points
 
-This module is **internal** (manifest: `publishability: internal`, `apiStability: internal`, `releaseInclusion: internal_only`) — there is **no published consumer API**. The following are repository-facing JVM-public entry points only (visible in `tramai-server/api/tramai-server.api`, not for external consumption):
+This module is **not published for external consumption** — there is **no published consumer API**. Authoritative classification (layer, maturity, publishability, release) is in `module-catalog.yml` / the module matrix. The following are repository-facing JVM-public entry points only (visible in `tramai-server/api/tramai-server.api`, not for external consumption):
 
 - `TramaiServerApplication` — server entry point
 - Controllers: `WorkflowController`, `WorkerController`, `AuditController`, `ScheduleController`
@@ -111,8 +111,11 @@ dependencies {
 ```kotlin
 // tramaiVersion is the canonical version property (see gradle.properties)
 val tramaiVersion: String by project
-implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
-implementation("dev.tramai:tramai-server")
+
+dependencies {
+    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
+    implementation("dev.tramai:tramai-server")
+}
 ```
 
 **Using the BOM with Spring Boot:**

--- a/docs/modules/tramai-server.md
+++ b/docs/modules/tramai-server.md
@@ -1,12 +1,58 @@
 # Module: `tramai-server`
 
 > **One-liner:** HTTP REST API surface for Tramai workflows — start, inspect, resume, cancel, and stream runs; receive webhooks; monitor workers and schedules; query audit logs.
-> **Module type:** `optional`
-> **Group:** `dev.tramai`
-> **Source files:** 12 main, **LOC:** ~1,927 (main)
-> **Dependencies:** `tramai-orchestration`, `tramai-scheduler`, `spring-boot-starter-web`, `spring-boot-starter-validation`, `jackson-module-kotlin`
 
 ---
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Spring Boot server: workflow/worker/audit/schedule HTTP endpoints, webhook verification, request-size limits, in-memory stores.
+
+### Public entry points
+
+- `TramaiServerApplication` — server entry point
+- Controllers: `WorkflowController`, `WorkerController`, `AuditController`, `ScheduleController`
+- `GitHubWebhookSignatureVerifier`, `RequestBodySizeLimitFilter`, `ReplayCache`
+- Stores: `InMemoryAuditLogStore`, `InMemoryWorkerRegistry`
+- Exceptions: `BadWorkflowRequestException`, `InvalidWebhookSignatureException`, `RequestBodyTooLargeException`
+
+Verify against `tramai-server/api/tramai-server.api`.
+
+### Internal extension points
+
+- Audit/worker-registry store implementations
+
+### Significant dependencies
+
+- `api(tramai-orchestration)`; `implementation(tramai-scheduler)`; Spring web/validation, Jackson, coroutines (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Spring context lifecycle; server start/stop via the Spring Boot application
+
+### Thread-safety and concurrency
+
+- Spring singletons; controllers must be safe for concurrent HTTP requests
+
+### Failure semantics
+
+- Invalid requests surface as typed HTTP error responses; signature failures are explicit
+
+### Contract tests / TCKs
+
+- `WorkflowControllerTest`, `WorkerControllerTest`, `AuditControllerTest`, `ScheduleControllerTest`, `WorkerRegistryTest`, `AuditLogStoreTest`
+
+### Do not
+
+- Do not add provider adapters here — server is a hosting surface
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — operations-observability layer
 
 ## L1: Quick Start (30-second read)
 
@@ -56,14 +102,14 @@ Workflows defined with `tramai-orchestration` run inside a JVM process. Without 
 
 ```kotlin
 dependencies {
-    implementation("dev.tramai:tramai-server:0.5.0")
+    implementation("dev.tramai:tramai-server")  // version from the TramAI BOM
 }
 ```
 
 **Bill of Materials:**
 
 ```kotlin
-implementation(platform("dev.tramai:tramai-bom:0.5.0"))
+implementation(platform("dev.tramai:tramai-bom"))  // version from the BOM
 implementation("dev.tramai:tramai-server")
 ```
 
@@ -75,7 +121,7 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("dev.tramai:tramai-bom:0.5.0"))
+    implementation(platform("dev.tramai:tramai-bom"))  // version from the BOM
     implementation("dev.tramai:tramai-server")
     implementation("dev.tramai:tramai-orchestration")
     // your workflow definitions
@@ -98,7 +144,7 @@ fun registerInvoiceWorkflow(): WorkflowRegistration = WorkflowRegistration { reg
 
 | Topic | Link |
 |---|---|
-| Workflow orchestration (steps, checkpointing, resume) | `docs/specs/spec-005.md` |
+| Workflow orchestration (steps, checkpointing, resume) | `docs/specs/spec-012-orchestration-and-coordination.md` |
 | Scheduling (cron, delays, business calendars) | `tramai-scheduler` module doc |
 | Dashboard (admin UI) | `docs/architecture/modules.md` |
 | Server spec | `docs/specs/spec-014-server.md` |

--- a/docs/modules/tramai-vectorstore-chroma.md
+++ b/docs/modules/tramai-vectorstore-chroma.md
@@ -1,7 +1,5 @@
 # tramai-vectorstore-chroma
 
-**Status:** Stable  
-**Role:** ChromaDB implementation of the vector store SPI.
 
 > **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
 

--- a/docs/modules/tramai-vectorstore-chroma.md
+++ b/docs/modules/tramai-vectorstore-chroma.md
@@ -56,8 +56,12 @@ This module provides a concrete implementation of `VectorStore` that connects to
 
 ```kotlin
 // build.gradle.kts
+// tramaiVersion is the canonical version property (see gradle.properties)
+val tramaiVersion: String by project
+
 dependencies {
-    implementation("dev.tramai:tramai-vectorstore-chroma")  // version from the TramAI BOM
+    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
+    implementation("dev.tramai:tramai-vectorstore-chroma")
 }
 ```
 

--- a/docs/modules/tramai-vectorstore-chroma.md
+++ b/docs/modules/tramai-vectorstore-chroma.md
@@ -1,8 +1,54 @@
 # tramai-vectorstore-chroma
 
-**Version:** 0.3.1  
 **Status:** Stable  
 **Role:** ChromaDB implementation of the vector store SPI.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Chroma vector-store adapter: `ChromaVectorStore` implementing the vector-store SPI.
+
+### Public entry points
+
+- `ChromaVectorStore` — `VectorStore` implementation
+- `ChromaException`
+
+Verify against `tramai-vectorstore-chroma/api/tramai-vectorstore-chroma.api`.
+
+### Internal extension points
+
+- Vector-store SPI implementation slot
+
+### Significant dependencies
+
+- `api(tramai-vectorstore-spi)`; coroutines + Jackson (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Store borrows caller-supplied HTTP client; no process lifecycle owned here
+
+### Thread-safety and concurrency
+
+- Store must be safe for concurrent access
+
+### Failure semantics
+
+- Store failures as `ChromaException` with context
+
+### Contract tests / TCKs
+
+- Covered via vector-store SPI TCK where enrolled; integration tests in module
+
+### Do not
+
+- Do not add provider/engine dependencies here
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — higher-capabilities layer
 
 ## Purpose
 
@@ -13,7 +59,7 @@ This module provides a concrete implementation of `VectorStore` that connects to
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("dev.tramai:tramai-vectorstore-chroma:0.5.0")
+    implementation("dev.tramai:tramai-vectorstore-chroma")  // version from the TramAI BOM
 }
 ```
 

--- a/docs/modules/tramai-vectorstore-pgvector.md
+++ b/docs/modules/tramai-vectorstore-pgvector.md
@@ -56,9 +56,13 @@ This module provides a concrete implementation of `VectorStore` that connects to
 
 ```kotlin
 // build.gradle.kts
+// tramaiVersion is the canonical version property (see gradle.properties)
+val tramaiVersion: String by project
+
 dependencies {
-    implementation("dev.tramai:tramai-vectorstore-pgvector")  // version from the TramAI BOM
-    // Depending on your stack, you'll need a JDBC driver (e.g. org.postgresql:postgresql)
+    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
+    implementation("dev.tramai:tramai-vectorstore-pgvector")
+    // Depending on your stack, you also need a JDBC driver (e.g. org.postgresql:postgresql)
 }
 ```
 

--- a/docs/modules/tramai-vectorstore-pgvector.md
+++ b/docs/modules/tramai-vectorstore-pgvector.md
@@ -1,8 +1,54 @@
 # tramai-vectorstore-pgvector
 
-**Version:** 0.3.1  
 **Status:** Stable  
 **Role:** PostgreSQL pgvector implementation of the vector store SPI.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+PostgreSQL pgvector adapter: `PgVectorStore` implementing the vector-store SPI.
+
+### Public entry points
+
+- `PgVectorStore` — `VectorStore` implementation
+- `PgVectorException`
+
+Verify against `tramai-vectorstore-pgvector/api/tramai-vectorstore-pgvector.api`.
+
+### Internal extension points
+
+- Vector-store SPI implementation slot
+
+### Significant dependencies
+
+- `api(tramai-vectorstore-spi)`; PostgreSQL driver, HikariCP, coroutines, Jackson (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Store borrows caller-supplied connection pool; ownership remains with the caller
+
+### Thread-safety and concurrency
+
+- Store must be safe for concurrent access; connection handling is store-scoped
+
+### Failure semantics
+
+- Store failures as `PgVectorException` with context
+
+### Contract tests / TCKs
+
+- Covered via vector-store SPI TCK where enrolled; integration tests in module
+
+### Do not
+
+- Do not add provider/engine dependencies here
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — higher-capabilities layer
 
 ## Purpose
 
@@ -13,7 +59,7 @@ This module provides a concrete implementation of `VectorStore` that connects to
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("dev.tramai:tramai-vectorstore-pgvector:0.5.0")
+    implementation("dev.tramai:tramai-vectorstore-pgvector")  // version from the TramAI BOM
     // Depending on your stack, you'll need a JDBC driver (e.g. org.postgresql:postgresql)
 }
 ```

--- a/docs/modules/tramai-vectorstore-pgvector.md
+++ b/docs/modules/tramai-vectorstore-pgvector.md
@@ -1,7 +1,5 @@
 # tramai-vectorstore-pgvector
 
-**Status:** Stable  
-**Role:** PostgreSQL pgvector implementation of the vector store SPI.
 
 > **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
 

--- a/docs/modules/tramai-vectorstore-spi.md
+++ b/docs/modules/tramai-vectorstore-spi.md
@@ -1,7 +1,5 @@
 # tramai-vectorstore-spi
 
-**Status:** Stable  
-**Role:** Contract layer for Vector Database operations.
 
 > **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
 

--- a/docs/modules/tramai-vectorstore-spi.md
+++ b/docs/modules/tramai-vectorstore-spi.md
@@ -1,8 +1,54 @@
 # tramai-vectorstore-spi
 
-**Version:** 0.3.1  
 **Status:** Stable  
 **Role:** Contract layer for Vector Database operations.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Vector-store SPI: `VectorStore` contract, `VectorEntry`, `SearchResult` — the seam concrete stores (Chroma, pgvector) implement.
+
+### Public entry points
+
+- `VectorStore` — SPI contract
+- `VectorEntry`, `SearchResult` — data types
+
+Verify against `tramai-vectorstore-spi/api/tramai-vectorstore-spi.api`.
+
+### Internal extension points
+
+- New store implementations (the public vector-store contract is listed under Public entry points)
+
+### Significant dependencies
+
+- Coroutines (implementation) only — no project deps. See [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- No process lifecycle owned here; store instances are caller-owned
+
+### Thread-safety and concurrency
+
+- Contract defines no blanket guarantee; each store documents its own concurrency behavior
+
+### Failure semantics
+
+- Contract-level failure types; concrete stores define their own exceptions
+
+### Contract tests / TCKs
+
+- `InMemoryVectorStoreTest`; concrete stores run their own integration/TCK tests
+
+### Do not
+
+- Do not add provider/engine dependencies here
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — higher-capabilities layer
 
 ## Purpose
 
@@ -19,7 +65,7 @@ This module provides the core `VectorStore` interfaces required by `tramai-rag`.
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("dev.tramai:tramai-vectorstore-spi:0.5.0")
+    implementation("dev.tramai:tramai-vectorstore-spi")  // version from the TramAI BOM
 }
 ```
 

--- a/docs/modules/tramai-vectorstore-spi.md
+++ b/docs/modules/tramai-vectorstore-spi.md
@@ -62,8 +62,12 @@ This module provides the core `VectorStore` interfaces required by `tramai-rag`.
 
 ```kotlin
 // build.gradle.kts
+// tramaiVersion is the canonical version property (see gradle.properties)
+val tramaiVersion: String by project
+
 dependencies {
-    implementation("dev.tramai:tramai-vectorstore-spi")  // version from the TramAI BOM
+    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
+    implementation("dev.tramai:tramai-vectorstore-spi")
 }
 ```
 


### PR DESCRIPTION
## Summary

Epic 11.2b2 — normalize all existing **non-Spring** module cards to the C2b1-established 10-heading architecture contract. 23 files, docs-only: 20 C2b2 cards + README + 2 C2b1 cards (tramai-engine, tramai-orchestration) receiving BOM-snippet hygiene only.

## What (23 files, docs-only)

**20 C2b2 cards normalized** (architecture section prepended, useful long-form preserved):

- **Provider adapters (7):** tramai-anthropic, tramai-azure-openai, tramai-bedrock, tramai-deepseek, tramai-gemini, tramai-ollama, tramai-openai
- **Higher capabilities (5):** tramai-embedding, tramai-memory, tramai-memory-store, tramai-rag, tramai-scheduler
- **Vector stores (3):** tramai-vectorstore-spi, tramai-vectorstore-chroma, tramai-vectorstore-pgvector
- **Operations/observability (4):** tramai-dashboard, tramai-mcp, tramai-platform, tramai-server
- **Core contracts (1):** tramai-bom

**`docs/modules/README.md`** updated: C2b2 slice note + new coverage counts.

**C2b1 scope note:** `tramai-engine.md` and `tramai-orchestration.md` were touched only for BOM-snippet hygiene (the same malformed-Kotlin defect fixed in the 7 C2b2 cards); no semantic content changed.

## Rules applied

- **10 required headings** in every card (Responsibility / Public entry points / Internal extension points / Significant dependencies / Lifecycle ownership / Thread-safety and concurrency / Failure semantics / Contract tests / TCKs / Do not / Related architecture).
- **Public entry points verified against `api/*.api`** — 40+ claimed types checked, 0 missing.
- **Whole-section Internal audit** — 0 public types in any Internal section (SPIs referenced by role, not name).
- **Significant dependencies verified against `build.gradle.kts`** (project deps spot-checked, api vs implementation respected).
- **Classification truth links to module-catalog.yml / module-matrix.md** — legacy `Module type:` / Group / Version / Source files / LOC metadata removed.
- **No stale claims:** hard-coded 0.3.1 / 0.5.0 coordinates replaced with BOM placeholders; stale spec links fixed by meaning (spec-003-provider-integration, spec-012-orchestration-and-coordination, spec-015-agent-steps).
- Useful long-form preserved below the architecture section.

## Explicitly NOT in scope

- tramai-spring (legacy facade — Spring slice)
- Missing Spring cards / Spring provider starters / Spring secrets / Spring consumer-boundary modules
- Examples
- 58/58 final verifier
- SPEC-015 status cleanup
- Engine-card 8.2g cleanup (newly-landed #302)

## Coverage

| Metric | Count |
|--------|-------|
| Manifest modules | 58 |
| Module cards | 32 |
| Conforming (C2b1 + C2b2) | **31** |
| Existing non-conforming | 1 (`tramai-spring`) |
| Missing | 26 |
| Orphans | 0 |

## Verification

- 20/20 C2b2 cards have all 10 headings (11 C2b1 cards re-verified).
- Whole-section internal audit: clean.
- Public claims vs API dumps: clean (0 missing).
- Deps vs build.gradle.kts: clean.
- All markdown links + inline repo paths resolve.
- Zero stale version/metadata claims in touched cards.
- `verifyPr` — BUILD SUCCESSFUL (320 tasks).
- `verify060Architecture` — BUILD SUCCESSFUL (92 tasks).

## Non-claims

- No production/build/catalog/baseline changes.
- No module classifications or boundaries modified.
- Not all 58 modules conform yet: 26 missing cards + tramai-spring remain for later slices.

## Review round 6 fixes (MCP cleanup)

1. Removed the leftover Maven `<dependencies>` fragment from `tramai-mcp.md` "How to include (repository-internal)" — the card is internal/unpublished; the `project(":tramai-mcp")` example is the correct composition path. No `dev.tramai:tramai-mcp` / `tramai-server` Maven consumption advertised.
2. L3 module dependency graph: `api: tramai-structured` → `impl: tramai-structured` (actual build.gradle.kts: `api(project(":tramai-server"))` + `implementation(project(":tramai-structured"))`).

Verified: verifyPr (320) + verify060Architecture (92) + verifySovereignRuntimeClosure (471) green; coverage 58/32/31/1/26/0.

This PR needs review before merge.
