### PR TITLE
fix(providers): bounded HTTP response-body reads across all providers (10.1d)

### DIFF
--- a/tramai-anthropic/src/main/kotlin/dev/tramai/anthropic/AnthropicProvider.kt
+++ b/tramai-anthropic/src/main/kotlin/dev/tramai/anthropic/AnthropicProvider.kt
@@ -3,6 +3,7 @@
 package dev.tramai.anthropic
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import dev.tramai.core.coroutines.rethrowIfCancellation
 import dev.tramai.core.exception.ProviderFailureCode
 import dev.tramai.core.model.ContentPart
 import dev.tramai.core.model.FinishReason
@@ -16,388 +17,428 @@ import dev.tramai.core.observation.NoOpProviderFailureDiagnosticObserver
 import dev.tramai.core.observation.ProviderFailureDiagnosticObserver
 import dev.tramai.core.provider.ModelProvider
 import dev.tramai.core.provider.ProviderCapability
-import dev.tramai.core.coroutines.rethrowIfCancellation
 import dev.tramai.core.provider.providerTransportFailureObserved
+import dev.tramai.core.provider.safeProviderFailure
 import dev.tramai.core.provider.transport.providerJsonRequest
+import dev.tramai.core.provider.transport.readBoundedResponseBody
 import dev.tramai.core.provider.transport.rejectedProviderHttpResponse
 import dev.tramai.core.provider.transport.sseDataPayload
 import dev.tramai.core.provider.transport.sseEventName
-import dev.tramai.core.provider.safeProviderFailure
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
-import kotlin.coroutines.CoroutineContext
-import java.net.URI
 import java.io.InputStream
+import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpResponse
-import java.util.Base64
 import java.nio.charset.StandardCharsets.UTF_8
+import java.util.Base64
+import kotlin.coroutines.CoroutineContext
 
 /**
  * [ModelProvider] implementation for Anthropic's Messages API.
  */
