### PR TITLE
fix(orchestration): Epic 8.3a — wall vs monotonic time semantics + injected Clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@
     never from wall-clock arithmetic. The drain residual is computed by the
     exact `MonotonicDrainBudget` (`timeout − monotonic elapsed`, clamped to
     ≥1ms) — a wall-clock jump can no longer shorten or stretch the drain.
-  - **One injected Clock for persisted timestamps.** Step-attempt records
-    (`startedAt`/`completedAt`), execution-tracker timestamps, checkpoint
-    saves (`savedAtEpochMillis`), and recovery resolution timestamps all read
-    the workflow's injected Clock. Stores preserve timestamps; they never
-    invent business time.
+  - **Persisted timestamps consume explicit Clock authorities.**
+    Step-attempt records (`startedAt`/`completedAt`), execution-tracker
+    timestamps, and checkpoint saves (`savedAtEpochMillis`) use the workflow's
+    injected Clock; operator recovery-resolution timestamps use the recovery
+    controller's Clock boundary (`Clock.systemUTC()` in production,
+    deterministic injection through the internal `forTest` seam). Stores
+    preserve timestamps; they never invent business time.
   - **Legacy checkpoint decode contract.** File records that lack
     `savedAtEpochMillis` decode as `0L` = "historical save time unavailable"
     — never 1970-01-01, never read-time synthesis. Present values are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@
 
 ### Fixed
 
