### PR TITLE
build(publishing): extract TramAI publishing convention plugin — Epic 9.2a

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -51,5 +51,9 @@ gradlePlugin {
             id = "tramai.maintainability-baseline"
             implementationClass = "dev.tramai.build.quality.MaintainabilityBaselinePlugin"
         }
+        create("tramaiPublishing") {
+            id = "tramai.publishing"
+            implementationClass = "dev.tramai.build.publishing.TramaiPublishingPlugin"
+        }
     }
 }

--- a/build-logic/src/main/kotlin/dev/tramai/build/publishing/TramaiPublicationMetadata.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/publishing/TramaiPublicationMetadata.kt
@@ -1,0 +1,72 @@
+package dev.tramai.build.publishing
+
+import org.gradle.api.Project
+
+/**
+ * Resolved publication metadata for Tramai modules.
+ *
+ * Defaults mirror the historical root build script exactly — 9.2c moves
+ * publication metadata to manifest-derived values deliberately.
+ */
+data class TramaiPublicationMetadata(
+    val projectUrl: String,
+    val scmUrl: String,
+    val scmConnection: String,
+    val scmDeveloperConnection: String,
+    val licenseName: String,
+    val licenseUrl: String,
+    val developerId: String,
+    val developerName: String,
+    val developerEmail: String,
+) {
+    companion object {
+        fun from(project: Project): TramaiPublicationMetadata {
+            fun property(name: String, default: String): String =
+                project.providers.gradleProperty(name).orElse(default).get()
+            return TramaiPublicationMetadata(
+                projectUrl = property("tramaiProjectUrl", "https://github.com/GionaGranchelli/tramAI"),
+                scmUrl = property("tramaiScmUrl", "https://github.com/GionaGranchelli/tramAI.git"),
+                scmConnection = property("tramaiScmConnection", "scm:git:https://github.com/GionaGranchelli/tramAI.git"),
+                scmDeveloperConnection = property("tramaiScmDeveloperConnection", "scm:git:ssh://git@github.com/GionaGranchelli/tramAI.git"),
+                licenseName = property("tramaiLicenseName", "Apache-2.0"),
+                licenseUrl = property("tramaiLicenseUrl", "https://www.apache.org/licenses/LICENSE-2.0.txt"),
+                developerId = property("tramaiDeveloperId", "GionaGranchelli"),
+                developerName = property("tramaiDeveloperName", "Giona"),
+                developerEmail = property("tramaiDeveloperEmail", "opensource@giona.dev"),
+            )
+        }
+    }
+}
+
+/**
+ * Compatibility description policy — moved verbatim from the historical root
+ * build script. Values are deliberately NOT changed in 9.2a; manifest-derived
+ * descriptions land in 9.2c.
+ */
+fun projectDescription(projectName: String): String = when (projectName) {
+    "tramai-core" -> "Core annotations, request models, provider registry, and exception types for Tramai."
+    "tramai-embedding" -> "Embedding model SPI with OpenAI and Ollama implementations for Tramai."
+    "tramai-engine" -> "Runtime engine that turns annotated Tramai service interfaces into executable proxies."
+    "tramai-structured" -> "Structured output schema generation, parsing, and validation support for Tramai."
+    "tramai-anthropic" -> "Anthropic provider integration for Tramai."
+    "tramai-gemini" -> "Google Gemini provider integration for Tramai."
+    "tramai-azure-openai" -> "Azure OpenAI provider integration for Tramai."
+    "tramai-bedrock" -> "AWS Bedrock provider integration for Tramai."
+    "tramai-deepseek" -> "Deepseek provider integration for Tramai."
+    "tramai-memory" -> "In-memory memory and state helpers for Tramai (memory primitives and adapters)."
+    "tramai-openai" -> "OpenAI and OpenAI-compatible provider integrations for Tramai."
+    "tramai-ollama" -> "Ollama provider integration for Tramai."
+    "tramai-observability" -> "OpenTelemetry-based observability hooks for Tramai."
+    "tramai-orchestration" -> "Typed workflow orchestration and coordination layer for Tramai."
+    "tramai-platform" -> "Platform services for plugins, tenancy, API keys, rate limiting, and audit logging."
+    "tramai-standalone" -> "Minimal standalone runtime bundle for Tramai."
+    "tramai-sovereign" -> "Secure embedded runtime profile for sovereign TramAI deployments."
+    "tramai-spring" -> "Spring Boot auto-configuration and integration support for Tramai."
+    "tramai-testing" -> "Testing utilities and deterministic assertion support for Tramai."
+    "tramai-bom" -> "Bill of materials for aligning Tramai module versions."
+    "tramai-vectorstore-spi" -> "Vector store SPI with data models and in-memory implementation for Tramai."
+    "tramai-vectorstore-chroma" -> "ChromaDB vector store adapter for Tramai."
+    "tramai-vectorstore-pgvector" -> "PostgreSQL pgvector vector store adapter for Tramai."
+    "tramai-rag" -> "RAG pipeline: document loading, chunking, retrieval, and context injection for Tramai."
+    else -> "Tramai module ${projectName.removePrefix("tramai-")}."
+}

