### PR TITLE
fix(worker): safe snapshot under concurrent shrinkage + deterministic stale-worker tests

### DIFF
--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowExecutionSupervisor.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowExecutionSupervisor.kt
@@ -59,7 +59,7 @@ internal class WorkflowExecutionSupervisor(
 
     fun activeExecutionCount(): Int = activeExecutions.size
 
-    fun activeExecutionsSnapshot(): List<ActiveExecution> = activeExecutions.values.map { it }
+    fun activeExecutionsSnapshot(): List<ActiveExecution> = stableConcurrentSnapshot(activeExecutions.values)
 
     fun latestFailure(workflowId: String): Throwable? = executionFailures[workflowId]
 
@@ -629,3 +629,14 @@ private suspend fun runCleanupPreservingCancellation(
         cancellation.addSuppressed(cleanupError)
     }
 }
+
+
+/**
+ * Snapshot iteration that is safe under concurrent growth/shrinkage of a
+ * thread-safe collection. Deliberately NOT [Collection.toList]: its singleton
+ * fast-path (`size == 1 -> iterator().next()`) can observe a size that the
+ * concurrent collection no longer satisfies, throwing NoSuchElementException.
+ * `map { it }` uses the standard hasNext()/next() progression and yields an
+ * empty list for an emptied collection.
+ */
+internal fun <T> stableConcurrentSnapshot(values: Collection<T>): List<T> = values.map { it }

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowExecutionSupervisor.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowExecutionSupervisor.kt
@@ -59,7 +59,7 @@ internal class WorkflowExecutionSupervisor(
 
     fun activeExecutionCount(): Int = activeExecutions.size
 
-    fun activeExecutionsSnapshot(): List<ActiveExecution> = activeExecutions.values.toList()
+    fun activeExecutionsSnapshot(): List<ActiveExecution> = activeExecutions.values.map { it }
 
     fun latestFailure(workflowId: String): Throwable? = executionFailures[workflowId]
 

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TramaiWorkerTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TramaiWorkerTest.kt
@@ -609,7 +609,7 @@ class TramaiWorkerTest {
     }
 
     @Test
-    fun `worker heartbeats are visible and stale workers are detectable`(): Unit = runBlocking {
+    fun `worker registration and heartbeats are visible`(): Unit = runBlocking {
         var now = 5_000L
         val leaseStore = InMemoryWorkflowLeaseStore(clockMillis = { now })
         val checkpointStore = InMemoryWorkflowCheckpointStore()
@@ -625,12 +625,39 @@ class TramaiWorkerTest {
             waitUntil {
                 leaseStore.listActiveWorkers().singleOrNull()?.workerId == "worker-0"
             }
-            now += 2_000
-            assertThat(leaseStore.listStaleWorkers(1_000).map { it.workerId })
-                .containsExactly("worker-0")
+            // The heartbeat loop must keep the registry row current: after the
+            // clock advances past the poll cadence, the row's last-heartbeat
+            // catches up to the new time (a live heartbeat updated it) and the
+            // worker is NOT stale. The waitUntil guarantees the refresh landed
+            // before the staleness assertion runs.
+            now += 500
+            waitUntil {
+                leaseStore.listActiveWorkers().single().lastHeartbeatEpochMillis == now
+            }
+            assertThat(leaseStore.listStaleWorkers(1_000)).isEmpty()
         } finally {
             worker.shutdown()
         }
+    }
+
+    @Test
+    fun `stale workers are detected from the registry clock without racing the heartbeat`(): Unit = runBlocking {
+        // Pure store semantics: no live worker/heartbeat involved. Register at
+        // T0, advance the fake wall clock past the threshold, assert stale at
+        // T1 — deterministic, no scheduling luck.
+        var now = 5_000L
+        val leaseStore = InMemoryWorkflowLeaseStore(clockMillis = { now })
+        leaseStore.registerWorker(
+            workerId = "worker-0",
+            poolName = "tests",
+            version = "dev",
+            capabilityLabels = emptySet(),
+            host = "host",
+        )
+        assertThat(leaseStore.listActiveWorkers().single().workerId).isEqualTo("worker-0")
+        now += 2_000
+        assertThat(leaseStore.listStaleWorkers(1_000).map { it.workerId })
+            .containsExactly("worker-0")
     }
 
     @Test

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TramaiWorkerTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/TramaiWorkerTest.kt
@@ -626,10 +626,10 @@ class TramaiWorkerTest {
                 leaseStore.listActiveWorkers().singleOrNull()?.workerId == "worker-0"
             }
             // The heartbeat loop must keep the registry row current: after the
-            // clock advances past the poll cadence, the row's last-heartbeat
-            // catches up to the new time (a live heartbeat updated it) and the
-            // worker is NOT stale. The waitUntil guarantees the refresh landed
-            // before the staleness assertion runs.
+            // clock advances to the next heartbeat cadence, the row's
+            // last-heartbeat catches up to the new time (a live heartbeat
+            // updated it) and the worker is NOT stale. The waitUntil
+            // guarantees the refresh landed before the staleness assertion.
             now += 500
             waitUntil {
                 leaseStore.listActiveWorkers().single().lastHeartbeatEpochMillis == now

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowExecutionSupervisorTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowExecutionSupervisorTest.kt
@@ -272,9 +272,9 @@ class WorkflowExecutionSupervisorTest {
     fun `snapshot iteration is safe when the map shrinks between size and iteration`() {
         // Models ConcurrentHashMap.values in the observed shutdown race: the
         // collection reports size == 1, then the map empties before the
-        // iterator advances. Collection.toList() singleton fast-path calls
-        // iterator().next() -> NoSuchElementException; snapshot via map { it }
-        // uses the hasNext()/next() progression -> empty list. No stress loop.
+        // iterator advances. Executes the SAME snapshot function production
+        // uses (stableConcurrentSnapshot), so a regression back to
+        // Collection.toList() in the snapshot path makes this RED.
         val shrinking = object : Collection<ActiveExecution> {
             override val size: Int get() = 1
             override fun isEmpty(): Boolean = false
@@ -284,7 +284,7 @@ class WorkflowExecutionSupervisorTest {
         }
         assertThatThrownBy { shrinking.toList() }
             .isInstanceOf(NoSuchElementException::class.java)
-        assertThat(shrinking.map { it }).isEmpty()
+        assertThat(stableConcurrentSnapshot(shrinking)).isEmpty()
     }
 
     private data class TestState(val value: String)

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowExecutionSupervisorTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkflowExecutionSupervisorTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -265,6 +266,25 @@ class WorkflowExecutionSupervisorTest {
         val attempt = runBlocking { store.listStepAttempts("w-1") }.single()
         assertThat(attempt.status).isEqualTo(StepAttemptStatus.FAILED)
         scope.cancel()
+    }
+
+    @Test
+    fun `snapshot iteration is safe when the map shrinks between size and iteration`() {
+        // Models ConcurrentHashMap.values in the observed shutdown race: the
+        // collection reports size == 1, then the map empties before the
+        // iterator advances. Collection.toList() singleton fast-path calls
+        // iterator().next() -> NoSuchElementException; snapshot via map { it }
+        // uses the hasNext()/next() progression -> empty list. No stress loop.
+        val shrinking = object : Collection<ActiveExecution> {
+            override val size: Int get() = 1
+            override fun isEmpty(): Boolean = false
+            override fun iterator(): Iterator<ActiveExecution> = emptyList<ActiveExecution>().iterator()
+            override fun contains(element: ActiveExecution): Boolean = false
+            override fun containsAll(elements: Collection<ActiveExecution>): Boolean = false
+        }
+        assertThatThrownBy { shrinking.toList() }
+            .isInstanceOf(NoSuchElementException::class.java)
+        assertThat(shrinking.map { it }).isEmpty()
     }
 
     private data class TestState(val value: String)


### PR DESCRIPTION
## Pre-existing worker-concurrency closure (independent of Epic 8.3a)

Both defects live in master and were exposed by #316 CI; neither is caused by
the 8.3a branch. Landing these first gives #316 a clean base to rebase onto.

### 1. `activeExecutionsSnapshot()` race (production)

`activeExecutions.values.toList()` over a `ConcurrentHashMap`. Kotlin's
`Collection.toList()` singleton fast-path (`size == 1 -> iterator().next()`)
can observe size 1, then the map empties, then `next()` throws
`NoSuchElementException`. CI stack: `ConcurrentHashMap$ValueIterator.next ->
CollectionsKt.toList -> activeExecutionsSnapshot ->
WorkerShutdownCoordinator.shutdown`.

Fix: `activeExecutions.values.map { it }` — standard `hasNext()/next()`
progression; an emptied map yields an empty list.

Deterministic test (no stress loop): a synthetic collection reporting
`size == 1` with an empty iterator proves `toList()` throws
`NoSuchElementException` while `map { it }` returns `[]` — the exact
size-vs-iteration inconsistency from the observed race.

### 2. Stale-worker test raced the live heartbeat (test defect)

The old test registered a worker (fake clock T=5000), advanced to T=7000,
and asserted stale — but the worker's live heartbeat loop can refresh the
row at T=7000 after the advance, making the stale list correctly empty
(observed in CI). Split into:

- **`worker registration and heartbeats are visible`** — integration: the
  heartbeat loop keeps `lastHeartbeatEpochMillis` current after the clock
  advances (bounded waitUntil), and the worker is not stale.
- **`stale workers are detected from the registry clock without racing the
  heartbeat`** — pure store semantics: register at T0, advance the fake
  clock, assert stale at T1. No worker, no heartbeat, deterministic.

### Evidence

- 2x full `:tramai-orchestration:test --rerun-tasks` green (previously this
  suite was the flake source)
- `apiCheck` green (no public ABI change)
- agy review: 0 P1 / 0 P2 / 1 P3 comment nit (adopted)
- No other `Collection.toList()` fast-path hazards in the orchestration
  module (verified: remaining sites are monitor-synchronized, List-backed,
  or single-threaded)
