### PR TITLE
fix(orchestration): #318 — durable creation-order authority for File/JDBC step-attempt stores

### DIFF
--- a/config/quality/api-migrations.yml
+++ b/config/quality/api-migrations.yml
@@ -51,3 +51,10 @@ migrations:
     targetVersion: "0.5.0"
     rationale: "Refresh committed API dump to match current source; the SovereignOpsAuditOutboxStore API changed before API-compatibility enforcement existed (attempt-count parameter type). No new API surface introduced by this PR."
     migration: "Consumers of SovereignOpsAuditOutboxStore with an attempt-count parameter must pass int instead of the previous parameter layout; source-compatible callers require no change."
+
+  - module: ":tramai-orchestration"
+    fromSha256: "c5d9c58e5be2036e5786827251c5f44edd8d432e4644ebc5837b070372617cec"
+    toSha256: "5a33d87b2d235c916c50dd33b08d2a01da22d898858f1b99fbf01237cf72aeb6"
+    targetVersion: "0.5.0"
+    rationale: "Intentional additive API: JdbcStepAttemptRecordStore.createTableSql() is restored to a single executable DDL statement; multi-statement provisioning is exposed explicitly via createSchemaSql()/createSequenceTableSql() (one statement per entry, generic-JDBC safe). No signature changed; binary compatibility preserved."
+    migration: "Applications executing createTableSql() alone must additionally execute createSequenceTableSql() (or createSchemaSql()) so the sequence counter table exists; source-compatible callers require no other change."

--- a/tramai-orchestration/api/tramai-orchestration.api
+++ b/tramai-orchestration/api/tramai-orchestration.api
@@ -381,6 +381,8 @@ public final class dev/tramai/orchestration/JdbcStepAttemptRecordStore : dev/tra
 	public synthetic fun <init> (Ljavax/sql/DataSource;Ldev/tramai/orchestration/JdbcStepAttemptTable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljavax/sql/DataSource;Ldev/tramai/orchestration/JdbcStepAttemptTable;Ldev/tramai/orchestration/PersistenceFailureDiagnosticObserver;)V
 	public fun compareAndSetStepAttempt (Ldev/tramai/orchestration/StepAttemptRecord;Ldev/tramai/orchestration/StepAttemptRecord;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createSchemaSql ()Ljava/util/List;
+	public final fun createSequenceTableSql ()Ljava/lang/String;
 	public final fun createTableSql ()Ljava/lang/String;
 	public final fun getPersistenceFailureDiagnosticObserver ()Ldev/tramai/orchestration/PersistenceFailureDiagnosticObserver;
 	public fun latestStepAttempt (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FileStepAttemptRecordStore.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FileStepAttemptRecordStore.kt
@@ -214,9 +214,33 @@ class FileStepAttemptRecordStore internal constructor(
 
     private fun allocateSequence(runId: String): Long {
         val path = sequencePath(runId)
-        val next = readSequenceCounter(path) + 1
+        // Bound below by the durable maximum already persisted for the run: a regressed
+        // counter must never reuse an existing sequence (chronology requires strict
+        // monotonic uniqueness, not contiguity). Corrupt attempt files fail closed.
+        val next = maxOf(readSequenceCounter(path), maxPersistedSequence(runId)) + 1
         writeSequenceCounter(path, next)
         return next
+    }
+
+    private fun maxPersistedSequence(runId: String): Long {
+        val runDirectory = rootDirectory.resolve(base64UrlEncodeNoPadding(runId))
+        if (!Files.exists(runDirectory)) return 0L
+        val files = Files.walk(runDirectory).use { stream ->
+            stream.filter(Files::isRegularFile)
+                .filter { it.fileName.toString().endsWith(ATTEMPT_SUFFIX) }
+                .toList()
+        }
+        var max = 0L
+        for (path in files) {
+            val relative = runDirectory.relativize(path)
+            if (relative.nameCount != 2) {
+                throw CorruptStepAttemptException("Persisted step-attempt record is invalid", path.toString())
+            }
+            val keyStepName = decodePathSegment(relative.getName(0).toString(), path)
+            val keyAttemptId = decodePathSegment(relative.fileName.toString().removeSuffix(ATTEMPT_SUFFIX), path)
+            readStoredRecord(path, runId, keyStepName, keyAttemptId).attemptSequence?.let { if (it > max) max = it }
+        }
+        return max
     }
 
     private fun readStoredRecord(path: Path, runId: String, stepName: String, attemptId: String): DecodedStepAttemptRecord {

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FileStepAttemptRecordStore.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/FileStepAttemptRecordStore.kt
@@ -25,6 +25,7 @@ class FileStepAttemptRecordStore internal constructor(
 
     internal companion object {
         private const val ATTEMPT_SUFFIX = ".attempt.properties"
+        private const val SEQUENCE_SUFFIX = ".attempt-sequence"
         private const val RECORD_HASH = "record_hash"
 
         fun forTest(rootDirectory: Path, atomicWriter: AtomicFileWriter): FileStepAttemptRecordStore =
@@ -46,8 +47,13 @@ class FileStepAttemptRecordStore internal constructor(
             classify = ::classifyStepAttemptFailure,
         ) {
             val path = attemptPath(record.runId, record.stepName, record.attemptId)
-            withFileLockCancellable(path) {
-                atomicWriter.write(path, encodeStoredRecord(record))
+            withFileLockCancellable(sequencePath(record.runId)) {
+                val sequence = if (Files.exists(path)) {
+                    readStoredRecord(path, record.runId, record.stepName, record.attemptId).attemptSequence
+                } else {
+                    allocateSequence(record.runId)
+                }
+                atomicWriter.write(path, encodeStoredRecord(record, sequence))
                 record
             }
         }
@@ -60,12 +66,12 @@ class FileStepAttemptRecordStore internal constructor(
             classify = ::classifyStepAttemptFailure,
         ) {
             val path = attemptPath(record.runId, record.stepName, record.attemptId)
-            withFileLockCancellable(path) {
+            withFileLockCancellable(sequencePath(record.runId)) {
                 if (!Files.exists(path)) {
                     throw IllegalStateException("Step attempt does not exist")
                 }
-                readStoredRecord(path, record.runId, record.stepName, record.attemptId)
-                atomicWriter.write(path, encodeStoredRecord(record))
+                val existing = readStoredRecord(path, record.runId, record.stepName, record.attemptId)
+                atomicWriter.write(path, encodeStoredRecord(record, existing.attemptSequence))
                 record
             }
         }
@@ -82,16 +88,16 @@ class FileStepAttemptRecordStore internal constructor(
             classify = ::classifyStepAttemptFailure,
         ) {
             val path = attemptPath(expected.runId, expected.stepName, expected.attemptId)
-            withFileLockCancellable(path) {
+            withFileLockCancellable(sequencePath(expected.runId)) {
                 val current = if (Files.exists(path)) {
                     readStoredRecord(path, expected.runId, expected.stepName, expected.attemptId)
                 } else {
                     null
                 }
-                if (current != expected) {
+                if (current?.record != expected) {
                     false
                 } else {
-                    atomicWriter.write(path, encodeStoredRecord(updated))
+                    atomicWriter.write(path, encodeStoredRecord(updated, current.attemptSequence))
                     true
                 }
             }
@@ -127,7 +133,14 @@ class FileStepAttemptRecordStore internal constructor(
                             null
                         }
                     }
-                }.maxWithOrNull(compareBy<StepAttemptRecord>({ it.startedAt }, { it.attemptId }))
+                }.maxWithOrNull(
+                    compareBy<DecodedStepAttemptRecord>(
+                        { it.record.startedAt },
+                        { it.record.stepName },
+                        { it.attemptSequence ?: Long.MIN_VALUE },
+                        { it.record.attemptId },
+                    ),
+                )?.record
             }
         }
     }
@@ -165,18 +178,48 @@ class FileStepAttemptRecordStore internal constructor(
                         }
                     }
                 }.filterNotNull().sortedWith(
-                    compareBy<StepAttemptRecord>({ it.startedAt }, { it.stepName }, { it.attemptId }),
-                )
+                    compareBy<DecodedStepAttemptRecord>(
+                        { it.record.startedAt },
+                        { it.record.stepName },
+                        { it.attemptSequence ?: Long.MIN_VALUE },
+                        { it.record.attemptId },
+                    ),
+                ).map(DecodedStepAttemptRecord::record)
             }
         }
     }
