### PR TITLE
feat(quality): typed verify060Architecture gate (Epic 9.2d-a3c3)

### DIFF
--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/ApiCompatibilityVerifier.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/ApiCompatibilityVerifier.kt
@@ -1,6 +1,5 @@
 package dev.tramai.build.quality
 
-import org.gradle.api.Project
 import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.constructor.SafeConstructor
@@ -42,7 +41,12 @@ data class ApiMigrationEntry(
     val migration: String,
 ) {
     /** Exact-transition authorization: both hashes AND the target version must match. */
-    fun authorizes(module: String, baseContent: String, committedContent: String, projectVersion: String): Boolean =
+    fun authorizes(
+        module: String,
+        baseContent: String,
+        committedContent: String,
+        projectVersion: String,
+    ): Boolean =
         this.module == module &&
             this.targetVersion == projectVersion &&
             this.fromSha256 == ApiCompatibilityVerifier.sha256(baseContent) &&
@@ -53,8 +57,10 @@ class ApiCompatibilityVerifier(
     private val catalogModules: Map<String, ModuleCatalog.ModuleEntry>,
     private val projectVersion: String,
 ) {
-
-    fun verify(evidence: ApiDumpEvidence, migrations: List<ApiMigrationEntry>): List<VerificationDiagnostic> {
+    fun verify(
+        evidence: ApiDumpEvidence,
+        migrations: List<ApiMigrationEntry>,
+    ): List<VerificationDiagnostic> {
         val diagnostics = mutableListOf<VerificationDiagnostic>()
         verifyContract1(evidence, diagnostics)
         verifyContract2(evidence, migrations, diagnostics)
@@ -65,33 +71,38 @@ class ApiCompatibilityVerifier(
 
     // ── Contract 1: source ↔ committed dump ────────────────────────────────
 
-    private fun verifyContract1(evidence: ApiDumpEvidence, diagnostics: MutableList<VerificationDiagnostic>) {
+    private fun verifyContract1(
+        evidence: ApiDumpEvidence,
+        diagnostics: MutableList<VerificationDiagnostic>,
+    ) {
         // Fail-closed (A12/A13 doctrine): every module with a committed dump MUST
         // also have generated (apiBuild) evidence. A silent skip would let a
         // clean workspace false-PASS because the intersection is empty.
         val expected = evidence.committed.keys
         val missing = expected - evidence.generated.keys
         missing.sorted().forEach { module ->
-            diagnostics += VerificationDiagnostic.failure(
-                DiagnosticCode.API_COMPATIBILITY_FAILED,
-                "Contract-1: generated (apiBuild) API dump for '$module' is unavailable; " +
-                    "cannot verify the committed dump represents current source. " +
-                    "Ensure the architecture gate runs apiBuild for every applicable module.",
-                modulePath = module
-            )
+            diagnostics +=
+                VerificationDiagnostic.failure(
+                    DiagnosticCode.API_COMPATIBILITY_FAILED,
+                    "Contract-1: generated (apiBuild) API dump for '$module' is unavailable; " +
+                        "cannot verify the committed dump represents current source. " +
+                        "Ensure the architecture gate runs apiBuild for every applicable module.",
+                    modulePath = module,
+                )
         }
         expected.intersect(evidence.generated.keys).sorted().forEach { module ->
             val generated = evidence.generated.getValue(module)
             val committed = evidence.committed.getValue(module)
             if (generated != committed) {
-                diagnostics += VerificationDiagnostic.failure(
-                    DiagnosticCode.API_COMPATIBILITY_FAILED,
-                    "Contract-1: committed API dump for '$module' does not represent current source " +
-                        "(generated ${generated.length} bytes vs committed ${committed.length} bytes); run apiDump and commit the dump",
-                    modulePath = module,
-                    baselineValue = sha256(committed),
-                    currentValue = sha256(generated)
-                )
+                diagnostics +=
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.API_COMPATIBILITY_FAILED,
+                        "Contract-1: committed API dump for '$module' does not represent current source " +
+                            "(generated ${generated.length} bytes vs committed ${committed.length} bytes); run apiDump and commit the dump",
+                        modulePath = module,
+                        baselineValue = sha256(committed),
+                        currentValue = sha256(generated),
+                    )
             }
         }
     }
@@ -101,7 +112,7 @@ class ApiCompatibilityVerifier(
     private fun verifyContract2(
         evidence: ApiDumpEvidence,
         migrations: List<ApiMigrationEntry>,
-        diagnostics: MutableList<VerificationDiagnostic>
+        diagnostics: MutableList<VerificationDiagnostic>,
     ) {
         evidence.committed.keys.sorted().forEach { module ->
             val stability = stabilityOf(module) ?: return@forEach
@@ -110,39 +121,44 @@ class ApiCompatibilityVerifier(
 
             if (module !in evidence.base) {
                 // Fail-closed: no base dump means no compatibility claim is possible.
-                diagnostics += VerificationDiagnostic.failure(
-                    DiagnosticCode.API_COMPATIBILITY_FAILED,
-                    "Contract-2: base-branch API dump for '$module' is unavailable; " +
-                        "cannot certify API compatibility (resolve -PchangePolicyBase or fetch origin/master)",
-                    modulePath = module
-                )
+                diagnostics +=
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.API_COMPATIBILITY_FAILED,
+                        "Contract-2: base-branch API dump for '$module' is unavailable; " +
+                            "cannot certify API compatibility (resolve -PchangePolicyBase or fetch origin/master)",
+                        modulePath = module,
+                    )
                 return@forEach
             }
             val base = evidence.base.getValue(module)
             if (base == committed) return@forEach
 
             when (stability) {
-                "stable" -> diagnostics += VerificationDiagnostic.failure(
-                    DiagnosticCode.API_COMPATIBILITY_FAILED,
-                    "Stable API module '$module' changed (breaking or additive); stable API is frozen for $projectVersion. " +
-                        "Migration entries cannot authorize stable changes.",
-                    modulePath = module,
-                    baselineValue = sha256(base),
-                    currentValue = sha256(committed)
-                )
+                "stable" -> {
+                    diagnostics +=
+                        VerificationDiagnostic.failure(
+                            DiagnosticCode.API_COMPATIBILITY_FAILED,
+                            "Stable API module '$module' changed (breaking or additive); stable API is frozen for $projectVersion. " +
+                                "Migration entries cannot authorize stable changes.",
+                            modulePath = module,
+                            baselineValue = sha256(base),
+                            currentValue = sha256(committed),
+                        )
+                }
 
                 "preview", "experimental" -> {
                     val authorized = migrations.any { it.authorizes(module, base, committed, projectVersion) }
                     if (!authorized) {
-                        diagnostics += VerificationDiagnostic.failure(
-                            DiagnosticCode.API_COMPATIBILITY_FAILED,
-                            "API module '$module' changed without an exact hash-bound migration entry; " +
-                                "add an entry binding fromSha256=${sha256(base)} toSha256=${sha256(committed)} " +
-                                "for targetVersion=$projectVersion in config/quality/api-migrations.yml",
-                            modulePath = module,
-                            baselineValue = sha256(base),
-                            currentValue = sha256(committed)
-                        )
+                        diagnostics +=
+                            VerificationDiagnostic.failure(
+                                DiagnosticCode.API_COMPATIBILITY_FAILED,
+                                "API module '$module' changed without an exact hash-bound migration entry; " +
+                                    "add an entry binding fromSha256=${sha256(base)} toSha256=${sha256(committed)} " +
+                                    "for targetVersion=$projectVersion in config/quality/api-migrations.yml",
+                                modulePath = module,
+                                baselineValue = sha256(base),
+                                currentValue = sha256(committed),
+                            )
                     }
                 }
 
@@ -156,21 +172,23 @@ class ApiCompatibilityVerifier(
     private fun verifyRegistryHygiene(
         evidence: ApiDumpEvidence,
         migrations: List<ApiMigrationEntry>,
-        diagnostics: MutableList<VerificationDiagnostic>
+        diagnostics: MutableList<VerificationDiagnostic>,
     ) {
         // duplicates: same (module, fromSha256, toSha256) more than once
-        migrations.groupBy { Triple(it.module, it.fromSha256, it.toSha256) }
+        migrations
+            .groupBy { Triple(it.module, it.fromSha256, it.toSha256) }
             .filterValues { it.size > 1 }
             .keys
             .sortedBy { it.first }
             .forEach { (module, from, to) ->
-                diagnostics += VerificationDiagnostic.failure(
-                    DiagnosticCode.API_COMPATIBILITY_FAILED,
-                    "Duplicate migration entries for '$module' ($from → $to); each transition needs exactly one entry",
-                    modulePath = module,
-                    baselineValue = from,
-                    currentValue = to
-                )
+                diagnostics +=
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.API_COMPATIBILITY_FAILED,
+                        "Duplicate migration entries for '$module' ($from → $to); one entry per transition",
+                        modulePath = module,
+                        baselineValue = from,
+                        currentValue = to,
+                    )
             }
 
         // Entry lifecycle (D1): a registry entry is valid evidence in exactly
@@ -186,30 +204,36 @@ class ApiCompatibilityVerifier(
             val realTransition = actualTransition(evidence, entry.module)
             val base = evidence.base[entry.module]
             val committed = evidence.committed[entry.module]
-            val active = realTransition != null &&
-                realTransition.first == entry.fromSha256 &&
-                realTransition.second == entry.toSha256 &&
-                entry.targetVersion == projectVersion
-            val landed = base != null && committed != null && (
-                (realTransition == null && sha256(committed) == entry.toSha256) ||
-                    (realTransition != null && sha256(base) == entry.toSha256)
+            val active =
+                realTransition != null &&
+                    realTransition.first == entry.fromSha256 &&
+                    realTransition.second == entry.toSha256 &&
+                    entry.targetVersion == projectVersion
+            val landed =
+                base != null && committed != null && (
+                    (realTransition == null && sha256(committed) == entry.toSha256) ||
+                        (realTransition != null && sha256(base) == entry.toSha256)
                 )
             if (!active && !landed) {
-                diagnostics += VerificationDiagnostic.failure(
-                    DiagnosticCode.API_COMPATIBILITY_FAILED,
-                    "Migration entry for '${entry.module}' is stale, orphaned, hash-mismatched, or not yet landed " +
-                        "(declared ${entry.fromSha256} → ${entry.toSha256} for ${entry.targetVersion}, " +
-                        "actual ${realTransition?.first ?: "<no change>"} → ${realTransition?.second ?: "<no change>"} " +
-                        "for $projectVersion)",
-                    modulePath = entry.module,
-                    baselineValue = entry.fromSha256,
-                    currentValue = entry.toSha256
-                )
+                diagnostics +=
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.API_COMPATIBILITY_FAILED,
+                        "Migration entry for '${entry.module}' is stale, orphaned, hash-mismatched, or not landed " +
+                            "(declared ${entry.fromSha256} → ${entry.toSha256} for ${entry.targetVersion}, " +
+                            "actual ${realTransition?.first ?: "<no change>"} → ${realTransition?.second ?: "<no change>"} " +
+                            "for $projectVersion)",
+                        modulePath = entry.module,
+                        baselineValue = entry.fromSha256,
+                        currentValue = entry.toSha256,
+                    )
             }
         }
     }
 
-    private fun actualTransition(evidence: ApiDumpEvidence, module: String): Pair<String, String>? {
+    private fun actualTransition(
+        evidence: ApiDumpEvidence,
+        module: String,
+    ): Pair<String, String>? {
         val base = evidence.base[module] ?: return null
         val committed = evidence.committed[module] ?: return null
         if (base == committed) return null
@@ -218,11 +242,15 @@ class ApiCompatibilityVerifier(
 
     // ── Stability-inversion leak scan ───────────────────────────────────────
 
-    private fun verifyStabilityInversions(evidence: ApiDumpEvidence, diagnostics: MutableList<VerificationDiagnostic>) {
+    private fun verifyStabilityInversions(
+        evidence: ApiDumpEvidence,
+        diagnostics: MutableList<VerificationDiagnostic>,
+    ) {
         val ownership = ownershipByModule(evidence.committed)
-        val descriptorToModule = ownership.entries
-            .flatMap { (module, descriptors) -> descriptors.map { it to module } }
-            .toMap()
+        val descriptorToModule =
+            ownership.entries
+                .flatMap { (module, descriptors) -> descriptors.map { it to module } }
+                .toMap()
 
         evidence.committed.keys.sorted().forEach { module ->
             val strength = strengthOf(module) ?: return@forEach
@@ -236,26 +264,29 @@ class ApiCompatibilityVerifier(
 
                 val preExisting = base?.contains(descriptor) == true
                 if (preExisting) {
-                    diagnostics += VerificationDiagnostic(
-                        code = DiagnosticCode.API_COMPATIBILITY_FAILED,
-                        severity = DiagnosticSeverity.WARNING,
-                        message = "Pre-existing stability inversion: '${module}' (${stabilityOf(module)}) references " +
-                            "'$descriptor' owned by '${owner}' (${stabilityOf(owner)}); stronger APIs may only expose " +
-                            "equally-strong or stronger types",
-                        modulePath = module,
-                        baselineValue = descriptor,
-                        currentValue = owner
-                    )
+                    diagnostics +=
+                        VerificationDiagnostic(
+                            code = DiagnosticCode.API_COMPATIBILITY_FAILED,
+                            severity = DiagnosticSeverity.WARNING,
+                            message =
+                                "Pre-existing stability inversion: '$module' (${stabilityOf(module)}) references " +
+                                    "'$descriptor' owned by '$owner' (${stabilityOf(owner)}); stronger APIs " +
+                                    "expose only equally-strong types",
+                            modulePath = module,
+                            baselineValue = descriptor,
+                            currentValue = owner,
+                        )
                 } else {
-                    diagnostics += VerificationDiagnostic.failure(
-                        DiagnosticCode.API_COMPATIBILITY_FAILED,
-                        "Stability inversion: '${module}' (${stabilityOf(module)}) now references '$descriptor' " +
-                            "owned by '${owner}' (${stabilityOf(owner)}); stronger APIs may only expose " +
-                            "equally-strong or stronger TramAI types",
-                        modulePath = module,
-                        baselineValue = descriptor,
-                        currentValue = owner
-                    )
+                    diagnostics +=
+                        VerificationDiagnostic.failure(
+                            DiagnosticCode.API_COMPATIBILITY_FAILED,
+                            "Stability inversion: '$module' (${stabilityOf(module)}) now references '$descriptor' " +
+                                "owned by '$owner' (${stabilityOf(owner)}); stronger APIs may only expose " +
+                                "equally-strong or stronger TramAI types",
+                            modulePath = module,
+                            baselineValue = descriptor,
+                            currentValue = owner,
+                        )
                 }
             }
         }
@@ -267,12 +298,12 @@ class ApiCompatibilityVerifier(
 
     /** Lines of the BCV dump form `public ... class <descriptor> ...` yield owned descriptors. */
     private fun ownedDescriptors(dumpContent: String): Set<String> =
-        dumpContent.lineSequence()
+        dumpContent
+            .lineSequence()
             .mapNotNull { line ->
                 val match = OWNED_CLASS_REGEX.find(line) ?: return@mapNotNull null
                 match.groupValues[1]
-            }
-            .toSet()
+            }.toSet()
 
     // ── helpers ─────────────────────────────────────────────────────────────
 
@@ -293,29 +324,38 @@ class ApiCompatibilityVerifier(
         private val OWNED_CLASS_REGEX = Regex("""\bclass\s+(dev/tramai/[\w/$]+)""")
 
         fun sha256(content: String): String =
-            MessageDigest.getInstance("SHA-256").digest(content.toByteArray(Charsets.UTF_8))
+            MessageDigest
+                .getInstance("SHA-256")
+                .digest(content.toByteArray(Charsets.UTF_8))
                 .joinToString("") { "%02x".format(it) }
     }
 }
 
 /** Guard for consumer-compile proofs: real non-empty sources AND real compiled classes. */
 object ConsumerCompatibilityGuard {
+    fun validate(
+        sourceDir: File,
+        classesDir: File,
+        extension: String,
+    ): List<VerificationDiagnostic> = validateSources(sourceDir, extension) + validateClasses(classesDir)
 
-    fun validate(sourceDir: File, classesDir: File, extension: String): List<VerificationDiagnostic> =
-        validateSources(sourceDir, extension) + validateClasses(classesDir)
-
-    fun validateSources(sourceDir: File, extension: String): List<VerificationDiagnostic> {
+    fun validateSources(
+        sourceDir: File,
+        extension: String,
+    ): List<VerificationDiagnostic> {
         val fileExtension = if (extension == "kotlin") "kt" else extension
-        val sources = sourceDir.walkTopDown()
-            .filter { it.isFile && it.extension == fileExtension }
-            .toList()
+        val sources =
+            sourceDir
+                .walkTopDown()
+                .filter { it.isFile && it.extension == fileExtension }
+                .toList()
         return if (sources.isEmpty()) {
             listOf(
                 VerificationDiagnostic.failure(
                     DiagnosticCode.API_COMPATIBILITY_FAILED,
                     "Consumer fixture '$sourceDir' has no .$fileExtension sources; " +
-                        "an empty fixture proves nothing (zero-source trap)"
-                )
+                        "an empty fixture proves nothing (zero-source trap)",
+                ),
             )
         } else {
             emptyList()
@@ -323,16 +363,18 @@ object ConsumerCompatibilityGuard {
     }
 
     fun validateClasses(classesDir: File): List<VerificationDiagnostic> {
-        val classes = classesDir.walkTopDown()
-            .filter { it.isFile && it.extension == "class" }
-            .toList()
+        val classes =
+            classesDir
+                .walkTopDown()
+                .filter { it.isFile && it.extension == "class" }
+                .toList()
         return if (classes.isEmpty()) {
             listOf(
                 VerificationDiagnostic.failure(
                     DiagnosticCode.API_COMPATIBILITY_FAILED,
                     "Consumer fixture produced no compiled classes in '$classesDir'; " +
-                        "compilation must actually succeed"
-                )
+                        "compilation must actually succeed",
+                ),
             )
         } else {
             emptyList()
@@ -348,21 +390,27 @@ object ConsumerCompatibilityGuard {
  *  - migration registry: config/quality/api-migrations.yml
  */
 object ApiCompatibilityEvidenceReader {
-
     /** Committed dump path convention: <moduleDir>/api/<moduleName>.api. */
-    fun committedDumpPath(moduleDir: File, moduleName: String): File =
-        File(moduleDir, "api/$moduleName.api")
+    fun committedDumpPath(
+        moduleDir: File,
+        moduleName: String,
+    ): File = File(moduleDir, "api/$moduleName.api")
 
     /** Generated dump path convention: <moduleBuildDir>/api/<moduleName>.api. */
-    fun generatedDumpPath(buildDir: File, moduleName: String): File =
-        File(buildDir, "api/$moduleName.api")
+    fun generatedDumpPath(
+        buildDir: File,
+        moduleName: String,
+    ): File = File(buildDir, "api/$moduleName.api")
 
     /**
      * Read committed dumps for every Gradle subproject with an apiCheck task.
      * Keys are project paths (e.g. ":tramai-core"); values are dump contents.
      * Modules without a committed dump are omitted (tramai-bom: not applicable).
      */
-    fun readCommittedDumps(rootDir: File, projectPaths: Collection<String>): Map<String, String> {
+    fun readCommittedDumps(
+        rootDir: File,
+        projectPaths: Collection<String>,
+    ): Map<String, String> {
         val result = linkedMapOf<String, String>()
         projectPaths.sorted().forEach { path ->
             val name = path.substringAfterLast(':')
@@ -373,15 +421,21 @@ object ApiCompatibilityEvidenceReader {
         return result
     }
 
-    /** Read apiBuild-generated dumps for subprojects that already produced them. */
-    fun readGeneratedDumps(project: Project): Map<String, String> {
+    /**
+     * Read apiBuild-generated dumps for the given project paths. Pure file
+     * reads on the declared convention path (<rootDir>/<path>/build/api/<name>.api);
+     * the caller declares the corresponding files as task inputs (a3c3).
+     */
+    fun readGeneratedDumps(
+        rootDir: File,
+        projectPaths: Collection<String>,
+    ): Map<String, String> {
         val result = linkedMapOf<String, String>()
-        project.allprojects.filter { it != project && it.buildFile.exists() }.sortedBy { it.path }.forEach { sub ->
-            val dump = generatedDumpPath(
-                sub.layout.buildDirectory.get().asFile,
-                sub.name,
-            )
-            if (dump.isFile) result[sub.path] = dump.readText(Charsets.UTF_8)
+        projectPaths.sorted().forEach { path ->
+            val name = path.substringAfterLast(':')
+            val dir = File(rootDir, path.removePrefix(":").replace(':', '/'))
+            val dump = generatedDumpPath(File(dir, "build"), name)
+            if (dump.isFile) result[path] = dump.readText(Charsets.UTF_8)
         }
         return result
     }
@@ -393,7 +447,11 @@ object ApiCompatibilityEvidenceReader {
      * (unresolvable ref, no repo) throws → the gate's fail-closed evidence
      * collector converts it into typed FAILURE diagnostics.
      */
-    fun readBaseDumps(rootDir: File, baseRef: String, modulePaths: Collection<String>): Map<String, String> {
+    fun readBaseDumps(
+        rootDir: File,
+        baseRef: String,
+        modulePaths: Collection<String>,
+    ): Map<String, String> {
         val result = linkedMapOf<String, String>()
         modulePaths.sorted().forEach { path ->
             val name = path.substringAfterLast(':')
@@ -405,11 +463,15 @@ object ApiCompatibilityEvidenceReader {
         return result
     }
 
-    private fun gitShow(rootDir: File, spec: String): String {
-        val process = ProcessBuilder("git", "show", spec)
-            .directory(rootDir)
-            .redirectErrorStream(true)
-            .start()
+    private fun gitShow(
+        rootDir: File,
+        spec: String,
+    ): String {
+        val process =
+            ProcessBuilder("git", "show", spec)
+                .directory(rootDir)
+                .redirectErrorStream(true)
+                .start()
         val output = process.inputStream.bufferedReader().readText()
         val exit = process.waitFor()
         if (exit != 0) {
@@ -426,42 +488,47 @@ object ApiCompatibilityEvidenceReader {
     fun parseMigrations(file: File): ApiMigrationParseResult {
         if (!file.isFile) return ApiMigrationParseResult(emptyList(), emptyList())
         val diagnostics = mutableListOf<VerificationDiagnostic>()
-        val raw: Map<String, Any>? = try {
-            FileInputStream(file).use { input ->
-                val options = LoaderOptions().apply { maxAliasesForCollections = 200 }
-                Yaml(SafeConstructor(options)).load<Map<String, Any>>(input)
+        val raw: Map<String, Any>? =
+            try {
+                FileInputStream(file).use { input ->
+                    val options = LoaderOptions().apply { maxAliasesForCollections = 200 }
+                    Yaml(SafeConstructor(options)).load<Map<String, Any>>(input)
+                }
+            } catch (e: Exception) {
+                diagnostics +=
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.API_COMPATIBILITY_FAILED,
+                        "Malformed api-migrations.yml: ${e.message}",
+                    )
+                return ApiMigrationParseResult(emptyList(), diagnostics)
             }
-        } catch (e: Exception) {
-            diagnostics += VerificationDiagnostic.failure(
-                DiagnosticCode.API_COMPATIBILITY_FAILED,
-                "Malformed api-migrations.yml: ${e.message}",
-            )
-            return ApiMigrationParseResult(emptyList(), diagnostics)
-        }
 
         val entries = raw?.get("migrations")
         if (entries == null) {
-            diagnostics += VerificationDiagnostic.failure(
-                DiagnosticCode.API_COMPATIBILITY_FAILED,
-                "api-migrations.yml must contain a 'migrations' list",
-            )
+            diagnostics +=
+                VerificationDiagnostic.failure(
+                    DiagnosticCode.API_COMPATIBILITY_FAILED,
+                    "api-migrations.yml must contain a 'migrations' list",
+                )
             return ApiMigrationParseResult(emptyList(), diagnostics)
         }
         if (entries !is List<*>) {
-            diagnostics += VerificationDiagnostic.failure(
-                DiagnosticCode.API_COMPATIBILITY_FAILED,
-                "api-migrations.yml 'migrations' must be a list, got ${entries.javaClass.simpleName}",
-            )
+            diagnostics +=
+                VerificationDiagnostic.failure(
+                    DiagnosticCode.API_COMPATIBILITY_FAILED,
+                    "api-migrations.yml 'migrations' must be a list, got ${entries.javaClass.simpleName}",
+                )
             return ApiMigrationParseResult(emptyList(), diagnostics)
         }
 
         val parsed = mutableListOf<ApiMigrationEntry>()
         entries.forEachIndexed { index, item ->
             if (item !is Map<*, *>) {
-                diagnostics += VerificationDiagnostic.failure(
-                    DiagnosticCode.API_COMPATIBILITY_FAILED,
-                    "api-migrations.yml entry #$index is not a map (${item?.javaClass?.simpleName ?: "null"})",
-                )
+                diagnostics +=
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.API_COMPATIBILITY_FAILED,
+                        "api-migrations.yml entry #$index is not a map (${item?.javaClass?.simpleName ?: "null"})",
+                    )
                 return@forEachIndexed
             }
             val module = item["module"]?.toString().orEmpty()
@@ -472,32 +539,35 @@ object ApiCompatibilityEvidenceReader {
             val migration = item["migration"]?.toString().orEmpty()
 
             if (module.isBlank() || targetVersion.isBlank() || rationale.isBlank() || migration.isBlank()) {
-                diagnostics += VerificationDiagnostic.failure(
-                    DiagnosticCode.API_COMPATIBILITY_FAILED,
-                    "api-migrations.yml entry #$index ($module) has blank required fields " +
-                        "(module/targetVersion/rationale/migration)",
-                    modulePath = module.ifBlank { null },
-                )
+                diagnostics +=
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.API_COMPATIBILITY_FAILED,
+                        "api-migrations.yml entry #$index ($module) has blank required fields " +
+                            "(module/targetVersion/rationale/migration)",
+                        modulePath = module.ifBlank { null },
+                    )
             }
             if (fromSha256.isBlank() || toSha256.isBlank() ||
                 !SHA256_HEX.matches(fromSha256) || !SHA256_HEX.matches(toSha256)
             ) {
-                diagnostics += VerificationDiagnostic.failure(
-                    DiagnosticCode.API_COMPATIBILITY_FAILED,
-                    "api-migrations.yml entry #$index ($module) has invalid sha256 " +
-                        "(expected 64-char hex, got from='$fromSha256' to='$toSha256')",
-                    modulePath = module.ifBlank { null },
-                )
+                diagnostics +=
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.API_COMPATIBILITY_FAILED,
+                        "api-migrations.yml entry #$index ($module) has invalid sha256 " +
+                            "(expected 64-char hex, got from='$fromSha256' to='$toSha256')",
+                        modulePath = module.ifBlank { null },
+                    )
             }
             if (module.isBlank()) return@forEachIndexed
-            parsed += ApiMigrationEntry(
-                module = module,
-                fromSha256 = fromSha256,
-                toSha256 = toSha256,
-                targetVersion = targetVersion,
-                rationale = rationale,
-                migration = migration,
-            )
+            parsed +=
+                ApiMigrationEntry(
+                    module = module,
+                    fromSha256 = fromSha256,
+                    toSha256 = toSha256,
+                    targetVersion = targetVersion,
+                    rationale = rationale,
+                    migration = migration,
+                )
         }
         return ApiMigrationParseResult(parsed, diagnostics)
     }

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
@@ -566,11 +566,16 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                                 .get()
                         },
                 )
-                // Generated BCV dumps — typed apiBuild task outputs.
+                // Generated BCV dumps — typed apiBuild task outputs, paired
+                // with their module paths so the gate consumes the EXACT
+                // declared files (a3c3 P1: no conventional build/api rediscovery).
                 project.allprojects
                     .filter { sub -> sub != project && sub.tasks.findByName("apiBuild") != null }
                     .filter { sub -> ApiCompatibilityEvidenceReader.committedDumpPath(sub.projectDir, sub.name).isFile }
-                    .forEach { sub -> generatedApiDumps.from(sub.tasks.named("apiBuild").map { it.outputs.files }) }
+                    .forEach { sub ->
+                        generatedApiDumpOwners.add(sub.path)
+                        generatedApiDumpFiles.from(sub.tasks.named("apiBuild").map { it.outputs.files })
+                    }
             }
         }
 

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
@@ -7,6 +7,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.testing.Test
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaToolchainService
@@ -22,7 +23,15 @@ import javax.xml.parsers.DocumentBuilderFactory
  * Apply in root build.gradle.kts with: `plugins { id("tramai.maintainability-baseline") }`
  */
 abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
+    /** Root project this plugin was applied to (set in apply()). */
+    private lateinit var rootProject: Project
+
+    /** Fail-soft consumer compile-proof producers (Epic 10.2); markers feed the
+     * architecture gate as typed api-architecture evidence (a3c3). */
+    private val consumerMarkerProviders = mutableListOf<TaskProvider<ConsumerSmokeCompileTask>>()
+
     override fun apply(project: Project) {
+        rootProject = project
         if (project != project.rootProject) return
 
         val ctx = MeasurementContext.fromProject(project)
@@ -155,6 +164,7 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
         // the gate reads their outputs and converts resolution failure into
         // typed fail-closed evidence, so the report is always written.
         val architectureProbeTasks = mutableListOf<String>()
+        val architectureProbeProviders = mutableListOf<TaskProvider<ArchitectureDependencyProbeTask>>()
         project.allprojects.filter { it != project && it.buildFile.exists() }.forEach { sub ->
             val probe = sub.tasks.register("architectureDependencyProbe", ArchitectureDependencyProbeTask::class.java)
             probe.configure {
@@ -184,6 +194,7 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                 )
             }
             architectureProbeTasks.add("${sub.path}:architectureDependencyProbe")
+            architectureProbeProviders.add(probe)
         }
 
         project.tasks.register("generateModuleDependencyGraph") {
@@ -516,6 +527,51 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                     ),
                 )
             }
+            // a3c3: same configuration-time snapshots for the architecture gate
+            // (declared inputs are the execution authority — no Project in the action).
+            project.tasks.withType(VerifyArchitectureTask::class.java).configureEach {
+                apiValidationModules.set(apiModules)
+                dependencyGraph.set(
+                    DependencyGraphSnapshot(
+                        production = graph.moduleDependencies,
+                        test = graph.moduleDependenciesTest,
+                    ),
+                )
+                actualProjectPaths.set(
+                    project.allprojects
+                        .filter { it != project && it.buildFile.exists() }
+                        .map { it.path },
+                )
+                publishedModulePaths.set(
+                    (project.extensions.extraProperties.properties["tramai.publishableModulePaths"] as? Collection<*>)
+                        ?.map { it.toString() }
+                        .orEmpty(),
+                )
+                val bomProject = project.allprojects.firstOrNull { it.name == "tramai-bom" }
+                bomModulePaths.set(
+                    bomProject
+                        ?.configurations
+                        ?.findByName("api")
+                        ?.dependencyConstraints
+                        .orEmpty()
+                        .mapNotNull { constraint ->
+                            constraint.name.takeIf { it.startsWith("tramai-") || it.startsWith("examples:") }?.let { ":$it" }
+                        },
+                )
+                enrollmentResultsDir.from(
+                    project.tasks
+                        .named("architectureContractEnrollmentTest", Test::class.java)
+                        .map {
+                            it.reports.junitXml.outputLocation
+                                .get()
+                        },
+                )
+                // Generated BCV dumps — typed apiBuild task outputs.
+                project.allprojects
+                    .filter { sub -> sub != project && sub.tasks.findByName("apiBuild") != null }
+                    .filter { sub -> ApiCompatibilityEvidenceReader.committedDumpPath(sub.projectDir, sub.name).isFile }
+                    .forEach { sub -> generatedApiDumps.from(sub.tasks.named("apiBuild").map { it.outputs.files }) }
+            }
         }
 
         // Typed, configuration-cache-safe: declared inputs (committed baseline,
@@ -627,7 +683,9 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
         project.tasks.register("verifyCancellationSafety") {
             group = "maintainability"
             description =
-                "Scans all production source for broad catches in suspend-capable code and rejects newly introduced critical/high findings and risk worsenings. Accepts -PtramaiCancellationBaseSha for PR base SHA comparison."
+                "Scans all production source for broad catches in suspend-capable code and rejects " +
+                "newly introduced critical/high findings and risk worsenings. Accepts " +
+                "-PtramaiCancellationBaseSha for PR base SHA comparison."
             doLast {
                 val scanningCtx = MeasurementContext.fromProject(project)
                 val inventory = CancellationCatchInventory(scanningCtx)
@@ -776,7 +834,8 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
 
                     println(delta.diagnostics.joinToString("\n"))
                     println(
-                        "verifyCancellationSafety PASSED: ${scopedFindings.size} findings in scoped modules, no new critical/high findings or risk worsenings against origin/master.",
+                        "verifyCancellationSafety PASSED: ${scopedFindings.size} findings in scoped modules, " +
+                            "no new critical/high findings or risk worsenings against origin/master.",
                     )
                 }
             }
@@ -875,7 +934,8 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                         val sourceRoot = project.rootDir.resolve(sourceRootProp).normalize()
                         if (!sourceRoot.isDirectory) {
                             throw GradleException(
-                                "maintainability.sourceRoot='$sourceRootProp' resolved to '${sourceRoot.absolutePath}' but is not a directory",
+                                "maintainability.sourceRoot='$sourceRootProp' resolved to " +
+                                    "'${sourceRoot.absolutePath}' but is not a directory",
                             )
                         }
                         BaselineGenerator.fromDirectory(sourceRoot, analyzerRoot = project.rootDir)
@@ -1131,7 +1191,7 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                 )
             }
 
-        project.tasks.register("verify060Architecture") {
+        project.tasks.register<VerifyArchitectureTask>("verify060Architecture") {
             group = "verification"
             description = "build(quality): add unified 0.6.0 architecture gate"
             dependsOn(*architectureProbeTasks.toTypedArray())
@@ -1145,117 +1205,71 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                     .filter { sub -> ApiCompatibilityEvidenceReader.committedDumpPath(sub.projectDir, sub.name).isFile }
                     .map { "${it.path}:apiBuild" }
             dependsOn(*apiBuildTasks.toTypedArray())
-            doLast {
-                val architectureDiagnostics =
-                    ArchitectureReportAggregator.checkIds
-                        .associateWith { mutableListOf<VerificationDiagnostic>() }
-                val context = MeasurementContext.fromProject(project)
-                val verificationReport = File(reportDir, "verification-report.json")
 
-                collectEvidence("baseline verification", baselineCheckIds, architectureDiagnostics) {
-                    // Read the fail-soft per-project dependency probes. Resolution
-                    // failure reaches the gate as typed evidence (the probe tasks
-                    // never abort the task graph), so the report is always written.
-                    val probeFiles =
-                        project.allprojects
-                            .filter { it != project && it.buildFile.exists() }
-                            .sortedBy { it.path }
-                            .map { sub ->
-                                File(
-                                    sub.layout.buildDirectory
-                                        .get()
-                                        .asFile,
-                                    "reports/maintainability/architecture-dependencies.json",
-                                )
-                            }
-                    val evidence = readDependencyProbeEvidence(probeFiles)
-                    if (evidence.failures.isNotEmpty()) {
-                        val message = "Dependency evidence unavailable: ${evidence.failures.joinToString("; ")}"
-                        baselineCheckIds.forEach { checkId ->
-                            architectureDiagnostics.getValue(checkId) +=
-                                VerificationDiagnostic.failure(
-                                    DiagnosticCode.DEPENDENCY_RESOLUTION_FAILED,
-                                    message,
-                                )
-                        }
-                    } else {
-                        val resolvedDependenciesFile = File(reportDir, "resolved-dependencies.json")
-                        reportDir.mkdirs()
-                        ReportNormalizer.writeJson(
-                            BaselineGenerator.sortResolvedDependencies(evidence.resolvedRecords),
-                            resolvedDependenciesFile,
-                        )
-                        BaselineVerifier(BaselineGenerator(context), context, reportDir).verify()
-                        routeBaselineDiagnostics(
-                            readBaselineDiagnostics(verificationReport),
-                            architectureDiagnostics,
-                            baselineCheckIds,
-                            ::baselineCheckFor,
+            // ---- Declared inputs (execution authority — a3 discipline) ----
+            val committedBaseline = project.layout.projectDirectory.file("config/quality/0.6.0-baseline.json")
+            if (committedBaseline.asFile.isFile) {
+                committedBaselineFile.set(committedBaseline)
+            } else {
+                committedBaselineFile.unset()
+            }
+            deviationsFile.set(project.layout.projectDirectory.file("config/quality/maintainability-deviations.yml"))
+            moduleCatalogFile.set(project.layout.projectDirectory.file("config/quality/module-catalog.yml"))
+            moduleBoundariesFile.set(project.layout.projectDirectory.file("config/quality/module-boundaries.yml"))
+            settingsFile.set(project.layout.projectDirectory.file("settings.gradle.kts"))
+            // api-migrations.yml is optional (absent in minimal fixtures and
+            // handled as empty by parseMigrations); set-but-missing would trip
+            // Gradle 9's eager @InputFile validation before the action runs.
+            val migrationsFile = project.layout.projectDirectory.file("config/quality/api-migrations.yml")
+            if (migrationsFile.asFile.isFile) {
+                apiMigrationsFile.set(migrationsFile)
+            } else {
+                apiMigrationsFile.unset()
+            }
+            baseRef.set(project.findProperty("changePolicyBase")?.toString() ?: "origin/master")
+            projectVersion.set(project.providers.gradleProperty("tramaiVersion").orElse("0.5.0"))
+            // Architecture gate owns its own report dir (the maintainability
+            // report dir belongs to verifyMaintainabilityBaselineTask).
+            this.reportDir.set(project.layout.buildDirectory.dir("reports/tramai/architecture"))
+            architectureReportFile.set(
+                project.layout.buildDirectory.file("reports/tramai/architecture/architecture-report.json"),
+            )
+            // Fail-soft probe outputs — typed task outputs, never a path walk.
+            dependencyProbeFiles.from(
+                architectureProbeProviders.map { probe -> probe.flatMap { it.outputFile } },
+            )
+            // Fail-soft consumer compile markers — typed task outputs (fixture
+            // projects; registered in registerConsumerCompatibilityTask).
+            consumerMarkers.from(consumerMarkerProviders.map { it.flatMap { task -> task.markerFile } })
+            // Measured tree: module sources/build files, settings, version
+            // properties, root build script + version catalog, committed api
+            // dumps, release notes (same universe as verifyMaintainabilityBaseline).
+            val measuredDirs =
+                project.allprojects
+                    .filter { it != project && it.buildFile.exists() }
+                    .flatMap { sub ->
+                        listOf(
+                            File(sub.projectDir, "src/main/kotlin"),
+                            File(sub.projectDir, "src/main/java"),
+                            File(sub.projectDir, "src/test/kotlin"),
+                            File(sub.projectDir, "src/testFixtures/kotlin"),
+                            sub.buildFile,
                         )
                     }
-                }
-
-                collectEvidence("module manifest verification", setOf("module-manifest", "publishing-topology"), architectureDiagnostics) {
-                    val catalog = ModuleManifest.catalog(project.rootDir)
-                    val actualProjects =
-                        project.allprojects
-                            .filter { it != project && it.buildFile.exists() }
-                            .map { it.path }
-                            .toSet()
-                    val actualPublished =
-                        (project.extensions.extraProperties.properties["tramai.publishableModulePaths"] as? Collection<*>)
-                            ?.map { it.toString() }
-                            ?.toSet()
-                            .orEmpty()
-                    val bomProject = project.allprojects.firstOrNull { it.name == "tramai-bom" }
-                    val actualBom =
-                        bomProject
-                            ?.configurations
-                            ?.findByName("api")
-                            ?.dependencyConstraints
-                            .orEmpty()
-                            .mapNotNull { constraint ->
-                                constraint.name.takeIf { it.startsWith("tramai-") || it.startsWith("examples:") }?.let { ":$it" }
-                            }.toSet()
-                    addManifestDiagnostics(
-                        ModuleManifestVerifier.verify(catalog.modules, actualProjects, actualPublished, actualBom),
-                        architectureDiagnostics,
-                    )
-                }
-
-                collectEvidence(
-                    "enrollment contract verification",
-                    setOf("provider-contracts", "store-contracts"),
-                    architectureDiagnostics,
-                ) {
-                    addEnrollmentDiagnostics(
-                        File(project.project(":tramai-testing").buildDir, "test-results/architectureContractEnrollmentTest"),
-                        architectureDiagnostics,
-                    )
-                }
-
-                collectEvidence("api compatibility verification", setOf("api-architecture"), architectureDiagnostics) {
-                    addApiCompatibilityDiagnostics(project, architectureDiagnostics)
-                }
-
-                val report = ArchitectureReportAggregator.aggregate(architectureDiagnostics)
-                val reportFile =
-                    File(
-                        project.layout.buildDirectory
-                            .get()
-                            .asFile,
-                        "reports/tramai/architecture/architecture-report.json",
-                    )
-                // Report is written BEFORE the terminal exception — failure must produce evidence.
-                ArchitectureReportJson.write(report, reportFile, project.rootDir)
-                if (report.status == ArchitectureCheckStatus.FAIL) {
-                    throw GradleException(
-                        "0.6.0 architecture verification FAILED: " +
-                            report.checks.filter { it.status == ArchitectureCheckStatus.FAIL }.joinToString { it.id } +
-                            " — see ${reportFile.path}",
-                    )
-                }
-            }
+            sourceTree.from(project.files(measuredDirs))
+            sourceTree.from(
+                project.files(
+                    project.rootDir.resolve("settings.gradle.kts"),
+                    project.rootDir.resolve("gradle.properties"),
+                    project.rootDir.resolve("build.gradle.kts"),
+                    project.rootDir.resolve("gradle/libs.versions.toml"),
+                ),
+            )
+            sourceTree.from(
+                project.fileTree(project.rootDir) {
+                    include("**/api/*.api", "docs/releases/0.6.0-maintainability-baseline.md")
+                },
+            )
         }
 
         // ---- Consumer compile proofs (Epic 10.2): real sources, real classes ----
@@ -1266,32 +1280,34 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
         // the markers as typed api-architecture evidence (B2 fail-closed model).
 
         registerConsumerCompatibilityTask(
-            project,
             "verifyJavaConsumerCompatibility",
             ":examples:java-consumer-smoke",
-            "src/main/java",
             "java",
             "java",
         )
         registerConsumerCompatibilityTask(
-            project,
             "verifyKotlinConsumerCompatibility",
             ":examples:kotlin-consumer-smoke",
-            "src/main/kotlin",
             "kotlin",
             "org.jetbrains.kotlin.jvm",
         )
         project.tasks.named("verify060Architecture") {
-            dependsOn(
-                ":examples:java-consumer-smoke:verifyJavaConsumerCompatibility",
-                ":examples:kotlin-consumer-smoke:verifyKotlinConsumerCompatibility",
-            )
+            // Depend on the collected producer providers, not hard-coded task
+            // paths: in minimal fixtures (TestKit) only the producers whose
+            // language plugin actually applied exist, and a missing path would
+            // abort task-graph resolution before the gate's report is written.
+            dependsOn(consumerMarkerProviders)
         }
 
         // Module documentation contract gate (Epic 11.2b3) — wired into the 0.6.0
         // architecture gate (verifyPr wiring follows its registration below).
-        project.tasks.named("verify060Architecture") {
-            dependsOn("verifyModuleDocContract")
+        // Registered by a separate plugin that minimal TestKit fixtures do not
+        // apply; guard so a missing task cannot abort task-graph resolution
+        // before the gate's fail-closed report is written.
+        if (project.tasks.findByName("verifyModuleDocContract") != null) {
+            project.tasks.named("verify060Architecture") {
+                dependsOn("verifyModuleDocContract")
+            }
         }
 
         // ---- PR Verification (primary local check gate) ----
@@ -1300,7 +1316,9 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             project.tasks.register("verifyPr") {
                 group = "verification"
                 description =
-                    "Primary local verification gate. Runs subproject tests, build-logic tests, maintainability baseline, and change policy. Not a full CI replica — see .github/AGENTS.md for additional step commands."
+                    "Primary local verification gate. Runs subproject tests, build-logic tests, " +
+                    "maintainability baseline, and change policy. Not a full CI replica — " +
+                    "see .github/AGENTS.md for additional step commands."
 
                 dependsOn("verifyMaintainabilityBaseline")
                 dependsOn("verifyChangePolicy")
@@ -1528,234 +1546,6 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
 
     private fun groovyString(value: String): String = value.replace("\\", "\\\\").replace("'", "\\'")
 
-    private fun readBaselineDiagnostics(reportFile: File): List<VerificationDiagnostic> {
-        if (!reportFile.isFile) {
-            throw GradleException("Baseline verifier did not produce ${reportFile.path}")
-        }
-        val report = ReportNormalizer.readJson(reportFile, Map::class.java)
-        val diagnostics =
-            report["diagnostics"] as? List<*>
-                ?: throw GradleException("Baseline verification report has no diagnostics array")
-        return diagnostics.map { raw ->
-            val entry = raw as? Map<*, *> ?: throw GradleException("Malformed baseline diagnostic")
-            VerificationDiagnostic(
-                code = DiagnosticCode.valueOf(entry["code"]?.toString() ?: error("Baseline diagnostic code missing")),
-                severity = DiagnosticSeverity.valueOf(entry["severity"]?.toString() ?: error("Baseline diagnostic severity missing")),
-                message = entry["message"]?.toString() ?: error("Baseline diagnostic message missing"),
-                modulePath = entry["modulePath"]?.toString(),
-                findingId = entry["findingId"]?.toString(),
-                deviationId = entry["deviationId"]?.toString(),
-                baselineValue = entry["baselineValue"]?.toString(),
-                currentValue = entry["currentValue"]?.toString(),
-            )
-        }
-    }
-
-    /**
-     * Exhaustive classification of every DiagnosticCode. No else branch: adding a
-     * new DiagnosticCode forces a decision at compile time — either it belongs to
-     * an architecture check here, or it is explicitly excluded.
-     */
-    private fun baselineCheckFor(code: DiagnosticCode): String? =
-        when (code) {
-            // Module catalogue (all codes except BOM/publishing drift, which are publishing-topology)
-            DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY,
-            DiagnosticCode.MODULE_CATALOG_UNKNOWN_ENTRY,
-            DiagnosticCode.MODULE_CATALOG_DUPLICATE_PATH,
-            DiagnosticCode.MODULE_CATALOG_INVALID_LAYER,
-            DiagnosticCode.MODULE_CATALOG_MISSING_API_STABILITY,
-            DiagnosticCode.MODULE_CATALOG_EXAMPLE_PUBLISHABLE,
-            DiagnosticCode.MODULE_CATALOG_DISAGREEMENT,
-            DiagnosticCode.MODULE_CATALOG_INVALID_SCHEMA,
-            DiagnosticCode.MODULE_CATALOG_INVALID_MATURITY,
-            DiagnosticCode.MODULE_CATALOG_INVALID_PUBLISHABILITY,
-            DiagnosticCode.MODULE_CATALOG_INVALID_VISIBILITY,
-            DiagnosticCode.MODULE_CATALOG_INVALID_RELEASE_INCLUSION,
-            DiagnosticCode.MODULE_CATALOG_INVALID_POLICY,
-            DiagnosticCode.MODULE_CATALOG_BLANK_OWNER,
-            DiagnosticCode.MODULE_CATALOG_BLANK_RATIONALE,
-            DiagnosticCode.MODULE_CATALOG_MISSING_DESCRIPTION,
-            DiagnosticCode.MODULE_CATALOG_INVALID_COMBINATION,
-            -> "module-manifest"
-
-            DiagnosticCode.MODULE_CATALOG_BOM_DRIFT,
-            DiagnosticCode.MODULE_CATALOG_PUBLISHING_DRIFT,
-            -> "publishing-topology"
-
-            DiagnosticCode.FORBIDDEN_LAYER_EDGE,
-            DiagnosticCode.SELF_DEPENDENCY,
-            -> "dependency-boundaries"
-
-            DiagnosticCode.NEW_DEPENDENCY_CYCLE,
-            -> "dependency-cycles"
-
-            DiagnosticCode.NEW_GLOBAL_STATE_FINDING,
-            -> "global-state"
-
-            DiagnosticCode.API_BASELINE_EMPTY,
-            DiagnosticCode.API_DUMP_MISSING,
-            DiagnosticCode.API_DUMP_DUPLICATE,
-            DiagnosticCode.API_MODULE_UNCLASSIFIED,
-            DiagnosticCode.API_VALIDATION_NOT_CONFIGURED,
-            DiagnosticCode.API_COMPATIBILITY_FAILED,
-            DiagnosticCode.API_HASH_CHANGED,
-            DiagnosticCode.API_DUMP_NONDETERMINISTIC,
-            -> "api-architecture"
-
-            DiagnosticCode.STABLE_PROTOCOL_CONTRACT_REMOVED,
-            -> "protocol-catalog"
-
-            DiagnosticCode.NEW_CANCELLATION_FINDING,
-            DiagnosticCode.CANCELLATION_RISK_WORSENED,
-            -> "cancellation-safety"
-
-            // Explicitly outside the 0.6.0 architecture gate.
-            DiagnosticCode.BASELINE_IDENTITY_MISMATCH,
-            DiagnosticCode.ANALYZER_COMMIT_NOT_ANCESTOR,
-            DiagnosticCode.MEASURED_TREE_MISMATCH,
-            DiagnosticCode.TAG_COMMIT_MISMATCH,
-            DiagnosticCode.TAG_TREE_MISMATCH,
-            DiagnosticCode.DIRTY_WORKTREE,
-            DiagnosticCode.DEPENDENCY_BASELINE_EMPTY,
-            DiagnosticCode.DEPENDENCY_RESOLUTION_FAILED,
-            DiagnosticCode.DYNAMIC_DEPENDENCY_VERSION,
-            DiagnosticCode.SNAPSHOT_DEPENDENCY,
-            DiagnosticCode.DEPENDENCY_CONVERGENCE_FAILURE,
-            DiagnosticCode.DEPENDENCY_ADDED,
-            DiagnosticCode.DEPENDENCY_REMOVED,
-            DiagnosticCode.DEPENDENCY_VERSION_CHANGED,
-            DiagnosticCode.TEST_QUALITY_CONFIGURATION_INVALID,
-            DiagnosticCode.COVERAGE_REPORT_MISSING,
-            DiagnosticCode.COVERAGE_REPORT_MALFORMED,
-            DiagnosticCode.COVERAGE_COUNTER_MISSING,
-            DiagnosticCode.COVERAGE_PATH_LEAK,
-            DiagnosticCode.COVERAGE_REGRESSION,
-            DiagnosticCode.COVERAGE_FAMILY_EMPTY,
-            DiagnosticCode.COVERAGE_EXCLUSION_UNDOCUMENTED,
-            DiagnosticCode.MUTATION_REPORT_MISSING,
-            DiagnosticCode.MUTATION_REPORT_MALFORMED,
-            DiagnosticCode.MUTATION_TARGET_EMPTY,
-            DiagnosticCode.MUTATION_REGRESSION,
-            DiagnosticCode.MUTATION_SURVIVOR_UNCLASSIFIED,
-            DiagnosticCode.MUTATION_MISSING_TEST_UNTRACKED,
-            DiagnosticCode.TEST_REPORT_MISSING,
-            DiagnosticCode.TEST_PERFORMANCE_REGRESSION,
-            DiagnosticCode.CRITICAL_TEST_REGRESSION,
-            DiagnosticCode.CRITICAL_TEST_NEWLY_SKIPPED,
-            DiagnosticCode.TEST_QUALITY_STATUS_PENDING,
-            DiagnosticCode.NEW_NONDETERMINISM_FINDING,
-            DiagnosticCode.HOTSPOT_REGRESSION,
-            DiagnosticCode.NEW_TOP_FIVE_HOTSPOT,
-            DiagnosticCode.FILE_GROWTH_EXCEEDED,
-            DiagnosticCode.INVALID_DEVIATION_SCOPE,
-            DiagnosticCode.ORPHANED_DEVIATION,
-            DiagnosticCode.EXPIRED_DEVIATION,
-            DiagnosticCode.DUPLICATE_DEVIATION,
-            DiagnosticCode.MALFORMED_DEVIATION,
-            DiagnosticCode.DEVIATION_BASELINE_MISMATCH,
-            DiagnosticCode.DEVIATION_COVERAGE_EXCEEDED,
-            DiagnosticCode.GENERATED_DOCUMENT_DRIFT,
-            DiagnosticCode.EMPTY_SECTION,
-            // Nondeterminism authority contract (Epic 8.3d PR 2) — enforced by the
-            // verifyRuntimeNondeterminism task directly, not the maintainability baseline.
-            DiagnosticCode.NONDETERMINISM_UNCLASSIFIED_FINDING,
-            DiagnosticCode.NONDETERMINISM_STALE_ENTRY,
-            DiagnosticCode.NONDETERMINISM_MISMATCHED_CLASSIFICATION,
-            DiagnosticCode.NONDETERMINISM_OCCURRENCE_MISMATCH,
-            DiagnosticCode.NONDETERMINISM_DUPLICATE_ENTRY,
-            DiagnosticCode.NONDETERMINISM_INVALID_DISPOSITION,
-            DiagnosticCode.NONDETERMINISM_MISSING_RATIONALE,
-            DiagnosticCode.NONDETERMINISM_INVALID_SCHEMA,
-            // Module documentation contract (Epic 11.2b3) — enforced by the
-            // verifyModuleDocContract task directly, not a maintainability baseline.
-            DiagnosticCode.MODULE_CARD_MISSING,
-            DiagnosticCode.MODULE_CARD_ORPHAN,
-            DiagnosticCode.MODULE_CARD_HEADING_MISSING,
-            DiagnosticCode.MODULE_CARD_LINK_BROKEN,
-            DiagnosticCode.MODULE_CARD_INLINE_PATH_BROKEN,
-            DiagnosticCode.MODULE_CARD_LEGACY_CLASSIFICATION,
-            DiagnosticCode.MODULE_CARD_VERSIONLESS_DEPENDENCY,
-            DiagnosticCode.MODULE_CARD_INTERNAL_MAVEN_ADVERTISEMENT,
-            DiagnosticCode.MODULE_CARD_COVERAGE_MISMATCH,
-            -> null
-        }
-
-    private fun addManifestDiagnostics(
-        diagnostics: List<VerificationDiagnostic>,
-        checks: Map<String, MutableList<VerificationDiagnostic>>,
-    ) {
-        diagnostics.forEach { diagnostic ->
-            val check = if (diagnostic.code in publishingTopologyCodes) "publishing-topology" else "module-manifest"
-            checks.getValue(check) += diagnostic
-        }
-    }
-
-    private fun addEnrollmentDiagnostics(
-        resultsDir: File,
-        checks: Map<String, MutableList<VerificationDiagnostic>>,
-    ) {
-        val reports =
-            resultsDir
-                .listFiles { file -> file.isFile && file.name.startsWith("TEST-") && file.extension == "xml" }
-                ?.sortedBy { it.name }
-                .orEmpty()
-        if (reports.isEmpty()) {
-            listOf("provider-contracts", "store-contracts").forEach { check ->
-                checks.getValue(check) +=
-                    VerificationDiagnostic.failure(
-                        DiagnosticCode.EMPTY_SECTION,
-                        "Enrollment architecture test results are missing from ${resultsDir.path}",
-                    )
-            }
-            return
-        }
-
-        val discoveredClasses = mutableSetOf<String>()
-        reports.forEach { report ->
-            val className = report.name.removePrefix("TEST-").removeSuffix(".xml")
-            discoveredClasses += className
-            val check =
-                when {
-                    className == "dev.tramai.testing.ProviderTckEnrollmentArchitectureTest" -> "provider-contracts"
-                    className.endsWith("EnrollmentArchitectureTest") -> "store-contracts"
-                    else -> null
-                } ?: return@forEach
-            val factory =
-                DocumentBuilderFactory.newInstance().apply {
-                    setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
-                    setFeature("http://xml.org/sax/features/external-general-entities", false)
-                    setFeature("http://xml.org/sax/features/external-parameter-entities", false)
-                    setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
-                    setAttribute("http://javax.xml.XMLConstants/property/accessExternalDTD", "")
-                    setAttribute("http://javax.xml.XMLConstants/property/accessExternalSchema", "")
-                    isXIncludeAware = false
-                    isExpandEntityReferences = false
-                }
-            val document = factory.newDocumentBuilder().parse(report)
-            val cases = document.getElementsByTagName("testcase")
-            for (index in 0 until cases.length) {
-                val testCase = cases.item(index) as org.w3c.dom.Element
-                for (childIndex in 0 until testCase.childNodes.length) {
-                    val child = testCase.childNodes.item(childIndex)
-                    if (child.nodeName !in setOf("failure", "error")) continue
-                    val failure = child as org.w3c.dom.Element
-                    val message = failure.getAttribute("message").ifBlank { failure.textContent.trim() }
-                    checks.getValue(check) +=
-                        VerificationDiagnostic.failure(
-                            DiagnosticCode.EMPTY_SECTION,
-                            "$className failed: $message",
-                        )
-                }
-            }
-        }
-
-        // Pin guard identities: deleting/renaming one enrollment class must FAIL
-        // even if the others still run. Discovery by identity, not by count.
-        enrollmentGuardDiagnostics(discoveredClasses).forEach { (check, diagnostics) ->
-            checks.getValue(check) += diagnostics
-        }
-    }
-
     /**
      * Registers a consumer-compatibility PRODUCER task (Epic 10.2, C3/C4).
      *
@@ -1771,171 +1561,58 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
      *   { "sources": N, "classes": M, "exitCode": E, "ok": bool }
      */
     private fun registerConsumerCompatibilityTask(
-        project: Project,
         taskName: String,
         modulePath: String,
-        sourceRelPath: String,
         extension: String,
         languagePluginId: String,
     ) {
-        // D6: the producer task belongs to the FIXTURE project, which owns its
-        // configurations. Resolving them inside the task action is therefore
-        // legal (project-owned, lazy, execution-phase) — a root task resolving
-        // a foreign project's configuration would trip the exclusive-lock rule.
-        // The fixture project applies its language plugin after the root plugin
-        // block, so register lazily via withPlugin: JavaToolchainService only
-        // exists then, and launcherFor/compilerFor providers are CC-serializable.
-        // fixture lookup happens inside the callback so a build that does not
-        // include the fixture (TestKit, minimal settings) never trips eagerly.
-        project.rootProject.subprojects.forEach { fixture ->
+        rootProject.subprojects.forEach { fixture ->
             if (fixture.path != modulePath) return@forEach
             fixture.pluginManager.withPlugin(languagePluginId) {
                 val markerFile = fixture.layout.buildDirectory.file("reports/maintainability/consumer-$extension.json")
                 val classesDir = fixture.layout.buildDirectory.dir("reports/maintainability/consumer-$extension-classes")
 
-                fixture.tasks.register<ConsumerSmokeCompileTask>(taskName) {
-                    group = "verification"
-                    description = "Compiles the $extension consumer smoke fixture against the stable API (fail-soft producer, Epic 10.2)"
+                val task =
+                    fixture.tasks.register<ConsumerSmokeCompileTask>(taskName) {
+                        group = "verification"
+                        description =
+                            "Compiles the $extension consumer smoke fixture against the stable API"
 
-                    // Only the dependency's jar must exist for the classpath. The
-                    // fixture's own compile tasks are deliberately NOT dependencies:
-                    // compileKotlin has no failOnError and would abort the graph
-                    // before verify060Architecture's report is written (C3/C4).
-                    dependsOn(":tramai-core:jar")
+                        dependsOn(":tramai-core:jar")
 
-                    this.extension.set(extension)
-                    this.workDir.set(project.rootDir)
-                    val toolchains = fixture.extensions.getByType(JavaToolchainService::class.java)
-                    if (extension == "java") {
-                        this.javacExecutable.set(
-                            toolchains
-                                .compilerFor { languageVersion.set(JavaLanguageVersion.of(21)) }
-                                .map { it.executablePath.toString() },
+                        this.extension.set(extension)
+                        this.workDir.set(project.rootDir)
+                        val toolchains = fixture.extensions.getByType(JavaToolchainService::class.java)
+                        if (extension == "java") {
+                            this.javacExecutable.set(
+                                toolchains
+                                    .compilerFor { languageVersion.set(JavaLanguageVersion.of(21)) }
+                                    .map { it.executablePath.toString() },
+                            )
+                        } else {
+                            this.javaExecutable.set(
+                                toolchains
+                                    .launcherFor { languageVersion.set(JavaLanguageVersion.of(21)) }
+                                    .map { it.executablePath.toString() },
+                            )
+                        }
+                        this.classesDir.set(classesDir)
+                        this.markerFile.set(markerFile)
+                        val sourceDir = if (extension == "kotlin") "kotlin" else "java"
+                        val sourceExt = if (extension == "kotlin") "kt" else "java"
+                        val sourceGlob = "**/src/main/$sourceDir/**/*.$sourceExt"
+                        sources.from(
+                            fixture.fileTree(fixture.projectDir) {
+                                include(sourceGlob)
+                            },
                         )
-                    } else {
-                        this.javaExecutable.set(
-                            toolchains
-                                .launcherFor { languageVersion.set(JavaLanguageVersion.of(21)) }
-                                .map { it.executablePath.toString() },
-                        )
+                        compileClasspath.from(fixture.configurations.getByName("compileClasspath"))
+                        if (extension == "kotlin") {
+                            kotlinCompilerClasspath.from(fixture.configurations.getByName("kotlinCompilerClasspath"))
+                        }
                     }
-                    this.classesDir.set(classesDir)
-                    this.markerFile.set(markerFile)
-                    sources.from(
-                        fixture.fileTree(fixture.projectDir) {
-                            include("**/$sourceRelPath/**/*.${if (extension == "kotlin") "kt" else "java"}")
-                        },
-                    )
-                    compileClasspath.from(fixture.configurations.getByName("compileClasspath"))
-                    if (extension == "kotlin") {
-                        kotlinCompilerClasspath.from(fixture.configurations.getByName("kotlinCompilerClasspath"))
-                    }
-                }
+                consumerMarkerProviders.add(task)
             }
         }
-    }
-
-    /**
-     * Epic 10.2 (Track B3): semantic API compatibility evidence for the
-     * api-architecture check. Two contracts:
-     *   Contract 1 — current source (apiBuild output) vs committed dump.
-     *   Contract 2 — base-branch dump (git show) vs current committed dump;
-     *                drives stability policy via ApiCompatibilityVerifier.
-     * Plus migration-registry enforcement and stability-inversion leak scan.
-     * All diagnostics are API_* codes routed to api-architecture; the report
-     * is written before any terminal exception (fail-closed via collectEvidence).
-     */
-    private fun addApiCompatibilityDiagnostics(
-        project: Project,
-        checks: Map<String, MutableList<VerificationDiagnostic>>,
-    ) {
-        val catalog = ModuleManifest.catalog(project.rootDir)
-        val apiProjectPaths =
-            project.allprojects
-                .filter { it != project && it.tasks.findByName("apiCheck") != null }
-                .map { it.path }
-                .toSet()
-        val committed = ApiCompatibilityEvidenceReader.readCommittedDumps(project.rootDir, apiProjectPaths)
-        val generated = ApiCompatibilityEvidenceReader.readGeneratedDumps(project)
-        val baseRef = project.findProperty("changePolicyBase")?.toString() ?: "origin/master"
-        val base = ApiCompatibilityEvidenceReader.readBaseDumps(project.rootDir, baseRef, committed.keys)
-        val migrationResult =
-            ApiCompatibilityEvidenceReader.parseMigrations(
-                File(project.rootDir, "config/quality/api-migrations.yml"),
-            )
-        checks.getValue("api-architecture") += migrationResult.diagnostics
-        val projectVersion =
-            project.providers
-                .gradleProperty("tramaiVersion")
-                .orElse("0.5.0")
-                .get()
-        val verifier =
-            ApiCompatibilityVerifier(
-                catalogModules = catalog.modules,
-                projectVersion = projectVersion,
-            )
-        val diagnostics =
-            verifier.verify(
-                ApiDumpEvidence(generated = generated, committed = committed, base = base),
-                migrations = migrationResult.entries,
-            )
-        // Contract-1/2 and migration diagnostics flow straight to api-architecture.
-        checks.getValue("api-architecture") += diagnostics
-        // C3/C4: consumer compile proofs are fail-soft producers. Read their
-        // markers; a failed compile surfaces as typed evidence here, and the
-        // report is written before the gate throws (B2 fail-closed contract).
-        listOf(
-            "java" to ":examples:java-consumer-smoke",
-            "kotlin" to ":examples:kotlin-consumer-smoke",
-        ).forEach { (language, fixturePath) ->
-            val marker =
-                File(
-                    project
-                        .project(fixturePath)
-                        .layout.buildDirectory
-                        .get()
-                        .asFile,
-                    "reports/maintainability/consumer-$language.json",
-                )
-            if (!marker.isFile) {
-                checks.getValue("api-architecture") +=
-                    VerificationDiagnostic.failure(
-                        DiagnosticCode.API_COMPATIBILITY_FAILED,
-                        "Consumer compile proof for '$language' produced no marker evidence at ${marker.path}",
-                    )
-                return@forEach
-            }
-            val state = ReportNormalizer.readJson(marker, Map::class.java)
-            val ok = state?.get("ok") == true
-            if (!ok) {
-                checks.getValue("api-architecture") +=
-                    VerificationDiagnostic.failure(
-                        DiagnosticCode.API_COMPATIBILITY_FAILED,
-                        "Consumer compile proof FAILED for '$language': " +
-                            "sources=${state?.get("sources")} classes=${state?.get("classes")} " +
-                            "exitCode=${state?.get("exitCode")} — the stable API is not usable from this consumer",
-                        baselineValue = state?.get("sources")?.toString(),
-                        currentValue = state?.get("classes")?.toString(),
-                    )
-            }
-        }
-    }
-
-    private companion object {
-        val publishingTopologyCodes =
-            setOf(
-                DiagnosticCode.MODULE_CATALOG_BOM_DRIFT,
-                DiagnosticCode.MODULE_CATALOG_PUBLISHING_DRIFT,
-            )
-        val baselineCheckIds =
-            setOf(
-                "module-manifest",
-                "dependency-boundaries",
-                "dependency-cycles",
-                "global-state",
-                "api-architecture",
-                "protocol-catalog",
-                "cancellation-safety",
-            )
     }
 }

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/VerifyArchitectureTask.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/VerifyArchitectureTask.kt
@@ -252,11 +252,23 @@ abstract class VerifyArchitectureTask : DefaultTask() {
     ) {
         val apiProjectPaths = apiValidationModules.get().toSet()
         val committed = ApiCompatibilityEvidenceReader.readCommittedDumps(rootDir, apiProjectPaths)
+        // Ordered pairing contract (a3c1 discipline): owner[i] <-> file[i].
+        // ConfigurableFileCollection iterates in insertion order (toList()),
+        // unlike the unordered Set<File> view of .files. Fail closed on
+        // cardinality mismatch and duplicate owners instead of mispairing.
+        val dumpOwners = generatedApiDumpOwners.get()
+        val dumpFiles = generatedApiDumpFiles.toList()
+        require(dumpOwners.size == dumpFiles.size) {
+            "Generated API dump owner/file evidence mismatch: " +
+                "${dumpOwners.size} owners, ${dumpFiles.size} files"
+        }
+        require(dumpOwners.distinct().size == dumpOwners.size) {
+            "Duplicate generated API dump owner evidence: ${dumpOwners.sorted()}"
+        }
         val generated =
-            generatedApiDumpOwners
-                .get()
-                .zip(generatedApiDumpFiles.files)
-                .associate { (modulePath, file) -> modulePath to file.readText(Charsets.UTF_8) }
+            dumpOwners.zip(dumpFiles).associate { (modulePath, file) ->
+                modulePath to file.readText(Charsets.UTF_8)
+            }
         val base = ApiCompatibilityEvidenceReader.readBaseDumps(rootDir, baseRef.get(), committed.keys)
         val migrationResult =
             ApiCompatibilityEvidenceReader.parseMigrations(

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/VerifyArchitectureTask.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/VerifyArchitectureTask.kt
@@ -103,10 +103,21 @@ abstract class VerifyArchitectureTask : DefaultTask() {
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val enrollmentResultsDir: ConfigurableFileCollection
 
-    /** Generated BCV dumps (apiBuild task outputs). */
+    /**
+     * Generated BCV dumps (apiBuild task outputs) — the EXACT files the
+     * action reads. Each entry in [generatedApiDumpOwners] is the module path
+     * of the file at the same index in [generatedApiDumpFiles]; the action
+     * zips them into the module→content map. No conventional-path rediscovery
+     * (a3c3 P1: declared output must be the execution authority, not
+     * <module>/build/api/<name>.api).
+     */
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    abstract val generatedApiDumps: ConfigurableFileCollection
+    abstract val generatedApiDumpFiles: ConfigurableFileCollection
+
+    /** Module path per generated dump file, same order as [generatedApiDumpFiles]. */
+    @get:Input
+    abstract val generatedApiDumpOwners: ListProperty<String>
 
     /** Consumer compile-proof markers (fail-soft producer outputs). */
     @get:InputFiles
@@ -241,7 +252,11 @@ abstract class VerifyArchitectureTask : DefaultTask() {
     ) {
         val apiProjectPaths = apiValidationModules.get().toSet()
         val committed = ApiCompatibilityEvidenceReader.readCommittedDumps(rootDir, apiProjectPaths)
-        val generated = ApiCompatibilityEvidenceReader.readGeneratedDumps(rootDir, apiProjectPaths)
+        val generated =
+            generatedApiDumpOwners
+                .get()
+                .zip(generatedApiDumpFiles.files)
+                .associate { (modulePath, file) -> modulePath to file.readText(Charsets.UTF_8) }
         val base = ApiCompatibilityEvidenceReader.readBaseDumps(rootDir, baseRef.get(), committed.keys)
         val migrationResult =
             ApiCompatibilityEvidenceReader.parseMigrations(

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/VerifyArchitectureTask.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/VerifyArchitectureTask.kt
@@ -252,23 +252,7 @@ abstract class VerifyArchitectureTask : DefaultTask() {
     ) {
         val apiProjectPaths = apiValidationModules.get().toSet()
         val committed = ApiCompatibilityEvidenceReader.readCommittedDumps(rootDir, apiProjectPaths)
-        // Ordered pairing contract (a3c1 discipline): owner[i] <-> file[i].
-        // ConfigurableFileCollection iterates in insertion order (toList()),
-        // unlike the unordered Set<File> view of .files. Fail closed on
-        // cardinality mismatch and duplicate owners instead of mispairing.
-        val dumpOwners = generatedApiDumpOwners.get()
-        val dumpFiles = generatedApiDumpFiles.toList()
-        require(dumpOwners.size == dumpFiles.size) {
-            "Generated API dump owner/file evidence mismatch: " +
-                "${dumpOwners.size} owners, ${dumpFiles.size} files"
-        }
-        require(dumpOwners.distinct().size == dumpOwners.size) {
-            "Duplicate generated API dump owner evidence: ${dumpOwners.sorted()}"
-        }
-        val generated =
-            dumpOwners.zip(dumpFiles).associate { (modulePath, file) ->
-                modulePath to file.readText(Charsets.UTF_8)
-            }
+        val generated = readDeclaredGeneratedDumps()
         val base = ApiCompatibilityEvidenceReader.readBaseDumps(rootDir, baseRef.get(), committed.keys)
         val migrationResult =
             ApiCompatibilityEvidenceReader.parseMigrations(
@@ -314,6 +298,28 @@ abstract class VerifyArchitectureTask : DefaultTask() {
                         currentValue = state?.get("classes")?.toString(),
                     )
             }
+        }
+    }
+
+    /**
+     * Read the declared generated dump files into a module→content map.
+     * Ordered pairing contract (a3c1 discipline): owner[i] <-> file[i].
+     * ConfigurableFileCollection iterates in insertion order (toList()),
+     * unlike the unordered Set<File> view of .files. Fail closed on
+     * cardinality mismatch and duplicate owners instead of mispairing.
+     */
+    private fun readDeclaredGeneratedDumps(): Map<String, String> {
+        val dumpOwners = generatedApiDumpOwners.get()
+        val dumpFiles = generatedApiDumpFiles.toList()
+        require(dumpOwners.size == dumpFiles.size) {
+            "Generated API dump owner/file evidence mismatch: " +
+                "${dumpOwners.size} owners, ${dumpFiles.size} files"
+        }
+        require(dumpOwners.distinct().size == dumpOwners.size) {
+            "Duplicate generated API dump owner evidence: ${dumpOwners.sorted()}"
+        }
+        return dumpOwners.zip(dumpFiles).associate { (modulePath, file) ->
+            modulePath to file.readText(Charsets.UTF_8)
         }
     }
 

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/VerifyArchitectureTask.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/VerifyArchitectureTask.kt
@@ -1,0 +1,524 @@
+package dev.tramai.build.quality
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+/**
+ * Typed 0.6.0 architecture gate (Epic 9.2d-a3c3). Same semantics as the
+ * legacy doLast gate in MaintainabilityBaselinePlugin, but executes in
+ * directory mode with declared inputs as the sole execution authority:
+ *
+ *  - baseline verification runs the same [BaselineVerifier] with
+ *    [DeclaredBaselineInputs] (a3c2 machinery, including the configuration-time
+ *    [DependencyGraphSnapshot] for cycle/forbidden-edge/policy enforcement)
+ *  - fail-soft per-project dependency probes arrive as declared [dependencyProbeFiles]
+ *  - module-manifest, enrollment and api-compatibility evidence arrive as
+ *    configuration-time snapshots / declared file inputs
+ *  - the report is written BEFORE the terminal exception (fail-closed contract)
+ *
+ * No Task.project access at execution time (a3 discipline).
+ */
+@Suppress("LongParameterList") // named-arg task; keeps the wiring block readable
+abstract class VerifyArchitectureTask : DefaultTask() {
+    private companion object {
+        val publishingTopologyCodes =
+            setOf(
+                DiagnosticCode.MODULE_CATALOG_BOM_DRIFT,
+                DiagnosticCode.MODULE_CATALOG_PUBLISHING_DRIFT,
+            )
+        val baselineCheckIds =
+            setOf(
+                "module-manifest",
+                "dependency-boundaries",
+                "dependency-cycles",
+                "global-state",
+                "api-architecture",
+                "protocol-catalog",
+                "cancellation-safety",
+            )
+    }
+
+    @get:InputFile
+    @get:Optional
+    abstract val committedBaselineFile: RegularFileProperty
+
+    @get:InputFile
+    abstract val deviationsFile: RegularFileProperty
+
+    @get:InputFile
+    abstract val moduleCatalogFile: RegularFileProperty
+
+    @get:InputFile
+    abstract val moduleBoundariesFile: RegularFileProperty
+
+    /** Settings script the root is derived from (same rule as a3c2). */
+    @get:InputFile
+    abstract val settingsFile: RegularFileProperty
+
+    /** Project dependency graph captured at configuration time (a3c2 machinery). */
+    @get:Input
+    abstract val dependencyGraph: Property<DependencyGraphSnapshot>
+
+    /** Fail-soft per-project probe outputs (architectureDependencyProbe). */
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val dependencyProbeFiles: ConfigurableFileCollection
+
+    /** apiCheck module paths — configuration-time snapshot (a3c1 discipline). */
+    @get:Input
+    abstract val apiValidationModules: ListProperty<String>
+
+    /** Actual Gradle project paths (manifest verification) — config-time snapshot. */
+    @get:Input
+    abstract val actualProjectPaths: ListProperty<String>
+
+    /** Configured publishable module paths (manifest verification) — config-time snapshot. */
+    @get:Input
+    abstract val publishedModulePaths: ListProperty<String>
+
+    /** tramai-bom api constraint module paths (manifest verification) — config-time snapshot. */
+    @get:Input
+    abstract val bomModulePaths: ListProperty<String>
+
+    /** Enrollment contract XML results (architectureContractEnrollmentTest junitXml output). */
+    @get:InputFiles
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val enrollmentResultsDir: ConfigurableFileCollection
+
+    /** Generated BCV dumps (apiBuild task outputs). */
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val generatedApiDumps: ConfigurableFileCollection
+
+    /** Consumer compile-proof markers (fail-soft producer outputs). */
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val consumerMarkers: ConfigurableFileCollection
+
+    @get:InputFile
+    @get:Optional
+    abstract val apiMigrationsFile: RegularFileProperty
+
+    /** Base-branch ref for `git show` base dumps (changePolicyBase or origin/master). */
+    @get:Input
+    abstract val baseRef: Property<String>
+
+    @get:Input
+    abstract val projectVersion: Property<String>
+
+    /** Measured repository tree (source, build scripts, committed api dumps, docs). */
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val sourceTree: ConfigurableFileCollection
+
+    @get:OutputDirectory
+    abstract val reportDir: DirectoryProperty
+
+    @get:OutputFile
+    abstract val architectureReportFile: RegularFileProperty
+
+    @TaskAction
+    fun verify() {
+        val rootDir = settingsFile.get().asFile.parentFile
+        val catalog = ModuleCatalog(moduleCatalogFile.get().asFile)
+        val catalogResult = catalog.parse()
+        val ctx = MeasurementContext.fromDirectory(rootDir, catalog)
+        val architectureDiagnostics =
+            ArchitectureReportAggregator.checkIds
+                .associateWith { mutableListOf<VerificationDiagnostic>() }
+
+        collectEvidence("baseline verification", baselineCheckIds, architectureDiagnostics) {
+            val probeFiles = dependencyProbeFiles.files.sortedBy { it.path }
+            val evidence = readDependencyProbeEvidence(probeFiles)
+            if (evidence.failures.isNotEmpty()) {
+                val message = "Dependency evidence unavailable: ${evidence.failures.joinToString("; ")}"
+                baselineCheckIds.forEach { checkId ->
+                    architectureDiagnostics.getValue(checkId) +=
+                        VerificationDiagnostic.failure(
+                            DiagnosticCode.DEPENDENCY_RESOLUTION_FAILED,
+                            message,
+                        )
+                }
+            } else {
+                val resolvedDependenciesFile = File(reportDir.get().asFile, "resolved-dependencies.json")
+                reportDir.get().asFile.mkdirs()
+                ReportNormalizer.writeJson(
+                    BaselineGenerator.sortResolvedDependencies(evidence.resolvedRecords),
+                    resolvedDependenciesFile,
+                )
+                val generator =
+                    BaselineGenerator(
+                        ctx = ctx,
+                        outputDir = reportDir.get().asFile,
+                        writeRepositoryArtifacts = false,
+                    )
+                BaselineVerifier(
+                    generator = generator,
+                    ctx = ctx,
+                    reportDir = reportDir.get().asFile,
+                    declaredInputs =
+                        DeclaredBaselineInputs(
+                            committedBaselineFile = committedBaselineFile.orNull?.asFile,
+                            resolvedDependenciesFile = resolvedDependenciesFile,
+                            apiValidationModules = apiValidationModules.get().toSet(),
+                            deviationsFile = deviationsFile.get().asFile,
+                            moduleCatalogFile = moduleCatalogFile.get().asFile,
+                            moduleBoundariesFile = moduleBoundariesFile.get().asFile,
+                            dependencyGraph = dependencyGraph.get(),
+                        ),
+                ).verify()
+                routeBaselineDiagnostics(
+                    readBaselineDiagnostics(File(reportDir.get().asFile, "verification-report.json")),
+                    architectureDiagnostics,
+                    baselineCheckIds,
+                    ::baselineCheckFor,
+                )
+            }
+        }
+
+        collectEvidence(
+            "module manifest verification",
+            setOf("module-manifest", "publishing-topology"),
+            architectureDiagnostics,
+        ) {
+            val actualProjects = actualProjectPaths.get().toSet()
+            val actualPublished = publishedModulePaths.get().toSet()
+            val actualBom = bomModulePaths.get().toSet()
+            addManifestDiagnostics(
+                ModuleManifestVerifier.verify(catalogResult.modules, actualProjects, actualPublished, actualBom),
+                architectureDiagnostics,
+            )
+        }
+
+        collectEvidence(
+            "enrollment contract verification",
+            setOf("provider-contracts", "store-contracts"),
+            architectureDiagnostics,
+        ) {
+            addEnrollmentDiagnostics(enrollmentResultsDir.files, architectureDiagnostics)
+        }
+
+        collectEvidence("api compatibility verification", setOf("api-architecture"), architectureDiagnostics) {
+            addApiCompatibilityDiagnostics(rootDir, catalogResult.modules, architectureDiagnostics)
+        }
+
+        val report = ArchitectureReportAggregator.aggregate(architectureDiagnostics)
+        val reportFile = architectureReportFile.get().asFile
+        // Report is written BEFORE the terminal exception — failure must produce evidence.
+        ArchitectureReportJson.write(report, reportFile, rootDir)
+        if (report.status == ArchitectureCheckStatus.FAIL) {
+            throw GradleException(
+                "0.6.0 architecture verification FAILED: " +
+                    report.checks.filter { it.status == ArchitectureCheckStatus.FAIL }.joinToString { it.id } +
+                    " — see ${reportFile.path}",
+            )
+        }
+        println("0.6.0 architecture verification PASSED — see ${reportFile.path}")
+    }
+
+    private fun addApiCompatibilityDiagnostics(
+        rootDir: File,
+        catalogModules: Map<String, ModuleCatalog.ModuleEntry>,
+        checks: Map<String, MutableList<VerificationDiagnostic>>,
+    ) {
+        val apiProjectPaths = apiValidationModules.get().toSet()
+        val committed = ApiCompatibilityEvidenceReader.readCommittedDumps(rootDir, apiProjectPaths)
+        val generated = ApiCompatibilityEvidenceReader.readGeneratedDumps(rootDir, apiProjectPaths)
+        val base = ApiCompatibilityEvidenceReader.readBaseDumps(rootDir, baseRef.get(), committed.keys)
+        val migrationResult =
+            ApiCompatibilityEvidenceReader.parseMigrations(
+                apiMigrationsFile.orNull?.asFile ?: File(rootDir, "config/quality/api-migrations.yml"),
+            )
+        checks.getValue("api-architecture") += migrationResult.diagnostics
+        val verifier =
+            ApiCompatibilityVerifier(
+                catalogModules = catalogModules,
+                projectVersion = projectVersion.get(),
+            )
+        val diagnostics =
+            verifier.verify(
+                ApiDumpEvidence(generated = generated, committed = committed, base = base),
+                migrations = migrationResult.entries,
+            )
+        checks.getValue("api-architecture") += diagnostics
+        // C3/C4: consumer compile proofs are fail-soft producers. Read their
+        // declared markers; a failed compile surfaces as typed evidence here,
+        // and the report is written before the gate throws (B2 fail-closed).
+        listOf("java", "kotlin").forEach { language ->
+            val marker =
+                consumerMarkers.files
+                    .firstOrNull { it.name == "consumer-$language.json" }
+            if (marker == null) {
+                checks.getValue("api-architecture") +=
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.API_COMPATIBILITY_FAILED,
+                        "Consumer compile proof for '$language' produced no marker evidence",
+                    )
+                return@forEach
+            }
+            val state = ReportNormalizer.readJson(marker, Map::class.java)
+            val ok = state?.get("ok") == true
+            if (!ok) {
+                checks.getValue("api-architecture") +=
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.API_COMPATIBILITY_FAILED,
+                        "Consumer compile proof FAILED for '$language': " +
+                            "sources=${state?.get("sources")} classes=${state?.get("classes")} " +
+                            "exitCode=${state?.get("exitCode")} — the stable API is not usable from this consumer",
+                        baselineValue = state?.get("sources")?.toString(),
+                        currentValue = state?.get("classes")?.toString(),
+                    )
+            }
+        }
+    }
+
+    private fun readBaselineDiagnostics(reportFile: File): List<VerificationDiagnostic> {
+        if (!reportFile.isFile) {
+            throw GradleException("Baseline verifier did not produce ${reportFile.path}")
+        }
+        val report = ReportNormalizer.readJson(reportFile, Map::class.java)
+        val diagnostics =
+            report["diagnostics"] as? List<*>
+                ?: throw GradleException("Baseline verification report has no diagnostics array")
+        return diagnostics.map { raw ->
+            val entry = raw as? Map<*, *> ?: throw GradleException("Malformed baseline diagnostic")
+            VerificationDiagnostic(
+                code = DiagnosticCode.valueOf(entry["code"]?.toString() ?: error("Baseline diagnostic code missing")),
+                severity =
+                    DiagnosticSeverity.valueOf(
+                        entry["severity"]?.toString() ?: error("Baseline diagnostic severity missing"),
+                    ),
+                message = entry["message"]?.toString() ?: error("Baseline diagnostic message missing"),
+                modulePath = entry["modulePath"]?.toString(),
+                findingId = entry["findingId"]?.toString(),
+                deviationId = entry["deviationId"]?.toString(),
+                baselineValue = entry["baselineValue"]?.toString(),
+                currentValue = entry["currentValue"]?.toString(),
+            )
+        }
+    }
+
+    /**
+     * Exhaustive classification of every DiagnosticCode. No else branch: adding a
+     * new DiagnosticCode forces a decision at compile time — either it belongs to
+     * an architecture check here, or it is explicitly excluded.
+     */
+    private fun baselineCheckFor(code: DiagnosticCode): String? =
+        when (code) {
+            // Module catalogue (all codes except BOM/publishing drift, which are publishing-topology)
+            DiagnosticCode.MODULE_CATALOG_MISSING_ENTRY,
+            DiagnosticCode.MODULE_CATALOG_UNKNOWN_ENTRY,
+            DiagnosticCode.MODULE_CATALOG_DUPLICATE_PATH,
+            DiagnosticCode.MODULE_CATALOG_INVALID_LAYER,
+            DiagnosticCode.MODULE_CATALOG_MISSING_API_STABILITY,
+            DiagnosticCode.MODULE_CATALOG_EXAMPLE_PUBLISHABLE,
+            DiagnosticCode.MODULE_CATALOG_DISAGREEMENT,
+            DiagnosticCode.MODULE_CATALOG_INVALID_SCHEMA,
+            DiagnosticCode.MODULE_CATALOG_INVALID_MATURITY,
+            DiagnosticCode.MODULE_CATALOG_INVALID_PUBLISHABILITY,
+            DiagnosticCode.MODULE_CATALOG_INVALID_VISIBILITY,
+            DiagnosticCode.MODULE_CATALOG_INVALID_RELEASE_INCLUSION,
+            DiagnosticCode.MODULE_CATALOG_INVALID_POLICY,
+            DiagnosticCode.MODULE_CATALOG_BLANK_OWNER,
+            DiagnosticCode.MODULE_CATALOG_BLANK_RATIONALE,
+            DiagnosticCode.MODULE_CATALOG_MISSING_DESCRIPTION,
+            DiagnosticCode.MODULE_CATALOG_INVALID_COMBINATION,
+            -> "module-manifest"
+
+            DiagnosticCode.MODULE_CATALOG_BOM_DRIFT,
+            DiagnosticCode.MODULE_CATALOG_PUBLISHING_DRIFT,
+            -> "publishing-topology"
+
+            DiagnosticCode.FORBIDDEN_LAYER_EDGE,
+            DiagnosticCode.SELF_DEPENDENCY,
+            -> "dependency-boundaries"
+
+            DiagnosticCode.NEW_DEPENDENCY_CYCLE,
+            -> "dependency-cycles"
+
+            DiagnosticCode.NEW_GLOBAL_STATE_FINDING,
+            -> "global-state"
+
+            DiagnosticCode.API_BASELINE_EMPTY,
+            DiagnosticCode.API_DUMP_MISSING,
+            DiagnosticCode.API_DUMP_DUPLICATE,
+            DiagnosticCode.API_MODULE_UNCLASSIFIED,
+            DiagnosticCode.API_VALIDATION_NOT_CONFIGURED,
+            DiagnosticCode.API_COMPATIBILITY_FAILED,
+            DiagnosticCode.API_HASH_CHANGED,
+            DiagnosticCode.API_DUMP_NONDETERMINISTIC,
+            -> "api-architecture"
+
+            DiagnosticCode.STABLE_PROTOCOL_CONTRACT_REMOVED,
+            -> "protocol-catalog"
+
+            DiagnosticCode.NEW_CANCELLATION_FINDING,
+            DiagnosticCode.CANCELLATION_RISK_WORSENED,
+            -> "cancellation-safety"
+
+            // Explicitly outside the 0.6.0 architecture gate.
+            DiagnosticCode.BASELINE_IDENTITY_MISMATCH,
+            DiagnosticCode.ANALYZER_COMMIT_NOT_ANCESTOR,
+            DiagnosticCode.MEASURED_TREE_MISMATCH,
+            DiagnosticCode.TAG_COMMIT_MISMATCH,
+            DiagnosticCode.TAG_TREE_MISMATCH,
+            DiagnosticCode.DIRTY_WORKTREE,
+            DiagnosticCode.DEPENDENCY_BASELINE_EMPTY,
+            DiagnosticCode.DEPENDENCY_RESOLUTION_FAILED,
+            DiagnosticCode.DYNAMIC_DEPENDENCY_VERSION,
+            DiagnosticCode.SNAPSHOT_DEPENDENCY,
+            DiagnosticCode.DEPENDENCY_CONVERGENCE_FAILURE,
+            DiagnosticCode.DEPENDENCY_ADDED,
+            DiagnosticCode.DEPENDENCY_REMOVED,
+            DiagnosticCode.DEPENDENCY_VERSION_CHANGED,
+            DiagnosticCode.TEST_QUALITY_CONFIGURATION_INVALID,
+            DiagnosticCode.COVERAGE_REPORT_MISSING,
+            DiagnosticCode.COVERAGE_REPORT_MALFORMED,
+            DiagnosticCode.COVERAGE_COUNTER_MISSING,
+            DiagnosticCode.COVERAGE_PATH_LEAK,
+            DiagnosticCode.COVERAGE_REGRESSION,
+            DiagnosticCode.COVERAGE_FAMILY_EMPTY,
+            DiagnosticCode.COVERAGE_EXCLUSION_UNDOCUMENTED,
+            DiagnosticCode.MUTATION_REPORT_MISSING,
+            DiagnosticCode.MUTATION_REPORT_MALFORMED,
+            DiagnosticCode.MUTATION_TARGET_EMPTY,
+            DiagnosticCode.MUTATION_REGRESSION,
+            DiagnosticCode.MUTATION_SURVIVOR_UNCLASSIFIED,
+            DiagnosticCode.MUTATION_MISSING_TEST_UNTRACKED,
+            DiagnosticCode.TEST_REPORT_MISSING,
+            DiagnosticCode.TEST_PERFORMANCE_REGRESSION,
+            DiagnosticCode.CRITICAL_TEST_REGRESSION,
+            DiagnosticCode.CRITICAL_TEST_NEWLY_SKIPPED,
+            DiagnosticCode.TEST_QUALITY_STATUS_PENDING,
+            DiagnosticCode.NEW_NONDETERMINISM_FINDING,
+            DiagnosticCode.HOTSPOT_REGRESSION,
+            DiagnosticCode.NEW_TOP_FIVE_HOTSPOT,
+            DiagnosticCode.FILE_GROWTH_EXCEEDED,
+            DiagnosticCode.INVALID_DEVIATION_SCOPE,
+            DiagnosticCode.ORPHANED_DEVIATION,
+            DiagnosticCode.EXPIRED_DEVIATION,
+            DiagnosticCode.DUPLICATE_DEVIATION,
+            DiagnosticCode.MALFORMED_DEVIATION,
+            DiagnosticCode.DEVIATION_BASELINE_MISMATCH,
+            DiagnosticCode.DEVIATION_COVERAGE_EXCEEDED,
+            DiagnosticCode.GENERATED_DOCUMENT_DRIFT,
+            DiagnosticCode.EMPTY_SECTION,
+            // Nondeterminism authority contract (Epic 8.3d PR 2) — enforced by the
+            // verifyRuntimeNondeterminism task directly, not the maintainability baseline.
+            DiagnosticCode.NONDETERMINISM_UNCLASSIFIED_FINDING,
+            DiagnosticCode.NONDETERMINISM_STALE_ENTRY,
+            DiagnosticCode.NONDETERMINISM_MISMATCHED_CLASSIFICATION,
+            DiagnosticCode.NONDETERMINISM_OCCURRENCE_MISMATCH,
+            DiagnosticCode.NONDETERMINISM_DUPLICATE_ENTRY,
+            DiagnosticCode.NONDETERMINISM_INVALID_DISPOSITION,
+            DiagnosticCode.NONDETERMINISM_MISSING_RATIONALE,
+            DiagnosticCode.NONDETERMINISM_INVALID_SCHEMA,
+            // Module documentation contract (Epic 11.2b3) — enforced by the
+            // verifyModuleDocContract task directly, not a maintainability baseline.
+            DiagnosticCode.MODULE_CARD_MISSING,
+            DiagnosticCode.MODULE_CARD_ORPHAN,
+            DiagnosticCode.MODULE_CARD_HEADING_MISSING,
+            DiagnosticCode.MODULE_CARD_LINK_BROKEN,
+            DiagnosticCode.MODULE_CARD_INLINE_PATH_BROKEN,
+            DiagnosticCode.MODULE_CARD_LEGACY_CLASSIFICATION,
+            DiagnosticCode.MODULE_CARD_VERSIONLESS_DEPENDENCY,
+            DiagnosticCode.MODULE_CARD_INTERNAL_MAVEN_ADVERTISEMENT,
+            DiagnosticCode.MODULE_CARD_COVERAGE_MISMATCH,
+            -> null
+        }
+
+    private fun addManifestDiagnostics(
+        diagnostics: List<VerificationDiagnostic>,
+        checks: Map<String, MutableList<VerificationDiagnostic>>,
+    ) {
+        diagnostics.forEach { diagnostic ->
+            val check = if (diagnostic.code in publishingTopologyCodes) "publishing-topology" else "module-manifest"
+            checks.getValue(check) += diagnostic
+        }
+    }
+
+    private fun addEnrollmentDiagnostics(
+        resultsFiles: Set<File>,
+        checks: Map<String, MutableList<VerificationDiagnostic>>,
+    ) {
+        val reports =
+            resultsFiles
+                .flatMap { file ->
+                    if (file.isDirectory) file.walkTopDown().filter { it.isFile }.toList() else listOf(file)
+                }.filter { it.name.startsWith("TEST-") && it.extension == "xml" }
+                .sortedBy { it.name }
+        if (reports.isEmpty()) {
+            listOf("provider-contracts", "store-contracts").forEach { check ->
+                checks.getValue(check) +=
+                    VerificationDiagnostic.failure(
+                        DiagnosticCode.EMPTY_SECTION,
+                        "Enrollment architecture test results are missing from ${resultsFiles.map { it.path }}",
+                    )
+            }
+            return
+        }
+
+        val discoveredClasses = mutableSetOf<String>()
+        reports.forEach { report ->
+            val className = report.name.removePrefix("TEST-").removeSuffix(".xml")
+            discoveredClasses += className
+            val check =
+                when {
+                    className == "dev.tramai.testing.ProviderTckEnrollmentArchitectureTest" -> "provider-contracts"
+                    className.endsWith("EnrollmentArchitectureTest") -> "store-contracts"
+                    else -> null
+                } ?: return@forEach
+            val factory =
+                DocumentBuilderFactory.newInstance().apply {
+                    setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+                    setFeature("http://xml.org/sax/features/external-general-entities", false)
+                    setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+                    setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+                    setAttribute("http://javax.xml.XMLConstants/property/accessExternalDTD", "")
+                    setAttribute("http://javax.xml.XMLConstants/property/accessExternalSchema", "")
+                    isXIncludeAware = false
+                    isExpandEntityReferences = false
+                }
+            val document = factory.newDocumentBuilder().parse(report)
+            val cases = document.getElementsByTagName("testcase")
+            for (index in 0 until cases.length) {
+                val testCase = cases.item(index) as org.w3c.dom.Element
+                for (childIndex in 0 until testCase.childNodes.length) {
+                    val child = testCase.childNodes.item(childIndex)
+                    if (child.nodeName !in setOf("failure", "error")) continue
+                    val failure = child as org.w3c.dom.Element
+                    val message = failure.getAttribute("message").ifBlank { failure.textContent.trim() }
+                    checks.getValue(check) +=
+                        VerificationDiagnostic.failure(
+                            DiagnosticCode.EMPTY_SECTION,
+                            "$className failed: $message",
+                        )
+                }
+            }
+        }
+
+        // Pin guard identities: deleting/renaming one enrollment class must FAIL
+        // even if the others still run. Discovery by identity, not by count.
+        enrollmentGuardDiagnostics(discoveredClasses).forEach { (check, diagnostics) ->
+            checks.getValue(check) += diagnostics
+        }
+    }
+}

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/MaintainabilityBaselineVerificationTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/MaintainabilityBaselineVerificationTest.kt
@@ -508,6 +508,9 @@ class MaintainabilityBaselineVerificationTest {
         // Each module's declared dump differs from its committed dump with a
         // distinct byte length, so a mispairing would emit the wrong delta.
         val dir = architectureFixture(applyPlugins = "")
+        // NON-natural order: settings declares :tramai-core before :sample, so
+        // the plugin adds core's owner+file first, while the relocated file
+        // paths sort sample first. A mispairing would emit the wrong delta.
         writeFile(
             dir,
             "settings.gradle.kts",
@@ -520,54 +523,11 @@ class MaintainabilityBaselineVerificationTest {
         val committedCore = "committed core dump"
         val declaredSample = "declared sample dump content"
         val declaredCore = "declared core dump content"
-        // apiCheck enters the module into apiValidationModules; apiBuild's
-        // RELOCATED output is the declared generated evidence (never the
-        // conventional build/api path).
-        writeFile(
-            dir,
-            "sample/build.gradle.kts",
-            """
-            plugins { `java-library` }
-            tasks.register("apiCheck")
-            tasks.register("apiBuild") {
-                val relocated = layout.buildDirectory.file("relocated/sample.api")
-                outputs.file(relocated)
-                doLast {
-                    relocated.get().asFile.parentFile.mkdirs()
-                    relocated.get().asFile.writeText("$declaredSample")
-                }
-            }
-            """.trimIndent(),
-        )
-        writeFile(
-            dir,
-            "tramai-core/build.gradle.kts",
-            """
-            plugins { `java-library` }
-            tasks.register("apiCheck")
-            tasks.register("apiBuild") {
-                val relocated = layout.buildDirectory.file("relocated/core.api")
-                outputs.file(relocated)
-                doLast {
-                    relocated.get().asFile.parentFile.mkdirs()
-                    relocated.get().asFile.writeText("$declaredCore")
-                }
-            }
-            """.trimIndent(),
-        )
+        writeRelocatedApiDumpModule(dir, "sample", "sample", declaredSample)
+        writeRelocatedApiDumpModule(dir, "tramai-core", "tramai-core", declaredCore)
         writeFile(dir, "sample/api/sample.api", committedSample)
         writeFile(dir, "tramai-core/api/tramai-core.api", committedCore)
-        writeFile(
-            dir,
-            "build.gradle.kts",
-            """
-            plugins { id("tramai.maintainability-baseline") }
-            import dev.tramai.build.quality.VerifyArchitectureTask
-            tasks.named<VerifyArchitectureTask>("verify060Architecture") {
-                baseRef.set("HEAD")
-            }
-            """.trimIndent(),
-        )
+        writeHeadBaseRefRoot(dir)
         generateCommittedBaseline(dir)
 
         val failed = runner(dir, *configurationCacheArguments("verify060Architecture")).buildAndFail()
@@ -717,6 +677,51 @@ class MaintainabilityBaselineVerificationTest {
     private fun architectureReport(dir: File): String {
         val report = dir.resolve("build/reports/tramai/architecture/architecture-report.json")
         return report.readText()
+    }
+
+    /**
+     * Writes a module build script that enters apiValidationModules (apiCheck)
+     * and produces a RELOCATED generated dump (apiBuild output under
+     * build/relocated/<name>.api — never the conventional build/api path).
+     */
+    private fun writeRelocatedApiDumpModule(
+        dir: File,
+        moduleDir: String,
+        moduleName: String,
+        declaredContent: String,
+    ) {
+        writeFile(
+            dir,
+            "$moduleDir/build.gradle.kts",
+            """
+            plugins { `java-library` }
+            tasks.register("apiCheck")
+            tasks.register("apiBuild") {
+                val relocated = layout.buildDirectory.file("relocated/$moduleName.api")
+                outputs.file(relocated)
+                doLast {
+                    relocated.get().asFile.parentFile.mkdirs()
+                    relocated.get().asFile.writeText("$declaredContent")
+                }
+            }
+            """.trimIndent(),
+        )
+        writeFile(dir, "$moduleDir/api/$moduleName.api", declaredContent)
+    }
+
+    /** Root script pinning baseRef to HEAD (fixture repo has no origin remote). */
+    private fun writeHeadBaseRefRoot(dir: File) {
+        writeFile(
+            dir,
+            "build.gradle.kts",
+            """
+            plugins { id("tramai.maintainability-baseline") }
+            import dev.tramai.build.quality.VerifyArchitectureTask
+            tasks.named<VerifyArchitectureTask>("verify060Architecture") {
+                baseRef.set("HEAD")
+            }
+            """.trimIndent(),
+        )
     }
 
     /**

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/MaintainabilityBaselineVerificationTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/MaintainabilityBaselineVerificationTest.kt
@@ -247,12 +247,11 @@ class MaintainabilityBaselineVerificationTest {
                     }
                     """.trimIndent(),
             )
-        // Alternative catalog B: same modules, :sample layer "core".
+        // Alternative catalog B: same modules, :sample layer "core-contracts".
         val altCatalog =
             MODULE_CATALOG_YML.replace(
-                """- path: ":sample""""",
-                """- path: ":sample"
-                layer: "core"""",
+                "- path: \":sample\"",
+                "- path: \":sample\"\n    layer: \"core-contracts\"",
             )
         writeFile(dir, "config/quality/alt-catalog.yml", altCatalog)
         generateCommittedBaseline(dir)
@@ -293,7 +292,281 @@ class MaintainabilityBaselineVerificationTest {
         )
     }
 
+    // ─── Epic 9.2d-a3c3: typed verify060Architecture discriminators ───
+
+    @Test
+    fun `verify060Architecture stores and reuses configuration cache on fixture`() {
+        // C5 north star: the architecture gate must be configuration-cache
+        // compatible (cold store, warm reuse). The fixture fails closed on
+        // enrollment evidence (no architectureContractEnrollmentTest classes),
+        // but the CC contract itself is observable on both runs.
+        val dir = architectureFixture(applyPlugins = "")
+        generateCommittedBaseline(dir)
+
+        val args = configurationCacheArguments("verify060Architecture")
+        val first = runner(dir, *args).buildAndFail()
+        assertTrue(
+            first.output.contains("Configuration cache entry stored"),
+            "cold run must store the configuration cache: ${first.output.take(1200)}",
+        )
+        val report = File(dir, "build/reports/tramai/architecture/architecture-report.json")
+        assertTrue(report.isFile, "architecture report must be written before the terminal exception")
+
+        val second = runner(dir, *args).buildAndFail()
+        assertTrue(
+            second.output.contains("Reusing configuration cache"),
+            "warm run must reuse the configuration cache: ${second.output.take(1200)}",
+        )
+    }
+
+    @Test
+    fun `verify060Architecture forbidden project edge fails closed with FORBIDDEN_LAYER_EDGE`() {
+        // The configuration-time project-edge snapshot must flow into the
+        // architecture gate: :sample -> :tramai-core violates the fixture
+        // boundaries, and the failure must surface as the exact architecture
+        // diagnostic in the report (fail-closed, report written before throw).
+        val dir =
+            architectureFixture(
+                applyPlugins = "",
+                extraSampleDeps = listOf("implementation(project(\":tramai-core\"))"),
+                boundariesYml =
+                    """
+                    forbiddenEdges:
+                      - fromLayer: "testing-support"
+                        toLayer: "testing-support"
+                        reason: "fixture forbids testing-support edges"
+                    allowedEdges: []
+                    """.trimIndent(),
+            )
+        generateCommittedBaseline(dir)
+
+        val failed = runner(dir, *configurationCacheArguments("verify060Architecture")).buildAndFail()
+        val report = architectureReport(dir)
+        assertTrue(
+            report.contains("FORBIDDEN_LAYER_EDGE"),
+            "report must contain the exact FORBIDDEN_LAYER_EDGE diagnostic: ${report.take(1200)}",
+        )
+        assertTrue(
+            report.contains("Forbidden edge: :sample"),
+            "report must name the offending edge: ${report.take(1200)}",
+        )
+    }
+
+    @Test
+    fun `verify060Architecture new project cycle is detected as NEW_DEPENDENCY_CYCLE`() {
+        // Committed baseline generated WITHOUT the back-edge; the
+        // :tramai-core -> :sample dependency is added AFTER, so the cycle is
+        // genuinely new. Only the declared graph snapshot can surface it.
+        val dir =
+            architectureFixture(
+                applyPlugins = "",
+                extraSampleDeps = listOf("implementation(project(\":tramai-core\"))"),
+            )
+        generateCommittedBaseline(dir)
+        // The gate depends on the consumer compile tasks, which depend on
+        // :tramai-core:jar. With a real sample<->tramai-core project cycle,
+        // that pulls :sample:jar back into the task graph -> circular task
+        // dependency -> Gradle aborts BEFORE the gate action runs (no report).
+        // The consumer fixtures are irrelevant to this discriminator, so drop
+        // them from the settings: the snapshot still carries the new cycle.
+        writeFile(
+            dir,
+            "settings.gradle.kts",
+            """
+            rootProject.name = "maintainability-verification"
+            include(":sample", ":tramai-core", ":tramai-testing")
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "tramai-core/build.gradle.kts",
+            """
+            plugins { `java-library` }
+            repositories { maven { url = uri(rootDir.resolve("repo")) } }
+            dependencies {
+                implementation(project(":sample"))
+            }
+            """.trimIndent(),
+        )
+
+        val failed = runner(dir, *configurationCacheArguments("verify060Architecture")).buildAndFail()
+        val report = architectureReport(dir)
+        assertTrue(
+            report.contains("NEW_DEPENDENCY_CYCLE"),
+            "report must contain the exact NEW_DEPENDENCY_CYCLE diagnostic: ${report.take(
+                1200,
+            )}. FIXTURE OUTPUT:\n${failed.output.take(2500)}",
+        )
+    }
+
+    @Test
+    fun `verify060Architecture missing dependency probe evidence fails closed`() {
+        // Break dependency resolution by removing the local repo :sample
+        // resolves from. The fail-soft probe tasks record a typed resolution
+        // failure; the gate must fail EVERY baseline-backed check with
+        // DEPENDENCY_RESOLUTION_FAILED instead of claiming a stale PASS.
+        val dir = architectureFixture(applyPlugins = "")
+        generateCommittedBaseline(dir)
+        File(dir, "repo").deleteRecursively()
+
+        val failed = runner(dir, *configurationCacheArguments("verify060Architecture")).buildAndFail()
+        val report = architectureReport(dir)
+        assertTrue(
+            report.contains("DEPENDENCY_RESOLUTION_FAILED"),
+            "report must fail closed with DEPENDENCY_RESOLUTION_FAILED: ${report.take(1200)}",
+        )
+    }
+
+    @Test
+    fun `verify060Architecture bad consumer compile evidence fails closed with API_COMPATIBILITY_FAILED`() {
+        // The java consumer smoke fixture compiles zero sources (no src tree),
+        // so its fail-soft producer marker records ok=false. The gate must read
+        // the marker as typed api-architecture evidence and fail closed.
+        val dir = architectureFixture(applyPlugins = "")
+        generateCommittedBaseline(dir)
+
+        val failed = runner(dir, *configurationCacheArguments("verify060Architecture")).buildAndFail()
+        val report = architectureReport(dir)
+        assertTrue(
+            report.contains("API_COMPATIBILITY_FAILED"),
+            "report must contain API_COMPATIBILITY_FAILED: ${report.take(1200)}",
+        )
+        assertTrue(
+            report.contains("Consumer compile proof"),
+            "report must carry the consumer compile proof message: ${report.take(1200)}",
+        )
+    }
+
+    @Test
+    fun `verify060Architecture declared alternative catalog drives boundary enforcement`() {
+        // Declared alt catalog B marks :sample as layer "core"; the fixture
+        // boundaries forbid core -> testing-support. If the gate fell back to
+        // the conventional catalog A (:sample testing-support), the
+        // :sample -> :tramai-core edge would be testing-support ->
+        // testing-support and NOT forbidden by these rules. Only the declared
+        // catalog driving both context and verifier produces FORBIDDEN_LAYER_EDGE
+        // without MODULE_CATALOG_DISAGREEMENT.
+        val dir =
+            architectureFixture(
+                applyPlugins =
+                    """
+                    import dev.tramai.build.quality.VerifyArchitectureTask
+                    tasks.named<VerifyArchitectureTask>("verify060Architecture") {
+                        moduleCatalogFile.set(layout.projectDirectory.file("config/quality/alt-catalog.yml"))
+                    }
+                    """.trimIndent(),
+                extraSampleDeps = listOf("implementation(project(\":tramai-core\"))"),
+                boundariesYml =
+                    """
+                    forbiddenEdges:
+                      - fromLayer: "core-contracts"
+                        toLayer: "testing-support"
+                        reason: "fixture forbids core-to-testing-support edges"
+                    allowedEdges: []
+                    """.trimIndent(),
+            )
+        val altCatalog =
+            architectureCatalogYml().replace(
+                "- path: \":sample\"",
+                "- path: \":sample\"\n    layer: \"core-contracts\"",
+            )
+        writeFile(dir, "config/quality/alt-catalog.yml", altCatalog)
+        generateCommittedBaseline(dir)
+
+        val failed = runner(dir, *configurationCacheArguments("verify060Architecture")).buildAndFail()
+        val report = architectureReport(dir)
+        assertTrue(
+            report.contains("FORBIDDEN_LAYER_EDGE"),
+            "declared catalog must drive boundary enforcement: ${report.take(2000)}",
+        )
+        assertTrue(
+            !report.contains("MODULE_CATALOG_DISAGREEMENT"),
+            "verifier and context must observe the same declared catalog: ${report.take(1200)}",
+        )
+    }
+
+    @Test
+    fun `verify060Architecture root build script mutation invalidates the gate`() {
+        // Root build.gradle.kts is a declared sourceTree input; a mutation must
+        // invalidate the configuration-cache entry (reconfiguration) and
+        // re-execute the gate rather than replaying a stale result.
+        val dir = architectureFixture(applyPlugins = "")
+        generateCommittedBaseline(dir)
+
+        val args = configurationCacheArguments("verify060Architecture")
+        val first = runner(dir, *args).buildAndFail()
+        assertTrue(
+            first.output.contains("Configuration cache entry stored"),
+            "cold run must store the configuration cache: ${first.output.take(1200)}",
+        )
+
+        val buildFile = File(dir, "build.gradle.kts")
+        buildFile.writeText(buildFile.readText() + "\n// mutation\n")
+
+        val second = runner(dir, *args).buildAndFail()
+        assertTrue(
+            !second.output.contains("Reusing configuration cache"),
+            "root build script mutation must invalidate the configuration cache: ${second.output.take(1200)}",
+        )
+        assertEquals(
+            TaskOutcome.FAILED,
+            second.task(":verify060Architecture")?.outcome,
+            "gate must re-execute after root build script mutation: ${second.output.take(800)}",
+        )
+    }
+
     // ─── Fixture ───
+
+    /** Module catalog for the architecture gate fixture (adds :tramai-testing,
+     *  which the enrollment test task requires at realization). */
+    private fun architectureCatalogYml(): String =
+        MODULE_CATALOG_YML.replace(
+            """- path: ":examples:kotlin-consumer-smoke"
+    <<: *internal""",
+            """- path: ":examples:kotlin-consumer-smoke"
+    <<: *internal
+  - path: ":tramai-testing"
+    <<: *internal""",
+        )
+
+    /**
+     * Architecture-gate fixture: the maintainability fixture plus the
+     * :tramai-testing project the architectureContractEnrollmentTest task
+     * touches at realization, and a catalog covering it. The enrollment test
+     * produces no XML results (no matching classes) — enrollment evidence is
+     * missing by design, which exercises the fail-closed path.
+     */
+    private fun architectureFixture(
+        applyPlugins: String,
+        extraSampleDeps: List<String> = emptyList(),
+        boundariesYml: String =
+            """
+            forbiddenEdges: []
+            allowedEdges: []
+            """.trimIndent(),
+    ): File {
+        val dir = File(tempDir, "fixture-${tempDir.listFiles()?.size ?: 0}").apply { mkdirs() }
+        writeGradleScripts(dir, applyPlugins, extraSampleDeps, emptyList())
+        writeFile(
+            dir,
+            "settings.gradle.kts",
+            """
+            rootProject.name = "maintainability-verification"
+            include(":sample", ":tramai-core", ":examples:java-consumer-smoke", ":examples:kotlin-consumer-smoke", ":tramai-testing")
+            """.trimIndent(),
+        )
+        writeFile(dir, "tramai-testing/build.gradle.kts", "plugins { `java` }")
+        writeProductionSource(dir)
+        writeQualityConfig(dir, boundariesYml, architectureCatalogYml())
+        writeLocalMavenRepo(dir)
+        initGit(dir)
+        return dir
+    }
+
+    private fun architectureReport(dir: File): String {
+        val report = dir.resolve("build/reports/tramai/architecture/architecture-report.json")
+        return report.readText()
+    }
 
     /**
      * Self-contained fixture with a committed git history and one production
@@ -419,8 +692,9 @@ class MaintainabilityBaselineVerificationTest {
     private fun writeQualityConfig(
         dir: File,
         boundariesYml: String,
+        catalogYml: String = MODULE_CATALOG_YML,
     ) {
-        writeFile(dir, "config/quality/module-catalog.yml", MODULE_CATALOG_YML)
+        writeFile(dir, "config/quality/module-catalog.yml", catalogYml)
         writeFile(dir, "config/quality/test-quality.yml", TEST_QUALITY_YML)
         writeFile(
             dir,

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/MaintainabilityBaselineVerificationTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/MaintainabilityBaselineVerificationTest.kt
@@ -500,6 +500,95 @@ class MaintainabilityBaselineVerificationTest {
     }
 
     @Test
+    fun `verify060Architecture preserves ordered owner file pairing across two modules`() {
+        // P1 pairing contract: owner[i] <-> file[i] is positional. Two modules
+        // with distinct dump contents are wired in NON-natural order (settings
+        // declares :tramai-core before :sample, so the plugin adds core's
+        // owner+file first, while the relocated file paths sort sample first).
+        // Each module's declared dump differs from its committed dump with a
+        // distinct byte length, so a mispairing would emit the wrong delta.
+        val dir = architectureFixture(applyPlugins = "")
+        writeFile(
+            dir,
+            "settings.gradle.kts",
+            """
+            rootProject.name = "maintainability-verification"
+            include(":tramai-core", ":sample", ":examples:java-consumer-smoke", ":examples:kotlin-consumer-smoke", ":tramai-testing")
+            """.trimIndent(),
+        )
+        val committedSample = "committed sample dump"
+        val committedCore = "committed core dump"
+        val declaredSample = "declared sample dump content"
+        val declaredCore = "declared core dump content"
+        // apiCheck enters the module into apiValidationModules; apiBuild's
+        // RELOCATED output is the declared generated evidence (never the
+        // conventional build/api path).
+        writeFile(
+            dir,
+            "sample/build.gradle.kts",
+            """
+            plugins { `java-library` }
+            tasks.register("apiCheck")
+            tasks.register("apiBuild") {
+                val relocated = layout.buildDirectory.file("relocated/sample.api")
+                outputs.file(relocated)
+                doLast {
+                    relocated.get().asFile.parentFile.mkdirs()
+                    relocated.get().asFile.writeText("$declaredSample")
+                }
+            }
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "tramai-core/build.gradle.kts",
+            """
+            plugins { `java-library` }
+            tasks.register("apiCheck")
+            tasks.register("apiBuild") {
+                val relocated = layout.buildDirectory.file("relocated/core.api")
+                outputs.file(relocated)
+                doLast {
+                    relocated.get().asFile.parentFile.mkdirs()
+                    relocated.get().asFile.writeText("$declaredCore")
+                }
+            }
+            """.trimIndent(),
+        )
+        writeFile(dir, "sample/api/sample.api", committedSample)
+        writeFile(dir, "tramai-core/api/tramai-core.api", committedCore)
+        writeFile(
+            dir,
+            "build.gradle.kts",
+            """
+            plugins { id("tramai.maintainability-baseline") }
+            import dev.tramai.build.quality.VerifyArchitectureTask
+            tasks.named<VerifyArchitectureTask>("verify060Architecture") {
+                baseRef.set("HEAD")
+            }
+            """.trimIndent(),
+        )
+        generateCommittedBaseline(dir)
+
+        val failed = runner(dir, *configurationCacheArguments("verify060Architecture")).buildAndFail()
+        val report = architectureReport(dir)
+        assertTrue(
+            report.contains(
+                "committed API dump for ':sample' does not represent current source " +
+                    "(generated ${declaredSample.length} bytes vs committed ${committedSample.length} bytes)",
+            ),
+            ":sample must receive ITS OWN declared dump content: ${report.take(2000)}",
+        )
+        assertTrue(
+            report.contains(
+                "committed API dump for ':tramai-core' does not represent current source " +
+                    "(generated ${declaredCore.length} bytes vs committed ${committedCore.length} bytes)",
+            ),
+            ":tramai-core must receive ITS OWN declared dump content: ${report.take(2000)}",
+        )
+    }
+
+    @Test
     fun `verify060Architecture declared alternative catalog drives boundary enforcement`() {
         // Declared alt catalog B marks :sample as layer "core"; the fixture
         // boundaries forbid core -> testing-support. If the gate fell back to

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/MaintainabilityBaselineVerificationTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/MaintainabilityBaselineVerificationTest.kt
@@ -438,6 +438,68 @@ class MaintainabilityBaselineVerificationTest {
     }
 
     @Test
+    fun `verify060Architecture consumes declared generated api dump not conventional build path`() {
+        // P1 authority discriminator: the gate must read the EXACT declared
+        // apiBuild output (relocated), never rediscover <module>/build/api.
+        // A conventional dump at the conventional path that matches the
+        // committed dump would PASS if rediscovered; the declared relocated
+        // dump differs and must FAIL.
+        val dir = architectureFixture(applyPlugins = "")
+        // :sample declares apiCheck (so it enters apiValidationModules) and an
+        // apiBuild whose output lands in a RELOCATED build dir.
+        writeFile(
+            dir,
+            "sample/build.gradle.kts",
+            """
+            plugins { `java-library` }
+            repositories { maven { url = uri(rootDir.resolve("repo")) } }
+            dependencies { implementation("com.example:fake:1.0") }
+            tasks.register("apiCheck")
+            tasks.register("apiBuild") {
+                val relocated = layout.buildDirectory.file("relocated/sample.api")
+                outputs.file(relocated)
+                doLast {
+                    relocated.get().asFile.parentFile.mkdirs()
+                    relocated.get().asFile.writeText("declared generated dump B - deliberately different")
+                }
+            }
+            """.trimIndent(),
+        )
+        // Committed dump X (matches the conventional generated A).
+        writeFile(dir, "sample/api/sample.api", "committed dump X")
+        // Conventional generated dump A at the rediscovery path — matches the
+        // committed dump, so a rediscovering implementation would PASS.
+        writeFile(dir, "sample/build/api/sample.api", "committed dump X")
+        // baseRef must resolve in the fixture repo (no origin remote): HEAD
+        // contains the committed dump after generateCommittedBaseline.
+        writeFile(
+            dir,
+            "build.gradle.kts",
+            """
+            plugins { id("tramai.maintainability-baseline") }
+            import dev.tramai.build.quality.VerifyArchitectureTask
+            tasks.named<VerifyArchitectureTask>("verify060Architecture") {
+                baseRef.set("HEAD")
+            }
+            """.trimIndent(),
+        )
+        generateCommittedBaseline(dir)
+        val committedDump = "committed dump X"
+        val declaredDump = "declared generated dump B - deliberately different"
+
+        val failed = runner(dir, *configurationCacheArguments("verify060Architecture")).buildAndFail()
+        val report = architectureReport(dir)
+        assertTrue(
+            report.contains("does not represent current source"),
+            "gate must consume the DECLARED relocated dump, not conventional build/api: ${report.take(2000)}",
+        )
+        assertTrue(
+            report.contains("generated ${declaredDump.length} bytes vs committed ${committedDump.length} bytes"),
+            "the byte delta must reflect the declared relocated dump B: ${report.take(1200)}",
+        )
+    }
+
+    @Test
     fun `verify060Architecture declared alternative catalog drives boundary enforcement`() {
         // Declared alt catalog B marks :sample as layer "core"; the fixture
         // boundaries forbid core -> testing-support. If the gate fell back to

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -20,8 +20,7 @@
     <ID>CyclomaticComplexMethod:AiToolScanner.kt$AiToolScanner$private fun findAnnotatedBeans(factory: ListableBeanFactory): List&lt;AnnotatedBean&gt;</ID>
     <ID>CyclomaticComplexMethod:ApiBaselineVerifier.kt$ApiBaselineVerifier$private fun validate( label: String, baseline: ApiBaseline, diagnostics: MutableList&lt;VerificationDiagnostic&gt; )</ID>
     <ID>CyclomaticComplexMethod:ApiCompatibilityVerifier.kt$ApiCompatibilityEvidenceReader$fun parseMigrations(file: File): ApiMigrationParseResult</ID>
-    <ID>CyclomaticComplexMethod:ApiCompatibilityVerifier.kt$ApiCompatibilityVerifier$private fun verifyRegistryHygiene( evidence: ApiDumpEvidence, migrations: List&lt;ApiMigrationEntry&gt;, diagnostics: MutableList&lt;VerificationDiagnostic&gt; )</ID>
-    <ID>CyclomaticComplexMethod:ApprovalContinuationLifecycleActionGenerator.kt$ApprovalContinuationLifecycleActionGenerator$fun generate( seed: Long, count: Int = ACTIONS_PER_SEQUENCE, initialNow: Instant, expiresAt: Instant, ): List&lt;ApprovalContinuationLifecycleAction&gt;</ID>
+        <ID>CyclomaticComplexMethod:ApprovalContinuationLifecycleActionGenerator.kt$ApprovalContinuationLifecycleActionGenerator$fun generate( seed: Long, count: Int = ACTIONS_PER_SEQUENCE, initialNow: Instant, expiresAt: Instant, ): List&lt;ApprovalContinuationLifecycleAction&gt;</ID>
     <ID>CyclomaticComplexMethod:ApprovalContinuationLifecycleActionGenerator.kt$ApprovalContinuationLifecycleActionGenerator$private fun pickPending( rng: Random, model: ApprovalContinuationLifecycleModel, expiresAt: Instant, ): ApprovalContinuationLifecycleAction</ID>
     <ID>CyclomaticComplexMethod:ApprovalContinuationLifecycleActionGeneratorTest.kt$ApprovalContinuationLifecycleActionGeneratorTest$private fun record( events: MutableList&lt;RecordedEvent&gt;, seed: Long, step: Int, action: ApprovalContinuationLifecycleAction, before: ApprovalContinuationLifecycleModel, outcome: ApprovalContinuationLifecycleOutcome, )</ID>
     <ID>CyclomaticComplexMethod:ApprovalContinuationLifecycleModel.kt$ApprovalContinuationLifecycleAction$fun describe(): String</ID>
@@ -65,8 +64,7 @@
     <ID>CyclomaticComplexMethod:KotlinCancellationCatchScanner.kt$KotlinCancellationCatchScanner$private fun checkRethrowsCancellation(lines: List&lt;String&gt;, catchIdx: Int): Boolean</ID>
     <ID>CyclomaticComplexMethod:KotlinCancellationCatchScanner.kt$KotlinCancellationCatchScanner$private fun findConstructEndIdx(lines: List&lt;String&gt;, startIdx: Int, match: MatchResult): Int?</ID>
     <ID>CyclomaticComplexMethod:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$override fun apply(project: Project)</ID>
-    <ID>CyclomaticComplexMethod:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$private fun addEnrollmentDiagnostics( resultsDir: File, checks: Map&lt;String, MutableList&lt;VerificationDiagnostic&gt;&gt;, )</ID>
-    <ID>CyclomaticComplexMethod:ModuleBoundaries.kt$ModuleBoundaries$fun checkEdge( fromPath: String, toPath: String, catalog: ModuleCatalog, ): VerificationDiagnostic?</ID>
+        <ID>CyclomaticComplexMethod:ModuleBoundaries.kt$ModuleBoundaries$fun checkEdge( fromPath: String, toPath: String, catalog: ModuleCatalog, ): VerificationDiagnostic?</ID>
     <ID>CyclomaticComplexMethod:ModuleBoundaries.kt$ModuleBoundaries$fun parse(): BoundaryResult</ID>
     <ID>CyclomaticComplexMethod:ModuleCatalog.kt$ModuleCatalog$private fun parseEntry( index: Int, raw: Map&lt;String, Any&gt;, policies: Map&lt;String, Set&lt;ModuleLayer&gt;&gt;, modules: MutableMap&lt;String, ModuleEntry&gt;, errors: MutableList&lt;VerificationDiagnostic&gt;, )</ID>
     <ID>CyclomaticComplexMethod:ModuleDocContractVerifier.kt$ModuleDocContractVerifier$fun verify(rootDir: File): List&lt;VerificationDiagnostic&gt;</ID>
@@ -739,8 +737,7 @@
     <ID>LongMethod:KotlinCancellationCatchScanner.kt$KotlinCancellationCatchScanner$private fun findConstructEndIdx(lines: List&lt;String&gt;, startIdx: Int, match: MatchResult): Int?</ID>
     <ID>LongMethod:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$override fun apply(project: Project)</ID>
     <ID>LongMethod:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$private fun addApiCompatibilityDiagnostics( project: Project, checks: Map&lt;String, MutableList&lt;VerificationDiagnostic&gt;&gt;, )</ID>
-    <ID>LongMethod:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$private fun baselineCheckFor(code: DiagnosticCode): String?</ID>
-    <ID>LongMethod:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$private fun mutationInitScript( configuration: TestQualityConfiguration, reportRoot: File, ): String</ID>
+        <ID>LongMethod:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$private fun mutationInitScript( configuration: TestQualityConfiguration, reportRoot: File, ): String</ID>
     <ID>LongMethod:McpStep.kt$McpWorkflowStep$private suspend fun executeMcpCall(toolCall: McpToolCall): McpToolResult</ID>
     <ID>LongMethod:McpStep.kt$McpWorkflowStep$suspend fun execute( workflowName: String, state: S, context: WorkflowContext, observer: WorkflowObserver, failureDiagnosticObserver: WorkflowStepFailureDiagnosticObserver = NoOpWorkflowStepFailureDiagnosticObserver, ): S</ID>
     <ID>LongMethod:ModuleBoundaries.kt$ModuleBoundaries$fun parse(): BoundaryResult</ID>
@@ -3821,8 +3818,7 @@
     <ID>NestedBlockDepth:JdbcWorkflowSchedulerStore.kt$JdbcWorkflowSchedulerStore$private fun createAndClaimDueTicks( connection: Connection, now: Instant, ownerId: String, claimExpiresAt: Instant, limit: Int, ): List&lt;ClaimedScheduledTick&gt;</ID>
     <ID>NestedBlockDepth:KotlinCancellationCatchScanner.kt$KotlinCancellationCatchScanner$private fun findConstructEndIdx(lines: List&lt;String&gt;, startIdx: Int, match: MatchResult): Int?</ID>
     <ID>NestedBlockDepth:KotlinCancellationCatchScanner.kt$KotlinCancellationCatchScanner$private fun joinCatchLines(lines: List&lt;String&gt;): JoinedLines</ID>
-    <ID>NestedBlockDepth:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$private fun addEnrollmentDiagnostics( resultsDir: File, checks: Map&lt;String, MutableList&lt;VerificationDiagnostic&gt;&gt;, )</ID>
-    <ID>NestedBlockDepth:MavenPublishedArtifactResolver.kt$MavenPublishedArtifactResolver$private fun snapshotValueForExtension(metadata: File, extension: String): String?</ID>
+        <ID>NestedBlockDepth:MavenPublishedArtifactResolver.kt$MavenPublishedArtifactResolver$private fun snapshotValueForExtension(metadata: File, extension: String): String?</ID>
     <ID>NestedBlockDepth:ModuleDocContractVerifier.kt$ModuleDocContractVerifier$fun verify(rootDir: File): List&lt;VerificationDiagnostic&gt;</ID>
     <ID>NestedBlockDepth:ModuleGraphAnalyzer.kt$ModuleGraphAnalyzer$fun analyze(): GraphResult</ID>
     <ID>NestedBlockDepth:MutationBaselineVerifier.kt$MutationBaselineVerifier$fun verify(committed: MutationData, current: MutationData): List&lt;VerificationDiagnostic&gt;</ID>
@@ -3860,8 +3856,7 @@
     <ID>ReturnCount:ApiBaselineVerifier.kt$ApiBaselineVerifier$private fun isSafeRepositoryPath(value: String): Boolean</ID>
     <ID>ReturnCount:ApiBaselineVerifier.kt$ApiBaselineVerifier$private fun validateDumpContent( label: String, record: ApiDumpRecord, diagnostics: MutableList&lt;VerificationDiagnostic&gt; )</ID>
     <ID>ReturnCount:ApiCompatibilityVerifier.kt$ApiCompatibilityEvidenceReader$fun parseMigrations(file: File): ApiMigrationParseResult</ID>
-    <ID>ReturnCount:ApiCompatibilityVerifier.kt$ApiCompatibilityVerifier$private fun actualTransition(evidence: ApiDumpEvidence, module: String): Pair&lt;String, String&gt;?</ID>
-    <ID>ReturnCount:ApprovalContinuationLifecycleModel.kt$ApprovalContinuationLifecycleModel$private fun applyCancel( expectedVersion: Long, expiresAt: Instant, ): ApprovalContinuationLifecycleOutcome</ID>
+        <ID>ReturnCount:ApprovalContinuationLifecycleModel.kt$ApprovalContinuationLifecycleModel$private fun applyCancel( expectedVersion: Long, expiresAt: Instant, ): ApprovalContinuationLifecycleOutcome</ID>
     <ID>ReturnCount:ApprovalContinuationLifecycleModel.kt$ApprovalContinuationLifecycleModel$private fun applyClaim( worker: String, expectedVersion: Long, expiresAt: Instant, ): ApprovalContinuationLifecycleOutcome</ID>
     <ID>ReturnCount:ApprovalContinuationLifecycleModel.kt$ApprovalContinuationLifecycleModel$private fun applyComplete( worker: String, expectedVersion: Long, expiresAt: Instant, ): ApprovalContinuationLifecycleOutcome</ID>
     <ID>ReturnCount:ApprovalContinuationLifecycleModel.kt$ApprovalContinuationLifecycleModel$private fun applyExpire( expectedVersion: Long, expiresAt: Instant, ): ApprovalContinuationLifecycleOutcome</ID>
@@ -4112,8 +4107,7 @@
     <ID>ThrowsCount:JdbcSuspendedInvocationStore.kt$JdbcSuspendedInvocationStore$private fun handleCreateConflict( conn: java.sql.Connection, approvalId: String, error: SQLException, ): Nothing</ID>
     <ID>ThrowsCount:JdbcSuspendedInvocationStore.kt$JdbcSuspendedInvocationStore$private fun readEncryptedFromRow(rs: ResultSet): JdbcEncryptedReplayEnvelope</ID>
     <ID>ThrowsCount:JdbcWorkflowLeaseStore.kt$JdbcWorkflowLeaseStore$private suspend fun replaceExpiredLease( lease: WorkflowLease, previous: WorkflowLease, ): WorkflowLease</ID>
-    <ID>ThrowsCount:MaintainabilityBaselinePlugin.kt$MaintainabilityBaselinePlugin$private fun readBaselineDiagnostics(reportFile: File): List&lt;VerificationDiagnostic&gt;</ID>
-    <ID>ThrowsCount:McpStep.kt$McpWorkflowStep$private fun validateDefinition(toolCall: McpToolCall)</ID>
+        <ID>ThrowsCount:McpStep.kt$McpWorkflowStep$private fun validateDefinition(toolCall: McpToolCall)</ID>
     <ID>ThrowsCount:McpStep.kt$McpWorkflowStep$private suspend fun executeMcpCall(toolCall: McpToolCall): McpToolResult</ID>
     <ID>ThrowsCount:McpStep.kt$McpWorkflowStep$suspend fun execute( workflowName: String, state: S, context: WorkflowContext, observer: WorkflowObserver, failureDiagnosticObserver: WorkflowStepFailureDiagnosticObserver = NoOpWorkflowStepFailureDiagnosticObserver, ): S</ID>
     <ID>ThrowsCount:ModelRegistryEnforcer.kt$ModelRegistryEnforcer$suspend fun authorize(providerId: String, modelName: String): RegisteredModel?</ID>
@@ -4782,5 +4776,14 @@
     <ID>NestedBlockDepth:GeminiProvider.kt$GeminiProvider$private suspend fun FlowCollector&lt;StreamChunk&gt;.parseGeminiStreamResponse(response: HttpResponse&lt;InputStream&gt;)</ID>
     <ID>NestedBlockDepth:OllamaProvider.kt$OllamaProvider$@Suppress("ktlint:standard:max-line-length") private suspend fun FlowCollector&lt;dev.tramai.core.model.StreamChunk&gt;.parseOllamaStreamResponse( response: HttpResponse&lt;InputStream&gt;, )</ID>
     <ID>ReturnCount:VaultSecretValueResolver.kt$VaultSecretValueResolver$private fun extractValue( payload: JsonNode, explicitField: String?, ): String?</ID>
+    <ID>CyclomaticComplexMethod:ApiCompatibilityVerifier.kt$ApiCompatibilityVerifier$private fun verifyRegistryHygiene( evidence: ApiDumpEvidence, migrations: List&lt;ApiMigrationEntry&gt;, diagnostics: MutableList&lt;VerificationDiagnostic&gt;, )</ID>
+    <ID>CyclomaticComplexMethod:VerifyArchitectureTask.kt$VerifyArchitectureTask$private fun addEnrollmentDiagnostics( resultsFiles: Set&lt;File&gt;, checks: Map&lt;String, MutableList&lt;VerificationDiagnostic&gt;&gt;, )</ID>
+    <ID>LongMethod:VerifyArchitectureTask.kt$VerifyArchitectureTask$@TaskAction fun verify()</ID>
+    <ID>LongMethod:VerifyArchitectureTask.kt$VerifyArchitectureTask$private fun addEnrollmentDiagnostics( resultsFiles: Set&lt;File&gt;, checks: Map&lt;String, MutableList&lt;VerificationDiagnostic&gt;&gt;, )</ID>
+    <ID>LongMethod:VerifyArchitectureTask.kt$VerifyArchitectureTask$private fun baselineCheckFor(code: DiagnosticCode): String?</ID>
+    <ID>NestedBlockDepth:VerifyArchitectureTask.kt$VerifyArchitectureTask$private fun addEnrollmentDiagnostics( resultsFiles: Set&lt;File&gt;, checks: Map&lt;String, MutableList&lt;VerificationDiagnostic&gt;&gt;, )</ID>
+    <ID>ReturnCount:ApiCompatibilityVerifier.kt$ApiCompatibilityVerifier$private fun actualTransition( evidence: ApiDumpEvidence, module: String, ): Pair&lt;String, String&gt;?</ID>
+    <ID>ThrowsCount:VerifyArchitectureTask.kt$VerifyArchitectureTask$private fun readBaselineDiagnostics(reportFile: File): List&lt;VerificationDiagnostic&gt;</ID>
+    <ID>LargeClass:MaintainabilityBaselineVerificationTest.kt$MaintainabilityBaselineVerificationTest</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/config/quality/api-migrations.yml
+++ b/config/quality/api-migrations.yml
@@ -54,7 +54,7 @@ migrations:
 
   - module: ":tramai-orchestration"
     fromSha256: "c5d9c58e5be2036e5786827251c5f44edd8d432e4644ebc5837b070372617cec"
-    toSha256: "5a33d87b2d235c916c50dd33b08d2a01da22d898858f1b99fbf01237cf72aeb6"
+    toSha256: "64c1ff59baae3a49faa0f1d1c8a617ab7cc7773413c302203b230e1ac2c8a733"
     targetVersion: "0.5.0"
-    rationale: "Intentional additive API: JdbcStepAttemptRecordStore.createTableSql() is restored to a single executable DDL statement; multi-statement provisioning is exposed explicitly via createSchemaSql()/createSequenceTableSql() (one statement per entry, generic-JDBC safe). No signature changed; binary compatibility preserved."
+    rationale: "Intentional additive API: JdbcStepAttemptRecordStore.createTableSql() is restored to a single executable DDL statement; multi-statement provisioning is exposed explicitly via createSchemaSql()/createSequenceTableSql() (one statement per entry, generic-JDBC safe). No signature changed; binary compatibility preserved. toSha256 reconciled to the post-BCV-surface (#352) canonical dump: 39 sanctioned-marked (@ExperimentalTramaiInternalApi) declarations removed from the surface, authorization unchanged."
     migration: "Applications executing createTableSql() alone must additionally execute createSequenceTableSql() (or createSchemaSql()) so the sequence counter table exists; source-compatible callers require no other change."


### PR DESCRIPTION
## What

Replaces the legacy doLast architecture gate in `MaintainabilityBaselinePlugin` with a typed `VerifyArchitectureTask` (Epic 9.2d-a3c3). The root build reduces toward high-level composition; the gate is now a directory-mode task whose declared inputs are the sole execution authority.

## Core changes

- **New `VerifyArchitectureTask.kt`** — typed gate with `@InputFile`/`@InputFiles`/`@Optional` snapshots captured at configuration time. No `Project`/`Configuration`/task-container discovery inside `@TaskAction` (a3 discipline). Report written BEFORE terminal exception (fail-closed contract preserved).
- **Fail-soft producers preserved** — dependency probes, consumer compile markers, enrollment XMLs, generated API dumps, module manifest all arrive as declared file inputs. A failed consumer compile surfaces as `API_COMPATIBILITY_FAILED` typed evidence, not a graph-resolution crash.
- **Consumer smoke compile** — wired via collected task providers (`consumerMarkerProviders`) instead of hard-coded task paths (minimal fixtures may never register them); kotlin source glob fixed to `src/main/kotlin`.
- **detekt baseline migration** — 6 relocated/signature-drift IDs moved from `MaintainabilityBaselinePlugin.kt`/reformatted signatures into `VerifyArchitectureTask.kt`; test-class `LargeClass` baselined (43 existing precedents).

## Discriminators (15/15 green)

7 new a3c3 + 8 carried a3c2: typed-vs-legacy wiring, CC compatibility (cold store / warm reuse), fail-soft marker propagation, cycle detection, alt-catalog overrides, consumer glob correctness.

## C5 proof (real repo)

`verify060Architecture --configuration-cache --configuration-cache-problems=fail`:
- **cold**: "Configuration cache entry stored" + PASSED (1m21s)
- **warm**: "Reusing configuration cache" + PASSED (5s)

C5 1 → 0: the last project-mode doLast gate is gone.

## Local checks

- `spotlessCheck` ✅
- `verifyStaticAnalysis -PchangeClass=baseline-migration` ✅ (0 new findings; baseline 4759 → 4762)
- `MaintainabilityBaselineVerificationTest` 15/15 ✅