### PR TITLE
docs: normalize tramai-spring + Spring family cards (Epic 11.2b3a)

### DIFF
--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -4,12 +4,12 @@ Per-module architecture and navigation cards for TramAI. The authoritative modul
 
 - Classification / ownership: [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml)
 - Dependency boundaries: [`config/quality/module-boundaries.yml`](../../config/quality/module-boundaries.yml)
-- Generated module matrix (all 58 modules): [`docs/reference/module-matrix.md`](../reference/module-matrix.md)
+- Generated module matrix (all 60 modules): [`docs/reference/module-matrix.md`](../reference/module-matrix.md)
 - Root navigation map: [`ARCHITECTURE.md`](../../ARCHITECTURE.md)
 
 ## Card contract
 
-Cards normalized under Epic 11.2b conform to the following architecture contract. C2b1 normalized 11 core/governance/persistence/observability/testing cards; **C2b2 normalized 20 non-Spring cards** (provider adapters, higher capabilities, vector stores, operations/observability, BOM). Remaining cards are migrated in subsequent slices.
+Cards normalized under Epic 11.2b conform to the following architecture contract. C2b1 normalized 11 core/governance/persistence/observability/testing cards; **C2b2 normalized 20 non-Spring cards** (provider adapters, higher capabilities, vector stores, operations/observability, BOM). **C2b3a normalized `tramai-spring` (legacy facade) and created the Spring family + testing/consumer-support cards**; the remaining example/application cards and the documentation verifier follow in C2b3b.
 
 Each conforming card starts with an `## Architecture` section using these headings:
 
