### PR TITLE
refactor(build-logic): a3c1 — typed dependency aggregate + module-topology snapshots — Epic 9.2d-a3c1

### DIFF
--- a/build-logic/src/main/kotlin/dev/tramai/build/publishing/TramaiPublishingPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/publishing/TramaiPublishingPlugin.kt
@@ -19,7 +19,6 @@ import org.gradle.plugins.signing.SigningExtension
  * script behavior exactly (9.2a extraction, behavior-preserving).
  */
 class TramaiPublishingPlugin : Plugin<Project> {
-
     override fun apply(project: Project) {
         project.pluginManager.withPlugin("java-library") {
             project.pluginManager.apply("maven-publish")
@@ -45,7 +44,10 @@ class TramaiPublishingPlugin : Plugin<Project> {
         }
     }
 
-    private fun configurePublication(project: Project, componentName: String) {
+    private fun configurePublication(
+        project: Project,
+        componentName: String,
+    ) {
         val metadata = TramaiPublicationMetadata.from(project)
 
         project.extensions.configure(PublishingExtension::class.java) {
@@ -80,11 +82,12 @@ class TramaiPublishingPlugin : Plugin<Project> {
 
             val releaseRepositoryUrl = project.providers.gradleProperty("tramaiPublishReleaseUrl").orNull
             val snapshotRepositoryUrl = project.providers.gradleProperty("tramaiPublishSnapshotUrl").orNull
-            val targetRepositoryUrl = TramaiPublishingRepositories.selectRepositoryUrl(
-                project.version.toString(),
-                releaseRepositoryUrl,
-                snapshotRepositoryUrl,
-            )
+            val targetRepositoryUrl =
+                TramaiPublishingRepositories.selectRepositoryUrl(
+                    project.version.toString(),
+                    releaseRepositoryUrl,
+                    snapshotRepositoryUrl,
+                )
 
             if (!targetRepositoryUrl.isNullOrBlank()) {
                 repositories {
@@ -124,7 +127,7 @@ class TramaiPublishingPlugin : Plugin<Project> {
      * and the POM omits the description element.
      */
     private fun catalogDescription(project: Project): String? {
-        val catalog = ModuleCatalog(project.rootProject.projectDir).parse()
+        val catalog = ModuleCatalog.fromRootDir(project.rootProject.projectDir).parse()
         val entry = catalog.modules[":${project.name}"]
         val description = entry?.description?.takeIf { it.isNotBlank() }
         if (entry?.publishability == ModulePublishability.PUBLISHED && description == null) {

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/BaselineVerifier.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/BaselineVerifier.kt
@@ -12,11 +12,11 @@ import java.io.File
 class BaselineVerifier(
     private val generator: BaselineGenerator,
     private val ctx: MeasurementContext,
-    private val reportDir: File
+    private val reportDir: File,
 ) {
     private val deviationParser = DeviationParser(ctx.rootDir)
     private val budgetEvaluator = DeviationBudgetEvaluator(deviationParser)
-    private val moduleCatalog = ModuleCatalog(ctx.rootDir)
+    private val moduleCatalog = ModuleCatalog.fromRootDir(ctx.rootDir)
     private val moduleBoundaries = ModuleBoundaries(ctx.rootDir)
 
     fun verify(): VerificationReport {
@@ -29,20 +29,27 @@ class BaselineVerifier(
             // 1. Load committed baseline
             val committedFile = File(ctx.rootDir, "config/quality/0.6.0-baseline.json")
             if (!committedFile.isFile) {
-                diagnostics.add(VerificationDiagnostic.failure(
-                    DiagnosticCode.EMPTY_SECTION,
-                    "Committed baseline not found: ${committedFile.absolutePath}"))
+                diagnostics.add(
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.EMPTY_SECTION,
+                        "Committed baseline not found: ${committedFile.absolutePath}",
+                    ),
+                )
                 return diagnosticsToReport(diagnostics)
             }
 
-            val committed: BaselineDocument = try {
-                ReportNormalizer.readJson(committedFile, BaselineDocument::class.java)
-            } catch (e: Exception) {
-                diagnostics.add(VerificationDiagnostic.failure(
-                    DiagnosticCode.EMPTY_SECTION,
-                    "Failed to read committed baseline: ${e.message}"))
-                return diagnosticsToReport(diagnostics)
-            }
+            val committed: BaselineDocument =
+                try {
+                    ReportNormalizer.readJson(committedFile, BaselineDocument::class.java)
+                } catch (e: Exception) {
+                    diagnostics.add(
+                        VerificationDiagnostic.failure(
+                            DiagnosticCode.EMPTY_SECTION,
+                            "Failed to read committed baseline: ${e.message}",
+                        ),
+                    )
+                    return diagnosticsToReport(diagnostics)
+                }
 
             // 2. Parse deviations with typed diagnostics
             val deviationResult = deviationParser.parse()
@@ -62,36 +69,48 @@ class BaselineVerifier(
             // 6. Generate current measurements (needed before catalogue validation)
             val currentGradle = ctx.gradleProject
             if (currentGradle == null) {
-                diagnostics.add(VerificationDiagnostic.failure(
-                    DiagnosticCode.EMPTY_SECTION,
-                    "Current baseline generation requires Gradle project mode"))
+                diagnostics.add(
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.EMPTY_SECTION,
+                        "Current baseline generation requires Gradle project mode",
+                    ),
+                )
                 return diagnosticsToReport(diagnostics)
             }
 
             val currentCtx = MeasurementContext.fromProject(currentGradle)
-            val tempGenerator = BaselineGenerator(
-                ctx = currentCtx,
-                outputDir = reportDir,
-                writeRepositoryArtifacts = false
-            )
+            val tempGenerator =
+                BaselineGenerator(
+                    ctx = currentCtx,
+                    outputDir = reportDir,
+                    writeRepositoryArtifacts = false,
+                )
 
-            val currentDependencies = try {
-                tempGenerator.generateResolvedDependencyGraph()
-            } catch (e: Exception) {
-                diagnostics.add(VerificationDiagnostic.failure(
-                    DiagnosticCode.DEPENDENCY_RESOLUTION_FAILED,
-                    "Failed to resolve current production dependencies: ${e.message}"))
-                return diagnosticsToReport(diagnostics)
-            }
+            val currentDependencies =
+                try {
+                    tempGenerator.generateResolvedDependencyGraph()
+                } catch (e: Exception) {
+                    diagnostics.add(
+                        VerificationDiagnostic.failure(
+                            DiagnosticCode.DEPENDENCY_RESOLUTION_FAILED,
+                            "Failed to resolve current production dependencies: ${e.message}",
+                        ),
+                    )
+                    return diagnosticsToReport(diagnostics)
+                }
 
-            val current: BaselineDocument = try {
-                tempGenerator.generateCompleteBaseline(dependencyOverride = currentDependencies)
-            } catch (e: Exception) {
-                diagnostics.add(VerificationDiagnostic.failure(
-                    DiagnosticCode.EMPTY_SECTION,
-                    "Failed to generate current baseline: ${e.message}"))
-                return diagnosticsToReport(diagnostics)
-            }
+            val current: BaselineDocument =
+                try {
+                    tempGenerator.generateCompleteBaseline(dependencyOverride = currentDependencies)
+                } catch (e: Exception) {
+                    diagnostics.add(
+                        VerificationDiagnostic.failure(
+                            DiagnosticCode.EMPTY_SECTION,
+                            "Failed to generate current baseline: ${e.message}",
+                        ),
+                    )
+                    return diagnosticsToReport(diagnostics)
+                }
 
             // 7. Verify module catalogue against CURRENT projects (not committed)
             verifyModuleCatalog(current, catalogResult, diagnostics)
@@ -100,31 +119,34 @@ class BaselineVerifier(
             verifyMandatorySections(current, diagnostics)
 
             // 9. Verify API and resolved dependency baselines with typed diagnostics
-            val apiValidationModules = currentGradle.allprojects
-                .filter { it.tasks.findByName("apiCheck") != null }
-                .map { it.path }
-                .toSet()
+            val apiValidationModules =
+                currentGradle.allprojects
+                    .filter { it.tasks.findByName("apiCheck") != null }
+                    .map { it.path }
+                    .toSet()
             diagnostics.addAll(
                 ApiBaselineVerifier(
                     repositoryRoot = ctx.rootDir,
                     catalogModules = catalogResult.modules,
-                    apiValidationModules = apiValidationModules
-                ).verify(committed.api, current.api)
+                    apiValidationModules = apiValidationModules,
+                ).verify(committed.api, current.api),
             )
-            val dependencyDiagnostics = DependencyBaselineVerifier().verify(
-                committed.dependencies.resolvedDependencies,
-                current.dependencies.resolvedDependencies
-            )
+            val dependencyDiagnostics =
+                DependencyBaselineVerifier().verify(
+                    committed.dependencies.resolvedDependencies,
+                    current.dependencies.resolvedDependencies,
+                )
             diagnostics.addAll(dependencyDiagnostics)
             ReportNormalizer.writeJson(
                 dependencyDiagnostics.filter {
-                    it.code in setOf(
-                        DiagnosticCode.DEPENDENCY_ADDED,
-                        DiagnosticCode.DEPENDENCY_REMOVED,
-                        DiagnosticCode.DEPENDENCY_VERSION_CHANGED
-                    )
+                    it.code in
+                        setOf(
+                            DiagnosticCode.DEPENDENCY_ADDED,
+                            DiagnosticCode.DEPENDENCY_REMOVED,
+                            DiagnosticCode.DEPENDENCY_VERSION_CHANGED,
+                        )
                 },
-                File(reportDir, "dependency-changes.json")
+                File(reportDir, "dependency-changes.json"),
             )
 
             // 10. Compare dimensions with FindingIdentity
@@ -149,60 +171,84 @@ class BaselineVerifier(
 
     private fun verifyBaselineIdentity(
         committed: BaselineDocument,
-        diagnostics: MutableList<VerificationDiagnostic>
+        diagnostics: MutableList<VerificationDiagnostic>,
     ) {
         val id = committed.baselineIdentity
 
         if (id.baselineCommitSha.isBlank()) {
-            diagnostics.add(VerificationDiagnostic.failure(
-                DiagnosticCode.BASELINE_IDENTITY_MISMATCH,
-                "Committed baseline has empty baselineCommitSha"))
+            diagnostics.add(
+                VerificationDiagnostic.failure(
+                    DiagnosticCode.BASELINE_IDENTITY_MISMATCH,
+                    "Committed baseline has empty baselineCommitSha",
+                ),
+            )
         }
         if (id.tramaiVersion == "unspecified" || id.tramaiVersion.isBlank()) {
-            diagnostics.add(VerificationDiagnostic.failure(
-                DiagnosticCode.BASELINE_IDENTITY_MISMATCH,
-                "Committed baseline has invalid tramaiVersion: '${id.tramaiVersion}'"))
+            diagnostics.add(
+                VerificationDiagnostic.failure(
+                    DiagnosticCode.BASELINE_IDENTITY_MISMATCH,
+                    "Committed baseline has invalid tramaiVersion: '${id.tramaiVersion}'",
+                ),
+            )
         }
 
         if (!id.workingTreeClean) {
-            diagnostics.add(VerificationDiagnostic.failure(
-                DiagnosticCode.DIRTY_WORKTREE,
-                "Committed baseline was generated from a dirty worktree"))
+            diagnostics.add(
+                VerificationDiagnostic.failure(
+                    DiagnosticCode.DIRTY_WORKTREE,
+                    "Committed baseline was generated from a dirty worktree",
+                ),
+            )
         }
         if (id.measuredSourceTreeHash.isBlank()) {
-            diagnostics.add(VerificationDiagnostic.failure(
-                DiagnosticCode.BASELINE_IDENTITY_MISMATCH,
-                "Committed baseline has empty measuredSourceTreeHash"))
+            diagnostics.add(
+                VerificationDiagnostic.failure(
+                    DiagnosticCode.BASELINE_IDENTITY_MISMATCH,
+                    "Committed baseline has empty measuredSourceTreeHash",
+                ),
+            )
         }
         if (id.measuredGitTreeSha.isBlank()) {
-            diagnostics.add(VerificationDiagnostic.failure(
-                DiagnosticCode.BASELINE_IDENTITY_MISMATCH,
-                "Committed baseline has empty measuredGitTreeSha"))
+            diagnostics.add(
+                VerificationDiagnostic.failure(
+                    DiagnosticCode.BASELINE_IDENTITY_MISMATCH,
+                    "Committed baseline has empty measuredGitTreeSha",
+                ),
+            )
         }
         if (id.analyzerCommitSha.isBlank()) {
-            diagnostics.add(VerificationDiagnostic.failure(
-                DiagnosticCode.BASELINE_IDENTITY_MISMATCH,
-                "Committed baseline has empty analyzerCommitSha"))
+            diagnostics.add(
+                VerificationDiagnostic.failure(
+                    DiagnosticCode.BASELINE_IDENTITY_MISMATCH,
+                    "Committed baseline has empty analyzerCommitSha",
+                ),
+            )
         }
 
         // Tag/commit/tree verification with typed diagnostics
         if (id.baselineCommitSha.isNotBlank() && id.measuredCommitSha.isNotBlank() &&
             id.baselineCommitSha != id.measuredCommitSha
         ) {
-            diagnostics.add(VerificationDiagnostic.failure(
-                DiagnosticCode.TAG_COMMIT_MISMATCH,
-                "Baseline provenance mismatch: measuredCommitSha (${id.measuredCommitSha.take(8)}) " +
-                    "differs from baselineCommitSha (${id.baselineCommitSha.take(8)})"))
+            diagnostics.add(
+                VerificationDiagnostic.failure(
+                    DiagnosticCode.TAG_COMMIT_MISMATCH,
+                    "Baseline provenance mismatch: measuredCommitSha (${id.measuredCommitSha.take(8)}) " +
+                        "differs from baselineCommitSha (${id.baselineCommitSha.take(8)})",
+                ),
+            )
         }
 
         // Independent tree SHA verification
         if (id.measuredGitTreeSha.isNotBlank() && id.measuredCommitSha.isNotBlank()) {
             val recomputedTreeSha = resolveRefOrFail("${id.measuredCommitSha}^{tree}", diagnostics)
             if (recomputedTreeSha != null && recomputedTreeSha != id.measuredGitTreeSha) {
-                diagnostics.add(VerificationDiagnostic.failure(
-                    DiagnosticCode.MEASURED_TREE_MISMATCH,
-                    "measuredGitTreeSha (${id.measuredGitTreeSha.take(8)}) does not match " +
-                        "independently computed tree SHA (${recomputedTreeSha.take(8)})"))
+                diagnostics.add(
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.MEASURED_TREE_MISMATCH,
+                        "measuredGitTreeSha (${id.measuredGitTreeSha.take(8)}) does not match " +
+                            "independently computed tree SHA (${recomputedTreeSha.take(8)})",
+                    ),
+                )
             }
         }
 
@@ -210,18 +256,24 @@ class BaselineVerifier(
         if (id.baselineCommitSha.isNotBlank()) {
             val tagCommit = resolveRefOrFail("${id.releaseTag}^{commit}", diagnostics)
             if (tagCommit != null && tagCommit != id.baselineCommitSha) {
-                diagnostics.add(VerificationDiagnostic.failure(
-                    DiagnosticCode.TAG_COMMIT_MISMATCH,
-                    "Release tag ${id.releaseTag} resolves to ${tagCommit.take(8)}, " +
-                        "but baseline claims ${id.baselineCommitSha.take(8)}"))
+                diagnostics.add(
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.TAG_COMMIT_MISMATCH,
+                        "Release tag ${id.releaseTag} resolves to ${tagCommit.take(8)}, " +
+                            "but baseline claims ${id.baselineCommitSha.take(8)}",
+                    ),
+                )
             }
             if (id.measuredGitTreeSha.isNotBlank()) {
                 val tagTree = resolveRefOrFail("${id.releaseTag}^{tree}", diagnostics)
                 if (tagTree != null && tagTree != id.measuredGitTreeSha) {
-                    diagnostics.add(VerificationDiagnostic.failure(
-                        DiagnosticCode.TAG_TREE_MISMATCH,
-                        "Release tag ${id.releaseTag} tree is ${tagTree.take(8)}, " +
-                            "but baseline records ${id.measuredGitTreeSha.take(8)}"))
+                    diagnostics.add(
+                        VerificationDiagnostic.failure(
+                            DiagnosticCode.TAG_TREE_MISMATCH,
+                            "Release tag ${id.releaseTag} tree is ${tagTree.take(8)}, " +
+                                "but baseline records ${id.measuredGitTreeSha.take(8)}",
+                        ),
+                    )
                 }
             }
         }
@@ -230,59 +282,79 @@ class BaselineVerifier(
         if (id.analyzerCommitSha.isNotBlank()) {
             val analyzerExists = resolveRefOrFail("${id.analyzerCommitSha}^{commit}", diagnostics)
             if (analyzerExists != null) {
-                val isAncestor = try {
-                    val process = ProcessBuilder(
-                        listOf("git", "merge-base", "--is-ancestor", id.analyzerCommitSha, "HEAD")
-                    ).directory(ctx.rootDir).redirectErrorStream(true).start()
-                    process.waitFor() == 0
-                } catch (_: Exception) { false }
+                val isAncestor =
+                    try {
+                        val process =
+                            ProcessBuilder(
+                                listOf("git", "merge-base", "--is-ancestor", id.analyzerCommitSha, "HEAD"),
+                            ).directory(ctx.rootDir).redirectErrorStream(true).start()
+                        process.waitFor() == 0
+                    } catch (_: Exception) {
+                        false
+                    }
 
                 if (!isAncestor) {
-                    diagnostics.add(VerificationDiagnostic.failure(
-                        DiagnosticCode.ANALYZER_COMMIT_NOT_ANCESTOR,
-                        "analyzerCommitSha (${id.analyzerCommitSha.take(8)}) is not an ancestor of HEAD"))
+                    diagnostics.add(
+                        VerificationDiagnostic.failure(
+                            DiagnosticCode.ANALYZER_COMMIT_NOT_ANCESTOR,
+                            "analyzerCommitSha (${id.analyzerCommitSha.take(8)}) is not an ancestor of HEAD",
+                        ),
+                    )
                 }
             }
         }
     }
 
-    private fun resolveRefOrFail(ref: String, diagnostics: MutableList<VerificationDiagnostic>): String? {
-        return try {
+    private fun resolveRefOrFail(
+        ref: String,
+        diagnostics: MutableList<VerificationDiagnostic>,
+    ): String? =
+        try {
             val result = ctx.runGit("rev-parse", ref)
             if (result.isBlank()) null else result
         } catch (e: Exception) {
-            diagnostics.add(VerificationDiagnostic.failure(
-                DiagnosticCode.BASELINE_IDENTITY_MISMATCH,
-                "Unable to resolve $ref: ${e.message}"))
+            diagnostics.add(
+                VerificationDiagnostic.failure(
+                    DiagnosticCode.BASELINE_IDENTITY_MISMATCH,
+                    "Unable to resolve $ref: ${e.message}",
+                ),
+            )
             null
         }
-    }
 
     // ─── Module catalogue verification ───
 
     private fun verifyModuleCatalog(
         current: BaselineDocument,
         catalogResult: ModuleCatalog.CatalogResult,
-        diagnostics: MutableList<VerificationDiagnostic>
+        diagnostics: MutableList<VerificationDiagnostic>,
     ) {
-        val projectPaths = current.structural.moduleDependencies.modules.toList()
+        val projectPaths =
+            current.structural.moduleDependencies.modules
+                .toList()
         val catalogModules = catalogResult.modules
 
         // Missing modules in catalogue
         for (projPath in projectPaths) {
             if (projPath !in catalogModules) {
-                diagnostics.add(VerificationDiagnostic.failure(
-                    DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY,
-                    "Gradle project '$projPath' has no module-catalog entry"))
+                diagnostics.add(
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY,
+                        "Gradle project '$projPath' has no module-catalog entry",
+                    ),
+                )
             }
         }
 
         // Unknown modules in catalogue
         for (catPath in catalogModules.keys) {
             if (catPath !in projectPaths) {
-                diagnostics.add(VerificationDiagnostic.failure(
-                    DiagnosticCode.MODULE_CATALOG_UNKNOWN_ENTRY,
-                    "Module-catalog entry '$catPath' does not exist as a Gradle project"))
+                diagnostics.add(
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.MODULE_CATALOG_UNKNOWN_ENTRY,
+                        "Module-catalog entry '$catPath' does not exist as a Gradle project",
+                    ),
+                )
             }
         }
 
@@ -290,18 +362,24 @@ class BaselineVerifier(
         for (mod in current.structural.modules) {
             val catalogEntry = catalogModules[mod.path] ?: continue
             if (catalogEntry.layer.yaml != mod.layer) {
-                diagnostics.add(VerificationDiagnostic.failure(
-                    DiagnosticCode.MODULE_CATALOG_DISAGREEMENT,
-                    "Module '${mod.path}': catalogue declares layer '${catalogEntry.layer.yaml}' but " +
-                        "current baseline has '${mod.layer}'"))
+                diagnostics.add(
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.MODULE_CATALOG_DISAGREEMENT,
+                        "Module '${mod.path}': catalogue declares layer '${catalogEntry.layer.yaml}' but " +
+                            "current baseline has '${mod.layer}'",
+                    ),
+                )
             }
 
             val expectedPublished = catalogEntry.publishability == ModulePublishability.PUBLISHED
             if (expectedPublished != mod.publishable) {
-                diagnostics.add(VerificationDiagnostic.failure(
-                    DiagnosticCode.MODULE_CATALOG_DISAGREEMENT,
-                    "Module '${mod.path}': catalogue declares publishability '${catalogEntry.publishability.yaml}' " +
-                        "but current baseline has '${if (mod.publishable) "published" else "not published"}'"))
+                diagnostics.add(
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.MODULE_CATALOG_DISAGREEMENT,
+                        "Module '${mod.path}': catalogue declares publishability '${catalogEntry.publishability.yaml}' " +
+                            "but current baseline has '${if (mod.publishable) "published" else "not published"}'",
+                    ),
+                )
             }
         }
     }
@@ -310,30 +388,41 @@ class BaselineVerifier(
 
     private fun verifyMandatorySections(
         current: BaselineDocument,
-        diagnostics: MutableList<VerificationDiagnostic>
+        diagnostics: MutableList<VerificationDiagnostic>,
     ) {
-        if (current.structural.moduleDependencies.modules.isEmpty()) {
-            diagnostics.add(VerificationDiagnostic.failure(
-                DiagnosticCode.EMPTY_SECTION, "Current baseline has empty module list"))
+        if (current.structural.moduleDependencies.modules
+                .isEmpty()
+        ) {
+            diagnostics.add(
+                VerificationDiagnostic.failure(DiagnosticCode.EMPTY_SECTION, "Current baseline has empty module list"),
+            )
         }
         if (current.runtimeSafety.cancellationCatches.isEmpty() &&
             current.runtimeSafety.testCancellationCatches.isEmpty()
         ) {
-            diagnostics.add(VerificationDiagnostic.failure(
-                DiagnosticCode.EMPTY_SECTION, "Current baseline has empty cancellation catch inventory"))
+            diagnostics.add(
+                VerificationDiagnostic.failure(DiagnosticCode.EMPTY_SECTION, "Current baseline has empty cancellation catch inventory"),
+            )
         }
-        if (current.structural.sourceMetrics.byModule.isEmpty()) {
-            diagnostics.add(VerificationDiagnostic.failure(
-                DiagnosticCode.EMPTY_SECTION, "Current baseline has empty source metrics"))
+        if (current.structural.sourceMetrics.byModule
+                .isEmpty()
+        ) {
+            diagnostics.add(
+                VerificationDiagnostic.failure(DiagnosticCode.EMPTY_SECTION, "Current baseline has empty source metrics"),
+            )
         }
         if (current.protocolCatalog.entries.isEmpty()) {
-            diagnostics.add(VerificationDiagnostic.failure(
-                DiagnosticCode.EMPTY_SECTION, "Current baseline has empty protocol catalog"))
+            diagnostics.add(
+                VerificationDiagnostic.failure(DiagnosticCode.EMPTY_SECTION, "Current baseline has empty protocol catalog"),
+            )
         }
         if (current.dependencies.resolvedDependencies.isEmpty()) {
-            diagnostics.add(VerificationDiagnostic.warning(
-                DiagnosticCode.DEPENDENCY_BASELINE_EMPTY,
-                "Current baseline has empty resolved dependencies"))
+            diagnostics.add(
+                VerificationDiagnostic.warning(
+                    DiagnosticCode.DEPENDENCY_BASELINE_EMPTY,
+                    "Current baseline has empty resolved dependencies",
+                ),
+            )
         }
     }
 
@@ -365,7 +454,7 @@ class BaselineVerifier(
         riskWorseCode: DiagnosticCode? = null,
         riskWorseningMetricName: String? = null,
         committedFindings: List<Any?>? = null,
-        diagnostics: MutableList<VerificationDiagnostic>
+        diagnostics: MutableList<VerificationDiagnostic>,
     ) {
         budgetEvaluator.evaluateDeviationBudget(
             metricName = metricName,
@@ -379,21 +468,18 @@ class BaselineVerifier(
             riskWorseCode = riskWorseCode,
             riskWorseningMetricName = riskWorseningMetricName,
             committedFindings = committedFindings,
-            diagnostics = diagnostics
+            diagnostics = diagnostics,
         )
     }
 
     /** Compute the FindingScope for module-based matching from a finding. */
-    private fun moduleScope(finding: Any?): DeviationParser.FindingScope =
-        DeviationBudgetEvaluator.moduleScope(finding)
+    private fun moduleScope(finding: Any?): DeviationParser.FindingScope = DeviationBudgetEvaluator.moduleScope(finding)
 
     /** Extract the module path string from an arbitrary finding. */
-    private fun modulePathOf(finding: Any?): String =
-        DeviationBudgetEvaluator.modulePathOf(finding)
+    private fun modulePathOf(finding: Any?): String = DeviationBudgetEvaluator.modulePathOf(finding)
 
     /** Extract a stable identity key from an arbitrary finding. */
-    private fun findingIdentityKey(finding: Any?): String =
-        DeviationBudgetEvaluator.findingIdentityKey(finding)
+    private fun findingIdentityKey(finding: Any?): String = DeviationBudgetEvaluator.findingIdentityKey(finding)
 
     // ─── Finding-level comparison with FindingIdentity ───
 
@@ -401,18 +487,20 @@ class BaselineVerifier(
         committed: BaselineDocument,
         current: BaselineDocument,
         deviations: List<DeviationParser.DeviationEntry>,
-        diagnostics: MutableList<VerificationDiagnostic>
+        diagnostics: MutableList<VerificationDiagnostic>,
     ) {
         val allCurrent = current.runtimeSafety.cancellationCatches.toList<Any?>()
         evaluateDeviationBudget(
             metricName = "cancellationCriticalCount",
             deviations = deviations,
-            committedIds = committed.runtimeSafety.cancellationCatches.map {
-                FindingIdentity.fromCancellationCatch(it).toIdentityKey()
-            },
-            currentIds = current.runtimeSafety.cancellationCatches.map {
-                FindingIdentity.fromCancellationCatch(it).toIdentityKey()
-            },
+            committedIds =
+                committed.runtimeSafety.cancellationCatches.map {
+                    FindingIdentity.fromCancellationCatch(it).toIdentityKey()
+                },
+            currentIds =
+                current.runtimeSafety.cancellationCatches.map {
+                    FindingIdentity.fromCancellationCatch(it).toIdentityKey()
+                },
             allCurrent = allCurrent,
             riskFilter = { f -> (f as CancellationCatchFinding).risk == "critical" },
             toModuleScope = { f -> moduleScope(f) },
@@ -420,18 +508,25 @@ class BaselineVerifier(
             riskWorseCode = DiagnosticCode.CANCELLATION_RISK_WORSENED,
             riskWorseningMetricName = "cancellationRiskWorsening",
             committedFindings = committed.runtimeSafety.cancellationCatches.toList<Any?>(),
-            diagnostics = diagnostics
+            diagnostics = diagnostics,
         )
 
-        val removed = committed.runtimeSafety.cancellationCatches.map {
-            FindingIdentity.fromCancellationCatch(it).toIdentityKey()
-        }.toSet() - current.runtimeSafety.cancellationCatches.map {
-            FindingIdentity.fromCancellationCatch(it).toIdentityKey()
-        }.toSet()
+        val removed =
+            committed.runtimeSafety.cancellationCatches
+                .map {
+                    FindingIdentity.fromCancellationCatch(it).toIdentityKey()
+                }.toSet() -
+                current.runtimeSafety.cancellationCatches
+                    .map {
+                        FindingIdentity.fromCancellationCatch(it).toIdentityKey()
+                    }.toSet()
         if (removed.isNotEmpty()) {
-            diagnostics.add(VerificationDiagnostic.improvement(
-                DiagnosticCode.NEW_CANCELLATION_FINDING,
-                "${removed.size} cancellation catch(es) resolved"))
+            diagnostics.add(
+                VerificationDiagnostic.improvement(
+                    DiagnosticCode.NEW_CANCELLATION_FINDING,
+                    "${removed.size} cancellation catch(es) resolved",
+                ),
+            )
         }
     }
 
@@ -439,22 +534,24 @@ class BaselineVerifier(
         committed: BaselineDocument,
         current: BaselineDocument,
         deviations: List<DeviationParser.DeviationEntry>,
-        diagnostics: MutableList<VerificationDiagnostic>
+        diagnostics: MutableList<VerificationDiagnostic>,
     ) {
         val allCurrent = current.runtimeSafety.globalState.toList<Any?>()
         evaluateDeviationBudget(
             metricName = "globalMutableState",
             deviations = deviations,
-            committedIds = committed.runtimeSafety.globalState.map {
-                FindingIdentity.fromGlobalState(it).toIdentityKey()
-            },
-            currentIds = current.runtimeSafety.globalState.map {
-                FindingIdentity.fromGlobalState(it).toIdentityKey()
-            },
+            committedIds =
+                committed.runtimeSafety.globalState.map {
+                    FindingIdentity.fromGlobalState(it).toIdentityKey()
+                },
+            currentIds =
+                current.runtimeSafety.globalState.map {
+                    FindingIdentity.fromGlobalState(it).toIdentityKey()
+                },
             allCurrent = allCurrent,
             toModuleScope = { f -> moduleScope(f) },
             diagnosticCode = DiagnosticCode.NEW_GLOBAL_STATE_FINDING,
-            diagnostics = diagnostics
+            diagnostics = diagnostics,
         )
     }
 
@@ -462,22 +559,24 @@ class BaselineVerifier(
         committed: BaselineDocument,
         current: BaselineDocument,
         deviations: List<DeviationParser.DeviationEntry>,
-        diagnostics: MutableList<VerificationDiagnostic>
+        diagnostics: MutableList<VerificationDiagnostic>,
     ) {
         val allCurrent = current.runtimeSafety.nondeterminism.toList<Any?>()
         evaluateDeviationBudget(
             metricName = "nondeterminismSources",
             deviations = deviations,
-            committedIds = committed.runtimeSafety.nondeterminism.map {
-                FindingIdentity.fromNondeterminism(it).toIdentityKey()
-            },
-            currentIds = current.runtimeSafety.nondeterminism.map {
-                FindingIdentity.fromNondeterminism(it).toIdentityKey()
-            },
+            committedIds =
+                committed.runtimeSafety.nondeterminism.map {
+                    FindingIdentity.fromNondeterminism(it).toIdentityKey()
+                },
+            currentIds =
+                current.runtimeSafety.nondeterminism.map {
+                    FindingIdentity.fromNondeterminism(it).toIdentityKey()
+                },
             allCurrent = allCurrent,
             toModuleScope = { f -> moduleScope(f) },
             diagnosticCode = DiagnosticCode.NEW_NONDETERMINISM_FINDING,
-            diagnostics = diagnostics
+            diagnostics = diagnostics,
         )
     }
 
@@ -485,30 +584,42 @@ class BaselineVerifier(
         committed: BaselineDocument,
         current: BaselineDocument,
         deviations: List<DeviationParser.DeviationEntry>,
-        diagnostics: MutableList<VerificationDiagnostic>
+        diagnostics: MutableList<VerificationDiagnostic>,
     ) {
-        val committedCycles = committed.structural.moduleDependencies.cycles.map { it.sorted().joinToString("\u2192") }.toSet()
-        val currentCycles = current.structural.moduleDependencies.cycles.map { it.sorted().joinToString("\u2192") }.toSet()
+        val committedCycles =
+            committed.structural.moduleDependencies.cycles
+                .map { it.sorted().joinToString("\u2192") }
+                .toSet()
+        val currentCycles =
+            current.structural.moduleDependencies.cycles
+                .map { it.sorted().joinToString("\u2192") }
+                .toSet()
 
         val newCycles = currentCycles - committedCycles
         for (cycle in newCycles) {
-            diagnostics.add(VerificationDiagnostic.failure(
-                DiagnosticCode.NEW_DEPENDENCY_CYCLE,
-                "New dependency cycle detected: $cycle"))
+            diagnostics.add(
+                VerificationDiagnostic.failure(
+                    DiagnosticCode.NEW_DEPENDENCY_CYCLE,
+                    "New dependency cycle detected: $cycle",
+                ),
+            )
         }
 
         val removedCycles = committedCycles - currentCycles
         if (removedCycles.isNotEmpty()) {
-            diagnostics.add(VerificationDiagnostic.improvement(
-                DiagnosticCode.NEW_DEPENDENCY_CYCLE,
-                "Dependency cycles resolved: ${removedCycles.joinToString(", ")}"))
+            diagnostics.add(
+                VerificationDiagnostic.improvement(
+                    DiagnosticCode.NEW_DEPENDENCY_CYCLE,
+                    "Dependency cycles resolved: ${removedCycles.joinToString(", ")}",
+                ),
+            )
         }
     }
 
     private fun verifyForbiddenEdges(
         committed: BaselineDocument,
         current: BaselineDocument,
-        diagnostics: MutableList<VerificationDiagnostic>
+        diagnostics: MutableList<VerificationDiagnostic>,
     ) {
         // Check edges from current Gradle mode (which has dependency resolution)
         for (edge in current.structural.moduleDependencies.edges) {
@@ -519,16 +630,21 @@ class BaselineVerifier(
         }
     }
 
-    private fun verifyDependencyPolicies(current: BaselineDocument, diagnostics: MutableList<VerificationDiagnostic>) {
+    private fun verifyDependencyPolicies(
+        current: BaselineDocument,
+        diagnostics: MutableList<VerificationDiagnostic>,
+    ) {
         for (edge in current.structural.moduleDependencies.edges) {
             val allowed = moduleCatalog.allowedLayersFor(edge.from) ?: continue
             val target = moduleCatalog.entryFor(edge.to) ?: continue
             if (target.layer !in allowed) {
-                diagnostics.add(VerificationDiagnostic.failure(
-                    DiagnosticCode.FORBIDDEN_LAYER_EDGE,
-                    "Dependency policy violation: ${edge.from} may not depend on ${edge.to} (${target.layer.yaml})",
-                    modulePath = edge.from
-                ))
+                diagnostics.add(
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.FORBIDDEN_LAYER_EDGE,
+                        "Dependency policy violation: ${edge.from} may not depend on ${edge.to} (${target.layer.yaml})",
+                        modulePath = edge.from,
+                    ),
+                )
             }
         }
     }
@@ -536,29 +652,37 @@ class BaselineVerifier(
     private fun verifyProtocolCatalog(
         committed: BaselineDocument,
         current: BaselineDocument,
-        diagnostics: MutableList<VerificationDiagnostic>
+        diagnostics: MutableList<VerificationDiagnostic>,
     ) {
-        val committedByKey = committed.protocolCatalog.entries.associateBy {
-            "${it.category}::${it.name}::${it.value}::${it.source}"
-        }
-        val currentByKey = current.protocolCatalog.entries.associateBy {
-            "${it.category}::${it.name}::${it.value}::${it.source}"
-        }
+        val committedByKey =
+            committed.protocolCatalog.entries.associateBy {
+                "${it.category}::${it.name}::${it.value}::${it.source}"
+            }
+        val currentByKey =
+            current.protocolCatalog.entries.associateBy {
+                "${it.category}::${it.name}::${it.value}::${it.source}"
+            }
 
         for ((key, entry) in committedByKey) {
             if (entry.stability == "stable-contract" && key !in currentByKey) {
-                diagnostics.add(VerificationDiagnostic.failure(
-                    DiagnosticCode.STABLE_PROTOCOL_CONTRACT_REMOVED,
-                    "Stable protocol contract removed: ${entry.name} (${entry.category})"))
+                diagnostics.add(
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.STABLE_PROTOCOL_CONTRACT_REMOVED,
+                        "Stable protocol contract removed: ${entry.name} (${entry.category})",
+                    ),
+                )
             }
         }
 
         val committedUnclassified = committed.protocolCatalog.entries.count { it.stability == "unclassified" }
         val currentUnclassified = current.protocolCatalog.entries.count { it.stability == "unclassified" }
         if (currentUnclassified > committedUnclassified) {
-            diagnostics.add(VerificationDiagnostic.warning(
-                DiagnosticCode.STABLE_PROTOCOL_CONTRACT_REMOVED,
-                "Unclassified protocol entries increased: $committedUnclassified \u2192 $currentUnclassified"))
+            diagnostics.add(
+                VerificationDiagnostic.warning(
+                    DiagnosticCode.STABLE_PROTOCOL_CONTRACT_REMOVED,
+                    "Unclassified protocol entries increased: $committedUnclassified \u2192 $currentUnclassified",
+                ),
+            )
         }
     }
 
@@ -566,7 +690,7 @@ class BaselineVerifier(
         committed: BaselineDocument,
         current: BaselineDocument,
         deviations: List<DeviationParser.DeviationEntry>,
-        diagnostics: MutableList<VerificationDiagnostic>
+        diagnostics: MutableList<VerificationDiagnostic>,
     ) {
         // Validate deviation baselines against committed measurements
         validateDeviationBaselines(committed, deviations, diagnostics)
@@ -576,37 +700,46 @@ class BaselineVerifier(
 
             when (dev.metric) {
                 "constructorParameterCount" -> {
-                    val matchedHotspots = current.structural.structuralHotspots.mostConstructorParameters
-                        .filter { h -> scopeMatchesHotspot(parsedScope, h) }
+                    val matchedHotspots =
+                        current.structural.structuralHotspots.mostConstructorParameters
+                            .filter { h -> scopeMatchesHotspot(parsedScope, h) }
 
                     for (hotspot in matchedHotspots) {
                         if (hotspot.value > dev.allowed) {
-                            diagnostics.add(VerificationDiagnostic.failure(
-                                DiagnosticCode.HOTSPOT_REGRESSION,
-                                "${dev.id}: ${hotspot.module}/${hotspot.declaration} constructor has ${hotspot.value} " +
-                                    "parameters, exceeds allowed ${dev.allowed}",
-                                modulePath = hotspot.module,
-                                deviationId = dev.id,
-                                baselineValue = dev.baseline.toString(),
-                                currentValue = hotspot.value.toString()))
+                            diagnostics.add(
+                                VerificationDiagnostic.failure(
+                                    DiagnosticCode.HOTSPOT_REGRESSION,
+                                    "${dev.id}: ${hotspot.module}/${hotspot.declaration} constructor has ${hotspot.value} " +
+                                        "parameters, exceeds allowed ${dev.allowed}",
+                                    modulePath = hotspot.module,
+                                    deviationId = dev.id,
+                                    baselineValue = dev.baseline.toString(),
+                                    currentValue = hotspot.value.toString(),
+                                ),
+                            )
                         }
                     }
                 }
+
                 "fileSize" -> {
-                    val allFiles = current.structural.structuralHotspots.largestProductionFiles +
-                        current.structural.structuralHotspots.largestBuildFiles
+                    val allFiles =
+                        current.structural.structuralHotspots.largestProductionFiles +
+                            current.structural.structuralHotspots.largestBuildFiles
                     val matchedHotspots = allFiles.filter { h -> scopeMatchesHotspot(parsedScope, h) }
 
                     for (hotspot in matchedHotspots) {
                         if (hotspot.value > dev.allowed) {
-                            diagnostics.add(VerificationDiagnostic.failure(
-                                DiagnosticCode.HOTSPOT_REGRESSION,
-                                "${dev.id}: file ${hotspot.path} is ${hotspot.value} lines, " +
-                                    "exceeds allowed ${dev.allowed}",
-                                modulePath = hotspot.module,
-                                deviationId = dev.id,
-                                baselineValue = dev.baseline.toString(),
-                                currentValue = hotspot.value.toString()))
+                            diagnostics.add(
+                                VerificationDiagnostic.failure(
+                                    DiagnosticCode.HOTSPOT_REGRESSION,
+                                    "${dev.id}: file ${hotspot.path} is ${hotspot.value} lines, " +
+                                        "exceeds allowed ${dev.allowed}",
+                                    modulePath = hotspot.module,
+                                    deviationId = dev.id,
+                                    baselineValue = dev.baseline.toString(),
+                                    currentValue = hotspot.value.toString(),
+                                ),
+                            )
                         }
                     }
                 }
@@ -614,23 +747,39 @@ class BaselineVerifier(
         }
 
         // Top-5 change detection
-        val committedTop = committed.structural.structuralHotspots.largestProductionFiles.take(5).map { it.path }.toSet()
-        val currentTop = current.structural.structuralHotspots.largestProductionFiles.take(5).map { it.path }.toSet()
+        val committedTop =
+            committed.structural.structuralHotspots.largestProductionFiles
+                .take(5)
+                .map { it.path }
+                .toSet()
+        val currentTop =
+            current.structural.structuralHotspots.largestProductionFiles
+                .take(5)
+                .map { it.path }
+                .toSet()
         val newInTop = currentTop - committedTop
         if (newInTop.isNotEmpty()) {
-            diagnostics.add(VerificationDiagnostic.warning(
-                DiagnosticCode.NEW_TOP_FIVE_HOTSPOT,
-                "New files entered top-5 production hotspots: ${newInTop.joinToString(", ")}"))
+            diagnostics.add(
+                VerificationDiagnostic.warning(
+                    DiagnosticCode.NEW_TOP_FIVE_HOTSPOT,
+                    "New files entered top-5 production hotspots: ${newInTop.joinToString(", ")}",
+                ),
+            )
         }
 
         // 20% growth detection
-        val committedByPath = committed.structural.structuralHotspots.largestProductionFiles.associateBy { it.path }
+        val committedByPath =
+            committed.structural.structuralHotspots.largestProductionFiles
+                .associateBy { it.path }
         for (currentHotspot in current.structural.structuralHotspots.largestProductionFiles) {
             val committedHotspot = committedByPath[currentHotspot.path]
             if (committedHotspot != null && currentHotspot.value > committedHotspot.value * 1.2) {
-                diagnostics.add(VerificationDiagnostic.warning(
-                    DiagnosticCode.FILE_GROWTH_EXCEEDED,
-                    "${currentHotspot.path} grew >20%: ${committedHotspot.value} \u2192 ${currentHotspot.value} lines"))
+                diagnostics.add(
+                    VerificationDiagnostic.warning(
+                        DiagnosticCode.FILE_GROWTH_EXCEEDED,
+                        "${currentHotspot.path} grew >20%: ${committedHotspot.value} \u2192 ${currentHotspot.value} lines",
+                    ),
+                )
             }
         }
 
@@ -640,35 +789,45 @@ class BaselineVerifier(
             if (dev.metric != "fileSize" && dev.metric != "constructorParameterCount") continue
             if (parsedScope.filePath == null && !parsedScope.isWildcard) continue
 
-            val allHotspots = current.structural.structuralHotspots.largestProductionFiles +
-                current.structural.structuralHotspots.largestBuildFiles +
-                current.structural.structuralHotspots.mostConstructorParameters +
-                current.structural.structuralHotspots.mostFunctionParameters
+            val allHotspots =
+                current.structural.structuralHotspots.largestProductionFiles +
+                    current.structural.structuralHotspots.largestBuildFiles +
+                    current.structural.structuralHotspots.mostConstructorParameters +
+                    current.structural.structuralHotspots.mostFunctionParameters
 
-            val matched = allHotspots.any { h ->
-                val findingScope = DeviationParser.FindingScope(
-                    modulePath = if (h.module.startsWith(":")) h.module else ":${h.module}",
-                    repositoryPath = h.path,
-                    declaration = h.declaration.ifBlank { null }
-                )
-                parsedScope.covers(findingScope)
-            }
+            val matched =
+                allHotspots.any { h ->
+                    val findingScope =
+                        DeviationParser.FindingScope(
+                            modulePath = if (h.module.startsWith(":")) h.module else ":${h.module}",
+                            repositoryPath = h.path,
+                            declaration = h.declaration.ifBlank { null },
+                        )
+                    parsedScope.covers(findingScope)
+                }
 
             if (!matched && !parsedScope.isWildcard) {
-                diagnostics.add(VerificationDiagnostic.warning(
-                    DiagnosticCode.ORPHANED_DEVIATION,
-                    "${dev.id}: deviation scope '${dev.scope}' does not match any current hotspot — orphaned?"))
+                diagnostics.add(
+                    VerificationDiagnostic.warning(
+                        DiagnosticCode.ORPHANED_DEVIATION,
+                        "${dev.id}: deviation scope '${dev.scope}' does not match any current hotspot — orphaned?",
+                    ),
+                )
             }
         }
     }
 
     /** Check whether a structural hotspot matches a parsed deviation scope. */
-    private fun scopeMatchesHotspot(scope: DeviationParser.DeviationScope, hotspot: StructuralHotspot): Boolean {
-        val findingScope = DeviationParser.FindingScope(
-            modulePath = if (hotspot.module.startsWith(":")) hotspot.module else ":${hotspot.module}",
-            repositoryPath = hotspot.path,
-            declaration = hotspot.declaration.ifBlank { null }
-        )
+    private fun scopeMatchesHotspot(
+        scope: DeviationParser.DeviationScope,
+        hotspot: StructuralHotspot,
+    ): Boolean {
+        val findingScope =
+            DeviationParser.FindingScope(
+                modulePath = if (hotspot.module.startsWith(":")) hotspot.module else ":${hotspot.module}",
+                repositoryPath = hotspot.path,
+                declaration = hotspot.declaration.ifBlank { null },
+            )
         return scope.covers(findingScope)
     }
 
@@ -680,17 +839,20 @@ class BaselineVerifier(
     private fun validateDeviationBaselines(
         committed: BaselineDocument,
         deviations: List<DeviationParser.DeviationEntry>,
-        diagnostics: MutableList<VerificationDiagnostic>
+        diagnostics: MutableList<VerificationDiagnostic>,
     ) {
         for (dev in deviations) {
             val actualBaseline = computeCommittedBaseline(committed, dev.metric, dev.scope)
             if (actualBaseline != null && actualBaseline != dev.baseline) {
-                diagnostics.add(VerificationDiagnostic.failure(
-                    DiagnosticCode.DEVIATION_BASELINE_MISMATCH,
-                    "${dev.id}: recorded baseline ${dev.baseline} does not match canonical measurement $actualBaseline for metric '${dev.metric}' at scope '${dev.scope}'",
-                    deviationId = dev.id,
-                    baselineValue = dev.baseline.toString(),
-                    currentValue = actualBaseline.toString()))
+                diagnostics.add(
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.DEVIATION_BASELINE_MISMATCH,
+                        "${dev.id}: recorded baseline ${dev.baseline} does not match canonical measurement $actualBaseline for metric '${dev.metric}' at scope '${dev.scope}'",
+                        deviationId = dev.id,
+                        baselineValue = dev.baseline.toString(),
+                        currentValue = actualBaseline.toString(),
+                    ),
+                )
             }
         }
     }
@@ -704,7 +866,7 @@ class BaselineVerifier(
     private fun computeCommittedBaseline(
         committed: BaselineDocument,
         metric: String,
-        scope: String
+        scope: String,
     ): Int? {
         val parsedScope = deviationParser.parseScope(scope) ?: return null
 
@@ -714,52 +876,70 @@ class BaselineVerifier(
         }
 
         return when (metric) {
-            "cancellationCriticalCount" ->
+            "cancellationCriticalCount" -> {
                 committed.runtimeSafety.cancellationCatches.count {
                     it.risk == "critical" && matchesScope(it.module)
                 }
-            "cancellationRiskWorsening" -> null
-            "globalMutableState" ->
+            }
+
+            "cancellationRiskWorsening" -> {
+                null
+            }
+
+            "globalMutableState" -> {
                 committed.runtimeSafety.globalState.count {
                     matchesScope(it.module)
                 }
-            "nondeterminismSources" ->
+            }
+
+            "nondeterminismSources" -> {
                 committed.runtimeSafety.nondeterminism.count {
                     matchesScope(it.module)
                 }
+            }
+
             "constructorParameterCount" -> {
                 // Filter committed constructor hotspots by scope, get max value
-                val matched = committed.structural.structuralHotspots.mostConstructorParameters.filter { h ->
-                    val fs = DeviationParser.FindingScope(
-                        modulePath = if (h.module.startsWith(":")) h.module else ":$h.module",
-                        repositoryPath = h.path,
-                        declaration = h.declaration.ifBlank { null }
-                    )
-                    parsedScope.covers(fs)
-                }
+                val matched =
+                    committed.structural.structuralHotspots.mostConstructorParameters.filter { h ->
+                        val fs =
+                            DeviationParser.FindingScope(
+                                modulePath = if (h.module.startsWith(":")) h.module else ":$h.module",
+                                repositoryPath = h.path,
+                                declaration = h.declaration.ifBlank { null },
+                            )
+                        parsedScope.covers(fs)
+                    }
                 if (matched.isEmpty()) null else matched.maxOf { it.value }
             }
+
             "fileSize" -> {
                 // Filter committed file hotspots by scope, get max value
-                val allCommittedFiles = committed.structural.structuralHotspots.largestProductionFiles +
-                    committed.structural.structuralHotspots.largestBuildFiles
-                val matched = allCommittedFiles.filter { h ->
-                    val fs = DeviationParser.FindingScope(
-                        modulePath = if (h.module.startsWith(":")) h.module else ":$h.module",
-                        repositoryPath = h.path,
-                        declaration = null
-                    )
-                    parsedScope.covers(fs)
-                }
+                val allCommittedFiles =
+                    committed.structural.structuralHotspots.largestProductionFiles +
+                        committed.structural.structuralHotspots.largestBuildFiles
+                val matched =
+                    allCommittedFiles.filter { h ->
+                        val fs =
+                            DeviationParser.FindingScope(
+                                modulePath = if (h.module.startsWith(":")) h.module else ":$h.module",
+                                repositoryPath = h.path,
+                                declaration = null,
+                            )
+                        parsedScope.covers(fs)
+                    }
                 if (matched.isEmpty()) null else matched.maxOf { it.value }
             }
-            else -> null
+
+            else -> {
+                null
+            }
         }
     }
 
     private fun verifyDocumentDrift(
         committed: BaselineDocument,
-        diagnostics: MutableList<VerificationDiagnostic>
+        diagnostics: MutableList<VerificationDiagnostic>,
     ) {
         val releaseNotesFile = File(ctx.rootDir, "docs/releases/0.6.0-maintainability-baseline.md")
         if (!releaseNotesFile.isFile) return
@@ -769,18 +949,24 @@ class BaselineVerifier(
         // Verify baseline SHA in release notes matches baseline JSON
         val canonicalSha = committed.baselineIdentity.baselineCommitSha
         if (canonicalSha.isNotBlank() && canonicalSha !in content) {
-            diagnostics.add(VerificationDiagnostic.failure(
-                DiagnosticCode.GENERATED_DOCUMENT_DRIFT,
-                "Release notes do not reference baseline commit SHA $canonicalSha"))
+            diagnostics.add(
+                VerificationDiagnostic.failure(
+                    DiagnosticCode.GENERATED_DOCUMENT_DRIFT,
+                    "Release notes do not reference baseline commit SHA $canonicalSha",
+                ),
+            )
         }
 
         // Verify module count
         val moduleCount = committed.structural.modules.size
         val moduleCountRefs = Regex("""(\d+)\s*modules?""", RegexOption.IGNORE_CASE).findAll(content)
         if (moduleCountRefs.any { it.groupValues[1].toIntOrNull() != moduleCount }) {
-            diagnostics.add(VerificationDiagnostic.warning(
-                DiagnosticCode.GENERATED_DOCUMENT_DRIFT,
-                "Release notes module count may differ from canonical baseline ($moduleCount)"))
+            diagnostics.add(
+                VerificationDiagnostic.warning(
+                    DiagnosticCode.GENERATED_DOCUMENT_DRIFT,
+                    "Release notes module count may differ from canonical baseline ($moduleCount)",
+                ),
+            )
         }
     }
 
@@ -789,28 +975,33 @@ class BaselineVerifier(
     private fun writeVerificationReport(diagnostics: List<VerificationDiagnostic>) {
         reportDir.mkdirs()
 
-        val executionSha = try {
-            ctx.runGit("rev-parse", "HEAD")
-        } catch (_: Exception) { "unknown" }
-
-        val report = mapOf(
-            "schemaVersion" to "1",
-            "description" to "TramAI 0.6.0 maintainability verification report",
-            "executionHeadSha" to executionSha,
-            "passed" to diagnostics.none { it.severity == DiagnosticSeverity.FAILURE },
-            "diagnostics" to diagnostics.map { diag ->
-                mapOf(
-                    "code" to diag.code.name,
-                    "severity" to diag.severity.name,
-                    "message" to diag.message,
-                    "modulePath" to diag.modulePath,
-                    "findingId" to diag.findingId,
-                    "deviationId" to diag.deviationId,
-                    "baselineValue" to diag.baselineValue,
-                    "currentValue" to diag.currentValue
-                ).filter { it.value != null }
+        val executionSha =
+            try {
+                ctx.runGit("rev-parse", "HEAD")
+            } catch (_: Exception) {
+                "unknown"
             }
-        )
+
+        val report =
+            mapOf(
+                "schemaVersion" to "1",
+                "description" to "TramAI 0.6.0 maintainability verification report",
+                "executionHeadSha" to executionSha,
+                "passed" to diagnostics.none { it.severity == DiagnosticSeverity.FAILURE },
+                "diagnostics" to
+                    diagnostics.map { diag ->
+                        mapOf(
+                            "code" to diag.code.name,
+                            "severity" to diag.severity.name,
+                            "message" to diag.message,
+                            "modulePath" to diag.modulePath,
+                            "findingId" to diag.findingId,
+                            "deviationId" to diag.deviationId,
+                            "baselineValue" to diag.baselineValue,
+                            "currentValue" to diag.currentValue,
+                        ).filter { it.value != null }
+                    },
+            )
         ReportNormalizer.writeJson(report, File(reportDir, "verification-report.json"))
     }
 

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/DependencyResolutionTasks.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/DependencyResolutionTasks.kt
@@ -9,11 +9,16 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
@@ -39,7 +44,6 @@ data class DependencyResolutionResult(
  * dependencies (fail-closed).
  */
 abstract class GenerateResolvedDependencyBaselineTask : DefaultTask() {
-
     init {
         outputs.upToDateWhen { false }
     }
@@ -64,6 +68,64 @@ abstract class GenerateResolvedDependencyBaselineTask : DefaultTask() {
             file.parentFile.mkdirs()
             ReportNormalizer.writeJson(normalized, file)
         }
+    }
+}
+
+/**
+ * Aggregates the per-project resolved dependency probes into one sorted
+ * baseline file (Epic 9.2d-a3c1 typed extraction of the root doLast closure).
+ *
+ * [probeFiles] and [expectedProbeOwners] are index-aligned: same index = same
+ * project. Fail-closed on missing or malformed probes with the exact legacy
+ * diagnostics. Configuration-cache compatible — no Task.project access at
+ * execution time.
+ */
+abstract class AggregateResolvedDependencyBaselineTask : DefaultTask() {
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val probeFiles: ConfigurableFileCollection
+
+    @get:Input
+    abstract val expectedProbeOwners: ListProperty<String>
+
+    @get:OutputFile
+    abstract val aggregateFile: RegularFileProperty
+
+    @TaskAction
+    fun aggregate() {
+        val owners = expectedProbeOwners.get()
+        val files = probeFiles.files.toList()
+        if (owners.size != files.size) {
+            throw GradleException(
+                "Dependency probe aggregation misconfigured: ${owners.size} expected owners but ${files.size} probe files",
+            )
+        }
+        val allRecords = mutableListOf<ResolvedDependency>()
+        owners.forEachIndexed { index, owner ->
+            val probeFile = files[index]
+            if (!probeFile.isFile) {
+                throw GradleException(
+                    "Missing dependency probe output for $owner: ${probeFile.absolutePath}",
+                )
+            }
+            val records =
+                try {
+                    ReportNormalizer.readJson(probeFile, Array<ResolvedDependency>::class.java).toList()
+                } catch (e: Exception) {
+                    throw GradleException(
+                        "Invalid dependency probe output for $owner: ${e.message}",
+                        e,
+                    )
+                }
+            allRecords.addAll(records)
+        }
+        val sorted = BaselineGenerator.sortResolvedDependencies(allRecords)
+        val output = aggregateFile.get().asFile
+        output.parentFile.mkdirs()
+        ReportNormalizer.writeJson(sorted, output)
+        val direct = sorted.count { it.direct }
+        val transitive = sorted.size - direct
+        println("Resolved dependency baseline: ${sorted.size} records ($direct direct, $transitive transitive)")
     }
 }
 
@@ -98,7 +160,7 @@ internal fun collectResolvedDependencies(
                 path = listOf(consumerPath),
                 depth = 0,
                 ancestry = mutableSetOf(root.id.displayName),
-                records = records
+                records = records,
             )
         }
     return records
@@ -115,7 +177,6 @@ internal fun collectResolvedDependencies(
  * all state is declared as task inputs.
  */
 abstract class ArchitectureDependencyProbeTask : DefaultTask() {
-
     init {
         outputs.upToDateWhen { false }
     }
@@ -158,23 +219,24 @@ private fun traverseDependencyTree(
     path: List<String>,
     depth: Int,
     ancestry: MutableSet<String>,
-    records: MutableList<ResolvedDependency>
+    records: MutableList<ResolvedDependency>,
 ) {
     component.dependencies.toList().sortedBy { it.requested.displayName }.forEach { dep ->
         if (dep is UnresolvedDependencyResult) {
             throw GradleException(
                 "Failed to resolve $consumer:$configuration dependency " +
-                    "${dep.requested.displayName}: ${dep.failure.message}"
+                    "${dep.requested.displayName}: ${dep.failure.message}",
             )
         }
         if (dep is ResolvedDependencyResult) {
             val selected = dep.selected
             val selectedId = selected.id
-            val pathElement = when (selectedId) {
-                is ModuleComponentIdentifier -> "${selectedId.group}:${selectedId.module}:${selectedId.version}"
-                is ProjectComponentIdentifier -> selectedId.projectPath
-                else -> selectedId.displayName
-            }
+            val pathElement =
+                when (selectedId) {
+                    is ModuleComponentIdentifier -> "${selectedId.group}:${selectedId.module}:${selectedId.version}"
+                    is ProjectComponentIdentifier -> selectedId.projectPath
+                    else -> selectedId.displayName
+                }
             val nextPath = path + pathElement
 
             if (selectedId is ModuleComponentIdentifier) {
@@ -187,13 +249,14 @@ private fun traverseDependencyTree(
                         requestedVersion = requested,
                         direct = depth == 0,
                         configuration = configuration,
-                        selectionReason = selected.selectionReason.descriptions
-                            .map { it.description }
-                            .sorted()
-                            .joinToString("; "),
+                        selectionReason =
+                            selected.selectionReason.descriptions
+                                .map { it.description }
+                                .sorted()
+                                .joinToString("; "),
                         dependencyPath = nextPath,
-                        consumers = listOf(consumer)
-                    )
+                        consumers = listOf(consumer),
+                    ),
                 )
             }
 
@@ -206,7 +269,7 @@ private fun traverseDependencyTree(
                     path = nextPath,
                     depth = depth + 1,
                     ancestry = ancestry,
-                    records = records
+                    records = records,
                 )
             }
         }

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/DependencyResolutionTasks.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/DependencyResolutionTasks.kt
@@ -94,7 +94,10 @@ abstract class AggregateResolvedDependencyBaselineTask : DefaultTask() {
     @TaskAction
     fun aggregate() {
         val owners = expectedProbeOwners.get()
-        val files = probeFiles.files.toList()
+        // Iterate the FileCollection itself (documented to preserve supplied-path
+        // order), NOT .files which returns an order-insensitive Set<File> — the
+        // index-aligned owner/file contract must not depend on Set semantics.
+        val files = probeFiles.toList()
         if (owners.size != files.size) {
             throw GradleException(
                 "Dependency probe aggregation misconfigured: ${owners.size} expected owners but ${files.size} probe files",

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
@@ -1006,6 +1006,12 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                 description = "Verifies manifest/settings equality and publishing/BOM membership against independent Gradle model signals"
                 moduleCatalogFile.set(project.layout.projectDirectory.file("config/quality/module-catalog.yml"))
                 projectPaths.set(ModuleTopologySnapshot.projectPaths(project))
+                // Fail-closed default: without the release plugin the historical
+                // implementation supplied an EMPTY publication set and produced the
+                // typed MODULE_CATALOG_PUBLISHING_DRIFT diagnostic. Preserve that —
+                // never die on an unset property. The withPlugin wiring below
+                // overrides the convention with the release task's typed model.
+                publishedPaths.convention(emptyList())
                 // BOM signal read LAZILY through a provider: the java-platform model
                 // is incomplete at plugin apply time (Epic 9.2d-a1 rule). Never eager,
                 // never a Configuration as a task property — converted to List<String>.

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
@@ -1,16 +1,17 @@
 package dev.tramai.build.quality
 
+import dev.tramai.build.release.VerifyPublicationMetadataTask
+import org.gradle.api.Action
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.GradleException
-import org.gradle.api.Action
 import org.gradle.api.plugins.JavaPluginExtension
-import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.testing.Test
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaToolchainService
-import org.gradle.testing.jacoco.tasks.JacocoReport
 import org.gradle.kotlin.dsl.register
+import org.gradle.testing.jacoco.tasks.JacocoReport
 import java.io.File
 import javax.xml.parsers.DocumentBuilderFactory
 
@@ -21,7 +22,6 @@ import javax.xml.parsers.DocumentBuilderFactory
  * Apply in root build.gradle.kts with: `plugins { id("tramai.maintainability-baseline") }`
  */
 abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
-
     override fun apply(project: Project) {
         if (project != project.rootProject) return
 
@@ -34,7 +34,13 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
         val nondeterminismInventory = NondeterminismInventory(ctx)
         val testQualityConfiguration = TestQualityConfiguration.load(project.rootDir)
         val criticalModules = testQualityConfiguration.criticalModules.toSet()
-        val reportDir = File(project.layout.buildDirectory.get().asFile, "reports/maintainability")
+        val reportDir =
+            File(
+                project.layout.buildDirectory
+                    .get()
+                    .asFile,
+                "reports/maintainability",
+            )
 
         // Register JaCoCo on critical modules using provider-safe API (no tasks.matching / executionData(TaskCollection))
         val criticalTestTaskPaths = criticalModules.sorted().map { "$it:test" }
@@ -56,15 +62,18 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                             html.required.set(true)
                         }
                         // Filter class directories to exclude patterns using Gradle fileTree
-                        val mainSourceSet = criticalProject.extensions.getByType(
-                            org.gradle.api.plugins.JavaPluginExtension::class.java
-                        ).sourceSets.getByName("main")
+                        val mainSourceSet =
+                            criticalProject.extensions
+                                .getByType(
+                                    org.gradle.api.plugins.JavaPluginExtension::class.java,
+                                ).sourceSets
+                                .getByName("main")
                         classDirectories.from(
                             mainSourceSet.output.classesDirs.files.map { root ->
                                 criticalProject.fileTree(root) {
                                     exclude(excludedPatterns)
                                 }
-                            }
+                            },
                         )
                     }
                 }
@@ -77,81 +86,67 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             description = "Generates per-module public API dump records"
             doLast {
                 val apiBaseline = generator.generateApiBaseline()
-                println("Public API baseline: ${apiBaseline.modules.size} modules, " +
-                    "${apiBaseline.modules.count { it.applicable }} applicable, " +
-                    "${apiBaseline.modules.count { it.sha256.isNotBlank() }} with dumps")
+                println(
+                    "Public API baseline: ${apiBaseline.modules.size} modules, " +
+                        "${apiBaseline.modules.count { it.applicable }} applicable, " +
+                        "${apiBaseline.modules.count { it.sha256.isNotBlank() }} with dumps",
+                )
             }
         }
 
         // Register per-project dependency probe tasks (Gradle 9: each task owns its config)
         val perProjectProbeTasks = mutableListOf<String>()
+        val dependencyProbeTaskName = "generateResolvedDependencyBaseline"
         project.allprojects.filter { it != project && it.buildFile.exists() }.forEach { sub ->
-            val taskName = "generateResolvedDependencyBaseline"
-            val probe = sub.tasks.register(taskName, GenerateResolvedDependencyBaselineTask::class.java)
+            val probe = sub.tasks.register(dependencyProbeTaskName, GenerateResolvedDependencyBaselineTask::class.java)
             probe.configure {
                 group = "maintainability"
                 description = "Resolves external dependencies for ${sub.path}"
                 outputFile.set(
-                    sub.layout.buildDirectory.file("reports/maintainability/resolved-dependencies.json")
+                    sub.layout.buildDirectory.file("reports/maintainability/resolved-dependencies.json"),
                 )
                 val probePath = sub.path
                 consumerPath.set(probePath)
-                resolution.set(sub.provider {
-                    val probeConfigs = listOf("compileClasspath", "runtimeClasspath")
-                        .mapNotNull { name -> sub.configurations.findByName(name) }
-                    runCatching { collectResolvedDependencies(probePath, probeConfigs) }
-                        .fold(
-                            onSuccess = { DependencyResolutionResult(it) },
-                            onFailure = { e ->
-                                DependencyResolutionResult(
-                                    records = emptyList(),
-                                    failureMessage = e.message ?: e.javaClass.name,
-                                )
-                            },
-                        )
-                })
+                resolution.set(
+                    sub.provider {
+                        val probeConfigs =
+                            listOf("compileClasspath", "runtimeClasspath")
+                                .mapNotNull { name -> sub.configurations.findByName(name) }
+                        runCatching { collectResolvedDependencies(probePath, probeConfigs) }
+                            .fold(
+                                onSuccess = { DependencyResolutionResult(it) },
+                                onFailure = { e ->
+                                    DependencyResolutionResult(
+                                        records = emptyList(),
+                                        failureMessage = e.message ?: e.javaClass.name,
+                                    )
+                                },
+                            )
+                    },
+                )
             }
-            perProjectProbeTasks.add("${sub.path}:$taskName")
+            perProjectProbeTasks.add("${sub.path}:$dependencyProbeTaskName")
         }
 
-        // Root aggregation task depends on all per-project probes and merges their outputs
-        project.tasks.register("generateResolvedDependencyBaseline") {
+        // Root aggregation task depends on all per-project probes and merges their outputs.
+        // Typed (Epic 9.2d-a3c1): probeFiles + expectedProbeOwners are paired,
+        // index-aligned inputs built in the same deterministic (sorted) order.
+        val expectedAggregateProjects =
+            project.allprojects
+                .filter { it != project && it.buildFile.exists() }
+                .sortedBy { it.path }
+        project.tasks.register<AggregateResolvedDependencyBaselineTask>("generateResolvedDependencyBaseline") {
             group = "maintainability"
             description = "Aggregates per-project resolved dependency baselines"
             dependsOn(*perProjectProbeTasks.toTypedArray())
-            doLast {
-                val reportDir = File(project.layout.buildDirectory.get().asFile, "reports/maintainability")
-                reportDir.mkdirs()
-                val aggregateFile = File(reportDir, "resolved-dependencies.json")
-                val allRecords = mutableListOf<ResolvedDependency>()
-                val expectedProjects = project.allprojects
-                    .filter { it != project && it.buildFile.exists() }
-                    .sortedBy { it.path }
-
-                expectedProjects.forEach { sub ->
-                    val probeFile = File(
-                        sub.layout.buildDirectory.get().asFile,
-                        "reports/maintainability/resolved-dependencies.json"
-                    )
-                    if (!probeFile.isFile) {
-                        throw GradleException(
-                            "Missing dependency probe output for ${sub.path}: ${probeFile.absolutePath}"
-                        )
-                    }
-                    val records = try {
-                        ReportNormalizer.readJson(probeFile, Array<ResolvedDependency>::class.java).toList()
-                    } catch (e: Exception) {
-                        throw GradleException(
-                            "Invalid dependency probe output for ${sub.path}: ${e.message}", e
-                        )
-                    }
-                    allRecords.addAll(records)
-                }
-                val sorted = BaselineGenerator.sortResolvedDependencies(allRecords)
-                ReportNormalizer.writeJson(sorted, aggregateFile)
-                val direct = sorted.count { it.direct }
-                val transitive = sorted.size - direct
-                println("Resolved dependency baseline: ${sorted.size} records ($direct direct, $transitive transitive)")
+            aggregateFile.set(project.layout.buildDirectory.file("reports/maintainability/resolved-dependencies.json"))
+            expectedAggregateProjects.forEach { sub ->
+                probeFiles.from(
+                    sub.tasks
+                        .named(dependencyProbeTaskName, GenerateResolvedDependencyBaselineTask::class.java)
+                        .flatMap { it.outputFile },
+                )
+                expectedProbeOwners.add(sub.path)
             }
         }
 
@@ -166,24 +161,27 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                 group = "verification"
                 description = "Resolves external dependencies for ${sub.path} (fail-soft, architecture gate)"
                 outputFile.set(
-                    sub.layout.buildDirectory.file("reports/maintainability/architecture-dependencies.json")
+                    sub.layout.buildDirectory.file("reports/maintainability/architecture-dependencies.json"),
                 )
                 val probePath = sub.path
                 consumerPath.set(probePath)
-                resolution.set(sub.provider {
-                    val probeConfigs = listOf("compileClasspath", "runtimeClasspath")
-                        .mapNotNull { name -> sub.configurations.findByName(name) }
-                    runCatching { collectResolvedDependencies(probePath, probeConfigs) }
-                        .fold(
-                            onSuccess = { DependencyResolutionResult(it) },
-                            onFailure = { e ->
-                                DependencyResolutionResult(
-                                    records = emptyList(),
-                                    failureMessage = e.message ?: e.javaClass.name,
-                                )
-                            },
-                        )
-                })
+                resolution.set(
+                    sub.provider {
+                        val probeConfigs =
+                            listOf("compileClasspath", "runtimeClasspath")
+                                .mapNotNull { name -> sub.configurations.findByName(name) }
+                        runCatching { collectResolvedDependencies(probePath, probeConfigs) }
+                            .fold(
+                                onSuccess = { DependencyResolutionResult(it) },
+                                onFailure = { e ->
+                                    DependencyResolutionResult(
+                                        records = emptyList(),
+                                        failureMessage = e.message ?: e.javaClass.name,
+                                    )
+                                },
+                            )
+                    },
+                )
             }
             architectureProbeTasks.add("${sub.path}:architectureDependencyProbe")
         }
@@ -235,7 +233,13 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                 val findings = cancellationInventory.inventory()
                 val critical = findings.count { it.risk == "critical" }
                 val high = findings.count { it.risk == "high" }
-                val outDir = File(project.layout.buildDirectory.get().asFile, "reports/maintainability")
+                val outDir =
+                    File(
+                        project.layout.buildDirectory
+                            .get()
+                            .asFile,
+                        "reports/maintainability",
+                    )
                 outDir.mkdirs()
                 ReportNormalizer.writeJson(mapOf("findings" to findings), File(outDir, "cancellation-safety.json"))
                 println("Cancellation catch inventory: ${findings.size} findings ($critical critical, $high high)")
@@ -247,7 +251,13 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             description = "Scans for process-global mutable state"
             doLast {
                 val findings = globalStateInventory.inventory()
-                val outDir = File(project.layout.buildDirectory.get().asFile, "reports/maintainability")
+                val outDir =
+                    File(
+                        project.layout.buildDirectory
+                            .get()
+                            .asFile,
+                        "reports/maintainability",
+                    )
                 outDir.mkdirs()
                 ReportNormalizer.writeJson(mapOf("findings" to findings), File(outDir, "global-state.json"))
                 println("Global state inventory: ${findings.size} mutable globals found")
@@ -259,7 +269,13 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             description = "Scans for direct clock/randomness/identity access"
             doLast {
                 val findings = nondeterminismInventory.inventory()
-                val outDir = File(project.layout.buildDirectory.get().asFile, "reports/maintainability")
+                val outDir =
+                    File(
+                        project.layout.buildDirectory
+                            .get()
+                            .asFile,
+                        "reports/maintainability",
+                    )
                 outDir.mkdirs()
                 ReportNormalizer.writeJson(mapOf("findings" to findings), File(outDir, "nondeterminism.json"))
                 val byCategory = findings.groupBy { it.category }
@@ -273,7 +289,11 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             description = "Reads the resolved dependency baseline and prints summary"
             dependsOn("generateResolvedDependencyBaseline")
             doLast {
-                val file = project.layout.buildDirectory.file("reports/maintainability/resolved-dependencies.json").get().asFile
+                val file =
+                    project.layout.buildDirectory
+                        .file("reports/maintainability/resolved-dependencies.json")
+                        .get()
+                        .asFile
                 if (file.isFile) {
                     val deps = ReportNormalizer.readJson(file, Array<ResolvedDependency>::class.java).toList()
                     println("Resolved dependency graph: ${deps.size} dependencies")
@@ -295,16 +315,17 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             description = "Generates JaCoCo coverage measurements for critical modules"
             dependsOn(criticalCoverageReportTaskPaths)
             doLast {
-                val coverage = CoverageCollector(
-                    project.rootDir,
-                    testQualityConfiguration
-                ).collect()
+                val coverage =
+                    CoverageCollector(
+                        project.rootDir,
+                        testQualityConfiguration,
+                    ).collect()
                 reportDir.mkdirs()
                 ReportNormalizer.writeJson(coverage, File(reportDir, "coverage-summary.json"))
                 println(
                     "Critical coverage baseline: ${coverage.criticalModules.size} modules, " +
                         "${"%.2f".format(coverage.overallLineCoverage)}% lines, " +
-                        "${"%.2f".format(coverage.overallBranchCoverage)}% branches"
+                        "${"%.2f".format(coverage.overallBranchCoverage)}% branches",
                 )
             }
         }
@@ -318,7 +339,7 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                 val initScript = File(reportDir, "critical-mutation-probe.init.gradle")
                 initScript.writeText(
                     mutationInitScript(testQualityConfiguration, mutationRoot),
-                    Charsets.UTF_8
+                    Charsets.UTF_8,
                 )
                 testQualityConfiguration.mutation.targetFamilies.keys.sorted().forEach { family ->
                     runNestedGradle(
@@ -327,18 +348,19 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                             "--init-script",
                             initScript.absolutePath,
                             "-PtramaiMutationFamily=$family",
-                            "canonicalMutationProbe"
-                        )
+                            "canonicalMutationProbe",
+                        ),
                     )
                 }
-                val mutation = generator.generateMutationBaseline(
-                    testQualityConfiguration,
-                    mutationRoot
-                )
+                val mutation =
+                    generator.generateMutationBaseline(
+                        testQualityConfiguration,
+                        mutationRoot,
+                    )
                 ReportNormalizer.writeJson(mutation, File(reportDir, "mutation-summary.json"))
                 println(
                     "Critical mutation baseline: ${mutation.totalMutants} mutants, " +
-                        "${"%.2f".format(mutation.mutationScore)}% killed"
+                        "${"%.2f".format(mutation.mutationScore)}% killed",
                 )
             }
         }
@@ -355,24 +377,25 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
 
                 runNestedGradle(project, listOf("--rerun-tasks") + testTaskPaths)
                 val collector = TestPerformanceCollector(project.rootDir, testQualityConfiguration)
-                val observations = (1..3).flatMap { run ->
-                    runNestedGradle(project, listOf("--rerun-tasks") + testTaskPaths)
-                    copyTestReports(project.rootDir, criticalModules, File(runsRoot, run.toString()))
-                    collector.collectMeasuredRun(
-                        run = run,
-                        gradleVersion = project.gradle.gradleVersion,
-                        reportRoot = runsRoot
-                    )
-                }
+                val observations =
+                    (1..3).flatMap { run ->
+                        runNestedGradle(project, listOf("--rerun-tasks") + testTaskPaths)
+                        copyTestReports(project.rootDir, criticalModules, File(runsRoot, run.toString()))
+                        collector.collectMeasuredRun(
+                            run = run,
+                            gradleVersion = project.gradle.gradleVersion,
+                            reportRoot = runsRoot,
+                        )
+                    }
                 val performance = TestPerformanceAggregator().aggregate(observations)
                 ReportNormalizer.writeJson(
                     observations,
-                    File(outputRoot, "observations.json")
+                    File(outputRoot, "observations.json"),
                 )
                 ReportNormalizer.writeJson(performance, File(outputRoot, "median.json"))
                 println(
                     "Test performance baseline: ${performance.totalTestCount} tests, " +
-                        "${performance.totalDurationMs}ms aggregate median"
+                        "${performance.totalDurationMs}ms aggregate median",
                 )
             }
         }
@@ -391,7 +414,7 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                 "generateNondeterminismInventory",
                 "generatePublicApiBaseline",
                 "generateResolvedDependencyBaseline",
-                "generateRuntimeProtocolCatalog"
+                "generateRuntimeProtocolCatalog",
             )
             doLast {
                 val baseline = generator.generateCompleteBaseline()
@@ -407,35 +430,39 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                 "generateMaintainabilityBaseline",
                 "generateCoverageBaseline",
                 "generateTestPerformanceBaseline",
-                "generateCriticalMutationBaseline"
+                "generateCriticalMutationBaseline",
             )
             doLast {
                 val baselineFile = File(project.rootDir, "config/quality/0.6.0-baseline.json")
                 val generated = generator.generateFullBaseline()
-                val structuralBaseline = ReportNormalizer.readJson(
-                    baselineFile,
-                    BaselineDocument::class.java
-                )
-                val coverage = ReportNormalizer.readJson(
-                    File(reportDir, "coverage-summary.json"),
-                    CoverageData::class.java
-                )
-                val mutation = ReportNormalizer.readJson(
-                    File(reportDir, "mutation-summary.json"),
-                    MutationData::class.java
-                )
-                val performance = ReportNormalizer.readJson(
-                    File(reportDir, "test-performance/median.json"),
-                    TestPerformanceData::class.java
-                )
+                val structuralBaseline =
+                    ReportNormalizer.readJson(
+                        baselineFile,
+                        BaselineDocument::class.java,
+                    )
+                val coverage =
+                    ReportNormalizer.readJson(
+                        File(reportDir, "coverage-summary.json"),
+                        CoverageData::class.java,
+                    )
+                val mutation =
+                    ReportNormalizer.readJson(
+                        File(reportDir, "mutation-summary.json"),
+                        MutationData::class.java,
+                    )
+                val performance =
+                    ReportNormalizer.readJson(
+                        File(reportDir, "test-performance/median.json"),
+                        TestPerformanceData::class.java,
+                    )
                 generator.updateBaselineJson(
                     structuralBaseline.copy(
                         baselineIdentity = generated.baselineIdentity,
                         testQuality = TestQualityBaseline(performance, coverage, mutation),
                         generatedAt = generated.generatedAt,
                         generatedBy = "generateFullMaintainabilityBaseline",
-                        environment = generated.environment
-                    )
+                        environment = generated.environment,
+                    ),
                 )
                 println("Full maintainability baseline generated: ${baselineFile.absolutePath}")
             }
@@ -467,7 +494,13 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             doLast {
                 val ctx = MeasurementContext.fromProject(project)
                 val generator = BaselineGenerator(ctx)
-                val reportDir = File(project.layout.buildDirectory.get().asFile, "reports/maintainability")
+                val reportDir =
+                    File(
+                        project.layout.buildDirectory
+                            .get()
+                            .asFile,
+                        "reports/maintainability",
+                    )
                 val verifier = BaselineVerifier(generator, ctx, reportDir)
                 val report = verifier.verify()
 
@@ -479,10 +512,11 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                 report.acceptedDeviations.forEach { project.logger.info("ACCEPTED: $it") }
 
                 if (!report.passed) {
-                    val summary = "Maintainability baseline verification FAILED:\n" +
-                        report.failures.joinToString("\n") { "  - $it" } +
-                        "\n\nRun './gradlew generateMaintainabilityBaseline' to regenerate." +
-                        "\nAdd deviations to config/quality/maintainability-deviations.yml for accepted regressions."
+                    val summary =
+                        "Maintainability baseline verification FAILED:\n" +
+                            report.failures.joinToString("\n") { "  - $it" } +
+                            "\n\nRun './gradlew generateMaintainabilityBaseline' to regenerate." +
+                            "\nAdd deviations to config/quality/maintainability-deviations.yml for accepted regressions."
                     throw GradleException(summary)
                 }
 
@@ -509,24 +543,30 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
         // the scanner's execution universe are the same set.
         val nonDetCtx = MeasurementContext.fromProject(project)
         val nonDetSourceFiles = project.objects.fileCollection()
-        val nonDetScanSpec = nonDetCtx.modules.map { mod ->
-            listOf("src/main/kotlin", "src/main/java").forEach { rel ->
-                val dir = File(mod.projectDir, rel)
-                nonDetSourceFiles.from(
-                    project.fileTree(mapOf("dir" to dir, "include" to listOf("**/*.kt", "**/*.java")))
-                )
+        val nonDetScanSpec =
+            nonDetCtx.modules.map { mod ->
+                listOf("src/main/kotlin", "src/main/java").forEach { rel ->
+                    val dir = File(mod.projectDir, rel)
+                    nonDetSourceFiles.from(
+                        project.fileTree(mapOf("dir" to dir, "include" to listOf("**/*.kt", "**/*.java"))),
+                    )
+                }
+                mapOf("name" to mod.name, "dir" to mod.projectDir.relativeTo(project.rootDir).path)
             }
-            mapOf("name" to mod.name, "dir" to mod.projectDir.relativeTo(project.rootDir).path)
-        }
         project.tasks.register("verifyRuntimeNondeterminism", VerifyRuntimeNondeterminismTask::class.java) {
             group = "maintainability"
-            description = "Fails on unclassified, stale, mismatched, or occurrence-drifted entries in config/quality/runtime-nondeterminism.yml"
+            description =
+                "Fails on unclassified, stale, mismatched, or occurrence-drifted entries in config/quality/runtime-nondeterminism.yml"
             allowlistFile.set(project.rootDir.resolve("config/quality/runtime-nondeterminism.yml"))
             sourceFiles.from(nonDetSourceFiles)
             scanSpec.set(
-                com.fasterxml.jackson.databind.ObjectMapper()
-                    .registerModule(com.fasterxml.jackson.module.kotlin.KotlinModule.Builder().build())
-                    .writeValueAsString(nonDetScanSpec)
+                com.fasterxml.jackson.databind
+                    .ObjectMapper()
+                    .registerModule(
+                        com.fasterxml.jackson.module.kotlin.KotlinModule
+                            .Builder()
+                            .build(),
+                    ).writeValueAsString(nonDetScanSpec),
             )
             rootDir.set(project.rootDir.absolutePath)
             reportFile.set(project.layout.buildDirectory.file("reports/maintainability/runtime-nondeterminism-verification.json"))
@@ -534,17 +574,19 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
 
         project.tasks.register("verifyCancellationSafety") {
             group = "maintainability"
-            description = "Scans all production source for broad catches in suspend-capable code and rejects newly introduced critical/high findings and risk worsenings. Accepts -PtramaiCancellationBaseSha for PR base SHA comparison."
+            description =
+                "Scans all production source for broad catches in suspend-capable code and rejects newly introduced critical/high findings and risk worsenings. Accepts -PtramaiCancellationBaseSha for PR base SHA comparison."
             doLast {
                 val scanningCtx = MeasurementContext.fromProject(project)
                 val inventory = CancellationCatchInventory(scanningCtx)
                 val findings = inventory.inventory()
 
                 // Derive scope from all non-example modules
-                val scopedModules = scanningCtx.modules
-                    .map { it.path }
-                    .filterNot { it.startsWith(":examples:") }
-                    .toSet()
+                val scopedModules =
+                    scanningCtx.modules
+                        .map { it.path }
+                        .filterNot { it.startsWith(":examples:") }
+                        .toSet()
 
                 val scopedFindings = findings.filter { it.module in scopedModules }
 
@@ -553,19 +595,26 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
 
                 if (baseSha != null) {
                     // ── PR mode: compare against base SHA ──
-                    val worktreeDir = java.nio.file.Files.createTempDirectory("tramai-base-${baseSha.take(8)}-").toFile()
+                    val worktreeDir =
+                        java.nio.file.Files
+                            .createTempDirectory("tramai-base-${baseSha.take(8)}-")
+                            .toFile()
                     val baseCatches: List<CancellationCatchFinding>
                     var worktreeCreated = false
 
                     try {
                         // Create temporary git worktree at base SHA
-                        val addProcess = ProcessBuilder(
-                            "git", "worktree", "add",
-                            worktreeDir.absolutePath, baseSha, "--detach"
-                        )
-                            .directory(project.rootDir)
-                            .redirectErrorStream(true)
-                            .start()
+                        val addProcess =
+                            ProcessBuilder(
+                                "git",
+                                "worktree",
+                                "add",
+                                worktreeDir.absolutePath,
+                                baseSha,
+                                "--detach",
+                            ).directory(project.rootDir)
+                                .redirectErrorStream(true)
+                                .start()
                         val addOutput = addProcess.inputStream.bufferedReader().readText()
                         val addExit = addProcess.waitFor()
                         if (addExit != 0) throw GradleException("Failed to create worktree at $baseSha: $addOutput")
@@ -601,17 +650,22 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                     println("verifyCancellationSafety PASSED: no new critical/high findings or risk worsenings against base SHA.")
                 } else {
                     // ── Local dev mode: auto-resolve merge base against origin/master ──
-                    val resolveProcess = ProcessBuilder("git", "merge-base", "HEAD", "origin/master")
-                        .directory(project.rootDir)
-                        .redirectErrorStream(true)
-                        .start()
-                    val resolveOutput = resolveProcess.inputStream.bufferedReader().readText().trim()
+                    val resolveProcess =
+                        ProcessBuilder("git", "merge-base", "HEAD", "origin/master")
+                            .directory(project.rootDir)
+                            .redirectErrorStream(true)
+                            .start()
+                    val resolveOutput =
+                        resolveProcess.inputStream
+                            .bufferedReader()
+                            .readText()
+                            .trim()
                     val resolveExit = resolveProcess.waitFor()
                     if (resolveExit != 0) {
                         throw GradleException(
                             "verifyCancellationSafety requires -PtramaiCancellationBaseSha when origin/master is not available.\n" +
-                            "Usage: ./gradlew verifyCancellationSafety -PtramaiCancellationBaseSha=<sha>\n" +
-                            "In CI this is auto-wired. Locally, use the base branch SHA."
+                                "Usage: ./gradlew verifyCancellationSafety -PtramaiCancellationBaseSha=<sha>\n" +
+                                "In CI this is auto-wired. Locally, use the base branch SHA.",
                         )
                     }
 
@@ -619,18 +673,25 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                     println("verifyCancellationSafety: auto-resolved merge base against origin/master = ${baseShaLocal.take(8)}")
 
                     // Scan merge base using the same worktree approach
-                    val worktreeDir = java.nio.file.Files.createTempDirectory("tramai-base-${baseShaLocal.take(8)}-").toFile()
+                    val worktreeDir =
+                        java.nio.file.Files
+                            .createTempDirectory("tramai-base-${baseShaLocal.take(8)}-")
+                            .toFile()
                     val localBaseCatches: List<CancellationCatchFinding>
                     var worktreeCreated = false
 
                     try {
-                        val addProcess = ProcessBuilder(
-                            "git", "worktree", "add",
-                            worktreeDir.absolutePath, baseShaLocal, "--detach"
-                        )
-                            .directory(project.rootDir)
-                            .redirectErrorStream(true)
-                            .start()
+                        val addProcess =
+                            ProcessBuilder(
+                                "git",
+                                "worktree",
+                                "add",
+                                worktreeDir.absolutePath,
+                                baseShaLocal,
+                                "--detach",
+                            ).directory(project.rootDir)
+                                .redirectErrorStream(true)
+                                .start()
                         val addOutput = addProcess.inputStream.bufferedReader().readText()
                         val addExit = addProcess.waitFor()
                         if (addExit != 0) throw GradleException("Failed to create worktree at $baseShaLocal: $addOutput")
@@ -662,7 +723,9 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                     }
 
                     println(delta.diagnostics.joinToString("\n"))
-                    println("verifyCancellationSafety PASSED: ${scopedFindings.size} findings in scoped modules, no new critical/high findings or risk worsenings against origin/master.")
+                    println(
+                        "verifyCancellationSafety PASSED: ${scopedFindings.size} findings in scoped modules, no new critical/high findings or risk worsenings against origin/master.",
+                    )
                 }
             }
         }
@@ -673,15 +736,16 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             dependsOn("generateCoverageBaseline")
             doLast {
                 val committed = readCommittedBaseline(project)
-                val current = ReportNormalizer.readJson(
-                    File(reportDir, "coverage-summary.json"),
-                    CoverageData::class.java
-                )
+                val current =
+                    ReportNormalizer.readJson(
+                        File(reportDir, "coverage-summary.json"),
+                        CoverageData::class.java,
+                    )
                 verifyTestQualityDiagnostics(
                     project,
                     "Critical coverage",
                     CoverageBaselineVerifier(testQualityConfiguration)
-                        .verify(committed.testQuality.coverage, current)
+                        .verify(committed.testQuality.coverage, current),
                 )
             }
         }
@@ -692,15 +756,16 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             dependsOn("generateCriticalMutationBaseline")
             doLast {
                 val committed = readCommittedBaseline(project)
-                val current = ReportNormalizer.readJson(
-                    File(reportDir, "mutation-summary.json"),
-                    MutationData::class.java
-                )
+                val current =
+                    ReportNormalizer.readJson(
+                        File(reportDir, "mutation-summary.json"),
+                        MutationData::class.java,
+                    )
                 verifyTestQualityDiagnostics(
                     project,
                     "Critical mutation",
                     MutationBaselineVerifier(testQualityConfiguration, project.rootDir)
-                        .verify(committed.testQuality.mutation, current)
+                        .verify(committed.testQuality.mutation, current),
                 )
             }
         }
@@ -711,15 +776,16 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             dependsOn("generateTestPerformanceBaseline")
             doLast {
                 val committed = readCommittedBaseline(project)
-                val current = ReportNormalizer.readJson(
-                    File(reportDir, "test-performance/median.json"),
-                    TestPerformanceData::class.java
-                )
+                val current =
+                    ReportNormalizer.readJson(
+                        File(reportDir, "test-performance/median.json"),
+                        TestPerformanceData::class.java,
+                    )
                 verifyTestQualityDiagnostics(
                     project,
                     "Test performance",
                     TestPerformanceVerifier(testQualityConfiguration)
-                        .verify(committed.testQuality.testPerformance, current)
+                        .verify(committed.testQuality.testPerformance, current),
                 )
             }
         }
@@ -731,95 +797,118 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
 
         project.tasks.register("generateCanonicalMaintainabilityBaseline") {
             group = "maintainability"
-            description = "Generates the canonical baseline from v0.5.0. Set -Pmaintainability.sourceRoot=<worktree> to scan a detached checkout."
+            description =
+                "Generates the canonical baseline from v0.5.0. Set -Pmaintainability.sourceRoot=<worktree> to scan a detached checkout."
 
             doLast {
                 // Verify the analyzer (PR) checkout is clean before generation
-                val analyzerStatus = ProcessBuilder(listOf("git", "status", "--porcelain"))
-                    .directory(project.rootDir)
-                    .redirectErrorStream(true)
-                    .start()
+                val analyzerStatus =
+                    ProcessBuilder(listOf("git", "status", "--porcelain"))
+                        .directory(project.rootDir)
+                        .redirectErrorStream(true)
+                        .start()
                 val analyzerOutput = analyzerStatus.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
                 val analyzerExitCode = analyzerStatus.waitFor()
                 project.logger.lifecycle("DEBUG analyzer checkout: exit=$analyzerExitCode output='${analyzerOutput.trim()}'")
                 if (analyzerExitCode != 0 || analyzerOutput.isNotBlank()) {
                     throw GradleException(
                         "Analyzer checkout must be clean before canonical generation.\n" +
-                            "Commit or stash changes in ${project.rootDir} first."
+                            "Commit or stash changes in ${project.rootDir} first.",
                     )
                 }
 
                 val sourceRootProp = project.findProperty("maintainability.sourceRoot")?.toString()
-                val canonicalGenerator = if (sourceRootProp != null) {
-                    val sourceRoot = project.rootDir.resolve(sourceRootProp).normalize()
-                    if (!sourceRoot.isDirectory) {
-                        throw GradleException("maintainability.sourceRoot='$sourceRootProp' resolved to '${sourceRoot.absolutePath}' but is not a directory")
+                val canonicalGenerator =
+                    if (sourceRootProp != null) {
+                        val sourceRoot = project.rootDir.resolve(sourceRootProp).normalize()
+                        if (!sourceRoot.isDirectory) {
+                            throw GradleException(
+                                "maintainability.sourceRoot='$sourceRootProp' resolved to '${sourceRoot.absolutePath}' but is not a directory",
+                            )
+                        }
+                        BaselineGenerator.fromDirectory(sourceRoot, analyzerRoot = project.rootDir)
+                    } else {
+                        BaselineGenerator.fromProject(project)
                     }
-                    BaselineGenerator.fromDirectory(sourceRoot, analyzerRoot = project.rootDir)
-                } else {
-                    BaselineGenerator.fromProject(project)
-                }
 
                 // When probing a detached worktree, use CanonicalGradleProbe for API/dependency
                 // measurements. The generator handles structural/scanner data from directory mode.
                 val sourceRootFile = if (sourceRootProp != null) project.rootDir.resolve(sourceRootProp).normalize() else null
                 val outputDirProp = project.findProperty("maintainability.outputDir")?.toString()
-                val probeOutputDir = if (outputDirProp != null) {
-                    project.rootDir.resolve(outputDirProp).also { it.mkdirs() }
-                } else null
-                val canonicalProbe = sourceRootFile?.let {
-                    CanonicalGradleProbe(
-                        sourceRoot = it,
-                        outputDir = probeOutputDir,
-                        analyzerRoot = project.rootDir
-                    )
-                }
-                val apiOverride: ApiBaseline? = if (sourceRootFile != null) {
-                    val result = canonicalProbe!!.probeApiBaseline()
-                    project.logger.lifecycle("Canonical API probe: ${result.records.size} records")
-                    val stabilities = result.records.groupBy { it.stability }.mapValues { it.value.size }
-                    project.logger.lifecycle("  Stability breakdown: $stabilities")
-                    if (result.records.none { it.applicable && it.sha256.isNotBlank() }) {
-                        throw GradleException("Canonical API probe produced no valid API hashes. " +
-                            "At least one applicable module must have a captured API dump.")
+                val probeOutputDir =
+                    if (outputDirProp != null) {
+                        project.rootDir.resolve(outputDirProp).also { it.mkdirs() }
+                    } else {
+                        null
                     }
-                    ApiBaseline(
-                        modules = result.records,
-                        aggregateHash = java.security.MessageDigest.getInstance("SHA-256")
-                            .digest(ReportNormalizer.toJson(result.records).toByteArray(Charsets.UTF_8))
-                            .joinToString("") { "%02x".format(it) }
-                    )
-                } else null
-
-                val dependencyOverride: List<ResolvedDependency>? = if (sourceRootFile != null) {
-                    val result = canonicalProbe!!.probeDependencyBaseline()
-                    project.logger.lifecycle("Canonical dependency probe: ${result.records.size} records")
-                    if (result.records.isEmpty()) {
-                        throw GradleException("Canonical dependency probe produced no dependency records. " +
-                            "Non-empty dependency baseline is required.")
+                val canonicalProbe =
+                    sourceRootFile?.let {
+                        CanonicalGradleProbe(
+                            sourceRoot = it,
+                            outputDir = probeOutputDir,
+                            analyzerRoot = project.rootDir,
+                        )
                     }
-                    result.records
-                } else null
+                val apiOverride: ApiBaseline? =
+                    if (sourceRootFile != null) {
+                        val result = canonicalProbe!!.probeApiBaseline()
+                        project.logger.lifecycle("Canonical API probe: ${result.records.size} records")
+                        val stabilities = result.records.groupBy { it.stability }.mapValues { it.value.size }
+                        project.logger.lifecycle("  Stability breakdown: $stabilities")
+                        if (result.records.none { it.applicable && it.sha256.isNotBlank() }) {
+                            throw GradleException(
+                                "Canonical API probe produced no valid API hashes. " +
+                                    "At least one applicable module must have a captured API dump.",
+                            )
+                        }
+                        ApiBaseline(
+                            modules = result.records,
+                            aggregateHash =
+                                java.security.MessageDigest
+                                    .getInstance("SHA-256")
+                                    .digest(ReportNormalizer.toJson(result.records).toByteArray(Charsets.UTF_8))
+                                    .joinToString("") { "%02x".format(it) },
+                        )
+                    } else {
+                        null
+                    }
 
-                val testQualityOverride = canonicalProbe?.probeTestQualityBaseline(
-                    testQualityConfiguration
-                )
+                val dependencyOverride: List<ResolvedDependency>? =
+                    if (sourceRootFile != null) {
+                        val result = canonicalProbe!!.probeDependencyBaseline()
+                        project.logger.lifecycle("Canonical dependency probe: ${result.records.size} records")
+                        if (result.records.isEmpty()) {
+                            throw GradleException(
+                                "Canonical dependency probe produced no dependency records. " +
+                                    "Non-empty dependency baseline is required.",
+                            )
+                        }
+                        result.records
+                    } else {
+                        null
+                    }
+
+                val testQualityOverride =
+                    canonicalProbe?.probeTestQualityBaseline(
+                        testQualityConfiguration,
+                    )
                 if (testQualityOverride != null) {
                     project.logger.lifecycle(
                         "Canonical test-quality probe: " +
                             "${testQualityOverride.coverage.criticalModules.size} coverage modules, " +
                             "${testQualityOverride.mutation.totalMutants} mutants, " +
-                            "${testQualityOverride.testPerformance.totalTestCount} tests"
+                            "${testQualityOverride.testPerformance.totalTestCount} tests",
                     )
                 }
 
-                val baseline = canonicalGenerator.generateCompleteBaseline(
-                    apiOverride = apiOverride,
-                    dependencyOverride = dependencyOverride,
-                    coverageOverride = testQualityOverride?.coverage,
-                    mutationOverride = testQualityOverride?.mutation,
-                    testPerformanceOverride = testQualityOverride?.testPerformance
-                )
+                val baseline =
+                    canonicalGenerator.generateCompleteBaseline(
+                        apiOverride = apiOverride,
+                        dependencyOverride = dependencyOverride,
+                        coverageOverride = testQualityOverride?.coverage,
+                        mutationOverride = testQualityOverride?.mutation,
+                        testPerformanceOverride = testQualityOverride?.testPerformance,
+                    )
                 val identity = baseline.baselineIdentity
 
                 // Provenance gates
@@ -828,28 +917,28 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                         "Canonical baseline must be generated at ${identity.releaseTag}. " +
                             "HEAD=${identity.measuredCommitSha.take(8)}, " +
                             "tag=${identity.baselineCommitSha.take(8)}. " +
-                            "Use -Pmaintainability.sourceRoot=<v0.5.0-worktree-path>"
+                            "Use -Pmaintainability.sourceRoot=<v0.5.0-worktree-path>",
                     )
                 }
 
                 if (!identity.workingTreeClean) {
                     throw GradleException(
                         "Canonical baseline must be generated from a clean worktree. " +
-                            "Commit or stash changes first."
+                            "Commit or stash changes first.",
                     )
                 }
 
                 if (identity.measuredSourceTreeHash.isBlank()) {
                     throw GradleException(
                         "Canonical baseline has an empty measuredSourceTreeHash. " +
-                            "Ensure the worktree is clean and git is available."
+                            "Ensure the worktree is clean and git is available.",
                     )
                 }
 
                 if (identity.measuredGitTreeSha.isBlank()) {
                     throw GradleException(
                         "Canonical baseline has an empty measuredGitTreeSha. " +
-                            "Ensure git is available in the source root."
+                            "Ensure git is available in the source root.",
                     )
                 }
 
@@ -859,7 +948,7 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                 println("  Wrote canonical baseline to ${prBaselineFile.absolutePath}")
                 println(
                     "Canonical maintainability baseline generated for " +
-                        "${identity.releaseTag} at ${identity.measuredCommitSha.take(8)}"
+                        "${identity.releaseTag} at ${identity.measuredCommitSha.take(8)}",
                 )
                 println("  Git tree SHA: ${identity.measuredGitTreeSha.take(8)}")
                 println("  Source tree hash: ${identity.measuredSourceTreeHash.take(16)}...")
@@ -874,7 +963,7 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                 "verifyCriticalCoverage",
                 "verifyCriticalMutationBaseline",
                 "verifyTestPerformanceBaseline",
-                "verifyRuntimeNondeterminism"
+                "verifyRuntimeNondeterminism",
             )
             doLast {
                 println("Full maintainability baseline verification complete.")
@@ -906,44 +995,36 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
         }
 
         // ---- Authoritative module manifest ----
-
-        project.tasks.register("verifyModuleManifest") {
-            group = "verification"
-            description = "Verifies manifest/settings equality and publishing/BOM membership against independent Gradle model signals"
-            doLast {
-                val catalog = ModuleManifest.catalog(project.rootDir)
-                // Independent signal 1: the actual Gradle project model (settings ↔ manifest).
-                val actualProjects = project.allprojects
-                    .filter { it != project && it.buildFile.exists() }
-                    .map { it.path }
-                    .toSet()
-                // Independent signal 2: the publication set the build actually wires into
-                // release tasks. In this build publishing is DERIVED from the manifest, so
-                // the check is a regression lock: it fires if the derivation is replaced
-                // by a literal list or the two disagree.
-                val actualPublished = (project.extensions.extraProperties.properties["tramai.publishableModulePaths"] as? Collection<*>)
-                    ?.map { it.toString() }?.toSet().orEmpty()
-                // Independent signal 3: the BOM's ACTUAL configured constraint graph, read
-                // from Gradle's model of tramai-bom's api configuration (not from a manifest
-                // round-trip).
-                val bomProject = project.allprojects.firstOrNull { it.name == "tramai-bom" }
-                val actualBom = bomProject
-                    ?.configurations
-                    ?.findByName("api")
-                    ?.dependencyConstraints
-                    .orEmpty()
-                    .mapNotNull { constraint ->
-                        val name = constraint.name
-                        if (name.startsWith("tramai-") || name.startsWith("examples:")) ":$name" else null
-                    }
-                    .toSet()
-                val diagnostics = ModuleManifestVerifier.verify(
-                    catalogModules = catalog.modules,
-                    projectPaths = actualProjects,
-                    publishedPaths = actualPublished,
-                    bomPaths = actualBom,
+        // Typed (Epic 9.2d-a3c1). projectPaths/bomPaths are configuration-side
+        // snapshots; publishedPaths is wired from the release task's typed model
+        // via withPlugin (the maintainability plugin applies BEFORE
+        // tramai.release-verification in the root build script, so the provider
+        // is connected lazily — never read the root extra here).
+        val verifyModuleManifest =
+            project.tasks.register<VerifyModuleManifestTask>("verifyModuleManifest") {
+                group = "verification"
+                description = "Verifies manifest/settings equality and publishing/BOM membership against independent Gradle model signals"
+                moduleCatalogFile.set(project.layout.projectDirectory.file("config/quality/module-catalog.yml"))
+                projectPaths.set(ModuleTopologySnapshot.projectPaths(project))
+                // BOM signal read LAZILY through a provider: the java-platform model
+                // is incomplete at plugin apply time (Epic 9.2d-a1 rule). Never eager,
+                // never a Configuration as a task property — converted to List<String>.
+                bomPaths.set(project.provider { ModuleTopologySnapshot.bomPaths(project) })
+            }
+        project.pluginManager.withPlugin("tramai.release-verification") {
+            verifyModuleManifest.configure {
+                val releaseTask =
+                    project.tasks.named(
+                        "verifyPublicationMetadata",
+                        VerifyPublicationMetadataTask::class.java,
+                    )
+                // Module names -> Gradle paths (":name"), sorted, from the release
+                // task's typed model — NOT the tramai.publishableModulePaths extra.
+                publishedPaths.set(
+                    releaseTask
+                        .flatMap { it.publishableModules }
+                        .map { names -> names.map { ":$it" }.sorted() },
                 )
-                if (diagnostics.isNotEmpty()) throw GradleException(diagnostics.joinToString("\n") { "[${it.code}] ${it.message}" })
             }
         }
 
@@ -965,30 +1046,32 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             moduleCatalogFile.from(project.layout.projectDirectory.file("config/quality/module-catalog.yml"))
         }
 
-        val enrollmentTest = project.tasks.register("architectureContractEnrollmentTest", Test::class.java) {
-            group = "verification"
-            description = "Runs provider and store enrollment architecture contracts"
-            val testingProject = project.project(":tramai-testing")
-            val testSourceSet = testingProject.extensions
-                .getByType(JavaPluginExtension::class.java)
-                .sourceSets
-                .getByName("test")
-            dependsOn(testingProject.tasks.named("testClasses"))
-            testClassesDirs = testSourceSet.output.classesDirs
-            classpath = testSourceSet.runtimeClasspath
-            useJUnitPlatform()
-            filter.includeTestsMatching("dev.tramai.testing.*EnrollmentArchitectureTest")
-            ignoreFailures = true
-            binaryResultsDirectory.set(
-                testingProject.layout.buildDirectory.dir("test-results/architectureContractEnrollmentTest/binary")
-            )
-            reports.junitXml.outputLocation.set(
-                testingProject.layout.buildDirectory.dir("test-results/architectureContractEnrollmentTest")
-            )
-            reports.html.outputLocation.set(
-                testingProject.layout.buildDirectory.dir("reports/tests/architectureContractEnrollmentTest")
-            )
-        }
+        val enrollmentTest =
+            project.tasks.register("architectureContractEnrollmentTest", Test::class.java) {
+                group = "verification"
+                description = "Runs provider and store enrollment architecture contracts"
+                val testingProject = project.project(":tramai-testing")
+                val testSourceSet =
+                    testingProject.extensions
+                        .getByType(JavaPluginExtension::class.java)
+                        .sourceSets
+                        .getByName("test")
+                dependsOn(testingProject.tasks.named("testClasses"))
+                testClassesDirs = testSourceSet.output.classesDirs
+                classpath = testSourceSet.runtimeClasspath
+                useJUnitPlatform()
+                filter.includeTestsMatching("dev.tramai.testing.*EnrollmentArchitectureTest")
+                ignoreFailures = true
+                binaryResultsDirectory.set(
+                    testingProject.layout.buildDirectory.dir("test-results/architectureContractEnrollmentTest/binary"),
+                )
+                reports.junitXml.outputLocation.set(
+                    testingProject.layout.buildDirectory.dir("test-results/architectureContractEnrollmentTest"),
+                )
+                reports.html.outputLocation.set(
+                    testingProject.layout.buildDirectory.dir("reports/tests/architectureContractEnrollmentTest"),
+                )
+            }
 
         project.tasks.register("verify060Architecture") {
             group = "verification"
@@ -998,14 +1081,16 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             // C1: regenerate every applicable BCV dump from current source so
             // Contract-1 runs on a clean workspace instead of silently skipping
             // missing build/api/*.api artifacts (fail-closed: absence → FAIL).
-            val apiBuildTasks = project.allprojects
-                .filter { sub -> sub != project && sub.tasks.findByName("apiBuild") != null }
-                .filter { sub -> ApiCompatibilityEvidenceReader.committedDumpPath(sub.projectDir, sub.name).isFile }
-                .map { "${it.path}:apiBuild" }
+            val apiBuildTasks =
+                project.allprojects
+                    .filter { sub -> sub != project && sub.tasks.findByName("apiBuild") != null }
+                    .filter { sub -> ApiCompatibilityEvidenceReader.committedDumpPath(sub.projectDir, sub.name).isFile }
+                    .map { "${it.path}:apiBuild" }
             dependsOn(*apiBuildTasks.toTypedArray())
             doLast {
-                val architectureDiagnostics = ArchitectureReportAggregator.checkIds
-                    .associateWith { mutableListOf<VerificationDiagnostic>() }
+                val architectureDiagnostics =
+                    ArchitectureReportAggregator.checkIds
+                        .associateWith { mutableListOf<VerificationDiagnostic>() }
                 val context = MeasurementContext.fromProject(project)
                 val verificationReport = File(reportDir, "verification-report.json")
 
@@ -1013,20 +1098,27 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                     // Read the fail-soft per-project dependency probes. Resolution
                     // failure reaches the gate as typed evidence (the probe tasks
                     // never abort the task graph), so the report is always written.
-                    val probeFiles = project.allprojects
-                        .filter { it != project && it.buildFile.exists() }
-                        .sortedBy { it.path }
-                        .map { sub ->
-                            File(sub.layout.buildDirectory.get().asFile, "reports/maintainability/architecture-dependencies.json")
-                        }
+                    val probeFiles =
+                        project.allprojects
+                            .filter { it != project && it.buildFile.exists() }
+                            .sortedBy { it.path }
+                            .map { sub ->
+                                File(
+                                    sub.layout.buildDirectory
+                                        .get()
+                                        .asFile,
+                                    "reports/maintainability/architecture-dependencies.json",
+                                )
+                            }
                     val evidence = readDependencyProbeEvidence(probeFiles)
                     if (evidence.failures.isNotEmpty()) {
                         val message = "Dependency evidence unavailable: ${evidence.failures.joinToString("; ")}"
                         baselineCheckIds.forEach { checkId ->
-                            architectureDiagnostics.getValue(checkId) += VerificationDiagnostic.failure(
-                                DiagnosticCode.DEPENDENCY_RESOLUTION_FAILED,
-                                message,
-                            )
+                            architectureDiagnostics.getValue(checkId) +=
+                                VerificationDiagnostic.failure(
+                                    DiagnosticCode.DEPENDENCY_RESOLUTION_FAILED,
+                                    message,
+                                )
                         }
                     } else {
                         val resolvedDependenciesFile = File(reportDir, "resolved-dependencies.json")
@@ -1047,29 +1139,37 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
 
                 collectEvidence("module manifest verification", setOf("module-manifest", "publishing-topology"), architectureDiagnostics) {
                     val catalog = ModuleManifest.catalog(project.rootDir)
-                    val actualProjects = project.allprojects
-                        .filter { it != project && it.buildFile.exists() }
-                        .map { it.path }
-                        .toSet()
-                    val actualPublished = (project.extensions.extraProperties.properties["tramai.publishableModulePaths"] as? Collection<*>)
-                        ?.map { it.toString() }?.toSet().orEmpty()
+                    val actualProjects =
+                        project.allprojects
+                            .filter { it != project && it.buildFile.exists() }
+                            .map { it.path }
+                            .toSet()
+                    val actualPublished =
+                        (project.extensions.extraProperties.properties["tramai.publishableModulePaths"] as? Collection<*>)
+                            ?.map { it.toString() }
+                            ?.toSet()
+                            .orEmpty()
                     val bomProject = project.allprojects.firstOrNull { it.name == "tramai-bom" }
-                    val actualBom = bomProject
-                        ?.configurations
-                        ?.findByName("api")
-                        ?.dependencyConstraints
-                        .orEmpty()
-                        .mapNotNull { constraint ->
-                            constraint.name.takeIf { it.startsWith("tramai-") || it.startsWith("examples:") }?.let { ":$it" }
-                        }
-                        .toSet()
+                    val actualBom =
+                        bomProject
+                            ?.configurations
+                            ?.findByName("api")
+                            ?.dependencyConstraints
+                            .orEmpty()
+                            .mapNotNull { constraint ->
+                                constraint.name.takeIf { it.startsWith("tramai-") || it.startsWith("examples:") }?.let { ":$it" }
+                            }.toSet()
                     addManifestDiagnostics(
                         ModuleManifestVerifier.verify(catalog.modules, actualProjects, actualPublished, actualBom),
                         architectureDiagnostics,
                     )
                 }
 
-                collectEvidence("enrollment contract verification", setOf("provider-contracts", "store-contracts"), architectureDiagnostics) {
+                collectEvidence(
+                    "enrollment contract verification",
+                    setOf("provider-contracts", "store-contracts"),
+                    architectureDiagnostics,
+                ) {
                     addEnrollmentDiagnostics(
                         File(project.project(":tramai-testing").buildDir, "test-results/architectureContractEnrollmentTest"),
                         architectureDiagnostics,
@@ -1081,13 +1181,21 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                 }
 
                 val report = ArchitectureReportAggregator.aggregate(architectureDiagnostics)
-                val reportFile = File(project.layout.buildDirectory.get().asFile, "reports/tramai/architecture/architecture-report.json")
+                val reportFile =
+                    File(
+                        project.layout.buildDirectory
+                            .get()
+                            .asFile,
+                        "reports/tramai/architecture/architecture-report.json",
+                    )
                 // Report is written BEFORE the terminal exception — failure must produce evidence.
                 ArchitectureReportJson.write(report, reportFile, project.rootDir)
                 if (report.status == ArchitectureCheckStatus.FAIL) {
-                    throw GradleException("0.6.0 architecture verification FAILED: " +
-                        report.checks.filter { it.status == ArchitectureCheckStatus.FAIL }.joinToString { it.id } +
-                        " — see ${reportFile.path}")
+                    throw GradleException(
+                        "0.6.0 architecture verification FAILED: " +
+                            report.checks.filter { it.status == ArchitectureCheckStatus.FAIL }.joinToString { it.id } +
+                            " — see ${reportFile.path}",
+                    )
                 }
             }
         }
@@ -1130,28 +1238,30 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
 
         // ---- PR Verification (primary local check gate) ----
 
-        val verifyPr = project.tasks.register("verifyPr") {
-            group = "verification"
-            description = "Primary local verification gate. Runs subproject tests, build-logic tests, maintainability baseline, and change policy. Not a full CI replica — see .github/AGENTS.md for additional step commands."
+        val verifyPr =
+            project.tasks.register("verifyPr") {
+                group = "verification"
+                description =
+                    "Primary local verification gate. Runs subproject tests, build-logic tests, maintainability baseline, and change policy. Not a full CI replica — see .github/AGENTS.md for additional step commands."
 
-            dependsOn("verifyMaintainabilityBaseline")
-            dependsOn("verifyChangePolicy")
-            dependsOn("verifyModuleManifest")
-            dependsOn("verifyModuleMatrixDrift")
-            dependsOn("verifyModuleDocContract")
+                dependsOn("verifyMaintainabilityBaseline")
+                dependsOn("verifyChangePolicy")
+                dependsOn("verifyModuleManifest")
+                dependsOn("verifyModuleMatrixDrift")
+                dependsOn("verifyModuleDocContract")
 
-            // Include build-logic tests (included build — must use includedBuild API)
-            val buildLogicTestTask = project.gradle.includedBuild("build-logic")?.task(":test")
-            if (buildLogicTestTask != null) {
-                dependsOn(buildLogicTestTask)
-            } else {
-                logger.warn("verifyPr: included build 'build-logic' not found, build-logic tests not aggregated")
+                // Include build-logic tests (included build — must use includedBuild API)
+                val buildLogicTestTask = project.gradle.includedBuild("build-logic")?.task(":test")
+                if (buildLogicTestTask != null) {
+                    dependsOn(buildLogicTestTask)
+                } else {
+                    logger.warn("verifyPr: included build 'build-logic' not found, build-logic tests not aggregated")
+                }
+
+                doLast {
+                    logger.lifecycle("verifyPr completed — see individual task results above.")
+                }
             }
-
-            doLast {
-                logger.lifecycle("verifyPr completed — see individual task results above.")
-            }
-        }
 
         // ---- JUnit test-signature integrity (silently-skipped tests guard) ----
         // JUnit Jupiter discards @Test methods whose JVM return type is not void.
@@ -1167,10 +1277,12 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             // api/) or Gradle 9 flags the input as overlapping a task output.
             // The scanner itself only inspects src/test|src/testFixtures .kt,
             // so excluding outputs changes no semantics.
-            testSources.from(project.fileTree(project.rootDir) {
-                include("**/src/test/**/*.kt", "**/src/testFixtures/**/*.kt")
-                exclude("**/build/**", "**/api/**")
-            })
+            testSources.from(
+                project.fileTree(project.rootDir) {
+                    include("**/src/test/**/*.kt", "**/src/testFixtures/**/*.kt")
+                    exclude("**/build/**", "**/api/**")
+                },
+            )
         }
         verifyPr.configure {
             dependsOn("verifyJUnitTestSignatures")
@@ -1205,46 +1317,53 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
     private fun verifyTestQualityDiagnostics(
         project: Project,
         label: String,
-        diagnostics: List<VerificationDiagnostic>
+        diagnostics: List<VerificationDiagnostic>,
     ) {
-        diagnostics.filter { it.severity == DiagnosticSeverity.WARNING }
+        diagnostics
+            .filter { it.severity == DiagnosticSeverity.WARNING }
             .forEach { project.logger.warn("WARN: ${it.message}") }
         val failures = diagnostics.filter { it.severity == DiagnosticSeverity.FAILURE }
         failures.forEach { project.logger.error("FAIL: ${it.message}") }
         if (failures.isNotEmpty()) {
             throw GradleException(
                 "$label baseline verification FAILED:\n" +
-                    failures.joinToString("\n") { "  - ${it.message}" }
+                    failures.joinToString("\n") { "  - ${it.message}" },
             )
         }
         println("$label baseline verification PASSED.")
     }
 
-    private fun runNestedGradle(project: Project, arguments: List<String>) {
-        val wrapper = File(
-            project.rootDir,
-            if (System.getProperty("os.name").startsWith("Windows")) "gradlew.bat" else "gradlew"
-        )
+    private fun runNestedGradle(
+        project: Project,
+        arguments: List<String>,
+    ) {
+        val wrapper =
+            File(
+                project.rootDir,
+                if (System.getProperty("os.name").startsWith("Windows")) "gradlew.bat" else "gradlew",
+            )
         val command = mutableListOf<String>()
         if (!wrapper.canExecute() && !wrapper.name.endsWith(".bat")) command += "bash"
         command += wrapper.absolutePath
-        command += listOf(
-            "--no-daemon",
-            "--no-build-cache",
-            "--no-configuration-cache",
-            "--no-parallel",
-            "--console=plain"
-        )
+        command +=
+            listOf(
+                "--no-daemon",
+                "--no-build-cache",
+                "--no-configuration-cache",
+                "--no-parallel",
+                "--console=plain",
+            )
         command += arguments
-        val process = ProcessBuilder(command)
-            .directory(project.rootDir)
-            .redirectErrorStream(true)
-            .start()
+        val process =
+            ProcessBuilder(command)
+                .directory(project.rootDir)
+                .redirectErrorStream(true)
+                .start()
         val output = process.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
         val exitCode = process.waitFor()
         if (exitCode != 0) {
             throw GradleException(
-                "Nested Gradle execution failed with exit code $exitCode:\n$output"
+                "Nested Gradle execution failed with exit code $exitCode:\n$output",
             )
         }
         project.logger.lifecycle(output.trimEnd())
@@ -1253,18 +1372,21 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
     private fun copyTestReports(
         repositoryRoot: File,
         criticalModules: Set<String>,
-        runRoot: File
+        runRoot: File,
     ) {
         criticalModules.sorted().forEach { module ->
             val modulePath = module.removePrefix(":").replace(":", "/")
             val sourceDir = File(repositoryRoot, "$modulePath/build/test-results/test")
             val destinationDir = File(runRoot, modulePath)
-            val reports = sourceDir.listFiles { file ->
-                file.isFile && file.name.startsWith("TEST-") && file.extension == "xml"
-            }?.sortedBy { it.name }.orEmpty()
+            val reports =
+                sourceDir
+                    .listFiles { file ->
+                        file.isFile && file.name.startsWith("TEST-") && file.extension == "xml"
+                    }?.sortedBy { it.name }
+                    .orEmpty()
             if (reports.isEmpty()) {
                 throw GradleException(
-                    "Missing expected test report for $module at ${sourceDir.absolutePath}"
+                    "Missing expected test report for $module at ${sourceDir.absolutePath}",
                 )
             }
             destinationDir.mkdirs()
@@ -1274,22 +1396,26 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
 
     private fun mutationInitScript(
         configuration: TestQualityConfiguration,
-        reportRoot: File
+        reportRoot: File,
     ): String {
-        val familyModules = configuration.mutation.targetFamilies.entries
-            .sortedBy { it.key }
-            .joinToString(",\n") { (family, target) ->
-                val modules = target.modules.sorted().joinToString(", ") {
-                    "'${groovyString(it)}'"
+        val familyModules =
+            configuration.mutation.targetFamilies.entries
+                .sortedBy { it.key }
+                .joinToString(",\n") { (family, target) ->
+                    val modules =
+                        target.modules.sorted().joinToString(", ") {
+                            "'${groovyString(it)}'"
+                        }
+                    val classes =
+                        target.targetClasses.sorted().joinToString(", ") {
+                            "'${groovyString(it)}'"
+                        }
+                    val tests =
+                        target.targetTests.sorted().joinToString(", ") {
+                            "'${groovyString(it)}'"
+                        }
+                    "    '${groovyString(family)}': [modules: [$modules], targetClasses: [$classes], targetTests: [$tests]]"
                 }
-                val classes = target.targetClasses.sorted().joinToString(", ") {
-                    "'${groovyString(it)}'"
-                }
-                val tests = target.targetTests.sorted().joinToString(", ") {
-                    "'${groovyString(it)}'"
-                }
-                "    '${groovyString(family)}': [modules: [$modules], targetClasses: [$classes], targetTests: [$tests]]"
-            }
         return """
             initscript {
                 repositories {
@@ -1339,19 +1465,19 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                     dependsOn mutationTasks.collect { it.get() }
                 }
             }
-        """.trimIndent() + "\n"
+            """.trimIndent() + "\n"
     }
 
-    private fun groovyString(value: String): String =
-        value.replace("\\", "\\\\").replace("'", "\\'")
+    private fun groovyString(value: String): String = value.replace("\\", "\\\\").replace("'", "\\'")
 
     private fun readBaselineDiagnostics(reportFile: File): List<VerificationDiagnostic> {
         if (!reportFile.isFile) {
             throw GradleException("Baseline verifier did not produce ${reportFile.path}")
         }
         val report = ReportNormalizer.readJson(reportFile, Map::class.java)
-        val diagnostics = report["diagnostics"] as? List<*>
-            ?: throw GradleException("Baseline verification report has no diagnostics array")
+        val diagnostics =
+            report["diagnostics"] as? List<*>
+                ?: throw GradleException("Baseline verification report has no diagnostics array")
         return diagnostics.map { raw ->
             val entry = raw as? Map<*, *> ?: throw GradleException("Malformed baseline diagnostic")
             VerificationDiagnostic(
@@ -1372,128 +1498,129 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
      * new DiagnosticCode forces a decision at compile time — either it belongs to
      * an architecture check here, or it is explicitly excluded.
      */
-    private fun baselineCheckFor(code: DiagnosticCode): String? = when (code) {
-        // Module catalogue (all codes except BOM/publishing drift, which are publishing-topology)
-        DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY,
-        DiagnosticCode.MODULE_CATALOG_UNKNOWN_ENTRY,
-        DiagnosticCode.MODULE_CATALOG_DUPLICATE_PATH,
-        DiagnosticCode.MODULE_CATALOG_INVALID_LAYER,
-        DiagnosticCode.MODULE_CATALOG_MISSING_API_STABILITY,
-        DiagnosticCode.MODULE_CATALOG_EXAMPLE_PUBLISHABLE,
-        DiagnosticCode.MODULE_CATALOG_DISAGREEMENT,
-        DiagnosticCode.MODULE_CATALOG_INVALID_SCHEMA,
-        DiagnosticCode.MODULE_CATALOG_INVALID_MATURITY,
-        DiagnosticCode.MODULE_CATALOG_INVALID_PUBLISHABILITY,
-        DiagnosticCode.MODULE_CATALOG_INVALID_VISIBILITY,
-        DiagnosticCode.MODULE_CATALOG_INVALID_RELEASE_INCLUSION,
-        DiagnosticCode.MODULE_CATALOG_INVALID_POLICY,
-        DiagnosticCode.MODULE_CATALOG_BLANK_OWNER,
-        DiagnosticCode.MODULE_CATALOG_BLANK_RATIONALE,
-        DiagnosticCode.MODULE_CATALOG_MISSING_DESCRIPTION,
-        DiagnosticCode.MODULE_CATALOG_INVALID_COMBINATION,
-        -> "module-manifest"
+    private fun baselineCheckFor(code: DiagnosticCode): String? =
+        when (code) {
+            // Module catalogue (all codes except BOM/publishing drift, which are publishing-topology)
+            DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY,
+            DiagnosticCode.MODULE_CATALOG_UNKNOWN_ENTRY,
+            DiagnosticCode.MODULE_CATALOG_DUPLICATE_PATH,
+            DiagnosticCode.MODULE_CATALOG_INVALID_LAYER,
+            DiagnosticCode.MODULE_CATALOG_MISSING_API_STABILITY,
+            DiagnosticCode.MODULE_CATALOG_EXAMPLE_PUBLISHABLE,
+            DiagnosticCode.MODULE_CATALOG_DISAGREEMENT,
+            DiagnosticCode.MODULE_CATALOG_INVALID_SCHEMA,
+            DiagnosticCode.MODULE_CATALOG_INVALID_MATURITY,
+            DiagnosticCode.MODULE_CATALOG_INVALID_PUBLISHABILITY,
+            DiagnosticCode.MODULE_CATALOG_INVALID_VISIBILITY,
+            DiagnosticCode.MODULE_CATALOG_INVALID_RELEASE_INCLUSION,
+            DiagnosticCode.MODULE_CATALOG_INVALID_POLICY,
+            DiagnosticCode.MODULE_CATALOG_BLANK_OWNER,
+            DiagnosticCode.MODULE_CATALOG_BLANK_RATIONALE,
+            DiagnosticCode.MODULE_CATALOG_MISSING_DESCRIPTION,
+            DiagnosticCode.MODULE_CATALOG_INVALID_COMBINATION,
+            -> "module-manifest"
 
-        DiagnosticCode.MODULE_CATALOG_BOM_DRIFT,
-        DiagnosticCode.MODULE_CATALOG_PUBLISHING_DRIFT,
-        -> "publishing-topology"
+            DiagnosticCode.MODULE_CATALOG_BOM_DRIFT,
+            DiagnosticCode.MODULE_CATALOG_PUBLISHING_DRIFT,
+            -> "publishing-topology"
 
-        DiagnosticCode.FORBIDDEN_LAYER_EDGE,
-        DiagnosticCode.SELF_DEPENDENCY,
-        -> "dependency-boundaries"
+            DiagnosticCode.FORBIDDEN_LAYER_EDGE,
+            DiagnosticCode.SELF_DEPENDENCY,
+            -> "dependency-boundaries"
 
-        DiagnosticCode.NEW_DEPENDENCY_CYCLE,
-        -> "dependency-cycles"
+            DiagnosticCode.NEW_DEPENDENCY_CYCLE,
+            -> "dependency-cycles"
 
-        DiagnosticCode.NEW_GLOBAL_STATE_FINDING,
-        -> "global-state"
+            DiagnosticCode.NEW_GLOBAL_STATE_FINDING,
+            -> "global-state"
 
-        DiagnosticCode.API_BASELINE_EMPTY,
-        DiagnosticCode.API_DUMP_MISSING,
-        DiagnosticCode.API_DUMP_DUPLICATE,
-        DiagnosticCode.API_MODULE_UNCLASSIFIED,
-        DiagnosticCode.API_VALIDATION_NOT_CONFIGURED,
-        DiagnosticCode.API_COMPATIBILITY_FAILED,
-        DiagnosticCode.API_HASH_CHANGED,
-        DiagnosticCode.API_DUMP_NONDETERMINISTIC,
-        -> "api-architecture"
+            DiagnosticCode.API_BASELINE_EMPTY,
+            DiagnosticCode.API_DUMP_MISSING,
+            DiagnosticCode.API_DUMP_DUPLICATE,
+            DiagnosticCode.API_MODULE_UNCLASSIFIED,
+            DiagnosticCode.API_VALIDATION_NOT_CONFIGURED,
+            DiagnosticCode.API_COMPATIBILITY_FAILED,
+            DiagnosticCode.API_HASH_CHANGED,
+            DiagnosticCode.API_DUMP_NONDETERMINISTIC,
+            -> "api-architecture"
 
-        DiagnosticCode.STABLE_PROTOCOL_CONTRACT_REMOVED,
-        -> "protocol-catalog"
+            DiagnosticCode.STABLE_PROTOCOL_CONTRACT_REMOVED,
+            -> "protocol-catalog"
 
-        DiagnosticCode.NEW_CANCELLATION_FINDING,
-        DiagnosticCode.CANCELLATION_RISK_WORSENED,
-        -> "cancellation-safety"
+            DiagnosticCode.NEW_CANCELLATION_FINDING,
+            DiagnosticCode.CANCELLATION_RISK_WORSENED,
+            -> "cancellation-safety"
 
-        // Explicitly outside the 0.6.0 architecture gate.
-        DiagnosticCode.BASELINE_IDENTITY_MISMATCH,
-        DiagnosticCode.ANALYZER_COMMIT_NOT_ANCESTOR,
-        DiagnosticCode.MEASURED_TREE_MISMATCH,
-        DiagnosticCode.TAG_COMMIT_MISMATCH,
-        DiagnosticCode.TAG_TREE_MISMATCH,
-        DiagnosticCode.DIRTY_WORKTREE,
-        DiagnosticCode.DEPENDENCY_BASELINE_EMPTY,
-        DiagnosticCode.DEPENDENCY_RESOLUTION_FAILED,
-        DiagnosticCode.DYNAMIC_DEPENDENCY_VERSION,
-        DiagnosticCode.SNAPSHOT_DEPENDENCY,
-        DiagnosticCode.DEPENDENCY_CONVERGENCE_FAILURE,
-        DiagnosticCode.DEPENDENCY_ADDED,
-        DiagnosticCode.DEPENDENCY_REMOVED,
-        DiagnosticCode.DEPENDENCY_VERSION_CHANGED,
-        DiagnosticCode.TEST_QUALITY_CONFIGURATION_INVALID,
-        DiagnosticCode.COVERAGE_REPORT_MISSING,
-        DiagnosticCode.COVERAGE_REPORT_MALFORMED,
-        DiagnosticCode.COVERAGE_COUNTER_MISSING,
-        DiagnosticCode.COVERAGE_PATH_LEAK,
-        DiagnosticCode.COVERAGE_REGRESSION,
-        DiagnosticCode.COVERAGE_FAMILY_EMPTY,
-        DiagnosticCode.COVERAGE_EXCLUSION_UNDOCUMENTED,
-        DiagnosticCode.MUTATION_REPORT_MISSING,
-        DiagnosticCode.MUTATION_REPORT_MALFORMED,
-        DiagnosticCode.MUTATION_TARGET_EMPTY,
-        DiagnosticCode.MUTATION_REGRESSION,
-        DiagnosticCode.MUTATION_SURVIVOR_UNCLASSIFIED,
-        DiagnosticCode.MUTATION_MISSING_TEST_UNTRACKED,
-        DiagnosticCode.TEST_REPORT_MISSING,
-        DiagnosticCode.TEST_PERFORMANCE_REGRESSION,
-        DiagnosticCode.CRITICAL_TEST_REGRESSION,
-        DiagnosticCode.CRITICAL_TEST_NEWLY_SKIPPED,
-        DiagnosticCode.TEST_QUALITY_STATUS_PENDING,
-        DiagnosticCode.NEW_NONDETERMINISM_FINDING,
-        DiagnosticCode.HOTSPOT_REGRESSION,
-        DiagnosticCode.NEW_TOP_FIVE_HOTSPOT,
-        DiagnosticCode.FILE_GROWTH_EXCEEDED,
-        DiagnosticCode.INVALID_DEVIATION_SCOPE,
-        DiagnosticCode.ORPHANED_DEVIATION,
-        DiagnosticCode.EXPIRED_DEVIATION,
-        DiagnosticCode.DUPLICATE_DEVIATION,
-        DiagnosticCode.MALFORMED_DEVIATION,
-        DiagnosticCode.DEVIATION_BASELINE_MISMATCH,
-        DiagnosticCode.DEVIATION_COVERAGE_EXCEEDED,
-        DiagnosticCode.GENERATED_DOCUMENT_DRIFT,
-        DiagnosticCode.EMPTY_SECTION,
-        // Nondeterminism authority contract (Epic 8.3d PR 2) — enforced by the
-        // verifyRuntimeNondeterminism task directly, not the maintainability baseline.
-        DiagnosticCode.NONDETERMINISM_UNCLASSIFIED_FINDING,
-        DiagnosticCode.NONDETERMINISM_STALE_ENTRY,
-        DiagnosticCode.NONDETERMINISM_MISMATCHED_CLASSIFICATION,
-        DiagnosticCode.NONDETERMINISM_OCCURRENCE_MISMATCH,
-        DiagnosticCode.NONDETERMINISM_DUPLICATE_ENTRY,
-        DiagnosticCode.NONDETERMINISM_INVALID_DISPOSITION,
-        DiagnosticCode.NONDETERMINISM_MISSING_RATIONALE,
-        DiagnosticCode.NONDETERMINISM_INVALID_SCHEMA,
-        // Module documentation contract (Epic 11.2b3) — enforced by the
-        // verifyModuleDocContract task directly, not a maintainability baseline.
-        DiagnosticCode.MODULE_CARD_MISSING,
-        DiagnosticCode.MODULE_CARD_ORPHAN,
-        DiagnosticCode.MODULE_CARD_HEADING_MISSING,
-        DiagnosticCode.MODULE_CARD_LINK_BROKEN,
-        DiagnosticCode.MODULE_CARD_INLINE_PATH_BROKEN,
-        DiagnosticCode.MODULE_CARD_LEGACY_CLASSIFICATION,
-        DiagnosticCode.MODULE_CARD_VERSIONLESS_DEPENDENCY,
-        DiagnosticCode.MODULE_CARD_INTERNAL_MAVEN_ADVERTISEMENT,
-        DiagnosticCode.MODULE_CARD_COVERAGE_MISMATCH,
-        -> null
-    }
+            // Explicitly outside the 0.6.0 architecture gate.
+            DiagnosticCode.BASELINE_IDENTITY_MISMATCH,
+            DiagnosticCode.ANALYZER_COMMIT_NOT_ANCESTOR,
+            DiagnosticCode.MEASURED_TREE_MISMATCH,
+            DiagnosticCode.TAG_COMMIT_MISMATCH,
+            DiagnosticCode.TAG_TREE_MISMATCH,
+            DiagnosticCode.DIRTY_WORKTREE,
+            DiagnosticCode.DEPENDENCY_BASELINE_EMPTY,
+            DiagnosticCode.DEPENDENCY_RESOLUTION_FAILED,
+            DiagnosticCode.DYNAMIC_DEPENDENCY_VERSION,
+            DiagnosticCode.SNAPSHOT_DEPENDENCY,
+            DiagnosticCode.DEPENDENCY_CONVERGENCE_FAILURE,
+            DiagnosticCode.DEPENDENCY_ADDED,
+            DiagnosticCode.DEPENDENCY_REMOVED,
+            DiagnosticCode.DEPENDENCY_VERSION_CHANGED,
+            DiagnosticCode.TEST_QUALITY_CONFIGURATION_INVALID,
+            DiagnosticCode.COVERAGE_REPORT_MISSING,
+            DiagnosticCode.COVERAGE_REPORT_MALFORMED,
+            DiagnosticCode.COVERAGE_COUNTER_MISSING,
+            DiagnosticCode.COVERAGE_PATH_LEAK,
+            DiagnosticCode.COVERAGE_REGRESSION,
+            DiagnosticCode.COVERAGE_FAMILY_EMPTY,
+            DiagnosticCode.COVERAGE_EXCLUSION_UNDOCUMENTED,
+            DiagnosticCode.MUTATION_REPORT_MISSING,
+            DiagnosticCode.MUTATION_REPORT_MALFORMED,
+            DiagnosticCode.MUTATION_TARGET_EMPTY,
+            DiagnosticCode.MUTATION_REGRESSION,
+            DiagnosticCode.MUTATION_SURVIVOR_UNCLASSIFIED,
+            DiagnosticCode.MUTATION_MISSING_TEST_UNTRACKED,
+            DiagnosticCode.TEST_REPORT_MISSING,
+            DiagnosticCode.TEST_PERFORMANCE_REGRESSION,
+            DiagnosticCode.CRITICAL_TEST_REGRESSION,
+            DiagnosticCode.CRITICAL_TEST_NEWLY_SKIPPED,
+            DiagnosticCode.TEST_QUALITY_STATUS_PENDING,
+            DiagnosticCode.NEW_NONDETERMINISM_FINDING,
+            DiagnosticCode.HOTSPOT_REGRESSION,
+            DiagnosticCode.NEW_TOP_FIVE_HOTSPOT,
+            DiagnosticCode.FILE_GROWTH_EXCEEDED,
+            DiagnosticCode.INVALID_DEVIATION_SCOPE,
+            DiagnosticCode.ORPHANED_DEVIATION,
+            DiagnosticCode.EXPIRED_DEVIATION,
+            DiagnosticCode.DUPLICATE_DEVIATION,
+            DiagnosticCode.MALFORMED_DEVIATION,
+            DiagnosticCode.DEVIATION_BASELINE_MISMATCH,
+            DiagnosticCode.DEVIATION_COVERAGE_EXCEEDED,
+            DiagnosticCode.GENERATED_DOCUMENT_DRIFT,
+            DiagnosticCode.EMPTY_SECTION,
+            // Nondeterminism authority contract (Epic 8.3d PR 2) — enforced by the
+            // verifyRuntimeNondeterminism task directly, not the maintainability baseline.
+            DiagnosticCode.NONDETERMINISM_UNCLASSIFIED_FINDING,
+            DiagnosticCode.NONDETERMINISM_STALE_ENTRY,
+            DiagnosticCode.NONDETERMINISM_MISMATCHED_CLASSIFICATION,
+            DiagnosticCode.NONDETERMINISM_OCCURRENCE_MISMATCH,
+            DiagnosticCode.NONDETERMINISM_DUPLICATE_ENTRY,
+            DiagnosticCode.NONDETERMINISM_INVALID_DISPOSITION,
+            DiagnosticCode.NONDETERMINISM_MISSING_RATIONALE,
+            DiagnosticCode.NONDETERMINISM_INVALID_SCHEMA,
+            // Module documentation contract (Epic 11.2b3) — enforced by the
+            // verifyModuleDocContract task directly, not a maintainability baseline.
+            DiagnosticCode.MODULE_CARD_MISSING,
+            DiagnosticCode.MODULE_CARD_ORPHAN,
+            DiagnosticCode.MODULE_CARD_HEADING_MISSING,
+            DiagnosticCode.MODULE_CARD_LINK_BROKEN,
+            DiagnosticCode.MODULE_CARD_INLINE_PATH_BROKEN,
+            DiagnosticCode.MODULE_CARD_LEGACY_CLASSIFICATION,
+            DiagnosticCode.MODULE_CARD_VERSIONLESS_DEPENDENCY,
+            DiagnosticCode.MODULE_CARD_INTERNAL_MAVEN_ADVERTISEMENT,
+            DiagnosticCode.MODULE_CARD_COVERAGE_MISMATCH,
+            -> null
+        }
 
     private fun addManifestDiagnostics(
         diagnostics: List<VerificationDiagnostic>,
@@ -1509,15 +1636,18 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
         resultsDir: File,
         checks: Map<String, MutableList<VerificationDiagnostic>>,
     ) {
-        val reports = resultsDir.listFiles { file -> file.isFile && file.name.startsWith("TEST-") && file.extension == "xml" }
-            ?.sortedBy { it.name }
-            .orEmpty()
+        val reports =
+            resultsDir
+                .listFiles { file -> file.isFile && file.name.startsWith("TEST-") && file.extension == "xml" }
+                ?.sortedBy { it.name }
+                .orEmpty()
         if (reports.isEmpty()) {
             listOf("provider-contracts", "store-contracts").forEach { check ->
-                checks.getValue(check) += VerificationDiagnostic.failure(
-                    DiagnosticCode.EMPTY_SECTION,
-                    "Enrollment architecture test results are missing from ${resultsDir.path}",
-                )
+                checks.getValue(check) +=
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.EMPTY_SECTION,
+                        "Enrollment architecture test results are missing from ${resultsDir.path}",
+                    )
             }
             return
         }
@@ -1526,21 +1656,23 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
         reports.forEach { report ->
             val className = report.name.removePrefix("TEST-").removeSuffix(".xml")
             discoveredClasses += className
-            val check = when {
-                className == "dev.tramai.testing.ProviderTckEnrollmentArchitectureTest" -> "provider-contracts"
-                className.endsWith("EnrollmentArchitectureTest") -> "store-contracts"
-                else -> null
-            } ?: return@forEach
-            val factory = DocumentBuilderFactory.newInstance().apply {
-                setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
-                setFeature("http://xml.org/sax/features/external-general-entities", false)
-                setFeature("http://xml.org/sax/features/external-parameter-entities", false)
-                setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
-                setAttribute("http://javax.xml.XMLConstants/property/accessExternalDTD", "")
-                setAttribute("http://javax.xml.XMLConstants/property/accessExternalSchema", "")
-                isXIncludeAware = false
-                isExpandEntityReferences = false
-            }
+            val check =
+                when {
+                    className == "dev.tramai.testing.ProviderTckEnrollmentArchitectureTest" -> "provider-contracts"
+                    className.endsWith("EnrollmentArchitectureTest") -> "store-contracts"
+                    else -> null
+                } ?: return@forEach
+            val factory =
+                DocumentBuilderFactory.newInstance().apply {
+                    setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+                    setFeature("http://xml.org/sax/features/external-general-entities", false)
+                    setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+                    setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+                    setAttribute("http://javax.xml.XMLConstants/property/accessExternalDTD", "")
+                    setAttribute("http://javax.xml.XMLConstants/property/accessExternalSchema", "")
+                    isXIncludeAware = false
+                    isExpandEntityReferences = false
+                }
             val document = factory.newDocumentBuilder().parse(report)
             val cases = document.getElementsByTagName("testcase")
             for (index in 0 until cases.length) {
@@ -1550,10 +1682,11 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                     if (child.nodeName !in setOf("failure", "error")) continue
                     val failure = child as org.w3c.dom.Element
                     val message = failure.getAttribute("message").ifBlank { failure.textContent.trim() }
-                    checks.getValue(check) += VerificationDiagnostic.failure(
-                        DiagnosticCode.EMPTY_SECTION,
-                        "$className failed: $message",
-                    )
+                    checks.getValue(check) +=
+                        VerificationDiagnostic.failure(
+                            DiagnosticCode.EMPTY_SECTION,
+                            "$className failed: $message",
+                        )
                 }
             }
         }
@@ -1617,20 +1750,24 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                     val toolchains = fixture.extensions.getByType(JavaToolchainService::class.java)
                     if (extension == "java") {
                         this.javacExecutable.set(
-                            toolchains.compilerFor { languageVersion.set(JavaLanguageVersion.of(21)) }
-                                .map { it.executablePath.toString() }
+                            toolchains
+                                .compilerFor { languageVersion.set(JavaLanguageVersion.of(21)) }
+                                .map { it.executablePath.toString() },
                         )
                     } else {
                         this.javaExecutable.set(
-                            toolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(21)) }
-                                .map { it.executablePath.toString() }
+                            toolchains
+                                .launcherFor { languageVersion.set(JavaLanguageVersion.of(21)) }
+                                .map { it.executablePath.toString() },
                         )
                     }
                     this.classesDir.set(classesDir)
                     this.markerFile.set(markerFile)
-                    sources.from(fixture.fileTree(fixture.projectDir) {
-                        include("**/$sourceRelPath/**/*.${if (extension == "kotlin") "kt" else "java"}")
-                    })
+                    sources.from(
+                        fixture.fileTree(fixture.projectDir) {
+                            include("**/$sourceRelPath/**/*.${if (extension == "kotlin") "kt" else "java"}")
+                        },
+                    )
                     compileClasspath.from(fixture.configurations.getByName("compileClasspath"))
                     if (extension == "kotlin") {
                         kotlinCompilerClasspath.from(fixture.configurations.getByName("kotlinCompilerClasspath"))
@@ -1655,27 +1792,35 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
         checks: Map<String, MutableList<VerificationDiagnostic>>,
     ) {
         val catalog = ModuleManifest.catalog(project.rootDir)
-        val apiProjectPaths = project.allprojects
-            .filter { it != project && it.tasks.findByName("apiCheck") != null }
-            .map { it.path }
-            .toSet()
+        val apiProjectPaths =
+            project.allprojects
+                .filter { it != project && it.tasks.findByName("apiCheck") != null }
+                .map { it.path }
+                .toSet()
         val committed = ApiCompatibilityEvidenceReader.readCommittedDumps(project.rootDir, apiProjectPaths)
         val generated = ApiCompatibilityEvidenceReader.readGeneratedDumps(project)
         val baseRef = project.findProperty("changePolicyBase")?.toString() ?: "origin/master"
         val base = ApiCompatibilityEvidenceReader.readBaseDumps(project.rootDir, baseRef, committed.keys)
-        val migrationResult = ApiCompatibilityEvidenceReader.parseMigrations(
-            File(project.rootDir, "config/quality/api-migrations.yml")
-        )
+        val migrationResult =
+            ApiCompatibilityEvidenceReader.parseMigrations(
+                File(project.rootDir, "config/quality/api-migrations.yml"),
+            )
         checks.getValue("api-architecture") += migrationResult.diagnostics
-        val projectVersion = project.providers.gradleProperty("tramaiVersion").orElse("0.5.0").get()
-        val verifier = ApiCompatibilityVerifier(
-            catalogModules = catalog.modules,
-            projectVersion = projectVersion,
-        )
-        val diagnostics = verifier.verify(
-            ApiDumpEvidence(generated = generated, committed = committed, base = base),
-            migrations = migrationResult.entries,
-        )
+        val projectVersion =
+            project.providers
+                .gradleProperty("tramaiVersion")
+                .orElse("0.5.0")
+                .get()
+        val verifier =
+            ApiCompatibilityVerifier(
+                catalogModules = catalog.modules,
+                projectVersion = projectVersion,
+            )
+        val diagnostics =
+            verifier.verify(
+                ApiDumpEvidence(generated = generated, committed = committed, base = base),
+                migrations = migrationResult.entries,
+            )
         // Contract-1/2 and migration diagnostics flow straight to api-architecture.
         checks.getValue("api-architecture") += diagnostics
         // C3/C4: consumer compile proofs are fail-soft producers. Read their
@@ -1685,45 +1830,54 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             "java" to ":examples:java-consumer-smoke",
             "kotlin" to ":examples:kotlin-consumer-smoke",
         ).forEach { (language, fixturePath) ->
-            val marker = File(
-                project.project(fixturePath).layout.buildDirectory.get().asFile,
-                "reports/maintainability/consumer-$language.json"
-            )
-            if (!marker.isFile) {
-                checks.getValue("api-architecture") += VerificationDiagnostic.failure(
-                    DiagnosticCode.API_COMPATIBILITY_FAILED,
-                    "Consumer compile proof for '$language' produced no marker evidence at ${marker.path}",
+            val marker =
+                File(
+                    project
+                        .project(fixturePath)
+                        .layout.buildDirectory
+                        .get()
+                        .asFile,
+                    "reports/maintainability/consumer-$language.json",
                 )
+            if (!marker.isFile) {
+                checks.getValue("api-architecture") +=
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.API_COMPATIBILITY_FAILED,
+                        "Consumer compile proof for '$language' produced no marker evidence at ${marker.path}",
+                    )
                 return@forEach
             }
             val state = ReportNormalizer.readJson(marker, Map::class.java)
             val ok = state?.get("ok") == true
             if (!ok) {
-                checks.getValue("api-architecture") += VerificationDiagnostic.failure(
-                    DiagnosticCode.API_COMPATIBILITY_FAILED,
-                    "Consumer compile proof FAILED for '$language': " +
-                        "sources=${state?.get("sources")} classes=${state?.get("classes")} " +
-                        "exitCode=${state?.get("exitCode")} — the stable API is not usable from this consumer",
-                    baselineValue = state?.get("sources")?.toString(),
-                    currentValue = state?.get("classes")?.toString(),
-                )
+                checks.getValue("api-architecture") +=
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.API_COMPATIBILITY_FAILED,
+                        "Consumer compile proof FAILED for '$language': " +
+                            "sources=${state?.get("sources")} classes=${state?.get("classes")} " +
+                            "exitCode=${state?.get("exitCode")} — the stable API is not usable from this consumer",
+                        baselineValue = state?.get("sources")?.toString(),
+                        currentValue = state?.get("classes")?.toString(),
+                    )
             }
         }
     }
 
     private companion object {
-        val publishingTopologyCodes = setOf(
-            DiagnosticCode.MODULE_CATALOG_BOM_DRIFT,
-            DiagnosticCode.MODULE_CATALOG_PUBLISHING_DRIFT,
-        )
-        val baselineCheckIds = setOf(
-            "module-manifest",
-            "dependency-boundaries",
-            "dependency-cycles",
-            "global-state",
-            "api-architecture",
-            "protocol-catalog",
-            "cancellation-safety",
-        )
+        val publishingTopologyCodes =
+            setOf(
+                DiagnosticCode.MODULE_CATALOG_BOM_DRIFT,
+                DiagnosticCode.MODULE_CATALOG_PUBLISHING_DRIFT,
+            )
+        val baselineCheckIds =
+            setOf(
+                "module-manifest",
+                "dependency-boundaries",
+                "dependency-cycles",
+                "global-state",
+                "api-architecture",
+                "protocol-catalog",
+                "cancellation-safety",
+            )
     }
 }

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/MeasurementContext.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/MeasurementContext.kt
@@ -20,14 +20,19 @@ class MeasurementContext(
     /** Modules discovered in this tree. */
     val modules: List<DiscoveredModule>,
     /** The Gradle project (null when scanning a detached worktree). */
-    val gradleProject: Project? = null
+    val gradleProject: Project? = null,
 ) {
     fun runGit(vararg arguments: String): String {
-        val process = ProcessBuilder(listOf("git") + arguments)
-            .directory(rootDir)
-            .redirectErrorStream(true)
-            .start()
-        val output = process.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }.trim()
+        val process =
+            ProcessBuilder(listOf("git") + arguments)
+                .directory(rootDir)
+                .redirectErrorStream(true)
+                .start()
+        val output =
+            process.inputStream
+                .bufferedReader(Charsets.UTF_8)
+                .use { it.readText() }
+                .trim()
         check(process.waitFor() == 0 && output.isNotBlank()) {
             "git ${arguments.joinToString(" ")} failed in ${rootDir.absolutePath}: ${output.ifBlank { "no output" }}"
         }
@@ -35,29 +40,34 @@ class MeasurementContext(
     }
 
     fun runGitMulti(vararg arguments: String): String {
-        val process = ProcessBuilder(listOf("git") + arguments)
-            .directory(rootDir)
-            .redirectErrorStream(true)
-            .start()
-        val output = process.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }.trim()
+        val process =
+            ProcessBuilder(listOf("git") + arguments)
+                .directory(rootDir)
+                .redirectErrorStream(true)
+                .start()
+        val output =
+            process.inputStream
+                .bufferedReader(Charsets.UTF_8)
+                .use { it.readText() }
+                .trim()
         check(process.waitFor() == 0) {
             "git ${arguments.joinToString(" ")} failed in ${rootDir.absolutePath}: ${output.ifBlank { "no output" }}"
         }
         return output
     }
 
-    fun isWorkingTreeClean(): Boolean {
-        return try {
-            val process = ProcessBuilder(listOf("git", "status", "--porcelain"))
-                .directory(rootDir)
-                .redirectErrorStream(true)
-                .start()
+    fun isWorkingTreeClean(): Boolean =
+        try {
+            val process =
+                ProcessBuilder(listOf("git", "status", "--porcelain"))
+                    .directory(rootDir)
+                    .redirectErrorStream(true)
+                    .start()
             val output = process.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
             process.waitFor() == 0 && output.isBlank()
         } catch (_: Exception) {
             false
         }
-    }
 
     companion object {
         // ── Factory methods ──
@@ -67,36 +77,43 @@ class MeasurementContext(
          * Falls back to "unknown"/false for uncatalogued modules.
          */
         fun fromProject(project: Project): MeasurementContext {
-            val catalog = ModuleCatalog(project.rootDir)
+            val catalog = ModuleCatalog.fromRootDir(project.rootDir)
             catalog.parse()
             return fromProject(project, catalog)
         }
 
-        fun fromProject(project: Project, catalog: ModuleCatalog): MeasurementContext {
-            val gradleModules = project.allprojects
-                .filter { it != project && it.buildFile.exists() }
-                .map { proj ->
-                    val entry = catalog.entryFor(proj.path)
-                    DiscoveredModule(
-                        name = proj.name,
-                        path = proj.path,
-                        projectDir = proj.projectDir,
-                        buildFile = proj.buildFile,
-                        sourceDirs = listOf(
-                            File(proj.projectDir, "src/main/kotlin"),
-                            File(proj.projectDir, "src/main/java"),
-                        ),
-                        testSourceDirs = listOf(
-                            File(proj.projectDir, "src/test/kotlin"),
-                        ),
-                        testFixtureDirs = listOf(
-                            File(proj.projectDir, "src/testFixtures/kotlin"),
-                        ),
-                        publishable = entry?.publishability == ModulePublishability.PUBLISHED,
-                        layer = entry?.layer?.yaml ?: "unknown",
-                        apiStability = entry?.apiStability?.yaml ?: "unclassified",
-                    )
-                }
+        fun fromProject(
+            project: Project,
+            catalog: ModuleCatalog,
+        ): MeasurementContext {
+            val gradleModules =
+                project.allprojects
+                    .filter { it != project && it.buildFile.exists() }
+                    .map { proj ->
+                        val entry = catalog.entryFor(proj.path)
+                        DiscoveredModule(
+                            name = proj.name,
+                            path = proj.path,
+                            projectDir = proj.projectDir,
+                            buildFile = proj.buildFile,
+                            sourceDirs =
+                                listOf(
+                                    File(proj.projectDir, "src/main/kotlin"),
+                                    File(proj.projectDir, "src/main/java"),
+                                ),
+                            testSourceDirs =
+                                listOf(
+                                    File(proj.projectDir, "src/test/kotlin"),
+                                ),
+                            testFixtureDirs =
+                                listOf(
+                                    File(proj.projectDir, "src/testFixtures/kotlin"),
+                                ),
+                            publishable = entry?.publishability == ModulePublishability.PUBLISHED,
+                            layer = entry?.layer?.yaml ?: "unknown",
+                            apiStability = entry?.apiStability?.yaml ?: "unclassified",
+                        )
+                    }
 
             return MeasurementContext(
                 rootDir = project.rootDir,
@@ -109,7 +126,7 @@ class MeasurementContext(
          * Create a MeasurementContext from a directory, loading the catalog internally.
          */
         fun fromDirectory(rootDir: File): MeasurementContext {
-            val catalog = ModuleCatalog(rootDir)
+            val catalog = ModuleCatalog.fromRootDir(rootDir)
             catalog.parse()
             return fromDirectory(rootDir, catalog)
         }
@@ -122,19 +139,24 @@ class MeasurementContext(
          *
          * @throws IllegalStateException if the catalog has parsing failures
          */
-        fun fromDirectory(rootDir: File, catalogRoot: File): MeasurementContext {
-            val catalog = ModuleCatalog(catalogRoot)
+        fun fromDirectory(
+            rootDir: File,
+            catalogRoot: File,
+        ): MeasurementContext {
+            val catalog = ModuleCatalog.fromRootDir(catalogRoot)
             val result = catalog.parse()
             val failedDiagnostics = result.errors.filter { it.severity == DiagnosticSeverity.FAILURE }
             if (failedDiagnostics.isNotEmpty()) {
                 val summary = failedDiagnostics.joinToString("; ") { it.message }
-                throw IllegalStateException(
-                    "Module catalog has ${failedDiagnostics.size} error(s): $summary")
+                throw IllegalStateException("Module catalog has ${failedDiagnostics.size} error(s): $summary")
             }
             return fromDirectory(rootDir, catalog)
         }
 
-        fun fromDirectory(rootDir: File, catalog: ModuleCatalog): MeasurementContext {
+        fun fromDirectory(
+            rootDir: File,
+            catalog: ModuleCatalog,
+        ): MeasurementContext {
             val modules = discoverModulesFromSettings(rootDir, catalog)
             return MeasurementContext(
                 rootDir = rootDir,
@@ -147,14 +169,15 @@ class MeasurementContext(
          * Build a MeasurementContext by loading the ModuleCatalog first.
          */
         fun loadFromCatalog(rootDir: File): Pair<MeasurementContext, ModuleCatalog.CatalogResult> {
-            val catalog = ModuleCatalog(rootDir)
+            val catalog = ModuleCatalog.fromRootDir(rootDir)
             val catalogResult = catalog.parse()
             val modules = discoverModulesFromSettings(rootDir, catalog)
-            val ctx = MeasurementContext(
-                rootDir = rootDir,
-                modules = modules,
-                gradleProject = null,
-            )
+            val ctx =
+                MeasurementContext(
+                    rootDir = rootDir,
+                    modules = modules,
+                    gradleProject = null,
+                )
             return ctx to catalogResult
         }
 
@@ -162,13 +185,17 @@ class MeasurementContext(
         // All paths are normalized to Gradle format (leading ":") so that
         // canonical and project modes produce identical module identities.
 
-        private fun discoverModulesFromSettings(rootDir: File, catalog: ModuleCatalog): List<DiscoveredModule> {
+        private fun discoverModulesFromSettings(
+            rootDir: File,
+            catalog: ModuleCatalog,
+        ): List<DiscoveredModule> {
             val settingsFile = File(rootDir, "settings.gradle.kts")
-            val includedPaths = if (settingsFile.isFile) {
-                parseSettingsIncludes(settingsFile)
-            } else {
-                emptyList()
-            }
+            val includedPaths =
+                if (settingsFile.isFile) {
+                    parseSettingsIncludes(settingsFile)
+                } else {
+                    emptyList()
+                }
 
             return includedPaths.mapNotNull { includePath ->
                 val moduleDir = File(rootDir, includePath.replace(":", "/"))
@@ -182,16 +209,19 @@ class MeasurementContext(
                     path = includePath,
                     projectDir = moduleDir,
                     buildFile = buildFile,
-                    sourceDirs = listOf(
-                        File(moduleDir, "src/main/kotlin"),
-                        File(moduleDir, "src/main/java"),
-                    ),
-                    testSourceDirs = listOf(
-                        File(moduleDir, "src/test/kotlin"),
-                    ),
-                    testFixtureDirs = listOf(
-                        File(moduleDir, "src/testFixtures/kotlin"),
-                    ),
+                    sourceDirs =
+                        listOf(
+                            File(moduleDir, "src/main/kotlin"),
+                            File(moduleDir, "src/main/java"),
+                        ),
+                    testSourceDirs =
+                        listOf(
+                            File(moduleDir, "src/test/kotlin"),
+                        ),
+                    testFixtureDirs =
+                        listOf(
+                            File(moduleDir, "src/testFixtures/kotlin"),
+                        ),
                     publishable = entry?.publishability == ModulePublishability.PUBLISHED,
                     layer = entry?.layer?.yaml ?: "unknown",
                     apiStability = entry?.apiStability?.yaml ?: "unclassified",
@@ -220,13 +250,15 @@ class MeasurementContext(
 
             // Extract all quoted strings from the block
             val quotedRegex = Regex(""""([^"]+)"""")
-            return quotedRegex.findAll(blockMatch.groupValues[1]).map { it.groupValues[1] }.toList()
+            return quotedRegex
+                .findAll(blockMatch.groupValues[1])
+                .map { it.groupValues[1] }
+                .toList()
                 .map { normalizeGradlePath(it) }
         }
 
         /** Normalize a module path to Gradle format (leading colon). */
-        private fun normalizeGradlePath(includePath: String): String =
-            if (includePath.startsWith(":")) includePath else ":$includePath"
+        private fun normalizeGradlePath(includePath: String): String = if (includePath.startsWith(":")) includePath else ":$includePath"
     }
 }
 

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/ModuleCatalog.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/ModuleCatalog.kt
@@ -6,90 +6,407 @@ import org.yaml.snakeyaml.constructor.SafeConstructor
 import java.io.File
 import java.io.FileInputStream
 
-enum class ModuleLayer(val yaml: String) {
-    CORE_CONTRACTS("core-contracts"), RUNTIME_EXECUTION("runtime-execution"), GOVERNANCE_SECURITY("governance-security"), PERSISTENCE("persistence"), PROVIDER_ADAPTERS("provider-adapters"), FRAMEWORK_INTEGRATIONS("framework-integrations"), OPERATIONS_OBSERVABILITY("operations-observability"), HIGHER_CAPABILITIES("higher-capabilities"), APPLICATIONS_EXAMPLES("applications-examples"), TESTING_SUPPORT("testing-support");
-    companion object { fun fromYaml(value: String) = entries.firstOrNull { it.yaml == value } }
-}
-enum class ModuleMaturity(val yaml: String) { STABLE("stable"), PREVIEW("preview"), EXPERIMENTAL("experimental"), INTERNAL("internal"); companion object { fun fromYaml(value: String) = entries.firstOrNull { it.yaml == value } } }
-enum class ModulePublishability(val yaml: String) { PUBLISHED("published"), INTERNAL("internal"), EXCLUDED("excluded"); companion object { fun fromYaml(value: String) = entries.firstOrNull { it.yaml == value } } }
-enum class ModuleApiStability(val yaml: String) { STABLE("stable"), PREVIEW("preview"), EXPERIMENTAL("experimental"), INTERNAL("internal"), EXCLUDED("excluded"); companion object { fun fromYaml(value: String) = entries.firstOrNull { it.yaml == value } } }
-enum class ModuleVisibility(val yaml: String) { PUBLIC("public"), INTERNAL("internal"), EXCLUDED("excluded"); companion object { fun fromYaml(value: String) = entries.firstOrNull { it.yaml == value } } }
-enum class ReleaseInclusion(val yaml: String) { INCLUDED("included"), INTERNAL_ONLY("internal_only"), EXCLUDED("excluded"); companion object { fun fromYaml(value: String) = entries.firstOrNull { it.yaml == value } } }
+enum class ModuleLayer(
+    val yaml: String,
+) {
+    CORE_CONTRACTS("core-contracts"),
+    RUNTIME_EXECUTION("runtime-execution"),
+    GOVERNANCE_SECURITY("governance-security"),
+    PERSISTENCE("persistence"),
+    PROVIDER_ADAPTERS("provider-adapters"),
+    FRAMEWORK_INTEGRATIONS("framework-integrations"),
+    OPERATIONS_OBSERVABILITY("operations-observability"),
+    HIGHER_CAPABILITIES("higher-capabilities"),
+    APPLICATIONS_EXAMPLES("applications-examples"),
+    TESTING_SUPPORT("testing-support"),
+    ;
 
-/** Parses the authoritative, versioned module architecture manifest. */
-class ModuleCatalog(private val rootDir: File) {
-    data class ModuleEntry(val path: String, val layer: ModuleLayer, val maturity: ModuleMaturity, val publishability: ModulePublishability, val apiStability: ModuleApiStability, val visibility: ModuleVisibility, val owner: String, val dependencyPolicy: String, val releaseInclusion: ReleaseInclusion, val rationale: String, val description: String?)
-    data class CatalogResult(val modules: Map<String, ModuleEntry>, val dependencyPolicies: Map<String, Set<ModuleLayer>>, val errors: List<VerificationDiagnostic>)
+    companion object {
+        fun fromYaml(value: String) = entries.firstOrNull { it.yaml == value }
+    }
+}
+
+enum class ModuleMaturity(
+    val yaml: String,
+) {
+    STABLE("stable"),
+    PREVIEW("preview"),
+    EXPERIMENTAL("experimental"),
+    INTERNAL("internal"),
+    ;
+
+    companion object {
+        fun fromYaml(value: String) =
+            entries.firstOrNull {
+                it.yaml ==
+                    value
+            }
+    }
+}
+
+enum class ModulePublishability(
+    val yaml: String,
+) {
+    PUBLISHED("published"),
+    INTERNAL("internal"),
+    EXCLUDED("excluded"),
+    ;
+
+    companion object {
+        fun fromYaml(value: String) =
+            entries.firstOrNull {
+                it.yaml ==
+                    value
+            }
+    }
+}
+
+enum class ModuleApiStability(
+    val yaml: String,
+) {
+    STABLE("stable"),
+    PREVIEW("preview"),
+    EXPERIMENTAL("experimental"),
+    INTERNAL("internal"),
+    EXCLUDED("excluded"),
+    ;
+
+    companion object {
+        fun fromYaml(value: String) =
+            entries.firstOrNull {
+                it.yaml ==
+                    value
+            }
+    }
+}
+
+enum class ModuleVisibility(
+    val yaml: String,
+) {
+    PUBLIC("public"),
+    INTERNAL("internal"),
+    EXCLUDED("excluded"),
+    ;
+
+    companion object {
+        fun fromYaml(value: String) =
+            entries.firstOrNull {
+                it.yaml ==
+                    value
+            }
+    }
+}
+
+enum class ReleaseInclusion(
+    val yaml: String,
+) {
+    INCLUDED("included"),
+    INTERNAL_ONLY("internal_only"),
+    EXCLUDED("excluded"),
+    ;
+
+    companion object {
+        fun fromYaml(value: String) =
+            entries.firstOrNull {
+                it.yaml ==
+                    value
+            }
+    }
+}
+
+/**
+ * Parses the authoritative, versioned module architecture manifest.
+ *
+ * The primary authority is the exact catalog [File] (declared input = execution
+ * authority, a3 discipline). [fromRootDir] retains the historical
+ * conventional-path contract (rootDir/config/quality/module-catalog.yml) for
+ * existing callers; the parser itself is not duplicated.
+ */
+class ModuleCatalog(
+    catalogFile: File,
+) {
+    private val catalogFile: File = catalogFile
+
+    data class ModuleEntry(
+        val path: String,
+        val layer: ModuleLayer,
+        val maturity: ModuleMaturity,
+        val publishability: ModulePublishability,
+        val apiStability: ModuleApiStability,
+        val visibility: ModuleVisibility,
+        val owner: String,
+        val dependencyPolicy: String,
+        val releaseInclusion: ReleaseInclusion,
+        val rationale: String,
+        val description: String?,
+    )
+
+    data class CatalogResult(
+        val modules: Map<String, ModuleEntry>,
+        val dependencyPolicies: Map<String, Set<ModuleLayer>>,
+        val errors: List<VerificationDiagnostic>,
+    )
+
     private var parsedModules: Map<String, ModuleEntry> = emptyMap()
     private var parsedPolicies: Map<String, Set<ModuleLayer>> = emptyMap()
     val validLayers = ModuleLayer.entries.map { it.yaml }.toSet()
 
     fun parse(): CatalogResult {
-        val file = File(rootDir, "config/quality/module-catalog.yml")
-        if (!file.isFile) return CatalogResult(emptyMap(), emptyMap(), listOf(failure(DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY, "Module catalog not found: ${file.absolutePath}")))
-        val errors = mutableListOf<VerificationDiagnostic>(); val modules = linkedMapOf<String, ModuleEntry>(); val policies = linkedMapOf<String, Set<ModuleLayer>>()
+        val file = catalogFile
+        if (!file.isFile) {
+            return CatalogResult(
+                emptyMap(),
+                emptyMap(),
+                listOf(failure(DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY, "Module catalog not found: ${file.absolutePath}")),
+            )
+        }
+        val errors = mutableListOf<VerificationDiagnostic>()
+        val modules = linkedMapOf<String, ModuleEntry>()
+        val policies = linkedMapOf<String, Set<ModuleLayer>>()
         try {
-            val root = FileInputStream(file).use {
-                val loaderOptions = LoaderOptions().apply { maxAliasesForCollections = 200 }
-                Yaml(SafeConstructor(loaderOptions)).load<Map<String, Any>>(it)
+            val root =
+                FileInputStream(file).use {
+                    val loaderOptions = LoaderOptions().apply { maxAliasesForCollections = 200 }
+                    Yaml(SafeConstructor(loaderOptions)).load<Map<String, Any>>(it)
+                }
+            if (root["schemaVersion"]?.toString() !=
+                "3"
+            ) {
+                errors += failure(DiagnosticCode.MODULE_CATALOG_INVALID_SCHEMA, "Module catalog schemaVersion must be '3'")
             }
-            if (root["schemaVersion"]?.toString() != "3") errors += failure(DiagnosticCode.MODULE_CATALOG_INVALID_SCHEMA, "Module catalog schemaVersion must be '3'")
             val policyRaw = root["dependencyPolicies"] as? Map<String, Map<String, Any>> ?: emptyMap()
             policyRaw.forEach { (name, definition) ->
                 val rawLayers = definition["allowedLayers"] as? List<*> ?: emptyList<Any>()
                 val layers = rawLayers.mapNotNull { ModuleLayer.fromYaml(it.toString()) }.toSet()
-                if (layers.size != rawLayers.size || layers.isEmpty()) errors += failure(DiagnosticCode.MODULE_CATALOG_INVALID_POLICY, "Dependency policy '$name' has invalid allowedLayers")
+                if (layers.size != rawLayers.size ||
+                    layers.isEmpty()
+                ) {
+                    errors +=
+                        failure(DiagnosticCode.MODULE_CATALOG_INVALID_POLICY, "Dependency policy '$name' has invalid allowedLayers")
+                }
                 policies[name] = layers
             }
             val entries = root["modules"] as? List<Map<String, Any>> ?: emptyList()
             entries.forEachIndexed { index, raw -> parseEntry(index, raw, policies, modules, errors) }
-            if (modules.isEmpty() && errors.isEmpty()) errors += failure(DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY, "Module catalog is empty — no module entries found")
-        } catch (e: Exception) { errors += failure(DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY, "Failed to parse module catalog: ${e.message}") }
-        parsedModules = modules; parsedPolicies = policies
+            if (modules.isEmpty() &&
+                errors.isEmpty()
+            ) {
+                errors +=
+                    failure(DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY, "Module catalog is empty — no module entries found")
+            }
+        } catch (e: Exception) {
+            errors +=
+                failure(DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY, "Failed to parse module catalog: ${e.message}")
+        }
+        parsedModules = modules
+        parsedPolicies = policies
         return CatalogResult(modules, policies, errors)
     }
 
-    private fun parseEntry(index: Int, raw: Map<String, Any>, policies: Map<String, Set<ModuleLayer>>, modules: MutableMap<String, ModuleEntry>, errors: MutableList<VerificationDiagnostic>) {
+    private fun parseEntry(
+        index: Int,
+        raw: Map<String, Any>,
+        policies: Map<String, Set<ModuleLayer>>,
+        modules: MutableMap<String, ModuleEntry>,
+        errors: MutableList<VerificationDiagnostic>,
+    ) {
         val path = raw["path"]?.toString().orEmpty()
-        if (path.isBlank()) { errors += failure(DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY, "Module catalog entry $index: path is blank"); return }
-        fun <T> enum(field: String, value: T?, code: DiagnosticCode): T? { if (value == null) errors += failure(code, "$path: invalid $field '${raw[field]?.toString().orEmpty()}'", path); return value }
+        if (path.isBlank()) {
+            errors += failure(DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY, "Module catalog entry $index: path is blank")
+            return
+        }
+
+        fun <T> enum(
+            field: String,
+            value: T?,
+            code: DiagnosticCode,
+        ): T? {
+            if (value == null) errors += failure(code, "$path: invalid $field '${raw[field]?.toString().orEmpty()}'", path)
+            return value
+        }
         val layer = enum("layer", ModuleLayer.fromYaml(raw["layer"]?.toString().orEmpty()), DiagnosticCode.MODULE_CATALOG_INVALID_LAYER)
-        val maturity = enum("maturity", ModuleMaturity.fromYaml(raw["maturity"]?.toString().orEmpty()), DiagnosticCode.MODULE_CATALOG_INVALID_MATURITY)
-        val publishability = enum("publishability", ModulePublishability.fromYaml(raw["publishability"]?.toString().orEmpty()), DiagnosticCode.MODULE_CATALOG_INVALID_PUBLISHABILITY)
-        val api = enum("apiStability", ModuleApiStability.fromYaml(raw["apiStability"]?.toString().orEmpty()), DiagnosticCode.MODULE_CATALOG_MISSING_API_STABILITY)
-        val visibility = enum("visibility", ModuleVisibility.fromYaml(raw["visibility"]?.toString().orEmpty()), DiagnosticCode.MODULE_CATALOG_INVALID_VISIBILITY)
-        val owner = raw["owner"]?.toString().orEmpty(); val policy = raw["dependencyPolicy"]?.toString().orEmpty(); val release = enum("releaseInclusion", ReleaseInclusion.fromYaml(raw["releaseInclusion"]?.toString().orEmpty()), DiagnosticCode.MODULE_CATALOG_INVALID_RELEASE_INCLUSION); val rationale = raw["rationale"]?.toString().orEmpty(); val description = raw["description"]?.toString()
+        val maturity =
+            enum("maturity", ModuleMaturity.fromYaml(raw["maturity"]?.toString().orEmpty()), DiagnosticCode.MODULE_CATALOG_INVALID_MATURITY)
+        val publishability =
+            enum(
+                "publishability",
+                ModulePublishability.fromYaml(raw["publishability"]?.toString().orEmpty()),
+                DiagnosticCode.MODULE_CATALOG_INVALID_PUBLISHABILITY,
+            )
+        val api =
+            enum(
+                "apiStability",
+                ModuleApiStability.fromYaml(raw["apiStability"]?.toString().orEmpty()),
+                DiagnosticCode.MODULE_CATALOG_MISSING_API_STABILITY,
+            )
+        val visibility =
+            enum(
+                "visibility",
+                ModuleVisibility.fromYaml(raw["visibility"]?.toString().orEmpty()),
+                DiagnosticCode.MODULE_CATALOG_INVALID_VISIBILITY,
+            )
+        val owner = raw["owner"]?.toString().orEmpty()
+        val policy = raw["dependencyPolicy"]?.toString().orEmpty()
+        val release =
+            enum(
+                "releaseInclusion",
+                ReleaseInclusion.fromYaml(raw["releaseInclusion"]?.toString().orEmpty()),
+                DiagnosticCode.MODULE_CATALOG_INVALID_RELEASE_INCLUSION,
+            )
+        val rationale = raw["rationale"]?.toString().orEmpty()
+        val description = raw["description"]?.toString()
         if (owner.isBlank()) errors += failure(DiagnosticCode.MODULE_CATALOG_BLANK_OWNER, "$path: owner is blank", path)
         if (rationale.isBlank()) errors += failure(DiagnosticCode.MODULE_CATALOG_BLANK_RATIONALE, "$path: rationale is blank", path)
-        if (policy !in policies) errors += failure(DiagnosticCode.MODULE_CATALOG_INVALID_POLICY, "$path: unknown dependencyPolicy '$policy'", path)
+        if (policy !in
+            policies
+        ) {
+            errors += failure(DiagnosticCode.MODULE_CATALOG_INVALID_POLICY, "$path: unknown dependencyPolicy '$policy'", path)
+        }
         if (path in modules) errors += failure(DiagnosticCode.MODULE_CATALOG_DUPLICATE_PATH, "Module catalog: duplicate path '$path'", path)
         if (layer == null || maturity == null || publishability == null || api == null || visibility == null || release == null) return
-        if (publishability == ModulePublishability.PUBLISHED && description.isNullOrBlank()) errors += failure(DiagnosticCode.MODULE_CATALOG_MISSING_DESCRIPTION, "$path: published modules must have a non-blank description", path)
-        if (publishability == ModulePublishability.PUBLISHED && api == ModuleApiStability.EXCLUDED) errors += failure(DiagnosticCode.MODULE_CATALOG_MISSING_API_STABILITY, "$path: published modules must not have apiStability 'excluded'", path)
-        if (layer == ModuleLayer.APPLICATIONS_EXAMPLES && publishability != ModulePublishability.EXCLUDED) errors += failure(DiagnosticCode.MODULE_CATALOG_EXAMPLE_PUBLISHABLE, "$path: examples must have publishability 'excluded'", path)
-        if (publishability == ModulePublishability.EXCLUDED && api != ModuleApiStability.EXCLUDED) errors += failure(DiagnosticCode.MODULE_CATALOG_MISSING_API_STABILITY, "$path: excluded modules must have apiStability 'excluded'", path)
-        if (visibility == ModuleVisibility.PUBLIC && publishability == ModulePublishability.INTERNAL) errors += failure(DiagnosticCode.MODULE_CATALOG_INVALID_COMBINATION, "$path: public visibility cannot be internal publishability", path)
-        if (!apiStrengthFitsMaturity(api, maturity)) errors += failure(DiagnosticCode.MODULE_CATALOG_INVALID_COMBINATION, "$path: API strength '$api' cannot exceed maturity '$maturity' (stable API requires stable maturity; preview requires preview+; experimental requires experimental+)", path)
-        if (release == ReleaseInclusion.INCLUDED && publishability != ModulePublishability.PUBLISHED) errors += failure(DiagnosticCode.MODULE_CATALOG_INVALID_COMBINATION, "$path: included release requires published module", path)
-        if (maturity == ModuleMaturity.INTERNAL && api != ModuleApiStability.INTERNAL && api != ModuleApiStability.EXCLUDED) errors += failure(DiagnosticCode.MODULE_CATALOG_INVALID_COMBINATION, "$path: internal maturity cannot promise stable/preview API", path)
-        if (errors.none { it.modulePath == path }) modules[path] = ModuleEntry(path, layer, maturity, publishability, api, visibility, owner, policy, release, rationale, description)
+        if (publishability == ModulePublishability.PUBLISHED &&
+            description.isNullOrBlank()
+        ) {
+            errors +=
+                failure(
+                    DiagnosticCode.MODULE_CATALOG_MISSING_DESCRIPTION,
+                    "$path: published modules must have a non-blank description",
+                    path,
+                )
+        }
+        if (publishability == ModulePublishability.PUBLISHED &&
+            api == ModuleApiStability.EXCLUDED
+        ) {
+            errors +=
+                failure(
+                    DiagnosticCode.MODULE_CATALOG_MISSING_API_STABILITY,
+                    "$path: published modules must not have apiStability 'excluded'",
+                    path,
+                )
+        }
+        if (layer == ModuleLayer.APPLICATIONS_EXAMPLES &&
+            publishability != ModulePublishability.EXCLUDED
+        ) {
+            errors +=
+                failure(DiagnosticCode.MODULE_CATALOG_EXAMPLE_PUBLISHABLE, "$path: examples must have publishability 'excluded'", path)
+        }
+        if (publishability == ModulePublishability.EXCLUDED &&
+            api != ModuleApiStability.EXCLUDED
+        ) {
+            errors +=
+                failure(
+                    DiagnosticCode.MODULE_CATALOG_MISSING_API_STABILITY,
+                    "$path: excluded modules must have apiStability 'excluded'",
+                    path,
+                )
+        }
+        if (visibility == ModuleVisibility.PUBLIC &&
+            publishability == ModulePublishability.INTERNAL
+        ) {
+            errors +=
+                failure(
+                    DiagnosticCode.MODULE_CATALOG_INVALID_COMBINATION,
+                    "$path: public visibility cannot be internal publishability",
+                    path,
+                )
+        }
+        if (!apiStrengthFitsMaturity(api, maturity)) {
+            errors +=
+                failure(
+                    DiagnosticCode.MODULE_CATALOG_INVALID_COMBINATION,
+                    "$path: API strength '$api' cannot exceed maturity '$maturity' (stable API requires stable maturity; preview requires preview+; experimental requires experimental+)",
+                    path,
+                )
+        }
+        if (release == ReleaseInclusion.INCLUDED &&
+            publishability != ModulePublishability.PUBLISHED
+        ) {
+            errors +=
+                failure(DiagnosticCode.MODULE_CATALOG_INVALID_COMBINATION, "$path: included release requires published module", path)
+        }
+        if (maturity == ModuleMaturity.INTERNAL && api != ModuleApiStability.INTERNAL &&
+            api != ModuleApiStability.EXCLUDED
+        ) {
+            errors +=
+                failure(
+                    DiagnosticCode.MODULE_CATALOG_INVALID_COMBINATION,
+                    "$path: internal maturity cannot promise stable/preview API",
+                    path,
+                )
+        }
+        if (errors.none { it.modulePath == path }) {
+            modules[path] =
+                ModuleEntry(path, layer, maturity, publishability, api, visibility, owner, policy, release, rationale, description)
+        }
     }
-    fun validateAgainstProjects(catalogModules: Map<String, ModuleEntry>, projectPaths: List<String>, errors: MutableList<VerificationDiagnostic>) { projectPaths.filter { it !in catalogModules }.forEach { errors += failure(DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY, "Gradle project '$it' has no module-catalog entry") }; catalogModules.keys.filter { it !in projectPaths }.forEach { errors += failure(DiagnosticCode.MODULE_CATALOG_UNKNOWN_ENTRY, "Module-catalog entry '$it' does not exist as a Gradle project") } }
+
+    fun validateAgainstProjects(
+        catalogModules: Map<String, ModuleEntry>,
+        projectPaths: List<String>,
+        errors: MutableList<VerificationDiagnostic>,
+    ) {
+        projectPaths
+            .filter {
+                it !in
+                    catalogModules
+            }.forEach {
+                errors +=
+                    failure(DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY, "Gradle project '$it' has no module-catalog entry")
+            }
+        catalogModules.keys
+            .filter {
+                it !in
+                    projectPaths
+            }.forEach {
+                errors +=
+                    failure(DiagnosticCode.MODULE_CATALOG_UNKNOWN_ENTRY, "Module-catalog entry '$it' does not exist as a Gradle project")
+            }
+    }
+
     fun layerFor(path: String): String? = parsedModules[path]?.layer?.yaml
+
     fun publishabilityFor(path: String): String? = parsedModules[path]?.publishability?.yaml
+
     fun apiStabilityFor(path: String): String? = parsedModules[path]?.apiStability?.yaml
+
     fun isPublished(path: String) = parsedModules[path]?.publishability == ModulePublishability.PUBLISHED
+
     fun entryFor(path: String): ModuleEntry? = parsedModules[path]
+
     fun allowedLayersFor(path: String): Set<ModuleLayer>? = parsedModules[path]?.dependencyPolicy?.let(parsedPolicies::get)
-    private fun failure(code: DiagnosticCode, message: String, path: String? = null) = VerificationDiagnostic.failure(code, message, path)
+
+    private fun failure(
+        code: DiagnosticCode,
+        message: String,
+        path: String? = null,
+    ) = VerificationDiagnostic.failure(code, message, path)
 
     companion object {
+        /** Conventional-path factory: rootDir/config/quality/module-catalog.yml (historical contract). */
+        fun fromRootDir(rootDir: File): ModuleCatalog = ModuleCatalog(File(rootDir, "config/quality/module-catalog.yml"))
+
         /** Strength matrix: API strength may never exceed module maturity. */
-        fun apiStrengthFitsMaturity(api: ModuleApiStability, maturity: ModuleMaturity): Boolean = when (api) {
-            ModuleApiStability.STABLE -> maturity == ModuleMaturity.STABLE
-            ModuleApiStability.PREVIEW -> maturity == ModuleMaturity.STABLE || maturity == ModuleMaturity.PREVIEW
-            ModuleApiStability.EXPERIMENTAL -> maturity == ModuleMaturity.STABLE || maturity == ModuleMaturity.PREVIEW || maturity == ModuleMaturity.EXPERIMENTAL
-            ModuleApiStability.INTERNAL, ModuleApiStability.EXCLUDED -> true
-        }
+        fun apiStrengthFitsMaturity(
+            api: ModuleApiStability,
+            maturity: ModuleMaturity,
+        ): Boolean =
+            when (api) {
+                ModuleApiStability.STABLE -> {
+                    maturity == ModuleMaturity.STABLE
+                }
+
+                ModuleApiStability.PREVIEW -> {
+                    maturity == ModuleMaturity.STABLE || maturity == ModuleMaturity.PREVIEW
+                }
+
+                ModuleApiStability.EXPERIMENTAL -> {
+                    maturity == ModuleMaturity.STABLE || maturity == ModuleMaturity.PREVIEW ||
+                        maturity == ModuleMaturity.EXPERIMENTAL
+                }
+
+                ModuleApiStability.INTERNAL, ModuleApiStability.EXCLUDED -> {
+                    true
+                }
+            }
     }
 }

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/ModuleDocContractVerifier.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/ModuleDocContractVerifier.kt
@@ -22,19 +22,19 @@ import java.io.FileFilter
  * thread-safety truth, public-JVM vs supported-API intent).
  */
 object ModuleDocContractVerifier {
-
-    val REQUIRED_HEADINGS = listOf(
-        "Responsibility",
-        "Public entry points",
-        "Internal extension points",
-        "Significant dependencies",
-        "Lifecycle ownership",
-        "Thread-safety and concurrency",
-        "Failure semantics",
-        "Contract tests / TCKs",
-        "Do not",
-        "Related architecture",
-    )
+    val REQUIRED_HEADINGS =
+        listOf(
+            "Responsibility",
+            "Public entry points",
+            "Internal extension points",
+            "Significant dependencies",
+            "Lifecycle ownership",
+            "Thread-safety and concurrency",
+            "Failure semantics",
+            "Contract tests / TCKs",
+            "Do not",
+            "Related architecture",
+        )
 
     /**
      * Legacy manual architecture-classification metadata — rejected ONLY in the
@@ -43,17 +43,18 @@ object ModuleDocContractVerifier {
      * "Status:"/"Role:" elsewhere (runtime/workflow state, descriptions) are
      * legitimate documentation vocabulary and must NOT be rejected.
      */
-    private val LEGACY_CLASSIFICATION_PATTERNS = listOf(
-        Regex("""\*\*Module type:\*\*"""),
-        Regex("""\*\*Source files:\*\*"""),
-        Regex("""\*\*Test files:\*\*"""),
-        Regex("""\*\*Build:\*\*\s*`?dev\.tramai"""),
-        Regex("""\*\*Version:\*\*\s*`?\d+\.\d+"""),
-        Regex("""\*\*Status:\*\*\s*(Stable|Preview|Internal|Experimental|GA|Beta|Alpha)"""),
-        Regex("""\*\*Publishability:\*\*"""),
-        Regex("""\*\*Maturity:\*\*"""),
-        Regex("""\*\*Release:\*\*"""),
-    )
+    private val LEGACY_CLASSIFICATION_PATTERNS =
+        listOf(
+            Regex("""\*\*Module type:\*\*"""),
+            Regex("""\*\*Source files:\*\*"""),
+            Regex("""\*\*Test files:\*\*"""),
+            Regex("""\*\*Build:\*\*\s*`?dev\.tramai"""),
+            Regex("""\*\*Version:\*\*\s*`?\d+\.\d+"""),
+            Regex("""\*\*Status:\*\*\s*(Stable|Preview|Internal|Experimental|GA|Beta|Alpha)"""),
+            Regex("""\*\*Publishability:\*\*"""),
+            Regex("""\*\*Maturity:\*\*"""),
+            Regex("""\*\*Release:\*\*"""),
+        )
 
     private val MANIFEST_LINK_MARKER = "module-catalog.yml"
     private val README = "README.md"
@@ -61,25 +62,29 @@ object ModuleDocContractVerifier {
     /** Verifies all module cards under docsDir against the manifest. */
     fun verify(rootDir: File): List<VerificationDiagnostic> {
         val diagnostics = mutableListOf<VerificationDiagnostic>()
-        val catalog = ModuleCatalog(rootDir).parse()
+        val catalog = ModuleCatalog.fromRootDir(rootDir).parse()
         val modules = catalog.modules
         val docsDir = File(rootDir, "docs/modules")
         if (!docsDir.isDirectory) {
-            diagnostics += VerificationDiagnostic.failure(
-                DiagnosticCode.MODULE_CARD_MISSING,
-                "docs/modules directory does not exist",
-            )
+            diagnostics +=
+                VerificationDiagnostic.failure(
+                    DiagnosticCode.MODULE_CARD_MISSING,
+                    "docs/modules directory does not exist",
+                )
             return diagnostics
         }
 
-        val cardFiles = docsDir.listFiles(FileFilter { f ->
-            f.name.endsWith(".md") &&
-                f.name != README &&
-                // Reference document, not a module card (README documents this).
-                f.name != "sovereign-runtime-module-matrix.md"
-        })
-            ?.sortedBy { it.name }
-            ?: emptyList<File>()
+        val cardFiles =
+            docsDir
+                .listFiles(
+                    FileFilter { f ->
+                        f.name.endsWith(".md") &&
+                            f.name != README &&
+                            // Reference document, not a module card (README documents this).
+                            f.name != "sovereign-runtime-module-matrix.md"
+                    },
+                )?.sortedBy { it.name }
+                ?: emptyList<File>()
         val cardNames = cardFiles.map { it.name.removeSuffix(".md") }.toSet()
 
         // 1. One card per manifest module (missing / orphan).
@@ -88,20 +93,22 @@ object ModuleDocContractVerifier {
         val manifestNames = modules.keys.map { it.substringAfterLast(':') }.toSet()
         for (name in manifestNames) {
             if (name !in cardNames) {
-                diagnostics += VerificationDiagnostic.failure(
-                    DiagnosticCode.MODULE_CARD_MISSING,
-                    "Manifest module '$name' has no card in docs/modules",
-                    modulePath = name,
-                )
+                diagnostics +=
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.MODULE_CARD_MISSING,
+                        "Manifest module '$name' has no card in docs/modules",
+                        modulePath = name,
+                    )
             }
         }
         for (card in cardNames) {
             if (card !in manifestNames) {
-                diagnostics += VerificationDiagnostic.failure(
-                    DiagnosticCode.MODULE_CARD_ORPHAN,
-                    "Card '$card' has no manifest module",
-                    modulePath = card,
-                )
+                diagnostics +=
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.MODULE_CARD_ORPHAN,
+                        "Card '$card' has no manifest module",
+                        modulePath = card,
+                    )
             }
         }
 
@@ -116,11 +123,12 @@ object ModuleDocContractVerifier {
             for (heading in REQUIRED_HEADINGS) {
                 val headingLine = Regex("""^### ${Regex.escape(heading)}\s*$""", RegexOption.MULTILINE)
                 if (!headingLine.containsMatchIn(text)) {
-                    diagnostics += VerificationDiagnostic.failure(
-                        DiagnosticCode.MODULE_CARD_HEADING_MISSING,
-                        "Card '$name' is missing heading '### $heading'",
-                        modulePath = name,
-                    )
+                    diagnostics +=
+                        VerificationDiagnostic.failure(
+                            DiagnosticCode.MODULE_CARD_HEADING_MISSING,
+                            "Card '$name' is missing heading '### $heading'",
+                            modulePath = name,
+                        )
                 }
             }
 
@@ -131,21 +139,23 @@ object ModuleDocContractVerifier {
             val header = text.substringBefore("## ")
             for (pattern in LEGACY_CLASSIFICATION_PATTERNS) {
                 if (pattern.containsMatchIn(header)) {
-                    diagnostics += VerificationDiagnostic.failure(
-                        DiagnosticCode.MODULE_CARD_LEGACY_CLASSIFICATION,
-                        "Card '$name' header contains legacy classification metadata matching ${pattern.pattern}",
-                        modulePath = name,
-                    )
+                    diagnostics +=
+                        VerificationDiagnostic.failure(
+                            DiagnosticCode.MODULE_CARD_LEGACY_CLASSIFICATION,
+                            "Card '$name' header contains legacy classification metadata matching ${pattern.pattern}",
+                            modulePath = name,
+                        )
                 }
             }
 
             // Manifest classification link present in the header block (before first '##')
             if (entry != null && MANIFEST_LINK_MARKER !in header) {
-                diagnostics += VerificationDiagnostic.failure(
-                    DiagnosticCode.MODULE_CARD_LEGACY_CLASSIFICATION,
-                    "Card '$name' header must link classification to module-catalog.yml",
-                    modulePath = name,
-                )
+                diagnostics +=
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.MODULE_CARD_LEGACY_CLASSIFICATION,
+                        "Card '$name' header must link classification to module-catalog.yml",
+                        modulePath = name,
+                    )
             }
 
             // Local markdown links resolve
@@ -155,11 +165,12 @@ object ModuleDocContractVerifier {
                 if (target.startsWith("http") || target.startsWith("#")) continue
                 val resolved = File(docsDir, target).normalize()
                 if (!resolved.isFile) {
-                    diagnostics += VerificationDiagnostic.failure(
-                        DiagnosticCode.MODULE_CARD_LINK_BROKEN,
-                        "Card '$name' link '$target' does not resolve (${resolved.path})",
-                        modulePath = name,
-                    )
+                    diagnostics +=
+                        VerificationDiagnostic.failure(
+                            DiagnosticCode.MODULE_CARD_LINK_BROKEN,
+                            "Card '$name' link '$target' does not resolve (${resolved.path})",
+                            modulePath = name,
+                        )
                 }
             }
 
@@ -168,11 +179,12 @@ object ModuleDocContractVerifier {
             for (match in inlineRegex.findAll(text)) {
                 val path = match.groupValues[1]
                 if (!File(rootDir, path).isFile) {
-                    diagnostics += VerificationDiagnostic.failure(
-                        DiagnosticCode.MODULE_CARD_INLINE_PATH_BROKEN,
-                        "Card '$name' inline repo path '$path' does not resolve",
-                        modulePath = name,
-                    )
+                    diagnostics +=
+                        VerificationDiagnostic.failure(
+                            DiagnosticCode.MODULE_CARD_INLINE_PATH_BROKEN,
+                            "Card '$name' inline repo path '$path' does not resolve",
+                            modulePath = name,
+                        )
                 }
             }
 
@@ -193,11 +205,12 @@ object ModuleDocContractVerifier {
                     val version = decl.groupValues[2]
                     if (artifact == "tramai-bom") continue // BOM import handled via hasVersionedBom
                     if (version.isBlank() && !hasVersionedBom) {
-                        diagnostics += VerificationDiagnostic.failure(
-                            DiagnosticCode.MODULE_CARD_VERSIONLESS_DEPENDENCY,
-                            "Card '$name' has versionless dependency declaration without a versioned TramAI BOM import in the same snippet: dev.tramai:$artifact",
-                            modulePath = name,
-                        )
+                        diagnostics +=
+                            VerificationDiagnostic.failure(
+                                DiagnosticCode.MODULE_CARD_VERSIONLESS_DEPENDENCY,
+                                "Card '$name' has versionless dependency declaration without a versioned TramAI BOM import in the same snippet: dev.tramai:$artifact",
+                                modulePath = name,
+                            )
                     }
                 }
             }
@@ -208,14 +221,18 @@ object ModuleDocContractVerifier {
             // regardless of version. Mentioning other (published) TramAI
             // dependencies is legitimate.
             if (entry != null && entry.publishability != ModulePublishability.PUBLISHED) {
-                val ownGradle = Regex("""(?:implementation|api)\(\s*"dev\.tramai:${Regex.escape(name)}(?::[^"]*)?"\s*\)""").containsMatchIn(text)
+                val ownGradle =
+                    Regex(
+                        """(?:implementation|api)\(\s*"dev\.tramai:${Regex.escape(name)}(?::[^"]*)?"\s*\)""",
+                    ).containsMatchIn(text)
                 val ownMaven = Regex("""<artifactId>\s*${Regex.escape(name)}\s*</artifactId>""").containsMatchIn(text)
                 if (ownGradle || ownMaven) {
-                    diagnostics += VerificationDiagnostic.failure(
-                        DiagnosticCode.MODULE_CARD_INTERNAL_MAVEN_ADVERTISEMENT,
-                        "Internal/unpublished module '$name' advertises external Maven consumption (dev.tramai:$name)",
-                        modulePath = name,
-                    )
+                    diagnostics +=
+                        VerificationDiagnostic.failure(
+                            DiagnosticCode.MODULE_CARD_INTERNAL_MAVEN_ADVERTISEMENT,
+                            "Internal/unpublished module '$name' advertises external Maven consumption (dev.tramai:$name)",
+                            modulePath = name,
+                        )
                 }
             }
         }
@@ -223,10 +240,11 @@ object ModuleDocContractVerifier {
         // 7. README coverage counts match reality — README absent is a failure.
         val readme = File(docsDir, README)
         if (!readme.isFile) {
-            diagnostics += VerificationDiagnostic.failure(
-                DiagnosticCode.MODULE_CARD_COVERAGE_MISMATCH,
-                "docs/modules/README.md is missing — coverage counts cannot be verified",
-            )
+            diagnostics +=
+                VerificationDiagnostic.failure(
+                    DiagnosticCode.MODULE_CARD_COVERAGE_MISMATCH,
+                    "docs/modules/README.md is missing — coverage counts cannot be verified",
+                )
         } else {
             val readmeText = readme.readText()
             val manifestCount = modules.size
@@ -237,27 +255,35 @@ object ModuleDocContractVerifier {
             for (file in cardFiles) {
                 val cardText = file.readText()
                 val cardHeader = cardText.substringBefore("## ")
-                val allHeadings = REQUIRED_HEADINGS.all { Regex("""^### ${Regex.escape(it)}\s*$""", RegexOption.MULTILINE).containsMatchIn(cardText) }
+                val allHeadings =
+                    REQUIRED_HEADINGS.all {
+                        Regex(
+                            """^### ${Regex.escape(it)}\s*$""",
+                            RegexOption.MULTILINE,
+                        ).containsMatchIn(cardText)
+                    }
                 val noLegacy = LEGACY_CLASSIFICATION_PATTERNS.none { it.containsMatchIn(cardHeader) }
                 if (allHeadings && noLegacy) conforming++
             }
             val missing = (manifestNames - cardNames).size
             val orphans = (cardNames - manifestNames).size
-            val expected = mapOf(
-                "Manifest modules" to manifestCount,
-                "Module cards" to cardNames.size,
-                "Conforming cards" to conforming,
-                "Existing non-conforming" to (cardNames.size - conforming),
-                "Missing cards" to missing,
-                "Orphans" to orphans,
-            )
+            val expected =
+                mapOf(
+                    "Manifest modules" to manifestCount,
+                    "Module cards" to cardNames.size,
+                    "Conforming cards" to conforming,
+                    "Existing non-conforming" to (cardNames.size - conforming),
+                    "Missing cards" to missing,
+                    "Orphans" to orphans,
+                )
             for ((label, count) in expected) {
                 val expectedLine = "| $label | $count |"
                 if (expectedLine !in readmeText) {
-                    diagnostics += VerificationDiagnostic.failure(
-                        DiagnosticCode.MODULE_CARD_COVERAGE_MISMATCH,
-                        "README coverage table must state '$label = $count' (found: $expectedLine not present)",
-                    )
+                    diagnostics +=
+                        VerificationDiagnostic.failure(
+                            DiagnosticCode.MODULE_CARD_COVERAGE_MISMATCH,
+                            "README coverage table must state '$label = $count' (found: $expectedLine not present)",
+                        )
                 }
             }
         }

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/ModuleManifest.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/ModuleManifest.kt
@@ -5,15 +5,17 @@ import java.io.File
 
 /** Configuration-time facade for the authoritative module architecture manifest. */
 object ModuleManifest {
-    fun catalog(rootDir: File): ModuleCatalog.CatalogResult = ModuleCatalog(rootDir).parse().also { result ->
-        if (result.errors.isNotEmpty()) throw GradleException(result.errors.joinToString("\n") { "[${it.code}] ${it.message}" })
-    }
+    fun catalog(rootDir: File): ModuleCatalog.CatalogResult = catalogFile(File(rootDir, "config/quality/module-catalog.yml"))
 
-    fun publishableModulePaths(rootDir: File): List<String> =
-        publishableModulePaths(catalog(rootDir).modules.values)
+    /** Exact-file parsing path: the declared file IS the authority (a3 discipline). */
+    fun catalogFile(catalogFile: File): ModuleCatalog.CatalogResult =
+        ModuleCatalog(catalogFile).parse().also { result ->
+            if (result.errors.isNotEmpty()) throw GradleException(result.errors.joinToString("\n") { "[${it.code}] ${it.message}" })
+        }
 
-    fun bomModulePaths(rootDir: File): List<String> =
-        bomModulePaths(catalog(rootDir).modules.values)
+    fun publishableModulePaths(rootDir: File): List<String> = publishableModulePaths(catalog(rootDir).modules.values)
+
+    fun bomModulePaths(rootDir: File): List<String> = bomModulePaths(catalog(rootDir).modules.values)
 
     /** Pure: published modules only, sorted by path. */
     fun publishableModulePaths(entries: Collection<ModuleCatalog.ModuleEntry>): List<String> =
@@ -21,16 +23,21 @@ object ModuleManifest {
 
     /** Pure: published + release-included modules (excluding the BOM itself), sorted. */
     fun bomModulePaths(entries: Collection<ModuleCatalog.ModuleEntry>): List<String> =
-        entries.filter {
-            it.path != ":tramai-bom" &&
-                it.publishability == ModulePublishability.PUBLISHED &&
-                it.releaseInclusion == ReleaseInclusion.INCLUDED
-        }.map { it.path }.sorted()
+        entries
+            .filter {
+                it.path != ":tramai-bom" &&
+                    it.publishability == ModulePublishability.PUBLISHED &&
+                    it.releaseInclusion == ReleaseInclusion.INCLUDED
+            }.map { it.path }
+            .sorted()
 
     fun matrix(rootDir: File): String {
-        val rows = catalog(rootDir).modules.values.sortedBy { it.path }.joinToString("\n") { entry ->
-            "| ${entry.path.removePrefix(":")} | ${entry.layer.yaml} | ${entry.maturity.yaml} | ${entry.apiStability.yaml} | ${if (entry.publishability == ModulePublishability.PUBLISHED) "Yes" else "No"} | ${entry.owner} | ${entry.releaseInclusion.yaml} |"
-        }
+        val rows =
+            catalog(rootDir).modules.values.sortedBy { it.path }.joinToString("\n") { entry ->
+                "| ${entry.path.removePrefix(
+                    ":",
+                )} | ${entry.layer.yaml} | ${entry.maturity.yaml} | ${entry.apiStability.yaml} | ${if (entry.publishability == ModulePublishability.PUBLISHED) "Yes" else "No"} | ${entry.owner} | ${entry.releaseInclusion.yaml} |"
+            }
         return """# TramAI Module Matrix
 
 <!-- generated from config/quality/module-catalog.yml — do not edit manually -->

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/ModuleTopologyVerificationTasks.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/ModuleTopologyVerificationTasks.kt
@@ -1,0 +1,79 @@
+package dev.tramai.build.quality
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Configuration-time snapshot of the three independent module-topology signals
+ * fed to [VerifyModuleManifestTask] (Epic 9.2d-a3c1). Pure data — small
+ * List<String> values; no Gradle model objects cross task boundaries.
+ */
+internal object ModuleTopologySnapshot {
+    /** All configured non-root projects with build files, deterministic (sorted). */
+    fun projectPaths(project: Project): List<String> =
+        project.allprojects
+            .filter { it != project && it.buildFile.exists() }
+            .map { it.path }
+            .sorted()
+
+    /**
+     * BOM api constraint module paths ("tramai-*" / "examples:*" names, ":"
+     * prefixed, sorted). LAZY ONLY: must be read inside a Provider after
+     * evaluation — the java-platform model is incomplete at plugin apply time
+     * (Epic 9.2d-a1 rule). Reads the configuration model; never resolves.
+     */
+    fun bomPaths(project: Project): List<String> =
+        project.allprojects
+            .firstOrNull { it.name == "tramai-bom" }
+            ?.configurations
+            ?.findByName("api")
+            ?.dependencyConstraints
+            .orEmpty()
+            .mapNotNull { constraint ->
+                val name = constraint.name
+                if (name.startsWith("tramai-") || name.startsWith("examples:")) ":$name" else null
+            }.sorted()
+}
+
+/**
+ * Typed module-manifest verifier (Epic 9.2d-a3c1). Compares the authoritative
+ * module catalog against three independent Gradle model signals via the pure
+ * [ModuleManifestVerifier]. No Task.project access at execution time; the
+ * catalog is read through its declared file input (rootDir derived from it).
+ */
+abstract class VerifyModuleManifestTask : DefaultTask() {
+    @get:InputFile
+    abstract val moduleCatalogFile: RegularFileProperty
+
+    @get:Input
+    abstract val projectPaths: ListProperty<String>
+
+    @get:Input
+    abstract val publishedPaths: ListProperty<String>
+
+    @get:Input
+    abstract val bomPaths: ListProperty<String>
+
+    @TaskAction
+    fun verify() {
+        val catalogFile = moduleCatalogFile.get().asFile
+        // config/quality/module-catalog.yml -> rootDir = three parents up.
+        val catalog = ModuleManifest.catalog(catalogFile.parentFile.parentFile.parentFile)
+        val diagnostics =
+            ModuleManifestVerifier.verify(
+                catalogModules = catalog.modules,
+                projectPaths = projectPaths.get().toSet(),
+                publishedPaths = publishedPaths.get().toSet(),
+                bomPaths = bomPaths.get().toSet(),
+            )
+        if (diagnostics.isNotEmpty()) {
+            throw GradleException(diagnostics.joinToString("\n") { "[${it.code}] ${it.message}" })
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/ModuleTopologyVerificationTasks.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/ModuleTopologyVerificationTasks.kt
@@ -63,8 +63,9 @@ abstract class VerifyModuleManifestTask : DefaultTask() {
     @TaskAction
     fun verify() {
         val catalogFile = moduleCatalogFile.get().asFile
-        // config/quality/module-catalog.yml -> rootDir = three parents up.
-        val catalog = ModuleManifest.catalog(catalogFile.parentFile.parentFile.parentFile)
+        // Exact-file authority: the declared catalog input IS the file parsed
+        // (a3 discipline — never re-discover a conventional path from it).
+        val catalog = ModuleManifest.catalogFile(catalogFile)
         val diagnostics =
             ModuleManifestVerifier.verify(
                 catalogModules = catalog.modules,

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/TestQualityConfiguration.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/TestQualityConfiguration.kt
@@ -9,64 +9,75 @@ data class TestQualityConfiguration(
     val schemaVersion: String,
     val criticalModules: List<String>,
     val coverage: CoverageConfiguration,
-    val mutation: MutationConfiguration
+    val mutation: MutationConfiguration,
 ) {
     data class CoverageConfiguration(
         val regressionTolerancePercentagePoints: Double,
-        val exclusions: List<CoverageExclusion>
+        val exclusions: List<CoverageExclusion>,
     )
 
     data class MutationConfiguration(
         val regressionTolerancePercentagePoints: Double,
-        val targetFamilies: Map<String, MutationTargetFamily>
+        val targetFamilies: Map<String, MutationTargetFamily>,
     )
 
     data class MutationTargetFamily(
         val modules: List<String>,
         val targetClasses: List<String> = listOf("dev.tramai.*"),
-        val targetTests: List<String> = listOf("dev.tramai.*")
+        val targetTests: List<String> = listOf("dev.tramai.*"),
     )
 
     companion object {
         fun load(repositoryRoot: File): TestQualityConfiguration {
-            val catalog = ModuleCatalog(repositoryRoot).parse()
+            val catalog = ModuleCatalog.fromRootDir(repositoryRoot).parse()
             val catalogFailures = catalog.errors.filter { it.severity == DiagnosticSeverity.FAILURE }
             if (catalogFailures.isNotEmpty()) {
                 throw GradleException(
                     "Cannot validate test-quality configuration because module catalog is invalid: " +
-                        catalogFailures.joinToString("; ") { it.message }
+                        catalogFailures.joinToString("; ") { it.message },
                 )
             }
             return parse(
                 File(repositoryRoot, "config/quality/test-quality.yml"),
-                catalog.modules.keys
+                catalog.modules.keys,
             )
         }
 
-        fun parse(file: File, knownModules: Set<String>): TestQualityConfiguration {
+        fun parse(
+            file: File,
+            knownModules: Set<String>,
+        ): TestQualityConfiguration {
             if (!file.isFile) {
                 throw GradleException("Test-quality configuration not found: ${file.absolutePath}")
             }
-            val loaderOptions = LoaderOptions().apply {
-                isAllowDuplicateKeys = false
-                maxAliasesForCollections = 20
-            }
-            val raw = try {
-                @Suppress("UNCHECKED_CAST")
-                Yaml(loaderOptions).load<Map<String, Any?>>(file.readText(Charsets.UTF_8))
-                    ?: emptyMap()
-            } catch (e: Exception) {
-                throw GradleException("Invalid test-quality configuration: ${e.message}", e)
-            }
+            val loaderOptions =
+                LoaderOptions().apply {
+                    isAllowDuplicateKeys = false
+                    maxAliasesForCollections = 20
+                }
+            val raw =
+                try {
+                    @Suppress("UNCHECKED_CAST")
+                    Yaml(loaderOptions).load<Map<String, Any?>>(file.readText(Charsets.UTF_8))
+                        ?: emptyMap()
+                } catch (e: Exception) {
+                    throw GradleException("Invalid test-quality configuration: ${e.message}", e)
+                }
 
-            fun map(value: Any?, path: String): Map<String, Any?> {
+            fun map(
+                value: Any?,
+                path: String,
+            ): Map<String, Any?> {
                 if (value !is Map<*, *>) throw GradleException("$path must be a mapping")
                 return value.entries.associate { (key, item) ->
                     (key as? String ?: throw GradleException("$path contains a non-string key")) to item
                 }
             }
 
-            fun strings(value: Any?, path: String): List<String> {
+            fun strings(
+                value: Any?,
+                path: String,
+            ): List<String> {
                 if (value !is List<*>) throw GradleException("$path must be a list")
                 return value.mapIndexed { index, item ->
                     (item as? String)?.trim()?.takeIf { it.isNotEmpty() }
@@ -74,18 +85,23 @@ data class TestQualityConfiguration(
                 }
             }
 
-            fun percentage(value: Any?, path: String): Double {
-                val result = (value as? Number)?.toDouble()
-                    ?: value?.toString()?.toDoubleOrNull()
-                    ?: throw GradleException("$path must be a percentage")
+            fun percentage(
+                value: Any?,
+                path: String,
+            ): Double {
+                val result =
+                    (value as? Number)?.toDouble()
+                        ?: value?.toString()?.toDoubleOrNull()
+                        ?: throw GradleException("$path must be a percentage")
                 if (!result.isFinite() || result < 0.0 || result > 100.0) {
                     throw GradleException("$path must be between 0 and 100")
                 }
                 return result
             }
 
-            val schemaVersion = raw["schemaVersion"]?.toString()
-                ?: throw GradleException("schemaVersion is required")
+            val schemaVersion =
+                raw["schemaVersion"]?.toString()
+                    ?: throw GradleException("schemaVersion is required")
             if (schemaVersion != "1") throw GradleException("Unsupported test-quality schemaVersion '$schemaVersion'")
 
             val criticalModules = strings(raw["criticalModules"], "criticalModules")
@@ -95,21 +111,23 @@ data class TestQualityConfiguration(
             }
 
             val coverageRaw = map(raw["coverage"], "coverage")
-            val exclusionsRaw = coverageRaw["exclusions"] as? List<*>
-                ?: throw GradleException("coverage.exclusions must be a list")
-            val exclusions = exclusionsRaw.mapIndexed { index, item ->
-                val entry = map(item, "coverage.exclusions[$index]")
-                val pattern = entry["pattern"]?.toString()?.trim().orEmpty()
-                val reason = entry["reason"]?.toString()?.trim().orEmpty()
-                if (pattern.isEmpty()) throw GradleException("coverage.exclusions[$index].pattern must not be empty")
-                if (isAbsolutePath(pattern)) {
-                    throw GradleException("coverage.exclusions[$index].pattern must be repository-relative")
+            val exclusionsRaw =
+                coverageRaw["exclusions"] as? List<*>
+                    ?: throw GradleException("coverage.exclusions must be a list")
+            val exclusions =
+                exclusionsRaw.mapIndexed { index, item ->
+                    val entry = map(item, "coverage.exclusions[$index]")
+                    val pattern = entry["pattern"]?.toString()?.trim().orEmpty()
+                    val reason = entry["reason"]?.toString()?.trim().orEmpty()
+                    if (pattern.isEmpty()) throw GradleException("coverage.exclusions[$index].pattern must not be empty")
+                    if (isAbsolutePath(pattern)) {
+                        throw GradleException("coverage.exclusions[$index].pattern must be repository-relative")
+                    }
+                    if (reason.isEmpty()) {
+                        throw GradleException("coverage.exclusions[$index].reason must not be empty")
+                    }
+                    CoverageExclusion(pattern, reason)
                 }
-                if (reason.isEmpty()) {
-                    throw GradleException("coverage.exclusions[$index].reason must not be empty")
-                }
-                CoverageExclusion(pattern, reason)
-            }
             val exclusionPatterns = exclusions.map { it.pattern }
             if (exclusionPatterns.size != exclusionPatterns.distinct().size) {
                 throw GradleException("coverage.exclusions must not contain duplicate patterns")
@@ -122,26 +140,29 @@ data class TestQualityConfiguration(
             familiesRaw.forEach { (family, value) ->
                 if (family.isBlank()) throw GradleException("Mutation family name must not be empty")
                 val familyMap = map(value, "mutation.targetFamilies.$family")
-                val modules = strings(
-                    familyMap["modules"],
-                    "mutation.targetFamilies.$family.modules"
-                )
+                val modules =
+                    strings(
+                        familyMap["modules"],
+                        "mutation.targetFamilies.$family.modules",
+                    )
                 if (modules.isEmpty()) {
                     throw GradleException("mutation.targetFamilies.$family.modules must not be empty")
                 }
                 if (modules.size != modules.distinct().size) {
                     throw GradleException("mutation.targetFamilies.$family.modules must not contain duplicates")
                 }
-                val targetClasses = if ("targetClasses" in familyMap) {
-                    strings(familyMap["targetClasses"], "mutation.targetFamilies.$family.targetClasses")
-                } else {
-                    listOf("dev.tramai.*")
-                }
-                val targetTests = if ("targetTests" in familyMap) {
-                    strings(familyMap["targetTests"], "mutation.targetFamilies.$family.targetTests")
-                } else {
-                    listOf("dev.tramai.*")
-                }
+                val targetClasses =
+                    if ("targetClasses" in familyMap) {
+                        strings(familyMap["targetClasses"], "mutation.targetFamilies.$family.targetClasses")
+                    } else {
+                        listOf("dev.tramai.*")
+                    }
+                val targetTests =
+                    if ("targetTests" in familyMap) {
+                        strings(familyMap["targetTests"], "mutation.targetFamilies.$family.targetTests")
+                    } else {
+                        listOf("dev.tramai.*")
+                    }
                 if (targetClasses.isEmpty()) {
                     throw GradleException("mutation.targetFamilies.$family.targetClasses must not be empty when specified")
                 }
@@ -154,11 +175,12 @@ data class TestQualityConfiguration(
                 if (targetTests.size != targetTests.distinct().size) {
                     throw GradleException("mutation.targetFamilies.$family.targetTests must not contain duplicate patterns")
                 }
-                families[family] = MutationTargetFamily(
-                    modules = modules,
-                    targetClasses = targetClasses,
-                    targetTests = targetTests
-                )
+                families[family] =
+                    MutationTargetFamily(
+                        modules = modules,
+                        targetClasses = targetClasses,
+                        targetTests = targetTests,
+                    )
             }
 
             val referencedModules = criticalModules + families.values.flatMap { it.modules }
@@ -170,24 +192,27 @@ data class TestQualityConfiguration(
             return TestQualityConfiguration(
                 schemaVersion = schemaVersion,
                 criticalModules = criticalModules,
-                coverage = CoverageConfiguration(
-                    regressionTolerancePercentagePoints = percentage(
-                        coverageRaw["regressionTolerancePercentagePoints"],
-                        "coverage.regressionTolerancePercentagePoints"
+                coverage =
+                    CoverageConfiguration(
+                        regressionTolerancePercentagePoints =
+                            percentage(
+                                coverageRaw["regressionTolerancePercentagePoints"],
+                                "coverage.regressionTolerancePercentagePoints",
+                            ),
+                        exclusions = exclusions,
                     ),
-                    exclusions = exclusions
-                ),
-                mutation = MutationConfiguration(
-                    regressionTolerancePercentagePoints = percentage(
-                        mutationRaw["regressionTolerancePercentagePoints"],
-                        "mutation.regressionTolerancePercentagePoints"
+                mutation =
+                    MutationConfiguration(
+                        regressionTolerancePercentagePoints =
+                            percentage(
+                                mutationRaw["regressionTolerancePercentagePoints"],
+                                "mutation.regressionTolerancePercentagePoints",
+                            ),
+                        targetFamilies = families,
                     ),
-                    targetFamilies = families
-                )
             )
         }
 
-        private fun isAbsolutePath(path: String): Boolean =
-            File(path).isAbsolute || Regex("""^[A-Za-z]:[\\/]""").containsMatchIn(path)
+        private fun isAbsolutePath(path: String): Boolean = File(path).isAbsolute || Regex("""^[A-Za-z]:[\\/]""").containsMatchIn(path)
     }
 }

--- a/build-logic/src/main/kotlin/dev/tramai/build/release/TramaiReleaseVerificationPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/release/TramaiReleaseVerificationPlugin.kt
@@ -14,7 +14,6 @@ import java.io.File
  * semantics are identical to the historical root build script.
  */
 class TramaiReleaseVerificationPlugin : Plugin<Project> {
-
     override fun apply(project: Project) {
         registerVerifyPublicationMetadata(project)
         registerVerifyPublishedLocalArtifacts(project)
@@ -31,9 +30,10 @@ class TramaiReleaseVerificationPlugin : Plugin<Project> {
      * that have neither.
      */
     private fun publishableModuleNames(project: Project): List<String> {
-        val fromExtra = (project.rootProject.extensions.extraProperties.properties["tramai.publishableModulePaths"] as? Collection<*>)
-            ?.map { it.toString().removePrefix(":") }
-            .orEmpty()
+        val fromExtra =
+            (project.rootProject.extensions.extraProperties.properties["tramai.publishableModulePaths"] as? Collection<*>)
+                ?.map { it.toString().removePrefix(":") }
+                .orEmpty()
         if (fromExtra.isNotEmpty()) return fromExtra.sorted()
         return runCatching { ModuleManifest.publishableModulePaths(project.rootDir) }
             .getOrDefault(emptyList())
@@ -41,8 +41,7 @@ class TramaiReleaseVerificationPlugin : Plugin<Project> {
             .sorted()
     }
 
-    private fun jarPublicationModuleNames(project: Project): List<String> =
-        publishableModuleNames(project) - "tramai-bom"
+    private fun jarPublicationModuleNames(project: Project): List<String> = publishableModuleNames(project) - "tramai-bom"
 
     /**
      * Publication descriptions, resolved from the module catalog (9.2c-c).
@@ -62,13 +61,13 @@ class TramaiReleaseVerificationPlugin : Plugin<Project> {
      * TestKit fixtures without a catalog still configure cleanly.
      */
     private fun catalogDescriptions(project: Project): Map<String, String> {
-        val catalog = ModuleCatalog(project.rootDir).parse()
-        return publishableModuleNames(project).mapNotNull { moduleName ->
-            val description = catalog.modules[":$moduleName"]?.description?.takeIf { it.isNotBlank() }
-            description?.let { moduleName to it }
-        }.toMap()
+        val catalog = ModuleCatalog.fromRootDir(project.rootDir).parse()
+        return publishableModuleNames(project)
+            .mapNotNull { moduleName ->
+                val description = catalog.modules[":$moduleName"]?.description?.takeIf { it.isNotBlank() }
+                description?.let { moduleName to it }
+            }.toMap()
     }
-
 
     private fun registerVerifyPublicationMetadata(project: Project) {
         project.tasks.register<VerifyPublicationMetadataTask>("verifyPublicationMetadata") {
@@ -82,10 +81,19 @@ class TramaiReleaseVerificationPlugin : Plugin<Project> {
             expectedVersion.set(project.providers.gradleProperty("tramaiVersion").orElse("0.5.0"))
             expectedProjectUrl.set(project.providers.gradleProperty("tramaiProjectUrl").orElse("https://github.com/GionaGranchelli/tramAI"))
             expectedScmUrl.set(project.providers.gradleProperty("tramaiScmUrl").orElse("https://github.com/GionaGranchelli/tramAI.git"))
-            expectedScmConnection.set(project.providers.gradleProperty("tramaiScmConnection").orElse("scm:git:https://github.com/GionaGranchelli/tramAI.git"))
-            expectedScmDeveloperConnection.set(project.providers.gradleProperty("tramaiScmDeveloperConnection").orElse("scm:git:ssh://git@github.com/GionaGranchelli/tramAI.git"))
+            expectedScmConnection.set(
+                project.providers.gradleProperty("tramaiScmConnection").orElse("scm:git:https://github.com/GionaGranchelli/tramAI.git"),
+            )
+            expectedScmDeveloperConnection.set(
+                project.providers
+                    .gradleProperty(
+                        "tramaiScmDeveloperConnection",
+                    ).orElse("scm:git:ssh://git@github.com/GionaGranchelli/tramAI.git"),
+            )
             expectedLicenseName.set(project.providers.gradleProperty("tramaiLicenseName").orElse("Apache-2.0"))
-            expectedLicenseUrl.set(project.providers.gradleProperty("tramaiLicenseUrl").orElse("https://www.apache.org/licenses/LICENSE-2.0.txt"))
+            expectedLicenseUrl.set(
+                project.providers.gradleProperty("tramaiLicenseUrl").orElse("https://www.apache.org/licenses/LICENSE-2.0.txt"),
+            )
             expectedDeveloperId.set(project.providers.gradleProperty("tramaiDeveloperId").orElse("GionaGranchelli"))
             expectedDeveloperName.set(project.providers.gradleProperty("tramaiDeveloperName").orElse("Giona"))
             expectedDeveloperEmail.set(project.providers.gradleProperty("tramaiDeveloperEmail").orElse("opensource@giona.dev"))
@@ -96,7 +104,7 @@ class TramaiReleaseVerificationPlugin : Plugin<Project> {
             pomFiles.from(
                 publishableModuleNames.map { moduleName ->
                     project.layout.projectDirectory.file("$moduleName/build/publications/maven/pom-default.xml")
-                }
+                },
             )
             dependsOn(publishableModuleNames.map { ":$it:generatePomFileForMavenPublication" })
         }
@@ -115,8 +123,9 @@ class TramaiReleaseVerificationPlugin : Plugin<Project> {
 
             // Resolved through a Provider so the task never touches System.getProperty
             repositoryDirectory.fileProvider(
-                project.providers.systemProperty("user.home")
-                    .map { home -> File(home, ".m2/repository/${expectedGroup.get().replace('.', '/')}") }
+                project.providers
+                    .systemProperty("user.home")
+                    .map { home -> File(home, ".m2/repository/${expectedGroup.get().replace('.', '/')}") },
             )
             dependsOn(publishableModuleNames.map { ":$it:publishToMavenLocal" })
         }
@@ -127,11 +136,36 @@ class TramaiReleaseVerificationPlugin : Plugin<Project> {
             group = "verification"
             description = "Verifies that the properties required for a real remote release publish are present."
 
-            releaseUrlPresent.set(project.providers.gradleProperty("tramaiPublishReleaseUrl").map { it.isNotBlank() }.orElse(false))
-            usernamePresent.set(project.providers.gradleProperty("tramaiPublishUsername").map { it.isNotBlank() }.orElse(false))
-            passwordPresent.set(project.providers.gradleProperty("tramaiPublishPassword").map { it.isNotBlank() }.orElse(false))
-            signingKeyPresent.set(project.providers.gradleProperty("signingKey").map { it.isNotBlank() }.orElse(false))
-            signingPasswordPresent.set(project.providers.gradleProperty("signingPassword").map { it.isNotBlank() }.orElse(false))
+            releaseUrlPresent.set(
+                project.providers
+                    .gradleProperty("tramaiPublishReleaseUrl")
+                    .map { it.isNotBlank() }
+                    .orElse(false),
+            )
+            usernamePresent.set(
+                project.providers
+                    .gradleProperty("tramaiPublishUsername")
+                    .map { it.isNotBlank() }
+                    .orElse(false),
+            )
+            passwordPresent.set(
+                project.providers
+                    .gradleProperty("tramaiPublishPassword")
+                    .map { it.isNotBlank() }
+                    .orElse(false),
+            )
+            signingKeyPresent.set(
+                project.providers
+                    .gradleProperty("signingKey")
+                    .map { it.isNotBlank() }
+                    .orElse(false),
+            )
+            signingPasswordPresent.set(
+                project.providers
+                    .gradleProperty("signingPassword")
+                    .map { it.isNotBlank() }
+                    .orElse(false),
+            )
             tramaiVersion.set(project.providers.gradleProperty("tramaiVersion").orElse("0.5.0"))
         }
     }
@@ -146,8 +180,18 @@ class TramaiReleaseVerificationPlugin : Plugin<Project> {
             expectedVersion.set(project.providers.gradleProperty("tramaiVersion").orElse("0.5.0"))
             expectedGroup.set(project.providers.gradleProperty("tramaiGroup").orElse("dev.tramai"))
             this.publishableModules.set(publishableModuleNames)
-            signingKeyPresent.set(project.providers.gradleProperty("signingKey").map { it.isNotBlank() }.orElse(false))
-            signingPasswordPresent.set(project.providers.gradleProperty("signingPassword").map { it.isNotBlank() }.orElse(false))
+            signingKeyPresent.set(
+                project.providers
+                    .gradleProperty("signingKey")
+                    .map { it.isNotBlank() }
+                    .orElse(false),
+            )
+            signingPasswordPresent.set(
+                project.providers
+                    .gradleProperty("signingPassword")
+                    .map { it.isNotBlank() }
+                    .orElse(false),
+            )
 
             val version = project.providers.gradleProperty("tramaiVersion").orElse("0.5.0")
             val releaseUrl = project.providers.gradleProperty("tramaiPublishReleaseUrl")
@@ -159,13 +203,20 @@ class TramaiReleaseVerificationPlugin : Plugin<Project> {
                         releaseUrl.orNull,
                         snapshotUrl.orNull,
                     )
-                }
+                },
             )
             repositoryDirectory.fileProvider(
                 repositoryUrl.map { url ->
-                    if (url.isNullOrBlank()) File(project.layout.projectDirectory.dir("build/verify-signed-publication-repo").asFile.absolutePath)
-                    else File(java.net.URI(url))
-                }
+                    if (url.isNullOrBlank()) {
+                        File(
+                            project.layout.projectDirectory
+                                .dir("build/verify-signed-publication-repo")
+                                .asFile.absolutePath,
+                        )
+                    } else {
+                        File(java.net.URI(url))
+                    }
+                },
             )
             dependsOn(publishableModuleNames.map { ":$it:publish" })
         }
@@ -178,7 +229,7 @@ class TramaiReleaseVerificationPlugin : Plugin<Project> {
 
             val jarPublicationModuleNames = jarPublicationModuleNames(project)
             dependsOn(
-                jarPublicationModuleNames.map { ":${it}:test" },
+                jarPublicationModuleNames.map { ":$it:test" },
                 "verifyPublicationMetadata",
                 "verifyPublishedLocalArtifacts",
                 "verifySovereignOpsObservabilityDocs",

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/ApiCompatibilityMutationTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/ApiCompatibilityMutationTest.kt
@@ -17,7 +17,6 @@ import kotlin.test.assertTrue
  * current dump (drives stability policy).
  */
 class ApiCompatibilityMutationTest {
-
     @TempDir
     lateinit var tempDir: File
 
@@ -28,33 +27,40 @@ class ApiCompatibilityMutationTest {
         apiStability: String,
         maturity: String = if (apiStability == "internal") "internal" else "preview",
         publishability: String = "published",
-    ): ModuleCatalog.ModuleEntry = ModuleCatalog.ModuleEntry(
-        path = path,
-        layer = ModuleLayer.fromYaml("core-contracts") ?: error("bad layer"),
-        maturity = ModuleMaturity.fromYaml(maturity) ?: error("bad maturity $maturity"),
-        publishability = ModulePublishability.fromYaml(publishability) ?: error("bad pub $publishability"),
-        apiStability = ModuleApiStability.fromYaml(apiStability) ?: error("bad api $apiStability"),
-        visibility = ModuleVisibility.fromYaml("public") ?: error("bad vis"),
-        owner = "test",
-        dependencyPolicy = "core",
-        releaseInclusion = ReleaseInclusion.fromYaml("included") ?: error("bad rel"),
-        rationale = "Test fixture entry.",
-        description = "Test fixture description."
-    )
+    ): ModuleCatalog.ModuleEntry =
+        ModuleCatalog.ModuleEntry(
+            path = path,
+            layer = ModuleLayer.fromYaml("core-contracts") ?: error("bad layer"),
+            maturity = ModuleMaturity.fromYaml(maturity) ?: error("bad maturity $maturity"),
+            publishability = ModulePublishability.fromYaml(publishability) ?: error("bad pub $publishability"),
+            apiStability = ModuleApiStability.fromYaml(apiStability) ?: error("bad api $apiStability"),
+            visibility = ModuleVisibility.fromYaml("public") ?: error("bad vis"),
+            owner = "test",
+            dependencyPolicy = "core",
+            releaseInclusion = ReleaseInclusion.fromYaml("included") ?: error("bad rel"),
+            rationale = "Test fixture entry.",
+            description = "Test fixture description.",
+        )
 
-    private val catalog = mapOf(
-        ":tramai-core" to entry(":tramai-core", "stable", maturity = "stable"),
-        ":tramai-engine" to entry(":tramai-engine", "preview"),
-        ":tramai-experimental" to entry(":tramai-experimental", "experimental", maturity = "experimental"),
-        ":tramai-internal" to entry(":tramai-internal", "internal", publishability = "internal"),
-        ":tramai-preview-leak" to entry(":tramai-preview-leak", "preview"),
-    )
+    private val catalog =
+        mapOf(
+            ":tramai-core" to entry(":tramai-core", "stable", maturity = "stable"),
+            ":tramai-engine" to entry(":tramai-engine", "preview"),
+            ":tramai-experimental" to entry(":tramai-experimental", "experimental", maturity = "experimental"),
+            ":tramai-internal" to entry(":tramai-internal", "internal", publishability = "internal"),
+            ":tramai-preview-leak" to entry(":tramai-preview-leak", "preview"),
+        )
 
     private fun sha256(content: String): String =
-        java.security.MessageDigest.getInstance("SHA-256").digest(content.toByteArray(Charsets.UTF_8))
+        java.security.MessageDigest
+            .getInstance("SHA-256")
+            .digest(content.toByteArray(Charsets.UTF_8))
             .joinToString("") { "%02x".format(it) }
 
-    private fun dump(module: String, vararg lines: String): String =
+    private fun dump(
+        module: String,
+        vararg lines: String,
+    ): String =
         (listOf("public final class dev/tramai/${module.removePrefix(":tramai-")}/Main {") + lines + listOf("}"))
             .joinToString("\n") + "\n"
 
@@ -68,10 +74,11 @@ class ApiCompatibilityMutationTest {
         base = base,
     )
 
-    private fun verifier() = ApiCompatibilityVerifier(
-        catalogModules = catalog,
-        projectVersion = "0.6.0",
-    )
+    private fun verifier() =
+        ApiCompatibilityVerifier(
+            catalogModules = catalog,
+            projectVersion = "0.6.0",
+        )
 
     private fun compatCodes(diagnostics: List<VerificationDiagnostic>): Set<DiagnosticCode> =
         diagnostics.filter { it.code == DiagnosticCode.API_COMPATIBILITY_FAILED }.map { it.code }.toSet()
@@ -88,7 +95,7 @@ class ApiCompatibilityMutationTest {
                 it.code == DiagnosticCode.API_COMPATIBILITY_FAILED &&
                     it.message.contains("does not represent current source")
             },
-            "expected Contract-1 source/committed mismatch to fail, got: $diagnostics"
+            "expected Contract-1 source/committed mismatch to fail, got: $diagnostics",
         )
     }
 
@@ -98,16 +105,17 @@ class ApiCompatibilityMutationTest {
     fun `B0b missing generated evidence fails fail-closed`() {
         val committed = mapOf(":tramai-core" to dump(":tramai-core", "\tpublic fun a ()V"))
         // generated evidence entirely absent (clean workspace before apiBuild)
-        val diagnostics = verifier().verify(
-            evidence(committed = committed, generated = emptyMap()),
-            migrations = emptyList()
-        )
+        val diagnostics =
+            verifier().verify(
+                evidence(committed = committed, generated = emptyMap()),
+                migrations = emptyList(),
+            )
         assertTrue(
             diagnostics.any {
                 it.code == DiagnosticCode.API_COMPATIBILITY_FAILED &&
                     it.message.contains("generated (apiBuild) API dump") && it.message.contains(":tramai-core")
             },
-            "missing generated evidence must fail, not silently pass, got: $diagnostics"
+            "missing generated evidence must fail, not silently pass, got: $diagnostics",
         )
     }
 
@@ -117,21 +125,22 @@ class ApiCompatibilityMutationTest {
     fun `B1 stable additive API change fails without migration rescue`() {
         val base = mapOf(":tramai-core" to dump(":tramai-core", "\tpublic fun a ()V"))
         val current = mapOf(":tramai-core" to dump(":tramai-core", "\tpublic fun a ()V", "\tpublic fun b ()V"))
-        val migration = ApiMigrationEntry(
-            module = ":tramai-core",
-            fromSha256 = sha256(base.getValue(":tramai-core")),
-            toSha256 = sha256(current.getValue(":tramai-core")),
-            targetVersion = "0.6.0",
-            rationale = "Added b",
-            migration = "No action needed."
-        )
+        val migration =
+            ApiMigrationEntry(
+                module = ":tramai-core",
+                fromSha256 = sha256(base.getValue(":tramai-core")),
+                toSha256 = sha256(current.getValue(":tramai-core")),
+                targetVersion = "0.6.0",
+                rationale = "Added b",
+                migration = "No action needed.",
+            )
         val diagnostics = verifier().verify(evidence(committed = current, base = base), migrations = listOf(migration))
         assertTrue(
             diagnostics.any {
                 it.code == DiagnosticCode.API_COMPATIBILITY_FAILED &&
                     it.message.contains("stable") && it.message.contains(":tramai-core")
             },
-            "stable additive change must fail even with a migration entry, got: $diagnostics"
+            "stable additive change must fail even with a migration entry, got: $diagnostics",
         )
     }
 
@@ -149,18 +158,19 @@ class ApiCompatibilityMutationTest {
     fun `B3 preview change with exact hash-bound migration passes`() {
         val base = mapOf(":tramai-engine" to dump(":tramai-engine", "\tpublic fun a ()V"))
         val current = mapOf(":tramai-engine" to dump(":tramai-engine", "\tpublic fun a ()V", "\tpublic fun b ()V"))
-        val migration = ApiMigrationEntry(
-            module = ":tramai-engine",
-            fromSha256 = sha256(base.getValue(":tramai-engine")),
-            toSha256 = sha256(current.getValue(":tramai-engine")),
-            targetVersion = "0.6.0",
-            rationale = "Added b",
-            migration = "No action needed."
-        )
+        val migration =
+            ApiMigrationEntry(
+                module = ":tramai-engine",
+                fromSha256 = sha256(base.getValue(":tramai-engine")),
+                toSha256 = sha256(current.getValue(":tramai-engine")),
+                targetVersion = "0.6.0",
+                rationale = "Added b",
+                migration = "No action needed.",
+            )
         val diagnostics = verifier().verify(evidence(committed = current, base = base), migrations = listOf(migration))
         assertTrue(
             diagnostics.none { it.code == DiagnosticCode.API_COMPATIBILITY_FAILED },
-            "exact transition entry must authorize preview change, got: $diagnostics"
+            "exact transition entry must authorize preview change, got: $diagnostics",
         )
     }
 
@@ -173,7 +183,7 @@ class ApiCompatibilityMutationTest {
         val diagnostics = verifier().verify(evidence(committed = current, base = base), migrations = emptyList())
         assertTrue(
             diagnostics.none { it.code == DiagnosticCode.API_COMPATIBILITY_FAILED },
-            "internal drift must not be a compat failure, got: $diagnostics"
+            "internal drift must not be a compat failure, got: $diagnostics",
         )
     }
 
@@ -188,21 +198,23 @@ class ApiCompatibilityMutationTest {
         val baseStable = dump(":tramai-core", "\tpublic fun a ()V")
         // current stable dump now references a class owned by the preview module
         val currentStable = dump(":tramai-core", "\tpublic fun a ()V", "\tpublic fun f (Ldev/tramai/previewleak/Internal;)V")
-        val committed = mapOf(
-            ":tramai-core" to currentStable,
-            ":tramai-preview-leak" to previewDump,
-        )
-        val base = mapOf(
-            ":tramai-core" to baseStable,
-            ":tramai-preview-leak" to previewDump,
-        )
+        val committed =
+            mapOf(
+                ":tramai-core" to currentStable,
+                ":tramai-preview-leak" to previewDump,
+            )
+        val base =
+            mapOf(
+                ":tramai-core" to baseStable,
+                ":tramai-preview-leak" to previewDump,
+            )
         val diagnostics = verifier().verify(evidence(committed = committed, base = base), migrations = emptyList())
         assertTrue(
             diagnostics.any {
                 it.code == DiagnosticCode.API_COMPATIBILITY_FAILED &&
                     it.message.contains("inversion") && it.message.contains(":tramai-core")
             },
-            "stable→preview type leak must fail, got: $diagnostics"
+            "stable→preview type leak must fail, got: $diagnostics",
         )
     }
 
@@ -217,14 +229,15 @@ class ApiCompatibilityMutationTest {
             "public final class dev/tramai/previewleak/Internal {\n\tpublic fun a ()V\n}\n"
         // references dev/tramai/previewleak2/Internal — shares prefix, different package
         val stableDump = dump(":tramai-core", "\tpublic fun a ()V", "\tpublic fun f (Ldev/tramai/previewleak2/Internal;)V")
-        val committed = mapOf(
-            ":tramai-core" to stableDump,
-            ":tramai-preview-leak" to previewDump,
-        )
+        val committed =
+            mapOf(
+                ":tramai-core" to stableDump,
+                ":tramai-preview-leak" to previewDump,
+            )
         val diagnostics = verifier().verify(evidence(committed = committed, base = committed), migrations = emptyList())
         assertTrue(
             diagnostics.none { it.code == DiagnosticCode.API_COMPATIBILITY_FAILED },
-            "descriptor prefix must not create an inversion, got: $diagnostics"
+            "descriptor prefix must not create an inversion, got: $diagnostics",
         )
     }
 
@@ -238,24 +251,26 @@ class ApiCompatibilityMutationTest {
         val withoutEntry = verifier().verify(evidence(committed = current, base = base), migrations = emptyList())
         assertTrue(
             compatCodes(withoutEntry).isNotEmpty(),
-            "experimental drift without entry must fail, got: $withoutEntry"
+            "experimental drift without entry must fail, got: $withoutEntry",
         )
-        val withEntry = verifier().verify(
-            evidence(committed = current, base = base),
-            migrations = listOf(
-                ApiMigrationEntry(
-                    module = ":tramai-experimental",
-                    fromSha256 = sha256(base.getValue(":tramai-experimental")),
-                    toSha256 = sha256(current.getValue(":tramai-experimental")),
-                    targetVersion = "0.6.0",
-                    rationale = "Experiments.",
-                    migration = "Experimental."
-                )
+        val withEntry =
+            verifier().verify(
+                evidence(committed = current, base = base),
+                migrations =
+                    listOf(
+                        ApiMigrationEntry(
+                            module = ":tramai-experimental",
+                            fromSha256 = sha256(base.getValue(":tramai-experimental")),
+                            toSha256 = sha256(current.getValue(":tramai-experimental")),
+                            targetVersion = "0.6.0",
+                            rationale = "Experiments.",
+                            migration = "Experimental.",
+                        ),
+                    ),
             )
-        )
         assertTrue(
             withEntry.none { it.code == DiagnosticCode.API_COMPATIBILITY_FAILED },
-            "experimental drift with exact entry must pass, got: $withEntry"
+            "experimental drift with exact entry must pass, got: $withEntry",
         )
     }
 
@@ -263,33 +278,34 @@ class ApiCompatibilityMutationTest {
 
     @Test
     fun `B7 stable API with preview or experimental maturity fails catalog validation`() {
-        val catalogFile = File(tempDir, "config/quality/module-catalog.yml").apply {
-            parentFile.mkdirs()
-            writeText(
-                """
-                schemaVersion: "3"
-                description: "test"
-                dependencyPolicies:
-                  core: { allowedLayers: [core-contracts] }
-                entryDefaults: {}
-                modules:
-                  - path: ":bad-stable-preview"
-                    layer: core-contracts
-                    maturity: preview
-                    visibility: public
-                    owner: test
-                    dependencyPolicy: core
-                    releaseInclusion: included
-                    publishability: published
-                    apiStability: stable
-                    description: "Bad combination fixture."
-                """.trimIndent()
-            )
-        }
-        val result = ModuleCatalog(tempDir).parse()
+        val catalogFile =
+            File(tempDir, "config/quality/module-catalog.yml").apply {
+                parentFile.mkdirs()
+                writeText(
+                    """
+                    schemaVersion: "3"
+                    description: "test"
+                    dependencyPolicies:
+                      core: { allowedLayers: [core-contracts] }
+                    entryDefaults: {}
+                    modules:
+                      - path: ":bad-stable-preview"
+                        layer: core-contracts
+                        maturity: preview
+                        visibility: public
+                        owner: test
+                        dependencyPolicy: core
+                        releaseInclusion: included
+                        publishability: published
+                        apiStability: stable
+                        description: "Bad combination fixture."
+                    """.trimIndent(),
+                )
+            }
+        val result = ModuleCatalog.fromRootDir(tempDir).parse()
         assertTrue(
             result.errors.any { it.code == DiagnosticCode.MODULE_CATALOG_INVALID_COMBINATION },
-            "stable API + preview maturity must fail catalog validation, got: ${result.errors}"
+            "stable API + preview maturity must fail catalog validation, got: ${result.errors}",
         )
     }
 
@@ -299,14 +315,15 @@ class ApiCompatibilityMutationTest {
     fun `B8 wrong-hash migration entry fails`() {
         val base = mapOf(":tramai-engine" to dump(":tramai-engine", "\tpublic fun a ()V"))
         val current = mapOf(":tramai-engine" to dump(":tramai-engine", "\tpublic fun a ()V", "\tpublic fun b ()V"))
-        val migration = ApiMigrationEntry(
-            module = ":tramai-engine",
-            fromSha256 = "deadbeef",
-            toSha256 = "cafebabe",
-            targetVersion = "0.6.0",
-            rationale = "wrong hashes",
-            migration = "x"
-        )
+        val migration =
+            ApiMigrationEntry(
+                module = ":tramai-engine",
+                fromSha256 = "deadbeef",
+                toSha256 = "cafebabe",
+                targetVersion = "0.6.0",
+                rationale = "wrong hashes",
+                migration = "x",
+            )
         val diagnostics = verifier().verify(evidence(committed = current, base = base), migrations = listOf(migration))
         assertTrue(compatCodes(diagnostics).isNotEmpty(), "wrong-hash entry must fail, got: $diagnostics")
     }
@@ -317,13 +334,15 @@ class ApiCompatibilityMutationTest {
         val current = mapOf(":tramai-engine" to dump(":tramai-engine", "\tpublic fun a ()V", "\tpublic fun b ()V"))
         val from = sha256(base.getValue(":tramai-engine"))
         val to = sha256(current.getValue(":tramai-engine"))
-        val diagnostics = verifier().verify(
-            evidence(committed = current, base = base),
-            migrations = listOf(
-                ApiMigrationEntry(":tramai-engine", from, to, "0.6.0", "r1", "m1"),
-                ApiMigrationEntry(":tramai-engine", from, to, "0.6.0", "r2", "m2"),
+        val diagnostics =
+            verifier().verify(
+                evidence(committed = current, base = base),
+                migrations =
+                    listOf(
+                        ApiMigrationEntry(":tramai-engine", from, to, "0.6.0", "r1", "m1"),
+                        ApiMigrationEntry(":tramai-engine", from, to, "0.6.0", "r2", "m2"),
+                    ),
             )
-        )
         assertTrue(compatCodes(diagnostics).isNotEmpty(), "duplicate entries must fail, got: $diagnostics")
     }
 
@@ -332,19 +351,21 @@ class ApiCompatibilityMutationTest {
         // A true orphan: entry whose `to` does NOT match the current (unchanged)
         // committed hash — base==current==A but entry claims A→deadbeef.
         val committed = mapOf(":tramai-engine" to dump(":tramai-engine", "\tpublic fun a ()V"))
-        val diagnostics = verifier().verify(
-            evidence(committed = committed, base = committed),
-            migrations = listOf(
-                ApiMigrationEntry(
-                    ":tramai-engine",
-                    sha256(dump(":tramai-engine", "\tpublic fun a ()V")),
-                    "deadbeef",
-                    "0.6.0",
-                    "orphan",
-                    "m"
-                )
+        val diagnostics =
+            verifier().verify(
+                evidence(committed = committed, base = committed),
+                migrations =
+                    listOf(
+                        ApiMigrationEntry(
+                            ":tramai-engine",
+                            sha256(dump(":tramai-engine", "\tpublic fun a ()V")),
+                            "deadbeef",
+                            "0.6.0",
+                            "orphan",
+                            "m",
+                        ),
+                    ),
             )
-        )
         assertTrue(compatCodes(diagnostics).isNotEmpty(), "orphan entry must fail, got: $diagnostics")
     }
 
@@ -355,21 +376,23 @@ class ApiCompatibilityMutationTest {
         // not FAIL as an orphan — otherwise merging B3 poisons the next PR.
         val baseB = dump(":tramai-engine", "\tpublic fun a ()V", "\tpublic fun b ()V")
         val committedB = baseB
-        val entry = ApiMigrationEntry(
-            ":tramai-engine",
-            sha256(dump(":tramai-engine", "\tpublic fun a ()V")),
-            sha256(baseB),
-            "0.6.0",
-            "landed",
-            "m"
-        )
-        val diagnostics = verifier().verify(
-            evidence(committed = mapOf(":tramai-engine" to committedB), base = mapOf(":tramai-engine" to baseB)),
-            migrations = listOf(entry)
-        )
+        val entry =
+            ApiMigrationEntry(
+                ":tramai-engine",
+                sha256(dump(":tramai-engine", "\tpublic fun a ()V")),
+                sha256(baseB),
+                "0.6.0",
+                "landed",
+                "m",
+            )
+        val diagnostics =
+            verifier().verify(
+                evidence(committed = mapOf(":tramai-engine" to committedB), base = mapOf(":tramai-engine" to baseB)),
+                migrations = listOf(entry),
+            )
         assertTrue(
             diagnostics.none { it.code == DiagnosticCode.API_COMPATIBILITY_FAILED },
-            "landed entry with unchanged module must pass, got: $diagnostics"
+            "landed entry with unchanged module must pass, got: $diagnostics",
         )
     }
 
@@ -380,21 +403,23 @@ class ApiCompatibilityMutationTest {
         // required.
         val baseB = dump(":tramai-engine", "\tpublic fun a ()V", "\tpublic fun b ()V")
         val currentC = dump(":tramai-engine", "\tpublic fun a ()V", "\tpublic fun b ()V", "\tpublic fun c ()V")
-        val oldEntry = ApiMigrationEntry(
-            ":tramai-engine",
-            sha256(dump(":tramai-engine", "\tpublic fun a ()V")),
-            sha256(baseB),
-            "0.6.0",
-            "landed",
-            "m"
-        )
-        val diagnostics = verifier().verify(
-            evidence(committed = mapOf(":tramai-engine" to currentC), base = mapOf(":tramai-engine" to baseB)),
-            migrations = listOf(oldEntry)
-        )
+        val oldEntry =
+            ApiMigrationEntry(
+                ":tramai-engine",
+                sha256(dump(":tramai-engine", "\tpublic fun a ()V")),
+                sha256(baseB),
+                "0.6.0",
+                "landed",
+                "m",
+            )
+        val diagnostics =
+            verifier().verify(
+                evidence(committed = mapOf(":tramai-engine" to currentC), base = mapOf(":tramai-engine" to baseB)),
+                migrations = listOf(oldEntry),
+            )
         assertTrue(
             compatCodes(diagnostics).isNotEmpty(),
-            "landed A→B entry must not authorize B→C, got: $diagnostics"
+            "landed A→B entry must not authorize B→C, got: $diagnostics",
         )
     }
 
@@ -402,29 +427,32 @@ class ApiCompatibilityMutationTest {
     fun `B8b new exact entry authorizes the later change`() {
         val baseB = dump(":tramai-engine", "\tpublic fun a ()V", "\tpublic fun b ()V")
         val currentC = dump(":tramai-engine", "\tpublic fun a ()V", "\tpublic fun b ()V", "\tpublic fun c ()V")
-        val landed = ApiMigrationEntry(
-            ":tramai-engine",
-            sha256(dump(":tramai-engine", "\tpublic fun a ()V")),
-            sha256(baseB),
-            "0.6.0",
-            "landed",
-            "m"
-        )
-        val newEntry = ApiMigrationEntry(
-            ":tramai-engine",
-            sha256(baseB),
-            sha256(currentC),
-            "0.6.0",
-            "new change",
-            "m"
-        )
-        val diagnostics = verifier().verify(
-            evidence(committed = mapOf(":tramai-engine" to currentC), base = mapOf(":tramai-engine" to baseB)),
-            migrations = listOf(landed, newEntry)
-        )
+        val landed =
+            ApiMigrationEntry(
+                ":tramai-engine",
+                sha256(dump(":tramai-engine", "\tpublic fun a ()V")),
+                sha256(baseB),
+                "0.6.0",
+                "landed",
+                "m",
+            )
+        val newEntry =
+            ApiMigrationEntry(
+                ":tramai-engine",
+                sha256(baseB),
+                sha256(currentC),
+                "0.6.0",
+                "new change",
+                "m",
+            )
+        val diagnostics =
+            verifier().verify(
+                evidence(committed = mapOf(":tramai-engine" to currentC), base = mapOf(":tramai-engine" to baseB)),
+                migrations = listOf(landed, newEntry),
+            )
         assertTrue(
             diagnostics.none { it.code == DiagnosticCode.API_COMPATIBILITY_FAILED },
-            "landed + new exact entry must pass, got: $diagnostics"
+            "landed + new exact entry must pass, got: $diagnostics",
         )
     }
 
@@ -436,21 +464,23 @@ class ApiCompatibilityMutationTest {
         // version check applies to ACTIVE authorizations only. This avoids
         // recreating the "registry poisons future builds" problem.
         val baseB = dump(":tramai-engine", "\tpublic fun a ()V", "\tpublic fun b ()V")
-        val landedHistorical = ApiMigrationEntry(
-            ":tramai-engine",
-            sha256(dump(":tramai-engine", "\tpublic fun a ()V")),
-            sha256(baseB),
-            "0.5.0", // historical release, project is now 0.6.0
-            "landed in 0.5.0",
-            "m"
-        )
-        val diagnostics = verifier().verify(
-            evidence(committed = mapOf(":tramai-engine" to baseB), base = mapOf(":tramai-engine" to baseB)),
-            migrations = listOf(landedHistorical)
-        )
+        val landedHistorical =
+            ApiMigrationEntry(
+                ":tramai-engine",
+                sha256(dump(":tramai-engine", "\tpublic fun a ()V")),
+                sha256(baseB),
+                "0.5.0", // historical release, project is now 0.6.0
+                "landed in 0.5.0",
+                "m",
+            )
+        val diagnostics =
+            verifier().verify(
+                evidence(committed = mapOf(":tramai-engine" to baseB), base = mapOf(":tramai-engine" to baseB)),
+                migrations = listOf(landedHistorical),
+            )
         assertTrue(
             diagnostics.none { it.code == DiagnosticCode.API_COMPATIBILITY_FAILED },
-            "landed entry with historical targetVersion must pass, got: $diagnostics"
+            "landed entry with historical targetVersion must pass, got: $diagnostics",
         )
     }
 
@@ -461,21 +491,23 @@ class ApiCompatibilityMutationTest {
         // 0.6.0 is required.
         val baseB = dump(":tramai-engine", "\tpublic fun a ()V", "\tpublic fun b ()V")
         val currentC = dump(":tramai-engine", "\tpublic fun a ()V", "\tpublic fun b ()V", "\tpublic fun c ()V")
-        val landedHistorical = ApiMigrationEntry(
-            ":tramai-engine",
-            sha256(dump(":tramai-engine", "\tpublic fun a ()V")),
-            sha256(baseB),
-            "0.5.0",
-            "landed in 0.5.0",
-            "m"
-        )
-        val diagnostics = verifier().verify(
-            evidence(committed = mapOf(":tramai-engine" to currentC), base = mapOf(":tramai-engine" to baseB)),
-            migrations = listOf(landedHistorical)
-        )
+        val landedHistorical =
+            ApiMigrationEntry(
+                ":tramai-engine",
+                sha256(dump(":tramai-engine", "\tpublic fun a ()V")),
+                sha256(baseB),
+                "0.5.0",
+                "landed in 0.5.0",
+                "m",
+            )
+        val diagnostics =
+            verifier().verify(
+                evidence(committed = mapOf(":tramai-engine" to currentC), base = mapOf(":tramai-engine" to baseB)),
+                migrations = listOf(landedHistorical),
+            )
         assertTrue(
             compatCodes(diagnostics).isNotEmpty(),
-            "historical landed entry must not authorize a new transition, got: $diagnostics"
+            "historical landed entry must not authorize a new transition, got: $diagnostics",
         )
     }
 
@@ -483,14 +515,15 @@ class ApiCompatibilityMutationTest {
     fun `B8 targetVersion mismatch fails`() {
         val base = mapOf(":tramai-engine" to dump(":tramai-engine", "\tpublic fun a ()V"))
         val current = mapOf(":tramai-engine" to dump(":tramai-engine", "\tpublic fun a ()V", "\tpublic fun b ()V"))
-        val migration = ApiMigrationEntry(
-            module = ":tramai-engine",
-            fromSha256 = sha256(base.getValue(":tramai-engine")),
-            toSha256 = sha256(current.getValue(":tramai-engine")),
-            targetVersion = "0.5.0",
-            rationale = "wrong version",
-            migration = "x"
-        )
+        val migration =
+            ApiMigrationEntry(
+                module = ":tramai-engine",
+                fromSha256 = sha256(base.getValue(":tramai-engine")),
+                toSha256 = sha256(current.getValue(":tramai-engine")),
+                targetVersion = "0.5.0",
+                rationale = "wrong version",
+                migration = "x",
+            )
         val diagnostics = verifier().verify(evidence(committed = current, base = base), migrations = listOf(migration))
         assertTrue(compatCodes(diagnostics).isNotEmpty(), "targetVersion mismatch must fail, got: $diagnostics")
     }
@@ -503,7 +536,7 @@ class ApiCompatibilityMutationTest {
         val diagnostics = ConsumerCompatibilityGuard.validateSources(sourceDir, "java")
         assertTrue(
             diagnostics.none { it.code == DiagnosticCode.API_COMPATIBILITY_FAILED },
-            "java consumer fixture must have real non-empty sources, got: $diagnostics"
+            "java consumer fixture must have real non-empty sources, got: $diagnostics",
         )
     }
 
@@ -513,7 +546,7 @@ class ApiCompatibilityMutationTest {
         val diagnostics = ConsumerCompatibilityGuard.validateSources(sourceDir, "kotlin")
         assertTrue(
             diagnostics.none { it.code == DiagnosticCode.API_COMPATIBILITY_FAILED },
-            "kotlin consumer fixture must have real non-empty sources, got: $diagnostics"
+            "kotlin consumer fixture must have real non-empty sources, got: $diagnostics",
         )
     }
 
@@ -523,7 +556,7 @@ class ApiCompatibilityMutationTest {
         val diagnostics = ConsumerCompatibilityGuard.validate(empty, File(tempDir, "classes"), "java")
         assertTrue(
             diagnostics.any { it.code == DiagnosticCode.API_COMPATIBILITY_FAILED },
-            "empty consumer source set must fail, got: $diagnostics"
+            "empty consumer source set must fail, got: $diagnostics",
         )
     }
 
@@ -534,7 +567,7 @@ class ApiCompatibilityMutationTest {
         val diagnostics = ConsumerCompatibilityGuard.validate(sources, File(tempDir, "missing-classes"), "java")
         assertTrue(
             diagnostics.any { it.code == DiagnosticCode.API_COMPATIBILITY_FAILED },
-            "consumer guard must fail when compilation produced no classes, got: $diagnostics"
+            "consumer guard must fail when compilation produced no classes, got: $diagnostics",
         )
     }
 
@@ -547,7 +580,7 @@ class ApiCompatibilityMutationTest {
         val diagnostics = ConsumerCompatibilityGuard.validate(sources, classes, "java")
         assertTrue(
             diagnostics.none { it.code == DiagnosticCode.API_COMPATIBILITY_FAILED },
-            "consumer guard must pass with sources and classes present, got: $diagnostics"
+            "consumer guard must pass with sources and classes present, got: $diagnostics",
         )
     }
 
@@ -560,7 +593,7 @@ class ApiCompatibilityMutationTest {
         val result = ApiCompatibilityEvidenceReader.parseMigrations(f)
         assertTrue(
             result.diagnostics.any { it.code == DiagnosticCode.API_COMPATIBILITY_FAILED },
-            "non-map entry must produce a parse diagnostic, got: ${result.diagnostics}"
+            "non-map entry must produce a parse diagnostic, got: ${result.diagnostics}",
         )
     }
 
@@ -573,12 +606,12 @@ class ApiCompatibilityMutationTest {
               - module: ":tramai-engine"
                 fromSha256: "${"a".repeat(64)}"
                 toSha256: "${"b".repeat(64)}"
-            """.trimIndent()
+            """.trimIndent(),
         )
         val result = ApiCompatibilityEvidenceReader.parseMigrations(f)
         assertTrue(
             result.diagnostics.any { it.code == DiagnosticCode.API_COMPATIBILITY_FAILED },
-            "blank required fields must produce a parse diagnostic, got: ${result.diagnostics}"
+            "blank required fields must produce a parse diagnostic, got: ${result.diagnostics}",
         )
     }
 
@@ -594,14 +627,14 @@ class ApiCompatibilityMutationTest {
                 targetVersion: "0.6.0"
                 rationale: "r"
                 migration: "m"
-            """.trimIndent()
+            """.trimIndent(),
         )
         val result = ApiCompatibilityEvidenceReader.parseMigrations(f)
         assertTrue(
             result.diagnostics.any {
                 it.code == DiagnosticCode.API_COMPATIBILITY_FAILED && it.message.contains("invalid sha256")
             },
-            "non-hex hash must produce a parse diagnostic, got: ${result.diagnostics}"
+            "non-hex hash must produce a parse diagnostic, got: ${result.diagnostics}",
         )
     }
 
@@ -612,7 +645,7 @@ class ApiCompatibilityMutationTest {
         val result = ApiCompatibilityEvidenceReader.parseMigrations(f)
         assertTrue(
             result.diagnostics.any { it.code == DiagnosticCode.API_COMPATIBILITY_FAILED },
-            "non-list migrations must produce a parse diagnostic, got: ${result.diagnostics}"
+            "non-list migrations must produce a parse diagnostic, got: ${result.diagnostics}",
         )
     }
 
@@ -628,7 +661,7 @@ class ApiCompatibilityMutationTest {
                 targetVersion: "0.6.0"
                 rationale: "r"
                 migration: "m"
-            """.trimIndent()
+            """.trimIndent(),
         )
         val result = ApiCompatibilityEvidenceReader.parseMigrations(f)
         assertTrue(result.diagnostics.isEmpty(), "valid entry must parse clean, got: ${result.diagnostics}")
@@ -636,7 +669,8 @@ class ApiCompatibilityMutationTest {
     }
 
     private fun repoRoot(): File =
-        System.getProperty("tramai.repositoryRoot")
+        System
+            .getProperty("tramai.repositoryRoot")
             ?.let { File(it) }
             ?: error("tramai.repositoryRoot system property not set (wired by build-logic/build.gradle.kts)")
 }

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/ArchitectureReportAggregatorTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/ArchitectureReportAggregatorTest.kt
@@ -10,14 +10,13 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class ArchitectureReportAggregatorTest {
-
     @TempDir
     lateinit var tempDir: File
 
     @Test
     fun `A1 forbidden edge fails dependency boundaries`() {
         fixtureDir()
-        val catalog = ModuleCatalog(tempDir)
+        val catalog = ModuleCatalog.fromRootDir(tempDir)
         assertTrue(catalog.parse().errors.isEmpty())
         val boundaries = ModuleBoundaries(tempDir).fromResult(ModuleBoundaries(tempDir).parse())
         val diagnostic = assertNotNull(boundaries.checkEdge(":tramai-core", ":tramai-openai", catalog))
@@ -28,15 +27,17 @@ class ArchitectureReportAggregatorTest {
 
     @Test
     fun `A2 dependency cycle fails dependency cycles`() {
-        val cycles = ModuleGraphAnalyzer(
-            MeasurementContext.fromDirectory(tempDir, ModuleCatalog(tempDir))
-        ).findCycles(
-            nodes = listOf(":a", ":b"),
-            edges = listOf(
-                DependencyEdge(":a", ":b", "api"),
-                DependencyEdge(":b", ":a", "api"),
-            ),
-        )
+        val cycles =
+            ModuleGraphAnalyzer(
+                MeasurementContext.fromDirectory(tempDir, ModuleCatalog.fromRootDir(tempDir)),
+            ).findCycles(
+                nodes = listOf(":a", ":b"),
+                edges =
+                    listOf(
+                        DependencyEdge(":a", ":b", "api"),
+                        DependencyEdge(":b", ":a", "api"),
+                    ),
+            )
         assertTrue(cycles.isNotEmpty())
 
         assertFailed(
@@ -48,13 +49,14 @@ class ArchitectureReportAggregatorTest {
     @Test
     fun `A3 manifest drift fails module manifest`() {
         fixtureDir()
-        val catalog = ModuleCatalog(tempDir).parse()
-        val diagnostics = ModuleManifestVerifier.verify(
-            catalogModules = catalog.modules,
-            projectPaths = catalog.modules.keys - ":tramai-core",
-            publishedPaths = ModuleManifest.publishableModulePaths(catalog.modules.values).toSet(),
-            bomPaths = ModuleManifest.bomModulePaths(catalog.modules.values).toSet(),
-        )
+        val catalog = ModuleCatalog.fromRootDir(tempDir).parse()
+        val diagnostics =
+            ModuleManifestVerifier.verify(
+                catalogModules = catalog.modules,
+                projectPaths = catalog.modules.keys - ":tramai-core",
+                publishedPaths = ModuleManifest.publishableModulePaths(catalog.modules.values).toSet(),
+                bomPaths = ModuleManifest.bomModulePaths(catalog.modules.values).toSet(),
+            )
         val diagnostic = assertNotNull(diagnostics.firstOrNull { it.code == DiagnosticCode.MODULE_CATALOG_UNKNOWN_ENTRY })
 
         assertFailed("module-manifest", diagnostic)
@@ -63,13 +65,14 @@ class ArchitectureReportAggregatorTest {
     @Test
     fun `A4 bom drift fails publishing topology`() {
         fixtureDir()
-        val catalog = ModuleCatalog(tempDir).parse()
-        val diagnostics = ModuleManifestVerifier.verify(
-            catalogModules = catalog.modules,
-            projectPaths = catalog.modules.keys,
-            publishedPaths = ModuleManifest.publishableModulePaths(catalog.modules.values).toSet(),
-            bomPaths = ModuleManifest.bomModulePaths(catalog.modules.values).toSet() - ":tramai-core",
-        )
+        val catalog = ModuleCatalog.fromRootDir(tempDir).parse()
+        val diagnostics =
+            ModuleManifestVerifier.verify(
+                catalogModules = catalog.modules,
+                projectPaths = catalog.modules.keys,
+                publishedPaths = ModuleManifest.publishableModulePaths(catalog.modules.values).toSet(),
+                bomPaths = ModuleManifest.bomModulePaths(catalog.modules.values).toSet() - ":tramai-core",
+            )
         val diagnostic = assertNotNull(diagnostics.firstOrNull { it.code == DiagnosticCode.MODULE_CATALOG_BOM_DRIFT })
 
         assertFailed("publishing-topology", diagnostic)
@@ -142,17 +145,24 @@ class ArchitectureReportAggregatorTest {
     fun `A12 baseline evidence unavailable fails every baseline-backed check`() {
         val target = emptyChecks()
         routeBaselineDiagnostics(
-            diagnostics = listOf(
-                VerificationDiagnostic.failure(
-                    DiagnosticCode.EMPTY_SECTION,
-                    "Committed baseline not found: ${tempDir.absolutePath}/config/quality/0.6.0-baseline.json",
+            diagnostics =
+                listOf(
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.EMPTY_SECTION,
+                        "Committed baseline not found: ${tempDir.absolutePath}/config/quality/0.6.0-baseline.json",
+                    ),
                 ),
-            ),
             target = target,
-            baselineCheckIds = setOf(
-                "module-manifest", "dependency-boundaries", "dependency-cycles",
-                "global-state", "api-architecture", "protocol-catalog", "cancellation-safety",
-            ),
+            baselineCheckIds =
+                setOf(
+                    "module-manifest",
+                    "dependency-boundaries",
+                    "dependency-cycles",
+                    "global-state",
+                    "api-architecture",
+                    "protocol-catalog",
+                    "cancellation-safety",
+                ),
             classify = { null },
         )
         val report = ArchitectureReportAggregator.aggregate(target)
@@ -160,10 +170,16 @@ class ArchitectureReportAggregatorTest {
         assertEquals(ArchitectureCheckStatus.FAIL, report.status)
         assertEquals(7, report.summary.failed)
         // Every baseline-backed check fails; the three non-baseline checks stay PASS.
-        val baselineIds = setOf(
-            "module-manifest", "dependency-boundaries", "dependency-cycles",
-            "global-state", "api-architecture", "protocol-catalog", "cancellation-safety",
-        )
+        val baselineIds =
+            setOf(
+                "module-manifest",
+                "dependency-boundaries",
+                "dependency-cycles",
+                "global-state",
+                "api-architecture",
+                "protocol-catalog",
+                "cancellation-safety",
+            )
         assertTrue(report.checks.filter { it.id in baselineIds }.all { it.status == ArchitectureCheckStatus.FAIL })
         assertTrue(report.checks.filter { it.id !in baselineIds }.all { it.status == ArchitectureCheckStatus.PASS })
         // Every baseline-backed check carries the evidence-failure diagnostic.
@@ -184,27 +200,40 @@ class ArchitectureReportAggregatorTest {
     fun `A13 dependency evidence unavailable fails every baseline-backed check`() {
         val target = emptyChecks()
         routeBaselineDiagnostics(
-            diagnostics = listOf(
-                VerificationDiagnostic.failure(
-                    DiagnosticCode.DEPENDENCY_RESOLUTION_FAILED,
-                    "Failed to resolve current production dependencies: broken",
+            diagnostics =
+                listOf(
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.DEPENDENCY_RESOLUTION_FAILED,
+                        "Failed to resolve current production dependencies: broken",
+                    ),
                 ),
-            ),
             target = target,
-            baselineCheckIds = setOf(
-                "module-manifest", "dependency-boundaries", "dependency-cycles",
-                "global-state", "api-architecture", "protocol-catalog", "cancellation-safety",
-            ),
+            baselineCheckIds =
+                setOf(
+                    "module-manifest",
+                    "dependency-boundaries",
+                    "dependency-cycles",
+                    "global-state",
+                    "api-architecture",
+                    "protocol-catalog",
+                    "cancellation-safety",
+                ),
             classify = { null },
         )
         val report = ArchitectureReportAggregator.aggregate(target)
 
         assertEquals(ArchitectureCheckStatus.FAIL, report.status)
         assertEquals(7, report.summary.failed)
-        val baselineIds = setOf(
-            "module-manifest", "dependency-boundaries", "dependency-cycles",
-            "global-state", "api-architecture", "protocol-catalog", "cancellation-safety",
-        )
+        val baselineIds =
+            setOf(
+                "module-manifest",
+                "dependency-boundaries",
+                "dependency-cycles",
+                "global-state",
+                "api-architecture",
+                "protocol-catalog",
+                "cancellation-safety",
+            )
         assertTrue(
             report.checks.filter { it.id in baselineIds }.all { check ->
                 check.diagnostics.any { it.code == DiagnosticCode.DEPENDENCY_RESOLUTION_FAILED }
@@ -217,10 +246,11 @@ class ArchitectureReportAggregatorTest {
         val root = File(tempDir, "repo").apply { mkdirs() }
         val target = emptyChecks()
         collectEvidence("baseline verification", setOf("module-manifest"), target) {
-            target.getValue("module-manifest") += VerificationDiagnostic.failure(
-                DiagnosticCode.EMPTY_SECTION,
-                "Committed baseline not found: ${root.absolutePath}/config/quality/0.6.0-baseline.json",
-            )
+            target.getValue("module-manifest") +=
+                VerificationDiagnostic.failure(
+                    DiagnosticCode.EMPTY_SECTION,
+                    "Committed baseline not found: ${root.absolutePath}/config/quality/0.6.0-baseline.json",
+                )
         }
         val report = ArchitectureReportAggregator.aggregate(target)
         val json = ArchitectureReportJson.toJson(report, root)
@@ -232,16 +262,18 @@ class ArchitectureReportAggregatorTest {
     @Test
     fun `A15 fail-soft dependency probe marker becomes typed evidence`() {
         val probeDir = File(tempDir, "probes").apply { mkdirs() }
-        val okProbe = File(probeDir, "ok.json").apply {
-            writeText(
-                """[{"group":"dev.tramai","artifact":"tramai-core","selectedVersion":"1.0","requestedVersion":"1.0","direct":true,"configuration":"compileClasspath","selectionReason":"","dependencyPath":[":tramai-core"],"consumers":[":tramai-core"]}]""",
-            )
-        }
-        val failedProbe = File(probeDir, "failed.json").apply {
-            writeText(
-                """[{"resolutionFailed":true,"message":"Failed to resolve :tramai-core:compileClasspath dependency org.example:missing:1.0: not found"}]""",
-            )
-        }
+        val okProbe =
+            File(probeDir, "ok.json").apply {
+                writeText(
+                    """[{"group":"dev.tramai","artifact":"tramai-core","selectedVersion":"1.0","requestedVersion":"1.0","direct":true,"configuration":"compileClasspath","selectionReason":"","dependencyPath":[":tramai-core"],"consumers":[":tramai-core"]}]""",
+                )
+            }
+        val failedProbe =
+            File(probeDir, "failed.json").apply {
+                writeText(
+                    """[{"resolutionFailed":true,"message":"Failed to resolve :tramai-core:compileClasspath dependency org.example:missing:1.0: not found"}]""",
+                )
+            }
 
         val okEvidence = readDependencyProbeEvidence(listOf(okProbe))
         assertTrue(okEvidence.failures.isEmpty())
@@ -268,8 +300,9 @@ class ArchitectureReportAggregatorTest {
 
     @Test
     fun `A10b renamed enrollment guard class fails by identity in both directions`() {
-        val discovered = (enrollmentArchitectureTestClasses - "dev.tramai.testing.AuditStoreTckEnrollmentArchitectureTest") +
-            "dev.tramai.testing.RenamedAuditStoreTckEnrollmentArchitectureTest"
+        val discovered =
+            (enrollmentArchitectureTestClasses - "dev.tramai.testing.AuditStoreTckEnrollmentArchitectureTest") +
+                "dev.tramai.testing.RenamedAuditStoreTckEnrollmentArchitectureTest"
         val diagnostics = enrollmentGuardDiagnostics(discovered)
 
         val storeDiagnostics = diagnostics["store-contracts"].orEmpty()
@@ -293,7 +326,10 @@ class ArchitectureReportAggregatorTest {
         }
     }
 
-    private fun assertFailed(checkId: String, diagnostic: VerificationDiagnostic) {
+    private fun assertFailed(
+        checkId: String,
+        diagnostic: VerificationDiagnostic,
+    ) {
         val report = ArchitectureReportAggregator.aggregate(emptyChecks().also { it.getValue(checkId) += diagnostic })
         assertEquals(ArchitectureCheckStatus.FAIL, report.status)
         assertEquals(ArchitectureCheckStatus.FAIL, report.checks.single { it.id == checkId }.status)
@@ -310,7 +346,9 @@ class ArchitectureReportAggregatorTest {
         File(config, "module-boundaries.yml").writeText(File(repoRoot(), "config/quality/module-boundaries.yml").readText())
     }
 
-    private fun repoRoot(): File = System.getProperty("tramai.repositoryRoot")
-        ?.let(::File)
-        ?: error("tramai.repositoryRoot system property not set")
+    private fun repoRoot(): File =
+        System
+            .getProperty("tramai.repositoryRoot")
+            ?.let(::File)
+            ?: error("tramai.repositoryRoot system property not set")
 }

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/ModuleCatalogMutationTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/ModuleCatalogMutationTest.kt
@@ -16,7 +16,6 @@ import kotlin.test.assertTrue
  * DiagnosticCode. Never touches config/quality/ during tests.
  */
 class ModuleCatalogMutationTest {
-
     @TempDir
     lateinit var tempDir: File
 
@@ -27,14 +26,13 @@ class ModuleCatalogMutationTest {
         return tempDir
     }
 
-    private fun realCatalogText(): String =
-        File(repoRoot(), "config/quality/module-catalog.yml").readText()
+    private fun realCatalogText(): String = File(repoRoot(), "config/quality/module-catalog.yml").readText()
 
-    private fun realBoundariesText(): String =
-        File(repoRoot(), "config/quality/module-boundaries.yml").readText()
+    private fun realBoundariesText(): String = File(repoRoot(), "config/quality/module-boundaries.yml").readText()
 
     private fun repoRoot(): File =
-        System.getProperty("tramai.repositoryRoot")
+        System
+            .getProperty("tramai.repositoryRoot")
             ?.let { File(it) }
             ?: error("tramai.repositoryRoot system property not set (wired by build-logic/build.gradle.kts)")
 
@@ -45,14 +43,13 @@ class ModuleCatalogMutationTest {
         return f
     }
 
-    private fun codes(result: ModuleCatalog.CatalogResult): Set<DiagnosticCode> =
-        result.errors.map { it.code }.toSet()
+    private fun codes(result: ModuleCatalog.CatalogResult): Set<DiagnosticCode> = result.errors.map { it.code }.toSet()
 
-    private fun codesOf(diagnostics: List<VerificationDiagnostic>): Set<DiagnosticCode> =
-        diagnostics.map { it.code }.toSet()
+    private fun codesOf(diagnostics: List<VerificationDiagnostic>): Set<DiagnosticCode> = diagnostics.map { it.code }.toSet()
 
     /** The exact committed block for :tramai-core (merge-anchor form). */
-    private val coreBlock = """
+    private val coreBlock =
+        """
         |  - path: ":tramai-core"
         |    description: "Core annotations, request models, provider registry, and exception types for Tramai."
         |    <<: *core
@@ -60,7 +57,7 @@ class ModuleCatalogMutationTest {
         |    publishability: published
         |    apiStability: stable
         |
-    """.trimMargin()
+        """.trimMargin()
 
     // ─── M1 — missing module ───
 
@@ -71,7 +68,7 @@ class ModuleCatalogMutationTest {
         assertNotEquals(realCatalogText(), mutated, "mutation must change content")
         writeCatalog(mutated)
 
-        val catalog = ModuleCatalog(tempDir)
+        val catalog = ModuleCatalog.fromRootDir(tempDir)
         val result = catalog.parse()
         assertEquals(emptySet(), codes(result), "parse itself must stay clean for a valid-remaining catalog")
 
@@ -79,7 +76,7 @@ class ModuleCatalogMutationTest {
         catalog.validateAgainstProjects(result.modules, listOf(":tramai-core"), diagnostics)
         assertTrue(
             codesOf(diagnostics).contains(DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY),
-            "expected MODULE_CATALOG_MISSING_ENTRY, got ${codesOf(diagnostics)}"
+            "expected MODULE_CATALOG_MISSING_ENTRY, got ${codesOf(diagnostics)}",
         )
     }
 
@@ -88,9 +85,10 @@ class ModuleCatalogMutationTest {
     @Test
     fun `M2 ghost module - unknown catalog entry fails project validation`() {
         fixtureDir()
-        val mutated = realCatalogText().replace(
-            coreBlock,
-            """
+        val mutated =
+            realCatalogText().replace(
+                coreBlock,
+                """
             |  - path: ":tramai-does-not-exist"
             |    layer: higher-capabilities
             |    publishability: internal
@@ -98,25 +96,26 @@ class ModuleCatalogMutationTest {
             |    <<: *internal
             |
             |$coreBlock
-            """.trimMargin()
-        )
+                """.trimMargin(),
+            )
         writeCatalog(mutated)
 
-        val catalog = ModuleCatalog(tempDir)
+        val catalog = ModuleCatalog.fromRootDir(tempDir)
         val result = catalog.parse()
         // All REAL module paths are the project set; only the ghost is unknown.
-        val realPaths = result.modules.keys
-            .filter { !it.contains("does-not-exist") }
-            .toList()
+        val realPaths =
+            result.modules.keys
+                .filter { !it.contains("does-not-exist") }
+                .toList()
         val diagnostics = mutableListOf<VerificationDiagnostic>()
         catalog.validateAgainstProjects(result.modules, realPaths, diagnostics)
         assertTrue(
             codesOf(diagnostics).contains(DiagnosticCode.MODULE_CATALOG_UNKNOWN_ENTRY),
-            "expected MODULE_CATALOG_UNKNOWN_ENTRY, got ${codesOf(diagnostics)}"
+            "expected MODULE_CATALOG_UNKNOWN_ENTRY, got ${codesOf(diagnostics)}",
         )
         assertTrue(
             diagnostics.any { it.message.contains(":tramai-does-not-exist") },
-            "diagnostic must name the ghost module"
+            "diagnostic must name the ghost module",
         )
     }
 
@@ -125,7 +124,7 @@ class ModuleCatalogMutationTest {
     @Test
     fun `M3 forbidden core dependency - core to openai is rejected`() {
         fixtureDir()
-        val catalog = ModuleCatalog(tempDir)
+        val catalog = ModuleCatalog.fromRootDir(tempDir)
         val catalogResult = catalog.parse()
         assertEquals(emptySet(), codes(catalogResult), "catalog must parse clean before edge check")
 
@@ -141,23 +140,26 @@ class ModuleCatalogMutationTest {
 
     @Test
     fun `M4 dependency cycle - A to B to A is detected`() {
-        val analyzer = ModuleGraphAnalyzer(
-            MeasurementContext.fromDirectory(
-                rootDir = tempDir,
-                catalog = ModuleCatalog(tempDir)
+        val analyzer =
+            ModuleGraphAnalyzer(
+                MeasurementContext.fromDirectory(
+                    rootDir = tempDir,
+                    catalog = ModuleCatalog.fromRootDir(tempDir),
+                ),
             )
-        )
-        val cycles = analyzer.findCycles(
-            nodes = listOf(":a", ":b"),
-            edges = listOf(
-                DependencyEdge(from = ":a", to = ":b", scope = "api"),
-                DependencyEdge(from = ":b", to = ":a", scope = "api"),
+        val cycles =
+            analyzer.findCycles(
+                nodes = listOf(":a", ":b"),
+                edges =
+                    listOf(
+                        DependencyEdge(from = ":a", to = ":b", scope = "api"),
+                        DependencyEdge(from = ":b", to = ":a", scope = "api"),
+                    ),
             )
-        )
         assertTrue(cycles.isNotEmpty(), "A -> B -> A must produce a cycle")
         assertTrue(
             cycles.any { it.toSet() == setOf(":a", ":b") },
-            "cycle must contain exactly A and B, got $cycles"
+            "cycle must contain exactly A and B, got $cycles",
         )
     }
 
@@ -166,29 +168,30 @@ class ModuleCatalogMutationTest {
     @Test
     fun `M5 BOM drift - manifest BOM set vs stale actual BOM set fails with BOM_DRIFT`() {
         fixtureDir()
-        val catalog = ModuleCatalog(tempDir).parse()
+        val catalog = ModuleCatalog.fromRootDir(tempDir).parse()
 
         // Manifest-derived expectation includes tramai-core in the BOM.
         assertTrue(
             ModuleManifest.bomModulePaths(catalog.modules.values).contains(":tramai-core"),
-            "fixture manifest must expect tramai-core in the BOM"
+            "fixture manifest must expect tramai-core in the BOM",
         )
 
         // Deliberately stale actual: BOM constraint graph omits tramai-core.
         val actualBom = ModuleManifest.bomModulePaths(catalog.modules.values).toSet() - ":tramai-core"
-        val diagnostics = ModuleManifestVerifier.verify(
-            catalogModules = catalog.modules,
-            projectPaths = catalog.modules.keys,
-            publishedPaths = ModuleManifest.publishableModulePaths(catalog.modules.values).toSet(),
-            bomPaths = actualBom,
-        )
+        val diagnostics =
+            ModuleManifestVerifier.verify(
+                catalogModules = catalog.modules,
+                projectPaths = catalog.modules.keys,
+                publishedPaths = ModuleManifest.publishableModulePaths(catalog.modules.values).toSet(),
+                bomPaths = actualBom,
+            )
         assertTrue(
             diagnostics.any { it.code == DiagnosticCode.MODULE_CATALOG_BOM_DRIFT },
-            "expected MODULE_CATALOG_BOM_DRIFT, got ${diagnostics.map { it.code }}"
+            "expected MODULE_CATALOG_BOM_DRIFT, got ${diagnostics.map { it.code }}",
         )
         assertTrue(
             diagnostics.any { it.message.contains(":tramai-core") },
-            "BOM drift diagnostic must name the diverging module"
+            "BOM drift diagnostic must name the diverging module",
         )
     }
 
@@ -197,29 +200,30 @@ class ModuleCatalogMutationTest {
     @Test
     fun `M6 publishing drift - manifest published set vs stale actual set fails with PUBLISHING_DRIFT`() {
         fixtureDir()
-        val catalog = ModuleCatalog(tempDir).parse()
+        val catalog = ModuleCatalog.fromRootDir(tempDir).parse()
 
         // Manifest-derived expectation includes tramai-core as publishable.
         assertTrue(
             ModuleManifest.publishableModulePaths(catalog.modules.values).contains(":tramai-core"),
-            "fixture manifest must expect tramai-core published"
+            "fixture manifest must expect tramai-core published",
         )
 
         // Deliberately stale actual: configured publication set omits tramai-core.
         val actualPublished = ModuleManifest.publishableModulePaths(catalog.modules.values).toSet() - ":tramai-core"
-        val diagnostics = ModuleManifestVerifier.verify(
-            catalogModules = catalog.modules,
-            projectPaths = catalog.modules.keys,
-            publishedPaths = actualPublished,
-            bomPaths = ModuleManifest.bomModulePaths(catalog.modules.values).toSet(),
-        )
+        val diagnostics =
+            ModuleManifestVerifier.verify(
+                catalogModules = catalog.modules,
+                projectPaths = catalog.modules.keys,
+                publishedPaths = actualPublished,
+                bomPaths = ModuleManifest.bomModulePaths(catalog.modules.values).toSet(),
+            )
         assertTrue(
             diagnostics.any { it.code == DiagnosticCode.MODULE_CATALOG_PUBLISHING_DRIFT },
-            "expected MODULE_CATALOG_PUBLISHING_DRIFT, got ${diagnostics.map { it.code }}"
+            "expected MODULE_CATALOG_PUBLISHING_DRIFT, got ${diagnostics.map { it.code }}",
         )
         assertTrue(
             diagnostics.any { it.message.contains(":tramai-core") },
-            "publishing drift diagnostic must name the diverging module"
+            "publishing drift diagnostic must name the diverging module",
         )
     }
 
@@ -230,30 +234,31 @@ class ModuleCatalogMutationTest {
         fixtureDir()
         // Turn tramai-core into a fully VALID internal module; the derivation guard
         // (ModuleManifest) must drop it from both the publishable set and the BOM set.
-        val mutated = realCatalogText().replace(
-            coreBlock,
-            """
+        val mutated =
+            realCatalogText().replace(
+                coreBlock,
+                """
             |  - path: ":tramai-core"
             |    <<: *internal
             |    layer: core-contracts
             |    publishability: internal
             |    apiStability: internal
             |
-            """.trimMargin()
-        )
+                """.trimMargin(),
+            )
         assertNotEquals(realCatalogText(), mutated, "mutation must change content")
         writeCatalog(mutated)
 
-        val result = ModuleCatalog(tempDir).parse()
+        val result = ModuleCatalog.fromRootDir(tempDir).parse()
         assertEquals(emptySet(), codes(result), "mutation must stay parse-valid to test derivation")
 
         assertTrue(
             !ModuleManifest.publishableModulePaths(tempDir).contains(":tramai-core"),
-            "internal module must not be publishable"
+            "internal module must not be publishable",
         )
         assertTrue(
             !ModuleManifest.bomModulePaths(tempDir).contains(":tramai-core"),
-            "internal module must not be in BOM"
+            "internal module must not be in BOM",
         )
     }
 
@@ -262,9 +267,10 @@ class ModuleCatalogMutationTest {
     @Test
     fun `M7 blank owner and rationale are rejected`() {
         fixtureDir()
-        val mutated = realCatalogText().replace(
-            coreBlock,
-            """
+        val mutated =
+            realCatalogText().replace(
+                coreBlock,
+                """
             |  - path: ":tramai-core"
             |    description: "Core annotations, request models, provider registry, and exception types for Tramai."
             |    <<: *core
@@ -273,21 +279,22 @@ class ModuleCatalogMutationTest {
             |    apiStability: stable
             |    owner: ""
             |
-            """.trimMargin()
-        )
+                """.trimMargin(),
+            )
         assertNotEquals(realCatalogText(), mutated, "owner mutation must change content")
         writeCatalog(mutated)
 
-        val result = ModuleCatalog(tempDir).parse()
+        val result = ModuleCatalog.fromRootDir(tempDir).parse()
         assertTrue(
             codes(result).contains(DiagnosticCode.MODULE_CATALOG_BLANK_OWNER),
-            "expected MODULE_CATALOG_BLANK_OWNER, got ${codes(result)}"
+            "expected MODULE_CATALOG_BLANK_OWNER, got ${codes(result)}",
         )
 
         // Now blank rationale on the same base.
-        val mutated2 = realCatalogText().replace(
-            coreBlock,
-            """
+        val mutated2 =
+            realCatalogText().replace(
+                coreBlock,
+                """
             |  - path: ":tramai-core"
             |    description: "Core annotations, request models, provider registry, and exception types for Tramai."
             |    <<: *core
@@ -296,13 +303,13 @@ class ModuleCatalogMutationTest {
             |    apiStability: stable
             |    rationale: ""
             |
-            """.trimMargin()
-        )
+                """.trimMargin(),
+            )
         writeCatalog(mutated2)
-        val result2 = ModuleCatalog(tempDir).parse()
+        val result2 = ModuleCatalog.fromRootDir(tempDir).parse()
         assertTrue(
             codes(result2).contains(DiagnosticCode.MODULE_CATALOG_BLANK_RATIONALE),
-            "expected MODULE_CATALOG_BLANK_RATIONALE, got ${codes(result2)}"
+            "expected MODULE_CATALOG_BLANK_RATIONALE, got ${codes(result2)}",
         )
     }
 
@@ -311,9 +318,10 @@ class ModuleCatalogMutationTest {
     @Test
     fun `M8 invalid policy - banana is rejected`() {
         fixtureDir()
-        val mutated = realCatalogText().replace(
-            coreBlock,
-            """
+        val mutated =
+            realCatalogText().replace(
+                coreBlock,
+                """
             |  - path: ":tramai-core"
             |    description: "Core annotations, request models, provider registry, and exception types for Tramai."
             |    <<: *core
@@ -322,19 +330,19 @@ class ModuleCatalogMutationTest {
             |    apiStability: stable
             |    dependencyPolicy: banana
             |
-            """.trimMargin()
-        )
+                """.trimMargin(),
+            )
         assertNotEquals(realCatalogText(), mutated, "policy mutation must change content")
         writeCatalog(mutated)
 
-        val result = ModuleCatalog(tempDir).parse()
+        val result = ModuleCatalog.fromRootDir(tempDir).parse()
         assertTrue(
             codes(result).contains(DiagnosticCode.MODULE_CATALOG_INVALID_POLICY),
-            "expected MODULE_CATALOG_INVALID_POLICY, got ${codes(result)}"
+            "expected MODULE_CATALOG_INVALID_POLICY, got ${codes(result)}",
         )
         assertTrue(
             result.errors.any { it.message.contains("banana") },
-            "error must name the unknown policy"
+            "error must name the unknown policy",
         )
     }
 
@@ -343,20 +351,20 @@ class ModuleCatalogMutationTest {
     @Test
     fun `D1 schema v3 accepted and v2 rejected`() {
         fixtureDir()
-        val result = ModuleCatalog(tempDir).parse()
+        val result = ModuleCatalog.fromRootDir(tempDir).parse()
         assertEquals(
             emptySet(),
             codes(result),
-            "committed schema v3 catalog must parse clean, got ${codes(result)}"
+            "committed schema v3 catalog must parse clean, got ${codes(result)}",
         )
 
         val v2 = realCatalogText().replace("schemaVersion: \"3\"", "schemaVersion: \"2\"")
         assertNotEquals(realCatalogText(), v2, "schema downgrade must change content")
         writeCatalog(v2)
-        val downgraded = ModuleCatalog(tempDir).parse()
+        val downgraded = ModuleCatalog.fromRootDir(tempDir).parse()
         assertTrue(
             codes(downgraded).contains(DiagnosticCode.MODULE_CATALOG_INVALID_SCHEMA),
-            "schema v2 must be rejected, got ${codes(downgraded)}"
+            "schema v2 must be rejected, got ${codes(downgraded)}",
         )
     }
 
@@ -365,33 +373,35 @@ class ModuleCatalogMutationTest {
     @Test
     fun `D2 published module missing description is rejected`() {
         fixtureDir()
-        val mutated = realCatalogText().replace(
-            coreBlock,
-            """
+        val mutated =
+            realCatalogText().replace(
+                coreBlock,
+                """
             |  - path: ":tramai-core"
             |    <<: *core
             |    layer: core-contracts
             |    publishability: published
             |    apiStability: stable
             |
-            """.trimMargin()
-        )
+                """.trimMargin(),
+            )
         assertNotEquals(realCatalogText(), mutated, "description-removal must change content")
         writeCatalog(mutated)
 
-        val result = ModuleCatalog(tempDir).parse()
+        val result = ModuleCatalog.fromRootDir(tempDir).parse()
         assertTrue(
             codes(result).contains(DiagnosticCode.MODULE_CATALOG_MISSING_DESCRIPTION),
-            "expected MODULE_CATALOG_MISSING_DESCRIPTION, got ${codes(result)}"
+            "expected MODULE_CATALOG_MISSING_DESCRIPTION, got ${codes(result)}",
         )
     }
 
     @Test
     fun `D3 published module blank description is rejected with same code`() {
         fixtureDir()
-        val mutated = realCatalogText().replace(
-            coreBlock,
-            """
+        val mutated =
+            realCatalogText().replace(
+                coreBlock,
+                """
             |  - path: ":tramai-core"
             |    description: "   "
             |    <<: *core
@@ -399,14 +409,14 @@ class ModuleCatalogMutationTest {
             |    publishability: published
             |    apiStability: stable
             |
-            """.trimMargin()
-        )
+                """.trimMargin(),
+            )
         writeCatalog(mutated)
 
-        val result = ModuleCatalog(tempDir).parse()
+        val result = ModuleCatalog.fromRootDir(tempDir).parse()
         assertTrue(
             codes(result).contains(DiagnosticCode.MODULE_CATALOG_MISSING_DESCRIPTION),
-            "blank description must produce MODULE_CATALOG_MISSING_DESCRIPTION, got ${codes(result)}"
+            "blank description must produce MODULE_CATALOG_MISSING_DESCRIPTION, got ${codes(result)}",
         )
     }
 
@@ -415,24 +425,25 @@ class ModuleCatalogMutationTest {
     @Test
     fun `D4 internal module without description parses clean`() {
         fixtureDir()
-        val mutated = realCatalogText().replace(
-            coreBlock,
-            """
+        val mutated =
+            realCatalogText().replace(
+                coreBlock,
+                """
             |  - path: ":tramai-core"
             |    <<: *internal
             |    layer: core-contracts
             |    publishability: internal
             |    apiStability: internal
             |
-            """.trimMargin()
-        )
+                """.trimMargin(),
+            )
         assertNotEquals(realCatalogText(), mutated, "internal mutation must change content")
         writeCatalog(mutated)
 
-        val result = ModuleCatalog(tempDir).parse()
+        val result = ModuleCatalog.fromRootDir(tempDir).parse()
         assertTrue(
             !codes(result).contains(DiagnosticCode.MODULE_CATALOG_MISSING_DESCRIPTION),
-            "internal module must not require a description, got ${codes(result)}"
+            "internal module must not require a description, got ${codes(result)}",
         )
     }
 
@@ -441,7 +452,7 @@ class ModuleCatalogMutationTest {
     @Test
     fun `D5 published descriptions exactly match the legacy projectDescription policy`() {
         fixtureDir()
-        val catalog = ModuleCatalog(tempDir).parse()
+        val catalog = ModuleCatalog.fromRootDir(tempDir).parse()
         assertEquals(emptySet(), codes(catalog), "catalog must parse clean, got ${codes(catalog)}")
 
         val legacy = LegacyPublicationDescriptions.byModule()

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/ModuleTopologyVerificationTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/ModuleTopologyVerificationTest.kt
@@ -120,6 +120,21 @@ class ModuleTopologyVerificationTest {
         assertTrue(result.task(":verifyModuleManifest")?.outcome == TaskOutcome.SUCCESS, result.output.take(800))
     }
 
+    @Test
+    fun `publishedPaths default is fail-closed when the release plugin is absent`() {
+        // P1 (a3c1 Round-2): without tramai.release-verification the historical
+        // implementation supplied an EMPTY publication set and produced the typed
+        // MODULE_CATALOG_PUBLISHING_DRIFT diagnostic. The typed task must not die
+        // on an unset ListProperty: convention(emptyList()) restores the old
+        // fail-closed behavior.
+        val dir = topologyFixture(applyReleasePlugin = false)
+        val result = runner(dir, "verifyModuleManifest").buildAndFail()
+        assertTrue(
+            result.output.contains("[MODULE_CATALOG_PUBLISHING_DRIFT]"),
+            "must fail with publishing-drift (empty published set), not an unset-property crash: ${result.output.take(800)}",
+        )
+    }
+
     // ── Configuration cache discriminators ──────────────────────────────────
 
     @Test
@@ -251,6 +266,7 @@ class ModuleTopologyVerificationTest {
         bomModules: List<String> = listOf("tramai-core", "tramai-engine"),
         engineEntry: String? = defaultEngineEntry,
         catalogFileOverride: String? = null,
+        applyReleasePlugin: Boolean = true,
     ): File {
         val dir = File(tempDir, "topology-${counter.incrementAndGet()}").apply { mkdirs() }
         writeFile(
@@ -288,7 +304,13 @@ class ModuleTopologyVerificationTest {
             // Imperative apply AFTER the extra is set: the release task's
             // publishableModules snapshot only reads the extra when it exists at
             // apply time, otherwise it falls back to the module catalog.
-            apply(plugin = "tramai.release-verification")
+            ${
+                if (applyReleasePlugin) {
+                    "apply(plugin = \"tramai.release-verification\")"
+                } else {
+                    "// release-verification deliberately NOT applied (fail-closed publishedPaths test)"
+                }
+            }
             $catalogOverrideBlock
             """.trimIndent(),
         )

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/ModuleTopologyVerificationTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/ModuleTopologyVerificationTest.kt
@@ -97,7 +97,7 @@ class ModuleTopologyVerificationTest {
         )
     }
 
-    // ── Ordering + decoupling discriminators ────────────────────────────────
+    // ──── //  Ordering + decoupling discriminators ────
 
     @Test
     fun `BOM signal resolves lazily after evaluation - eager apply-time lookup would fail`() {
@@ -131,11 +131,12 @@ class ModuleTopologyVerificationTest {
         val result = runner(dir, "verifyModuleManifest").buildAndFail()
         assertTrue(
             result.output.contains("[MODULE_CATALOG_PUBLISHING_DRIFT]"),
-            "must fail with publishing-drift (empty published set), not an unset-property crash: ${result.output.take(800)}",
+            "must fail with publishing-drift (empty published set), " +
+                "not an unset-property crash: ${result.output.take(800)}",
         )
     }
 
-    // ── Configuration cache discriminators ──────────────────────────────────
+    // ──── //  Configuration cache discriminators ────
 
     @Test
     fun `declared catalog file is the execution authority - kill the old rediscovery`() {
@@ -167,11 +168,17 @@ class ModuleTopologyVerificationTest {
         val args = arrayOf("verifyModuleManifest", "--configuration-cache", "--configuration-cache-problems=fail")
 
         val first = runner(dir, *args).build()
-        assertTrue(first.output.contains("Configuration cache entry stored"), "cold run must store: ${first.output.take(800)}")
+        assertTrue(
+            first.output.contains("Configuration cache entry stored"),
+            "cold run must store: ${first.output.take(800)}",
+        )
         assertTrue(first.task(":verifyModuleManifest")?.outcome == TaskOutcome.SUCCESS)
 
         val second = runner(dir, *args).build()
-        assertTrue(second.output.contains("Reusing configuration cache"), "warm run must reuse: ${second.output.take(800)}")
+        assertTrue(
+            second.output.contains("Reusing configuration cache"),
+            "warm run must reuse: ${second.output.take(800)}",
+        )
         assertTrue(second.task(":verifyModuleManifest")?.outcome == TaskOutcome.SUCCESS)
 
         // Mutate ONLY the declared B file (remove the engine entry -> must fail
@@ -182,7 +189,10 @@ class ModuleTopologyVerificationTest {
             third.output.contains("[MODULE_CATALOG_MISSING_ENTRY]"),
             "mutated declared catalog must be observed and fail: ${third.output.take(800)}",
         )
-        assertTrue(third.output.contains("Reusing configuration cache"), "CC entry must still be reused after input mutation")
+        assertTrue(
+            third.output.contains("Reusing configuration cache"),
+            "CC entry must still be reused after input mutation",
+        )
     }
 
     @Test
@@ -191,22 +201,34 @@ class ModuleTopologyVerificationTest {
         val args = arrayOf("verifyModuleManifest", "--configuration-cache", "--configuration-cache-problems=fail")
 
         val first = runner(dir, *args).build()
-        assertTrue(first.output.contains("Configuration cache entry stored"), "cold run must store: ${first.output.take(800)}")
+        assertTrue(
+            first.output.contains("Configuration cache entry stored"),
+            "cold run must store: ${first.output.take(800)}",
+        )
 
         val second = runner(dir, *args).build()
-        assertTrue(second.output.contains("Reusing configuration cache"), "warm run must reuse: ${second.output.take(800)}")
+        assertTrue(
+            second.output.contains("Reusing configuration cache"),
+            "warm run must reuse: ${second.output.take(800)}",
+        )
         // Verifier has no output artifact (deliberately never up-to-date/skippable):
         // warm run reuses the CC entry but the task still executes.
-        assertTrue(second.task(":verifyModuleManifest")?.outcome == TaskOutcome.SUCCESS, "warm run must still execute the verifier")
+        assertTrue(
+            second.task(":verifyModuleManifest")?.outcome == TaskOutcome.SUCCESS,
+            "warm run must still execute the verifier",
+        )
 
         // Input mutation (catalog content) -> task re-executes.
         val mutatedCatalog = catalog(defaultEngineEntry).replace("Fixture core module.", "Fixture core module v2.")
         writeFile(dir, "config/quality/module-catalog.yml", mutatedCatalog)
         val third = runner(dir, *args).build()
-        assertTrue(third.task(":verifyModuleManifest")?.outcome == TaskOutcome.SUCCESS, "mutated catalog must re-execute")
+        assertTrue(
+            third.task(":verifyModuleManifest")?.outcome == TaskOutcome.SUCCESS,
+            "mutated catalog must re-execute",
+        )
     }
 
-    // ── Fixtures & helpers ──────────────────────────────────────────────────
+    // ──── //  Fixtures & helpers ────
 
     private val defaultEngineEntry = """
               - path: ":tramai-engine"
@@ -288,7 +310,8 @@ class ModuleTopologyVerificationTest {
         // discriminator can prove the declared file is parsed directly.
         val catalogOverrideBlock =
             if (catalogFileOverride != null) {
-                "tasks.named<VerifyModuleManifestTask>(\"verifyModuleManifest\") { moduleCatalogFile.set(layout.projectDirectory.file(\"$catalogFileOverride\")) }"
+                "tasks.named<VerifyModuleManifestTask>(\"verifyModuleManifest\") " +
+                    "{ moduleCatalogFile.set(layout.projectDirectory.file(\"$catalogFileOverride\")) }"
             } else {
                 ""
             }

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/ModuleTopologyVerificationTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/ModuleTopologyVerificationTest.kt
@@ -123,6 +123,54 @@ class ModuleTopologyVerificationTest {
     // ── Configuration cache discriminators ──────────────────────────────────
 
     @Test
+    fun `declared catalog file is the execution authority - kill the old rediscovery`() {
+        // P1 (a3c1 Round-1): moduleCatalogFile must BE the parsed file, not a
+        // pointer used to rediscover the conventional path. The conventional
+        // config/quality/module-catalog.yml holds VALID catalog A; the declared
+        // input points at fixtures/catalog-B.yml holding a DIFFERENT catalog B
+        // that omits :tramai-engine. The fixed implementation parses B and
+        // fails with MODULE_CATALOG_MISSING_ENTRY; the old implementation
+        // rediscovered A from B's parent chain and passed.
+        val dir = topologyFixture(catalogFileOverride = "fixtures/catalog-B.yml")
+        // Catalog B (declared): engine entry REMOVED -> missing-entry diagnostic.
+        val catalogB = catalog(engineEntry = null)
+        writeFile(dir, "fixtures/catalog-B.yml", catalogB)
+        val result = runner(dir, "verifyModuleManifest").buildAndFail()
+        assertTrue(
+            result.output.contains("[MODULE_CATALOG_MISSING_ENTRY]"),
+            "must observe the DECLARED catalog B, not the conventional catalog A: ${result.output.take(800)}",
+        )
+    }
+
+    @Test
+    fun `declared catalog file mutation is observed by the configuration cache`() {
+        // CC variant of the exact-file authority: cold -> warm reuse -> mutate
+        // ONLY the declared B file -> task re-executes and observes B's change.
+        val dir = topologyFixture(catalogFileOverride = "fixtures/catalog-B.yml")
+        // Initial B (declared): valid (same modules as the model) -> passes.
+        writeFile(dir, "fixtures/catalog-B.yml", catalog(defaultEngineEntry))
+        val args = arrayOf("verifyModuleManifest", "--configuration-cache", "--configuration-cache-problems=fail")
+
+        val first = runner(dir, *args).build()
+        assertTrue(first.output.contains("Configuration cache entry stored"), "cold run must store: ${first.output.take(800)}")
+        assertTrue(first.task(":verifyModuleManifest")?.outcome == TaskOutcome.SUCCESS)
+
+        val second = runner(dir, *args).build()
+        assertTrue(second.output.contains("Reusing configuration cache"), "warm run must reuse: ${second.output.take(800)}")
+        assertTrue(second.task(":verifyModuleManifest")?.outcome == TaskOutcome.SUCCESS)
+
+        // Mutate ONLY the declared B file (remove the engine entry -> must fail
+        // against the unchanged project/published/BOM model).
+        writeFile(dir, "fixtures/catalog-B.yml", catalog(engineEntry = null))
+        val third = runner(dir, *args).buildAndFail()
+        assertTrue(
+            third.output.contains("[MODULE_CATALOG_MISSING_ENTRY]"),
+            "mutated declared catalog must be observed and fail: ${third.output.take(800)}",
+        )
+        assertTrue(third.output.contains("Reusing configuration cache"), "CC entry must still be reused after input mutation")
+    }
+
+    @Test
     fun `verifyModuleManifest stores and reuses configuration cache and re-executes on catalog mutation`() {
         val dir = topologyFixture()
         val args = arrayOf("verifyModuleManifest", "--configuration-cache", "--configuration-cache-problems=fail")
@@ -202,6 +250,7 @@ class ModuleTopologyVerificationTest {
         publishableExtra: String? = """listOf(":tramai-core", ":tramai-engine", ":tramai-bom")""",
         bomModules: List<String> = listOf("tramai-core", "tramai-engine"),
         engineEntry: String? = defaultEngineEntry,
+        catalogFileOverride: String? = null,
     ): File {
         val dir = File(tempDir, "topology-${counter.incrementAndGet()}").apply { mkdirs() }
         writeFile(
@@ -218,10 +267,20 @@ class ModuleTopologyVerificationTest {
             } else {
                 ""
             }
+        // Exact-file authority override: point moduleCatalogFile at a
+        // non-conventional path so the P1 kill-the-old-implementation
+        // discriminator can prove the declared file is parsed directly.
+        val catalogOverrideBlock =
+            if (catalogFileOverride != null) {
+                "tasks.named<VerifyModuleManifestTask>(\"verifyModuleManifest\") { moduleCatalogFile.set(layout.projectDirectory.file(\"$catalogFileOverride\")) }"
+            } else {
+                ""
+            }
         writeFile(
             dir,
             "build.gradle.kts",
             """
+            import dev.tramai.build.quality.VerifyModuleManifestTask
             plugins {
                 id("tramai.maintainability-baseline")
             }
@@ -230,6 +289,7 @@ class ModuleTopologyVerificationTest {
             // publishableModules snapshot only reads the extra when it exists at
             // apply time, otherwise it falls back to the module catalog.
             apply(plugin = "tramai.release-verification")
+            $catalogOverrideBlock
             """.trimIndent(),
         )
         writeFile(

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/ModuleTopologyVerificationTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/ModuleTopologyVerificationTest.kt
@@ -1,0 +1,302 @@
+package dev.tramai.build.quality
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertTrue
+
+/**
+ * Discriminator suite for VerifyModuleManifestTask (Epic 9.2d-a3c1): real
+ * multi-project + java-platform BOM fixture, five failing mutations with exact
+ * diagnostics, lazy-BOM ordering guard, root-extra decoupling, and
+ * configuration-cache reuse + input-mutation re-execution.
+ *
+ * The release-verification plugin is applied IMPERATIVELY after the extra is
+ * set, mirroring how the release task's typed publishableModules snapshot can
+ * differ from the catalog (the extra is read only if present at apply time).
+ */
+class ModuleTopologyVerificationTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    private val counter = AtomicInteger(0)
+
+    @Test
+    fun `verifyModuleManifest passes with consistent topology`() {
+        val dir = topologyFixture()
+        val result = runner(dir, "verifyModuleManifest").build()
+        assertTrue(result.task(":verifyModuleManifest")?.outcome == TaskOutcome.SUCCESS, result.output.take(800))
+    }
+
+    // ── Five failing mutations (each with the correct diagnostic) ───────────
+
+    @Test
+    fun `mutation 1 - project exists but catalog entry removed fails`() {
+        val dir = topologyFixture(engineEntry = null)
+        val result = runner(dir, "verifyModuleManifest").buildAndFail()
+        assertTrue(
+            result.output.contains(
+                "[MODULE_CATALOG_MISSING_ENTRY] Gradle project ':tramai-engine' has no module-catalog entry",
+            ),
+            "expected exact missing-entry diagnostic: ${result.output.take(800)}",
+        )
+    }
+
+    @Test
+    fun `mutation 2 - catalog says published but release snapshot omits it fails`() {
+        // Release task snapshot = extra (set before imperative apply): engine omitted.
+        val dir = topologyFixture(publishableExtra = """listOf(":tramai-core", ":tramai-bom")""")
+        val result = runner(dir, "verifyModuleManifest").buildAndFail()
+        assertTrue(
+            result.output.contains(
+                "[MODULE_CATALOG_PUBLISHING_DRIFT] Publishing drift: configured publication set " +
+                    "[:tramai-bom, :tramai-core] but manifest requires " +
+                    "[:tramai-bom, :tramai-core, :tramai-engine]",
+            ),
+            "expected exact publishing-drift diagnostic: ${result.output.take(800)}",
+        )
+    }
+
+    @Test
+    fun `mutation 3 - release snapshot includes unexpected published module fails`() {
+        val dir =
+            topologyFixture(
+                publishableExtra = """listOf(":tramai-core", ":tramai-engine", ":tramai-bom", ":tramai-extra")""",
+            )
+        val result = runner(dir, "verifyModuleManifest").buildAndFail()
+        assertTrue(
+            result.output.contains("[MODULE_CATALOG_PUBLISHING_DRIFT]") && result.output.contains(":tramai-extra"),
+            "expected publishing drift mentioning :tramai-extra: ${result.output.take(800)}",
+        )
+    }
+
+    @Test
+    fun `mutation 4 - BOM constraint removed fails`() {
+        val dir = topologyFixture(bomModules = listOf("tramai-core"))
+        val result = runner(dir, "verifyModuleManifest").buildAndFail()
+        assertTrue(
+            result.output.contains(
+                "[MODULE_CATALOG_BOM_DRIFT] BOM drift: configured BOM constraints " +
+                    "[:tramai-core] but manifest requires " +
+                    "[:tramai-core, :tramai-engine]",
+            ),
+            "expected exact bom-drift diagnostic: ${result.output.take(800)}",
+        )
+    }
+
+    @Test
+    fun `mutation 5 - unexpected BOM constraint added fails`() {
+        val dir = topologyFixture(bomModules = listOf("tramai-core", "tramai-engine", "tramai-extra"))
+        val result = runner(dir, "verifyModuleManifest").buildAndFail()
+        assertTrue(
+            result.output.contains("[MODULE_CATALOG_BOM_DRIFT]") && result.output.contains(":tramai-extra"),
+            "expected bom drift mentioning :tramai-extra: ${result.output.take(800)}",
+        )
+    }
+
+    // ── Ordering + decoupling discriminators ────────────────────────────────
+
+    @Test
+    fun `BOM signal resolves lazily after evaluation - eager apply-time lookup would fail`() {
+        // BOM constraints are declared in tramai-bom/build.gradle.kts, evaluated
+        // AFTER the root plugin apply. An eager plugin-apply-time lookup would
+        // see an empty api constraint graph and fail with BOM drift; passing
+        // proves the provider resolves lazily (Epic 9.2d-a1 rule).
+        val dir = topologyFixture()
+        val result = runner(dir, "verifyModuleManifest").build()
+        assertTrue(result.task(":verifyModuleManifest")?.outcome == TaskOutcome.SUCCESS, result.output.take(800))
+    }
+
+    @Test
+    fun `publishedPaths come from the release task model when the root extra is absent`() {
+        // No tramai.publishableModulePaths extra anywhere: the release task's
+        // publishableModules falls back to the module catalog, and
+        // verifyModuleManifest still passes (9.2d-b can delete the extra later).
+        val dir = topologyFixture(publishableExtra = null)
+        val result = runner(dir, "verifyModuleManifest").build()
+        assertTrue(result.task(":verifyModuleManifest")?.outcome == TaskOutcome.SUCCESS, result.output.take(800))
+    }
+
+    // ── Configuration cache discriminators ──────────────────────────────────
+
+    @Test
+    fun `verifyModuleManifest stores and reuses configuration cache and re-executes on catalog mutation`() {
+        val dir = topologyFixture()
+        val args = arrayOf("verifyModuleManifest", "--configuration-cache", "--configuration-cache-problems=fail")
+
+        val first = runner(dir, *args).build()
+        assertTrue(first.output.contains("Configuration cache entry stored"), "cold run must store: ${first.output.take(800)}")
+
+        val second = runner(dir, *args).build()
+        assertTrue(second.output.contains("Reusing configuration cache"), "warm run must reuse: ${second.output.take(800)}")
+        // Verifier has no output artifact (deliberately never up-to-date/skippable):
+        // warm run reuses the CC entry but the task still executes.
+        assertTrue(second.task(":verifyModuleManifest")?.outcome == TaskOutcome.SUCCESS, "warm run must still execute the verifier")
+
+        // Input mutation (catalog content) -> task re-executes.
+        val mutatedCatalog = catalog(defaultEngineEntry).replace("Fixture core module.", "Fixture core module v2.")
+        writeFile(dir, "config/quality/module-catalog.yml", mutatedCatalog)
+        val third = runner(dir, *args).build()
+        assertTrue(third.task(":verifyModuleManifest")?.outcome == TaskOutcome.SUCCESS, "mutated catalog must re-execute")
+    }
+
+    // ── Fixtures & helpers ──────────────────────────────────────────────────
+
+    private val defaultEngineEntry = """
+              - path: ":tramai-engine"
+                <<: *core
+                layer: core-contracts
+                publishability: published
+                apiStability: stable
+                description: "Fixture engine module."
+    """
+
+    private fun catalog(engineEntry: String?): String {
+        val engine = engineEntry ?: ""
+        return """
+            schemaVersion: "3"
+            dependencyPolicies:
+              core: { allowedLayers: [core-contracts] }
+              testing: { allowedLayers: [testing-support] }
+            entryDefaults:
+              core: &core { maturity: stable, visibility: public, owner: core, dependencyPolicy: core, releaseInclusion: included, rationale: "Fixture module." }
+              internal: &internal { maturity: internal, visibility: internal, owner: testing, dependencyPolicy: testing, releaseInclusion: internal_only, rationale: "Fixture internal module." }
+            modules:
+              - path: ":tramai-core"
+                <<: *core
+                layer: core-contracts
+                publishability: published
+                apiStability: stable
+                description: "Fixture core module."
+              $engine
+              - path: ":tramai-testing"
+                <<: *internal
+                layer: testing-support
+                publishability: internal
+                apiStability: internal
+              - path: ":tramai-bom"
+                <<: *core
+                layer: core-contracts
+                publishability: published
+                apiStability: stable
+                description: "Fixture BOM."
+            """.trimIndent()
+    }
+
+    private fun bomScript(modules: List<String>): String {
+        val constraints = modules.joinToString("\n") { "            api(\"dev.tramai:$it:0.6.0\")" }
+        return """
+            plugins { `java-platform` }
+            dependencies {
+                constraints {
+            $constraints
+                }
+            }
+            """.trimIndent()
+    }
+
+    private fun topologyFixture(
+        publishableExtra: String? = """listOf(":tramai-core", ":tramai-engine", ":tramai-bom")""",
+        bomModules: List<String> = listOf("tramai-core", "tramai-engine"),
+        engineEntry: String? = defaultEngineEntry,
+    ): File {
+        val dir = File(tempDir, "topology-${counter.incrementAndGet()}").apply { mkdirs() }
+        writeFile(
+            dir,
+            "settings.gradle.kts",
+            """
+            rootProject.name = "topology-fixture"
+            include(":tramai-core", ":tramai-engine", ":tramai-testing", ":tramai-bom")
+            """.trimIndent(),
+        )
+        val extraBlock =
+            if (publishableExtra != null) {
+                "extra[\"tramai.publishableModulePaths\"] = $publishableExtra"
+            } else {
+                ""
+            }
+        writeFile(
+            dir,
+            "build.gradle.kts",
+            """
+            plugins {
+                id("tramai.maintainability-baseline")
+            }
+            $extraBlock
+            // Imperative apply AFTER the extra is set: the release task's
+            // publishableModules snapshot only reads the extra when it exists at
+            // apply time, otherwise it falls back to the module catalog.
+            apply(plugin = "tramai.release-verification")
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "tramai-core/build.gradle.kts",
+            """
+            plugins { `java-library` }
+            tasks.register("generatePomFileForMavenPublication")
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "tramai-engine/build.gradle.kts",
+            """
+            plugins { `java-library` }
+            tasks.register("generatePomFileForMavenPublication")
+            """.trimIndent(),
+        )
+        writeFile(dir, "tramai-testing/build.gradle.kts", """plugins { `java-library` }""")
+        writeFile(
+            dir,
+            "tramai-bom/build.gradle.kts",
+            """
+            ${bomScript(bomModules)}
+            tasks.register("generatePomFileForMavenPublication")
+            """.trimIndent(),
+        )
+        writeFile(dir, "config/quality/module-catalog.yml", catalog(engineEntry))
+        writeFile(
+            dir,
+            "config/quality/test-quality.yml",
+            """
+            schemaVersion: "1"
+            criticalModules: [":tramai-core"]
+            coverage:
+              regressionTolerancePercentagePoints: 1.0
+              exclusions: []
+            mutation:
+              regressionTolerancePercentagePoints: 1.0
+              targetFamilies:
+                core:
+                  modules: [":tramai-core"]
+                  targetClasses: ["example.*"]
+                  targetTests: ["example.*"]
+            """.trimIndent(),
+        )
+        return dir
+    }
+
+    private fun runner(
+        dir: File,
+        vararg args: String,
+    ): GradleRunner =
+        GradleRunner
+            .create()
+            .withProjectDir(dir)
+            .withGradleVersion("9.0.0")
+            .withArguments(*args, "--stacktrace")
+            .withPluginClasspath()
+
+    private fun writeFile(
+        base: File,
+        relativePath: String,
+        content: String,
+    ) {
+        val target = File(base, relativePath)
+        target.parentFile.mkdirs()
+        target.writeText(content)
+    }
+}

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/ResolvedDependencyAggregateTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/ResolvedDependencyAggregateTest.kt
@@ -1,0 +1,355 @@
+package dev.tramai.build.quality
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Discriminator suite for AggregateResolvedDependencyBaselineTask (Epic 9.2d-a3c1):
+ * sorted deterministic merge, fail-closed diagnostics, no empty success oracle,
+ * plugin wiring, and configuration-cache reuse + input-mutation re-execution.
+ */
+class ResolvedDependencyAggregateTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    private val counter = AtomicInteger(0)
+    private val mapper = ObjectMapper()
+
+    // ── Direct task-registration discriminators ─────────────────────────────
+
+    @Test
+    fun `aggregate merges unsorted probe records into a sorted deterministic baseline`() {
+        val dir = aggregateFixture(listOf(":a", ":b"), listOf("a.json", "b.json"))
+        // Records arrive UNSORTED: a.json carries zeta BEFORE alpha; b.json adds beta.
+        writeProbe(dir, "probes/a.json", record("zeta", ":a"), record("alpha", ":a"))
+        writeProbe(dir, "probes/b.json", record("beta", ":b"))
+
+        val result = runner(dir, "aggregate").build()
+
+        val output = File(dir, "build/reports/maintainability/resolved-dependencies.json")
+        assertTrue(output.isFile, "aggregate file must be written")
+        val artifacts = parse(output.readText()).map { it.get("artifact").asText() }
+        // Sorted by consumers (":a" < ":b") then artifact: alpha, zeta, beta.
+        assertEquals(listOf("alpha", "zeta", "beta"), artifacts)
+        // No empty dependency universe as success oracle: non-empty, both projects present.
+        assertEquals(3, artifacts.size)
+        assertTrue(
+            result.output.contains("Resolved dependency baseline: 3 records (3 direct, 0 transitive)"),
+            "exact summary line must be printed: ${result.output.take(800)}",
+        )
+
+        // Deterministic: forced re-run must produce byte-identical output.
+        runner(dir, "aggregate", "--rerun-tasks").build()
+        assertEquals(output.readText(), File(dir, "build/reports/maintainability/resolved-dependencies.json").readText())
+    }
+
+    @Test
+    fun `missing probe fails with the exact missing-probe diagnostic`() {
+        val dir = aggregateFixture(listOf(":a", ":b"), listOf("a.json", "b.json"))
+        writeProbe(dir, "probes/a.json", record("alpha", ":a"))
+        // b.json intentionally never written.
+
+        val result = runner(dir, "aggregate").buildAndFail()
+
+        val expected = "Missing dependency probe output for :b: ${File(dir, "probes/b.json").absolutePath}"
+        assertTrue(result.output.contains(expected), "expected '$expected' in output: ${result.output.take(800)}")
+    }
+
+    @Test
+    fun `malformed probe fails with the exact invalid-probe diagnostic`() {
+        val dir = aggregateFixture(listOf(":a", ":b"), listOf("a.json", "b.json"))
+        writeProbe(dir, "probes/a.json", record("alpha", ":a"))
+        writeFile(dir, "probes/b.json", "{ this is not json ")
+
+        val result = runner(dir, "aggregate").buildAndFail()
+
+        assertTrue(
+            result.output.contains("Invalid dependency probe output for :b:"),
+            "expected invalid-probe diagnostic in output: ${result.output.take(800)}",
+        )
+    }
+
+    @Test
+    fun `records from project B are not lost when project A is valid`() {
+        val dir = aggregateFixture(listOf(":a", ":b"), listOf("a.json", "b.json"))
+        writeProbe(dir, "probes/a.json", record("alpha", ":a"), record("zeta", ":a"))
+        writeProbe(dir, "probes/b.json", record("beta", ":b"), record("gamma", ":b"))
+
+        runner(dir, "aggregate").build()
+
+        val artifacts =
+            parse(File(dir, "build/reports/maintainability/resolved-dependencies.json").readText())
+                .map { it.get("artifact").asText() }
+        assertEquals(listOf("alpha", "zeta", "beta", "gamma"), artifacts, "both projects' records must survive the merge")
+    }
+
+    @Test
+    fun `aggregate stores and reuses configuration cache and re-executes on probe mutation`() {
+        val dir = aggregateFixture(listOf(":a", ":b"), listOf("a.json", "b.json"))
+        writeProbe(dir, "probes/a.json", record("alpha", ":a"))
+        writeProbe(dir, "probes/b.json", record("beta", ":b"))
+
+        val args = arrayOf("aggregate", "--configuration-cache", "--configuration-cache-problems=fail")
+        val first = runner(dir, *args).build()
+        assertTrue(first.output.contains("Configuration cache entry stored"), "cold run must store: ${first.output.take(800)}")
+
+        val second = runner(dir, *args).build()
+        assertTrue(second.output.contains("Reusing configuration cache"), "warm run must reuse: ${second.output.take(800)}")
+        assertTrue(second.task(":aggregate")?.outcome == TaskOutcome.UP_TO_DATE, "unchanged inputs must be up-to-date")
+
+        // Input mutation -> re-executes.
+        writeProbe(dir, "probes/b.json", record("beta", ":b"), record("gamma", ":b"))
+        val third = runner(dir, *args).build()
+        assertTrue(third.task(":aggregate")?.outcome == TaskOutcome.SUCCESS, "mutated input must re-execute")
+        val artifacts =
+            parse(File(dir, "build/reports/maintainability/resolved-dependencies.json").readText())
+                .map { it.get("artifact").asText() }
+        assertEquals(listOf("alpha", "beta", "gamma"), artifacts)
+    }
+
+    // ── Plugin wiring integration ───────────────────────────────────────────
+
+    @Test
+    fun `plugin wires root aggregate from per-project probes in deterministic order`() {
+        val dir = multiProjectFixture()
+        val result = runner(dir, "generateResolvedDependencyBaseline").build()
+
+        val output = File(dir, "build/reports/maintainability/resolved-dependencies.json")
+        assertTrue(output.isFile, "aggregate file must be written by the root task")
+        val parsed = parse(output.readText())
+        assertTrue(parsed.size >= 3, "both projects' records must be merged: ${output.readText()}")
+        assertTrue(parsed.all { it.get("group").asText() == "com.example" })
+        assertTrue(result.output.contains("Resolved dependency baseline:"), "summary line must be printed")
+        assertTrue(result.task(":generateResolvedDependencyBaseline")?.outcome == TaskOutcome.SUCCESS)
+    }
+
+    // ── Fixtures & helpers ──────────────────────────────────────────────────
+
+    /** Direct-registration fixture: full control over probe file existence/content. */
+    private fun aggregateFixture(
+        owners: List<String>,
+        fileNames: List<String>,
+    ): File {
+        val dir = File(tempDir, "agg-${counter.incrementAndGet()}").apply { mkdirs() }
+        writeFile(dir, "settings.gradle.kts", "rootProject.name = \"agg-fixture\"\n")
+        val files = fileNames.joinToString(", ") { """layout.projectDirectory.file("probes/$it")""" }
+        val ownersArg = owners.joinToString(", ") { "\"$it\"" }
+        // Apply the maintainability plugin so TestKit injects the build-logic
+        // classpath (withPluginClasspath exposes classes through plugin
+        // resolution, not the raw script classpath). The custom aggregate task
+        // then resolves the import.
+        writeFile(
+            dir,
+            "config/quality/module-catalog.yml",
+            """
+            schemaVersion: "3"
+            dependencyPolicies:
+              core: { allowedLayers: [core-contracts] }
+            entryDefaults:
+              core: &core { maturity: stable, visibility: public, owner: core, dependencyPolicy: core, releaseInclusion: included, rationale: "Fixture module." }
+            modules:
+              - path: ":alpha"
+                <<: *core
+                layer: core-contracts
+                publishability: published
+                apiStability: stable
+                description: "Alpha fixture."
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "config/quality/test-quality.yml",
+            """
+            schemaVersion: "1"
+            criticalModules: [":alpha"]
+            coverage:
+              regressionTolerancePercentagePoints: 1.0
+              exclusions: []
+            mutation:
+              regressionTolerancePercentagePoints: 1.0
+              targetFamilies:
+                alpha:
+                  modules: [":alpha"]
+                  targetClasses: ["example.*"]
+                  targetTests: ["example.*"]
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "build.gradle.kts",
+            """
+            plugins { id("tramai.maintainability-baseline") }
+            import dev.tramai.build.quality.AggregateResolvedDependencyBaselineTask
+
+            tasks.register<AggregateResolvedDependencyBaselineTask>("aggregate") {
+                probeFiles.from($files)
+                expectedProbeOwners.set(listOf($ownersArg))
+                aggregateFile.set(layout.buildDirectory.file("reports/maintainability/resolved-dependencies.json"))
+            }
+            """.trimIndent(),
+        )
+        return dir
+    }
+
+    /** Real multi-project fixture: probes resolve real external modules from a local repo. */
+    private fun multiProjectFixture(): File {
+        val dir = File(tempDir, "agg-integration-${counter.incrementAndGet()}").apply { mkdirs() }
+        writeFile(
+            dir,
+            "settings.gradle.kts",
+            """
+            rootProject.name = "agg-integration"
+            include(":alpha", ":beta")
+            """.trimIndent(),
+        )
+        writeFile(dir, "build.gradle.kts", """plugins { id("tramai.maintainability-baseline") }""")
+        writeFile(
+            dir,
+            "alpha/build.gradle.kts",
+            """
+            plugins { `java-library` }
+            repositories { maven { url = uri(rootDir.resolve("repo")) } }
+            dependencies { implementation("com.example:fake:1.0") }
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "beta/build.gradle.kts",
+            """
+            plugins { `java-library` }
+            repositories { maven { url = uri(rootDir.resolve("repo")) } }
+            dependencies {
+                implementation("com.example:fake:1.0")
+                implementation("com.example:fake2:1.0")
+            }
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "config/quality/module-catalog.yml",
+            """
+            schemaVersion: "3"
+            dependencyPolicies:
+              core: { allowedLayers: [core-contracts] }
+            entryDefaults:
+              core: &core { maturity: stable, visibility: public, owner: core, dependencyPolicy: core, releaseInclusion: included, rationale: "Fixture module." }
+            modules:
+              - path: ":alpha"
+                <<: *core
+                layer: core-contracts
+                publishability: published
+                apiStability: stable
+                description: "Alpha fixture."
+              - path: ":beta"
+                <<: *core
+                layer: core-contracts
+                publishability: published
+                apiStability: stable
+                description: "Beta fixture."
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "config/quality/test-quality.yml",
+            """
+            schemaVersion: "1"
+            criticalModules: [":alpha"]
+            coverage:
+              regressionTolerancePercentagePoints: 1.0
+              exclusions: []
+            mutation:
+              regressionTolerancePercentagePoints: 1.0
+              targetFamilies:
+                alpha:
+                  modules: [":alpha"]
+                  targetClasses: ["example.*"]
+                  targetTests: ["example.*"]
+            """.trimIndent(),
+        )
+        for ((name, version) in listOf("fake" to "1.0", "fake2" to "1.0")) {
+            val moduleDir = File(dir, "repo/com/example/$name/$version")
+            moduleDir.mkdirs()
+            writeFile(
+                moduleDir,
+                "$name-$version.pom",
+                """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>$name</artifactId>
+                  <version>$version</version>
+                </project>
+                """.trimIndent(),
+            )
+            java.util.zip
+                .ZipOutputStream(File(moduleDir, "$name-$version.jar").outputStream())
+                .use { it.close() }
+        }
+        return dir
+    }
+
+    private fun record(
+        artifact: String,
+        consumer: String,
+    ): String {
+        val json =
+            """
+            {
+              "group": "com.example",
+              "artifact": "$artifact",
+              "selectedVersion": "1.0",
+              "requestedVersion": "1.0",
+              "direct": true,
+              "configuration": "compileClasspath",
+              "selectionReason": "requested",
+              "dependencyPath": ["$consumer", "com.example:$artifact:1.0"],
+              "consumers": ["$consumer"]
+            }
+            """.trimIndent()
+        return json
+    }
+
+    private fun writeProbe(
+        base: File,
+        relativePath: String,
+        vararg records: String,
+    ) {
+        writeFile(base, relativePath, records.joinToString(separator = ",\n", prefix = "[", postfix = "]"))
+    }
+
+    private fun parse(json: String): List<JsonNode> {
+        val tree = mapper.readTree(json)
+        val list = mutableListOf<JsonNode>()
+        tree.forEach { list.add(it) }
+        return list
+    }
+
+    private fun runner(
+        dir: File,
+        vararg args: String,
+    ): GradleRunner =
+        GradleRunner
+            .create()
+            .withProjectDir(dir)
+            .withGradleVersion("9.0.0")
+            .withArguments(*args, "--stacktrace")
+            .withPluginClasspath()
+
+    private fun writeFile(
+        base: File,
+        relativePath: String,
+        content: String,
+    ) {
+        val target = File(base, relativePath)
+        target.parentFile.mkdirs()
+        target.writeText(content)
+    }
+}

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/ResolvedDependencyAggregateTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/ResolvedDependencyAggregateTest.kt
@@ -23,7 +23,7 @@ class ResolvedDependencyAggregateTest {
     private val counter = AtomicInteger(0)
     private val mapper = ObjectMapper()
 
-    // ── Direct task-registration discriminators ─────────────────────────────
+    // ──── //  Direct task-registration discriminators ────
 
     @Test
     fun `aggregate merges unsorted probe records into a sorted deterministic baseline`() {
@@ -48,7 +48,10 @@ class ResolvedDependencyAggregateTest {
 
         // Deterministic: forced re-run must produce byte-identical output.
         runner(dir, "aggregate", "--rerun-tasks").build()
-        assertEquals(output.readText(), File(dir, "build/reports/maintainability/resolved-dependencies.json").readText())
+        assertEquals(
+            output.readText(),
+            File(dir, "build/reports/maintainability/resolved-dependencies.json").readText(),
+        )
     }
 
     @Test
@@ -88,7 +91,11 @@ class ResolvedDependencyAggregateTest {
         val artifacts =
             parse(File(dir, "build/reports/maintainability/resolved-dependencies.json").readText())
                 .map { it.get("artifact").asText() }
-        assertEquals(listOf("alpha", "zeta", "beta", "gamma"), artifacts, "both projects' records must survive the merge")
+        assertEquals(
+            listOf("alpha", "zeta", "beta", "gamma"),
+            artifacts,
+            "both projects' records must survive the merge",
+        )
     }
 
     @Test
@@ -99,10 +106,16 @@ class ResolvedDependencyAggregateTest {
 
         val args = arrayOf("aggregate", "--configuration-cache", "--configuration-cache-problems=fail")
         val first = runner(dir, *args).build()
-        assertTrue(first.output.contains("Configuration cache entry stored"), "cold run must store: ${first.output.take(800)}")
+        assertTrue(
+            first.output.contains("Configuration cache entry stored"),
+            "cold run must store: ${first.output.take(800)}",
+        )
 
         val second = runner(dir, *args).build()
-        assertTrue(second.output.contains("Reusing configuration cache"), "warm run must reuse: ${second.output.take(800)}")
+        assertTrue(
+            second.output.contains("Reusing configuration cache"),
+            "warm run must reuse: ${second.output.take(800)}",
+        )
         assertTrue(second.task(":aggregate")?.outcome == TaskOutcome.UP_TO_DATE, "unchanged inputs must be up-to-date")
 
         // Input mutation -> re-executes.
@@ -115,7 +128,7 @@ class ResolvedDependencyAggregateTest {
         assertEquals(listOf("alpha", "beta", "gamma"), artifacts)
     }
 
-    // ── Plugin wiring integration ───────────────────────────────────────────
+    // ──── //  Plugin wiring integration ────
 
     @Test
     fun `plugin wires root aggregate from per-project probes in deterministic order`() {
@@ -131,7 +144,7 @@ class ResolvedDependencyAggregateTest {
         assertTrue(result.task(":generateResolvedDependencyBaseline")?.outcome == TaskOutcome.SUCCESS)
     }
 
-    // ── Fixtures & helpers ──────────────────────────────────────────────────
+    // ──── //  Fixtures & helpers ────
 
     /** Direct-registration fixture: full control over probe file existence/content. */
     private fun aggregateFixture(

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/StaticAnalysisContractTestBase.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/StaticAnalysisContractTestBase.kt
@@ -169,6 +169,25 @@ abstract class StaticAnalysisContractTestBase {
         return "base"
     }
 
+    /**
+     * Branch pointing at a synthetic commit that is identical to the current
+     * worktree HEAD except the Detekt baseline file is ABSENT. Used to exercise
+     * the one-time bootstrap path hermetically (post-10.1b, live origin/master
+     * always carries the baseline, so remote state can no longer provide the
+     * no-baseline precondition).
+     */
+    protected fun baselineBranch(name: String): String {
+        git(worktree, "reset", "--hard", baseHead)
+        val baseline = File(worktree, "config/detekt/baseline.xml")
+        check(baseline.isFile) { "worktree must carry the committed Detekt baseline" }
+        check(baseline.delete()) { "failed to delete baseline for synthetic base" }
+        commit("synthetic base without Detekt baseline")
+        val ref = git(worktree, "rev-parse", "HEAD").trim()
+        git(worktree, "branch", "-f", name, ref)
+        git(worktree, "reset", "--hard", baseHead)
+        return name
+    }
+
     /** Runs the canonical gate against the given exact base ref. */
     protected fun staticAnalysis(
         baseRef: String,

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/StaticAnalysisScopeTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/StaticAnalysisScopeTest.kt
@@ -42,9 +42,13 @@ class StaticAnalysisScopeTest : StaticAnalysisContractTestBase() {
 
     @Test
     fun `p0-g bootstrap is one-time`() {
-        // (a) initial adoption: base (origin/master) has NO Detekt baseline, current
-        // has one, change class is build-logic, no runtime changes -> allowed.
-        val runAdoption = staticAnalysis("origin/master", changeClass = "build-logic")
+        // Hermetic base WITHOUT the committed baseline: after 10.1b merged, live
+        // origin/master always carries the baseline, so the bootstrap scenario
+        // must be synthesized on a local ref instead of depending on remote state.
+        val noBaseline = baselineBranch("nobaseline")
+        // (a) initial adoption: base has NO Detekt baseline, current has one,
+        // change class is build-logic, no runtime changes -> allowed.
+        val runAdoption = staticAnalysis(noBaseline, changeClass = "build-logic")
         assertPasses(runAdoption, "initial adoption bootstrap")
         assertTrue(
             runAdoption.output.contains("Initial Detekt baseline adoption"),
@@ -52,7 +56,7 @@ class StaticAnalysisScopeTest : StaticAnalysisContractTestBase() {
         )
 
         // (b) the same absence but with a runtime change class -> refused.
-        val runAbuse = staticAnalysis("origin/master", changeClass = "runtime-behaviour")
+        val runAbuse = staticAnalysis(noBaseline, changeClass = "runtime-behaviour")
         assertFails(runAbuse, "bootstrap under runtime change class")
         assertTrue(
             runAbuse.output.contains("DETEKT_BASELINE_BOOTSTRAP_ABUSE"),

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -32,9 +32,9 @@
     <ID>CyclomaticComplexMethod:ApprovalLifecycleActionGeneratorTest.kt$ApprovalLifecycleActionGeneratorTest$private fun record( events: MutableList&lt;RecordedEvent&gt;, seed: Long, step: Int, action: ApprovalLifecycleAction, before: ApprovalLifecycleModel, outcome: ApprovalLifecycleOutcome, )</ID>
     <ID>CyclomaticComplexMethod:ApprovalLifecycleModel.kt$ApprovalLifecycleModel$fun invariants(): List&lt;String&gt;</ID>
     <ID>CyclomaticComplexMethod:ApprovalStoreTck.kt$ApprovalStoreTck$private suspend fun executeLifecycleAction( action: ApprovalLifecycleAction, model: ApprovalLifecycleModel, store: ApprovalStore, id: String, ): LifecycleExecutionResult</ID>
-    <ID>CyclomaticComplexMethod:BaselineVerifier.kt$BaselineVerifier$private fun computeCommittedBaseline( committed: BaselineDocument, metric: String, scope: String ): Int?</ID>
-    <ID>CyclomaticComplexMethod:BaselineVerifier.kt$BaselineVerifier$private fun verifyBaselineIdentity( committed: BaselineDocument, diagnostics: MutableList&lt;VerificationDiagnostic&gt; )</ID>
-    <ID>CyclomaticComplexMethod:BaselineVerifier.kt$BaselineVerifier$private fun verifyStructuralHotspots( committed: BaselineDocument, current: BaselineDocument, deviations: List&lt;DeviationParser.DeviationEntry&gt;, diagnostics: MutableList&lt;VerificationDiagnostic&gt; )</ID>
+    <ID>CyclomaticComplexMethod:BaselineVerifier.kt$BaselineVerifier$private fun computeCommittedBaseline( committed: BaselineDocument, metric: String, scope: String, ): Int?</ID>
+    <ID>CyclomaticComplexMethod:BaselineVerifier.kt$BaselineVerifier$private fun verifyBaselineIdentity( committed: BaselineDocument, diagnostics: MutableList&lt;VerificationDiagnostic&gt;, )</ID>
+    <ID>CyclomaticComplexMethod:BaselineVerifier.kt$BaselineVerifier$private fun verifyStructuralHotspots( committed: BaselineDocument, current: BaselineDocument, deviations: List&lt;DeviationParser.DeviationEntry&gt;, diagnostics: MutableList&lt;VerificationDiagnostic&gt;, )</ID>
     <ID>CyclomaticComplexMethod:BedrockProvider.kt$BedrockProvider$@Suppress("UNCHECKED_CAST") internal fun buildClaudeMessage(message: dev.tramai.core.model.Message): Map&lt;String, Any?&gt;</ID>
     <ID>CyclomaticComplexMethod:CancellationDeltaComparator.kt$CancellationDeltaComparator$fun compare(baseCatches: List&lt;CancellationCatchFinding&gt;, currentCatches: List&lt;CancellationCatchFinding&gt;): Result</ID>
     <ID>CyclomaticComplexMethod:CanonicalGradleProbe.kt$CanonicalGradleProbe$fun probeApiBaseline(): ApiProbeResult</ID>
@@ -68,7 +68,7 @@
     <ID>CyclomaticComplexMethod:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$private fun addEnrollmentDiagnostics( resultsDir: File, checks: Map&lt;String, MutableList&lt;VerificationDiagnostic&gt;&gt;, )</ID>
     <ID>CyclomaticComplexMethod:ModuleBoundaries.kt$ModuleBoundaries$fun checkEdge( fromPath: String, toPath: String, catalog: ModuleCatalog ): VerificationDiagnostic?</ID>
     <ID>CyclomaticComplexMethod:ModuleBoundaries.kt$ModuleBoundaries$fun parse(): BoundaryResult</ID>
-    <ID>CyclomaticComplexMethod:ModuleCatalog.kt$ModuleCatalog$private fun parseEntry(index: Int, raw: Map&lt;String, Any&gt;, policies: Map&lt;String, Set&lt;ModuleLayer&gt;&gt;, modules: MutableMap&lt;String, ModuleEntry&gt;, errors: MutableList&lt;VerificationDiagnostic&gt;)</ID>
+    <ID>CyclomaticComplexMethod:ModuleCatalog.kt$ModuleCatalog$private fun parseEntry( index: Int, raw: Map&lt;String, Any&gt;, policies: Map&lt;String, Set&lt;ModuleLayer&gt;&gt;, modules: MutableMap&lt;String, ModuleEntry&gt;, errors: MutableList&lt;VerificationDiagnostic&gt;, )</ID>
     <ID>CyclomaticComplexMethod:ModuleDocContractVerifier.kt$ModuleDocContractVerifier$fun verify(rootDir: File): List&lt;VerificationDiagnostic&gt;</ID>
     <ID>CyclomaticComplexMethod:ModuleGraphAnalyzer.kt$ModuleGraphAnalyzer$fun analyze(): GraphResult</ID>
     <ID>CyclomaticComplexMethod:MutationBaselineVerifier.kt$MutationBaselineVerifier$fun verify(committed: MutationData, current: MutationData): List&lt;VerificationDiagnostic&gt;</ID>
@@ -101,7 +101,7 @@
     <ID>CyclomaticComplexMethod:SovereignRoutingValidationPolicy.kt$SovereignRoutingValidationPolicy$fun validate(plan: ProviderRoutingPlan, profile: SovereignProfileConfiguration)</ID>
     <ID>CyclomaticComplexMethod:StreamingExecutionCoordinator.kt$StreamingExecutionCoordinator$fun execute(request: StreamingExecutionRequest): Flow&lt;StreamChunk&gt;</ID>
     <ID>CyclomaticComplexMethod:TestPerformanceCollector.kt$TestPerformanceCollector$fun collectMeasuredRun( run: Int, gradleVersion: String, jdkVersion: String = Runtime.version().feature().toString(), reportRoot: File? = null ): List&lt;TestPerformanceObservation&gt;</ID>
-    <ID>CyclomaticComplexMethod:TestQualityConfiguration.kt$TestQualityConfiguration.Companion$fun parse(file: File, knownModules: Set&lt;String&gt;): TestQualityConfiguration</ID>
+    <ID>CyclomaticComplexMethod:TestQualityConfiguration.kt$TestQualityConfiguration.Companion$fun parse( file: File, knownModules: Set&lt;String&gt;, ): TestQualityConfiguration</ID>
     <ID>CyclomaticComplexMethod:TrustedReplayEnvelopeRegistryTest.kt$TrustedReplayEnvelopeRegistryTest$private fun operationAnnotation(model: String, prompt: String): dev.tramai.core.annotations.Operation</ID>
     <ID>CyclomaticComplexMethod:VerifySovereignSignedBundleTask.kt$VerifySovereignSignedBundleTask$@TaskAction fun verify()</ID>
     <ID>CyclomaticComplexMethod:WorkerLifecycleController.kt$WorkerLifecycleController$suspend fun shutdown()</ID>
@@ -128,7 +128,6 @@
     <ID>DestructuringDeclarationWithTooManyEntries:WorkflowMcpStepTest.kt$WorkflowMcpStepTest$val (clientInput, serverToClient, clientToServer, serverInput, pipeCloseable) = createPipes()</ID>
     <ID>EmptyClassBlock:JdbcSovereignOpsApprovalDecisionControlPlaneTest.kt$JdbcSovereignOpsTestConfig${ }</ID>
     <ID>EmptyClassBlock:WorkflowBuilder.kt$BranchWorkflowBuilder${ }</ID>
-    <ID>EmptyElseBlock:ModuleCatalog.kt$ModuleCatalog$if (value == null) errors += failure(code, "$path: invalid $field '${raw[field]?.toString().orEmpty()}'", path)</ID>
     <ID>EmptyElseBlock:ProviderRetryFallbackLifecyclePropertyTest.kt$ProviderRetryFallbackLifecyclePropertyTest.ScriptedProvider$if (it is StreamChunk.Token) sink.record("stream.token")</ID>
     <ID>EmptyFunctionBlock:JdbcSovereignRuntimeE2ETest.kt$JdbcSovereignRuntimeE2ETest.AlwaysFailingDataSourceConfig.&lt;no name provided&gt;${}</ID>
     <ID>EmptyFunctionBlock:PolicyEnforcementTest.kt$PolicyEnforcementTest.&lt;no name provided&gt;${}</ID>
@@ -683,8 +682,8 @@
     <ID>LongMethod:BaselineGenerator.kt$BaselineGenerator$fun generateRuntimeProtocolCatalog(): ProtocolCatalog</ID>
     <ID>LongMethod:BaselineGenerator.kt$BaselineGenerator$fun generateStructuralHotspots(): StructuralHotspots</ID>
     <ID>LongMethod:BaselineVerifier.kt$BaselineVerifier$fun verify(): VerificationReport</ID>
-    <ID>LongMethod:BaselineVerifier.kt$BaselineVerifier$private fun verifyBaselineIdentity( committed: BaselineDocument, diagnostics: MutableList&lt;VerificationDiagnostic&gt; )</ID>
-    <ID>LongMethod:BaselineVerifier.kt$BaselineVerifier$private fun verifyStructuralHotspots( committed: BaselineDocument, current: BaselineDocument, deviations: List&lt;DeviationParser.DeviationEntry&gt;, diagnostics: MutableList&lt;VerificationDiagnostic&gt; )</ID>
+    <ID>LongMethod:BaselineVerifier.kt$BaselineVerifier$private fun verifyBaselineIdentity( committed: BaselineDocument, diagnostics: MutableList&lt;VerificationDiagnostic&gt;, )</ID>
+    <ID>LongMethod:BaselineVerifier.kt$BaselineVerifier$private fun verifyStructuralHotspots( committed: BaselineDocument, current: BaselineDocument, deviations: List&lt;DeviationParser.DeviationEntry&gt;, diagnostics: MutableList&lt;VerificationDiagnostic&gt;, )</ID>
     <ID>LongMethod:BedrockProvider.kt$BedrockProvider$@Suppress("UNCHECKED_CAST") internal fun buildClaudeMessage(message: dev.tramai.core.model.Message): Map&lt;String, Any?&gt;</ID>
     <ID>LongMethod:CancellationDeltaComparator.kt$CancellationDeltaComparator$fun compare(baseCatches: List&lt;CancellationCatchFinding&gt;, currentCatches: List&lt;CancellationCatchFinding&gt;): Result</ID>
     <ID>LongMethod:CanonicalGradleProbe.kt$CanonicalGradleProbe$fun probeApiBaseline(): ApiProbeResult</ID>
@@ -739,13 +738,16 @@
     <ID>LongMethod:JdbcWorkflowSchedulerStore.kt$JdbcWorkflowSchedulerStore$suspend fun recover( now: Instant = Instant.now(), limit: Int = 500, ): Int</ID>
     <ID>LongMethod:KotlinCancellationCatchScanner.kt$KotlinCancellationCatchScanner$private fun findConstructEndIdx(lines: List&lt;String&gt;, startIdx: Int, match: MatchResult): Int?</ID>
     <ID>LongMethod:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$override fun apply(project: Project)</ID>
+    <ID>LongMethod:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$private fun addApiCompatibilityDiagnostics( project: Project, checks: Map&lt;String, MutableList&lt;VerificationDiagnostic&gt;&gt;, )</ID>
     <ID>LongMethod:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$private fun baselineCheckFor(code: DiagnosticCode): String?</ID>
-    <ID>LongMethod:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$private fun mutationInitScript( configuration: TestQualityConfiguration, reportRoot: File ): String</ID>
+    <ID>LongMethod:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$private fun mutationInitScript( configuration: TestQualityConfiguration, reportRoot: File, ): String</ID>
     <ID>LongMethod:McpStep.kt$McpWorkflowStep$private suspend fun executeMcpCall(toolCall: McpToolCall): McpToolResult</ID>
     <ID>LongMethod:McpStep.kt$McpWorkflowStep$suspend fun execute( workflowName: String, state: S, context: WorkflowContext, observer: WorkflowObserver, failureDiagnosticObserver: WorkflowStepFailureDiagnosticObserver = NoOpWorkflowStepFailureDiagnosticObserver, ): S</ID>
     <ID>LongMethod:ModuleBoundaries.kt$ModuleBoundaries$fun parse(): BoundaryResult</ID>
+    <ID>LongMethod:ModuleCatalog.kt$ModuleCatalog$private fun parseEntry( index: Int, raw: Map&lt;String, Any&gt;, policies: Map&lt;String, Set&lt;ModuleLayer&gt;&gt;, modules: MutableMap&lt;String, ModuleEntry&gt;, errors: MutableList&lt;VerificationDiagnostic&gt;, )</ID>
     <ID>LongMethod:ModuleDocContractVerifier.kt$ModuleDocContractVerifier$fun verify(rootDir: File): List&lt;VerificationDiagnostic&gt;</ID>
     <ID>LongMethod:ModuleGraphAnalyzer.kt$ModuleGraphAnalyzer$fun analyze(): GraphResult</ID>
+    <ID>LongMethod:ModuleTopologyVerificationTest.kt$ModuleTopologyVerificationTest$private fun topologyFixture( publishableExtra: String? = """listOf(":tramai-core", ":tramai-engine", ":tramai-bom")""", bomModules: List&lt;String&gt; = listOf("tramai-core", "tramai-engine"), engineEntry: String? = defaultEngineEntry, catalogFileOverride: String? = null, applyReleasePlugin: Boolean = true, ): File</ID>
     <ID>LongMethod:MutationBaselineVerifier.kt$MutationBaselineVerifier$fun verify(committed: MutationData, current: MutationData): List&lt;VerificationDiagnostic&gt;</ID>
     <ID>LongMethod:MutationBaselineVerifier.kt$MutationBaselineVerifier.Companion$fun aggregate( reports: List&lt;ParsedMutationReport&gt;, analyzerVersion: String = "", measuredCommit: String = "" ): MutationData</ID>
     <ID>LongMethod:MutationClassificationLoader.kt$MutationClassificationLoader$fun load(repositoryRoot: File): MutationClassifications</ID>
@@ -773,6 +775,7 @@
     <ID>LongMethod:ReleaseManifestVerifier.kt$ReleaseManifestVerifier$private fun verifyCore(manifestFile: File, artifactsDir: File?, artifactFiles: Collection&lt;File&gt;?)</ID>
     <ID>LongMethod:ReleaseVerificationPluginTest.kt$ReleaseVerificationPluginTest$@Test fun `T13 prepareSovereignReleaseArtifacts has real producer edges from a clean workspace`()</ID>
     <ID>LongMethod:ReleaseVerificationPluginTest.kt$ReleaseVerificationPluginTest$private fun baseFixture(extra: String = ""): File</ID>
+    <ID>LongMethod:ResolvedDependencyAggregateTest.kt$ResolvedDependencyAggregateTest$private fun multiProjectFixture(): File</ID>
     <ID>LongMethod:RetryJitterDiscriminatorTest.kt$RetryJitterDiscriminatorTest$@Test fun `P0-E engine composition graph consumes the injected jitter source`()</ID>
     <ID>LongMethod:RootDocGuardVerifiers.kt$RootDocGuardVerifiers$fun exampleSelectionGuide(rootDir: File)</ID>
     <ID>LongMethod:RootDocGuardVerifiers.kt$RootDocGuardVerifiers$fun governedWorkflowArticle(rootDir: File)</ID>
@@ -809,7 +812,7 @@
     <ID>LongMethod:TestApprovalGatewayPersistenceRequestBuilder.kt$TestApprovalGatewayPersistenceRequestBuilder$fun build(): ApprovalGatewayPersistenceRequest</ID>
     <ID>LongMethod:TestPerformanceCollector.kt$TestPerformanceCollector$fun collectMeasuredRun( run: Int, gradleVersion: String, jdkVersion: String = Runtime.version().feature().toString(), reportRoot: File? = null ): List&lt;TestPerformanceObservation&gt;</ID>
     <ID>LongMethod:TestPerformanceVerifier.kt$TestPerformanceVerifier$fun verify(committed: TestPerformanceData, current: TestPerformanceData): List&lt;VerificationDiagnostic&gt;</ID>
-    <ID>LongMethod:TestQualityConfiguration.kt$TestQualityConfiguration.Companion$fun parse(file: File, knownModules: Set&lt;String&gt;): TestQualityConfiguration</ID>
+    <ID>LongMethod:TestQualityConfiguration.kt$TestQualityConfiguration.Companion$fun parse( file: File, knownModules: Set&lt;String&gt;, ): TestQualityConfiguration</ID>
     <ID>LongMethod:TimeSemanticsDiscriminatorTest.kt$TimeSemanticsDiscriminatorTest$@Test fun `P0-C retry-approval consumption stamps from or preserves the injected clock`()</ID>
     <ID>LongMethod:ToolLoopCoordinator.kt$ToolLoopCoordinator$suspend fun execute( context: ToolLoopContext, ): ProviderCallResult</ID>
     <ID>LongMethod:TramaiAutoConfiguration.kt$TramaiAutoConfiguration$@Bean(destroyMethod = "close") @ConditionalOnMissingBean fun tramai( properties: TramaiProperties, applicationContext: org.springframework.context.ApplicationContext, ): Tramai</ID>
@@ -817,7 +820,7 @@
     <ID>LongMethod:TramaiAutoConfigurationTest.kt$TramaiAutoConfigurationTest$@Test fun `creates an openai provider from the built in aws secrets manager resolver`()</ID>
     <ID>LongMethod:TramaiAutoConfigurationTest.kt$TramaiAutoConfigurationTest$@Test fun `creates an openai provider from the built in vault secret resolver`()</ID>
     <ID>LongMethod:TramaiDocsGuardsPlugin.kt$TramaiDocsGuardsPlugin$override fun apply(project: Project)</ID>
-    <ID>LongMethod:TramaiPublishingPlugin.kt$TramaiPublishingPlugin$private fun configurePublication(project: Project, componentName: String)</ID>
+    <ID>LongMethod:TramaiPublishingPlugin.kt$TramaiPublishingPlugin$private fun configurePublication( project: Project, componentName: String, )</ID>
     <ID>LongMethod:TramaiPublishingPluginTest.kt$TramaiPublishingPluginTest$@Test fun `P8 sovereignBundleLocal exists as file repository on selected projects only`(@TempDir tempDir: File)</ID>
     <ID>LongMethod:TramaiWorkerTest.kt$TramaiWorkerTest$@Test fun `operator retryStep enables genuine retry with a new attempt`()</ID>
     <ID>LongMethod:TypedTaskConfigurationCacheTest.kt$TypedTaskConfigurationCacheTest$private fun maintainabilityFixture(): File</ID>
@@ -869,7 +872,7 @@
     <ID>LongParameterList:AuditStoreFixtures.kt$AuditStoreFixtures$( auditStreamId: String, eventId: String, latest: AuditEvent?, sequenceNumber: Long? = null, previousEventHash: String? = null, eventHash: String? = null, schemaVersion: Int = CURRENT_AUDIT_SCHEMA_VERSION, auditStreamIdOverride: String? = null, timestamp: Instant = BASE_TIME, metadata: Map&lt;String, String&gt; = emptyMap(), decision: String = "APPROVED", )</ID>
     <ID>LongParameterList:AwsSecretsManagerSecretValueResolver.kt$AwsSecretsManagerSecretValueResolver.Companion$( region: String, endpoint: String? = null, accessKeyId: String? = null, secretAccessKey: String? = null, sessionToken: String? = null, defaultField: String = "value", objectMapper: ObjectMapper = ObjectMapper(), )</ID>
     <ID>LongParameterList:AzureOpenAiProvider.kt$AzureOpenAiProvider$( private val resourceName: String, private val deploymentId: String, private val apiKey: String? = null, private val apiVersion: String = DEFAULT_API_VERSION, private val httpClient: HttpClient = HttpClient.newHttpClient(), private val objectMapper: ObjectMapper = ObjectMapper(), /** Source for Entra ID (Azure AD) bearer tokens. Called on every request. */ private val entraAccessTokenSource: AzureEntraAccessTokenSource? = null, private val ioDispatcher: CoroutineContext = Dispatchers.IO, private val providerFailureDiagnosticObserver: ProviderFailureDiagnosticObserver = NoOpProviderFailureDiagnosticObserver, )</ID>
-    <ID>LongParameterList:BaselineVerifier.kt$BaselineVerifier$( metricName: String, deviations: List&lt;DeviationParser.DeviationEntry&gt;, committedIds: List&lt;String&gt;, currentIds: List&lt;String&gt;, allCurrent: List&lt;Any?&gt;, riskFilter: ((Any?) -&gt; Boolean)? = null, toModuleScope: (Any?) -&gt; DeviationParser.FindingScope, diagnosticCode: DiagnosticCode, riskWorseCode: DiagnosticCode? = null, riskWorseningMetricName: String? = null, committedFindings: List&lt;Any?&gt;? = null, diagnostics: MutableList&lt;VerificationDiagnostic&gt; )</ID>
+    <ID>LongParameterList:BaselineVerifier.kt$BaselineVerifier$( metricName: String, deviations: List&lt;DeviationParser.DeviationEntry&gt;, committedIds: List&lt;String&gt;, currentIds: List&lt;String&gt;, allCurrent: List&lt;Any?&gt;, riskFilter: ((Any?) -&gt; Boolean)? = null, toModuleScope: (Any?) -&gt; DeviationParser.FindingScope, diagnosticCode: DiagnosticCode, riskWorseCode: DiagnosticCode? = null, riskWorseningMetricName: String? = null, committedFindings: List&lt;Any?&gt;? = null, diagnostics: MutableList&lt;VerificationDiagnostic&gt;, )</ID>
     <ID>LongParameterList:BedrockProvider.kt$BedrockProvider$( region: String, modelId: String = DEFAULT_MODEL_ID, credentialsProvider: AwsCredentialsProvider = DefaultCredentialsProvider.builder().build(), objectMapper: ObjectMapper = ObjectMapper(), ioDispatcher: CoroutineContext = Dispatchers.IO, providerFailureDiagnosticObserver: ProviderFailureDiagnosticObserver = NoOpProviderFailureDiagnosticObserver, bedrockRuntimeClientFactory: BedrockRuntimeClientFactory, )</ID>
     <ID>LongParameterList:CancellationDeltaComparatorTest.kt$CancellationDeltaComparatorTest$( risk: String, module: String = "test-module", file: String = "Test.kt", function: String = "riskyOperation", catchType: String = "Exception", sourceLine: Int = 10, sourceFingerprint: String = "" )</ID>
     <ID>LongParameterList:ChangePolicyEvaluatorTest.kt$ChangePolicyEvaluatorTest$( baseline: Number = 10, allowed: Number = 10, reason: String = "\"Test reason.\"", acceptedAt: String = "\"2026-07-26\"", targetPhase: String = "\"0.6.1\"", owner: String = "\"agent\"", extraFields: String = "" )</ID>
@@ -888,7 +891,7 @@
     <ID>LongParameterList:DefaultApprovalGatewayTest.kt$DefaultApprovalGatewayTest$( approvalId: String, workflowRunId: String = "wf-run-${approvalId}", requestedBy: String = "test-actor", requestedAt: Instant = fixedClock.instant(), expiresAt: Instant = fixedClock.instant().plusSeconds(3600), status: ApprovalStatus = ApprovalStatus.PENDING, version: Long = 0L, )</ID>
     <ID>LongParameterList:DefaultPolicyEngineTest.kt$DefaultPolicyEngineTest$( enforcementPoint: EnforcementPoint, correlationId: String = "c1", toolName: String? = null, toolSecurity: ToolSecurityMetadata? = null, modelName: String? = null, providerId: String? = null, fallbackProviderId: String? = null, dataClassification: DataClassification? = null, )</ID>
     <ID>LongParameterList:DependencyBaselineVerifierTest.kt$DependencyBaselineVerifierTest$( group: String = "org.jetbrains.kotlinx", artifact: String = "kotlinx-coroutines-core-jvm", selectedVersion: String = "1.10.2", requestedVersion: String? = "1.10.2", direct: Boolean = true, configuration: String = "runtimeClasspath", selectionReason: String = "requested", dependencyPath: List&lt;String&gt; = listOf(":tramai-engine", "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.2"), consumers: List&lt;String&gt; = listOf(":tramai-engine") )</ID>
-    <ID>LongParameterList:DependencyResolutionTasks.kt$( consumer: String, configuration: String, component: ResolvedComponentResult, path: List&lt;String&gt;, depth: Int, ancestry: MutableSet&lt;String&gt;, records: MutableList&lt;ResolvedDependency&gt; )</ID>
+    <ID>LongParameterList:DependencyResolutionTasks.kt$( consumer: String, configuration: String, component: ResolvedComponentResult, path: List&lt;String&gt;, depth: Int, ancestry: MutableSet&lt;String&gt;, records: MutableList&lt;ResolvedDependency&gt;, )</ID>
     <ID>LongParameterList:DetektBaselineGrowthVerifier.kt$DetektBaselineGrowthVerifier$( code: String?, added: List&lt;String&gt;, removed: List&lt;String&gt;, baseTotal: Int, currentTotal: Int, message: String, )</ID>
     <ID>LongParameterList:DeviationBudgetEvaluator.kt$DeviationBudgetEvaluator$( metricName: String, deviations: List&lt;DeviationParser.DeviationEntry&gt;, allCurrent: List&lt;Any?&gt;, committedIds: List&lt;String&gt;, committedFindings: List&lt;Any?&gt;?, toModuleScope: (Any?) -&gt; DeviationParser.FindingScope, riskWorseCode: DiagnosticCode, diagnostics: MutableList&lt;VerificationDiagnostic&gt; )</ID>
     <ID>LongParameterList:DeviationBudgetEvaluator.kt$DeviationBudgetEvaluator$( metricName: String, deviations: List&lt;DeviationParser.DeviationEntry&gt;, committedIds: List&lt;String&gt;, currentIds: List&lt;String&gt;, allCurrent: List&lt;Any?&gt;, riskFilter: ((Any?) -&gt; Boolean)? = null, toModuleScope: (Any?) -&gt; DeviationParser.FindingScope, diagnosticCode: DiagnosticCode, riskWorseCode: DiagnosticCode? = null, riskWorseningMetricName: String? = null, committedFindings: List&lt;Any?&gt;? = null, diagnostics: MutableList&lt;VerificationDiagnostic&gt; )</ID>
@@ -1959,7 +1962,6 @@
     <ID>MaxLineLength:ArchitectureReportAggregatorTest.kt$ArchitectureReportAggregatorTest$File(config, "module-boundaries.yml").writeText(File(repoRoot(), "config/quality/module-boundaries.yml").readText())</ID>
     <ID>MaxLineLength:ArchitectureReportAggregatorTest.kt$ArchitectureReportAggregatorTest$assertTrue(storeDiagnostics.any { it.message.contains("AuditStoreTckEnrollmentArchitectureTest was not discovered") })</ID>
     <ID>MaxLineLength:ArchitectureReportAggregatorTest.kt$ArchitectureReportAggregatorTest$assertTrue(storeDiagnostics.any { it.message.contains("RenamedAuditStoreTckEnrollmentArchitectureTest was discovered") })</ID>
-    <ID>MaxLineLength:ArchitectureReportAggregatorTest.kt$ArchitectureReportAggregatorTest$val</ID>
     <ID>MaxLineLength:ArchitectureReportAggregatorTest.kt$ArchitectureReportAggregatorTest$val diagnostic = assertNotNull(diagnostics.firstOrNull { it.code == DiagnosticCode.MODULE_CATALOG_UNKNOWN_ENTRY })</ID>
     <ID>MaxLineLength:ArchitectureReportAggregatorTest.kt$ArchitectureReportAggregatorTest$val discovered = enrollmentArchitectureTestClasses - "dev.tramai.testing.ApprovalStoreTckEnrollmentArchitectureTest"</ID>
     <ID>MaxLineLength:AuditEngine.kt$AuditEngine$@Deprecated("Use AuditEmission overload", ReplaceWith("emit(AuditEmission(auditStreamId, workflowRunId, correlationId, actor, enforcementPoint, decision, policyVersion, workflowDigest, reasonCode, metadata))"))</ID>
@@ -1989,12 +1991,14 @@
     <ID>MaxLineLength:BaselineGenerator.kt$BaselineGenerator$val classRegex = Regex("""^\s*(?:data\s+)?(?:sealed\s+)?(?:abstract\s+)?(?:open\s+)?class\s+(\w+)""", RegexOption.MULTILINE)</ID>
     <ID>MaxLineLength:BaselineGenerator.kt$BaselineGenerator$val nextClassStart = classMatches.firstOrNull { it.range.first &gt; classStart }?.range?.first ?: content.length</ID>
     <ID>MaxLineLength:BaselineGenerator.kt$BaselineGenerator$val records = ReportNormalizer.readJson(generatedFile, Array&lt;ResolvedDependency&gt;::class.java).toList()</ID>
+    <ID>MaxLineLength:BaselineVerifier.kt$BaselineVerifier$"${currentHotspot.path} grew &gt;20%: ${committedHotspot.value} \u2192 ${currentHotspot.value} lines"</ID>
     <ID>MaxLineLength:BaselineVerifier.kt$BaselineVerifier$"${dev.id}: ${hotspot.module}/${hotspot.declaration} constructor has ${hotspot.value} "</ID>
     <ID>MaxLineLength:BaselineVerifier.kt$BaselineVerifier$"${dev.id}: recorded baseline ${dev.baseline} does not match canonical measurement $actualBaseline for metric '${dev.metric}' at scope '${dev.scope}'"</ID>
+    <ID>MaxLineLength:BaselineVerifier.kt$BaselineVerifier$"Module '${mod.path}': catalogue declares publishability '${catalogEntry.publishability.yaml}' "</ID>
+    <ID>MaxLineLength:BaselineVerifier.kt$BaselineVerifier$VerificationDiagnostic.failure(DiagnosticCode.EMPTY_SECTION, "Current baseline has empty cancellation catch inventory")</ID>
+    <ID>MaxLineLength:BaselineVerifier.kt$BaselineVerifier$VerificationDiagnostic.failure(DiagnosticCode.EMPTY_SECTION, "Current baseline has empty protocol catalog")</ID>
+    <ID>MaxLineLength:BaselineVerifier.kt$BaselineVerifier$VerificationDiagnostic.failure(DiagnosticCode.EMPTY_SECTION, "Current baseline has empty source metrics")</ID>
     <ID>MaxLineLength:BaselineVerifier.kt$BaselineVerifier$val accepted = diagnostics.filter { it.severity == DiagnosticSeverity.ACCEPTED }.map { "${it.code}: ${it.message}" }</ID>
-    <ID>MaxLineLength:BaselineVerifier.kt$BaselineVerifier$val committedCycles = committed.structural.moduleDependencies.cycles.map { it.sorted().joinToString("\u2192") }.toSet()</ID>
-    <ID>MaxLineLength:BaselineVerifier.kt$BaselineVerifier$val committedTop = committed.structural.structuralHotspots.largestProductionFiles.take(5).map { it.path }.toSet()</ID>
-    <ID>MaxLineLength:BaselineVerifier.kt$BaselineVerifier$val currentCycles = current.structural.moduleDependencies.cycles.map { it.sorted().joinToString("\u2192") }.toSet()</ID>
     <ID>MaxLineLength:BaselineVerifier.kt$BaselineVerifier$val failures = diagnostics.filter { it.severity == DiagnosticSeverity.FAILURE }.map { "${it.code}: ${it.message}" }</ID>
     <ID>MaxLineLength:BaselineVerifier.kt$BaselineVerifier$val warnings = diagnostics.filter { it.severity == DiagnosticSeverity.WARNING }.map { "${it.code}: ${it.message}" }</ID>
     <ID>MaxLineLength:BedrockProvider.kt$BedrockProvider$val resolved = dev.tramai.core.util.ImageDownloader.resolveToImagePart(part) as ContentPart.ImagePart</ID>
@@ -2107,7 +2111,7 @@
     <ID>MaxLineLength:DependencyBaselineVerifierTest.kt$DependencyBaselineVerifierTest$val d1 = dep(consumers = listOf(":tramai-engine"), group = "com.example", artifact = "lib", selectedVersion = "1.0")</ID>
     <ID>MaxLineLength:DependencyBaselineVerifierTest.kt$DependencyBaselineVerifierTest$val d2 = dep(consumers = listOf(":tramai-core"), group = "com.example", artifact = "lib", selectedVersion = "2.0")</ID>
     <ID>MaxLineLength:DependencyEdgeNormalizerTest.kt$DependencyEdgeNormalizerTest$dependencyPath = listOf(":consumer", "com.example:lib-b:1.5", "com.example:lib-c:2.0", "com.example:lib-d:0.5")</ID>
-    <ID>MaxLineLength:DetektBaselineGrowthVerifier.kt$DetektBaselineGrowthVerifier$message</ID>
+    <ID>MaxLineLength:DependencyResolutionTasks.kt$AggregateResolvedDependencyBaselineTask$"Dependency probe aggregation misconfigured: ${owners.size} expected owners but ${files.size} probe files"</ID>
     <ID>MaxLineLength:DeviationBudgetEvaluator.kt$DeviationBudgetEvaluator$"${covered.size} new finding(s) — accepted by ${dev.id} (${matchingAll.size} total in scope ≤ ${dev.allowed})"</ID>
     <ID>MaxLineLength:DeviationBudgetEvaluator.kt$DeviationBudgetEvaluator$"${covered.size} risk worsenings — accepted by ${dev.id} (${matching} total in scope ≤ ${dev.allowed})"</ID>
     <ID>MaxLineLength:DeviationBudgetEvaluator.kt$DeviationBudgetEvaluator$"${resolvedIds.size} cancellation catch(es) resolved — risk worsening check skipped for resolved findings"</ID>
@@ -2445,36 +2449,32 @@
     <ID>MaxLineLength:LoggingTramaiWorkerObserver.kt$LoggingTramaiWorkerObserver$override fun onWorkTakenOver(workflowId: String, previousWorkerId: String, newWorkerId: String)</ID>
     <ID>MaxLineLength:LoggingTramaiWorkerObserver.kt$LoggingTramaiWorkerObserver$override fun onWorkerHeartbeat(workerId: String, uptimeMillis: Long, claimedCount: Int)</ID>
     <ID>MaxLineLength:LoggingTramaiWorkerObserver.kt$LoggingTramaiWorkerObserver$override fun onWorkflowAbandoned(workflowId: String, workerId: String, lastStep: String?, timeoutMillis: Long)</ID>
+    <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$" '${groovyString(family)}': [modules: [$modules], targetClasses: [$classes], targetTests: [$tests]]"</ID>
+    <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$"Fails on unclassified, stale, mismatched, or occurrence-drifted entries in config/quality/runtime-nondeterminism.yml"</ID>
+    <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$"Generates the canonical baseline from v0.5.0. Set -Pmaintainability.sourceRoot=&lt;worktree&gt; to scan a detached checkout."</ID>
+    <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$"Primary local verification gate. Runs subproject tests, build-logic tests, maintainability baseline, and change policy. Not a full CI replica — see .github/AGENTS.md for additional step commands."</ID>
+    <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$"Scans all production source for broad catches in suspend-capable code and rejects newly introduced critical/high findings and risk worsenings. Accepts -PtramaiCancellationBaseSha for PR base SHA comparison."</ID>
+    <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$"\nAdd deviations to config/quality/maintainability-deviations.yml for accepted regressions."</ID>
+    <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$"maintainability.sourceRoot='$sourceRootProp' resolved to '${sourceRoot.absolutePath}' but is not a directory"</ID>
+    <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$"verifyCancellationSafety PASSED: ${scopedFindings.size} findings in scoped modules, no new critical/high findings or risk worsenings against origin/master."</ID>
     <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$"verifyCancellationSafety requires -PtramaiCancellationBaseSha when origin/master is not available.\n"</ID>
+    <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$(project.extensions.extraProperties.properties["tramai.publishableModulePaths"] as? Collection&lt;*&gt;)</ID>
     <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$// Override base ref for CI: ./gradlew verifyChangePolicy -PchangePolicyBase=${{ github.event.pull_request.base.sha }}</ID>
     <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$// Register JaCoCo on critical modules using provider-safe API (no tasks.matching / executionData(TaskCollection))</ID>
     <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$File(project.project(":tramai-testing").buildDir, "test-results/architectureContractEnrollmentTest")</ID>
-    <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$File(sub.layout.buildDirectory.get().asFile, "reports/maintainability/architecture-dependencies.json")</ID>
     <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$collectEvidence</ID>
     <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$constraint.name.takeIf { it.startsWith("tramai-") || it.startsWith("examples:") }?.let { ":$it" }</ID>
     <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$description = "Compiles the $extension consumer smoke fixture against the stable API (fail-soft producer, Epic 10.2)"</ID>
-    <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$description = "Fails on unclassified, stale, mismatched, or occurrence-drifted entries in config/quality/runtime-nondeterminism.yml"</ID>
-    <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$description = "Generates the canonical baseline from v0.5.0. Set -Pmaintainability.sourceRoot=&lt;worktree&gt; to scan a detached checkout."</ID>
-    <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$description = "Primary local verification gate. Runs subproject tests, build-logic tests, maintainability baseline, and change policy. Not a full CI replica — see .github/AGENTS.md for additional step commands."</ID>
-    <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$description = "Scans all production source for broad catches in suspend-capable code and rejects newly introduced critical/high findings and risk worsenings. Accepts -PtramaiCancellationBaseSha for PR base SHA comparison."</ID>
     <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$description = "Verifies manifest/settings equality and publishing/BOM membership against independent Gradle model signals"</ID>
     <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$if (addExit != 0) throw GradleException("Failed to create worktree at $baseShaLocal: $addOutput")</ID>
-    <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$if (diagnostics.isNotEmpty()) throw GradleException(diagnostics.joinToString("\n") { "[${it.code}] ${it.message}" })</ID>
-    <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$println("verifyCancellationSafety PASSED: ${scopedFindings.size} findings in scoped modules, no new critical/high findings or risk worsenings against origin/master.")</ID>
     <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$println("verifyCancellationSafety PASSED: no new critical/high findings or risk worsenings against base SHA.")</ID>
     <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$println("verifyCancellationSafety: auto-resolved merge base against origin/master = ${baseShaLocal.take(8)}")</ID>
     <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$project.logger.lifecycle("DEBUG analyzer checkout: exit=$analyzerExitCode output='${analyzerOutput.trim()}'")</ID>
     <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$project.logger.warn("WARN: ${report.warnings.size - 100} additional warnings; see dependency-changes.json")</ID>
     <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$reportFile.set(project.layout.buildDirectory.file("reports/maintainability/runtime-nondeterminism-verification.json"))</ID>
     <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$severity = DiagnosticSeverity.valueOf(entry["severity"]?.toString() ?: error("Baseline diagnostic severity missing"))</ID>
-    <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$throw GradleException("maintainability.sourceRoot='$sourceRootProp' resolved to '${sourceRoot.absolutePath}' but is not a directory")</ID>
-    <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$val</ID>
     <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$val classesDir = fixture.layout.buildDirectory.dir("reports/maintainability/consumer-$extension-classes")</ID>
-    <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$val file = project.layout.buildDirectory.file("reports/maintainability/resolved-dependencies.json").get().asFile</ID>
-    <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$val reportFile = File(project.layout.buildDirectory.get().asFile, "reports/tramai/architecture/architecture-report.json")</ID>
     <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$val sourceRootFile = if (sourceRootProp != null) project.rootDir.resolve(sourceRootProp).normalize() else null</ID>
-    <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$val worktreeDir = java.nio.file.Files.createTempDirectory("tramai-base-${baseSha.take(8)}-").toFile()</ID>
-    <ID>MaxLineLength:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$val worktreeDir = java.nio.file.Files.createTempDirectory("tramai-base-${baseShaLocal.take(8)}-").toFile()</ID>
     <ID>MaxLineLength:MarkdownWorkflowCheckpointStore.kt$MarkdownWorkflowCheckpointStore$private val pathStrategy: WorkflowCheckpointPathStrategy = CollisionFreeWorkflowCheckpointPathStrategy("checkpoint.md")</ID>
     <ID>MaxLineLength:MarkdownWorkflowCheckpointStore.kt$if (closingFenceIndex &lt;= fenceLineIndex) throw CorruptCheckpointException("Persisted workflow checkpoint is invalid", content)</ID>
     <ID>MaxLineLength:MarkdownWorkflowCheckpointStore.kt$if (fenceLineIndex &lt;= payloadHeaderIndex) throw CorruptCheckpointException("Persisted workflow checkpoint is invalid", content)</ID>
@@ -2492,51 +2492,31 @@
     <ID>MaxLineLength:McpToolHandlers.kt$McpToolHandlers$is WorkflowConflictException -&gt; ToolExecutionException(error.message ?: "Workflow request conflicts with current state", "conflict")</ID>
     <ID>MaxLineLength:McpToolHandlers.kt$McpToolHandlers$is WorkflowNotRegisteredException -&gt; ToolExecutionException(error.message ?: "Workflow was not found", "not_found")</ID>
     <ID>MaxLineLength:McpToolHandlers.kt$McpToolHandlers$is WorkflowRunNotFoundException -&gt; ToolExecutionException(error.message ?: "Workflow run was not found", "not_found")</ID>
+    <ID>MaxLineLength:MeasurementContext.kt$MeasurementContext.Companion$private</ID>
     <ID>MaxLineLength:Message.kt$Message$fun</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleApiStability</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$CatalogResult</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$ModuleEntry</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$fun &lt;T&gt; enum(field: String, value: T?, code: DiagnosticCode): T?</ID>
+    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$"$path: API strength '$api' cannot exceed maturity '$maturity' (stable API requires stable maturity; preview requires preview+; experimental requires experimental+)"</ID>
+    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$ModuleEntry(path, layer, maturity, publishability, api, visibility, owner, policy, release, rationale, description)</ID>
+    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$enum("maturity", ModuleMaturity.fromYaml(raw["maturity"]?.toString().orEmpty()), DiagnosticCode.MODULE_CATALOG_INVALID_MATURITY)</ID>
+    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$errors += failure(DiagnosticCode.MODULE_CATALOG_INVALID_POLICY, "$path: unknown dependencyPolicy '$policy'", path)</ID>
+    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$errors += failure(DiagnosticCode.MODULE_CATALOG_INVALID_SCHEMA, "Module catalog schemaVersion must be '3'")</ID>
+    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$failure(DiagnosticCode.MODULE_CATALOG_EXAMPLE_PUBLISHABLE, "$path: examples must have publishability 'excluded'", path)</ID>
+    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$failure(DiagnosticCode.MODULE_CATALOG_INVALID_COMBINATION, "$path: included release requires published module", path)</ID>
+    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$failure(DiagnosticCode.MODULE_CATALOG_INVALID_POLICY, "Dependency policy '$name' has invalid allowedLayers")</ID>
+    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$failure(DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY, "Gradle project '$it' has no module-catalog entry")</ID>
+    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$failure(DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY, "Module catalog is empty — no module entries found")</ID>
+    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$failure(DiagnosticCode.MODULE_CATALOG_UNKNOWN_ENTRY, "Module-catalog entry '$it' does not exist as a Gradle project")</ID>
     <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$fun allowedLayersFor(path: String): Set&lt;ModuleLayer&gt;?</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$fun validateAgainstProjects(catalogModules: Map&lt;String, ModuleEntry&gt;, projectPaths: List&lt;String&gt;, errors: MutableList&lt;VerificationDiagnostic&gt;)</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$if (!apiStrengthFitsMaturity(api, maturity)) errors += failure(DiagnosticCode.MODULE_CATALOG_INVALID_COMBINATION, "$path: API strength '$api' cannot exceed maturity '$maturity' (stable API requires stable maturity; preview requires preview+; experimental requires experimental+)", path)</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$if (!file.isFile) return CatalogResult(emptyMap(), emptyMap(), listOf(failure(DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY, "Module catalog not found: ${file.absolutePath}")))</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$if (errors.none { it.modulePath == path }) modules[path] = ModuleEntry(path, layer, maturity, publishability, api, visibility, owner, policy, release, rationale, description)</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$if (layer == ModuleLayer.APPLICATIONS_EXAMPLES &amp;&amp; publishability != ModulePublishability.EXCLUDED) errors += failure(DiagnosticCode.MODULE_CATALOG_EXAMPLE_PUBLISHABLE, "$path: examples must have publishability 'excluded'", path)</ID>
     <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$if (layer == null || maturity == null || publishability == null || api == null || visibility == null || release == null) return</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$if (layers.size != rawLayers.size || layers.isEmpty()) errors += failure(DiagnosticCode.MODULE_CATALOG_INVALID_POLICY, "Dependency policy '$name' has invalid allowedLayers")</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$if (maturity == ModuleMaturity.INTERNAL &amp;&amp; api != ModuleApiStability.INTERNAL &amp;&amp; api != ModuleApiStability.EXCLUDED) errors += failure(DiagnosticCode.MODULE_CATALOG_INVALID_COMBINATION, "$path: internal maturity cannot promise stable/preview API", path)</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$if (modules.isEmpty() &amp;&amp; errors.isEmpty()) errors += failure(DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY, "Module catalog is empty — no module entries found")</ID>
     <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$if (path in modules) errors += failure(DiagnosticCode.MODULE_CATALOG_DUPLICATE_PATH, "Module catalog: duplicate path '$path'", path)</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$if (path.isBlank()) { errors += failure(DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY, "Module catalog entry $index: path is blank"); return }</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$if (policy !in policies) errors += failure(DiagnosticCode.MODULE_CATALOG_INVALID_POLICY, "$path: unknown dependencyPolicy '$policy'", path)</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$if (publishability == ModulePublishability.EXCLUDED &amp;&amp; api != ModuleApiStability.EXCLUDED) errors += failure(DiagnosticCode.MODULE_CATALOG_MISSING_API_STABILITY, "$path: excluded modules must have apiStability 'excluded'", path)</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$if (publishability == ModulePublishability.PUBLISHED &amp;&amp; api == ModuleApiStability.EXCLUDED) errors += failure(DiagnosticCode.MODULE_CATALOG_MISSING_API_STABILITY, "$path: published modules must not have apiStability 'excluded'", path)</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$if (publishability == ModulePublishability.PUBLISHED &amp;&amp; description.isNullOrBlank()) errors += failure(DiagnosticCode.MODULE_CATALOG_MISSING_DESCRIPTION, "$path: published modules must have a non-blank description", path)</ID>
     <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$if (rationale.isBlank()) errors += failure(DiagnosticCode.MODULE_CATALOG_BLANK_RATIONALE, "$path: rationale is blank", path)</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$if (release == ReleaseInclusion.INCLUDED &amp;&amp; publishability != ModulePublishability.PUBLISHED) errors += failure(DiagnosticCode.MODULE_CATALOG_INVALID_COMBINATION, "$path: included release requires published module", path)</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$if (root["schemaVersion"]?.toString() != "3") errors += failure(DiagnosticCode.MODULE_CATALOG_INVALID_SCHEMA, "Module catalog schemaVersion must be '3'")</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$if (visibility == ModuleVisibility.PUBLIC &amp;&amp; publishability == ModulePublishability.INTERNAL) errors += failure(DiagnosticCode.MODULE_CATALOG_INVALID_COMBINATION, "$path: public visibility cannot be internal publishability", path)</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$private</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$private fun failure(code: DiagnosticCode, message: String, path: String? = null)</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$val api = enum("apiStability", ModuleApiStability.fromYaml(raw["apiStability"]?.toString().orEmpty()), DiagnosticCode.MODULE_CATALOG_MISSING_API_STABILITY)</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$val errors = mutableListOf&lt;VerificationDiagnostic&gt;()</ID>
+    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$if (value == null) errors += failure(code, "$path: invalid $field '${raw[field]?.toString().orEmpty()}'", path)</ID>
+    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$listOf(failure(DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY, "Module catalog not found: ${file.absolutePath}"))</ID>
     <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$val layer = enum("layer", ModuleLayer.fromYaml(raw["layer"]?.toString().orEmpty()), DiagnosticCode.MODULE_CATALOG_INVALID_LAYER)</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$val maturity = enum("maturity", ModuleMaturity.fromYaml(raw["maturity"]?.toString().orEmpty()), DiagnosticCode.MODULE_CATALOG_INVALID_MATURITY)</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$val owner = raw["owner"]?.toString().orEmpty()</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$val publishability = enum("publishability", ModulePublishability.fromYaml(raw["publishability"]?.toString().orEmpty()), DiagnosticCode.MODULE_CATALOG_INVALID_PUBLISHABILITY)</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$val visibility = enum("visibility", ModuleVisibility.fromYaml(raw["visibility"]?.toString().orEmpty()), DiagnosticCode.MODULE_CATALOG_INVALID_VISIBILITY)</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog$}</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog.Companion$ModuleApiStability.EXPERIMENTAL -&gt; maturity == ModuleMaturity.STABLE || maturity == ModuleMaturity.PREVIEW || maturity == ModuleMaturity.EXPERIMENTAL</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleLayer$CORE_CONTRACTS : ModuleLayer</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleMaturity</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModulePublishability</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ModuleVisibility</ID>
-    <ID>MaxLineLength:ModuleCatalog.kt$ReleaseInclusion</ID>
+    <ID>MaxLineLength:ModuleCatalog.kt$ModuleCatalog.Companion$fun</ID>
+    <ID>MaxLineLength:ModuleCatalogMutationTest.kt$ModuleCatalogMutationTest$private fun codesOf(diagnostics: List&lt;VerificationDiagnostic&gt;): Set&lt;DiagnosticCode&gt;</ID>
     <ID>MaxLineLength:ModuleDocContractVerifier.kt$ModuleDocContractVerifier$"Card '$name' has versionless dependency declaration without a versioned TramAI BOM import in the same snippet: dev.tramai:$artifact"</ID>
-    <ID>MaxLineLength:ModuleDocContractVerifier.kt$ModuleDocContractVerifier$val allHeadings = REQUIRED_HEADINGS.all { Regex("""^### ${Regex.escape(it)}\s*$""", RegexOption.MULTILINE).containsMatchIn(cardText) }</ID>
+    <ID>MaxLineLength:ModuleDocContractVerifier.kt$ModuleDocContractVerifier$"Internal/unpublished module '$name' advertises external Maven consumption (dev.tramai:$name)"</ID>
     <ID>MaxLineLength:ModuleDocContractVerifier.kt$ModuleDocContractVerifier$val declarationRegex = Regex("""(?:implementation|api)\(\s*"dev\.tramai:([a-z0-9-]+)(?::([^"]*))?"\s*\)""")</ID>
-    <ID>MaxLineLength:ModuleDocContractVerifier.kt$ModuleDocContractVerifier$val ownGradle = Regex("""(?:implementation|api)\(\s*"dev\.tramai:${Regex.escape(name)}(?::[^"]*)?"\s*\)""").containsMatchIn(text)</ID>
     <ID>MaxLineLength:ModuleDocContractVerifierTest.kt$ModuleDocContractVerifierTest$"&gt; **Classification / layer / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml) and the [module matrix](../../docs/reference/module-matrix.md)"</ID>
     <ID>MaxLineLength:ModuleDocContractVerifierTest.kt$ModuleDocContractVerifierTest$File(dir, "docs/modules/README.md").writeText(readme.replace("| Conforming cards | 2 |", "| Conforming cards | 1 |"))</ID>
     <ID>MaxLineLength:ModuleDocContractVerifierTest.kt$ModuleDocContractVerifierTest$assertTrue(diags.any { it.code == DiagnosticCode.MODULE_CARD_COVERAGE_MISMATCH }, "coverage mismatch must be caught: $diags")</ID>
@@ -2563,7 +2543,8 @@
     <ID>MaxLineLength:ModuleDocContractVerifierTest.kt$ModuleDocContractVerifierTest$assertTrue(diags.none { it.code == DiagnosticCode.MODULE_CARD_VERSIONLESS_DEPENDENCY }, "self-contained BOM snippet must pass: $diags")</ID>
     <ID>MaxLineLength:ModuleDocContractVerifierTest.kt$ModuleDocContractVerifierTest$private</ID>
     <ID>MaxLineLength:ModuleDocContractVerifierTest.kt$ModuleDocContractVerifierTest$val dir = fixture(cards = mapOf("tramai-core" to String.format(CARD_TEMPLATE, "tramai-core").replace("### Do not", "### Removed")))</ID>
-    <ID>MaxLineLength:ModuleManifest.kt$ModuleManifest$"| ${entry.path.removePrefix(":")} | ${entry.layer.yaml} | ${entry.maturity.yaml} | ${entry.apiStability.yaml} | ${if (entry.publishability == ModulePublishability.PUBLISHED) "Yes" else "No"} | ${entry.owner} | ${entry.releaseInclusion.yaml} |"</ID>
+    <ID>MaxLineLength:ModuleManifest.kt$ModuleManifest$)</ID>
+    <ID>MaxLineLength:ModuleManifest.kt$ModuleManifest$fun catalog(rootDir: File): ModuleCatalog.CatalogResult</ID>
     <ID>MaxLineLength:ModuleManifest.kt$ModuleManifest$if (result.errors.isNotEmpty()) throw GradleException(result.errors.joinToString("\n") { "[${it.code}] ${it.message}" })</ID>
     <ID>MaxLineLength:MutationBaselineVerifier.kt$MutationBaselineVerifier$"Missing-test survivor ${survivor.identity.ifBlank { survivor.mutator }} has no issue or target phase"</ID>
     <ID>MaxLineLength:MutationBaselineVerifierTest.kt$MutationBaselineVerifierTest$data(80.0).copy(survivingMutants = listOf(survivor().copy(status = "NO_COVERAGE", classification = "unclassified")))</ID>
@@ -3290,6 +3271,8 @@
     <ID>MaxLineLength:TestApprovalGatewayPersistenceRequestBuilder.kt$TestApprovalGatewayPersistenceRequestBuilder$fun resumeDefinitionDigest(resumeDefinitionDigest: Sha256Digest)</ID>
     <ID>MaxLineLength:TestPerformanceAggregator.kt$TestPerformanceAggregator$observations = observations.sortedWith(compareBy&lt;TestPerformanceObservation&gt; { it.run }.thenBy { it.module })</ID>
     <ID>MaxLineLength:TestPerformanceVerifier.kt$TestPerformanceVerifier$"$module median test duration regressed from ${baseline.medianDurationMs}ms to ${measured.medianDurationMs}ms"</ID>
+    <ID>MaxLineLength:TestQualityConfiguration.kt$TestQualityConfiguration.Companion$if (pattern.isEmpty()) throw GradleException("coverage.exclusions[$index].pattern must not be empty")</ID>
+    <ID>MaxLineLength:TestQualityConfiguration.kt$TestQualityConfiguration.Companion$private fun isAbsolutePath(path: String): Boolean</ID>
     <ID>MaxLineLength:TestQualityConfiguration.kt$TestQualityConfiguration.Companion$throw GradleException("Test-quality configuration references unknown modules: ${unknownModules.sorted().joinToString()}")</ID>
     <ID>MaxLineLength:TestQualityConfiguration.kt$TestQualityConfiguration.Companion$throw GradleException("mutation.targetFamilies.$family.targetClasses must not be empty when specified")</ID>
     <ID>MaxLineLength:TestQualityConfiguration.kt$TestQualityConfiguration.Companion$throw GradleException("mutation.targetFamilies.$family.targetClasses must not contain duplicate patterns")</ID>
@@ -3479,21 +3462,16 @@
     <ID>MaxLineLength:TramaiPublishingPluginTest.kt$TramaiPublishingPluginTest$val both = runProbe(dir, args = arrayOf("-PtramaiPublishReleaseUrl=https://release.example.com/repo", "-PtramaiPublishSnapshotUrl=https://snapshot.example.com/repo"))</ID>
     <ID>MaxLineLength:TramaiPublishingPluginTest.kt$TramaiPublishingPluginTest$val withKeysProbe = runProbe(withKeys, args = arrayOf("-PsigningKey=test-key", "-PsigningPassword=test-password"))</ID>
     <ID>MaxLineLength:TramaiPublishingRepositories.kt$TramaiPublishingRepositories$val</ID>
+    <ID>MaxLineLength:TramaiReleaseVerificationPlugin.kt$TramaiReleaseVerificationPlugin$(project.rootProject.extensions.extraProperties.properties["tramai.publishableModulePaths"] as? Collection&lt;*&gt;)</ID>
     <ID>MaxLineLength:TramaiReleaseVerificationPlugin.kt$TramaiReleaseVerificationPlugin$description = "Publishes to Maven Local and verifies POM/module/jar/sources/javadoc artifacts for every Tramai module."</ID>
     <ID>MaxLineLength:TramaiReleaseVerificationPlugin.kt$TramaiReleaseVerificationPlugin$description = "Publishes to a configured file-based Maven repository and verifies generated signature files."</ID>
     <ID>MaxLineLength:TramaiReleaseVerificationPlugin.kt$TramaiReleaseVerificationPlugin$description = "Runs the repo-local release verification checks for publication metadata and published artifacts."</ID>
     <ID>MaxLineLength:TramaiReleaseVerificationPlugin.kt$TramaiReleaseVerificationPlugin$expectedDeveloperEmail.set(project.providers.gradleProperty("tramaiDeveloperEmail").orElse("opensource@giona.dev"))</ID>
-    <ID>MaxLineLength:TramaiReleaseVerificationPlugin.kt$TramaiReleaseVerificationPlugin$expectedLicenseUrl.set(project.providers.gradleProperty("tramaiLicenseUrl").orElse("https://www.apache.org/licenses/LICENSE-2.0.txt"))</ID>
     <ID>MaxLineLength:TramaiReleaseVerificationPlugin.kt$TramaiReleaseVerificationPlugin$expectedProjectUrl.set(project.providers.gradleProperty("tramaiProjectUrl").orElse("https://github.com/GionaGranchelli/tramAI"))</ID>
-    <ID>MaxLineLength:TramaiReleaseVerificationPlugin.kt$TramaiReleaseVerificationPlugin$expectedScmConnection.set(project.providers.gradleProperty("tramaiScmConnection").orElse("scm:git:https://github.com/GionaGranchelli/tramAI.git"))</ID>
-    <ID>MaxLineLength:TramaiReleaseVerificationPlugin.kt$TramaiReleaseVerificationPlugin$expectedScmDeveloperConnection.set(project.providers.gradleProperty("tramaiScmDeveloperConnection").orElse("scm:git:ssh://git@github.com/GionaGranchelli/tramAI.git"))</ID>
     <ID>MaxLineLength:TramaiReleaseVerificationPlugin.kt$TramaiReleaseVerificationPlugin$expectedScmUrl.set(project.providers.gradleProperty("tramaiScmUrl").orElse("https://github.com/GionaGranchelli/tramAI.git"))</ID>
-    <ID>MaxLineLength:TramaiReleaseVerificationPlugin.kt$TramaiReleaseVerificationPlugin$if</ID>
-    <ID>MaxLineLength:TramaiReleaseVerificationPlugin.kt$TramaiReleaseVerificationPlugin$passwordPresent.set(project.providers.gradleProperty("tramaiPublishPassword").map { it.isNotBlank() }.orElse(false))</ID>
-    <ID>MaxLineLength:TramaiReleaseVerificationPlugin.kt$TramaiReleaseVerificationPlugin$releaseUrlPresent.set(project.providers.gradleProperty("tramaiPublishReleaseUrl").map { it.isNotBlank() }.orElse(false))</ID>
-    <ID>MaxLineLength:TramaiReleaseVerificationPlugin.kt$TramaiReleaseVerificationPlugin$signingPasswordPresent.set(project.providers.gradleProperty("signingPassword").map { it.isNotBlank() }.orElse(false))</ID>
-    <ID>MaxLineLength:TramaiReleaseVerificationPlugin.kt$TramaiReleaseVerificationPlugin$usernamePresent.set(project.providers.gradleProperty("tramaiPublishUsername").map { it.isNotBlank() }.orElse(false))</ID>
-    <ID>MaxLineLength:TramaiReleaseVerificationPlugin.kt$TramaiReleaseVerificationPlugin$val</ID>
+    <ID>MaxLineLength:TramaiReleaseVerificationPlugin.kt$TramaiReleaseVerificationPlugin$private fun jarPublicationModuleNames(project: Project): List&lt;String&gt;</ID>
+    <ID>MaxLineLength:TramaiReleaseVerificationPlugin.kt$TramaiReleaseVerificationPlugin$project.providers.gradleProperty("tramaiLicenseUrl").orElse("https://www.apache.org/licenses/LICENSE-2.0.txt")</ID>
+    <ID>MaxLineLength:TramaiReleaseVerificationPlugin.kt$TramaiReleaseVerificationPlugin$project.providers.gradleProperty("tramaiScmConnection").orElse("scm:git:https://github.com/GionaGranchelli/tramAI.git")</ID>
     <ID>MaxLineLength:TramaiRuntimeProfileSupport.kt$TramaiRuntimeProfileSupport$"Unsupported tramai.profile '$configuredProfile'. Supported values: ${supportedProfiles.joinToString(", ")}."</ID>
     <ID>MaxLineLength:TramaiSecretResolutionAutoConfiguration.kt$TramaiSecretResolutionAutoConfiguration$(definition?.getAttribute(org.springframework.beans.factory.support.AbstractBeanDefinition.ORDER_ATTRIBUTE) as? Int)</ID>
     <ID>MaxLineLength:TramaiSecretResolutionAutoConfiguration.kt$TramaiSecretResolutionAutoConfiguration$beanFactory.getMergedBeanDefinition(beanName) as? org.springframework.beans.factory.support.RootBeanDefinition</ID>
@@ -3602,9 +3580,6 @@
     <ID>MaxLineLength:VerifySignedPublicationBundleTask.kt$VerifySignedPublicationBundleTask$"verifySignedPublicationBundle only supports file:// repositories for local verification, but got $repositoryUrl"</ID>
     <ID>MaxLineLength:VerifySovereignRuntimeVerificationRepoClosureTask.kt$VerifySovereignRuntimeVerificationRepoClosureTask$val moduleMetadata = MavenPublishedArtifactResolver.resolve(moduleDir, moduleName, expectedVersion, "module")</ID>
     <ID>MaxLineLength:VerifySovereignSignedBundleTask.kt$VerifySovereignSignedBundleTask$append("\"checksums\": {${checksums.entries.joinToString(", ") { "\"${Hashing.jsonEscape(it.key)}\": \"${Hashing.jsonEscape(it.value)}\"" }}}")</ID>
-    <ID>MaxLineLength:VerifyStaticAnalysisTask.kt$VerifyStaticAnalysisTask$val baseTotal = (DetektBaselineParser.parse(baseBaselineXml) as? BaselineParseResult.Success)?.document?.currentIssueIds?.size ?: 0</ID>
-    <ID>MaxLineLength:VerifyStaticAnalysisTask.kt$VerifyStaticAnalysisTask$val byRule = newFindings.entries.sortedByDescending { it.value }.joinToString("\n") { " ${it.key}: ${it.value}" }</ID>
-    <ID>MaxLineLength:VerifyStaticAnalysisTask.kt$VerifyStaticAnalysisTask$val currentTotal = (DetektBaselineParser.parse(currentBaselineXml) as? BaselineParseResult.Success)?.document?.currentIssueIds?.size ?: 0</ID>
     <ID>MaxLineLength:WorkerLifecycleActionGenerator.kt$WorkerLifecycleActionGenerator$fun</ID>
     <ID>MaxLineLength:WorkerLifecycleController.kt$WorkerLifecycleController$if</ID>
     <ID>MaxLineLength:WorkerLifecycleController.kt$WorkerLifecycleController$is WorkerLifecycleState.ShuttingDown -&gt; current.root === claimed.root &amp;&amp; current.generation == claimed.generation</ID>
@@ -3808,7 +3783,7 @@
     <ID>NestedBlockDepth:BaselineGenerator.kt$BaselineGenerator$fun generateRuntimeProtocolCatalog(): ProtocolCatalog</ID>
     <ID>NestedBlockDepth:BaselineGenerator.kt$BaselineGenerator$private fun computeAnalyzerCommitSha(): String</ID>
     <ID>NestedBlockDepth:BaselineGenerator.kt$BaselineGenerator$private fun computeSourceTreeHash(): String</ID>
-    <ID>NestedBlockDepth:BaselineVerifier.kt$BaselineVerifier$private fun verifyStructuralHotspots( committed: BaselineDocument, current: BaselineDocument, deviations: List&lt;DeviationParser.DeviationEntry&gt;, diagnostics: MutableList&lt;VerificationDiagnostic&gt; )</ID>
+    <ID>NestedBlockDepth:BaselineVerifier.kt$BaselineVerifier$private fun verifyStructuralHotspots( committed: BaselineDocument, current: BaselineDocument, deviations: List&lt;DeviationParser.DeviationEntry&gt;, diagnostics: MutableList&lt;VerificationDiagnostic&gt;, )</ID>
     <ID>NestedBlockDepth:CancellationCatchInventory.kt$CancellationCatchInventory$fun inventory(): List&lt;CancellationCatchFinding&gt;</ID>
     <ID>NestedBlockDepth:CancellationDeltaComparator.kt$CancellationDeltaComparator$fun compare(baseCatches: List&lt;CancellationCatchFinding&gt;, currentCatches: List&lt;CancellationCatchFinding&gt;): Result</ID>
     <ID>NestedBlockDepth:ChangePolicyEvaluator.kt$ChangePolicyEvaluator$fun evaluate(input: ChangePolicyInput): ChangePolicyResult</ID>
@@ -4094,6 +4069,7 @@
     <ID>ThrowsCount:DefaultApprovalGateCoordinator.kt$DefaultApprovalGateCoordinator$private fun revalidateBinding( request: ApprovalRequest, approvalId: String, workflowRunId: String, toolName: String, argumentsDigest: dev.tramai.core.approval.Sha256Digest, policyVersion: String, workflowDigest: dev.tramai.core.approval.Sha256Digest, )</ID>
     <ID>ThrowsCount:DefaultApprovalGateCoordinator.kt$DefaultApprovalGateCoordinator$private fun validateAuthorizationCandidate( request: ApprovalRequest, approvalId: String, expectedVersion: Long, presentedTokenDigest: dev.tramai.core.approval.Sha256Digest, consumedBy: String, )</ID>
     <ID>ThrowsCount:DefaultApprovalGateCoordinator.kt$DefaultApprovalGateCoordinator$private suspend fun prepareResumeAuthorization( preparation: ResumeAuthorizationPreparation, ): Pair&lt;ApprovalRequest, dev.tramai.core.approval.Sha256Digest&gt;</ID>
+    <ID>ThrowsCount:DependencyResolutionTasks.kt$AggregateResolvedDependencyBaselineTask$@TaskAction fun aggregate()</ID>
     <ID>ThrowsCount:DocsContractVerifierTask.kt$DocsContractVerifierTask$@TaskAction fun verify()</ID>
     <ID>ThrowsCount:DocsContractVerifierTask.kt$DocsContractVerifierTask$private fun verifyGenericClaims(id: String)</ID>
     <ID>ThrowsCount:FileApprovalContinuationStore.kt$FileApprovalContinuationStore$private fun readCommittedContinuationEntryStrict(entry: java.nio.file.Path): PersistedApprovalContinuationRecordV1</ID>
@@ -4160,7 +4136,7 @@
     <ID>ThrowsCount:StreamingExecutionCoordinator.kt$StreamingExecutionCoordinator$private suspend fun executeStreamingRoute(request: StreamingExecutionRoute, correlationId: String, securityContext: ExecutionSecurityContext, arguments: List&lt;Any?&gt;): StreamingRouteResult</ID>
     <ID>ThrowsCount:StructuredResponseCoordinator.kt$StructuredResponseCoordinator$suspend fun finalizeResumed(request: ResumedStructuredResponseRequest): Any</ID>
     <ID>ThrowsCount:TestPerformanceAggregator.kt$TestPerformanceAggregator$fun aggregate(observations: List&lt;TestPerformanceObservation&gt;): TestPerformanceData</ID>
-    <ID>ThrowsCount:TestQualityConfiguration.kt$TestQualityConfiguration.Companion$fun parse(file: File, knownModules: Set&lt;String&gt;): TestQualityConfiguration</ID>
+    <ID>ThrowsCount:TestQualityConfiguration.kt$TestQualityConfiguration.Companion$fun parse( file: File, knownModules: Set&lt;String&gt;, ): TestQualityConfiguration</ID>
     <ID>ThrowsCount:ToolLoopCoordinator.kt$ToolLoopCoordinator$suspend fun execute( context: ToolLoopContext, ): ProviderCallResult</ID>
     <ID>ThrowsCount:VerifyStaticAnalysisTask.kt$VerifyStaticAnalysisTask$@TaskAction fun verifyStaticAnalysis()</ID>
     <ID>ThrowsCount:WorkflowCheckpointResumeDiscriminatorTest.kt$WorkflowCheckpointResumeDiscriminatorTest$@Test fun `failure suspension and cancellation retain the last durable checkpoint`()</ID>
@@ -4208,6 +4184,7 @@
     <ID>TooGenericExceptionCaught:DefaultApprovalGateCoordinator.kt$DefaultApprovalGateCoordinator$e: Exception</ID>
     <ID>TooGenericExceptionCaught:DefaultJdbcPayloadCrypto.kt$DefaultJdbcPayloadCrypto$e: Exception</ID>
     <ID>TooGenericExceptionCaught:DefaultSovereignOpsAuditOutboxOperations.kt$DefaultSovereignOpsAuditOutboxOperations$e: RuntimeException</ID>
+    <ID>TooGenericExceptionCaught:DependencyResolutionTasks.kt$AggregateResolvedDependencyBaselineTask$e: Exception</ID>
     <ID>TooGenericExceptionCaught:DetektBaselineModel.kt$DetektBaselineParser$e: Exception</ID>
     <ID>TooGenericExceptionCaught:DeviationParser.kt$DeviationParser$e: Exception</ID>
     <ID>TooGenericExceptionCaught:FailureIsolatingEngineEventObserver.kt$FailureIsolatingEngineEventObserver$error: Exception</ID>
@@ -4537,7 +4514,7 @@
     <ID>UnusedPrivateMember:PersistedDtosTest.kt$PersistedDtosTest$private fun sha256(value: String): Sha256Digest</ID>
     <ID>UnusedPrivateMember:StreamingExecutionCoordinatorTest.kt$StreamingExecutionCoordinatorTest$private fun List&lt;String&gt;.join()</ID>
     <ID>UnusedPrivateProperty:AesGcmFileEncryption.kt$AesGcmFileEncryption$private const val KEY_SIZE_BITS = 256</ID>
-    <ID>UnusedPrivateProperty:ApiCompatibilityMutationTest.kt$ApiCompatibilityMutationTest$val catalogFile = File(tempDir, "config/quality/module-catalog.yml").apply { parentFile.mkdirs() writeText( """ schemaVersion: "3" description: "test" dependencyPolicies: core: { allowedLayers: [core-contracts] } entryDefaults: {} modules: - path: ":bad-stable-preview" layer: core-contracts maturity: preview visibility: public owner: test dependencyPolicy: core releaseInclusion: included publishability: published apiStability: stable description: "Bad combination fixture." """.trimIndent() ) }</ID>
+    <ID>UnusedPrivateProperty:ApiCompatibilityMutationTest.kt$ApiCompatibilityMutationTest$val catalogFile = File(tempDir, "config/quality/module-catalog.yml").apply { parentFile.mkdirs() writeText( """ schemaVersion: "3" description: "test" dependencyPolicies: core: { allowedLayers: [core-contracts] } entryDefaults: {} modules: - path: ":bad-stable-preview" layer: core-contracts maturity: preview visibility: public owner: test dependencyPolicy: core releaseInclusion: included publishability: published apiStability: stable description: "Bad combination fixture." """.trimIndent(), ) }</ID>
     <ID>UnusedPrivateProperty:ApprovalInboxControllerTest.kt$ApprovalInboxControllerTest$@Autowired private lateinit var objectMapper: ObjectMapper</ID>
     <ID>UnusedPrivateProperty:ApprovalRecoveryAuditUnavailableException.kt$ApprovalRecoveryAuditUnavailableException$cause: Throwable?</ID>
     <ID>UnusedPrivateProperty:ApprovalRecoveryUnavailableException.kt$ApprovalRecoveryUnavailableException$cause: Throwable?</ID>
@@ -4646,7 +4623,7 @@
     <ID>UseCheckOrError:JdbcSuspendedInvocationStoreTest.kt$JdbcSuspendedInvocationStoreTest$throw IllegalStateException("Migration script not found")</ID>
     <ID>UseCheckOrError:JdbcSuspendedInvocationStoreTest.kt$JdbcSuspendedInvocationStoreTest.&lt;no name provided&gt;$throw IllegalStateException("decryption-not-possible-with-wrong-metadata")</ID>
     <ID>UseCheckOrError:LeasedSovereignOpsAuditOutboxBackgroundWorkerTest.kt$LeasedSovereignOpsAuditOutboxBackgroundWorkerTest.FakeLeaseStore$throw IllegalStateException("acquireResult not set")</ID>
-    <ID>UseCheckOrError:MeasurementContext.kt$MeasurementContext.Companion$throw IllegalStateException( "Module catalog has ${failedDiagnostics.size} error(s): $summary")</ID>
+    <ID>UseCheckOrError:MeasurementContext.kt$MeasurementContext.Companion$throw IllegalStateException("Module catalog has ${failedDiagnostics.size} error(s): $summary")</ID>
     <ID>UseCheckOrError:ModelRegistryEnforcerTest.kt$ModelRegistryEnforcerTest.&lt;no name provided&gt;$throw IllegalStateException( "token=secret-value url=http://internal-registry.local", )</ID>
     <ID>UseCheckOrError:PolicyEnforcementTest.kt$PolicyEnforcementTest.&lt;no name provided&gt;$throw IllegalStateException("registry-down")</ID>
     <ID>UseCheckOrError:ReleaseManifestVerifier.kt$ReleaseManifestVerifier$throw IllegalStateException( "sovereign-release-manifest-invalid-artifact-entry (index $i): classifier must be String or null, got ${rawClassifier::class.simpleName}" )</ID>


### PR DESCRIPTION
## Epic 9.2d-a3c1 — Topology + Dependency Aggregate Snapshots

First slice of the a3c model-snapshots track (frozen brief). Converts 2 of the 4 C4 offenders to typed configuration-cache-safe tasks.

### Changes

**`generateResolvedDependencyBaseline`** — root doLast aggregator (MaintainabilityBaselinePlugin.kt L118-156) becomes typed `AggregateResolvedDependencyBaselineTask`:
- declared `probeFiles` (@InputFiles, index-aligned with `expectedProbeOwners` @Input) + `aggregateFile` @OutputFile
- exact missing-probe / invalid-probe diagnostics preserved; fail-closed (a glob is NOT used — absence of one expected project probe still fails)
- sorted merge via `BaselineGenerator.sortResolvedDependencies`, exact summary line preserved
- no `Project` in the action

**`verifyModuleManifest`** — closure (L910-948) becomes typed `VerifyModuleManifestTask`:
- `moduleCatalogFile` @InputFile (rootDir derived from it) + `projectPaths`/`publishedPaths`/`bomPaths` as plain ListProperty inputs
- calls the existing pure `ModuleManifestVerifier` — exact diagnostics/group/description preserved
- **publishedPaths now from the release task's typed model** (`verifyPublicationMetadata.publishableModules` via `pluginManager.withPlugin("tramai.release-verification")`, module names → `:paths`) — the root `tramai.publishableModulePaths` extra is NO LONGER read by this verifier (its deletion belongs to 9.2d-b)
- **bomPaths resolved lazily** through a provider (a1 rule: java-platform model incomplete at plugin apply; never a Configuration as a task property)
- `ModuleTopologySnapshot` shared configuration-side helper (small List<String> values; no Gradle model objects cross task boundaries)

### Discriminators (15 tests)
- Dependency aggregate: unsorted→sorted deterministic (no empty oracle), missing probe → exact diagnostic, malformed probe → exact diagnostic, records from B not lost when A valid, CC cold→warm + input mutation re-executes
- Module topology: real multi-project + java-platform BOM fixture; 5 mutations fail with correct diagnostics (catalog entry removed, published omitted, unexpected published, BOM constraint removed, unexpected BOM constraint added)
- Lazy-BOM ordering guard (fails on eager apply-time lookup)
- Root-extra decoupling: no `tramai.publishableModulePaths` extra → correct result from release task model (proves 9.2d-b can delete it later)

### Evidence
- Full build-logic suite green (CanonicalProbeFunctionalTest env gap pre-existing: needs system `gradle` on PATH — fails identically on master)
- Real-repo: `generateResolvedDependencyBaseline` + `verifyModuleManifest` green (6183 records aggregated)
- CC: both tasks cold→warm, 0 problems
- verifyChangePolicy PASSED (5 files, build-logic)
- spotless formatted (10.1a ratchet; touched files get full ktlint normalization — master's plugin file predates the gate)
- **C4 verifyPr CC offenders: 3 → 1** — only `verifyMaintainabilityBaseline` remains (a3c2 target); C5 stays 1 (verify060Architecture); C3 stays the single deliberate exclusion

Note on the formatting churn: MaintainabilityBaselinePlugin.kt shows ~1390 changed lines because the new 10.1a gate ratchets from origin/master and fully normalizes any touched file — the functional diff is the ~120-line extraction + wiring shown above.
