### PR TITLE
refactor(orchestration): 8.3b2b — make step-attempt identity an explicit authority

### DIFF
--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/StepAttemptIdentitySource.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/StepAttemptIdentitySource.kt
@@ -1,0 +1,26 @@
+package dev.tramai.orchestration
+
+/**
+ * 8.3b2b — step-attempt identity authority.
+ *
+ * Every newly-created [StepAttemptRecord.attemptId] originates from this explicit
+ * orchestration composition boundary. Attempt identity is opaque: it must never
+ * acquire chronology, wall-time, lease, or claim authority (the #318 split keeps
+ * `attemptSequence` as the only chronology; `startedAt` as the only wall time).
+ *
+ * Invariant: an attempt samples its identity exactly once at creation,
+ * propagates it unchanged through update/CAS/re-record, and resume/recovery
+ * never manufactures replacement identity.
+ *
+ * The interface is deliberately a single method: there is exactly one identity
+ * kind an attempt owns. Blank values are rejected by the consumer (fail closed
+ * before persistence), not silently normalized here.
+ */
+internal fun interface StepAttemptIdentitySource {
+    fun newAttemptId(): String
+}
+
+/** Production default: UUID-backed opaque identity. */
+internal object DefaultStepAttemptIdentitySource : StepAttemptIdentitySource {
+    override fun newAttemptId(): String = java.util.UUID.randomUUID().toString()
+}

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowExecutionSupervisor.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/WorkflowExecutionSupervisor.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.time.Clock
 import java.security.MessageDigest
-import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
 
