### PR TITLE
feat(engine): Epic 8.3b1 — retry jitter at one explicit composition boundary

### DIFF
--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -171,7 +171,7 @@ internal typealias ResumeOperationRegistry = ApprovalResumeOperationRegistry
 /**
  * Runtime engine that turns annotated service interfaces into AI-backed proxies.
  */
-class TramaiEngine private constructor(
+class TramaiEngine internal constructor(
     private val components: EngineComponents,
 ) : AutoCloseable {
     private val routingPlan = components.providers.routingPlan
@@ -183,7 +183,7 @@ class TramaiEngine private constructor(
     private val modelRegistry = components.security.modelRegistry
     private val modelRegistrySettings = components.security.modelRegistrySettings
     private val circuitBreakerSettings = components.execution.circuitBreakerSettings
-    private val retryPolicySettings = components.execution.retryPolicySettings
+    private val retryDelayPolicy = components.execution.retryDelayPolicy
     private val tokenBudgetSettings = components.execution.tokenBudgetSettings
     private val promptSanitizer = components.security.promptSanitizer
     private val serviceDefinitionCompiler by lazy {
@@ -247,7 +247,6 @@ class TramaiEngine private constructor(
     approvalLifecycleAuditEmitter, clock,
 ))
     private val circuitBreaker = ProviderCircuitBreaker(circuitBreakerSettings)
-    private val retryDelayPolicy = ProviderRetryDelayPolicy(retryPolicySettings)
     private val migrationWarningGuard = java.util.concurrent.atomic.AtomicBoolean(false)
     private val resolvedPolicyEngine: PolicyEngine = components.security.resolvedPolicyEngine
     private val isLegacyFallback: Boolean = components.security.isLegacyFallback

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/components/EngineComponentFactory.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/components/EngineComponentFactory.kt
@@ -14,6 +14,9 @@ import dev.tramai.core.provider.ProviderRegistry
 import dev.tramai.core.security.*
 import dev.tramai.core.structured.*
 import dev.tramai.engine.*
+import dev.tramai.engine.provider.DefaultRetryJitterSource
+import dev.tramai.engine.provider.ProviderRetryDelayPolicy
+import dev.tramai.engine.provider.RetryJitterSource
 import java.time.Clock
 
 /** One authoritative composition boundary: validates collaborators and creates the immutable snapshot. */
@@ -30,6 +33,7 @@ internal object EngineComponentFactory {
         suspendedInvocationStore: SuspendedInvocationStore, approvalContinuationStore: ApprovalContinuationStore?,
         toolArgumentsDigester: ToolArgumentsDigester?, approvalGateCoordinator: ApprovalGateCoordinator?,
         approvalLifecycleAuditEmitter: ApprovalLifecycleAuditEmitter, clock: Clock,
+        retryJitterSource: RetryJitterSource = DefaultRetryJitterSource,
         structuredOutputFailureDiagnosticObserver: StructuredOutputFailureDiagnosticObserver = NoOpStructuredOutputFailureDiagnosticObserver,
     ): EngineComponents {
         val capability = approvalCapability(approvalContinuationStore, toolArgumentsDigester, approvalGateCoordinator)
@@ -49,7 +53,13 @@ internal object EngineComponentFactory {
                 toolFailureDiagnosticObserver,
                 structuredOutputFailureDiagnosticObserver,
             ),
-            ExecutionComponents(structuredOutputHandler, circuitBreakerSettings, retryPolicySettings, tokenBudgetSettings, clock),
+            ExecutionComponents(
+                structuredOutputHandler = structuredOutputHandler,
+                circuitBreakerSettings = circuitBreakerSettings,
+                retryDelayPolicy = ProviderRetryDelayPolicy(retryPolicySettings, retryJitterSource),
+                tokenBudgetSettings = tokenBudgetSettings,
+                clock = clock,
+            ),
         )
     }
 

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/components/EngineComponents.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/components/EngineComponents.kt
@@ -22,11 +22,11 @@ import dev.tramai.core.structured.StructuredOutputHandler
 import dev.tramai.engine.CircuitBreakerSettings
 import dev.tramai.engine.EngineEventObserver
 import dev.tramai.engine.OperationResponseCache
-import dev.tramai.engine.RetryPolicySettings
 import dev.tramai.engine.SuspendedInvocationStore
 import dev.tramai.engine.TokenBudgetSettings
 import dev.tramai.engine.ToolRegistry
 import dev.tramai.engine.ToolResultFilteringSettings
+import dev.tramai.engine.provider.ProviderRetryDelayPolicy
 import java.time.Clock
 
 /**
@@ -104,7 +104,7 @@ internal data class ObservationComponents(
 internal data class ExecutionComponents(
     val structuredOutputHandler: StructuredOutputHandler?,
     val circuitBreakerSettings: CircuitBreakerSettings,
-    val retryPolicySettings: RetryPolicySettings,
+    val retryDelayPolicy: ProviderRetryDelayPolicy,
     val tokenBudgetSettings: TokenBudgetSettings,
     val clock: Clock,
 )

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/provider/ProviderRetryPolicy.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/provider/ProviderRetryPolicy.kt
@@ -40,6 +40,10 @@ internal class ProviderRetryDelayPolicy(
         val cappedBaseDelay = if (error is ProviderException && error.retryAfterMillis != null) {
             minOf(requireNotNull(error.retryAfterMillis), settings.maxRetryAfterMillis)
         } else fallbackDelayMillis
-        return cappedBaseDelay + (cappedBaseDelay * settings.jitterRatio * retryJitterSource.nextDouble()).toLong()
+        val jitterSample = retryJitterSource.nextDouble()
+        require(jitterSample >= 0.0 && jitterSample < 1.0) {
+            "Retry jitter sample must be in [0.0, 1.0), got $jitterSample"
+        }
+        return cappedBaseDelay + (cappedBaseDelay * settings.jitterRatio * jitterSample).toLong()
     }
 }

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/provider/ProviderRetryPolicy.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/provider/ProviderRetryPolicy.kt
@@ -9,6 +9,12 @@ internal sealed interface ProviderRetryDecision {
     data object Stop : ProviderRetryDecision
 }
 
+internal fun interface RetryJitterSource { fun nextDouble(): Double }
+
+internal object DefaultRetryJitterSource : RetryJitterSource {
+    override fun nextDouble(): Double = kotlin.random.Random.nextDouble()
+}
+
 internal open class ProviderRetryPolicy(private val retryDelayPolicy: ProviderRetryDelayPolicy) {
     open fun decide(error: Throwable, retryIndex: Int, maxAttempts: Int): ProviderRetryDecision {
         if (retryIndex >= maxAttempts - 1 || !isRetryable(error)) return ProviderRetryDecision.Stop
@@ -28,12 +34,12 @@ internal open class ProviderRetryPolicy(private val retryDelayPolicy: ProviderRe
 
 internal class ProviderRetryDelayPolicy(
     private val settings: RetryPolicySettings,
-    private val randomDouble: () -> Double = { kotlin.random.Random.nextDouble() },
+    private val retryJitterSource: RetryJitterSource = DefaultRetryJitterSource,
 ) {
     fun delayMillis(error: Throwable, fallbackDelayMillis: Long): Long {
         val cappedBaseDelay = if (error is ProviderException && error.retryAfterMillis != null) {
             minOf(requireNotNull(error.retryAfterMillis), settings.maxRetryAfterMillis)
         } else fallbackDelayMillis
-        return cappedBaseDelay + (cappedBaseDelay * settings.jitterRatio * randomDouble()).toLong()
+        return cappedBaseDelay + (cappedBaseDelay * settings.jitterRatio * retryJitterSource.nextDouble()).toLong()
     }
 }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/RetryJitterDiscriminatorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/RetryJitterDiscriminatorTest.kt
@@ -63,6 +63,18 @@ class RetryJitterDiscriminatorTest {
     // ── P0-B — one sample per retry decision ────────────────────────────────
 
     @Test
+    fun `P0-B one sample per retry decision - decision policy samples once per authorized retry`() {
+        val source = QueuedJitterSource(0.25, 0.75)
+        val retryPolicy = ProviderRetryPolicy(
+            ProviderRetryDelayPolicy(RetryPolicySettings(jitterRatio = 0.20), source),
+        )
+        val decision = retryPolicy.decide(retryableError(), retryIndex = 0, maxAttempts = 2)
+        // Authorized retry at index 0: fallback base = minOf(50 shl 0, 1000) = 50; 50 + 50*.2*.25 = 52.5 -> 52.
+        assertThat((decision as ProviderRetryDecision.Retry).delayMillis).isEqualTo(52L)
+        assertThat(source.calls).isEqualTo(1)
+    }
+
+    @Test
     fun `P0-B one sample per retry delay - injected sequence is authoritative`() {
         val source = QueuedJitterSource(0.25, 0.75)
         val policy = ProviderRetryDelayPolicy(RetryPolicySettings(jitterRatio = 0.20), source)
@@ -197,8 +209,8 @@ class RetryJitterDiscriminatorTest {
             }
         }
         check(outcome.first == "retry") {
-            "expected RETRY_SCHEDULED, got invocation failure: " +
-                (if (capture.invocationFailure.isCompleted) capture.invocationFailure.getCompleted() else "timeout")
+            "expected RETRY_SCHEDULED, got invocation failure " +
+                "(completed=${capture.invocationFailure.isCompleted}, timeout=10s)"
         }
         val attributes = outcome.second!!
         // fallback base for retryIndex 0 = minOf(50 shl 0, 1000) = 50; jitter .20, sample .25:

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/RetryJitterDiscriminatorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/RetryJitterDiscriminatorTest.kt
@@ -19,6 +19,7 @@ import dev.tramai.engine.RetryPolicySettings
 import dev.tramai.engine.TramaiEngine
 import dev.tramai.engine.components.EngineComponentFactory
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
@@ -32,14 +33,15 @@ import org.junit.jupiter.api.Test
  */
 class RetryJitterDiscriminatorTest {
 
-    /** Queued source: deterministic nextDouble() sequence, counts calls. */
+    /** Queued source: deterministic nextDouble() sequence, counts SUCCESSFUL samples. */
     private class QueuedJitterSource(vararg samples: Double) : RetryJitterSource {
         private val queue = ArrayDeque(samples.toList())
         var calls = 0
             private set
         override fun nextDouble(): Double {
+            val sample = queue.removeFirst()
             calls++
-            return queue.removeFirst()
+            return sample
         }
     }
 
@@ -121,6 +123,22 @@ class RetryJitterDiscriminatorTest {
             .isEqualTo(1_100L)
     }
 
+    // ── P0-F — invalid jitter samples fail closed ────────────────────────────
+
+    @Test
+    fun `P0-F invalid jitter sample fails closed`() {
+        for (sample in listOf(-0.1, 1.0, Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)) {
+            val policy = ProviderRetryDelayPolicy(
+                RetryPolicySettings(jitterRatio = 0.20),
+                QueuedJitterSource(sample),
+            )
+            org.assertj.core.api.Assertions.assertThatThrownBy {
+                policy.delayMillis(retryableError(), fallbackDelayMillis = 100L)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("Retry jitter sample must be in [0.0, 1.0)")
+        }
+    }
+
     // ── P0-E — whole-engine composition consumes the injected source ─────────
 
     @AiService
@@ -160,7 +178,7 @@ class RetryJitterDiscriminatorTest {
 
     @Test
     fun `P0-E engine composition graph consumes the injected jitter source`() = runBlocking {
-        val source = QueuedJitterSource(0.25, 0.75)
+        val source = QueuedJitterSource(0.25)
         val capture = RetryEventCapture()
         val registry = ProviderRegistry.singleProvider(FailingProvider())
         val components = EngineComponentFactory.create(
@@ -214,10 +232,16 @@ class RetryJitterDiscriminatorTest {
         }
         val attributes = outcome.second!!
         // fallback base for retryIndex 0 = minOf(50 shl 0, 1000) = 50; jitter .20, sample .25:
-        // 50 + 50*.2*.25 = 52.5 -> 52. One sample consumed for the first authorized retry.
+        // 50 + 50*.2*.25 = 52.5 -> 52.
         assertThat(attributes[RuntimeAttributes.DELAY_MILLIS.name]).isEqualTo(52L)
+
+        // Freeze the invocation before asserting entropy consumption: the engine-owned
+        // coroutine must be definitively terminated, not merely signalled to cancel.
+        // The source carries exactly ONE sample, so no later attempt can mint a second
+        // call even if cancellation delivery races the engine's retry delay.
+        job.cancelAndJoin()
+
         assertThat(source.calls).isEqualTo(1)
-        job.cancel()
         engine.close()
     }
 }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/RetryJitterDiscriminatorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/RetryJitterDiscriminatorTest.kt
@@ -1,0 +1,211 @@
+package dev.tramai.engine.provider
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.exception.ProviderException
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.observation.OperationCallContext
+import dev.tramai.core.observation.OperationObservation
+import dev.tramai.core.observation.OperationObserver
+import dev.tramai.core.provider.ModelProvider
+import dev.tramai.core.provider.ProviderRegistry
+import dev.tramai.core.observation.NoOpToolFailureDiagnosticObserver
+import dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter
+import dev.tramai.core.policy.NoOpPolicyDecisionAuditEmitter
+import dev.tramai.core.observation.event.RuntimeAttributes
+import dev.tramai.core.observation.event.RuntimeEvents
+import dev.tramai.engine.RetryPolicySettings
+import dev.tramai.engine.TramaiEngine
+import dev.tramai.engine.components.EngineComponentFactory
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * 8.3b1 discriminators: retry jitter randomness lives at exactly one explicit
+ * composition boundary. Randomness may modify only the magnitude of an
+ * already-authorized retry delay; every retry/fallback decision stays
+ * deterministic. No timing thresholds, no sleeps.
+ */
+class RetryJitterDiscriminatorTest {
+
+    /** Queued source: deterministic nextDouble() sequence, counts calls. */
+    private class QueuedJitterSource(vararg samples: Double) : RetryJitterSource {
+        private val queue = ArrayDeque(samples.toList())
+        var calls = 0
+            private set
+        override fun nextDouble(): Double {
+            calls++
+            return queue.removeFirst()
+        }
+    }
+
+    private fun retryableError(retryAfterMillis: Long? = null): ProviderException =
+        ProviderException("retryable failure", retryable = true, retryAfterMillis = retryAfterMillis)
+
+    // ── P0-A — exact injected jitter ─────────────────────────────────────────
+
+    @Test
+    fun `P0-A exact injected jitter - sample 0-25 gives 105ms`() {
+        val policy = ProviderRetryDelayPolicy(RetryPolicySettings(jitterRatio = 0.20), QueuedJitterSource(0.25))
+        assertThat(policy.delayMillis(retryableError(), fallbackDelayMillis = 100L)).isEqualTo(105L)
+    }
+
+    @Test
+    fun `P0-A exact injected jitter - sample 0-75 gives 115ms`() {
+        val policy = ProviderRetryDelayPolicy(RetryPolicySettings(jitterRatio = 0.20), QueuedJitterSource(0.75))
+        assertThat(policy.delayMillis(retryableError(), fallbackDelayMillis = 100L)).isEqualTo(115L)
+    }
+
+    // ── P0-B — one sample per retry decision ────────────────────────────────
+
+    @Test
+    fun `P0-B one sample per retry delay - injected sequence is authoritative`() {
+        val source = QueuedJitterSource(0.25, 0.75)
+        val policy = ProviderRetryDelayPolicy(RetryPolicySettings(jitterRatio = 0.20), source)
+        // Two authorized retries at base 100: 100 + 100*.2*.25 = 105; 100 + 100*.2*.75 = 115.
+        assertThat(policy.delayMillis(retryableError(), fallbackDelayMillis = 100L)).isEqualTo(105L)
+        assertThat(policy.delayMillis(retryableError(), fallbackDelayMillis = 100L)).isEqualTo(115L)
+        assertThat(source.calls).isEqualTo(2)
+    }
+
+    // ── P0-C — Stop consumes zero randomness ─────────────────────────────────
+
+    @Test
+    fun `P0-C non-retryable error stops without sampling`() {
+        val source = QueuedJitterSource(0.25)
+        val retryPolicy = ProviderRetryPolicy(
+            ProviderRetryDelayPolicy(RetryPolicySettings(jitterRatio = 0.20), source),
+        )
+        assertThat(retryPolicy.decide(IllegalStateException("boom"), retryIndex = 0, maxAttempts = 3))
+            .isEqualTo(ProviderRetryDecision.Stop)
+        assertThat(source.calls).isZero()
+    }
+
+    @Test
+    fun `P0-C exhausted budget stops without sampling`() {
+        val source = QueuedJitterSource(0.25)
+        val retryPolicy = ProviderRetryPolicy(
+            ProviderRetryDelayPolicy(RetryPolicySettings(jitterRatio = 0.20), source),
+        )
+        assertThat(retryPolicy.decide(retryableError(), retryIndex = 1, maxAttempts = 2))
+            .isEqualTo(ProviderRetryDecision.Stop)
+        assertThat(source.calls).isZero()
+    }
+
+    // ── P0-D — retry-after capping precedes jitter ───────────────────────────
+
+    @Test
+    fun `P0-D retry-after is capped before jitter is applied`() {
+        val policy = ProviderRetryDelayPolicy(
+            RetryPolicySettings(jitterRatio = 0.20, maxRetryAfterMillis = 1_000L),
+            QueuedJitterSource(0.50),
+        )
+        // retryAfter 10_000 capped to 1_000, then jittered: 1000 + 1000*.2*.5 = 1100.
+        assertThat(policy.delayMillis(retryableError(retryAfterMillis = 10_000L), fallbackDelayMillis = 50L))
+            .isEqualTo(1_100L)
+    }
+
+    // ── P0-E — whole-engine composition consumes the injected source ─────────
+
+    @AiService
+    private interface ExplicitRetryService {
+        @Operation(prompt = "Answer", model = "logical-model", providerRetries = 2)
+        fun answer(input: String): String
+    }
+
+    private class FailingProvider : ModelProvider {
+        override fun providerId(): String = "p0"
+        override suspend fun complete(request: ModelRequest): ModelResponse {
+            throw ProviderException("always retryable", retryable = true, retryAfterMillis = null)
+        }
+    }
+
+    private class RetryEventCapture : OperationObserver {
+        val retryScheduled = CompletableDeferred<Map<String, Any?>>()
+        val invocationFailure = CompletableDeferred<Throwable>()
+        val delayMillisSeen = mutableListOf<Long>()
+        override fun onCallStarted(context: OperationCallContext): OperationObservation =
+            RetryScheduledObservation(this)
+    }
+
+    private class RetryScheduledObservation(private val capture: RetryEventCapture) : OperationObservation {
+        override fun onProviderResponse(response: ModelResponse) = Unit
+        override fun onProviderFailure(error: Throwable) = Unit
+        override fun onStructuredParseFailure(rawResponse: String, errorSummary: String) = Unit
+        override fun onEngineEvent(name: String, attributes: Map<String, Any?>) {
+            if (name == RuntimeEvents.RETRY_SCHEDULED.name) {
+                capture.delayMillisSeen += attributes[RuntimeAttributes.DELAY_MILLIS.name] as Long
+                capture.retryScheduled.complete(attributes)
+            }
+        }
+        override fun onCallCompleted(parseSuccess: Boolean?) = Unit
+        override fun onCallCancelled() = Unit
+    }
+
+    @Test
+    fun `P0-E engine composition graph consumes the injected jitter source`() = runBlocking {
+        val source = QueuedJitterSource(0.25, 0.75)
+        val capture = RetryEventCapture()
+        val registry = ProviderRegistry.singleProvider(FailingProvider())
+        val components = EngineComponentFactory.create(
+            providerRegistry = registry,
+            structuredOutputHandler = null,
+            toolRegistry = dev.tramai.engine.ToolRegistry(),
+            operationObserver = capture,
+            operationInterceptor = object : dev.tramai.core.observation.OperationInterceptor {},
+            responseCache = dev.tramai.engine.NoOpOperationResponseCache,
+            modelRegistry = dev.tramai.core.model.NoOpModelRegistry,
+            modelRegistrySettings = dev.tramai.core.model.ModelRegistrySettings(),
+            circuitBreakerSettings = dev.tramai.engine.CircuitBreakerSettings(),
+            retryPolicySettings = RetryPolicySettings(jitterRatio = 0.20),
+            tokenBudgetSettings = dev.tramai.engine.TokenBudgetSettings(),
+            promptSanitizer = null,
+            chatMemory = null,
+            conversationIdProvider = dev.tramai.core.memory.UuidConversationIdProvider(),
+            policyEngine = dev.tramai.core.policy.PolicyEngine { _ -> dev.tramai.core.policy.PolicyDecision.Allow },
+            dlpInterceptor = dev.tramai.core.security.NoOpDlpInterceptor,
+            dlpRedactionAuditEmitter = dev.tramai.core.security.NoOpDlpRedactionAuditEmitter,
+            toolResultFilteringSettings = dev.tramai.engine.ToolResultFilteringSettings(),
+            engineEventObserver = dev.tramai.engine.NoOpEngineEventObserver,
+            toolFailureDiagnosticObserver = NoOpToolFailureDiagnosticObserver,
+            policyDecisionAuditEmitter = NoOpPolicyDecisionAuditEmitter,
+            suspendedInvocationStore = dev.tramai.engine.InMemorySuspendedInvocationStore(),
+            approvalContinuationStore = null,
+            toolArgumentsDigester = null,
+            approvalGateCoordinator = null,
+            approvalLifecycleAuditEmitter = NoOpApprovalLifecycleAuditEmitter,
+            clock = java.time.Clock.systemUTC(),
+            retryJitterSource = source,
+        )
+        val engine = TramaiEngine(components)
+        val service = engine.create(ExplicitRetryService::class)
+        val job = launch {
+            try {
+                service.answer("hello")
+            } catch (t: Throwable) {
+                capture.invocationFailure.complete(t)
+            }
+        }
+        val outcome = kotlinx.coroutines.withTimeout(10_000) {
+            kotlinx.coroutines.selects.select {
+                capture.retryScheduled.onAwait { "retry" to it }
+                capture.invocationFailure.onAwait { "failure" to null }
+            }
+        }
+        check(outcome.first == "retry") {
+            "expected RETRY_SCHEDULED, got invocation failure: " +
+                (if (capture.invocationFailure.isCompleted) capture.invocationFailure.getCompleted() else "timeout")
+        }
+        val attributes = outcome.second!!
+        // fallback base for retryIndex 0 = minOf(50 shl 0, 1000) = 50; jitter .20, sample .25:
+        // 50 + 50*.2*.25 = 52.5 -> 52. One sample consumed for the first authorized retry.
+        assertThat(attributes[RuntimeAttributes.DELAY_MILLIS.name]).isEqualTo(52L)
+        assertThat(source.calls).isEqualTo(1)
+        job.cancel()
+        engine.close()
+    }
+}


### PR DESCRIPTION
## Epic 8.3b1 — Retry jitter randomness boundary

**Base:** master `71a33c8d` · **Head:** `df44a71b`

### Invariant
For identical retry inputs and identical injected jitter samples, retry decisions and delays are deterministic. **Randomness affects only the magnitude of an already-authorized retry delay** — never whether to retry, which route, fallback, or breaker ownership. Retry entropy is sampled only after retry authorization, exactly once per authorized delay, from a source whose sample is constrained to `[0,1)`; invalid entropy fails fast.

### Change
- `RetryJitterSource` fun-interface + `DefaultRetryJitterSource` (global Random) in `ProviderRetryPolicy.kt`
- `ProviderRetryDelayPolicy` takes the source and **validates the sample domain `[0.0, 1.0)`** (rejects negative, ≥1.0, NaN, ±Inf) — source owns entropy, policy owns validation
- `ExecutionComponents` carries the **composed** `retryDelayPolicy`, not raw settings
- `EngineComponentFactory` composes `ProviderRetryDelayPolicy(settings, retryJitterSource)` — the single authoritative boundary
- `TramaiEngine` consumes `components.execution.retryDelayPolicy`; hidden global-Random reconstruction deleted; primary ctor `internal` (ABI-clean test seam — the private-ctor + companion alternative generates a public synthetic `DefaultConstructorMarker` constructor in the API dump and fails apiCheck)
- Public API byte-identical (apiCheck zero dump diff)

### Evidence (all local, exact head)
- **9 discriminators GREEN** (3 consecutive runs): P0-A exact 105/115 · P0-B decide-level one sample + delay-sequence authoritative · P0-C Stop×2 zero entropy · P0-D cap-then-jitter 1100 · P0-F invalid samples (−0.1, 1.0, NaN, ±Inf) → IllegalArgumentException · P0-E whole-engine `RETRY_SCHEDULED.delayMillis == 52`, exactly 1 sample, `cancelAndJoin()` before the entropy assertion (single-sample source — no attempt can mint a second call even if cancellation races the retry delay), no sleeps
- **Mutation campaign 10 STRONG / 0 WEAK / 0 REDUNDANT** (M01 engine-ignores-source … M09 base bypass, M10 validation-bypassed; restored-source probe GREEN)
- `:tramai-engine:test --rerun-tasks` GREEN (2m44s, incl. 8.2h lifecycle suite)
- apiCheck GREEN · verifyChangePolicy (runtime-behaviour, 10 files) · verify060Architecture · verifyMaintainabilityBaseline PASSED
- Rebased onto `71a33c8d` (#322 build-conventions); **zero engine tree drift** vs pre-rebase head

### Out of scope
UUID attempt IDs, WorkflowContext default workflowId, lease IDs, scheduler owner IDs, conversation IDs, approval IDs, SecureRandom tokens, scheduler/delay ownership, #318 File/JDBC chronology.
