### PR TITLE
test(tramai-engine): restore explicit Unit test signature — verifyPr baseline repair

### DIFF
--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/RetryJitterDiscriminatorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/RetryJitterDiscriminatorTest.kt
@@ -177,7 +177,8 @@ class RetryJitterDiscriminatorTest {
     }
 
     @Test
-    fun `P0-E engine composition graph consumes the injected jitter source`() = runBlocking {
+    fun `P0-E engine composition graph consumes the injected jitter source`() {
+        runBlocking {
         val source = QueuedJitterSource(0.25)
         val capture = RetryEventCapture()
         val registry = ProviderRegistry.singleProvider(FailingProvider())
@@ -243,5 +244,6 @@ class RetryJitterDiscriminatorTest {
 
         assertThat(source.calls).isEqualTo(1)
         engine.close()
+        }
     }
 }


### PR DESCRIPTION
## Baseline repair (a2-8)

`verifyJUnitTestSignatures` flags `RetryJitterDiscriminatorTest`'s expression-bodied `= runBlocking` as a @Test with non-Unit inferred return type (silently skipped by JUnit). This made `verifyPr` red on clean master (proven at 66198f33 and 495d28a7). One-file change: signature to explicit Unit block body; test body/behavior unchanged.

### Gates (all green locally)
- RetryJitterDiscriminatorTest ✅
- verifyJUnitTestSignatures ✅
- verifyMaintainabilityBaseline ✅
- verify060Architecture ✅
- verifyPr ✅ (one retry after daemon Metaspace crash — known flake)
- verifyChangePolicy -PchangeClass=runtime-behaviour PASSED (1 file)