@@ -46,6 +45,7 @@ internal class WorkflowExecutionSupervisor(
     private val recoveryCoordinator: WorkflowRecoveryCoordinator,
     private val leaseRenewalLoop: LeaseRenewalLoop,
     private val shuttingDownGracefully: () -> Boolean,
+    private val stepAttemptIdentitySource: StepAttemptIdentitySource = DefaultStepAttemptIdentitySource,
 ) {
     private val activeExecutions = ConcurrentHashMap<String, ActiveExecution>()
     private val executionFailures = ConcurrentHashMap<String, Throwable>()
@@ -135,6 +135,7 @@ internal class WorkflowExecutionSupervisor(
             observability = observability,
             clock = typedWorkflow.clock,
             leaseProvider = { handle.lease.get() },
+            stepAttemptIdentitySource = stepAttemptIdentitySource,
         )
         handle.tracker = tracker
         tracker.prepareForCheckpoint(checkpoint)
@@ -304,6 +305,7 @@ internal class ExecutionTracker(
     private val observability: TramaiWorkerObserver,
     private val clock: Clock,
     private val leaseProvider: () -> WorkflowLease?,
+    private val stepAttemptIdentitySource: StepAttemptIdentitySource,
 ) {
     private val monitor = Any()
     private val observerScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -372,7 +374,11 @@ internal class ExecutionTracker(
         val attempt = StepAttemptRecord(
             runId = context.workflowId,
             stepName = stepName,
-            attemptId = UUID.randomUUID().toString(),
+            attemptId = stepAttemptIdentitySource.newAttemptId().also { generated ->
+                require(generated.isNotBlank()) {
+                    "Step-attempt attemptId must not be blank (workflow '${context.workflowId}', step '$stepName', worker '$workerId')"
+                }
+            },
             workerId = workerId,
             leaseToken = leaseProvider()?.leaseId ?: "unknown",
             status = StepAttemptStatus.STARTED,

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/StepAttemptIdentityDiscriminatorTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/StepAttemptIdentityDiscriminatorTest.kt
@@ -1,0 +1,297 @@
+package dev.tramai.orchestration
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * 8.3b2b — step-attempt identity authority.
+ *
+ * Invariant: every newly-created StepAttemptRecord.attemptId originates from one
+ * explicit orchestration composition authority ([StepAttemptIdentitySource]).
+ * Attempt identity is opaque: it never acquires chronology, wall-time, lease,
+ * or claim authority, and update/CAS/re-record never manufacture replacement
+ * identity.
+ *
+ * The harness exhausts the source with IllegalStateException on any extra
+ * sample, so "sampled exactly once" and "zero new identity" are structural:
+ * any hidden re-sampling fails the test instead of being asserted away.
+ */
+class StepAttemptIdentityDiscriminatorTest {
+
+    private val config = WorkerConfig(
+        workerId = "identity-supervisor",
+        poolName = "tests",
+        pollIntervalMillis = 20,
+        leaseDurationMillis = 5_000,
+        drainTimeoutMillis = 1_000,
+    )
+
+    private class QueuedStepAttemptIdentitySource(vararg ids: String) : StepAttemptIdentitySource {
+        private val queue = ArrayDeque(ids.toList())
+        var samples: Int = 0
+            private set
+
+        override fun newAttemptId(): String {
+            samples++
+            return queue.removeFirstOrNull()
+                ?: throw IllegalStateException("identity source exhausted — unexpected extra sample")
+        }
+    }
+
+    private data class TestState(val value: String)
+
+    private object TestCodec : WorkflowStateCodec<TestState> {
+        override fun encode(state: TestState): String = state.value
+        override fun decode(payload: String): TestState = TestState(payload)
+    }
+
+    private class RecordingObserver : TramaiWorkerObserver {
+        val leaseReleased = CopyOnWriteArrayList<String>()
+
+        override fun onLeaseReleased(workflowId: String, workerId: String) {
+            leaseReleased += workflowId
+        }
+    }
+
+    private fun supervisor(
+        store: InMemoryWorkflowCheckpointStore,
+        leaseStore: InMemoryWorkflowLeaseStore,
+        workflowBindings: WorkflowBindingRegistry,
+        identitySource: StepAttemptIdentitySource,
+    ): Pair<WorkflowExecutionSupervisor, RecordingObserver> {
+        val observer = RecordingObserver()
+        val leaseCoordinator = LeaseCoordinator(config, leaseStore, observer)
+        val s = WorkflowExecutionSupervisor(
+            config = config,
+            leaseStore = leaseStore,
+            checkpointStore = store,
+            stepAttemptStore = store,
+            workflowBindings = workflowBindings,
+            observability = observer,
+            leaseCoordinator = leaseCoordinator,
+            recoveryCoordinator = WorkflowRecoveryCoordinator(leaseStore, store),
+            leaseRenewalLoop = LeaseRenewalLoop(config, leaseStore, observer),
+            shuttingDownGracefully = { false },
+            stepAttemptIdentitySource = identitySource,
+        )
+        return s to observer
+    }
+
+    private fun checkpoint(
+        name: String = "wf",
+        id: String = "w-1",
+        metadata: Map<String, String> = mapOf(WORKFLOW_DEFINITION_VERSION_METADATA_KEY to "v1"),
+    ): WorkflowCheckpoint = WorkflowCheckpoint(
+        workflowName = name,
+        workflowId = id,
+        nextStepIndex = 0,
+        stepExecutions = 0,
+        lastCompletedStepName = null,
+        statePayload = TestCodec.encode(TestState("start")),
+        metadata = metadata,
+    )
+
+    private fun lease(
+        name: String = "wf",
+        id: String = "w-1",
+        leaseId: String = "l-1",
+    ): WorkflowLease = WorkflowLease(
+        workflowName = name,
+        workflowId = id,
+        leaseId = leaseId,
+        ownerId = "identity-supervisor",
+        checkpointRevision = 1L,
+        acquiredAtEpochMillis = 0L,
+        expiresAtEpochMillis = 5_000L,
+    )
+
+    private fun attempt(
+        attemptId: String,
+        status: StepAttemptStatus,
+        stepName: String = "plan",
+    ) = StepAttemptRecord(
+        runId = "w-1",
+        stepName = stepName,
+        attemptId = attemptId,
+        workerId = "worker",
+        leaseToken = "lease",
+        status = status,
+        startedAt = 1_000L,
+        replayPolicy = ReplayPolicy.IDEMPOTENT,
+    )
+
+    private fun runToCompletion(
+        store: InMemoryWorkflowCheckpointStore,
+        leaseStore: InMemoryWorkflowLeaseStore,
+        workflow: Workflow<TestState, String>,
+        identitySource: StepAttemptIdentitySource,
+    ): Pair<WorkflowExecutionSupervisor, RecordingObserver> {
+        val bindings = WorkflowBindingRegistry {
+            bind(workflow, WorkflowPersistence(checkpointStore = store, stateCodec = TestCodec))
+        }
+        val (s, observer) = supervisor(store, leaseStore, bindings, identitySource)
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        s.attachScope(scope)
+        val cp = runBlocking { store.save(checkpoint(metadata = workflow.checkpointMetadata())) }
+        val lease = runBlocking {
+            leaseStore.claim("wf", "w-1", "identity-supervisor", cp.revision, 5_000)
+        }
+        s.launch(cp, lease)
+        try {
+            runBlocking {
+                withTimeout(10_000) {
+                    while (s.activeExecutionCount() != 0) delay(10)
+                }
+            }
+        } finally {
+            scope.cancel()
+        }
+        return s to observer
+    }
+
+    private fun singleStepWorkflow(): Workflow<TestState, String> =
+        workflow<TestState>("wf", definitionVersion = "v1") {
+            localStep("mark") { state, _ -> state.copy(value = "done") }
+        }.build { it.value }
+
+    @Test
+    fun `P0-A injected attempt ID is persisted exactly`() {
+        val store = InMemoryWorkflowCheckpointStore()
+        val leaseStore = InMemoryWorkflowLeaseStore()
+        val source = QueuedStepAttemptIdentitySource("attempt-A")
+
+        val (s, _) = runToCompletion(store, leaseStore, singleStepWorkflow(), source)
+
+        val attempt = runBlocking { store.listStepAttempts("w-1") }.single()
+        assertThat(attempt.attemptId).isEqualTo("attempt-A")
+        assertThat(source.samples).isEqualTo(1)
+        assertThat(s.latestFailure("w-1")).isNull()
+    }
+
+    @Test
+    fun `P0-B source sampled exactly once per newly-created attempt`() {
+        val store = InMemoryWorkflowCheckpointStore()
+        val leaseStore = InMemoryWorkflowLeaseStore()
+        val source = QueuedStepAttemptIdentitySource("attempt-B")
+
+        runToCompletion(store, leaseStore, singleStepWorkflow(), source)
+
+        val attempts = runBlocking { store.listStepAttempts("w-1") }
+        assertThat(attempts).hasSize(1)
+        assertThat(source.samples).isEqualTo(1)
+    }
+
+    @Test
+    fun `P0-C two created attempts consume two distinct source values in creation order`() {
+        val store = InMemoryWorkflowCheckpointStore()
+        val leaseStore = InMemoryWorkflowLeaseStore()
+        val source = QueuedStepAttemptIdentitySource("attempt-C1", "attempt-C2")
+        val workflow = workflow<TestState>("wf", definitionVersion = "v1") {
+            localStep("first") { state, _ -> state.copy(value = "one") }
+            localStep("second") { state, _ -> state.copy(value = "two") }
+        }.build { it.value }
+
+        runToCompletion(store, leaseStore, workflow, source)
+
+        val attempts = runBlocking { store.listStepAttempts("w-1") }
+        assertThat(attempts.map { it.attemptId })
+            .containsExactly("attempt-C1", "attempt-C2")
+        assertThat(attempts.map { it.attemptId }.distinct()).hasSize(2)
+        assertThat(source.samples).isEqualTo(2)
+    }
+
+    @Test
+    fun `P0-D update preserves original ID and consumes zero new identity`() {
+        val store = InMemoryWorkflowCheckpointStore()
+        val leaseStore = InMemoryWorkflowLeaseStore()
+        val source = QueuedStepAttemptIdentitySource("attempt-D")
+
+        runToCompletion(store, leaseStore, singleStepWorkflow(), source)
+
+        val attempt = runBlocking { store.listStepAttempts("w-1") }.single()
+        assertThat(attempt.attemptId).isEqualTo("attempt-D")
+        assertThat(attempt.status).isEqualTo(StepAttemptStatus.COMPLETED)
+        assertThat(source.samples).isEqualTo(1)
+    }
+
+    @Test
+    fun `P0-E CAS preserves original ID and consumes zero new identity`() {
+        val store = InMemoryWorkflowCheckpointStore()
+        val source = QueuedStepAttemptIdentitySource()
+        runBlocking {
+            val original = attempt("attempt-E", StepAttemptStatus.STARTED)
+            store.recordStepAttempt(original)
+            val updated = original.copy(
+                status = StepAttemptStatus.COMPLETED,
+                completedAt = 2_000L,
+            )
+
+            val replaced = store.compareAndSetStepAttempt(original, updated)
+
+            assertThat(replaced).isTrue()
+            assertThat(store.latestStepAttempt("w-1", "plan")?.attemptId).isEqualTo("attempt-E")
+            assertThat(source.samples).isEqualTo(0)
+        }
+    }
+
+    @Test
+    fun `P0-F chronology remains governed by creation order, never attempt ID`() {
+        val store = InMemoryWorkflowCheckpointStore()
+        val source = QueuedStepAttemptIdentitySource("zzz-b2b-original", "aaa-b2b-rerun")
+        runBlocking {
+            // Ids produced by the identity authority in lexical-opposite order to creation.
+            val original = attempt(source.newAttemptId(), StepAttemptStatus.UNKNOWN)
+            val rerun = attempt(source.newAttemptId(), StepAttemptStatus.COMPLETED)
+            store.recordStepAttempt(original)
+            store.recordStepAttempt(rerun)
+
+            assertThat(store.latestStepAttempt("w-1", "plan")?.attemptId)
+                .withFailMessage("Equal startedAt must resolve 'latest' to the last-created attempt, never the attempt id")
+                .isEqualTo("aaa-b2b-rerun")
+            assertThat(store.listStepAttempts("w-1").map { it.attemptId })
+                .withFailMessage("Equal startedAt must order by creation, never by the attempt id")
+                .containsExactly("zzz-b2b-original", "aaa-b2b-rerun")
+            assertThat(source.samples).isEqualTo(2)
+        }
+    }
+
+    @Test
+    fun `P0-G blank generated ID fails before persistence`() {
+        val store = InMemoryWorkflowCheckpointStore()
+        val leaseStore = InMemoryWorkflowLeaseStore()
+        val source = QueuedStepAttemptIdentitySource("  ")
+
+        val (s, _) = runToCompletion(store, leaseStore, singleStepWorkflow(), source)
+
+        assertThat(s.latestFailure("w-1"))
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("attemptId")
+        assertThat(runBlocking { store.listStepAttempts("w-1") }).isEmpty()
+        assertThat(source.samples).isEqualTo(1)
+    }
+
+    @Test
+    fun `P0-H failAttempt preserves original ID and consumes zero new identity`() {
+        val store = InMemoryWorkflowCheckpointStore()
+        val leaseStore = InMemoryWorkflowLeaseStore()
+        val source = QueuedStepAttemptIdentitySource("attempt-H")
+        val workflow = workflow<TestState>("wf", definitionVersion = "v1") {
+            localStep("boom") { _, _ -> throw IllegalStateException("step exploded") }
+        }.build { it.value }
+
+        runToCompletion(store, leaseStore, workflow, source)
+
+        val attempt = runBlocking { store.listStepAttempts("w-1") }.single()
+        assertThat(attempt.attemptId).isEqualTo("attempt-H")
+        assertThat(attempt.status).isEqualTo(StepAttemptStatus.FAILED)
+        assertThat(source.samples).isEqualTo(1)
+    }
+}


### PR DESCRIPTION
## 8.3b2b — Step-attempt identity authority

**Primary invariant:** every newly-created `StepAttemptRecord.attemptId` originates from one explicit orchestration composition authority. Attempt identity is opaque and independent from chronology, wall time, checkpoint generations, leases, and claim capabilities.

### What changed
- **NEW `StepAttemptIdentitySource`** (internal): single `newAttemptId()` method; `DefaultStepAttemptIdentitySource` UUID-backed — the 8.3b1/8.3b2a composition pattern.
- **`WorkflowExecutionSupervisor`** ctor param (internal default) → forwarded to `ExecutionTracker`. `startAttempt` samples exactly once and `require(isNotBlank())` **before** `recordStepAttempt` — fail closed before persistence.
- **Zero public API change** — `TramaiWorker` / `WorkerLifecycleController` untouched (both use the internal default).
- The source appears in exactly 4 places in production (ctor ×2, forward, the single sample at `startAttempt`) — update/CAS/re-record/fail/cancel/recovery structurally cannot manufacture identity.

### Verification
- **RED→GREEN:** 8 discriminators (P0-A..P0-H) could not compile against pre-seam production (seam absent); all GREEN after wiring.
- **Mutation campaign: 7/7 STRONG / 0 WEAK / 0 UNREACHABLE** — M01 bypass source w/ UUID · M02 sample twice · M03 replace ID in completion · M04 reuse one ID · M05 derive from wall time · M06 remove blank validation · M07 completion samples fresh identity.
- **Structural grep:** zero inline `attemptId` UUID generation in tramai-orchestration main; sole UUID-backed attemptId site = `DefaultStepAttemptIdentitySource`. Remaining UUID sites (`checkpointGeneration`, `leaseId` ×3, `WorkflowObservation.workflowId`) are **explicitly out of scope** (separate semantic authorities — fencing/convenience).
- **Gates:** full `:tramai-orchestration:test --rerun-tasks` GREEN; apiCheck zero drift; verifyChangePolicy / verify060Architecture / verifyMaintainabilityBaseline GREEN.
- **agy review:** APPROVED — 0 P1, 1 P2 (failure-path coverage → added P0-H), 1 P3 (**rejected deliberately**: adding `requirePersistableIdentity` to `InMemoryWorkflowCheckpointStore` would mask the authority's fail-closed role — the supervisor require is InMemory's only guard, which is what keeps M06 STRONG).

### Out of scope (frozen)
`checkpointGeneration`, `leaseId`, `WorkflowObservation.workflowId`, scheduler claim tokens, server run IDs, `EngineIdentitySource`/8.3b2a, `attemptSequence` allocation, `startedAt`/time semantics.