### PR TITLE
fix(orchestration): stable creation-order authority for step-attempt ordering

### DIFF
--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/StepAttemptRecord.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/StepAttemptRecord.kt
@@ -72,15 +72,19 @@ internal fun decodeResolutionAction(name: String?): StepAttemptResolutionAction?
  *   record because the attempt store and the checkpoint store are independent.
  *
  * Ordering and retrieval:
- * - [listStepAttempts] returns records for one run ordered deterministically by
- *   `startedAt`, then `stepName`. For attempts with EQUAL persisted `startedAt`,
- *   the tie-break must be a stable creation-order authority, never the random
- *   `attemptId` (the in-memory implementation preserves insertion order; the
- *   file/JDBC implementations still use `attemptId` pending a durable sequence
- *   column — tracked as a cross-store contract follow-up).
- * - [latestStepAttempt] returns the record for the given run and step with the maximum
- *   `startedAt`; ties resolve to the LAST-created attempt (in-memory: insertion order;
- *   file/JDBC pending the same follow-up), or `null` when absent.
+ * - [listStepAttempts] returns records for one run ordered by `startedAt`, then
+ *   `stepName`. Equal-key ordering must be deterministic and stable across reads;
+ *   the final tie authority is implementation-specific today.
+ * - [latestStepAttempt] returns the record for the given run and step with the
+ *   maximum `startedAt`. The equal-startedAt tie authority is implementation-specific
+ *   today, or `null` when absent.
+ *
+ * Tie authority today:
+ * - `InMemoryWorkflowCheckpointStore` additionally guarantees creation-order tie
+ *   semantics (last-created wins `latest`; insertion order survives `list`).
+ * - The file/JDBC implementations currently use `attemptId` (a random UUID) as the
+ *   final deterministic tie-break. A durable creation-order authority requires a
+ *   persisted sequence and is deferred (tracked as a cross-store follow-up).
  *
  * Durability and failure behaviour:
  * - Persistent implementations must survive store recreation and process restart, and

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/StepAttemptRecord.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/StepAttemptRecord.kt
@@ -73,9 +73,14 @@ internal fun decodeResolutionAction(name: String?): StepAttemptResolutionAction?
  *
  * Ordering and retrieval:
  * - [listStepAttempts] returns records for one run ordered deterministically by
- *   `startedAt`, then `stepName`, then `attemptId`.
+ *   `startedAt`, then `stepName`. For attempts with EQUAL persisted `startedAt`,
+ *   the tie-break must be a stable creation-order authority, never the random
+ *   `attemptId` (the in-memory implementation preserves insertion order; the
+ *   file/JDBC implementations still use `attemptId` pending a durable sequence
+ *   column — tracked as a cross-store contract follow-up).
  * - [latestStepAttempt] returns the record for the given run and step with the maximum
- *   `startedAt`, then `attemptId` (ties broken by `attemptId`), or `null` when absent.
+ *   `startedAt`; ties resolve to the LAST-created attempt (in-memory: insertion order;
+ *   file/JDBC pending the same follow-up), or `null` when absent.
  *
  * Durability and failure behaviour:
  * - Persistent implementations must survive store recreation and process restart, and

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowPersistence.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowPersistence.kt
@@ -422,7 +422,7 @@ class InMemoryWorkflowCheckpointStore :
         stepAttempts.values
             .asSequence()
             .filter { it.runId == runId && it.stepName == stepName }
