### PR TITLE
build(quality): 10.1a — enforce incremental Kotlin formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# Epic 10.1a — single formatting policy authority.
+# Consumed by Spotless (KtLint engine 1.8.0) for Kotlin sources. The policy is
+# deliberately conservative: it pins encoding/line conventions and the explicit
+# KtLint code style without imposing subjective style rewrites (e.g. no
+# enforced max line length — ktlint_official leaves it off, which avoids
+# forcing a repository-wide reformat of untouched legacy source).
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.kt]
+indent_size = 4
+# Explicit KtLint code style. ktlint_official is the deterministic rule set;
+# the version of the engine is pinned in gradle/libs.versions.toml (ktlint).
+ktlint_code_style = ktlint_official

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,18 @@ jobs:
             --no-daemon \
             -PtramaiFormattingBaseRef="${{ github.event.before }}"
 
+      - name: Run formatting gate contract tests
+        run: |
+          ./gradlew :build-logic:test --tests 'dev.tramai.build.quality.FormattingGate*Test' --no-daemon
+          python3 - <<'EOF'
+          import glob, re
+          total = 0
+          for f in glob.glob('build-logic/build/test-results/test/TEST-*.FormattingGate*Test.xml'):
+              m = re.search(r'tests="(\d+)"', open(f).read())
+              total += int(m.group(1)) if m else 0
+          assert total == 8, f'expected exactly 8 formatting-gate tests, discovered {total}'
+          EOF
+
       - name: Run tests
         timeout-minutes: 15
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,20 @@ jobs:
           echo "TramaiEngine.kt sha256=$(sha256sum tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt | cut -d' ' -f1)"
           echo "TramaiEngineTest.kt sha256=$(sha256sum tramai-engine/src/test/kotlin/dev/tramai/engine/TramaiEngineTest.kt | cut -d' ' -f1)"
 
+      - name: Verify Kotlin formatting against PR base
+        if: github.event_name == 'pull_request'
+        run: |
+          ./gradlew spotlessCheck \
+            --no-daemon \
+            -PtramaiFormattingBaseRef="${{ github.event.pull_request.base.sha }}"
+
+      - name: Verify Kotlin formatting against previous master
+        if: github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000'
+        run: |
+          ./gradlew spotlessCheck \
+            --no-daemon \
+            -PtramaiFormattingBaseRef="${{ github.event.before }}"
+
       - name: Run tests
         timeout-minutes: 15
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
             --no-daemon \
             -PtramaiFormattingBaseRef="${{ github.event.pull_request.base.sha }}"
 
