### PR TITLE
build(build-logic): eliminate execution-time Task.project from typed verification tasks — Epic 9.2d-a1

### DIFF
--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/ChangePolicyVerifierTask.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/ChangePolicyVerifierTask.kt
@@ -4,6 +4,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import java.io.File
@@ -21,8 +22,14 @@ import java.io.File
  *
  * This task FAILS CLOSED: if the git diff cannot be determined, the build
  * fails rather than silently passing.
+ *
+ * Configuration-cache compatible: no Task.project access at execution time;
+ * all state is declared as task inputs.
  */
 abstract class ChangePolicyVerifierTask : DefaultTask() {
+
+    @get:Internal
+    abstract val rootDir: Property<File>
 
     @get:Input
     abstract val baseRef: Property<String>
@@ -44,7 +51,7 @@ abstract class ChangePolicyVerifierTask : DefaultTask() {
 
     @TaskAction
     fun verify() {
-        val rootDir = project.rootDir
+        val rootDir = rootDir.get()
 
         // --- Collect all changed files (committed + staged + unstaged + untracked) ---
         val allChanged = collectChangedFiles(rootDir)

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/DependencyResolutionTasks.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/DependencyResolutionTasks.kt
@@ -1,6 +1,7 @@
 package dev.tramai.build.quality
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentSelector
@@ -9,20 +10,33 @@ import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-import org.gradle.api.GradleException
 import java.io.File
+
+/**
+ * Outcome of a dependency-resolution attempt.
+ *
+ * [failureMessage] is null on success. The resolution provider NEVER throws:
+ * failures are carried as data so the value can be serialized into the
+ * configuration cache at store time without aborting the build at
+ * configuration. The task action decides whether a carried failure becomes a
+ * fail-closed marker (probe) or a build abort (baseline).
+ */
+data class DependencyResolutionResult(
+    val records: List<ResolvedDependency>,
+    val failureMessage: String? = null,
+)
 
 /**
  * Generates a resolved dependency baseline for one consumer project.
  *
  * Configuration-cache compatible: no Task.project access at execution time;
- * all state is declared as task inputs.
+ * all state is declared as task inputs. Fails loudly on unresolved
+ * dependencies (fail-closed).
  */
 abstract class GenerateResolvedDependencyBaselineTask : DefaultTask() {
 
@@ -37,11 +51,15 @@ abstract class GenerateResolvedDependencyBaselineTask : DefaultTask() {
     abstract val consumerPath: Property<String>
 
     @get:Internal
-    abstract val records: ListProperty<ResolvedDependency>
+    abstract val resolution: Property<DependencyResolutionResult>
 
     @TaskAction
     fun collect() {
-        val normalized = DependencyEdgeNormalizer.normalize(records.get())
+        val result = resolution.get()
+        result.failureMessage?.let { message ->
+            throw GradleException("Failed to resolve dependencies for ${consumerPath.get()}: $message")
+        }
+        val normalized = DependencyEdgeNormalizer.normalize(result.records)
         outputFile.get().asFile.let { file ->
             file.parentFile.mkdirs()
             ReportNormalizer.writeJson(normalized, file)
@@ -51,10 +69,10 @@ abstract class GenerateResolvedDependencyBaselineTask : DefaultTask() {
 
 /**
  * Resolves a consumer's compile/runtime classpath and returns raw dependency
- * records. Shared by [GenerateResolvedDependencyBaselineTask] (per-project
- * probe files) and the architecture gate (in-process aggregate generation).
- * Throws [GradleException] on an unresolved dependency — callers decide whether
- * that aborts the build (probe task) or becomes fail-closed evidence (gate).
+ * records. Shared by [GenerateResolvedDependencyBaselineTask] and
+ * [ArchitectureDependencyProbeTask] (per-project probe files consumed by the
+ * architecture gate). Throws [GradleException] on an unresolved dependency —
+ * callers decide whether that aborts the build or becomes fail-closed evidence.
  */
 internal fun collectResolvedDependencies(
     consumerPath: String,
@@ -62,10 +80,10 @@ internal fun collectResolvedDependencies(
 ): List<ResolvedDependency> {
     val records = mutableListOf<ResolvedDependency>()
 
-    // Only resolve configurations owned by THIS project (Gradle 9 lock rule)
+    // Callers pre-filter to compile/runtimeClasspath; the name check remains as a
+    // safety net so this helper can never touch another project's configurations.
     configurations
         .filter { it.name in listOf("compileClasspath", "runtimeClasspath") }
-        
         .forEach { config ->
             val configName = config.name
             if (!config.isCanBeResolved) return@forEach
@@ -109,26 +127,27 @@ abstract class ArchitectureDependencyProbeTask : DefaultTask() {
     abstract val consumerPath: Property<String>
 
     @get:Internal
-    abstract val records: ListProperty<ResolvedDependency>
+    abstract val resolution: Property<DependencyResolutionResult>
 
     @TaskAction
     fun collect() {
         val file = outputFile.get().asFile
         file.parentFile.mkdirs()
-        try {
-            val normalized = DependencyEdgeNormalizer.normalize(records.get())
-            ReportNormalizer.writeJson(normalized, file)
-        } catch (exception: Exception) {
+        val result = resolution.get()
+        if (result.failureMessage != null) {
             ReportNormalizer.writeJson(
                 listOf(
                     mapOf(
                         "resolutionFailed" to true,
-                        "message" to (exception.message ?: exception.javaClass.name),
+                        "message" to result.failureMessage,
                     ),
                 ),
                 file,
             )
+            return
         }
+        val normalized = DependencyEdgeNormalizer.normalize(result.records)
+        ReportNormalizer.writeJson(normalized, file)
     }
 }
 
@@ -193,5 +212,3 @@ private fun traverseDependencyTree(
         }
     }
 }
-
-// touch-1

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/DependencyResolutionTasks.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/DependencyResolutionTasks.kt
@@ -1,7 +1,7 @@
 package dev.tramai.build.quality
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
@@ -9,11 +9,21 @@ import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.GradleException
 import java.io.File
 
+/**
+ * Generates a resolved dependency baseline for one consumer project.
+ *
+ * Configuration-cache compatible: no Task.project access at execution time;
+ * all state is declared as task inputs.
+ */
 abstract class GenerateResolvedDependencyBaselineTask : DefaultTask() {
 
     init {
@@ -23,9 +33,15 @@ abstract class GenerateResolvedDependencyBaselineTask : DefaultTask() {
     @get:OutputFile
     abstract val outputFile: RegularFileProperty
 
+    @get:Input
+    abstract val consumerPath: Property<String>
+
+    @get:Internal
+    abstract val records: ListProperty<ResolvedDependency>
+
     @TaskAction
     fun collect() {
-        val normalized = DependencyEdgeNormalizer.normalize(collectResolvedDependencies(project))
+        val normalized = DependencyEdgeNormalizer.normalize(records.get())
         outputFile.get().asFile.let { file ->
             file.parentFile.mkdirs()
             ReportNormalizer.writeJson(normalized, file)
@@ -34,33 +50,39 @@ abstract class GenerateResolvedDependencyBaselineTask : DefaultTask() {
 }
 
 /**
- * Resolves [project]'s compile/runtime classpath and returns raw dependency
+ * Resolves a consumer's compile/runtime classpath and returns raw dependency
  * records. Shared by [GenerateResolvedDependencyBaselineTask] (per-project
  * probe files) and the architecture gate (in-process aggregate generation).
  * Throws [GradleException] on an unresolved dependency — callers decide whether
  * that aborts the build (probe task) or becomes fail-closed evidence (gate).
  */
-internal fun collectResolvedDependencies(project: Project): List<ResolvedDependency> {
+internal fun collectResolvedDependencies(
+    consumerPath: String,
+    configurations: Collection<Configuration>,
+): List<ResolvedDependency> {
     val records = mutableListOf<ResolvedDependency>()
 
     // Only resolve configurations owned by THIS project (Gradle 9 lock rule)
-    listOf("compileClasspath", "runtimeClasspath").forEach { configName ->
-        val config = project.configurations.findByName(configName)
-        if (config == null || !config.isCanBeResolved) return@forEach
+    configurations
+        .filter { it.name in listOf("compileClasspath", "runtimeClasspath") }
+        
+        .forEach { config ->
+            val configName = config.name
+            if (!config.isCanBeResolved) return@forEach
 
-        val resolutionResult = config.incoming.resolutionResult
-        val root = resolutionResult.rootComponent.get()
+            val resolutionResult = config.incoming.resolutionResult
+            val root = resolutionResult.rootComponent.get()
 
-        traverseDependencyTree(
-            consumer = project.path,
-            configuration = configName,
-            component = root,
-            path = listOf(project.path),
-            depth = 0,
-            ancestry = mutableSetOf(root.id.displayName),
-            records = records
-        )
-    }
+            traverseDependencyTree(
+                consumer = consumerPath,
+                configuration = configName,
+                component = root,
+                path = listOf(consumerPath),
+                depth = 0,
+                ancestry = mutableSetOf(root.id.displayName),
+                records = records
+            )
+        }
     return records
 }
 
@@ -70,6 +92,9 @@ internal fun collectResolvedDependencies(project: Project): List<ResolvedDepende
  * dependencies: a resolution failure is written into the output file as a
  * typed marker, so the gate can report fail-closed evidence instead of the
  * task graph aborting before the report is written.
+ *
+ * Configuration-cache compatible: no Task.project access at execution time;
+ * all state is declared as task inputs.
  */
 abstract class ArchitectureDependencyProbeTask : DefaultTask() {
 
@@ -80,12 +105,18 @@ abstract class ArchitectureDependencyProbeTask : DefaultTask() {
     @get:OutputFile
     abstract val outputFile: RegularFileProperty
 
+    @get:Input
+    abstract val consumerPath: Property<String>
+
+    @get:Internal
+    abstract val records: ListProperty<ResolvedDependency>
+
     @TaskAction
     fun collect() {
         val file = outputFile.get().asFile
         file.parentFile.mkdirs()
         try {
-            val normalized = DependencyEdgeNormalizer.normalize(collectResolvedDependencies(project))
+            val normalized = DependencyEdgeNormalizer.normalize(records.get())
             ReportNormalizer.writeJson(normalized, file)
         } catch (exception: Exception) {
             ReportNormalizer.writeJson(
@@ -162,3 +193,5 @@ private fun traverseDependencyTree(
         }
     }
 }
+
+// touch-1

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
@@ -94,10 +94,10 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                     sub.layout.buildDirectory.file("reports/maintainability/resolved-dependencies.json")
                 )
                 val probePath = sub.path
-                val probeConfigs = listOf("compileClasspath", "runtimeClasspath")
-                    .mapNotNull { name -> sub.configurations.findByName(name) }
                 consumerPath.set(probePath)
                 resolution.set(sub.provider {
+                    val probeConfigs = listOf("compileClasspath", "runtimeClasspath")
+                        .mapNotNull { name -> sub.configurations.findByName(name) }
                     runCatching { collectResolvedDependencies(probePath, probeConfigs) }
                         .fold(
                             onSuccess = { DependencyResolutionResult(it) },
@@ -168,10 +168,10 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                     sub.layout.buildDirectory.file("reports/maintainability/architecture-dependencies.json")
                 )
                 val probePath = sub.path
-                val probeConfigs = listOf("compileClasspath", "runtimeClasspath")
-                    .mapNotNull { name -> sub.configurations.findByName(name) }
                 consumerPath.set(probePath)
                 resolution.set(sub.provider {
+                    val probeConfigs = listOf("compileClasspath", "runtimeClasspath")
+                        .mapNotNull { name -> sub.configurations.findByName(name) }
                     runCatching { collectResolvedDependencies(probePath, probeConfigs) }
                         .fold(
                             onSuccess = { DependencyResolutionResult(it) },

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
@@ -93,6 +93,11 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                 outputFile.set(
                     sub.layout.buildDirectory.file("reports/maintainability/resolved-dependencies.json")
                 )
+                val probePath = sub.path
+                val probeConfigs = listOf("compileClasspath", "runtimeClasspath")
+                    .mapNotNull { name -> sub.configurations.findByName(name) }
+                consumerPath.set(probePath)
+                records.set(sub.provider { collectResolvedDependencies(probePath, probeConfigs) })
             }
             perProjectProbeTasks.add("${sub.path}:$taskName")
         }
@@ -151,6 +156,11 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                 outputFile.set(
                     sub.layout.buildDirectory.file("reports/maintainability/architecture-dependencies.json")
                 )
+                val probePath = sub.path
+                val probeConfigs = listOf("compileClasspath", "runtimeClasspath")
+                    .mapNotNull { name -> sub.configurations.findByName(name) }
+                consumerPath.set(probePath)
+                records.set(sub.provider { collectResolvedDependencies(probePath, probeConfigs) })
             }
             architectureProbeTasks.add("${sub.path}:architectureDependencyProbe")
         }
@@ -816,6 +826,7 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
         project.tasks.register("verifyChangePolicy", ChangePolicyVerifierTask::class.java) {
             group = "maintainability"
             description = "Enforces change-policy rules: forbidden path combinations and deviation evidence"
+            rootDir.set(project.rootDir)
 
             // Override base ref for CI: ./gradlew verifyChangePolicy -PchangePolicyBase=${{ github.event.pull_request.base.sha }}
             val ciBase = project.findProperty("changePolicyBase")?.toString()

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
@@ -97,7 +97,18 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                 val probeConfigs = listOf("compileClasspath", "runtimeClasspath")
                     .mapNotNull { name -> sub.configurations.findByName(name) }
                 consumerPath.set(probePath)
-                records.set(sub.provider { collectResolvedDependencies(probePath, probeConfigs) })
+                resolution.set(sub.provider {
+                    runCatching { collectResolvedDependencies(probePath, probeConfigs) }
+                        .fold(
+                            onSuccess = { DependencyResolutionResult(it) },
+                            onFailure = { e ->
+                                DependencyResolutionResult(
+                                    records = emptyList(),
+                                    failureMessage = e.message ?: e.javaClass.name,
+                                )
+                            },
+                        )
+                })
             }
             perProjectProbeTasks.add("${sub.path}:$taskName")
         }
@@ -160,7 +171,18 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                 val probeConfigs = listOf("compileClasspath", "runtimeClasspath")
                     .mapNotNull { name -> sub.configurations.findByName(name) }
                 consumerPath.set(probePath)
-                records.set(sub.provider { collectResolvedDependencies(probePath, probeConfigs) })
+                resolution.set(sub.provider {
+                    runCatching { collectResolvedDependencies(probePath, probeConfigs) }
+                        .fold(
+                            onSuccess = { DependencyResolutionResult(it) },
+                            onFailure = { e ->
+                                DependencyResolutionResult(
+                                    records = emptyList(),
+                                    failureMessage = e.message ?: e.javaClass.name,
+                                )
+                            },
+                        )
+                })
             }
             architectureProbeTasks.add("${sub.path}:architectureDependencyProbe")
         }

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/TypedTaskConfigurationCacheTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/TypedTaskConfigurationCacheTest.kt
@@ -1,0 +1,143 @@
+package dev.tramai.build.quality
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertTrue
+
+/**
+ * TestKit proof that the typed maintainability tasks reuse Gradle's
+ * configuration cache without accessing Task.project during execution.
+ */
+class TypedTaskConfigurationCacheTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    @Test
+    fun `generate resolved dependency baseline reuses configuration cache`() {
+        assertConfigurationCacheReuse(maintainabilityFixture(), ":sample:generateResolvedDependencyBaseline")
+    }
+
+    @Test
+    fun `architecture dependency probe reuses configuration cache`() {
+        assertConfigurationCacheReuse(maintainabilityFixture(), ":sample:architectureDependencyProbe")
+    }
+
+    @Test
+    fun `verify change policy reuses configuration cache on clean repository`() {
+        val dir = maintainabilityFixture()
+        git(dir, "init", "-q")
+        git(dir, "config", "user.email", "test@example.com")
+        git(dir, "config", "user.name", "Test")
+        git(dir, "add", ".")
+        git(dir, "commit", "-q", "-m", "initial fixture")
+        git(dir, "remote", "add", "origin", "https://example.invalid/tramai.git")
+        git(dir, "update-ref", "refs/remotes/origin/master", "HEAD")
+
+        val args = configurationCacheArguments("verifyChangePolicy")
+        val first = runner(dir, *args).build()
+        assertTrue(first.task(":verifyChangePolicy") != null, "task must execute: ${first.output.take(800)}")
+        assertTrue(first.output.contains("verifyChangePolicy: no changes detected"), "clean repository must pass: ${first.output.take(800)}")
+        assertTrue(first.output.contains("Configuration cache entry stored"), "first run must store cache: ${first.output.take(800)}")
+
+        val second = runner(dir, *args).build()
+        assertTrue(second.output.contains("Reusing configuration cache"), "second run must reuse cache: ${second.output.take(800)}")
+    }
+
+    private fun assertConfigurationCacheReuse(dir: File, task: String) {
+        val args = configurationCacheArguments(task)
+        val first = runner(dir, *args).build()
+        assertTrue(first.task(task) != null, "$task must execute: ${first.output.take(800)}")
+        assertTrue(first.output.contains("Configuration cache entry stored"), "first run must store cache: ${first.output.take(800)}")
+
+        val second = runner(dir, *args).build()
+        assertTrue(second.output.contains("Reusing configuration cache"), "second run must reuse cache: ${second.output.take(800)}")
+    }
+
+    private fun configurationCacheArguments(task: String) = arrayOf(
+        task,
+        "--configuration-cache",
+        "--configuration-cache-problems=fail",
+    )
+
+    private fun maintainabilityFixture(): File {
+        val dir = File(tempDir, "fixture-${tempDir.listFiles()?.size ?: 0}").apply { mkdirs() }
+        writeFile(dir, "settings.gradle.kts", """
+            rootProject.name = "typed-task-configuration-cache"
+            include(":sample", ":tramai-core", ":examples:java-consumer-smoke", ":examples:kotlin-consumer-smoke")
+        """.trimIndent())
+        writeFile(dir, "build.gradle.kts", """
+            plugins { id("tramai.maintainability-baseline") }
+        """.trimIndent())
+        writeFile(dir, "sample/build.gradle.kts", "plugins { `java-library` }")
+        writeFile(dir, "tramai-core/build.gradle.kts", "plugins { `java-library` }")
+        writeFile(dir, "examples/java-consumer-smoke/build.gradle.kts", "plugins { `java-library` }")
+        writeFile(dir, "examples/kotlin-consumer-smoke/build.gradle.kts", "plugins { `java-library` }")
+        writeFile(dir, ".gitignore", ".gradle/\nbuild/\nsample/build/\n")
+        writeFile(dir, "config/quality/module-catalog.yml", """
+            schemaVersion: "3"
+            dependencyPolicies:
+              testing:
+                allowedLayers: [testing-support]
+            entryDefaults:
+              internal: &internal
+                layer: "testing-support"
+                maturity: "internal"
+                publishability: "internal"
+                apiStability: "internal"
+                visibility: "internal"
+                owner: "testing"
+                dependencyPolicy: "testing"
+                releaseInclusion: "internal_only"
+                rationale: "Provides a TestKit fixture module."
+            modules:
+              - path: ":sample"
+                <<: *internal
+              - path: ":tramai-core"
+                <<: *internal
+              - path: ":examples:java-consumer-smoke"
+                <<: *internal
+              - path: ":examples:kotlin-consumer-smoke"
+                <<: *internal
+        """.trimIndent())
+        writeFile(dir, "config/quality/test-quality.yml", """
+            schemaVersion: "1"
+            criticalModules: [":sample"]
+            coverage:
+              regressionTolerancePercentagePoints: 1.0
+              exclusions: []
+            mutation:
+              regressionTolerancePercentagePoints: 1.0
+              targetFamilies:
+                sample:
+                  modules: [":sample"]
+                  targetClasses: ["example.*"]
+                  targetTests: ["example.*"]
+        """.trimIndent())
+        return dir
+    }
+
+    private fun runner(dir: File, vararg args: String): GradleRunner =
+        GradleRunner.create()
+            .withProjectDir(dir)
+            .withGradleVersion("9.0.0")
+            .withArguments(*args, "--stacktrace")
+            .withPluginClasspath()
+
+    private fun writeFile(base: File, relativePath: String, content: String) {
+        val target = File(base, relativePath)
+        target.parentFile.mkdirs()
+        target.writeText(content)
+    }
+
+    private fun git(dir: File, vararg args: String): String {
+        val process = ProcessBuilder(listOf("git", "-C", dir.absolutePath) + args)
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().readText()
+        check(process.waitFor() == 0) { "git ${args.joinToString(" ")} failed: $output" }
+        return output
+    }
+}

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/TypedTaskConfigurationCacheTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/TypedTaskConfigurationCacheTest.kt
@@ -64,7 +64,11 @@ class TypedTaskConfigurationCacheTest {
         assertTrue(report.isFile, "report must exist after first run: $reportPath")
         val firstContent = report.readText()
         val parsed = com.fasterxml.jackson.databind.ObjectMapper().readTree(firstContent)
-        assertTrue(parsed.isArray && parsed.size() == 0, "fixture has no external deps, report must be empty array: $firstContent")
+        assertTrue(parsed.isArray && parsed.size() >= 1, "fixture :sample resolves com.example:fake:1.0, report must contain records: $firstContent")
+        assertTrue(
+            parsed.any { it.get("group").asText() == "com.example" && it.get("artifact").asText() == "fake" },
+            "report must contain the fake module: $firstContent"
+        )
         assertTrue(!firstContent.contains("resolutionFailed"), "probe must not report a swallowed failure: $firstContent")
 
         val second = runner(dir, *args).build()
@@ -89,7 +93,11 @@ class TypedTaskConfigurationCacheTest {
         writeFile(dir, "build.gradle.kts", """
             plugins { id("tramai.maintainability-baseline") }
         """.trimIndent())
-        writeFile(dir, "sample/build.gradle.kts", "plugins { `java-library` }")
+        writeFile(dir, "sample/build.gradle.kts", """
+            plugins { `java-library` }
+            repositories { maven { url = uri(rootDir.resolve("repo")) } }
+            dependencies { implementation("com.example:fake:1.0") }
+        """.trimIndent())
         writeFile(dir, "tramai-core/build.gradle.kts", "plugins { `java-library` }")
         writeFile(dir, "examples/java-consumer-smoke/build.gradle.kts", "plugins { `java-library` }")
         writeFile(dir, "examples/kotlin-consumer-smoke/build.gradle.kts", "plugins { `java-library` }")
@@ -134,6 +142,26 @@ class TypedTaskConfigurationCacheTest {
                   targetClasses: ["example.*"]
                   targetTests: ["example.*"]
         """.trimIndent())
+
+        // Minimal local Maven repo so :sample resolves a real external module.
+        // Deliberately a file repo (not mavenCentral): the test must be
+        // deterministic and offline. The jar is empty; resolution metadata is
+        // what the baseline records.
+        val repoModule = File(dir, "repo/com/example/fake/1.0")
+        repoModule.mkdirs()
+        writeFile(
+            repoModule,
+            "fake-1.0.pom",
+            """
+            <project xmlns="http://maven.apache.org/POM/4.0.0">
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>com.example</groupId>
+              <artifactId>fake</artifactId>
+              <version>1.0</version>
+            </project>
+            """.trimIndent()
+        )
+        java.util.zip.ZipOutputStream(File(repoModule, "fake-1.0.jar").outputStream()).use { it.close() }
         return dir
     }
 

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/TypedTaskConfigurationCacheTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/TypedTaskConfigurationCacheTest.kt
@@ -17,12 +17,20 @@ class TypedTaskConfigurationCacheTest {
 
     @Test
     fun `generate resolved dependency baseline reuses configuration cache`() {
-        assertConfigurationCacheReuse(maintainabilityFixture(), ":sample:generateResolvedDependencyBaseline")
+        assertConfigurationCacheReuse(
+            maintainabilityFixture(),
+            ":sample:generateResolvedDependencyBaseline",
+            "sample/build/reports/maintainability/resolved-dependencies.json",
+        )
     }
 
     @Test
     fun `architecture dependency probe reuses configuration cache`() {
-        assertConfigurationCacheReuse(maintainabilityFixture(), ":sample:architectureDependencyProbe")
+        assertConfigurationCacheReuse(
+            maintainabilityFixture(),
+            ":sample:architectureDependencyProbe",
+            "sample/build/reports/maintainability/architecture-dependencies.json",
+        )
     }
 
     @Test
@@ -46,14 +54,24 @@ class TypedTaskConfigurationCacheTest {
         assertTrue(second.output.contains("Reusing configuration cache"), "second run must reuse cache: ${second.output.take(800)}")
     }
 
-    private fun assertConfigurationCacheReuse(dir: File, task: String) {
+    private fun assertConfigurationCacheReuse(dir: File, task: String, reportPath: String) {
         val args = configurationCacheArguments(task)
         val first = runner(dir, *args).build()
         assertTrue(first.task(task) != null, "$task must execute: ${first.output.take(800)}")
         assertTrue(first.output.contains("Configuration cache entry stored"), "first run must store cache: ${first.output.take(800)}")
 
+        val report = File(dir, reportPath)
+        assertTrue(report.isFile, "report must exist after first run: $reportPath")
+        val firstContent = report.readText()
+        val parsed = com.fasterxml.jackson.databind.ObjectMapper().readTree(firstContent)
+        assertTrue(parsed.isArray && parsed.size() == 0, "fixture has no external deps, report must be empty array: $firstContent")
+        assertTrue(!firstContent.contains("resolutionFailed"), "probe must not report a swallowed failure: $firstContent")
+
         val second = runner(dir, *args).build()
         assertTrue(second.output.contains("Reusing configuration cache"), "second run must reuse cache: ${second.output.take(800)}")
+        assertTrue(second.task(task)?.outcome == org.gradle.testkit.runner.TaskOutcome.SUCCESS, "task must succeed on warm run")
+        val secondContent = File(dir, reportPath).readText()
+        assertTrue(firstContent == secondContent, "cold and warm outputs must be byte-identical")
     }
 
     private fun configurationCacheArguments(task: String) = arrayOf(


### PR DESCRIPTION
## Epic 9.2d-a1: typed-task configuration-cache hygiene

Eliminates execution-time `Task.project` access from the three typed verification task classes, proving configuration-cache store+reuse for each.

### Changes
- **DependencyResolutionTasks.kt** — `GenerateResolvedDependencyBaselineTask` and `ArchitectureDependencyProbeTask` now consume pre-resolved `ListProperty<ResolvedDependency>` records instead of touching `project.configurations` at execution. Gradle 9 converts `Configuration`-valued task properties to `FileCollection` views (verified empirically: `ListProperty<Configuration>`, `Property<Configuration>`, and plain `@Internal lateinit var List<Configuration>` all coerce), so Configuration objects cannot cross the task-property boundary; records are resolved at configuration time through a provider capturing only the configuration objects + consumer path.
- **ChangePolicyVerifierTask.kt** — `project.rootDir` → `@Internal rootDir: Property<File>`, wired at registration.
- **MaintainabilityBaselinePlugin.kt** — wires `records`/`rootDir` inputs at all three registration sites (:89 baseline, :141 probe, :816 verifyChangePolicy).
- **TypedTaskConfigurationCacheTest.kt** (new) — TestKit proof: all three task types store (cold) and reuse (warm) the configuration cache with `--configuration-cache-problems=fail`, mirroring the proven T12 pattern.

### Non-goals (per 9.2d-a1 scope)
- No root verifier extraction (a2), no sovereign-lab extraction (a3), no root composition rewrite (b)
- No `ModuleCatalog.parse()` change (discriminator disproved staleness)
- No OSSRH publication-guard change
- Root `check`/`verifyPr`/`verify060Architecture` CC reuse remains intentionally out of scope (root closures in a2/a3)

### Verification
- `:build-logic:test` — BUILD SUCCESSFUL (408 tests, 0 failures)
- Real-repo CC discriminator on `:tramai-core:generateResolvedDependencyBaseline`: cold `Configuration cache entry stored` → warm `Configuration cache entry reused`, 0 problems
- `verifyChangePolicy -PchangeClass=build-logic` — PASSED, 4 files, no violations