### PR TITLE
docs: add Epic 11.2c change guides (AI navigation closure)

### DIFF
--- a/docs/architecture/change-guides/README.md
+++ b/docs/architecture/change-guides/README.md
@@ -2,7 +2,7 @@
 
 Step-by-step guides for the most common modifications in the TramAI repository. Each guide names the exact extension point (interface/SPI/builder), the files that must change, the mandatory contract tests (TCKs), and the verification commands.
 
-**Start here:** [`ARCHITECTURE.md`](../../ARCHITECTURE.md) for the module map and ownership pointers; then open the guide for the change you are making; then follow [`AGENTS.md`](../../AGENTS.md) for the execution protocol (change classification, stop conditions, gates).
+**Start here:** [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) for the module map and ownership pointers; then open the guide for the change you are making; then follow [`AGENTS.md`](../../../AGENTS.md) for the execution protocol (change classification, stop conditions, gates).
 
 ## Guides
 
@@ -21,6 +21,6 @@ Every guide was written against the current source tree (verified file:line refe
 
 ## Related navigation
 
-- Module cards with per-module responsibilities: [`docs/modules/`](../modules/README.md)
+- Module cards with per-module responsibilities: [`docs/modules/`](../../modules/README.md)
 - Runtime execution ownership map: [`execution-sequence.md`](../execution-sequence.md)
-- Machine-readable module catalog / boundaries: [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml), [`config/quality/module-boundaries.yml`](../../config/quality/module-boundaries.yml)
+- Machine-readable module catalog / boundaries: [`config/quality/module-catalog.yml`](../../../config/quality/module-catalog.yml), [`config/quality/module-boundaries.yml`](../../../config/quality/module-boundaries.yml)

--- a/docs/architecture/change-guides/README.md
+++ b/docs/architecture/change-guides/README.md
@@ -1,0 +1,26 @@
+# Change Guides
+
+Step-by-step guides for the most common modifications in the TramAI repository. Each guide names the exact extension point (interface/SPI/builder), the files that must change, the mandatory contract tests (TCKs), and the verification commands.
+
+**Start here:** [`ARCHITECTURE.md`](../../ARCHITECTURE.md) for the module map and ownership pointers; then open the guide for the change you are making; then follow [`AGENTS.md`](../../AGENTS.md) for the execution protocol (change classification, stop conditions, gates).
+
+## Guides
+
+| Change | Guide | Key contract |
+|---|---|---|
+| New provider adapter module | [adding-a-provider.md](adding-a-provider.md) | `ProviderTck` + `ProviderTckEnrollmentArchitectureTest` |
+| New workflow step (built-in or external) | [adding-a-workflow-step.md](adding-a-workflow-step.md) | step TCK + digest golden + cancellation scanner |
+| New persistence store implementation | [adding-a-store.md](adding-a-store.md) | shared store TCK + `*EnrollmentArchitectureTest` |
+| New runtime event (catalogue + guards) | [adding-an-event.md](adding-an-event.md) | `RuntimeEventCatalogueArchitectureTest` (ASM + source) |
+| New approval state / transition | [adding-an-approval-state.md](adding-an-approval-state.md) | `ApprovalStoreTck` + `ApprovalContinuationStoreTck` + lifecycle-model property tests |
+| Change structured-output constraints | [changing-structured-output-constraints.md](changing-structured-output-constraints.md) | `StructuredOutputContractTck` + `ContractEvolutionTest` |
+
+## How the guides stay honest
+
+Every guide was written against the current source tree (verified file:line references). The TCKs named by each guide are **independent oracles** — they fail loudly on drift. If a guide's facts no longer match the code, the codebase moved: update the guide in the same PR that moves the contract, or the next agent following it will waste a review round.
+
+## Related navigation
+
+- Module cards with per-module responsibilities: [`docs/modules/`](../modules/README.md)
+- Runtime execution ownership map: [`execution-sequence.md`](../execution-sequence.md)
+- Machine-readable module catalog / boundaries: [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml), [`config/quality/module-boundaries.yml`](../../config/quality/module-boundaries.yml)

--- a/docs/architecture/change-guides/adding-a-provider.md
+++ b/docs/architecture/change-guides/adding-a-provider.md
@@ -1,0 +1,54 @@
+# Change Guide: Adding a Provider
+
+**Applies to:** a new provider adapter module (e.g. `tramai-<vendor>`), `tramai-core` provider SPI, `tramai-testing` ProviderTck, build configuration.
+
+## TL;DR
+
+Providers are **not** service-loaded — registration is explicit via `ProviderRegistry.builder()`. A provider adapter implements `ModelProvider` (one abstract method) and proves vendor-wire conformance by enrolling in `ProviderTck` (one runner test per provider, architecture-enforced).
+
+## 1. Implement the SPI
+
+- `ModelProvider` — `tramai-core/src/main/kotlin/dev/tramai/core/provider/ModelProvider.kt:19`:
+  - `suspend fun complete(request: ModelRequest): ModelResponse` (L23) — the only abstract member
+  - `fun providerId(): String` defaults to `simpleName` (L28) — stable id used by registry + TCK
+  - `fun supportsCapability(capability: ProviderCapability): Boolean = false` (L34); enum `ProviderCapability { VISION, TOOL_CALLING, STRUCTURED_OUTPUT, STREAMING }` (L9-14)
+- If STREAMING is claimed, implement `StreamCapable` — `tramai-core/.../provider/StreamCapable.kt:10-18`: `fun stream(request: ModelRequest): Flow<StreamChunk>`.
+- Supporting types: `ModelRequest`/`ModelResponse` (`dev.tramai.core.model`), `ProviderException`/`ProviderFailureCode` (`dev.tramai.core.exception`), `StreamChunk` (`dev.tramai.core.model`). There is **no** `ModelProviderAdapter` interface.
+- Transport translation only: retries, fallbacks, and admission live in the engine's `ProviderExecutionCoordinator`, never inside the adapter.
+
+## 2. Register (manual, not ServiceLoader)
+
+- `ProviderRegistry` — `tramai-core/.../provider/ProviderRegistry.kt:32` is a pure facade over an immutable `ProviderRoutingPlan`. Entry points: `builder()` (L38), `singleProvider(provider)` (L40), `from(plan)` (L46).
+- Builder registration: `fun provider(name: String, provider: ModelProvider, default: Boolean = false): Builder` (L52); plus `model(...)` (L56), `fallbackModel`/`fallbackProvider` (L58/62), `defaultProvider(...)` (L66), `build()` (L68). The plan is the exact object consulted at runtime (`ProviderRoutingPlan.kt:35-75`).
+
+## 3. Enroll in ProviderTck (mandatory)
+
+- Contract: `tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/provider/ProviderTck.kt` (abstract, `abstract val harness: ProviderTckHarness` L53) — ~40 offline tests: identity, capabilities, cancellation, safe-error redaction, HTTP wire, tools, vision, structured, streaming.
+- Fixtures in the same dir: `ProviderTckHarness.kt` (L95), `StubHttpClient`, `ProviderHttpFixtures`, `RecordingProviderFailureDiagnosticObserver`.
+- **Enrollment gate:** `tramai-testing/src/test/kotlin/dev/tramai/testing/ProviderTckEnrollmentArchitectureTest.kt:26` pins runners by name (L32-41); any new `ModelProvider` implementation needs `<ProviderName>TckTest.kt` in the same module's `src/test/kotlin` (L55-69, L126-131).
+- Runner template: `tramai-deepseek/src/test/kotlin/dev/tramai/deepseek/DeepSeekProviderTckTest.kt:23-76`.
+- Execution: `architectureContractEnrollmentTest` task (build-logic `MaintainabilityBaselinePlugin.kt:914-937`) feeds the `provider-contracts` check of `verify060Architecture` (L1018). Doc: `docs/reference/provider-compatibility-contract.md` (enroll L9-26, matrix L53-62).
+
+## 4. Module catalog + boundaries + BOM
+
+- `config/quality/module-catalog.yml`: anchor `&provider` (L16) `maturity: preview, visibility: public, owner: providers, dependencyPolicy: provider-adapter`; entry shape (tramai-deepseek L126-131, tramai-openai L189-194): `path: ":tramai-<name>"`, `<<: *provider`, `rationale: "Provider adapter for ..."`, `layer: provider-adapters`, `publishability: published`, `apiStability: preview`.
+- `config/quality/module-boundaries.yml`: forbidden edges (L9+), enforced by `verify060Architecture` dependency probes.
+- Add the project to `settings.gradle.kts` and to the published BOM set — the manifest verifier checks catalog vs actual projects/published/BOM (`MaintainabilityBaselinePlugin.kt:994-1015`).
+
+## 5. API baseline (generated, must commit)
+
+- Binary Compatibility Validator (BCV 0.16.3, `build.gradle.kts:19`, `gradle/libs.versions.toml:75`) gives every subproject `apiCheck`/`apiDump`.
+- Run `./gradlew apiDump` → creates `<module>/api/<module>.api`; commit it (`ApiCompatibilityVerifier.kt:90`). Verified by `apiCheck` + `api-architecture` in `verify060Architecture` (regenerates + compares, `MaintainabilityBaselinePlugin.kt:947-951`, L1628-1650).
+
+## 6. Mandatory verification
+
+```bash
+./gradlew :tramai-<name>:test --tests '*ProviderTckTest'
+./gradlew verify060Architecture   # includes provider-contracts + api-architecture
+./gradlew verifyPr                # primary gate: subproject + build-logic tests, baseline, change policy
+./scripts/verify-zero-egress.sh   # CI-level Docker --network=none harness (not in verifyPr)
+```
+
+Use `-PchangeClass=...` per AGENTS.md classification (`runtime-behaviour` default).
+
+**Guardrails:** no service-loader files; provider adapters own transport/vendor translation only (retry/fallback lives in the engine); a new module without its TCK runner fails `verify060Architecture`; never edit analyzer/baseline in the same PR.

--- a/docs/architecture/change-guides/adding-a-provider.md
+++ b/docs/architecture/change-guides/adding-a-provider.md
@@ -1,54 +1,82 @@
 # Change Guide: Adding a Provider
 
-**Applies to:** a new provider adapter module (e.g. `tramai-<vendor>`), `tramai-core` provider SPI, `tramai-testing` ProviderTck, build configuration.
+## Start here
 
-## TL;DR
+A provider adapter is a new module (e.g. `tramai-<vendor>`) implementing `ModelProvider` and proving vendor-wire conformance by enrolling in `ProviderTck`. Providers are **not** service-loaded — registration is explicit via `ProviderRegistry.builder()`.
 
-Providers are **not** service-loaded — registration is explicit via `ProviderRegistry.builder()`. A provider adapter implements `ModelProvider` (one abstract method) and proves vendor-wire conformance by enrolling in `ProviderTck` (one runner test per provider, architecture-enforced).
+Start from [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) (framework-integrations layer → provider adapters), read the module card [`docs/modules/tramai-openai.md`](../../modules/tramai-openai.md) or `tramai-deepseek.md` as a template, then follow this guide.
 
-## 1. Implement the SPI
+## Owning module
+
+- New module: `tramai-<vendor>` (layer `provider-adapters`, owner `providers`, see `config/quality/module-catalog.yml` anchors `&provider` L16 and entries `tramai-deepseek` L126-131, `tramai-openai` L189-194).
+- SPI contract lives in `tramai-core`; shared conformance fixtures in `tramai-testing`.
+
+## Authoritative contracts
 
 - `ModelProvider` — `tramai-core/src/main/kotlin/dev/tramai/core/provider/ModelProvider.kt:19`:
   - `suspend fun complete(request: ModelRequest): ModelResponse` (L23) — the only abstract member
   - `fun providerId(): String` defaults to `simpleName` (L28) — stable id used by registry + TCK
   - `fun supportsCapability(capability: ProviderCapability): Boolean = false` (L34); enum `ProviderCapability { VISION, TOOL_CALLING, STRUCTURED_OUTPUT, STREAMING }` (L9-14)
-- If STREAMING is claimed, implement `StreamCapable` — `tramai-core/.../provider/StreamCapable.kt:10-18`: `fun stream(request: ModelRequest): Flow<StreamChunk>`.
+- `StreamCapable` — `tramai-core/.../provider/StreamCapable.kt:10-18`: `fun stream(request: ModelRequest): Flow<StreamChunk>` (declare iff STREAMING claimed).
 - Supporting types: `ModelRequest`/`ModelResponse` (`dev.tramai.core.model`), `ProviderException`/`ProviderFailureCode` (`dev.tramai.core.exception`), `StreamChunk` (`dev.tramai.core.model`). There is **no** `ModelProviderAdapter` interface.
-- Transport translation only: retries, fallbacks, and admission live in the engine's `ProviderExecutionCoordinator`, never inside the adapter.
 
-## 2. Register (manual, not ServiceLoader)
+## Files normally changed
 
-- `ProviderRegistry` — `tramai-core/.../provider/ProviderRegistry.kt:32` is a pure facade over an immutable `ProviderRoutingPlan`. Entry points: `builder()` (L38), `singleProvider(provider)` (L40), `from(plan)` (L46).
-- Builder registration: `fun provider(name: String, provider: ModelProvider, default: Boolean = false): Builder` (L52); plus `model(...)` (L56), `fallbackModel`/`fallbackProvider` (L58/62), `defaultProvider(...)` (L66), `build()` (L68). The plan is the exact object consulted at runtime (`ProviderRoutingPlan.kt:35-75`).
+- New `tramai-<vendor>/` module: `build.gradle.kts`, source implementing `ModelProvider` (+ `StreamCapable` if streaming), `api/tramai-<vendor>.api` (generated, committed).
+- `config/quality/module-catalog.yml` — new entry with `<<: *provider`, `path: ":tramai-<name>"`, `rationale`, `layer: provider-adapters`, `publishability: published`, `apiStability: preview`.
+- `config/quality/module-boundaries.yml` — no change unless a new edge is required (defaults forbid `published → internal`, cycles).
+- `settings.gradle.kts` — register the project; BOM membership follows from the catalog (manifest verifier checks catalog vs actual projects/published/BOM, `MaintainabilityBaselinePlugin.kt:994-1015`).
+- `tramai-<vendor>/src/test/kotlin/.../<Vendor>ProviderTckTest.kt` — the enrollment runner (template: `tramai-deepseek/src/test/kotlin/dev/tramai/deepseek/DeepSeekProviderTckTest.kt:23-76`).
 
-## 3. Enroll in ProviderTck (mandatory)
+## NOT changed
 
-- Contract: `tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/provider/ProviderTck.kt` (abstract, `abstract val harness: ProviderTckHarness` L53) — ~40 offline tests: identity, capabilities, cancellation, safe-error redaction, HTTP wire, tools, vision, structured, streaming.
-- Fixtures in the same dir: `ProviderTckHarness.kt` (L95), `StubHttpClient`, `ProviderHttpFixtures`, `RecordingProviderFailureDiagnosticObserver`.
-- **Enrollment gate:** `tramai-testing/src/test/kotlin/dev/tramai/testing/ProviderTckEnrollmentArchitectureTest.kt:26` pins runners by name (L32-41); any new `ModelProvider` implementation needs `<ProviderName>TckTest.kt` in the same module's `src/test/kotlin` (L55-69, L126-131).
-- Runner template: `tramai-deepseek/src/test/kotlin/dev/tramai/deepseek/DeepSeekProviderTckTest.kt:23-76`.
-- Execution: `architectureContractEnrollmentTest` task (build-logic `MaintainabilityBaselinePlugin.kt:914-937`) feeds the `provider-contracts` check of `verify060Architecture` (L1018). Doc: `docs/reference/provider-compatibility-contract.md` (enroll L9-26, matrix L53-62).
+- **Engine retry/fallback/admission** — `ProviderExecutionCoordinator` owns these; provider adapters do transport/vendor translation only (see ADR-009).
+- **`ProviderTck` itself** — the conformance contract is an independent oracle; do not weaken it to make a store pass.
+- **Analyzer/baseline** — never edit `config/quality/0.6.0-baseline.json` in the same PR.
+- **`tramai-core` provider registry** — no changes needed unless the SPI itself is extended (that is a separate `public-api` change).
 
-## 4. Module catalog + boundaries + BOM
+## Required tests / TCK
 
-- `config/quality/module-catalog.yml`: anchor `&provider` (L16) `maturity: preview, visibility: public, owner: providers, dependencyPolicy: provider-adapter`; entry shape (tramai-deepseek L126-131, tramai-openai L189-194): `path: ":tramai-<name>"`, `<<: *provider`, `rationale: "Provider adapter for ..."`, `layer: provider-adapters`, `publishability: published`, `apiStability: preview`.
-- `config/quality/module-boundaries.yml`: forbidden edges (L9+), enforced by `verify060Architecture` dependency probes.
-- Add the project to `settings.gradle.kts` and to the published BOM set — the manifest verifier checks catalog vs actual projects/published/BOM (`MaintainabilityBaselinePlugin.kt:994-1015`).
+- `ProviderTck` — `tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/provider/ProviderTck.kt` (abstract, `abstract val harness: ProviderTckHarness` L53): ~40 offline tests (identity, capabilities, cancellation, safe-error redaction, HTTP wire, tools, vision, structured, streaming).
+- Fixtures: `ProviderTckHarness.kt` (L95), `StubHttpClient`, `ProviderHttpFixtures`, `RecordingProviderFailureDiagnosticObserver`.
+- **Enrollment gate:** `tramai-testing/src/test/kotlin/dev/tramai/testing/ProviderTckEnrollmentArchitectureTest.kt:26` — any new `ModelProvider` implementation needs a runner named after it in its module (L55-69, L126-131). Runs inside `verify060Architecture` via the `architectureContractEnrollmentTest` task (`MaintainabilityBaselinePlugin.kt:914-937`, `provider-contracts` check L1018).
+- Doc: `docs/reference/provider-compatibility-contract.md` (enroll L9-26, matrix L53-62).
 
-## 5. API baseline (generated, must commit)
+## Compatibility
 
-- Binary Compatibility Validator (BCV 0.16.3, `build.gradle.kts:19`, `gradle/libs.versions.toml:75`) gives every subproject `apiCheck`/`apiDump`.
-- Run `./gradlew apiDump` → creates `<module>/api/<module>.api`; commit it (`ApiCompatibilityVerifier.kt:90`). Verified by `apiCheck` + `api-architecture` in `verify060Architecture` (regenerates + compares, `MaintainabilityBaselinePlugin.kt:947-951`, L1628-1650).
+- **BCV API dump is mandatory and generated:** `./gradlew apiDump` → `<module>/api/<module>.api`; commit it (`ApiCompatibilityVerifier.kt:90`). Verified by `apiCheck` + `api-architecture` in `verify060Architecture` (regenerates + compares, `MaintainabilityBaselinePlugin.kt:947-951`, L1628-1650).
+- `providerId()` is a stable identity — changing it after release breaks routing and TCK enrollment.
+- Preview API stability: provider modules are `apiStability: preview`; coordinate with the BOM release.
 
-## 6. Mandatory verification
+## Failure / cancellation / lifecycle
+
+- Failures: throw `ProviderException` with a `ProviderFailureCode` (`dev.tramai.core.exception`); never leak raw vendor errors to callers.
+- Cancellation: propagate `CancellationException` unchanged (the engine's provider-execution boundary owns retry/fallback on admitted attempts).
+- Lifecycle: providers are long-lived singletons in the `ProviderRegistry`; no per-request lifecycle hooks unless the vendor SDK requires explicit close (then implement it in the adapter and document it in the card).
+
+## Verification
 
 ```bash
 ./gradlew :tramai-<name>:test --tests '*ProviderTckTest'
 ./gradlew verify060Architecture   # includes provider-contracts + api-architecture
-./gradlew verifyPr                # primary gate: subproject + build-logic tests, baseline, change policy
+./gradlew verifyPr                # primary gate
 ./scripts/verify-zero-egress.sh   # CI-level Docker --network=none harness (not in verifyPr)
 ```
 
 Use `-PchangeClass=...` per AGENTS.md classification (`runtime-behaviour` default).
 
-**Guardrails:** no service-loader files; provider adapters own transport/vendor translation only (retry/fallback lives in the engine); a new module without its TCK runner fails `verify060Architecture`; never edit analyzer/baseline in the same PR.
+## Common mistakes
+
+- Adding a `META-INF/services` file — providers are explicitly registered, not service-loaded.
+- Implementing retry/fallback inside the adapter — that belongs in the engine's `ProviderExecutionCoordinator`.
+- Forgetting the TCK runner — the enrollment gate fails `verify060Architecture`.
+- Editing the analyzer/baseline in the same PR — forbidden per AGENTS.md.
+- Changing `providerId()` after first release — breaks routing + TCK.
+
+## Related ADRs / specs
+
+- [ADR-007](../../adr/adr-007.md) — resolve providers from model names with explicit override support
+- [ADR-009](../../adr/adr-009.md) — retry orchestration stays in tramai-engine, structured analysis in tramai-structured
+- [ADR-013](../../adr/adr-013.md) — streaming: raw text + dedicated streaming contract; [ADR-015](../../adr/adr-015.md) — streaming failover limited to startup
+- [spec-003-provider-integration.md](../../specs/spec-003-provider-integration.md) — provider SPI + registration
+- [docs/reference/provider-compatibility-contract.md](../../reference/provider-compatibility-contract.md) — TCK enrollment + matrix

--- a/docs/architecture/change-guides/adding-a-provider.md
+++ b/docs/architecture/change-guides/adding-a-provider.md
@@ -31,7 +31,7 @@ Start from [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) (framework-integrations
 ## NOT changed
 
 - **Engine retry/fallback/admission** — `ProviderExecutionCoordinator` owns these; provider adapters do transport/vendor translation only (see ADR-009).
-- **`ProviderTck` itself** — the conformance contract is an independent oracle; do not weaken it to make a store pass.
+- **`ProviderTck` itself** — the conformance contract is an independent oracle; do not weaken it to make a provider pass.
 - **Analyzer/baseline** — never edit `config/quality/0.6.0-baseline.json` in the same PR.
 - **`tramai-core` provider registry** — no changes needed unless the SPI itself is extended (that is a separate `public-api` change).
 

--- a/docs/architecture/change-guides/adding-a-store.md
+++ b/docs/architecture/change-guides/adding-a-store.md
@@ -1,28 +1,47 @@
 # Change Guide: Adding a Store
 
-**Applies to:** persistence store implementations for approval, continuation, audit, suspended-invocation, workflow checkpoint/lease, chat-memory, and ops outbox stores.
+## Start here
 
-## TL;DR
+A store implementation (approval, continuation, credential, audit, suspended-invocation, checkpoint, lease) implements a **core SPI** and proves conformance by enrolling in the matching **shared TCK** in `tramai-testing` — enrollment is architecture-enforced, so a store without its TCK runner fails the build. The TCK is the contract, not a documentation exercise.
 
-Every durable store implements a **core SPI** and proves conformance by enrolling in the matching **shared TCK** in `tramai-testing` — enrollment is architecture-enforced, so a store without its TCK runner fails the build. The TCK is the contract, not a documentation exercise.
+Start from [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) (persistence layer), read the relevant module card ([`tramai-persistence-file.md`](../../modules/tramai-persistence-file.md), [`tramai-persistence-jdbc.md`](../../modules/tramai-persistence-jdbc.md), [`tramai-security.md`](../../modules/tramai-security.md)), then follow this guide.
 
-## 1. Pick the SPI (interface + required methods)
+## Owning module
+
+- Store SPI: `tramai-core` (approval/continuation/credential), `tramai-security` (audit), `tramai-engine` (suspended-invocation), `tramai-orchestration` (checkpoint/lease).
+- Store implementations: new code lands in the owning persistence module (`tramai-persistence-file`, `tramai-persistence-jdbc`) or the module that will own the new backend; in-memory defaults stay in the module owning the SPI.
+- Shared TCK fixtures: `tramai-testing`.
+
+## Authoritative contracts
 
 | Store | SPI file | Required methods |
 |---|---|---|
 | ApprovalStore | `tramai-core/.../approval/ApprovalStore.kt` | `create` L22 · `get` L30 · `transition(approvalId, expectedVersion, transition)` L45 · `consumeApprovedOrReplay` L87 (thread-safe, atomic RMW; rethrow `CancellationException`, L6-11) |
 | ApprovalContinuationStore | `tramai-core/.../approval/ApprovalContinuationStore.kt` | `create(continuation, arguments)` L6 · `get` L11 · `claimForExecution` L13 (only path exposing raw args) · `complete` L19 · `expire` L25 · `cancel` L30 · `findStaleClaimed` L35 · `forceCancelClaimed` L40 · `sweepExpired` L47 |
-| ApprovalResumeCredentialStore | `tramai-core/.../approval/gateway/ApprovalResumeCredentialStore.kt` | `create` L20 (dup → IllegalStateException) · `get` L26 · `delete` L33 — MUST encrypt SealedResumeToken at rest (L10-12); **no shared TCK** (module tests only) |
+| ApprovalResumeCredentialStore | `tramai-core/.../approval/gateway/ApprovalResumeCredentialStore.kt` | `create` L20 (dup → IllegalStateException) · `get` L26 · `delete` L33 — MUST encrypt SealedResumeToken at rest (L10-12) |
 | AuditStore | `tramai-security/.../audit/AuditStore.kt` | `appendNext` L4 · `readStream` L9 · `readStreamPage` L23 · `latestEvent` L41 |
 | SuspendedInvocationStore | `tramai-engine/.../SuspendedInvocationStore.kt` | `create(metadata, replayEnvelope)` L155 · `get` L167 · `revealReplayEnvelope` L175 (only after claim) · `remove` L181 — envelope NOT exposed via `get` (L139-142) |
 | WorkflowCheckpointStore | `tramai-orchestration/.../WorkflowPersistence.kt` | `load` L73 · `save(checkpoint, expectedRevision)` L77 · `delete` L81 · `requireRecovery` L96 · `clearRecovery` L139 + `WorkflowStateCodec<S>` L63 |
 | WorkflowLeaseStore | `tramai-orchestration/.../WorkflowLease.kt` | `currentLease` L34 · `claim` L38 · `renew` L45 · `release` L50 (+ optional `WorkflowLeaseCheckpointFence` L56-72) |
 
-Ops-level stores (sovereign starter, no engine SPI): `SovereignOpsWorkerLeaseStore`, `SovereignOpsAuditOutboxStore`, `SovereignOpsApprovalMutationStore`, `SovereignOpsApprovalRequestMutationStore`, `ApprovedContinuationResumeQueueStatusStore`, `ApprovedContinuationResumeWorkerStatusStore` — under `tramai-spring-boot-starter-sovereign-ops/.../{lease,outbox}/`.
+## Files normally changed
 
-## 2. Enroll in the shared TCK (mandatory, architecture-enforced)
+- New store implementation class + its TCK runner `<Store>TckTest.kt` in the owning module's `src/test/kotlin`.
+- Codecs (JDBC): `JdbcReplayEnvelopeCodec.kt:10-24`, `JdbcAuditPayloadCodec.kt:10-24`, `JdbcContinuationArgumentsCodec.kt` (JdbcApprovalContinuationStore.kt L992-1006), `JdbcOpsAuditOutboxPayloadCodec.kt` (spring starter).
+- Spring wiring (if auto-configurable): `@ConditionalOnMissingBean` store bean in `SovereignJdbcPersistenceAutoConfiguration.kt` (store beans L171-285) or `SovereignFilePersistenceAutoConfiguration.kt` (bundle `@Bean(destroyMethod="close")` L82-110), plus the `.imports` registration.
+- Ops stores under `tramai-spring-boot-starter-sovereign-ops/.../{lease,outbox}/` (no engine SPI — module tests only).
 
-All TCKs live in `tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/`:
+## NOT changed
+
+- **TCKs themselves** — `tramai-testing` TCKs are independent oracles; never weaken them to make a store pass.
+- **SPI contracts** — `ApprovalStore`, `ApprovalContinuationStore`, etc. change only for a `public-api`-classified change, never when adding an implementation.
+- **`ReplayEnvelopeValidator` / `ReplayEnvelopeDigestHelper`** — the replay-security invariants are shared; stores re-validate, they do not re-define.
+- **Analyzer/baseline** — `config/quality/0.6.0-baseline.json` never changes in the same PR.
+- Do not copy behavior from a sibling store; the TCK is authoritative.
+
+## Required tests / TCK
+
+All TCKs in `tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/`:
 
 | Store | TCK | Enrollment shape |
 |---|---|---|
@@ -34,31 +53,24 @@ All TCKs live in `tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/pers
 | WorkflowLeaseStore | `lease/WorkflowLeaseStoreTck.kt` | direct `createStore(clock: MutableMillisClock)` |
 | ChatMemoryStore | `memory/ChatMemoryStoreTck.kt` | harness |
 
-Runner pattern: `<Store>TckTest.kt` in the **same module's** `src/test/kotlin` extending the shared TCK — harness-style: `tramai-persistence-file/src/test/.../FileApprovalStoreTckTest.kt:22,40-60`; direct-style: `tramai-persistence-jdbc/src/test/.../JdbcSuspendedInvocationStoreTckTest.kt:30`; `tramai-orchestration/src/test/.../MarkdownWorkflowCheckpointStoreTckTest.kt:18`.
+Runner pattern: harness-style (`tramai-persistence-file/src/test/.../FileApprovalStoreTckTest.kt:22,40-60`), direct-style (`tramai-persistence-jdbc/src/test/.../JdbcSuspendedInvocationStoreTckTest.kt:30`), Markdown (`tramai-orchestration/src/test/.../MarkdownWorkflowCheckpointStoreTckTest.kt:18`).
 
-**Enforcement:** `tramai-testing/src/test/kotlin/dev/tramai/testing/StoreEnrollmentScanner.kt:13-98` + per-family `*EnrollmentArchitectureTest.kt` (e.g. `ApprovalStoreTckEnrollmentArchitectureTest.kt:31-71`: pinned runner allowlist + every concrete impl must have a valid runner). Families: ApprovalStore, ApprovalContinuationStore, AuditStore, SuspendedInvocationStore, WorkflowCheckpointStore, WorkflowLeaseStore, ChatMemoryStore, SovereignOpsAuditOutboxStore.
+**Enforcement:** `tramai-testing/src/test/kotlin/dev/tramai/testing/StoreEnrollmentScanner.kt:13-98` + per-family `*EnrollmentArchitectureTest.kt` (e.g. `ApprovalStoreTckEnrollmentArchitectureTest.kt:31-71`: pinned runner allowlist + every concrete impl must have a valid runner).
 
-## 3. Copy the right existing implementation as a template
+## Compatibility
 
-- **In-memory** (process-local default): `tramai-security/.../approval/InMemoryApprovalStore.kt`, `InMemoryAuditStore.kt`; `tramai-engine/.../InMemorySuspendedInvocationStore.kt`; `tramai-orchestration/.../InMemoryWorkflowCheckpointStore.kt` (WorkflowPersistence.kt L304), `InMemoryWorkflowLeaseStore.kt` (WorkflowLease.kt L126).
-- **Encrypted file** (restart durability): `tramai-persistence-file/.../FileApprovalStore.kt` etc., bundled in `FileBackedSovereignStores.kt:45-101` (exclusive `.tramai.lock`, 0700 dirs, `manifest.json` v1, per-record locks, verify-on-open).
-- **JDBC** (PostgreSQL durability): `tramai-persistence-jdbc/.../JdbcApprovalStore.kt`, `JdbcWorkflowCheckpointStore.kt` (orchestration), `JdbcStepAttemptRecordStore.kt` (orchestration), `JdbcWorkflowSchedulerStore.kt` (scheduler); spring-starter JDBC variants (`JdbcSovereignOps*`, `JdbcApprovalResumeCredentialStore`). JDBC TCK runners use Testcontainers PostgreSQL.
-- **Markdown** (format ≠ contract): `MarkdownWorkflowCheckpointStore.kt` — deliberately omits `WorkflowCheckpointCatalog` (`WorkflowCheckpointStoreTck.kt:28-30`).
+- **Replay-envelope security:** `SensitiveReplayEnvelope` (`tramai-engine/.../SensitiveReplayEnvelope.kt:21-51`) is opaque (`toString` = `[REDACTED]`), only `revealForResume()` (L29). Store must verify `metadata.replayEnvelopeDigest` at create (`InMemorySuspendedInvocationStore.kt:69-70`, `JdbcSuspendedInvocationStore.kt:140-144`) and re-validate invariants before persist (`JdbcSuspendedInvocationStore.kt:279-290`). Breaking these breaks replay/continuation trust for existing consumers.
+- **Codec encrypt-at-rest** is the implementer's seam: key management, algorithm, nonce are owned by the store (JDBC codecs above).
+- **Spring override semantics:** `@ConditionalOnMissingBean` means user-provided beans win — a new default store must not override an explicit user bean.
+- JDBC stores imply PostgreSQL durability contracts; TCK runners require Docker (Testcontainers).
 
-## 4. Replay envelope / codec obligations (suspended-invocation stores)
+## Failure / cancellation / lifecycle
 
-- `SensitiveReplayEnvelope` (`tramai-engine/.../SensitiveReplayEnvelope.kt:21-51`): opaque, deep-copied on `of()`, `toString` = `[REDACTED]`, only `revealForResume()` (L29). Raw suspended tool args replaced by sentinel `__redacted_approval_continuation_args__` (`ReplayEnvelopeFactory.kt:13`).
-- `ReplayEnvelopeFactory.prepareForSuspension` (L41-61): fail-closed validation (unique slot, index/name match, exactly one sentinel), digest from exact redacted snapshot.
-- `ReplayEnvelopeDigestHelper.compute` (L17-36): canonical SHA-256 via `CanonicalMessageEncoder` — store must verify `metadata.replayEnvelopeDigest` at create (`InMemorySuspendedInvocationStore.kt:69-70`, `JdbcSuspendedInvocationStore.kt:140-144`) and re-validate invariants before persist (`JdbcSuspendedInvocationStore.kt:279-290`).
-- JDBC codec seams (encrypt-at-rest, you own key mgmt/algorithm/nonce): `JdbcReplayEnvelopeCodec.kt:10-24`, `JdbcAuditPayloadCodec.kt:10-24`, `JdbcContinuationArgumentsCodec.kt` (JdbcApprovalContinuationStore.kt L992-1006), `JdbcOpsAuditOutboxPayloadCodec.kt` (spring starter).
+- Store methods must **rethrow `CancellationException` unchanged** (`ApprovalStore.kt:9-11`).
+- Atomic RMW with optimistic concurrency (`transition(..., expectedVersion, ...)`) — rejected actions must not mutate durable state (`ApprovalStoreTck.kt:567-571`).
+- Lifecycle: file stores use exclusive `.tramai.lock` + 0700 dirs + `manifest.json` v1 + verify-on-open (`FileBackedSovereignStores.kt:45-101`); JDBC stores own connection/transaction management; in-memory stores are process-local defaults.
 
-## 5. Spring wiring (if the store must be auto-configurable)
-
-- Persistence starters register **before** the base starter so in-memory defaults back off: `@ConditionalOnMissingBean` in `tramai-spring-sovereign/.../SovereignTramaiAutoConfiguration.kt` L60, store defaults L118-139.
-- JDBC pattern: `SovereignJdbcPersistenceAutoConfiguration.kt` — `@AutoConfiguration(before = SovereignTramaiAutoConfiguration)` L85, gated `tramai.sovereign.persistence.type=jdbc` L87-91, fail-fast without DataSource L104-110, AES key bean L120-127, codec beans L134-164, store beans L171-285 (all `@ConditionalOnMissingBean`, key injection `@Qualifier("sovereignJdbcEncryptionKey")`). Register via `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`.
-- File pattern: `SovereignFilePersistenceAutoConfiguration.kt` (`type=file` L66-70, `FileBackedSovereignStores` bundle `@Bean(destroyMethod="close")` L82-110).
-
-## 6. Mandatory verification
+## Verification
 
 ```bash
 ./gradlew :tramai-testing:test                          # runs all *EnrollmentArchitectureTest gates
@@ -67,6 +79,16 @@ Runner pattern: `<Store>TckTest.kt` in the **same module's** `src/test/kotlin` e
 ./gradlew verifyChangePolicy -PchangeClass=runtime-behaviour
 ```
 
-JDBC TCK runners require Docker (Testcontainers PostgreSQL).
+## Common mistakes
 
-**Guardrails:** the TCKs are independent oracles — do not weaken them to make a store pass; do not copy behavior from a sibling store, the TCK is authoritative; never edit analyzer/baseline in the same PR. Stores without a shared TCK (`ApprovalResumeCredentialStore`, `SovereignOpsWorkerLeaseStore`) must still be covered by module-level contract tests.
+- Writing a runner that extends nothing / extends a copy of the TCK — enrollment scan fails.
+- Exposing the raw replay envelope via `get()` — only `revealReplayEnvelope` after claim.
+- Skipping digest verification at create — replay trust breaks.
+- Editing a TCK to fit the store — the TCK is the oracle, not the store.
+- Adding a Spring bean without `@ConditionalOnMissingBean` — silently overrides user beans.
+
+## Related ADRs / specs
+
+- [ADR-018](../../adr/adr-018.md) — separate security enforcement from SaaS platform concerns
+- [spec-007-testing-support.md](../../specs/spec-007-testing-support.md) — testing-support + TCK philosophy
+- Module cards: [`tramai-persistence-file.md`](../../modules/tramai-persistence-file.md), [`tramai-persistence-jdbc.md`](../../modules/tramai-persistence-jdbc.md), [`tramai-security.md`](../../modules/tramai-security.md)

--- a/docs/architecture/change-guides/adding-a-store.md
+++ b/docs/architecture/change-guides/adding-a-store.md
@@ -1,0 +1,72 @@
+# Change Guide: Adding a Store
+
+**Applies to:** persistence store implementations for approval, continuation, audit, suspended-invocation, workflow checkpoint/lease, chat-memory, and ops outbox stores.
+
+## TL;DR
+
+Every durable store implements a **core SPI** and proves conformance by enrolling in the matching **shared TCK** in `tramai-testing` — enrollment is architecture-enforced, so a store without its TCK runner fails the build. The TCK is the contract, not a documentation exercise.
+
+## 1. Pick the SPI (interface + required methods)
+
+| Store | SPI file | Required methods |
+|---|---|---|
+| ApprovalStore | `tramai-core/.../approval/ApprovalStore.kt` | `create` L22 · `get` L30 · `transition(approvalId, expectedVersion, transition)` L45 · `consumeApprovedOrReplay` L87 (thread-safe, atomic RMW; rethrow `CancellationException`, L6-11) |
+| ApprovalContinuationStore | `tramai-core/.../approval/ApprovalContinuationStore.kt` | `create(continuation, arguments)` L6 · `get` L11 · `claimForExecution` L13 (only path exposing raw args) · `complete` L19 · `expire` L25 · `cancel` L30 · `findStaleClaimed` L35 · `forceCancelClaimed` L40 · `sweepExpired` L47 |
+| ApprovalResumeCredentialStore | `tramai-core/.../approval/gateway/ApprovalResumeCredentialStore.kt` | `create` L20 (dup → IllegalStateException) · `get` L26 · `delete` L33 — MUST encrypt SealedResumeToken at rest (L10-12); **no shared TCK** (module tests only) |
+| AuditStore | `tramai-security/.../audit/AuditStore.kt` | `appendNext` L4 · `readStream` L9 · `readStreamPage` L23 · `latestEvent` L41 |
+| SuspendedInvocationStore | `tramai-engine/.../SuspendedInvocationStore.kt` | `create(metadata, replayEnvelope)` L155 · `get` L167 · `revealReplayEnvelope` L175 (only after claim) · `remove` L181 — envelope NOT exposed via `get` (L139-142) |
+| WorkflowCheckpointStore | `tramai-orchestration/.../WorkflowPersistence.kt` | `load` L73 · `save(checkpoint, expectedRevision)` L77 · `delete` L81 · `requireRecovery` L96 · `clearRecovery` L139 + `WorkflowStateCodec<S>` L63 |
+| WorkflowLeaseStore | `tramai-orchestration/.../WorkflowLease.kt` | `currentLease` L34 · `claim` L38 · `renew` L45 · `release` L50 (+ optional `WorkflowLeaseCheckpointFence` L56-72) |
+
+Ops-level stores (sovereign starter, no engine SPI): `SovereignOpsWorkerLeaseStore`, `SovereignOpsAuditOutboxStore`, `SovereignOpsApprovalMutationStore`, `SovereignOpsApprovalRequestMutationStore`, `ApprovedContinuationResumeQueueStatusStore`, `ApprovedContinuationResumeWorkerStatusStore` — under `tramai-spring-boot-starter-sovereign-ops/.../{lease,outbox}/`.
+
+## 2. Enroll in the shared TCK (mandatory, architecture-enforced)
+
+All TCKs live in `tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/`:
+
+| Store | TCK | Enrollment shape |
+|---|---|---|
+| ApprovalStore | `approval/ApprovalStoreTck.kt` | harness `approval/ApprovalStoreTckHarness.kt:13-18` (`createStore(clock: MutableClock)`, `closeStore`) |
+| ApprovalContinuationStore | `approval/continuation/ApprovalContinuationStoreTck.kt` | harness L15-20 |
+| AuditStore | `audit/AuditStoreTck.kt` | direct `createStore()` L38 |
+| SuspendedInvocationStore | `engine/SuspendedInvocationStoreTck.kt` | direct |
+| WorkflowCheckpointStore | `checkpoint/WorkflowCheckpointStoreTck.kt` | direct `createStore()` L32-35 |
+| WorkflowLeaseStore | `lease/WorkflowLeaseStoreTck.kt` | direct `createStore(clock: MutableMillisClock)` |
+| ChatMemoryStore | `memory/ChatMemoryStoreTck.kt` | harness |
+
+Runner pattern: `<Store>TckTest.kt` in the **same module's** `src/test/kotlin` extending the shared TCK — harness-style: `tramai-persistence-file/src/test/.../FileApprovalStoreTckTest.kt:22,40-60`; direct-style: `tramai-persistence-jdbc/src/test/.../JdbcSuspendedInvocationStoreTckTest.kt:30`; `tramai-orchestration/src/test/.../MarkdownWorkflowCheckpointStoreTckTest.kt:18`.
+
+**Enforcement:** `tramai-testing/src/test/kotlin/dev/tramai/testing/StoreEnrollmentScanner.kt:13-98` + per-family `*EnrollmentArchitectureTest.kt` (e.g. `ApprovalStoreTckEnrollmentArchitectureTest.kt:31-71`: pinned runner allowlist + every concrete impl must have a valid runner). Families: ApprovalStore, ApprovalContinuationStore, AuditStore, SuspendedInvocationStore, WorkflowCheckpointStore, WorkflowLeaseStore, ChatMemoryStore, SovereignOpsAuditOutboxStore.
+
+## 3. Copy the right existing implementation as a template
+
+- **In-memory** (process-local default): `tramai-security/.../approval/InMemoryApprovalStore.kt`, `InMemoryAuditStore.kt`; `tramai-engine/.../InMemorySuspendedInvocationStore.kt`; `tramai-orchestration/.../InMemoryWorkflowCheckpointStore.kt` (WorkflowPersistence.kt L304), `InMemoryWorkflowLeaseStore.kt` (WorkflowLease.kt L126).
+- **Encrypted file** (restart durability): `tramai-persistence-file/.../FileApprovalStore.kt` etc., bundled in `FileBackedSovereignStores.kt:45-101` (exclusive `.tramai.lock`, 0700 dirs, `manifest.json` v1, per-record locks, verify-on-open).
+- **JDBC** (PostgreSQL durability): `tramai-persistence-jdbc/.../JdbcApprovalStore.kt`, `JdbcWorkflowCheckpointStore.kt` (orchestration), `JdbcStepAttemptRecordStore.kt` (orchestration), `JdbcWorkflowSchedulerStore.kt` (scheduler); spring-starter JDBC variants (`JdbcSovereignOps*`, `JdbcApprovalResumeCredentialStore`). JDBC TCK runners use Testcontainers PostgreSQL.
+- **Markdown** (format ≠ contract): `MarkdownWorkflowCheckpointStore.kt` — deliberately omits `WorkflowCheckpointCatalog` (`WorkflowCheckpointStoreTck.kt:28-30`).
+
+## 4. Replay envelope / codec obligations (suspended-invocation stores)
+
+- `SensitiveReplayEnvelope` (`tramai-engine/.../SensitiveReplayEnvelope.kt:21-51`): opaque, deep-copied on `of()`, `toString` = `[REDACTED]`, only `revealForResume()` (L29). Raw suspended tool args replaced by sentinel `__redacted_approval_continuation_args__` (`ReplayEnvelopeFactory.kt:13`).
+- `ReplayEnvelopeFactory.prepareForSuspension` (L41-61): fail-closed validation (unique slot, index/name match, exactly one sentinel), digest from exact redacted snapshot.
+- `ReplayEnvelopeDigestHelper.compute` (L17-36): canonical SHA-256 via `CanonicalMessageEncoder` — store must verify `metadata.replayEnvelopeDigest` at create (`InMemorySuspendedInvocationStore.kt:69-70`, `JdbcSuspendedInvocationStore.kt:140-144`) and re-validate invariants before persist (`JdbcSuspendedInvocationStore.kt:279-290`).
+- JDBC codec seams (encrypt-at-rest, you own key mgmt/algorithm/nonce): `JdbcReplayEnvelopeCodec.kt:10-24`, `JdbcAuditPayloadCodec.kt:10-24`, `JdbcContinuationArgumentsCodec.kt` (JdbcApprovalContinuationStore.kt L992-1006), `JdbcOpsAuditOutboxPayloadCodec.kt` (spring starter).
+
+## 5. Spring wiring (if the store must be auto-configurable)
+
+- Persistence starters register **before** the base starter so in-memory defaults back off: `@ConditionalOnMissingBean` in `tramai-spring-sovereign/.../SovereignTramaiAutoConfiguration.kt` L60, store defaults L118-139.
+- JDBC pattern: `SovereignJdbcPersistenceAutoConfiguration.kt` — `@AutoConfiguration(before = SovereignTramaiAutoConfiguration)` L85, gated `tramai.sovereign.persistence.type=jdbc` L87-91, fail-fast without DataSource L104-110, AES key bean L120-127, codec beans L134-164, store beans L171-285 (all `@ConditionalOnMissingBean`, key injection `@Qualifier("sovereignJdbcEncryptionKey")`). Register via `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`.
+- File pattern: `SovereignFilePersistenceAutoConfiguration.kt` (`type=file` L66-70, `FileBackedSovereignStores` bundle `@Bean(destroyMethod="close")` L82-110).
+
+## 6. Mandatory verification
+
+```bash
+./gradlew :tramai-testing:test                          # runs all *EnrollmentArchitectureTest gates
+./gradlew :<module>:test --tests '*TckTest'            # your store's TCK runner
+./gradlew verifyPr
+./gradlew verifyChangePolicy -PchangeClass=runtime-behaviour
+```
+
+JDBC TCK runners require Docker (Testcontainers PostgreSQL).
+
+**Guardrails:** the TCKs are independent oracles — do not weaken them to make a store pass; do not copy behavior from a sibling store, the TCK is authoritative; never edit analyzer/baseline in the same PR. Stores without a shared TCK (`ApprovalResumeCredentialStore`, `SovereignOpsWorkerLeaseStore`) must still be covered by module-level contract tests.

--- a/docs/architecture/change-guides/adding-a-store.md
+++ b/docs/architecture/change-guides/adding-a-store.md
@@ -2,7 +2,9 @@
 
 ## Start here
 
-A store implementation (approval, continuation, credential, audit, suspended-invocation, checkpoint, lease) implements a **core SPI** and proves conformance by enrolling in the matching **shared TCK** in `tramai-testing` — enrollment is architecture-enforced, so a store without its TCK runner fails the build. The TCK is the contract, not a documentation exercise.
+A store implementation (approval, continuation, credential, audit, suspended-invocation, checkpoint, lease) implements an **authoritative store SPI in its owning module** (core, security, engine, or orchestration — see the Owning module section) and, where a shared TCK exists, proves conformance by enrolling in it — enrollment is architecture-enforced, so a store without its TCK runner fails the build. The TCK is the contract, not a documentation exercise.
+
+**Exception — no shared TCK today:** `ApprovalResumeCredentialStore` has **no** `ApprovalResumeCredentialStoreTck` and no architecture-enrolled TCK gate. It is covered only by implementation/module tests (e.g. `JdbcApprovalResumeCredentialStoreTest.kt` under `tramai-spring-boot-starter-sovereign-persistence-jdbc/src/test/`). Its contract obligations are: SPI methods (`create`/`get`/`delete`), encryption of the `SealedResumeToken` at rest, and module-level contract tests. Do not search for a shared TCK for this store — none exists.
 
 Start from [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) (persistence layer), read the relevant module card ([`tramai-persistence-file.md`](../../modules/tramai-persistence-file.md), [`tramai-persistence-jdbc.md`](../../modules/tramai-persistence-jdbc.md), [`tramai-security.md`](../../modules/tramai-security.md)), then follow this guide.
 
@@ -29,7 +31,9 @@ Start from [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) (persistence layer), re
 - New store implementation class + its TCK runner `<Store>TckTest.kt` in the owning module's `src/test/kotlin`.
 - Codecs (JDBC): `JdbcReplayEnvelopeCodec.kt:10-24`, `JdbcAuditPayloadCodec.kt:10-24`, `JdbcContinuationArgumentsCodec.kt` (JdbcApprovalContinuationStore.kt L992-1006), `JdbcOpsAuditOutboxPayloadCodec.kt` (spring starter).
 - Spring wiring (if auto-configurable): `@ConditionalOnMissingBean` store bean in `SovereignJdbcPersistenceAutoConfiguration.kt` (store beans L171-285) or `SovereignFilePersistenceAutoConfiguration.kt` (bundle `@Bean(destroyMethod="close")` L82-110), plus the `.imports` registration.
-- Ops stores under `tramai-spring-boot-starter-sovereign-ops/.../{lease,outbox}/` (no engine SPI — module tests only).
+- Ops stores under `tramai-spring-boot-starter-sovereign-ops/.../{lease,outbox,approval}/` (no engine SPI — they are starter-local):
+  - `SovereignOpsAuditOutboxStore` — **has** a shared TCK (`SovereignOpsAuditOutboxStoreTck` in tramai-testing) with an architecture-enforced enrollment gate (`SovereignOpsAuditOutboxStoreTckEnrollmentArchitectureTest`) and in-memory/file/JDBC runners.
+  - Other ops stores (`SovereignOpsWorkerLeaseStore`, `SovereignOpsApprovalMutationStore`, `SovereignOpsApprovalRequestMutationStore`, `ApprovedContinuationResumeQueueStatusStore`, `ApprovedContinuationResumeWorkerStatusStore`) — **no shared TCK**; covered by module-level tests only. Verify per store before assuming either situation.
 
 ## NOT changed
 
@@ -43,19 +47,22 @@ Start from [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) (persistence layer), re
 
 All TCKs in `tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/`:
 
-| Store | TCK | Enrollment shape |
+| Store family | Shared TCK? | Enrollment |
 |---|---|---|
-| ApprovalStore | `approval/ApprovalStoreTck.kt` | harness `approval/ApprovalStoreTckHarness.kt:13-18` (`createStore(clock: MutableClock)`, `closeStore`) |
-| ApprovalContinuationStore | `approval/continuation/ApprovalContinuationStoreTck.kt` | harness L15-20 |
-| AuditStore | `audit/AuditStoreTck.kt` | direct `createStore()` L38 |
-| SuspendedInvocationStore | `engine/SuspendedInvocationStoreTck.kt` | direct |
-| WorkflowCheckpointStore | `checkpoint/WorkflowCheckpointStoreTck.kt` | direct `createStore()` L32-35 |
-| WorkflowLeaseStore | `lease/WorkflowLeaseStoreTck.kt` | direct `createStore(clock: MutableMillisClock)` |
-| ChatMemoryStore | `memory/ChatMemoryStoreTck.kt` | harness |
+| ApprovalStore | ✅ `approval/ApprovalStoreTck.kt` | harness `approval/ApprovalStoreTckHarness.kt:13-18` (`createStore(clock: MutableClock)`, `closeStore`) |
+| ApprovalContinuationStore | ✅ `approval/continuation/ApprovalContinuationStoreTck.kt` | harness L15-20 |
+| AuditStore | ✅ `audit/AuditStoreTck.kt` | direct `createStore()` L38 |
+| SuspendedInvocationStore | ✅ `engine/SuspendedInvocationStoreTck.kt` | direct |
+| WorkflowCheckpointStore | ✅ `checkpoint/WorkflowCheckpointStoreTck.kt` | direct `createStore()` L32-35 |
+| WorkflowLeaseStore | ✅ `lease/WorkflowLeaseStoreTck.kt` | direct `createStore(clock: MutableMillisClock)` |
+| ChatMemoryStore | ✅ `memory/ChatMemoryStoreTck.kt` | harness |
+| SovereignOpsAuditOutboxStore | ✅ `outbox/SovereignOpsAuditOutboxStoreTck.kt` | `SovereignOpsAuditOutboxStoreTckEnrollmentArchitectureTest` + in-memory/file/JDBC runners |
+| ApprovalResumeCredentialStore | ❌ **no shared TCK today** | module-level tests only (`JdbcApprovalResumeCredentialStoreTest.kt`) — implement SPI + encryption-at-rest + module tests |
+| SovereignOpsWorkerLeaseStore | ❌ **no shared TCK** | module-level tests only (`JdbcSovereignOpsWorkerLeaseStoreTest.kt`) |
 
 Runner pattern: harness-style (`tramai-persistence-file/src/test/.../FileApprovalStoreTckTest.kt:22,40-60`), direct-style (`tramai-persistence-jdbc/src/test/.../JdbcSuspendedInvocationStoreTckTest.kt:30`), Markdown (`tramai-orchestration/src/test/.../MarkdownWorkflowCheckpointStoreTckTest.kt:18`).
 
-**Enforcement:** `tramai-testing/src/test/kotlin/dev/tramai/testing/StoreEnrollmentScanner.kt:13-98` + per-family `*EnrollmentArchitectureTest.kt` (e.g. `ApprovalStoreTckEnrollmentArchitectureTest.kt:31-71`: pinned runner allowlist + every concrete impl must have a valid runner).
+**Enforcement:** `tramai-testing/src/test/kotlin/dev/tramai/testing/StoreEnrollmentScanner.kt:13-98` + per-family `*EnrollmentArchitectureTest.kt` (e.g. `ApprovalStoreTckEnrollmentArchitectureTest.kt:31-71`: pinned runner allowlist + every concrete impl must have a valid runner). **Stores marked ❌ have no enrollment gate** — their obligation is SPI conformance + module-level contract tests.
 
 ## Compatibility
 

--- a/docs/architecture/change-guides/adding-a-workflow-step.md
+++ b/docs/architecture/change-guides/adding-a-workflow-step.md
@@ -1,0 +1,59 @@
+# Change Guide: Adding a Workflow Step
+
+**Applies to:** `tramai-orchestration` step types, the `WorkflowBuilder` DSL, and the workflow persistence/execution seams.
+
+## TL;DR
+
+Workflow steps are a **builder DSL over a sealed internal step contract** — there is no public `WorkflowStep` interface for external implementation. Adding a built-in step means: a new sealed subclass + a DSL function + exhaustive-`when` updates + tests. Adding an *external* step means the `ExternalStepExecutorRegistry`.
+
+## 1. Understand the step model
+
+- Runtime contract: `InternalWorkflowStep<S>` (sealed) — `tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowStepExecution.kt:80-89`: `val name`, `suspensionMode` (default `NONE`), `suspend fun execute(request: WorkflowStepExecutionRequest<S>): WorkflowStepExecutionResult<S>` (sealed `Completed(state)` / `Suspended`, L26-32).
+- Built-in impls are sealed subclasses: `LocalWorkflowStep` (:93), `AiWorkflowStep` (:104), `GateWorkflowStep` (:123), `PluginWorkflowStep` (:140), `DelayWorkflowStep` (`WorkflowDelayCoordinator.kt:23`, the only built-in with `suspensionMode = TOP_LEVEL_CHECKPOINT`, :28); Shell/Http/Hermes/Codex/Mcp/Branch/Parallel in their own files.
+- DSL: `WorkflowBuilder.kt:16` extends `AbstractWorkflowBuilder<S>` (:71, owns the step list :72, `appendStep` :377, `stepsSnapshot` :384). Step functions: `localStep` :75, `aiStep` ×4 :96-161, `httpStep` :180, `shellStep` :190, `hermesStep` :206/220, `codexStep` :235/249, `mcpStep` :264/280, `pluginStep` :297/310, `gateStep` :324, `delayStep` :334, `branchStep` :349, `parallelStep` :363. Entry: `workflow(name, definitionVersion)` (`Workflow.kt:98-114`), `build(...)` (`WorkflowBuilder.kt:26-37`), build-time validation (duplicate names, static command policies, nested-suspension rejection) at `WorkflowBuilder.kt:470-496`.
+
+## 2. External/plugin steps (no new sealed type needed)
+
+- `ExternalStepExecutorRegistry.register(factory)` — `WorkflowStepExecution.kt:195`; interfaces `ExternalStepExecutorFactory` :173, `ExternalStepExecutor` :178, `ExternalStepExecutorResolver` :186-190. Consumed via `pluginStep` + `Workflow.requiredExternalStepTypes()` (`Workflow.kt:78`). Missing executor → `ExternalStepExecutorNotRegisteredException` (:182).
+
+## 3. Wiring points for a new BUILT-IN step (beyond class + DSL)
+
+| Point | File | Why |
+|---|---|---|
+| `replayDescriptor` exhaustive `when` | `Workflow.kt:120-136` | replay of the new step must round-trip |
+| Definition digest | `WorkflowDefinitionCompatibility.kt:19-46` | sha256 over canonical definition — new fields change digests (golden test must be updated deliberately) |
+| Worker binding | `WorkflowBindingRegistry.bind(workflow, persistence)` `WorkflowBindingRegistry.kt:82` | step execution needs the persistence session |
+| Suspension rule | `WorkflowBuilder.kt:484-496` + ASM guard `WorkflowStepExecutionArchitectureTest.kt:29` | only `TOP_LEVEL_CHECKPOINT` steps may suspend, top-level only |
+
+## 4. Execution path + stores you integrate with (usually unchanged)
+
+- All steps route through the shared wrapper `WorkflowStepExecutor.executeStep` (`WorkflowStepExecutor.kt:36-54`): `StepCounter` budget (:67), observer events, failure sanitisation, `CancellationException` passthrough.
+- Stores (SPIs in `tramai-orchestration`): `WorkflowCheckpointStore` (`WorkflowPersistence.kt:72-171`, `WorkflowStateCodec<S>` :63), `WorkflowLeaseStore` (`WorkflowLease.kt:33-51`, `WorkflowLeaseCheckpointFence` :56-72), `StepAttemptRecordStore` (`StepAttemptRecord.kt:93-121`). A new step type does not change these; a new *store implementation* is the `adding-a-store` guide.
+- Lifecycle ownership: `WorkflowExecutionSupervisor` (:37), `WorkerLifecycleController` (:67), `WorkerShutdownCoordinator` — steps execute through the runner, they don't touch these directly.
+
+## 5. Mandatory contract tests
+
+- Step-level test following the pattern of `WorkflowStepFailureBoundaryTest.kt`, `WorkflowReplayDecisionPolicyTest.kt`.
+- Replay/failure boundary + digest: `WorkflowDefinitionDigestGoldenTest.kt`, `BinaryCompatibilityFixtureTest.kt` (fixture `src/test/resources/binary-compat/BinaryCompatFixture.kt`), `WorkflowCheckpointLegacyMigrationContractTest.kt`.
+- Store TCKs only if you also add a store: `WorkflowCheckpointStoreTck.kt:32`, `WorkflowLeaseStoreTck.kt`, `WorkflowLeaseCheckpointFenceTck.kt` (tramai-testing) + enrollment guards (`WorkflowLeaseStoreTckEnrollmentArchitectureTest.kt` etc.).
+
+## 6. Module boundaries
+
+- `:tramai-orchestration` = layer `runtime-execution`, published, preview — `config/quality/module-catalog.yml:196-201`.
+- `config/quality/module-boundaries.yml` forbidden edges: `published → internal` (:69-72), `published → applications-examples` (:60-62), `published → excluded` (:65-67), self-edges (:75), cycles (programmatic). A step inside orchestration may depend on any **published** module in an allowed layer; **not** internal/excluded/application/example modules, and no cycles.
+- New public DSL additions must be classified in `docs/workflow-api-stability-boundary.md` (guarded by `verifyWorkflowApiStabilityBoundary`, wired into `check`).
+
+## 7. Mandatory verification
+
+```bash
+./gradlew :tramai-orchestration:test
+./gradlew verifyWorkflowApiStabilityBoundary
+./gradlew apiCheck
+./gradlew verifyCancellationSafety
+./gradlew verifyPr
+./gradlew verifyChangePolicy -PchangeClass=runtime-behaviour   # or public-api
+# publish smoke (CI parity):
+./gradlew publishToMavenLocal && ./gradlew -p examples/kotlin-springboot-example test -PtramaiVersion=$(grep '^tramaiVersion=' gradle.properties | cut -d= -f2)
+```
+
+**Guardrails:** `verifyMaintainabilityBaseline` must stay green with **no** baseline/deviation edits; adding a step type forces exhaustive-`when` updates (compiler will tell you where); suspension mode is frozen by the ASM architecture guard — do not add new suspending steps casually.

--- a/docs/architecture/change-guides/adding-a-workflow-step.md
+++ b/docs/architecture/change-guides/adding-a-workflow-step.md
@@ -1,49 +1,60 @@
 # Change Guide: Adding a Workflow Step
 
-**Applies to:** `tramai-orchestration` step types, the `WorkflowBuilder` DSL, and the workflow persistence/execution seams.
-
-## TL;DR
+## Start here
 
 Workflow steps are a **builder DSL over a sealed internal step contract** — there is no public `WorkflowStep` interface for external implementation. Adding a built-in step means: a new sealed subclass + a DSL function + exhaustive-`when` updates + tests. Adding an *external* step means the `ExternalStepExecutorRegistry`.
 
-## 1. Understand the step model
+Start from [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) (workflow/worker ownership → `tramai-orchestration`), read the module card [`docs/modules/tramai-orchestration.md`](../../modules/tramai-orchestration.md), then follow this guide.
 
-- Runtime contract: `InternalWorkflowStep<S>` (sealed) — `tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowStepExecution.kt:80-89`: `val name`, `suspensionMode` (default `NONE`), `suspend fun execute(request: WorkflowStepExecutionRequest<S>): WorkflowStepExecutionResult<S>` (sealed `Completed(state)` / `Suspended`, L26-32).
-- Built-in impls are sealed subclasses: `LocalWorkflowStep` (:93), `AiWorkflowStep` (:104), `GateWorkflowStep` (:123), `PluginWorkflowStep` (:140), `DelayWorkflowStep` (`WorkflowDelayCoordinator.kt:23`, the only built-in with `suspensionMode = TOP_LEVEL_CHECKPOINT`, :28); Shell/Http/Hermes/Codex/Mcp/Branch/Parallel in their own files.
-- DSL: `WorkflowBuilder.kt:16` extends `AbstractWorkflowBuilder<S>` (:71, owns the step list :72, `appendStep` :377, `stepsSnapshot` :384). Step functions: `localStep` :75, `aiStep` ×4 :96-161, `httpStep` :180, `shellStep` :190, `hermesStep` :206/220, `codexStep` :235/249, `mcpStep` :264/280, `pluginStep` :297/310, `gateStep` :324, `delayStep` :334, `branchStep` :349, `parallelStep` :363. Entry: `workflow(name, definitionVersion)` (`Workflow.kt:98-114`), `build(...)` (`WorkflowBuilder.kt:26-37`), build-time validation (duplicate names, static command policies, nested-suspension rejection) at `WorkflowBuilder.kt:470-496`.
+## Owning module
 
-## 2. External/plugin steps (no new sealed type needed)
+- `tramai-orchestration` — layer `runtime-execution`, `publishability: published`, `apiStability: preview` (`config/quality/module-catalog.yml:196-201`).
+- Contracts and TCK fixtures additionally live in `tramai-testing`.
 
-- `ExternalStepExecutorRegistry.register(factory)` — `WorkflowStepExecution.kt:195`; interfaces `ExternalStepExecutorFactory` :173, `ExternalStepExecutor` :178, `ExternalStepExecutorResolver` :186-190. Consumed via `pluginStep` + `Workflow.requiredExternalStepTypes()` (`Workflow.kt:78`). Missing executor → `ExternalStepExecutorNotRegisteredException` (:182).
+## Authoritative contracts
 
-## 3. Wiring points for a new BUILT-IN step (beyond class + DSL)
+- Runtime step contract: `InternalWorkflowStep<S>` (sealed) — `tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowStepExecution.kt:80-89`: `val name`, `suspensionMode` (default `NONE`), `suspend fun execute(request: WorkflowStepExecutionRequest<S>): WorkflowStepExecutionResult<S>` (sealed `Completed(state)` / `Suspended`, L26-32).
+- Builder DSL: `WorkflowBuilder.kt:16` extends `AbstractWorkflowBuilder<S>` (:71, owns step list :72, `appendStep` :377, `stepsSnapshot` :384). Step functions: `localStep` :75, `aiStep` ×4 :96-161, `httpStep` :180, `shellStep` :190, `hermesStep` :206/220, `codexStep` :235/249, `mcpStep` :264/280, `pluginStep` :297/310, `gateStep` :324, `delayStep` :334, `branchStep` :349, `parallelStep` :363.
+- External step SPI: `ExternalStepExecutorRegistry.register(factory)` (`WorkflowStepExecution.kt:195`); `ExternalStepExecutorFactory` :173, `ExternalStepExecutor` :178, `ExternalStepExecutorResolver` :186-190. Missing executor → `ExternalStepExecutorNotRegisteredException` (:182).
 
-| Point | File | Why |
-|---|---|---|
-| `replayDescriptor` exhaustive `when` | `Workflow.kt:120-136` | replay of the new step must round-trip |
-| Definition digest | `WorkflowDefinitionCompatibility.kt:19-46` | sha256 over canonical definition — new fields change digests (golden test must be updated deliberately) |
-| Worker binding | `WorkflowBindingRegistry.bind(workflow, persistence)` `WorkflowBindingRegistry.kt:82` | step execution needs the persistence session |
-| Suspension rule | `WorkflowBuilder.kt:484-496` + ASM guard `WorkflowStepExecutionArchitectureTest.kt:29` | only `TOP_LEVEL_CHECKPOINT` steps may suspend, top-level only |
+## Files normally changed
 
-## 4. Execution path + stores you integrate with (usually unchanged)
+- New step class (sealed subclass of `InternalWorkflowStep<S>`) in `tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/` (template: `LocalWorkflowStep` :93, `AiWorkflowStep` :104, `GateWorkflowStep` :123, `PluginWorkflowStep` :140; `DelayWorkflowStep` in `WorkflowDelayCoordinator.kt:23`).
+- DSL function in `AbstractWorkflowBuilder` (`WorkflowBuilder.kt`).
+- **Exhaustive-`when` wiring points (compiler-enforced):**
+  - `replayDescriptor` `when` — `Workflow.kt:120-136`
+  - definition digest — `WorkflowDefinitionCompatibility.kt:19-46` (sha256 over canonical definition)
+  - worker binding — `WorkflowBindingRegistry.bind(workflow, persistence)` `WorkflowBindingRegistry.kt:82`
+  - suspension rule — `WorkflowBuilder.kt:484-496` (nested suspension rejected)
+- Tests in `tramai-orchestration/src/test/kotlin/.../` (step-level + replay/failure boundary).
+- `docs/workflow-api-stability-boundary.md` — new public DSL additions must be classified (guarded by `verifyWorkflowApiStabilityBoundary`).
 
-- All steps route through the shared wrapper `WorkflowStepExecutor.executeStep` (`WorkflowStepExecutor.kt:36-54`): `StepCounter` budget (:67), observer events, failure sanitisation, `CancellationException` passthrough.
-- Stores (SPIs in `tramai-orchestration`): `WorkflowCheckpointStore` (`WorkflowPersistence.kt:72-171`, `WorkflowStateCodec<S>` :63), `WorkflowLeaseStore` (`WorkflowLease.kt:33-51`, `WorkflowLeaseCheckpointFence` :56-72), `StepAttemptRecordStore` (`StepAttemptRecord.kt:93-121`). A new step type does not change these; a new *store implementation* is the `adding-a-store` guide.
-- Lifecycle ownership: `WorkflowExecutionSupervisor` (:37), `WorkerLifecycleController` (:67), `WorkerShutdownCoordinator` — steps execute through the runner, they don't touch these directly.
+## NOT changed
 
-## 5. Mandatory contract tests
+- **`WorkflowExecutionSupervisor`** (:37), **`WorkerLifecycleController`** (:67), **`WorkerShutdownCoordinator`** — steps execute through the runner; they don't touch these directly.
+- **Store SPIs** — `WorkflowCheckpointStore`, `WorkflowLeaseStore`, `StepAttemptRecordStore` only change when you add a *store implementation* (see `adding-a-store.md`).
+- **Suspension semantics** — only `suspensionMode = TOP_LEVEL_CHECKPOINT` steps may suspend, top-level only; ASM-guarded by `WorkflowStepExecutionArchitectureTest.kt:29` (checks the getter returns the constant directly).
+- **Analyzer/baseline** — `config/quality/0.6.0-baseline.json` never changes in the same PR.
 
-- Step-level test following the pattern of `WorkflowStepFailureBoundaryTest.kt`, `WorkflowReplayDecisionPolicyTest.kt`.
-- Replay/failure boundary + digest: `WorkflowDefinitionDigestGoldenTest.kt`, `BinaryCompatibilityFixtureTest.kt` (fixture `src/test/resources/binary-compat/BinaryCompatFixture.kt`), `WorkflowCheckpointLegacyMigrationContractTest.kt`.
+## Required tests / TCK
+
+- Step-level test following `WorkflowStepFailureBoundaryTest.kt` / `WorkflowReplayDecisionPolicyTest.kt` patterns.
+- Replay/digest: `WorkflowDefinitionDigestGoldenTest.kt` (digest changes must be deliberate), `BinaryCompatibilityFixtureTest.kt` (fixture `src/test/resources/binary-compat/BinaryCompatFixture.kt`), `WorkflowCheckpointLegacyMigrationContractTest.kt`.
 - Store TCKs only if you also add a store: `WorkflowCheckpointStoreTck.kt:32`, `WorkflowLeaseStoreTck.kt`, `WorkflowLeaseCheckpointFenceTck.kt` (tramai-testing) + enrollment guards (`WorkflowLeaseStoreTckEnrollmentArchitectureTest.kt` etc.).
+- Cancellation: `verifyCancellationSafety` (cancellation scanner) + `WorkflowCancellationContractTest.kt`.
 
-## 6. Module boundaries
+## Compatibility
 
-- `:tramai-orchestration` = layer `runtime-execution`, published, preview — `config/quality/module-catalog.yml:196-201`.
-- `config/quality/module-boundaries.yml` forbidden edges: `published → internal` (:69-72), `published → applications-examples` (:60-62), `published → excluded` (:65-67), self-edges (:75), cycles (programmatic). A step inside orchestration may depend on any **published** module in an allowed layer; **not** internal/excluded/application/example modules, and no cycles.
-- New public DSL additions must be classified in `docs/workflow-api-stability-boundary.md` (guarded by `verifyWorkflowApiStabilityBoundary`, wired into `check`).
+- **Definition digest changes are breaking:** the sha256 canonical digest (`WorkflowDefinitionCompatibility.kt:19-46`) drives recovery/fencing — a new step with different digest semantics invalidates in-flight checkpoints. Update the golden test deliberately.
+- **Public DSL = public API:** new DSL functions are covered by `docs/workflow-api-stability-boundary.md` and `verifyWorkflowApiStabilityBoundary` (wired into `check`); `apiCheck` enforces the BCV dump.
+- **Replay compatibility:** the `replayDescriptor` `when` must round-trip the new step, or replay of in-flight workflows fails.
 
-## 7. Mandatory verification
+## Failure / cancellation / lifecycle
+
+- All steps route through `WorkflowStepExecutor.executeStep` (`WorkflowStepExecutor.kt:36-54`): `StepCounter` budget (:67), observer events, **failure sanitisation** (safe public errors, no internal exception leakage), `CancellationException` passthrough.
+- Lifecycle: step execution is bounded by the worker lifecycle (supervisor → lease → recovery); a suspending step creates a durable checkpoint before suspension (checkpoint store semantics in `adding-a-store.md`).
+
+## Verification
 
 ```bash
 ./gradlew :tramai-orchestration:test
@@ -56,4 +67,15 @@ Workflow steps are a **builder DSL over a sealed internal step contract** — th
 ./gradlew publishToMavenLocal && ./gradlew -p examples/kotlin-springboot-example test -PtramaiVersion=$(grep '^tramaiVersion=' gradle.properties | cut -d= -f2)
 ```
 
-**Guardrails:** `verifyMaintainabilityBaseline` must stay green with **no** baseline/deviation edits; adding a step type forces exhaustive-`when` updates (compiler will tell you where); suspension mode is frozen by the ASM architecture guard — do not add new suspending steps casually.
+## Common mistakes
+
+- Adding a step without updating the exhaustive-`when` wiring — the compiler will tell you, but only after you touch the right file.
+- New suspending steps — suspension mode is frozen by the ASM architecture guard; don't add them casually.
+- Depending on internal/excluded/application modules — `config/quality/module-boundaries.yml` forbids `published → internal` (:69-72), `published → applications-examples` (:60-62), `published → excluded` (:65-67), self-edges (:75), cycles (programmatic).
+- Forgetting `docs/workflow-api-stability-boundary.md` classification — `verifyWorkflowApiStabilityBoundary` fails.
+
+## Related ADRs / specs
+
+- [ADR-017](../../adr/adr-017.md) — keep orchestration typed, workflow-owned, optional above tramai-engine
+- [spec-001-core-engine.md](../../specs/spec-001-core-engine.md) — core + engine contract
+- [`docs/workflow-api-stability-boundary.md`](../../workflow-api-stability-boundary.md) — public DSL stability rules

--- a/docs/architecture/change-guides/adding-an-approval-state.md
+++ b/docs/architecture/change-guides/adding-an-approval-state.md
@@ -1,0 +1,57 @@
+# Change Guide: Adding an Approval State
+
+**Applies to:** approval lifecycle in `tramai-core`, `tramai-security`, `tramai-engine`, `tramai-persistence-file`, `tramai-persistence-jdbc`, `tramai-testing`.
+
+## TL;DR
+
+There are **two independent state machines**:
+
+- `ApprovalStatus` — the decision outcome: `PENDING → {APPROVED, DENIED, TIMED_OUT}`; everything except `PENDING` is terminal. `tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalStatus.kt:9-14`
+- `ApprovalContinuationStatus` — the resume lifecycle: `PENDING, CLAIMED, COMPLETED, EXPIRED, CANCELLED_UNCERTAIN, CANCELLED`. `tramai-core/.../approval/ApprovalContinuationStatus.kt:3-10`
+
+Transitions are declared by `ApprovalTransition` (sealed `Approve/Deny/Timeout`, each with `targetStatus()`) at `tramai-core/.../approval/ApprovalTransition.kt:9-48`.
+
+**Decision first:** decide which machine the new state belongs to. Adding a decision outcome (`ApprovalStatus`) is a different, much wider change than adding a continuation-lifecycle state (`ApprovalContinuationStatus`). Most real changes are the latter.
+
+## What a new continuation state touches (blast radius)
+
+| Layer | File | What changes |
+|---|---|---|
+| Enum | `tramai-core/.../approval/ApprovalContinuationStatus.kt` | new constant |
+| DTO serialization | `tramai-persistence-file/.../PersistedDtos.kt` | status encoding |
+| Store impls | `InMemoryApprovalContinuationStore.kt` (tramai-security), `FileApprovalContinuationStore.kt` (tramai-persistence-file), `JdbcApprovalContinuationStore.kt` (tramai-persistence-jdbc) | transition logic in `claim`, `complete`, `expire`, `cancel`, `forceCancelClaimed` |
+| Coordinators | `ApprovalResumeCoordinator.kt:39-61` (status-sensitive branch), `ContinuationClaimService.kt:16` (`validateBindings` requires `status == PENDING`), `ApprovalSuspensionCoordinator.kt:146` (creates hardcoded `PENDING`) | explicit handling of the new state |
+| Gate | `DefaultApprovalGateCoordinator.kt:172-180,307-345` (requires `consumed.status == APPROVED`) | authorization path |
+| Gateway mapping | `DefaultApprovalGateway.kt:110-153` (`toGatewayResult` — new statuses silently fall into `Suspended`) | explicit mapping |
+| Audit emitter | `tramai-security/.../audit/AuditEngineApprovalLifecycleAuditEmitter.kt` | enforcementPoint/decision strings per callback (never emit raw args/tokens — SPI contract `tramai-core/.../approval/ApprovalLifecycleAuditEmitter.kt:9-126`) |
+| Lifecycle oracles | `tramai-testing/.../approval/ApprovalLifecycleModel.kt:30-231`, `.../continuation/ApprovalContinuationLifecycleModel.kt:19-275` | transition application + invariant audit — deliberately independent of production code |
+
+## Invariants that must not break
+
+- **Version ceiling ≤ 2** per continuation, field-shape per status: `ApprovalContinuationStoreTck.kt:803-857` (L810).
+- **Exactly-once argument release** — raw args are exposed only via `claimForExecution`, once: `ApprovalContinuationStoreTck.kt:283-315`.
+- **Expiry boundary:** `now < expiresAt` → decisions legal while PENDING; `now >= expiresAt` → timeout legal, decisions illegal. `ApprovalLifecycleModel.kt:22-27`, `InMemoryApprovalStore.kt:246-269`.
+- **Rejected actions must not mutate durable state:** `ApprovalStoreTck.kt:567-571`.
+- **Late claim/cancel DO mutate** (PENDING → EXPIRED) before the typed failure: `ApprovalContinuationLifecycleModel.kt:12-17`, TCK L341-366.
+- Store methods must rethrow `CancellationException` (`ApprovalStore.kt:9-11`).
+
+## Mandatory contract tests (run before push)
+
+- `ApprovalStoreTck` — `tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/ApprovalStoreTck.kt` (transition matrix L133-255, consumption/exact-replay L257-450, model-based property 32×32 L532-574, wrong-version matrix L577-608).
+- `ApprovalContinuationStoreTck` — `.../continuation/ApprovalContinuationStoreTck.kt` (creation validation L107-218, claim L222-279, exactly-once L283-315, expiry L319-414, cancel L418-468, complete L472-527, recovery L531-634, sweep L638-677, races L701-779, model property L781-857 + L951+).
+- Enroll every new store implementation: `InMemoryApprovalStoreTckTest`, `JdbcApprovalStoreTckTest`, `FileApprovalStoreTckTest` + continuation equivalents — enforced by `ApprovalStoreTckEnrollmentArchitectureTest.kt` / `ApprovalContinuationStoreTckEnrollmentArchitectureTest.kt`.
+- Generators: extend `ApprovalLifecycleActionGenerator.kt:26-27` / `ApprovalContinuationLifecycleActionGenerator.kt:38-39` (SEED_COUNT=32, ACTIONS_PER_SEQUENCE=32) + unit tests in `tramai-testing/src/test/`.
+
+## Verification commands
+
+```bash
+./gradlew verifyPr
+./gradlew verifyChangePolicy -PchangeClass=runtime-behaviour
+./gradlew :tramai-security:test :tramai-persistence-jdbc:test :tramai-persistence-file:test :tramai-testing:test :tramai-engine:test --tests '*Tck*'
+```
+
+**Guardrail:** never edit the analyzer/baseline (`config/quality/0.6.0-baseline.json`) in the same PR; adding an enum constant may shift scanner cardinality — if `verifyChangePolicy` flags it, stop and report rather than weakening the gate.
+
+## Why the TCKs are the safety net
+
+The lifecycle models (`ApprovalLifecycleModel`, `ApprovalContinuationLifecycleModel`) are deliberately independent oracles. Any drift between the new state and production code fails the model-based property tests loudly — the TCKs are the contract, not a documentation exercise.

--- a/docs/architecture/change-guides/adding-an-approval-state.md
+++ b/docs/architecture/change-guides/adding-an-approval-state.md
@@ -1,48 +1,73 @@
 # Change Guide: Adding an Approval State
 
-**Applies to:** approval lifecycle in `tramai-core`, `tramai-security`, `tramai-engine`, `tramai-persistence-file`, `tramai-persistence-jdbc`, `tramai-testing`.
+## Start here
 
-## TL;DR
-
-There are **two independent state machines**:
+There are **two independent state machines**. Decide first which one the new state belongs to:
 
 - `ApprovalStatus` — the decision outcome: `PENDING → {APPROVED, DENIED, TIMED_OUT}`; everything except `PENDING` is terminal. `tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalStatus.kt:9-14`
 - `ApprovalContinuationStatus` — the resume lifecycle: `PENDING, CLAIMED, COMPLETED, EXPIRED, CANCELLED_UNCERTAIN, CANCELLED`. `tramai-core/.../approval/ApprovalContinuationStatus.kt:3-10`
 
-Transitions are declared by `ApprovalTransition` (sealed `Approve/Deny/Timeout`, each with `targetStatus()`) at `tramai-core/.../approval/ApprovalTransition.kt:9-48`.
+Adding a decision outcome (`ApprovalStatus`) is a different, much wider change than adding a continuation-lifecycle state (`ApprovalContinuationStatus`). Most real changes are the latter.
 
-**Decision first:** decide which machine the new state belongs to. Adding a decision outcome (`ApprovalStatus`) is a different, much wider change than adding a continuation-lifecycle state (`ApprovalContinuationStatus`). Most real changes are the latter.
+Start from [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) (governance-security layer → approval), read [`docs/architecture/human-approval-workflow-ergonomics.md`](../human-approval-workflow-ergonomics.md) and the module card [`tramai-security.md`](../../modules/tramai-security.md), then follow this guide.
 
-## What a new continuation state touches (blast radius)
+## Owning module
 
-| Layer | File | What changes |
-|---|---|---|
-| Enum | `tramai-core/.../approval/ApprovalContinuationStatus.kt` | new constant |
-| DTO serialization | `tramai-persistence-file/.../PersistedDtos.kt` | status encoding |
-| Store impls | `InMemoryApprovalContinuationStore.kt` (tramai-security), `FileApprovalContinuationStore.kt` (tramai-persistence-file), `JdbcApprovalContinuationStore.kt` (tramai-persistence-jdbc) | transition logic in `claim`, `complete`, `expire`, `cancel`, `forceCancelClaimed` |
-| Coordinators | `ApprovalResumeCoordinator.kt:39-61` (status-sensitive branch), `ContinuationClaimService.kt:16` (`validateBindings` requires `status == PENDING`), `ApprovalSuspensionCoordinator.kt:146` (creates hardcoded `PENDING`) | explicit handling of the new state |
-| Gate | `DefaultApprovalGateCoordinator.kt:172-180,307-345` (requires `consumed.status == APPROVED`) | authorization path |
-| Gateway mapping | `DefaultApprovalGateway.kt:110-153` (`toGatewayResult` — new statuses silently fall into `Suspended`) | explicit mapping |
-| Audit emitter | `tramai-security/.../audit/AuditEngineApprovalLifecycleAuditEmitter.kt` | enforcementPoint/decision strings per callback (never emit raw args/tokens — SPI contract `tramai-core/.../approval/ApprovalLifecycleAuditEmitter.kt:9-126`) |
-| Lifecycle oracles | `tramai-testing/.../approval/ApprovalLifecycleModel.kt:30-231`, `.../continuation/ApprovalContinuationLifecycleModel.kt:19-275` | transition application + invariant audit — deliberately independent of production code |
+- Contracts: `tramai-core/approval` (enums, `ApprovalTransition`, store SPIs, `ApprovalLifecycleAuditEmitter` SPI).
+- Store implementations: `tramai-security` (in-memory + gate), `tramai-persistence-file`, `tramai-persistence-jdbc`.
+- Coordinators: `tramai-engine/approval`.
+- Oracles + TCKs: `tramai-testing`.
 
-## Invariants that must not break
+## Authoritative contracts
 
-- **Version ceiling ≤ 2** per continuation, field-shape per status: `ApprovalContinuationStoreTck.kt:803-857` (L810).
-- **Exactly-once argument release** — raw args are exposed only via `claimForExecution`, once: `ApprovalContinuationStoreTck.kt:283-315`.
-- **Expiry boundary:** `now < expiresAt` → decisions legal while PENDING; `now >= expiresAt` → timeout legal, decisions illegal. `ApprovalLifecycleModel.kt:22-27`, `InMemoryApprovalStore.kt:246-269`.
-- **Rejected actions must not mutate durable state:** `ApprovalStoreTck.kt:567-571`.
-- **Late claim/cancel DO mutate** (PENDING → EXPIRED) before the typed failure: `ApprovalContinuationLifecycleModel.kt:12-17`, TCK L341-366.
-- Store methods must rethrow `CancellationException` (`ApprovalStore.kt:9-11`).
+- Transitions: `ApprovalTransition` (sealed `Approve/Deny/Timeout`, each with `targetStatus()`) — `tramai-core/.../approval/ApprovalTransition.kt:9-48`.
+- Persistence: `ApprovalStore` (`tramai-core/.../approval/ApprovalStore.kt:13-98`; `create` must be PENDING v0 L18/35-43, `transition(approvalId, expectedVersion, transition)` optimistic-concurrency L45-49, `consumeApprovedOrReplay` strict fresh vs exact-replay L51-92) and `ApprovalContinuationStore` (`tramai-core/.../approval/ApprovalContinuationStore.kt:5-48`; `claimForExecution` is the only path exposing raw args).
+- Lifecycle oracles (deliberately independent of production code): `tramai-testing/.../persistence/approval/ApprovalLifecycleModel.kt:30-231`, `.../continuation/ApprovalContinuationLifecycleModel.kt:19-275`.
+- Audit SPI: `tramai-core/.../approval/ApprovalLifecycleAuditEmitter.kt:9-126` (never emit raw args/tokens).
 
-## Mandatory contract tests (run before push)
+## Files normally changed
 
-- `ApprovalStoreTck` — `tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/ApprovalStoreTck.kt` (transition matrix L133-255, consumption/exact-replay L257-450, model-based property 32×32 L532-574, wrong-version matrix L577-608).
-- `ApprovalContinuationStoreTck` — `.../continuation/ApprovalContinuationStoreTck.kt` (creation validation L107-218, claim L222-279, exactly-once L283-315, expiry L319-414, cancel L418-468, complete L472-527, recovery L531-634, sweep L638-677, races L701-779, model property L781-857 + L951+).
-- Enroll every new store implementation: `InMemoryApprovalStoreTckTest`, `JdbcApprovalStoreTckTest`, `FileApprovalStoreTckTest` + continuation equivalents — enforced by `ApprovalStoreTckEnrollmentArchitectureTest.kt` / `ApprovalContinuationStoreTckEnrollmentArchitectureTest.kt`.
-- Generators: extend `ApprovalLifecycleActionGenerator.kt:26-27` / `ApprovalContinuationLifecycleActionGenerator.kt:38-39` (SEED_COUNT=32, ACTIONS_PER_SEQUENCE=32) + unit tests in `tramai-testing/src/test/`.
+| Layer | File |
+|---|---|
+| Enum | `tramai-core/.../approval/ApprovalContinuationStatus.kt` (or `ApprovalStatus.kt`) |
+| DTO serialization | `tramai-persistence-file/.../PersistedDtos.kt` |
+| Store impls | `InMemoryApprovalContinuationStore.kt` (tramai-security), `FileApprovalContinuationStore.kt` (file), `JdbcApprovalContinuationStore.kt` (jdbc) |
+| Coordinators | `ApprovalResumeCoordinator.kt:39-61`, `ContinuationClaimService.kt:16` (`validateBindings` requires `status == PENDING`), `ApprovalSuspensionCoordinator.kt:146` (creates hardcoded `PENDING`) |
+| Gate | `DefaultApprovalGateCoordinator.kt:172-180,307-345` (authorization requires `consumed.status == APPROVED`) |
+| Gateway mapping | `DefaultApprovalGateway.kt:110-153` (`toGatewayResult` — new statuses silently fall into `Suspended`) |
+| Audit emitter | `tramai-security/.../audit/AuditEngineApprovalLifecycleAuditEmitter.kt` (fixed enforcementPoint/decision strings per callback) |
+| Lifecycle oracles | `ApprovalLifecycleModel.kt`, `ApprovalContinuationLifecycleModel.kt` |
+| TCK invariant tables | `ApprovalStoreTck.kt`, `ApprovalContinuationStoreTck.kt` |
+| Action generators | `ApprovalLifecycleActionGenerator.kt:26-27`, `ApprovalContinuationLifecycleActionGenerator.kt:38-39` |
 
-## Verification commands
+## NOT changed
+
+- **TCKs are oracles** — do not weaken them; they fail loudly on drift by design.
+- **Expiry/invariant semantics** — `now < expiresAt` decision-legal vs `now >= expiresAt` timeout-legal while PENDING (`ApprovalLifecycleModel.kt:22-27`, `InMemoryApprovalStore.kt:246-269`) stays as-is unless the new state explicitly needs new expiry rules (that is a contract change).
+- **Replay envelope security** — `ReplayEnvelopeFactory`/`ReplayEnvelopeValidator` stay untouched by a state addition.
+- **Analyzer/baseline** — same-PR edits forbidden; adding an enum constant may shift scanner cardinality — if `verifyChangePolicy` flags it, stop and report.
+
+## Required tests / TCK
+
+- `ApprovalStoreTck` — `tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/persistence/approval/ApprovalStoreTck.kt:37-866` (transition matrix L133-255, consumption/exact-replay L257-450, model-based property 32×32 L532-574, wrong-version matrix L577-608, 8-way race L611-646).
+- `ApprovalContinuationStoreTck` — `.../continuation/ApprovalContinuationStoreTck.kt:39-1382` (claim L222-279, exactly-once L283-315, expiry L319-414, cancel L418-468, complete L472-527, recovery L531-634, sweep L638-677, races L701-779, model property L781-857 + L951+).
+- Enrollment: `InMemoryApprovalStoreTckTest`, `JdbcApprovalStoreTckTest`, `FileApprovalStoreTckTest` + continuation equivalents, enforced by `ApprovalStoreTckEnrollmentArchitectureTest.kt` / `ApprovalContinuationStoreTckEnrollmentArchitectureTest.kt`.
+- Generators + their unit tests in `tramai-testing/src/test/.../`.
+
+## Compatibility
+
+- **Version ceiling ≤ 2** per continuation with field-shape per status: `ApprovalContinuationStoreTck.kt:803-857` (L810 `version ≤ 2`). A new state that increments version breaks existing stored records.
+- **Exactly-once argument release** — raw args are exposed once via claim: `ApprovalContinuationStoreTck.kt:283-315`.
+- **Outcome mapping `when`s** — `DefaultApprovalGateway.toGatewayResult` L110-153 and the gate coordinator's APPROVED checks silently treat unknown statuses as `Suspended`/denied; new states need explicit mapping or authorization fails.
+- **Audit event strings** are consumed by external tooling — the fixed enforcementPoint/decision strings in `AuditEngineApprovalLifecycleAuditEmitter.kt` are a compatibility surface.
+
+## Failure / cancellation / lifecycle
+
+- Store methods rethrow `CancellationException` (`ApprovalStore.kt:9-11`).
+- Rejected actions must not mutate durable state (`ApprovalStoreTck.kt:567-571`); late claim/cancel DO mutate (PENDING→EXPIRED) before typed failure (`ApprovalContinuationLifecycleModel.kt:12-17`, TCK L341-366).
+- Lifecycle: `ApprovalSuspensionCoordinator` creates continuations hardcoded `PENDING` (L146); new pre-claim states break `ContinuationClaimService.validateBindings` (L16 requires `PENDING`) until it is relaxed deliberately.
+
+## Verification
 
 ```bash
 ./gradlew verifyPr
@@ -50,8 +75,15 @@ Transitions are declared by `ApprovalTransition` (sealed `Approve/Deny/Timeout`,
 ./gradlew :tramai-security:test :tramai-persistence-jdbc:test :tramai-persistence-file:test :tramai-testing:test :tramai-engine:test --tests '*Tck*'
 ```
 
-**Guardrail:** never edit the analyzer/baseline (`config/quality/0.6.0-baseline.json`) in the same PR; adding an enum constant may shift scanner cardinality — if `verifyChangePolicy` flags it, stop and report rather than weakening the gate.
+## Common mistakes
 
-## Why the TCKs are the safety net
+- Adding a state to one store impl and not the other three — all four impl layers + DTOs must change together.
+- Breaking the version ceiling — stored records fail `version ≤ 2` assertions.
+- Letting a new status fall through `toGatewayResult` — it silently maps to `Suspended`.
+- Editing the lifecycle oracles to match the code — the oracles are the independent spec; code must match them.
 
-The lifecycle models (`ApprovalLifecycleModel`, `ApprovalContinuationLifecycleModel`) are deliberately independent oracles. Any drift between the new state and production code fails the model-based property tests loudly — the TCKs are the contract, not a documentation exercise.
+## Related ADRs / specs
+
+- [ADR-018](../../adr/adr-018.md) — separate security enforcement from SaaS platform concerns
+- [`docs/architecture/human-approval-workflow-ergonomics.md`](../human-approval-workflow-ergonomics.md) — golden-path guide (documents `ApprovalStatus`-shaped outcomes; not continuation transitions)
+- Module card [`tramai-security.md`](../../modules/tramai-security.md)

--- a/docs/architecture/change-guides/adding-an-event.md
+++ b/docs/architecture/change-guides/adding-an-event.md
@@ -1,48 +1,66 @@
 # Change Guide: Adding an Event
 
-**Applies to:** the runtime event catalogue in `tramai-core` and the ASM/source architecture guard in `tramai-observability`.
-
-## TL;DR
+## Start here
 
 Every `tramai.*` runtime event is **declared once in `RuntimeEventCatalogue`**, referenced through the compile-time `RuntimeEvents` registry, and emitted via `emitRuntimeEvent`. The architecture guard scans both bytecode (LDC constants) and source: any `tramai.*` literal that does not go through `RuntimeEvents.X` fails the build — even if the literal already exists in the catalogue.
 
-## 1. The mechanism (all in `tramai-core/src/main/kotlin/dev/tramai/core/observation/event/`)
+Start from [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) (observability/event ownership → `tramai-core`), read the module cards [`tramai-core.md`](../../modules/tramai-core.md) + [`tramai-observability.md`](../../modules/tramai-observability.md), then follow this guide.
 
-- `RuntimeEventCatalogue.kt` (926 lines): `object RuntimeEventCatalogue` (L16) owns `allEvents: List<RuntimeEventDefinition>` (L17). Init block (L862-891) fails fast on: duplicate event names (L864), conflicting attribute key types (L868), required attrs outside allowed set (L874-879), undeclared metric mappings (L882-886), duplicate metric names (L889). `event(name)` errors on unknown id (L893-894). Dynamic namespace: `DynamicAttributeNamespaces.WORKFLOW_CONTEXT` (L914-926).
-- `RuntimeEventModel.kt`: `RuntimeAttributeKey<T>(name, valueType)` (L55), `RuntimeMetricDefinition` (L62-68), `RuntimeEventDefinition` (L80-91: name, domain, allowedAttributes, requiredAttributes, sensitivity, auditEligible, evidenceEligible, metricMapping, spanEligible, failurePolicy), enums `RuntimeEventDomain` (L8), `RuntimeEventSensitivity` (L23), `RuntimeEventFailurePolicy` (L37), `RuntimeMetricInstrumentType` (L45).
-- `RuntimeAttributes.kt`: one `RuntimeAttributeKey<T>("tramai…", T::class)` per canonical key (object L8).
-- `RuntimeMetrics.kt`: `object RuntimeMetrics` (L8), descriptors (e.g. L9-15), `val all` L151.
-- `RuntimeEvents.kt`: compile-time registry (L6-80), e.g. `val WORKER_HEARTBEAT = RuntimeEventCatalogue.event("tramai.worker.heartbeat")` (L7).
-- `RuntimeEvent.kt`: typed builder — `set(key, value)` rejects non-allowed attrs (L52-57) and wrong value types (L61-64); `build()` enforces required (L69-72); `RuntimeEvent.of(definition|name)` (L30-42); `RuntimeEventValidator` (L81-98).
-- Emission: `tramai-engine/.../engine/RuntimeEventEmission.kt:13-15` (`emitRuntimeEvent` → `onEngineEvent(event)`, honors failure policy); same file in `tramai-orchestration`.
+## Owning module
 
-## 2. Adding an event = 4 edits + docs regen
+- `tramai-core` — the catalogue, attribute/metric registries, typed event builder, renderer.
+- `tramai-observability` — the fail-closed architecture guard test + OTel observer.
+- `tramai-engine` / `tramai-orchestration` — emission helpers (`emitRuntimeEvent`).
 
-1. New `RuntimeAttributeKey` in `RuntimeAttributes.kt` (if a new attribute is needed)
-2. New `RuntimeMetricDefinition` in `RuntimeMetrics.kt` (if a new metric is needed)
-3. `RuntimeEventDefinition(...)` entry in `RuntimeEventCatalogue.kt` `allEvents`
-4. `val X = RuntimeEventCatalogue.event("tramai…")` in `RuntimeEvents.kt`
-5. Regenerate `docs/reference/runtime-event-catalogue.md` (see §4)
+## Authoritative contracts
 
-Custom (non-`tramai.`) third-party definitions are supported via `RuntimeEvent.of(definition)` (`RuntimeEvent.kt:22-29`).
+All in `tramai-core/src/main/kotlin/dev/tramai/core/observation/event/`:
 
-## 3. The architecture guard (fail-closed, both layers)
+- `RuntimeEventCatalogue.kt` (926 lines): `object` L16 owns `allEvents: List<RuntimeEventDefinition>` L17; init fails fast on duplicates/type conflicts/undeclared metrics (L862-891); `event(name)` errors on unknown id (L893-894). Dynamic namespace `DynamicAttributeNamespaces.WORKFLOW_CONTEXT` (L914-926).
+- `RuntimeEventModel.kt`: `RuntimeAttributeKey<T>(name, valueType)` L55, `RuntimeMetricDefinition` L62-68, `RuntimeEventDefinition` L80-91 (name, domain, allowedAttributes, requiredAttributes, sensitivity, auditEligible, evidenceEligible, metricMapping, spanEligible, failurePolicy).
+- `RuntimeAttributes.kt`: `object` L8 — one `RuntimeAttributeKey<T>("tramai…", T::class)` per canonical key.
+- `RuntimeMetrics.kt`: `object` L8, descriptors, `val all` L151.
+- `RuntimeEvents.kt`: compile-time registry (L6-80), e.g. `val WORKER_HEARTBEAT = RuntimeEventCatalogue.event("tramai.worker.heartbeat")` L7.
+- `RuntimeEvent.kt`: typed builder — `set` rejects non-allowed attrs (L52-57) and wrong types (L61-64); `build` enforces required (L69-72); `RuntimeEvent.of(definition|name)` L30-42; `RuntimeEventValidator` L81-98.
 
-`tramai-observability/src/test/kotlin/dev/tramai/observability/RuntimeEventCatalogueArchitectureTest.kt` (208 lines):
+## Files normally changed
 
-1. **Bytecode scan** (test L96-122): loads core/engine/orchestration/observability classes via `moduleClassesLocations()` (L124-133), skips only package `dev/tramai/core/observation/event/` (L37, L105), collects String LDC constants starting `"tramai."` via ASM9 `visitLdcInsn` (L155-173); fails on any found (L116-121), fails closed on zero classes (L101-103).
-2. **Repo-wide source scan** `sourceLiterals()` (L182-207): every `tramai-*` module's `src/main/**/*.kt`, regex `"tramai\.[a-zA-Z0-9_.-]*"` (L186); only the exact allowlist `configPropertyLiterals` (L44-80) passes `classifySourceLiteral` (L92-93). Even a literal already in the catalogue is an offender — it must reference `RuntimeEvents.X`.
+1. `RuntimeAttributes.kt` — new `RuntimeAttributeKey` (if a new attribute is needed).
+2. `RuntimeMetrics.kt` — new `RuntimeMetricDefinition` (if a new metric is needed).
+3. `RuntimeEventCatalogue.kt` — new `RuntimeEventDefinition(...)` entry in `allEvents`.
+4. `RuntimeEvents.kt` — `val X = RuntimeEventCatalogue.event("tramai…")`.
+5. `docs/reference/runtime-event-catalogue.md` — **regenerate** (see NOT changed → renderer).
+6. Emission call site in the owning module — via `emitRuntimeEvent` (`tramai-engine/.../engine/RuntimeEventEmission.kt:13-15`, same file in `tramai-orchestration`).
 
-Mutation semantics pinned by `RuntimeEventCatalogueVerifierRulesTest.kt` (same dir, 57 lines). `tramai-observability/build.gradle.kts:41-46` declares every module's production Kotlin sources as test inputs so the guard re-runs when a literal is added anywhere (no Gradle up-to-date skip).
+## NOT changed
 
-## 4. Docs generation (drift-checked, no Gradle task)
+- **`RuntimeEventCatalogueDocumentationTest.kt`** and the renderer — the reference doc is generated; never hand-edit it (header "do not edit by hand"; drift fails with "Regenerate it from RuntimeEventCatalogueRenderer").
+- **The architecture guard test** — `RuntimeEventCatalogueArchitectureTest.kt` and `RuntimeEventCatalogueVerifierRulesTest.kt` pin mutation semantics; never weaken them.
+- **Existing event names/attribute types** — renaming is a breaking change to observability consumers (catalogue init fails on conflicts, but external dashboards/alerts depend on the names).
+- **Analyzer/baseline** — same-PR edits forbidden.
 
-- `RuntimeEventCatalogueRenderer.kt` (tramai-core, 53 lines) deterministically renders the catalogue (L10-52).
-- `RuntimeEventCatalogueDocumentationTest.kt` (tramai-core test, L13-26) asserts `docs/reference/runtime-event-catalogue.md` (header: "do not edit by hand") equals `renderer.render()` — drift fails with "Regenerate it from RuntimeEventCatalogueRenderer".
-- There is **no** Gradle regen task; regenerate the checked-in file manually to match.
-- `RuntimeEventCatalogueTest.kt` (51 lines) asserts uniqueness/metadata/canonical types/determinism.
+## Required tests / TCK
 
-## 5. Mandatory verification
+- `RuntimeEventCatalogueTest.kt` (tramai-core, 51 lines) — uniqueness/metadata/canonical types/determinism.
+- `RuntimeEventCatalogueDocumentationTest.kt` (tramai-core test, L13-26) — generated doc matches renderer.
+- `RuntimeEventCatalogueArchitectureTest.kt` (tramai-observability, 208 lines) — two fail-closed layers:
+  1. **Bytecode scan** (L96-122): ASM9 `visitLdcInsn` over core/engine/orchestration/observability classes, skips only `dev/tramai/core/observation/event/`, fails on any `"tramai."` LDC, fails closed on zero classes (L101-103).
+  2. **Repo-wide source scan** `sourceLiterals()` (L182-207): every `tramai-*` module's `src/main/**/*.kt`, regex `"tramai\.[a-zA-Z0-9_.-]*"`; only exact allowlist `configPropertyLiterals` (L44-80) passes.
+- `RuntimeEventCatalogueVerifierRulesTest.kt` — pins mutation semantics.
+
+## Compatibility
+
+- Event/attribute/metric names are the long-term observability contract — external dashboards, alerts, and audit tooling depend on them.
+- The catalogue init fails fast on duplicate names, conflicting attribute types, required attrs outside allowed set, undeclared metric mappings, duplicate metric names (L862-891) — a new event must be consistent with all registries at once.
+- The guard fails closed: zero classes scanned = failure, so a broken classpath can never silently pass.
+
+## Failure / cancellation / lifecycle
+
+- Emission honors `failurePolicy` (`RuntimeEventFailurePolicy`, `RuntimeEventModel.kt:37`) — emit failures must not break the invocation flow.
+- The guard re-runs whenever a literal is added anywhere: `tramai-observability/build.gradle.kts:41-46` declares every module's production Kotlin sources as test inputs (no Gradle up-to-date skip).
+- Lifecycle: events are emitted at defined points in the engine/orchestration flows; a new event must declare its domain (`RuntimeEventDomain`) and sensitivity.
+
+## Verification
 
 ```bash
 ./gradlew :tramai-observability:test --tests '*RuntimeEventCatalogueArchitectureTest*' --tests '*RuntimeEventCatalogueVerifierRulesTest*'
@@ -50,4 +68,15 @@ Mutation semantics pinned by `RuntimeEventCatalogueVerifierRulesTest.kt` (same d
 ./gradlew verifyPr
 ```
 
-**Guardrails:** event/attribute/metric names are the long-term contract — changing a name is a breaking change to observability consumers; the catalogue init fails fast on duplicates/type conflicts; the guard fails closed (zero classes scanned = failure), so a broken classpath can never silently pass.
+## Common mistakes
+
+- Hand-editing `docs/reference/runtime-event-catalogue.md` — the drift test fails; regenerate instead.
+- Emitting a string literal instead of referencing `RuntimeEvents.X` — the guard flags even already-catalogued literals.
+- Adding an event with a required attribute that is not in `allowedAttributes` — init fails fast.
+- Skipping the metric mapping — undeclared metric mappings fail init (L882-886).
+
+## Related ADRs / specs
+
+- [ADR-006](../../adr/adr-006.md) — enable OpenTelemetry observability automatically when present
+- [spec-004-observability.md](../../specs/spec-004-observability.md) — observability contract
+- [`docs/reference/runtime-event-catalogue.md`](../../reference/runtime-event-catalogue.md) — generated catalogue (do not hand-edit)

--- a/docs/architecture/change-guides/adding-an-event.md
+++ b/docs/architecture/change-guides/adding-an-event.md
@@ -1,0 +1,53 @@
+# Change Guide: Adding an Event
+
+**Applies to:** the runtime event catalogue in `tramai-core` and the ASM/source architecture guard in `tramai-observability`.
+
+## TL;DR
+
+Every `tramai.*` runtime event is **declared once in `RuntimeEventCatalogue`**, referenced through the compile-time `RuntimeEvents` registry, and emitted via `emitRuntimeEvent`. The architecture guard scans both bytecode (LDC constants) and source: any `tramai.*` literal that does not go through `RuntimeEvents.X` fails the build — even if the literal already exists in the catalogue.
+
+## 1. The mechanism (all in `tramai-core/src/main/kotlin/dev/tramai/core/observation/event/`)
+
+- `RuntimeEventCatalogue.kt` (926 lines): `object RuntimeEventCatalogue` (L16) owns `allEvents: List<RuntimeEventDefinition>` (L17). Init block (L862-891) fails fast on: duplicate event names (L864), conflicting attribute key types (L868), required attrs outside allowed set (L874-879), undeclared metric mappings (L882-886), duplicate metric names (L889). `event(name)` errors on unknown id (L893-894). Dynamic namespace: `DynamicAttributeNamespaces.WORKFLOW_CONTEXT` (L914-926).
+- `RuntimeEventModel.kt`: `RuntimeAttributeKey<T>(name, valueType)` (L55), `RuntimeMetricDefinition` (L62-68), `RuntimeEventDefinition` (L80-91: name, domain, allowedAttributes, requiredAttributes, sensitivity, auditEligible, evidenceEligible, metricMapping, spanEligible, failurePolicy), enums `RuntimeEventDomain` (L8), `RuntimeEventSensitivity` (L23), `RuntimeEventFailurePolicy` (L37), `RuntimeMetricInstrumentType` (L45).
+- `RuntimeAttributes.kt`: one `RuntimeAttributeKey<T>("tramai…", T::class)` per canonical key (object L8).
+- `RuntimeMetrics.kt`: `object RuntimeMetrics` (L8), descriptors (e.g. L9-15), `val all` L151.
+- `RuntimeEvents.kt`: compile-time registry (L6-80), e.g. `val WORKER_HEARTBEAT = RuntimeEventCatalogue.event("tramai.worker.heartbeat")` (L7).
+- `RuntimeEvent.kt`: typed builder — `set(key, value)` rejects non-allowed attrs (L52-57) and wrong value types (L61-64); `build()` enforces required (L69-72); `RuntimeEvent.of(definition|name)` (L30-42); `RuntimeEventValidator` (L81-98).
+- Emission: `tramai-engine/.../engine/RuntimeEventEmission.kt:13-15` (`emitRuntimeEvent` → `onEngineEvent(event)`, honors failure policy); same file in `tramai-orchestration`.
+
+## 2. Adding an event = 4 edits + docs regen
+
+1. New `RuntimeAttributeKey` in `RuntimeAttributes.kt` (if a new attribute is needed)
+2. New `RuntimeMetricDefinition` in `RuntimeMetrics.kt` (if a new metric is needed)
+3. `RuntimeEventDefinition(...)` entry in `RuntimeEventCatalogue.kt` `allEvents`
+4. `val X = RuntimeEventCatalogue.event("tramai…")` in `RuntimeEvents.kt`
+5. Regenerate `docs/reference/runtime-event-catalogue.md` (see §4)
+
+Custom (non-`tramai.`) third-party definitions are supported via `RuntimeEvent.of(definition)` (`RuntimeEvent.kt:22-29`).
+
+## 3. The architecture guard (fail-closed, both layers)
+
+`tramai-observability/src/test/kotlin/dev/tramai/observability/RuntimeEventCatalogueArchitectureTest.kt` (208 lines):
+
+1. **Bytecode scan** (test L96-122): loads core/engine/orchestration/observability classes via `moduleClassesLocations()` (L124-133), skips only package `dev/tramai/core/observation/event/` (L37, L105), collects String LDC constants starting `"tramai."` via ASM9 `visitLdcInsn` (L155-173); fails on any found (L116-121), fails closed on zero classes (L101-103).
+2. **Repo-wide source scan** `sourceLiterals()` (L182-207): every `tramai-*` module's `src/main/**/*.kt`, regex `"tramai\.[a-zA-Z0-9_.-]*"` (L186); only the exact allowlist `configPropertyLiterals` (L44-80) passes `classifySourceLiteral` (L92-93). Even a literal already in the catalogue is an offender — it must reference `RuntimeEvents.X`.
+
+Mutation semantics pinned by `RuntimeEventCatalogueVerifierRulesTest.kt` (same dir, 57 lines). `tramai-observability/build.gradle.kts:41-46` declares every module's production Kotlin sources as test inputs so the guard re-runs when a literal is added anywhere (no Gradle up-to-date skip).
+
+## 4. Docs generation (drift-checked, no Gradle task)
+
+- `RuntimeEventCatalogueRenderer.kt` (tramai-core, 53 lines) deterministically renders the catalogue (L10-52).
+- `RuntimeEventCatalogueDocumentationTest.kt` (tramai-core test, L13-26) asserts `docs/reference/runtime-event-catalogue.md` (header: "do not edit by hand") equals `renderer.render()` — drift fails with "Regenerate it from RuntimeEventCatalogueRenderer".
+- There is **no** Gradle regen task; regenerate the checked-in file manually to match.
+- `RuntimeEventCatalogueTest.kt` (51 lines) asserts uniqueness/metadata/canonical types/determinism.
+
+## 5. Mandatory verification
+
+```bash
+./gradlew :tramai-observability:test --tests '*RuntimeEventCatalogueArchitectureTest*' --tests '*RuntimeEventCatalogueVerifierRulesTest*'
+./gradlew :tramai-core:test --tests '*RuntimeEventCatalogue*'
+./gradlew verifyPr
+```
+
+**Guardrails:** event/attribute/metric names are the long-term contract — changing a name is a breaking change to observability consumers; the catalogue init fails fast on duplicates/type conflicts; the guard fails closed (zero classes scanned = failure), so a broken classpath can never silently pass.

--- a/docs/architecture/change-guides/changing-structured-output-constraints.md
+++ b/docs/architecture/change-guides/changing-structured-output-constraints.md
@@ -1,0 +1,71 @@
+# Change Guide: Changing Structured-Output Constraints
+
+**Applies to:** structured-output contract handling in `tramai-core` (contracts), `tramai-structured` (handler + descriptor compiler), and `tramai-engine` (`StructuredResponseCoordinator`).
+
+## TL;DR
+
+Structured output is: `@AiService` return type → compiled `StructuredTypeDescriptor` → JSON schema → shape validation → Jackson deserialize → value validation. **Constraints are compiled at descriptor build time** (`@AiRange`, `@AiMinItems`, `@AiDescription`, nullability) and enforced by `StructuredJsonShapeValidator` (pre-deserialize) + `StructuredValueValidator` (post-deserialize). Changing a constraint means changing the compiler + validator + TCK fixtures — the TCK pins every failure stage.
+
+## 1. The contracts (`tramai-core/src/main/kotlin/dev/tramai/core/structured/`)
+
+- `StructuredOutputHandler.kt`: interface — `createContract` (L12), `analyze` (L17-20), `generateSchema` (L25), `deserialize` (L30-33), `serialize` (L38).
+- `StructuredOutputContract.kt` (`targetType`, `schemaJson`, L8-13).
+- `StructuredOutputResult.kt` — `Success(value, rawResponse)` L10-15; `Failure(rawResponse, errorSummary, feedbackMessage)` L20-36 (mutable diagnostic `failure` L35, ABI-stable 3-arg ctor).
+- `StructuredOutputFailureCode.kt`: `CONTRACT_FAILED / OUTPUT_REJECTED / REPAIR_EXHAUSTED / HANDLER_FAILED` (L8-17).
+- Constraint annotations: `tramai-core/.../annotations/AiRange.kt`, `AiMinItems.kt`, `AiDescription.kt`.
+
+## 2. The handler (`tramai-structured/.../JacksonStructuredOutputHandler.kt`, 182 lines)
+
+- Pure orchestration (L18-27): delegates to descriptor machinery — `typeCompiler` L34, cache L35, `schemaRenderer` L36, `shapeValidator` L37, `valueValidator` L38.
+- `analyze` pipeline (L46-111): `extractJsonCandidate` (fenced/bare/bracket, L134-181) → `readTree` (L66-75) → shape validation (L79-85) → Jackson deserialize (L87-96) → value validation (L98-105) → Success/Failure with repair `feedbackMessage`.
+- `generateSchema` L113, `deserialize` L116-127, `serialize` L129.
+
+## 3. The compiled descriptor model (`tramai-structured/.../descriptor/`)
+
+- `StructuredTypeDescriptor.kt` — sealed: `Scalar` L22, `Enum(values)` L35 (first-class), `Collection(item, minItems)` L41, `Object(typeName, properties)` L48; `StructuredPropertyDescriptor(name, type, required, description, range, accessor)` L70-77; `NumericRange` L80 (from `@AiRange`).
+- `StructuredTypeCompiler.kt` — facade (L17): scalars L36-40, List→Collection L41-49, Map→error L50, enum L53-57, Kotlin-vs-JavaBean dispatch via `kotlin.Metadata` L58-62/73-74, recursion via `CompileContext`.
+- `KotlinStructuredTypeCompiler.kt` — cycle detection L21-31; **constraints compiled here** in `compileProperty` (L64-92): `@AiMinItems` (collection-only, compile error otherwise, L70-82), `required = !nullable` (L87), `@AiDescription` (L88), `@AiRange`→`NumericRange` (L89). `JacksonJavaBeanStructuredTypeCompiler.kt` is the JavaBean counterpart.
+- `StructuredSchemaRenderer.kt` — descriptor→schema: minimum/maximum, minItems, `required` list, `additionalProperties:false` (L80).
+- `StructuredJsonShapeValidator.kt` — pre-deserialization: required presence/nullability (L62-72), unknown-key rejection (L55-60), array-ness (L36); enum membership deliberately delegated to Jackson (L12-16).
+- `StructuredValueValidator.kt` — post-deserialization runtime: `@AiMinItems` (L36-42), `@AiRange` bounds (L74-81), nullability (L18-21).
+- `StructuredContractFingerprint.kt` — SHA-256 of descriptor (L21-28); excludes typeName (L50-53) and accessors so Kotlin/JavaBean parity holds.
+- `StructuredDescriptorCache.kt` — per-handler ConcurrentHashMap (L15-33).
+
+## 4. What a constraint change touches
+
+| Constraint | Compile | Schema | Shape-validate | Value-validate |
+|---|---|---|---|---|
+| `@AiRange` | `KotlinStructuredTypeCompiler.kt:89` | `StructuredSchemaRenderer.kt` | — | `StructuredValueValidator.kt:74-81` |
+| `@AiMinItems` | `KotlinStructuredTypeCompiler.kt:70-82` (collection-only) | renderer minItems | `StructuredJsonShapeValidator.kt:36` (array-ness) | `StructuredValueValidator.kt:36-42` |
+| required/nullable | `compileProperty:87` | renderer `required` list | `StructuredJsonShapeValidator.kt:62-72` | `StructuredValueValidator.kt:18-21` |
+| new annotation | new key in descriptor + compiler | renderer | validator | validator |
+
+The **fingerprint** (SHA-256 over descriptor) changes whenever the compiled descriptor changes — cache keys and repair semantics follow.
+
+## 5. Mandatory contract tests
+
+- `tramai-structured/src/test/kotlin/dev/tramai/structured/tck/StructuredOutputContractCase.kt` — case model + `FailureStage` enum `EXTRACTION/JSON_PARSE/SHAPE/DESERIALIZATION/VALUE_VALIDATION` (L41-52).
+- `tck/StructuredOutputContractTck.kt` — lifecycle verifier: compile-failure L49-61, schema L63-83, valid round-trip L85-96, per-stage failure pinning L98-131, direct layer proof for SHAPE vs VALUE_VALIDATION L142-168, deterministic repair L170-181.
+- `tck/JacksonStructuredOutputContractTckTest.kt` (553 lines) — concrete fixtures: required-string L31-49, nullable L52-65, nested L83-100, root-array L136-149, enum regression.
+- `JacksonStructuredOutputHandlerTest.kt`, `JacksonStructuredOutputHandlerBoundaryTest.kt`, `JacksonStructuredOutputHandlerContractEvolutionTest.kt` (field evolution: new required field breaks old JSON), `JavaBeanStructuredOutputHandlerTest.kt`, `descriptor/StructuredDescriptorSchemaValidationAgreementTest.kt`.
+
+## 6. Engine consumption (what the coordinator enforces)
+
+`tramai-engine/.../structured/StructuredResponseCoordinator.kt` (485 lines, internal class L39):
+
+- Missing handler → `ConfigurationException` (L51-53); `operation.structuredContract(handler)` (L55) = `handler.createContract(requireNotNull(returnType))` (`TramaiEngine.kt:901-905`).
+- Success path → BEFORE_RESPONSE_RETURN policy (L142-150), memory persist (L151-164), `onCallCompleted(parseSuccess=true)` (L165).
+- Failure path → diagnostic `OUTPUT_REJECTED` (L175-189), throws `safeStructuredOutputFailure` (L195-198).
+- Repair loop: appends raw response as assistant + `feedbackMessage` as user (L391-392), terminal `REPAIR_EXHAUSTED` on last attempt (L382-388); handler exceptions → `HANDLER_FAILED` always terminal (`rethrowOrSanitizeStructuredHandlerFailure` L395-436); contract failures → `CONTRACT_FAILED` (`rethrowContractFailure` L438-463).
+- Test: `tramai-engine/src/test/kotlin/dev/tramai/engine/structured/StructuredResponseCoordinatorTest.kt`.
+
+## 7. Mandatory verification
+
+```bash
+./gradlew :tramai-structured:test --tests '*StructuredOutputContractTck*' --tests '*ContractEvolution*' --tests '*SchemaValidationAgreement*'
+./gradlew :tramai-engine:test --tests '*StructuredResponseCoordinator*'
+./gradlew verifyPr
+./gradlew verifyChangePolicy -PchangeClass=public-api   # if annotations/contracts change
+```
+
+**Guardrails:** constraint semantics are the contract — changing `@AiRange` bounds or `@AiMinItems` silently breaks downstream consumers, so the ContractEvolution tests must be extended deliberately; Kotlin/JavaBean descriptor parity is pinned by the fingerprint (typeName + accessors excluded); failure stages are pinned — a new constraint must map to exactly one `FailureStage`.

--- a/docs/architecture/change-guides/changing-structured-output-constraints.md
+++ b/docs/architecture/change-guides/changing-structured-output-constraints.md
@@ -1,65 +1,66 @@
 # Change Guide: Changing Structured-Output Constraints
 
-**Applies to:** structured-output contract handling in `tramai-core` (contracts), `tramai-structured` (handler + descriptor compiler), and `tramai-engine` (`StructuredResponseCoordinator`).
-
-## TL;DR
+## Start here
 
 Structured output is: `@AiService` return type → compiled `StructuredTypeDescriptor` → JSON schema → shape validation → Jackson deserialize → value validation. **Constraints are compiled at descriptor build time** (`@AiRange`, `@AiMinItems`, `@AiDescription`, nullability) and enforced by `StructuredJsonShapeValidator` (pre-deserialize) + `StructuredValueValidator` (post-deserialize). Changing a constraint means changing the compiler + validator + TCK fixtures — the TCK pins every failure stage.
 
-## 1. The contracts (`tramai-core/src/main/kotlin/dev/tramai/core/structured/`)
+Start from [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) (structured-output ownership → `tramai-structured`), read the module cards [`tramai-structured.md`](../../modules/tramai-structured.md) + [`tramai-core.md`](../../modules/tramai-core.md), then follow this guide.
 
-- `StructuredOutputHandler.kt`: interface — `createContract` (L12), `analyze` (L17-20), `generateSchema` (L25), `deserialize` (L30-33), `serialize` (L38).
-- `StructuredOutputContract.kt` (`targetType`, `schemaJson`, L8-13).
-- `StructuredOutputResult.kt` — `Success(value, rawResponse)` L10-15; `Failure(rawResponse, errorSummary, feedbackMessage)` L20-36 (mutable diagnostic `failure` L35, ABI-stable 3-arg ctor).
-- `StructuredOutputFailureCode.kt`: `CONTRACT_FAILED / OUTPUT_REJECTED / REPAIR_EXHAUSTED / HANDLER_FAILED` (L8-17).
-- Constraint annotations: `tramai-core/.../annotations/AiRange.kt`, `AiMinItems.kt`, `AiDescription.kt`.
+## Owning module
 
-## 2. The handler (`tramai-structured/.../JacksonStructuredOutputHandler.kt`, 182 lines)
+- Contracts + annotations: `tramai-core/structured`, `tramai-core/annotations` (`AiRange`, `AiMinItems`, `AiDescription`).
+- Handler + descriptor machinery: `tramai-structured`.
+- Engine consumption: `tramai-engine/structured` (`StructuredResponseCoordinator`).
 
-- Pure orchestration (L18-27): delegates to descriptor machinery — `typeCompiler` L34, cache L35, `schemaRenderer` L36, `shapeValidator` L37, `valueValidator` L38.
-- `analyze` pipeline (L46-111): `extractJsonCandidate` (fenced/bare/bracket, L134-181) → `readTree` (L66-75) → shape validation (L79-85) → Jackson deserialize (L87-96) → value validation (L98-105) → Success/Failure with repair `feedbackMessage`.
-- `generateSchema` L113, `deserialize` L116-127, `serialize` L129.
+## Authoritative contracts
 
-## 3. The compiled descriptor model (`tramai-structured/.../descriptor/`)
+- `StructuredOutputHandler` — `tramai-core/src/main/kotlin/dev/tramai/core/structured/StructuredOutputHandler.kt`: `createContract` L12, `analyze` L17-20, `generateSchema` L25, `deserialize` L30-33, `serialize` L38.
+- `StructuredOutputResult` — `Success(value, rawResponse)` L10-15; `Failure(rawResponse, errorSummary, feedbackMessage)` L20-36 (ABI-stable 3-arg ctor, mutable diagnostic L35).
+- `StructuredOutputFailureCode` — `CONTRACT_FAILED / OUTPUT_REJECTED / REPAIR_EXHAUSTED / HANDLER_FAILED` (L8-17).
+- Descriptor model — `tramai-structured/.../descriptor/StructuredTypeDescriptor.kt`: sealed `Scalar` L22, `Enum(values)` L35, `Collection(item, minItems)` L41, `Object(typeName, properties)` L48; `StructuredPropertyDescriptor(name, type, required, description, range, accessor)` L70-77; `NumericRange` L80.
+- Constraint compile point — `KotlinStructuredTypeCompiler.kt` `compileProperty` L64-92: `@AiMinItems` (collection-only, L70-82), `required = !nullable` (L87), `@AiDescription` (L88), `@AiRange`→`NumericRange` (L89). JavaBean counterpart: `JacksonJavaBeanStructuredTypeCompiler.kt`.
+- Fingerprint — `StructuredContractFingerprint.kt:21-28` (SHA-256 of descriptor; excludes typeName L50-53 and accessors so Kotlin/JavaBean parity holds).
 
-- `StructuredTypeDescriptor.kt` — sealed: `Scalar` L22, `Enum(values)` L35 (first-class), `Collection(item, minItems)` L41, `Object(typeName, properties)` L48; `StructuredPropertyDescriptor(name, type, required, description, range, accessor)` L70-77; `NumericRange` L80 (from `@AiRange`).
-- `StructuredTypeCompiler.kt` — facade (L17): scalars L36-40, List→Collection L41-49, Map→error L50, enum L53-57, Kotlin-vs-JavaBean dispatch via `kotlin.Metadata` L58-62/73-74, recursion via `CompileContext`.
-- `KotlinStructuredTypeCompiler.kt` — cycle detection L21-31; **constraints compiled here** in `compileProperty` (L64-92): `@AiMinItems` (collection-only, compile error otherwise, L70-82), `required = !nullable` (L87), `@AiDescription` (L88), `@AiRange`→`NumericRange` (L89). `JacksonJavaBeanStructuredTypeCompiler.kt` is the JavaBean counterpart.
-- `StructuredSchemaRenderer.kt` — descriptor→schema: minimum/maximum, minItems, `required` list, `additionalProperties:false` (L80).
-- `StructuredJsonShapeValidator.kt` — pre-deserialization: required presence/nullability (L62-72), unknown-key rejection (L55-60), array-ness (L36); enum membership deliberately delegated to Jackson (L12-16).
-- `StructuredValueValidator.kt` — post-deserialization runtime: `@AiMinItems` (L36-42), `@AiRange` bounds (L74-81), nullability (L18-21).
-- `StructuredContractFingerprint.kt` — SHA-256 of descriptor (L21-28); excludes typeName (L50-53) and accessors so Kotlin/JavaBean parity holds.
-- `StructuredDescriptorCache.kt` — per-handler ConcurrentHashMap (L15-33).
-
-## 4. What a constraint change touches
+## Files normally changed
 
 | Constraint | Compile | Schema | Shape-validate | Value-validate |
 |---|---|---|---|---|
 | `@AiRange` | `KotlinStructuredTypeCompiler.kt:89` | `StructuredSchemaRenderer.kt` | — | `StructuredValueValidator.kt:74-81` |
-| `@AiMinItems` | `KotlinStructuredTypeCompiler.kt:70-82` (collection-only) | renderer minItems | `StructuredJsonShapeValidator.kt:36` (array-ness) | `StructuredValueValidator.kt:36-42` |
+| `@AiMinItems` | `KotlinStructuredTypeCompiler.kt:70-82` | renderer minItems | `StructuredJsonShapeValidator.kt:36` (array-ness) | `StructuredValueValidator.kt:36-42` |
 | required/nullable | `compileProperty:87` | renderer `required` list | `StructuredJsonShapeValidator.kt:62-72` | `StructuredValueValidator.kt:18-21` |
 | new annotation | new key in descriptor + compiler | renderer | validator | validator |
 
-The **fingerprint** (SHA-256 over descriptor) changes whenever the compiled descriptor changes — cache keys and repair semantics follow.
+Plus: `StructuredSchemaRenderer.kt` (descriptor→schema, `additionalProperties:false` L80), `StructuredContractFingerprint.kt` (fingerprint changes when the descriptor changes), TCK fixtures in `tramai-structured/src/test/.../tck/`.
 
-## 5. Mandatory contract tests
+## NOT changed
 
-- `tramai-structured/src/test/kotlin/dev/tramai/structured/tck/StructuredOutputContractCase.kt` — case model + `FailureStage` enum `EXTRACTION/JSON_PARSE/SHAPE/DESERIALIZATION/VALUE_VALIDATION` (L41-52).
-- `tck/StructuredOutputContractTck.kt` — lifecycle verifier: compile-failure L49-61, schema L63-83, valid round-trip L85-96, per-stage failure pinning L98-131, direct layer proof for SHAPE vs VALUE_VALIDATION L142-168, deterministic repair L170-181.
-- `tck/JacksonStructuredOutputContractTckTest.kt` (553 lines) — concrete fixtures: required-string L31-49, nullable L52-65, nested L83-100, root-array L136-149, enum regression.
-- `JacksonStructuredOutputHandlerTest.kt`, `JacksonStructuredOutputHandlerBoundaryTest.kt`, `JacksonStructuredOutputHandlerContractEvolutionTest.kt` (field evolution: new required field breaks old JSON), `JavaBeanStructuredOutputHandlerTest.kt`, `descriptor/StructuredDescriptorSchemaValidationAgreementTest.kt`.
+- **`StructuredResponseCoordinator`** (engine) — it consumes the handler contract; constraint semantics don't live there. Only `StructuredOutputContractTck` failure stages are engine-visible.
+- **The TCKs** — `StructuredOutputContractTck.kt` pins failure stages; never weaken it.
+- **Kotlin/JavaBean parity** — descriptor fingerprints exclude typeName + accessors so both compilers must produce identical descriptors; don't introduce a Kotlin-only constraint.
+- **Analyzer/baseline** — same-PR edits forbidden.
+- Failure stage mapping: a new constraint must map to exactly one `FailureStage` — don't blur EXTRACTION/JSON_PARSE/SHAPE/DESERIALIZATION/VALUE_VALIDATION.
 
-## 6. Engine consumption (what the coordinator enforces)
+## Required tests / TCK
 
-`tramai-engine/.../structured/StructuredResponseCoordinator.kt` (485 lines, internal class L39):
+- `tramai-structured/src/test/kotlin/dev/tramai/structured/tck/StructuredOutputContractCase.kt` — case model + `FailureStage` enum (L41-52).
+- `tck/StructuredOutputContractTck.kt` — lifecycle verifier: compile-failure L49-61, schema L63-83, valid round-trip L85-96, per-stage failure pinning L98-131, SHAPE vs VALUE_VALIDATION direct proof L142-168, deterministic repair L170-181.
+- `tck/JacksonStructuredOutputContractTckTest.kt` (553 lines) — concrete fixtures (required-string L31-49, nullable L52-65, nested L83-100, root-array L136-149, enum regression).
+- `JacksonStructuredOutputHandlerContractEvolutionTest.kt` — field evolution: new required field breaks old JSON, `@AiRange`/`@AiMinItems`.
+- `JacksonStructuredOutputHandlerTest.kt`, `JacksonStructuredOutputHandlerBoundaryTest.kt`, `JavaBeanStructuredOutputHandlerTest.kt`, `descriptor/StructuredDescriptorSchemaValidationAgreementTest.kt`.
 
-- Missing handler → `ConfigurationException` (L51-53); `operation.structuredContract(handler)` (L55) = `handler.createContract(requireNotNull(returnType))` (`TramaiEngine.kt:901-905`).
-- Success path → BEFORE_RESPONSE_RETURN policy (L142-150), memory persist (L151-164), `onCallCompleted(parseSuccess=true)` (L165).
-- Failure path → diagnostic `OUTPUT_REJECTED` (L175-189), throws `safeStructuredOutputFailure` (L195-198).
-- Repair loop: appends raw response as assistant + `feedbackMessage` as user (L391-392), terminal `REPAIR_EXHAUSTED` on last attempt (L382-388); handler exceptions → `HANDLER_FAILED` always terminal (`rethrowOrSanitizeStructuredHandlerFailure` L395-436); contract failures → `CONTRACT_FAILED` (`rethrowContractFailure` L438-463).
-- Test: `tramai-engine/src/test/kotlin/dev/tramai/engine/structured/StructuredResponseCoordinatorTest.kt`.
+## Compatibility
 
-## 7. Mandatory verification
+- **Constraint semantics are the contract** — changing `@AiRange` bounds or `@AiMinItems` silently breaks downstream consumers; extend `ContractEvolutionTest` deliberately.
+- **Fingerprint changes** alter cache keys and repair semantics (`StructuredDescriptorCache.kt:15-33`, `StructuredContractFingerprint.kt`).
+- **Schema drift** — the rendered schema (`StructuredSchemaRenderer.kt`) is what clients compile against; `StructuredDescriptorSchemaValidationAgreementTest.kt` pins agreement between descriptor and schema.
+- **ABI** — `StructuredOutputResult`/`StructuredOutputFailureCode` shapes are stable public API; changing the 3-arg ctor or failure codes is a `public-api`-classified change.
+
+## Failure / cancellation / lifecycle
+
+- Failure classification: `StructuredResponseCoordinator.kt` (engine) maps — missing handler → `ConfigurationException` (L51-53); parse/validation failure → `OUTPUT_REJECTED` (L175-189) + `safeStructuredOutputFailure` (L195-198); repair loop appends raw response as assistant + `feedbackMessage` as user (L391-392), terminal `REPAIR_EXHAUSTED` (L382-388); handler exceptions → `HANDLER_FAILED` always terminal (`rethrowOrSanitizeStructuredHandlerFailure` L395-436); contract failures → `CONTRACT_FAILED` (`rethrowContractFailure` L438-463).
+- Lifecycle: `createContract` is cached per handler (`StructuredDescriptorCache`); new constraint annotations must be safe under concurrent cache access (ConcurrentHashMap).
+
+## Verification
 
 ```bash
 ./gradlew :tramai-structured:test --tests '*StructuredOutputContractTck*' --tests '*ContractEvolution*' --tests '*SchemaValidationAgreement*'
@@ -68,4 +69,17 @@ The **fingerprint** (SHA-256 over descriptor) changes whenever the compiled desc
 ./gradlew verifyChangePolicy -PchangeClass=public-api   # if annotations/contracts change
 ```
 
-**Guardrails:** constraint semantics are the contract — changing `@AiRange` bounds or `@AiMinItems` silently breaks downstream consumers, so the ContractEvolution tests must be extended deliberately; Kotlin/JavaBean descriptor parity is pinned by the fingerprint (typeName + accessors excluded); failure stages are pinned — a new constraint must map to exactly one `FailureStage`.
+## Common mistakes
+
+- Adding a constraint to the Kotlin compiler only — JavaBean parity breaks the fingerprint.
+- Changing a constraint without updating the schema renderer — schema/descriptor agreement test fails.
+- Blurring failure stages — the TCK pins each stage; a new constraint must map to exactly one.
+- Hand-editing `StructuredOutputResult` shapes — ABI break.
+
+## Related ADRs / specs
+
+- [ADR-003](../../adr/adr-003.md) — structured output is the default non-String contract
+- [ADR-004](../../adr/adr-004.md) — custom Jackson-based schema generation
+- [ADR-009](../../adr/adr-009.md) — structured analysis stays in tramai-structured
+- [spec-002-structured-output.md](../../specs/spec-002-structured-output.md) — structured-output contract
+- Module card [`tramai-structured.md`](../../modules/tramai-structured.md)


### PR DESCRIPTION
# docs: add Epic 11.2c change guides (AI navigation closure)

C2c of Track C — the final Epic 11.2 deliverable. `ARCHITECTURE.md` has referenced `docs/architecture/change-guides/` ("added in Epic 11.2c") since #305; this PR creates the directory it points to.

## Scope (7 files, docs-only)

- **`adding-a-provider.md`** — `ModelProvider` SPI, manual `ProviderRegistry` builder (not ServiceLoader), `ProviderTck` enrollment gate, module-catalog/BOM wiring, BCV `apiDump` obligation, zero-egress.
- **`adding-a-workflow-step.md`** — sealed `InternalWorkflowStep<S>` model, builder DSL, `ExternalStepExecutorRegistry` for plugin steps, exhaustive-`when` wiring points, suspension rule + ASM guard, boundary rules, `verifyWorkflowApiStabilityBoundary`.
- **`adding-a-store.md`** — 7 store SPIs, shared TCK enrollment (architecture-enforced by `StoreEnrollmentScanner` + `*EnrollmentArchitectureTest`), replay-envelope/codec obligations, Spring auto-config patterns, template implementations.
- **`adding-an-event.md`** — `RuntimeEventCatalogue` mechanism, 4-edit recipe, dual-layer ASM LDC + source architecture guard (fail-closed), docs drift-check.
- **`adding-an-approval-state.md`** — dual state machines (`ApprovalStatus` / `ApprovalContinuationStatus`), full blast radius, invariants (version ceiling ≤ 2, exactly-once args, expiry boundary), TCKs + lifecycle oracles.
- **`changing-structured-output-constraints.md`** — compiled descriptor model, constraint compile/validate path, `FailureStage` contract, engine coordinator semantics, ContractEvolution tests.
- **`README.md`** — guide index with the key contract per change.

## Review round-3 correction (final re-review — one narrow semantic fix)

**P0 — store guide no longer overstates TCK coverage.** `adding-a-store.md`:

- `ApprovalResumeCredentialStore` is now documented as an explicit exception: **no `ApprovalResumeCredentialStoreTck`, no enrollment gate today**; obligation = SPI conformance + encryption-at-rest + module-level tests (`JdbcApprovalResumeCredentialStoreTest.kt`).
- "core SPI" replaced with "authoritative store SPI in its owning module" (core/security/engine/orchestration).
- Ops stores no longer generalized as "module tests only": `SovereignOpsAuditOutboxStore` documented as **having** `SovereignOpsAuditOutboxStoreTck` + `SovereignOpsAuditOutboxStoreTckEnrollmentArchitectureTest` + in-memory/file/JDBC runners; the other ops stores listed individually with their actual no-shared-TCK situation.
- Required tests / TCK section is now an explicit per-family table: shared-TCK ✅/❌ + enrollment shape, with ❌ rows stating the module-test obligation.

**Tiny cleanup:** `adding-a-provider.md` — "make a store pass" → "make a provider pass".

**Drill:** persistence/store AI-navigation drill **PASS** — the guide answers the testing obligation for `ApprovalResumeCredentialStore` and `SovereignOpsAuditOutboxStore` from its own text alone, no repo-wide discovery. Full suite: link audit 0 broken, schema 6/6, all drills 6/6, verifyPr ✅, verify060Architecture ✅.

## Review round-2 fixes (REQ CHANGES → re-review)

**1. README navigation paths fixed (P0).** `docs/architecture/change-guides/` is 3 levels below repo root; all links now resolve to the authoritative root documents:
`../../../ARCHITECTURE.md`, `../../../AGENTS.md`, `../../modules/README.md`, `../../../config/quality/module-catalog.yml`, `../../../config/quality/module-boundaries.yml`. Full link audit of all 7 files (resolved from each containing directory): **0 broken links** — the earlier `docs/ARCHITECTURE.md` misroute and the nonexistent `docs/AGENTS.md` are gone.

**2. All six guides normalized to the agreed C2c schema (P1).** Every guide has the same semantic sections, in order:
`## Start here` → `## Owning module` → `## Authoritative contracts` → `## Files normally changed` → `## NOT changed` → `## Required tests / TCK` → `## Compatibility` → `## Failure / cancellation / lifecycle` → `## Verification` → `## Common mistakes` → `## Related ADRs / specs`.
Technical file:line content preserved and reorganized; ADR/spec pointers now explicit per guide. Schema check: **6/6 guides, all 11 headings present and in order**.

**3. AI-navigation acceptance demonstrated (P1).**

**AI navigation drills: 6/6 PASS**

| Drill | Owning module | Authoritative contract | Files changed | NOT changed | TCK/tests | Compatibility | Failure/cancel/lifecycle | Verification |
|---|---|---|---|---|---|---|---|---|
| provider | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| persistence/store | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| workflow step | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| runtime event | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| approval state | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| structured-output constraint | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

Each dry-run starts only from `ARCHITECTURE.md` → relevant change guide → referenced module card(s) and confirms the agent can identify all eight items **without a repo-wide discovery pass** (a targeted read of a guide-named path is allowed; a repo-wide search would have been a FAIL). No guide fixes were exposed by the drills.

## Grounding

Every guide carries verified `file:line` references against the current source tree (collected by read-only codebase surveys; no invented APIs). Each guide names its mandatory contract tests (TCKs are independent oracles that fail loudly on drift) and the exact verification commands.

## Verification

- verifyPr ✅
- verify060Architecture ✅
- Link/path audit: 0 broken (all 7 files, resolved from containing dir)
- Guide schema: 6/6 in order
- AI navigation drills: 6/6 PASS
- Documentation-only, zero production source changes

Open for final re-review.
