### PR TITLE
refactor(build-logic): residual quality verifier CC hygiene — Epic 9.2d-a3a

### DIFF
--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
@@ -10,6 +10,7 @@ import org.gradle.api.tasks.JavaExec
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.testing.jacoco.tasks.JacocoReport
+import org.gradle.kotlin.dsl.register
 import java.io.File
 import javax.xml.parsers.DocumentBuilderFactory
 
@@ -919,16 +920,12 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             }
         }
 
-        project.tasks.register("verifyModuleMatrixDrift") {
+        project.tasks.register<ModuleMatrixDriftVerifierTask>("verifyModuleMatrixDrift") {
             group = "verification"
             description = "Fails when docs/reference/module-matrix.md differs from the manifest"
-            doLast {
-                val target = File(project.rootDir, "docs/reference/module-matrix.md")
-                val expected = ModuleManifest.matrix(project.rootDir)
-                if (!target.isFile || target.readText() != expected) throw GradleException(
-                    "[${DiagnosticCode.GENERATED_DOCUMENT_DRIFT}] Module matrix drift: run ./gradlew generateModuleMatrix"
-                )
-            }
+            this.rootDir.set(project.rootDir)
+            moduleMatrixFile.set(project.layout.projectDirectory.file("docs/reference/module-matrix.md"))
+            moduleCatalogFile.from(project.layout.projectDirectory.file("config/quality/module-catalog.yml"))
         }
 
         val enrollmentTest = project.tasks.register("architectureContractEnrollmentTest", Test::class.java) {
@@ -1071,6 +1068,7 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             ":examples:java-consumer-smoke",
             "src/main/java",
             "java",
+            "java",
         )
         registerConsumerCompatibilityTask(
             project,
@@ -1078,6 +1076,7 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             ":examples:kotlin-consumer-smoke",
             "src/main/kotlin",
             "kotlin",
+            "org.jetbrains.kotlin.jvm",
         )
         project.tasks.named("verify060Architecture") {
             dependsOn(
@@ -1122,20 +1121,19 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
         // Kotlin expression-bodied tests ending in a chainable assertion compile
         // to non-void methods and are silently never discovered. This task scans
         // every test source and fails on non-Unit expression-bodied @Test fns.
-        project.tasks.register("verifyJUnitTestSignatures") {
+        project.tasks.register<JUnitTestSignatureVerifierTask>("verifyJUnitTestSignatures") {
             group = "verification"
             description = "Fails if any @Test function uses an expression body whose inferred " +
                 "return type is not provably Unit (JUnit silently skips non-void @Test methods)."
-            doLast {
-                val violations = JUnitTestSignatureVerifier.scan(project.rootDir.toPath())
-                if (violations.isNotEmpty()) {
-                    throw GradleException(
-                        "verifyJUnitTestSignatures: ${violations.size} @Test function(s) with " +
-                            "non-Unit expression bodies would be silently skipped by JUnit.\n" +
-                            JUnitTestSignatureVerifier.render(violations),
-                    )
-                }
-            }
+            this.scanRoot.set(project.rootDir)
+            // FileTree base is rootDir; exclude task-output dirs (build/,
+            // api/) or Gradle 9 flags the input as overlapping a task output.
+            // The scanner itself only inspects src/test|src/testFixtures .kt,
+            // so excluding outputs changes no semantics.
+            testSources.from(project.fileTree(project.rootDir) {
+                include("**/src/test/**/*.kt", "**/src/testFixtures/**/*.kt")
+                exclude("**/build/**", "**/api/**")
+            })
         }
         verifyPr.configure {
             dependsOn("verifyJUnitTestSignatures")
@@ -1540,100 +1538,59 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
         modulePath: String,
         sourceRelPath: String,
         extension: String,
+        languagePluginId: String,
     ) {
-        val fixture = project.project(modulePath)
         // D6: the producer task belongs to the FIXTURE project, which owns its
         // configurations. Resolving them inside the task action is therefore
         // legal (project-owned, lazy, execution-phase) — a root task resolving
         // a foreign project's configuration would trip the exclusive-lock rule.
-        val markerFile = fixture.layout.buildDirectory.file("reports/maintainability/consumer-$extension.json")
-        val classesDir = fixture.layout.buildDirectory.dir("reports/maintainability/consumer-$extension-classes")
-        val sourcesProvider = fixture.provider {
-            File(fixture.projectDir, sourceRelPath)
-                .walkTopDown()
-                .filter { it.isFile && it.extension == (if (extension == "kotlin") "kt" else "java") }
-                .map { it.absolutePath }
-                .toList()
-        }
+        // The fixture project applies its language plugin after the root plugin
+        // block, so register lazily via withPlugin: JavaToolchainService only
+        // exists then, and launcherFor/compilerFor providers are CC-serializable.
+        // fixture lookup happens inside the callback so a build that does not
+        // include the fixture (TestKit, minimal settings) never trips eagerly.
+        project.rootProject.subprojects.forEach { fixture ->
+            if (fixture.path != modulePath) return@forEach
+            fixture.pluginManager.withPlugin(languagePluginId) {
+                val markerFile = fixture.layout.buildDirectory.file("reports/maintainability/consumer-$extension.json")
+                val classesDir = fixture.layout.buildDirectory.dir("reports/maintainability/consumer-$extension-classes")
 
-        fixture.tasks.register(taskName) {
-            group = "verification"
-            description = "Compiles the $extension consumer smoke fixture against the stable API (fail-soft producer, Epic 10.2)"
+                fixture.tasks.register<ConsumerSmokeCompileTask>(taskName) {
+                    group = "verification"
+                    description = "Compiles the $extension consumer smoke fixture against the stable API (fail-soft producer, Epic 10.2)"
 
-            // Only the dependency's jar must exist for the classpath. The
-            // fixture's own compile tasks are deliberately NOT dependencies:
-            // compileKotlin has no failOnError and would abort the graph
-            // before verify060Architecture's report is written (C3/C4).
-            dependsOn(":tramai-core:jar")
+                    // Only the dependency's jar must exist for the classpath. The
+                    // fixture's own compile tasks are deliberately NOT dependencies:
+                    // compileKotlin has no failOnError and would abort the graph
+                    // before verify060Architecture's report is written (C3/C4).
+                    dependsOn(":tramai-core:jar")
 
-            doLast {
-                val sources = sourcesProvider.get()
-                // Project-owned configuration resolution at execution time:
-                // this task lives in the fixture project, so its own
-                // configurations are locked and resolvable here (D6).
-                val classpath = fixture.configurations.getByName("compileClasspath").asPath
-                val k2jvmClasspath = if (extension == "kotlin") {
-                    fixture.configurations.getByName("kotlinCompilerClasspath").asPath
-                } else {
-                    ""
-                }
-                val outDir = classesDir.get().asFile.apply { mkdirs() }
-                outDir.listFiles()?.forEach { it.deleteRecursively() }
-                var exitCode = -1
-                if (extension == "java") {
+                    this.extension.set(extension)
+                    this.workDir.set(project.rootDir)
                     val toolchains = fixture.extensions.getByType(JavaToolchainService::class.java)
-                    val compiler = toolchains.compilerFor { languageVersion.set(JavaLanguageVersion.of(21)) }
-                    val javac = compiler.get().executablePath.toString()
-                    exitCode = runProcess(
-                        listOf(javac, "-cp", classpath, "-d", outDir.absolutePath) + sources,
-                        project.rootDir,
-                        project,
-                    )
-                } else {
-                    exitCode = runProcess(
-                        listOf(
-                            javaLauncherExecutable(fixture),
-                            "-cp", k2jvmClasspath,
-                            "org.jetbrains.kotlin.cli.jvm.K2JVMCompiler",
-                            "-classpath", classpath,
-                            "-d", outDir.absolutePath,
-                        ) + sources,
-                        project.rootDir,
-                        project,
-                    )
-                }
-                val classCount = outDir.walkTopDown().count { it.isFile && it.extension == "class" }
-                val marker = mapOf(
-                    "sources" to sources.size,
-                    "classes" to classCount,
-                    "exitCode" to exitCode,
-                    "ok" to (sources.isNotEmpty() && classCount > 0 && exitCode == 0),
-                )
-                markerFile.get().asFile.apply {
-                    parentFile.mkdirs()
-                    writeText(ReportNormalizer.toJson(marker))
+                    if (extension == "java") {
+                        this.javacExecutable.set(
+                            toolchains.compilerFor { languageVersion.set(JavaLanguageVersion.of(21)) }
+                                .map { it.executablePath.toString() }
+                        )
+                    } else {
+                        this.javaExecutable.set(
+                            toolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(21)) }
+                                .map { it.executablePath.toString() }
+                        )
+                    }
+                    this.classesDir.set(classesDir)
+                    this.markerFile.set(markerFile)
+                    sources.from(fixture.fileTree(fixture.projectDir) {
+                        include("**/$sourceRelPath/**/*.${if (extension == "kotlin") "kt" else "java"}")
+                    })
+                    compileClasspath.from(fixture.configurations.getByName("compileClasspath"))
+                    if (extension == "kotlin") {
+                        kotlinCompilerClasspath.from(fixture.configurations.getByName("kotlinCompilerClasspath"))
+                    }
                 }
             }
         }
-    }
-
-    private fun runProcess(command: List<String>, workDir: File, project: Project): Int {
-        val process = ProcessBuilder(command)
-            .directory(workDir)
-            .redirectErrorStream(true)
-            .start()
-        val output = process.inputStream.bufferedReader().readText()
-        val exit = process.waitFor()
-        if (exit != 0) {
-            project.logger.warn("consumer compile failed (exit $exit):\n${output.take(1500)}")
-        }
-        return exit
-    }
-
-    private fun javaLauncherExecutable(project: Project): String {
-        val toolchains = project.extensions.getByType(JavaToolchainService::class.java)
-        val launcher = toolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(21)) }
-        return launcher.get().executablePath.toString()
     }
 
     /**

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/ResidualQualityVerifierTasks.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/ResidualQualityVerifierTasks.kt
@@ -1,0 +1,192 @@
+package dev.tramai.build.quality
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import java.io.File
+
+/**
+ * Typed documentation/quality verifier tasks (Epic 9.2d-a3a — residual surgical
+ * CC hygiene). Each replaces an ordinary doLast closure whose execution only
+ * reads declared inputs; none touches Task.project during execution
+ * (configuration-cache safe).
+ */
+
+/**
+ * Fails when docs/reference/module-matrix.md differs from the authoritative
+ * module catalog (config/quality/module-catalog.yml).
+ */
+@DisableCachingByDefault(because = "Verification task has no output artifact")
+abstract class ModuleMatrixDriftVerifierTask : DefaultTask() {
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val moduleMatrixFile: RegularFileProperty
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val moduleCatalogFile: ConfigurableFileCollection
+
+    @get:Input
+    abstract val rootDir: Property<File>
+
+    @TaskAction
+    fun verify() {
+        val target = moduleMatrixFile.get().asFile
+        val expected = ModuleManifest.matrix(rootDir.get())
+        if (!target.isFile || target.readText() != expected) {
+            throw GradleException(
+                "[${DiagnosticCode.GENERATED_DOCUMENT_DRIFT}] Module matrix drift: run ./gradlew generateModuleMatrix"
+            )
+        }
+    }
+}
+
+/**
+ * Fails if any @Test function uses an expression body whose inferred return
+ * type is not provably Unit (JUnit silently skips non-void @Test methods).
+ * Pure scan over declared source inputs — no project model access.
+ */
+@DisableCachingByDefault(because = "Verification task has no output artifact")
+abstract class JUnitTestSignatureVerifierTask : DefaultTask() {
+
+    /** Root to walk (same as historical closure: project.rootDir). */
+    @get:Input
+    abstract val scanRoot: Property<File>
+
+    /** Files the scanner actually inspects (test-source trees); content key. */
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val testSources: ConfigurableFileCollection
+
+    @TaskAction
+    fun verify() {
+        // Historical semantics: scan(rootDir.toPath()) walks the whole root
+        // and filters to src/test|src/testFixtures .kt files. The declared
+        // testSources input is the invalidation key; the walk reproduces the
+        // exact historical behavior (same file set, same diagnostics).
+        val violations = JUnitTestSignatureVerifier.scan(scanRoot.get().toPath())
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                "verifyJUnitTestSignatures: ${violations.size} @Test function(s) with " +
+                    "non-Unit expression bodies would be silently skipped by JUnit.\n" +
+                    JUnitTestSignatureVerifier.render(violations),
+            )
+        }
+    }
+}
+
+/**
+ * Compiles the Java/Kotlin consumer smoke fixture against the stable API and
+ * writes the semantic-compatibility marker (Epic 10.2). Typed replacement for
+ * the register + doLast closure: declared inputs (sources, classpaths,
+ * toolchain executable, workDir) and outputs (classes dir, marker json), no
+ * Task.project at execution.
+ */
+@DisableCachingByDefault(because = "Marker output is evidence, not a build artifact")
+abstract class ConsumerSmokeCompileTask : DefaultTask() {
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val sources: ConfigurableFileCollection
+
+    @get:Classpath
+    abstract val compileClasspath: ConfigurableFileCollection
+
+    @get:Optional
+    @get:Classpath
+    abstract val kotlinCompilerClasspath: ConfigurableFileCollection
+
+    @get:Input
+    abstract val extension: Property<String>
+
+    /** Toolchain executables, resolved eagerly by the plugin (JDK 21). */
+    @get:Optional
+    @get:Input
+    abstract val javaExecutable: Property<String>
+
+    @get:Optional
+    @get:Input
+    abstract val javacExecutable: Property<String>
+
+    /** Process working directory (historical: root project dir). */
+    @get:Input
+    abstract val workDir: Property<File>
+
+    @get:OutputDirectory
+    abstract val classesDir: DirectoryProperty
+
+    @get:OutputFile
+    abstract val markerFile: RegularFileProperty
+
+    @TaskAction
+    fun compile() {
+        val sourcesList = sources.files
+            .filter { it.isFile && it.extension == (if (extension.get() == "kotlin") "kt" else "java") }
+            .map { it.absolutePath }
+        val classpath = compileClasspath.asPath
+        val kotlinClasspath = if (kotlinCompilerClasspath.files.isEmpty()) "" else kotlinCompilerClasspath.asPath
+
+        val outDir = classesDir.get().asFile.apply { mkdirs() }
+        outDir.listFiles()?.forEach { it.deleteRecursively() }
+
+        var exitCode = -1
+        if (extension.get() == "java") {
+            val javac = javacExecutable.get()
+            exitCode = runProcess(
+                listOf(javac, "-cp", classpath, "-d", outDir.absolutePath) + sourcesList,
+                workDir.get(),
+            )
+        } else {
+            val java = javaExecutable.get()
+            exitCode = runProcess(
+                listOf(
+                    java,
+                    "-cp", kotlinClasspath,
+                    "org.jetbrains.kotlin.cli.jvm.K2JVMCompiler",
+                    "-classpath", classpath,
+                    "-d", outDir.absolutePath,
+                ) + sourcesList,
+                workDir.get(),
+            )
+        }
+        val classCount = outDir.walkTopDown().count { it.isFile && it.extension == "class" }
+        val marker = mapOf(
+            "sources" to sourcesList.size,
+            "classes" to classCount,
+            "exitCode" to exitCode,
+            "ok" to (sourcesList.isNotEmpty() && classCount > 0 && exitCode == 0),
+        )
+        markerFile.get().asFile.apply {
+            parentFile.mkdirs()
+            writeText(ReportNormalizer.toJson(marker))
+        }
+    }
+
+    private fun runProcess(command: List<String>, workDir: File): Int {
+        val process = ProcessBuilder(command)
+            .directory(workDir)
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().readText()
+        val exit = process.waitFor()
+        // Historical behavior preserved: log only on failure, warn with prefix.
+        if (exit != 0 && output.isNotBlank()) {
+            logger.warn("consumer compile failed (exit $exit):\n${output.take(1500)}")
+        }
+        return exit
+    }
+}

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/ResidualQualityVerifierTasksTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/ResidualQualityVerifierTasksTest.kt
@@ -1,0 +1,330 @@
+package dev.tramai.build.quality
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertTrue
+
+/**
+ * Discriminating TestKit tests for the 9.2d-a3a residual surgical CC-hygiene
+ * typed tasks (verifyModuleMatrixDrift, verifyJUnitTestSignatures, and the two
+ * consumer-smoke compile tasks).
+ *
+ * Standing rule (user-mandated): NO empty fixture may serve as the successful
+ * oracle when the verifier must discover real content. Fixtures copy REAL repo
+ * files via git ls-files; positives assert SUCCESS on fresh dirs; fail-closed
+ * negatives mutate exactly one real file and assert the exact diagnostic.
+ */
+class ResidualQualityVerifierTasksTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private val repoRoot: File by lazy {
+        var dir = File(System.getProperty("user.dir")).absoluteFile
+        while (!File(dir, ".git").isDirectory) {
+            dir = dir.parentFile ?: error("repo root not found from ${System.getProperty("user.dir")}")
+        }
+        dir
+    }
+
+    private fun copyFromRepo(dir: File, vararg relativePaths: String) {
+        val git = ProcessBuilder("git", "-C", repoRoot.absolutePath, "ls-files", *relativePaths)
+            .redirectErrorStream(true)
+            .start()
+        val listing = git.inputStream.bufferedReader().readText()
+        check(git.waitFor() == 0) { "git ls-files failed: $listing" }
+        listing.lineSequence().filter { it.isNotBlank() }.forEach { rel ->
+            val src = File(repoRoot, rel)
+            val dst = File(dir, rel)
+            if (src.isFile) {
+                dst.parentFile.mkdirs()
+                src.copyTo(dst, overwrite = true)
+            }
+        }
+    }
+
+    private fun fixture(): File {
+        val dir = File(tempDir, "fixture-${System.nanoTime()}").apply { mkdirs() }
+        writeFile(dir, "settings.gradle.kts", "rootProject.name = \"quality-fixture\"\n")
+        writeFile(dir, "build.gradle.kts", "plugins { id(\"tramai.maintainability-baseline\") }\n")
+        // The maintainability plugin reads these at apply time; use the real ones.
+        copyFromRepo(
+            dir,
+            "config/quality/test-quality.yml",
+            "config/quality/maintainability-deviations.yml",
+            "config/quality/module-catalog.yml",
+        )
+        return dir
+    }
+
+    private fun runner(dir: File, vararg args: String): GradleRunner =
+        GradleRunner.create()
+            .withProjectDir(dir)
+            .withGradleVersion("9.0.0")
+            .withArguments(*args, "--no-build-cache", "--stacktrace")
+            .withPluginClasspath()
+
+    private fun writeFile(base: File, relativePath: String, content: String) {
+        val target = File(base, relativePath)
+        target.parentFile.mkdirs()
+        target.writeText(content)
+    }
+
+    private fun runTask(dir: File, task: String): org.gradle.testkit.runner.BuildResult {
+        val result = runner(dir, task).build()
+        assertTrue(
+            result.task(":$task")?.outcome == TaskOutcome.SUCCESS,
+            "$task must succeed: ${result.output.take(1200)}"
+        )
+        return result
+    }
+
+    // ------------------------------------------------------------------
+    // verifyModuleMatrixDrift
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `verifyModuleMatrixDrift passes on real generated matrix`() {
+        val dir = fixture()
+        copyFromRepo(
+            dir,
+            "config/quality/module-catalog.yml",
+            "docs/reference/module-matrix.md",
+        )
+        runTask(dir, "verifyModuleMatrixDrift")
+    }
+
+    @Test
+    fun `verifyModuleMatrixDrift fails when matrix drifts from catalog`() {
+        val dir = fixture()
+        copyFromRepo(
+            dir,
+            "config/quality/module-catalog.yml",
+            "docs/reference/module-matrix.md",
+        )
+        val matrix = File(dir, "docs/reference/module-matrix.md")
+        matrix.appendText("| tampered | row |\n")
+        val result = runner(dir, "verifyModuleMatrixDrift").buildAndFail()
+        assertContains(result.output, "[GENERATED_DOCUMENT_DRIFT] Module matrix drift: run ./gradlew generateModuleMatrix")
+    }
+
+    // ------------------------------------------------------------------
+    // verifyJUnitTestSignatures
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `verifyJUnitTestSignatures passes on clean test sources`() {
+        val dir = fixture()
+        // A REAL repo test file (block-body @Test methods) — the scanner's
+        // known-safe classification. Not a synthetic oracle.
+        copyFromRepo(
+            dir,
+            "tramai-core/src/test/kotlin/dev/tramai/core/approval/IdempotencyKeyUtilTest.kt",
+        )
+        runTask(dir, "verifyJUnitTestSignatures")
+    }
+
+    @Test
+    fun `verifyJUnitTestSignatures fails on expression-bodied test`() {
+        val dir = fixture()
+        writeFile(dir, "tramai-fake/src/test/kotlin/com/example/FakeTest.kt", """
+            package com.example
+            import kotlin.test.Test
+            import kotlinx.coroutines.runBlocking
+            class FakeTest {
+                @Test
+                fun `bad`() = runBlocking {
+                    check(true)
+                }
+            }
+        """.trimIndent())
+        val result = runner(dir, "verifyJUnitTestSignatures").buildAndFail()
+        assertContains(result.output, "non-Unit expression bodies would be silently skipped by JUnit")
+    }
+
+    // ------------------------------------------------------------------
+    // Consumer-smoke compile tasks
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `java consumer smoke compiles real fixture and writes marker`() {
+        val dir = fixture()
+        copyFromRepo(
+            dir,
+            "examples/java-consumer-smoke/src",
+            "tramai-core/src/main/kotlin/dev/tramai/core/annotations",
+            // Transitive closure of the annotations' imports:
+            // model/SideEffectLevel lives in Tool.kt; all policy enums used by
+            // AiTool (ApprovalMode, AuditDetail, ManagedNetworkEgress, RiskLevel)
+            // plus ToolSecurityMetadata are in the self-contained policy package.
+            "tramai-core/src/main/kotlin/dev/tramai/core/model/Tool.kt",
+            "tramai-core/src/main/kotlin/dev/tramai/core/model/ToolResult.kt",
+            "tramai-core/src/main/kotlin/dev/tramai/core/model/ContentPart.kt",
+            "tramai-core/src/main/kotlin/dev/tramai/core/model/ModelVisibleToolMessage.kt",
+            "tramai-core/src/main/kotlin/dev/tramai/core/model/ToolFailureCode.kt",
+            "tramai-core/src/main/kotlin/dev/tramai/core/policy",
+        )
+        writeFile(dir, "settings.gradle.kts", """
+            rootProject.name = "quality-fixture"
+            include(":tramai-core")
+            include(":examples:java-consumer-smoke")
+        """.trimIndent())
+        writeFile(dir, "tramai-core/build.gradle.kts", """
+            plugins { id("org.jetbrains.kotlin.jvm") }
+            group = "dev.tramai"
+            version = "0.5.0"
+            repositories { mavenCentral() }
+        """.trimIndent())
+        writeFile(dir, "examples/java-consumer-smoke/build.gradle.kts", """
+            plugins { id("java") }
+            repositories { mavenCentral() }
+            dependencies { implementation(project(":tramai-core")) }
+        """.trimIndent())
+        val result = runner(dir, ":examples:java-consumer-smoke:verifyJavaConsumerCompatibility").build()
+        assertTrue(
+            result.task(":examples:java-consumer-smoke:verifyJavaConsumerCompatibility")?.outcome == TaskOutcome.SUCCESS,
+            result.output.take(1200)
+        )
+        val marker = File(dir, "examples/java-consumer-smoke/build/reports/maintainability/consumer-java.json")
+        val found = dir.walkTopDown().filter { it.name.contains("consumer-java") }.map { it.absolutePath }.toList()
+        assertTrue(
+            marker.isFile && marker.readText().contains("\"ok\" : true"),
+            "marker must be written and ok. expected=$marker found=$found content=${if (marker.isFile) marker.readText() else "<no file>"} output=${result.output.take(2000)}"
+        )
+    }
+
+    @Test
+    fun `kotlin consumer smoke compiles real fixture and writes marker`() {
+        val dir = fixture()
+        copyFromRepo(
+            dir,
+            "examples/kotlin-consumer-smoke/src",
+            "tramai-core/src/main/kotlin/dev/tramai/core/annotations",
+            // Transitive closure of the annotations' imports:
+            // model/SideEffectLevel lives in Tool.kt; all policy enums used by
+            // AiTool (ApprovalMode, AuditDetail, ManagedNetworkEgress, RiskLevel)
+            // plus ToolSecurityMetadata are in the self-contained policy package.
+            "tramai-core/src/main/kotlin/dev/tramai/core/model/Tool.kt",
+            "tramai-core/src/main/kotlin/dev/tramai/core/model/ToolResult.kt",
+            "tramai-core/src/main/kotlin/dev/tramai/core/model/ContentPart.kt",
+            "tramai-core/src/main/kotlin/dev/tramai/core/model/ModelVisibleToolMessage.kt",
+            "tramai-core/src/main/kotlin/dev/tramai/core/model/ToolFailureCode.kt",
+            "tramai-core/src/main/kotlin/dev/tramai/core/policy",
+        )
+        writeFile(dir, "settings.gradle.kts", """
+            rootProject.name = "quality-fixture"
+            include(":tramai-core")
+            include(":examples:kotlin-consumer-smoke")
+        """.trimIndent())
+        writeFile(dir, "tramai-core/build.gradle.kts", """
+            plugins { id("org.jetbrains.kotlin.jvm") }
+            group = "dev.tramai"
+            version = "0.5.0"
+            repositories { mavenCentral() }
+        """.trimIndent())
+        writeFile(dir, "examples/kotlin-consumer-smoke/build.gradle.kts", """
+            plugins { id("org.jetbrains.kotlin.jvm") }
+            repositories { mavenCentral() }
+            dependencies { implementation(project(":tramai-core")) }
+        """.trimIndent())
+        val result = runner(dir, ":examples:kotlin-consumer-smoke:verifyKotlinConsumerCompatibility").build()
+        assertTrue(
+            result.task(":examples:kotlin-consumer-smoke:verifyKotlinConsumerCompatibility")?.outcome == TaskOutcome.SUCCESS,
+            result.output.take(1200)
+        )
+        val marker = File(dir, "examples/kotlin-consumer-smoke/build/reports/maintainability/consumer-kotlin.json")
+        val found = dir.walkTopDown().filter { it.name.contains("consumer-kotlin") }.map { it.absolutePath }.toList()
+        assertTrue(
+            marker.isFile && marker.readText().contains("\"ok\" : true"),
+            "marker must be written and ok. expected=$marker found=$found content=${if (marker.isFile) marker.readText() else "<no file>"} output=${result.output.take(2000)}"
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // Fail-soft producer contract (C3/C4): the consumer tasks NEVER throw —
+    // a compile failure must still produce SUCCESS + a marker recording it.
+    // ------------------------------------------------------------------
+
+    private fun consumerFixture(language: String): File {
+        val dir = fixture()
+        val (settingsLine, plugin, srcRel) = if (language == "java") {
+            Triple(
+                "include(\":examples:java-consumer-smoke\")",
+                "id(\"java\")",
+                "examples/java-consumer-smoke/src",
+            )
+        } else {
+            Triple(
+                "include(\":examples:kotlin-consumer-smoke\")",
+                "id(\"org.jetbrains.kotlin.jvm\")",
+                "examples/kotlin-consumer-smoke/src",
+            )
+        }
+        copyFromRepo(
+            dir,
+            srcRel,
+            "tramai-core/src/main/kotlin/dev/tramai/core/annotations",
+            "tramai-core/src/main/kotlin/dev/tramai/core/model/Tool.kt",
+            "tramai-core/src/main/kotlin/dev/tramai/core/model/ToolResult.kt",
+            "tramai-core/src/main/kotlin/dev/tramai/core/model/ContentPart.kt",
+            "tramai-core/src/main/kotlin/dev/tramai/core/model/ModelVisibleToolMessage.kt",
+            "tramai-core/src/main/kotlin/dev/tramai/core/model/ToolFailureCode.kt",
+            "tramai-core/src/main/kotlin/dev/tramai/core/policy",
+        )
+        writeFile(dir, "settings.gradle.kts", """
+            rootProject.name = "quality-fixture"
+            include(":tramai-core")
+            $settingsLine
+        """.trimIndent())
+        writeFile(dir, "tramai-core/build.gradle.kts", """
+            plugins { id("org.jetbrains.kotlin.jvm") }
+            group = "dev.tramai"
+            version = "0.5.0"
+            repositories { mavenCentral() }
+        """.trimIndent())
+        writeFile(dir, "examples/$language-consumer-smoke/build.gradle.kts", """
+            plugins { $plugin }
+            repositories { mavenCentral() }
+            dependencies { implementation(project(":tramai-core")) }
+        """.trimIndent())
+        return dir
+    }
+
+    @Test
+    fun `java consumer smoke is fail-soft - broken source records failure in marker`() {
+        val dir = consumerFixture("java")
+        val broken = File(dir, "examples/java-consumer-smoke/src/main/java/dev/tramai/examples/javaconsumer/JavaConsumerSmoke.java")
+        broken.appendText("\npublic final class Broken { this is not valid java }\n")
+        val result = runner(dir, ":examples:java-consumer-smoke:verifyJavaConsumerCompatibility").build()
+        assertTrue(
+            result.task(":examples:java-consumer-smoke:verifyJavaConsumerCompatibility")?.outcome == TaskOutcome.SUCCESS,
+            "fail-soft task must not throw: ${result.output.take(1200)}"
+        )
+        val marker = File(dir, "examples/java-consumer-smoke/build/reports/maintainability/consumer-java.json")
+        assertTrue(marker.isFile, "marker must be written even on compile failure")
+        val content = marker.readText()
+        assertTrue(content.contains("\"ok\" : false"), "marker must record ok:false, was: $content")
+        assertTrue(content.contains("\"exitCode\""), "marker must record exitCode, was: $content")
+    }
+
+    @Test
+    fun `kotlin consumer smoke is fail-soft - broken source records failure in marker`() {
+        val dir = consumerFixture("kotlin")
+        val broken = File(dir, "examples/kotlin-consumer-smoke/src/main/kotlin/dev/tramai/examples/kotlinconsumer/KotlinConsumerSmoke.kt")
+        broken.appendText("\nfun broken() { this is not valid kotlin }\n")
+        val result = runner(dir, ":examples:kotlin-consumer-smoke:verifyKotlinConsumerCompatibility").build()
+        assertTrue(
+            result.task(":examples:kotlin-consumer-smoke:verifyKotlinConsumerCompatibility")?.outcome == TaskOutcome.SUCCESS,
+            "fail-soft task must not throw: ${result.output.take(1200)}"
+        )
+        val marker = File(dir, "examples/kotlin-consumer-smoke/build/reports/maintainability/consumer-kotlin.json")
+        assertTrue(marker.isFile, "marker must be written even on compile failure")
+        val content = marker.readText()
+        assertTrue(content.contains("\"ok\" : false"), "marker must record ok:false, was: $content")
+        assertTrue(content.contains("\"exitCode\""), "marker must record exitCode, was: $content")
+    }
+}


### PR DESCRIPTION
## Epic 9.2d-a3a — residual surgical CC hygiene (4 offenders)

Converts the 4 remaining surgical configuration-cache offenders to typed, CC-safe tasks. Sovereign extraction (a3b) and model-snapshot work (a3c) are deliberately OUT per the frozen plan.

### Tasks converted
- **verifyModuleMatrixDrift** → `ModuleMatrixDriftVerifierTask` (@InputFiles matrix + module-catalog, @Input rootDir)
- **verifyJUnitTestSignatures** → `JUnitTestSignatureVerifierTask` (scanRoot + test-source fileTree; excludes `build/` and `api/` per the #333 task-output-overlap fix)
- **verifyJavaConsumerCompatibility** + **verifyKotlinConsumerCompatibility** → `ConsumerSmokeCompileTask`, registered lazily via `withPlugin(languagePluginId)` (a1 standing rule: toolchain service only exists after the fixture's language plugin; eager `project.project()` breaks TestKit). Toolchain executables wired as CC-serializable providers.

### Evidence
- 6/6 new discriminating tests (real repo files as oracles; fail-closed negatives for drift + signatures; real-compile marker proofs for both consumer smokes)
- Full build-logic suite green (434 tests, 33 classes)
- verifyChangePolicy -PchangePolicyBase=5aae0ec3 -PchangeClass=build-logic PASSED (3 files)
- Real-repo smoke: all 4 tasks BUILD SUCCESSFUL, consumer markers ok:true
- CC cold→warm: entry stored + reused, 0 problems

### Expected post-merge matrix (from frozen evidence)
C4 5→3 · C5 3→1 · C3 stays 3 (2 sovereign + deliberate verify050ReleaseReadiness exclusion)