### PR TITLE
chore: un-ignore dev.tramai.build Kotlin package dir in build-logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,15 @@
 .gradle
 /build/
 **/build/
+
+# `dev.tramai.build` is a legitimate build-logic Kotlin package directory,
+# NOT generated output. `**/build/` above matches it; un-ignore it so new
+# source files there (e.g. ModuleDocContractVerifier.kt) can be tracked
+# without `git add -f`.
+!build-logic/src/main/kotlin/dev/tramai/build/
+!build-logic/src/main/kotlin/dev/tramai/build/**
+!build-logic/src/test/kotlin/dev/tramai/build/
+!build-logic/src/test/kotlin/dev/tramai/build/**
 gradle-app.setting
 *.iml
 *.log


### PR DESCRIPTION
# chore: un-ignore `dev.tramai.build` Kotlin package dir in build-logic

Tiny build-hygiene fix. **Scope: `.gitignore` only.**

## Problem

`.gitignore` contains `**/build/` (line 5), which is intended for generated Gradle build outputs — but it also matches the legitimate Kotlin package directory:

```
build-logic/src/main/kotlin/dev/tramai/build/
build-logic/src/test/kotlin/dev/tramai/build/
```

This caused `ModuleDocContractVerifier.kt` to **disappear from commits twice** during Epic 11.2b3 (lost during stash recovery, missing from a rebase cherry-pick) — each time requiring `git add -f` and a CI-red → amend → force-push cycle to recover. Any new source file under `dev/tramai/build/` silently stays untracked.

## Fix

Keep `**/build/` for all generated outputs. Add narrow negation exceptions for exactly the two source trees:

```gitignore
!build-logic/src/main/kotlin/dev/tramai/build/
!build-logic/src/main/kotlin/dev/tramai/build/**
!build-logic/src/test/kotlin/dev/tramai/build/
!build-logic/src/test/kotlin/dev/tramai/build/**
```

Deliberately NOT changed to `/*/build/` — that could stop ignoring nested Gradle build outputs in subprojects.

## Acceptance (verified)

| Path | Expected | Result |
|------|----------|--------|
| `build-logic/src/main/kotlin/dev/tramai/build/quality/__probe__.kt` | not ignored | ✅ (real probe file shows `??` in git status) |
| `build-logic/src/test/kotlin/dev/tramai/build/quality/__probe__.kt` | not ignored | ✅ (real probe file shows `??`) |
| `build-logic/build/classes/__probe__` | still ignored | ✅ (`**/build/`) |
| `tramai-core/build/classes/__probe__` | still ignored | ✅ (`**/build/`) |
| `ModuleDocContractVerifier.kt` | still tracked | ✅ `git ls-files` prints it |

## Verification

- verifyPr ✅
- verify060Architecture ✅
- No production source changes.

Open for review — should land before starting C2c.
