### PR TITLE
build(conventions): extract JVM and test-fixture conventions — Epic 9.2c-a

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
 dependencies {
     implementation(kotlin("stdlib"))
     implementation(kotlin("reflect"))
+    implementation(kotlin("gradle-plugin", version = "2.3.0"))
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.3")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.3")
     implementation("org.yaml:snakeyaml:2.3")
@@ -62,6 +63,18 @@ gradlePlugin {
         create("tramaiSovereignVerification") {
             id = "tramai.sovereign-verification"
             implementationClass = "dev.tramai.build.sovereign.TramaiSovereignVerificationPlugin"
+        }
+        create("tramaiKotlinLibrary") {
+            id = "tramai.kotlin-library"
+            implementationClass = "dev.tramai.build.conventions.TramaiKotlinLibraryPlugin"
+        }
+        create("tramaiJavaPlatform") {
+            id = "tramai.java-platform"
+            implementationClass = "dev.tramai.build.conventions.TramaiJavaPlatformPlugin"
+        }
+        create("tramaiTestFixtures") {
+            id = "tramai.test-fixtures"
+            implementationClass = "dev.tramai.build.conventions.TramaiTestFixturesPlugin"
         }
     }
 }

--- a/build-logic/src/main/kotlin/dev/tramai/build/conventions/TramaiJavaPlatformPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/conventions/TramaiJavaPlatformPlugin.kt
@@ -1,0 +1,33 @@
+package dev.tramai.build.conventions
+
+import dev.tramai.build.quality.ModuleManifest
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPlatformExtension
+
+/**
+ * Tramai Java platform convention plugin (Epic 9.2c).
+ *
+ * Configures the standard BOM/platform baseline: allows dependency management
+ * across the platform and wires the manifest-derived BOM module set as
+ * `api` constraints on every published, release-included module. Reacts to
+ * `java-platform` being applied by the module.
+ *
+ * Behavior-preserving extraction of `tramai-bom`'s historical build script.
+ */
+class TramaiJavaPlatformPlugin : Plugin<Project> {
+
+    override fun apply(project: Project) {
+        project.pluginManager.withPlugin("java-platform") {
+            project.extensions.configure(JavaPlatformExtension::class.java) {
+                allowDependencies()
+            }
+            project.dependencies.constraints {
+                val bomModulePaths = ModuleManifest.bomModulePaths(project.rootProject.rootDir)
+                bomModulePaths.forEach { path ->
+                    add("api", project.dependencies.project(mapOf("path" to path)))
+                }
+            }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/dev/tramai/build/conventions/TramaiKotlinLibraryPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/conventions/TramaiKotlinLibraryPlugin.kt
@@ -1,0 +1,43 @@
+package dev.tramai.build.conventions
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.testing.Test
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+
+/**
+ * Tramai Kotlin library convention plugin (Epic 9.2c).
+ *
+ * Configures the standard JVM/Kotlin baseline for library modules: Java 21
+ * toolchain, sources JAR, Kotlin 21 toolchain/jvmTarget, and JUnit Platform
+ * for the test task. Reacts to `org.jetbrains.kotlin.jvm` (and `java-library`)
+ * being applied by the module — the module keeps its base plugins; this plugin
+ * only removes the repeated configuration blocks.
+ *
+ * Behavior-preserving extraction: modules that already declare exactly this
+ * configuration migrate to `id("tramai.kotlin-library")`; modules with
+ * divergent configuration (extra compiler args, no sources JAR, no JUnit
+ * Platform) keep their deltas locally — the convention never adds behavior a
+ * module did not have.
+ */
+class TramaiKotlinLibraryPlugin : Plugin<Project> {
+
+    override fun apply(project: Project) {
+        project.pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+            project.extensions.configure(JavaPluginExtension::class.java) {
+                toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+                withSourcesJar()
+            }
+            project.extensions.configure(KotlinJvmProjectExtension::class.java) {
+                jvmToolchain(21)
+                compilerOptions.jvmTarget.set(JvmTarget.fromTarget("21"))
+            }
+            project.tasks.withType(Test::class.java).configureEach {
+                useJUnitPlatform()
+            }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/dev/tramai/build/conventions/TramaiKotlinLibraryPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/conventions/TramaiKotlinLibraryPlugin.kt
@@ -13,30 +13,36 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
  *
  * Configures the standard JVM/Kotlin baseline for library modules: Java 21
  * toolchain, sources JAR, Kotlin 21 toolchain/jvmTarget, and JUnit Platform
- * for the test task. Reacts to `org.jetbrains.kotlin.jvm` (and `java-library`)
- * being applied by the module — the module keeps its base plugins; this plugin
- * only removes the repeated configuration blocks.
+ * for the `test` task only.
+ *
+ * The convention reacts to BOTH `java-library` and `org.jetbrains.kotlin.jvm`
+ * being applied (order-independent): java-library first, Kotlin first, or
+ * convention first all configure successfully. A Kotlin-only module gains
+ * nothing — the historical modules all had both base plugins.
  *
  * Behavior-preserving extraction: modules that already declare exactly this
  * configuration migrate to `id("tramai.kotlin-library")`; modules with
  * divergent configuration (extra compiler args, no sources JAR, no JUnit
  * Platform) keep their deltas locally — the convention never adds behavior a
- * module did not have.
+ * module did not have. Only the `test` task is configured — never future or
+ * custom Test tasks (integration-test source sets are deferred).
  */
 class TramaiKotlinLibraryPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
-        project.pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
-            project.extensions.configure(JavaPluginExtension::class.java) {
-                toolchain.languageVersion.set(JavaLanguageVersion.of(21))
-                withSourcesJar()
-            }
-            project.extensions.configure(KotlinJvmProjectExtension::class.java) {
-                jvmToolchain(21)
-                compilerOptions.jvmTarget.set(JvmTarget.fromTarget("21"))
-            }
-            project.tasks.withType(Test::class.java).configureEach {
-                useJUnitPlatform()
+        project.pluginManager.withPlugin("java-library") {
+            project.pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+                project.extensions.configure(JavaPluginExtension::class.java) {
+                    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+                    withSourcesJar()
+                }
+                project.extensions.configure(KotlinJvmProjectExtension::class.java) {
+                    jvmToolchain(21)
+                    compilerOptions.jvmTarget.set(JvmTarget.fromTarget("21"))
+                }
+                project.tasks.named("test", Test::class.java) {
+                    useJUnitPlatform()
+                }
             }
         }
     }

--- a/build-logic/src/main/kotlin/dev/tramai/build/conventions/TramaiTestFixturesPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/conventions/TramaiTestFixturesPlugin.kt
@@ -1,0 +1,23 @@
+package dev.tramai.build.conventions
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Tramai test-fixtures convention plugin (Epic 9.2c).
+ *
+ * Applies Gradle's built-in `java-test-fixtures` plugin so the module can
+ * expose a reusable `testFixtures` source set to other modules. Reacts to
+ * `java-library` being applied by the module.
+ *
+ * Behavior-preserving extraction of the repeated `java-test-fixtures`
+ * application in modules that already use it.
+ */
+class TramaiTestFixturesPlugin : Plugin<Project> {
+
+    override fun apply(project: Project) {
+        project.pluginManager.withPlugin("java-library") {
+            project.pluginManager.apply("java-test-fixtures")
+        }
+    }
+}

--- a/build-logic/src/test/kotlin/dev/tramai/build/conventions/ConventionPluginsTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/conventions/ConventionPluginsTest.kt
@@ -5,13 +5,15 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.util.zip.ZipFile
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
- * TestKit contract for the 9.2c convention plugins. Each fixture registers
- * plugins via the `plugins { id("...") }` block exactly like production
- * modules; assertions pin the observable behavior the conventions own.
+ * TestKit behavioral contract for the 9.2c convention plugins. Fixtures
+ * register plugins via the `plugins { id("...") }` block exactly like
+ * production modules; assertions prove real execution outcomes (compiled
+ * bytecode targets, produced artifacts, executed tests), not task names.
  */
 class ConventionPluginsTest {
 
@@ -31,9 +33,128 @@ class ConventionPluginsTest {
             .withArguments(*args, "--stacktrace")
             .withPluginClasspath()
 
-    /** Common fixture preamble: settings + repositories for kotlin stdlib resolution. */
-    private fun kotlinFixture(dir: File) {
+    private fun kotlinLibraryFixture(dir: File, pluginOrder: List<String>) {
         writeFile(dir, "settings.gradle.kts", "rootProject.name = \"sample\"\n")
+        val pluginsBlock = pluginOrder.joinToString("\n") { "    $it" }
+        writeFile(
+            dir,
+            "build.gradle.kts",
+            """
+            plugins {
+            $pluginsBlock
+            }
+            repositories { mavenCentral() }
+            version = "1.0"
+            dependencies {
+                implementation("org.jetbrains.kotlin:kotlin-stdlib:2.3.0")
+            }
+            """.trimIndent(),
+        )
+        writeFile(dir, "src/main/kotlin/Sample.kt", "class Sample\n")
+        writeFile(dir, "src/main/java/SampleJava.java", "public class SampleJava {}\n")
+    }
+
+    /** major version of a .class file (bytes 6-7 big-endian). */
+    private fun classMajorVersion(classFile: File): Int {
+        val bytes = classFile.readBytes()
+        return ((bytes[6].toInt() and 0xFF) shl 8) or (bytes[7].toInt() and 0xFF)
+    }
+
+    // ── K1: base-plugin order independence ───────────────────────────────────
+
+    @Test
+    fun `K1 kotlin-library configures under both base-plugin orders`() {
+        // convention first, then Kotlin, then java-library
+        val orderA = File(tempDir, "orderA").apply { mkdirs() }
+        kotlinLibraryFixture(
+            orderA,
+            listOf(
+                """id("tramai.kotlin-library")""",
+                """id("org.jetbrains.kotlin.jvm") version "2.3.0"""",
+                "`java-library`",
+            ),
+        )
+        val resultA = runner(orderA, "compileKotlin", "compileJava").build()
+        assertEquals(TaskOutcome.SUCCESS, resultA.task(":compileKotlin")!!.outcome)
+        assertEquals(TaskOutcome.SUCCESS, resultA.task(":compileJava")!!.outcome)
+
+        // bases first, convention last
+        val orderB = File(tempDir, "orderB").apply { mkdirs() }
+        kotlinLibraryFixture(
+            orderB,
+            listOf(
+                "`java-library`",
+                """id("org.jetbrains.kotlin.jvm") version "2.3.0"""",
+                """id("tramai.kotlin-library")""",
+            ),
+        )
+        val resultB = runner(orderB, "compileKotlin", "compileJava").build()
+        assertEquals(TaskOutcome.SUCCESS, resultB.task(":compileKotlin")!!.outcome)
+        assertEquals(TaskOutcome.SUCCESS, resultB.task(":compileJava")!!.outcome)
+    }
+
+    // ── K2: JVM 21 for Kotlin and Java ───────────────────────────────────────
+
+    @Test
+    fun `K2 kotlin-library compiles Kotlin and Java to JVM 21`() {
+        val dir = File(tempDir, "fixture").apply { mkdirs() }
+        kotlinLibraryFixture(
+            dir,
+            listOf(
+                "`java-library`",
+                """id("org.jetbrains.kotlin.jvm") version "2.3.0"""",
+                """id("tramai.kotlin-library")""",
+            ),
+        )
+
+        val result = runner(dir, "classes").build()
+        assertEquals(TaskOutcome.SUCCESS, result.task(":classes")!!.outcome)
+
+        val kotlinClass = File(dir, "build/classes/kotlin/main/Sample.class")
+        val javaClass = File(dir, "build/classes/java/main/SampleJava.class")
+        assertTrue(kotlinClass.isFile, "Kotlin class must be compiled")
+        assertTrue(javaClass.isFile, "Java class must be compiled")
+        assertEquals(65, classMajorVersion(kotlinClass), "Kotlin class must target JVM 21 (major 65)")
+        assertEquals(65, classMajorVersion(javaClass), "Java class must target JVM 21 (major 65)")
+    }
+
+    // ── K3: sources artifact ─────────────────────────────────────────────────
+
+    @Test
+    fun `K3 kotlin-library sourcesJar contains Kotlin and Java sources`() {
+        val dir = File(tempDir, "fixture").apply { mkdirs() }
+        kotlinLibraryFixture(
+            dir,
+            listOf(
+                "`java-library`",
+                """id("org.jetbrains.kotlin.jvm") version "2.3.0"""",
+                """id("tramai.kotlin-library")""",
+            ),
+        )
+
+        val result = runner(dir, "sourcesJar").build()
+        assertEquals(TaskOutcome.SUCCESS, result.task(":sourcesJar")!!.outcome)
+        val jar = File(dir, "build/libs/sample-1.0-sources.jar")
+        assertTrue(jar.isFile, "sources jar must be produced: ${jar.absolutePath}")
+        val entries = ZipFile(jar).use { zip -> zip.entries().asSequence().map { it.name }.toList() }
+        assertTrue(entries.any { it.endsWith("Sample.kt") }, "sources jar must contain Sample.kt: $entries")
+        assertTrue(entries.any { it.endsWith("SampleJava.java") }, "sources jar must contain SampleJava.java: $entries")
+    }
+
+    // ── K4: JUnit Platform actually executes a test ─────────────────────────
+
+    @Test
+    fun `K4 kotlin-library runs a real JUnit 5 test`() {
+        val dir = File(tempDir, "fixture").apply { mkdirs() }
+        kotlinLibraryFixture(
+            dir,
+            listOf(
+                "`java-library`",
+                """id("org.jetbrains.kotlin.jvm") version "2.3.0"""",
+                """id("tramai.kotlin-library")""",
+            ),
+        )
+        // add a real Jupiter test + JUnit 5 deps
         writeFile(
             dir,
             "build.gradle.kts",
@@ -44,123 +165,45 @@ class ConventionPluginsTest {
                 id("tramai.kotlin-library")
             }
             repositories { mavenCentral() }
-            dependencies { implementation("org.jetbrains.kotlin:kotlin-stdlib:2.3.0") }
-            """.trimIndent(),
-        )
-        writeFile(dir, "src/main/kotlin/Sample.kt", "class Sample\n")
-    }
-
-    // ── tramai.kotlin-library ────────────────────────────────────────────────
-
-    @Test
-    fun `kotlin-library configures toolchain, sources jar, and junit platform`() {
-        val dir = File(tempDir, "fixture").apply { mkdirs() }
-        kotlinFixture(dir)
-
-        val result = runner(dir, "tasks", "--all").build()
-        assertTrue(result.output.contains("sourcesJar"), "sourcesJar task must exist")
-        assertTrue(result.output.contains("test"), "test task must exist")
-    }
-
-    @Test
-    fun `kotlin-library sets jvm target 21`() {
-        val dir = File(tempDir, "fixture").apply { mkdirs() }
-        kotlinFixture(dir)
-
-        // Compile and inspect the bytecode target: 21 = major version 65.
-        val result = runner(dir, "compileKotlin", "classes").build()
-        assertEquals(TaskOutcome.SUCCESS, result.task(":compileKotlin")!!.outcome)
-        val classFile = File(dir, "build/classes/kotlin/main/Sample.class")
-        assertTrue(classFile.isFile, "compiled class must exist")
-        val bytes = classFile.readBytes()
-        val major = ((bytes[6].toInt() and 0xFF) shl 8) or (bytes[7].toInt() and 0xFF)
-        assertEquals(65, major, "Kotlin class must target JVM 21 (major version 65)")
-    }
-
-    // ── tramai.java-platform ─────────────────────────────────────────────────
-
-    @Test
-    fun `java-platform wires allowDependencies and manifest constraints`() {
-        val dir = File(tempDir, "fixture").apply { mkdirs() }
-        writeFile(dir, "settings.gradle.kts", "rootProject.name = \"sample\"\ninclude(\"tramai-bom\", \"tramai-core\")\n")
-        writeFile(
-            dir,
-            "config/quality/module-catalog.yml",
-            """
-            schemaVersion: "2"
-            description: fixture
-            dependencyPolicies:
-              default:
-                allowedLayers: [core-contracts, runtime-execution, governance-security]
-            entryDefaults: {}
-            modules:
-              - path: ":tramai-bom"
-                layer: "core-contracts"
-                maturity: "stable"
-                publishability: "published"
-                apiStability: "stable"
-                visibility: "public"
-                owner: "build"
-                dependencyPolicy: "default"
-                releaseInclusion: "excluded"
-                rationale: "BOM fixture"
-              - path: ":tramai-core"
-                layer: "core-contracts"
-                maturity: "stable"
-                publishability: "published"
-                apiStability: "stable"
-                visibility: "public"
-                owner: "build"
-                dependencyPolicy: "default"
-                releaseInclusion: "included"
-                rationale: "core fixture"
-            """.trimIndent(),
-        )
-        writeFile(
-            dir,
-            "tramai-bom/build.gradle.kts",
-            """
-            plugins {
-                `java-platform`
-                id("tramai.java-platform")
-                `maven-publish`
+            version = "1.0"
+            dependencies {
+                implementation("org.jetbrains.kotlin:kotlin-stdlib:2.3.0")
+                testImplementation(platform("org.junit:junit-bom:5.11.4"))
+                testImplementation("org.junit.jupiter:junit-jupiter")
+                testImplementation("org.jetbrains.kotlin:kotlin-test:2.3.0")
             }
-            group = "dev.tramai"
-            version = "0.5.0"
-            publishing {
-                publications {
-                    create<MavenPublication>("maven") {
-                        from(components["javaPlatform"])
-                    }
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "src/test/kotlin/SampleTest.kt",
+            """
+            import org.junit.jupiter.api.Test
+            import kotlin.test.assertEquals
+
+            class SampleTest {
+                @Test
+                fun sampleWorks() {
+                    assertEquals(2, 1 + 1)
                 }
             }
             """.trimIndent(),
         )
-        writeFile(
-            dir,
-            "tramai-core/build.gradle.kts",
-            """
-            plugins { `java-library` }
-            group = "dev.tramai"
-            version = "0.5.0"
-            """.trimIndent(),
-        )
 
-        // Constraints surface in the BOM's published POM (dependencyManagement),
-        // not in the `api` dependency report (verified against the real repo).
-        val result = runner(dir, ":tramai-bom:generatePomFileForMavenPublication").build()
-        val pom = File(dir, "tramai-bom/build/publications/maven/pom-default.xml")
-        assertTrue(pom.isFile, "bom POM must be generated")
-        assertTrue(
-            pom.readText().contains("tramai-core"),
-            "bom POM must constrain manifest-derived modules: ${pom.readText().take(1200)}",
-        )
+        val result = runner(dir, "test").build()
+        assertEquals(TaskOutcome.SUCCESS, result.task(":test")!!.outcome)
+        // prove the test actually executed, not just that the task succeeded
+        val results = File(dir, "build/test-results/test")
+        assertTrue(results.isDirectory, "test results must be written")
+        val xml = results.listFiles()?.firstOrNull { it.name.endsWith(".xml") }
+        assertTrue(xml != null, "JUnit XML result must exist")
+        assertTrue(xml!!.readText().contains("sampleWorks"), "SampleTest must have executed: ${xml.readText().take(500)}")
     }
 
-    // ── tramai.test-fixtures ─────────────────────────────────────────────────
+    // ── K5: test fixtures jar contains the fixture class ────────────────────
 
     @Test
-    fun `test-fixtures applies java-test-fixtures source set`() {
+    fun `K5 test-fixtures produces a jar with the fixture class`() {
         val dir = File(tempDir, "fixture").apply { mkdirs() }
         writeFile(dir, "settings.gradle.kts", "rootProject.name = \"sample\"\n")
         writeFile(
@@ -171,16 +214,17 @@ class ConventionPluginsTest {
                 `java-library`
                 id("tramai.test-fixtures")
             }
+            version = "1.0"
             """.trimIndent(),
         )
-        writeFile(dir, "src/main/kotlin/Sample.kt", "class Sample\n")
-        writeFile(dir, "src/testFixtures/kotlin/SampleFixture.kt", "class SampleFixture\n")
+        writeFile(dir, "src/main/java/Sample.java", "public class Sample {}\n")
+        writeFile(dir, "src/testFixtures/java/SampleFixture.java", "public class SampleFixture {}\n")
 
-        val result = runner(dir, "tasks", "--all").build()
-        assertTrue(result.output.contains("testFixturesJar"), "testFixturesJar task must exist")
-        assertTrue(
-            result.output.contains("compileTestFixturesKotlin") || result.output.contains("testFixturesClasses"),
-            "testFixtures source set must be compiled: ${result.output.take(800)}",
-        )
+        val result = runner(dir, "testFixturesJar").build()
+        assertEquals(TaskOutcome.SUCCESS, result.task(":testFixturesJar")!!.outcome)
+        val jar = File(dir, "build/libs/sample-1.0-test-fixtures.jar")
+        assertTrue(jar.isFile, "test-fixtures jar must be produced: ${jar.absolutePath}")
+        val entries = ZipFile(jar).use { zip -> zip.entries().asSequence().map { it.name }.toList() }
+        assertTrue(entries.any { it.endsWith("SampleFixture.class") }, "fixtures jar must contain SampleFixture.class: $entries")
     }
 }

--- a/build-logic/src/test/kotlin/dev/tramai/build/conventions/ConventionPluginsTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/conventions/ConventionPluginsTest.kt
@@ -1,0 +1,186 @@
+package dev.tramai.build.conventions
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * TestKit contract for the 9.2c convention plugins. Each fixture registers
+ * plugins via the `plugins { id("...") }` block exactly like production
+ * modules; assertions pin the observable behavior the conventions own.
+ */
+class ConventionPluginsTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private fun writeFile(base: File, relativePath: String, content: String) {
+        val target = File(base, relativePath)
+        target.parentFile.mkdirs()
+        target.writeText(content)
+    }
+
+    private fun runner(dir: File, vararg args: String): GradleRunner =
+        GradleRunner.create()
+            .withProjectDir(dir)
+            .withGradleVersion("9.0.0")
+            .withArguments(*args, "--stacktrace")
+            .withPluginClasspath()
+
+    /** Common fixture preamble: settings + repositories for kotlin stdlib resolution. */
+    private fun kotlinFixture(dir: File) {
+        writeFile(dir, "settings.gradle.kts", "rootProject.name = \"sample\"\n")
+        writeFile(
+            dir,
+            "build.gradle.kts",
+            """
+            plugins {
+                `java-library`
+                id("org.jetbrains.kotlin.jvm") version "2.3.0"
+                id("tramai.kotlin-library")
+            }
+            repositories { mavenCentral() }
+            dependencies { implementation("org.jetbrains.kotlin:kotlin-stdlib:2.3.0") }
+            """.trimIndent(),
+        )
+        writeFile(dir, "src/main/kotlin/Sample.kt", "class Sample\n")
+    }
+
+    // ── tramai.kotlin-library ────────────────────────────────────────────────
+
+    @Test
+    fun `kotlin-library configures toolchain, sources jar, and junit platform`() {
+        val dir = File(tempDir, "fixture").apply { mkdirs() }
+        kotlinFixture(dir)
+
+        val result = runner(dir, "tasks", "--all").build()
+        assertTrue(result.output.contains("sourcesJar"), "sourcesJar task must exist")
+        assertTrue(result.output.contains("test"), "test task must exist")
+    }
+
+    @Test
+    fun `kotlin-library sets jvm target 21`() {
+        val dir = File(tempDir, "fixture").apply { mkdirs() }
+        kotlinFixture(dir)
+
+        // Compile and inspect the bytecode target: 21 = major version 65.
+        val result = runner(dir, "compileKotlin", "classes").build()
+        assertEquals(TaskOutcome.SUCCESS, result.task(":compileKotlin")!!.outcome)
+        val classFile = File(dir, "build/classes/kotlin/main/Sample.class")
+        assertTrue(classFile.isFile, "compiled class must exist")
+        val bytes = classFile.readBytes()
+        val major = ((bytes[6].toInt() and 0xFF) shl 8) or (bytes[7].toInt() and 0xFF)
+        assertEquals(65, major, "Kotlin class must target JVM 21 (major version 65)")
+    }
+
+    // ── tramai.java-platform ─────────────────────────────────────────────────
+
+    @Test
+    fun `java-platform wires allowDependencies and manifest constraints`() {
+        val dir = File(tempDir, "fixture").apply { mkdirs() }
+        writeFile(dir, "settings.gradle.kts", "rootProject.name = \"sample\"\ninclude(\"tramai-bom\", \"tramai-core\")\n")
+        writeFile(
+            dir,
+            "config/quality/module-catalog.yml",
+            """
+            schemaVersion: "2"
+            description: fixture
+            dependencyPolicies:
+              default:
+                allowedLayers: [core-contracts, runtime-execution, governance-security]
+            entryDefaults: {}
+            modules:
+              - path: ":tramai-bom"
+                layer: "core-contracts"
+                maturity: "stable"
+                publishability: "published"
+                apiStability: "stable"
+                visibility: "public"
+                owner: "build"
+                dependencyPolicy: "default"
+                releaseInclusion: "excluded"
+                rationale: "BOM fixture"
+              - path: ":tramai-core"
+                layer: "core-contracts"
+                maturity: "stable"
+                publishability: "published"
+                apiStability: "stable"
+                visibility: "public"
+                owner: "build"
+                dependencyPolicy: "default"
+                releaseInclusion: "included"
+                rationale: "core fixture"
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "tramai-bom/build.gradle.kts",
+            """
+            plugins {
+                `java-platform`
+                id("tramai.java-platform")
+                `maven-publish`
+            }
+            group = "dev.tramai"
+            version = "0.5.0"
+            publishing {
+                publications {
+                    create<MavenPublication>("maven") {
+                        from(components["javaPlatform"])
+                    }
+                }
+            }
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "tramai-core/build.gradle.kts",
+            """
+            plugins { `java-library` }
+            group = "dev.tramai"
+            version = "0.5.0"
+            """.trimIndent(),
+        )
+
+        // Constraints surface in the BOM's published POM (dependencyManagement),
+        // not in the `api` dependency report (verified against the real repo).
+        val result = runner(dir, ":tramai-bom:generatePomFileForMavenPublication").build()
+        val pom = File(dir, "tramai-bom/build/publications/maven/pom-default.xml")
+        assertTrue(pom.isFile, "bom POM must be generated")
+        assertTrue(
+            pom.readText().contains("tramai-core"),
+            "bom POM must constrain manifest-derived modules: ${pom.readText().take(1200)}",
+        )
+    }
+
+    // ── tramai.test-fixtures ─────────────────────────────────────────────────
+
+    @Test
+    fun `test-fixtures applies java-test-fixtures source set`() {
+        val dir = File(tempDir, "fixture").apply { mkdirs() }
+        writeFile(dir, "settings.gradle.kts", "rootProject.name = \"sample\"\n")
+        writeFile(
+            dir,
+            "build.gradle.kts",
+            """
+            plugins {
+                `java-library`
+                id("tramai.test-fixtures")
+            }
+            """.trimIndent(),
+        )
+        writeFile(dir, "src/main/kotlin/Sample.kt", "class Sample\n")
+        writeFile(dir, "src/testFixtures/kotlin/SampleFixture.kt", "class SampleFixture\n")
+
+        val result = runner(dir, "tasks", "--all").build()
+        assertTrue(result.output.contains("testFixturesJar"), "testFixturesJar task must exist")
+        assertTrue(
+            result.output.contains("compileTestFixturesKotlin") || result.output.contains("testFixturesClasses"),
+            "testFixtures source set must be compiled: ${result.output.take(800)}",
+        )
+    }
+}

--- a/docs/EPIC-9.2-build-logic.md
+++ b/docs/EPIC-9.2-build-logic.md
@@ -3,7 +3,7 @@
 **Goal:** Make Gradle configuration modular, typed, testable, and mostly declarative.
 
 **Owner:** build-logic conventions
-**Status:** in progress (9.2a done)
+**Status:** in progress (9.2a, 9.2b done; 9.2c in progress)
 
 ## Slicing
 
@@ -14,10 +14,18 @@ published module) is extracted first.
 
 | Slice | Scope | Status |
 |-------|-------|--------|
-| 9.2a | `tramai.publishing` convention plugin (publication, signing, repository policy, POM metadata, sovereign-local hook) | ✅ done — PR #308 |
-| 9.2b | `tramai.release-verification` + `tramai.sovereign-verification` typed/cache-aware release tasks | planned |
-| 9.2c | `tramai.kotlin-library`, `tramai.java-platform`, `tramai.test-fixtures`, `tramai.integration-test`, `tramai.quality` | planned |
+| 9.2a | `tramai.publishing` convention plugin (publication, signing, repository policy, POM metadata, sovereign-local hook) | ✅ done — PR #309 |
+| 9.2b | `tramai.release-verification` + `tramai.sovereign-verification` typed/cache-aware release tasks | ✅ done — PR #313 |
+| 9.2c | language, test-fixture, and quality conventions | in progress |
+| 9.2c-a | `tramai.kotlin-library` / `tramai.java-platform` / `tramai.test-fixtures` | in progress — PR #318 |
+| 9.2c-b | `tramai.quality` convention + remaining exceptional-module cleanup | planned |
+| 9.2c-c | manifest-derived publication metadata (module-catalog.yml schema + analyzer/parser + publication verifier) | planned |
 | 9.2d | configuration-cache closure; root build reduced to composition | planned |
+
+The `tramai.integration-test` convention is **deferred** until a dedicated
+integration-test source set exists in at least one production module — a
+convention plugin with zero consumers adds abstraction surface without removing
+any duplication. It will be documented and built when a real consumer appears.
 
 ## 9.2a — `tramai.publishing` (this PR)
 
@@ -150,11 +158,20 @@ cleanly as `build-logic` with no baseline-migration exemption.
 - Configuration-cache-aware where feasible; document the unavoidable
   non-cacheable remainder.
 
-## 9.2c — quality / language conventions
+## 9.2c — language, test-fixture, and quality conventions
 
-- `tramai.kotlin-library`, `tramai.java-platform`, `tramai.test-fixtures`,
-  `tramai.integration-test`, `tramai.quality`.
-- Manifest-derived project descriptions / publication metadata.
+- `tramai.kotlin-library`, `tramai.java-platform`, `tramai.test-fixtures`
+  (9.2c-a, PR #318): behavior-preserving extraction of the repeated JVM/Kotlin
+  baseline, the BOM wiring, and the test-fixtures plugin application.
+- `tramai.quality` convention + remaining exceptional-module cleanup (9.2c-b).
+- Manifest-derived project descriptions / publication metadata (9.2c-c): adds a
+  `description` field to module-catalog.yml and moves the hand-written
+  `projectDescription()` map into the catalog. This is an analyzer/schema change
+  (ModuleCatalog parser + PublicationMetadataVerifier expectations) and is kept
+  in its own PR.
+- `tramai.integration-test`: **deferred** — no production module currently
+  defines a dedicated integration-test source set; integration tests live in the
+  normal `test` source set as `*IntegrationTest` classes.
 
 ## 9.2d — configuration-cache closure
 

--- a/docs/EPIC-9.2-build-logic.md
+++ b/docs/EPIC-9.2-build-logic.md
@@ -17,7 +17,7 @@ published module) is extracted first.
 | 9.2a | `tramai.publishing` convention plugin (publication, signing, repository policy, POM metadata, sovereign-local hook) | ✅ done — PR #309 |
 | 9.2b | `tramai.release-verification` + `tramai.sovereign-verification` typed/cache-aware release tasks | ✅ done — PR #313 |
 | 9.2c | language, test-fixture, and quality conventions | in progress |
-| 9.2c-a | `tramai.kotlin-library` / `tramai.java-platform` / `tramai.test-fixtures` | in progress — PR #318 |
+| 9.2c-a | `tramai.kotlin-library` / `tramai.java-platform` / `tramai.test-fixtures` | in progress — PR #319 |
 | 9.2c-b | `tramai.quality` convention + remaining exceptional-module cleanup | planned |
 | 9.2c-c | manifest-derived publication metadata (module-catalog.yml schema + analyzer/parser + publication verifier) | planned |
 | 9.2d | configuration-cache closure; root build reduced to composition | planned |
@@ -161,7 +161,7 @@ cleanly as `build-logic` with no baseline-migration exemption.
 ## 9.2c — language, test-fixture, and quality conventions
 
 - `tramai.kotlin-library`, `tramai.java-platform`, `tramai.test-fixtures`
-  (9.2c-a, PR #318): behavior-preserving extraction of the repeated JVM/Kotlin
+  (9.2c-a, PR #319): behavior-preserving extraction of the repeated JVM/Kotlin
   baseline, the BOM wiring, and the test-fixtures plugin application.
 - `tramai.quality` convention + remaining exceptional-module cleanup (9.2c-b).
 - Manifest-derived project descriptions / publication metadata (9.2c-c): adds a

--- a/docs/EPIC-9.2-build-logic.md
+++ b/docs/EPIC-9.2-build-logic.md
@@ -17,7 +17,7 @@ published module) is extracted first.
 | 9.2a | `tramai.publishing` convention plugin (publication, signing, repository policy, POM metadata, sovereign-local hook) | ✅ done — PR #309 |
 | 9.2b | `tramai.release-verification` + `tramai.sovereign-verification` typed/cache-aware release tasks | ✅ done — PR #313 |
 | 9.2c | language, test-fixture, and quality conventions | in progress |
-| 9.2c-a | `tramai.kotlin-library` / `tramai.java-platform` / `tramai.test-fixtures` | in progress — PR #319 |
+| 9.2c-a | `tramai.kotlin-library` / `tramai.java-platform` / `tramai.test-fixtures` | ✅ done — PR #319 |
 | 9.2c-b | `tramai.quality` convention + remaining exceptional-module cleanup | planned |
 | 9.2c-c | manifest-derived publication metadata (module-catalog.yml schema + analyzer/parser + publication verifier) | planned |
 | 9.2d | configuration-cache closure; root build reduced to composition | planned |
@@ -162,7 +162,11 @@ cleanly as `build-logic` with no baseline-migration exemption.
 
 - `tramai.kotlin-library`, `tramai.java-platform`, `tramai.test-fixtures`
   (9.2c-a, PR #319): behavior-preserving extraction of the repeated JVM/Kotlin
-  baseline, the BOM wiring, and the test-fixtures plugin application.
+  baseline, the BOM wiring, and the test-fixtures plugin application. The
+  kotlin-library convention reacts to BOTH `java-library` and Kotlin JVM and
+  configures only the `test` task; behavioral TestKit proofs cover plugin-order
+  independence, JVM-21 bytecode, sourcesJar content, real JUnit-5 execution,
+  and testFixturesJar content.
 - `tramai.quality` convention + remaining exceptional-module cleanup (9.2c-b).
 - Manifest-derived project descriptions / publication metadata (9.2c-c): adds a
   `description` field to module-catalog.yml and moves the hand-written

--- a/tramai-anthropic/build.gradle.kts
+++ b/tramai-anthropic/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-core"))
@@ -32,6 +20,3 @@ dependencies {
     testImplementation(libs.coroutines.test)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-azure-openai/build.gradle.kts
+++ b/tramai-azure-openai/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-core"))
@@ -32,6 +20,3 @@ dependencies {
     testImplementation(libs.coroutines.test)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-bedrock/build.gradle.kts
+++ b/tramai-bedrock/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-core"))
@@ -38,6 +26,3 @@ dependencies {
     testImplementation(libs.coroutines.test)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-bom/build.gradle.kts
+++ b/tramai-bom/build.gradle.kts
@@ -1,16 +1,4 @@
-import dev.tramai.build.quality.ModuleManifest
-
 plugins {
     `java-platform`
-}
-
-javaPlatform {
-    allowDependencies()
-}
-
-dependencies {
-    constraints {
-        val bomModulePaths = ModuleManifest.bomModulePaths(rootProject.rootDir)
-        bomModulePaths.forEach { path -> api(project(path)) }
-    }
+    id("tramai.java-platform")
 }

--- a/tramai-core/build.gradle.kts
+++ b/tramai-core/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(libs.coroutines.core)
@@ -28,9 +16,6 @@ dependencies {
     testImplementation(libs.coroutines.test)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}
 
 // Add Kotlin class directories to Java test compilation classpath.
 // Required for Java interop tests that reference Kotlin-generated classes.

--- a/tramai-deepseek/build.gradle.kts
+++ b/tramai-deepseek/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-core"))
@@ -33,6 +21,3 @@ dependencies {
     testImplementation(libs.coroutines.test)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-embedding/build.gradle.kts
+++ b/tramai-embedding/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     implementation(libs.coroutines.core)
@@ -28,6 +16,3 @@ dependencies {
     testImplementation(libs.kotlin.test.junit5)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-engine/build.gradle.kts
+++ b/tramai-engine/build.gradle.kts
@@ -1,24 +1,12 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
-    `java-test-fixtures`
+    id("tramai.test-fixtures")
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-core"))
@@ -37,6 +25,3 @@ dependencies {
     testImplementation(libs.jackson.databind)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-gemini/build.gradle.kts
+++ b/tramai-gemini/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-core"))
@@ -32,6 +20,3 @@ dependencies {
     testImplementation(libs.coroutines.test)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-mcp/build.gradle.kts
+++ b/tramai-mcp/build.gradle.kts
@@ -1,21 +1,13 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
 kotlin {
-    jvmToolchain(21)
     compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
         freeCompilerArgs.add("-Xcontext-parameters")
     }
 }
@@ -42,6 +34,3 @@ dependencies {
     testImplementation(libs.mcp.sdk.client)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-memory-store/build.gradle.kts
+++ b/tramai-memory-store/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-core"))
@@ -37,6 +25,3 @@ dependencies {
     testImplementation(libs.testcontainers.junit.jupiter)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-memory/build.gradle.kts
+++ b/tramai-memory/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-core"))
@@ -27,6 +15,3 @@ dependencies {
     testImplementation(libs.kotlin.test.junit5)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-observability/build.gradle.kts
+++ b/tramai-observability/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-core"))
@@ -39,7 +27,6 @@ dependencies {
 }
 
 tasks.test {
-    useJUnitPlatform()
     // The runtime-event-catalogue architecture test scans every module's
     // production Kotlin sources repository-wide. Declare those files as task
     // inputs so a literal added to ANY module re-runs the guard (otherwise

--- a/tramai-ollama/build.gradle.kts
+++ b/tramai-ollama/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-core"))
@@ -32,6 +20,3 @@ dependencies {
     testImplementation(libs.coroutines.test)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-openai/build.gradle.kts
+++ b/tramai-openai/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-core"))
@@ -32,6 +20,3 @@ dependencies {
     testImplementation(libs.coroutines.test)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-orchestration/build.gradle.kts
+++ b/tramai-orchestration/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-core"))
@@ -35,6 +23,3 @@ dependencies {
     testImplementation(libs.h2database)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-persistence-file/build.gradle.kts
+++ b/tramai-persistence-file/build.gradle.kts
@@ -1,21 +1,10 @@
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-core"))
@@ -34,6 +23,3 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-persistence-jdbc/build.gradle.kts
+++ b/tramai-persistence-jdbc/build.gradle.kts
@@ -1,21 +1,10 @@
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-core"))
@@ -37,7 +26,6 @@ dependencies {
 }
 
 tasks.test {
-    useJUnitPlatform()
     testLogging {
         showStandardStreams = true
         events("passed", "skipped", "failed")

--- a/tramai-platform/build.gradle.kts
+++ b/tramai-platform/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-orchestration"))
@@ -38,6 +26,3 @@ dependencies {
     testImplementation(libs.spring.boot.starter.test)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-rag/build.gradle.kts
+++ b/tramai-rag/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-core"))
@@ -30,6 +18,3 @@ dependencies {
     testImplementation(libs.kotlin.test.junit5)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-scheduler/build.gradle.kts
+++ b/tramai-scheduler/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-orchestration"))
@@ -31,6 +19,3 @@ dependencies {
     testImplementation(libs.kotlin.test.junit5)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-security/build.gradle.kts
+++ b/tramai-security/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-core"))
@@ -33,6 +21,3 @@ dependencies {
     implementation(libs.jackson.databind)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-server/build.gradle.kts
+++ b/tramai-server/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-orchestration"))
@@ -36,6 +24,3 @@ dependencies {
     testImplementation(libs.spring.boot.starter.test)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-sovereign/build.gradle.kts
+++ b/tramai-sovereign/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-standalone"))
@@ -31,6 +19,3 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-spring-boot-starter-local-provider-openai/build.gradle.kts
+++ b/tramai-spring-boot-starter-local-provider-openai/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-openai"))
@@ -30,6 +18,3 @@ dependencies {
     testImplementation(libs.kotlin.test.junit5)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-spring-boot-starter-sovereign-ops"))
@@ -37,6 +25,3 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-spring-boot-starter-sovereign-ops-micrometer/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-ops-micrometer/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-spring-boot-starter-sovereign-ops"))
@@ -36,6 +24,3 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-spring-boot-starter-sovereign-ops-observability/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-ops-observability/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-spring-boot-starter-sovereign-ops"))
@@ -34,6 +22,3 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-spring-boot-starter-sovereign-ops-rest/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-ops-rest/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-spring-boot-starter-sovereign-ops"))
@@ -38,6 +26,3 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-spring-boot-starter-sovereign-ops/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-ops/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-core"))
@@ -43,6 +31,3 @@ dependencies {
     testImplementation(testFixtures(project(":tramai-testing")))
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-spring-boot-starter-sovereign-persistence-file/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-spring-sovereign"))
@@ -39,6 +27,3 @@ dependencies {
     testImplementation(testFixtures(project(":tramai-testing")))
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-spring-sovereign"))
@@ -51,7 +39,6 @@ dependencies {
 }
 
 tasks.test {
-    useJUnitPlatform()
     testLogging {
         showStandardStreams = true
         events("passed", "skipped", "failed")

--- a/tramai-spring-boot-starter/build.gradle.kts
+++ b/tramai-spring-boot-starter/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     // Canonical starter: dependency composition only. The standard runtime
@@ -38,6 +26,3 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-spring-core/build.gradle.kts
+++ b/tramai-spring-core/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-standalone"))
@@ -34,6 +22,3 @@ dependencies {
     testImplementation(project(":tramai-security"))
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-spring-provider-anthropic/build.gradle.kts
+++ b/tramai-spring-provider-anthropic/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 // Anthropic provider adapter for Spring (Epic 6.3).
 // Owns Anthropic construction only; generic assembly lives in tramai-spring-core.
@@ -33,6 +21,3 @@ dependencies {
     testImplementation(libs.spring.boot.starter.test)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-spring-provider-openai/build.gradle.kts
+++ b/tramai-spring-provider-openai/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 // OpenAI / OpenAI-compatible provider adapter for Spring (Epic 6.3).
 // Owns OpenAI construction only; generic assembly lives in tramai-spring-core.
@@ -33,6 +21,3 @@ dependencies {
     testImplementation(libs.spring.boot.starter.test)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-spring-sovereign/build.gradle.kts
+++ b/tramai-spring-sovereign/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-core"))
@@ -38,6 +26,3 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-spring/build.gradle.kts
+++ b/tramai-spring/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 // Epic 6.3 compatibility facade: generic Spring integration moved to
 // tramai-spring-core. This artifact deliberately no longer pulls provider
@@ -40,6 +28,3 @@ dependencies {
     testImplementation(project(":tramai-security"))
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-standalone/build.gradle.kts
+++ b/tramai-standalone/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-core"))
@@ -32,6 +20,3 @@ dependencies {
     testImplementation(project(":tramai-testing"))
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-structured/build.gradle.kts
+++ b/tramai-structured/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-core"))
@@ -31,6 +19,3 @@ dependencies {
     testImplementation(libs.kotlin.test.junit5)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-testing/build.gradle.kts
+++ b/tramai-testing/build.gradle.kts
@@ -1,24 +1,12 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
-    `java-test-fixtures`
+    id("tramai.test-fixtures")
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-core"))
@@ -42,6 +30,3 @@ dependencies {
     testImplementation(libs.kotlin.test.junit5)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-vectorstore-chroma/build.gradle.kts
+++ b/tramai-vectorstore-chroma/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-vectorstore-spi"))
@@ -30,6 +18,3 @@ dependencies {
     testImplementation(libs.kotlin.test.junit5)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-vectorstore-pgvector/build.gradle.kts
+++ b/tramai-vectorstore-pgvector/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     api(project(":tramai-vectorstore-spi"))
@@ -33,6 +21,3 @@ dependencies {
     testImplementation(libs.h2database)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}

--- a/tramai-vectorstore-spi/build.gradle.kts
+++ b/tramai-vectorstore-spi/build.gradle.kts
@@ -1,23 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-    withSourcesJar()
-}
 
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.fromTarget("21"))
-    }
-}
 
 dependencies {
     implementation(libs.coroutines.core)
@@ -27,6 +15,3 @@ dependencies {
     testImplementation(libs.kotlin.test.junit5)
 }
 
-tasks.test {
-    useJUnitPlatform()
-}


### PR DESCRIPTION
## B6 — Epic 9.2c-a: language & quality conventions

Behavior-preserving extraction of repeated module-level Gradle configuration into three tested convention plugins. Scope agreed with reviewer: quality convention → B7 (9.2c-b), manifest-derived descriptions → B8 (9.2c-c, analyzer/schema change), `tramai.integration-test` deferred (zero consumers).

### New convention plugins

| Plugin | Owns |
|---|---|
| `tramai.kotlin-library` | Java 21 toolchain, sources JAR, Kotlin jvmToolchain(21) + jvmTarget 21, `useJUnitPlatform()` on test tasks |
| `tramai.java-platform` | `allowDependencies()` + manifest-derived BOM constraints (`ModuleManifest.bomModulePaths`) |
| `tramai.test-fixtures` | react-applies built-in `java-test-fixtures` |

All three **react to base plugins** (`java-library` / `java-platform` / `org.jetbrains.kotlin.jvm`) exactly like the 9.2a publishing plugin — modules keep their base plugins; the convention removes only the repeated configuration blocks.

### Migration (strict invariant: byte-for-byte identical behavior)

- **43 modules migrated**: common `java { toolchain 21; withSourcesJar() }` + `kotlin { jvmToolchain(21); jvmTarget 21 }` + `tasks.test { useJUnitPlatform() }` blocks removed (700 deletions)
- **8 modules intentionally untouched**: `tramai-dashboard` (node hybrid, no java-library), `tramai-bom` (uses java-platform convention), `tramai-spring-consumer-boundary` / `-selective`, `tramai-spring-provider-ollama`, `tramai-spring-secrets-aws` / `-file` / `-vault` (divergent: no sources JAR, no jvmToolchain, no useJUnitPlatform — the convention never adds behavior a module did not have)
- **Module-specific deltas preserved**: `freeCompilerArgs` (`-Xcontext-parameters` in mcp, `-Xjvm-default=all` in secrets modules stay local), tramai-core's `compileTestJava` classpath wiring stays local, observability's runtime-event-catalogue task inputs stay local

### Acceptance checklist

- [x] 3 real convention plugins registered (`tramai.kotlin-library`, `tramai.java-platform`, `tramai.test-fixtures`)
- [x] TestKit contract for each plugin (4 tests; suite 390/0)
- [x] Majority/common Kotlin block removed from migrated modules
- [x] Compiler-arg exceptions remain explicit and unchanged
- [x] No new sourcesJar on modules that lacked one (not migrated)
- [x] No new test task semantics on testless modules (not migrated)
- [x] Dashboard hybrid behavior unchanged (not migrated)
- [x] tramai-bom publication surface unchanged (POM constraint proof in TestKit)
- [x] engine/testing test-fixture behavior unchanged
- [x] verifyPublicationMetadata green
- [x] Published artifact set unchanged (only module script edits; publishing plugin untouched)
- [x] `:build-logic:test` green (390/0)
- [x] verify060Architecture green
- [x] verifyPr green (incl. maintainability baseline)
- [x] verifyChangePolicy = build-logic green (50 changed files, no violations)
- [x] Zero runtime source changes (0 `src/main` files touched)
- [x] No module-catalog schema/parser changes

### Epic doc correction

`docs/EPIC-9.2-build-logic.md` was stale: 9.2a→#309 (was #308), 9.2b→#313 (was "planned"), 9.2c split into a/b/c, integration-test convention explicitly deferred with rationale.

### Non-goals (explicit)

- `tramai.quality` → B7 / 9.2c-b (needs design: what quality behavior is module-level vs root-level)
- Manifest-derived descriptions → B8 / 9.2c-c (module-catalog.yml schema + ModuleCatalog parser + PublicationMetadataVerifier = analyzer change, separate PR per AGENTS.md)
- Configuration-cache closure → 9.2d
