### PR TITLE
chore(quality): migrate detekt baseline for formatting-ratchet ID drift (10.1d)

### DIFF
--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/DetektBaselineGrowthVerifier.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/DetektBaselineGrowthVerifier.kt
@@ -131,6 +131,19 @@ object DetektBaselineGrowthVerifier {
         val removed = (baseDoc.currentIssueIds - currentDoc.currentIssueIds).sorted()
         val migrationAuthorized = input.changeClass == "baseline-migration"
 
+        // Formatting-ratchet drift diagnosis: entities appearing in BOTH the
+        // added and removed sets under a different signature shape. ktlint_official
+        // re-wraps declaration signatures (trailing commas, multi-line params),
+        // which changes detekt's signature-embedded IDs without changing the
+        // finding itself. Surfacing these turns an opaque "N added, M removed"
+        // into an actionable migration diagnosis (see the a3c3 drift reference).
+        val driftHint =
+            if (added.any { a -> removed.any { r -> a.substringBeforeLast('$') == r.substringBeforeLast('$') } }) {
+                " Formatting-ratchet ID drift suspected (same entities added and removed — signature text changed)."
+            } else {
+                ""
+            }
+
         if (added.isNotEmpty() && !migrationAuthorized) {
             val detail = added.take(10).joinToString("\n    ") { "  + $it" }
             return fail(
@@ -152,7 +165,7 @@ object DetektBaselineGrowthVerifier {
             message =
                 "Detekt baseline OK: base ${baseDoc.currentIssueIds.size} -> current " +
                     "${currentDoc.currentIssueIds.size}; " +
-                    "${removed.size} removed, ${added.size} added.",
+                    "${removed.size} removed, ${added.size} added.$driftHint",
         )
     }
 

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/DetektBaselineGrowthDriftTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/DetektBaselineGrowthDriftTest.kt
@@ -1,0 +1,77 @@
+package dev.tramai.build.quality
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Epic 10.1d: DetektBaselineGrowthVerifier drift diagnosis. When a baseline
+ * migration adds and removes IDs for the SAME entity (signature text changed
+ * by the ktlint_official formatting ratchet), the verdict must surface the
+ * suspects so the migration is not mistaken for genuine debt movement.
+ */
+class DetektBaselineGrowthDriftTest {
+    private fun baseline(vararg ids: String): String =
+        """
+        <SmellBaseline>
+          <ManuallySuppressedIssues/>
+          <CurrentIssues>
+        ${ids.joinToString("\n") { "    <ID>$it</ID>" }}
+          </CurrentIssues>
+        </SmellBaseline>
+        """.trimIndent()
+
+    @Test
+    fun `same entity added and removed is flagged as drift suspect`() {
+        val oldSig = "NestedBlockDepth:AnthropicProvider.kt\$AnthropicProvider\$parse(\n    old: String,\n)"
+        val newSig =
+            "NestedBlockDepth:AnthropicProvider.kt\$AnthropicProvider\$parse(\n" +
+                "    old: String,\n    new: String,\n)"
+        val base = baseline(oldSig)
+        val current = baseline(newSig)
+        val verdict =
+            DetektBaselineGrowthVerifier.verify(
+                DetektGrowthInput(
+                    baseBaselineXml = base,
+                    currentBaselineXml = current,
+                    changeClass = "baseline-migration",
+                    runtimeSourceChanged = false,
+                ),
+            )
+        assertTrue(verdict.passed, verdict.message)
+        assertTrue(verdict.message.contains("Formatting-ratchet ID drift suspected"))
+    }
+
+    @Test
+    fun `unrelated addition and removal are not drift suspects`() {
+        val base = baseline("NestedBlockDepth:FileA.kt\$A\$old(")
+        val current = baseline("NestedBlockDepth:FileB.kt\$B\$new(")
+        val verdict =
+            DetektBaselineGrowthVerifier.verify(
+                DetektGrowthInput(
+                    baseBaselineXml = base,
+                    currentBaselineXml = current,
+                    changeClass = "baseline-migration",
+                    runtimeSourceChanged = false,
+                ),
+            )
+        assertTrue(verdict.passed, verdict.message)
+        assertTrue(!verdict.message.contains("drift suspected"))
+    }
+
+    @Test
+    fun `growth without migration still fails`() {
+        val base = baseline("NestedBlockDepth:FileA.kt\$A\$old(")
+        val current = baseline("NestedBlockDepth:FileA.kt\$A\$old(", "NestedBlockDepth:FileA.kt\$A\$new(")
+        val verdict =
+            DetektBaselineGrowthVerifier.verify(
+                DetektGrowthInput(
+                    baseBaselineXml = base,
+                    currentBaselineXml = current,
+                    changeClass = null,
+                    runtimeSourceChanged = false,
+                ),
+            )
+        assertEquals(DetektGrowthVerdict.GROWTH, verdict.code)
+    }
+}

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -4761,5 +4761,26 @@
     <ID>WildcardImport:ToolResultSanitizerTest.kt$import dev.tramai.core.security.*</ID>
     <ID>WildcardImport:ToolResultSanitizerTest.kt$import dev.tramai.engine.*</ID>
     <ID>WildcardImport:TramaiEngine.kt$import dev.tramai.core.model.*</ID>
+    <ID>LongMethod:AnthropicProvider.kt$AnthropicProvider$private fun messageToMap(message: dev.tramai.core.model.Message): Map&lt;String, Any?&gt;</ID>
+    <ID>LongMethod:OpenAiProvider.kt$OpenAiCompatibleProvider$private fun messageToMap( message: dev.tramai.core.model.Message, imageDetail: dev.tramai.core.model.ImageDetail = dev.tramai.core.model.ImageDetail.AUTO, ): Map&lt;String, Any?&gt;</ID>
+    <ID>MaxLineLength:AnthropicProvider.kt$AnthropicProvider$// Anthropic accepts the system prompt separately from the conversational message list.</ID>
+    <ID>MaxLineLength:AnthropicProvider.kt$AnthropicProvider$emit(StreamChunk.Error(providerTransportFailureObserved(PROVIDER_ID, e, providerFailureDiagnosticObserver)))</ID>
+    <ID>MaxLineLength:AnthropicProvider.kt$AnthropicProvider$private suspend</ID>
+    <ID>MaxLineLength:AnthropicProvider.kt$AnthropicProvider$val systemMessage = request.messages.firstOrNull { it.role.name.lowercase() == "system" }?.content</ID>
+    <ID>MaxLineLength:AzureOpenAiProvider.kt$AzureOpenAiProvider$"Unsupported image mimeType '${part.mimeType}'. Supported types: $SUPPORTED_IMAGE_TYPES"</ID>
+    <ID>MaxLineLength:AzureOpenAiProvider.kt$AzureOpenAiProvider$emit(StreamChunk.Error(providerTransportFailureObserved(PROVIDER_ID, e, providerFailureDiagnosticObserver)))</ID>
+    <ID>MaxLineLength:GeminiProvider.kt$GeminiProvider$emit(StreamChunk.Error(providerTransportFailureObserved(PROVIDER_ID, e, providerFailureDiagnosticObserver)))</ID>
+    <ID>MaxLineLength:GeminiProvider.kt$GeminiProvider$val url = "${baseUrl.trimEnd('/')}/$apiVersion/models/$modelName:streamGenerateContent?alt=sse"</ID>
+    <ID>MaxLineLength:OllamaProvider.kt$OllamaProvider$private suspend</ID>
+    <ID>MaxLineLength:OpenAiProvider.kt$OpenAiCompatibleProvider$"Unsupported image mimeType '${part.mimeType}'. Supported types: $SUPPORTED_IMAGE_TYPES"</ID>
+    <ID>MaxLineLength:OpenAiProvider.kt$OpenAiCompatibleProvider$"messages" to request.messages.map { message -&gt; messageToMap(message, request.imageDetail) }</ID>
+    <ID>MaxLineLength:OpenAiProvider.kt$OpenAiCompatibleProvider$"url" to "data:${part.mimeType};base64,${Base64.getEncoder().encodeToString(part.data)}"</ID>
+    <ID>MaxLineLength:OpenAiProvider.kt$OpenAiCompatibleProvider$)</ID>
+    <ID>MaxLineLength:OpenAiProvider.kt$OpenAiCompatibleProvider$private suspend</ID>
+    <ID>NestedBlockDepth:AnthropicProvider.kt$AnthropicProvider$private suspend fun FlowCollector&lt;StreamChunk&gt;.parseAnthropicStreamResponse(response: HttpResponse&lt;InputStream&gt;)</ID>
+    <ID>NestedBlockDepth:AzureOpenAiProvider.kt$AzureOpenAiProvider$private suspend fun FlowCollector&lt;StreamChunk&gt;.parseAzureSseResponse(response: HttpResponse&lt;InputStream&gt;)</ID>
+    <ID>NestedBlockDepth:GeminiProvider.kt$GeminiProvider$private suspend fun FlowCollector&lt;StreamChunk&gt;.parseGeminiStreamResponse(response: HttpResponse&lt;InputStream&gt;)</ID>
+    <ID>NestedBlockDepth:OllamaProvider.kt$OllamaProvider$@Suppress("ktlint:standard:max-line-length") private suspend fun FlowCollector&lt;dev.tramai.core.model.StreamChunk&gt;.parseOllamaStreamResponse( response: HttpResponse&lt;InputStream&gt;, )</ID>
+    <ID>ReturnCount:VaultSecretValueResolver.kt$VaultSecretValueResolver$private fun extractValue( payload: JsonNode, explicitField: String?, ): String?</ID>
   </CurrentIssues>
 </SmellBaseline>


### PR DESCRIPTION
## Summary

Prerequisite for Epic 10.1d (forbidden/lifecycle/security static guards + closure). The 10.1a formatting ratchet forces a full ktlint_official reformat of any legacy file it touches; that reformat re-wraps declaration signatures (single-line ↔ multi-line, trailing commas), which changes detekt's signature-embedded baseline IDs (`Rule:File$signature`) **without changing the findings themselves**. The companion runtime PR (bounded HTTP response-body reads, `epic/10.1d-response-body-hardening`) must reformat 6 provider files and would otherwise fail `verifyStaticAnalysis` with ~23 "new" findings that are pure ID drift.

This PR pre-migrates the detekt baseline so the runtime PR lands green, and makes the drift diagnosable in future migrations.

## What

- **`config/detekt/baseline.xml` (union migration):** adds the 21 drifted IDs (same entities, new signature shapes) while keeping the existing 4759 entries. 4759 → 4780. Master stays green (old signature IDs still match the unformatted tree); the runtime PR's reformatted tree matches the new IDs.
- **`DetektBaselineGrowthVerifier`:** when a baseline comparison adds AND removes IDs for the same entity (signature text changed), the pass verdict now appends a "Formatting-ratchet ID drift suspected" hint — turning an opaque "N removed, M added" into an actionable migration diagnosis (precedent: a3c3, `detekt-baseline-id-drift-migration`).
- **`DetektBaselineGrowthDriftTest`:** 3 tests (drift flagged, unrelated add/remove not flagged, growth without migration still fails).

No runtime production source changes. Change class: `baseline-migration` (label applied for the CI change-policy step).

## Verification

- `./gradlew verifyStaticAnalysis -PchangeClass=baseline-migration` — PASS (`baseline OK: base 4759 -> current 4780; 0 removed, 21 added`)
- `./gradlew verifyChangePolicy -PchangeClass=baseline-migration` — PASS
- `./gradlew :build-logic:test --tests 'dev.tramai.build.quality.Detekt*' --tests 'dev.tramai.build.quality.ChangePolicy*'` — PASS (incl. new drift tests)
- `./gradlew spotlessKotlinCheck` — PASS

## Non-claims

- This PR does NOT change production source (the follow-up runtime PR does the bounded-read remediation and consumes these migrated IDs).
- The 19 old-shape IDs are intentionally retained (union) until the runtime PR merges; a later cleanup PR may remove them (removals are always allowed by the growth contract).
- No analyzer behavior change for the growth contract itself (additions still fail without `baseline-migration`).

This PR needs review before merge.