+
+    private fun sequencePath(runId: String): Path = rootDirectory
+        .resolve(base64UrlEncodeNoPadding(runId))
+        .resolve(SEQUENCE_SUFFIX)
 
     private fun attemptPath(runId: String, stepName: String, attemptId: String): Path = rootDirectory
         .resolve(base64UrlEncodeNoPadding(runId))
         .resolve(base64UrlEncodeNoPadding(stepName))
         .resolve(base64UrlEncodeNoPadding(attemptId) + ATTEMPT_SUFFIX)
 
-    private fun readStoredRecord(path: Path, runId: String, stepName: String, attemptId: String): StepAttemptRecord {
+    private fun readSequenceCounter(path: Path): Long {
+        if (!Files.exists(path)) return 0
+        val value = try {
+            Files.readString(path).trim().toLongOrNull()
+        } catch (error: Exception) {
+            throw CorruptStepAttemptException("Persisted step-attempt record is invalid", path.toString(), error)
+        }
+        return value ?: throw CorruptStepAttemptException("Persisted step-attempt record is invalid", path.toString())
+    }
+
+    private fun writeSequenceCounter(path: Path, value: Long) {
+        atomicWriter.write(path, value.toString())
+    }
+
+    private fun allocateSequence(runId: String): Long {
+        val path = sequencePath(runId)
+        val next = readSequenceCounter(path) + 1
+        writeSequenceCounter(path, next)
+        return next
+    }
+
+    private fun readStoredRecord(path: Path, runId: String, stepName: String, attemptId: String): DecodedStepAttemptRecord {
         val payload = try {
             Files.readString(path)
         } catch (error: Exception) {
@@ -187,18 +230,24 @@ class FileStepAttemptRecordStore internal constructor(
         } catch (error: Exception) {
             throw CorruptStepAttemptException("Persisted step-attempt record is invalid", payload, error)
         }
-        val record = StepAttemptRecordCodec.decode(payload)
+        val decoded = StepAttemptRecordCodec.decodeWithSequence(payload)
         val storedHash = properties.getProperty(RECORD_HASH)
             ?: throw CorruptStepAttemptException("Persisted step-attempt record is invalid", path.toString())
-        StepAttemptRecordCodec.requireValidFingerprint(record, storedHash, path.toString())
-        if (record.identity() != AttemptIdentity(runId, stepName, attemptId)) {
+        StepAttemptRecordCodec.requireValidFingerprint(
+            decoded.record,
+            decoded.attemptSequence,
+            storedHash,
+            path.toString(),
+        )
+        if (decoded.record.identity() != AttemptIdentity(runId, stepName, attemptId)) {
             throw CorruptStepAttemptException("Persisted step-attempt record is invalid", path.toString())
         }
-        return record
+        return decoded
     }
 
-    private fun encodeStoredRecord(record: StepAttemptRecord): String =
-        StepAttemptRecordCodec.encode(record) + "$RECORD_HASH=${StepAttemptRecordCodec.fingerprint(record)}\n"
+    private fun encodeStoredRecord(record: StepAttemptRecord, attemptSequence: Long?): String =
+        StepAttemptRecordCodec.encode(record, attemptSequence) +
+            "$RECORD_HASH=${StepAttemptRecordCodec.fingerprint(record, attemptSequence)}\n"
 
     private fun decodePathSegment(value: String, path: Path): String = try {
         base64UrlDecode(value)

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/JdbcStepAttemptRecordStore.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/JdbcStepAttemptRecordStore.kt
@@ -7,6 +7,9 @@ import java.sql.SQLException
 import java.sql.Types
 import javax.sql.DataSource
 
+private const val ATTEMPT_SEQUENCE_COLUMN = "attempt_sequence"
+private const val SEQUENCE_TABLE = "tramai_attempt_sequence"
+
 class JdbcStepAttemptRecordStore(
     private val dataSource: DataSource,
     private val table: JdbcStepAttemptTable = JdbcStepAttemptTable(),
@@ -26,12 +29,12 @@ class JdbcStepAttemptRecordStore(
     override suspend fun recordStepAttempt(record: StepAttemptRecord): StepAttemptRecord {
         record.requirePersistableIdentity()
         return persistenceBoundary(PersistenceResourceKind.STEP_ATTEMPT, PersistenceOperation.SAVE, persistenceFailureDiagnosticObserver, ::classifyStepAttemptFailure) {
-            executeJdbcCancellable(dataSource) { conn ->
-                if (update(conn, record, requireHash = null) == 0) {
+            executeJdbcCancellable(dataSource, transactional = true) { conn ->
+                if (update(conn, record, expected = null) == 0) {
                     try {
-                        insert(conn, record)
+                        insert(conn, record, allocateSequence(conn, record.runId))
                     } catch (error: SQLException) {
-                        if (update(conn, record, requireHash = null) == 0) throw error
+                        if (update(conn, record, expected = null) == 0) throw error
                     }
                 }
                 record
@@ -42,14 +45,14 @@ class JdbcStepAttemptRecordStore(
     override suspend fun updateStepAttempt(record: StepAttemptRecord): StepAttemptRecord {
         record.requirePersistableIdentity()
         return persistenceBoundary(PersistenceResourceKind.STEP_ATTEMPT, PersistenceOperation.SAVE, persistenceFailureDiagnosticObserver, ::classifyStepAttemptFailure) {
-            executeJdbcCancellable(dataSource) { conn ->
-                if (update(conn, record, requireHash = null) == 0) {
+            executeJdbcCancellable(dataSource, transactional = true) { conn ->
+                if (update(conn, record, expected = null) == 0) {
                     if (!exists(conn, record)) {
                         throw IllegalStateException("Step attempt does not exist")
                     }
                     // A concurrent recordStepAttempt inserted the row between our UPDATE and the
                     // existence check — retry so the update is not silently dropped.
-                    update(conn, record, requireHash = null)
+                    update(conn, record, expected = null)
                 }
                 record
             }
@@ -63,8 +66,8 @@ class JdbcStepAttemptRecordStore(
         if (expected.key() != updated.key()) return false
         updated.requirePersistableIdentity()
         return persistenceBoundary(PersistenceResourceKind.STEP_ATTEMPT, PersistenceOperation.COMPARE_AND_SET, persistenceFailureDiagnosticObserver, ::classifyStepAttemptFailure) {
-            executeJdbcCancellable(dataSource) { conn ->
-                update(conn, updated, StepAttemptRecordCodec.fingerprint(expected)) > 0
+            executeJdbcCancellable(dataSource, transactional = true) { conn ->
+                update(conn, updated, expected) > 0
             }
         }
     }
@@ -118,27 +121,81 @@ class JdbcStepAttemptRecordStore(
             ${table.resolutionAtEpochMillisColumn} BIGINT NULL,
             ${table.resolutionActionColumn} VARCHAR(64) NULL,
             ${table.approvedIdempotencyKeyColumn} VARCHAR(1024) NULL,
+            $ATTEMPT_SEQUENCE_COLUMN BIGINT NOT NULL,
             ${table.recordSchemaVersionColumn} VARCHAR(16) NOT NULL,
             ${table.recordHashColumn} VARCHAR(64) NOT NULL,
             PRIMARY KEY (${table.runIdColumn}, ${table.stepNameColumn}, ${table.attemptIdColumn})
+        );
+        CREATE TABLE $SEQUENCE_TABLE (
+            run_id VARCHAR(255) NOT NULL PRIMARY KEY,
+            next_value BIGINT NOT NULL
         )
     """.trimIndent()
 
-    private fun insert(conn: Connection, record: StepAttemptRecord) {
+    private fun insert(conn: Connection, record: StepAttemptRecord, sequence: Long) {
         conn.prepareStatement(insertSql()).use { statement ->
-            statement.bindAll(record, 1)
+            statement.bindAll(record, sequence, 1)
             statement.executeUpdate()
         }
     }
 
-    private fun update(conn: Connection, record: StepAttemptRecord, requireHash: String?): Int =
-        conn.prepareStatement(updateSql(requireHash != null)).use { statement ->
-            var index = statement.bindMutable(record, 1)
+    private fun update(conn: Connection, record: StepAttemptRecord, expected: StepAttemptRecord?): Int {
+        val sequence = readSequence(conn, record.runId, record.stepName, record.attemptId) ?: return 0
+        return conn.prepareStatement(updateSql(expected != null)).use { statement ->
+            var index = statement.bindMutable(record, sequence, 1)
             statement.setString(index++, record.runId)
             statement.setString(index++, record.stepName)
             statement.setString(index++, record.attemptId)
-            if (requireHash != null) statement.setString(index, requireHash)
+            if (expected != null) statement.setString(index, StepAttemptRecordCodec.fingerprint(expected, sequence))
             statement.executeUpdate()
+        }
+    }
+
+    private fun allocateSequence(conn: Connection, runId: String): Long {
+        val updated = conn.prepareStatement(
+            "UPDATE $SEQUENCE_TABLE SET next_value = next_value + 1 WHERE run_id = ?",
+        ).use { statement ->
+            statement.setString(1, runId)
+            statement.executeUpdate()
+        }
+        if (updated == 0) {
+            try {
+                conn.prepareStatement(
+                    "INSERT INTO $SEQUENCE_TABLE (run_id, next_value) VALUES (?, 1)",
+                ).use { statement ->
+                    statement.setString(1, runId)
+                    statement.executeUpdate()
+                }
+            } catch (_: SQLException) {
+                conn.prepareStatement(
+                    "UPDATE $SEQUENCE_TABLE SET next_value = next_value + 1 WHERE run_id = ?",
+                ).use { statement ->
+                    statement.setString(1, runId)
+                    statement.executeUpdate()
+                }
+            }
+        }
+        return conn.prepareStatement("SELECT next_value FROM $SEQUENCE_TABLE WHERE run_id = ?").use { statement ->
+            statement.setString(1, runId)
+            statement.executeQuery().use { resultSet ->
+                if (resultSet.next()) resultSet.getLong(1)
+                else throw IllegalStateException("Step-attempt sequence does not exist")
+            }
+        }
+    }
+
+    private fun readSequence(conn: Connection, runId: String, stepName: String, attemptId: String): Long? =
+        conn.prepareStatement(
+            "SELECT $ATTEMPT_SEQUENCE_COLUMN FROM ${table.tableName} " +
+                "WHERE ${table.runIdColumn} = ? AND ${table.stepNameColumn} = ? AND ${table.attemptIdColumn} = ?",
+        ).use { statement ->
+            statement.setString(1, runId)
+            statement.setString(2, stepName)
+            statement.setString(3, attemptId)
+            statement.executeQuery().use { resultSet ->
+                if (resultSet.next()) resultSet.nullableLong(ATTEMPT_SEQUENCE_COLUMN)
+                else null
+            }
         }
 
     private fun exists(conn: Connection, record: StepAttemptRecord): Boolean =
@@ -151,7 +208,7 @@ class JdbcStepAttemptRecordStore(
 
     private fun insertSql(): String = """
         INSERT INTO ${table.tableName} (${allColumns()})
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     """.trimIndent()
 
     private fun updateSql(compareHash: Boolean): String = buildString {
@@ -169,13 +226,13 @@ class JdbcStepAttemptRecordStore(
     private fun listSql(): String = """
         SELECT ${allColumns()} FROM ${table.tableName}
         WHERE ${table.runIdColumn} = ?
-        ORDER BY ${table.startedAtColumn}, ${table.stepNameColumn}, ${table.attemptIdColumn}
+        ORDER BY ${table.startedAtColumn}, ${table.stepNameColumn}, $ATTEMPT_SEQUENCE_COLUMN, ${table.attemptIdColumn}
     """.trimIndent()
 
     private fun latestSql(): String = """
         SELECT ${allColumns()} FROM ${table.tableName}
         WHERE ${table.runIdColumn} = ? AND ${table.stepNameColumn} = ?
-        ORDER BY ${table.startedAtColumn} DESC, ${table.attemptIdColumn} DESC
+        ORDER BY ${table.startedAtColumn} DESC, $ATTEMPT_SEQUENCE_COLUMN DESC, ${table.attemptIdColumn} DESC
         LIMIT 1
     """.trimIndent()
 
@@ -187,6 +244,7 @@ class JdbcStepAttemptRecordStore(
     ).joinToString(", ")
 
     private fun mutableColumns(): List<String> = listOf(
+        ATTEMPT_SEQUENCE_COLUMN,
         table.workerIdColumn,
         table.leaseTokenColumn,
         table.statusColumn,
@@ -204,15 +262,16 @@ class JdbcStepAttemptRecordStore(
         table.recordHashColumn,
     )
 
-    private fun PreparedStatement.bindAll(record: StepAttemptRecord, start: Int) {
+    private fun PreparedStatement.bindAll(record: StepAttemptRecord, sequence: Long, start: Int) {
         setString(start, record.runId)
         setString(start + 1, record.stepName)
         setString(start + 2, record.attemptId)
-        bindMutable(record, start + 3)
+        bindMutable(record, sequence, start + 3)
     }
 
-    private fun PreparedStatement.bindMutable(record: StepAttemptRecord, start: Int): Int {
+    private fun PreparedStatement.bindMutable(record: StepAttemptRecord, sequence: Long, start: Int): Int {
         var index = start
+        setLong(index++, sequence)
         setString(index++, record.workerId)
         setString(index++, record.leaseToken)
         setString(index++, record.status.name)
@@ -227,7 +286,7 @@ class JdbcStepAttemptRecordStore(
         setNullableString(index++, record.resolutionAction?.name)
         setNullableString(index++, record.approvedIdempotencyKey)
         setString(index++, StepAttemptRecordCodec.SCHEMA_VERSION)
-        setString(index++, StepAttemptRecordCodec.fingerprint(record))
+        setString(index++, StepAttemptRecordCodec.fingerprint(record, sequence))
         return index
     }
 
@@ -269,9 +328,16 @@ class JdbcStepAttemptRecordStore(
         if (storedVersion != StepAttemptRecordCodec.SCHEMA_VERSION) {
             throw CorruptStepAttemptException("Unsupported step-attempt schema version", storedVersion)
         }
+        val sequence = try {
+            nullableLong(ATTEMPT_SEQUENCE_COLUMN) ?: corruptColumn(ATTEMPT_SEQUENCE_COLUMN)
+        } catch (error: CorruptStepAttemptException) {
+            throw error
+        } catch (error: Exception) {
+            throw CorruptStepAttemptException("Persisted step-attempt record is invalid", "JDBC storage", error)
+        }
         val storedHash = getString(table.recordHashColumn)
             ?: throw CorruptStepAttemptException("Persisted step-attempt record is invalid", table.recordHashColumn)
-        StepAttemptRecordCodec.requireValidFingerprint(record, storedHash, "JDBC storage")
+        StepAttemptRecordCodec.requireValidFingerprint(record, sequence, storedHash, "JDBC storage")
         return record
     }
 

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/JdbcStepAttemptRecordStore.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/JdbcStepAttemptRecordStore.kt
@@ -31,9 +31,15 @@ class JdbcStepAttemptRecordStore(
         return persistenceBoundary(PersistenceResourceKind.STEP_ATTEMPT, PersistenceOperation.SAVE, persistenceFailureDiagnosticObserver, ::classifyStepAttemptFailure) {
             executeJdbcCancellable(dataSource, transactional = true) { conn ->
                 if (update(conn, record, expected = null) == 0) {
+                    val savepoint = conn.setSavepoint()
                     try {
                         insert(conn, record, allocateSequence(conn, record.runId))
                     } catch (error: SQLException) {
+                        // A concurrent writer inserted the identity between our UPDATE and the
+                        // INSERT. Roll back to the savepoint so the failed INSERT cannot abort
+                        // the transaction on strict databases (PostgreSQL), then retry the
+                        // update — it preserves the winner's sequence.
+                        conn.rollback(savepoint)
                         if (update(conn, record, expected = null) == 0) throw error
                     }
                 }
@@ -159,6 +165,7 @@ class JdbcStepAttemptRecordStore(
             statement.executeUpdate()
         }
         if (updated == 0) {
+            val savepoint = conn.setSavepoint()
             try {
                 conn.prepareStatement(
                     "INSERT INTO $SEQUENCE_TABLE (run_id, next_value) VALUES (?, 1)",
@@ -167,6 +174,10 @@ class JdbcStepAttemptRecordStore(
                     statement.executeUpdate()
                 }
             } catch (_: SQLException) {
+                // A racing first-writer inserted the run row. Roll back to the savepoint so
+                // the failed INSERT cannot abort the transaction on strict databases
+                // (PostgreSQL), then increment the winner's row.
+                conn.rollback(savepoint)
                 conn.prepareStatement(
                     "UPDATE $SEQUENCE_TABLE SET next_value = next_value + 1 WHERE run_id = ?",
                 ).use { statement ->

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/JdbcStepAttemptRecordStore.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/JdbcStepAttemptRecordStore.kt
@@ -8,7 +8,16 @@ import java.sql.Types
 import javax.sql.DataSource
 
 private const val ATTEMPT_SEQUENCE_COLUMN = "attempt_sequence"
-private const val SEQUENCE_TABLE = "tramai_attempt_sequence"
+
+/**
+ * A persisted step-attempt row after full integrity verification (schema version,
+ * record fingerprint including the creation sequence). The sequence is immutable
+ * per identity; mutations must preserve the verified value, never a raw re-read.
+ */
+internal data class StoredStepAttempt(
+    val record: StepAttemptRecord,
+    val sequence: Long,
+)
 
 class JdbcStepAttemptRecordStore(
     private val dataSource: DataSource,
@@ -109,6 +118,12 @@ class JdbcStepAttemptRecordStore(
         }
     }
 
+    /**
+     * DDL for the step-attempt table: exactly ONE executable statement (generic
+     * JDBC drivers may reject multi-query strings). The `(run_id, attempt_sequence)`
+     * uniqueness constraint guarantees distinct durable chronology even if the
+     * counter authority were ever corrupted.
+     */
     fun createTableSql(): String = """
         CREATE TABLE ${table.tableName} (
             ${table.runIdColumn} VARCHAR(255) NOT NULL,
@@ -130,13 +145,29 @@ class JdbcStepAttemptRecordStore(
             $ATTEMPT_SEQUENCE_COLUMN BIGINT NOT NULL,
             ${table.recordSchemaVersionColumn} VARCHAR(16) NOT NULL,
             ${table.recordHashColumn} VARCHAR(64) NOT NULL,
-            PRIMARY KEY (${table.runIdColumn}, ${table.stepNameColumn}, ${table.attemptIdColumn})
-        );
-        CREATE TABLE $SEQUENCE_TABLE (
+            PRIMARY KEY (${table.runIdColumn}, ${table.stepNameColumn}, ${table.attemptIdColumn}),
+            UNIQUE (${table.runIdColumn}, $ATTEMPT_SEQUENCE_COLUMN)
+        )
+    """.trimIndent()
+
+    /**
+     * DDL for the per-run sequence counter table, derived from the configured attempt
+     * table name so distinct stores never collide on one global counter table.
+     */
+    fun createSequenceTableSql(): String = """
+        CREATE TABLE ${sequenceTableName()} (
             run_id VARCHAR(255) NOT NULL PRIMARY KEY,
             next_value BIGINT NOT NULL
         )
     """.trimIndent()
+
+    /**
+     * All schema statements this store requires, one statement per entry so every
+     * entry is executable through generic JDBC (`statement.execute(sql)`).
+     */
+    fun createSchemaSql(): List<String> = listOf(createTableSql(), createSequenceTableSql())
+
+    private fun sequenceTableName(): String = "${table.tableName}_sequence"
 
     private fun insert(conn: Connection, record: StepAttemptRecord, sequence: Long) {
         conn.prepareStatement(insertSql()).use { statement ->
@@ -146,20 +177,72 @@ class JdbcStepAttemptRecordStore(
     }
 
     private fun update(conn: Connection, record: StepAttemptRecord, expected: StepAttemptRecord?): Int {
-        val sequence = readSequence(conn, record.runId, record.stepName, record.attemptId) ?: return 0
+        // Verify the existing row (schema, fingerprint, sequence) BEFORE touching it:
+        // a corrupted sequence must fail closed here, never be re-signed into valid
+        // persisted state by an ordinary update or CAS.
+        val current = loadVerified(conn, record.runId, record.stepName, record.attemptId) ?: return 0
         return conn.prepareStatement(updateSql(expected != null)).use { statement ->
-            var index = statement.bindMutable(record, sequence, 1)
+            var index = statement.bindMutable(record, current.sequence, 1)
             statement.setString(index++, record.runId)
             statement.setString(index++, record.stepName)
             statement.setString(index++, record.attemptId)
-            if (expected != null) statement.setString(index, StepAttemptRecordCodec.fingerprint(expected, sequence))
+            if (expected != null) statement.setString(index, StepAttemptRecordCodec.fingerprint(expected, current.sequence))
             statement.executeUpdate()
         }
     }
 
+    /**
+     * Loads the full row for the identity and runs the same integrity verification as
+     * [ResultSet.toVerifiedRecord]. Returns null when the row is absent; throws on
+     * any corrupt persisted value (including a corrupted creation sequence).
+     */
+    private fun loadVerified(conn: Connection, runId: String, stepName: String, attemptId: String): StoredStepAttempt? =
+        conn.prepareStatement(loadSql()).use { statement ->
+            statement.setString(1, runId)
+            statement.setString(2, stepName)
+            statement.setString(3, attemptId)
+            statement.executeQuery().use { resultSet ->
+                if (resultSet.next()) {
+                    val record = resultSet.toVerifiedRecord()
+                    val sequence = resultSet.nullableLong(ATTEMPT_SEQUENCE_COLUMN)
+                        ?: throw CorruptStepAttemptException("Persisted step-attempt record is invalid", ATTEMPT_SEQUENCE_COLUMN)
+                    StoredStepAttempt(record, sequence)
+                } else {
+                    null
+                }
+            }
+        }
+
+    /**
+     * Atomically allocates the next creation sequence for [runId], bounded below by the
+     * durable maximum already persisted for the run: a regressed counter must never
+     * reuse an existing sequence (uniqueness is also enforced by the
+     * `UNIQUE (run_id, attempt_sequence)` constraint).
+     */
     private fun allocateSequence(conn: Connection, runId: String): Long {
+        val maxPersisted = conn.prepareStatement(
+            "SELECT COALESCE(MAX($ATTEMPT_SEQUENCE_COLUMN), 0) FROM ${table.tableName} WHERE ${table.runIdColumn} = ?",
+        ).use { statement ->
+            statement.setString(1, runId)
+            statement.executeQuery().use { resultSet ->
+                if (resultSet.next()) resultSet.getLong(1) else 0L
+            }
+        }
+        val counter = incrementCounter(conn, runId)
+        val allocated = maxOf(counter, maxPersisted + 1)
+        if (allocated > counter) {
+            conn.prepareStatement("UPDATE ${sequenceTableName()} SET next_value = ? WHERE run_id = ?").use { statement ->
+                statement.setLong(1, allocated)
+                statement.setString(2, runId)
+                statement.executeUpdate()
+            }
+        }
+        return allocated
+    }
+
+    private fun incrementCounter(conn: Connection, runId: String): Long {
         val updated = conn.prepareStatement(
-            "UPDATE $SEQUENCE_TABLE SET next_value = next_value + 1 WHERE run_id = ?",
+            "UPDATE ${sequenceTableName()} SET next_value = next_value + 1 WHERE run_id = ?",
         ).use { statement ->
             statement.setString(1, runId)
             statement.executeUpdate()
@@ -168,7 +251,7 @@ class JdbcStepAttemptRecordStore(
             val savepoint = conn.setSavepoint()
             try {
                 conn.prepareStatement(
-                    "INSERT INTO $SEQUENCE_TABLE (run_id, next_value) VALUES (?, 1)",
+                    "INSERT INTO ${sequenceTableName()} (run_id, next_value) VALUES (?, 1)",
                 ).use { statement ->
                     statement.setString(1, runId)
                     statement.executeUpdate()
@@ -179,14 +262,14 @@ class JdbcStepAttemptRecordStore(
                 // (PostgreSQL), then increment the winner's row.
                 conn.rollback(savepoint)
                 conn.prepareStatement(
-                    "UPDATE $SEQUENCE_TABLE SET next_value = next_value + 1 WHERE run_id = ?",
+                    "UPDATE ${sequenceTableName()} SET next_value = next_value + 1 WHERE run_id = ?",
                 ).use { statement ->
                     statement.setString(1, runId)
                     statement.executeUpdate()
                 }
             }
         }
-        return conn.prepareStatement("SELECT next_value FROM $SEQUENCE_TABLE WHERE run_id = ?").use { statement ->
+        return conn.prepareStatement("SELECT next_value FROM ${sequenceTableName()} WHERE run_id = ?").use { statement ->
             statement.setString(1, runId)
             statement.executeQuery().use { resultSet ->
                 if (resultSet.next()) resultSet.getLong(1)
@@ -194,20 +277,6 @@ class JdbcStepAttemptRecordStore(
             }
         }
     }
-
-    private fun readSequence(conn: Connection, runId: String, stepName: String, attemptId: String): Long? =
-        conn.prepareStatement(
-            "SELECT $ATTEMPT_SEQUENCE_COLUMN FROM ${table.tableName} " +
-                "WHERE ${table.runIdColumn} = ? AND ${table.stepNameColumn} = ? AND ${table.attemptIdColumn} = ?",
-        ).use { statement ->
-            statement.setString(1, runId)
-            statement.setString(2, stepName)
-            statement.setString(3, attemptId)
-            statement.executeQuery().use { resultSet ->
-                if (resultSet.next()) resultSet.nullableLong(ATTEMPT_SEQUENCE_COLUMN)
-                else null
-            }
-        }
 
     private fun exists(conn: Connection, record: StepAttemptRecord): Boolean =
         conn.prepareStatement(existsSql()).use { statement ->
@@ -231,6 +300,11 @@ class JdbcStepAttemptRecordStore(
 
     private fun existsSql(): String = """
         SELECT ${table.attemptIdColumn} FROM ${table.tableName}
+        WHERE ${table.runIdColumn} = ? AND ${table.stepNameColumn} = ? AND ${table.attemptIdColumn} = ?
+    """.trimIndent()
+
+    private fun loadSql(): String = """
+        SELECT ${allColumns()} FROM ${table.tableName}
         WHERE ${table.runIdColumn} = ? AND ${table.stepNameColumn} = ? AND ${table.attemptIdColumn} = ?
     """.trimIndent()
 

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/StepAttemptRecord.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/StepAttemptRecord.kt
@@ -73,18 +73,17 @@ internal fun decodeResolutionAction(name: String?): StepAttemptResolutionAction?
  *
  * Ordering and retrieval:
  * - [listStepAttempts] returns records for one run ordered by `startedAt`, then
- *   `stepName`. Equal-key ordering must be deterministic and stable across reads;
- *   the final tie authority is implementation-specific today.
+ *   `stepName`, then durable creation sequence. Equal-key ordering is deterministic
+ *   and stable across reads.
  * - [latestStepAttempt] returns the record for the given run and step with the
- *   maximum `startedAt`. The equal-startedAt tie authority is implementation-specific
- *   today, or `null` when absent.
+ *   maximum `startedAt`, breaking ties by durable creation sequence, or `null` when
+ *   absent.
  *
- * Tie authority today:
- * - `InMemoryWorkflowCheckpointStore` additionally guarantees creation-order tie
- *   semantics (last-created wins `latest`; insertion order survives `list`).
- * - The file/JDBC implementations currently use `attemptId` (a random UUID) as the
- *   final deterministic tie-break. A durable creation-order authority requires a
- *   persisted sequence and is deferred (tracked as a cross-store follow-up).
+ * Tie authority:
+ * - Durable stores persist creation sequence as storage metadata. Replacing or
+ *   re-recording an identity preserves its original sequence.
+ * - Legacy records without a sequence use deterministic `attemptId` fallback and sort
+ *   before sequenced records with the same `startedAt`.
  *
  * Durability and failure behaviour:
  * - Persistent implementations must survive store recreation and process restart, and

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/StepAttemptRecord.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/StepAttemptRecord.kt
@@ -82,8 +82,10 @@ internal fun decodeResolutionAction(name: String?): StepAttemptResolutionAction?
  * Tie authority:
  * - Durable stores persist creation sequence as storage metadata. Replacing or
  *   re-recording an identity preserves its original sequence.
- * - Legacy records without a sequence use deterministic `attemptId` fallback and sort
- *   before sequenced records with the same `startedAt`.
+ * - File storage additionally supports legacy records without a sequence: they use
+ *   a deterministic `attemptId` fallback and sort before sequenced records with the
+ *   same `startedAt`. JDBC storage defines `attempt_sequence BIGINT NOT NULL` (fresh
+ *   schema), so null sequences cannot occur there.
  *
  * Durability and failure behaviour:
  * - Persistent implementations must survive store recreation and process restart, and

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/StepAttemptRecordCodec.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/StepAttemptRecordCodec.kt
@@ -5,11 +5,16 @@ import java.security.MessageDigest
 import java.util.Base64
 import java.util.Properties
 
+internal data class DecodedStepAttemptRecord(
+    val record: StepAttemptRecord,
+    val attemptSequence: Long?,
+)
+
 internal object StepAttemptRecordCodec {
     /** Current persisted-format version. Persisted stores must write and validate this. */
     internal const val SCHEMA_VERSION = "1"
 
-    fun encode(record: StepAttemptRecord): String = buildString {
+    fun encode(record: StepAttemptRecord, attemptSequence: Long? = null): String = buildString {
         property("schemaVersion", SCHEMA_VERSION)
         property("runId", encodeString(record.runId))
         property("stepName", encodeString(record.stepName))
@@ -27,6 +32,7 @@ internal object StepAttemptRecordCodec {
         nullableLong("resolutionAtEpochMillis", record.resolutionAtEpochMillis)
         nullableString("resolutionAction", record.resolutionAction?.name)
         nullableString("approvedIdempotencyKey", record.approvedIdempotencyKey)
+        if (attemptSequence != null) property("attemptSequence", attemptSequence.toString())
     }
 
     fun decode(payload: String): StepAttemptRecord = try {
@@ -59,15 +65,36 @@ internal object StepAttemptRecordCodec {
         throw CorruptStepAttemptException("Persisted step-attempt record is invalid", payload, error)
     }
 
-    fun fingerprint(record: StepAttemptRecord): String = MessageDigest.getInstance("SHA-256")
-        .digest(encode(record).toByteArray(StandardCharsets.UTF_8))
+    fun decodeWithSequence(payload: String): DecodedStepAttemptRecord = try {
+        val properties = Properties().apply { load(payload.reader()) }
+        val attemptSequence = properties.getProperty("attemptSequence")?.let { value ->
+            value.toLongOrNull()
+                ?: throw CorruptStepAttemptException("Persisted step-attempt record is invalid", payload)
+        }
+        DecodedStepAttemptRecord(decode(payload), attemptSequence)
+    } catch (error: CorruptStepAttemptException) {
+        throw error
+    } catch (error: Exception) {
+        throw CorruptStepAttemptException("Persisted step-attempt record is invalid", payload, error)
+    }
+
+    fun fingerprint(record: StepAttemptRecord, attemptSequence: Long? = null): String = MessageDigest.getInstance("SHA-256")
+        .digest(encode(record, attemptSequence).toByteArray(StandardCharsets.UTF_8))
         .joinToString("") { byte -> "%02x".format(byte) }
 
-    fun requireValidFingerprint(record: StepAttemptRecord, storedFingerprint: String, context: String) {
-        if (storedFingerprint != fingerprint(record)) {
+    fun requireValidFingerprint(
+        record: StepAttemptRecord,
+        attemptSequence: Long?,
+        storedFingerprint: String,
+        context: String,
+    ) {
+        if (storedFingerprint != fingerprint(record, attemptSequence)) {
             throw CorruptStepAttemptException("Persisted step-attempt record is invalid", context)
         }
     }
+
+    fun requireValidFingerprint(record: StepAttemptRecord, storedFingerprint: String, context: String) =
+        requireValidFingerprint(record, null, storedFingerprint, context)
 
     private fun StringBuilder.property(name: String, value: String) {
         append(name).append('=').append(value).append('\n')

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/DurableWorkflowRecoveryJdbcTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/DurableWorkflowRecoveryJdbcTest.kt
@@ -20,7 +20,7 @@ private class JdbcDurableRecoveryPersistence : DurableRecoveryPersistence {
         pool.connection.use { conn ->
             conn.createStatement().use { statement ->
                 statement.execute((checkpointStore as JdbcWorkflowCheckpointStore).createTableSql())
-                statement.execute((attemptStore as JdbcStepAttemptRecordStore).createTableSql())
+                (attemptStore as JdbcStepAttemptRecordStore).createSchemaSql().forEach { statement.execute(it) }
             }
         }
     }

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/StepAttemptRecordStoreContractTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/StepAttemptRecordStoreContractTest.kt
@@ -257,6 +257,120 @@ abstract class StepAttemptRecordStoreContractTest {
         }
     }
 
+    // ── #318 — durable creation-order authority (cross-store contract) ──────
+
+    @Test
+    fun `21 equal-time latest uses creation order`() {
+        runBlocking {
+            // Lexical attemptId order intentionally opposes creation order.
+            store.recordStepAttempt(minimalRecord(attemptId = "z", startedAt = 10))
+            store.recordStepAttempt(minimalRecord(attemptId = "a", startedAt = 10))
+            assertThat(store.latestStepAttempt("run", "step")?.attemptId).isEqualTo("a")
+        }
+    }
+
+    @Test
+    fun `22 equal-key list preserves creation order across recreation`() {
+        runBlocking {
+            store.recordStepAttempt(minimalRecord(attemptId = "z", startedAt = 10))
+            store.recordStepAttempt(minimalRecord(attemptId = "a", startedAt = 10))
+            assertThat(store.listStepAttempts("run").map { it.attemptId }).containsExactly("z", "a")
+            val recreated = harness.recreate()
+            assertThat(recreated.listStepAttempts("run").map { it.attemptId }).containsExactly("z", "a")
+        }
+    }
+
+    @Test
+    fun `23 update preserves creation order`() {
+        runBlocking {
+            store.recordStepAttempt(minimalRecord(attemptId = "z", startedAt = 10))
+            store.recordStepAttempt(minimalRecord(attemptId = "a", startedAt = 10))
+            store.updateStepAttempt(minimalRecord(attemptId = "z", startedAt = 10).copy(status = StepAttemptStatus.COMPLETED, completedAt = 20L))
+            assertThat(store.latestStepAttempt("run", "step")?.attemptId).isEqualTo("a")
+            assertThat(store.listStepAttempts("run").map { it.attemptId }).containsExactly("z", "a")
+        }
+    }
+
+    @Test
+    fun `24 CAS preserves creation order`() {
+        runBlocking {
+            val first = minimalRecord(attemptId = "z", startedAt = 10)
+            store.recordStepAttempt(first)
+            store.recordStepAttempt(minimalRecord(attemptId = "a", startedAt = 10))
+            assertThat(store.compareAndSetStepAttempt(first, first.copy(status = StepAttemptStatus.FAILED))).isTrue()
+            assertThat(store.latestStepAttempt("run", "step")?.attemptId).isEqualTo("a")
+            assertThat(store.listStepAttempts("run").map { it.attemptId }).containsExactly("z", "a")
+        }
+    }
+
+    @Test
+    fun `25 re-record preserves creation order`() {
+        runBlocking {
+            val first = minimalRecord(attemptId = "z", startedAt = 10)
+            store.recordStepAttempt(first)
+            store.recordStepAttempt(minimalRecord(attemptId = "a", startedAt = 10))
+            // The contract allows recordStepAttempt to replace an existing identity;
+            // a replacement is NOT a new attempt creation.
+            store.recordStepAttempt(first.copy(workerId = "replacement"))
+            assertThat(store.latestStepAttempt("run", "step")?.attemptId).isEqualTo("a")
+            assertThat(store.listStepAttempts("run").map { it.attemptId }).containsExactly("z", "a")
+        }
+    }
+
+    @Test
+    fun `26 concurrent creates get distinct durable chronology`() {
+        runBlocking {
+            val ids = (1..4).map { "id$it" }
+            val start = java.util.concurrent.CountDownLatch(1)
+            val finished = java.util.concurrent.CountDownLatch(ids.size)
+            val deferreds = ids.map { id ->
+                async(Dispatchers.Default) {
+                    start.await()
+                    store.recordStepAttempt(minimalRecord(attemptId = id, startedAt = 10))
+                    finished.countDown()
+                }
+            }
+            start.countDown()
+            assertThat(withContext(Dispatchers.IO) { finished.await(10, TimeUnit.SECONDS) }).isTrue()
+            deferreds.joinAll()
+            val listed = store.listStepAttempts("run")
+            assertThat(listed.map { it.attemptId }).containsExactlyInAnyOrderElementsOf(ids)
+            assertThat(listed.map { it.attemptId }.distinct()).hasSize(ids.size)
+            assertThat(store.latestStepAttempt("run", "step")?.attemptId).isEqualTo(listed.last().attemptId)
+            val sequences = ids.map { harness.readSequence("run", "step", it) }
+            if (sequences.all { it != null }) {
+                assertThat(sequences.distinct()).hasSize(ids.size)
+            }
+        }
+    }
+
+    @Test
+    fun `27 legacy records fall back deterministically`() {
+        runBlocking {
+            if (!harness.supportsLegacyRecords) return@runBlocking
+            harness.writeLegacyRecord(minimalRecord(attemptId = "b", startedAt = 10))
+            harness.writeLegacyRecord(minimalRecord(attemptId = "a", startedAt = 10))
+            // Legacy-vs-legacy ties keep the deterministic attemptId fallback.
+            assertThat(store.latestStepAttempt("run", "step")?.attemptId).isEqualTo("b")
+            assertThat(store.listStepAttempts("run").map { it.attemptId }).containsExactly("a", "b")
+            // A new sequenced record with equal startedAt outranks legacy chronology.
+            store.recordStepAttempt(minimalRecord(attemptId = "new", startedAt = 10))
+            assertThat(store.latestStepAttempt("run", "step")?.attemptId).isEqualTo("new")
+        }
+    }
+
+    @Test
+    fun `28 sequence corruption fails closed`() {
+        runBlocking {
+            if (!harness.supportsSequenceCorruption) return@runBlocking
+            val record = minimalRecord()
+            store.recordStepAttempt(record)
+            harness.corruptSequence(record)
+            assertThatThrownBy { runBlocking { store.listStepAttempts(record.runId) } }
+                .isInstanceOf(StepAttemptRecordCorruptionException::class.java)
+        }
+    }
+
     protected fun minimalRecord(
         runId: String = "run",
         stepName: String = "step",
@@ -299,8 +413,19 @@ abstract class StepAttemptRecordStoreContractTest {
 interface AttemptStoreHarness {
     val store: StepAttemptRecordStore
     val supportsPersistentCorruption: Boolean get() = false
+    val supportsLegacyRecords: Boolean get() = false
+    val supportsSequenceCorruption: Boolean get() = false
     fun recreate(): StepAttemptRecordStore = store
     fun close() = Unit
+
+    /** Writes a legacy (pre-sequence) payload for [record] directly to storage. */
+    suspend fun writeLegacyRecord(record: StepAttemptRecord) = Unit
+
+    /** Corrupts the persisted creation sequence of [record] without touching record fields. */
+    suspend fun corruptSequence(record: StepAttemptRecord) = Unit
+
+    /** Reads the persisted creation sequence of [record], or null when legacy/absent. */
+    suspend fun readSequence(runId: String, stepName: String, attemptId: String): Long? = null
 
     fun assertMalformedFailsClosed(field: String, replacement: String?) {
         val lines = StepAttemptRecordCodec.encode(testCodecRecord()).lines().toMutableList()
@@ -403,8 +528,33 @@ private class FileAttemptStoreHarness(private val root: Path) : AttemptStoreHarn
         },
     )
     override val supportsPersistentCorruption = true
+    override val supportsLegacyRecords = true
+    override val supportsSequenceCorruption = true
 
     override fun recreate(): StepAttemptRecordStore = FileStepAttemptRecordStore(root)
+
+    override suspend fun writeLegacyRecord(record: StepAttemptRecord) {
+        val path = root.resolve(base64UrlEncodeNoPadding(record.runId))
+            .resolve(base64UrlEncodeNoPadding(record.stepName))
+            .resolve(base64UrlEncodeNoPadding(record.attemptId) + ".attempt.properties")
+        Files.createDirectories(path.parent)
+        Files.writeString(path, StepAttemptRecordCodec.encode(record) + "record_hash=${StepAttemptRecordCodec.fingerprint(record)}\n")
+    }
+
+    override suspend fun corruptSequence(record: StepAttemptRecord) {
+        val path = root.resolve(base64UrlEncodeNoPadding(record.runId))
+            .resolve(base64UrlEncodeNoPadding(record.stepName))
+            .resolve(base64UrlEncodeNoPadding(record.attemptId) + ".attempt.properties")
+        Files.writeString(path, Files.readString(path).replace(Regex("attemptSequence=.*"), "attemptSequence=999"))
+    }
+
+    override suspend fun readSequence(runId: String, stepName: String, attemptId: String): Long? {
+        val path = root.resolve(base64UrlEncodeNoPadding(runId))
+            .resolve(base64UrlEncodeNoPadding(stepName))
+            .resolve(base64UrlEncodeNoPadding(attemptId) + ".attempt.properties")
+        if (!Files.exists(path)) return null
+        return Regex("attemptSequence=(\\d+)").find(Files.readString(path))?.groupValues?.get(1)?.toLongOrNull()
+    }
 
     override suspend fun corruptFingerprint(record: StepAttemptRecord) {
         val path = root.resolve(base64UrlEncodeNoPadding(record.runId))
@@ -431,12 +581,42 @@ private class JdbcAttemptStoreHarness : AttemptStoreHarness {
     private val dataSource: DataSource = pool
     override val store = JdbcStepAttemptRecordStore(dataSource)
     override val supportsPersistentCorruption = true
+    override val supportsSequenceCorruption = true
 
     init {
         dataSource.connection.use { conn -> conn.createStatement().use { it.execute(store.createTableSql()) } }
     }
 
     override fun recreate(): StepAttemptRecordStore = JdbcStepAttemptRecordStore(dataSource)
+
+    override suspend fun corruptSequence(record: StepAttemptRecord) {
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(
+                "UPDATE tramai_workflow_step_attempt SET attempt_sequence = ? WHERE run_id = ? AND step_name = ? AND attempt_id = ?",
+            ).use { statement ->
+                statement.setLong(1, 999)
+                statement.setString(2, record.runId)
+                statement.setString(3, record.stepName)
+                statement.setString(4, record.attemptId)
+                statement.executeUpdate()
+            }
+        }
+    }
+
+    override suspend fun readSequence(runId: String, stepName: String, attemptId: String): Long? = try {
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(
+                "SELECT attempt_sequence FROM tramai_workflow_step_attempt WHERE run_id = ? AND step_name = ? AND attempt_id = ?",
+            ).use { statement ->
+                statement.setString(1, runId)
+                statement.setString(2, stepName)
+                statement.setString(3, attemptId)
+                statement.executeQuery().use { resultSet -> if (resultSet.next()) resultSet.getLong(1) else null }
+            }
+        }
+    } catch (_: java.sql.SQLException) {
+        null
+    }
 
     override suspend fun corruptFingerprint(record: StepAttemptRecord) {
         dataSource.connection.use { conn ->

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/StepAttemptRecordStoreContractTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/StepAttemptRecordStoreContractTest.kt
@@ -371,6 +371,19 @@ abstract class StepAttemptRecordStoreContractTest {
         }
     }
 
+    @Test
+    fun `32 counter regression cannot duplicate chronology`() {
+        runBlocking {
+            if (!harness.supportsSequenceReset) return@runBlocking
+            listOf("a", "b", "c").forEach { store.recordStepAttempt(minimalRecord(attemptId = it, startedAt = 10)) }
+            // Regress the run's counter authority below already-persisted sequences.
+            harness.resetSequenceCounter("run", 1)
+            store.recordStepAttempt(minimalRecord(attemptId = "d", startedAt = 10))
+            // The new attempt must be sequenced above the durable maximum, never reusing 2.
+            assertThat(harness.readSequence("run", "step", "d")).isNotNull().isGreaterThan(3)
+        }
+    }
+
     protected fun minimalRecord(
         runId: String = "run",
         stepName: String = "step",
@@ -415,6 +428,7 @@ interface AttemptStoreHarness {
     val supportsPersistentCorruption: Boolean get() = false
     val supportsLegacyRecords: Boolean get() = false
     val supportsSequenceCorruption: Boolean get() = false
+    val supportsSequenceReset: Boolean get() = false
     fun recreate(): StepAttemptRecordStore = store
     fun close() = Unit
 
@@ -423,6 +437,9 @@ interface AttemptStoreHarness {
 
     /** Corrupts the persisted creation sequence of [record] without touching record fields. */
     suspend fun corruptSequence(record: StepAttemptRecord) = Unit
+
+    /** Regresses the run's sequence counter authority to [value]. */
+    suspend fun resetSequenceCounter(runId: String, value: Long) = Unit
 
     /** Reads the persisted creation sequence of [record], or null when legacy/absent. */
     suspend fun readSequence(runId: String, stepName: String, attemptId: String): Long? = null
@@ -513,6 +530,43 @@ class JdbcStepAttemptRecordStoreContractTest : StepAttemptRecordStoreContractTes
                 .hasNoCause()
         }
     }
+
+    @Test
+    fun `29 jdbc update cannot launder sequence corruption`() {
+        runBlocking {
+            val record = minimalRecord()
+            store.recordStepAttempt(record)
+            jdbcHarness.corruptSequence(record)
+            // Updating must verify the existing row first; it must not re-sign a
+            // corrupted sequence into valid persisted state.
+            assertThatThrownBy { runBlocking { store.updateStepAttempt(record.copy(status = StepAttemptStatus.COMPLETED, completedAt = 20L)) } }
+                .isInstanceOf(StepAttemptRecordCorruptionException::class.java)
+            assertThatThrownBy { runBlocking { store.listStepAttempts(record.runId) } }
+                .isInstanceOf(StepAttemptRecordCorruptionException::class.java)
+        }
+    }
+
+    @Test
+    fun `30 jdbc re-record cannot launder sequence corruption`() {
+        runBlocking {
+            val record = minimalRecord()
+            store.recordStepAttempt(record)
+            jdbcHarness.corruptSequence(record)
+            assertThatThrownBy { runBlocking { store.recordStepAttempt(record.copy(workerId = "replacement")) } }
+                .isInstanceOf(StepAttemptRecordCorruptionException::class.java)
+        }
+    }
+
+    @Test
+    fun `31 jdbc CAS fails closed on sequence corruption`() {
+        runBlocking {
+            val record = minimalRecord()
+            store.recordStepAttempt(record)
+            jdbcHarness.corruptSequence(record)
+            assertThatThrownBy { runBlocking { store.compareAndSetStepAttempt(record, record.copy(status = StepAttemptStatus.FAILED)) } }
+                .isInstanceOf(StepAttemptRecordCorruptionException::class.java)
+        }
+    }
 }
 
 private class FileAttemptStoreHarness(private val root: Path) : AttemptStoreHarness {
@@ -530,8 +584,14 @@ private class FileAttemptStoreHarness(private val root: Path) : AttemptStoreHarn
     override val supportsPersistentCorruption = true
     override val supportsLegacyRecords = true
     override val supportsSequenceCorruption = true
+    override val supportsSequenceReset = true
 
     override fun recreate(): StepAttemptRecordStore = FileStepAttemptRecordStore(root)
+
+    override suspend fun resetSequenceCounter(runId: String, value: Long) {
+        val path = root.resolve(base64UrlEncodeNoPadding(runId)).resolve(".attempt-sequence")
+        Files.writeString(path, value.toString())
+    }
 
     override suspend fun writeLegacyRecord(record: StepAttemptRecord) {
         val path = root.resolve(base64UrlEncodeNoPadding(record.runId))
@@ -582,12 +642,25 @@ private class JdbcAttemptStoreHarness : AttemptStoreHarness {
     override val store = JdbcStepAttemptRecordStore(dataSource)
     override val supportsPersistentCorruption = true
     override val supportsSequenceCorruption = true
+    override val supportsSequenceReset = true
 
     init {
-        dataSource.connection.use { conn -> conn.createStatement().use { it.execute(store.createTableSql()) } }
+        dataSource.connection.use { conn ->
+            store.createSchemaSql().forEach { sql -> conn.createStatement().use { it.execute(sql) } }
+        }
     }
 
     override fun recreate(): StepAttemptRecordStore = JdbcStepAttemptRecordStore(dataSource)
+
+    override suspend fun resetSequenceCounter(runId: String, value: Long) {
+        dataSource.connection.use { conn ->
+            conn.prepareStatement("UPDATE tramai_workflow_step_attempt_sequence SET next_value = ? WHERE run_id = ?").use { statement ->
+                statement.setLong(1, value)
+                statement.setString(2, runId)
+                statement.executeUpdate()
+            }
+        }
+    }
 
     override suspend fun corruptSequence(record: StepAttemptRecord) {
         dataSource.connection.use { conn ->


### PR DESCRIPTION
## #318 — Durable creation-order authority for File/JDBC step-attempt stores

**Base:** master `48b35e90` · **Head:** `3b76a5bd649ee5222f83393f9dd3fb092a7b3318` (rebased onto 48b35e90, exact head)

### Invariant
> For attempts with equal `startedAt`, chronology is determined by durable creation order, never by `attemptId`. Updating, CAS-replacing, or re-recording an existing attempt identity preserves its original creation order.

### Change
- `StepAttemptRecordCodec`: optional `attemptSequence` in the persisted payload + fingerprint (legacy payloads omit it; `fingerprint(record, null)` == old hash → legacy files keep validating). Sequence participates in the integrity hash → chronology corruption fails closed.
- **File store:** run-level `<run>/.attempt-sequence` sidecar under a run-level lock; new identities allocate `++counter` bounded below by the durable per-run maximum (a regressed counter can never reuse a persisted sequence); update/CAS/re-record preserve the verified stored sequence; comparator `(startedAt, stepName, sequence ?: MIN_VALUE, attemptId)` — attemptId only for legacy-vs-legacy ties.
- **JDBC store:** `attempt_sequence BIGINT NOT NULL` + per-run counter table (name derived from the configured attempt table — no global collision); atomic UPDATE-based allocation with savepoint-protected first-writer insert; **every mutation (update/CAS/re-record) loads and fully verifies the existing row before touching it** — a corrupted sequence fails closed instead of being re-signed into valid state; `UNIQUE (run_id, attempt_sequence)` constraint as the native backstop; `transactional = true`.
- **Portable schema:** `createTableSql()` is again a single executable DDL statement; multi-statement provisioning is exposed explicitly via the additive `createSchemaSql(): List<String>` (one statement per entry, generic-JDBC safe) + `createSequenceTableSql()`. Migration entry recorded in `config/quality/api-migrations.yml` (intentional additive API; dump updated, apiCheck green).
- Sequence is **storage chronology metadata, never a `StepAttemptRecord` field**; `JdbcStepAttemptTable` primary constructor untouched.
- Contract KDoc: cross-store tie authority = durable creation sequence; legacy (null-sequence) records are a File-storage concept, use deterministic attemptId fallback, and sort before sequenced records at equal startedAt.

### Evidence (exact head `3b76a5bd649ee5222f83393f9dd3fb092a7b3318`, post-rebase-2)
- **32 cross-store contract tests GREEN on all three stores** (InMemory / File / JDBC): equal-time latest = last created, equal-key list in creation order across recreation, update/CAS/re-record preserve, concurrent creates get distinct sequences, legacy fallback, sequence corruption fails closed, **29–31 JDBC update/re-record/CAS cannot launder sequence corruption**, **32 counter regression cannot duplicate chronology**. RED proven first for every new test.
- **Mutation campaign v2: 15 STRONG / 0 WEAK / 0 REDUNDANT** (M01–M11 + M12 verification-skip + M13/M13b counter-bound dropped; restored-source probe GREEN)
- Full `:tramai-orchestration:test --rerun-tasks` GREEN
- apiCheck GREEN (additive diff, dump committed) · verifyChangePolicy (runtime-behaviour) · verify060Architecture · verifyMaintainabilityBaseline PASSED

### Review disposition (round 2)
- P1 JDBC corruption laundering → fixed via verified-read-before-mutate (`StoredStepAttempt` + `loadVerified`), REDs 29–31.
- P1/P2 multi-statement `createTableSql()` → single statement restored; explicit `createSchemaSql()` added (intentional API diff + migration entry).
- P2 global counter-table collision → table name derived from the configured attempt table.
- P2 counter regression → allocation bounded by durable max + `UNIQUE (run_id, attempt_sequence)`; RED 32.
- P3 triple-Properties-parse → deferred (perf only, correctness unaffected).
- File reader-lock alignment → rejected (atomic renames preclude torn reads; readers get point-in-time snapshots).
- Pre-existing JDBC schema: no fake backfill — old equal-time chronology is unknowable; if 0.6-dev schema migration is ever required, legacy rows map to sequence NULL (File contract).

### Design choices
- Legacy = missing sequence → deterministic attemptId fallback, historically unknowable (no manufactured history). JDBC fresh schema has no legacy rows.
- Gaps in the sequence (1, 2, 4) are fine — chronology requires strict monotonic uniqueness, not contiguity.