@@ -28,63 +28,67 @@ Below the architecture section, cards may carry long-form usage/design content (
 
 ## Coverage
 
-Coverage is computed against the 58-module authoritative manifest (`module-catalog.yml`). `sovereign-runtime-module-matrix.md` is a reference document, not a module card, and is not counted.
+Coverage is computed against the 60-module authoritative manifest (`module-catalog.yml`). `sovereign-runtime-module-matrix.md` is a reference document, not a module card, and is not counted.
 
 | Metric | Count |
 |--------|-------|
-| Manifest modules | 58 |
-| Module cards | 32 |
-| Conforming cards (C2b1 + C2b2) | 31 |
-| Existing non-conforming | 1 (`tramai-spring`, Spring slice) |
-| Missing cards | 26 |
+| Manifest modules | 60 |
+| Module cards | 51 |
+| Conforming cards (C2b1 + C2b2 + C2b3a) | 51 |
+| Existing non-conforming | 0 |
+| Missing cards | 9 (application/example slice — C2b3b) |
 | Orphans | 0 |
 
-### Cards (32)
+### Cards (51)
 
-- tramai-bom
-- tramai-core
-- tramai-engine
-- tramai-structured
-- tramai-standalone
-- tramai-orchestration
-- tramai-sovereign
-- tramai-security
-- tramai-persistence-file
-- tramai-persistence-jdbc
-- tramai-observability
-- tramai-testing
 - tramai-anthropic
 - tramai-azure-openai
 - tramai-bedrock
+- tramai-bom
+- tramai-core
+- tramai-dashboard
 - tramai-deepseek
-- tramai-gemini
-- tramai-ollama
-- tramai-openai
 - tramai-embedding
+- tramai-engine
+- tramai-gemini
+- tramai-mcp
 - tramai-memory
 - tramai-memory-store
+- tramai-observability
+- tramai-ollama
+- tramai-openai
+- tramai-orchestration
+- tramai-persistence-file
+- tramai-persistence-jdbc
+- tramai-platform
 - tramai-rag
 - tramai-scheduler
-- tramai-vectorstore-spi
-- tramai-vectorstore-chroma
-- tramai-vectorstore-pgvector
-- tramai-platform
+- tramai-security
 - tramai-server
-- tramai-mcp
-- tramai-dashboard
+- tramai-sovereign
 - tramai-spring
-
-### Missing (26, next slices)
-
-- tramai-spring-core
-- tramai-spring-sovereign
 - tramai-spring-boot-starter
 - tramai-spring-boot-starter-local-provider-openai
-- tramai-spring-boot-starter-sovereign-ops (+ actuator, micrometer, observability, rest)
+- tramai-spring-boot-starter-sovereign-ops
+- tramai-spring-boot-starter-sovereign-ops-actuator
+- tramai-spring-boot-starter-sovereign-ops-micrometer
+- tramai-spring-boot-starter-sovereign-ops-observability
+- tramai-spring-boot-starter-sovereign-ops-rest
 - tramai-spring-boot-starter-sovereign-persistence-file
 - tramai-spring-boot-starter-sovereign-persistence-jdbc
-- tramai-spring-provider-anthropic / ollama / openai
-- tramai-spring-secrets-aws / file / vault
 - tramai-spring-consumer-boundary
 - tramai-spring-consumer-selective
-- examples (approval-resume, governed-workflow, sovereign-document-intelligence, sovereign-offline-verification, spring-sovereign-starter, support-agent, tool-governance)
+- tramai-spring-core
+- tramai-spring-provider-anthropic
+- tramai-spring-provider-ollama
+- tramai-spring-provider-openai
+- tramai-spring-secrets-aws
+- tramai-spring-secrets-file
+- tramai-spring-secrets-vault
+- tramai-spring-sovereign
+- tramai-standalone
+- tramai-structured
+- tramai-testing
+- tramai-vectorstore-chroma
+- tramai-vectorstore-pgvector
+- tramai-vectorstore-spi

--- a/docs/modules/tramai-spring-boot-starter-local-provider-openai.md
+++ b/docs/modules/tramai-spring-boot-starter-local-provider-openai.md
@@ -1,0 +1,50 @@
+# Module: `tramai-spring-boot-starter-local-provider-openai`
+
+> **One-liner:** Local (non-egress) OpenAI-compatible provider starter — auto-configures a loopback/offline ModelProvider bean for development.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Local (non-egress) OpenAI-compatible provider starter: auto-configures an OpenAI-compatible `ModelProvider` bean for offline/loopback development.
+
+### Public entry points
+
+- `OpenAiCompatibleProviderAutoConfiguration` — auto-configuration
+- `TramaiProviderProperties` — configuration properties
+
+Verify against `tramai-spring-boot-starter-local-provider-openai/api/tramai-spring-boot-starter-local-provider-openai.api`.
+
+### Internal extension points
+
+- Provider property namespace (`tramai.providers.*`)
+
+### Significant dependencies
+
+- `api(tramai-openai)` — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Spring context lifecycle
+
+### Thread-safety and concurrency
+
+- Spring singleton provider; must be safe for concurrent invocation
+
+### Failure semantics
+
+- Provider misconfiguration surfaces at context startup
+
+### Contract tests / TCKs
+
+- `OpenAiCompatibleProviderAutoConfigurationTest` (in sovereign-lab smoke/E2E)
+
+### Do not
+
+- Do not add cloud-egress providers here — this is the local-development surface
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — framework-integrations layer

--- a/docs/modules/tramai-spring-boot-starter-sovereign-ops-actuator.md
+++ b/docs/modules/tramai-spring-boot-starter-sovereign-ops-actuator.md
@@ -1,0 +1,51 @@
+# Module: `tramai-spring-boot-starter-sovereign-ops-actuator`
+
+> **One-liner:** Actuator surface for sovereign ops — health indicators and worker-status/metrics snapshot endpoints.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Actuator surface for sovereign ops: health indicators (`SovereignOpsWorkerHealthIndicator`, `ApprovedContinuationResumeWorkerHealthIndicator`), worker-status endpoint properties, resume-queue metrics snapshots.
+
+### Public entry points
+
+- `SovereignOpsWorkerHealthIndicator`, `ApprovedContinuationResumeWorkerHealthIndicator` — health indicators
+- `SovereignOpsWorkerStatusEndpointProperties`, `ApprovedContinuationResumeWorkerMetricsProperties` — properties
+- `ApprovedResumeQueueMetricsSnapshotProvider` — metrics snapshot
+
+Verify against `tramai-spring-boot-starter-sovereign-ops-actuator/api/tramai-spring-boot-starter-sovereign-ops-actuator.api`.
+
+### Internal extension points
+
+- Health/metrics providers for the ops surface
+
+### Significant dependencies
+
+- `api(tramai-spring-boot-starter-sovereign-ops)`; Spring Boot actuator (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Spring context lifecycle
+
+### Thread-safety and concurrency
+
+- Spring singletons; health/metrics calls must be safe for concurrent HTTP requests
+
+### Failure semantics
+
+- Health indicator degrades to DOWN rather than throwing on store unavailability
+
+### Contract tests / TCKs
+
+- `SovereignOpsWorkerHealthIndicatorTest`, `ApprovedResumeQueueMetricsSnapshotProviderTest`
+
+### Do not
+
+- Do not add micrometer/OTel bindings here — use the dedicated ops-observability starters
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — framework-integrations layer

--- a/docs/modules/tramai-spring-boot-starter-sovereign-ops-micrometer.md
+++ b/docs/modules/tramai-spring-boot-starter-sovereign-ops-micrometer.md
@@ -1,0 +1,50 @@
+# Module: `tramai-spring-boot-starter-sovereign-ops-micrometer`
+
+> **One-liner:** Micrometer binding for sovereign ops — exports audit-outbox worker metrics via a worker observer.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Micrometer binding for sovereign ops: exports audit-outbox worker metrics (`MicrometerSovereignOpsAuditOutboxWorkerObserver`) via `SovereignOpsOutboxMicrometerAutoConfiguration`.
+
+### Public entry points
+
+- `MicrometerSovereignOpsAuditOutboxWorkerObserver` — metrics observer
+- `SovereignOpsOutboxMicrometerAutoConfiguration` — auto-configuration
+
+Verify against `tramai-spring-boot-starter-sovereign-ops-micrometer/api/tramai-spring-boot-starter-sovereign-ops-micrometer.api`.
+
+### Internal extension points
+
+- Audit-outbox worker observer slot
+
+### Significant dependencies
+
+- `api(tramai-spring-boot-starter-sovereign-ops)`; Micrometer (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Spring context lifecycle
+
+### Thread-safety and concurrency
+
+- Metrics registration is idempotent; observer must be safe for concurrent use
+
+### Failure semantics
+
+- Metrics export failures must not break the worker path
+
+### Contract tests / TCKs
+
+- Covered via sovereign ops E2E (metrics assertions)
+
+### Do not
+
+- Do not add OTel bindings here — use the observability starter
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — framework-integrations layer

--- a/docs/modules/tramai-spring-boot-starter-sovereign-ops-observability.md
+++ b/docs/modules/tramai-spring-boot-starter-sovereign-ops-observability.md
@@ -1,0 +1,50 @@
+# Module: `tramai-spring-boot-starter-sovereign-ops-observability`
+
+> **One-liner:** OpenTelemetry binding for sovereign ops — exports audit-outbox worker spans via a worker observer.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+OpenTelemetry binding for sovereign ops: exports audit-outbox worker spans (`OpenTelemetrySovereignOpsAuditOutboxWorkerObserver`) via `SovereignOpsOutboxObservabilityAutoConfiguration`.
+
+### Public entry points
+
+- `OpenTelemetrySovereignOpsAuditOutboxWorkerObserver` — observability observer
+- `SovereignOpsOutboxObservabilityAutoConfiguration` — auto-configuration
+
+Verify against `tramai-spring-boot-starter-sovereign-ops-observability/api/tramai-spring-boot-starter-sovereign-ops-observability.api`.
+
+### Internal extension points
+
+- Audit-outbox worker observer slot
+
+### Significant dependencies
+
+- `api(tramai-spring-boot-starter-sovereign-ops)`; OpenTelemetry SDK (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Spring context lifecycle
+
+### Thread-safety and concurrency
+
+- Observer must be safe for concurrent use
+
+### Failure semantics
+
+- Tracing failures must not break the worker path
+
+### Contract tests / TCKs
+
+- Covered via sovereign ops E2E
+
+### Do not
+
+- Do not add micrometer bindings here — use the micrometer starter
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — framework-integrations layer

--- a/docs/modules/tramai-spring-boot-starter-sovereign-ops-rest.md
+++ b/docs/modules/tramai-spring-boot-starter-sovereign-ops-rest.md
@@ -1,0 +1,51 @@
+# Module: `tramai-spring-boot-starter-sovereign-ops-rest`
+
+> **One-liner:** REST surface for sovereign ops — approval control-plane and inbox controllers with reviewer UI support.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+REST surface for sovereign ops: approval control-plane + inbox controllers (`ApprovalControlPlaneController`, `ApprovalInboxController`), reviewer UI controller, DTOs.
+
+### Public entry points
+
+- `ApprovalControlPlaneController`, `ApprovalInboxController`, `ApprovalReviewerUiController` — controllers
+- `ApprovalInboxDtos`, `ApprovalControlPlaneRestDtos` — DTOs
+- `ApprovalControlPlaneRestAutoConfiguration` — auto-configuration
+
+Verify against `tramai-spring-boot-starter-sovereign-ops-rest/api/tramai-spring-boot-starter-sovereign-ops-rest.api`.
+
+### Internal extension points
+
+- REST transport over the ops operations
+
+### Significant dependencies
+
+- `api(tramai-spring-boot-starter-sovereign-ops)`; Spring Web (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Spring context lifecycle; controllers are container singletons
+
+### Thread-safety and concurrency
+
+- Controllers must be safe for concurrent HTTP requests
+
+### Failure semantics
+
+- Approval operations surface typed HTTP error responses
+
+### Contract tests / TCKs
+
+- `ApprovalControlPlaneControllerTest`, `ApprovalInboxControllerTest`
+
+### Do not
+
+- Do not add persistence here — controllers delegate to the ops operations
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — framework-integrations layer

--- a/docs/modules/tramai-spring-boot-starter-sovereign-ops.md
+++ b/docs/modules/tramai-spring-boot-starter-sovereign-ops.md
@@ -1,0 +1,51 @@
+# Module: `tramai-spring-boot-starter-sovereign-ops`
+
+> **One-liner:** Sovereign operations core — approval/resume control plane, audit operations, suspended-invocation operations, and the approved-continuation resume worker.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Sovereign operations core: approval/resume control plane, audit operations, suspended-invocation operations, approved-continuation resume worker — the ops surface shared by all sovereign ops starters.
+
+### Public entry points
+
+- `SovereignAuditOperations`, `SovereignSuspendedInvocationOperations`, `DefaultSovereignSuspendedInvocationOperations` — operations
+- `ApprovalResumeControlPlaneAutoConfiguration`, `ApprovedContinuationResumeWorkerAutoConfiguration` — auto-configurations
+- `ApprovedContinuationResumeWorkerStatusSnapshot` — status model
+
+Verify against `tramai-spring-boot-starter-sovereign-ops/api/tramai-spring-boot-starter-sovereign-ops.api` (largest sovereign-ops api dump).
+
+### Internal extension points
+
+- Store/observer seams for persistence and observability (implemented by persistence/ops starters)
+
+### Significant dependencies
+
+- `api(tramai-core)`, `api(tramai-security)`, `api(tramai-sovereign)`, `api(tramai-spring-sovereign)`; `implementation(tramai-engine)` — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Spring context lifecycle; worker lifecycle via auto-configuration
+
+### Thread-safety and concurrency
+
+- Spring singletons; worker must handle concurrent tick dispatch
+
+### Failure semantics
+
+- Approval/resume failures surface as typed store/operation errors; no silent partial writes
+
+### Contract tests / TCKs
+
+- Sovereign ops E2E tests (JDBC persistence, regulated-claim triage)
+
+### Do not
+
+- Do not add persistence or observability bindings here — those are separate starters
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — framework-integrations layer

--- a/docs/modules/tramai-spring-boot-starter-sovereign-persistence-file.md
+++ b/docs/modules/tramai-spring-boot-starter-sovereign-persistence-file.md
@@ -1,0 +1,52 @@
+# Module: `tramai-spring-boot-starter-sovereign-persistence-file`
+
+> **One-liner:** File persistence for sovereign ops — file-backed audit-outbox store, store key loading, and file persistence auto-configuration.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+File persistence for sovereign ops: `FileSovereignOpsAuditOutboxStore`, `SovereignStoreKeyLoader`, sovereign file persistence properties + auto-configuration.
+
+### Public entry points
+
+- `FileSovereignOpsAuditOutboxStore` — audit-outbox store implementation
+- `SovereignFilePersistenceProperties` — configuration properties
+- `SovereignStoreKeyLoader` — store key loading
+- `SovereignFilePersistenceAutoConfiguration` — auto-configuration
+
+Verify against `tramai-spring-boot-starter-sovereign-persistence-file/api/tramai-spring-boot-starter-sovereign-persistence-file.api`.
+
+### Internal extension points
+
+- Ops store implementation slot (file-backed)
+
+### Significant dependencies
+
+- `api(tramai-spring-sovereign)`, `api(tramai-persistence-file)`, `api(tramai-spring-boot-starter-sovereign-ops)` — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Spring context lifecycle; file resources managed by the store
+
+### Thread-safety and concurrency
+
+- Store must be safe for concurrent access; file locking is store-scoped
+
+### Failure semantics
+
+- Persistence failures surface as typed store errors; no silent partial writes
+
+### Contract tests / TCKs
+
+- `SovereignFilePersistenceTest`, sovereign ops E2E (file profile)
+
+### Do not
+
+- Do not add JDBC logic here — use the JDBC persistence starter
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — framework-integrations layer

--- a/docs/modules/tramai-spring-boot-starter-sovereign-persistence-jdbc.md
+++ b/docs/modules/tramai-spring-boot-starter-sovereign-persistence-jdbc.md
@@ -1,0 +1,51 @@
+# Module: `tramai-spring-boot-starter-sovereign-persistence-jdbc`
+
+> **One-liner:** JDBC persistence for sovereign ops — JDBC audit-outbox/approval/lease stores, payload codecs, and auto-configuration.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+JDBC persistence for sovereign ops: JDBC stores for audit outbox, approval mutations, approval requests, worker leases; suspended-invocation payload codec; auto-configuration.
+
+### Public entry points
+
+- `JdbcSovereignOpsAuditOutboxStore`, `JdbcSovereignOpsApprovalMutationStore`, `JdbcSovereignOpsApprovalRequestMutationStore`, `JdbcSovereignOpsWorkerLeaseStore` — JDBC stores
+- `DefaultJdbcSuspendedInvocationPayloadCodec`, `JdbcOpsAuditOutboxPayloadCodec` — codecs
+- `SovereignJdbcPersistenceAutoConfiguration` — auto-configuration
+
+Verify against `tramai-spring-boot-starter-sovereign-persistence-jdbc/api/tramai-spring-boot-starter-sovereign-persistence-jdbc.api`.
+
+### Internal extension points
+
+- Ops store implementation slot (JDBC-backed)
+
+### Significant dependencies
+
+- `api(tramai-spring-sovereign)`, `api(tramai-spring-boot-starter-sovereign-ops)`, `api(tramai-persistence-jdbc)`, `api(tramai-security)` — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Spring context lifecycle; connections/pools borrowed from the container datasource
+
+### Thread-safety and concurrency
+
+- Stores must be safe for concurrent access; lease/claim locking is store-scoped
+
+### Failure semantics
+
+- Persistence failures surface as typed store errors; audit stream remains tamper-evident (E2E-verified)
+
+### Contract tests / TCKs
+
+- `JdbcSovereignRuntimeE2ETest` (embedded Postgres), regulated-claim triage E2E
+
+### Do not
+
+- Do not add file persistence here — use the file persistence starter
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — framework-integrations layer

--- a/docs/modules/tramai-spring-boot-starter.md
+++ b/docs/modules/tramai-spring-boot-starter.md
@@ -1,0 +1,47 @@
+# Module: `tramai-spring-boot-starter`
+
+> **One-liner:** Unified Spring Boot starter — aggregates tramai-spring-core (generic runtime) and tramai-spring-sovereign (sovereign profile) into one dependency, profile selected via tramai.profile.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Unified Spring Boot starter: aggregation module composing `tramai-spring-core` (generic runtime) + `tramai-spring-sovereign` (sovereign profile) into one dependency. New applications select the profile via `tramai.profile`.
+
+### Public entry points
+
+- Starter artifact only — aggregates `tramai-spring-core` + `tramai-spring-sovereign` (no source of its own)
+
+### Internal extension points
+
+- None — composition/publishing module
+
+### Significant dependencies
+
+- `api(tramai-spring-core)`, `api(tramai-spring-sovereign)` — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- No runtime resources; delegates to the composed modules
+
+### Thread-safety and concurrency
+
+- N/A — no runtime code
+
+### Failure semantics
+
+- N/A — no runtime code
+
+### Contract tests / TCKs
+
+- Covered via consumer tests (spring-sovereign-starter example, E2E)
+
+### Do not
+
+- Do not add provider/secret adapters here — add them via the dedicated starter modules
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — framework-integrations layer

--- a/docs/modules/tramai-spring-consumer-boundary.md
+++ b/docs/modules/tramai-spring-consumer-boundary.md
@@ -1,0 +1,47 @@
+# Module: `tramai-spring-consumer-boundary`
+
+> **One-liner:** Consumer-boundary fixture module — compilation/API evidence for the external-consumer boundary, no runtime code.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Consumer-boundary fixture module: represents the external-consumer boundary for Spring integration (compilation/API evidence), not a runtime library.
+
+### Public entry points
+
+- None — fixture module (no production source, empty api dump)
+
+### Internal extension points
+
+- N/A — fixture
+
+### Significant dependencies
+
+- None (java-library, no project deps) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- N/A — fixture module
+
+### Thread-safety and concurrency
+
+- N/A — fixture module
+
+### Failure semantics
+
+- N/A — fixture module; used by build-time consumer evidence
+
+### Contract tests / TCKs
+
+- Consumed by API-compatibility verification (Epic 10.2)
+
+### Do not
+
+- Do not add runtime code here — this is a boundary fixture
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — testing-support layer

--- a/docs/modules/tramai-spring-consumer-selective.md
+++ b/docs/modules/tramai-spring-consumer-selective.md
@@ -1,0 +1,47 @@
+# Module: `tramai-spring-consumer-selective`
+
+> **One-liner:** Selective-consumer fixture module — compiles against a subset of Spring modules as API-compatibility consumer evidence.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Selective-consumer fixture module: compiles against a subset of Spring modules (`tramai-spring` facade + `tramai-spring-provider-openai`) as consumer evidence for API compatibility.
+
+### Public entry points
+
+- None — fixture module (no production source, empty api dump)
+
+### Internal extension points
+
+- N/A — fixture
+
+### Significant dependencies
+
+- `implementation(tramai-spring)`, `implementation(tramai-spring-provider-openai)` — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- N/A — fixture module
+
+### Thread-safety and concurrency
+
+- N/A — fixture module
+
+### Failure semantics
+
+- N/A — fixture module; used by build-time consumer evidence
+
+### Contract tests / TCKs
+
+- Consumed by API-compatibility verification (Epic 10.2)
+
+### Do not
+
+- Do not add runtime code here — this is a consumer fixture
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — testing-support layer

--- a/docs/modules/tramai-spring-core.md
+++ b/docs/modules/tramai-spring-core.md
@@ -1,0 +1,53 @@
+# Module: `tramai-spring-core`
+
+> **One-liner:** Profile-neutral Spring integration core — auto-configures the TramAI runtime, scans @AiService interfaces and @AiTool beans, and binds tramai.* properties for all Spring adapters.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Profile-neutral Spring integration core: `Tramai` runtime wiring, `@AiService` proxy registration, `@AiTool` bean scanning, secret resolution chain, security classification — the shared base for all Spring adapters.
+
+### Public entry points
+
+- `TramaiAutoConfiguration`, `AiServiceProxyAutoConfiguration`, `SecurityClassificationAutoConfiguration` — auto-configurations
+- `SpringSecretChain`, `SecretValueResolver`, `SpringBuiltInSecretValueResolver` — secret resolution
+- `AiToolScanner` — tool discovery
+- `EnableTramai` — annotation opt-in for non-Boot Spring contexts
+
+Verify against `tramai-spring-core/api/tramai-spring-core.api`.
+
+### Internal extension points
+
+- `SecretValueResolver` implementation slot (secrets modules plug in here)
+
+### Significant dependencies
+
+- `api(tramai-standalone)`; Spring Boot autoconfigure/context, Jackson (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Spring context lifecycle; beans managed by the container
+
+### Thread-safety and concurrency
+
+- Spring singletons; proxies must be safe for concurrent invocation
+
+### Failure semantics
+
+- Misconfigured services/providers surface as context startup failures or typed proxy errors
+
+### Contract tests / TCKs
+
+- `TramaiAutoConfigurationTest`, `AiServiceProxyAutoConfigurationTest`, `AiToolScannerTest`
+
+### Do not
+
+- Do not add provider adapters or sovereign composition here — those live in dedicated modules
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — framework-integrations layer
+- [modules.md](../architecture/modules.md) — framework-integrations layer policy

--- a/docs/modules/tramai-spring-provider-anthropic.md
+++ b/docs/modules/tramai-spring-provider-anthropic.md
@@ -1,0 +1,50 @@
+# Module: `tramai-spring-provider-anthropic`
+
+> **One-liner:** Spring auto-configuration for the Anthropic provider — wires AnthropicProvider as a bean with anthropic property namespace.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Spring auto-configuration for the Anthropic provider: `AnthropicProviderAutoConfiguration` + `AnthropicProperties` wiring `AnthropicProvider` as a bean.
+
+### Public entry points
+
+- `AnthropicProviderAutoConfiguration` — auto-configuration
+- `AnthropicProperties` — configuration properties
+
+Verify against `tramai-spring-provider-anthropic/api/tramai-spring-provider-anthropic.api`.
+
+### Internal extension points
+
+- Provider property namespace (`tramai.providers.anthropic.*`)
+
+### Significant dependencies
+
+- `api(tramai-spring-core)`; `implementation(tramai-anthropic)` — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Spring context lifecycle; provider bean retains injected/default `HttpClient` (no close contract)
+
+### Thread-safety and concurrency
+
+- Provider bean must be safe for concurrent invocation
+
+### Failure semantics
+
+- Provider failures normalized per `AnthropicProvider` contracts; misconfiguration fails at startup
+
+### Contract tests / TCKs
+
+- `AnthropicProviderAutoConfigurationTest`
+
+### Do not
+
+- Do not add retry/fallback logic here — the engine owns that
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — framework-integrations layer

--- a/docs/modules/tramai-spring-provider-ollama.md
+++ b/docs/modules/tramai-spring-provider-ollama.md
@@ -1,0 +1,50 @@
+# Module: `tramai-spring-provider-ollama`
+
+> **One-liner:** Spring auto-configuration for the Ollama provider — wires OllamaProvider as a bean with ollama property namespace.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Spring auto-configuration for the Ollama provider: `OllamaProviderAutoConfiguration` + `OllamaProperties` wiring `OllamaProvider` as a bean.
+
+### Public entry points
+
+- `OllamaProviderAutoConfiguration` — auto-configuration
+- `OllamaProperties` — configuration properties
+
+Verify against `tramai-spring-provider-ollama/api/tramai-spring-provider-ollama.api`.
+
+### Internal extension points
+
+- Provider property namespace (`tramai.providers.ollama.*`)
+
+### Significant dependencies
+
+- `api(tramai-spring-core)`; `implementation(tramai-ollama)` — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Spring context lifecycle; provider bean retains injected/default `HttpClient` (no close contract)
+
+### Thread-safety and concurrency
+
+- Provider bean must be safe for concurrent invocation
+
+### Failure semantics
+
+- Provider failures normalized per `OllamaProvider` contracts; misconfiguration fails at startup
+
+### Contract tests / TCKs
+
+- `OllamaProviderAutoConfigurationTest`
+
+### Do not
+
+- Do not add retry/fallback logic here — the engine owns that
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — framework-integrations layer

--- a/docs/modules/tramai-spring-provider-openai.md
+++ b/docs/modules/tramai-spring-provider-openai.md
@@ -1,0 +1,51 @@
+# Module: `tramai-spring-provider-openai`
+
+> **One-liner:** Spring auto-configuration for OpenAI/OpenAI-compatible providers — wires provider beans with openai property namespace and Codex auth support.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Spring auto-configuration for OpenAI/OpenAI-compatible providers: `OpenAiProviderAutoConfiguration` + `OpenAiProperties`/`OpenAiCompatibleProperties`/`CodexAuth` wiring provider beans.
+
+### Public entry points
+
+- `OpenAiProviderAutoConfiguration` — auto-configuration
+- `OpenAiProperties`, `OpenAiCompatibleProperties` — configuration properties
+- `CodexAuth` — Codex auth support
+
+Verify against `tramai-spring-provider-openai/api/tramai-spring-provider-openai.api`.
+
+### Internal extension points
+
+- Provider property namespace (`tramai.providers.openai.*`)
+
+### Significant dependencies
+
+- `api(tramai-spring-core)`; `implementation(tramai-openai)` — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Spring context lifecycle; provider beans retain injected/default `HttpClient` (no close contract)
+
+### Thread-safety and concurrency
+
+- Provider beans must be safe for concurrent invocation
+
+### Failure semantics
+
+- Provider failures normalized per `OpenAiProvider` contracts; misconfiguration fails at startup
+
+### Contract tests / TCKs
+
+- `OpenAiProviderAutoConfigurationTest`
+
+### Do not
+
+- Do not add retry/fallback logic here — the engine owns that
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — framework-integrations layer

--- a/docs/modules/tramai-spring-secrets-aws.md
+++ b/docs/modules/tramai-spring-secrets-aws.md
@@ -1,0 +1,51 @@
+# Module: `tramai-spring-secrets-aws`
+
+> **One-liner:** AWS Secrets Manager secret resolution — plugs AwsSecretsManagerSecretValueResolver into the core SecretValueResolver chain.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+AWS Secrets Manager secret resolution: `AwsSecretsManagerSecretValueResolver` + properties + auto-configuration, plugged into the core `SecretValueResolver` chain.
+
+### Public entry points
+
+- `AwsSecretsManagerSecretValueResolver` — `SecretValueResolver` implementation
+- `AwsSecretsManagerProperties` — configuration properties
+- `AwsSecretsManagerSecretValueResolverAutoConfiguration` — auto-configuration
+
+Verify against `tramai-spring-secrets-aws/api/tramai-spring-secrets-aws.api`.
+
+### Internal extension points
+
+- Core secret-resolution chain slot
+
+### Significant dependencies
+
+- `api(tramai-spring-core)`; AWS SDK secretsmanager (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Spring context lifecycle
+
+### Thread-safety and concurrency
+
+- Resolver must be safe for concurrent resolution calls
+
+### Failure semantics
+
+- Secret-resolution failures surface as typed resolver errors; secrets never logged
+
+### Contract tests / TCKs
+
+- `AwsSecretsManagerSecretValueResolverTest` (mock AWS SDK)
+
+### Do not
+
+- Do not add file/vault resolvers here — use the dedicated secrets modules
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — framework-integrations layer

--- a/docs/modules/tramai-spring-secrets-file.md
+++ b/docs/modules/tramai-spring-secrets-file.md
@@ -1,0 +1,50 @@
+# Module: `tramai-spring-secrets-file`
+
+> **One-liner:** File-based secret resolution — plugs a file-backed resolver into the core SecretValueResolver chain.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+File-based secret resolution: `FileSecretProperties` + `FileSecretValueResolverAutoConfiguration` plugged into the core `SecretValueResolver` chain.
+
+### Public entry points
+
+- `FileSecretProperties` — configuration properties
+- `FileSecretValueResolverAutoConfiguration` — auto-configuration
+
+Verify against `tramai-spring-secrets-file/api/tramai-spring-secrets-file.api`.
+
+### Internal extension points
+
+- Core secret-resolution chain slot
+
+### Significant dependencies
+
+- `api(tramai-spring-core)` — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Spring context lifecycle
+
+### Thread-safety and concurrency
+
+- Resolver must be safe for concurrent resolution calls
+
+### Failure semantics
+
+- Secret-resolution failures surface as typed resolver errors; secrets never logged
+
+### Contract tests / TCKs
+
+- `FileSecretValueResolverTest`
+
+### Do not
+
+- Do not add cloud/vault resolvers here — use the dedicated secrets modules
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — framework-integrations layer

--- a/docs/modules/tramai-spring-secrets-vault.md
+++ b/docs/modules/tramai-spring-secrets-vault.md
@@ -1,0 +1,51 @@
+# Module: `tramai-spring-secrets-vault`
+
+> **One-liner:** HashiCorp Vault secret resolution — plugs VaultSecretValueResolver into the core SecretValueResolver chain.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+HashiCorp Vault secret resolution: `VaultSecretValueResolver` + `VaultSecretProperties` + auto-configuration plugged into the core `SecretValueResolver` chain.
+
+### Public entry points
+
+- `VaultSecretValueResolver` — `SecretValueResolver` implementation
+- `VaultSecretProperties` — configuration properties
+- `VaultSecretValueResolverAutoConfiguration` — auto-configuration
+
+Verify against `tramai-spring-secrets-vault/api/tramai-spring-secrets-vault.api`.
+
+### Internal extension points
+
+- Core secret-resolution chain slot
+
+### Significant dependencies
+
+- `api(tramai-spring-core)`; Spring Vault (implementation) — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Spring context lifecycle
+
+### Thread-safety and concurrency
+
+- Resolver must be safe for concurrent resolution calls
+
+### Failure semantics
+
+- Secret-resolution failures surface as typed resolver errors; secrets never logged
+
+### Contract tests / TCKs
+
+- `VaultSecretValueResolverTest`
+
+### Do not
+
+- Do not add file/AWS resolvers here — use the dedicated secrets modules
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — framework-integrations layer

--- a/docs/modules/tramai-spring-sovereign.md
+++ b/docs/modules/tramai-spring-sovereign.md
@@ -1,0 +1,53 @@
+# Module: `tramai-spring-sovereign`
+
+> **One-liner:** Sovereign-profile Spring integration — auto-configures the sovereign TramAI runtime (authority guard, sovereign AI-service proxy, sovereign properties) for profile-enabled Boot applications.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+## Architecture
+
+### Responsibility
+
+Sovereign profile Spring integration: the sovereign composition layer under the unified starter. Provides the top-level `SovereignTramaiAutoConfiguration` that wires the sovereign runtime into a Boot context, plus the `SovereignTramaiProperties` namespace.
+
+### Public entry points
+
+- `SovereignTramaiAutoConfiguration` — auto-configuration (top-level public type in the API dump)
+- `SovereignTramaiProperties` — configuration properties
+
+Verify against `tramai-spring-sovereign/api/tramai-spring-sovereign.api` — only these two are top-level public types.
+
+### Internal extension points
+
+- `SovereignTramaiProfileAutoConfiguration` — internal profile-activation wiring (not public API)
+- `StandardProfileSovereignAuthorityGuardAutoConfiguration` — internal authority-guard wiring (not public API)
+- `SovereignAiServiceProxyAutoConfiguration` — internal sovereign AI-service proxy wiring (not public API)
+- Sovereign profile wiring; authority-guard seam
+
+### Significant dependencies
+
+- `api(tramai-core)`, `api(tramai-security)`, `api(tramai-sovereign)`, `api(tramai-spring-core)` — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Spring context lifecycle; sovereign runtime owned by the container
+
+### Thread-safety and concurrency
+
+- Spring singletons; proxies must be safe for concurrent invocation
+
+### Failure semantics
+
+- Sovereignty violations surface as typed guard/authority errors
+
+### Contract tests / TCKs
+
+- Sovereign spring tests + E2E (sovereign-lab profile)
+
+### Do not
+
+- Do not add ops/persistence here — those live in the sovereign-ops/persistence starters
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — framework-integrations layer

--- a/docs/modules/tramai-spring.md
+++ b/docs/modules/tramai-spring.md
@@ -1,11 +1,62 @@
 # Module: `tramai-spring`
 
-> **One-liner:** Spring Boot auto-configuration that wires Tramai's `Tramai` runtime, scans `@AiService` interfaces, discovers `@AiTool` beans, and binds `tramai.*` application properties — all with zero manual bean declarations.
-> **Module type:** `framework-adapter`
-> **Source files:** 9 — `EnableTramai.kt`, `TramaiAutoConfiguration.kt`, `TramaiProperties.kt`, `AiServiceBeanDefinitionRegistrar.kt`, `AiServiceFactoryBean.kt`, `AiToolScanner.kt`, `TramaiSecretResolutionAutoConfiguration.kt`, `SpringSecretResolution.kt`, `SpringBuiltInSecretValueResolver.kt`
-> **Test files:** 3 — `TramaiAutoConfigurationTest.kt`, `TramaiAutoConfigurationConditionsTest.kt`, `SecurityAutoConfigurationTest.kt`
-> **Build:** `dev.tramai:tramai-spring:0.5.0`
-> **Depends on:** `tramai-spring-core` (thin facade; provider and secret adapters are separate modules)
+> **One-liner:** Legacy Spring Boot facade over `tramai-spring-core`. Retained for back-compatibility; **not** the onboarding entry point — new applications use the unified `tramai-spring-boot-starter`.
+
+> **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)
+
+---
+
+## Architecture
+
+### Responsibility
+
+**Legacy facade** over `tramai-spring-core` (manifest rationale: "Legacy Spring facade over :tramai-spring-core retained for back-compatibility; not the onboarding entry point"). Provides the classic `@AutoConfiguration` wiring of the `Tramai` runtime with `@AiService` scanning, `@AiTool` discovery, and `tramai.*` property binding for existing 0.5.x applications.
+
+### Public entry points
+
+- `TramaiAutoConfiguration` — auto-configuration
+- `TramaiProperties` — configuration properties
+- `AiServiceBeanDefinitionRegistrar`, `AiServiceFactoryBean` — `@AiService` scanning/registration
+- `AiToolScanner` — tool discovery
+- `EnableTramai` — annotation opt-in
+- `SpringSecretResolution`, `SpringBuiltInSecretValueResolver` — secret resolution
+
+Verify against `tramai-spring/api/tramai-spring.api`.
+
+### Internal extension points
+
+- Secret-resolution chain slot (delegates to `tramai-spring-core`)
+
+### Significant dependencies
+
+- `api(tramai-spring-core)` (thin facade); provider and secret adapters are separate modules — see [module-catalog.yml](../../config/quality/module-catalog.yml)
+
+### Lifecycle ownership
+
+- Spring context lifecycle; beans managed by the container
+
+### Thread-safety and concurrency
+
+- Spring singletons; proxies must be safe for concurrent invocation
+
+### Failure semantics
+
+- Misconfiguration surfaces at context startup; provider failures normalized per provider contracts
+
+### Contract tests / TCKs
+
+- `TramaiAutoConfigurationTest`, `TramaiAutoConfigurationConditionsTest`, `SecurityAutoConfigurationTest`
+
+### Do not
+
+- Do not present legacy APIs as canonical — new integrations use the unified starter
+- Do not add provider/secret adapters here — use the dedicated Spring starter modules
+
+### Related architecture
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — framework-integrations layer
+- [modules.md](../architecture/modules.md) — framework-integrations layer policy
+- [module-matrix.md](../../docs/reference/module-matrix.md)
 
 ---
 
@@ -13,7 +64,7 @@
 
 ### What
 
-`tramai-spring` is the 0.6.0 compatibility facade over `tramai-spring-core`. New applications should depend on the canonical [`tramai-spring-boot-starter`](sovereign-runtime-module-matrix.md) instead — one starter for both runtime profiles, profile selected via `tramai.profile`.
+`tramai-spring` is the 0.6.0 compatibility facade over `tramai-spring-core`. New applications should depend on the canonical [`tramai-spring-boot-starter`](tramai-spring-boot-starter.md) instead — one starter for both runtime profiles, profile selected via `tramai.profile`.
 
 `tramai-spring` is a thin Spring Boot `@AutoConfiguration` that takes the same `Tramai` runtime you'd build manually with `tramai-standalone` and makes it available through Spring's DI container. Add the dependency, define an `@AiService` interface, and it becomes an injectable bean — no `@Bean` factory methods, no manual `Tramai.builder()` chains. Under Spring Boot, `@EnableTramai` is normally unnecessary; in annotation-driven/non-Boot Spring contexts it is the explicit opt-in.
 
@@ -48,8 +99,11 @@ Don't use this module when:
 
 ```kotlin
 // build.gradle.kts
+// tramaiVersion is the canonical version property (see gradle.properties)
+val tramaiVersion: String by project
+
 dependencies {
-    implementation(platform("dev.tramai:tramai-bom:0.5.0"))
+    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
     implementation("dev.tramai:tramai-spring")
     // 0.6.0: select adapters explicitly
     implementation("dev.tramai:tramai-spring-provider-openai") // or -anthropic, -ollama
@@ -65,7 +119,7 @@ dependencies {
     <dependency>
       <groupId>dev.tramai</groupId>
       <artifactId>tramai-bom</artifactId>
-      <version>0.5.0</version>
+      <version>${tramai.version}</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>
@@ -103,7 +157,11 @@ Three steps: add `tramai-spring` **plus the adapter(s) you select**, define an `
 
 ```kotlin
 // build.gradle.kts
+// tramaiVersion is the canonical version property (see gradle.properties)
+val tramaiVersion: String by project
+
 dependencies {
+    implementation(platform("dev.tramai:tramai-bom:$tramaiVersion"))
     implementation("dev.tramai:tramai-spring")
     implementation("dev.tramai:tramai-spring-provider-openai") // 0.6.0: explicit adapter
 }


### PR DESCRIPTION
# docs: normalize tramai-spring + Spring family cards (Epic 11.2b3a)

Normalize the final non-conforming card and add the Spring family — the first slice of C2b3 (Epic 11.2b closure). **Base: master. Stacked under: C2b3b (docs/0.6.0-module-cards-b3b).**

## Scope (docs-only, 21 files)

- **tramai-spring normalized as the LEGACY FACADE** over `tramai-spring-core` (manifest rationale: "retained for back-compatibility; not the onboarding entry point"). Removed legacy header metadata (`Module type:` / `Source files:` / `Test files:` / `Build: 0.5.0`), added the 10-heading Architecture contract, canonical new-user routing points at the unified `tramai-spring-boot-starter`, all Gradle/Maven snippets made self-contained (BOM-imported or explicit version).
- **17 new framework-integration cards**: `tramai-spring-core`, `tramai-spring-boot-starter`, `tramai-spring-boot-starter-local-provider-openai`, sovereign-ops (+actuator/micrometer/observability/rest), sovereign-persistence-file/jdbc, `tramai-spring-provider-{anthropic,ollama,openai}`, `tramai-spring-secrets-{aws,file,vault}`, `tramai-spring-sovereign` — public entry points verified against api dumps, dependencies verified against `build.gradle.kts`.
- **2 new testing-support cards**: `tramai-spring-consumer-boundary`, `tramai-spring-consumer-selective` (fixture modules; repository composition only, no runtime surface).

## Semantic rules applied

- Manifest owns classification (cards link, never duplicate maturity/publishability/release).
- JVM-public ≠ supported consumer API; manifest publishability decides.
- Internal modules document `project(":...")` composition, never external Maven consumption.
- Every dependency snippet resolves as copied.
- Links are meaning-based, not merely existent.

## Coverage after this slice

60 manifest / **51 cards / 51 conforming / 0 non-conforming / 9 missing (example slice → C2b3b) / 0 orphan**

## Verification

- verifyPr, verify060Architecture, verifySovereignRuntimeClosure (471 tasks): green
- No production source changes.

This PR needs review before merge.
