### PR TITLE
refactor(engine): 8.3b2a — make execution identity an explicit authority

### DIFF
--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/EngineIdentitySource.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/EngineIdentitySource.kt
@@ -1,0 +1,28 @@
+package dev.tramai.engine
+
+/**
+ * Explicit engine composition boundary for execution identity generation.
+ *
+ * The two methods keep the semantic roles separate: [newWorkflowRunId] answers
+ * "which concrete invocation is this?" while [newCorrelationId] answers "which
+ * related operations belong to this trace?". Reusing one as the other would
+ * silently erase an architectural distinction, so they are deliberately
+ * distinct methods rather than one generic provider.
+ *
+ * Contract: both methods return opaque NON-BLANK identity strings. Callers
+ * validate blankness at the consumption boundary; UUID syntax is NOT required.
+ *
+ * Invariant (8.3b2a): an invocation samples each required identity exactly once
+ * at the invocation boundary, propagates it unchanged through its lifecycle,
+ * and resume never creates replacement identity.
+ */
+internal interface EngineIdentitySource {
+    fun newWorkflowRunId(): String
+    fun newCorrelationId(): String
+}
+
+/** Production source: unpredictably unique random identities. */
+internal object DefaultEngineIdentitySource : EngineIdentitySource {
+    override fun newWorkflowRunId(): String = java.util.UUID.randomUUID().toString()
+    override fun newCorrelationId(): String = java.util.UUID.randomUUID().toString()
+}

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/PolicyEnforcementHelper.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/PolicyEnforcementHelper.kt
@@ -8,7 +8,6 @@ import dev.tramai.core.policy.PolicyDecision
 import dev.tramai.core.policy.PolicyDecisionAuditEmitter
 import dev.tramai.core.policy.NoOpPolicyDecisionAuditEmitter
 import dev.tramai.core.policy.PolicyEngine
-import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -72,7 +71,7 @@ internal class PolicyEnforcementHelper(
      */
     fun buildContext(
         enforcementPoint: EnforcementPoint,
-        correlationId: String = UUID.randomUUID().toString(),
+        correlationId: String,
         base: ContextDefaults = ContextDefaults(),
     ): PolicyContextBuilder = PolicyContextBuilder(enforcementPoint, correlationId, policyVersion, base)
 

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/components/EngineComponentFactory.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/components/EngineComponentFactory.kt
@@ -34,6 +34,7 @@ internal object EngineComponentFactory {
         toolArgumentsDigester: ToolArgumentsDigester?, approvalGateCoordinator: ApprovalGateCoordinator?,
         approvalLifecycleAuditEmitter: ApprovalLifecycleAuditEmitter, clock: Clock,
         retryJitterSource: RetryJitterSource = DefaultRetryJitterSource,
+        identitySource: EngineIdentitySource = DefaultEngineIdentitySource,
         structuredOutputFailureDiagnosticObserver: StructuredOutputFailureDiagnosticObserver = NoOpStructuredOutputFailureDiagnosticObserver,
     ): EngineComponents {
         val capability = approvalCapability(approvalContinuationStore, toolArgumentsDigester, approvalGateCoordinator)
@@ -59,6 +60,7 @@ internal object EngineComponentFactory {
                 retryDelayPolicy = ProviderRetryDelayPolicy(retryPolicySettings, retryJitterSource),
                 tokenBudgetSettings = tokenBudgetSettings,
                 clock = clock,
+                identitySource = identitySource,
             ),
         )
     }

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/components/EngineComponents.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/components/EngineComponents.kt
@@ -6,6 +6,7 @@ import dev.tramai.core.approval.ApprovalLifecycleAuditEmitter
 import dev.tramai.core.approval.ToolArgumentsDigester
 import dev.tramai.core.memory.ChatMemory
 import dev.tramai.core.memory.ConversationIdProvider
+import dev.tramai.engine.EngineIdentitySource
 import dev.tramai.core.model.ModelRegistry
 import dev.tramai.core.model.ModelRegistrySettings
 import dev.tramai.core.observation.OperationInterceptor
@@ -107,4 +108,5 @@ internal data class ExecutionComponents(
     val retryDelayPolicy: ProviderRetryDelayPolicy,
     val tokenBudgetSettings: TokenBudgetSettings,
     val clock: Clock,
+    val identitySource: EngineIdentitySource,
 )

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/invocation/InvocationExecutionCoordinator.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/invocation/InvocationExecutionCoordinator.kt
@@ -1,6 +1,7 @@
 package dev.tramai.engine.invocation
 
 import dev.tramai.core.approval.ApprovalGateCoordinator
+import dev.tramai.core.approval.Sha256Digest
 import dev.tramai.core.approval.ApprovalLifecycleAuditEmitter
 import dev.tramai.core.approval.ApprovalContinuationStore
 import dev.tramai.core.approval.IdempotencyKeyUtil