+- **Orchestration time semantics (Epic 8.3a).** Wall time is separated from
+  elapsed time, and every new persisted orchestration timestamp is supplied
+  by one injected `Clock` threaded from the worker boundary:
+  - **Monotonic elapsed authority.** Worker uptime and the shutdown drain
+    residual are now derived from a `MonotonicTimeSource` seam
+    (`NanoTimeSource` binds `System::nanoTime` at the composition point),
+    never from wall-clock arithmetic. The drain residual is computed by the
+    exact `MonotonicDrainBudget` (`timeout − monotonic elapsed`, clamped to
+    ≥1ms) — a wall-clock jump can no longer shorten or stretch the drain.
+  - **One injected Clock for persisted timestamps.** Step-attempt records
+    (`startedAt`/`completedAt`), execution-tracker timestamps, checkpoint
+    saves (`savedAtEpochMillis`), and recovery resolution timestamps all read
+    the workflow's injected Clock. Stores preserve timestamps; they never
+    invent business time.
+  - **Legacy checkpoint decode contract.** File records that lack
+    `savedAtEpochMillis` decode as `0L` = "historical save time unavailable"
+    — never 1970-01-01, never read-time synthesis. Present values are
+    preserved exactly.
+  - **Recovery-controller ABI unchanged.** `InMemoryWorkflowRecoveryController`
+    keeps its original two-argument public constructor (apiCheck green, zero
+    API-dump drift); clock injection lives behind an internal `forTest` seam.
+  - Proven by a 14-discriminator suite (exact arithmetic, zero timing
+    thresholds) and a 17-candidate mutation campaign (16 STRONG, 1 REDUNDANT,
+    0 reachable WEAK). Contract: `docs/reference/time-semantics-contract.md`.
+
 - **Circuit-breaker lifecycle hardening (Epic 8.2g, PR #302).** The provider
   circuit breaker now tracks the ownership of every admitted attempt instead
   of only the breaker state:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,11 @@
     keeps its original two-argument public constructor (apiCheck green, zero
     API-dump drift); clock injection lives behind an internal `forTest` seam.
   - Proven by a 14-discriminator suite (exact arithmetic, zero timing
-    thresholds) and a 17-candidate mutation campaign (16 STRONG, 1 REDUNDANT,
-    0 reachable WEAK). Contract: `docs/reference/time-semantics-contract.md`.
+    thresholds) and a 16-candidate mutation campaign (15 STRONG, 1 REDUNDANT,
+    0 WEAK, 0 INVALID). The former fresh-heartbeat-mark mutation is now
+    structurally impossible because the heartbeat loop receives a captured
+    `MonotonicMark`, not a mark supplier. Contract:
+    `docs/reference/time-semantics-contract.md`.
 
 - **Circuit-breaker lifecycle hardening (Epic 8.2g, PR #302).** The provider
   circuit breaker now tracks the ownership of every admitted attempt instead

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1344,16 +1344,18 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ## Epic 8.3: Time, randomness, and scheduling abstractions
 
+**Status: 🚧 IN PROGRESS** — 8.3a (wall vs monotonic time semantics) functionally complete and frozen; 8.3b (identity + randomness), 8.3c (scheduler ownership), 8.3d (closure) pending. Contract: `docs/reference/time-semantics-contract.md`.
+
 **Goal:** Eliminate incidental nondeterminism from domain decisions.
 
 ### Tasks
 
-1. Use `Clock` for wall-clock timestamps.
-2. Use a monotonic time source for duration and timeout accounting where appropriate.
-3. Inject jitter/random sources into retry policies.
-4. Avoid direct `System.currentTimeMillis()` in domain logic.
-5. Centralize scheduler ownership.
-6. Make tests independent of real sleeps whenever possible.
+1. Use `Clock` for wall-clock timestamps. — **8.3a: done** — one injected Clock per worker boundary; recovery controller ABI unchanged (internal `forTest` seam).
+2. Use a monotonic time source for duration and timeout accounting where appropriate. — **8.3a: done** — `MonotonicTimeSource`/`NanoTimeSource` seam; `MonotonicDrainBudget` exact residual; heartbeat uptime monotonic.
+3. Inject jitter/random sources into retry policies. — **8.3b**.
+4. Avoid direct `System.currentTimeMillis()` in domain logic. — **8.3a: done** in orchestration elapsed/persisted paths; the public `WorkflowCheckpoint(savedAtEpochMillis = System.currentTimeMillis())` default remains deliberately (composition boundary, own compatibility scrutiny).
+5. Centralize scheduler ownership. — **8.3c**.
+6. Make tests independent of real sleeps whenever possible. — **8.3a: done** for the affected paths — 14 discriminators, exact arithmetic, zero timing thresholds (M04-hardened).
 
 ### Acceptance criteria
 

--- a/docs/architecture/change-guides/adding-a-store.md
+++ b/docs/architecture/change-guides/adding-a-store.md
@@ -23,7 +23,7 @@ Start from [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) (persistence layer), re
 | ApprovalResumeCredentialStore | `tramai-core/.../approval/gateway/ApprovalResumeCredentialStore.kt` | `create` L20 (dup → IllegalStateException) · `get` L26 · `delete` L33 — MUST encrypt SealedResumeToken at rest (L10-12) |
 | AuditStore | `tramai-security/.../audit/AuditStore.kt` | `appendNext` L4 · `readStream` L9 · `readStreamPage` L23 · `latestEvent` L41 |
 | SuspendedInvocationStore | `tramai-engine/.../SuspendedInvocationStore.kt` | `create(metadata, replayEnvelope)` L155 · `get` L167 · `revealReplayEnvelope` L175 (only after claim) · `remove` L181 — envelope NOT exposed via `get` (L139-142) |
-| WorkflowCheckpointStore | `tramai-orchestration/.../WorkflowPersistence.kt` | `load` L73 · `save(checkpoint, expectedRevision)` L77 · `delete` L81 · `requireRecovery` L96 · `clearRecovery` L139 + `WorkflowStateCodec<S>` L63 |
+| WorkflowCheckpointStore | `tramai-orchestration/.../WorkflowPersistence.kt` | `load` L80 · `save(checkpoint, expectedRevision)` L84 · `delete` L88 · `requireRecovery` L103 · `clearRecovery` L146 + `WorkflowStateCodec<S>` L70 |
 | WorkflowLeaseStore | `tramai-orchestration/.../WorkflowLease.kt` | `currentLease` L34 · `claim` L38 · `renew` L45 · `release` L50 (+ optional `WorkflowLeaseCheckpointFence` L56-72) |
 
 ## Files normally changed

--- a/docs/reference/time-semantics-contract.md
+++ b/docs/reference/time-semantics-contract.md
@@ -37,15 +37,24 @@ must never be derived from wall time.
 
 | Decision | Authority |
 |---|---|
-| Worker uptime (heartbeat) | `startedAtMark().elapsedMillis()` |
+| Worker uptime (heartbeat) | `startedAtMark.elapsedMillis()` |
 | Drain residual budget | `MonotonicDrainBudget` |
 | Anything else | monotonic source only — never `Clock` |
 
 ## Persisted-timestamp authority (injected Clock)
 
-Every NEW persisted orchestration timestamp is supplied by one injected
-`Clock`, threaded from the worker boundary. Stores preserve timestamps; they
-never invent business time.
+Every NEW persisted orchestration timestamp consumes an explicit `Clock` —
+never a direct `System.currentTimeMillis()` read. The composition boundary
+differs by decision class:
+
+- **Worker-owned execution/checkpoint timestamps** (step-attempt
+  `startedAt`/`completedAt`, execution-tracker timestamps, checkpoint saves)
+  → the workflow's injected `Clock`, threaded from the worker boundary.
+- **Operator recovery-controller timestamps** (retry approval resolution)
+  → a controller-owned clock boundary: `Clock.systemUTC()` in production,
+  injectable through the internal `forTest` seam for deterministic tests.
+
+Stores preserve timestamps; they never invent business time.
 
 - `Workflow` / `WorkflowBuilder.build(clock: Clock = Clock.systemUTC())` — the
   existing public seam; the workflow's clock feeds step-attempt records
@@ -54,9 +63,10 @@ never invent business time.
 - `WorkflowPersistenceSession` — checkpoint saves stamp
   `savedAtEpochMillis = clock.millis()`.
 - `InMemoryWorkflowRecoveryController` — recovery resolution timestamps come
-  from the workflow clock via the internal `forTest` seam; the public
-  two-argument constructor and its JVM ABI are unchanged, production defaults
-  to `Clock.systemUTC()`.
+  from a **controller-owned clock boundary**: production defaults to
+  `Clock.systemUTC()`, and the internal `forTest` seam injects a deterministic
+  clock for tests. The public two-argument constructor and its JVM ABI are
+  unchanged.
 - Stores (`FileWorkflowCheckpointStore`, in-memory, JDBC) preserve
   timestamps as persisted; no store reads a clock to invent business time.
 
@@ -89,8 +99,13 @@ values: injected clocks in tests, fake monotonic sources, exact arithmetic.
 
 ## Mutation evidence (frozen head)
 
-17-mutant campaign across every independently reachable authority:
-**16 STRONG / 1 REDUNDANT (clamp-removal, honest) / 0 WEAK / 0 INVALID.**
+16-mutant campaign across every independently reachable authority:
+**15 STRONG / 1 REDUNDANT (M13, honest) / 0 WEAK / 0 INVALID.**
+
+The former fresh-heartbeat-mark mutant (M03) is **structurally eliminated**,
+not killed: the heartbeat loop receives a captured `MonotonicMark` instead of
+a mark supplier, so a fresh-mark-per-heartbeat behaviour cannot be expressed
+through the API at all.
 
 The 14-discriminator suite (`TimeSemanticsDiscriminatorTest`) covers:
 P0-A uptime (delta fake + full-worker heartbeat wiring), P0-A deterministic
@@ -104,6 +119,6 @@ UNKNOWN decode.
 - 8.3b — identity + randomness (UUID boundaries, retry jitter composition).
 - 8.3c — scheduler ownership (`withTimeoutOrNull` placement, executor
   lifecycle).
-- Step-attempt listing/selection ordering when `startedAt` ties: the
-  comparator's random-`attemptId` tie-break is a known defect tracked
-  separately (see PR history); not an 8.3a change.
+- Durable equal-`startedAt` chronology for the File/JDBC
+  `StepAttemptRecordStore` implementations remains deferred to #318. The
+  in-memory implementation already uses creation-order authority after #317.

--- a/docs/reference/time-semantics-contract.md
+++ b/docs/reference/time-semantics-contract.md
@@ -1,0 +1,109 @@
+# Time Semantics Contract (Epic 8.3a)
+
+> Status: frozen at the 8.3a exact head. This contract describes the ACTUAL
+> frozen types and behaviours; it is the authoritative reference for what
+> 8.3a guarantees and what it deliberately leaves at composition boundaries.
+
+## Goal
+
+> No incidental nondeterministic source participates directly in a domain
+> decision. Nondeterminism exists only at explicit composition/boundary
+> points.
+
+8.3a removes wall-clock (`System.currentTimeMillis()`) participation from
+elapsed-time and persisted-timestamp decisions in `tramai-orchestration`.
+
+## Elapsed-time authority (monotonic)
+
+Wall time can jump (NTP, manual correction, VM pause). Elapsed-time decisions
+must never be derived from wall time.
+
+- `MonotonicTimeSource` (`MonotonicTime.kt`) — internal seam.
+  `markNow(): MonotonicMark`; `MonotonicMark.elapsedMillis()` measures elapsed
+  against the SAME source that produced the mark.
+- `NanoTime` — production composition: `NanoTimeSource(nanoTime: () -> Long =
+  System::nanoTime)`. The raw-nanos supplier is the composition point;
+  `System.nanoTime` is bound there, nowhere in domain arithmetic.
+- Elapsed arithmetic: `(nanoTime() - startNanos) / 1_000_000`, clamped to
+  `>= 0` (hypervisor/TSC jitter). Deterministically testable with controlled
+  readings — no sleep, no tolerance, no scheduler assumption.
+- `MonotonicDrainBudget(timeoutMillis, timeSource)` — the drain-residual
+  authority: `remainingMillis() = (timeoutMillis - elapsed).coerceAtLeast(1L)`.
+  Production drain consumes `remainingMillis()` for the residual phase after
+  the first `withTimeoutOrNull` expires. The budget arithmetic is exact and
+  wall-clock independent.
+
+### Consumers
+
+| Decision | Authority |
+|---|---|
+| Worker uptime (heartbeat) | `startedAtMark().elapsedMillis()` |
+| Drain residual budget | `MonotonicDrainBudget` |
+| Anything else | monotonic source only — never `Clock` |
+
+## Persisted-timestamp authority (injected Clock)
+
+Every NEW persisted orchestration timestamp is supplied by one injected
+`Clock`, threaded from the worker boundary. Stores preserve timestamps; they
+never invent business time.
+
+- `Workflow` / `WorkflowBuilder.build(clock: Clock = Clock.systemUTC())` — the
+  existing public seam; the workflow's clock feeds step-attempt records
+  (`startedAt`/`completedAt`), execution-tracker timestamps, and checkpoint
+  saves.
+- `WorkflowPersistenceSession` — checkpoint saves stamp
+  `savedAtEpochMillis = clock.millis()`.
+- `InMemoryWorkflowRecoveryController` — recovery resolution timestamps come
+  from the workflow clock via the internal `forTest` seam; the public
+  two-argument constructor and its JVM ABI are unchanged, production defaults
+  to `Clock.systemUTC()`.
+- Stores (`FileWorkflowCheckpointStore`, in-memory, JDBC) preserve
+  timestamps as persisted; no store reads a clock to invent business time.
+
+## Legacy checkpoint contract (0L sentinel)
+
+`WorkflowCheckpoint.savedAtEpochMillis`:
+
+- Framework-owned saves explicitly supply the workflow's injected Clock
+  reading.
+- When decoding legacy file records that lack the field, `0L` represents
+  UNAVAILABLE historical save time — never "1970-01-01" and never a
+  read-time synthesis ("unknown historical time ≠ the time we happened to
+  read the record").
+- Present values are preserved exactly; encode/load round-trips never
+  transform `0L` into "now".
+- The public `WorkflowCheckpoint(savedAtEpochMillis =
+  System.currentTimeMillis())` default is deliberately UNTOUCHED in 8.3a —
+  changing public construction behaviour needs its own compatibility
+  scrutiny (composition/default boundary).
+
+## Boundary points (nondeterminism allowed here)
+
+1. `NanoTimeSource(System::nanoTime)` — the monotonic composition point.
+2. `Clock.systemUTC()` defaults on public constructors — wall-clock
+   composition points (worker, workflow, recovery controller).
+3. `WorkflowCheckpoint.savedAtEpochMillis` public default.
+
+Everywhere else in the affected paths, domain decisions consume controlled
+values: injected clocks in tests, fake monotonic sources, exact arithmetic.
+
+## Mutation evidence (frozen head)
+
+17-mutant campaign across every independently reachable authority:
+**16 STRONG / 1 REDUNDANT (clamp-removal, honest) / 0 WEAK / 0 INVALID.**
+
+The 14-discriminator suite (`TimeSemanticsDiscriminatorTest`) covers:
+P0-A uptime (delta fake + full-worker heartbeat wiring), P0-A deterministic
+NanoTime arithmetic, P0-B exact drain residual (500−50=450), P0-B2 exact
+clamp (500−5000=1), P0-C ×7 (start/complete/fail/cancel/UNKNOWN-recovery/
+consume/failWorkflow), P0-D checkpoint producer ownership, P0-E legacy
+UNKNOWN decode.
+
+## Out of scope (later slices)
+
+- 8.3b — identity + randomness (UUID boundaries, retry jitter composition).
+- 8.3c — scheduler ownership (`withTimeoutOrNull` placement, executor
+  lifecycle).
+- Step-attempt listing/selection ordering when `startedAt` ties: the
+  comparator's random-`attemptId` tie-break is a known defect tracked
+  separately (see PR history); not an 8.3a change.

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FileWorkflowCheckpointStore.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FileWorkflowCheckpointStore.kt
@@ -330,7 +330,7 @@ internal fun decodeCheckpoint(content: String): WorkflowCheckpoint = try {
         statePayload = base64Decode(properties.requireProperty("statePayloadBase64")),
         revision = properties.getProperty("revision")?.toLong() ?: 0,
         metadata = metadata,
-        savedAtEpochMillis = properties.getProperty("savedAtEpochMillis")?.toLong() ?: System.currentTimeMillis(),
+        savedAtEpochMillis = properties.getProperty("savedAtEpochMillis")?.toLong() ?: 0L,
         recoveryState = decodeRecoveryState(properties.getProperty("recoveryState")?.takeIf { it.isNotBlank() }?.let(::base64Decode)),
         checkpointGeneration = properties.getProperty("checkpointGeneration")?.ifBlank { null },
     )

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/MonotonicTime.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/MonotonicTime.kt
@@ -44,3 +44,19 @@ internal class NanoTimeSource(
 internal interface MonotonicMark {
     fun elapsedMillis(): Long
 }
+
+/**
+ * Drain-budget authority (8.3a P0-B): the residual budget remaining after the
+ * first drain phase is `timeoutMillis - monotonic elapsed since the budget
+ * started`, clamped to a minimum of 1ms. Never wall-clock derived — the
+ * calculation is exact and deterministically testable with a fake source.
+ */
+internal class MonotonicDrainBudget(
+    private val timeoutMillis: Long,
+    timeSource: MonotonicTimeSource,
+) {
+    private val startedAt = timeSource.markNow()
+
+    fun remainingMillis(): Long =
+        (timeoutMillis - startedAt.elapsedMillis()).coerceAtLeast(1L)
+}

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/MonotonicTime.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/MonotonicTime.kt
@@ -1,0 +1,35 @@
+package dev.tramai.orchestration
+
+/**
+ * Epic 8.3a — elapsed-time seam.
+ *
+ * A monotonic source answers "how much time elapsed?" and must never be
+ * derived from the wall clock: NTP/operator adjustments can make
+ * `System.currentTimeMillis()` jump forward or even backwards, which would
+ * corrupt uptime, drain budgets, and timeout authority. The default
+ * [NanoTime] implementation is nanoTime-backed.
+ *
+ * Wall-clock absolute timestamps are a separate semantic dimension and stay
+ * on `java.time.Clock` (see 8.3a P0-C/P0-D); this seam exists ONLY for
+ * elapsed-time decisions.
+ */
+internal fun interface MonotonicTimeSource {
+    fun markNow(): MonotonicMark
+
+    companion object {
+        /** nanoTime-backed monotonic source (JVM monotonic clock). */
+        val NanoTime: MonotonicTimeSource = object : MonotonicTimeSource {
+            override fun markNow(): MonotonicMark = object : MonotonicMark {
+                private val startNanos = System.nanoTime()
+                // coerceAtLeast(0): hypervisor/TSC jitter can make a single
+                // reading negative; an uptime/drain delta must never go below 0.
+                override fun elapsedMillis(): Long = ((System.nanoTime() - startNanos) / 1_000_000).coerceAtLeast(0L)
+            }
+        }
+    }
+}
+
+/** A captured monotonic instant; elapsed is measured against the SAME source. */
+internal interface MonotonicMark {
+    fun elapsedMillis(): Long
+}

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/MonotonicTime.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/MonotonicTime.kt
@@ -18,14 +18,25 @@ internal fun interface MonotonicTimeSource {
 
     companion object {
         /** nanoTime-backed monotonic source (JVM monotonic clock). */
-        val NanoTime: MonotonicTimeSource = object : MonotonicTimeSource {
-            override fun markNow(): MonotonicMark = object : MonotonicMark {
-                private val startNanos = System.nanoTime()
-                // coerceAtLeast(0): hypervisor/TSC jitter can make a single
-                // reading negative; an uptime/drain delta must never go below 0.
-                override fun elapsedMillis(): Long = ((System.nanoTime() - startNanos) / 1_000_000).coerceAtLeast(0L)
-            }
-        }
+        val NanoTime: MonotonicTimeSource = NanoTimeSource()
+    }
+}
+
+/**
+ * Monotonic source whose raw reading is supplied by [nanoTime]; production
+ * composes [System::nanoTime] at the boundary. The injected supplier makes
+ * the elapsed ARITHMETIC deterministically testable (8.3a rule: external
+ * entropy may exist at the boundary; every assertion about domain behavior
+ * consumes controlled values).
+ */
+internal class NanoTimeSource(
+    private val nanoTime: () -> Long = System::nanoTime,
+) : MonotonicTimeSource {
+    override fun markNow(): MonotonicMark = object : MonotonicMark {
+        private val startNanos = nanoTime()
+        // coerceAtLeast(0): hypervisor/TSC jitter can make a single
+        // reading negative; an uptime/drain delta must never go below 0.
+        override fun elapsedMillis(): Long = ((nanoTime() - startNanos) / 1_000_000).coerceAtLeast(0L)
     }
 }
 

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/TramaiWorker.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/TramaiWorker.kt
@@ -167,6 +167,13 @@ class TramaiWorker(
             lifecycle.onLifecycleStateClaimed = value
         }
 
+    /** 8.3a test seam: elapsed-time authority for the shutdown drain. */
+    internal var timeSourceForTest: MonotonicTimeSource
+        get() = lifecycle.timeSource
+        set(value) {
+            lifecycle.timeSource = value
+        }
+
     internal fun isShuttingDownGracefullyForTest(): Boolean = lifecycle.isShuttingDownGracefullyForTest()
 
     internal fun isAcceptingWorkForTest(): Boolean = lifecycle.isAcceptingWorkForTest()

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkerHeartbeatPublisher.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkerHeartbeatPublisher.kt
@@ -29,12 +29,12 @@ internal class WorkerHeartbeatPublisher(
     }
 
     suspend fun heartbeatLoop(
-        startedAtMark: () -> MonotonicMark,
+        startedAtMark: MonotonicMark,
         claimedCount: () -> Int,
     ) {
         val interval = maxOf(1L, config.pollIntervalMillis / 2)
         while (currentCoroutineContext().isActive) {
-            val uptime = startedAtMark().elapsedMillis()
+            val uptime = startedAtMark.elapsedMillis()
             workerRegistryStore?.updateHeartbeat(config.workerId)
             observability.onWorkerHeartbeat(config.workerId, uptime, claimedCount())
             delay(interval)

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkerHeartbeatPublisher.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkerHeartbeatPublisher.kt
@@ -29,12 +29,12 @@ internal class WorkerHeartbeatPublisher(
     }
 
     suspend fun heartbeatLoop(
-        startedAtMillis: () -> Long,
+        startedAtMark: () -> MonotonicMark,
         claimedCount: () -> Int,
     ) {
         val interval = maxOf(1L, config.pollIntervalMillis / 2)
         while (currentCoroutineContext().isActive) {
-            val uptime = System.currentTimeMillis() - startedAtMillis()
+            val uptime = startedAtMark().elapsedMillis()
             workerRegistryStore?.updateHeartbeat(config.workerId)
             observability.onWorkerHeartbeat(config.workerId, uptime, claimedCount())
             delay(interval)

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkerLifecycleController.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkerLifecycleController.kt
@@ -284,9 +284,12 @@ internal class WorkerLifecycleController(
                 shutdownCoordinator.onShutdownHook(hook)
                 executionSupervisor.attachScope(scope)
                 shutdownCoordinator.beginAcceptingWork()
+                val heartbeatStartedMark = checkNotNull(startedMark) {
+                    "worker start mark must exist before heartbeat activation"
+                }
                 val heartbeatJob = scope.launch(start = CoroutineStart.LAZY) {
                     heartbeatPublisher.heartbeatLoop(
-                        startedAtMark = { startedMark ?: timeSource.markNow() },
+                        startedAtMark = heartbeatStartedMark,
                         claimedCount = { executionSupervisor.activeExecutionCount() },
                     )
                 }

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkerLifecycleController.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkerLifecycleController.kt
@@ -99,7 +99,19 @@ internal class WorkerLifecycleController(
     private val activationLock = Any()
 
     private var workerScope: CoroutineScope? = null
-    private var startedAt: Long = 0L
+    private var startedMark: MonotonicMark? = null
+
+    /**
+     * Elapsed-time authority (8.3a P0-B): the shutdown drain's residual
+     * budget must be computed from a monotonic source, never the wall clock.
+     * Test-visible via [TramaiWorker.timeSourceForTest]; the coordinator
+     * reads it lazily at drain time.
+     */
+    internal var timeSource: MonotonicTimeSource = MonotonicTimeSource.NanoTime
+        set(value) {
+            field = value
+            if (::shutdownCoordinator.isInitialized) shutdownCoordinator.timeSource = value
+        }
 
     private val leaseCoordinator = LeaseCoordinator(config, leaseStore, observability)
     private val recoveryCoordinator = WorkflowRecoveryCoordinator(leaseStore, stepAttemptStore)
@@ -144,6 +156,7 @@ internal class WorkerLifecycleController(
             observability = observability,
             executionSupervisor = executionSupervisor,
             workerRegistryStore = workerRegistryStore,
+            timeSource = timeSource,
         )
     }
 
@@ -200,7 +213,7 @@ internal class WorkerLifecycleController(
             return
         }
         workerScope = scope
-        startedAt = System.currentTimeMillis()
+        startedMark = timeSource.markNow()
         // Test seam: suspend the winner between the ownership claim and the
         // shutdown-state reset (M24). A shutdown arriving here wins the
         // STARTING→SHUTTING_DOWN transition; we re-check below.
@@ -273,7 +286,7 @@ internal class WorkerLifecycleController(
                 shutdownCoordinator.beginAcceptingWork()
                 val heartbeatJob = scope.launch(start = CoroutineStart.LAZY) {
                     heartbeatPublisher.heartbeatLoop(
-                        startedAtMillis = { startedAt },
+                        startedAtMark = { startedMark ?: timeSource.markNow() },
                         claimedCount = { executionSupervisor.activeExecutionCount() },
                     )
                 }

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkerShutdownCoordinator.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkerShutdownCoordinator.kt
@@ -27,6 +27,7 @@ internal class WorkerShutdownCoordinator(
     private val observability: TramaiWorkerObserver,
     private val executionSupervisor: WorkflowExecutionSupervisor,
     private val workerRegistryStore: WorkerRegistryStore?,
+    internal var timeSource: MonotonicTimeSource = MonotonicTimeSource.NanoTime,
 ) {
     /**
      * Per-root shutdown idempotency. The CONTROLLER's atomic lifecycle state
@@ -116,7 +117,7 @@ internal class WorkerShutdownCoordinator(
         observability.onShutdownStarted(config.workerId)
         pollJob?.cancelAndJoin()
         val executions = executionSupervisor.activeExecutionsSnapshot()
-        val drainStartedAt = System.currentTimeMillis()
+        val drainStartedMark = timeSource.markNow()
         val drainTimeoutMillis = config.drainTimeoutMillis
         val drained = withTimeoutOrNull(drainTimeoutMillis) {
             executions.mapNotNull { it.executionJob }.joinAll()
@@ -126,7 +127,7 @@ internal class WorkerShutdownCoordinator(
             executions.forEach { execution ->
                 execution.executionJob?.cancel(CancellationException("Worker drain timeout exceeded"))
             }
-            val residualTimeoutMillis = (drainTimeoutMillis - (System.currentTimeMillis() - drainStartedAt)).coerceAtLeast(1L)
+            val residualTimeoutMillis = (drainTimeoutMillis - drainStartedMark.elapsedMillis()).coerceAtLeast(1L)
             withTimeoutOrNull(residualTimeoutMillis) {
                 executions.mapNotNull { it.executionJob }.joinAll()
             }

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkerShutdownCoordinator.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkerShutdownCoordinator.kt
@@ -117,7 +117,7 @@ internal class WorkerShutdownCoordinator(
         observability.onShutdownStarted(config.workerId)
         pollJob?.cancelAndJoin()
         val executions = executionSupervisor.activeExecutionsSnapshot()
-        val drainStartedMark = timeSource.markNow()
+        val drainBudget = MonotonicDrainBudget(config.drainTimeoutMillis, timeSource)
         val drainTimeoutMillis = config.drainTimeoutMillis
         val drained = withTimeoutOrNull(drainTimeoutMillis) {
             executions.mapNotNull { it.executionJob }.joinAll()
@@ -127,7 +127,7 @@ internal class WorkerShutdownCoordinator(
             executions.forEach { execution ->
                 execution.executionJob?.cancel(CancellationException("Worker drain timeout exceeded"))
             }
-            val residualTimeoutMillis = (drainTimeoutMillis - drainStartedMark.elapsedMillis()).coerceAtLeast(1L)
+            val residualTimeoutMillis = drainBudget.remainingMillis()
             withTimeoutOrNull(residualTimeoutMillis) {
                 executions.mapNotNull { it.executionJob }.joinAll()
             }

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/Workflow.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/Workflow.kt
@@ -33,7 +33,7 @@ class Workflow<S, R> internal constructor(
     private val steps: List<InternalWorkflowStep<S>>,
     private val resultSelector: (S) -> R,
     private val stopPolicy: StopPolicy,
-    private val clock: Clock,
+    internal val clock: Clock,
     private val externalStepExecutorResolver: ExternalStepExecutorResolver,
     private val httpClient: HttpClient = WorkflowHttpClients.default,
     private val httpTransport: HttpTransport? = null,

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowExecutionSupervisor.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowExecutionSupervisor.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.time.Clock
 import java.security.MessageDigest
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -132,6 +133,7 @@ internal class WorkflowExecutionSupervisor(
             context = context,
             stepAttemptStore = stepAttemptStore,
             observability = observability,
+            clock = typedWorkflow.clock,
             leaseProvider = { handle.lease.get() },
         )
         handle.tracker = tracker
@@ -300,6 +302,7 @@ internal class ExecutionTracker(
     private val context: WorkflowContext,
     private val stepAttemptStore: StepAttemptRecordStore,
     private val observability: TramaiWorkerObserver,
+    private val clock: Clock,
     private val leaseProvider: () -> WorkflowLease?,
 ) {
     private val monitor = Any()
@@ -334,7 +337,7 @@ internal class ExecutionTracker(
         if (latest.status == StepAttemptStatus.STARTED) {
             val unknown = latest.copy(
                 status = StepAttemptStatus.UNKNOWN,
-                completedAt = System.currentTimeMillis(),
+                completedAt = clock.millis(),
                 outputSummary = latest.outputSummary ?: "Lease expired before the step reached a durable checkpoint",
             )
             stepAttemptStore.updateStepAttempt(unknown)
@@ -373,7 +376,7 @@ internal class ExecutionTracker(
             workerId = workerId,
             leaseToken = leaseProvider()?.leaseId ?: "unknown",
             status = StepAttemptStatus.STARTED,
-            startedAt = System.currentTimeMillis(),
+            startedAt = clock.millis(),
             idempotencyKey = descriptor.idempotencyKey,
             replayPolicy = descriptor.toPersistedReplayPolicy(),
             inputFingerprint = fingerprint,
@@ -393,7 +396,7 @@ internal class ExecutionTracker(
         }
         val consumed = attempt.copy(
             status = StepAttemptStatus.FAILED,
-            completedAt = attempt.completedAt ?: System.currentTimeMillis(),
+            completedAt = attempt.completedAt ?: clock.millis(),
         )
         // Atomic CAS: the approval is consumed exactly once. A concurrent writer (e.g. a
         // stale-approval void) between the recovery read and here must not be overwritten;
@@ -423,7 +426,7 @@ internal class ExecutionTracker(
         }
         val completed = attempt.copy(
             status = StepAttemptStatus.COMPLETED,
-            completedAt = System.currentTimeMillis(),
+            completedAt = clock.millis(),
             outputSummary = "Checkpoint revision ${persistedCheckpoint.revision}",
         )
         stepAttemptStore.updateStepAttempt(completed)
@@ -451,7 +454,7 @@ internal class ExecutionTracker(
         }
         val failed = attempt.copy(
             status = StepAttemptStatus.FAILED,
-            completedAt = System.currentTimeMillis(),
+            completedAt = clock.millis(),
             outputSummary = summarize(observableFailure),
         )
         stepAttemptStore.updateStepAttempt(failed)
@@ -478,7 +481,7 @@ internal class ExecutionTracker(
         val attempt = synchronized(monitor) { activeAttempt } ?: return
         val cancelled = attempt.copy(
             status = StepAttemptStatus.CANCELLED,
-            completedAt = System.currentTimeMillis(),
+            completedAt = clock.millis(),
             outputSummary = summary,
         )
         stepAttemptStore.updateStepAttempt(cancelled)

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowPersistence.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowPersistence.kt
@@ -55,10 +55,10 @@ data class WorkflowCheckpoint(
     val metadata: Map<String, String> = emptyMap(),
     /**
      * Wall-clock instant (epoch millis) at which this checkpoint revision was
-     * saved. 0L is the DECODED-LEGACY sentinel: a checkpoint read from a
-     * format that predates this field has NO historical save time — the value
-     * means "unavailable", never "1970-01-01". New saves always supply a real
-     * reading via the persistence coordinator's injected Clock.
+     * saved. Framework-owned workflow checkpoint saves explicitly supply the
+     * workflow's injected Clock reading. When decoding legacy file records
+     * that lack the field, 0L represents UNAVAILABLE historical save time —
+     * never "1970-01-01".
      */
     val savedAtEpochMillis: Long = System.currentTimeMillis(),
     val recoveryState: WorkflowRecoveryState = WorkflowRecoveryState.Normal,

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowPersistence.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowPersistence.kt
@@ -53,6 +53,13 @@ data class WorkflowCheckpoint(
     val statePayload: String,
     val revision: Long = 0,
     val metadata: Map<String, String> = emptyMap(),
+    /**
+     * Wall-clock instant (epoch millis) at which this checkpoint revision was
+     * saved. 0L is the DECODED-LEGACY sentinel: a checkpoint read from a
+     * format that predates this field has NO historical save time — the value
+     * means "unavailable", never "1970-01-01". New saves always supply a real
+     * reading via the persistence coordinator's injected Clock.
+     */
     val savedAtEpochMillis: Long = System.currentTimeMillis(),
     val recoveryState: WorkflowRecoveryState = WorkflowRecoveryState.Normal,
     val checkpointGeneration: String? = null,

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowPersistenceSession.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowPersistenceSession.kt
@@ -3,6 +3,7 @@ package dev.tramai.orchestration
 import dev.tramai.core.observation.event.RuntimeAttributes
 import dev.tramai.core.observation.event.RuntimeEvent
 import dev.tramai.core.observation.event.RuntimeEvents
+import java.time.Clock
 import java.time.Instant
 
 /**
@@ -18,6 +19,7 @@ internal class WorkflowPersistenceSession<S>(
     private val context: WorkflowContext,
     private val observer: WorkflowObserver,
     private val workflowDefinitionCompatibility: WorkflowDefinitionCompatibility,
+    private val clock: Clock,
     private var lease: WorkflowLease?,
     initialRevision: Long?,
     initialGeneration: String?,
@@ -41,6 +43,7 @@ internal class WorkflowPersistenceSession<S>(
                 lastCompletedStepName = lastCompletedStepName,
                 statePayload = persistence.stateCodec.encode(state),
                 metadata = workflowDefinitionCompatibility.toCheckpointMetadata() + extraMetadata,
+                savedAtEpochMillis = clock.millis(),
                 checkpointGeneration = currentGeneration,
             ),
             expectedRevision = currentRevision,
@@ -141,6 +144,7 @@ internal suspend fun <S> WorkflowPersistence<S>.session(
     context: WorkflowContext,
     observer: WorkflowObserver,
     workflowDefinitionCompatibility: WorkflowDefinitionCompatibility,
+    clock: Clock,
     initialRevision: Long? = null,
     initialGeneration: String? = null,
 ): WorkflowPersistenceSession<S> = WorkflowPersistenceSession(
@@ -149,6 +153,7 @@ internal suspend fun <S> WorkflowPersistence<S>.session(
     context = context,
     observer = observer,
     workflowDefinitionCompatibility = workflowDefinitionCompatibility,
+    clock = clock,
     lease = acquireLeaseIfConfigured(
         workflowName = workflowName,
         workflowId = context.workflowId,

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowRecoveryController.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowRecoveryController.kt
@@ -118,8 +118,21 @@ interface WorkflowRecoveryController {
 class InMemoryWorkflowRecoveryController(
     private val checkpointStore: WorkflowCheckpointStore,
     private val stepAttemptStore: StepAttemptRecordStore? = null,
-    private val clock: Clock = Clock.systemUTC(),
 ) : WorkflowRecoveryController {
+
+    // Determinism seam (8.3a P0-C): injected only via [forTest] so the public
+    // constructor and its JVM ABI remain EXACTLY the original two-argument form.
+    private var clock: Clock = Clock.systemUTC()
+
+    internal companion object {
+        /** Determinism seam for tests: injects the clock without expanding the public API. */
+        fun forTest(
+            checkpointStore: WorkflowCheckpointStore,
+            stepAttemptStore: StepAttemptRecordStore?,
+            clock: Clock,
+        ): InMemoryWorkflowRecoveryController =
+            InMemoryWorkflowRecoveryController(checkpointStore, stepAttemptStore).also { it.clock = clock }
+    }
 
     override suspend fun retryStep(
         workflowName: String,

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowRecoveryController.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowRecoveryController.kt
@@ -1,6 +1,7 @@
 package dev.tramai.orchestration
 
 import dev.tramai.core.coroutines.rethrowIfCancellation
+import java.time.Clock
 
 /**
  * Raised when a recovery-resolution operation ([WorkflowRecoveryController.retryStep]
@@ -117,6 +118,7 @@ interface WorkflowRecoveryController {
 class InMemoryWorkflowRecoveryController(
     private val checkpointStore: WorkflowCheckpointStore,
     private val stepAttemptStore: StepAttemptRecordStore? = null,
+    private val clock: Clock = Clock.systemUTC(),
 ) : WorkflowRecoveryController {
 
     override suspend fun retryStep(
@@ -295,7 +297,7 @@ class InMemoryWorkflowRecoveryController(
             }
             return
         }
-        val resolvedAt = System.currentTimeMillis()
+        val resolvedAt = clock.millis()
         val updated = attempt.copy(
             resolutionAction = StepAttemptResolutionAction.RETRY_APPROVED,
             resolutionReason = reason,
@@ -343,7 +345,7 @@ class InMemoryWorkflowRecoveryController(
             val attempt = store.listStepAttempts(workflowId).singleOrNull {
                 it.stepName == record.stepName && it.attemptId == record.attemptId
             } ?: return
-            val resolvedAt = System.currentTimeMillis()
+            val resolvedAt = clock.millis()
             store.updateStepAttempt(
                 attempt.copy(
                     status = StepAttemptStatus.FAILED,

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowRunner.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowRunner.kt
@@ -86,6 +86,7 @@ internal class WorkflowRunner<S, R>(
                 context = context,
                 observer = isolatedObserver,
                 workflowDefinitionCompatibility = definitionCompatibility,
+                clock = clock,
             )
             persistenceSession?.saveCheckpoint(
                 state = initialState,
@@ -176,6 +177,7 @@ internal class WorkflowRunner<S, R>(
             workflowName = name,
             context = context,
             observer = isolatedObserver,
+            clock = clock,
             initialRevision = checkpoint.revision,
             initialGeneration = checkpoint.checkpointGeneration,
             workflowDefinitionCompatibility = definitionCompatibility,

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TimeSemanticsDiscriminatorTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TimeSemanticsDiscriminatorTest.kt
@@ -66,7 +66,8 @@ class TimeSemanticsDiscriminatorTest {
     /**
      * Delta-based fake: a mark captures the source's reading at creation, so
      * elapsed = now - markOrigin. Distinguishes a mark captured once at start
-     * (correct) from a fresh mark sampled per heartbeat (M03 defect).
+     * (correct) from a fresh mark sampled per heartbeat (the pre-8.3a M03
+     * defect, now structurally impossible: the loop receives a captured mark).
      */
     private class DeltaMonotonicTimeSource : MonotonicTimeSource {
         var now = 0L
@@ -166,7 +167,8 @@ class TimeSemanticsDiscriminatorTest {
         // Contract: the start mark is created at monotonic T=0. Heartbeats at
         // T=50 and T=100 must report [50, 100], independently of wall clock.
         // Delta-based fake: a mark captures its creation instant, so a fresh
-        // mark per heartbeat (M03) would report ~0 and fail this sequence.
+        // mark per heartbeat (pre-8.3a M03 defect) would report ~0 and fail
+        // this sequence; the captured-mark API makes it structurally impossible.
         val observer = HeartbeatObserver()
         val publisher = WorkerHeartbeatPublisher(heartbeatConfig, null, observer)
         val delta = DeltaMonotonicTimeSource()
@@ -204,8 +206,9 @@ class TimeSemanticsDiscriminatorTest {
     fun `P0-A worker heartbeat uptime tracks the captured start mark`() {
         // Exercises the CONTROLLER's heartbeat wiring (the publisher-direct
         // test cannot see it): the worker must capture the start mark ONCE and
-        // report growing uptime from it. Kills the M03 mutant (fresh mark per
-        // heartbeat via timeSource.markNow() -> uptime always ~0).
+        // report growing uptime from it. Guards against the pre-8.3a M03
+        // fresh-mark-per-heartbeat behaviour (uptime always ~0), which the
+        // captured-mark API now makes structurally impossible.
         val delta = DeltaMonotonicTimeSource()
         val heartbeats = CopyOnWriteArrayList<Long>()
         val gate = CompletableDeferred<Unit>()
@@ -257,8 +260,9 @@ class TimeSemanticsDiscriminatorTest {
     @Test
     fun `P0-C step-attempt timestamps come from the injected workflow clock`() {
         // Contract: startedAt = clock at start (T0), completedAt = clock at
-        // completion (T1). RED: production stamps System.currentTimeMillis(),
-        // so the persisted values never equal the injected clock's readings.
+        // completion (T1). Pre-8.3a RED: production stamped
+        // System.currentTimeMillis(), so the persisted values never equal the
+        // injected clock's readings.
         val clock = MutableClock(1_000L)
         val gate = CompletableDeferred<Unit>()
         val (worker, store) = gatedWorker(gate, drainTimeoutMillis = 60_000, clock = clock)
@@ -291,8 +295,9 @@ class TimeSemanticsDiscriminatorTest {
     @Test
     fun `P0-C recovery resolution timestamps come from the injected clock`() {
         // Contract: an operator retry approval records resolutionAtEpochMillis
-        // from the injected clock. RED: production stamps
-        // System.currentTimeMillis(), never equal to the injected reading.
+        // from the controller-owned clock boundary (forTest injection).
+        // Pre-8.3a RED: production stamped System.currentTimeMillis(), never
+        // equal to the injected reading.
         val clock = MutableClock(1_000L)
         val store = InMemoryWorkflowCheckpointStore()
         runBlocking {
@@ -346,7 +351,7 @@ class TimeSemanticsDiscriminatorTest {
     @Test
     fun `P0-D checkpoint savedAt is supplied by the injected clock`() {
         // Contract: the persistence coordinator stamps savedAtEpochMillis from
-        // the injected clock at each save. RED: production lets the
+        // the injected clock at each save. Pre-8.3a RED: production let the
         // WorkflowCheckpoint default fire (System.currentTimeMillis()), so the
         // persisted value never equals the injected reading.
         val clock = MutableClock(3_000L)
@@ -616,7 +621,7 @@ class TimeSemanticsDiscriminatorTest {
             ),
         )
         val legacy = encoded.lines().filterNot { it.startsWith("savedAtEpochMillis") }.joinToString("\n")
-        // RED: production synthesizes System.currentTimeMillis() here.
+        // Pre-8.3a RED: production synthesized System.currentTimeMillis() here.
         assertThat(decodeCheckpoint(legacy).savedAtEpochMillis)
             .withFailMessage("P0-E legacy missing savedAt must decode as UNKNOWN (0L)")
             .isEqualTo(0L)

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TimeSemanticsDiscriminatorTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TimeSemanticsDiscriminatorTest.kt
@@ -244,34 +244,14 @@ class TimeSemanticsDiscriminatorTest {
 
     @Test
     fun `P0-B shutdown drain residual budget is monotonic and wall-clock independent`() {
-        // Contract: drain budget = 500ms; the monotonic source reports only
-        // 50ms consumed (the wall clock in reality jumped far ahead), so the
-        // residual must be ~450ms — the drain must NOT re-consume the full
-        // budget. RED: production computes residual from
-        // System.currentTimeMillis(), which after a full first-phase timeout
-        // reports ~500ms real elapsed -> residual clamps to 1ms, so the whole
-        // shutdown finishes in ~drainTimeout (well under the 700ms threshold).
-        val gate = CompletableDeferred<Unit>()
+        // Exact arithmetic, no timing: budget 500ms, monotonic elapsed 50ms
+        // (the wall clock in reality jumped far ahead) -> residual must be
+        // exactly 450ms. RED: a wall-clock-derived residual would clamp to 1.
         val fake = FakeMonotonicTimeSource().apply { elapsedMillis = 50L }
-        val (worker, store) = gatedWorker(gate, drainTimeoutMillis = 500)
-        worker.timeSourceForTest = fake
-        try {
-            runBlocking {
-                worker.start()
-                withTimeout(10_000) {
-                    while (store.latestStepAttempt("w-1", "hold") == null) delay(5)
-                }
-                val drainStartedNanos = System.nanoTime()
-                worker.shutdown()
-                val totalMillis = (System.nanoTime() - drainStartedNanos) / 1_000_000
-                assertThat(totalMillis)
-                    .withFailMessage("P0-B residual must use monotonic elapsed (50ms consumed -> ~450ms residual), not wall-clock derived")
-                    .isGreaterThanOrEqualTo(700L)
-                gate.complete(Unit)
-            }
-        } finally {
-            runBlocking { runCatching { worker.close() } }
-        }
+        val budget = MonotonicDrainBudget(timeoutMillis = 500, timeSource = fake)
+        assertThat(budget.remainingMillis())
+            .withFailMessage("P0-B residual must be timeoutMillis - monotonic elapsed (450ms)")
+            .isEqualTo(450L)
     }
 
     @Test
@@ -349,7 +329,7 @@ class TimeSemanticsDiscriminatorTest {
                 ),
             )
             val saved = store.load("time-semantics", "w-1")!!
-            InMemoryWorkflowRecoveryController(store, store, clock = clock).retryStep(
+            InMemoryWorkflowRecoveryController.forTest(store, store, clock).retryStep(
                 workflowName = "time-semantics",
                 workflowId = "w-1",
                 expectedRevision = saved.revision,
@@ -399,31 +379,14 @@ class TimeSemanticsDiscriminatorTest {
 
     @Test
     fun `P0-B2 drain residual clamps to minimum when monotonic elapsed exceeds the budget`() {
-        // Companion to P0-B: when the monotonic source reports MORE elapsed
-        // than the budget (fake = 5000ms vs 500ms budget), the residual must
-        // clamp to ~1ms — the drain must NOT re-consume the full budget.
-        // Kills the M05 mutant (residual = full drainTimeout regardless).
-        val gate = CompletableDeferred<Unit>()
+        // Exact arithmetic, no timing: budget 500ms, monotonic elapsed 5000ms
+        // -> residual must clamp to exactly 1ms (never negative, never the
+        // full budget). Kills the M05 mutant (residual = full drainTimeout).
         val fake = FakeMonotonicTimeSource().apply { elapsedMillis = 5_000L }
-        val (worker, store) = gatedWorker(gate, drainTimeoutMillis = 500)
-        worker.timeSourceForTest = fake
-        try {
-            runBlocking {
-                worker.start()
-                withTimeout(10_000) {
-                    while (store.latestStepAttempt("w-1", "hold") == null) delay(5)
-                }
-                val drainStartedNanos = System.nanoTime()
-                worker.shutdown()
-                val totalMillis = (System.nanoTime() - drainStartedNanos) / 1_000_000
-                assertThat(totalMillis)
-                    .withFailMessage("P0-B2 residual must clamp to ~1ms when elapsed exceeds the budget")
-                    .isLessThan(800L)
-                gate.complete(Unit)
-            }
-        } finally {
-            runBlocking { runCatching { worker.close() } }
-        }
+        val budget = MonotonicDrainBudget(timeoutMillis = 500, timeSource = fake)
+        assertThat(budget.remainingMillis())
+            .withFailMessage("P0-B2 residual must clamp to 1ms when elapsed exceeds the budget")
+            .isEqualTo(1L)
     }
 
     @Test
@@ -618,7 +581,7 @@ class TimeSemanticsDiscriminatorTest {
                 ),
             )
             val saved = store.load("time-semantics", "w-1")!!
-            InMemoryWorkflowRecoveryController(store, store, clock = clock).failWorkflow(
+            InMemoryWorkflowRecoveryController.forTest(store, store, clock).failWorkflow(
                 workflowName = "time-semantics",
                 workflowId = "w-1",
                 expectedRevision = saved.revision,

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TimeSemanticsDiscriminatorTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TimeSemanticsDiscriminatorTest.kt
@@ -25,9 +25,9 @@ import java.util.concurrent.CopyOnWriteArrayList
  * time, never wall-clock derived (a wall-clock jump must not inflate or
  * destroy the remaining drain budget).
  *
- * Both tests are RED on the current production code: the uptime formula
- * reads System.currentTimeMillis() and the drain residual reads
- * System.currentTimeMillis(), so neither can express the monotonic
+ * Both tests were RED on the pre-fix production code: the uptime formula
+ * read System.currentTimeMillis() and the drain residual read
+ * System.currentTimeMillis(), so neither could express the monotonic
  * contract.
  */
 class TimeSemanticsDiscriminatorTest {
@@ -174,7 +174,7 @@ class TimeSemanticsDiscriminatorTest {
         runBlocking {
             delta.now = 50L
             val job = launch {
-                publisher.heartbeatLoop(startedAtMark = { startedMark }, claimedCount = { 0 })
+                publisher.heartbeatLoop(startedAtMark = startedMark, claimedCount = { 0 })
             }
             while (observer.uptimes.size < 1) delay(5)
             delta.now = 100L

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TimeSemanticsDiscriminatorTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TimeSemanticsDiscriminatorTest.kt
@@ -63,6 +63,19 @@ class TimeSemanticsDiscriminatorTest {
         }
     }
 
+    /**
+     * Delta-based fake: a mark captures the source's reading at creation, so
+     * elapsed = now - markOrigin. Distinguishes a mark captured once at start
+     * (correct) from a fresh mark sampled per heartbeat (M03 defect).
+     */
+    private class DeltaMonotonicTimeSource : MonotonicTimeSource {
+        var now = 0L
+        override fun markNow(): MonotonicMark = object : MonotonicMark {
+            private val origin = this@DeltaMonotonicTimeSource.now
+            override fun elapsedMillis(): Long = (this@DeltaMonotonicTimeSource.now - origin).coerceAtLeast(0L)
+        }
+    }
+
     /** Mutable wall clock for P0-C/P0-D persisted-timestamp discriminators. */
     private class MutableClock(var millis: Long) : Clock() {
         override fun instant(): Instant = Instant.ofEpochMilli(millis)
@@ -88,12 +101,22 @@ class TimeSemanticsDiscriminatorTest {
         drainTimeoutMillis: Long,
         clock: Clock = Clock.systemUTC(),
         keepCheckpoint: Boolean = false,
+        failingStep: Boolean = false,
+        cancellableGate: Boolean = false,
+        observer: TramaiWorkerObserver = object : TramaiWorkerObserver {},
     ): Pair<TramaiWorker, InMemoryWorkflowCheckpointStore> {
         val store = InMemoryWorkflowCheckpointStore()
         val leaseStore = InMemoryWorkflowLeaseStore()
         val workflow = workflow<LifecycleState>("time-semantics", definitionVersion = "v1") {
             localStep("hold") { state, _ ->
-                withContext(NonCancellable) { gate.await() }
+                if (failingStep) {
+                    throw RuntimeException("boom")
+                }
+                if (cancellableGate) {
+                    gate.await()
+                } else {
+                    withContext(NonCancellable) { gate.await() }
+                }
                 state
             }
         }.build(clock = clock) { it.value }
@@ -120,7 +143,7 @@ class TimeSemanticsDiscriminatorTest {
             checkpointCatalog = store,
             stepAttemptStore = store,
             workflowBindings = bindings,
-            observability = object : TramaiWorkerObserver {},
+            observability = observer,
         )
         runBlocking {
             store.save(
@@ -142,23 +165,79 @@ class TimeSemanticsDiscriminatorTest {
     fun `P0-A worker uptime is monotonic and ignores the wall clock`() {
         // Contract: the start mark is created at monotonic T=0. Heartbeats at
         // T=50 and T=100 must report [50, 100], independently of wall clock.
+        // Delta-based fake: a mark captures its creation instant, so a fresh
+        // mark per heartbeat (M03) would report ~0 and fail this sequence.
         val observer = HeartbeatObserver()
         val publisher = WorkerHeartbeatPublisher(heartbeatConfig, null, observer)
-        val fake = FakeMonotonicTimeSource()
-        val startedMark = fake.markNow()
+        val delta = DeltaMonotonicTimeSource()
+        val startedMark = delta.markNow()
         runBlocking {
-            fake.elapsedMillis = 50L
+            delta.now = 50L
             val job = launch {
                 publisher.heartbeatLoop(startedAtMark = { startedMark }, claimedCount = { 0 })
             }
             while (observer.uptimes.size < 1) delay(5)
-            fake.elapsedMillis = 100L
+            delta.now = 100L
             while (observer.uptimes.size < 2) delay(5)
             job.cancelAndJoin()
         }
         assertThat(observer.uptimes)
             .withFailMessage("P0-A uptime must be monotonic elapsed (50ms), not wall-clock derived")
             .containsExactly(50L, 100L)
+    }
+
+    @Test
+    fun `P0-A default monotonic source measures positive elapsed time`() {
+        // Exercises the REAL nanoTime-backed source (all other discriminators
+        // inject fakes): elapsed must be positive and grow. Kills the M04
+        // sign-swap mutant (startNanos - now -> always 0).
+        val mark = MonotonicTimeSource.NanoTime.markNow()
+        Thread.sleep(50)
+        assertThat(mark.elapsedMillis())
+            .withFailMessage("P0-A default monotonic source must measure positive elapsed time")
+            .isGreaterThanOrEqualTo(10L)
+    }
+
+    @Test
+    fun `P0-A worker heartbeat uptime tracks the captured start mark`() {
+        // Exercises the CONTROLLER's heartbeat wiring (the publisher-direct
+        // test cannot see it): the worker must capture the start mark ONCE and
+        // report growing uptime from it. Kills the M03 mutant (fresh mark per
+        // heartbeat via timeSource.markNow() -> uptime always ~0).
+        val delta = DeltaMonotonicTimeSource()
+        val heartbeats = CopyOnWriteArrayList<Long>()
+        val gate = CompletableDeferred<Unit>()
+        val (worker, store) = gatedWorker(
+            gate,
+            drainTimeoutMillis = 500,
+            observer = object : TramaiWorkerObserver {
+                override fun onWorkerHeartbeat(workerId: String, uptimeMillis: Long, claimedCount: Int) {
+                    heartbeats += uptimeMillis
+                }
+            },
+        )
+        worker.timeSourceForTest = delta
+        try {
+            runBlocking {
+                worker.start()
+                withTimeout(10_000) {
+                    while (store.latestStepAttempt("w-1", "hold") == null) delay(5)
+                }
+                while (heartbeats.size < 2) delay(5)
+                delta.now = 50L
+                val before = heartbeats.size
+                while (heartbeats.size <= before) delay(5)
+                delta.now = 100L
+                val before2 = heartbeats.size
+                while (heartbeats.size <= before2) delay(5)
+                gate.complete(Unit)
+            }
+        } finally {
+            runBlocking { runCatching { worker.close() } }
+        }
+        assertThat(heartbeats.takeLast(3))
+            .withFailMessage("P0-A worker uptime must track the captured start mark (fresh-mark M03 -> all ~0)")
+            .contains(50L, 100L)
     }
 
     @Test
@@ -294,8 +373,11 @@ class TimeSemanticsDiscriminatorTest {
         try {
             runBlocking {
                 worker.start()
+                // Wait for the WORKER's execution (STARTED attempt), not the
+                // seeded checkpoint: the persistence session is created before
+                // the initial save, so this guarantees it exists at clock=3000.
                 withTimeout(10_000) {
-                    while (store.load("time-semantics", "w-1") == null) delay(5)
+                    while (store.latestStepAttempt("w-1", "hold") == null) delay(5)
                 }
                 clock.millis = 4_000L
                 gate.complete(Unit)
@@ -311,5 +393,275 @@ class TimeSemanticsDiscriminatorTest {
         } finally {
             runBlocking { runCatching { worker.close() } }
         }
+    }
+
+    @Test
+    fun `P0-B2 drain residual clamps to minimum when monotonic elapsed exceeds the budget`() {
+        // Companion to P0-B: when the monotonic source reports MORE elapsed
+        // than the budget (fake = 5000ms vs 500ms budget), the residual must
+        // clamp to ~1ms — the drain must NOT re-consume the full budget.
+        // Kills the M05 mutant (residual = full drainTimeout regardless).
+        val gate = CompletableDeferred<Unit>()
+        val fake = FakeMonotonicTimeSource().apply { elapsedMillis = 5_000L }
+        val (worker, store) = gatedWorker(gate, drainTimeoutMillis = 500)
+        worker.timeSourceForTest = fake
+        try {
+            runBlocking {
+                worker.start()
+                withTimeout(10_000) {
+                    while (store.latestStepAttempt("w-1", "hold") == null) delay(5)
+                }
+                val drainStartedNanos = System.nanoTime()
+                worker.shutdown()
+                val totalMillis = (System.nanoTime() - drainStartedNanos) / 1_000_000
+                assertThat(totalMillis)
+                    .withFailMessage("P0-B2 residual must clamp to ~1ms when elapsed exceeds the budget")
+                    .isLessThan(800L)
+                gate.complete(Unit)
+            }
+        } finally {
+            runBlocking { runCatching { worker.close() } }
+        }
+    }
+
+    @Test
+    fun `P0-C failed attempt terminal timestamp comes from the injected clock`() {
+        val clock = MutableClock(1_000L)
+        val gate = CompletableDeferred<Unit>()
+        val (worker, store) = gatedWorker(gate, drainTimeoutMillis = 60_000, clock = clock, failingStep = true)
+        try {
+            runBlocking {
+                worker.start()
+                withTimeout(10_000) {
+                    while (store.latestStepAttempt("w-1", "hold")?.status != StepAttemptStatus.FAILED) delay(5)
+                }
+                val failed = store.latestStepAttempt("w-1", "hold")!!
+                assertThat(failed.completedAt)
+                    .withFailMessage("P0-C failed attempt completedAt must be the injected clock's reading")
+                    .isEqualTo(1_000L)
+            }
+        } finally {
+            runBlocking { runCatching { worker.close() } }
+        }
+    }
+
+    @Test
+    fun `P0-C cancelled attempt terminal timestamp comes from the injected clock`() {
+        val clock = MutableClock(1_000L)
+        val gate = CompletableDeferred<Unit>()
+        val (worker, store) = gatedWorker(gate, drainTimeoutMillis = 500, clock = clock, cancellableGate = true)
+        try {
+            runBlocking {
+                worker.start()
+                withTimeout(10_000) {
+                    while (store.latestStepAttempt("w-1", "hold")?.status != StepAttemptStatus.STARTED) delay(5)
+                }
+                worker.shutdown()
+                withTimeout(10_000) {
+                    while (store.latestStepAttempt("w-1", "hold")?.status != StepAttemptStatus.CANCELLED) delay(5)
+                }
+                val cancelled = store.latestStepAttempt("w-1", "hold")!!
+                assertThat(cancelled.completedAt)
+                    .withFailMessage("P0-C cancelled attempt completedAt must be the injected clock's reading")
+                    .isEqualTo(1_000L)
+            }
+        } finally {
+            runBlocking { runCatching { worker.close() } }
+        }
+    }
+
+    @Test
+    fun `P0-C UNKNOWN recovery completion timestamp comes from the injected clock`() {
+        val clock = MutableClock(1_000L)
+        val gate = CompletableDeferred<Unit>()
+        val (worker, store) = gatedWorker(gate, drainTimeoutMillis = 500, clock = clock)
+        try {
+            runBlocking {
+                // A previous worker's attempt is still STARTED; the new worker
+                // must flip it to UNKNOWN with the injected clock's reading.
+                store.recordStepAttempt(
+                    StepAttemptRecord(
+                        runId = "w-1",
+                        stepName = "hold",
+                        attemptId = "attempt-old",
+                        workerId = "worker-old",
+                        leaseToken = "lease-old",
+                        status = StepAttemptStatus.STARTED,
+                        startedAt = 10,
+                        replayPolicy = ReplayPolicy.NON_REPLAYABLE,
+                    ),
+                )
+                worker.start()
+                withTimeout(10_000) {
+                    while (store.latestStepAttempt("w-1", "hold")?.status != StepAttemptStatus.UNKNOWN) delay(5)
+                }
+                val unknown = store.latestStepAttempt("w-1", "hold")!!
+                assertThat(unknown.completedAt)
+                    .withFailMessage("P0-C UNKNOWN recovery completedAt must be the injected clock's reading")
+                    .isEqualTo(1_000L)
+                gate.complete(Unit)
+            }
+        } finally {
+            runBlocking { runCatching { worker.close() } }
+        }
+    }
+
+    @Test
+    fun `P0-C retry-approval consumption stamps from or preserves the injected clock`() {
+        val clock = MutableClock(1_000L)
+        // Scenario A: completedAt absent -> stamped from the injected clock.
+        val gateA = CompletableDeferred<Unit>()
+        val (workerA, storeA) = gatedWorker(gateA, drainTimeoutMillis = 500, clock = clock)
+        try {
+            runBlocking {
+                storeA.recordStepAttempt(
+                    StepAttemptRecord(
+                        runId = "w-1",
+                        stepName = "hold",
+                        attemptId = "attempt-1",
+                        workerId = "worker-old",
+                        leaseToken = "lease-old",
+                        status = StepAttemptStatus.UNKNOWN,
+                        startedAt = 10,
+                        replayPolicy = ReplayPolicy.NON_REPLAYABLE,
+                        resolutionAction = StepAttemptResolutionAction.RETRY_APPROVED,
+                        resolutionReason = "safe after inspection",
+                        approvedIdempotencyKey = null,
+                    ),
+                )
+                workerA.start()
+                withTimeout(10_000) {
+                    while (storeA.listStepAttempts("w-1").firstOrNull { it.attemptId == "attempt-1" }?.status != StepAttemptStatus.FAILED) delay(5)
+                }
+                val consumed = storeA.listStepAttempts("w-1").first { it.attemptId == "attempt-1" }
+                assertThat(consumed.completedAt)
+                    .withFailMessage("P0-C retry-approval consumption must stamp completedAt from the injected clock")
+                    .isEqualTo(1_000L)
+                gateA.complete(Unit)
+            }
+        } finally {
+            runBlocking { runCatching { workerA.close() } }
+        }
+        // Scenario B: completedAt already present (999) -> must remain unchanged (T3).
+        val gateB = CompletableDeferred<Unit>()
+        val (workerB, storeB) = gatedWorker(gateB, drainTimeoutMillis = 500, clock = clock)
+        try {
+            runBlocking {
+                storeB.recordStepAttempt(
+                    StepAttemptRecord(
+                        runId = "w-1",
+                        stepName = "hold",
+                        attemptId = "attempt-1",
+                        workerId = "worker-old",
+                        leaseToken = "lease-old",
+                        status = StepAttemptStatus.UNKNOWN,
+                        startedAt = 10,
+                        completedAt = 999L,
+                        replayPolicy = ReplayPolicy.NON_REPLAYABLE,
+                        resolutionAction = StepAttemptResolutionAction.RETRY_APPROVED,
+                        resolutionReason = "safe after inspection",
+                        approvedIdempotencyKey = null,
+                    ),
+                )
+                workerB.start()
+                withTimeout(10_000) {
+                    while (storeB.listStepAttempts("w-1").firstOrNull { it.attemptId == "attempt-1" }?.status != StepAttemptStatus.FAILED) delay(5)
+                }
+                val consumed = storeB.listStepAttempts("w-1").first { it.attemptId == "attempt-1" }
+                assertThat(consumed.completedAt)
+                    .withFailMessage("P0-C retry-approval consumption must preserve an existing completedAt")
+                    .isEqualTo(999L)
+                gateB.complete(Unit)
+            }
+        } finally {
+            runBlocking { runCatching { workerB.close() } }
+        }
+    }
+
+    @Test
+    fun `P0-C failWorkflow resolution timestamp comes from the injected clock`() {
+        val clock = MutableClock(1_000L)
+        val store = InMemoryWorkflowCheckpointStore()
+        runBlocking {
+            store.save(
+                WorkflowCheckpoint(
+                    workflowName = "time-semantics",
+                    workflowId = "w-1",
+                    nextStepIndex = 0,
+                    stepExecutions = 0,
+                    lastCompletedStepName = null,
+                    statePayload = LifecycleCodec.encode(LifecycleState("start")),
+                    metadata = emptyMap(),
+                    recoveryState = WorkflowRecoveryState.Required(
+                        WorkflowRecoveryRecord(
+                            reason = WorkflowRecoveryReason.NON_REPLAYABLE_OUTCOME_UNKNOWN,
+                            stepName = "hold",
+                            attemptId = "attempt-1",
+                            priorWorkerId = "worker-a",
+                            detectedAtEpochMillis = 20,
+                        ),
+                    ),
+                ),
+            )
+            store.recordStepAttempt(
+                StepAttemptRecord(
+                    runId = "w-1",
+                    stepName = "hold",
+                    attemptId = "attempt-1",
+                    workerId = "worker-a",
+                    leaseToken = "lease-a",
+                    status = StepAttemptStatus.UNKNOWN,
+                    startedAt = 10,
+                    replayPolicy = ReplayPolicy.NON_REPLAYABLE,
+                ),
+            )
+            val saved = store.load("time-semantics", "w-1")!!
+            InMemoryWorkflowRecoveryController(store, store, clock = clock).failWorkflow(
+                workflowName = "time-semantics",
+                workflowId = "w-1",
+                expectedRevision = saved.revision,
+                expectedGeneration = saved.checkpointGeneration,
+                reason = "resolved by operator",
+            )
+            val attempt = store.listStepAttempts("w-1").single()
+            assertThat(attempt.resolutionAtEpochMillis)
+                .withFailMessage("P0-C failWorkflow resolutionAtEpochMillis must be the injected clock's reading")
+                .isEqualTo(1_000L)
+            assertThat(attempt.completedAt)
+                .withFailMessage("P0-C failWorkflow evidence completedAt must be the injected clock's reading")
+                .isEqualTo(1_000L)
+        }
+    }
+
+    @Test
+    fun `P0-E legacy checkpoint missing savedAt decodes as UNKNOWN not read-time`() {
+        // Contract: a legacy record with no savedAtEpochMillis property must
+        // decode to 0L (historical save time unknown) — never
+        // System.currentTimeMillis() at read time, and never a fresh Clock
+        // reading. TramAI never fabricates a historical save timestamp.
+        val encoded = encodeCheckpoint(
+            WorkflowCheckpoint(
+                workflowName = "time-semantics",
+                workflowId = "w-1",
+                nextStepIndex = 0,
+                stepExecutions = 0,
+                lastCompletedStepName = null,
+                statePayload = LifecycleCodec.encode(LifecycleState("start")),
+                savedAtEpochMillis = 123_456L,
+            ),
+        )
+        val legacy = encoded.lines().filterNot { it.startsWith("savedAtEpochMillis") }.joinToString("\n")
+        // RED: production synthesizes System.currentTimeMillis() here.
+        assertThat(decodeCheckpoint(legacy).savedAtEpochMillis)
+            .withFailMessage("P0-E legacy missing savedAt must decode as UNKNOWN (0L)")
+            .isEqualTo(0L)
+        // Deterministic across repeated decodes of the same bytes.
+        assertThat(decodeCheckpoint(legacy).savedAtEpochMillis)
+            .withFailMessage("P0-E legacy decode must be stable, never read-time")
+            .isEqualTo(0L)
+        // A present value must survive exactly.
+        assertThat(decodeCheckpoint(encoded).savedAtEpochMillis)
+            .withFailMessage("P0-E a present savedAtEpochMillis must be preserved exactly")
+            .isEqualTo(123_456L)
     }
 }

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TimeSemanticsDiscriminatorTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TimeSemanticsDiscriminatorTest.kt
@@ -1,0 +1,175 @@
+package dev.tramai.orchestration
+
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Epic 8.3a — wall-clock vs monotonic-time discriminators (RED-first).
+ *
+ * P0-A: worker uptime must be monotonic elapsed time, never wall-clock
+ * derived (an NTP/operator wall-clock jump must not change uptime).
+ * P0-B: the shutdown drain's residual budget must be monotonic elapsed
+ * time, never wall-clock derived (a wall-clock jump must not inflate or
+ * destroy the remaining drain budget).
+ *
+ * Both tests are RED on the current production code: the uptime formula
+ * reads System.currentTimeMillis() and the drain residual reads
+ * System.currentTimeMillis(), so neither can express the monotonic
+ * contract.
+ */
+class TimeSemanticsDiscriminatorTest {
+
+    private val heartbeatConfig = WorkerConfig(
+        workerId = "time-semantics-heartbeat",
+        poolName = "tests",
+        pollIntervalMillis = 20,
+        leaseDurationMillis = 5_000,
+        drainTimeoutMillis = 60_000,
+    )
+
+    private val drainConfig = WorkerConfig(
+        workerId = "time-semantics-drain",
+        poolName = "tests",
+        pollIntervalMillis = 20,
+        leaseDurationMillis = 5_000,
+        drainTimeoutMillis = 500,
+    )
+
+    private class HeartbeatObserver : TramaiWorkerObserver {
+        val uptimes = CopyOnWriteArrayList<Long>()
+        override fun onWorkerHeartbeat(workerId: String, uptimeMillis: Long, claimedCount: Int) {
+            uptimes += uptimeMillis
+        }
+    }
+
+    /** Fake monotonic source whose elapsed reading is fully test-controlled. */
+    private class FakeMonotonicTimeSource : MonotonicTimeSource {
+        var elapsedMillis = 0L
+        override fun markNow(): MonotonicMark = object : MonotonicMark {
+            override fun elapsedMillis(): Long = this@FakeMonotonicTimeSource.elapsedMillis
+        }
+    }
+
+    private data class LifecycleState(val value: String)
+
+    private object LifecycleCodec : WorkflowStateCodec<LifecycleState> {
+        override fun encode(state: LifecycleState): String = state.value
+        override fun decode(payload: String): LifecycleState = LifecycleState(payload)
+    }
+
+    /**
+     * Worker whose single step blocks on [gate] inside NonCancellable: once
+     * draining starts, the execution ignores cancellation until the gate
+     * opens, so the drain's second phase actually has to wait out its
+     * residual budget (the observable under test).
+     */
+    private fun gatedWorker(
+        gate: CompletableDeferred<Unit>,
+        drainTimeoutMillis: Long,
+    ): Pair<TramaiWorker, InMemoryWorkflowCheckpointStore> {
+        val store = InMemoryWorkflowCheckpointStore()
+        val leaseStore = InMemoryWorkflowLeaseStore()
+        val workflow = workflow<LifecycleState>("time-semantics", definitionVersion = "v1") {
+            localStep("hold") { state, _ ->
+                withContext(NonCancellable) { gate.await() }
+                state
+            }
+        }.build { it.value }
+        val bindings = WorkflowBindingRegistry {
+            bind(workflow, WorkflowPersistence(checkpointStore = store, stateCodec = LifecycleCodec))
+        }
+        val worker = TramaiWorker(
+            config = WorkerConfig(
+                workerId = "time-semantics-drain",
+                poolName = "tests",
+                pollIntervalMillis = 20,
+                leaseDurationMillis = 5_000,
+                drainTimeoutMillis = drainTimeoutMillis,
+            ),
+            leaseStore = leaseStore,
+            checkpointStore = store,
+            checkpointCatalog = store,
+            stepAttemptStore = store,
+            workflowBindings = bindings,
+            observability = object : TramaiWorkerObserver {},
+        )
+        runBlocking {
+            store.save(
+                WorkflowCheckpoint(
+                    workflowName = "time-semantics",
+                    workflowId = "w-1",
+                    nextStepIndex = 0,
+                    stepExecutions = 0,
+                    lastCompletedStepName = null,
+                    statePayload = LifecycleCodec.encode(LifecycleState("start")),
+                    metadata = workflow.checkpointMetadata(),
+                ),
+            )
+        }
+        return worker to store
+    }
+
+    @Test
+    fun `P0-A worker uptime is monotonic and ignores the wall clock`() {
+        // Contract: the start mark is created at monotonic T=0. Heartbeats at
+        // T=50 and T=100 must report [50, 100], independently of wall clock.
+        val observer = HeartbeatObserver()
+        val publisher = WorkerHeartbeatPublisher(heartbeatConfig, null, observer)
+        val fake = FakeMonotonicTimeSource()
+        val startedMark = fake.markNow()
+        runBlocking {
+            fake.elapsedMillis = 50L
+            val job = launch {
+                publisher.heartbeatLoop(startedAtMark = { startedMark }, claimedCount = { 0 })
+            }
+            while (observer.uptimes.size < 1) delay(5)
+            fake.elapsedMillis = 100L
+            while (observer.uptimes.size < 2) delay(5)
+            job.cancelAndJoin()
+        }
+        assertThat(observer.uptimes)
+            .withFailMessage("P0-A uptime must be monotonic elapsed (50ms), not wall-clock derived")
+            .containsExactly(50L, 100L)
+    }
+
+    @Test
+    fun `P0-B shutdown drain residual budget is monotonic and wall-clock independent`() {
+        // Contract: drain budget = 500ms; the monotonic source reports only
+        // 50ms consumed (the wall clock in reality jumped far ahead), so the
+        // residual must be ~450ms — the drain must NOT re-consume the full
+        // budget. RED: production computes residual from
+        // System.currentTimeMillis(), which after a full first-phase timeout
+        // reports ~500ms real elapsed -> residual clamps to 1ms, so the whole
+        // shutdown finishes in ~drainTimeout (well under the 700ms threshold).
+        val gate = CompletableDeferred<Unit>()
+        val fake = FakeMonotonicTimeSource().apply { elapsedMillis = 50L }
+        val (worker, store) = gatedWorker(gate, drainTimeoutMillis = 500)
+        worker.timeSourceForTest = fake
+        try {
+            runBlocking {
+                worker.start()
+                withTimeout(10_000) {
+                    while (store.latestStepAttempt("w-1", "hold") == null) delay(5)
+                }
+                val drainStartedNanos = System.nanoTime()
+                worker.shutdown()
+                val totalMillis = (System.nanoTime() - drainStartedNanos) / 1_000_000
+                assertThat(totalMillis)
+                    .withFailMessage("P0-B residual must use monotonic elapsed (50ms consumed -> ~450ms residual), not wall-clock derived")
+                    .isGreaterThanOrEqualTo(700L)
+                gate.complete(Unit)
+            }
+        } finally {
+            runBlocking { runCatching { worker.close() } }
+        }
+    }
+}

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TimeSemanticsDiscriminatorTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TimeSemanticsDiscriminatorTest.kt
@@ -187,15 +187,17 @@ class TimeSemanticsDiscriminatorTest {
     }
 
     @Test
-    fun `P0-A default monotonic source measures positive elapsed time`() {
-        // Exercises the REAL nanoTime-backed source (all other discriminators
-        // inject fakes): elapsed must be positive and grow. Kills the M04
-        // sign-swap mutant (startNanos - now -> always 0).
-        val mark = MonotonicTimeSource.NanoTime.markNow()
-        Thread.sleep(50)
+    fun `P0-A monotonic elapsed arithmetic is deterministic`() {
+        // The NanoTimeSource elapsed calculation must be exactly
+        // (currentReading - startReading): controlled raw readings prove the
+        // arithmetic without depending on real elapsed time. Kills the M04
+        // sign-swap mutant (startReading - currentReading -> clamped to 0).
+        val readings = ArrayDeque(listOf(100_000_000L, 150_000_000L))
+        val source = NanoTimeSource(nanoTime = { readings.removeFirst() })
+        val mark = source.markNow()
         assertThat(mark.elapsedMillis())
-            .withFailMessage("P0-A default monotonic source must measure positive elapsed time")
-            .isGreaterThanOrEqualTo(10L)
+            .withFailMessage("P0-A monotonic elapsed must be currentReading - startReading (50ms)")
+            .isEqualTo(50L)
     }
 
     @Test

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TimeSemanticsDiscriminatorTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TimeSemanticsDiscriminatorTest.kt
@@ -10,6 +10,10 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
@@ -59,6 +63,13 @@ class TimeSemanticsDiscriminatorTest {
         }
     }
 
+    /** Mutable wall clock for P0-C/P0-D persisted-timestamp discriminators. */
+    private class MutableClock(var millis: Long) : Clock() {
+        override fun instant(): Instant = Instant.ofEpochMilli(millis)
+        override fun withZone(zone: ZoneId): Clock = this
+        override fun getZone(): ZoneId = ZoneOffset.UTC
+    }
+
     private data class LifecycleState(val value: String)
 
     private object LifecycleCodec : WorkflowStateCodec<LifecycleState> {
@@ -75,6 +86,8 @@ class TimeSemanticsDiscriminatorTest {
     private fun gatedWorker(
         gate: CompletableDeferred<Unit>,
         drainTimeoutMillis: Long,
+        clock: Clock = Clock.systemUTC(),
+        keepCheckpoint: Boolean = false,
     ): Pair<TramaiWorker, InMemoryWorkflowCheckpointStore> {
         val store = InMemoryWorkflowCheckpointStore()
         val leaseStore = InMemoryWorkflowLeaseStore()
@@ -83,9 +96,16 @@ class TimeSemanticsDiscriminatorTest {
                 withContext(NonCancellable) { gate.await() }
                 state
             }
-        }.build { it.value }
+        }.build(clock = clock) { it.value }
         val bindings = WorkflowBindingRegistry {
-            bind(workflow, WorkflowPersistence(checkpointStore = store, stateCodec = LifecycleCodec))
+            bind(
+                workflow,
+                WorkflowPersistence(
+                    checkpointStore = store,
+                    stateCodec = LifecycleCodec,
+                    deleteCheckpointOnCompletion = !keepCheckpoint,
+                ),
+            )
         }
         val worker = TramaiWorker(
             config = WorkerConfig(
@@ -167,6 +187,126 @@ class TimeSemanticsDiscriminatorTest {
                     .withFailMessage("P0-B residual must use monotonic elapsed (50ms consumed -> ~450ms residual), not wall-clock derived")
                     .isGreaterThanOrEqualTo(700L)
                 gate.complete(Unit)
+            }
+        } finally {
+            runBlocking { runCatching { worker.close() } }
+        }
+    }
+
+    @Test
+    fun `P0-C step-attempt timestamps come from the injected workflow clock`() {
+        // Contract: startedAt = clock at start (T0), completedAt = clock at
+        // completion (T1). RED: production stamps System.currentTimeMillis(),
+        // so the persisted values never equal the injected clock's readings.
+        val clock = MutableClock(1_000L)
+        val gate = CompletableDeferred<Unit>()
+        val (worker, store) = gatedWorker(gate, drainTimeoutMillis = 60_000, clock = clock)
+        try {
+            runBlocking {
+                worker.start()
+                withTimeout(10_000) {
+                    while (store.latestStepAttempt("w-1", "hold") == null) delay(5)
+                }
+                val started = store.latestStepAttempt("w-1", "hold")!!
+                clock.millis = 2_000L
+                gate.complete(Unit)
+                withTimeout(10_000) {
+                    while (store.latestStepAttempt("w-1", "hold")?.status != StepAttemptStatus.COMPLETED) delay(5)
+                }
+                val completed = store.latestStepAttempt("w-1", "hold")!!
+                assertThat(started.startedAt)
+                    .withFailMessage("P0-C startedAt must be the injected clock's T0")
+                    .isEqualTo(1_000L)
+                assertThat(completed.completedAt)
+                    .withFailMessage("P0-C completedAt must be the injected clock's T1")
+                    .isEqualTo(2_000L)
+                worker.shutdown()
+            }
+        } finally {
+            runBlocking { runCatching { worker.close() } }
+        }
+    }
+
+    @Test
+    fun `P0-C recovery resolution timestamps come from the injected clock`() {
+        // Contract: an operator retry approval records resolutionAtEpochMillis
+        // from the injected clock. RED: production stamps
+        // System.currentTimeMillis(), never equal to the injected reading.
+        val clock = MutableClock(1_000L)
+        val store = InMemoryWorkflowCheckpointStore()
+        runBlocking {
+            store.save(
+                WorkflowCheckpoint(
+                    workflowName = "time-semantics",
+                    workflowId = "w-1",
+                    nextStepIndex = 0,
+                    stepExecutions = 0,
+                    lastCompletedStepName = null,
+                    statePayload = LifecycleCodec.encode(LifecycleState("start")),
+                    metadata = emptyMap(),
+                    recoveryState = WorkflowRecoveryState.Required(
+                        WorkflowRecoveryRecord(
+                            reason = WorkflowRecoveryReason.NON_REPLAYABLE_OUTCOME_UNKNOWN,
+                            stepName = "hold",
+                            attemptId = "attempt-1",
+                            priorWorkerId = "worker-a",
+                            detectedAtEpochMillis = 20,
+                        ),
+                    ),
+                ),
+            )
+            store.recordStepAttempt(
+                StepAttemptRecord(
+                    runId = "w-1",
+                    stepName = "hold",
+                    attemptId = "attempt-1",
+                    workerId = "worker-a",
+                    leaseToken = "lease-a",
+                    status = StepAttemptStatus.UNKNOWN,
+                    startedAt = 10,
+                    replayPolicy = ReplayPolicy.NON_REPLAYABLE,
+                ),
+            )
+            val saved = store.load("time-semantics", "w-1")!!
+            InMemoryWorkflowRecoveryController(store, store, clock = clock).retryStep(
+                workflowName = "time-semantics",
+                workflowId = "w-1",
+                expectedRevision = saved.revision,
+                expectedGeneration = saved.checkpointGeneration,
+                reason = "safe after inspection",
+            )
+            val attempt = store.listStepAttempts("w-1").single()
+            assertThat(attempt.resolutionAtEpochMillis)
+                .withFailMessage("P0-C resolutionAtEpochMillis must be the injected clock's reading")
+                .isEqualTo(1_000L)
+        }
+    }
+
+    @Test
+    fun `P0-D checkpoint savedAt is supplied by the injected clock`() {
+        // Contract: the persistence coordinator stamps savedAtEpochMillis from
+        // the injected clock at each save. RED: production lets the
+        // WorkflowCheckpoint default fire (System.currentTimeMillis()), so the
+        // persisted value never equals the injected reading.
+        val clock = MutableClock(3_000L)
+        val gate = CompletableDeferred<Unit>()
+        val (worker, store) = gatedWorker(gate, drainTimeoutMillis = 60_000, clock = clock, keepCheckpoint = true)
+        try {
+            runBlocking {
+                worker.start()
+                withTimeout(10_000) {
+                    while (store.load("time-semantics", "w-1") == null) delay(5)
+                }
+                clock.millis = 4_000L
+                gate.complete(Unit)
+                withTimeout(10_000) {
+                    while (store.load("time-semantics", "w-1")?.lastCompletedStepName != "hold") delay(5)
+                }
+                val saved = store.load("time-semantics", "w-1")!!
+                assertThat(saved.savedAtEpochMillis)
+                    .withFailMessage("P0-D savedAtEpochMillis must be the injected clock's reading at save time")
+                    .isEqualTo(4_000L)
+                worker.shutdown()
             }
         } finally {
             runBlocking { runCatching { worker.close() } }


### PR DESCRIPTION
## Epic 8.3a — Time semantics: monotonic uptime, injected clock, deterministic evidence

**Base:** `17cfb61e` (includes #317 step-attempt ordering + #320 worker snapshot safety)
**Head:** `12f14a50`

### What changed (production)

- **P0-A/B** — monotonic time for worker uptime and drain budgets (`MonotonicTime` seam, `NanoTimeSource`, `MonotonicDrainBudget`; exact residual arithmetic 450L, clamp 1L; no timing thresholds).
- **P0-C** — step-attempt/execution timestamps come from the workflow's injected `Clock`, threaded from the worker boundary.
- **P0-D** — checkpoint `savedAtEpochMillis` supplied by the injected clock at save time.
- **P0-E** — legacy checkpoint records missing `savedAtEpochMillis` decode as `0L`/UNKNOWN (never 1970-01-01, never read-time synthesis).
- **ABI preserved** — `InMemoryWorkflowRecoveryController` keeps its public two-argument constructor (apiCheck zero dump diff); the clock is an internal `forTest` seam. Public `WorkflowCheckpoint` default deliberately untouched.
- **Structural fix (review)** — the heartbeat loop receives a captured `MonotonicMark`, not a mark supplier; `WorkerLifecycleController` fails loudly if the start mark is absent. Fresh-mark-per-heartbeat behaviour is now structurally impossible.

### Evidence (exact head)

- 14-discriminator suite (exact arithmetic, zero timing thresholds) — GREEN
- 16-candidate mutation campaign: **15 STRONG / 1 REDUNDANT (M13) / 0 WEAK / 0 INVALID**; M03 structurally eliminated by the captured-mark API
- Full orchestration suite + apiCheck — GREEN
- verifyChangePolicy (runtime-behaviour) / verify060Architecture / verifyMaintainabilityBaseline — PASSED

### verifyPr note

`verifyPr` fails locally on `ReleaseVerificationPluginTest T13` — proven identical on `origin/master` (J2-attributed; the clean-workspace producer-edge test is order/context-dependent under the verifyPr suite, unrelated to 8.3a). The clean-runner CI is the integration evidence.

### Follow-ups

- #318 owns durable File/JDBC equal-`startedAt` chronology; the in-memory store already uses creation-order authority after #317.
- 8.3b (identity + randomness) → 8.3c (scheduler ownership) → 8.3d (closure).
