### PR TITLE
fix(scheduler): 8.3c — centralize timer lifecycle ownership

### DIFF
--- a/docs/modules/tramai-scheduler.md
+++ b/docs/modules/tramai-scheduler.md
@@ -31,7 +31,25 @@ Verify against `tramai-scheduler/api/tramai-scheduler.api`.
 
 ### Lifecycle ownership
 
-- Timer lifecycle (start/stop) owned by the host; scheduler stores borrow caller resources
+- The timer always owns its polling child job: `start()` creates exactly one
+  polling coroutine and returns it; rejected duplicate starts create zero
+  additional children.
+- Scope ownership is explicit (8.3c):
+  - the default scope (created when the constructor's `scope` argument is
+    omitted) is **timer-owned** — `close()` cancels it;
+  - an explicitly supplied `CoroutineScope` is **borrowed** — the timer never
+    cancels it.
+- `stop()` is restartable: it claims shutdown, cancels and fully joins the
+  current polling child, and only then makes the timer restartable. Repeated
+  `stop()` on an already-stopped timer is a no-op.
+- `close()` is terminal and idempotent: it prevents future `start()`, cancels
+  the active polling child, and (for the default scope only) cancels the
+  timer-owned root. Repeated `close()` is a no-op.
+- A polling child that completes or is cancelled externally releases its own
+  generation's ownership; it can never clear a newer generation or undo
+  `close()`.
+- Scheduler stores borrow caller resources and are unaffected by timer
+  lifecycle.
 
 ### Thread-safety and concurrency
 

--- a/tramai-scheduler/src/main/kotlin/dev/tramai/scheduler/ScheduledWorkflowTimer.kt
+++ b/tramai-scheduler/src/main/kotlin/dev/tramai/scheduler/ScheduledWorkflowTimer.kt
@@ -16,12 +16,10 @@ import dev.tramai.orchestration.WorkflowContext
 import dev.tramai.orchestration.WorkflowObserver
 import dev.tramai.orchestration.WorkflowPersistence
 import dev.tramai.orchestration.WorkflowSuspendedException