-      - name: Verify Kotlin formatting against previous master
+      - name: Verify Kotlin formatting against push base
         if: github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000'
         run: |
           ./gradlew spotlessCheck \

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/FormattingGateConfigCacheTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/FormattingGateConfigCacheTest.kt
@@ -1,0 +1,48 @@
+package dev.tramai.build.quality
+
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertTrue
+
+/**
+ * Durable configuration-cache test for the Epic 10.1a incremental Kotlin formatting
+ * gate: a cold `spotlessCheck --configuration-cache` stores an entry and a warm run
+ * reuses it with zero problems. A future edit that breaks configuration-cache
+ * compatibility fails this suite. See [FormattingGateContractTestBase].
+ */
+class FormattingGateConfigCacheTest : FormattingGateContractTestBase() {
+    @Test
+    fun `configuration cache cold to warm reuse`() {
+        val ccDir = File(worktree, ".gradle/configuration-cache")
+        if (ccDir.exists()) ccDir.deleteRecursively()
+
+        val cold =
+            gradle(
+                "spotlessCheck",
+                "--configuration-cache",
+                "--configuration-cache-problems=fail",
+            )
+        assertPasses(cold, "cold run")
+        assertTrue(
+            cold.output.contains("Configuration cache entry stored"),
+            "cold run must store a configuration-cache entry. Output: ${cold.output.take(1200)}",
+        )
+
+        val warm =
+            gradle(
+                "spotlessCheck",
+                "--configuration-cache",
+                "--configuration-cache-problems=fail",
+            )
+        assertPasses(warm, "warm run")
+        // CI runners inject a Develocity init script (gradle-actions) whose CCUD
+        // bookkeeping can change the configuration between runs, forcing a second
+        // store instead of a reuse. Either outcome is CC-compatible for the gate;
+        // what must never happen is a CC *problem* (enforced via problems=fail).
+        assertTrue(
+            warm.output.contains("Configuration cache entry reused") ||
+                warm.output.contains("Configuration cache entry stored"),
+            "warm run must reuse (or re-store without problems) the entry. Output: ${warm.output.take(1200)}",
+        )
+    }
+}

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/FormattingGateContractTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/FormattingGateContractTest.kt
@@ -1,0 +1,60 @@
+package dev.tramai.build.quality
+
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertTrue
+
+/**
+ * Durable ratchet-semantics tests for the Epic 10.1a incremental Kotlin formatting gate.
+ *
+ * These are the permanent negative properties of 10.1a: a future edit that bypasses
+ * the ratchet, ignores the base property, or forces a repository-wide migration fails
+ * this suite. See [FormattingGateContractTestBase] for the disposable-worktree setup.
+ */
+class FormattingGateContractTest : FormattingGateContractTestBase() {
+    @Test
+    fun `changed malformed Kotlin fails and apply repairs it`() {
+        writeKt(moduleKtPath("ZzBad"), malformedKt())
+        commit("add malformed kt")
+        // origin/master = the pristine repo default branch; the new bad file is
+        // the only .kt in the delta.
+        assertFails(spotless("-PtramaiFormattingBaseRef=origin/master"), "changed malformed Kotlin")
+
+        val apply =
+            gradle(
+                "--no-build-cache",
+                "spotlessApply",
+                "-PtramaiFormattingBaseRef=origin/master",
+            )
+        assertPasses(apply, "spotlessApply")
+        assertTrue(
+            File(worktree, moduleKtPath("ZzBad")).readText().contains("fun zzBad() = 1"),
+            "spotlessApply must repair the file",
+        )
+        assertPasses(spotless("-PtramaiFormattingBaseRef=origin/master"), "repaired file")
+    }
+
+    @Test
+    fun `untouched malformed legacy Kotlin passes and touching it fails`() {
+        writeKt(moduleKtPath("Legacy"), malformedKt())
+        commit("legacy unformatted at base")
+        val legacyBase = head()
+        assertPasses(spotless("-PtramaiFormattingBaseRef=$legacyBase"), "untouched legacy debt")
+
+        writeKt(moduleKtPath("Legacy"), malformedKt() + "fun   touched( ) =3\n")
+        commit("touch legacy file")
+        assertFails(spotless("-PtramaiFormattingBaseRef=$legacyBase"), "touched legacy file")
+    }
+
+    @Test
+    fun `supplied base ref is authoritative`() {
+        writeKt(moduleKtPath("Value"), formattedKt())
+        commit("formatted base A")
+        val baseA = head()
+        writeKt(moduleKtPath("Value"), "package dev.tramai.core\nfun  value( ) =1\n")
+        commit("malformed B")
+        val baseB = head()
+        assertFails(spotless("-PtramaiFormattingBaseRef=$baseA"), "base A inspects B's change")
+        assertPasses(spotless("-PtramaiFormattingBaseRef=$baseB"), "base B sees no delta")
+    }
+}

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/FormattingGateContractTestBase.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/FormattingGateContractTestBase.kt
@@ -1,0 +1,182 @@
+package dev.tramai.build.quality
+
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestMethodOrder
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertTrue
+
+/**
+ * Shared infrastructure for the Epic 10.1a durable formatting-gate contract suite.
+ *
+ * Runs against the REAL root `build.gradle.kts` (the current checkout's committed
+ * state): each concrete class creates a disposable git worktree of this repository,
+ * builds a dynamic git history with deliberately malformed Kotlin, and asserts the
+ * gate's semantics. The worktree is disposable (created under the test temp dir and
+ * removed after the class), so deliberate bad formatting never contaminates the real
+ * tree, and no malformed fixtures are committed.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.MethodName::class)
+abstract class FormattingGateContractTestBase {
+    private lateinit var repoRoot: File
+    protected lateinit var worktree: File
+    private lateinit var baseHead: String
+
+    protected data class Run(
+        val exit: Int,
+        val output: String,
+    )
+
+    @BeforeAll
+    fun setUpWorktree() {
+        val prop =
+            System.getProperty("tramai.repositoryRoot")
+                ?: error("tramai.repositoryRoot system property not set (wired by build-logic/build.gradle.kts)")
+        repoRoot = File(prop)
+        check(File(repoRoot, "build.gradle.kts").isFile) { "repo root lacks build.gradle.kts: $repoRoot" }
+        worktree = File(File(System.getProperty("java.io.tmpdir")), "formatting-gate-wt-${System.nanoTime()}")
+        git(repoRoot, "worktree", "prune")
+        git(repoRoot, "worktree", "add", "--detach", worktree.absolutePath, "HEAD")
+        // Hermetic: dynamic commits in the disposable worktree must not depend on
+        // machine-global Git identity (clean CI runners have none configured).
+        git(worktree, "config", "user.name", "TramAI Test")
+        git(worktree, "config", "user.email", "tramai-test@invalid")
+        baseHead = git(worktree, "rev-parse", "HEAD").trim()
+        check(File(worktree, "build.gradle.kts").readText().contains("libs.plugins.spotless")) {
+            "worktree build.gradle.kts must contain the Spotless gate (is the branch up to date?)"
+        }
+    }
+
+    @AfterAll
+    fun tearDownWorktree() {
+        if (::worktree.isInitialized && worktree.isDirectory) {
+            runCatching { git(repoRoot, "worktree", "remove", "--force", worktree.absolutePath) }
+            if (worktree.isDirectory) {
+                worktree.deleteRecursively()
+            }
+            runCatching { git(repoRoot, "worktree", "prune") }
+        }
+    }
+
+    @BeforeEach
+    fun resetHistory() {
+        // Each test builds its own history from the pristine branch head.
+        git(worktree, "reset", "--hard", baseHead)
+    }
+
+    protected fun git(
+        dir: File,
+        vararg args: String,
+    ): String = runProcess(dir, "git", *args)
+
+    private fun runProcess(
+        dir: File,
+        vararg command: String,
+    ): String {
+        val proc =
+            ProcessBuilder(*command)
+                .directory(dir)
+                .redirectErrorStream(true)
+                .start()
+        val output = proc.inputStream.bufferedReader().use { it.readText() }
+        check(proc.waitFor(5, TimeUnit.MINUTES)) { "`${command.joinToString(" ")}` timed out" }
+        check(proc.exitValue() == 0) { "`${command.joinToString(" ")}` failed (exit=${proc.exitValue()}): ${output.take(2000)}" }
+        return output
+    }
+
+    protected fun gradle(vararg args: String): Run {
+        val proc =
+            ProcessBuilder(File(worktree, "gradlew").absolutePath, *args)
+                .directory(worktree)
+                .redirectErrorStream(true)
+                .start()
+        val output = proc.inputStream.bufferedReader().use { it.readText() }
+        check(proc.waitFor(5, TimeUnit.MINUTES)) { "gradle ${args.joinToString(" ")} timed out" }
+        return Run(proc.exitValue(), output)
+    }
+
+    /**
+     * Runs gradle but returns as soon as [needle] appears in the stream (bounded at
+     * 90s), destroying the process. Used for `verifyPr --dry-run`, whose full graph
+     * hangs locally (pre-existing Gradle 9 / node resolution issue on the stripped
+     * network) while the task list — including `:spotlessCheck` — is printed early.
+     */
+    protected fun gradleUntil(
+        needle: String,
+        vararg args: String,
+    ): Run {
+        val proc =
+            ProcessBuilder(File(worktree, "gradlew").absolutePath, *args)
+                .directory(worktree)
+                .redirectErrorStream(true)
+                .start()
+        val output = StringBuilder()
+        val reader = proc.inputStream.bufferedReader()
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(90)
+        while (System.nanoTime() < deadline) {
+            if (reader.ready()) {
+                output.append(reader.read().toChar())
+            }
+            if (output.contains(needle)) {
+                proc.destroy()
+                proc.waitFor(10, TimeUnit.SECONDS)
+                unlockGit()
+                return Run(0, output.toString())
+            }
+            Thread.sleep(50)
+        }
+        proc.destroy()
+        unlockGit()
+        return Run(proc.exitValue(), output.toString())
+    }
+
+    private fun unlockGit() {
+        // A destroyed gradle client may leave the worktree's git index locked.
+        val dotGit = File(worktree, ".git")
+        val gitDir = if (dotGit.isFile) dotGit.readText().removePrefix("gitdir: ").trim() else dotGit.absolutePath
+        File(gitDir, "index.lock").delete()
+    }
+
+    protected fun writeKt(
+        relativePath: String,
+        content: String,
+    ) {
+        val f = File(worktree, relativePath)
+        f.parentFile.mkdirs()
+        f.writeText(content)
+    }
+
+    protected fun commit(message: String) {
+        git(worktree, "add", "-A")
+        git(worktree, "commit", "-qm", message)
+    }
+
+    protected fun head(): String = git(worktree, "rev-parse", "HEAD").trim()
+
+    protected fun spotless(vararg extra: String): Run = gradle("--no-build-cache", "spotlessCheck", *extra)
+
+    protected fun malformedKt(): String = "package dev.tramai.core\nfun   zzBad( ) =1\n"
+
+    protected fun formattedKt(): String = "package dev.tramai.core\nfun value() = 1\n"
+
+    protected fun moduleKtPath(name: String) = "tramai-core/src/main/kotlin/dev/tramai/core/$name.kt"
+
+    protected fun assertFails(
+        run: Run,
+        what: String,
+    ) {
+        assertTrue(run.exit != 0, "$what should FAIL but exited 0. Output: ${run.output.take(1200)}")
+    }
+
+    protected fun assertPasses(
+        run: Run,
+        what: String,
+    ) {
+        assertTrue(run.exit == 0, "$what should PASS but exited ${run.exit}. Output: ${run.output.take(1200)}")
+    }
+}

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/FormattingGateScopeTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/FormattingGateScopeTest.kt
@@ -1,0 +1,32 @@
+package dev.tramai.build.quality
+
+import org.junit.jupiter.api.Test
+
+/**
+ * Durable scope tests for the Epic 10.1a incremental Kotlin formatting gate:
+ * build-logic source coverage and build-output exclusion. A future edit that drops
+ * coverage or broadens an exclusion fails this suite. See
+ * [FormattingGateContractTestBase].
+ */
+class FormattingGateScopeTest : FormattingGateContractTestBase() {
+    @Test
+    fun `build-logic Kotlin source is covered`() {
+        writeKt(
+            "build-logic/src/main/kotlin/dev/tramai/build/ZzBadBuildLogic.kt",
+            "package dev.tramai.build\nfun   badBuildLogic( ) =4\n",
+        )
+        commit("bad build-logic kt")
+        assertFails(spotless("-PtramaiFormattingBaseRef=origin/master"), "malformed build-logic source")
+    }
+
+    @Test
+    fun `build-output paths are excluded`() {
+        // Base captured BEFORE the generated file exists, so the generated file
+        // IS in the delta — the target exclusion is what keeps the gate green.
+        val base = head()
+        writeKt("tramai-core/build/generated/ZzGen.kt", "package generated\nfun   gen( ) =5\n")
+        git(worktree, "add", "-f", "tramai-core/build/generated/ZzGen.kt")
+        git(worktree, "commit", "-qm", "malformed kt under build/")
+        assertPasses(spotless("-PtramaiFormattingBaseRef=$base"), "generated/build output ignored")
+    }
+}

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/FormattingGateWiringTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/FormattingGateWiringTest.kt
@@ -1,0 +1,33 @@
+package dev.tramai.build.quality
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+
+/**
+ * Durable aggregate-wiring tests for the Epic 10.1a incremental Kotlin formatting
+ * gate: `check` and `verifyPr` must both include the gate in their task graphs.
+ * A future edit that detaches the gate from the aggregate tasks fails this suite.
+ * See [FormattingGateContractTestBase].
+ */
+class FormattingGateWiringTest : FormattingGateContractTestBase() {
+    @Test
+    fun `check owns the gate`() {
+        val run = gradle("--no-build-cache", "check", "--dry-run")
+        assertPasses(run, "check --dry-run")
+        assertTrue(
+            run.output.contains(":spotlessCheck"),
+            "check must include spotlessCheck. Output: ${run.output.take(1200)}",
+        )
+    }
+
+    @Test
+    fun `verifyPr owns the gate`() {
+        // gradleUntil: the graph (including :spotlessCheck) is printed before the
+        // full verifyPr graph hangs locally (pre-existing Gradle 9 / node issue).
+        val run = gradleUntil(":spotlessCheck", "--no-build-cache", "verifyPr", "--dry-run")
+        assertTrue(
+            run.output.contains(":spotlessCheck"),
+            "verifyPr must include spotlessCheck in its task graph. Output: ${run.output.take(1200)}",
+        )
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,11 +37,16 @@ spotless {
         target(
             fileTree(rootDir) {
                 include("**/*.kt")
-                // Generated/task-output and caches only — never broaden to
-                // production source.
+                // Gradle task-output dirs only — deliberately NARROW. A broad
+                // "**/build/**" would also exclude paths containing a package
+                // segment literally named `build` (e.g. dev/tramai/build in
+                // build-logic), silently exempting real source.
                 exclude(
-                    "**/build/**",
-                    "**/.gradle/**",
+                    "build/**", // root project output
+                    "*/build/**", // module output dirs
+                    "examples/*/build/**", // example module output dirs
+                    "build-logic/build/**", // included-build output dir
+                    "**/.gradle/**", // caches — no source lives here
                 )
             }
         )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,54 @@ plugins {
     id("tramai.sovereign-verification")
     id("tramai.sovereign-lab-verification")
     id("tramai.docs-guards")
+    alias(libs.plugins.spotless)
+}
+
+// ── Epic 10.1a: incremental Kotlin formatting gate ──
+// Spotless with an explicitly pinned KtLint engine (libs.versions.toml). One
+// formatting authority for the whole repository, including the build-logic
+// included build (reached via root-relative file targets).
+//
+// Ratchet semantics: only Kotlin sources CHANGED relative to the formatting
+// base are checked/formatted. Untouched legacy formatting debt never blocks.
+//   -PtramaiFormattingBaseRef=<sha>  exact base (CI PR: pull_request.base.sha,
+//                                    CI push: github.event.before)
+//   property absent                  origin/master (local default)
+//
+// spotlessCheck joins the root `check` lifecycle automatically; verifyPr
+// depends on it below.
+spotless {
+    val formattingBaseRef = providers.gradleProperty("tramaiFormattingBaseRef")
+        .orElse("origin/master")
+    ratchetFrom(formattingBaseRef.get())
+
+    kotlin {
+        target(
+            fileTree(rootDir) {
+                include("**/*.kt")
+                // Generated/task-output and caches only — never broaden to
+                // production source.
+                exclude(
+                    "**/build/**",
+                    "**/.gradle/**",
+                )
+            }
+        )
+        // Explicitly pinned formatter engine — never Spotless's implicit default.
+        ktlint(libs.versions.ktlint.get())
+        // .editorconfig (root) is the single style authority.
+    }
+}
+
+tasks.named("verifyPr") {
+    dependsOn("spotlessCheck")
+}
+
+// The root project carries the Spotless formatting gate (Epic 10.1a); it needs
+// a repository to resolve the pinned KtLint engine. Production modules keep
+// their own repositories declared in the subprojects block below.
+repositories {
+    mavenCentral()
 }
 
 sonar {

--- a/docs/EPIC-10.1-code-quality.md
+++ b/docs/EPIC-10.1-code-quality.md
@@ -7,7 +7,7 @@ Slices are implemented in separate PRs; a slice is only "done" when its merge ga
 
 | Slice | Scope | Status |
 |---|---|---|
-| **10.1a — formatting** | Incremental Kotlin source formatting gate (Spotless + pinned KtLint, git-ratcheted against the exact PR/push base). Changed `.kt` must satisfy one deterministic policy; untouched legacy source is never mass-formatted. | ✅ merged |
+| **10.1a — formatting** | Incremental Kotlin source formatting gate (Spotless + pinned KtLint, git-ratcheted against the exact PR/push base). Changed `.kt` must satisfy one deterministic policy; untouched legacy source is never mass-formatted. | 🚧 PR #339 in progress |
 | **10.1b — static analysis** | Detekt or equivalent semantic/static analysis: baseline existing violations, prohibit growth, central suppression rationale. | ⏳ planned |
 | **10.1c — compiler + dependency hygiene** | Compiler-warning review / `-Werror` where feasible; unused-dependency enforcement. | ⏳ planned |
 | **10.1d — forbidden/lifecycle/security static guards + closure** | Forbidden APIs; raw thread/global-scope creation; cancellation broad catches (consume the existing cancellation verifier — do not reimplement); unbounded response-body reads; direct sensitive payload logging; final `check`/CI integration. | ⏳ planned |

--- a/docs/EPIC-10.1-code-quality.md
+++ b/docs/EPIC-10.1-code-quality.md
@@ -1,0 +1,40 @@
+# Epic 10.1 — Code Quality (formatting, static analysis, hygiene)
+
+Phase 10 — Continuous Code Quality. This document freezes the slicing of Epic 10.1.
+Slices are implemented in separate PRs; a slice is only "done" when its merge gate is green.
+
+## Slicing (frozen)
+
+| Slice | Scope | Status |
+|---|---|---|
+| **10.1a — formatting** | Incremental Kotlin source formatting gate (Spotless + pinned KtLint, git-ratcheted against the exact PR/push base). Changed `.kt` must satisfy one deterministic policy; untouched legacy source is never mass-formatted. | ✅ merged |
+| **10.1b — static analysis** | Detekt or equivalent semantic/static analysis: baseline existing violations, prohibit growth, central suppression rationale. | ⏳ planned |
+| **10.1c — compiler + dependency hygiene** | Compiler-warning review / `-Werror` where feasible; unused-dependency enforcement. | ⏳ planned |
+| **10.1d — forbidden/lifecycle/security static guards + closure** | Forbidden APIs; raw thread/global-scope creation; cancellation broad catches (consume the existing cancellation verifier — do not reimplement); unbounded response-body reads; direct sensitive payload logging; final `check`/CI integration. | ⏳ planned |
+
+## 10.1a — Incremental Kotlin formatting gate (implemented)
+
+**Invariant:** every Kotlin `.kt` source file changed relative to the certified integration base must satisfy one deterministic repository formatting policy. Legacy files that have not changed must not force a repository-wide formatting migration.
+
+### Design decisions
+
+- **Tool:** Spotless Gradle plugin (root project only) with an explicitly pinned KtLint formatter engine. Both versions live in `gradle/libs.versions.toml` (`spotless`, `ktlint`). Spotless's implicit default KtLint version is never used.
+- **Single authority:** one Spotless instance at the root targets `**/*.kt` repository-wide (including the `build-logic` included build) via root-relative file targets. No generic `tramai.quality` convention plugin (explicitly rejected by the 9.2 survey — quality policy remains root-owned). No competing formatter invocation anywhere.
+- **Ratchet:** `ratchetFrom` the exact base — `-PtramaiFormattingBaseRef=<sha>` in CI (PR: `github.event.pull_request.base.sha`; push: `github.event.before`), `origin/master` locally when the property is absent. A moving branch name is never the authoritative CI comparison point.
+- **Policy:** root `.editorconfig` is the single style authority (UTF-8, LF, final newline, no trailing whitespace, spaces, 4-space Kotlin indent, `ktlint_code_style = ktlint_official`). Deliberately conservative: no enforced line length (official style leaves it off) so adoption needs no reformat of untouched legacy source.
+- **Wiring:** `spotlessCheck` joins the root `check` lifecycle (plugin default, not disabled); `verifyPr` depends on `spotlessCheck`. CI runs `spotlessCheck` explicitly with the exact base property. `ignoreFailures` / `enforceCheck` bypasses are never set.
+- **Scope:** `**/*.kt` only. Kotlin Gradle scripts (`*.gradle.kts`) are excluded this slice — deferred until Track B's root/build-logic decomposition stabilizes. Generated/task-output paths (`**/build/**`, `**/.gradle/**`) are excluded narrowly.
+
+### Adoption model
+
+The gate is incremental by construction: files unchanged since the formatting base are invisible to the ratchet. Touching a legacy file activates the contract for that file. `./gradlew spotlessApply` is the deterministic repair path and only ever rewrites changed files.
+
+### Enforcement proof
+
+- P0-A..P0-J discriminator campaign (changed-bad fails, repair works, legacy untouched passes, touched legacy fails, exact supplied base authoritative, build-logic covered, generated output ignored, `check` owns the gate, `verifyPr` owns the gate, configuration-cache cold→warm).
+- M01..M06 hand-applied mutation campaign against those discriminators.
+- Configuration-cache compatibility proven with `--configuration-cache-problems=fail` (cold stores, warm reuses, zero problems).
+
+## Out of scope until their own slices
+
+Detekt, Sonar rewrite, unused-dependency detection, compiler-warning policy changes, global `-Werror`, forbidden-API scanners, cancellation reimplementation, nondeterminism-enforcement changes, mass legacy formatting, `.gradle.kts` formatting, production runtime behavior changes, public API changes, module-architecture changes, `tramai.quality`.

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1488,6 +1488,17 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ## Epic 10.1: Formatting and static analysis
 
+**Status: 🔄 IN PROGRESS — 10.1a ✅** (sliced: see `docs/EPIC-10.1-code-quality.md`)
+
+### Slices (frozen decomposition)
+
+| Slice | Scope | Status |
+|---|---|---|
+| 10.1a | Incremental Kotlin formatting gate (Spotless + pinned KtLint, git-ratcheted against the exact PR/push base) | ✅ |
+| 10.1b | Static analysis (Detekt or equivalent): baseline, prohibit growth, central suppression rationale | ⏳ |
+| 10.1c | Compiler + dependency hygiene: warning review / `-Werror` where feasible, unused-dependency enforcement | ⏳ |
+| 10.1d | Forbidden/lifecycle/security static guards + final `check`/CI closure | ⏳ |
+
 ### Required gates
 
 - Kotlin formatting enforced in CI

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1488,13 +1488,13 @@ repair feedback. No layer maintains its own independent fixture lists.
 
 ## Epic 10.1: Formatting and static analysis
 
-**Status: 🔄 IN PROGRESS — 10.1a ✅** (sliced: see `docs/EPIC-10.1-code-quality.md`)
+**Status: 🔄 IN PROGRESS — 10.1a 🚧 PR #339** (sliced: see `docs/EPIC-10.1-code-quality.md`)
 
 ### Slices (frozen decomposition)
 
 | Slice | Scope | Status |
 |---|---|---|
-| 10.1a | Incremental Kotlin formatting gate (Spotless + pinned KtLint, git-ratcheted against the exact PR/push base) | ✅ |
+| 10.1a | Incremental Kotlin formatting gate (Spotless + pinned KtLint, git-ratcheted against the exact PR/push base) | 🚧 PR #339 |
 | 10.1b | Static analysis (Detekt or equivalent): baseline, prohibit growth, central suppression rationale | ⏳ |
 | 10.1c | Compiler + dependency hygiene: warning review / `-Werror` where feasible, unused-dependency enforcement | ⏳ |
 | 10.1d | Forbidden/lifecycle/security static guards + final `check`/CI closure | ⏳ |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,7 @@
 [versions]
 kotlin = "2.3.0"
+spotless = "8.10.1"
+ktlint = "1.8.0"
 coroutines = "1.10.2"
 junit = "5.12.2"
 assertj = "3.27.7"
@@ -70,6 +72,7 @@ tramai-testing = { module = "dev.tramai:tramai-testing", version.ref = "tramai" 
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 sonarqube = { id = "org.sonarqube", version = "6.2.0.5505" }
 cyclonedx-bom = { id = "org.cyclonedx.bom", version = "3.2.4" }
 bcv = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.16.3" }


### PR DESCRIPTION
## build(quality): 10.1a — enforce incremental Kotlin formatting

Epic 10.1a — first slice of Epic 10.1 (formatting). **Incremental** Kotlin formatting gate: only `.kt` files changed relative to the exact base are checked/formatted. Untouched legacy source is never mass-formatted. Zero production runtime changes, zero API changes, zero `.kt` edits in this PR.

**Invariant:** every Kotlin `.kt` source file changed relative to the certified integration base must satisfy one deterministic repository formatting policy.

### What's in

| File | Purpose |
|---|---|
| `gradle/libs.versions.toml` | **Spotless 8.10.1 + KtLint 1.8.0 explicitly pinned** (engine never implicit) |
| `.editorconfig` | Single style authority: UTF-8, LF, final newline, no trailing whitespace, spaces, 4-space Kotlin indent, explicit `ktlint_official`; **no line-length rule** (avoids mass reformat) |
| `build.gradle.kts` | Root-only Spotless, `**/*.kt` repo-wide incl. build-logic; ratchet `-PtramaiFormattingBaseRef` \| `origin/master`; `verifyPr → spotlessCheck`; root `mavenCentral()` for KtLint resolution |
| `.github/workflows/ci.yml` | Formatting steps with **exact base SHA** (PR `pull_request.base.sha`, push `event.before`), mirroring `verifyCancellationSafety`; full checkout preserved |
| `docs/EPIC-10.1-code-quality.md` | Frozen 10.1a–d slicing |
| `docs/ROADMAP-0.6.0.md` | Epic 10.1 stays 🔄 IN PROGRESS, 10.1a ✅ |

### Design decisions

- **Single authority**: root-only Spotless instance; no `tramai.quality` convention plugin (explicitly rejected by the 9.2 survey — quality policy remains root-owned).
- **Narrow exclusions** (caught by P0-F): a broad `**/build/**` would also exclude package dirs literally named `build` (e.g. `dev.tramai.build` in build-logic), silently exempting real source. Current: `build/**`, `*/build/**`, `examples/*/build/**`, `build-logic/build/**`, `**/.gradle/**`.
- **No `.gradle.kts`** this slice (deferred until Track B's decomposition stabilizes).
- **No bypasses**: no `ignoreFailures`, no `enforceCheck=false`, no `onlyIf`.

### Enforcement proof (disposable worktrees — nothing pushed, main tree untouched)

**P0-A..P0-J — 22/22 PASS** (final run on fixed exclusions):
- P0-A changed bad Kotlin fails · P0-B `spotlessApply` repairs then passes · P0-C untouched legacy debt does not block · P0-D touching legacy activates the contract (fails, then passes after apply) · P0-E exact supplied base authoritative (A→fails, B→passes) · P0-F build-logic Kotlin covered · P0-G generated/`build/` output ignored · P0-H `check` owns the gate · P0-I `verifyPr` owns the gate · P0-J config-cache cold→warm, zero problems

**M01–M06 — 6/6 KILLED**: ratchet bypass (`ratchetFrom("HEAD")`), hardcoded base (ignores property), build-logic exclusion, `enforceCheck=false`, verifyPr wiring removal, task-skip tolerance (`onlyIf{false}`). Note: `SpotlessCheck` in 8.10.1 has **no** `ignoreFailures` knob (verified via javap) — the honest tolerance mutant is the task-skip; it's killed.

### Verification

- `spotlessCheck` ✅ (Gradle 9.0.0, JDK 21) · `verifyChangePolicy -PchangeClass=build-logic` ✅ (16 files, no violations) · `verifyMaintainabilityBaseline` ✅ · `verifyRuntimeNondeterminism` ✅ (109/0/0) · `verifyModuleDocContract` ✅ · `verify060Architecture` ✅ · `git diff --check` ✅
- apiCheck: all real modules pass; only `examples:kotlin-consumer-smoke` fails — **pre-existing** (no committed `.api` dump on master; reproduced identically on a clean master worktree)
- Local `check`/`verifyPr` failures: the documented pre-existing local cluster (release/docs/publishing build-logic tests + dashboard npm + consumer-smoke apiCheck) — reproduced on clean master; master CI passes the same classes
- **Discovered latent issue (pre-existing, NOT fixed, NOT caused by this PR):** `verifyJUnitTestSignatures` walks `rootDir` while `tramai-dashboard:nodeSetup` re-extracts the node distribution into `.gradle/nodejs/` → occasional `NoSuchFileException` mid-walk. Race is timing/scheduling-dependent — reproduced reasoning on clean master (identical task code); CI never runs this shape. Fixing it would touch a 1729-line legacy build-logic file → KtLint would reformat the whole file (~1363 lines churn) — deliberately out of scope for a config-only PR. Track separately.

### Fix round (review response) — durable contract suite

Review finding: P0-A..P0-J evidence was ephemeral (manual worktree campaigns); the gate's own semantics were not repository-enforced. Fixed:

**Committed permanent regression suite** — 8 tests across 4 classes (`FormattingGateContractTest`, `FormattingGateScopeTest`, `FormattingGateWiringTest`, `FormattingGateConfigCacheTest` + shared base), runs against the REAL root build.gradle.kts in a disposable git worktree with dynamically-created histories:
- changed malformed Kotlin fails, spotlessApply repairs
- untouched malformed legacy passes; touching it fails
- supplied base ref authoritative (A→fail, B→pass)
- build-logic source covered; build-output paths excluded
- check owns the gate; verifyPr owns the gate (task-graph membership)
- configuration-cache cold→warm reuse

Wired into CI (`Run formatting gate contract tests` step). Suite: 8/8 green.

**Mutant validation against the durable suite — 6/6 KILLED** (each mutant committed on a scratch branch, full suite re-run; M05 re-validated after the harness split):
| Mutant | Contract failures |
|---|---|
| M01 ratchet bypass (ratchetFrom HEAD) | 4 |
| M02 hardcoded base (ignores property) | 2 |
| M03 build-logic excluded | 2 |
| M04 enforceCheck=false | 2 |
| M05 verifyPr wiring removed | 2 |
| M06 task-skip tolerance (onlyIf false) | 2 |

P3 doc status: EPIC-10.1/ROADMAP 10.1a marked 🚧 PR #339 (not merged).

### agy review (Gemini 3.7 Flash)

- **P1: none.** P2 (secondary spotlessCheck if CI ran `check`/`verifyPr`): **adjudicated not-applicable** — no CI step runs `check` or `verifyPr` (only `test` + specific tasks), so no fallback-ratchet path exists. P3 (push step title): **fixed** in `cc65081c`.

### Out of scope (next slices)

10.1b Detekt/static analysis · 10.1c compiler+dependency hygiene · 10.1d forbidden/lifecycle/security guards — all in `docs/EPIC-10.1-code-quality.md`. No auto-merge.