--- a/build-logic/src/main/kotlin/dev/tramai/build/publishing/TramaiPublishingPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/publishing/TramaiPublishingPlugin.kt
@@ -1,0 +1,125 @@
+package dev.tramai.build.publishing
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.tasks.javadoc.Javadoc
+import org.gradle.plugins.signing.SigningExtension
+
+/**
+ * Tramai publishing convention plugin.
+ *
+ * Applies Maven publication/signing configuration to subprojects that apply
+ * `java-library` or `java-platform`, preserving the historical root build
+ * script behavior exactly (9.2a extraction, behavior-preserving).
+ */
+class TramaiPublishingPlugin : Plugin<Project> {
+
+    override fun apply(project: Project) {
+        project.pluginManager.withPlugin("java-library") {
+            project.pluginManager.apply("maven-publish")
+            project.pluginManager.apply("signing")
+
+            project.extensions.configure(JavaPluginExtension::class.java) {
+                withJavadocJar()
+            }
+            project.tasks.withType(Javadoc::class.java).configureEach {
+                isFailOnError = false
+            }
+
+            configurePublication(project, componentName = "java")
+            configureSovereignBundleLocalRepo(project)
+        }
+
+        project.pluginManager.withPlugin("java-platform") {
+            project.pluginManager.apply("maven-publish")
+            project.pluginManager.apply("signing")
+
+            configurePublication(project, componentName = "javaPlatform")
+            configureSovereignBundleLocalRepo(project)
+        }
+    }
+
+    private fun configurePublication(project: Project, componentName: String) {
+        val metadata = TramaiPublicationMetadata.from(project)
+
+        project.extensions.configure(PublishingExtension::class.java) {
+            val publication = publications.create("maven", MavenPublication::class.java)
+            publication.from(project.components.getByName(componentName))
+            publication.artifactId = project.name
+
+            publication.pom {
+                name.set(project.name)
+                description.set(projectDescription(project.name))
+                url.set(metadata.projectUrl)
+
+                licenses {
+                    license {
+                        name.set(metadata.licenseName)
+                        url.set(metadata.licenseUrl)
+                    }
+                }
+                developers {
+                    developer {
+                        id.set(metadata.developerId)
+                        name.set(metadata.developerName)
+                        email.set(metadata.developerEmail)
+                    }
+                }
+                scm {
+                    url.set(metadata.scmUrl)
+                    connection.set(metadata.scmConnection)
+                    developerConnection.set(metadata.scmDeveloperConnection)
+                }
+            }
+
+            val releaseRepositoryUrl = project.providers.gradleProperty("tramaiPublishReleaseUrl").orNull
+            val snapshotRepositoryUrl = project.providers.gradleProperty("tramaiPublishSnapshotUrl").orNull
+            val targetRepositoryUrl = TramaiPublishingRepositories.selectRepositoryUrl(
+                project.version.toString(),
+                releaseRepositoryUrl,
+                snapshotRepositoryUrl,
+            )
+
+            if (!targetRepositoryUrl.isNullOrBlank()) {
+                repositories {
+                    maven {
+                        name = TramaiPublishingRepositories.TRAMAI_REMOTE_NAME
+                        url = project.uri(targetRepositoryUrl)
+                        if (!targetRepositoryUrl.startsWith("file:")) {
+                            credentials {
+                                username = project.providers.gradleProperty("tramaiPublishUsername").orNull
+                                password = project.providers.gradleProperty("tramaiPublishPassword").orNull
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        project.extensions.configure(SigningExtension::class.java) {
+            val signingKey = project.providers.gradleProperty("signingKey").orNull
+            val signingPassword = project.providers.gradleProperty("signingPassword").orNull
+            if (!signingKey.isNullOrBlank() && !signingPassword.isNullOrBlank()) {
+                useInMemoryPgpKeys(null, signingKey, signingPassword)
+                sign(project.extensions.getByType(PublishingExtension::class.java).publications)
+            }
+        }
+    }
+
+    private fun configureSovereignBundleLocalRepo(project: Project) {
+        val sovereignBundleModules = TramaiPublishingRepositories.sovereignBundleModuleNames(project.rootProject)
+        if (project.name in sovereignBundleModules) {
+            project.extensions.configure(PublishingExtension::class.java) {
+                repositories {
+                    maven {
+                        name = TramaiPublishingRepositories.SOVEREIGN_BUNDLE_LOCAL_NAME
+                        url = project.uri(TramaiPublishingRepositories.sovereignBundleRepoUrl(project.rootProject).get())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/dev/tramai/build/publishing/TramaiPublishingRepositories.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/publishing/TramaiPublishingRepositories.kt
@@ -1,0 +1,59 @@
+package dev.tramai.build.publishing
+
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
+
+/**
+ * Tramai publication repository policy.
+ *
+ * Remote repository selection and the dedicated sovereignBundleLocal
+ * verification repository. Moved from the root build script as behavior-
+ * preserving extraction (9.2a); membership is NOT redesigned in this slice.
+ */
+object TramaiPublishingRepositories {
+
+    const val TRAMAI_REMOTE_NAME = "tramaiRemote"
+    const val SOVEREIGN_BUNDLE_LOCAL_NAME = "sovereignBundleLocal"
+
+    /**
+     * Modules excluded from the sovereign signed runtime bundle. The bundle is
+     * the published manifest set minus modules outside its signed runtime scope.
+     */
+    val sovereignBundleExcludedProjectNames = setOf(
+        "tramai-anthropic", "tramai-azure-openai", "tramai-bedrock", "tramai-deepseek", "tramai-embedding",
+        "tramai-gemini", "tramai-memory", "tramai-observability", "tramai-ollama", "tramai-openai",
+        "tramai-orchestration", "tramai-platform", "tramai-rag", "tramai-scheduler", "tramai-spring",
+        "tramai-spring-provider-anthropic", "tramai-spring-provider-ollama", "tramai-spring-provider-openai",
+        "tramai-spring-secrets-aws", "tramai-spring-secrets-file", "tramai-spring-secrets-vault", "tramai-testing",
+        "tramai-vectorstore-chroma", "tramai-vectorstore-pgvector", "tramai-vectorstore-spi"
+    )
+
+    /**
+     * Sovereign bundle module names for the root build: the publishable set
+     * (published by the root build script as the `tramai.publishableModulePaths`
+     * extra property, manifest-derived) minus the excluded set.
+     */
+    fun sovereignBundleModuleNames(rootProject: Project): Set<String> {
+        val publishable = (rootProject.extensions.extraProperties.properties["tramai.publishableModulePaths"] as? Collection<*>)
+            ?.map { it.toString().removePrefix(":") }
+            .orEmpty()
+        return publishable.toSet() - sovereignBundleExcludedProjectNames
+    }
+
+    /**
+     * Always local file path for the sovereign bundle verification repository.
+     * Never remote — this is only used for dry-run signing verification and
+     * consumer smoke resolution. Do not use tramaiPublishReleaseUrl here.
+     */
+    fun sovereignBundleRepoUrl(rootProject: Project): Provider<String> =
+        rootProject.layout.buildDirectory.dir("sovereign-runtime-release-verification-repo")
+            .map { "file://${it.asFile.absolutePath}" }
+
+    /**
+     * Version-based remote repository selection (unchanged from the historical
+     * root script): SNAPSHOT → snapshot URL → release URL fallback; release
+     * version → release URL → snapshot URL fallback.
+     */
+    fun selectRepositoryUrl(version: String, releaseUrl: String?, snapshotUrl: String?): String? =
+        if (version.endsWith("-SNAPSHOT")) snapshotUrl ?: releaseUrl else releaseUrl ?: snapshotUrl
+}

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/ChangePolicyEvaluator.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/ChangePolicyEvaluator.kt
@@ -51,11 +51,25 @@ object ChangePolicyEvaluator {
 
     /** Auto-detected change class when -PchangeClass is not provided. */
     fun detectChangeClass(changedFiles: List<String>): String = when {
-        // If the only changes are in build-logic, it's a build-logic PR
-        changedFiles.all { it.startsWith("build-logic/") || it.startsWith("docs/") || it.endsWith(".md") } -> "build-logic"
+        // If the only changes are build tooling (build-logic, root build scripts,
+        // docs), it's a build-logic PR. Root build scripts are configuration, not
+        // runtime production code.
+        changedFiles.all {
+            it.startsWith("build-logic/") ||
+                it.startsWith("docs/") ||
+                it.endsWith(".md") ||
+                isBuildScriptPath(it)
+        } -> "build-logic"
         // Default to runtime
         else -> "runtime-behaviour"
     }
+
+    /** Root-level build configuration files count as build tooling, not runtime. */
+    fun isBuildScriptPath(path: String): Boolean =
+        path == "build.gradle.kts" ||
+            path == "settings.gradle.kts" ||
+            path == "gradle.properties" ||
+            path.startsWith("gradle/")
 
     fun evaluate(input: ChangePolicyInput): ChangePolicyResult {
         val violations = mutableListOf<PolicyViolation>()

--- a/build-logic/src/test/kotlin/dev/tramai/build/publishing/TramaiPublishingPluginTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/publishing/TramaiPublishingPluginTest.kt
@@ -1,0 +1,409 @@
+package dev.tramai.build.publishing
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * TestKit discriminator suite for the tramai.publishing convention plugin
+ * (Epic 9.2a). Each test builds a minimal fixture in a temp directory and
+ * asserts externally observable publishing behavior — no credentials are used
+ * in test data.
+ *
+ * Version is provided via gradle.properties so project.version is set before
+ * the convention plugin reacts to java-library/java-platform (the plugin
+ * applies during the plugins block).
+ */
+class TramaiPublishingPluginTest {
+
+    // ── fixture helpers ──────────────────────────────────────────────────────
+
+    private fun writeFile(base: File, relativePath: String, content: String) {
+        val target = File(base, relativePath)
+        target.parentFile.mkdirs()
+        target.writeText(content)
+    }
+
+    private fun singleProjectFixture(
+        dir: File,
+        plugins: String = "java-library",
+        probeBody: String = "",
+        version: String = "0.6.0",
+    ): File {
+        writeFile(
+            dir,
+            "settings.gradle.kts",
+            """
+            rootProject.name = "sample"
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "gradle.properties",
+            """
+            version=$version
+            group=dev.tramai
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "build.gradle.kts",
+            """
+            import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+            import org.gradle.api.publish.maven.MavenPublication
+
+            plugins {
+                `$plugins`
+                id("tramai.publishing")
+            }
+
+            tasks.register("probe") {
+                doLast {
+                    $probeBody
+                }
+            }
+            """.trimIndent(),
+        )
+        return dir
+    }
+
+    private fun runner(dir: File, vararg args: String): GradleRunner =
+        GradleRunner.create()
+            .withProjectDir(dir)
+            .withPluginClasspath()
+            .withArguments(*args)
+
+    private fun runProbe(dir: File, task: String = "probe", vararg args: String): Map<String, String> {
+        val result = runner(dir, task, "--quiet", *args).build()
+        return result.output.lineSequence()
+            .filter { it.startsWith("PROBE:") }
+            .associate { line ->
+                val (key, value) = line.removePrefix("PROBE:").split("=", limit = 2)
+                key to value
+            }
+    }
+
+    private fun probeRepositoriesBody(): String = """
+        val repos = publishing.repositories.map { repo ->
+            val artifactRepo = repo as MavenArtifactRepository
+            artifactRepo.name + "|" + artifactRepo.url
+        }.sorted().joinToString(",")
+        println("PROBE:repos=" + repos)
+    """.trimIndent()
+
+    // ── P1 — java-library publication ────────────────────────────────────────
+
+    @Test
+    fun `P1 java-library publication has java component artifactId and javadoc jar`(@TempDir tempDir: File) {
+        val dir = File(tempDir, "p1")
+        dir.mkdirs()
+        singleProjectFixture(
+            dir,
+            plugins = "java-library",
+            probeBody = """
+                val pub = publishing.publications.getByName("maven") as MavenPublication
+                println("PROBE:pubName=" + pub.name)
+                println("PROBE:artifactId=" + pub.artifactId)
+                println("PROBE:components=" + components.names.sorted().joinToString(","))
+                println("PROBE:hasJavadocJar=" + tasks.names.contains("javadocJar"))
+            """.trimIndent(),
+        )
+        val probe = runProbe(dir)
+        assertEquals("maven", probe["pubName"])
+        assertEquals("sample", probe["artifactId"])
+        assertTrue(probe["components"]!!.split(",").contains("java"), "java component must exist")
+        assertEquals("true", probe["hasJavadocJar"], "javadocJar task must exist for java-library")
+    }
+
+    // ── P2 — java-platform publication ───────────────────────────────────────
+
+    @Test
+    fun `P2 java-platform publication uses javaPlatform component and pom packaging`(@TempDir tempDir: File) {
+        val dir = File(tempDir, "p2")
+        dir.mkdirs()
+        singleProjectFixture(
+            dir,
+            plugins = "java-platform",
+            probeBody = """
+                val pub = publishing.publications.getByName("maven") as MavenPublication
+                println("PROBE:pubName=" + pub.name)
+                println("PROBE:artifactId=" + pub.artifactId)
+                println("PROBE:components=" + components.names.sorted().joinToString(","))
+            """.trimIndent(),
+        )
+        val probe = runProbe(dir)
+        assertEquals("maven", probe["pubName"])
+        assertTrue(probe["components"]!!.split(",").contains("javaPlatform"), "javaPlatform component must exist")
+
+        // POM packaging must be pom for a platform publication.
+        runner(dir, "generatePomFileForMavenPublication", "--quiet").build()
+        val pomFile = File(dir, "build/publications/maven/pom-default.xml")
+        assertTrue(pomFile.isFile, "generated POM must exist")
+        val pomText = pomFile.readText()
+        assertTrue(pomText.contains("<packaging>pom</packaging>"), "platform POM must declare packaging=pom")
+    }
+
+    // ── P3 — release repository selection ────────────────────────────────────
+
+    @Test
+    fun `P3 release version selects release URL with snapshot fallback`(@TempDir tempDir: File) {
+        val dir = File(tempDir, "p3")
+        dir.mkdirs()
+        singleProjectFixture(dir, version = "0.6.0", probeBody = probeRepositoriesBody())
+
+        // Both URLs present → release URL wins.
+        val both = runProbe(dir, args = arrayOf("-PtramaiPublishReleaseUrl=https://release.example.com/repo", "-PtramaiPublishSnapshotUrl=https://snapshot.example.com/repo"))
+        assertEquals("tramaiRemote|https://release.example.com/repo", both["repos"])
+
+        // Only snapshot URL → fallback to snapshot URL for a release version.
+        val fallback = runProbe(dir, args = arrayOf("-PtramaiPublishSnapshotUrl=https://snapshot.example.com/repo"))
+        assertEquals("tramaiRemote|https://snapshot.example.com/repo", fallback["repos"])
+
+        // Only release URL → release URL.
+        val releaseOnly = runProbe(dir, args = arrayOf("-PtramaiPublishReleaseUrl=https://release.example.com/repo"))
+        assertEquals("tramaiRemote|https://release.example.com/repo", releaseOnly["repos"])
+    }
+
+    // ── P4 — snapshot repository selection ───────────────────────────────────
+
+    @Test
+    fun `P4 snapshot version selects snapshot URL with release fallback`(@TempDir tempDir: File) {
+        val dir = File(tempDir, "p4")
+        dir.mkdirs()
+        singleProjectFixture(dir, version = "0.6.1-SNAPSHOT", probeBody = probeRepositoriesBody())
+
+        // Both URLs present → snapshot URL wins.
+        val both = runProbe(dir, args = arrayOf("-PtramaiPublishReleaseUrl=https://release.example.com/repo", "-PtramaiPublishSnapshotUrl=https://snapshot.example.com/repo"))
+        assertEquals("tramaiRemote|https://snapshot.example.com/repo", both["repos"])
+
+        // Only release URL → fallback to release URL for a snapshot version.
+        val fallback = runProbe(dir, args = arrayOf("-PtramaiPublishReleaseUrl=https://release.example.com/repo"))
+        assertEquals("tramaiRemote|https://release.example.com/repo", fallback["repos"])
+
+        // Only snapshot URL → snapshot URL.
+        val snapshotOnly = runProbe(dir, args = arrayOf("-PtramaiPublishSnapshotUrl=https://snapshot.example.com/repo"))
+        assertEquals("tramaiRemote|https://snapshot.example.com/repo", snapshotOnly["repos"])
+    }
+
+    // ── P5 — no repository configured when both URLs absent ──────────────────
+
+    @Test
+    fun `P5 no remote repository is configured when both URLs are absent`(@TempDir tempDir: File) {
+        val dir = File(tempDir, "p5")
+        dir.mkdirs()
+        singleProjectFixture(
+            dir,
+            probeBody = """
+                println("PROBE:repos=" + publishing.repositories.map { it.name }.sorted().joinToString(","))
+            """.trimIndent(),
+        )
+        val probe = runProbe(dir)
+        assertEquals("", probe["repos"] ?: "", "no repositories must be configured on a developer machine")
+    }
+
+    // ── P6 — file repository never receives credentials ──────────────────────
+
+    @Test
+    fun `P6 file repository is configured without credentials even when properties are provided`(@TempDir tempDir: File) {
+        val dir = File(tempDir, "p6")
+        dir.mkdirs()
+        singleProjectFixture(
+            dir,
+            version = "0.6.0",
+            probeBody = """
+                val repo = publishing.repositories.getByName("tramaiRemote") as MavenArtifactRepository
+                println("PROBE:repoUrl=" + repo.url)
+                println("PROBE:credUser=" + (repo.credentials.username ?: "NULL"))
+                println("PROBE:credPass=" + (repo.credentials.password ?: "NULL"))
+            """.trimIndent(),
+        )
+        val probe = runProbe(
+            dir,
+            args = arrayOf(
+                "-PtramaiPublishReleaseUrl=file:///tmp/repo",
+                "-PtramaiPublishUsername=secret-user",
+                "-PtramaiPublishPassword=secret-pass",
+            ),
+        )
+        assertEquals("file:/tmp/repo", probe["repoUrl"], "file repository URL must remain file-based")
+        assertEquals("NULL", probe["credUser"], "file repository must never receive credentials")
+        assertEquals("NULL", probe["credPass"], "file repository must never receive credentials")
+    }
+
+    // ── P7 — signing is optional ─────────────────────────────────────────────
+
+    @Test
+    fun `P7 configuration succeeds without signing keys and adds signing tasks with keys`(@TempDir tempDir: File) {
+        // Case 1: no keys → configuration succeeds, no signing tasks.
+        val noKeys = File(tempDir, "p7-nokeys")
+        noKeys.mkdirs()
+        singleProjectFixture(
+            noKeys,
+            probeBody = """
+                println("PROBE:signTasks=" + tasks.names.filter { it.contains("sign", ignoreCase = true) }.sorted().joinToString(","))
+            """.trimIndent(),
+        )
+        val noKeysProbe = runProbe(noKeys)
+        assertFalse(noKeysProbe["signTasks"]!!.contains("Sign"), "no signing tasks must exist without signing material")
+
+        // Case 2: keys present → signing tasks exist. No real credentials in test data.
+        val withKeys = File(tempDir, "p7-keys")
+        withKeys.mkdirs()
+        singleProjectFixture(
+            withKeys,
+            probeBody = """
+                println("PROBE:signTasks=" + tasks.names.filter { it.contains("sign", ignoreCase = true) }.sorted().joinToString(","))
+            """.trimIndent(),
+        )
+        val withKeysProbe = runProbe(withKeys, args = arrayOf("-PsigningKey=test-key", "-PsigningPassword=test-password"))
+        assertTrue(withKeysProbe["signTasks"]!!.contains("signMavenPublication"), "signing tasks must exist when keys are provided")
+    }
+
+    // ── P8 — sovereign local repository safety ───────────────────────────────
+
+    @Test
+    fun `P8 sovereignBundleLocal exists as file repository on selected projects only`(@TempDir tempDir: File) {
+        val dir = File(tempDir, "p8")
+        dir.mkdirs()
+        writeFile(
+            dir,
+            "settings.gradle.kts",
+            """
+            rootProject.name = "fixture"
+            include("tramai-core")
+            include("tramai-spring")
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "build.gradle.kts",
+            """
+            extra["tramai.publishableModulePaths"] = listOf(":tramai-core", ":tramai-spring")
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "tramai-core/build.gradle.kts",
+            """
+            import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+
+            plugins {
+                `java-library`
+                id("tramai.publishing")
+            }
+            group = "dev.tramai"
+            version = "0.6.0"
+            tasks.register("probe") {
+                doLast {
+                    val repos = publishing.repositories.map { repo ->
+                        val artifactRepo = repo as MavenArtifactRepository
+                        artifactRepo.name + "|" + artifactRepo.url
+                    }.sorted().joinToString(",")
+                    println("PROBE:repos=" + repos)
+                    if (publishing.repositories.names.contains("sovereignBundleLocal")) {
+                        val repo = publishing.repositories.getByName("sovereignBundleLocal") as MavenArtifactRepository
+                        println("PROBE:sovereignCredUser=" + (repo.credentials.username ?: "NULL"))
+                    }
+                }
+            }
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "tramai-spring/build.gradle.kts",
+            """
+            plugins {
+                `java-library`
+                id("tramai.publishing")
+            }
+            group = "dev.tramai"
+            version = "0.6.0"
+            tasks.register("probe") {
+                doLast {
+                    println("PROBE:repos=" + publishing.repositories.map { it.name }.sorted().joinToString(","))
+                }
+            }
+            """.trimIndent(),
+        )
+
+        // tramai-core is in the sovereign bundle → sovereignBundleLocal exists, file://, no credentials.
+        val coreProbe = runProbe(dir, task = ":tramai-core:probe")
+        assertTrue(coreProbe["repos"]!!.contains("sovereignBundleLocal|file:"), "selected project must get the file-based sovereign repo")
+        assertEquals("NULL", coreProbe["sovereignCredUser"], "sovereign repo must never receive credentials")
+
+        // tramai-spring is excluded from the sovereign bundle → no sovereignBundleLocal.
+        val springProbe = runProbe(dir, task = ":tramai-spring:probe")
+        assertFalse(springProbe["repos"]!!.contains("sovereignBundleLocal"), "non-selected project must not get the sovereign repo")
+    }
+
+    // ── P9 — publication metadata parity ─────────────────────────────────────
+
+    @Test
+    fun `P9 generated POM carries unchanged publication metadata`(@TempDir tempDir: File) {
+        val dir = File(tempDir, "p9")
+        dir.mkdirs()
+        singleProjectFixture(
+            dir,
+            plugins = "java-library",
+            probeBody = """ println("PROBE:done=true") """.trimIndent(),
+        )
+        runner(dir, "generatePomFileForMavenPublication", "--quiet").build()
+        val pomFile = File(dir, "build/publications/maven/pom-default.xml")
+        assertTrue(pomFile.isFile, "generated POM must exist")
+        val pom = pomFile.readText()
+
+        // group / artifactId / version / name / description / URL / license / developer / SCM / packaging
+        assertTrue(pom.contains("<groupId>dev.tramai</groupId>"), "POM must carry groupId")
+        assertTrue(pom.contains("<artifactId>sample</artifactId>"), "POM must carry artifactId")
+        assertTrue(pom.contains("<version>0.6.0</version>"), "POM must carry version")
+        assertTrue(pom.contains("<name>sample</name>"), "POM must carry name")
+        assertTrue(pom.contains("<description>Tramai module sample.</description>"), "POM must carry compatibility description")
+        assertTrue(pom.contains("<url>https://github.com/GionaGranchelli/tramAI</url>"), "POM must carry project URL")
+        assertTrue(pom.contains("<name>Apache-2.0</name>"), "POM must carry license name")
+        assertTrue(pom.contains("<id>GionaGranchelli</id>"), "POM must carry developer id")
+        assertTrue(pom.contains("<connection>scm:git:https://github.com/GionaGranchelli/tramAI.git</connection>"), "POM must carry SCM")
+        assertFalse(pom.contains("<packaging>pom</packaging>"), "library POM must not be pom-packaged")
+    }
+
+    // ── P10 — configuration cache at the convention boundary ─────────────────
+
+    @Test
+    fun `P10 configuration cache is reused on second run`(@TempDir tempDir: File) {
+        val dir = File(tempDir, "p10")
+        dir.mkdirs()
+        singleProjectFixture(dir, plugins = "java-library")
+
+        runner(dir, "help", "--configuration-cache").build()
+        val second = runner(dir, "help", "--configuration-cache").build()
+        assertTrue(
+            second.output.contains("Reusing configuration cache"),
+            "second run must reuse the configuration cache. Output: ${second.output.takeLast(500)}",
+        )
+    }
+
+    // ── S1 — structural guard: publishing stays out of the root script ───────
+
+    @Test
+    fun `S1 root build script contains no publishing implementation`() {
+        val repositoryRoot = System.getProperty("tramai.repositoryRoot")
+            ?: error("tramai.repositoryRoot system property must be set")
+        val rootBuildScript = File(repositoryRoot, "build.gradle.kts")
+        assertTrue(rootBuildScript.isFile, "root build.gradle.kts must exist at $repositoryRoot")
+        val text = rootBuildScript.readText()
+
+        val forbidden = listOf(
+            "configureTramaiPublishing",
+            "configureSovereignBundleLocalRepo",
+            "import org.gradle.api.publish.PublishingExtension",
+            "import org.gradle.api.publish.maven.MavenPublication",
+            "import org.gradle.plugins.signing.SigningExtension",
+        )
+        forbidden.forEach { identifier ->
+            assertFalse(text.contains(identifier), "root build.gradle.kts must not contain $identifier")
+        }
+    }
+}

--- a/build-logic/src/test/kotlin/dev/tramai/build/publishing/TramaiPublishingPluginTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/publishing/TramaiPublishingPluginTest.kt
@@ -248,7 +248,7 @@ class TramaiPublishingPluginTest {
             """.trimIndent(),
         )
         val noKeysProbe = runProbe(noKeys)
-        assertFalse(noKeysProbe["signTasks"]!!.contains("Sign"), "no signing tasks must exist without signing material")
+        assertEquals("", noKeysProbe["signTasks"].orEmpty(), "no signing tasks must exist without signing material")
 
         // Case 2: keys present → signing tasks exist. No real credentials in test data.
         val withKeys = File(tempDir, "p7-keys")

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/ChangePolicyEvaluatorTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/ChangePolicyEvaluatorTest.kt
@@ -563,9 +563,25 @@ class ChangePolicyEvaluatorTest {
     }
 
     @Test
+    fun `root build script is build tooling not runtime`() {
+        assertEquals("build-logic", ChangePolicyEvaluator.detectChangeClass(
+            listOf("build.gradle.kts")))
+        assertEquals("build-logic", ChangePolicyEvaluator.detectChangeClass(
+            listOf("settings.gradle.kts")))
+        assertEquals("build-logic", ChangePolicyEvaluator.detectChangeClass(
+            listOf("build-logic/src/main/kotlin/Plugin.kt", "build.gradle.kts", "docs/EPIC-9.2.md")))
+    }
+
+    @Test
     fun `runtime with docs is runtime-behaviour`() {
         assertEquals("runtime-behaviour", ChangePolicyEvaluator.detectChangeClass(
             listOf("tramai-engine/src/main/kotlin/Engine.kt", "docs/guide.md")))
+    }
+
+    @Test
+    fun `runtime with root build script is runtime-behaviour`() {
+        assertEquals("runtime-behaviour", ChangePolicyEvaluator.detectChangeClass(
+            listOf("tramai-engine/src/main/kotlin/Engine.kt", "build.gradle.kts")))
     }
 
     // --- Helpers ---

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,4 @@
 import org.gradle.api.Project
-import org.gradle.api.plugins.JavaPluginExtension
-import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.api.tasks.javadoc.Javadoc
-import org.gradle.kotlin.dsl.configure
-import org.gradle.plugins.signing.SigningExtension
 import org.gradle.util.GradleVersion
 import org.w3c.dom.Element
 import groovy.json.JsonOutput
@@ -12,6 +6,8 @@ import groovy.json.JsonSlurper
 import java.io.File
 import java.net.URI
 import javax.xml.parsers.DocumentBuilderFactory
+import dev.tramai.build.publishing.TramaiPublishingRepositories
+import dev.tramai.build.publishing.projectDescription
 import dev.tramai.build.quality.ModuleManifest
 
 plugins {
@@ -61,15 +57,8 @@ val jarPublishingProjectNames = publishableProjectNames - "tramai-bom"
 // file-based Maven repository — never to a remote — preventing accidental remote
 // publication during dry-run validation.
 // The sovereign bundle is the published manifest set minus modules outside its signed runtime scope.
-val sovereignBundleExcludedProjectNames = setOf(
-    "tramai-anthropic", "tramai-azure-openai", "tramai-bedrock", "tramai-deepseek", "tramai-embedding",
-    "tramai-gemini", "tramai-memory", "tramai-observability", "tramai-ollama", "tramai-openai",
-    "tramai-orchestration", "tramai-platform", "tramai-rag", "tramai-scheduler", "tramai-spring",
-    "tramai-spring-provider-anthropic", "tramai-spring-provider-ollama", "tramai-spring-provider-openai",
-    "tramai-spring-secrets-aws", "tramai-spring-secrets-file", "tramai-spring-secrets-vault", "tramai-testing",
-    "tramai-vectorstore-chroma", "tramai-vectorstore-pgvector", "tramai-vectorstore-spi"
-)
-val sovereignBundleModuleNames = publishableProjectNames - sovereignBundleExcludedProjectNames
+// Membership lives in TramaiPublishingRepositories (9.2a extraction, behavior-preserving).
+val sovereignBundleModuleNames = TramaiPublishingRepositories.sovereignBundleModuleNames(rootProject)
 
 // ──────────────────────────────────────────────
 // Sovereign Release Evidence Index - Typed Model
@@ -177,8 +166,7 @@ data class DevTramaiResolutionPolicy(
 // Always local file path for the sovereign bundle verification repository.
 // This is never a remote URL — it is only used for dry-run signing verification
 // and consumer smoke resolution. Do not use tramaiPublishReleaseUrl here.
-val sovereignBundleRepoUrl = rootProject.layout.buildDirectory.dir("sovereign-runtime-release-verification-repo")
-    .map { "file://${it.asFile.absolutePath}" }
+val sovereignBundleRepoUrl = TramaiPublishingRepositories.sovereignBundleRepoUrl(rootProject)
 
 subprojects {
     group = tramaiGroup.get()
@@ -188,192 +176,10 @@ subprojects {
         mavenCentral()
     }
 
-    plugins.withId("java-library") {
-        apply(plugin = "maven-publish")
-        apply(plugin = "signing")
-
-        extensions.configure(JavaPluginExtension::class.java) {
-            withJavadocJar()
-        }
-
-        tasks.withType(Javadoc::class.java).configureEach {
-            isFailOnError = false
-        }
-
-        configureTramaiPublishing(
-            componentName = "java",
-            artifactDescription = projectDescription(name),
-            projectUrl = tramaiProjectUrl.get(),
-            scmUrl = tramaiScmUrl.get(),
-            scmConnection = tramaiScmConnection.get(),
-            scmDeveloperConnection = tramaiScmDeveloperConnection.get(),
-            licenseName = tramaiLicenseName.get(),
-            licenseUrl = tramaiLicenseUrl.get(),
-            developerId = tramaiDeveloperId.get(),
-            developerName = tramaiDeveloperName.get(),
-            developerEmail = tramaiDeveloperEmail.get(),
-        )
-
-        // Dedicated local-only Maven repository for the sovereign signed bundle dry-run.
-        // Added inside the plugin block so maven-publish has already registered
-        // PublishingExtension. This repo is always file:// (build-local by default)
-        // and is never configured with remote credentials.
-        if (project.name in sovereignBundleModuleNames) {
-            configureSovereignBundleLocalRepo()
-        }
-    }
-
-    plugins.withId("java-platform") {
-        apply(plugin = "maven-publish")
-        apply(plugin = "signing")
-
-        configureTramaiPublishing(
-            componentName = "javaPlatform",
-            artifactDescription = projectDescription(name),
-            projectUrl = tramaiProjectUrl.get(),
-            scmUrl = tramaiScmUrl.get(),
-            scmConnection = tramaiScmConnection.get(),
-            scmDeveloperConnection = tramaiScmDeveloperConnection.get(),
-            licenseName = tramaiLicenseName.get(),
-            licenseUrl = tramaiLicenseUrl.get(),
-            developerId = tramaiDeveloperId.get(),
-            developerName = tramaiDeveloperName.get(),
-            developerEmail = tramaiDeveloperEmail.get(),
-        )
-
-        // Dedicated local-only Maven repository for the sovereign signed bundle dry-run.
-        // Added inside the plugin block so maven-publish has already registered
-        // PublishingExtension. This repo is always file:// (build-local by default)
-        // and is never configured with remote credentials.
-        if (project.name in sovereignBundleModuleNames) {
-            configureSovereignBundleLocalRepo()
-        }
-    }
-}
-
-fun Project.configureTramaiPublishing(
-    componentName: String,
-    artifactDescription: String,
-    projectUrl: String,
-    scmUrl: String,
-    scmConnection: String,
-    scmDeveloperConnection: String,
-    licenseName: String,
-    licenseUrl: String,
-    developerId: String,
-    developerName: String,
-    developerEmail: String,
-) {
-    extensions.configure<PublishingExtension> {
-        val publication = publications.create("maven", MavenPublication::class.java)
-        publication.from(components.getByName(componentName))
-        publication.artifactId = project.name
-
-        publication.pom {
-            name.set(project.name)
-            description.set(artifactDescription)
-            url.set(projectUrl)
-
-            licenses {
-                license {
-                    name.set(licenseName)
-                    url.set(licenseUrl)
-                }
-            }
-
-            developers {
-                developer {
-                    id.set(developerId)
-                    name.set(developerName)
-                    email.set(developerEmail)
-                }
-            }
-
-            scm {
-                url.set(scmUrl)
-                connection.set(scmConnection)
-                developerConnection.set(scmDeveloperConnection)
-            }
-        }
-
-        val releaseRepositoryUrl = providers.gradleProperty("tramaiPublishReleaseUrl").orNull
-        val snapshotRepositoryUrl = providers.gradleProperty("tramaiPublishSnapshotUrl").orNull
-        val targetRepositoryUrl = when {
-            version.toString().endsWith("-SNAPSHOT") -> snapshotRepositoryUrl ?: releaseRepositoryUrl
-            else -> releaseRepositoryUrl ?: snapshotRepositoryUrl
-        }
-
-        if (!targetRepositoryUrl.isNullOrBlank()) {
-            repositories {
-                maven {
-                    name = "tramaiRemote"
-                    url = uri(targetRepositoryUrl)
-                    if (!targetRepositoryUrl.startsWith("file:")) {
-                        credentials {
-                            username = providers.gradleProperty("tramaiPublishUsername").orNull
-                            password = providers.gradleProperty("tramaiPublishPassword").orNull
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    extensions.configure<SigningExtension> {
-        val signingKey = providers.gradleProperty("signingKey").orNull
-        val signingPassword = providers.gradleProperty("signingPassword").orNull
-        if (!signingKey.isNullOrBlank() && !signingPassword.isNullOrBlank()) {
-            useInMemoryPgpKeys(signingKey, signingPassword)
-            sign(extensions.getByType(PublishingExtension::class.java).publications)
-        }
-    }
-}
-
-/**
- * Adds the dedicated sovereignBundleLocal Maven repository to this project's
- * PublishingExtension. This repo is always file:// (build-local by default,
- * or overridden via -PtramaiPublishReleaseUrl=file://...) and is never
- * configured with remote credentials. The verifySovereignRuntimeSignedBundle
- * task publishes exclusively to this repo using the generated
- * *ToSovereignBundleLocalRepository tasks, never to tramaiRemote or :publish.
- */
-fun Project.configureSovereignBundleLocalRepo() {
-    extensions.configure<PublishingExtension> {
-        repositories {
-            maven {
-                name = "sovereignBundleLocal"
-                url = URI(sovereignBundleRepoUrl.get())
-            }
-        }
-    }
-}
-
-fun projectDescription(projectName: String): String = when (projectName) {
-    "tramai-core" -> "Core annotations, request models, provider registry, and exception types for Tramai."
-    "tramai-embedding" -> "Embedding model SPI with OpenAI and Ollama implementations for Tramai."
-    "tramai-engine" -> "Runtime engine that turns annotated Tramai service interfaces into executable proxies."
-    "tramai-structured" -> "Structured output schema generation, parsing, and validation support for Tramai."
-    "tramai-anthropic" -> "Anthropic provider integration for Tramai."
-    "tramai-gemini" -> "Google Gemini provider integration for Tramai."
-    "tramai-azure-openai" -> "Azure OpenAI provider integration for Tramai."
-    "tramai-bedrock" -> "AWS Bedrock provider integration for Tramai."
-    "tramai-deepseek" -> "Deepseek provider integration for Tramai."
-    "tramai-memory" -> "In-memory memory and state helpers for Tramai (memory primitives and adapters)."
-    "tramai-openai" -> "OpenAI and OpenAI-compatible provider integrations for Tramai."
-    "tramai-ollama" -> "Ollama provider integration for Tramai."
-    "tramai-observability" -> "OpenTelemetry-based observability hooks for Tramai."
-    "tramai-orchestration" -> "Typed workflow orchestration and coordination layer for Tramai."
-    "tramai-platform" -> "Platform services for plugins, tenancy, API keys, rate limiting, and audit logging."
-    "tramai-standalone" -> "Minimal standalone runtime bundle for Tramai."
-    "tramai-sovereign" -> "Secure embedded runtime profile for sovereign TramAI deployments."
-    "tramai-spring" -> "Spring Boot auto-configuration and integration support for Tramai."
-    "tramai-testing" -> "Testing utilities and deterministic assertion support for Tramai."
-    "tramai-bom" -> "Bill of materials for aligning Tramai module versions."
-    "tramai-vectorstore-spi" -> "Vector store SPI with data models and in-memory implementation for Tramai."
-    "tramai-vectorstore-chroma" -> "ChromaDB vector store adapter for Tramai."
-    "tramai-vectorstore-pgvector" -> "PostgreSQL pgvector vector store adapter for Tramai."
-    "tramai-rag" -> "RAG pipeline: document loading, chunking, retrieval, and context injection for Tramai."
-    else -> "Tramai module ${projectName.removePrefix("tramai-")}."
+    // 9.2a: publishing/signing/repository/POM configuration moved into the
+    // tramai.publishing convention plugin. The plugin reacts to java-library
+    // and java-platform itself (no plugin ordering dependency).
+    apply(plugin = "tramai.publishing")
 }
 
 fun Element.directChild(name: String): Element? {
@@ -395,14 +201,17 @@ fun parseXml(file: File): Element {
     return documentBuilderFactory.newDocumentBuilder().parse(file).documentElement
 }
 
-fun releaseRepositoryUrlFor(version: String): String? {
-    val releaseRepositoryUrl = providers.gradleProperty("tramaiPublishReleaseUrl").orNull
-    val snapshotRepositoryUrl = providers.gradleProperty("tramaiPublishSnapshotUrl").orNull
-    return when {
-        version.endsWith("-SNAPSHOT") -> snapshotRepositoryUrl ?: releaseRepositoryUrl
-        else -> releaseRepositoryUrl ?: snapshotRepositoryUrl
-    }
-}
+/**
+ * Version-based remote repository selection for release verification tasks.
+ * Logic lives in TramaiPublishingRepositories (9.2a); this root-level helper
+ * keeps the 9.2b release tasks call-compatible until they are extracted.
+ */
+fun releaseRepositoryUrlFor(version: String): String? =
+    TramaiPublishingRepositories.selectRepositoryUrl(
+        version,
+        providers.gradleProperty("tramaiPublishReleaseUrl").orNull,
+        providers.gradleProperty("tramaiPublishSnapshotUrl").orNull,
+    )
 
 tasks.register("verifyPublicationMetadata") {
     group = "verification"
@@ -837,8 +646,9 @@ tasks.register("verifySovereignRuntimeSignedBundle") {
     // Resolve the dedicated bundle repo URL (default or user-provided file://)
     val bundleRepoUrl = sovereignBundleRepoUrl.get()
 
-    // Signing key properties — evaluated at configuration time by the signing extension
-    // in configureTramaiPublishing, so .asc files are produced automatically during publish.
+    // Signing key properties — evaluated at configuration time by the
+    // tramai.publishing convention plugin, so .asc files are produced
+    // automatically during publish.
     val signingKey = providers.gradleProperty("signingKey").orNull
     val signingPassword = providers.gradleProperty("signingPassword").orNull
     val wantsSigning = !signingKey.isNullOrBlank() && !signingPassword.isNullOrBlank()

--- a/docs/EPIC-9.2-build-logic.md
+++ b/docs/EPIC-9.2-build-logic.md
@@ -1,0 +1,162 @@
+# EPIC 9.2 — Move build logic into `build-logic`
+
+**Goal:** Make Gradle configuration modular, typed, testable, and mostly declarative.
+
+**Owner:** build-logic conventions
+**Status:** in progress (9.2a done)
+
+## Slicing
+
+The epic is deliberately split into small behavior-preserving slices. Each slice
+is a separate PR with its own TestKit suite and acceptance checklist. The slices
+are ordered so that the riskiest boundary (publishing, which touches every
+published module) is extracted first.
+
+| Slice | Scope | Status |
+|-------|-------|--------|
+| 9.2a | `tramai.publishing` convention plugin (publication, signing, repository policy, POM metadata, sovereign-local hook) | ✅ done — PR #308 |
+| 9.2b | `tramai.release-verification` + `tramai.sovereign-verification` typed/cache-aware release tasks | planned |
+| 9.2c | `tramai.kotlin-library`, `tramai.java-platform`, `tramai.test-fixtures`, `tramai.integration-test`, `tramai.quality` | planned |
+| 9.2d | configuration-cache closure; root build reduced to composition | planned |
+
+## 9.2a — `tramai.publishing` (this PR)
+
+### Objective
+
+Move ordinary Maven publication/signing configuration out of the root
+`build.gradle.kts` into a tested convention plugin `tramai.publishing`,
+producing exactly the same publication surface as today.
+
+**Before:** root `build.gradle.kts` owns maven-publish application, signing,
+java/javaPlatform publication setup, POM metadata, remote repository selection,
+credentials, the sovereign local verification repository, and the
+`projectDescription()` mapping.
+
+**After:** root `build.gradle.kts` is composition only:
+
+```kotlin
+subprojects {
+    group = tramaiGroup.get()
+    version = tramaiVersion.get()
+    repositories { mavenCentral() }
+    apply(plugin = "tramai.publishing")
+}
+```
+
+### Behavior contract (must be preserved exactly)
+
+1. **Java-library** modules (`java-library` applied): maven-publish, signing,
+   `withJavadocJar()`, `Javadoc.failOnError = false`, publication component
+   `java`, `artifactId = project.name`.
+2. **Java-platform / BOM** modules: publication component `javaPlatform`,
+   `artifactId = project.name`, POM packaging `pom`, dependency-management
+   output unchanged.
+3. **Remote repository selection**: `version.endsWith("-SNAPSHOT")` → snapshot
+   URL → release URL fallback; release version → release URL → snapshot URL
+   fallback. Properties: `tramaiPublishReleaseUrl`, `tramaiPublishSnapshotUrl`,
+   `tramaiPublishUsername`, `tramaiPublishPassword`.
+4. **Security contract**: `file:` repositories never receive credentials;
+   non-file repositories may receive credentials from Gradle properties.
+5. **Signing**: only when both `signingKey` AND `signingPassword` are present →
+   in-memory PGP + sign Maven publications. Otherwise no signing
+   configuration requiring credentials.
+6. **Sovereign local publication repository** `sovereignBundleLocal`: always
+   `file://` (build-local by default), no remote credentials, never
+   interchangeable with `tramaiRemote`. Membership is the existing
+   `publishable - sovereignBundleExcluded` set — membership is NOT redesigned
+   in this slice (a later `tramai.sovereign-verification` slice owns that).
+7. **Description policy**: the existing hand-written `projectDescription()`
+   mapping moves into build-logic as compatibility behavior. Values are NOT
+   changed in this slice; manifest-derived descriptions land in 9.2c.
+
+### Non-goals (explicitly out of scope)
+
+- No `tramai-*/src/main/**` changes.
+- No Maven coordinates / artifactId / scopes / publishability / signing
+  requirements / repository precedence / POM contents / BOM membership /
+  API dumps / migration registry / architecture report changes.
+- Do NOT extract: `verifyPublicationMetadata`, `verifyPublishedLocalArtifacts`,
+  `verifySovereignRuntimePublication`, `verifySovereignRuntimeSignedBundle`,
+  release evidence-index generation — those are 9.2b typed tasks.
+
+### Architecture
+
+```
+build-logic/src/main/kotlin/dev/tramai/build/publishing/
+    TramaiPublishingPlugin.kt        # plugin entry; reacts to java-library / java-platform
+    TramaiPublicationMetadata.kt     # metadata resolution + projectDescription() compatibility policy
+    TramaiPublishingRepositories.kt  # repository selection, credentials guard, sovereignBundleLocal hook
+```
+
+The plugin registers `withPlugin("java-library")` / `withPlugin("java-platform")`
+callbacks — no `afterEvaluate`, no eager lookup that depends on plugin ordering.
+
+### Discriminator suite (TestKit)
+
+`build-logic/src/test/kotlin/dev/tramai/build/publishing/TramaiPublishingPluginTest.kt`
+
+- P1 — java-library publication: publication exists, component `java`,
+  `artifactId == project.name`, javadocJar present.
+- P2 — java-platform publication: publication exists, component
+  `javaPlatform`, POM packaging `pom`.
+- P3 — release repository selection (`0.6.0` + both URLs → release URL), plus
+  both fallback directions.
+- P4 — snapshot repository selection (`0.6.1-SNAPSHOT` + both URLs → snapshot
+  URL), plus both fallback directions.
+- P5 — no repository configured when both URLs absent (developer machines).
+- P6 — `file:` repository never receives credentials even when username /
+  password are provided.
+- P7 — signing optional: no keys → configuration succeeds; keys present →
+  signing tasks exist. No real credentials in test data.
+- P8 — sovereignBundleLocal exists (file://, no credentials) on selected
+  projects only.
+- P9 — POM metadata parity: group, artifactId, version, name, description,
+  project URL, license, developer, SCM, packaging unchanged. End-to-end oracle:
+  the repository's existing `verifyPublicationMetadata`.
+- P10 — configuration cache: minimal build passes twice with cache reuse on the
+  second run.
+- S1 — structural guard: root `build.gradle.kts` must not contain
+  `configureTramaiPublishing`, `MavenPublication`, `SigningExtension`,
+  `PublishingExtension`, or `configureSovereignBundleLocalRepo`.
+
+### Acceptance checklist
+
+- [x] `tramai.publishing` registered as a real convention plugin
+- [x] Java-library publishing behavior identical
+- [x] Java-platform/BOM behavior identical
+- [x] POM metadata identical
+- [x] Repository URL precedence identical
+- [x] File repositories never receive credentials
+- [x] Signing behavior identical
+- [x] `sovereignBundleLocal` remains local-only
+- [x] Publishing implementation removed from root `build.gradle.kts`
+- [x] TestKit P1–P10 + S1 green
+- [x] `:build-logic:test` green
+- [x] `verifyPublicationMetadata` green
+- [x] `verifyPublishedLocalArtifacts` green
+- [x] `verify060Architecture` green
+- [x] `verifyPr` green
+- [x] zero `tramai-*/src/main` diffs
+
+Because this is a build-logic-only PR, `verifyChangePolicy` classifies it
+cleanly as `build-logic` with no baseline-migration exemption.
+
+## 9.2b — release-verification typed tasks
+
+- Extract `verifyPublicationMetadata`, `verifyPublishedLocalArtifacts`,
+  `verifySovereignRuntimePublication`, `verifySovereignRuntimeSignedBundle`,
+  evidence-index generation into typed task classes with declared
+  inputs/outputs and fail-closed evidence semantics.
+- Configuration-cache-aware where feasible; document the unavoidable
+  non-cacheable remainder.
+
+## 9.2c — quality / language conventions
+
+- `tramai.kotlin-library`, `tramai.java-platform`, `tramai.test-fixtures`,
+  `tramai.integration-test`, `tramai.quality`.
+- Manifest-derived project descriptions / publication metadata.
+
+## 9.2d — configuration-cache closure
+
+- Normal developer tasks (`test`, `check`) configuration-cache compatible.
+- Root build reduced to high-level composition.

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1416,6 +1416,23 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 **Goal:** Make Gradle configuration modular, typed, testable, and mostly declarative.
 
+> **Slicing:** see [docs/EPIC-9.2-build-logic.md](./EPIC-9.2-build-logic.md).
+> 9.2a (`tramai.publishing` convention plugin) is done; 9.2b–9.2d are planned slices.
+
+### Status: 🔄 In progress (9.2a ✅, 9.2b–9.2d planned)
+
+- **9.2a — `tramai.publishing` convention plugin** — ✅ PR #308: extracted
+  publication/signing/repository/POM configuration from the root
+  `build.gradle.kts` into a tested TestKit convention plugin
+  (`dev.tramai.build.publishing`), behavior-preserving: same publication
+  surface, POM metadata, repository precedence, credential rules, signing
+  semantics, and sovereignBundleLocal membership. Discriminator suite
+  P1–P10 + S1 in `TramaiPublishingPluginTest`; `verifyChangePolicy`
+  auto-classifies as `build-logic`.
+- **9.2b** — typed release/evidence tasks (`tramai.release-verification`).
+- **9.2c** — quality/test conventions + manifest-derived metadata.
+- **9.2d** — configuration-cache closure; root reduced to composition.
+
 ### Target convention plugins
 
 - `tramai.kotlin-library`


### PR DESCRIPTION
## build(publishing): extract TramAI publishing convention plugin — Epic 9.2a

Extract ordinary Maven publication/signing configuration out of the root `build.gradle.kts` into a tested convention plugin **`tramai.publishing`**, producing **exactly the same publication surface as today**. Ownership/refactoring PR — zero runtime behavior changes, zero `tramai-*/src/main` diffs.

### Scope

**New (build-logic):**
- `dev.tramai.build.publishing.TramaiPublishingPlugin` — reacts to `java-library` (component `java`, `withJavadocJar()`, Javadoc `failOnError=false`) and `java-platform` (component `javaPlatform`); `withPlugin` callbacks, no `afterEvaluate`, no plugin-ordering dependency.
- `TramaiPublicationMetadata` — POM metadata resolution (project URL, SCM, license, developer) with the historical defaults; `projectDescription()` moved **verbatim** as compatibility behavior (values deliberately unchanged — manifest-derived descriptions land in 9.2c).
- `TramaiPublishingRepositories` — version-based remote selection (SNAPSHOT → snapshot ?: release; release → release ?: snapshot), **file-repository credential guard**, `sovereignBundleLocal` (always `file://`, no credentials, unchanged membership: published manifest set minus the historical excluded set).

**Changed:**
- `build-logic/build.gradle.kts` — registers `tramai.publishing` plugin.
- `build.gradle.kts` — reduced to composition: `subprojects { group/version/repositories + apply(plugin = "tramai.publishing") }`. Publishing/signing/POM/repository implementation, `configureTramaiPublishing`, `configureSovereignBundleLocalRepo`, and the root-level `projectDescription` mapping removed. Release tasks (9.2b scope) untouched — they keep working through thin delegations to the build-logic helpers.
- `ChangePolicyEvaluator` — root build scripts (`build.gradle.kts`, `settings.gradle.kts`, `gradle.properties`, `gradle/`) now count as build tooling, so build-script-only PRs auto-classify as `build-logic` (was `runtime-behaviour`). Small, test-covered classifier fix; negative case (runtime + root build script) still `runtime-behaviour`.
- `docs/ROADMAP-0.6.0.md` + new `docs/EPIC-9.2-build-logic.md` — 9.2a/9.2b/9.2c/9.2d slicing.

### Explicit non-goals honored

- No Maven coordinates / artifactIds / scopes / publishability / signing requirements / repository precedence / POM contents / BOM membership / API dumps / migration registry / architecture report changes.
- Release verification tasks (`verifyPublicationMetadata`, `verifyPublishedLocalArtifacts`, `verifySovereignRuntimePublication`, `verifySovereignRuntimeSignedBundle`, evidence-index generation) are **not** extracted — they stay in the root for 9.2b.
- No `tramai-*/src/main/**` changes (verified empty).

### Judgment calls (documented)

1. **Root `releaseRepositoryUrlFor()` kept as a thin delegation** to `TramaiPublishingRepositories.selectRepositoryUrl` — the 9.2b release tasks still live in the root and need the helper; the actual selection logic now lives once in build-logic. The structural guard does not forbid this helper name.
2. **Classifier change included** — the reviewer-specified acceptance criterion is that this build-script-only PR classifies cleanly as `build-logic`; the auto-detector previously had no category for root build scripts. Fix is minimal (`isBuildScriptPath`) with positive + negative tests; no baseline/deviations touched.
3. **`sovereignBundleExcludedProjectNames` moved** into `TramaiPublishingRepositories` — membership observable behavior is identical (same 26-module exclusion set); a later `tramai.sovereign-verification` slice owns the concept fully.

### Discriminator suite (TestKit, `TramaiPublishingPluginTest`)

- P1 java-library publication (component java, artifactId=name, javadocJar) ✅
- P2 java-platform publication (component javaPlatform, POM packaging=pom) ✅
- P3 release repo selection + both fallback directions ✅
- P4 snapshot repo selection + both fallback directions ✅
- P5 no repo configured when both URLs absent ✅
- P6 file:// repo never receives credentials ✅
- P7 signing optional: no keys → no signing tasks; keys → signMavenPublication exists (dummy data only) ✅
- P8 sovereignBundleLocal: file:// + no creds on selected project; absent on non-selected ✅
- P9 POM metadata parity (group/artifactId/version/name/description/URL/license/developer/SCM/packaging) ✅ + real `verifyPublicationMetadata` as end-to-end oracle ✅
- P10 configuration cache reuse on second run ✅
- S1 structural guard: root build.gradle.kts contains no `configureTramaiPublishing` / `MavenPublication` / `SigningExtension` / `PublishingExtension` / `configureSovereignBundleLocalRepo` ✅

### Verification (all real runs)

| Check | Result |
|-------|--------|
| `:build-logic:test` | 310 tests, 0 failures (was 297; +11 TestKit +2 classifier) |
| `verifyPublicationMetadata` | PASS (real POM parity oracle, incl. BOM contents) |
| `verifyPublishedLocalArtifacts` | PASS |
| `verify060Architecture` | PASS (10 checks, report written) |
| `verifyPr` | PASS, 0 failed tasks |
| `verifyChangePolicy` | PASS — change class: **build-logic**, no baseline-migration exemption |
| `tramai-*/src/main` diffs | 0 |