-class AnthropicProvider @JvmOverloads constructor(
-    private val apiKey: String,
-    private val baseUrl: String = "https://api.anthropic.com",
-    private val anthropicVersion: String = ANTHROPIC_API_VERSION,
-    private val httpClient: HttpClient = HttpClient.newHttpClient(),
-    private val objectMapper: ObjectMapper = ObjectMapper(),
-    private val ioDispatcher: CoroutineContext = Dispatchers.IO,
-    private val providerFailureDiagnosticObserver: ProviderFailureDiagnosticObserver =
-        NoOpProviderFailureDiagnosticObserver,
-) : dev.tramai.core.provider.ModelProvider, dev.tramai.core.provider.StreamCapable {
+class AnthropicProvider
+    @JvmOverloads
+    constructor(
+        private val apiKey: String,
+        private val baseUrl: String = "https://api.anthropic.com",
+        private val anthropicVersion: String = ANTHROPIC_API_VERSION,
+        private val httpClient: HttpClient = HttpClient.newHttpClient(),
+        private val objectMapper: ObjectMapper = ObjectMapper(),
+        private val ioDispatcher: CoroutineContext = Dispatchers.IO,
+        private val providerFailureDiagnosticObserver: ProviderFailureDiagnosticObserver =
+            NoOpProviderFailureDiagnosticObserver,
+    ) : dev.tramai.core.provider.ModelProvider,
+        dev.tramai.core.provider.StreamCapable {
+        override suspend fun complete(request: ModelRequest): ModelResponse =
+            withContext(ioDispatcher) {
+                try {
+                    val payload =
+                        linkedMapOf<String, Any?>(
+                            "model" to request.model,
+                            "max_tokens" to (request.maxTokens ?: 1024),
+                            "messages" to
+                                request.messages
+                                    // Anthropic accepts the system prompt separately from the conversational message list.
+                                    .filter { it.role.name.lowercase() != "system" }
+                                    .map { message -> messageToMap(message) },
+                        )
 
-    override suspend fun complete(request: ModelRequest): ModelResponse = withContext(ioDispatcher) {
-        try {
-            val payload = linkedMapOf<String, Any?>(
-                "model" to request.model,
-                "max_tokens" to (request.maxTokens ?: 1024),
-                "messages" to request.messages
-                    // Anthropic accepts the system prompt separately from the conversational message list.
-                    .filter { it.role.name.lowercase() != "system" }
-                    .map { message -> messageToMap(message) },
-            )
+                    val systemMessage = request.messages.firstOrNull { it.role.name.lowercase() == "system" }?.content
+                    if (!systemMessage.isNullOrBlank()) {
+                        payload["system"] = systemMessage
+                    }
 
-            val systemMessage = request.messages.firstOrNull { it.role.name.lowercase() == "system" }?.content
-            if (!systemMessage.isNullOrBlank()) {
-                payload["system"] = systemMessage
-            }
+                    request.tools?.let { tools ->
+                        payload["tools"] =
+                            tools.map { tool ->
+                                mapOf(
+                                    "name" to tool.name,
+                                    "description" to tool.description,
+                                    "input_schema" to objectMapper.readTree(tool.inputSchemaJson),
+                                )
+                            }
+                    }
 
-            request.tools?.let { tools ->
-                payload["tools"] = tools.map { tool ->
-                    mapOf(
-                        "name" to tool.name,
-                        "description" to tool.description,
-                        "input_schema" to objectMapper.readTree(tool.inputSchemaJson),
+                    val httpRequest =
+                        providerJsonRequest(
+                            URI.create("${baseUrl.trimEnd('/')}/v1/messages"),
+                            request,
+                            objectMapper.writeValueAsString(payload),
+                        ).apply {
+                            header("x-api-key", apiKey)
+                            header("anthropic-version", anthropicVersion)
+                        }.build()
+
+                    val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
+                    if (response.statusCode() !in 200..299) {
+                        throw rejectedProviderHttpResponse(
+                            providerId = PROVIDER_ID,
+                            providerAlias = null,
+                            response = response,
+                            observer = providerFailureDiagnosticObserver,
+                            logger = providerLogger,
+                        )
+                    }
+
+                    val body = objectMapper.readTree(readBoundedResponseBody(response).text)
+                    val contentBlocks = body.path("content")
+                    val textBlocks = contentBlocks.filter { node -> node.path("type").asText("") == "text" }
+                    val toolCalls =
+                        contentBlocks
+                            .filter { node -> node.path("type").asText("") == "tool_use" }
+                            .map { node ->
+                                ToolCall(
+                                    id = node.path("id").asText(),
+                                    name = node.path("name").asText(),
+                                    argumentsJson = node.path("input").toString(),
+                                )
+                            }
+                    if (textBlocks.isEmpty() && toolCalls.isEmpty()) {
+                        throw safeProviderFailure(
+                            "Anthropic response did not contain a text or tool_use content block",
+                            ProviderFailureCode.UNEXPECTED_FAILURE,
+                        )
+                    }
+
+                    ModelResponse(
+                        content = textBlocks.joinToString("") { it.path("text").asText("") },
+                        toolCalls = toolCalls.ifEmpty { null },
+                        inputTokens =
+                            body
+                                .path("usage")
+                                .path("input_tokens")
+                                .takeIf { !it.isMissingNode }
+                                ?.asInt(),
+                        outputTokens =
+                            body
+                                .path("usage")
+                                .path("output_tokens")
+                                .takeIf { !it.isMissingNode }
+                                ?.asInt(),
+                        thinkingTokens = null,
+                        modelUsed = body.path("model").takeIf { !it.isMissingNode }?.asText(),
+                        finishReason =
+                            when (body.path("stop_reason").asText("")) {
+                                "end_turn" -> FinishReason.STOP
+                                "max_tokens" -> FinishReason.LENGTH
+                                else -> FinishReason.OTHER
+                            },
                     )
+                } catch (error: Throwable) {
+                    error.rethrowIfCancellation()
+                    throw providerTransportFailureObserved(PROVIDER_ID, error, providerFailureDiagnosticObserver)
                 }
             }
 
-            val httpRequest = providerJsonRequest(
-                URI.create("${baseUrl.trimEnd('/')}/v1/messages"),
-                request,
-                objectMapper.writeValueAsString(payload),
-            ).apply {
-                header("x-api-key", apiKey)
-                header("anthropic-version", anthropicVersion)
-            }.build()
+        /**
+         * Returns the stable provider id used by the registry.
+         */
+        override fun providerId(): String = PROVIDER_ID
 
-            val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
-            if (response.statusCode() !in 200..299) {
-                throw rejectedProviderHttpResponse(
+        override fun supportsCapability(capability: ProviderCapability): Boolean =
+            when (capability) {
+                ProviderCapability.VISION -> true
+                ProviderCapability.TOOL_CALLING -> true
+                ProviderCapability.STRUCTURED_OUTPUT -> true
+                ProviderCapability.STREAMING -> true
+            }
+
+        override fun stream(request: ModelRequest): Flow<StreamChunk> =
+            flow {
+                val response =
+                    try {
+                        withContext(ioDispatcher) {
+                            val payload =
+                                linkedMapOf<String, Any?>(
+                                    "model" to request.model,
+                                    "stream" to true,
+                                    "max_tokens" to (request.maxTokens ?: 1024),
+                                    "messages" to
+                                        request.messages
+                                            .filter { it.role.name.lowercase() != "system" }
+                                            .map { message -> messageToMap(message) },
+                                )
+                            val systemMessage = request.messages.firstOrNull { it.role.name.lowercase() == "system" }?.content
+                            if (!systemMessage.isNullOrBlank()) payload["system"] = systemMessage
+
+                            request.tools?.let { tools ->
+                                payload["tools"] =
+                                    tools.map { tool ->
+                                        mapOf(
+                                            "name" to tool.name,
+                                            "description" to tool.description,
+                                            "input_schema" to objectMapper.readTree(tool.inputSchemaJson),
+                                        )
+                                    }
+                            }
+
+                            val httpRequest =
+                                providerJsonRequest(
+                                    URI.create("${baseUrl.trimEnd('/')}/v1/messages"),
+                                    request,
+                                    objectMapper.writeValueAsString(payload),
+                                ).apply {
+                                    header("x-api-key", apiKey)
+                                    header("anthropic-version", anthropicVersion)
+                                }.build()
+                            httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
+                        }
+                    } catch (error: Throwable) {
+                        error.rethrowIfCancellation()
+                        emit(StreamChunk.Error(providerTransportFailureObserved(PROVIDER_ID, error, providerFailureDiagnosticObserver)))
+                        return@flow
+                    }
+
+                val errorChunk = handleHttpError(response)
+                if (errorChunk != null) {
+                    emit(errorChunk)
+                    return@flow
+                }
+
+                parseAnthropicStreamResponse(response)
+            }
+
+        /**
+         * Handles non-2xx HTTP responses for streaming requests.
+         * Returns a [StreamChunk.Error] for failed responses, or `null` for 2xx.
+         */
+        private suspend fun handleHttpError(response: HttpResponse<InputStream>): StreamChunk.Error? {
+            if (response.statusCode() in 200..299) return null
+            return StreamChunk.Error(
+                rejectedProviderHttpResponse(
                     providerId = PROVIDER_ID,
                     providerAlias = null,
                     response = response,
                     observer = providerFailureDiagnosticObserver,
                     logger = providerLogger,
-                )
-            }
-
-            val body = objectMapper.readTree(response.body().use { it.readAllBytes().decodeToString() })
-            val contentBlocks = body.path("content")
-            val textBlocks = contentBlocks.filter { node -> node.path("type").asText("") == "text" }
-            val toolCalls = contentBlocks
-                .filter { node -> node.path("type").asText("") == "tool_use" }
-                .map { node ->
-                    ToolCall(
-                        id = node.path("id").asText(),
-                        name = node.path("name").asText(),
-                        argumentsJson = node.path("input").toString(),
-                    )
-                }
-            if (textBlocks.isEmpty() && toolCalls.isEmpty()) {
-                throw safeProviderFailure(
-                    "Anthropic response did not contain a text or tool_use content block",
-                    ProviderFailureCode.UNEXPECTED_FAILURE,
-                )
-            }
-
-            ModelResponse(
-                content = textBlocks.joinToString("") { it.path("text").asText("") },
-                toolCalls = toolCalls.ifEmpty { null },
-                inputTokens = body.path("usage").path("input_tokens").takeIf { !it.isMissingNode }?.asInt(),
-                outputTokens = body.path("usage").path("output_tokens").takeIf { !it.isMissingNode }?.asInt(),
-                thinkingTokens = null,
-                modelUsed = body.path("model").takeIf { !it.isMissingNode }?.asText(),
-                finishReason = when (body.path("stop_reason").asText("")) {
-                    "end_turn" -> FinishReason.STOP
-                    "max_tokens" -> FinishReason.LENGTH
-                    else -> FinishReason.OTHER
-                },
+                ),
             )
-        } catch (error: Throwable) {
-            error.rethrowIfCancellation()
-            throw providerTransportFailureObserved(PROVIDER_ID, error, providerFailureDiagnosticObserver)
         }
-    }
 
-    /**
-     * Returns the stable provider id used by the registry.
-     */
-    override fun providerId(): String = PROVIDER_ID
+        /**
+         * Parses the Anthropic SSE stream response, handling Anthropic-specific events:
+         * - `content_block_delta` for text tokens
+         * - `message_start` for initial usage metrics
+         * - `message_delta` for output token updates
+         */
+        private suspend fun FlowCollector<StreamChunk>.parseAnthropicStreamResponse(response: HttpResponse<InputStream>) {
+            val fullText = StringBuilder()
+            var lastUsage: UsageMetrics? = null
 
-    override fun supportsCapability(capability: ProviderCapability): Boolean = when (capability) {
-        ProviderCapability.VISION -> true
-        ProviderCapability.TOOL_CALLING -> true
-        ProviderCapability.STRUCTURED_OUTPUT -> true
-        ProviderCapability.STREAMING -> true
-    }
+            try {
+                response.body().bufferedReader(UTF_8).use { reader ->
+                    var currentEvent: String? = null
+                    while (true) {
+                        val line = reader.readLine() ?: break
+                        sseEventName(line)?.let { currentEvent = it }
+                        val data = sseDataPayload(line) ?: continue
+                        val node = objectMapper.readTree(data)
+                        lastUsage = handleAnthropicEvent(currentEvent, node, fullText, lastUsage)
+                    }
+                }
+                emit(StreamChunk.Complete(fullText.toString(), lastUsage ?: UsageMetrics()))
+            } catch (e: Exception) {
+                e.rethrowIfCancellation()
+                emit(StreamChunk.Error(providerTransportFailureObserved(PROVIDER_ID, e, providerFailureDiagnosticObserver)))
+            }
+        }
 
-    override fun stream(request: ModelRequest): Flow<StreamChunk> = flow {
-        val response = try {
-            withContext(ioDispatcher) {
-                val payload = linkedMapOf<String, Any?>(
-                    "model" to request.model,
-                    "stream" to true,
-                    "max_tokens" to (request.maxTokens ?: 1024),
-                    "messages" to request.messages
-                        .filter { it.role.name.lowercase() != "system" }
-                        .map { message -> messageToMap(message) },
-                )
-                val systemMessage = request.messages.firstOrNull { it.role.name.lowercase() == "system" }?.content
-                if (!systemMessage.isNullOrBlank()) payload["system"] = systemMessage
+        /**
+         * Handles a single Anthropic SSE event (content_block_delta, message_start, message_delta)
+         * and returns the updated [UsageMetrics].
+         */
+        private suspend fun FlowCollector<StreamChunk>.handleAnthropicEvent(
+            currentEvent: String?,
+            node: com.fasterxml.jackson.databind.JsonNode,
+            fullText: StringBuilder,
+            lastUsage: UsageMetrics?,
+        ): UsageMetrics? {
+            when (currentEvent) {
+                "content_block_delta" -> {
+                    val text = node.path("delta").path("text").asText("")
+                    if (text.isNotEmpty()) {
+                        fullText.append(text)
+                        emit(StreamChunk.Token(text))
+                    }
+                }
 
-                request.tools?.let { tools ->
-                    payload["tools"] = tools.map { tool ->
-                        mapOf(
-                            "name" to tool.name,
-                            "description" to tool.description,
-                            "input_schema" to objectMapper.readTree(tool.inputSchemaJson),
+                "message_start" -> {
+                    val usage = node.path("message").path("usage")
+                    if (!usage.isMissingNode) {
+                        return UsageMetrics(
+                            inputTokens = usage.path("input_tokens").asInt(),
+                            outputTokens = usage.path("output_tokens").asInt(),
+                            thinkingTokens = null,
                         )
                     }
                 }
 
-                val httpRequest = providerJsonRequest(
-                    URI.create("${baseUrl.trimEnd('/')}/v1/messages"),
-                    request,
-                    objectMapper.writeValueAsString(payload),
-                ).apply {
-                    header("x-api-key", apiKey)
-                    header("anthropic-version", anthropicVersion)
-                }.build()
-                httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
-            }
-        } catch (error: Throwable) {
-            error.rethrowIfCancellation()
-            emit(StreamChunk.Error(providerTransportFailureObserved(PROVIDER_ID, error, providerFailureDiagnosticObserver)))
-            return@flow
-        }
-
-        val errorChunk = handleHttpError(response)
-        if (errorChunk != null) {
-            emit(errorChunk)
-            return@flow
-        }
-
-        parseAnthropicStreamResponse(response)
-    }
-
-    /**
-     * Handles non-2xx HTTP responses for streaming requests.
-     * Returns a [StreamChunk.Error] for failed responses, or `null` for 2xx.
-     */
-    private suspend fun handleHttpError(
-        response: HttpResponse<InputStream>,
-    ): StreamChunk.Error? {
-        if (response.statusCode() in 200..299) return null
-        return StreamChunk.Error(
-            rejectedProviderHttpResponse(
-                providerId = PROVIDER_ID,
-                providerAlias = null,
-                response = response,
-                observer = providerFailureDiagnosticObserver,
-                logger = providerLogger,
-            ),
-        )
-    }
-
-    /**
-     * Parses the Anthropic SSE stream response, handling Anthropic-specific events:
-     * - `content_block_delta` for text tokens
-     * - `message_start` for initial usage metrics
-     * - `message_delta` for output token updates
-     */
-    private suspend fun FlowCollector<StreamChunk>.parseAnthropicStreamResponse(
-        response: HttpResponse<InputStream>,
-    ) {
-        val fullText = StringBuilder()
-        var lastUsage: UsageMetrics? = null
-
-        try {
-            response.body().bufferedReader(UTF_8).use { reader ->
-                var currentEvent: String? = null
-                while (true) {
-                    val line = reader.readLine() ?: break
-                    sseEventName(line)?.let { currentEvent = it }
-                    val data = sseDataPayload(line) ?: continue
-                    val node = objectMapper.readTree(data)
-                    lastUsage = handleAnthropicEvent(currentEvent, node, fullText, lastUsage)
-                }
-            }
-            emit(StreamChunk.Complete(fullText.toString(), lastUsage ?: UsageMetrics()))
-        } catch (e: Exception) {
-            e.rethrowIfCancellation()
-            emit(StreamChunk.Error(providerTransportFailureObserved(PROVIDER_ID, e, providerFailureDiagnosticObserver)))
-        }
-    }
-
-    /**
-     * Handles a single Anthropic SSE event (content_block_delta, message_start, message_delta)
-     * and returns the updated [UsageMetrics].
-     */
-    private suspend fun FlowCollector<StreamChunk>.handleAnthropicEvent(
-        currentEvent: String?,
-        node: com.fasterxml.jackson.databind.JsonNode,
-        fullText: StringBuilder,
-        lastUsage: UsageMetrics?,
-    ): UsageMetrics? {
-        when (currentEvent) {
-            "content_block_delta" -> {
-                val text = node.path("delta").path("text").asText("")
-                if (text.isNotEmpty()) {
-                    fullText.append(text)
-                    emit(StreamChunk.Token(text))
-                }
-            }
-            "message_start" -> {
-                val usage = node.path("message").path("usage")
-                if (!usage.isMissingNode) {
-                    return UsageMetrics(
-                        inputTokens = usage.path("input_tokens").asInt(),
-                        outputTokens = usage.path("output_tokens").asInt(),
-                        thinkingTokens = null,
-                    )
-                }
-            }
-            "message_delta" -> {
-                val usage = node.path("usage")
-                if (!usage.isMissingNode) {
-                    return UsageMetrics(
-                        inputTokens = lastUsage?.inputTokens,
-                        outputTokens = usage.path("output_tokens").asInt(),
-                        thinkingTokens = null,
-                    )
-                }
-            }
-        }
-        return lastUsage
-    }
-
-    /**
-     * Converts a Tramai [dev.tramai.core.model.Message] to an Anthropic-compatible request map.
-     *
-     * Three shapes are produced:
-     * - Plain text (and image-carrying) messages keep the existing string/block content.
-     * - Assistant messages carrying [dev.tramai.core.model.ToolCall]s become a content array
-     *   of a text block (when non-blank) plus one `tool_use` block per call.
-     * - [MessageRole.TOOL] results become a `user`-role message with a `tool_result` block.
-     */
-    private fun messageToMap(message: dev.tramai.core.model.Message): Map<String, Any?> {
-        val role = when (message.role) {
-            MessageRole.TOOL -> "user" // Anthropic requires tool results in user-role messages
-            else -> message.role.name.lowercase()
-        }
-        val content: Any = when {
-            message.role == MessageRole.TOOL -> {
-                val toolCallId = requireNotNull(message.toolCallId) {
-                    "TOOL message must carry a toolCallId to map to an Anthropic tool_result block"
-                }
-                // Rich tool results carry their payload in contentParts (the engine
-                // empties content for those); a text-only result stays a plain string.
-                // Anthropic accepts tool_result.content as a string or a block array.
-                val toolParts = message.contentParts
-                val resultContent =
-                    if (!toolParts.isNullOrEmpty()) {
-                        toolParts.map(::anthropicContentPart)
-                    } else {
-                        message.content
+                "message_delta" -> {
+                    val usage = node.path("usage")
+                    if (!usage.isMissingNode) {
+                        return UsageMetrics(
+                            inputTokens = lastUsage?.inputTokens,
+                            outputTokens = usage.path("output_tokens").asInt(),
+                            thinkingTokens = null,
+                        )
                     }
-                listOf(
-                    mapOf(
-                        "type" to "tool_result",
-                        "tool_use_id" to toolCallId,
-                        "content" to resultContent,
-                    ),
-                )
+                }
             }
-            message.role == MessageRole.ASSISTANT && !message.toolCalls.isNullOrEmpty() -> {
-                val toolCalls = message.toolCalls.orEmpty()
-                buildList {
-                    if (message.content.isNotBlank()) {
-                        add(mapOf("type" to "text", "text" to message.content))
-                    }
-                    toolCalls.forEach { call ->
-                        add(
+            return lastUsage
+        }
+
+        /**
+         * Converts a Tramai [dev.tramai.core.model.Message] to an Anthropic-compatible request map.
+         *
+         * Three shapes are produced:
+         * - Plain text (and image-carrying) messages keep the existing string/block content.
+         * - Assistant messages carrying [dev.tramai.core.model.ToolCall]s become a content array
+         *   of a text block (when non-blank) plus one `tool_use` block per call.
+         * - [MessageRole.TOOL] results become a `user`-role message with a `tool_result` block.
+         */
+        private fun messageToMap(message: dev.tramai.core.model.Message): Map<String, Any?> {
+            val role =
+                when (message.role) {
+                    MessageRole.TOOL -> "user"
+
+                    // Anthropic requires tool results in user-role messages
+                    else -> message.role.name.lowercase()
+                }
+            val content: Any =
+                when {
+                    message.role == MessageRole.TOOL -> {
+                        val toolCallId =
+                            requireNotNull(message.toolCallId) {
+                                "TOOL message must carry a toolCallId to map to an Anthropic tool_result block"
+                            }
+                        // Rich tool results carry their payload in contentParts (the engine
+                        // empties content for those); a text-only result stays a plain string.
+                        // Anthropic accepts tool_result.content as a string or a block array.
+                        val toolParts = message.contentParts
+                        val resultContent =
+                            if (!toolParts.isNullOrEmpty()) {
+                                toolParts.map(::anthropicContentPart)
+                            } else {
+                                message.content
+                            }
+                        listOf(
                             mapOf(
-                                "type" to "tool_use",
-                                "id" to call.id,
-                                "name" to call.name,
-                                "input" to objectMapper.readTree(call.argumentsJson),
+                                "type" to "tool_result",
+                                "tool_use_id" to toolCallId,
+                                "content" to resultContent,
                             ),
                         )
                     }
-                }
-            }
-            else -> {
-                val msgParts = message.contentParts
-                if (!msgParts.isNullOrEmpty()) {
-                    msgParts.map(::anthropicContentPart)
-                } else {
-                    message.content
-                }
-            }
-        }
 
-        return mapOf(
-            "role" to role,
-            "content" to content,
-        )
-    }
+                    message.role == MessageRole.ASSISTANT && !message.toolCalls.isNullOrEmpty() -> {
+                        val toolCalls = message.toolCalls.orEmpty()
+                        buildList {
+                            if (message.content.isNotBlank()) {
+                                add(mapOf("type" to "text", "text" to message.content))
+                            }
+                            toolCalls.forEach { call ->
+                                add(
+                                    mapOf(
+                                        "type" to "tool_use",
+                                        "id" to call.id,
+                                        "name" to call.name,
+                                        "input" to objectMapper.readTree(call.argumentsJson),
+                                    ),
+                                )
+                            }
+                        }
+                    }
 
-    /** Converts one TramAI content part to an Anthropic content block (text or image). */
-    private fun anthropicContentPart(part: ContentPart): Map<String, Any?> = when (part) {
-        is ContentPart.TextPart -> mapOf(
-            "type" to "text",
-            "text" to part.text,
-        )
-        is ContentPart.ImagePart -> {
-            require(part.mimeType in SUPPORTED_IMAGE_TYPES) {
-                "Unsupported image mimeType '${part.mimeType}'. Supported types: $SUPPORTED_IMAGE_TYPES"
-            }
-            mapOf(
-                "type" to "image",
-                "source" to mapOf(
-                    "type" to "base64",
-                    "media_type" to part.mimeType,
-                    "data" to Base64.getEncoder().encodeToString(part.data),
-                ),
+                    else -> {
+                        val msgParts = message.contentParts
+                        if (!msgParts.isNullOrEmpty()) {
+                            msgParts.map(::anthropicContentPart)
+                        } else {
+                            message.content
+                        }
+                    }
+                }
+
+            return mapOf(
+                "role" to role,
+                "content" to content,
             )
         }
-        is ContentPart.ImageUrlContent -> {
-            val resolved = dev.tramai.core.util.ImageDownloader.resolveToImagePart(part) as ContentPart.ImagePart
-            require(resolved.mimeType in SUPPORTED_IMAGE_TYPES) {
-                "Unsupported image mimeType '${resolved.mimeType}'. Supported types: $SUPPORTED_IMAGE_TYPES"
+
+        /** Converts one TramAI content part to an Anthropic content block (text or image). */
+        private fun anthropicContentPart(part: ContentPart): Map<String, Any?> =
+            when (part) {
+                is ContentPart.TextPart -> {
+                    mapOf(
+                        "type" to "text",
+                        "text" to part.text,
+                    )
+                }
+
+                is ContentPart.ImagePart -> {
+                    require(part.mimeType in SUPPORTED_IMAGE_TYPES) {
+                        "Unsupported image mimeType '${part.mimeType}'. Supported types: $SUPPORTED_IMAGE_TYPES"
+                    }
+                    mapOf(
+                        "type" to "image",
+                        "source" to
+                            mapOf(
+                                "type" to "base64",
+                                "media_type" to part.mimeType,
+                                "data" to Base64.getEncoder().encodeToString(part.data),
+                            ),
+                    )
+                }
+
+                is ContentPart.ImageUrlContent -> {
+                    val resolved =
+                        dev.tramai.core.util.ImageDownloader
+                            .resolveToImagePart(part) as ContentPart.ImagePart
+                    require(resolved.mimeType in SUPPORTED_IMAGE_TYPES) {
+                        "Unsupported image mimeType '${resolved.mimeType}'. Supported types: $SUPPORTED_IMAGE_TYPES"
+                    }
+                    mapOf(
+                        "type" to "image",
+                        "source" to
+                            mapOf(
+                                "type" to "base64",
+                                "media_type" to resolved.mimeType,
+                                "data" to Base64.getEncoder().encodeToString(resolved.data),
+                            ),
+                    )
+                }
             }
-            mapOf(
-                "type" to "image",
-                "source" to mapOf(
-                    "type" to "base64",
-                    "media_type" to resolved.mimeType,
-                    "data" to Base64.getEncoder().encodeToString(resolved.data),
-                ),
-            )
+
+        private companion object {
+            private val providerLogger: System.Logger = System.getLogger(AnthropicProvider::class.java.name)
+
+            val SUPPORTED_IMAGE_TYPES: Set<String> = setOf("image/png", "image/jpeg", "image/gif", "image/webp")
+
+            const val ANTHROPIC_API_VERSION: String = "2023-06-01"
+            const val PROVIDER_ID: String = "anthropic"
         }
     }
-
-    private companion object {
-        private val providerLogger: System.Logger = System.getLogger(AnthropicProvider::class.java.name)
-
-        val SUPPORTED_IMAGE_TYPES: Set<String> = setOf("image/png", "image/jpeg", "image/gif", "image/webp")
-
-        const val ANTHROPIC_API_VERSION: String = "2023-06-01"
-        const val PROVIDER_ID: String = "anthropic"
-    }
-}

--- a/tramai-azure-openai/src/main/kotlin/dev/tramai/azureopenai/AzureOpenAiProvider.kt
+++ b/tramai-azure-openai/src/main/kotlin/dev/tramai/azureopenai/AzureOpenAiProvider.kt
@@ -4,6 +4,7 @@ package dev.tramai.azureopenai
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import dev.tramai.core.coroutines.rethrowIfCancellation
 import dev.tramai.core.exception.ConfigurationException
 import dev.tramai.core.exception.ProviderFailureCode
 import dev.tramai.core.model.ContentPart
@@ -19,23 +20,23 @@ import dev.tramai.core.provider.ModelProvider
 import dev.tramai.core.provider.ProviderCapability
 import dev.tramai.core.provider.StreamCapable
 import dev.tramai.core.provider.providerTransportFailureObserved
+import dev.tramai.core.provider.safeProviderFailure
 import dev.tramai.core.provider.transport.providerJsonRequest
+import dev.tramai.core.provider.transport.readBoundedResponseBody
 import dev.tramai.core.provider.transport.readSseDataPayload
 import dev.tramai.core.provider.transport.rejectedProviderHttpResponse
-import dev.tramai.core.provider.safeProviderFailure
-import dev.tramai.core.coroutines.rethrowIfCancellation
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
-import kotlin.coroutines.CoroutineContext
-import java.net.URI
 import java.io.InputStream
+import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpResponse
-import java.util.Base64
 import java.nio.charset.StandardCharsets.UTF_8
+import java.util.Base64
+import kotlin.coroutines.CoroutineContext
 
 /**
  * [ModelProvider] implementation for Azure OpenAI.
@@ -54,328 +55,381 @@ import java.nio.charset.StandardCharsets.UTF_8
  * Responses may include content-filtering metadata in headers and content-filter
  * finish reasons.
  */
-class AzureOpenAiProvider @JvmOverloads constructor(
-    private val resourceName: String,
-    private val deploymentId: String,
-    private val apiKey: String? = null,
-    private val apiVersion: String = DEFAULT_API_VERSION,
-    private val httpClient: HttpClient = HttpClient.newHttpClient(),
-    private val objectMapper: ObjectMapper = ObjectMapper(),
-    /** Source for Entra ID (Azure AD) bearer tokens. Called on every request. */
-    private val entraAccessTokenSource: AzureEntraAccessTokenSource? = null,
-    private val ioDispatcher: CoroutineContext = Dispatchers.IO,
-    private val providerFailureDiagnosticObserver: ProviderFailureDiagnosticObserver =
-        NoOpProviderFailureDiagnosticObserver,
-) : ModelProvider, StreamCapable {
-
-    init {
-        require(resourceName.isNotBlank()) { "resourceName must not be blank" }
-        require(deploymentId.isNotBlank()) { "deploymentId must not be blank" }
-        require(apiKey != null || entraAccessTokenSource != null) {
-            "Either apiKey or entraAccessTokenSource must be provided"
+class AzureOpenAiProvider
+    @JvmOverloads
+    constructor(
+        private val resourceName: String,
+        private val deploymentId: String,
+        private val apiKey: String? = null,
+        private val apiVersion: String = DEFAULT_API_VERSION,
+        private val httpClient: HttpClient = HttpClient.newHttpClient(),
+        private val objectMapper: ObjectMapper = ObjectMapper(),
+        /** Source for Entra ID (Azure AD) bearer tokens. Called on every request. */
+        private val entraAccessTokenSource: AzureEntraAccessTokenSource? = null,
+        private val ioDispatcher: CoroutineContext = Dispatchers.IO,
+        private val providerFailureDiagnosticObserver: ProviderFailureDiagnosticObserver =
+            NoOpProviderFailureDiagnosticObserver,
+    ) : ModelProvider,
+        StreamCapable {
+        init {
+            require(resourceName.isNotBlank()) { "resourceName must not be blank" }
+            require(deploymentId.isNotBlank()) { "deploymentId must not be blank" }
+            require(apiKey != null || entraAccessTokenSource != null) {
+                "Either apiKey or entraAccessTokenSource must be provided"
+            }
         }
-    }
 
-    override fun providerId(): String = PROVIDER_ID
+        override fun providerId(): String = PROVIDER_ID
 
-    override fun supportsCapability(capability: ProviderCapability): Boolean = when (capability) {
-        ProviderCapability.VISION -> true
-        ProviderCapability.TOOL_CALLING -> true
-        ProviderCapability.STRUCTURED_OUTPUT -> true
-        ProviderCapability.STREAMING -> true
-    }
+        override fun supportsCapability(capability: ProviderCapability): Boolean =
+            when (capability) {
+                ProviderCapability.VISION -> true
+                ProviderCapability.TOOL_CALLING -> true
+                ProviderCapability.STRUCTURED_OUTPUT -> true
+                ProviderCapability.STREAMING -> true
+            }
 
-    private fun buildUrl(): String {
-        return "https://$resourceName.openai.azure.com/openai/deployments/$deploymentId" +
-            "/chat/completions?apiVersion=$apiVersion"
-    }
+        private fun buildUrl(): String =
+            "https://$resourceName.openai.azure.com/openai/deployments/$deploymentId" +
+                "/chat/completions?apiVersion=$apiVersion"
 
-    private fun resolveAuthToken(): String? {
-        apiKey?.let { return it }
-        return entraAccessTokenSource?.accessToken()
-            ?: throw ConfigurationException(
-                "Azure OpenAI requires either an API key or an Entra ID access token"
-            )
-    }
+        private fun resolveAuthToken(): String? {
+            apiKey?.let { return it }
+            return entraAccessTokenSource?.accessToken()
+                ?: throw ConfigurationException(
+                    "Azure OpenAI requires either an API key or an Entra ID access token",
+                )
+        }
 
-    override suspend fun complete(request: ModelRequest): ModelResponse = withContext(ioDispatcher) {
-        try {
-            val payload = linkedMapOf<String, Any?>(
-                "model" to request.model,
-                "stream" to false,
-                "messages" to request.messages.map { message -> messageToMap(message) },
-            )
+        override suspend fun complete(request: ModelRequest): ModelResponse =
+            withContext(ioDispatcher) {
+                try {
+                    val payload =
+                        linkedMapOf<String, Any?>(
+                            "model" to request.model,
+                            "stream" to false,
+                            "messages" to request.messages.map { message -> messageToMap(message) },
+                        )
 
-            request.tools?.let { tools ->
-                payload["tools"] = tools.map { tool ->
-                    mapOf(
-                        "type" to "function",
-                        "function" to mapOf(
-                            "name" to tool.name,
-                            "description" to tool.description,
-                            "parameters" to objectMapper.readTree(tool.inputSchemaJson),
-                        ),
-                    )
+                    request.tools?.let { tools ->
+                        payload["tools"] =
+                            tools.map { tool ->
+                                mapOf(
+                                    "type" to "function",
+                                    "function" to
+                                        mapOf(
+                                            "name" to tool.name,
+                                            "description" to tool.description,
+                                            "parameters" to objectMapper.readTree(tool.inputSchemaJson),
+                                        ),
+                                )
+                            }
+                    }
+
+                    request.maxTokens?.let { payload["max_tokens"] = it }
+                    request.temperature?.let { payload["temperature"] = it }
+
+                    val authToken = resolveAuthToken()
+                    val httpRequest =
+                        providerJsonRequest(
+                            URI.create(buildUrl()),
+                            request,
+                            objectMapper.writeValueAsString(payload),
+                        ).apply {
+                            // API key auth uses the api-key header; Entra ID uses Bearer auth
+                            if (apiKey != null) {
+                                header("api-key", authToken!!)
+                            } else {
+                                header("Authorization", "Bearer $authToken")
+                            }
+                        }.build()
+
+                    val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
+                    if (response.statusCode() !in 200..299) {
+                        throw rejectedProviderHttpResponse(
+                            providerId = PROVIDER_ID,
+                            providerAlias = null,
+                            response = response,
+                            observer = providerFailureDiagnosticObserver,
+                            logger = providerLogger,
+                        )
+                    }
+
+                    mapResponse(objectMapper.readTree(readBoundedResponseBody(response).text))
+                } catch (error: Throwable) {
+                    error.rethrowIfCancellation()
+                    throw providerTransportFailureObserved(PROVIDER_ID, error, providerFailureDiagnosticObserver)
                 }
             }
 
-            request.maxTokens?.let { payload["max_tokens"] = it }
-            request.temperature?.let { payload["temperature"] = it }
+        override fun stream(request: ModelRequest): Flow<StreamChunk> =
+            flow {
+                val response =
+                    try {
+                        withContext(ioDispatcher) {
+                            val payload =
+                                linkedMapOf<String, Any?>(
+                                    "model" to request.model,
+                                    "stream" to true,
+                                    "messages" to request.messages.map { message -> messageToMap(message) },
+                                )
+                            request.maxTokens?.let { payload["max_tokens"] = it }
+                            request.temperature?.let { payload["temperature"] = it }
 
-            val authToken = resolveAuthToken()
-            val httpRequest = providerJsonRequest(
-                URI.create(buildUrl()),
-                request,
-                objectMapper.writeValueAsString(payload),
-            ).apply {
-                // API key auth uses the api-key header; Entra ID uses Bearer auth
-                if (apiKey != null) {
-                    header("api-key", authToken!!)
-                } else {
-                    header("Authorization", "Bearer $authToken")
+                            val authToken = resolveAuthToken()
+                            val httpRequest =
+                                providerJsonRequest(
+                                    URI.create(buildUrl()),
+                                    request,
+                                    objectMapper.writeValueAsString(payload),
+                                ).apply {
+                                    if (apiKey != null) {
+                                        header("api-key", authToken!!)
+                                    } else {
+                                        header("Authorization", "Bearer $authToken")
+                                    }
+                                }.build()
+                            httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
+                        }
+                    } catch (error: Throwable) {
+                        error.rethrowIfCancellation()
+                        emit(StreamChunk.Error(providerTransportFailureObserved(PROVIDER_ID, error, providerFailureDiagnosticObserver)))
+                        return@flow
+                    }
+
+                val errorChunk = handleHttpError(response)
+                if (errorChunk != null) {
+                    emit(errorChunk)
+                    return@flow
                 }
-            }.build()
 
-            val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
-            if (response.statusCode() !in 200..299) {
-                throw rejectedProviderHttpResponse(
+                parseAzureSseResponse(response)
+            }
+
+        /**
+         * Handles non-2xx HTTP responses for streaming requests.
+         * Returns a [StreamChunk.Error] for failed responses, or `null` for 2xx.
+         */
+        private suspend fun handleHttpError(response: HttpResponse<InputStream>): StreamChunk.Error? {
+            if (response.statusCode() in 200..299) return null
+            return StreamChunk.Error(
+                rejectedProviderHttpResponse(
                     providerId = PROVIDER_ID,
                     providerAlias = null,
                     response = response,
                     observer = providerFailureDiagnosticObserver,
                     logger = providerLogger,
-                )
-            }
-
-            mapResponse(objectMapper.readTree(response.body().use { it.readAllBytes().decodeToString() }))
-        } catch (error: Throwable) {
-            error.rethrowIfCancellation()
-            throw providerTransportFailureObserved(PROVIDER_ID, error, providerFailureDiagnosticObserver)
+                ),
+            )
         }
-    }
 
-    override fun stream(request: ModelRequest): Flow<StreamChunk> = flow {
-        val response = try {
-            withContext(ioDispatcher) {
-                val payload = linkedMapOf<String, Any?>(
-                    "model" to request.model,
-                    "stream" to true,
-                    "messages" to request.messages.map { message -> messageToMap(message) },
-                )
-                request.maxTokens?.let { payload["max_tokens"] = it }
-                request.temperature?.let { payload["temperature"] = it }
+        /**
+         * Parses an Azure OpenAI SSE stream response, handling `data: ` prefix,
+         * `[DONE]` delimiter, delta/content extraction, and usage metrics tracking.
+         */
+        private suspend fun FlowCollector<StreamChunk>.parseAzureSseResponse(response: HttpResponse<InputStream>) {
+            val fullText = StringBuilder()
+            var lastUsage: UsageMetrics? = null
 
-                val authToken = resolveAuthToken()
-                val httpRequest = providerJsonRequest(
-                    URI.create(buildUrl()),
-                    request,
-                    objectMapper.writeValueAsString(payload),
-                ).apply {
-                    if (apiKey != null) {
-                        header("api-key", authToken!!)
-                    } else {
-                        header("Authorization", "Bearer $authToken")
+            try {
+                response.body().bufferedReader(UTF_8).use { reader ->
+                    while (true) {
+                        val data = readSseDataPayload(reader) ?: break
+                        if (data == "[DONE]") break
+                        lastUsage = handleAzureDataLine(data, fullText, lastUsage)
                     }
-                }.build()
-                httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
-            }
-        } catch (error: Throwable) {
-            error.rethrowIfCancellation()
-            emit(StreamChunk.Error(providerTransportFailureObserved(PROVIDER_ID, error, providerFailureDiagnosticObserver)))
-            return@flow
-        }
-
-        val errorChunk = handleHttpError(response)
-        if (errorChunk != null) {
-            emit(errorChunk)
-            return@flow
-        }
-
-        parseAzureSseResponse(response)
-    }
-
-    /**
-     * Handles non-2xx HTTP responses for streaming requests.
-     * Returns a [StreamChunk.Error] for failed responses, or `null` for 2xx.
-     */
-    private suspend fun handleHttpError(
-        response: HttpResponse<InputStream>,
-    ): StreamChunk.Error? {
-        if (response.statusCode() in 200..299) return null
-        return StreamChunk.Error(
-            rejectedProviderHttpResponse(
-                providerId = PROVIDER_ID,
-                providerAlias = null,
-                response = response,
-                observer = providerFailureDiagnosticObserver,
-                logger = providerLogger,
-            ),
-        )
-    }
-
-    /**
-     * Parses an Azure OpenAI SSE stream response, handling `data: ` prefix,
-     * `[DONE]` delimiter, delta/content extraction, and usage metrics tracking.
-     */
-    private suspend fun FlowCollector<StreamChunk>.parseAzureSseResponse(
-        response: HttpResponse<InputStream>,
-    ) {
-        val fullText = StringBuilder()
-        var lastUsage: UsageMetrics? = null
-
-        try {
-            response.body().bufferedReader(UTF_8).use { reader ->
-                while (true) {
-                    val data = readSseDataPayload(reader) ?: break
-                    if (data == "[DONE]") break
-                    lastUsage = handleAzureDataLine(data, fullText, lastUsage)
                 }
+                emit(StreamChunk.Complete(fullText.toString(), lastUsage ?: UsageMetrics()))
+            } catch (e: Exception) {
+                e.rethrowIfCancellation()
+                emit(StreamChunk.Error(providerTransportFailureObserved(PROVIDER_ID, e, providerFailureDiagnosticObserver)))
             }
-            emit(StreamChunk.Complete(fullText.toString(), lastUsage ?: UsageMetrics()))
-        } catch (e: Exception) {
-            e.rethrowIfCancellation()
-            emit(StreamChunk.Error(providerTransportFailureObserved(PROVIDER_ID, e, providerFailureDiagnosticObserver)))
-        }
-    }
-
-    /**
-     * Handles a single Azure SSE data line, extracting content delta and usage metrics.
-     */
-    private suspend fun FlowCollector<StreamChunk>.handleAzureDataLine(
-        data: String,
-        fullText: StringBuilder,
-        lastUsage: UsageMetrics?,
-    ): UsageMetrics? {
-        val chunk = objectMapper.readTree(data)
-        val delta = chunk.path("choices").firstOrNull()?.path("delta")
-        val content = delta?.path("content")?.asText("") ?: ""
-        if (content.isNotEmpty()) {
-            fullText.append(content)
-            emit(StreamChunk.Token(content))
         }
 
-        val usage = chunk.path("usage")
-        return if (!usage.isMissingNode) {
-            UsageMetrics(
-                inputTokens = usage.path("prompt_tokens").asInt(),
-                outputTokens = usage.path("completion_tokens").asInt(),
-                thinkingTokens = usage.path("completion_tokens_details").path("reasoning_tokens").takeIf { !it.isMissingNode }?.asInt(),
-            )
-        } else lastUsage
-    }
+        /**
+         * Handles a single Azure SSE data line, extracting content delta and usage metrics.
+         */
+        private suspend fun FlowCollector<StreamChunk>.handleAzureDataLine(
+            data: String,
+            fullText: StringBuilder,
+            lastUsage: UsageMetrics?,
+        ): UsageMetrics? {
+            val chunk = objectMapper.readTree(data)
+            val delta = chunk.path("choices").firstOrNull()?.path("delta")
+            val content = delta?.path("content")?.asText("") ?: ""
+            if (content.isNotEmpty()) {
+                fullText.append(content)
+                emit(StreamChunk.Token(content))
+            }
 
-    // ---- Response mapping ----
-
-    private fun mapResponse(body: JsonNode): ModelResponse {
-        val firstChoice = body.path("choices").firstOrNull()
-            ?: throw safeProviderFailure(
-                "Azure OpenAI response did not contain any completion choices",
-                ProviderFailureCode.UNEXPECTED_FAILURE,
-            )
-        val message = firstChoice.path("message")
-
-        val toolCalls = message.path("tool_calls").takeIf { it.isArray }?.map { tc ->
-            ToolCall(
-                id = tc.path("id").asText(),
-                name = tc.path("function").path("name").asText(),
-                argumentsJson = tc.path("function").path("arguments").asText(),
-            )
+            val usage = chunk.path("usage")
+            return if (!usage.isMissingNode) {
+                UsageMetrics(
+                    inputTokens = usage.path("prompt_tokens").asInt(),
+                    outputTokens = usage.path("completion_tokens").asInt(),
+                    thinkingTokens =
+                        usage
+                            .path("completion_tokens_details")
+                            .path("reasoning_tokens")
+                            .takeIf { !it.isMissingNode }
+                            ?.asInt(),
+                )
+            } else {
+                lastUsage
+            }
         }
 
-        val finishReason = when (firstChoice.path("finish_reason").asText("")) {
-            "stop" -> FinishReason.STOP
-            "length" -> FinishReason.LENGTH
-            "tool_calls" -> FinishReason.STOP
-            "content_filter" -> FinishReason.CONTENT_FILTER
-            else -> FinishReason.OTHER
-        }
+        // ---- Response mapping ----
 
-        return ModelResponse(
-            content = extractContent(message.path("content")),
-            toolCalls = toolCalls,
-            inputTokens = body.path("usage").path("prompt_tokens").takeIf { !it.isMissingNode }?.asInt(),
-            outputTokens = body.path("usage").path("completion_tokens").takeIf { !it.isMissingNode }?.asInt(),
-            thinkingTokens = body.path("usage").path("completion_tokens_details").path("reasoning_tokens").takeIf { !it.isMissingNode }?.asInt(),
-            modelUsed = body.path("model").takeIf { !it.isMissingNode }?.asText(),
-            finishReason = finishReason,
-        )
-    }
+        private fun mapResponse(body: JsonNode): ModelResponse {
+            val firstChoice =
+                body.path("choices").firstOrNull()
+                    ?: throw safeProviderFailure(
+                        "Azure OpenAI response did not contain any completion choices",
+                        ProviderFailureCode.UNEXPECTED_FAILURE,
+                    )
+            val message = firstChoice.path("message")
 
-    private fun extractContent(contentNode: JsonNode): String {
-        if (contentNode.isTextual) {
-            return contentNode.asText("")
-        }
-        if (contentNode.isArray) {
-            return contentNode.mapNotNull { part ->
-                when {
-                    part.path("type").asText("") in setOf("text", "output_text") ->
-                        part.path("text").asText("").takeIf { it.isNotBlank() }
-                    part.hasNonNull("text") -> part.path("text").asText("").takeIf { it.isNotBlank() }
-                    else -> null
-                }
-            }.joinToString(separator = "\n")
-        }
-        return contentNode.path("text").asText("")
-    }
-
-    // ---- Message conversion ----
-
-    internal fun messageToMap(message: dev.tramai.core.model.Message): Map<String, Any?> {
-        val msgMap = mutableMapOf<String, Any?>("role" to message.role.name.lowercase())
-
-        val msgParts = message.contentParts
-        if (!msgParts.isNullOrEmpty()) {
-            msgMap["content"] = msgParts.map { part ->
-                when (part) {
-                    is ContentPart.TextPart -> mapOf("type" to "text", "text" to part.text)
-                    is ContentPart.ImagePart -> {
-                        require(part.mimeType in SUPPORTED_IMAGE_TYPES) {
-                            "Unsupported image mimeType '${part.mimeType}'. Supported types: $SUPPORTED_IMAGE_TYPES"
-                        }
-                        mapOf(
-                            "type" to "image_url",
-                            "image_url" to mapOf(
-                                "url" to "data:${part.mimeType};base64,${Base64.getEncoder().encodeToString(part.data)}",
-                            ),
-                        )
-                    }
-                    is ContentPart.ImageUrlContent -> mapOf(
-                        "type" to "image_url",
-                        "image_url" to mapOf(
-                            "url" to part.url,
-                        ),
+            val toolCalls =
+                message.path("tool_calls").takeIf { it.isArray }?.map { tc ->
+                    ToolCall(
+                        id = tc.path("id").asText(),
+                        name = tc.path("function").path("name").asText(),
+                        argumentsJson = tc.path("function").path("arguments").asText(),
                     )
                 }
-            }
-        } else {
-            msgMap["content"] = message.content
+
+            val finishReason =
+                when (firstChoice.path("finish_reason").asText("")) {
+                    "stop" -> FinishReason.STOP
+                    "length" -> FinishReason.LENGTH
+                    "tool_calls" -> FinishReason.STOP
+                    "content_filter" -> FinishReason.CONTENT_FILTER
+                    else -> FinishReason.OTHER
+                }
+
+            return ModelResponse(
+                content = extractContent(message.path("content")),
+                toolCalls = toolCalls,
+                inputTokens =
+                    body
+                        .path("usage")
+                        .path("prompt_tokens")
+                        .takeIf { !it.isMissingNode }
+                        ?.asInt(),
+                outputTokens =
+                    body
+                        .path("usage")
+                        .path("completion_tokens")
+                        .takeIf { !it.isMissingNode }
+                        ?.asInt(),
+                thinkingTokens =
+                    body
+                        .path(
+                            "usage",
+                        ).path("completion_tokens_details")
+                        .path("reasoning_tokens")
+                        .takeIf { !it.isMissingNode }
+                        ?.asInt(),
+                modelUsed = body.path("model").takeIf { !it.isMissingNode }?.asText(),
+                finishReason = finishReason,
+            )
         }
 
-        message.toolCallId?.let { msgMap["tool_call_id"] = it }
-        message.toolCalls?.let { toolCalls ->
-            msgMap["tool_calls"] = toolCalls.map { tc ->
-                mapOf(
-                    "id" to tc.id,
-                    "type" to "function",
-                    "function" to mapOf(
-                        "name" to tc.name,
-                        "arguments" to tc.argumentsJson,
-                    ),
-                )
+        private fun extractContent(contentNode: JsonNode): String {
+            if (contentNode.isTextual) {
+                return contentNode.asText("")
             }
+            if (contentNode.isArray) {
+                return contentNode
+                    .mapNotNull { part ->
+                        when {
+                            part.path("type").asText("") in setOf("text", "output_text") -> {
+                                part.path("text").asText("").takeIf { it.isNotBlank() }
+                            }
+
+                            part.hasNonNull("text") -> {
+                                part.path("text").asText("").takeIf { it.isNotBlank() }
+                            }
+
+                            else -> {
+                                null
+                            }
+                        }
+                    }.joinToString(separator = "\n")
+            }
+            return contentNode.path("text").asText("")
         }
-        return msgMap
+
+        // ---- Message conversion ----
+
+        internal fun messageToMap(message: dev.tramai.core.model.Message): Map<String, Any?> {
+            val msgMap = mutableMapOf<String, Any?>("role" to message.role.name.lowercase())
+
+            val msgParts = message.contentParts
+            if (!msgParts.isNullOrEmpty()) {
+                msgMap["content"] =
+                    msgParts.map { part ->
+                        when (part) {
+                            is ContentPart.TextPart -> {
+                                mapOf("type" to "text", "text" to part.text)
+                            }
+
+                            is ContentPart.ImagePart -> {
+                                require(part.mimeType in SUPPORTED_IMAGE_TYPES) {
+                                    "Unsupported image mimeType '${part.mimeType}'. Supported types: $SUPPORTED_IMAGE_TYPES"
+                                }
+                                mapOf(
+                                    "type" to "image_url",
+                                    "image_url" to
+                                        mapOf(
+                                            "url" to "data:${part.mimeType};base64,${Base64.getEncoder().encodeToString(part.data)}",
+                                        ),
+                                )
+                            }
+
+                            is ContentPart.ImageUrlContent -> {
+                                mapOf(
+                                    "type" to "image_url",
+                                    "image_url" to
+                                        mapOf(
+                                            "url" to part.url,
+                                        ),
+                                )
+                            }
+                        }
+                    }
+            } else {
+                msgMap["content"] = message.content
+            }
+
+            message.toolCallId?.let { msgMap["tool_call_id"] = it }
+            message.toolCalls?.let { toolCalls ->
+                msgMap["tool_calls"] =
+                    toolCalls.map { tc ->
+                        mapOf(
+                            "id" to tc.id,
+                            "type" to "function",
+                            "function" to
+                                mapOf(
+                                    "name" to tc.name,
+                                    "arguments" to tc.argumentsJson,
+                                ),
+                        )
+                    }
+            }
+            return msgMap
+        }
+
+        companion object {
+            private val providerLogger: System.Logger = System.getLogger(AzureOpenAiProvider::class.java.name)
+
+            const val PROVIDER_ID: String = "azure-openai"
+            const val DEFAULT_API_VERSION: String = "2024-10-21"
+
+            val SUPPORTED_IMAGE_TYPES: Set<String> = setOf("image/png", "image/jpeg", "image/gif", "image/webp")
+        }
     }
-
-    companion object {
-        private val providerLogger: System.Logger = System.getLogger(AzureOpenAiProvider::class.java.name)
-
-        const val PROVIDER_ID: String = "azure-openai"
-        const val DEFAULT_API_VERSION: String = "2024-10-21"
-
-        val SUPPORTED_IMAGE_TYPES: Set<String> = setOf("image/png", "image/jpeg", "image/gif", "image/webp")
-    }
-}
 
 /**
  * Source for Entra ID (Azure AD) bearer tokens used by [AzureOpenAiProvider].
@@ -393,6 +447,7 @@ fun interface AzureEntraAccessTokenSource {
 class StaticAzureEntraAccessTokenSource(
     private val token: String,
 ) : AzureEntraAccessTokenSource {
-    override fun accessToken(): String = token.trim().takeIf { it.isNotBlank() }
-        ?: throw ConfigurationException("Azure Entra ID access token must not be blank")
+    override fun accessToken(): String =
+        token.trim().takeIf { it.isNotBlank() }
+            ?: throw ConfigurationException("Azure Entra ID access token must not be blank")
 }

--- a/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/BoundedBody.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/BoundedBody.kt
@@ -1,0 +1,15 @@
+package dev.tramai.core.provider.transport
+
+/**
+ * Byte-bounded body read result.
+ *
+ * [text] holds at most [limitBytes] UTF-8 bytes of the source body; [truncated]
+ * reports whether the source contained more than the limit. A truncated result
+ * is a diagnostic signal — callers decide whether to fail loud or surface the
+ * preview.
+ */
+@ExperimentalProviderTransportApi
+data class BoundedBody(
+    val text: String,
+    val truncated: Boolean,
+)

--- a/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/ProviderTransport.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/ProviderTransport.kt
@@ -15,7 +15,7 @@ import java.net.URI
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 
-/**
+/*
  * Low-level HTTP/stream transport machinery shared by provider adapters.
  *
  * This package centralises transport invariants only: request framing,
@@ -27,6 +27,96 @@ import java.net.http.HttpResponse
  * This is cross-module implementation machinery for the built-in adapters,
  * not stable application-facing API; it may change or move in any release.
  */
+
+/** Byte-bounded body read result. */
+@ExperimentalProviderTransportApi
+data class BoundedBody(
+    val text: String,
+    val truncated: Boolean,
+)
+
+/**
+ * Success responses are expected to be JSON; 16 MiB is generous for tool
+ * results and far beyond any legitimate provider/embedding/store response
+ * seen in the test suite.
+ */
+const val PROVIDER_SUCCESS_BODY_LIMIT_BYTES = 16 * 1024 * 1024
+
+/**
+ * Reads at most [limitBytes] bytes from [input] as UTF-8 text, reusing the
+ * proven byte-bounded loop from [readErrorBodyPreview] (byte cap + UTF-8-safe
+ * trim). The stream is always closed. [truncated] reports whether the source
+ * contained more than [limitBytes] bytes.
+ */
+@ExperimentalProviderTransportApi
+fun readBoundedBody(
+    input: InputStream,
+    limitBytes: Int,
+): BoundedBody {
+    require(limitBytes >= 0) { "limitBytes must not be negative" }
+    return input.use { stream ->
+        val bytes = ByteArray(limitBytes + 1)
+        var read = 0
+        while (read < bytes.size) {
+            val count = stream.read(bytes, read, bytes.size - read)
+            if (count < 0) break
+            if (count == 0) {
+                val single = stream.read()
+                if (single < 0) break
+                bytes[read++] = single.toByte()
+            } else {
+                read += count
+            }
+        }
+        val retained = minOf(read, limitBytes)
+        var text = String(bytes, 0, retained, Charsets.UTF_8)
+        while (text.toByteArray(Charsets.UTF_8).size > limitBytes) {
+            text = text.dropLast(1)
+        }
+        BoundedBody(text = text, truncated = read == limitBytes + 1)
+    }
+}
+
+/**
+ * Reads a bounded UTF-8 preview of a java.net.http response body.
+ * Equivalent to [readBoundedBody] applied to [HttpResponse.body]; closes the
+ * body stream on every exit. [truncated] reports overflow beyond [limitBytes].
+ */
+@ExperimentalProviderTransportApi
+fun readBoundedResponseBody(
+    response: HttpResponse<InputStream>,
+    limitBytes: Int = PROVIDER_SUCCESS_BODY_LIMIT_BYTES,
+): BoundedBody = readBoundedBody(response.body(), limitBytes)
+
+/**
+ * Reads at most [limitBytes] bytes from [input] into memory, throwing
+ * IllegalArgumentException when the source exceeds the limit (fail loud, no
+ * silent truncation). The stream is always closed.
+ */
+@ExperimentalProviderTransportApi
+fun readBoundedBodyBytes(
+    input: InputStream,
+    limitBytes: Int,
+): ByteArray {
+    require(limitBytes >= 0) { "limitBytes must not be negative" }
+    return input.use { stream ->
+        val bytes = ByteArray(limitBytes + 1)
+        var read = 0
+        while (read < bytes.size) {
+            val count = stream.read(bytes, read, bytes.size - read)
+            if (count < 0) break
+            if (count == 0) {
+                val single = stream.read()
+                if (single < 0) break
+                bytes[read++] = single.toByte()
+            } else {
+                read += count
+            }
+        }
+        require(read <= limitBytes) { "Response body exceeds limit of $limitBytes bytes" }
+        bytes.copyOf(read)
+    }
+}
 
 /**
  * Builds a JSON HTTP request for a provider endpoint with the normalized
@@ -46,11 +136,13 @@ fun providerJsonRequest(
     uri: URI,
     request: ModelRequest,
     body: String,
-): HttpRequest.Builder = HttpRequest.newBuilder()
-    .uri(uri)
-    .header("Content-Type", "application/json")
-    .applyTramaiTimeout(request)
-    .POST(HttpRequest.BodyPublishers.ofString(body))
+): HttpRequest.Builder =
+    HttpRequest
+        .newBuilder()
+        .uri(uri)
+        .header("Content-Type", "application/json")
+        .applyTramaiTimeout(request)
+        .POST(HttpRequest.BodyPublishers.ofString(body))
 
 /**
  * Builds the safe failure for a rejected (non-2xx) provider HTTP response.
@@ -75,12 +167,13 @@ suspend fun rejectedProviderHttpResponse(
     observer: ProviderFailureDiagnosticObserver,
     logger: System.Logger? = null,
 ): ProviderException {
-    val errorBody = try {
-        readErrorBodyPreview(response.body())
-    } catch (error: Throwable) {
-        error.rethrowIfCancellation()
-        return providerTransportFailureObserved(providerId, providerAlias, error, observer)
-    }
+    val errorBody =
+        try {
+            readErrorBodyPreview(response.body())
+        } catch (error: Throwable) {
+            error.rethrowIfCancellation()
+            return providerTransportFailureObserved(providerId, providerAlias, error, observer)
+        }
     logProviderHttpFailureDebug(logger, providerId, response.statusCode(), errorBody.text)
     return providerHttpFailureObserved(
         providerId = providerId,
@@ -117,8 +210,7 @@ fun readSseDataPayload(reader: BufferedReader): String? {
  * [sseEventName] in their own loop.
  */
 @ExperimentalProviderTransportApi
-fun sseDataPayload(line: String): String? =
-    if (line.startsWith("data: ")) line.substring(6).trim() else null
+fun sseDataPayload(line: String): String? = if (line.startsWith("data: ")) line.substring(6).trim() else null
 
 /**
  * Returns the event name of an SSE `event: ` line, or `null` for any other
@@ -126,5 +218,4 @@ fun sseDataPayload(line: String): String? =
  * [sseDataPayload] in their own loop.
  */
 @ExperimentalProviderTransportApi
-fun sseEventName(line: String): String? =
-    if (line.startsWith("event: ")) line.substring(7).trim() else null
+fun sseEventName(line: String): String? = if (line.startsWith("event: ")) line.substring(7).trim() else null

--- a/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/ProviderTransport.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/ProviderTransport.kt
@@ -105,10 +105,17 @@ fun readBoundedBodyBytes(
  * zero-length-read edge case of blocking streams is handled with a
  * single-byte fallback read.
  */
-private fun readBoundedChunk(stream: InputStream, bytes: ByteArray, offset: Int): Int {
+private fun readBoundedChunk(
+    stream: InputStream,
+    bytes: ByteArray,
+    offset: Int,
+): Int {
     val count = stream.read(bytes, offset, bytes.size - offset)
     return when {
-        count > 0 -> count
+        count > 0 -> {
+            count
+        }
+
         count == 0 -> {
             val single = stream.read()
             if (single >= 0) {
@@ -118,7 +125,10 @@ private fun readBoundedChunk(stream: InputStream, bytes: ByteArray, offset: Int)
                 -1
             }
         }
-        else -> -1
+
+        else -> {
+            -1
+        }
     }
 }
 

--- a/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/ProviderTransport.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/ProviderTransport.kt
@@ -28,13 +28,6 @@ import java.net.http.HttpResponse
  * not stable application-facing API; it may change or move in any release.
  */
 
-/** Byte-bounded body read result. */
-@ExperimentalProviderTransportApi
-data class BoundedBody(
-    val text: String,
-    val truncated: Boolean,
-)
-
 /**
  * Success responses are expected to be JSON; 16 MiB is generous for tool
  * results and far beyond any legitimate provider/embedding/store response
@@ -58,15 +51,9 @@ fun readBoundedBody(
         val bytes = ByteArray(limitBytes + 1)
         var read = 0
         while (read < bytes.size) {
-            val count = stream.read(bytes, read, bytes.size - read)
-            if (count < 0) break
-            if (count == 0) {
-                val single = stream.read()
-                if (single < 0) break
-                bytes[read++] = single.toByte()
-            } else {
-                read += count
-            }
+            val chunk = readBoundedChunk(stream, bytes, read)
+            if (chunk < 0) break
+            read += chunk
         }
         val retained = minOf(read, limitBytes)
         var text = String(bytes, 0, retained, Charsets.UTF_8)
@@ -103,18 +90,35 @@ fun readBoundedBodyBytes(
         val bytes = ByteArray(limitBytes + 1)
         var read = 0
         while (read < bytes.size) {
-            val count = stream.read(bytes, read, bytes.size - read)
-            if (count < 0) break
-            if (count == 0) {
-                val single = stream.read()
-                if (single < 0) break
-                bytes[read++] = single.toByte()
+            val chunk = readBoundedChunk(stream, bytes, read)
+            if (chunk < 0) break
+            read += chunk
+        }
+        require(read <= limitBytes) { "Body exceeds limit of $limitBytes bytes" }
+        bytes.copyOf(read)
+    }
+}
+
+/**
+ * Reads up to [bytes.size] - [offset] bytes from [stream] into [bytes],
+ * returning the number of bytes read, or -1 at end of stream. The
+ * zero-length-read edge case of blocking streams is handled with a
+ * single-byte fallback read.
+ */
+private fun readBoundedChunk(stream: InputStream, bytes: ByteArray, offset: Int): Int {
+    val count = stream.read(bytes, offset, bytes.size - offset)
+    return when {
+        count > 0 -> count
+        count == 0 -> {
+            val single = stream.read()
+            if (single >= 0) {
+                bytes[offset] = single.toByte()
+                1
             } else {
-                read += count
+                -1
             }
         }
-        require(read <= limitBytes) { "Response body exceeds limit of $limitBytes bytes" }
-        bytes.copyOf(read)
+        else -> -1
     }
 }
 

--- a/tramai-core/src/main/kotlin/dev/tramai/core/util/ImageDownloader.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/util/ImageDownloader.kt
@@ -1,12 +1,15 @@
 package dev.tramai.core.util
 
 import dev.tramai.core.model.ContentPart
+import dev.tramai.core.provider.transport.ExperimentalProviderTransportApi
+import dev.tramai.core.provider.transport.readBoundedBodyBytes
 import java.net.URI
 
 /**
  * Utility for downloading images from URLs and resolving [ContentPart.ImageUrlContent]
  * to [ContentPart.ImagePart] by fetching the bytes.
  */
+@OptIn(ExperimentalProviderTransportApi::class)
 object ImageDownloader {
     private const val MAX_DOWNLOAD_SIZE = 20 * 1024 * 1024 // 20MB max per image
 
@@ -20,9 +23,11 @@ object ImageDownloader {
         connection.connectTimeout = 10_000
         connection.readTimeout = 30_000
         val stream = connection.getInputStream()
-        return stream.use { it.readBytes().also { bytes ->
-            require(bytes.size <= MAX_DOWNLOAD_SIZE) { "Image download exceeds maximum size: ${bytes.size} > $MAX_DOWNLOAD_SIZE" }
-        }}
+        return try {
+            readBoundedBodyBytes(stream, MAX_DOWNLOAD_SIZE)
+        } catch (error: IllegalArgumentException) {
+            throw IllegalArgumentException("Image download exceeds maximum size: $MAX_DOWNLOAD_SIZE", error)
+        }
     }
 
     /**
@@ -30,17 +35,24 @@ object ImageDownloader {
      * the URL. If [part] is already an [ContentPart.ImagePart], returns it as-is.
      * Non-image parts are returned unchanged.
      */
-    fun resolveToImagePart(part: ContentPart): ContentPart = when (part) {
-        is ContentPart.ImagePart -> part
-        is ContentPart.ImageUrlContent -> {
-            val bytes = download(part.url)
-            ContentPart.ImagePart(
-                mimeType = part.mimeType ?: detectMimeType(part.url),
-                data = bytes,
-            )
+    fun resolveToImagePart(part: ContentPart): ContentPart =
+        when (part) {
+            is ContentPart.ImagePart -> {
+                part
+            }
+
+            is ContentPart.ImageUrlContent -> {
+                val bytes = download(part.url)
+                ContentPart.ImagePart(
+                    mimeType = part.mimeType ?: detectMimeType(part.url),
+                    data = bytes,
+                )
+            }
+
+            else -> {
+                part
+            }
         }
-        else -> part
-    }
 
     /**
      * Detects a likely MIME type from a URL's file extension.

--- a/tramai-core/src/test/kotlin/dev/tramai/core/provider/transport/BoundedBodyReadTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/provider/transport/BoundedBodyReadTest.kt
@@ -1,0 +1,101 @@
+package dev.tramai.core.provider.transport
+
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpHeaders
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.util.Optional
+import javax.net.ssl.SSLSession
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalProviderTransportApi::class)
+class BoundedBodyReadTest {
+    private class CloseTrackingStream(
+        bytes: ByteArray,
+    ) : ByteArrayInputStream(bytes) {
+        var closed = false
+            private set
+
+        override fun close() {
+            closed = true
+            super.close()
+        }
+    }
+
+    private class FakeResponse(
+        private val bodyStream: InputStream,
+    ) : HttpResponse<InputStream> {
+        override fun statusCode(): Int = 200
+
+        override fun body(): InputStream = bodyStream
+
+        override fun headers(): HttpHeaders = HttpHeaders.of(emptyMap()) { _, _ -> true }
+
+        override fun uri(): URI = URI.create("https://example.invalid")
+
+        override fun request(): HttpRequest = throw UnsupportedOperationException()
+
+        override fun version(): HttpClient.Version? = HttpClient.Version.HTTP_1_1
+
+        override fun previousResponse(): Optional<HttpResponse<InputStream>> = Optional.empty()
+
+        override fun sslSession(): Optional<SSLSession> = Optional.empty()
+    }
+
+    @Test
+    fun `readBoundedBody reads small body fully`() {
+        val result = readBoundedBody(ByteArrayInputStream("hello".toByteArray()), 10)
+
+        assertEquals("hello", result.text)
+        assertTrue(!result.truncated)
+    }
+
+    @Test
+    fun `readBoundedBody truncates oversized body`() {
+        val result = readBoundedBody(ByteArrayInputStream("0123456789".toByteArray()), 4)
+
+        assertEquals("0123", result.text)
+        assertTrue(result.text.toByteArray().size <= 4)
+        assertTrue(result.truncated)
+    }
+
+    @Test
+    fun `readBoundedBody closes stream`() {
+        val stream = CloseTrackingStream("body".toByteArray())
+
+        readBoundedBody(stream, 10)
+
+        assertTrue(stream.closed)
+    }
+
+    @Test
+    fun `readBoundedBodyBytes returns exact bytes within limit`() {
+        val bytes = byteArrayOf(0, 1, 127, -1)
+
+        assertTrue(readBoundedBodyBytes(ByteArrayInputStream(bytes), bytes.size).contentEquals(bytes))
+    }
+
+    @Test
+    fun `readBoundedBodyBytes throws with limit when source exceeds it`() {
+        val error =
+            assertFailsWith<IllegalArgumentException> {
+                readBoundedBodyBytes(ByteArrayInputStream(byteArrayOf(1, 2, 3)), 2)
+            }
+
+        assertTrue(error.message.orEmpty().contains("2"))
+    }
+
+    @Test
+    fun `readBoundedResponseBody reads response body`() {
+        val result = readBoundedResponseBody(FakeResponse(ByteArrayInputStream("{}".toByteArray())), 10)
+
+        assertEquals("{}", result.text)
+        assertTrue(!result.truncated)
+    }
+}

--- a/tramai-embedding/build.gradle.kts
+++ b/tramai-embedding/build.gradle.kts
@@ -9,8 +9,8 @@ plugins {
 
 
 dependencies {
+    implementation(project(":tramai-core"))
     implementation(libs.coroutines.core)
     implementation(libs.jackson.databind)
 
             }
-

--- a/tramai-embedding/src/main/kotlin/dev/tramai/embedding/OllamaEmbeddingModel.kt
+++ b/tramai-embedding/src/main/kotlin/dev/tramai/embedding/OllamaEmbeddingModel.kt
@@ -1,13 +1,15 @@
 package dev.tramai.embedding
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import dev.tramai.core.provider.transport.ExperimentalProviderTransportApi
+import dev.tramai.core.provider.transport.readBoundedResponseBody
 import kotlinx.coroutines.withContext
-import kotlin.coroutines.CoroutineContext
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.time.Duration
+import kotlin.coroutines.CoroutineContext
 
 /**
  * [EmbeddingModel] implementation backed by a local Ollama API.
@@ -20,6 +22,7 @@ import java.time.Duration
  * @param timeoutMs    HTTP request timeout in milliseconds (default: 60000).
  * @param httpClient   HTTP client for making requests.
  */
+@OptIn(ExperimentalProviderTransportApi::class)
 class OllamaEmbeddingModel(
     private val baseUrl: String = "http://localhost:11434",
     private val model: String = "nomic-embed-text",
@@ -28,7 +31,6 @@ class OllamaEmbeddingModel(
     private val httpClient: HttpClient = HttpClient.newHttpClient(),
     private val ioDispatcher: CoroutineContext = kotlinx.coroutines.Dispatchers.IO,
 ) : EmbeddingModel {
-
     override fun providerId(): String = "ollama"
 
     @Volatile
@@ -43,39 +45,44 @@ class OllamaEmbeddingModel(
     override suspend fun embedAll(texts: List<String>): List<FloatArray> {
         require(texts.isNotEmpty()) { "texts must not be empty" }
 
-        val payload = mapOf(
-            "model" to model,
-            "input" to texts,
-        )
+        val payload =
+            mapOf(
+                "model" to model,
+                "input" to texts,
+            )
         val jsonPayload = MAPPER.writeValueAsString(payload)
 
         return withContext(ioDispatcher) {
             try {
-                val requestBuilder = HttpRequest.newBuilder()
-                    .uri(URI.create("${baseUrl.trimEnd('/')}/api/embed"))
-                    .header("Content-Type", "application/json")
-                    .timeout(Duration.ofMillis(timeoutMs))
-                    .POST(HttpRequest.BodyPublishers.ofString(jsonPayload))
+                val requestBuilder =
+                    HttpRequest
+                        .newBuilder()
+                        .uri(URI.create("${baseUrl.trimEnd('/')}/api/embed"))
+                        .header("Content-Type", "application/json")
+                        .timeout(Duration.ofMillis(timeoutMs))
+                        .POST(HttpRequest.BodyPublishers.ofString(jsonPayload))
 
                 token?.let { requestBuilder.header("Authorization", "Bearer $it") }
 
                 val httpRequest = requestBuilder.build()
-                val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString())
+                val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
+                val bounded = readBoundedResponseBody(response)
                 if (response.statusCode() !in 200..299) {
                     throw EmbeddingException(
-                        "Ollama embeddings API returned HTTP ${response.statusCode()}: ${response.body().take(500)}"
+                        "Ollama embeddings API returned HTTP ${response.statusCode()}: ${bounded.text.take(500)}",
                     )
                 }
 
-                val body = MAPPER.readTree(response.body())
+                val body = MAPPER.readTree(bounded.text)
                 val embeddingsArray = body.path("embeddings")
                 if (!embeddingsArray.isArray) {
                     throw EmbeddingException("Ollama embeddings response missing 'embeddings' array")
                 }
 
-                val results = embeddingsArray.map { entry ->
-                    entry.map { it.floatValue() }.toFloatArray()
-                }
+                val results =
+                    embeddingsArray.map { entry ->
+                        entry.map { it.floatValue() }.toFloatArray()
+                    }
 
                 // Validate all results have the same positive dimension.
                 require(results.all { it.isNotEmpty() }) {
@@ -99,13 +106,12 @@ class OllamaEmbeddingModel(
         }
     }
 
-    override fun dimensions(): Int {
-        return cachedDimensions
+    override fun dimensions(): Int =
+        cachedDimensions
             ?: throw IllegalStateException(
                 "Ollama embeddings dimensions are not available until after the first successful embed() call. " +
-                    "Call embed() or embedAll() first."
+                    "Call embed() or embedAll() first.",
             )
-    }
 
     companion object {
         private val MAPPER: ObjectMapper = ObjectMapper()

--- a/tramai-embedding/src/main/kotlin/dev/tramai/embedding/OpenAiEmbeddingModel.kt
+++ b/tramai-embedding/src/main/kotlin/dev/tramai/embedding/OpenAiEmbeddingModel.kt
@@ -2,13 +2,15 @@ package dev.tramai.embedding
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import dev.tramai.core.provider.transport.ExperimentalProviderTransportApi
+import dev.tramai.core.provider.transport.readBoundedResponseBody
 import kotlinx.coroutines.withContext
-import kotlin.coroutines.CoroutineContext
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.time.Duration
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Request payload for the OpenAI Embeddings API.
@@ -36,6 +38,7 @@ internal data class OpenAiEmbeddingRequest(
  * @param timeoutMs    HTTP request timeout in milliseconds (default: 60000).
  * @param httpClient   HTTP client for making requests.
  */
+@OptIn(ExperimentalProviderTransportApi::class)
 class OpenAiEmbeddingModel(
     private val apiKey: String,
     private val model: String = "text-embedding-3-small",
@@ -45,7 +48,6 @@ class OpenAiEmbeddingModel(
     private val httpClient: HttpClient = HttpClient.newHttpClient(),
     private val ioDispatcher: CoroutineContext = kotlinx.coroutines.Dispatchers.IO,
 ) : EmbeddingModel {
-
     override fun providerId(): String = "openai"
 
     @Volatile
@@ -61,44 +63,49 @@ class OpenAiEmbeddingModel(
     override suspend fun embedAll(texts: List<String>): List<FloatArray> {
         require(texts.isNotEmpty()) { "texts must not be empty" }
         // Build the JSON payload on the calling thread (CPU-bound work).
-        val payload = OpenAiEmbeddingRequest(
-            model = model,
-            input = texts,
-            dimensions = dimensions,
-        )
+        val payload =
+            OpenAiEmbeddingRequest(
+                model = model,
+                input = texts,
+                dimensions = dimensions,
+            )
         val jsonPayload = MAPPER.writeValueAsString(payload)
 
         // Only the HTTP send is dispatched to IO.
         return withContext(ioDispatcher) {
             try {
-                val httpRequest = HttpRequest.newBuilder()
-                    .uri(URI.create("${baseUrl.trimEnd('/')}/embeddings"))
-                    .header("Authorization", "Bearer $apiKey")
-                    .header("Content-Type", "application/json")
-                    .timeout(Duration.ofMillis(timeoutMs))
-                    .POST(HttpRequest.BodyPublishers.ofString(jsonPayload))
-                    .build()
+                val httpRequest =
+                    HttpRequest
+                        .newBuilder()
+                        .uri(URI.create("${baseUrl.trimEnd('/')}/embeddings"))
+                        .header("Authorization", "Bearer $apiKey")
+                        .header("Content-Type", "application/json")
+                        .timeout(Duration.ofMillis(timeoutMs))
+                        .POST(HttpRequest.BodyPublishers.ofString(jsonPayload))
+                        .build()
 
-                val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString())
+                val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
+                val bounded = readBoundedResponseBody(response)
                 if (response.statusCode() !in 200..299) {
                     throw EmbeddingException(
-                        "OpenAI embeddings API returned HTTP ${response.statusCode()}: ${response.body().take(500)}"
+                        "OpenAI embeddings API returned HTTP ${response.statusCode()}: ${bounded.text.take(500)}",
                     )
                 }
 
-                val body = MAPPER.readTree(response.body())
+                val body = MAPPER.readTree(bounded.text)
                 val data = body.path("data")
                 if (!data.isArray) {
                     throw EmbeddingException("OpenAI embeddings response missing 'data' array")
                 }
 
-                val results = data.map { entry ->
-                    val embeddingArray = entry.path("embedding")
-                    if (!embeddingArray.isArray) {
-                        throw EmbeddingException("OpenAI embeddings response entry missing 'embedding' array")
+                val results =
+                    data.map { entry ->
+                        val embeddingArray = entry.path("embedding")
+                        if (!embeddingArray.isArray) {
+                            throw EmbeddingException("OpenAI embeddings response entry missing 'embedding' array")
+                        }
+                        embeddingArray.map { it.floatValue() }.toFloatArray()
                     }
-                    embeddingArray.map { it.floatValue() }.toFloatArray()
-                }
 
                 // Dynamically derive dimensions from first API response if not hardcoded.
                 if (dimensions == null && results.isNotEmpty()) {
@@ -113,13 +120,12 @@ class OpenAiEmbeddingModel(
         }
     }
 
-    override fun dimensions(): Int {
-        return cachedDimensions
+    override fun dimensions(): Int =
+        cachedDimensions
             ?: throw EmbeddingException(
                 "OpenAI embedding dimensions are not available until after the first successful embed() call. " +
-                    "Call embed() or embedAll() first."
+                    "Call embed() or embedAll() first.",
             )
-    }
 
     companion object {
         const val DEFAULT_BASE_URL: String = "https://api.openai.com/v1"

--- a/tramai-gemini/src/main/kotlin/dev/tramai/gemini/GeminiProvider.kt
+++ b/tramai-gemini/src/main/kotlin/dev/tramai/gemini/GeminiProvider.kt
@@ -4,6 +4,7 @@ package dev.tramai.gemini
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import dev.tramai.core.coroutines.rethrowIfCancellation
 import dev.tramai.core.exception.ProviderFailureCode
 import dev.tramai.core.model.ContentPart
 import dev.tramai.core.model.FinishReason
@@ -19,24 +20,24 @@ import dev.tramai.core.provider.ModelProvider
 import dev.tramai.core.provider.ProviderCapability
 import dev.tramai.core.provider.StreamCapable
 import dev.tramai.core.provider.providerTransportFailureObserved
+import dev.tramai.core.provider.safeProviderFailure
 import dev.tramai.core.provider.transport.providerJsonRequest
+import dev.tramai.core.provider.transport.readBoundedResponseBody
 import dev.tramai.core.provider.transport.readSseDataPayload
 import dev.tramai.core.provider.transport.rejectedProviderHttpResponse
-import dev.tramai.core.provider.safeProviderFailure
-import dev.tramai.core.coroutines.rethrowIfCancellation
 import dev.tramai.core.util.ImageDownloader
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
-import kotlin.coroutines.CoroutineContext
-import java.net.URI
 import java.io.InputStream
+import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpResponse
-import java.util.Base64
 import java.nio.charset.StandardCharsets.UTF_8
+import java.util.Base64
+import kotlin.coroutines.CoroutineContext
 
 /**
  * [ModelProvider] implementation for Google Gemini API.
@@ -55,361 +56,387 @@ import java.nio.charset.StandardCharsets.UTF_8
  * | Streaming              | streamGenerateContent                                      |
  * | ImagePart              | inlineData { mimeType, data } within content parts         |
  */
-class GeminiProvider @JvmOverloads constructor(
-    private val apiKey: String,
-    private val baseUrl: String = DEFAULT_BASE_URL,
-    private val httpClient: HttpClient = HttpClient.newHttpClient(),
-    private val objectMapper: ObjectMapper = ObjectMapper(),
-    /** Optional JSON schema string for structured output (responseSchema). */
-    private val responseSchema: String? = null,
-    /** Gemini API version to use, e.g. "v1" or "v1beta". */
-    private val apiVersion: String = DEFAULT_API_VERSION,
-    private val ioDispatcher: CoroutineContext = Dispatchers.IO,
-    private val providerFailureDiagnosticObserver: ProviderFailureDiagnosticObserver =
-        NoOpProviderFailureDiagnosticObserver,
-) : ModelProvider, StreamCapable {
+class GeminiProvider
+    @JvmOverloads
+    constructor(
+        private val apiKey: String,
+        private val baseUrl: String = DEFAULT_BASE_URL,
+        private val httpClient: HttpClient = HttpClient.newHttpClient(),
+        private val objectMapper: ObjectMapper = ObjectMapper(),
+        /** Optional JSON schema string for structured output (responseSchema). */
+        private val responseSchema: String? = null,
+        /** Gemini API version to use, e.g. "v1" or "v1beta". */
+        private val apiVersion: String = DEFAULT_API_VERSION,
+        private val ioDispatcher: CoroutineContext = Dispatchers.IO,
+        private val providerFailureDiagnosticObserver: ProviderFailureDiagnosticObserver =
+            NoOpProviderFailureDiagnosticObserver,
+    ) : ModelProvider,
+        StreamCapable {
+        override fun providerId(): String = PROVIDER_ID
 
-    override fun providerId(): String = PROVIDER_ID
+        override fun supportsCapability(capability: ProviderCapability): Boolean =
+            when (capability) {
+                ProviderCapability.VISION -> true
+                ProviderCapability.TOOL_CALLING -> true
+                ProviderCapability.STRUCTURED_OUTPUT -> true
+                ProviderCapability.STREAMING -> true
+            }
 
-    override fun supportsCapability(capability: ProviderCapability): Boolean = when (capability) {
-        ProviderCapability.VISION -> true
-        ProviderCapability.TOOL_CALLING -> true
-        ProviderCapability.STRUCTURED_OUTPUT -> true
-        ProviderCapability.STREAMING -> true
-    }
+        override suspend fun complete(request: ModelRequest): ModelResponse =
+            withContext(ioDispatcher) {
+                try {
+                    val modelName = request.model.takeIf { it.isNotBlank() } ?: DEFAULT_MODEL
+                    val url = "${baseUrl.trimEnd('/')}/$apiVersion/models/$modelName:generateContent"
+                    val payload = buildPayload(request)
+                    val httpRequest =
+                        providerJsonRequest(
+                            URI.create(url),
+                            request,
+                            objectMapper.writeValueAsString(payload),
+                        ).apply {
+                            header("X-Goog-Api-Key", apiKey)
+                        }.build()
 
-    override suspend fun complete(request: ModelRequest): ModelResponse = withContext(ioDispatcher) {
-        try {
-            val modelName = request.model.takeIf { it.isNotBlank() } ?: DEFAULT_MODEL
-            val url = "${baseUrl.trimEnd('/')}/$apiVersion/models/$modelName:generateContent"
-            val payload = buildPayload(request)
-            val httpRequest = providerJsonRequest(
-                URI.create(url),
-                request,
-                objectMapper.writeValueAsString(payload),
-            ).apply {
-                header("X-Goog-Api-Key", apiKey)
-            }.build()
+                    val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
+                    if (response.statusCode() !in 200..299) {
+                        throw rejectedProviderHttpResponse(
+                            providerId = PROVIDER_ID,
+                            providerAlias = null,
+                            response = response,
+                            observer = providerFailureDiagnosticObserver,
+                            logger = providerLogger,
+                        )
+                    }
 
-            val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
-            if (response.statusCode() !in 200..299) {
-                throw rejectedProviderHttpResponse(
+                    val body = objectMapper.readTree(readBoundedResponseBody(response).text)
+                    mapResponse(body)
+                } catch (error: Throwable) {
+                    error.rethrowIfCancellation()
+                    throw providerTransportFailureObserved(PROVIDER_ID, error, providerFailureDiagnosticObserver)
+                }
+            }
+
+        override fun stream(request: ModelRequest): Flow<StreamChunk> =
+            flow {
+                val response =
+                    try {
+                        withContext(ioDispatcher) {
+                            val modelName = request.model.takeIf { it.isNotBlank() } ?: DEFAULT_MODEL
+                            val url = "${baseUrl.trimEnd('/')}/$apiVersion/models/$modelName:streamGenerateContent?alt=sse"
+                            val payload = buildPayload(request)
+                            val httpRequest =
+                                providerJsonRequest(
+                                    URI.create(url),
+                                    request,
+                                    objectMapper.writeValueAsString(payload),
+                                ).apply {
+                                    header("X-Goog-Api-Key", apiKey)
+                                }.build()
+                            httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
+                        }
+                    } catch (error: Throwable) {
+                        error.rethrowIfCancellation()
+                        emit(StreamChunk.Error(providerTransportFailureObserved(PROVIDER_ID, error, providerFailureDiagnosticObserver)))
+                        return@flow
+                    }
+
+                val errorChunk = handleHttpError(response)
+                if (errorChunk != null) {
+                    emit(errorChunk)
+                    return@flow
+                }
+
+                parseGeminiStreamResponse(response)
+            }
+
+        /**
+         * Handles non-2xx HTTP responses for streaming requests.
+         * Returns a [StreamChunk.Error] for failed responses, or `null` for 2xx.
+         */
+        private suspend fun handleHttpError(response: HttpResponse<InputStream>): StreamChunk.Error? {
+            if (response.statusCode() in 200..299) return null
+            return StreamChunk.Error(
+                rejectedProviderHttpResponse(
                     providerId = PROVIDER_ID,
                     providerAlias = null,
                     response = response,
                     observer = providerFailureDiagnosticObserver,
                     logger = providerLogger,
+                ),
+            )
+        }
+
+        /**
+         * Parses the Gemini SSE stream response, handling Gemini-specific
+         * `data: ` format with nested `candidates[].content.parts[].text` structure
+         * and `usageMetadata` tracking.
+         */
+        private suspend fun FlowCollector<StreamChunk>.parseGeminiStreamResponse(response: HttpResponse<InputStream>) {
+            val fullText = StringBuilder()
+            var lastUsage: UsageMetrics? = null
+
+            try {
+                response.body().bufferedReader(UTF_8).use { reader ->
+                    while (true) {
+                        val data = readSseDataPayload(reader) ?: break
+                        // Gemini SSE format: "data: {...}"
+                        if (data.isEmpty()) continue
+                        if (data == "[DONE]") break
+                        lastUsage = handleGeminiDataLine(data, fullText, lastUsage)
+                    }
+                }
+                emit(StreamChunk.Complete(fullText.toString(), lastUsage ?: UsageMetrics()))
+            } catch (e: Exception) {
+                e.rethrowIfCancellation()
+                emit(StreamChunk.Error(providerTransportFailureObserved(PROVIDER_ID, e, providerFailureDiagnosticObserver)))
+            }
+        }
+
+        /**
+         * Handles a single Gemini SSE data line, extracting candidate text parts and usage metadata.
+         */
+        private suspend fun FlowCollector<StreamChunk>.handleGeminiDataLine(
+            data: String,
+            fullText: StringBuilder,
+            lastUsage: UsageMetrics?,
+        ): UsageMetrics? {
+            val chunk = objectMapper.readTree(data)
+            val candidates = chunk.path("candidates")
+            if (candidates.isArray && candidates.size() > 0) {
+                val content = candidates[0].path("content")
+                val parts = content.path("parts")
+                if (parts.isArray) {
+                    for (part in parts) {
+                        val text = part.path("text").asText("")
+                        if (text.isNotEmpty()) {
+                            fullText.append(text)
+                            emit(StreamChunk.Token(text))
+                        }
+                    }
+                }
+            }
+
+            val usageMetadata = chunk.path("usageMetadata")
+            return if (!usageMetadata.isMissingNode) {
+                UsageMetrics(
+                    inputTokens = usageMetadata.path("promptTokenCount").takeIf { !it.isMissingNode }?.asInt(),
+                    outputTokens = usageMetadata.path("candidatesTokenCount").takeIf { !it.isMissingNode }?.asInt(),
+                )
+            } else {
+                lastUsage
+            }
+        }
+
+        // ---- Payload construction ----
+
+        private fun buildPayload(request: ModelRequest): Map<String, Any?> {
+            val payload = linkedMapOf<String, Any?>()
+
+            // Map messages to Gemini contents array
+            val contents =
+                request.messages
+                    .filter { it.role.name.lowercase() != "system" }
+                    .map { message ->
+                        val role =
+                            when (message.role.name.lowercase()) {
+                                "assistant" -> "model"
+                                "tool" -> "function"
+                                else -> "user"
+                            }
+                        mapOf(
+                            "role" to role,
+                            "parts" to buildContentParts(message),
+                        )
+                    }
+
+            if (contents.isNotEmpty()) {
+                payload["contents"] = contents
+            }
+
+            // System instruction
+            val systemMessage = request.messages.firstOrNull { it.role.name.lowercase() == "system" }?.content
+            if (!systemMessage.isNullOrBlank()) {
+                payload["system_instruction"] =
+                    mapOf(
+                        "parts" to listOf(mapOf("text" to systemMessage)),
+                    )
+            }
+
+            // Tool definitions — wrap all in a single function_declarations array
+            request.tools?.let { tools ->
+                payload["tools"] =
+                    listOf(
+                        mapOf(
+                            "function_declarations" to
+                                tools.map { tool ->
+                                    mapOf(
+                                        "name" to tool.name,
+                                        "description" to tool.description,
+                                        "parameters" to objectMapper.readTree(tool.inputSchemaJson),
+                                    )
+                                },
+                        ),
+                    )
+            }
+
+            // Generation configuration
+            val generationConfig = linkedMapOf<String, Any?>()
+            request.maxTokens?.let { generationConfig["maxOutputTokens"] = it }
+            request.temperature?.let { generationConfig["temperature"] = it }
+            val schema = responseSchema
+            if (schema != null) {
+                generationConfig["responseMimeType"] = APPLICATION_JSON
+                generationConfig["responseSchema"] = objectMapper.readTree(schema)
+            }
+
+            if (generationConfig.isNotEmpty()) {
+                payload["generationConfig"] = generationConfig
+            }
+
+            return payload
+        }
+
+        private fun buildContentParts(message: dev.tramai.core.model.Message): List<Any> {
+            // Tool (function) responses use Gemini's functionResponse format
+            if (message.role == MessageRole.TOOL) {
+                val name = message.toolCallId ?: "unknown_function"
+                return listOf(
+                    mapOf(
+                        "functionResponse" to
+                            mapOf(
+                                "name" to name,
+                                "response" to
+                                    mapOf(
+                                        "content" to message.content,
+                                    ),
+                            ),
+                    ),
                 )
             }
 
-            val body = objectMapper.readTree(response.body().use { it.readAllBytes().decodeToString() })
-            mapResponse(body)
-        } catch (error: Throwable) {
-            error.rethrowIfCancellation()
-            throw providerTransportFailureObserved(PROVIDER_ID, error, providerFailureDiagnosticObserver)
-        }
-    }
-
-    override fun stream(request: ModelRequest): Flow<StreamChunk> = flow {
-        val response = try {
-            withContext(ioDispatcher) {
-                val modelName = request.model.takeIf { it.isNotBlank() } ?: DEFAULT_MODEL
-                val url = "${baseUrl.trimEnd('/')}/$apiVersion/models/$modelName:streamGenerateContent?alt=sse"
-                val payload = buildPayload(request)
-                val httpRequest = providerJsonRequest(
-                    URI.create(url),
-                    request,
-                    objectMapper.writeValueAsString(payload),
-                ).apply {
-                    header("X-Goog-Api-Key", apiKey)
-                }.build()
-                httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
+            val msgParts = message.contentParts
+            if (msgParts.isNullOrEmpty()) {
+                // Fall back to plain text content
+                return listOf(mapOf("text" to message.content))
             }
-        } catch (error: Throwable) {
-            error.rethrowIfCancellation()
-            emit(StreamChunk.Error(providerTransportFailureObserved(PROVIDER_ID, error, providerFailureDiagnosticObserver)))
-            return@flow
-        }
 
-        val errorChunk = handleHttpError(response)
-        if (errorChunk != null) {
-            emit(errorChunk)
-            return@flow
-        }
+            return msgParts.map { part ->
+                when (part) {
+                    is ContentPart.TextPart -> {
+                        mapOf("text" to part.text)
+                    }
 
-        parseGeminiStreamResponse(response)
-    }
+                    is ContentPart.ImagePart -> {
+                        mapOf(
+                            "inlineData" to
+                                mapOf(
+                                    "mimeType" to part.mimeType,
+                                    "data" to Base64.getEncoder().encodeToString(part.data),
+                                ),
+                        )
+                    }
 
-    /**
-     * Handles non-2xx HTTP responses for streaming requests.
-     * Returns a [StreamChunk.Error] for failed responses, or `null` for 2xx.
-     */
-    private suspend fun handleHttpError(
-        response: HttpResponse<InputStream>,
-    ): StreamChunk.Error? {
-        if (response.statusCode() in 200..299) return null
-        return StreamChunk.Error(
-            rejectedProviderHttpResponse(
-                providerId = PROVIDER_ID,
-                providerAlias = null,
-                response = response,
-                observer = providerFailureDiagnosticObserver,
-                logger = providerLogger,
-            ),
-        )
-    }
-
-    /**
-     * Parses the Gemini SSE stream response, handling Gemini-specific
-     * `data: ` format with nested `candidates[].content.parts[].text` structure
-     * and `usageMetadata` tracking.
-     */
-    private suspend fun FlowCollector<StreamChunk>.parseGeminiStreamResponse(
-        response: HttpResponse<InputStream>,
-    ) {
-        val fullText = StringBuilder()
-        var lastUsage: UsageMetrics? = null
-
-        try {
-            response.body().bufferedReader(UTF_8).use { reader ->
-                while (true) {
-                    val data = readSseDataPayload(reader) ?: break
-                    // Gemini SSE format: "data: {...}"
-                    if (data.isEmpty()) continue
-                    if (data == "[DONE]") break
-                    lastUsage = handleGeminiDataLine(data, fullText, lastUsage)
-                }
-            }
-            emit(StreamChunk.Complete(fullText.toString(), lastUsage ?: UsageMetrics()))
-        } catch (e: Exception) {
-            e.rethrowIfCancellation()
-            emit(StreamChunk.Error(providerTransportFailureObserved(PROVIDER_ID, e, providerFailureDiagnosticObserver)))
-        }
-    }
-
-    /**
-     * Handles a single Gemini SSE data line, extracting candidate text parts and usage metadata.
-     */
-    private suspend fun FlowCollector<StreamChunk>.handleGeminiDataLine(
-        data: String,
-        fullText: StringBuilder,
-        lastUsage: UsageMetrics?,
-    ): UsageMetrics? {
-        val chunk = objectMapper.readTree(data)
-        val candidates = chunk.path("candidates")
-        if (candidates.isArray && candidates.size() > 0) {
-            val content = candidates[0].path("content")
-            val parts = content.path("parts")
-            if (parts.isArray) {
-                for (part in parts) {
-                    val text = part.path("text").asText("")
-                    if (text.isNotEmpty()) {
-                        fullText.append(text)
-                        emit(StreamChunk.Token(text))
+                    is ContentPart.ImageUrlContent -> {
+                        val resolved = ImageDownloader.resolveToImagePart(part) as ContentPart.ImagePart
+                        mapOf(
+                            "inlineData" to
+                                mapOf(
+                                    "mimeType" to resolved.mimeType,
+                                    "data" to Base64.getEncoder().encodeToString(resolved.data),
+                                ),
+                        )
                     }
                 }
             }
         }
 
-        val usageMetadata = chunk.path("usageMetadata")
-        return if (!usageMetadata.isMissingNode) {
-            UsageMetrics(
+        // ---- Response mapping ----
+
+        private fun mapResponse(body: JsonNode): ModelResponse {
+            val candidate =
+                body.path("candidates").firstOrNull()
+                    ?: throw safeProviderFailure(
+                        "Gemini response did not contain any candidates",
+                        ProviderFailureCode.UNEXPECTED_FAILURE,
+                    )
+
+            val content = candidate.path("content")
+            val parts = content.path("parts")
+
+            val text =
+                if (parts.isArray) {
+                    parts
+                        .mapNotNull { it.path("text").asText("").takeIf { t -> t.isNotEmpty() } }
+                        .joinToString("")
+                } else {
+                    ""
+                }
+
+            // Extract function calls if present
+            val toolCalls =
+                if (parts.isArray) {
+                    val calls = mutableListOf<ToolCall>()
+                    var index = 0
+                    for (part in parts) {
+                        val fc = part.path("functionCall")
+                        if (!fc.isMissingNode) {
+                            val name = fc.path("name").asText("")
+                            calls.add(
+                                ToolCall(
+                                    id = "fc_${name}_$index",
+                                    name = name,
+                                    argumentsJson = objectMapper.writeValueAsString(fc.path("args")),
+                                ),
+                            )
+                            index++
+                        } else {
+                            // Log warning for non-text, non-function-call response parts.
+                            // The part itself is untrusted response data: never log it.
+                            val partText = part.path("text").asText("")
+                            if (partText.isEmpty()) {
+                                providerLogger.log(
+                                    System.Logger.Level.WARNING,
+                                    "Gemini response contained a part that is neither text nor functionCall",
+                                )
+                            }
+                        }
+                    }
+                    calls.ifEmpty { null }
+                } else {
+                    null
+                }
+
+            val finishReason = candidate.path("finishReason").asText("")
+            val usageMetadata = body.path("usageMetadata")
+
+            return ModelResponse(
+                content = text,
+                toolCalls = toolCalls,
                 inputTokens = usageMetadata.path("promptTokenCount").takeIf { !it.isMissingNode }?.asInt(),
                 outputTokens = usageMetadata.path("candidatesTokenCount").takeIf { !it.isMissingNode }?.asInt(),
+                modelUsed = body.path("model").takeIf { !it.isMissingNode }?.asText(),
+                finishReason = mapFinishReason(finishReason),
             )
-        } else lastUsage
-    }
+        }
 
-    // ---- Payload construction ----
-
-    private fun buildPayload(request: ModelRequest): Map<String, Any?> {
-        val payload = linkedMapOf<String, Any?>()
-
-        // Map messages to Gemini contents array
-        val contents = request.messages
-            .filter { it.role.name.lowercase() != "system" }
-            .map { message ->
-                val role = when (message.role.name.lowercase()) {
-                    "assistant" -> "model"
-                    "tool" -> "function"
-                    else -> "user"
-                }
-                mapOf(
-                    "role" to role,
-                    "parts" to buildContentParts(message),
-                )
+        private fun mapFinishReason(reason: String): FinishReason =
+            when (reason) {
+                "STOP" -> FinishReason.STOP
+                "MAX_TOKENS" -> FinishReason.LENGTH
+                "SAFETY" -> FinishReason.CONTENT_FILTER
+                "RECITATION" -> FinishReason.CONTENT_FILTER
+                else -> FinishReason.OTHER
             }
 
-        if (contents.isNotEmpty()) {
-            payload["contents"] = contents
-        }
+        companion object {
+            private val providerLogger: System.Logger = System.getLogger(GeminiProvider::class.java.name)
 
-        // System instruction
-        val systemMessage = request.messages.firstOrNull { it.role.name.lowercase() == "system" }?.content
-        if (!systemMessage.isNullOrBlank()) {
-            payload["system_instruction"] = mapOf(
-                "parts" to listOf(mapOf("text" to systemMessage)),
-            )
-        }
-
-        // Tool definitions — wrap all in a single function_declarations array
-        request.tools?.let { tools ->
-            payload["tools"] = listOf(
-                mapOf(
-                    "function_declarations" to tools.map { tool ->
-                        mapOf(
-                            "name" to tool.name,
-                            "description" to tool.description,
-                            "parameters" to objectMapper.readTree(tool.inputSchemaJson),
-                        )
-                    },
-                ),
-            )
-        }
-
-        // Generation configuration
-        val generationConfig = linkedMapOf<String, Any?>()
-        request.maxTokens?.let { generationConfig["maxOutputTokens"] = it }
-        request.temperature?.let { generationConfig["temperature"] = it }
-        val schema = responseSchema
-        if (schema != null) {
-            generationConfig["responseMimeType"] = APPLICATION_JSON
-            generationConfig["responseSchema"] = objectMapper.readTree(schema)
-        }
-
-        if (generationConfig.isNotEmpty()) {
-            payload["generationConfig"] = generationConfig
-        }
-
-        return payload
-    }
-
-    private fun buildContentParts(message: dev.tramai.core.model.Message): List<Any> {
-        // Tool (function) responses use Gemini's functionResponse format
-        if (message.role == MessageRole.TOOL) {
-            val name = message.toolCallId ?: "unknown_function"
-            return listOf(
-                mapOf(
-                    "functionResponse" to mapOf(
-                        "name" to name,
-                        "response" to mapOf(
-                            "content" to message.content,
-                        ),
-                    ),
-                ),
-            )
-        }
-
-        val msgParts = message.contentParts
-        if (msgParts.isNullOrEmpty()) {
-            // Fall back to plain text content
-            return listOf(mapOf("text" to message.content))
-        }
-
-        return msgParts.map { part ->
-            when (part) {
-                is ContentPart.TextPart -> mapOf("text" to part.text)
-                is ContentPart.ImagePart -> mapOf(
-                    "inlineData" to mapOf(
-                        "mimeType" to part.mimeType,
-                        "data" to Base64.getEncoder().encodeToString(part.data),
-                    ),
-                )
-                is ContentPart.ImageUrlContent -> {
-                    val resolved = ImageDownloader.resolveToImagePart(part) as ContentPart.ImagePart
-                    mapOf(
-                        "inlineData" to mapOf(
-                            "mimeType" to resolved.mimeType,
-                            "data" to Base64.getEncoder().encodeToString(resolved.data),
-                        ),
-                    )
-                }
-            }
+            const val DEFAULT_BASE_URL: String = "https://generativelanguage.googleapis.com"
+            const val DEFAULT_MODEL: String = "gemini-2.0-flash"
+            const val DEFAULT_API_VERSION: String = "v1beta"
+            const val PROVIDER_ID: String = "gemini"
         }
     }
-
-    // ---- Response mapping ----
-
-    private fun mapResponse(body: JsonNode): ModelResponse {
-        val candidate = body.path("candidates").firstOrNull()
-            ?: throw safeProviderFailure(
-                "Gemini response did not contain any candidates",
-                ProviderFailureCode.UNEXPECTED_FAILURE,
-            )
-
-        val content = candidate.path("content")
-        val parts = content.path("parts")
-
-        val text = if (parts.isArray) {
-            parts.mapNotNull { it.path("text").asText("").takeIf { t -> t.isNotEmpty() } }
-                .joinToString("")
-        } else {
-            ""
-        }
-
-        // Extract function calls if present
-        val toolCalls = if (parts.isArray) {
-            val calls = mutableListOf<ToolCall>()
-            var index = 0
-            for (part in parts) {
-                val fc = part.path("functionCall")
-                if (!fc.isMissingNode) {
-                    val name = fc.path("name").asText("")
-                    calls.add(
-                        ToolCall(
-                            id = "fc_${name}_$index",
-                            name = name,
-                            argumentsJson = objectMapper.writeValueAsString(fc.path("args")),
-                        ),
-                    )
-                    index++
-                } else {
-                    // Log warning for non-text, non-function-call response parts.
-                    // The part itself is untrusted response data: never log it.
-                    val partText = part.path("text").asText("")
-                    if (partText.isEmpty()) {
-                        providerLogger.log(
-                            System.Logger.Level.WARNING,
-                            "Gemini response contained a part that is neither text nor functionCall"
-                        )
-                    }
-                }
-            }
-            calls.ifEmpty { null }
-        } else {
-            null
-        }
-
-        val finishReason = candidate.path("finishReason").asText("")
-        val usageMetadata = body.path("usageMetadata")
-
-        return ModelResponse(
-            content = text,
-            toolCalls = toolCalls,
-            inputTokens = usageMetadata.path("promptTokenCount").takeIf { !it.isMissingNode }?.asInt(),
-            outputTokens = usageMetadata.path("candidatesTokenCount").takeIf { !it.isMissingNode }?.asInt(),
-            modelUsed = body.path("model").takeIf { !it.isMissingNode }?.asText(),
-            finishReason = mapFinishReason(finishReason),
-        )
-    }
-
-    private fun mapFinishReason(reason: String): FinishReason = when (reason) {
-        "STOP" -> FinishReason.STOP
-        "MAX_TOKENS" -> FinishReason.LENGTH
-        "SAFETY" -> FinishReason.CONTENT_FILTER
-        "RECITATION" -> FinishReason.CONTENT_FILTER
-        else -> FinishReason.OTHER
-    }
-
-    companion object {
-        private val providerLogger: System.Logger = System.getLogger(GeminiProvider::class.java.name)
-
-        const val DEFAULT_BASE_URL: String = "https://generativelanguage.googleapis.com"
-        const val DEFAULT_MODEL: String = "gemini-2.0-flash"
-        const val DEFAULT_API_VERSION: String = "v1beta"
-        const val PROVIDER_ID: String = "gemini"
-    }
-}
 
 /** @see GeminiProvider */
 private const val APPLICATION_JSON = "application/json"

--- a/tramai-ollama/src/main/kotlin/dev/tramai/ollama/OllamaProvider.kt
+++ b/tramai-ollama/src/main/kotlin/dev/tramai/ollama/OllamaProvider.kt
@@ -3,6 +3,7 @@
 package dev.tramai.ollama
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import dev.tramai.core.coroutines.rethrowIfCancellation
 import dev.tramai.core.exception.ProviderFailureCode
 import dev.tramai.core.model.ContentPart
 import dev.tramai.core.model.FinishReason
@@ -16,248 +17,281 @@ import dev.tramai.core.observation.ProviderFailureDiagnosticObserver
 import dev.tramai.core.provider.ModelProvider
 import dev.tramai.core.provider.ProviderCapability
 import dev.tramai.core.provider.providerTransportFailureObserved
-import dev.tramai.core.provider.transport.providerJsonRequest
-import dev.tramai.core.provider.transport.rejectedProviderHttpResponse
 import dev.tramai.core.provider.safeProviderFailure
-import dev.tramai.core.coroutines.rethrowIfCancellation
+import dev.tramai.core.provider.transport.providerJsonRequest
+import dev.tramai.core.provider.transport.readBoundedResponseBody
+import dev.tramai.core.provider.transport.rejectedProviderHttpResponse
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
-import kotlin.coroutines.CoroutineContext
-import java.net.URI
 import java.io.InputStream
+import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpResponse
-import java.util.Base64
 import java.nio.charset.StandardCharsets.UTF_8
+import java.util.Base64
+import kotlin.coroutines.CoroutineContext
 
 /**
  * [ModelProvider] implementation for Ollama's chat API.
  */
-class OllamaProvider @JvmOverloads constructor(
-    private val baseUrl: String = "http://localhost:11434",
-    private val httpClient: HttpClient = HttpClient.newHttpClient(),
-    private val objectMapper: ObjectMapper = ObjectMapper(),
-    private val ioDispatcher: CoroutineContext = Dispatchers.IO,
-    private val providerFailureDiagnosticObserver: ProviderFailureDiagnosticObserver =
-        NoOpProviderFailureDiagnosticObserver,
-) : ModelProvider, dev.tramai.core.provider.StreamCapable {
+class OllamaProvider
+    @JvmOverloads
+    constructor(
+        private val baseUrl: String = "http://localhost:11434",
+        private val httpClient: HttpClient = HttpClient.newHttpClient(),
+        private val objectMapper: ObjectMapper = ObjectMapper(),
+        private val ioDispatcher: CoroutineContext = Dispatchers.IO,
+        private val providerFailureDiagnosticObserver: ProviderFailureDiagnosticObserver =
+            NoOpProviderFailureDiagnosticObserver,
+    ) : ModelProvider,
+        dev.tramai.core.provider.StreamCapable {
+        override suspend fun complete(request: ModelRequest): ModelResponse =
+            withContext(ioDispatcher) {
+                try {
+                    val payload =
+                        mapOf(
+                            "model" to request.model,
+                            "stream" to false,
+                            "messages" to request.messages.map { message -> messageToMap(message) },
+                        )
 
-    override suspend fun complete(request: ModelRequest): ModelResponse = withContext(ioDispatcher) {
-        try {
-            val payload = mapOf(
-                "model" to request.model,
-                "stream" to false,
-                "messages" to request.messages.map { message -> messageToMap(message) },
-            )
+                    val httpRequest =
+                        providerJsonRequest(
+                            URI.create("${baseUrl.trimEnd('/')}/api/chat"),
+                            request,
+                            objectMapper.writeValueAsString(payload),
+                        ).build()
 
-            val httpRequest = providerJsonRequest(
-                URI.create("${baseUrl.trimEnd('/')}/api/chat"),
-                request,
-                objectMapper.writeValueAsString(payload),
-            ).build()
+                    val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
+                    if (response.statusCode() !in 200..299) {
+                        throw rejectedProviderHttpResponse(
+                            providerId = PROVIDER_ID,
+                            providerAlias = null,
+                            response = response,
+                            observer = providerFailureDiagnosticObserver,
+                            logger = providerLogger,
+                        )
+                    }
 
-            val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
-            if (response.statusCode() !in 200..299) {
-                throw rejectedProviderHttpResponse(
+                    val body = objectMapper.readTree(readBoundedResponseBody(response).text)
+                    val message = body.path("message")
+                    val role = message.path("role").asText("").lowercase()
+                    if (role.isNotBlank() && role != MessageRole.ASSISTANT.name.lowercase()) {
+                        throw safeProviderFailure(
+                            "Unexpected Ollama response role",
+                            ProviderFailureCode.UNEXPECTED_FAILURE,
+                        )
+                    }
+                    val content = message.path("content").asText("")
+                    if (content.isBlank()) {
+                        throw safeProviderFailure(
+                            "Ollama response contained no content",
+                            ProviderFailureCode.UNEXPECTED_FAILURE,
+                        )
+                    }
+
+                    ModelResponse(
+                        content = content,
+                        inputTokens = body.path("prompt_eval_count").takeIf { !it.isMissingNode }?.asInt(),
+                        outputTokens = body.path("eval_count").takeIf { !it.isMissingNode }?.asInt(),
+                        modelUsed = body.path("model").takeIf { !it.isMissingNode }?.asText(),
+                        finishReason =
+                            when (body.path("done_reason").asText("")) {
+                                "stop" -> FinishReason.STOP
+                                "length" -> FinishReason.LENGTH
+                                else -> FinishReason.OTHER
+                            },
+                    )
+                } catch (error: Throwable) {
+                    error.rethrowIfCancellation()
+                    throw providerTransportFailureObserved(PROVIDER_ID, error, providerFailureDiagnosticObserver)
+                }
+            }
+
+        /**
+         * Returns the stable provider id used by the registry.
+         */
+        override fun providerId(): String = PROVIDER_ID
+
+        override fun supportsCapability(capability: ProviderCapability): Boolean =
+            when (capability) {
+                ProviderCapability.VISION -> true
+                ProviderCapability.STREAMING -> true
+                else -> false
+            }
+
+        override fun stream(request: ModelRequest): Flow<StreamChunk> =
+            flow {
+                val response =
+                    try {
+                        withContext(ioDispatcher) {
+                            val payload =
+                                mapOf(
+                                    "model" to request.model,
+                                    "stream" to true,
+                                    "messages" to request.messages.map { message -> messageToMap(message) },
+                                )
+                            val httpRequest =
+                                providerJsonRequest(
+                                    URI.create("${baseUrl.trimEnd('/')}/api/chat"),
+                                    request,
+                                    objectMapper.writeValueAsString(payload),
+                                ).build()
+                            httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
+                        }
+                    } catch (error: Throwable) {
+                        error.rethrowIfCancellation()
+                        emit(
+                            dev.tramai.core.model.StreamChunk.Error(
+                                providerTransportFailureObserved(PROVIDER_ID, error, providerFailureDiagnosticObserver),
+                            ),
+                        )
+                        return@flow
+                    }
+
+                val errorChunk = handleHttpError(response)
+                if (errorChunk != null) {
+                    emit(errorChunk)
+                    return@flow
+                }
+
+                parseOllamaStreamResponse(response)
+            }
+
+        /**
+         * Handles non-2xx HTTP responses by logging the error and returning a [StreamChunk.Error].
+         * Returns `null` for successful (2xx) responses.
+         */
+        private suspend fun handleHttpError(response: HttpResponse<InputStream>): dev.tramai.core.model.StreamChunk.Error? {
+            if (response.statusCode() in 200..299) return null
+            return dev.tramai.core.model.StreamChunk.Error(
+                rejectedProviderHttpResponse(
                     providerId = PROVIDER_ID,
                     providerAlias = null,
                     response = response,
                     observer = providerFailureDiagnosticObserver,
                     logger = providerLogger,
-                )
-            }
-
-            val body = objectMapper.readTree(response.body().use { it.readAllBytes().decodeToString() })
-            val message = body.path("message")
-            val role = message.path("role").asText("").lowercase()
-            if (role.isNotBlank() && role != MessageRole.ASSISTANT.name.lowercase()) {
-                throw safeProviderFailure(
-                    "Unexpected Ollama response role",
-                    ProviderFailureCode.UNEXPECTED_FAILURE,
-                )
-            }
-            val content = message.path("content").asText("")
-            if (content.isBlank()) {
-                throw safeProviderFailure(
-                    "Ollama response contained no content",
-                    ProviderFailureCode.UNEXPECTED_FAILURE,
-                )
-            }
-
-            ModelResponse(
-                content = content,
-                inputTokens = body.path("prompt_eval_count").takeIf { !it.isMissingNode }?.asInt(),
-                outputTokens = body.path("eval_count").takeIf { !it.isMissingNode }?.asInt(),
-                modelUsed = body.path("model").takeIf { !it.isMissingNode }?.asText(),
-                finishReason = when (body.path("done_reason").asText("")) {
-                    "stop" -> FinishReason.STOP
-                    "length" -> FinishReason.LENGTH
-                    else -> FinishReason.OTHER
-                },
-            )
-        } catch (error: Throwable) {
-            error.rethrowIfCancellation()
-            throw providerTransportFailureObserved(PROVIDER_ID, error, providerFailureDiagnosticObserver)
-        }
-    }
-
-    /**
-     * Returns the stable provider id used by the registry.
-     */
-    override fun providerId(): String = PROVIDER_ID
-
-    override fun supportsCapability(capability: ProviderCapability): Boolean = when (capability) {
-        ProviderCapability.VISION -> true
-        ProviderCapability.STREAMING -> true
-        else -> false
-    }
-
-    override fun stream(request: ModelRequest): Flow<StreamChunk> = flow {
-        val response = try {
-            withContext(ioDispatcher) {
-                val payload = mapOf(
-                    "model" to request.model,
-                    "stream" to true,
-                    "messages" to request.messages.map { message -> messageToMap(message) },
-                )
-                val httpRequest = providerJsonRequest(
-                    URI.create("${baseUrl.trimEnd('/')}/api/chat"),
-                    request,
-                    objectMapper.writeValueAsString(payload),
-                ).build()
-                httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
-            }
-        } catch (error: Throwable) {
-            error.rethrowIfCancellation()
-            emit(
-                dev.tramai.core.model.StreamChunk.Error(
-                    providerTransportFailureObserved(PROVIDER_ID, error, providerFailureDiagnosticObserver),
                 ),
             )
-            return@flow
         }
 
-        val errorChunk = handleHttpError(response)
-        if (errorChunk != null) {
-            emit(errorChunk)
-            return@flow
-        }
+        /**
+         * Parses the Ollama SSE stream response, emitting [StreamChunk.Token] for each
+         * content JSON line and a final [StreamChunk.Complete] when done.
+         */
+        @Suppress("ktlint:standard:max-line-length")
+        private suspend fun FlowCollector<dev.tramai.core.model.StreamChunk>.parseOllamaStreamResponse(
+            response: HttpResponse<InputStream>,
+        ) {
+            val fullText = StringBuilder()
+            var lastUsage: dev.tramai.core.model.UsageMetrics? = null
 
-        parseOllamaStreamResponse(response)
-    }
+            try {
+                response.body().bufferedReader(UTF_8).use { reader ->
+                    while (true) {
+                        val line = reader.readLine() ?: break
+                        if (line.isBlank()) continue
 
-    /**
-     * Handles non-2xx HTTP responses by logging the error and returning a [StreamChunk.Error].
-     * Returns `null` for successful (2xx) responses.
-     */
-    private suspend fun handleHttpError(
-        response: HttpResponse<InputStream>,
-    ): dev.tramai.core.model.StreamChunk.Error? {
-        if (response.statusCode() in 200..299) return null
-        return dev.tramai.core.model.StreamChunk.Error(
-            rejectedProviderHttpResponse(
-                providerId = PROVIDER_ID,
-                providerAlias = null,
-                response = response,
-                observer = providerFailureDiagnosticObserver,
-                logger = providerLogger,
-            ),
-        )
-    }
+                        val node = objectMapper.readTree(line)
+                        val content = node.path("message").path("content").asText("")
+                        if (content.isNotEmpty()) {
+                            fullText.append(content)
+                            emit(
+                                dev.tramai.core.model.StreamChunk
+                                    .Token(content),
+                            )
+                        }
 
-    /**
-     * Parses the Ollama SSE stream response, emitting [StreamChunk.Token] for each
-     * content JSON line and a final [StreamChunk.Complete] when done.
-     */
-    private suspend fun FlowCollector<dev.tramai.core.model.StreamChunk>.parseOllamaStreamResponse(
-        response: HttpResponse<InputStream>,
-    ) {
-        val fullText = StringBuilder()
-        var lastUsage: dev.tramai.core.model.UsageMetrics? = null
-
-        try {
-            response.body().bufferedReader(UTF_8).use { reader ->
-                while (true) {
-                    val line = reader.readLine() ?: break
-                    if (line.isBlank()) continue
-
-                    val node = objectMapper.readTree(line)
-                    val content = node.path("message").path("content").asText("")
-                    if (content.isNotEmpty()) {
-                        fullText.append(content)
-                        emit(dev.tramai.core.model.StreamChunk.Token(content))
-                    }
-
-                    if (node.path("done").asBoolean()) {
-                        lastUsage = dev.tramai.core.model.UsageMetrics(
-                            inputTokens = node.path("prompt_eval_count").takeIf { !it.isMissingNode }?.asInt(),
-                            outputTokens = node.path("eval_count").takeIf { !it.isMissingNode }?.asInt(),
-                        )
-                        break
+                        if (node.path("done").asBoolean()) {
+                            lastUsage =
+                                dev.tramai.core.model.UsageMetrics(
+                                    inputTokens = node.path("prompt_eval_count").takeIf { !it.isMissingNode }?.asInt(),
+                                    outputTokens = node.path("eval_count").takeIf { !it.isMissingNode }?.asInt(),
+                                )
+                            break
+                        }
                     }
                 }
+                emit(
+                    dev.tramai.core.model.StreamChunk
+                        .Complete(
+                            fullText.toString(),
+                            lastUsage ?: dev.tramai.core.model
+                                .UsageMetrics(),
+                        ),
+                )
+            } catch (e: Exception) {
+                e.rethrowIfCancellation()
+                emit(
+                    dev.tramai.core.model.StreamChunk.Error(
+                        providerTransportFailureObserved(PROVIDER_ID, e, providerFailureDiagnosticObserver),
+                    ),
+                )
             }
-            emit(dev.tramai.core.model.StreamChunk.Complete(fullText.toString(), lastUsage ?: dev.tramai.core.model.UsageMetrics()))
-        } catch (e: Exception) {
-            e.rethrowIfCancellation()
-            emit(
-                dev.tramai.core.model.StreamChunk.Error(
-                    providerTransportFailureObserved(PROVIDER_ID, e, providerFailureDiagnosticObserver),
-                ),
-            )
         }
-    }
 
-    /**
-     * Converts a Tramai [Message] to an Ollama-compatible request map.
-     *
-     * When the message carries [ContentPart.ImagePart] items, the image data is
-     * included as base64-encoded strings in the `images` field.
-     * Otherwise, the plain text [content] is used directly.
-     */
-    private fun messageToMap(message: dev.tramai.core.model.Message): Map<String, Any?> {
-        val msgMap = linkedMapOf<String, Any?>(
-            "role" to message.role.name.lowercase(),
-        )
+        /**
+         * Converts a Tramai [Message] to an Ollama-compatible request map.
+         *
+         * When the message carries [ContentPart.ImagePart] items, the image data is
+         * included as base64-encoded strings in the `images` field.
+         * Otherwise, the plain text [content] is used directly.
+         */
+        private fun messageToMap(message: dev.tramai.core.model.Message): Map<String, Any?> {
+            val msgMap =
+                linkedMapOf<String, Any?>(
+                    "role" to message.role.name.lowercase(),
+                )
 
-        val msgParts = message.contentParts
-        if (!msgParts.isNullOrEmpty()) {
-            // Extract text from parts for the content field
-            val textParts = msgParts.filterIsInstance<ContentPart.TextPart>()
-            msgMap["content"] = if (textParts.isNotEmpty()) {
-                textParts.joinToString("\n") { it.text }
+            val msgParts = message.contentParts
+            if (!msgParts.isNullOrEmpty()) {
+                // Extract text from parts for the content field
+                val textParts = msgParts.filterIsInstance<ContentPart.TextPart>()
+                msgMap["content"] =
+                    if (textParts.isNotEmpty()) {
+                        textParts.joinToString("\n") { it.text }
+                    } else {
+                        ""
+                    }
+
+                // Extract images as base64 strings for Ollama's images field
+                val imageParts =
+                    msgParts.mapNotNull { part ->
+                        when (part) {
+                            is ContentPart.ImagePart -> {
+                                part
+                            }
+
+                            is ContentPart.ImageUrlContent -> {
+                                val resolved =
+                                    dev.tramai.core.util.ImageDownloader
+                                        .resolveToImagePart(part) as ContentPart.ImagePart
+                                resolved
+                            }
+
+                            else -> {
+                                null
+                            }
+                        }
+                    }
+                if (imageParts.isNotEmpty()) {
+                    msgMap["images"] =
+                        imageParts.map { part ->
+                            Base64.getEncoder().encodeToString(part.data)
+                        }
+                }
             } else {
-                ""
+                msgMap["content"] = message.content
             }
 
-            // Extract images as base64 strings for Ollama's images field
-            val imageParts = msgParts.mapNotNull { part ->
-                when (part) {
-                    is ContentPart.ImagePart -> part
-                    is ContentPart.ImageUrlContent -> {
-                        val resolved = dev.tramai.core.util.ImageDownloader.resolveToImagePart(part) as ContentPart.ImagePart
-                        resolved
-                    }
-                    else -> null
-                }
-            }
-            if (imageParts.isNotEmpty()) {
-                msgMap["images"] = imageParts.map { part ->
-                    Base64.getEncoder().encodeToString(part.data)
-                }
-            }
-        } else {
-            msgMap["content"] = message.content
+            return msgMap
         }
 
-        return msgMap
+        private companion object {
+            private val providerLogger: System.Logger = System.getLogger(OllamaProvider::class.java.name)
+            const val PROVIDER_ID: String = "ollama"
+        }
     }
-
-    private companion object {
-        private val providerLogger: System.Logger = System.getLogger(OllamaProvider::class.java.name)
-        const val PROVIDER_ID: String = "ollama"
-    }
-}

--- a/tramai-openai/src/main/kotlin/dev/tramai/openai/OpenAiProvider.kt
+++ b/tramai-openai/src/main/kotlin/dev/tramai/openai/OpenAiProvider.kt
@@ -4,6 +4,7 @@ package dev.tramai.openai
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import dev.tramai.core.coroutines.rethrowIfCancellation
 import dev.tramai.core.exception.ConfigurationException
 import dev.tramai.core.exception.ProviderFailureCode
 import dev.tramai.core.model.ContentPart
@@ -18,26 +19,26 @@ import dev.tramai.core.observation.ProviderFailureDiagnosticObserver
 import dev.tramai.core.provider.ModelProvider
 import dev.tramai.core.provider.ProviderCapability
 import dev.tramai.core.provider.StreamCapable
-import dev.tramai.core.coroutines.rethrowIfCancellation
 import dev.tramai.core.provider.providerTransportFailureObserved
 import dev.tramai.core.provider.safeProviderFailure
 import dev.tramai.core.provider.transport.providerJsonRequest
+import dev.tramai.core.provider.transport.readBoundedResponseBody
 import dev.tramai.core.provider.transport.readSseDataPayload
 import dev.tramai.core.provider.transport.rejectedProviderHttpResponse
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
-import kotlin.coroutines.CoroutineContext
-import java.net.URI
 import java.io.InputStream
+import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.Base64
-import java.nio.charset.StandardCharsets.UTF_8
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Source for bearer tokens used by OpenAI-compatible providers.
@@ -55,8 +56,9 @@ fun interface OpenAiAccessTokenSource {
 class StaticOpenAiAccessTokenSource(
     private val token: String,
 ) : OpenAiAccessTokenSource {
-    override fun accessToken(): String = token.trim().takeIf { it.isNotBlank() }
-        ?: throw ConfigurationException("OpenAI access token must not be blank")
+    override fun accessToken(): String =
+        token.trim().takeIf { it.isNotBlank() }
+            ?: throw ConfigurationException("OpenAI access token must not be blank")
 }
 
 /**
@@ -70,7 +72,6 @@ class CodexAuthFileTokenSource(
     private val authFile: Path = defaultAuthFile(),
     private val objectMapper: ObjectMapper = ObjectMapper(),
 ) : OpenAiAccessTokenSource {
-
     override fun accessToken(): String {
         if (!Files.exists(authFile)) {
             throw ConfigurationException("Codex auth file was not found at $authFile")
@@ -82,7 +83,11 @@ class CodexAuthFileTokenSource(
             throw ConfigurationException("Codex auth file at $authFile is not configured for ChatGPT authentication")
         }
 
-        return auth.path("tokens").path("access_token").asText("").trim()
+        return auth
+            .path("tokens")
+            .path("access_token")
+            .asText("")
+            .trim()
             .takeIf { it.isNotBlank() }
             ?: throw ConfigurationException("Codex auth file at $authFile does not contain an access token")
     }
@@ -99,392 +104,454 @@ class CodexAuthFileTokenSource(
 /**
  * Provider for any OpenAI-compatible `/chat/completions` endpoint.
  */
-open class OpenAiCompatibleProvider @JvmOverloads constructor(
-    private val accessTokenSource: OpenAiAccessTokenSource,
-    private val providerName: String = PROVIDER_LABEL,
-    private val baseUrl: String,
-    private val httpClient: HttpClient = HttpClient.newHttpClient(),
-    private val objectMapper: ObjectMapper = ObjectMapper(),
-    private val organization: String? = null,
-    private val project: String? = null,
-    private val ioDispatcher: CoroutineContext = kotlinx.coroutines.Dispatchers.IO,
-    private val providerFailureDiagnosticObserver: ProviderFailureDiagnosticObserver =
-        NoOpProviderFailureDiagnosticObserver,
-    private val diagnosticProviderId: String = PROVIDER_DIAGNOSTIC_ID,
-) : ModelProvider, StreamCapable {
-
-    override suspend fun complete(request: ModelRequest): ModelResponse = withContext(ioDispatcher) {
-        try {
-            val payload = linkedMapOf<String, Any?>(
-                "model" to request.model,
-                "stream" to false,
-                "messages" to request.messages.map { message -> messageToMap(message, request.imageDetail) },
-            )
-
-            request.tools?.let { tools ->
-                payload["tools"] = tools.map { tool ->
-                    mapOf(
-                        "type" to "function",
-                        "function" to mapOf(
-                            "name" to tool.name,
-                            "description" to tool.description,
-                            "parameters" to objectMapper.readTree(tool.inputSchemaJson)
-                        )
-                    )
-                }
-            }
-
-            request.maxTokens?.let { payload["max_tokens"] = it }
-            request.temperature?.let { payload["temperature"] = it }
-
-            val httpRequest = providerJsonRequest(
-                URI.create("${baseUrl.trimEnd('/')}/chat/completions"),
-                request,
-                objectMapper.writeValueAsString(payload),
-            ).apply {
-                header("Authorization", "Bearer ${accessTokenSource.accessToken()}")
-                organization?.takeIf { it.isNotBlank() }?.let { header("OpenAI-Organization", it) }
-                project?.takeIf { it.isNotBlank() }?.let { header("OpenAI-Project", it) }
-            }.build()
-
-            val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
-            if (response.statusCode() !in 200..299) {
-                throw rejectedProviderHttpResponse(
-                    providerId = diagnosticProviderId,
-                    providerAlias = providerName,
-                    response = response,
-                    observer = providerFailureDiagnosticObserver,
-                    logger = providerLogger,
-                )
-            }
-
-            val body = objectMapper.readTree(response.body().use { it.readAllBytes().decodeToString() })
-            val firstChoice = body.path("choices").firstOrNull()
-                ?: throw safeProviderFailure(
-                    "Provider response did not contain any completion choices",
-                    ProviderFailureCode.UNEXPECTED_FAILURE,
-                )
-            val message = firstChoice.path("message")
-
-            val toolCalls = message.path("tool_calls").takeIf { it.isArray }?.map { tc ->
-                ToolCall(
-                    id = tc.path("id").asText(),
-                    name = tc.path("function").path("name").asText(),
-                    argumentsJson = tc.path("function").path("arguments").asText(),
-                )
-            }
-
-            ModelResponse(
-                content = extractContent(message.path("content")),
-                toolCalls = toolCalls,
-                inputTokens = body.path("usage").path("prompt_tokens").takeIf { !it.isMissingNode }?.asInt(),
-                outputTokens = body.path("usage").path("completion_tokens").takeIf { !it.isMissingNode }?.asInt(),
-                thinkingTokens = body.path("usage").path("completion_tokens_details").path("reasoning_tokens").takeIf { !it.isMissingNode }?.asInt(),
-                modelUsed = body.path("model").takeIf { !it.isMissingNode }?.asText(),
-                finishReason = when (firstChoice.path("finish_reason").asText("")) {
-                    "stop" -> FinishReason.STOP
-                    "length" -> FinishReason.LENGTH
-                    "tool_calls" -> FinishReason.STOP // We map tool_calls to STOP for simple orchestration
-                    "content_filter" -> FinishReason.CONTENT_FILTER
-                    else -> FinishReason.OTHER
-                },
-            )
-        } catch (error: Throwable) {
-            error.rethrowIfCancellation()
-            throw providerTransportFailureObserved(
-                diagnosticProviderId,
-                providerName,
-                error,
-                providerFailureDiagnosticObserver,
-            )
-        }
-    }
-
-    override fun providerId(): String = providerName
-
-    override fun supportsCapability(capability: ProviderCapability): Boolean = when (capability) {
-        ProviderCapability.VISION -> true
-        ProviderCapability.TOOL_CALLING -> true
-        ProviderCapability.STRUCTURED_OUTPUT -> true
-        ProviderCapability.STREAMING -> true
-    }
-
-    override fun stream(request: ModelRequest): Flow<StreamChunk> = flow {
-        val response = try {
+@Suppress("ktlint:standard:max-line-length")
+open class OpenAiCompatibleProvider
+    @JvmOverloads
+    constructor(
+        private val accessTokenSource: OpenAiAccessTokenSource,
+        private val providerName: String = PROVIDER_LABEL,
+        private val baseUrl: String,
+        private val httpClient: HttpClient = HttpClient.newHttpClient(),
+        private val objectMapper: ObjectMapper = ObjectMapper(),
+        private val organization: String? = null,
+        private val project: String? = null,
+        private val ioDispatcher: CoroutineContext = kotlinx.coroutines.Dispatchers.IO,
+        private val providerFailureDiagnosticObserver: ProviderFailureDiagnosticObserver =
+            NoOpProviderFailureDiagnosticObserver,
+        private val diagnosticProviderId: String = PROVIDER_DIAGNOSTIC_ID,
+    ) : ModelProvider,
+        StreamCapable {
+        override suspend fun complete(request: ModelRequest): ModelResponse =
             withContext(ioDispatcher) {
-                val payload = linkedMapOf<String, Any?>(
-                    "model" to request.model,
-                    "stream" to true,
-                    "messages" to request.messages.map { message -> messageToMap(message, request.imageDetail) },
-                )
-                request.maxTokens?.let { payload["max_tokens"] = it }
-                request.temperature?.let { payload["temperature"] = it }
+                try {
+                    val payload =
+                        linkedMapOf<String, Any?>(
+                            "model" to request.model,
+                            "stream" to false,
+                            "messages" to request.messages.map { message -> messageToMap(message, request.imageDetail) },
+                        )
 
-                val httpRequest = providerJsonRequest(
-                    URI.create("${baseUrl.trimEnd('/')}/chat/completions"),
-                    request,
-                    objectMapper.writeValueAsString(payload),
-                ).apply {
-                    header("Authorization", "Bearer ${accessTokenSource.accessToken()}")
-                    organization?.takeIf { it.isNotBlank() }?.let { header("OpenAI-Organization", it) }
-                    project?.takeIf { it.isNotBlank() }?.let { header("OpenAI-Project", it) }
-                }.build()
+                    request.tools?.let { tools ->
+                        payload["tools"] =
+                            tools.map { tool ->
+                                mapOf(
+                                    "type" to "function",
+                                    "function" to
+                                        mapOf(
+                                            "name" to tool.name,
+                                            "description" to tool.description,
+                                            "parameters" to objectMapper.readTree(tool.inputSchemaJson),
+                                        ),
+                                )
+                            }
+                    }
 
-                httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
-            }
-        } catch (error: Throwable) {
-            error.rethrowIfCancellation()
-            emit(
-                StreamChunk.Error(
-                    providerTransportFailureObserved(
+                    request.maxTokens?.let { payload["max_tokens"] = it }
+                    request.temperature?.let { payload["temperature"] = it }
+
+                    val httpRequest =
+                        providerJsonRequest(
+                            URI.create("${baseUrl.trimEnd('/')}/chat/completions"),
+                            request,
+                            objectMapper.writeValueAsString(payload),
+                        ).apply {
+                            header("Authorization", "Bearer ${accessTokenSource.accessToken()}")
+                            organization?.takeIf { it.isNotBlank() }?.let { header("OpenAI-Organization", it) }
+                            project?.takeIf { it.isNotBlank() }?.let { header("OpenAI-Project", it) }
+                        }.build()
+
+                    val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
+                    if (response.statusCode() !in 200..299) {
+                        throw rejectedProviderHttpResponse(
+                            providerId = diagnosticProviderId,
+                            providerAlias = providerName,
+                            response = response,
+                            observer = providerFailureDiagnosticObserver,
+                            logger = providerLogger,
+                        )
+                    }
+
+                    val body = objectMapper.readTree(readBoundedResponseBody(response).text)
+                    val firstChoice =
+                        body.path("choices").firstOrNull()
+                            ?: throw safeProviderFailure(
+                                "Provider response did not contain any completion choices",
+                                ProviderFailureCode.UNEXPECTED_FAILURE,
+                            )
+                    val message = firstChoice.path("message")
+
+                    val toolCalls =
+                        message.path("tool_calls").takeIf { it.isArray }?.map { tc ->
+                            ToolCall(
+                                id = tc.path("id").asText(),
+                                name = tc.path("function").path("name").asText(),
+                                argumentsJson = tc.path("function").path("arguments").asText(),
+                            )
+                        }
+
+                    ModelResponse(
+                        content = extractContent(message.path("content")),
+                        toolCalls = toolCalls,
+                        inputTokens =
+                            body
+                                .path("usage")
+                                .path("prompt_tokens")
+                                .takeIf { !it.isMissingNode }
+                                ?.asInt(),
+                        outputTokens =
+                            body
+                                .path("usage")
+                                .path("completion_tokens")
+                                .takeIf { !it.isMissingNode }
+                                ?.asInt(),
+                        thinkingTokens =
+                            body
+                                .path(
+                                    "usage",
+                                ).path("completion_tokens_details")
+                                .path("reasoning_tokens")
+                                .takeIf { !it.isMissingNode }
+                                ?.asInt(),
+                        modelUsed = body.path("model").takeIf { !it.isMissingNode }?.asText(),
+                        finishReason =
+                            when (firstChoice.path("finish_reason").asText("")) {
+                                "stop" -> FinishReason.STOP
+
+                                "length" -> FinishReason.LENGTH
+
+                                "tool_calls" -> FinishReason.STOP
+
+                                // We map tool_calls to STOP for simple orchestration
+                                "content_filter" -> FinishReason.CONTENT_FILTER
+
+                                else -> FinishReason.OTHER
+                            },
+                    )
+                } catch (error: Throwable) {
+                    error.rethrowIfCancellation()
+                    throw providerTransportFailureObserved(
                         diagnosticProviderId,
                         providerName,
                         error,
                         providerFailureDiagnosticObserver,
-                    ),
-                ),
-            )
-            return@flow
-        }
-
-        if (handleHttpResponseError(response)) return@flow
-
-        try {
-            response.body().bufferedReader(UTF_8).use { reader ->
-                val fullText = StringBuilder()
-                var lastUsage: UsageMetrics? = null
-
-                while (true) {
-                    val data = readSseDataPayload(reader) ?: break
-                    val result = parseSseData(data)
-                    if (result.isDone) break
-                    if (result.tokenText.isNotEmpty()) {
-                        fullText.append(result.tokenText)
-                        emit(StreamChunk.Token(result.tokenText))
-                    }
-                    if (result.usage != null) {
-                        lastUsage = result.usage
-                    }
+                    )
                 }
-
-                emit(StreamChunk.Complete(fullText.toString(), lastUsage ?: UsageMetrics()))
             }
-        } catch (e: Exception) {
-            e.rethrowIfCancellation()
+
+        override fun providerId(): String = providerName
+
+        override fun supportsCapability(capability: ProviderCapability): Boolean =
+            when (capability) {
+                ProviderCapability.VISION -> true
+                ProviderCapability.TOOL_CALLING -> true
+                ProviderCapability.STRUCTURED_OUTPUT -> true
+                ProviderCapability.STREAMING -> true
+            }
+
+        override fun stream(request: ModelRequest): Flow<StreamChunk> =
+            flow {
+                val response =
+                    try {
+                        withContext(ioDispatcher) {
+                            val payload =
+                                linkedMapOf<String, Any?>(
+                                    "model" to request.model,
+                                    "stream" to true,
+                                    "messages" to request.messages.map { message -> messageToMap(message, request.imageDetail) },
+                                )
+                            request.maxTokens?.let { payload["max_tokens"] = it }
+                            request.temperature?.let { payload["temperature"] = it }
+
+                            val httpRequest =
+                                providerJsonRequest(
+                                    URI.create("${baseUrl.trimEnd('/')}/chat/completions"),
+                                    request,
+                                    objectMapper.writeValueAsString(payload),
+                                ).apply {
+                                    header("Authorization", "Bearer ${accessTokenSource.accessToken()}")
+                                    organization?.takeIf { it.isNotBlank() }?.let { header("OpenAI-Organization", it) }
+                                    project?.takeIf { it.isNotBlank() }?.let { header("OpenAI-Project", it) }
+                                }.build()
+
+                            httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
+                        }
+                    } catch (error: Throwable) {
+                        error.rethrowIfCancellation()
+                        emit(
+                            StreamChunk.Error(
+                                providerTransportFailureObserved(
+                                    diagnosticProviderId,
+                                    providerName,
+                                    error,
+                                    providerFailureDiagnosticObserver,
+                                ),
+                            ),
+                        )
+                        return@flow
+                    }
+
+                if (handleHttpResponseError(response)) return@flow
+
+                try {
+                    response.body().bufferedReader(UTF_8).use { reader ->
+                        val fullText = StringBuilder()
+                        var lastUsage: UsageMetrics? = null
+
+                        while (true) {
+                            val data = readSseDataPayload(reader) ?: break
+                            val result = parseSseData(data)
+                            if (result.isDone) break
+                            if (result.tokenText.isNotEmpty()) {
+                                fullText.append(result.tokenText)
+                                emit(StreamChunk.Token(result.tokenText))
+                            }
+                            if (result.usage != null) {
+                                lastUsage = result.usage
+                            }
+                        }
+
+                        emit(StreamChunk.Complete(fullText.toString(), lastUsage ?: UsageMetrics()))
+                    }
+                } catch (e: Exception) {
+                    e.rethrowIfCancellation()
+                    emit(
+                        StreamChunk.Error(
+                            providerTransportFailureObserved(
+                                diagnosticProviderId,
+                                providerName,
+                                e,
+                                providerFailureDiagnosticObserver,
+                            ),
+                        ),
+                    )
+                }
+            }
+
+        /**
+         * Handles HTTP error responses (non-2xx status codes) from the OpenAI-compatible API.
+         * Reads a bounded preview of the error body, logs metadata only, and emits a
+         * [StreamChunk.Error].
+         *
+         * @return `true` if the response was an error (non-2xx), `false` if the response is OK.
+         */
+        private suspend fun FlowCollector<StreamChunk>.handleHttpResponseError(response: HttpResponse<InputStream>): Boolean {
+            if (response.statusCode() in 200..299) return false
+
             emit(
                 StreamChunk.Error(
-                    providerTransportFailureObserved(
-                        diagnosticProviderId,
-                        providerName,
-                        e,
-                        providerFailureDiagnosticObserver,
+                    rejectedProviderHttpResponse(
+                        providerId = diagnosticProviderId,
+                        providerAlias = providerName,
+                        response = response,
+                        observer = providerFailureDiagnosticObserver,
+                        logger = providerLogger,
                     ),
                 ),
             )
+            return true
         }
-    }
-
-    /**
-     * Handles HTTP error responses (non-2xx status codes) from the OpenAI-compatible API.
-     * Reads a bounded preview of the error body, logs metadata only, and emits a
-     * [StreamChunk.Error].
-     *
-     * @return `true` if the response was an error (non-2xx), `false` if the response is OK.
-     */
-    private suspend fun FlowCollector<StreamChunk>.handleHttpResponseError(
-        response: HttpResponse<InputStream>,
-    ): Boolean {
-        if (response.statusCode() in 200..299) return false
-
-        emit(
-            StreamChunk.Error(
-                rejectedProviderHttpResponse(
-                    providerId = diagnosticProviderId,
-                    providerAlias = providerName,
-                    response = response,
-                    observer = providerFailureDiagnosticObserver,
-                    logger = providerLogger,
-                ),
-            ),
-        )
-        return true
-    }
-
-    /**
-     * Parsed result of a single SSE data line.
-     */
-    private data class SseData(
-        val isDone: Boolean = false,
-        val tokenText: String = "",
-        val usage: UsageMetrics? = null,
-    )
-
-    /**
-     * Parses a single SSE `data: ` line body from an OpenAI-compatible stream.
-     *
-     * @param dataLine the raw JSON payload after stripping the `data: ` prefix (already trimmed).
-     * @return [SseData] describing whether the stream is done, the delta token, and any usage metrics.
-     */
-    private fun parseSseData(dataLine: String): SseData {
-        if (dataLine == "[DONE]") return SseData(isDone = true)
-
-        val chunk = objectMapper.readTree(dataLine)
-
-        val delta = chunk.path("choices").firstOrNull()?.path("delta")
-        val content = delta?.path("content")?.asText("") ?: ""
-
-        val usageNode = chunk.path("usage")
-        val usage = if (!usageNode.isMissingNode) {
-            UsageMetrics(
-                inputTokens = usageNode.path("prompt_tokens").asInt(),
-                outputTokens = usageNode.path("completion_tokens").asInt(),
-                thinkingTokens = usageNode.path("completion_tokens_details").path("reasoning_tokens").takeIf { !it.isMissingNode }?.asInt(),
-            )
-        } else null
-
-        return SseData(tokenText = content, usage = usage)
-    }
-
-    private fun extractContent(contentNode: JsonNode): String {
-        if (contentNode.isTextual) {
-            return contentNode.asText("")
-        }
-
-        if (contentNode.isArray) {
-            return contentNode.mapNotNull { part ->
-                when {
-                    part.path("type").asText("") in setOf("text", "output_text") -> part.path("text").asText("").takeIf { it.isNotBlank() }
-                    part.hasNonNull("text") -> part.path("text").asText("").takeIf { it.isNotBlank() }
-                    else -> null
-                }
-            }.joinToString(separator = "\n")
-        }
-
-        return contentNode.path("text").asText("")
-    }
-
-    /**
-     * Converts a Tramai [Message] to an OpenAI-compatible request map.
-     *
-     * When the message carries [ContentPart.ImagePart] items, the content is
-     * serialised as a JSON content-array; otherwise a plain string is used.
-     */
-    private fun messageToMap(
-        message: dev.tramai.core.model.Message,
-        imageDetail: dev.tramai.core.model.ImageDetail = dev.tramai.core.model.ImageDetail.AUTO,
-    ): Map<String, Any?> {
-        val msgMap = mutableMapOf<String, Any?>(
-            "role" to message.role.name.lowercase(),
-        )
-
-        val msgParts = message.contentParts
-        if (!msgParts.isNullOrEmpty()) {
-            msgMap["content"] = msgParts.map { part ->
-                when (part) {
-                    is ContentPart.TextPart -> mapOf(
-                        "type" to "text",
-                        "text" to part.text,
-                    )
-                    is ContentPart.ImagePart -> {
-                        require(part.mimeType in SUPPORTED_IMAGE_TYPES) {
-                            "Unsupported image mimeType '${part.mimeType}'. Supported types: $SUPPORTED_IMAGE_TYPES"
-                        }
-                        val imageUrl = mutableMapOf<String, Any?>(
-                            "url" to "data:${part.mimeType};base64,${Base64.getEncoder().encodeToString(part.data)}",
-                        )
-                        if (imageDetail != dev.tramai.core.model.ImageDetail.AUTO) {
-                            imageUrl["detail"] = imageDetail.name.lowercase()
-                        }
-                        mapOf(
-                            "type" to "image_url",
-                            "image_url" to imageUrl,
-                        )
-                    }
-                    is ContentPart.ImageUrlContent -> {
-                        val imageUrl = mutableMapOf<String, Any?>(
-                            "url" to part.url,
-                        )
-                        if (imageDetail != dev.tramai.core.model.ImageDetail.AUTO) {
-                            imageUrl["detail"] = imageDetail.name.lowercase()
-                        }
-                        mapOf(
-                            "type" to "image_url",
-                            "image_url" to imageUrl,
-                        )
-                    }
-                }
-            }
-        } else {
-            msgMap["content"] = message.content
-        }
-
-        message.toolCallId?.let { msgMap["tool_call_id"] = it }
-        message.toolCalls?.let { toolCalls ->
-            msgMap["tool_calls"] = toolCalls.map { tc ->
-                mapOf(
-                    "id" to tc.id,
-                    "type" to "function",
-                    "function" to mapOf(
-                        "name" to tc.name,
-                        "arguments" to tc.argumentsJson,
-                    ),
-                )
-            }
-        }
-        return msgMap
-    }
-
-    companion object {
-        private val providerLogger: System.Logger = System.getLogger(OpenAiCompatibleProvider::class.java.name)
-
-        val SUPPORTED_IMAGE_TYPES: Set<String> = setOf("image/png", "image/jpeg", "image/gif", "image/webp")
 
         /**
-         * Creates an OpenAI-compatible provider backed by a static bearer token.
+         * Parsed result of a single SSE data line.
          */
-        @JvmStatic
-        fun bearerToken(
-            bearerToken: String,
-            baseUrl: String,
-            providerName: String = PROVIDER_LABEL,
-            httpClient: HttpClient = HttpClient.newHttpClient(),
-            objectMapper: ObjectMapper = ObjectMapper(),
-            providerFailureDiagnosticObserver: ProviderFailureDiagnosticObserver =
-                NoOpProviderFailureDiagnosticObserver,
-        ): OpenAiCompatibleProvider = OpenAiCompatibleProvider(
-            accessTokenSource = StaticOpenAiAccessTokenSource(bearerToken),
-            providerName = providerName,
-            baseUrl = baseUrl,
-            httpClient = httpClient,
-            objectMapper = objectMapper,
-            providerFailureDiagnosticObserver = providerFailureDiagnosticObserver,
+        private data class SseData(
+            val isDone: Boolean = false,
+            val tokenText: String = "",
+            val usage: UsageMetrics? = null,
         )
 
         /**
-         * Creates an OpenAI-compatible provider that reads its bearer token from Codex ChatGPT auth.
+         * Parses a single SSE `data: ` line body from an OpenAI-compatible stream.
          *
-         * Experimental: intended for local testing and exploratory integrations.
+         * @param dataLine the raw JSON payload after stripping the `data: ` prefix (already trimmed).
+         * @return [SseData] describing whether the stream is done, the delta token, and any usage metrics.
          */
-        @ExperimentalCodexAuth
-        @JvmStatic
-        fun codexAuth(
-            baseUrl: String,
-            providerName: String = PROVIDER_LABEL,
-            authFile: Path = CodexAuthFileTokenSource.defaultAuthFile(),
-            httpClient: HttpClient = HttpClient.newHttpClient(),
-            objectMapper: ObjectMapper = ObjectMapper(),
-            providerFailureDiagnosticObserver: ProviderFailureDiagnosticObserver =
-                NoOpProviderFailureDiagnosticObserver,
-        ): OpenAiCompatibleProvider = OpenAiCompatibleProvider(
-            accessTokenSource = CodexAuthFileTokenSource(authFile = authFile, objectMapper = objectMapper),
-            providerName = providerName,
-            baseUrl = baseUrl,
-            httpClient = httpClient,
-            objectMapper = objectMapper,
-            providerFailureDiagnosticObserver = providerFailureDiagnosticObserver,
-        )
+        private fun parseSseData(dataLine: String): SseData {
+            if (dataLine == "[DONE]") return SseData(isDone = true)
+
+            val chunk = objectMapper.readTree(dataLine)
+
+            val delta = chunk.path("choices").firstOrNull()?.path("delta")
+            val content = delta?.path("content")?.asText("") ?: ""
+
+            val usageNode = chunk.path("usage")
+            val usage =
+                if (!usageNode.isMissingNode) {
+                    UsageMetrics(
+                        inputTokens = usageNode.path("prompt_tokens").asInt(),
+                        outputTokens = usageNode.path("completion_tokens").asInt(),
+                        thinkingTokens =
+                            usageNode
+                                .path("completion_tokens_details")
+                                .path("reasoning_tokens")
+                                .takeIf { !it.isMissingNode }
+                                ?.asInt(),
+                    )
+                } else {
+                    null
+                }
+
+            return SseData(tokenText = content, usage = usage)
+        }
+
+        private fun extractContent(contentNode: JsonNode): String {
+            if (contentNode.isTextual) {
+                return contentNode.asText("")
+            }
+
+            if (contentNode.isArray) {
+                return contentNode
+                    .mapNotNull { part ->
+                        when {
+                            part
+                                .path(
+                                    "type",
+                                ).asText("") in setOf("text", "output_text") -> part.path("text").asText("").takeIf { it.isNotBlank() }
+
+                            part.hasNonNull("text") -> part.path("text").asText("").takeIf { it.isNotBlank() }
+
+                            else -> null
+                        }
+                    }.joinToString(separator = "\n")
+            }
+
+            return contentNode.path("text").asText("")
+        }
+
+        /**
+         * Converts a Tramai [Message] to an OpenAI-compatible request map.
+         *
+         * When the message carries [ContentPart.ImagePart] items, the content is
+         * serialised as a JSON content-array; otherwise a plain string is used.
+         */
+        private fun messageToMap(
+            message: dev.tramai.core.model.Message,
+            imageDetail: dev.tramai.core.model.ImageDetail = dev.tramai.core.model.ImageDetail.AUTO,
+        ): Map<String, Any?> {
+            val msgMap =
+                mutableMapOf<String, Any?>(
+                    "role" to message.role.name.lowercase(),
+                )
+
+            val msgParts = message.contentParts
+            if (!msgParts.isNullOrEmpty()) {
+                msgMap["content"] =
+                    msgParts.map { part ->
+                        when (part) {
+                            is ContentPart.TextPart -> {
+                                mapOf(
+                                    "type" to "text",
+                                    "text" to part.text,
+                                )
+                            }
+
+                            is ContentPart.ImagePart -> {
+                                require(part.mimeType in SUPPORTED_IMAGE_TYPES) {
+                                    "Unsupported image mimeType '${part.mimeType}'. Supported types: $SUPPORTED_IMAGE_TYPES"
+                                }
+                                val imageUrl =
+                                    mutableMapOf<String, Any?>(
+                                        "url" to "data:${part.mimeType};base64,${Base64.getEncoder().encodeToString(part.data)}",
+                                    )
+                                if (imageDetail != dev.tramai.core.model.ImageDetail.AUTO) {
+                                    imageUrl["detail"] = imageDetail.name.lowercase()
+                                }
+                                mapOf(
+                                    "type" to "image_url",
+                                    "image_url" to imageUrl,
+                                )
+                            }
+
+                            is ContentPart.ImageUrlContent -> {
+                                val imageUrl =
+                                    mutableMapOf<String, Any?>(
+                                        "url" to part.url,
+                                    )
+                                if (imageDetail != dev.tramai.core.model.ImageDetail.AUTO) {
+                                    imageUrl["detail"] = imageDetail.name.lowercase()
+                                }
+                                mapOf(
+                                    "type" to "image_url",
+                                    "image_url" to imageUrl,
+                                )
+                            }
+                        }
+                    }
+            } else {
+                msgMap["content"] = message.content
+            }
+
+            message.toolCallId?.let { msgMap["tool_call_id"] = it }
+            message.toolCalls?.let { toolCalls ->
+                msgMap["tool_calls"] =
+                    toolCalls.map { tc ->
+                        mapOf(
+                            "id" to tc.id,
+                            "type" to "function",
+                            "function" to
+                                mapOf(
+                                    "name" to tc.name,
+                                    "arguments" to tc.argumentsJson,
+                                ),
+                        )
+                    }
+            }
+            return msgMap
+        }
+
+        companion object {
+            private val providerLogger: System.Logger = System.getLogger(OpenAiCompatibleProvider::class.java.name)
+
+            val SUPPORTED_IMAGE_TYPES: Set<String> = setOf("image/png", "image/jpeg", "image/gif", "image/webp")
+
+            /**
+             * Creates an OpenAI-compatible provider backed by a static bearer token.
+             */
+            @JvmStatic
+            fun bearerToken(
+                bearerToken: String,
+                baseUrl: String,
+                providerName: String = PROVIDER_LABEL,
+                httpClient: HttpClient = HttpClient.newHttpClient(),
+                objectMapper: ObjectMapper = ObjectMapper(),
+                providerFailureDiagnosticObserver: ProviderFailureDiagnosticObserver =
+                    NoOpProviderFailureDiagnosticObserver,
+            ): OpenAiCompatibleProvider =
+                OpenAiCompatibleProvider(
+                    accessTokenSource = StaticOpenAiAccessTokenSource(bearerToken),
+                    providerName = providerName,
+                    baseUrl = baseUrl,
+                    httpClient = httpClient,
+                    objectMapper = objectMapper,
+                    providerFailureDiagnosticObserver = providerFailureDiagnosticObserver,
+                )
+
+            /**
+             * Creates an OpenAI-compatible provider that reads its bearer token from Codex ChatGPT auth.
+             *
+             * Experimental: intended for local testing and exploratory integrations.
+             */
+            @ExperimentalCodexAuth
+            @JvmStatic
+            fun codexAuth(
+                baseUrl: String,
+                providerName: String = PROVIDER_LABEL,
+                authFile: Path = CodexAuthFileTokenSource.defaultAuthFile(),
+                httpClient: HttpClient = HttpClient.newHttpClient(),
+                objectMapper: ObjectMapper = ObjectMapper(),
+                providerFailureDiagnosticObserver: ProviderFailureDiagnosticObserver =
+                    NoOpProviderFailureDiagnosticObserver,
+            ): OpenAiCompatibleProvider =
+                OpenAiCompatibleProvider(
+                    accessTokenSource = CodexAuthFileTokenSource(authFile = authFile, objectMapper = objectMapper),
+                    providerName = providerName,
+                    baseUrl = baseUrl,
+                    httpClient = httpClient,
+                    objectMapper = objectMapper,
+                    providerFailureDiagnosticObserver = providerFailureDiagnosticObserver,
+                )
+        }
     }
-}
 
 /** @see OpenAiCompatibleProvider */
 private const val PROVIDER_LABEL = "openai-compatible"
@@ -493,32 +560,10 @@ private const val PROVIDER_DIAGNOSTIC_ID = PROVIDER_LABEL
 /**
  * Provider for OpenAI's public API.
  */
-class OpenAiProvider @JvmOverloads constructor(
-    accessTokenSource: OpenAiAccessTokenSource,
-    baseUrl: String = DEFAULT_BASE_URL,
-    httpClient: HttpClient = HttpClient.newHttpClient(),
-    objectMapper: ObjectMapper = ObjectMapper(),
-    organization: String? = null,
-    project: String? = null,
-    providerFailureDiagnosticObserver: ProviderFailureDiagnosticObserver =
-        NoOpProviderFailureDiagnosticObserver,
-) : OpenAiCompatibleProvider(
-    accessTokenSource = accessTokenSource,
-    providerName = "openai",
-    diagnosticProviderId = "openai",
-    baseUrl = baseUrl,
-    httpClient = httpClient,
-    objectMapper = objectMapper,
-    organization = organization,
-    project = project,
-    providerFailureDiagnosticObserver = providerFailureDiagnosticObserver,
-) {
-    /**
-     * Creates an OpenAI provider using a standard API key.
-     */
+class OpenAiProvider
     @JvmOverloads
     constructor(
-        apiKey: String,
+        accessTokenSource: OpenAiAccessTokenSource,
         baseUrl: String = DEFAULT_BASE_URL,
         httpClient: HttpClient = HttpClient.newHttpClient(),
         objectMapper: ObjectMapper = ObjectMapper(),
@@ -526,25 +571,23 @@ class OpenAiProvider @JvmOverloads constructor(
         project: String? = null,
         providerFailureDiagnosticObserver: ProviderFailureDiagnosticObserver =
             NoOpProviderFailureDiagnosticObserver,
-    ) : this(
-        accessTokenSource = StaticOpenAiAccessTokenSource(apiKey),
-        baseUrl = baseUrl,
-        httpClient = httpClient,
-        objectMapper = objectMapper,
-        organization = organization,
-        project = project,
-        providerFailureDiagnosticObserver = providerFailureDiagnosticObserver,
-    )
-
-    companion object {
-        const val DEFAULT_BASE_URL: String = "https://api.openai.com/v1"
-
+    ) : OpenAiCompatibleProvider(
+            accessTokenSource = accessTokenSource,
+            providerName = "openai",
+            diagnosticProviderId = "openai",
+            baseUrl = baseUrl,
+            httpClient = httpClient,
+            objectMapper = objectMapper,
+            organization = organization,
+            project = project,
+            providerFailureDiagnosticObserver = providerFailureDiagnosticObserver,
+        ) {
         /**
-         * Creates an OpenAI provider using a static bearer token.
+         * Creates an OpenAI provider using a standard API key.
          */
-        @JvmStatic
-        fun bearerToken(
-            bearerToken: String,
+        @JvmOverloads
+        constructor(
+            apiKey: String,
             baseUrl: String = DEFAULT_BASE_URL,
             httpClient: HttpClient = HttpClient.newHttpClient(),
             objectMapper: ObjectMapper = ObjectMapper(),
@@ -552,8 +595,8 @@ class OpenAiProvider @JvmOverloads constructor(
             project: String? = null,
             providerFailureDiagnosticObserver: ProviderFailureDiagnosticObserver =
                 NoOpProviderFailureDiagnosticObserver,
-        ): OpenAiProvider = OpenAiProvider(
-            accessTokenSource = StaticOpenAiAccessTokenSource(bearerToken),
+        ) : this(
+            accessTokenSource = StaticOpenAiAccessTokenSource(apiKey),
             baseUrl = baseUrl,
             httpClient = httpClient,
             objectMapper = objectMapper,
@@ -562,30 +605,58 @@ class OpenAiProvider @JvmOverloads constructor(
             providerFailureDiagnosticObserver = providerFailureDiagnosticObserver,
         )
 
-        /**
-         * Creates an OpenAI provider that reads the bearer token from Codex ChatGPT auth.
-         *
-         * Experimental: intended for local testing and exploratory integrations.
-         */
-        @ExperimentalCodexAuth
-        @JvmStatic
-        fun codexAuth(
-            authFile: Path = CodexAuthFileTokenSource.defaultAuthFile(),
-            baseUrl: String = DEFAULT_BASE_URL,
-            httpClient: HttpClient = HttpClient.newHttpClient(),
-            objectMapper: ObjectMapper = ObjectMapper(),
-            organization: String? = null,
-            project: String? = null,
-            providerFailureDiagnosticObserver: ProviderFailureDiagnosticObserver =
-                NoOpProviderFailureDiagnosticObserver,
-        ): OpenAiProvider = OpenAiProvider(
-            accessTokenSource = CodexAuthFileTokenSource(authFile = authFile, objectMapper = objectMapper),
-            baseUrl = baseUrl,
-            httpClient = httpClient,
-            objectMapper = objectMapper,
-            organization = organization,
-            project = project,
-            providerFailureDiagnosticObserver = providerFailureDiagnosticObserver,
-        )
+        companion object {
+            const val DEFAULT_BASE_URL: String = "https://api.openai.com/v1"
+
+            /**
+             * Creates an OpenAI provider using a static bearer token.
+             */
+            @JvmStatic
+            fun bearerToken(
+                bearerToken: String,
+                baseUrl: String = DEFAULT_BASE_URL,
+                httpClient: HttpClient = HttpClient.newHttpClient(),
+                objectMapper: ObjectMapper = ObjectMapper(),
+                organization: String? = null,
+                project: String? = null,
+                providerFailureDiagnosticObserver: ProviderFailureDiagnosticObserver =
+                    NoOpProviderFailureDiagnosticObserver,
+            ): OpenAiProvider =
+                OpenAiProvider(
+                    accessTokenSource = StaticOpenAiAccessTokenSource(bearerToken),
+                    baseUrl = baseUrl,
+                    httpClient = httpClient,
+                    objectMapper = objectMapper,
+                    organization = organization,
+                    project = project,
+                    providerFailureDiagnosticObserver = providerFailureDiagnosticObserver,
+                )
+
+            /**
+             * Creates an OpenAI provider that reads the bearer token from Codex ChatGPT auth.
+             *
+             * Experimental: intended for local testing and exploratory integrations.
+             */
+            @ExperimentalCodexAuth
+            @JvmStatic
+            fun codexAuth(
+                authFile: Path = CodexAuthFileTokenSource.defaultAuthFile(),
+                baseUrl: String = DEFAULT_BASE_URL,
+                httpClient: HttpClient = HttpClient.newHttpClient(),
+                objectMapper: ObjectMapper = ObjectMapper(),
+                organization: String? = null,
+                project: String? = null,
+                providerFailureDiagnosticObserver: ProviderFailureDiagnosticObserver =
+                    NoOpProviderFailureDiagnosticObserver,
+            ): OpenAiProvider =
+                OpenAiProvider(
+                    accessTokenSource = CodexAuthFileTokenSource(authFile = authFile, objectMapper = objectMapper),
+                    baseUrl = baseUrl,
+                    httpClient = httpClient,
+                    objectMapper = objectMapper,
+                    organization = organization,
+                    project = project,
+                    providerFailureDiagnosticObserver = providerFailureDiagnosticObserver,
+                )
+        }
     }
-}

--- a/tramai-rag/src/main/kotlin/dev/tramai/rag/loaders/UrlDocumentLoader.kt
+++ b/tramai-rag/src/main/kotlin/dev/tramai/rag/loaders/UrlDocumentLoader.kt
@@ -1,13 +1,15 @@
 package dev.tramai.rag.loaders
 
+import dev.tramai.core.provider.transport.ExperimentalProviderTransportApi
+import dev.tramai.core.provider.transport.readBoundedResponseBody
 import dev.tramai.rag.Document
 import dev.tramai.rag.DocumentLoader
+import kotlinx.coroutines.withContext
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.time.Duration
-import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -15,10 +17,9 @@ import kotlin.coroutines.CoroutineContext
  *
  * Sets metadata with the URL, HTTP status code, and content type of the response.
  *
- * NOTE: This loader uses UTF-8 encoding by default via [HttpResponse.BodyHandlers.ofString].
+ * NOTE: This loader uses UTF-8 encoding by default after a bounded byte read.
  * If the HTTP response specifies a non-UTF-8 charset in the Content-Type header,
- * that charset is NOT automatically used. For proper charset handling, consider
- * using [HttpResponse.BodyHandlers.ofInputStream] and decoding with the detected charset.
+ * that charset is NOT automatically used.
  *
  * @param maxBytes Maximum number of bytes to read; throws [IllegalArgumentException]
  *                 if the response body exceeds this limit (default: 10 MB).
@@ -26,65 +27,71 @@ import kotlin.coroutines.CoroutineContext
  * @throws RuntimeException if the HTTP request fails.
  * @throws IllegalStateException if the HTTP response returns a non-2xx status code.
  */
+@OptIn(ExperimentalProviderTransportApi::class)
 class UrlDocumentLoader(
     private val maxBytes: Long = 10_000_000,
     private val ioDispatcher: CoroutineContext = kotlinx.coroutines.Dispatchers.IO,
 ) : DocumentLoader {
-
-    private val client: HttpClient = HttpClient.newBuilder()
-        .followRedirects(HttpClient.Redirect.NORMAL)
-        .connectTimeout(Duration.ofSeconds(10))
-        .build()
+    private val client: HttpClient =
+        HttpClient
+            .newBuilder()
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .connectTimeout(Duration.ofSeconds(10))
+            .build()
 
     override suspend fun load(source: String): Document {
         require(source.isNotBlank()) { "UrlDocumentLoader: source must not be blank" }
 
-        val uri = try {
-            URI.create(source)
-        } catch (e: IllegalArgumentException) {
-            throw IllegalArgumentException("UrlDocumentLoader: invalid URL: $source", e)
-        }
+        val uri =
+            try {
+                URI.create(source)
+            } catch (e: IllegalArgumentException) {
+                throw IllegalArgumentException("UrlDocumentLoader: invalid URL: $source", e)
+            }
 
         require(uri.scheme == "http" || uri.scheme == "https") {
             "UrlDocumentLoader: unsupported scheme '${uri.scheme}' for URL: $source"
         }
 
-        val request = HttpRequest.newBuilder()
-            .uri(uri)
-            .GET()
-            .timeout(Duration.ofSeconds(30))
-            .build()
+        val request =
+            HttpRequest
+                .newBuilder()
+                .uri(uri)
+                .GET()
+                .timeout(Duration.ofSeconds(30))
+                .build()
 
-        val response = try {
-            withContext(ioDispatcher) {
-                client.send(request, HttpResponse.BodyHandlers.ofString())
+        val response =
+            try {
+                withContext(ioDispatcher) {
+                    client.send(request, HttpResponse.BodyHandlers.ofInputStream())
+                }
+            } catch (e: Exception) {
+                throw RuntimeException("UrlDocumentLoader: failed to fetch URL: $source", e)
             }
-        } catch (e: Exception) {
-            throw RuntimeException("UrlDocumentLoader: failed to fetch URL: $source", e)
-        }
 
         val statusCode = response.statusCode()
         check(statusCode in 200..299) {
-                "UrlDocumentLoader: HTTP $statusCode for URL: $source"
+            "UrlDocumentLoader: HTTP $statusCode for URL: $source"
         }
 
-        val body = response.body()
-        val bodyBytes = body.toByteArray().size.toLong()
-        require(bodyBytes <= maxBytes) {
-            "UrlDocumentLoader: response body for $source is $bodyBytes bytes, exceeds maxBytes limit of $maxBytes"
+        val bounded = readBoundedResponseBody(response, maxBytes.toInt())
+        require(!bounded.truncated) {
+            "UrlDocumentLoader: response body for $source exceeds maxBytes limit of $maxBytes"
         }
 
         val contentType = response.headers().firstValue("Content-Type").orElse("text/plain")
 
         return Document(
             source = source,
-            content = body,
-            metadata = mapOf(
-                "source_type" to "url",
-                "url" to source,
-                "status_code" to statusCode.toString(),
-                "content_type" to contentType,
-            ),
+            content = bounded.text,
+            metadata =
+                mapOf(
+                    "source_type" to "url",
+                    "url" to source,
+                    "status_code" to statusCode.toString(),
+                    "content_type" to contentType,
+                ),
         )
     }
 }

--- a/tramai-spring-secrets-vault/build.gradle.kts
+++ b/tramai-spring-secrets-vault/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
 
 dependencies {
     api(project(":tramai-spring-core"))
+    implementation(project(":tramai-core"))
     implementation(libs.jackson.databind)
     implementation(libs.spring.context)
     implementation(libs.spring.boot.autoconfigure)

--- a/tramai-spring-secrets-vault/src/main/kotlin/dev/tramai/spring/secret/VaultSecretValueResolver.kt
+++ b/tramai-spring-secrets-vault/src/main/kotlin/dev/tramai/spring/secret/VaultSecretValueResolver.kt
@@ -2,6 +2,8 @@ package dev.tramai.spring.secret
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import dev.tramai.core.provider.transport.ExperimentalProviderTransportApi
+import dev.tramai.core.provider.transport.readBoundedResponseBody
 import dev.tramai.core.secret.SecretValueResolver
 import dev.tramai.spring.SpringBuiltInSecretValueResolver
 import java.net.URI
@@ -15,6 +17,7 @@ import java.net.http.HttpResponse
  * By default, the resolver assumes a KV v2 mount and returns the `value` field
  * when no explicit `#field` selector is present.
  */
+@OptIn(ExperimentalProviderTransportApi::class)
 class VaultSecretValueResolver(
     private val baseUrl: String,
     private val token: String,
@@ -24,7 +27,8 @@ class VaultSecretValueResolver(
     private val defaultField: String = "value",
     private val httpClient: HttpClient = HttpClient.newHttpClient(),
     private val objectMapper: ObjectMapper = ObjectMapper(),
-) : SecretValueResolver, SpringBuiltInSecretValueResolver {
+) : SecretValueResolver,
+    SpringBuiltInSecretValueResolver {
     init {
         require(baseUrl.isNotBlank()) { "Vault baseUrl must not be blank" }
         require(token.isNotBlank()) { "Vault token must not be blank" }
@@ -35,16 +39,18 @@ class VaultSecretValueResolver(
 
     override fun resolve(secretRef: String): String? {
         val reference = parse(secretRef) ?: return null
-        val request = HttpRequest.newBuilder()
-            .uri(URI.create(vaultPath(reference.path)))
-            .header("X-Vault-Token", token)
-            .apply {
-                namespace?.takeIf { it.isNotBlank() }?.let { header("X-Vault-Namespace", it) }
-            }
-            .GET()
-            .build()
+        val request =
+            HttpRequest
+                .newBuilder()
+                .uri(URI.create(vaultPath(reference.path)))
+                .header("X-Vault-Token", token)
+                .apply {
+                    namespace?.takeIf { it.isNotBlank() }?.let { header("X-Vault-Namespace", it) }
+                }.GET()
+                .build()
 
-        val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+        val response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream())
+        val bounded = readBoundedResponseBody(response)
         if (response.statusCode() == 404) {
             return null
         }
@@ -52,11 +58,12 @@ class VaultSecretValueResolver(
             "Vault secret lookup failed for '${reference.path}' with HTTP ${response.statusCode()}"
         }
 
-        val body = objectMapper.readTree(response.body())
-        val payload = when (kvVersion) {
-            1 -> body.path("data")
-            else -> body.path("data").path("data")
-        }
+        val body = objectMapper.readTree(bounded.text)
+        val payload =
+            when (kvVersion) {
+                1 -> body.path("data")
+                else -> body.path("data").path("data")
+            }
 
         return extractValue(payload, reference.field)
     }
@@ -71,13 +78,17 @@ class VaultSecretValueResolver(
         }
     }
 
-    private fun extractValue(payload: JsonNode, explicitField: String?): String? {
+    private fun extractValue(
+        payload: JsonNode,
+        explicitField: String?,
+    ): String? {
         if (payload.isMissingNode || payload.isNull) {
             return null
         }
 
         if (!explicitField.isNullOrBlank()) {
-            return payload.path(explicitField)
+            return payload
+                .path(explicitField)
                 .takeIf { !it.isMissingNode && !it.isNull && it.isValueNode }
                 ?.asText()
                 ?.takeIf { it.isNotBlank() }
@@ -87,7 +98,8 @@ class VaultSecretValueResolver(
             return payload.asText().takeIf { it.isNotBlank() }
         }
 
-        payload.path(defaultField)
+        payload
+            .path(defaultField)
             .takeIf { !it.isMissingNode && !it.isNull && it.isValueNode }
             ?.asText()
             ?.takeIf { it.isNotBlank() }

--- a/tramai-vectorstore-chroma/build.gradle.kts
+++ b/tramai-vectorstore-chroma/build.gradle.kts
@@ -11,8 +11,8 @@ plugins {
 dependencies {
     api(project(":tramai-vectorstore-spi"))
 
+    implementation(project(":tramai-core"))
     implementation(libs.coroutines.core)
     implementation(libs.jackson.databind)
 
             }
-

--- a/tramai-vectorstore-chroma/src/main/kotlin/dev/tramai/vectorstore/chroma/ChromaVectorStore.kt
+++ b/tramai-vectorstore-chroma/src/main/kotlin/dev/tramai/vectorstore/chroma/ChromaVectorStore.kt
@@ -1,12 +1,13 @@
 package dev.tramai.vectorstore.chroma
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import dev.tramai.core.provider.transport.ExperimentalProviderTransportApi
+import dev.tramai.core.provider.transport.readBoundedResponseBody
 import dev.tramai.vectorstore.SearchResult
 import dev.tramai.vectorstore.VectorEntry
 import dev.tramai.vectorstore.VectorStore
 import kotlinx.coroutines.withContext
-import kotlin.coroutines.CoroutineContext
 import java.net.URI
 import java.net.URLEncoder
 import java.net.http.HttpClient
@@ -15,6 +16,7 @@ import java.net.http.HttpResponse
 import java.nio.charset.StandardCharsets
 import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.coroutines.CoroutineContext
 
 /**
  * [VectorStore] implementation backed by Chroma's HTTP API.
@@ -23,13 +25,13 @@ import java.util.concurrent.ConcurrentHashMap
  * @param httpClient   HTTP client for making requests.
  * @param objectMapper Jackson mapper for JSON serialization/deserialization.
  */
+@OptIn(ExperimentalProviderTransportApi::class)
 class ChromaVectorStore(
     private val baseUrl: String = "http://localhost:8000",
     private val httpClient: HttpClient = HttpClient.newHttpClient(),
     private val objectMapper: ObjectMapper = ObjectMapper(),
     private val ioDispatcher: CoroutineContext = kotlinx.coroutines.Dispatchers.IO,
 ) : VectorStore {
-
     private val collectionExistsCache = ConcurrentHashMap<String, Boolean>()
 
     /**
@@ -43,30 +45,38 @@ class ChromaVectorStore(
         collectionExistsCache.clear()
     }
 
-    override suspend fun upsert(collection: String, vectors: List<VectorEntry>) = withContext(ioDispatcher) {
+    override suspend fun upsert(
+        collection: String,
+        vectors: List<VectorEntry>,
+    ) = withContext(ioDispatcher) {
         try {
             ensureCollectionExists(collection)
 
-            val payload = mutableMapOf<String, Any?>(
-                "ids" to vectors.map { it.id },
-                "embeddings" to vectors.map { entry -> entry.vector.toList() },
-                "documents" to vectors.map { it.content },
-                "metadatas" to vectors.map { entry ->
-                    entry.metadata.ifEmpty { emptyMap<String, String>() }
-                },
-            )
+            val payload =
+                mutableMapOf<String, Any?>(
+                    "ids" to vectors.map { it.id },
+                    "embeddings" to vectors.map { entry -> entry.vector.toList() },
+                    "documents" to vectors.map { it.content },
+                    "metadatas" to
+                        vectors.map { entry ->
+                            entry.metadata.ifEmpty { emptyMap<String, String>() }
+                        },
+                )
 
-            val httpRequest = HttpRequest.newBuilder()
-                .uri(URI.create("${baseUrl.trimEnd('/')}/api/v1/collections/${urlEncode(collection)}/add"))
-                .header(HEADER_CONTENT_TYPE, APPLICATION_JSON)
-                .timeout(Duration.ofSeconds(30))
-                .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)))
-                .build()
+            val httpRequest =
+                HttpRequest
+                    .newBuilder()
+                    .uri(URI.create("${baseUrl.trimEnd('/')}/api/v1/collections/${urlEncode(collection)}/add"))
+                    .header(HEADER_CONTENT_TYPE, APPLICATION_JSON)
+                    .timeout(Duration.ofSeconds(30))
+                    .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)))
+                    .build()
 
-            val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString())
+            val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
+            val bounded = readBoundedResponseBody(response)
             if (response.statusCode() !in 200..299) {
                 throw ChromaException(
-                    "Chroma upsert returned HTTP ${response.statusCode()}: ${response.body().take(500)}"
+                    "Chroma upsert returned HTTP ${response.statusCode()}: ${bounded.text.take(500)}",
                 )
             }
         } catch (e: ChromaException) {
@@ -81,38 +91,43 @@ class ChromaVectorStore(
         query: FloatArray,
         topK: Int,
         filter: Map<String, String>?,
-    ): List<SearchResult> = withContext(ioDispatcher) {
-        try {
-            val payload = mutableMapOf<String, Any?>(
-                "query_embeddings" to listOf(query.toList()),
-                "n_results" to topK,
-            )
+    ): List<SearchResult> =
+        withContext(ioDispatcher) {
+            try {
+                val payload =
+                    mutableMapOf<String, Any?>(
+                        "query_embeddings" to listOf(query.toList()),
+                        "n_results" to topK,
+                    )
 
-            if (!filter.isNullOrEmpty()) {
-                payload["where"] = filter
+                if (!filter.isNullOrEmpty()) {
+                    payload["where"] = filter
+                }
+
+                val httpRequest =
+                    HttpRequest
+                        .newBuilder()
+                        .uri(URI.create("${baseUrl.trimEnd('/')}/api/v1/collections/${urlEncode(collection)}/query"))
+                        .header(HEADER_CONTENT_TYPE, APPLICATION_JSON)
+                        .timeout(Duration.ofSeconds(30))
+                        .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)))
+                        .build()
+
+                val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
+                val bounded = readBoundedResponseBody(response)
+                if (response.statusCode() !in 200..299) {
+                    throw ChromaException(
+                        "Chroma query returned HTTP ${response.statusCode()}: ${bounded.text.take(500)}",
+                    )
+                }
+
+                parseChromaSearchResponse(objectMapper, bounded.text)
+            } catch (e: ChromaException) {
+                throw e
+            } catch (e: Exception) {
+                throw ChromaException("Chroma search failed: ${e.message}", e)
             }
-
-            val httpRequest = HttpRequest.newBuilder()
-                .uri(URI.create("${baseUrl.trimEnd('/')}/api/v1/collections/${urlEncode(collection)}/query"))
-                .header(HEADER_CONTENT_TYPE, APPLICATION_JSON)
-                .timeout(Duration.ofSeconds(30))
-                .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)))
-                .build()
-
-            val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString())
-            if (response.statusCode() !in 200..299) {
-                throw ChromaException(
-                    "Chroma query returned HTTP ${response.statusCode()}: ${response.body().take(500)}"
-                )
-            }
-
-            parseChromaSearchResponse(objectMapper, response.body())
-        } catch (e: ChromaException) {
-            throw e
-        } catch (e: Exception) {
-            throw ChromaException("Chroma search failed: ${e.message}", e)
         }
-    }
 
     /**
      * Extracts a single [SearchResult] from the Chroma response arrays at the given [index].
@@ -131,22 +146,36 @@ class ChromaVectorStore(
         distances: JsonNode,
         index: Int,
     ): SearchResult {
-        val entryId = if (!ids.isMissingNode && ids.isArray && ids.size() > index) {
-            ids.get(index).asText("")
-        } else ""
+        val entryId =
+            if (!ids.isMissingNode && ids.isArray && ids.size() > index) {
+                ids.get(index).asText("")
+            } else {
+                ""
+            }
 
-        val metadata = if (!metadatas.isMissingNode && metadatas.isArray && metadatas.size() > index) {
-            val metaNode = metadatas.get(index)
-            if (metaNode.isObject) {
-                metaNode.fieldNames().asSequence().map { name ->
-                    name to metaNode.get(name).asText("")
-                }.toMap()
-            } else emptyMap()
-        } else emptyMap()
+        val metadata =
+            if (!metadatas.isMissingNode && metadatas.isArray && metadatas.size() > index) {
+                val metaNode = metadatas.get(index)
+                if (metaNode.isObject) {
+                    metaNode
+                        .fieldNames()
+                        .asSequence()
+                        .map { name ->
+                            name to metaNode.get(name).asText("")
+                        }.toMap()
+                } else {
+                    emptyMap()
+                }
+            } else {
+                emptyMap()
+            }
 
-        val distance = if (!distances.isMissingNode && distances.isArray && distances.size() > index) {
-            distances.get(index).asDouble()
-        } else 0.0
+        val distance =
+            if (!distances.isMissingNode && distances.isArray && distances.size() > index) {
+                distances.get(index).asDouble()
+            } else {
+                0.0
+            }
 
         // Chroma returns L2 distance by default.
         // This is an approximate conversion from L2 distance to a similarity score in [0, 1].
@@ -177,7 +206,7 @@ class ChromaVectorStore(
 
         if (documents.isMissingNode || !documents.isArray) {
             throw ChromaException(
-                "Chroma response missing 'documents' array: ${rawBody.take(500)}"
+                "Chroma response missing 'documents' array: ${rawBody.take(500)}",
             )
         }
 
@@ -187,21 +216,27 @@ class ChromaVectorStore(
         }
     }
 
-    override suspend fun delete(collection: String, ids: List<String>) = withContext(ioDispatcher) {
+    override suspend fun delete(
+        collection: String,
+        ids: List<String>,
+    ) = withContext(ioDispatcher) {
         try {
             val payload = mapOf("ids" to ids)
 
-            val httpRequest = HttpRequest.newBuilder()
-                .uri(URI.create("${baseUrl.trimEnd('/')}/api/v1/collections/${urlEncode(collection)}/delete"))
-                .header(HEADER_CONTENT_TYPE, APPLICATION_JSON)
-                .timeout(Duration.ofSeconds(30))
-                .method("DELETE", HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)))
-                .build()
+            val httpRequest =
+                HttpRequest
+                    .newBuilder()
+                    .uri(URI.create("${baseUrl.trimEnd('/')}/api/v1/collections/${urlEncode(collection)}/delete"))
+                    .header(HEADER_CONTENT_TYPE, APPLICATION_JSON)
+                    .timeout(Duration.ofSeconds(30))
+                    .method("DELETE", HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)))
+                    .build()
 
-            val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString())
+            val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
+            val bounded = readBoundedResponseBody(response)
             if (response.statusCode() !in 200..299) {
                 throw ChromaException(
-                    "Chroma delete returned HTTP ${response.statusCode()}: ${response.body().take(500)}"
+                    "Chroma delete returned HTTP ${response.statusCode()}: ${bounded.text.take(500)}",
                 )
             }
         } catch (e: ChromaException) {
@@ -211,34 +246,38 @@ class ChromaVectorStore(
         }
     }
 
-    override suspend fun listCollections(): List<String> = withContext(ioDispatcher) {
-        try {
-            val httpRequest = HttpRequest.newBuilder()
-                .uri(URI.create("${baseUrl.trimEnd('/')}/api/v1/collections"))
-                .header(HEADER_CONTENT_TYPE, APPLICATION_JSON)
-                .timeout(Duration.ofSeconds(30))
-                .GET()
-                .build()
+    override suspend fun listCollections(): List<String> =
+        withContext(ioDispatcher) {
+            try {
+                val httpRequest =
+                    HttpRequest
+                        .newBuilder()
+                        .uri(URI.create("${baseUrl.trimEnd('/')}/api/v1/collections"))
+                        .header(HEADER_CONTENT_TYPE, APPLICATION_JSON)
+                        .timeout(Duration.ofSeconds(30))
+                        .GET()
+                        .build()
 
-            val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString())
-            if (response.statusCode() !in 200..299) {
-                throw ChromaException(
-                    "Chroma list collections returned HTTP ${response.statusCode()}: ${response.body().take(500)}"
-                )
-            }
+                val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
+                val bounded = readBoundedResponseBody(response)
+                if (response.statusCode() !in 200..299) {
+                    throw ChromaException(
+                        "Chroma list collections returned HTTP ${response.statusCode()}: ${bounded.text.take(500)}",
+                    )
+                }
 
-            val body = objectMapper.readTree(response.body())
-            if (body.isArray) {
-                body.map { it.path("name").asText("") }.filter { it.isNotBlank() }
-            } else {
-                emptyList()
+                val body = objectMapper.readTree(bounded.text)
+                if (body.isArray) {
+                    body.map { it.path("name").asText("") }.filter { it.isNotBlank() }
+                } else {
+                    emptyList()
+                }
+            } catch (e: ChromaException) {
+                throw e
+            } catch (e: Exception) {
+                throw ChromaException("Chroma list collections failed: ${e.message}", e)
             }
-        } catch (e: ChromaException) {
-            throw e
-        } catch (e: Exception) {
-            throw ChromaException("Chroma list collections failed: ${e.message}", e)
         }
-    }
 
     /**
      * Ensures the named collection exists. If not, creates it.
@@ -258,18 +297,21 @@ class ChromaVectorStore(
 
         val payload = mapOf("name" to collection)
 
-        val httpRequest = HttpRequest.newBuilder()
-            .uri(URI.create("${baseUrl.trimEnd('/')}/api/v1/collections"))
-            .header(HEADER_CONTENT_TYPE, APPLICATION_JSON)
-            .timeout(Duration.ofSeconds(30))
-            .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)))
-            .build()
+        val httpRequest =
+            HttpRequest
+                .newBuilder()
+                .uri(URI.create("${baseUrl.trimEnd('/')}/api/v1/collections"))
+                .header(HEADER_CONTENT_TYPE, APPLICATION_JSON)
+                .timeout(Duration.ofSeconds(30))
+                .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)))
+                .build()
 
-        val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString())
+        val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
+        val bounded = readBoundedResponseBody(response)
         if (response.statusCode() !in 200..299 && response.statusCode() != 409) {
             // Collection may have been created by another caller; ignore if it already exists.
             throw ChromaException(
-                "Chroma create collection returned HTTP ${response.statusCode()}: ${response.body().take(500)}"
+                "Chroma create collection returned HTTP ${response.statusCode()}: ${bounded.text.take(500)}",
             )
         }
         collectionExistsCache[collection] = true


### PR DESCRIPTION
## Summary

Second slice of Epic 10.1d (forbidden/lifecycle/security static guards + closure). This PR is the **runtime-remediation** half: every genuinely unbounded remote HTTP response-body read in production now crosses a bounded-reading helper.

T0 inventory found 12 unbounded remote-response reads:

- 5 provider adapters read a `java.net.http` response body unbounded (`response.body().use { it.readAllBytes().decodeToString() }`): anthropic, azure-openai, gemini, ollama, openai.
- `ImageDownloader` read a URLConnection stream fully with a **post-read** 20 MB check (read-then-reject).
- 2 embedding models, `UrlDocumentLoader`, `ChromaVectorStore` (2 success paths) and `VaultSecretValueResolver` buffered the whole body via `HttpResponse.BodyHandlers.ofString()` (rag/chroma only post-read size checks).

The companion gate PR (`epic/10.1d-static-safety-guards`, separate) adds the `verifyStaticSafetyGuards` analyzer that enforces this invariant forward; it is separate because the repository's change policy forbids shipping an analyzer and production remediation in one PR.

## What

- **New bounded-read primitives** in `dev.tramai.core.provider.transport`, all `@ExperimentalProviderTransportApi` (no stable API change):
  - `BoundedBody` (text, truncated) — own file `BoundedBody.kt`.
  - `readBoundedBody(input, limitBytes)` — byte-bounded UTF-8 read, same proven loop as `readErrorBodyPreview`, stream always closed, `truncated` flag on overflow.
  - `readBoundedResponseBody(response, limitBytes = 16 MiB)` — bounded read of a `java.net.http` response body.
  - `readBoundedBodyBytes(input, limitBytes)` — bounded byte read that throws on overflow (fail loud) for binary payloads.
  - `readBoundedChunk` — shared single-break/low-nesting loop helper (keeps detekt clean).
- **12 call sites repaired** to use the bounded helpers; `ImageDownloader` now fails before buffering beyond its 20 MB limit instead of after.
- **Dependency additions** (implementation scope only, no `api()` change): `tramai-embedding`, `tramai-vectorstore-chroma`, `tramai-spring-secrets-vault` now depend on `tramai-core` to reach the shared helpers.
- **Formatting:** the 10.1a ratchet requires the full ktlint_official style on every touched legacy file, so these provider files are mass-reformatted (large but mechanical diffs; the detekt baseline was pre-migrated for the resulting ID drift in PR #348).
- **6 tests** for the new primitives (`BoundedBodyReadTest`): full read, truncation, stream closure, byte variant, overflow throw, response variant.

## Verification

- `./gradlew verifyStaticAnalysis -PchangeClass=baseline-migration` — PASS (union baseline from PR #348 covers the reformatted tree; 0 unbaselined)
- `./gradlew verifyCancellationSafety` — PASS (313 findings, no new critical/high against origin/master)
- `./gradlew :tramai-core:test --tests '*BoundedBodyRead*'` — PASS (6/6)
- Targeted module tests (9 provider/embedding/rag/chroma/vault suites) — PASS
- `./gradlew verifyPr` — result reported in the PR thread (known pre-existing env failures: `TramaiDocsGuardsPluginTest`, `TramaiPublishingPluginTest`, `SovereignLabVerifierTasksTest` order-dependent TestKit failures; Gradle-9 task-graph overlap warning on `verifyMaintainabilityBaseline`)
- Forbidden surface sweep: `grep -rn 'BodyHandlers.ofString\|readAllBytes\|readBytes()' --include='*.kt' */src/main` → **zero matches**

## Non-claims

- This PR does NOT add the `verifyStaticSafetyGuards` analyzer (separate PR).
- It does NOT change `readErrorBodyPreview` / `BoundedProviderErrorBody` / `rejectedProviderHttpResponse` behavior.
- It does NOT touch CI workflows, docs, or quality baselines (baseline changes live in PR #348).
- It does NOT change any public/stable API (additions are `@ExperimentalProviderTransportApi`).
- Truncation semantics: `readBoundedBody`/`readBoundedResponseBody` return a `truncated` flag (callers parse/validate); `readBoundedBodyBytes` fails loud on overflow. No silent truncation of success payloads beyond the documented 16 MiB bound.
- CI will be red on the static-analysis step until PR #348 (baseline migration) merges to master — this PR is intentionally based on it.

This PR needs review before merge.