-            .maxWithOrNull(compareBy<StepAttemptRecord>({ it.startedAt }, { it.attemptId }))
+            .fold(null as StepAttemptRecord?) { acc, record -> if (acc == null || record.startedAt >= acc.startedAt) record else acc }
     } }
 
     override suspend fun listStepAttempts(runId: String): List<StepAttemptRecord> = persistenceBoundary(
@@ -431,7 +431,7 @@ class InMemoryWorkflowCheckpointStore :
     ) { synchronized(monitor) {
         stepAttempts.values
             .filter { it.runId == runId }
-            .sortedWith(compareBy<StepAttemptRecord>({ it.startedAt }, { it.stepName }, { it.attemptId }))
+            .sortedWith(compareBy<StepAttemptRecord>({ it.startedAt }, { it.stepName }))
     } }
 }
 private data class CheckpointKey(

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/StepAttemptOrderingDiscriminatorTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/StepAttemptOrderingDiscriminatorTest.kt
@@ -1,0 +1,70 @@
+package dev.tramai.orchestration
+
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Deterministic creation-order authority for step attempts with EQUAL persisted
+ * startedAt (same real millisecond — the fake-lease takeover path can complete
+ * within one ms). Invariant: "latest" and listing order must use a stable
+ * creation-order authority, never random identity (the attemptId UUID).
+ *
+ * The attemptIds are chosen so UUID lexicographic order is the OPPOSITE of
+ * insertion order: with the old (startedAt, stepName, attemptId) comparators
+ * these assertions fail deterministically — no timing involved.
+ */
+class StepAttemptOrderingDiscriminatorTest {
+
+    private fun attempt(
+        attemptId: String,
+        status: StepAttemptStatus,
+    ) = StepAttemptRecord(
+        runId = "w-1",
+        stepName = "plan",
+        attemptId = attemptId,
+        workerId = "worker",
+        leaseToken = "lease",
+        status = status,
+        startedAt = 1_000L,
+        replayPolicy = ReplayPolicy.IDEMPOTENT,
+    )
+
+    @Test
+    fun `listStepAttempts orders same-startedAt attempts by creation, never by attempt id`() {
+        val store = InMemoryWorkflowCheckpointStore()
+        runBlocking {
+            val original = attempt("zzz-original", StepAttemptStatus.UNKNOWN)
+            val rerun = attempt("aaa-rerun", StepAttemptStatus.COMPLETED)
+            store.recordStepAttempt(original)
+            store.recordStepAttempt(rerun)
+
+            val listed = store.listStepAttempts("w-1")
+            assertThat(listed.map { it.attemptId })
+                .withFailMessage(
+                    "Equal startedAt must order by creation (original before re-run), " +
+                        "never by the random attemptId UUID",
+                )
+                .containsExactly("zzz-original", "aaa-rerun")
+        }
+    }
+
+    @Test
+    fun `latestStepAttempt prefers the last-created attempt on equal startedAt`() {
+        val store = InMemoryWorkflowCheckpointStore()
+        runBlocking {
+            val original = attempt("zzz-original", StepAttemptStatus.UNKNOWN)
+            val rerun = attempt("aaa-rerun", StepAttemptStatus.COMPLETED)
+            store.recordStepAttempt(original)
+            store.recordStepAttempt(rerun)
+
+            val latest = store.latestStepAttempt("w-1", "plan")
+            assertThat(latest?.attemptId)
+                .withFailMessage(
+                    "Equal startedAt must resolve 'latest' to the last-created attempt " +
+                        "(the re-run), never the random attemptId UUID",
+                )
+                .isEqualTo("aaa-rerun")
+        }
+    }
+}

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/StepAttemptRecordStoreContractTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/StepAttemptRecordStoreContractTest.kt
@@ -146,7 +146,7 @@ abstract class StepAttemptRecordStoreContractTest {
             listOf(
                 minimalRecord(attemptId = "z", startedAt = 9),
                 minimalRecord(attemptId = "a", startedAt = 10),
-                minimalRecord(attemptId = "b", startedAt = 10),
+                minimalRecord(attemptId = "b", startedAt = 11),
             ).forEach { store.recordStepAttempt(it) }
             assertThat(store.latestStepAttempt("run", "step")?.attemptId).isEqualTo("b")
         }

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/StepAttemptRecordStoreContractTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/StepAttemptRecordStoreContractTest.kt
@@ -141,7 +141,7 @@ abstract class StepAttemptRecordStoreContractTest {
     }
 
     @Test
-    fun `10 latest uses startedAt then attemptId`() {
+    fun `10 latest picks the max startedAt`() {
         runBlocking {
             listOf(
                 minimalRecord(attemptId = "z", startedAt = 9),
@@ -153,7 +153,7 @@ abstract class StepAttemptRecordStoreContractTest {
     }
 
     @Test
-    fun `11 list ordering is deterministic`() {
+    fun `11 list ordering is deterministic across reads`() {
         runBlocking {
             listOf(
                 minimalRecord(stepName = "z", attemptId = "b", startedAt = 2),
@@ -161,8 +161,12 @@ abstract class StepAttemptRecordStoreContractTest {
                 minimalRecord(stepName = "a", attemptId = "z", startedAt = 1),
                 minimalRecord(stepName = "a", attemptId = "a", startedAt = 1),
             ).forEach { store.recordStepAttempt(it) }
-            assertThat(store.listStepAttempts("run").map { "${it.startedAt}:${it.stepName}:${it.attemptId}" })
-                .containsExactly("1:a:a", "1:a:z", "1:b:c", "2:z:b")
+            val first = store.listStepAttempts("run")
+            // Primary keys (startedAt, stepName) order is contract across stores;
+            // the equal-key tie authority is store-specific (in-memory: creation order).
+            assertThat(first.map { "${it.startedAt}:${it.stepName}" }).containsExactly("1:a", "1:a", "1:b", "2:z")
+            val second = store.listStepAttempts("run")
+            assertThat(second).containsExactlyElementsOf(first)
         }
     }
 


### PR DESCRIPTION
## Stable creation-order authority for step-attempt ordering (follow-up to 8.3a review)

**Defect (pre-existing, surfaced during Epic 8.3a review):**
`InMemoryWorkflowCheckpointStore` ordered step attempts by
`(startedAt, stepName, attemptId)` / `(startedAt, attemptId)` where
`attemptId` is a random UUID. When two attempts carry EQUAL persisted
`startedAt` (same real millisecond — the fake-lease takeover path completes
within one ms), the random UUID becomes the ordering/selection authority:

- `listStepAttempts` order flips ~50% — observed as full-suite takeover flakes
  (`[COMPLETED, UNKNOWN]` vs `[UNKNOWN, COMPLETED]`), reproduced with captured
  data (`[COMPLETED@…9282/9a9d6707, UNKNOWN@…9282/ad5f97f7]` — equal stamps,
  UUID-decided order).
- `latestStepAttempt` can return the original UNKNOWN attempt instead of the
  re-run COMPLETED attempt — a recovery-selection correctness risk (potential
  re-replay loop in `recoverAttemptIfNeeded`).

**Invariant established (in-memory implementation):**
> For attempts with equal persisted startedAt, "latest" and listing order use
> a stable creation-order authority, never random identity.

- `listStepAttempts`: `(startedAt, stepName)` — stable sort over the
  insertion-ordered map preserves creation order on ties.
- `latestStepAttempt`: fold with `record.startedAt >= acc.startedAt` — the
  LAST-created attempt wins equal-startedAt ties.

**Evidence:**
- `StepAttemptOrderingDiscriminatorTest` — deterministic RED pre-fix, GREEN
  post-fix (attemptIds chosen so UUID order is the OPPOSITE of creation
  order; no timing involved).
- Mutants proven RED: list comparator with `attemptId` restored; latest
  tie-break `>=` → `>`; latest comparator with `attemptId` restored.
- Shared `StepAttemptRecordStoreContractTest` test 11 now asserts the
  cross-store primary-key order (`startedAt, stepName`) + read stability;
  the equal-key tie authority is store-specific (the old test pinned the
  random-UUID tie-break as "determinism" — false determinism in production).
- Full orchestration suite: 4 consecutive green runs — the takeover flake is
  gone (was failing 2/3 full-suite runs).

**Deferred (documented in interface KDoc, separate review):**
File/JDBC stores share the same same-ms tie (file: lexicographic path order =
UUID order; JDBC: `ORDER BY … attemptId`). A durable creation-order column is
a schema/format change and needs its own contract review.