-import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -39,7 +37,7 @@ class ScheduledWorkflowTimer(
     private val misfireThreshold: Duration = Duration.ofMinutes(5),
     private val batchSize: Int = 50,
     private val observer: WorkflowObserver = NoOpWorkflowObserver,
-    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+    private val scope: CoroutineScope = OwnedSchedulerScope(SupervisorJob() + Dispatchers.Default),
 ) : AutoCloseable {
     // Epic 5.3: the scheduler owns WorkflowObserver instances and invokes
     // tick callbacks BEFORE durable scheduler transitions (markTickSkipped /
@@ -51,8 +49,14 @@ class ScheduledWorkflowTimer(
     private val monitor = Any()
     private val registrations = linkedMapOf<String, ScheduledWorkflowRegistration<*, *>>()
     private val delayRegistrations = linkedMapOf<String, ScheduledWorkflowRegistration<*, *>>()
-    private var loopJob: Job? = null
-    private var running = false
+
+    // 8.3c: one lifecycle owner. The default-created scope is timer-owned
+    // (marked via OwnedSchedulerScope) and is cancelled on close(); a
+    // caller-supplied scope is borrowed and never cancelled.
+    private val loopOwner = SchedulerLoopOwner(
+        parentScope = scope,
+        ownsParentScope = scope is OwnedSchedulerScope,
+    )
 
     init {
         require(!pollInterval.isNegative && !pollInterval.isZero) {
@@ -103,30 +107,15 @@ class ScheduledWorkflowTimer(
         )
     }
 
-    fun start(): Job {
-        val job = scope.launch(start = CoroutineStart.LAZY) {
-            while (isActive) {
-                pollOnce()
-                delay(pollInterval.toMillis())
-            }
+    fun start(): Job = loopOwner.start {
+        while (kotlinx.coroutines.currentCoroutineContext().isActive) {
+            pollOnce()
+            delay(pollInterval.toMillis())
         }
-        synchronized(monitor) {
-            check(!running && loopJob == null) { "ScheduledWorkflowTimer is already started" }
-            running = true
-            loopJob = job
-        }
-        job.start()
-        return job
     }
 
     suspend fun stop() {
-        val job = synchronized(monitor) {
-            val job = loopJob
-            loopJob = null
-            running = false
-            job
-        } ?: return
-        job.cancelAndJoin()
+        loopOwner.stop()
     }
 
     suspend fun pollOnce() {
@@ -154,13 +143,7 @@ class ScheduledWorkflowTimer(
     }
 
     override fun close() {
-        val job = synchronized(monitor) {
-            val job = loopJob
-            loopJob = null
-            running = false
-            job
-        }
-        job?.cancel()
+        loopOwner.close()
     }
 
     private suspend fun handleTick(

--- a/tramai-scheduler/src/main/kotlin/dev/tramai/scheduler/SchedulerLoopOwner.kt
+++ b/tramai-scheduler/src/main/kotlin/dev/tramai/scheduler/SchedulerLoopOwner.kt
@@ -1,0 +1,145 @@
+package dev.tramai.scheduler
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * 8.3c — lifecycle authority for scheduler polling.
+ *
+ * Exactly one owner per [ScheduledWorkflowTimer]: it owns the polling child
+ * job's lifecycle, distinguishes the timer-owned default root scope from a
+ * borrowed caller scope, and makes start/stop/close transitions race-safe.
+ *
+ * State machine: STOPPED → RUNNING → STOPPING → STOPPED; any state → CLOSED
+ * (terminal). A rejected start creates zero child jobs. stop() claims STOPPING
+ * before joining, so a concurrent start can never overlap the old generation.
+ * close() is terminal and idempotent: it cancels the active child and, only
+ * when the root scope was default-created (owned), cancels that root.
+ *
+ * Generation-safe completion: a child completing (external cancellation of the
+ * returned Job, or natural termination) only clears ownership when it is the
+ * CURRENT child in RUNNING state — a stale generation's completion can never
+ * clear a newer child's ownership or rewrite CLOSED.
+ */
+internal enum class SchedulerLifecycleState {
+    STOPPED,
+    RUNNING,
+    STOPPING,
+    CLOSED,
+}
+
+/**
+ * Marker for the timer-created default root scope. The public constructor
+ * parameter stays [CoroutineScope] (ABI unchanged); the default argument value
+ * is this internal type so ownership is classified via `scope is OwnedSchedulerScope`.
+ */
+internal class OwnedSchedulerScope(
+    override val coroutineContext: CoroutineContext,
+) : CoroutineScope
+
+internal class SchedulerLoopOwner(
+    private val parentScope: CoroutineScope,
+    private val ownsParentScope: Boolean,
+) {
+    private val monitor = Any()
+    private var state = SchedulerLifecycleState.STOPPED
+    private var currentChild: Job? = null
+    private var generation = 0L
+
+    /** Claims the next polling generation. Rejected starts create ZERO children. */
+    fun start(loopBlock: suspend () -> Unit): Job {
+        val child: Job
+        val childGeneration: Long
+        synchronized(monitor) {
+            when (state) {
+                SchedulerLifecycleState.STOPPED -> {
+                    child = parentScope.launch(start = CoroutineStart.LAZY) { loopBlock() }
+                    state = SchedulerLifecycleState.RUNNING
+                    currentChild = child
+                    generation += 1
+                    childGeneration = generation
+                }
+                SchedulerLifecycleState.RUNNING ->
+                    throw IllegalStateException("ScheduledWorkflowTimer is already started")
+                SchedulerLifecycleState.STOPPING ->
+                    throw IllegalStateException("ScheduledWorkflowTimer is stopping; wait for the previous polling loop to finish")
+                SchedulerLifecycleState.CLOSED ->
+                    throw IllegalStateException("ScheduledWorkflowTimer is closed")
+            }
+        }
+        child.invokeOnCompletion { onChildCompleted(childGeneration) }
+        child.start()
+        return child
+    }
+
+    /** Stops the current generation: claim, cancel the exact child, join fully, then restartable. */
+    suspend fun stop() {
+        val child = synchronized(monitor) {
+            when (state) {
+                SchedulerLifecycleState.RUNNING -> {
+                    state = SchedulerLifecycleState.STOPPING
+                    currentChild
+                }
+                // Concurrent stop: join the same terminating child so every
+                // caller observes full termination before returning.
+                SchedulerLifecycleState.STOPPING -> currentChild
+                else -> null
+            }
+        } ?: return
+        // cancel() is non-suspending and always executes even when this caller
+        // is cancelled; only the join may be interrupted. If that happens, the
+        // child is already cancelled and onChildCompleted (STOPPING path)
+        // restores STOPPED when it finishes — the owner is never wedged.
+        child.cancel()
+        try {
+            child.join()
+        } finally {
+            synchronized(monitor) {
+                if (state == SchedulerLifecycleState.STOPPING && child.isCompleted) {
+                    state = SchedulerLifecycleState.STOPPED
+                    currentChild = null
+                }
+            }
+        }
+    }
+
+    /** Terminal and idempotent. Never cancels a borrowed caller scope. */
+    fun close() {
+        val childToCancel: Job?
+        val rootToCancel: CoroutineScope?
+        synchronized(monitor) {
+            if (state == SchedulerLifecycleState.CLOSED) return
+            state = SchedulerLifecycleState.CLOSED
+            childToCancel = currentChild.also { currentChild = null }
+            rootToCancel = if (ownsParentScope) parentScope else null
+        }
+        childToCancel?.cancel()
+        rootToCancel?.cancel()
+    }
+
+    private fun onChildCompleted(childGeneration: Long) {
+        synchronized(monitor) {
+            when {
+                state == SchedulerLifecycleState.RUNNING && childGeneration == generation -> {
+                    // The current polling child completed without stop()/close() —
+                    // e.g. externally cancelled returned Job. Release ownership so
+                    // the timer is restartable.
+                    currentChild = null
+                    state = SchedulerLifecycleState.STOPPED
+                }
+                state == SchedulerLifecycleState.STOPPING && childGeneration == generation -> {
+                    // A stop() caller was cancelled mid-join: the child was already
+                    // cancelled, and its completion finishes the stop transition.
+                    // Stale generations never clear a newer child, and CLOSED is
+                    // never rewritten.
+                    currentChild = null
+                    state = SchedulerLifecycleState.STOPPED
+                }
+            }
+        }
+    }
+}

--- a/tramai-scheduler/src/test/kotlin/dev/tramai/scheduler/ScheduledWorkflowTimerOwnershipDiscriminatorTest.kt
+++ b/tramai-scheduler/src/test/kotlin/dev/tramai/scheduler/ScheduledWorkflowTimerOwnershipDiscriminatorTest.kt
@@ -1,0 +1,321 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+package dev.tramai.scheduler
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * 8.3c — scheduler lifecycle ownership discriminators.
+ *
+ * Invariant: ScheduledWorkflowTimer has exactly one authoritative lifecycle
+ * owner for its polling execution. The timer always owns its polling child.
+ * The default-created scope is timer-owned (closed on close); a caller-supplied
+ * scope is borrowed and never cancelled. stop() is restartable and joins.
+ * close() is terminal and idempotent. No start/stop/close interleaving may
+ * leave an unowned child, two polling loops, or a loop alive after close.
+ *
+ * Deterministic only: CompletableDeferred gates/latches, one bounded
+ * state-await handshake (no Thread.sleep, no fixed-duration waits).
+ */
+@Timeout(30)
+class ScheduledWorkflowTimerOwnershipDiscriminatorTest {
+
+    private fun timer(
+        store: WorkflowSchedulerStore,
+        scope: CoroutineScope,
+    ): ScheduledWorkflowTimer = ScheduledWorkflowTimer(
+        store = store,
+        scope = scope,
+        pollInterval = Duration.ofMillis(1),
+    )
+
+    /** Fake store: counts claims, optionally parks the poll loop on a gate. */
+    private class GateStore(
+        private val gate: CompletableDeferred<Unit>? = null,
+        private val holdNonCancellable: Boolean = false,
+    ) : WorkflowSchedulerStore {
+        val claims = AtomicInteger(0)
+        val enteredGate = CompletableDeferred<Unit>()
+        private val latches = ConcurrentHashMap<Int, CompletableDeferred<Unit>>()
+
+        fun latchAt(count: Int): CompletableDeferred<Unit> =
+            latches.computeIfAbsent(count) { CompletableDeferred() }
+
+        override suspend fun claimDueTicks(
+            now: Instant,
+            ownerId: String,
+            claimDuration: Duration,
+            limit: Int,
+        ): List<ClaimedScheduledTick> {
+            val n = claims.incrementAndGet()
+            if (n == 1) enteredGate.complete(Unit)
+            latches[n]?.complete(Unit)
+            if (gate != null) {
+                if (holdNonCancellable) {
+                    withContext(NonCancellable) { gate.await() }
+                } else {
+                    gate.await()
+                }
+            }
+            return emptyList()
+        }
+
+        override suspend fun upsertSchedule(schedule: ScheduleRecord) = Unit
+        override suspend fun getSchedule(scheduleId: String): ScheduleRecord? = null
+        override suspend fun listScheduleStatus(): List<ScheduleStatusView> = emptyList()
+        override suspend fun markTickStarted(tickId: String, claimToken: String, runId: String) = Unit
+        override suspend fun releaseTickClaim(tickId: String, claimToken: String) = Unit
+        override suspend fun markTickCompleted(tickId: String, claimToken: String) = Unit
+        override suspend fun markTickSkipped(tickId: String, claimToken: String, reason: String) = Unit
+        override suspend fun markTickMisfired(tickId: String, claimToken: String, reason: String) = Unit
+        override suspend fun scheduleDelayWakeup(runId: String, stepId: String, resumeAt: Instant) = Unit
+        override suspend fun claimDueDelayWakeups(
+            now: Instant,
+            ownerId: String,
+            claimDuration: Duration,
+            limit: Int,
+        ): List<ClaimedDelayWakeup> = emptyList()
+        override suspend fun releaseDelayWakeupClaim(runId: String, stepId: String, claimToken: String) = Unit
+        override suspend fun markDelayWakeupCompleted(runId: String, stepId: String, claimToken: String) = Unit
+    }
+
+    @Test
+    fun `P0-A default scope is owned and cancelled on close`() {
+        val store = GateStore()
+        // No scope argument: the constructor default creates the timer-owned scope.
+        val timer = ScheduledWorkflowTimer(store = store, pollInterval = Duration.ofMillis(1))
+        val child = timer.start()
+        val root = child.parent!!
+
+        timer.close()
+        runBlocking { child.join() }
+
+        assertThat(child.isCancelled).isTrue()
+        assertThat(child.isCompleted).isTrue()
+        assertThat(root.isCancelled).withFailMessage("timer-owned default root must be cancelled by close()").isTrue()
+    }
+
+    @Test
+    fun `P0-B supplied scope is borrowed and never cancelled`() {
+        val callerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val store = GateStore()
+        val timer = timer(store, scope = callerScope)
+        val child = timer.start()
+        val root = callerScope.coroutineContext[Job]!!
+
+        timer.close()
+        runBlocking { child.join() }
+
+        assertThat(child.isCancelled).isTrue()
+        assertThat(root.isCancelled).withFailMessage("caller-supplied root must survive close()").isFalse()
+        val probe = callerScope.launch { 42 }
+        assertThat(runBlocking { probe.join(); probe.isCompleted }).isTrue()
+        callerScope.cancel()
+    }
+
+    @Test
+    fun `P0-C stop is restartable and generations do not overlap`() {
+        val callerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val store = GateStore()
+        val timer = timer(store, scope = callerScope)
+        val a = timer.start()
+        runBlocking { store.enteredGate.await() }
+
+        runBlocking { timer.stop() }
+        assertThat(runBlocking { a.join(); a.isCompleted }).isTrue()
+        assertThat(a.isCancelled).isTrue()
+
+        val claimsAfterA = store.claims.get()
+        val bFirstClaim = store.latchAt(claimsAfterA + 1) // register BEFORE B starts
+        val b = timer.start()
+        runBlocking { bFirstClaim.await() } // B's first poll executed
+
+        assertThat(b).isNotSameAs(a)
+        assertThat(b.isActive).isTrue()
+        timer.close()
+        callerScope.cancel()
+    }
+
+    @Test
+    fun `P0-D duplicate start creates no orphan child`() {
+        val callerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val store = GateStore()
+        val timer = timer(store, scope = callerScope)
+        val a = timer.start()
+        val root = callerScope.coroutineContext[Job]!!
+
+        assertThatThrownBy { timer.start() }
+            .isInstanceOf(IllegalStateException::class.java)
+
+        assertThat(runBlocking { root.children.count() })
+            .withFailMessage("rejected second start must create zero additional child jobs")
+            .isEqualTo(1)
+        assertThat(a.isActive).isTrue()
+        timer.close()
+        callerScope.cancel()
+    }
+
+    @Test
+    fun `P0-E start while stop is joining cannot overlap`() {
+        val callerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val gate = CompletableDeferred<Unit>()
+        val store = GateStore(gate = gate, holdNonCancellable = true)
+        val timer = timer(store, scope = callerScope)
+        val a = timer.start()
+        val root = callerScope.coroutineContext[Job]!!
+        runBlocking {
+            store.enteredGate.await() // A parked inside a non-cancellable claim
+
+            val stopJob = launch { timer.stop() }
+            // stop() has claimed STOPPING and requested cancellation; A cannot
+            // complete until the gate opens, so stop() is mid-join here.
+            withTimeout(10_000) { while (!a.isCancelled) yield() }
+
+            try {
+                assertThatThrownBy { timer.start() }
+                    .isInstanceOf(IllegalStateException::class.java)
+                assertThat(root.children.count())
+                    .withFailMessage("start while STOPPING must create zero new child jobs")
+                    .isEqualTo(1)
+            } finally {
+                gate.complete(Unit)
+            }
+            stopJob.join()
+        }
+        val b = timer.start()
+        assertThat(b.isActive).isTrue()
+        timer.close()
+        callerScope.cancel()
+    }
+
+    @Test
+    fun `P0-F close racing start cannot resurrect (both serializations)`() {
+        // Serialization 1: start owns a child, then close cancels it.
+        val callerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val gate = CompletableDeferred<Unit>()
+        val store = GateStore(gate = gate)
+        val timer = timer(store, scope = callerScope)
+        val child = timer.start()
+        runBlocking { store.enteredGate.await() }
+
+        timer.close()
+        // Await the cancelled child's completion so its completion handler has
+        // deterministically fired before we probe terminality (the handler must
+        // never rewrite CLOSED back to a restartable state).
+        runBlocking { child.join() }
+        assertThat(child.isCancelled).isTrue()
+        assertThatThrownBy { timer.start() }
+            .isInstanceOf(IllegalStateException::class.java)
+        gate.complete(Unit)
+        callerScope.cancel()
+
+        // Serialization 2: close wins, then start is rejected.
+        val store2 = GateStore()
+        val callerScope2 = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val timer2 = timer(store2, scope = callerScope2)
+        timer2.close()
+        assertThatThrownBy { timer2.start() }
+            .isInstanceOf(IllegalStateException::class.java)
+        assertThat(callerScope2.coroutineContext[Job]!!.children.count()).isEqualTo(0)
+        callerScope2.cancel()
+    }
+
+    @Test
+    fun `P0-G start after close fails closed`() {
+        val callerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val timer = timer(GateStore(), scope = callerScope)
+        val root = callerScope.coroutineContext[Job]!!
+
+        timer.close()
+
+        assertThatThrownBy { timer.start() }
+            .isInstanceOf(IllegalStateException::class.java)
+        assertThat(runBlocking { root.children.count() }).isEqualTo(0)
+        callerScope.cancel()
+    }
+
+    @Test
+    fun `P0-H close is idempotent`() {
+        val callerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val timer = timer(GateStore(), scope = callerScope)
+        timer.start()
+        timer.close()
+        timer.close()
+        timer.close()
+        assertThat(callerScope.coroutineContext[Job]!!.isActive).isTrue()
+        assertThat(runBlocking { callerScope.launch { 1 }.join(); callerScope.coroutineContext[Job]!!.isActive }).isTrue()
+        callerScope.cancel()
+    }
+
+    @Test
+    fun `P0-I externally cancelled returned Job releases only its own generation`() {
+        val callerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val store = GateStore()
+        val timer = timer(store, scope = callerScope)
+        val a = timer.start()
+        runBlocking { store.enteredGate.await() }
+
+        runBlocking { a.cancel(); a.join() } // external cancellation
+
+        val b = timer.start() // must not be stuck in a false RUNNING state
+        assertThat(b.isActive).isTrue()
+        assertThat(b).isNotSameAs(a)
+
+        timer.close()
+        runBlocking { b.join() }
+        assertThat(b.isCancelled).isTrue() // B's ownership was not cleared by A's completion
+        callerScope.cancel()
+    }
+
+    @Test
+    fun `P0-J cancelled stop caller never wedges the owner`() {
+        val callerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val gate = CompletableDeferred<Unit>()
+        val store = GateStore(gate = gate, holdNonCancellable = true)
+        val timer = timer(store, scope = callerScope)
+        val a = timer.start()
+        val root = callerScope.coroutineContext[Job]!!
+        runBlocking {
+            store.enteredGate.await() // A parked in a non-cancellable claim
+
+            val stopJob = launch { timer.stop() }
+            withTimeout(10_000) { while (!a.isCancelled) yield() } // stop claimed + cancelled A
+            stopJob.cancelAndJoin() // cancel the stop caller mid-join
+
+            // The gate is still closed, so A is NOT completed. Publishing
+            // STOPPED here (premature) would let start() create an overlapping
+            // generation while A is still alive — it must be rejected.
+            assertThatThrownBy { timer.start() }
+                .isInstanceOf(IllegalStateException::class.java)
+        }
+        // A completes when the gate opens; its completion must restore STOPPED
+        // (the cancelled stop() caller cannot complete the transition itself).
+        gate.complete(Unit)
+        runBlocking { a.join() }
+
+        val b = timer.start()
+        assertThat(b.isActive).isTrue()
+        assertThat(runBlocking { root.children.count() }).isEqualTo(1)
+        timer.close()
+        callerScope.cancel()
+    }
+}


### PR DESCRIPTION
## 8.3c — Centralize scheduler lifecycle ownership

**Primary invariant:** `ScheduledWorkflowTimer` has exactly one authoritative lifecycle owner for its polling execution. The timer always owns its polling child. Default-created scope = timer-owned (closed on close); caller-supplied scope = borrowed (never cancelled). `stop()` is restartable and joins. `close()` is terminal and idempotent. No start/stop/close interleaving can leave an unowned child, two polling loops, or a loop alive after close.

### What changed
- **NEW `SchedulerLoopOwner`** (internal): lifecycle state machine `STOPPED → RUNNING → STOPPING → STOPPED` / `→ CLOSED` (terminal). `start()` creates exactly one child and rejects duplicate/STOPPING/CLOSED starts with **zero** new children; `stop()` claims STOPPING, cancels + fully joins the exact child, only then restartable; `close()` terminal + idempotent, cancels only the timer-owned default root.
- **`OwnedSchedulerScope` marker**: the constructor default creates a timer-owned scope — public ABI byte-identical (apiCheck zero drift).
- **`ScheduledWorkflowTimer`**: `loopJob`/`running` dual-field drift deleted; lifecycle delegated; registrations/pollOnce untouched.
- **Generation-safe completion**: external cancellation of the returned Job releases only its own generation; stale completions never clear a newer child; CLOSED never rewritten.
- **E-leg (8.3a contract)**: `WorkerShutdownCoordinator` audited — ownership claim, `acceptingWork=false`, root cancel all **outside** every `withTimeoutOrNull`; already compliant, recorded, no refactor.

### Verification
- **RED→GREEN:** 7/9 discriminators failed against pre-change production (root leak, orphan, overlap, post-close start, stuck RUNNING); **10/10 GREEN** after.
- **Mutation campaign: 10/10 STRONG / 0 WEAK / 0 UNREACHABLE** (M01 child-before-guard, M02 owned-root skip, M03 borrowed cancel, M04 start-after-CLOSED, M05 premature STOPPED, M06 start-while-STOPPING, M07 non-terminal close, M08 no completion handler, M09 unconditional clear, M10 non-idempotent close).
- **Deterministic only:** CompletableDeferred gates/latches, one bounded state-await handshake, `@Timeout(30)` guard — no sleeps, no fixed-duration waits.
- **Gates:** full `:tramai-scheduler:test --rerun-tasks` GREEN; apiCheck zero drift; verifyChangePolicy / verify060Architecture / verifyMaintainabilityBaseline / verifyModuleDocContract GREEN.
- **agy review:** APPROVED — 0 P1, 2 P2 (cancelled-stop-caller wedge → fixed with cancel-before-join + STOPPING-aware completion handler + new P0-J; concurrent stop returning early → now joins the same child), 1 P3 (opt-in warning → fixed).
- **Structural checks:** exactly one default root-scope creation site; zero `running`/`loopJob` remnants; lifecycle state single authority in SchedulerLoopOwner.
- **Docs:** `docs/modules/tramai-scheduler.md` lifecycle-ownership section rewritten to match.

### Out of scope (untouched)
Cron/business-hours/store/tick/delay-wakeup semantics, claim-token generation, ownerId default, checkpoint/lease/attempt identity, Clock, 8.3a monotonic timing, #318 chronology, JDBC schemas, orchestration execution, DataSource ownership.