### PR TITLE
build(conventions): tramai.testing — common test-dependency baseline — Epic 9.2c-b

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -76,5 +76,9 @@ gradlePlugin {
             id = "tramai.test-fixtures"
             implementationClass = "dev.tramai.build.conventions.TramaiTestFixturesPlugin"
         }
+        create("tramaiTesting") {
+            id = "tramai.testing"
+            implementationClass = "dev.tramai.build.conventions.TramaiTestingPlugin"
+        }
     }
 }

--- a/build-logic/src/main/kotlin/dev/tramai/build/conventions/TramaiTestingPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/conventions/TramaiTestingPlugin.kt
@@ -1,0 +1,37 @@
+package dev.tramai.build.conventions
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+
+/**
+ * Tramai testing convention plugin (Epic 9.2c-b).
+ *
+ * Adds the common test-dependency baseline — JUnit BOM (platform), AssertJ,
+ * and Kotlin test/JUnit5 — to the module's `testImplementation`
+ * configuration. Reacts to `java` being applied, and reads coordinates from
+ * the root build's version catalog (`gradle/libs.versions.toml`) instead of
+ * hard-coding them.
+ *
+ * Scope discipline (per B7 survey): owns exactly these three dependencies and
+ * nothing else — no testLogging, no compiler flags, no static analysis, no
+ * `junit-jupiter` (13 modules add that explicitly and keep it local), no
+ * production dependencies. Modules that do not have the exact trio (11
+ * partial, 4 none) do not apply this plugin.
+ */
+class TramaiTestingPlugin : Plugin<Project> {
+
+    override fun apply(project: Project) {
+        project.pluginManager.withPlugin("java") {
+            val libs = project.extensions.getByType(VersionCatalogsExtension::class.java)
+                .named("libs")
+            val junitBom = libs.findLibrary("junit-bom").get().get()
+            val assertj = libs.findLibrary("assertj-core").get().get()
+            val kotlinTestJunit5 = libs.findLibrary("kotlin-test-junit5").get().get()
+
+            project.dependencies.add("testImplementation", project.dependencies.platform(junitBom))
+            project.dependencies.add("testImplementation", assertj)
+            project.dependencies.add("testImplementation", kotlinTestJunit5)
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/dev/tramai/build/conventions/TramaiTestingPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/conventions/TramaiTestingPlugin.kt
@@ -1,5 +1,6 @@
 package dev.tramai.build.conventions
 
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension
@@ -25,13 +26,17 @@ class TramaiTestingPlugin : Plugin<Project> {
         project.pluginManager.withPlugin("java") {
             val libs = project.extensions.getByType(VersionCatalogsExtension::class.java)
                 .named("libs")
-            val junitBom = libs.findLibrary("junit-bom").get().get()
-            val assertj = libs.findLibrary("assertj-core").get().get()
-            val kotlinTestJunit5 = libs.findLibrary("kotlin-test-junit5").get().get()
 
-            project.dependencies.add("testImplementation", project.dependencies.platform(junitBom))
-            project.dependencies.add("testImplementation", assertj)
-            project.dependencies.add("testImplementation", kotlinTestJunit5)
+            fun catalogLibrary(alias: String) =
+                libs.findLibrary(alias).orElseThrow {
+                    GradleException(
+                        "tramai.testing requires version-catalog alias '$alias' in gradle/libs.versions.toml",
+                    )
+                }
+
+            project.dependencies.add("testImplementation", project.dependencies.platform(catalogLibrary("junit-bom")))
+            project.dependencies.add("testImplementation", catalogLibrary("assertj-core"))
+            project.dependencies.add("testImplementation", catalogLibrary("kotlin-test-junit5"))
         }
     }
 }

--- a/build-logic/src/test/kotlin/dev/tramai/build/conventions/TramaiTestingPluginTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/conventions/TramaiTestingPluginTest.kt
@@ -1,7 +1,6 @@
 package dev.tramai.build.conventions
 
 import org.gradle.testkit.runner.GradleRunner
-import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
@@ -17,6 +16,11 @@ import kotlin.test.assertTrue
  * reading coordinates from the root version catalog. It must never add
  * production dependencies, never add `junit-jupiter` implicitly, and be safe
  * under plugin-order and double-application.
+ *
+ * T1 and T3 inspect the declared direct-dependency model (via the fixture's
+ * `printDirectDeps` task) rather than parsing the human-readable dependency
+ * report, so a stray fourth dependency or a lost `platform(...)` wrapper
+ * cannot slip through.
  */
 class TramaiTestingPluginTest {
 
@@ -58,6 +62,9 @@ class TramaiTestingPluginTest {
             dir,
             "build.gradle.kts",
             """
+            import org.gradle.api.artifacts.ModuleDependency
+            import org.gradle.api.attributes.Category
+
             plugins {
                 `java`
                 id("tramai.testing")
@@ -65,6 +72,20 @@ class TramaiTestingPluginTest {
             }
             repositories { mavenCentral() }
             $extraDeps
+
+            // dumps the declared direct dependencies of testImplementation —
+            // group:name plus the dependency category attribute
+            tasks.register("printDirectDeps") {
+                doLast {
+                    configurations.testImplementation.get().dependencies
+                        .sortedBy { "${'$'}{it.group}:${'$'}{it.name}" }
+                        .forEach { d ->
+                            val category = (d as? ModuleDependency)
+                                ?.attributes?.getAttribute(Category.CATEGORY_ATTRIBUTE)?.name ?: "none"
+                            println("DIRECTDEP ${'$'}{d.group}:${'$'}{d.name} category=${'$'}category")
+                        }
+                }
+            }
             """.trimIndent(),
         )
         return dir
@@ -73,15 +94,29 @@ class TramaiTestingPluginTest {
     private fun resolvedDeps(dir: File): String =
         runner(dir, "dependencies", "--configuration", "testRuntimeClasspath").build().output
 
+    private fun directDeps(dir: File): List<String> =
+        runner(dir, "printDirectDeps").build().output
+            .lineSequence()
+            .filter { it.startsWith("DIRECTDEP ") }
+            .map { it.removePrefix("DIRECTDEP ") }
+            .toList()
+
     // ── T1: exactly the three expected test dependencies ─────────────────────
 
     @Test
     fun `T1 adds exactly junit-bom assertj and kotlin-test-junit5`() {
         val dir = fixture(File(tempDir, "fixture").apply { mkdirs() })
-        val out = resolvedDeps(dir)
-        assertTrue(out.contains("org.junit:junit-bom:"), "junit-bom missing: ${out.take(800)}")
-        assertTrue(out.contains("org.assertj:assertj-core:"), "assertj-core missing: ${out.take(800)}")
-        assertTrue(out.contains("org.jetbrains.kotlin:kotlin-test-junit5:"), "kotlin-test-junit5 missing: ${out.take(800)}")
+        val deps = directDeps(dir)
+        val coords = deps.map { it.substringBefore(" category=") }.sorted()
+        assertEquals(
+            listOf(
+                "org.assertj:assertj-core",
+                "org.jetbrains.kotlin:kotlin-test-junit5",
+                "org.junit:junit-bom",
+            ),
+            coords,
+            "direct testImplementation deps must be exactly the trio: $deps",
+        )
     }
 
     // ── T2: scopes are testImplementation only ───────────────────────────────
@@ -89,42 +124,48 @@ class TramaiTestingPluginTest {
     @Test
     fun `T2 dependencies are added only to testImplementation`() {
         val dir = fixture(File(tempDir, "fixture").apply { mkdirs() })
-        // testImplementation carries the trio
         val testOut = runner(dir, "dependencies", "--configuration", "testImplementation").build().output
-        assertTrue(testOut.contains("junit-bom"), "junit-bom missing from testImplementation: ${testOut.take(600)}")
+        assertTrue(testOut.contains("junit-bom"), "junit-bom missing from testImplementation")
         assertTrue(testOut.contains("assertj"), "assertj missing from testImplementation")
         assertTrue(testOut.contains("kotlin-test"), "kotlin-test missing from testImplementation")
-        // main configurations must be empty of the trio
         val mainOut = runner(dir, "dependencies", "--configuration", "runtimeClasspath").build().output
         assertFalse(mainOut.contains("junit-bom"), "junit-bom leaked to main runtime classpath")
         assertFalse(mainOut.contains("assertj"), "assertj leaked to main runtime classpath")
         assertFalse(mainOut.contains("kotlin-test"), "kotlin-test leaked to main runtime classpath")
     }
 
-    // ── T3: JUnit BOM remains a platform dependency ──────────────────────────
+    // ── T3: JUnit BOM is a platform dependency, not a plain jar ──────────────
 
     @Test
-    fun `T3 junit-bom is a platform constraint not a plain jar`() {
+    fun `T3 junit-bom is a platform dependency`() {
         val dir = fixture(File(tempDir, "fixture").apply { mkdirs() })
-        val out = resolvedDeps(dir)
-        // A platform dependency renders with "(n)" marker / is consumed as BOM metadata.
-        assertTrue(out.contains("junit-bom") && (out.contains("(n)") || out.contains("junit-bom:")), "junit-bom must be platform: ${out.take(900)}")
+        val bomLine = directDeps(dir).first { it.startsWith("org.junit:junit-bom") }
+        assertTrue(
+            bomLine.contains("category=platform"),
+            "junit-bom must carry the platform category attribute: $bomLine",
+        )
     }
 
-    // ── T4: no junit-jupiter added implicitly ────────────────────────────────
+    // ── T4: no junit-jupiter added as a direct dependency ────────────────────
 
     @Test
     fun `T4 does not add junit-jupiter implicitly`() {
         val dir = fixture(File(tempDir, "fixture").apply { mkdirs() })
-        val out = resolvedDeps(dir)
-        assertFalse(
-            out.contains("org.junit.jupiter:junit-jupiter") && !out.contains("org.junit.jupiter:junit-jupiter-api"),
-            "plugin must not pull junit-jupiter engine: ${out.take(900)}",
+        // T1 proves the direct deps are exactly the trio; here we additionally
+        // prove no org.junit.jupiter coordinate is declared directly. The
+        // engine on the runtime classpath comes transitively from
+        // kotlin-test-junit5 (which is how JUnit5 tests run) — that is
+        // intended, not plugin-added.
+        val direct = directDeps(dir).map { it.substringBefore(" category=") }
+        assertTrue(
+            direct.none { it.startsWith("org.junit.jupiter:") },
+            "plugin must not add any junit-jupiter dependency directly: $direct",
         )
-        // The BOM platform itself may list junit-jupiter as a managed module,
-        // but the plugin must not ADD it as a direct dependency.
-        val pluginDeps = runner(dir, "dependencies", "--configuration", "testImplementation").build().output
-        assertFalse(pluginDeps.contains("org.junit.jupiter:junit-jupiter:"), "plugin added junit-jupiter directly")
+        val out = resolvedDeps(dir)
+        assertTrue(
+            out.contains("org.jetbrains.kotlin:kotlin-test-junit5:"),
+            "sanity: kotlin-test-junit5 present on runtime classpath",
+        )
     }
 
     // ── T5: no production implementation/api dependencies ────────────────────

--- a/build-logic/src/test/kotlin/dev/tramai/build/conventions/TramaiTestingPluginTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/conventions/TramaiTestingPluginTest.kt
@@ -1,0 +1,195 @@
+package dev.tramai.build.conventions
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * TestKit behavioral contract for the 9.2c-b `tramai.testing` convention.
+ *
+ * The plugin owns exactly the three-dependency test baseline (JUnit BOM as
+ * platform, AssertJ, Kotlin test/JUnit5) added to `testImplementation` only,
+ * reading coordinates from the root version catalog. It must never add
+ * production dependencies, never add `junit-jupiter` implicitly, and be safe
+ * under plugin-order and double-application.
+ */
+class TramaiTestingPluginTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private fun writeFile(base: File, relativePath: String, content: String) {
+        val target = File(base, relativePath)
+        target.parentFile.mkdirs()
+        target.writeText(content)
+    }
+
+    private fun runner(dir: File, vararg args: String): GradleRunner =
+        GradleRunner.create()
+            .withProjectDir(dir)
+            .withGradleVersion("9.0.0")
+            .withArguments(*args, "--stacktrace")
+            .withPluginClasspath()
+
+    private fun fixture(dir: File, extraPlugins: String = "", extraDeps: String = ""): File {
+        writeFile(dir, "settings.gradle.kts", "rootProject.name = \"sample\"\n")
+        // the plugin reads coordinates from the version catalog — the fixture
+        // must provide one so the catalog path is exercised honestly
+        writeFile(
+            dir,
+            "gradle/libs.versions.toml",
+            """
+            [versions]
+            junit = "5.12.2"
+            assertj = "3.27.7"
+            kotlin = "2.3.0"
+            [libraries]
+            junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+            assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+            kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref = "kotlin" }
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "build.gradle.kts",
+            """
+            plugins {
+                `java`
+                id("tramai.testing")
+                $extraPlugins
+            }
+            repositories { mavenCentral() }
+            $extraDeps
+            """.trimIndent(),
+        )
+        return dir
+    }
+
+    private fun resolvedDeps(dir: File): String =
+        runner(dir, "dependencies", "--configuration", "testRuntimeClasspath").build().output
+
+    // ── T1: exactly the three expected test dependencies ─────────────────────
+
+    @Test
+    fun `T1 adds exactly junit-bom assertj and kotlin-test-junit5`() {
+        val dir = fixture(File(tempDir, "fixture").apply { mkdirs() })
+        val out = resolvedDeps(dir)
+        assertTrue(out.contains("org.junit:junit-bom:"), "junit-bom missing: ${out.take(800)}")
+        assertTrue(out.contains("org.assertj:assertj-core:"), "assertj-core missing: ${out.take(800)}")
+        assertTrue(out.contains("org.jetbrains.kotlin:kotlin-test-junit5:"), "kotlin-test-junit5 missing: ${out.take(800)}")
+    }
+
+    // ── T2: scopes are testImplementation only ───────────────────────────────
+
+    @Test
+    fun `T2 dependencies are added only to testImplementation`() {
+        val dir = fixture(File(tempDir, "fixture").apply { mkdirs() })
+        // testImplementation carries the trio
+        val testOut = runner(dir, "dependencies", "--configuration", "testImplementation").build().output
+        assertTrue(testOut.contains("junit-bom"), "junit-bom missing from testImplementation: ${testOut.take(600)}")
+        assertTrue(testOut.contains("assertj"), "assertj missing from testImplementation")
+        assertTrue(testOut.contains("kotlin-test"), "kotlin-test missing from testImplementation")
+        // main configurations must be empty of the trio
+        val mainOut = runner(dir, "dependencies", "--configuration", "runtimeClasspath").build().output
+        assertFalse(mainOut.contains("junit-bom"), "junit-bom leaked to main runtime classpath")
+        assertFalse(mainOut.contains("assertj"), "assertj leaked to main runtime classpath")
+        assertFalse(mainOut.contains("kotlin-test"), "kotlin-test leaked to main runtime classpath")
+    }
+
+    // ── T3: JUnit BOM remains a platform dependency ──────────────────────────
+
+    @Test
+    fun `T3 junit-bom is a platform constraint not a plain jar`() {
+        val dir = fixture(File(tempDir, "fixture").apply { mkdirs() })
+        val out = resolvedDeps(dir)
+        // A platform dependency renders with "(n)" marker / is consumed as BOM metadata.
+        assertTrue(out.contains("junit-bom") && (out.contains("(n)") || out.contains("junit-bom:")), "junit-bom must be platform: ${out.take(900)}")
+    }
+
+    // ── T4: no junit-jupiter added implicitly ────────────────────────────────
+
+    @Test
+    fun `T4 does not add junit-jupiter implicitly`() {
+        val dir = fixture(File(tempDir, "fixture").apply { mkdirs() })
+        val out = resolvedDeps(dir)
+        assertFalse(
+            out.contains("org.junit.jupiter:junit-jupiter") && !out.contains("org.junit.jupiter:junit-jupiter-api"),
+            "plugin must not pull junit-jupiter engine: ${out.take(900)}",
+        )
+        // The BOM platform itself may list junit-jupiter as a managed module,
+        // but the plugin must not ADD it as a direct dependency.
+        val pluginDeps = runner(dir, "dependencies", "--configuration", "testImplementation").build().output
+        assertFalse(pluginDeps.contains("org.junit.jupiter:junit-jupiter:"), "plugin added junit-jupiter directly")
+    }
+
+    // ── T5: no production implementation/api dependencies ────────────────────
+
+    @Test
+    fun `T5 adds no production dependencies`() {
+        val dir = fixture(File(tempDir, "fixture").apply { mkdirs() })
+        val implOut = runner(dir, "dependencies", "--configuration", "implementation").build().output
+        assertFalse(implOut.contains("junit-bom"), "junit-bom leaked to implementation")
+        assertFalse(implOut.contains("assertj"), "assertj leaked to implementation")
+        assertFalse(implOut.contains("kotlin-test"), "kotlin-test leaked to implementation")
+        val apiOut = runner(dir, "dependencies", "--configuration", "api").build().output
+        assertFalse(apiOut.contains("junit-bom") && !apiOut.contains("No dependencies"), "junit-bom leaked to api")
+        assertFalse(apiOut.contains("assertj"), "assertj leaked to api")
+        assertFalse(apiOut.contains("kotlin-test"), "kotlin-test leaked to api")
+    }
+
+    // ── T6: plugin application order is safe ─────────────────────────────────
+
+    @Test
+    fun `T6 works under both plugin orders`() {
+        val orderA = File(tempDir, "orderA").apply { mkdirs() }
+        fixture(orderA, extraPlugins = """id("org.jetbrains.kotlin.jvm") version "2.3.0"""").let {
+            assertTrue(resolvedDeps(it).contains("assertj-core"), "order A failed")
+        }
+        val orderB = File(tempDir, "orderB").apply { mkdirs() }
+        fixture(orderB).let { }
+        // overwrite with reversed plugin order (catalog already present from fixture)
+        writeFile(
+            orderB,
+            "build.gradle.kts",
+            """
+            plugins {
+                id("org.jetbrains.kotlin.jvm") version "2.3.0"
+                id("tramai.testing")
+                `java`
+            }
+            repositories { mavenCentral() }
+            """.trimIndent(),
+        )
+        assertTrue(resolvedDeps(orderB).contains("assertj-core"), "order B failed")
+    }
+
+    // ── T7: double application does not duplicate semantics ──────────────────
+
+    @Test
+    fun `T7 applying twice does not duplicate dependencies`() {
+        val dir = fixture(File(tempDir, "fixture").apply { mkdirs() })
+        // overwrite: request the plugin twice (plugins block + explicit apply)
+        // Gradle dedupes plugin application; the trio must appear exactly once.
+        writeFile(
+            dir,
+            "build.gradle.kts",
+            """
+            plugins {
+                `java`
+                id("tramai.testing")
+            }
+            repositories { mavenCentral() }
+            apply(plugin = "tramai.testing")
+            """.trimIndent(),
+        )
+        val out = runner(dir, "dependencies", "--configuration", "testImplementation").build().output
+        // count occurrences of the assertj coordinate in the resolved graph
+        val occurrences = Regex("org\\.assertj:assertj-core:").findAll(out).count()
+        assertEquals(1, occurrences, "assertj must appear exactly once despite double application")
+    }
+}

--- a/docs/EPIC-9.2-build-logic.md
+++ b/docs/EPIC-9.2-build-logic.md
@@ -16,9 +16,9 @@ published module) is extracted first.
 |-------|-------|--------|
 | 9.2a | `tramai.publishing` convention plugin (publication, signing, repository policy, POM metadata, sovereign-local hook) | ✅ done — PR #309 |
 | 9.2b | `tramai.release-verification` + `tramai.sovereign-verification` typed/cache-aware release tasks | ✅ done — PR #313 |
-| 9.2c | language, test-fixture, and quality conventions | in progress |
+| 9.2c | language, test-fixture, and testing conventions | in progress |
 | 9.2c-a | `tramai.kotlin-library` / `tramai.java-platform` / `tramai.test-fixtures` | ✅ done — PR #319 |
-| 9.2c-b | `tramai.quality` convention + remaining exceptional-module cleanup | planned |
+| 9.2c-b | `tramai.testing` convention — common test-dependency baseline | ✅ done — PR #322 |
 | 9.2c-c | manifest-derived publication metadata (module-catalog.yml schema + analyzer/parser + publication verifier) | planned |
 | 9.2d | configuration-cache closure; root build reduced to composition | planned |
 
@@ -158,7 +158,7 @@ cleanly as `build-logic` with no baseline-migration exemption.
 - Configuration-cache-aware where feasible; document the unavoidable
   non-cacheable remainder.
 
-## 9.2c — language, test-fixture, and quality conventions
+## 9.2c — language, test-fixture, and testing conventions
 
 - `tramai.kotlin-library`, `tramai.java-platform`, `tramai.test-fixtures`
   (9.2c-a, PR #319): behavior-preserving extraction of the repeated JVM/Kotlin
@@ -167,7 +167,14 @@ cleanly as `build-logic` with no baseline-migration exemption.
   configures only the `test` task; behavioral TestKit proofs cover plugin-order
   independence, JVM-21 bytecode, sourcesJar content, real JUnit-5 execution,
   and testFixturesJar content.
-- `tramai.quality` convention + remaining exceptional-module cleanup (9.2c-b).
+- `tramai.testing` convention (9.2c-b, PR #322): owns the common test-dependency
+  baseline — JUnit BOM (platform), AssertJ, Kotlin test/JUnit5 — added to
+  `testImplementation` only, reading coordinates from the version catalog.
+  Migrates the 36 exact trio consumers; 11 partial and 4 none stay untouched.
+- `tramai.quality` **not created**: the B7 survey found no coherent repeated
+  module-level quality policy — Sonar, BCV, maintainability, compiler policy,
+  and test logging are root-owned or module-specific. Recording this in the
+  roadmap instead of preserving a speculative plugin name.
 - Manifest-derived project descriptions / publication metadata (9.2c-c): adds a
   `description` field to module-catalog.yml and moves the hand-written
   `projectDescription()` map into the catalog. This is an analyzer/schema change

--- a/tramai-anthropic/build.gradle.kts
+++ b/tramai-anthropic/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -13,10 +14,7 @@ dependencies {
     implementation(libs.coroutines.core)
     implementation(libs.jackson.databind)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(testFixtures(project(":tramai-testing")))
+                testImplementation(testFixtures(project(":tramai-testing")))
     testImplementation(libs.coroutines.test)
 }
 

--- a/tramai-azure-openai/build.gradle.kts
+++ b/tramai-azure-openai/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -13,10 +14,7 @@ dependencies {
     implementation(libs.coroutines.core)
     implementation(libs.jackson.databind)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(testFixtures(project(":tramai-testing")))
+                testImplementation(testFixtures(project(":tramai-testing")))
     testImplementation(libs.coroutines.test)
 }
 

--- a/tramai-bedrock/build.gradle.kts
+++ b/tramai-bedrock/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -19,10 +20,7 @@ dependencies {
     implementation(libs.aws.sdk.auth)
     implementation(libs.aws.sdk.regions)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(testFixtures(project(":tramai-testing")))
+                testImplementation(testFixtures(project(":tramai-testing")))
     testImplementation(libs.coroutines.test)
 }
 

--- a/tramai-core/build.gradle.kts
+++ b/tramai-core/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -10,10 +11,7 @@ plugins {
 dependencies {
     api(libs.coroutines.core)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(libs.coroutines.test)
+                testImplementation(libs.coroutines.test)
 }
 
 

--- a/tramai-deepseek/build.gradle.kts
+++ b/tramai-deepseek/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -14,10 +15,7 @@ dependencies {
     implementation(libs.coroutines.core)
     implementation(libs.jackson.databind)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(testFixtures(project(":tramai-testing")))
+                testImplementation(testFixtures(project(":tramai-testing")))
     testImplementation(libs.coroutines.test)
 }
 

--- a/tramai-embedding/build.gradle.kts
+++ b/tramai-embedding/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -11,8 +12,5 @@ dependencies {
     implementation(libs.coroutines.core)
     implementation(libs.jackson.databind)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-}
+            }
 

--- a/tramai-engine/build.gradle.kts
+++ b/tramai-engine/build.gradle.kts
@@ -2,6 +2,7 @@
 plugins {
     `java-library`
     id("tramai.test-fixtures")
+    id("tramai.testing")
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
 }
@@ -16,10 +17,7 @@ dependencies {
     implementation(libs.coroutines.core)
     implementation(libs.kotlin.reflect)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(project(":tramai-structured"))
+                testImplementation(project(":tramai-structured"))
     testImplementation(testFixtures(project(":tramai-testing")))
     testImplementation(libs.coroutines.test)
     testImplementation(libs.jackson.databind)

--- a/tramai-gemini/build.gradle.kts
+++ b/tramai-gemini/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -13,10 +14,7 @@ dependencies {
     implementation(libs.coroutines.core)
     implementation(libs.jackson.databind)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(testFixtures(project(":tramai-testing")))
+                testImplementation(testFixtures(project(":tramai-testing")))
     testImplementation(libs.coroutines.test)
 }
 

--- a/tramai-memory-store/build.gradle.kts
+++ b/tramai-memory-store/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -16,11 +17,8 @@ dependencies {
 
     testImplementation(project(":tramai-testing"))
     testImplementation(testFixtures(project(":tramai-testing")))
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.h2database)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(platform(libs.testcontainers.bom))
+            testImplementation(libs.h2database)
+        testImplementation(platform(libs.testcontainers.bom))
     testImplementation(libs.testcontainers.core)
     testImplementation(libs.testcontainers.junit.jupiter)
 }

--- a/tramai-memory/build.gradle.kts
+++ b/tramai-memory/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -10,8 +11,5 @@ plugins {
 dependencies {
     api(project(":tramai-core"))
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-}
+            }
 

--- a/tramai-observability/build.gradle.kts
+++ b/tramai-observability/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -21,10 +22,7 @@ dependencies {
     testImplementation(libs.opentelemetry.sdk.metrics)
     testImplementation(libs.opentelemetry.sdk.trace)
     testImplementation(libs.opentelemetry.sdk.testing)
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-}
+            }
 
 tasks.test {
     // The runtime-event-catalogue architecture test scans every module's

--- a/tramai-ollama/build.gradle.kts
+++ b/tramai-ollama/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -13,10 +14,7 @@ dependencies {
     implementation(libs.coroutines.core)
     implementation(libs.jackson.databind)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(testFixtures(project(":tramai-testing")))
+                testImplementation(testFixtures(project(":tramai-testing")))
     testImplementation(libs.coroutines.test)
 }
 

--- a/tramai-openai/build.gradle.kts
+++ b/tramai-openai/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -13,10 +14,7 @@ dependencies {
     implementation(libs.coroutines.core)
     implementation(libs.jackson.databind)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(testFixtures(project(":tramai-testing")))
+                testImplementation(testFixtures(project(":tramai-testing")))
     testImplementation(libs.coroutines.test)
 }
 

--- a/tramai-orchestration/build.gradle.kts
+++ b/tramai-orchestration/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -16,10 +17,7 @@ dependencies {
     testImplementation(project(":tramai-engine"))
     testImplementation(project(":tramai-testing"))
     testImplementation(testFixtures(project(":tramai-testing")))
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(libs.mcp.sdk.server)
+                testImplementation(libs.mcp.sdk.server)
     testImplementation(libs.h2database)
 }
 

--- a/tramai-persistence-file/build.gradle.kts
+++ b/tramai-persistence-file/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -16,10 +17,7 @@ dependencies {
     implementation(libs.jackson.module.kotlin)
 
     testImplementation(testFixtures(project(":tramai-testing")))
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.coroutines.test)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation("org.junit.jupiter:junit-jupiter")
+            testImplementation(libs.coroutines.test)
+        testImplementation("org.junit.jupiter:junit-jupiter")
 }
 

--- a/tramai-persistence-jdbc/build.gradle.kts
+++ b/tramai-persistence-jdbc/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -15,11 +16,8 @@ dependencies {
     implementation(libs.jackson.datatype.jsr310)
 
     testImplementation(testFixtures(project(":tramai-testing")))
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(platform(libs.testcontainers.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation("org.junit.jupiter:junit-jupiter")
+        testImplementation(platform(libs.testcontainers.bom))
+            testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.testcontainers.junit.jupiter)
     testImplementation(libs.postgresql)

--- a/tramai-platform/build.gradle.kts
+++ b/tramai-platform/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -19,10 +20,7 @@ dependencies {
     implementation(libs.spring.boot.starter.web)
     implementation(libs.spring.security.crypto)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.h2database)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(libs.spring.boot.starter.test)
+            testImplementation(libs.h2database)
+        testImplementation(libs.spring.boot.starter.test)
 }
 

--- a/tramai-rag/build.gradle.kts
+++ b/tramai-rag/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -13,8 +14,5 @@ dependencies {
     api(project(":tramai-vectorstore-spi"))
     implementation(libs.coroutines.core)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-}
+            }
 

--- a/tramai-scheduler/build.gradle.kts
+++ b/tramai-scheduler/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -13,9 +14,6 @@ dependencies {
     implementation(libs.coroutines.core)
     implementation(libs.hikaricp)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.h2database)
-    testImplementation(libs.kotlin.test.junit5)
-}
+            testImplementation(libs.h2database)
+    }
 

--- a/tramai-security/build.gradle.kts
+++ b/tramai-security/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -13,11 +14,8 @@ dependencies {
     implementation(libs.coroutines.core)
 
     testImplementation(testFixtures(project(":tramai-testing")))
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.coroutines.test)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation("org.junit.jupiter:junit-jupiter")
+            testImplementation(libs.coroutines.test)
+        testImplementation("org.junit.jupiter:junit-jupiter")
     implementation(libs.jackson.databind)
 }
 

--- a/tramai-server/build.gradle.kts
+++ b/tramai-server/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -17,10 +18,7 @@ dependencies {
     implementation(libs.spring.boot.starter.validation)
     implementation(libs.spring.boot.starter.web)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.h2database)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(libs.spring.boot.starter.test)
+            testImplementation(libs.h2database)
+        testImplementation(libs.spring.boot.starter.test)
 }
 

--- a/tramai-sovereign/build.gradle.kts
+++ b/tramai-sovereign/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -11,11 +12,8 @@ dependencies {
     api(project(":tramai-standalone"))
     api(project(":tramai-security"))
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.coroutines.core)
+            testImplementation(libs.coroutines.core)
     testImplementation(libs.coroutines.test)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation("org.junit.jupiter:junit-jupiter")
+        testImplementation("org.junit.jupiter:junit-jupiter")
 }
 

--- a/tramai-spring-boot-starter-sovereign-ops-actuator/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-ops-actuator/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -16,10 +17,7 @@ dependencies {
 
     annotationProcessor(libs.spring.boot.configuration.processor)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(libs.spring.boot.starter.test)
+                testImplementation(libs.spring.boot.starter.test)
     testImplementation(libs.spring.boot.actuator.autoconfigure)
     testImplementation(libs.micrometer.core)
     testImplementation("org.junit.jupiter:junit-jupiter")

--- a/tramai-spring-boot-starter-sovereign-ops-micrometer/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-ops-micrometer/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -15,10 +16,7 @@ dependencies {
 
     annotationProcessor(libs.spring.boot.configuration.processor)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(libs.spring.boot.starter.test)
+                testImplementation(libs.spring.boot.starter.test)
     testImplementation(libs.micrometer.core)
     testImplementation(libs.micrometer.registry.prometheus)
     testImplementation("org.junit.jupiter:junit-jupiter")

--- a/tramai-spring-boot-starter-sovereign-ops-observability/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-ops-observability/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -13,10 +14,7 @@ dependencies {
     implementation(libs.opentelemetry.api)
     implementation(libs.spring.boot.autoconfigure)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(libs.spring.boot.starter.test)
+                testImplementation(libs.spring.boot.starter.test)
     testImplementation(libs.opentelemetry.sdk.testing)
     testImplementation(libs.opentelemetry.sdk.metrics)
     testImplementation("org.junit.jupiter:junit-jupiter")

--- a/tramai-spring-boot-starter-sovereign-ops-rest/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-ops-rest/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -18,10 +19,7 @@ dependencies {
 
     annotationProcessor(libs.spring.boot.configuration.processor)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(libs.coroutines.core)
+                testImplementation(libs.coroutines.core)
     testImplementation(libs.spring.boot.starter.test)
     testImplementation("org.junit.jupiter:junit-jupiter")
 }

--- a/tramai-spring-boot-starter-sovereign-ops/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-ops/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -21,10 +22,7 @@ dependencies {
 
     annotationProcessor(libs.spring.boot.configuration.processor)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(libs.coroutines.core)
+                testImplementation(libs.coroutines.core)
     testImplementation(libs.spring.boot.starter.test)
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation(libs.jackson.databind)

--- a/tramai-spring-boot-starter-sovereign-persistence-file/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-persistence-file/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -18,11 +19,8 @@ dependencies {
 
     annotationProcessor(libs.spring.boot.configuration.processor)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.coroutines.core)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(libs.spring.boot.starter.test)
+            testImplementation(libs.coroutines.core)
+        testImplementation(libs.spring.boot.starter.test)
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation(testFixtures(project(":tramai-testing")))
 }

--- a/tramai-spring-boot-starter-sovereign-persistence-jdbc/build.gradle.kts
+++ b/tramai-spring-boot-starter-sovereign-persistence-jdbc/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -22,11 +23,8 @@ dependencies {
 
     annotationProcessor(libs.spring.boot.configuration.processor)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(platform(libs.testcontainers.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(libs.coroutines.core)
+        testImplementation(platform(libs.testcontainers.bom))
+            testImplementation(libs.coroutines.core)
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.junit.platform:junit-platform-launcher")
     testImplementation(libs.spring.boot.starter.test)

--- a/tramai-spring-boot-starter/build.gradle.kts
+++ b/tramai-spring-boot-starter/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -17,11 +18,8 @@ dependencies {
 
     implementation(libs.spring.boot.autoconfigure)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.coroutines.core)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(libs.spring.boot.starter.test)
+            testImplementation(libs.coroutines.core)
+        testImplementation(libs.spring.boot.starter.test)
     testImplementation(project(":tramai-spring-provider-openai"))
     testImplementation("org.junit.jupiter:junit-jupiter")
 }

--- a/tramai-spring-sovereign/build.gradle.kts
+++ b/tramai-spring-sovereign/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -18,11 +19,8 @@ dependencies {
     annotationProcessor(libs.spring.boot.configuration.processor)
 
     testImplementation(project(":tramai-spring"))
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.coroutines.core)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(libs.spring.boot.starter.test)
+            testImplementation(libs.coroutines.core)
+        testImplementation(libs.spring.boot.starter.test)
     testImplementation("org.junit.jupiter:junit-jupiter")
 }
 

--- a/tramai-standalone/build.gradle.kts
+++ b/tramai-standalone/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -14,9 +15,6 @@ dependencies {
     api(libs.kotlin.reflect)
 
     testImplementation(libs.coroutines.core)
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(project(":tramai-testing"))
+                testImplementation(project(":tramai-testing"))
 }
 

--- a/tramai-structured/build.gradle.kts
+++ b/tramai-structured/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -14,8 +15,5 @@ dependencies {
     implementation(libs.jackson.module.kotlin)
     implementation(libs.kotlin.reflect)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-}
+            }
 

--- a/tramai-vectorstore-chroma/build.gradle.kts
+++ b/tramai-vectorstore-chroma/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -13,8 +14,5 @@ dependencies {
     implementation(libs.coroutines.core)
     implementation(libs.jackson.databind)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-}
+            }
 

--- a/tramai-vectorstore-pgvector/build.gradle.kts
+++ b/tramai-vectorstore-pgvector/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -15,9 +16,6 @@ dependencies {
     implementation(libs.hikaricp)
     implementation(libs.jackson.databind)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-    testImplementation(libs.h2database)
+                testImplementation(libs.h2database)
 }
 

--- a/tramai-vectorstore-spi/build.gradle.kts
+++ b/tramai-vectorstore-spi/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
+    id("tramai.testing")
 }
 
 
@@ -10,8 +11,5 @@ plugins {
 dependencies {
     implementation(libs.coroutines.core)
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.kotlin.test.junit5)
-}
+            }
 


### PR DESCRIPTION
## B7 — Epic 9.2c-b: `tramai.testing` convention

### What it owns (exactly)

The repeated test-dependency baseline, added to `testImplementation` only:

- JUnit BOM (as a **platform** dependency)
- AssertJ
- Kotlin test/JUnit5

Coordinates read from the root version catalog (`gradle/libs.versions.toml`) via `project.versionCatalogs.named("libs")` — no hard-coded versions. Plugin reacts to `java` being applied (order-independent).

### Why not `tramai.quality`

Survey of 51 module scripts (on `f368acbb`):
- **Q1 test deps**: 36 exact byte-identical trio consumers, 11 partial, 4 none
- **Q2 testLogging**: 2 modules, **different** configs → module-specific
- **Q3 compiler policy**: 5 modules, **all distinct** freeCompilerArgs → local
- **Q4 static analysis**: zero module-level; Sonar is root-only
- **Q5 BCV**: root-only

`tramai.quality` would be a misleading wrapper around three dependency lines and a dumping ground for future root policy. **Not created** — recorded in the roadmap instead.

### Migration (same discipline as B6)

- **36 exact consumers migrated** (156 deletions) — trio removed, plugin added
- **11 partial consumers untouched** (byte-identical, proven via git diff)
- **4 none untouched** (bom, dashboard, provider-ollama, secrets-file)
- **13 explicit `org.junit.jupiter:junit-jupiter` lines preserved** locally
- testLogging, compiler flags, Sonar, BCV, examples/: all untouched
- Zero `src/main` changes, zero module-catalog changes

### TestKit contract (T1–T7, 7 new, 398 total)

- T1 adds exactly the three expected dependencies
- T2 scopes are testImplementation only — no main/api leaks
- T3 JUnit BOM remains a platform dependency
- T4 no junit-jupiter added implicitly
- T5 no production dependencies added
- T6 plugin application order is safe (both orders)
- T7 double application does not duplicate dependencies

### Gates

- [x] `:build-logic:test` 398/0
- [x] verify060Architecture
- [x] verifyPr (incl. maintainability baseline)
- [x] verifyChangePolicy = build-logic (40 files, no violations)
- [x] verifyPublicationMetadata
- [x] compileKotlin + compileTestKotlin full repo
- [x] Structural proof: 0 leftover trio, 11 partial unchanged, 13 junit-jupiter preserved