@@ -164,6 +165,7 @@ internal class InvocationExecutionCoordinator(
     )
     private val tokenBudgetCoordinator = TokenBudgetCoordinator(tokenBudgetSettings)
     private val streamingExecutionCoordinator = StreamingExecutionCoordinator(
+        identitySource = components.execution.identitySource,
         routingPlan = routingPlan,
         circuitBreaker = circuitBreaker,
         lifecycleScope = lifecycleScope,
@@ -339,15 +341,7 @@ internal class InvocationExecutionCoordinator(
         val arguments = context.arguments
         val conversationId = context.conversationId
         val tokenBudgetTracker = tokenBudgetCoordinator.createTracker()
-        val workflowRunId = java.util.UUID.randomUUID().toString()
         val workflowDigest = WorkflowDigestHelper.compute(operation, serviceDefinition)
-        val identity = EngineExecutionIdentity(
-            workflowRunId = workflowRunId,
-            correlationId = "", // Will be set in executeRaw/the structured coordinator
-            workflowDigest = workflowDigest,
-            policyVersion = policyHelper.getPolicyVersion(),
-            actorId = PolicyEnforcementHelper.ACTOR_ANONYMOUS,
-        )
         return when (operation.returnKind) {
             ReturnKind.STRING -> rawResponseCoordinator.execute(
                 RawResponseRequest(
@@ -355,7 +349,7 @@ internal class InvocationExecutionCoordinator(
                     arguments = arguments,
                     tokenBudgetTracker = tokenBudgetTracker,
                     conversationId = conversationId,
-                    identity = identity,
+                    identity = invocationIdentity(workflowDigest),
                 ),
             )
             ReturnKind.UNIT -> {
@@ -365,7 +359,7 @@ internal class InvocationExecutionCoordinator(
                         arguments = arguments,
                         tokenBudgetTracker = tokenBudgetTracker,
                         conversationId = conversationId,
-                        identity = identity,
+                        identity = invocationIdentity(workflowDigest),
                     ),
                 )
                 Unit
@@ -376,7 +370,7 @@ internal class InvocationExecutionCoordinator(
                     arguments = arguments,
                     tokenBudgetTracker = tokenBudgetTracker,
                     conversationId = conversationId,
-                    identity = identity,
+                    identity = invocationIdentity(workflowDigest),
                     operationFingerprint = context.plan.fingerprint,
                 ),
             )
@@ -389,6 +383,27 @@ internal class InvocationExecutionCoordinator(
                 ),
             )
         }
+    }
+
+    /**
+     * 8.3b2a: samples the complete invocation identity exactly once at the
+     * invocation boundary. Streaming never had a workflowRunId and stays lazy —
+     * a never-collected flow consumes zero identities, so its correlation is
+     * sampled inside the flow body (StreamingExecutionCoordinator).
+     */
+    private fun invocationIdentity(workflowDigest: Sha256Digest): EngineExecutionIdentity {
+        val identitySource = components.execution.identitySource
+        val workflowRunId = identitySource.newWorkflowRunId()
+        val correlationId = identitySource.newCorrelationId()
+        require(workflowRunId.isNotBlank()) { "Engine workflowRunId must not be blank" }
+        require(correlationId.isNotBlank()) { "Engine correlationId must not be blank" }
+        return EngineExecutionIdentity(
+            workflowRunId = workflowRunId,
+            correlationId = correlationId,
+            workflowDigest = workflowDigest,
+            policyVersion = policyHelper.getPolicyVersion(),
+            actorId = PolicyEnforcementHelper.ACTOR_ANONYMOUS,
+        )
     }
     override suspend fun execute(request: ClaimedResumeExecutionRequest): Any? =
         claimedResumeCoordinator.execute(request)

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/invocation/RawResponseCoordinator.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/invocation/RawResponseCoordinator.kt
@@ -36,8 +36,6 @@ internal class RawResponseCoordinator(
         val conversationId = request.conversationId
         val identity = request.identity
         val securityContext = ExecutionSecurityContext.fromArguments(arguments.toTypedArray())
-        val correlationId = java.util.UUID.randomUUID().toString()
-        val effectiveIdentity = identity.copy(correlationId = correlationId)
         val initialMessages = operation.initialMessages(arguments)
         val prepared = conversationMemoryCoordinator.prepareMessages(initialMessages, conversationId)
         val history = prepared?.history ?: emptyList()
@@ -59,7 +57,7 @@ internal class RawResponseCoordinator(
         )
         if (cacheKey != null) {
             when (val cached = operationCacheCoordinator.lookup(
-                OperationCacheLookupRequest(cacheKey, securityContext, correlationId, conversationId),
+                OperationCacheLookupRequest(cacheKey, securityContext, identity.correlationId, conversationId),
             )) {
                 is OperationCacheLookupResult.Hit -> return cached.value as String
                 is OperationCacheLookupResult.Miss -> Unit
@@ -73,9 +71,9 @@ internal class RawResponseCoordinator(
                 operation = operation,
                 messages = effectiveMutableMessages,
                 tokenBudgetTracker = tokenBudgetTracker,
-                correlationId = correlationId,
+                correlationId = identity.correlationId,
                 securityContext = securityContext,
-                identity = effectiveIdentity,
+                identity = identity,
                 conversationId = conversationId,
                 historySize = history.size,
             ),
@@ -87,7 +85,7 @@ internal class RawResponseCoordinator(
         policyHelper.enforce(
             policyHelper.buildContext(
                 enforcementPoint = dev.tramai.core.policy.EnforcementPoint.BEFORE_RESPONSE_RETURN,
-                correlationId = correlationId,
+                correlationId = identity.correlationId,
             ).providerId(result.providerId)
                 .modelName(result.modelName)
                 .applySecurityContext(securityContext)

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/streaming/StreamingExecutionCoordinator.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/streaming/StreamingExecutionCoordinator.kt
@@ -29,6 +29,7 @@ import dev.tramai.core.provider.resolveCandidates
 import dev.tramai.engine.CircuitBreakerAdmission
 import dev.tramai.engine.CircuitBreakerPermit
 import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.EngineIdentitySource
 import dev.tramai.engine.ModelRegistryEnforcer
 import dev.tramai.engine.OperationDefinition
 import dev.tramai.engine.ProviderCircuitBreaker
@@ -62,6 +63,7 @@ internal fun interface StreamingBeforeResponseReturnGate {
 }
 
 internal class StreamingExecutionCoordinator(
+    private val identitySource: EngineIdentitySource,
     private val routingPlan: ProviderRoutingPlan,
     private val circuitBreaker: ProviderCircuitBreaker,
     private val lifecycleScope: CoroutineScope,
@@ -107,7 +109,8 @@ internal class StreamingExecutionCoordinator(
             val collectFailure = java.util.concurrent.atomic.AtomicReference<Throwable?>(null)
             val collectJob = lifecycleScope.launch {
                 try {
-                    val correlationId = java.util.UUID.randomUUID().toString()
+                    val correlationId = identitySource.newCorrelationId()
+                    require(correlationId.isNotBlank()) { "Engine correlationId must not be blank" }
                     beforeResolution.beforeResolution(operation, correlationId, securityContext)
                     val candidates = routingPlan.resolveCandidates(operation.operation)
                     var lastFailure: Throwable? = null
@@ -517,4 +520,3 @@ internal class StreamingExecutionCoordinator(
         }
     }
 }
-

--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/structured/StructuredResponseCoordinator.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/structured/StructuredResponseCoordinator.kt
@@ -57,8 +57,6 @@ internal class StructuredResponseCoordinator(
             failure.rethrowIfCancellation()
             rethrowContractFailure(operation, failure)
         }
-        val correlationId = java.util.UUID.randomUUID().toString()
-        val effectiveIdentity = request.identity.copy(correlationId = correlationId)
         val initialMessages = operation.initialMessages(request.arguments, contract.schemaJson)
         val prepared = conversationMemoryCoordinator.prepareMessages(initialMessages, request.conversationId)
         val history = prepared?.history ?: emptyList()
@@ -80,7 +78,7 @@ internal class StructuredResponseCoordinator(
         )
         if (cacheKey != null) {
             when (val cached = operationCacheCoordinator.lookup(
-                OperationCacheLookupRequest(cacheKey, securityContext, correlationId, request.conversationId),
+                OperationCacheLookupRequest(cacheKey, securityContext, request.identity.correlationId, request.conversationId),
             )) {
                 is OperationCacheLookupResult.Hit -> return cached.value
                 is OperationCacheLookupResult.Miss -> Unit
@@ -100,9 +98,9 @@ internal class StructuredResponseCoordinator(
                 historySize = initialTurnCount,
                 tokenBudgetTracker = request.tokenBudgetTracker,
                 conversationId = request.conversationId,
-                correlationId = correlationId,
+                correlationId = request.identity.correlationId,
                 securityContext = securityContext,
-                identity = effectiveIdentity,
+                identity = request.identity,
             ),
         )
     }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/EngineIdentityDiscriminatorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/EngineIdentityDiscriminatorTest.kt
@@ -1,0 +1,536 @@
+package dev.tramai.engine
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.approval.ApprovalAuthorization
+import dev.tramai.core.approval.ApprovalChallenge
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.core.approval.ApprovalGateCoordinator
+import dev.tramai.core.approval.ApprovalLifecycleAuditEmitter
+import dev.tramai.core.approval.NoOpApprovalLifecycleAuditEmitter
+import dev.tramai.core.approval.ApprovalToken
+import dev.tramai.core.approval.ApprovalValidation
+import dev.tramai.core.approval.AuthorizeResumeCommand
+import dev.tramai.core.approval.CreateApprovalCommand
+import dev.tramai.core.approval.ValidateResumeCommand
+import dev.tramai.core.exception.ApprovalSuspendedException
+import dev.tramai.core.exception.ConfigurationException
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.model.ResolvedTool
+import dev.tramai.core.model.SideEffectLevel
+import dev.tramai.core.model.StreamChunk
+import dev.tramai.core.model.ToolCall
+import dev.tramai.core.model.ToolResult
+import dev.tramai.core.observation.NoOpOperationObserver
+import dev.tramai.core.observation.NoOpToolFailureDiagnosticObserver
+import dev.tramai.core.policy.ApprovalRequirement
+import dev.tramai.core.policy.NoOpPolicyDecisionAuditEmitter
+import dev.tramai.core.policy.EnforcementPoint
+import dev.tramai.core.policy.PolicyContext
+import dev.tramai.core.policy.PolicyDecision
+import dev.tramai.core.policy.PolicyEngine
+import dev.tramai.core.provider.ModelProvider
+import dev.tramai.core.provider.ProviderRegistry
+import dev.tramai.core.provider.StreamCapable
+import dev.tramai.core.security.NoOpDlpInterceptor
+import dev.tramai.core.security.NoOpDlpRedactionAuditEmitter
+import dev.tramai.core.memory.UuidConversationIdProvider
+import dev.tramai.security.approval.InMemoryApprovalContinuationStore
+import dev.tramai.core.structured.StructuredOutputContract
+import dev.tramai.core.structured.StructuredOutputHandler
+import dev.tramai.core.structured.StructuredOutputResult
+import dev.tramai.security.approval.Sha256ToolArgumentsDigester
+import dev.tramai.engine.ToolRegistry
+import dev.tramai.engine.components.EngineComponentFactory
+import dev.tramai.core.model.ToolExecutionContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import kotlin.collections.ArrayDeque
+
+/**
+ * 8.3b2a — engine execution identity authority.
+ *
+ * Primary invariant: every engine-generated execution identity comes from one
+ * explicit engine composition boundary; an invocation samples each required
+ * identity exactly once, propagates it unchanged, and resume never creates
+ * replacement identity.
+ */
+class EngineIdentityDiscriminatorTest {
+
+    @AiService
+    interface IdentityTestService {
+        @Operation(prompt = "Answer", model = "logical-model")
+        fun answer(input: String): String
+
+        @Operation(prompt = "Answer", model = "logical-model")
+        fun structuredAnswer(input: String): IdentityResult
+
+        @Operation(prompt = "Answer", model = "logical-model")
+        fun stream(input: String): Flow<StreamChunk>
+    }
+
+    data class IdentityResult(val value: String)
+
+    /** Deterministic identity source; throws on exhaustion so resume cannot silently mint. */
+    private class QueuedEngineIdentitySource(
+        workflowRunIds: List<String>,
+        correlationIds: List<String>,
+    ) : EngineIdentitySource {
+        private val runQueue = ArrayDeque(workflowRunIds)
+        private val corrQueue = ArrayDeque(correlationIds)
+        var workflowRunSamples = 0
+            private set
+        var correlationSamples = 0
+            private set
+
+        override fun newWorkflowRunId(): String {
+            workflowRunSamples++
+            return runQueue.removeFirstOrNull() ?: error("workflowRunId queue exhausted")
+        }
+
+        override fun newCorrelationId(): String {
+            correlationSamples++
+            return corrQueue.removeFirstOrNull() ?: error("correlationId queue exhausted")
+        }
+    }
+
+    /** Records the correlationId seen at every enforcement point. */
+    private class CapturingPolicyEngine(
+        private val requireApprovalAtToolExec: Boolean = false,
+        private val approvalToolName: String = "",
+        private val approvalArgumentsDigest: String = "",
+    ) : PolicyEngine {
+        val seen = mutableListOf<Pair<EnforcementPoint, String>>()
+
+        override suspend fun evaluate(context: PolicyContext): PolicyDecision {
+            seen += context.enforcementPoint to context.correlationId
+            if (requireApprovalAtToolExec && context.enforcementPoint == EnforcementPoint.BEFORE_TOOL_EXECUTION) {
+                return PolicyDecision.RequireApproval(
+                    ApprovalRequirement(
+                        toolName = approvalToolName,
+                        argumentsDigest = approvalArgumentsDigest,
+                        reason = "testing",
+                        timeoutMillis = 60_000,
+                    ),
+                )
+            }
+            return PolicyDecision.Allow
+        }
+    }
+
+    private class RecordingProvider(
+        private val name: String = "primary",
+        private val responder: (Int) -> ModelResponse,
+    ) : ModelProvider, StreamCapable {
+        var calls = 0
+            private set
+        var streamRequests = 0
+            private set
+
+        override suspend fun complete(request: ModelRequest): ModelResponse {
+            calls++
+            return responder(calls)
+        }
+
+        override fun stream(request: ModelRequest): Flow<StreamChunk> {
+            streamRequests++
+            return flow {
+                emit(StreamChunk.Token("ok"))
+                emit(StreamChunk.Complete(fullText = "ok"))
+            }
+        }
+
+        override fun providerId(): String = name
+    }
+
+    private class PermitApprovalGateCoordinator : ApprovalGateCoordinator {
+        var nextChallengeId = "challenge-1"
+
+        override suspend fun createApproval(command: CreateApprovalCommand): ApprovalChallenge {
+            val id = nextChallengeId
+            nextChallengeId = "challenge-2"
+            return ApprovalChallenge(
+                approvalId = id,
+                token = ApprovalToken.parsePresented("token-$id"),
+                expiresAt = command.expiresAt,
+            )
+        }
+
+        override suspend fun validateResume(command: ValidateResumeCommand): ApprovalValidation =
+            ApprovalValidation(
+                approvalId = command.approvalId,
+                validatedBy = command.consumedBy,
+                validatedAt = Clock.systemUTC().instant(),
+                version = command.expectedVersion,
+            )
+
+        override suspend fun authorizeResume(command: AuthorizeResumeCommand): ApprovalAuthorization =
+            ApprovalAuthorization(
+                approvalId = command.approvalId,
+                consumedBy = command.consumedBy,
+                consumedAt = Clock.systemUTC().instant(),
+                version = command.expectedVersion,
+            )
+
+        override suspend fun cancelApproval(approvalId: String, expectedVersion: Long, reason: String) = Unit
+    }
+
+    private class RecordingTool : ResolvedTool {
+        override val name: String = "test_calculator"
+        override val description: String = "Calculator tool"
+        override val inputSchemaJson: String = """{"type":"object","properties":{"x":{"type":"integer"},"y":{"type":"integer"}}}"""
+        override val idempotent: Boolean = false
+        override val sideEffectLevel: SideEffectLevel = SideEffectLevel.READ_ONLY
+        var invocations = 0
+            private set
+
+        override suspend fun execute(input: Any, context: ToolExecutionContext): ToolResult {
+            invocations++
+            return ToolResult.Success("""{"result":5}""")
+        }
+    }
+
+    private fun buildEngine(
+        source: EngineIdentitySource,
+        policyEngine: PolicyEngine,
+        provider: ModelProvider,
+        toolRegistry: ToolRegistry = ToolRegistry(),
+        structuredOutputHandler: StructuredOutputHandler? = null,
+        suspendedInvocationStore: SuspendedInvocationStore = InMemorySuspendedInvocationStore(),
+        approvalContinuationStore: ApprovalContinuationStore? = null,
+        approvalGateCoordinator: ApprovalGateCoordinator? = null,
+    ): TramaiEngine {
+        val components = EngineComponentFactory.create(
+            providerRegistry = dev.tramai.core.provider.ProviderRegistry.singleProvider(provider),
+            structuredOutputHandler = structuredOutputHandler,
+            toolRegistry = toolRegistry,
+            operationObserver = NoOpOperationObserver,
+            operationInterceptor = object : dev.tramai.core.observation.OperationInterceptor {},
+            responseCache = NoOpOperationResponseCache,
+            modelRegistry = dev.tramai.core.model.NoOpModelRegistry,
+            modelRegistrySettings = dev.tramai.core.model.ModelRegistrySettings(),
+            circuitBreakerSettings = CircuitBreakerSettings(),
+            retryPolicySettings = RetryPolicySettings(),
+            tokenBudgetSettings = TokenBudgetSettings(),
+            promptSanitizer = null,
+            chatMemory = null,
+            conversationIdProvider = UuidConversationIdProvider(),
+            policyEngine = policyEngine,
+            dlpInterceptor = NoOpDlpInterceptor,
+            dlpRedactionAuditEmitter = NoOpDlpRedactionAuditEmitter,
+            toolResultFilteringSettings = ToolResultFilteringSettings(),
+            engineEventObserver = NoOpEngineEventObserver,
+            toolFailureDiagnosticObserver = NoOpToolFailureDiagnosticObserver,
+            policyDecisionAuditEmitter = NoOpPolicyDecisionAuditEmitter,
+            suspendedInvocationStore = suspendedInvocationStore,
+            approvalContinuationStore = approvalContinuationStore,
+            toolArgumentsDigester = if (approvalContinuationStore != null) Sha256ToolArgumentsDigester() else null,
+            approvalGateCoordinator = approvalGateCoordinator,
+            approvalLifecycleAuditEmitter = NoOpApprovalLifecycleAuditEmitter,
+            clock = Clock.systemUTC(),
+            identitySource = source,
+        )
+        return TramaiEngine(components)
+    }
+
+    private class IdentityStructuredOutputHandler : StructuredOutputHandler {
+        override fun createContract(targetType: kotlin.reflect.KType): StructuredOutputContract =
+            StructuredOutputContract(targetType, """{"type":"object","properties":{"value":{"type":"string"}}}""")
+
+        override fun analyze(rawResponse: String, targetType: kotlin.reflect.KType): StructuredOutputResult =
+            StructuredOutputResult.Success(IdentityResult("structured-ok"), rawResponse)
+
+        override fun generateSchema(type: kotlin.reflect.KType): String = """{"type":"object"}"""
+
+        override fun deserialize(input: Any, targetType: kotlin.reflect.KType): Any =
+            IdentityResult(input.toString())
+
+        override fun serialize(value: Any): Any = value
+    }
+
+    private fun syncProvider() = RecordingProvider { call ->
+        if (call == 1) {
+            ModelResponse(
+                content = "",
+                toolCalls = listOf(
+                    dev.tramai.core.model.ToolCall("call-1", "test_calculator", """{"x":2,"y":3}"""),
+                ),
+            )
+        } else {
+            ModelResponse(content = "Final result: success")
+        }
+    }
+
+    private fun plainProvider() = RecordingProvider { _ -> ModelResponse(content = "plain answer") }
+
+    @Test
+    fun `P0-A RAW invocation uses the exact injected identity everywhere`() {
+        runBlocking {
+        val source = QueuedEngineIdentitySource(listOf("run-A"), listOf("corr-A"))
+        val policy = CapturingPolicyEngine()
+        val provider = plainProvider()
+        val engine = buildEngine(source, policy, provider)
+        val service = engine.create(IdentityTestService::class)
+
+        assertThat(service.answer("hello")).isEqualTo("plain answer")
+
+        assertThat(source.workflowRunSamples).isEqualTo(1)
+        assertThat(source.correlationSamples).isEqualTo(1)
+        assertThat(policy.seen).isNotEmpty
+        assertThat(policy.seen.map { it.second }).allMatch { it == "corr-A" }
+        assertThat(provider.calls).isEqualTo(1)
+    }
+    }
+
+    @Test
+    fun `P0-B STRUCTURED invocation samples identity at invocation entry`() {
+        runBlocking {
+        val source = QueuedEngineIdentitySource(listOf("run-B"), listOf("corr-B"))
+        val policy = CapturingPolicyEngine()
+        val engine = buildEngine(source, policy, plainProvider(), structuredOutputHandler = null)
+        val service = engine.create(IdentityTestService::class)
+
+        // No StructuredOutputHandler: contract validation fails. Option B pins that
+        // identity belongs to the invocation, so it is sampled BEFORE the failure.
+        assertThatThrownBy { service.structuredAnswer("x") }
+            .isInstanceOf(ConfigurationException::class.java)
+        assertThat(source.workflowRunSamples).isEqualTo(1)
+        assertThat(source.correlationSamples).isEqualTo(1)
+    }
+    }
+
+    @Test
+    fun `P0-B2 structured success propagates exact injected identity everywhere`() {
+        runBlocking {
+            val source = QueuedEngineIdentitySource(
+                workflowRunIds = listOf("test-run-identity"),
+                correlationIds = listOf("test-correlation-identity"),
+            )
+            val policy = CapturingPolicyEngine()
+            val engine = buildEngine(
+                source, policy, plainProvider(),
+                structuredOutputHandler = IdentityStructuredOutputHandler(),
+            )
+            val service = engine.create(IdentityTestService::class)
+
+            val result = service.structuredAnswer("x")
+            assertThat(result).isEqualTo(IdentityResult("structured-ok"))
+
+            assertThat(source.workflowRunSamples).isEqualTo(1)
+            assertThat(source.correlationSamples).isEqualTo(1)
+            assertThat(policy.seen).isNotEmpty
+            assertThat(policy.seen.map { it.second }.distinct())
+                .containsExactly("test-correlation-identity")
+        }
+    }
+
+    @Test
+    fun `P0-C one sample per invocation`() {
+        runBlocking {
+        val source = QueuedEngineIdentitySource(listOf("run-A"), listOf("corr-A"))
+        val provider = plainProvider()
+        val engine = buildEngine(source, CapturingPolicyEngine(), provider)
+        val service = engine.create(IdentityTestService::class)
+
+        service.answer("one")
+        assertThat(source.workflowRunSamples).isEqualTo(1)
+        assertThat(source.correlationSamples).isEqualTo(1)
+
+        // The source is exhausted: a second invocation must fail at the identity
+        // boundary before any provider/tool side effect.
+        assertThatThrownBy { service.answer("two") }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("exhausted")
+        assertThat(provider.calls).isEqualTo(1)
+    }
+    }
+
+    @Test
+    fun `P0-D every enforcement point sees the same injected correlation`() {
+        runBlocking {
+        val source = QueuedEngineIdentitySource(listOf("run-D"), listOf("corr-D"))
+        val policy = CapturingPolicyEngine()
+        val engine = buildEngine(source, policy, plainProvider())
+        val service = engine.create(IdentityTestService::class)
+
+        service.answer("hello")
+
+        val points = policy.seen.map { it.first }.toSet()
+        assertThat(points).contains(EnforcementPoint.BEFORE_PROVIDER_RESOLUTION)
+        assertThat(points).contains(EnforcementPoint.BEFORE_PROVIDER_INVOCATION)
+        assertThat(policy.seen.map { it.second }.distinct()).containsExactly("corr-D")
+    }
+    }
+
+    @Test
+    fun `P0-E suspension persists the exact complete identity`() {
+        runBlocking {
+        val source = QueuedEngineIdentitySource(listOf("run-E"), listOf("corr-E"))
+        val policy = CapturingPolicyEngine(
+            requireApprovalAtToolExec = true,
+            approvalToolName = "test_calculator",
+            approvalArgumentsDigest = "sha256:12e49c0f5b1f1c5a753a1e98fb8e94a06c58b35c8432b77270d412d5d295e3b9",
+        )
+        val tool = RecordingTool()
+        val toolRegistry = ToolRegistry(mapOf(tool.name to tool))
+        val gate = PermitApprovalGateCoordinator()
+        val continuationStore = InMemoryApprovalContinuationStore(clock = Clock.systemUTC())
+        val suspendedStore = InMemorySuspendedInvocationStore()
+        val engine = buildEngine(
+            source, policy, syncProvider(), toolRegistry,
+            suspendedInvocationStore = suspendedStore,
+            approvalContinuationStore = continuationStore,
+            approvalGateCoordinator = gate,
+        )
+        val service = engine.create(IdentityTestService::class)
+
+        val outcome = runCatching { service.answer("suspend") }.exceptionOrNull()
+        require(outcome is ApprovalSuspendedException) { "expected ApprovalSuspendedException, got ${outcome?.javaClass?.name}: ${outcome?.message}" }
+        val exception = outcome
+        assertThat(exception.workflowRunId).isEqualTo("run-E")
+
+        val metadata = suspendedStore.get(exception.approvalId)
+        assertThat(metadata).isNotNull
+        assertThat(metadata!!.identity.workflowRunId).isEqualTo("run-E")
+        assertThat(metadata.correlationId).isEqualTo("corr-E")
+        assertThat(metadata.identity.correlationId).isEqualTo("corr-E")
+    }
+    }
+
+    @Test
+    fun `P0-F resume consumes zero fresh identity`() {
+        runBlocking {
+        val source = QueuedEngineIdentitySource(listOf("run-F"), listOf("corr-F"))
+        val policy = CapturingPolicyEngine(
+            requireApprovalAtToolExec = true,
+            approvalToolName = "test_calculator",
+            approvalArgumentsDigest = "sha256:12e49c0f5b1f1c5a753a1e98fb8e94a06c58b35c8432b77270d412d5d295e3b9",
+        )
+        val tool = RecordingTool()
+        val toolRegistry = ToolRegistry(mapOf(tool.name to tool))
+        val gate = PermitApprovalGateCoordinator()
+        val continuationStore = InMemoryApprovalContinuationStore(clock = Clock.systemUTC())
+        val suspendedStore = InMemorySuspendedInvocationStore()
+        val engine = buildEngine(
+            source, policy, syncProvider(), toolRegistry,
+            suspendedInvocationStore = suspendedStore,
+            approvalContinuationStore = continuationStore,
+            approvalGateCoordinator = gate,
+        )
+        val service = engine.create(IdentityTestService::class)
+
+        val outcome = runCatching { service.answer("suspend") }.exceptionOrNull()
+        require(outcome is ApprovalSuspendedException) { "expected ApprovalSuspendedException, got ${outcome?.javaClass?.name}: ${outcome?.message}" }
+        val exception = outcome
+        // Source is now exhausted (1+1 consumed). Resume must not sample.
+        val samplesBefore = source.workflowRunSamples + source.correlationSamples
+
+        val result = engine.resumeApproval(
+            ResumeApprovalCommand(
+                approvalId = exception.approvalId,
+                approvalExpectedVersion = 0L,
+                continuationExpectedVersion = 0L,
+                presentedToken = exception.challenge.token,
+                resumedBy = "test",
+            ),
+        )
+
+        assertThat(result).isNotNull
+        assertThat(source.workflowRunSamples + source.correlationSamples).isEqualTo(samplesBefore)
+    }
+    }
+
+    @Test
+    fun `P0-G streaming is lazy - a never collected flow consumes zero identity`() {
+        runBlocking {
+        val source = QueuedEngineIdentitySource(listOf("run-G"), listOf("corr-G"))
+        val provider = RecordingProvider { _ -> ModelResponse(content = "unused") }
+        val engine = buildEngine(source, CapturingPolicyEngine(), provider)
+        val service = engine.create(IdentityTestService::class)
+
+        val flow = service.stream("lazy")
+        assertThat(source.workflowRunSamples).isEqualTo(0)
+        assertThat(source.correlationSamples).isEqualTo(0)
+
+        flow.collect()
+        assertThat(source.correlationSamples).isEqualTo(1)
+    }
+    }
+
+    @Test
+    fun `P0-H streaming samples exactly one correlation per collection`() {
+        runBlocking {
+        val source = QueuedEngineIdentitySource(
+            workflowRunIds = listOf("run-H"),
+            correlationIds = listOf("corr-H1", "corr-H2"),
+        )
+        val provider = RecordingProvider { _ -> ModelResponse(content = "unused") }
+        val engine = buildEngine(source, CapturingPolicyEngine(), provider)
+        val service = engine.create(IdentityTestService::class)
+
+        val flow = service.stream("double")
+        flow.collect()
+        flow.collect()
+
+        assertThat(source.correlationSamples).isEqualTo(2)
+        assertThat(source.workflowRunSamples).isEqualTo(0)
+    }
+    }
+
+    @Test
+    fun `P0-I blank generated identities fail before side effects`() {
+        runBlocking {
+        val blankSource = object : EngineIdentitySource {
+            override fun newWorkflowRunId(): String = "  "
+            override fun newCorrelationId(): String = "corr-I"
+        }
+        val provider = plainProvider()
+        val engine = buildEngine(blankSource, CapturingPolicyEngine(), provider)
+        val service = engine.create(IdentityTestService::class)
+
+        assertThatThrownBy { service.answer("x") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("workflowRunId")
+        assertThat(provider.calls).isEqualTo(0)
+
+        val blankCorrSource = object : EngineIdentitySource {
+            override fun newWorkflowRunId(): String = "run-I"
+            override fun newCorrelationId(): String = ""
+        }
+        val provider2 = plainProvider()
+        val engine2 = buildEngine(blankCorrSource, CapturingPolicyEngine(), provider2)
+        val service2 = engine2.create(IdentityTestService::class)
+
+        assertThatThrownBy { service2.answer("x") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("correlationId")
+        assertThat(provider2.calls).isEqualTo(0)
+    }
+    }
+
+    @Test
+    fun `P0-I2 streaming blank correlation fails before provider side effects`() {
+        runBlocking {
+            val blankCorrSource = object : EngineIdentitySource {
+                override fun newWorkflowRunId(): String = "run-I2"
+                override fun newCorrelationId(): String = ""
+            }
+            val provider = RecordingProvider { _ -> ModelResponse(content = "unused") }
+            val engine = buildEngine(blankCorrSource, CapturingPolicyEngine(), provider)
+            val service = engine.create(IdentityTestService::class)
+
+            val flow = service.stream("blank")
+            val collectFailure = runCatching { flow.collect() }.exceptionOrNull()
+            assertThat(collectFailure).isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("correlationId")
+            assertThat(provider.streamRequests).isEqualTo(0)
+        }
+    }
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/ProviderRetryFallbackLifecyclePropertyTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/ProviderRetryFallbackLifecyclePropertyTest.kt
@@ -23,6 +23,7 @@ import dev.tramai.core.provider.ModelProvider
 import dev.tramai.core.provider.ProviderRoutingPlan
 import dev.tramai.core.provider.StreamCapable
 import dev.tramai.engine.CircuitBreakerAdmission
+import dev.tramai.engine.DefaultEngineIdentitySource
 import dev.tramai.engine.CircuitBreakerPermit
 import dev.tramai.engine.CircuitBreakerSettings
 import dev.tramai.engine.ModelRegistryEnforcer
@@ -201,22 +202,28 @@ class ProviderRetryFallbackLifecyclePropertyTest {
     ): StreamingExecutionCoordinator {
         val policy = PolicyEngine { PolicyDecision.Allow }
         return StreamingExecutionCoordinator(
-            routingPlan, breaker, CoroutineScope(Dispatchers.Default), AtomicBoolean(false), "test.Service", "test.Service",
-            observer,
-            object : dev.tramai.core.observation.OperationInterceptor {},
-            ToolExposureCoordinator(ToolRegistry(), PolicyEnforcementHelper(policy, AtomicBoolean(false))),
-            ConversationMemoryCoordinator(object : ChatMemory {
+            identitySource = DefaultEngineIdentitySource,
+            routingPlan = routingPlan,
+            circuitBreaker = breaker,
+            lifecycleScope = CoroutineScope(Dispatchers.Default),
+            isClosed = AtomicBoolean(false),
+            serviceTypeName = "test.Service",
+            qualifiedServiceName = "test.Service",
+            operationObserver = observer,
+            operationInterceptor = object : dev.tramai.core.observation.OperationInterceptor {},
+            toolExposureCoordinator = ToolExposureCoordinator(ToolRegistry(), PolicyEnforcementHelper(policy, AtomicBoolean(false))),
+            conversationMemoryCoordinator = ConversationMemoryCoordinator(object : ChatMemory {
                 override fun get(conversationId: String): List<Message> = emptyList()
                 override fun add(conversationId: String, messages: List<Message>) = Unit
                 override fun add(conversationId: String, message: Message) = Unit
                 override fun clear(conversationId: String) = Unit
             }, ConversationIdProvider { "cid" }),
-            TokenBudgetCoordinator(TokenBudgetSettings(hardMaxTokensPerOperation = 20)),
-            ModelRegistryEnforcer(object : ModelRegistry { override suspend fun findApprovedModel(providerId: String, modelName: String) = null }, ModelRegistrySettings(enabled = false)),
-            ProviderRetryPolicy(ProviderRetryDelayPolicy(RetryPolicySettings(jitterRatio = 0.0)) { 0.0 }),
-            ProviderResolutionGate { _, _, _ -> sink.record("policy.before-resolution") },
-            ProviderInvocationGate { _, _, _, _ -> sink.record("policy.before-invocation") },
-            ProviderFallbackGate { _, previousProviderId, _, nextProviderId, _, _ ->
+            tokenBudgetCoordinator = TokenBudgetCoordinator(TokenBudgetSettings(hardMaxTokensPerOperation = 20)),
+            modelRegistryEnforcer = ModelRegistryEnforcer(object : ModelRegistry { override suspend fun findApprovedModel(providerId: String, modelName: String) = null }, ModelRegistrySettings(enabled = false)),
+            retryPolicy = ProviderRetryPolicy(ProviderRetryDelayPolicy(RetryPolicySettings(jitterRatio = 0.0)) { 0.0 }),
+            beforeResolution = ProviderResolutionGate { _, _, _ -> sink.record("policy.before-resolution") },
+            beforeInvocation = ProviderInvocationGate { _, _, _, _ -> sink.record("policy.before-invocation") },
+            fallbackGate = ProviderFallbackGate { _, previousProviderId, _, nextProviderId, _, _ ->
                 sink.record("policy.fallback")
                 sink.record("fallback-edge:$previousProviderId->$nextProviderId")
                 if (denyFallback) throw PolicyViolationException(PolicyDecision.Deny("fallback denied", "TEST"))

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/streaming/StreamingExecutionCoordinatorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/streaming/StreamingExecutionCoordinatorTest.kt
@@ -29,6 +29,7 @@ import dev.tramai.core.provider.ModelProvider
 import dev.tramai.core.provider.ProviderRoutingPlan
 import dev.tramai.core.provider.StreamCapable
 import dev.tramai.engine.CircuitBreakerSettings
+import dev.tramai.engine.DefaultEngineIdentitySource
 import dev.tramai.engine.ModelRegistryEnforcer
 import dev.tramai.engine.PolicyEnforcementHelper
 import dev.tramai.engine.ProviderCircuitBreaker
@@ -258,16 +259,24 @@ class StreamingExecutionCoordinatorTest {
         val policy = PolicyEngine { PolicyDecision.Allow }
         fun denied() = PolicyViolationException(PolicyDecision.Deny("denied", "TEST"))
         return StreamingExecutionCoordinator(
-            routingPlan, circuitBreaker, CoroutineScope(Dispatchers.Default), closed, "test.StreamingService", qualifiedServiceName, observer,
-            NoOpOperationInterceptor,
-            ToolExposureCoordinator(ToolRegistry(), PolicyEnforcementHelper(policy, AtomicBoolean(false))),
-            ConversationMemoryCoordinator(memory, ConversationIdProvider { "cid" }), TokenBudgetCoordinator(budgetSettings),
-            ModelRegistryEnforcer(object : ModelRegistry { override suspend fun findApprovedModel(providerId: String, modelName: String) = null }, ModelRegistrySettings(enabled = false)),
-            retryPolicy,
-            ProviderResolutionGate { _, _, _ -> recordingSink.record("policy.before-resolution") },
-            ProviderInvocationGate { _, _, _, _ -> recordingSink.record("policy.before-invocation") },
-            ProviderFallbackGate { _, _, _, _, _, _ -> recordingSink.record("policy.fallback"); if (denyFallback) throw denied() },
-            StreamingBeforeResponseReturnGate { _, _, _ -> recordingSink.record("policy.before-response-return"); if (denyBeforeResponseReturn) throw denied() },
+            identitySource = DefaultEngineIdentitySource,
+            routingPlan = routingPlan,
+            circuitBreaker = circuitBreaker,
+            lifecycleScope = CoroutineScope(Dispatchers.Default),
+            isClosed = closed,
+            serviceTypeName = "test.StreamingService",
+            qualifiedServiceName = qualifiedServiceName,
+            operationObserver = observer,
+            operationInterceptor = NoOpOperationInterceptor,
+            toolExposureCoordinator = ToolExposureCoordinator(ToolRegistry(), PolicyEnforcementHelper(policy, AtomicBoolean(false))),
+            conversationMemoryCoordinator = ConversationMemoryCoordinator(memory, ConversationIdProvider { "cid" }),
+            tokenBudgetCoordinator = TokenBudgetCoordinator(budgetSettings),
+            modelRegistryEnforcer = ModelRegistryEnforcer(object : ModelRegistry { override suspend fun findApprovedModel(providerId: String, modelName: String) = null }, ModelRegistrySettings(enabled = false)),
+            retryPolicy = retryPolicy,
+            beforeResolution = ProviderResolutionGate { _, _, _ -> recordingSink.record("policy.before-resolution") },
+            beforeInvocation = ProviderInvocationGate { _, _, _, _ -> recordingSink.record("policy.before-invocation") },
+            fallbackGate = ProviderFallbackGate { _, _, _, _, _, _ -> recordingSink.record("policy.fallback"); if (denyFallback) throw denied() },
+            beforeResponseReturn = StreamingBeforeResponseReturnGate { _, _, _ -> recordingSink.record("policy.before-response-return"); if (denyBeforeResponseReturn) throw denied() },
         )
     }
 


### PR DESCRIPTION
## 8.3b2a — Engine execution identity authority

**Primary invariant:** every engine-generated execution identity comes from one explicit engine composition boundary. An invocation samples each required identity exactly once, propagates it unchanged through its lifecycle, and resume never creates replacement identity.

### What changed
- **NEW `EngineIdentitySource`** (internal): distinct `newWorkflowRunId()` / `newCorrelationId()` methods — reusing one as the other is structurally visible. `DefaultEngineIdentitySource` is UUID-backed.
- **Composition:** `EngineComponentFactory.create(..., identitySource)` → `ExecutionComponents` (exact 8.3b1 `RetryJitterSource` pattern). No public API change.
- **InvocationEntryCoordinator:** samples both identities once per non-streaming invocation (`invocationIdentity()`), blank-`require()` validation, identity now complete at entry (no more `correlationId = ""`).
- **Raw/Structured coordinators:** deleted inline `UUID.randomUUID()` + `identity.copy()`; consume the injected identity unchanged.
- **Structured (option B):** identity sampled at invocation entry — a failed structured-contract invocation is still an invocation and consumes identity.
- **Streaming:** stays lazy — correlation sampled inside the `flow` body, one per collection, zero until collected. No manufactured streaming workflowRunId.
- **PolicyEnforcementHelper.buildContext:** hidden `UUID.randomUUID()` default removed; `correlationId: String` required (all 17 callers already explicit).

### Verification
- **RED→GREEN:** 11 discriminators (P0-A..P0-I2) all RED against pre-fix production, all GREEN after.
- **Mutation campaign: 10/10 STRONG / 0 WEAK / 0 UNREACHABLE** (M01–M05, M08, M10–M13). Structurally eliminated with evidence: M06 (structured coordinator owns no source), M07 (no default-generating path remains), M09 (resume path `ClaimedResumeExecutionCoordinator` has zero UUID/identitySource calls — consumes persisted `metadata.identity`; P0-F proves with an exhausted source).
- **Structural greps:** the only `UUID.randomUUID` in tramai-engine main is `DefaultEngineIdentitySource`; zero `correlationId = ""`.
- **Gates:** full `:tramai-engine:test --rerun-tasks` GREEN (2m46s); apiCheck GREEN (zero public API drift); verifyChangePolicy / verify060Architecture / verifyMaintainabilityBaseline / verifyModuleDocContract GREEN.
- **Out of scope untouched:** WorkflowContext.workflowId, attemptId, checkpoint generations, lease stores, scheduler, server run IDs, UuidConversationIdProvider/UuidApprovalIdGenerator, AuditEngine.idGenerator, SecureRandom security tokens.