### PR TITLE
ci: raise sovereign closure timeout for full quality verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
         run: ./gradlew :examples:spring-sovereign-starter:e2eTest
 
       - name: Verify Sovereign Runtime closure
-        timeout-minutes: 15
+        timeout-minutes: 30
         # No --rerun-tasks: the normal test phase already ran the full suite.
         # Rerunning here doubles the exposure to probabilistic concurrency flakes
         # (observed: JdbcStepAttemptRecordStoreContractTest #19 failed only in


### PR DESCRIPTION
**One-line workflow fix — no gate logic touched.**

`Verify Sovereign Runtime closure` (ci.yml) sets `timeout-minutes: 15`, but post-10.1c the aggregate `verifySovereignRuntimeClosure` pulls in full-repo compiler-warnings verification (105 compile units, 234 compile tasks) whenever a PR delta touches `build-logic/`. That single gate runs ~14 minutes; the step cap blows ~2s into the following `verifyStaticAnalysis` — with every inner gate green.

Observed deterministically 2/2 on PR #346 at head `69221fb3`:
- `compiler-warnings: 129 baseline-covered warning identities; gate green`
- step terminated at 12:45:04, started 12:30:03 — exactly the 15-minute cap

This is not bypassing or disabling a gate: the same `verifySovereignRuntimeClosure` command executes with identical semantics. Only the wall-clock envelope is corrected (30m gives useful bounded containment after the ~14m verification plus static analysis, without making the timeout meaningless).

Classification: `workflow-defect` (step budget too tight for legitimately-triggered full verification) — not production/test/analyzer/baseline defect. Repo-wide: any build-logic PR hits this.

Per .github/AGENTS.md rule 5, this is isolated as its own workflow PR — no runtime/analyzer changes ride along.