### PR TITLE
fix(quality): define BCV public surface via nonPublicMarkers (10.2)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,20 @@ tasks.named("verifyPr") {
     dependsOn("spotlessCheck")
 }
 
+// ── Epic 10.2: BCV public-surface boundary ──
+// BCV's committed API dumps are the signature authority. Declarations carrying
+// a sanctioned non-public marker are technically public only for cross-module
+// composition — they are not stable application-facing API and "may change or
+// move in any release" (their own KDoc). nonPublicMarkers removes them from
+// the dump so Contract-1/Contract-2 stay byte-exact on the true stable
+// surface. Adding a marker here is the ONLY way to opt a declaration out of
+// the stable freeze: an unmarked new public declaration still enters the dump
+// and Contract-2 still fails.
+apiValidation {
+    nonPublicMarkers.add("dev.tramai.core.provider.transport.ExperimentalProviderTransportApi")
+    nonPublicMarkers.add("dev.tramai.core.observation.secondary.ExperimentalTramaiInternalApi")
+}
+
 // ── Epic 10.1b: baseline-backed Kotlin static analysis ──
 // One repository-level Detekt authority (tramai.static-analysis plugin): one
 // pinned Detekt version, one central config (config/detekt/detekt.yml), one

--- a/tramai-core/api/tramai-core.api
+++ b/tramai-core/api/tramai-core.api
@@ -1611,11 +1611,6 @@ public final class dev/tramai/core/observation/CompositeOperationInterceptor : d
 	public fun interceptResponse (Ldev/tramai/core/observation/OperationCallContext;Ldev/tramai/core/model/ModelResponse;)Ldev/tramai/core/model/ModelResponse;
 }
 
-public final class dev/tramai/core/observation/FailureIsolatingOperationObserver : dev/tramai/core/observation/OperationObserver {
-	public fun <init> (Ldev/tramai/core/observation/OperationObserver;)V
-	public fun onCallStarted (Ldev/tramai/core/observation/OperationCallContext;)Ldev/tramai/core/observation/OperationObservation;
-}
-
 public final class dev/tramai/core/observation/NoOpOperationInterceptor : dev/tramai/core/observation/OperationInterceptor {
 	public static final field INSTANCE Ldev/tramai/core/observation/NoOpOperationInterceptor;
 	public fun interceptRequest (Ldev/tramai/core/observation/OperationCallContext;Ljava/util/List;)Ljava/util/List;
@@ -1729,10 +1724,6 @@ public final class dev/tramai/core/observation/ProviderFailureDiagnosticEvent {
 
 public abstract interface class dev/tramai/core/observation/ProviderFailureDiagnosticObserver {
 	public abstract fun record (Ldev/tramai/core/observation/ProviderFailureDiagnosticEvent;)V
-}
-
-public abstract interface class dev/tramai/core/observation/SecondaryFailureRecording {
-	public abstract fun getLastCompletionFailure ()Ljava/lang/Throwable;
 }
 
 public final class dev/tramai/core/observation/ToolFailureDiagnosticEvent {
@@ -2153,30 +2144,6 @@ public final class dev/tramai/core/observation/event/RuntimeMetrics {
 }
 
 public abstract interface annotation class dev/tramai/core/observation/secondary/ExperimentalTramaiInternalApi : java/lang/annotation/Annotation {
-}
-
-public final class dev/tramai/core/observation/secondary/SecondaryEffectAuthority : java/lang/Enum {
-	public static final field AUTHORITATIVE Ldev/tramai/core/observation/secondary/SecondaryEffectAuthority;
-	public static final field NON_AUTHORITATIVE Ldev/tramai/core/observation/secondary/SecondaryEffectAuthority;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Ldev/tramai/core/observation/secondary/SecondaryEffectAuthority;
-	public static fun values ()[Ldev/tramai/core/observation/secondary/SecondaryEffectAuthority;
-}
-
-public final class dev/tramai/core/observation/secondary/SecondaryFailureDiagnostic {
-	public static final field INSTANCE Ldev/tramai/core/observation/secondary/SecondaryFailureDiagnostic;
-	public final fun report (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-}
-
-public final class dev/tramai/core/observation/secondary/SecondaryFailureDisposition : java/lang/Enum {
-	public static final field BUFFERED Ldev/tramai/core/observation/secondary/SecondaryFailureDisposition;
-	public static final field FAIL_CLOSED Ldev/tramai/core/observation/secondary/SecondaryFailureDisposition;
-	public static final field FAIL_OPEN_DIAGNOSTIC Ldev/tramai/core/observation/secondary/SecondaryFailureDisposition;
-	public static final field IGNORE Ldev/tramai/core/observation/secondary/SecondaryFailureDisposition;
-	public static final field RETRY Ldev/tramai/core/observation/secondary/SecondaryFailureDisposition;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Ldev/tramai/core/observation/secondary/SecondaryFailureDisposition;
-	public static fun values ()[Ldev/tramai/core/observation/secondary/SecondaryFailureDisposition;
 }
 
 public final class dev/tramai/core/policy/ApprovalMode : java/lang/Enum {
@@ -2602,20 +2569,6 @@ public abstract interface class dev/tramai/core/provider/StreamCapable {
 }
 
 public abstract interface annotation class dev/tramai/core/provider/transport/ExperimentalProviderTransportApi : java/lang/annotation/Annotation {
-}
-
-public final class dev/tramai/core/provider/transport/ProviderTransportKt {
-	public static final fun providerJsonRequest (Ljava/net/URI;Ldev/tramai/core/model/ModelRequest;Ljava/lang/String;)Ljava/net/http/HttpRequest$Builder;
-	public static final fun readSseDataPayload (Ljava/io/BufferedReader;)Ljava/lang/String;
-	public static final fun rejectedProviderHttpResponse (Ljava/lang/String;Ljava/lang/String;Ljava/net/http/HttpResponse;Ldev/tramai/core/observation/ProviderFailureDiagnosticObserver;Ljava/lang/System$Logger;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun rejectedProviderHttpResponse$default (Ljava/lang/String;Ljava/lang/String;Ljava/net/http/HttpResponse;Ldev/tramai/core/observation/ProviderFailureDiagnosticObserver;Ljava/lang/System$Logger;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun sseDataPayload (Ljava/lang/String;)Ljava/lang/String;
-	public static final fun sseEventName (Ljava/lang/String;)Ljava/lang/String;
-}
-
-public final class dev/tramai/core/provider/transport/RetryAfterKt {
-	public static final fun parseRetryAfterMillis (Ljava/lang/String;Ljava/time/Clock;)Ljava/lang/Long;
-	public static synthetic fun parseRetryAfterMillis$default (Ljava/lang/String;Ljava/time/Clock;ILjava/lang/Object;)Ljava/lang/Long;
 }
 
 public final class dev/tramai/core/retry/DefaultRetryJitterSource : dev/tramai/core/retry/RetryJitterSource {

--- a/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/ProviderTransport.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/ProviderTransport.kt
@@ -33,7 +33,7 @@ import java.net.http.HttpResponse
  * results and far beyond any legitimate provider/embedding/store response
  * seen in the test suite.
  */
-const val PROVIDER_SUCCESS_BODY_LIMIT_BYTES = 16 * 1024 * 1024
+private const val PROVIDER_SUCCESS_BODY_LIMIT_BYTES = 16 * 1024 * 1024
 
 /**
  * Reads at most [limitBytes] bytes from [input] as UTF-8 text, reusing the

--- a/tramai-engine/api/tramai-engine.api
+++ b/tramai-engine/api/tramai-engine.api
@@ -113,12 +113,6 @@ public final class dev/tramai/engine/ExecutionSecurityContext$Companion {
 	public final fun fromArguments ([Ljava/lang/Object;)Ldev/tramai/engine/ExecutionSecurityContext;
 }
 
-public final class dev/tramai/engine/FailureIsolatingEngineEventObserver : dev/tramai/engine/EngineEventObserver {
-	public fun <init> (Ldev/tramai/engine/EngineEventObserver;)V
-	public fun onEngineEvent (Ldev/tramai/core/observation/event/RuntimeEvent;)V
-	public fun onEngineEvent (Ljava/lang/String;Ljava/util/Map;)V
-}
-
 public final class dev/tramai/engine/InMemoryOperationResponseCache : dev/tramai/engine/OperationResponseCache {
 	public fun <init> ()V
 	public fun <init> (ILkotlin/jvm/functions/Function0;)V

--- a/tramai-orchestration/api/tramai-orchestration.api
+++ b/tramai-orchestration/api/tramai-orchestration.api
@@ -159,45 +159,6 @@ public abstract interface class dev/tramai/orchestration/ExternalStepExecutorRes
 	public abstract fun registeredTypeIds ()Ljava/util/Set;
 }
 
-public final class dev/tramai/orchestration/FailureIsolatingTramaiWorkerObserver : dev/tramai/orchestration/TramaiWorkerObserver {
-	public fun <init> (Ldev/tramai/orchestration/TramaiWorkerObserver;)V
-	public fun onDrainProgress (Ljava/lang/String;II)V
-	public fun onLeaseAcquired (Ljava/lang/String;Ljava/lang/String;)V
-	public fun onLeaseContested (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public fun onLeaseExpired (Ljava/lang/String;Ljava/lang/String;)V
-	public fun onLeaseReleaseFailed (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
-	public fun onLeaseReleased (Ljava/lang/String;Ljava/lang/String;)V
-	public fun onLeaseRenewalFailed (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
-	public fun onLeaseRenewed (Ljava/lang/String;Ljava/lang/String;J)V
-	public fun onPollFailed (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public fun onShutdownComplete (Ljava/lang/String;)V
-	public fun onShutdownStarted (Ljava/lang/String;)V
-	public fun onStepAttemptCompleted (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public fun onStepAttemptFailed (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
-	public fun onStepAttemptStarted (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public fun onUnknownAttempt (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;J)V
-	public fun onWorkTakenOver (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public fun onWorkerHeartbeat (Ljava/lang/String;JI)V
-	public fun onWorkerStarted (Ljava/lang/String;)V
-	public fun onWorkerStopped (Ljava/lang/String;)V
-	public fun onWorkflowAbandoned (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;J)V
-}
-
-public final class dev/tramai/orchestration/FailureIsolatingWorkflowObserver : dev/tramai/orchestration/WorkflowObserver {
-	public fun <init> (Ldev/tramai/orchestration/WorkflowObserver;)V
-	public fun onMissedTick (Ljava/lang/String;Ljava/time/Instant;Ljava/lang/String;Ldev/tramai/orchestration/WorkflowContext;)V
-	public fun onScheduledTick (Ljava/lang/String;Ljava/time/Instant;Ldev/tramai/orchestration/WorkflowContext;)V
-	public fun onSkippedTick (Ljava/lang/String;Ljava/time/Instant;Ljava/lang/String;Ldev/tramai/orchestration/WorkflowContext;)V
-	public fun onStepCompleted (Ljava/lang/String;Ljava/lang/String;Ldev/tramai/orchestration/WorkflowContext;)V
-	public fun onStepFailed (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;Ldev/tramai/orchestration/WorkflowContext;)V
-	public fun onStepStarted (Ljava/lang/String;Ljava/lang/String;Ldev/tramai/orchestration/WorkflowContext;)V
-	public fun onWorkflowCompleted (Ljava/lang/String;Ldev/tramai/orchestration/WorkflowContext;)V
-	public fun onWorkflowEvent (Ljava/lang/String;Ldev/tramai/core/observation/event/RuntimeEvent;Ldev/tramai/orchestration/WorkflowContext;)V
-	public fun onWorkflowEvent (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ldev/tramai/orchestration/WorkflowContext;)V
-	public fun onWorkflowFailed (Ljava/lang/String;Ljava/lang/Throwable;Ldev/tramai/orchestration/WorkflowContext;)V
-	public fun onWorkflowStarted (Ljava/lang/String;Ldev/tramai/orchestration/WorkflowContext;)V
-}
-
 public final class dev/tramai/orchestration/FileStepAttemptRecordStore : dev/tramai/orchestration/StepAttemptRecordStore {
 	public fun <init> (Ljava/nio/file/Path;)V
 	public fun <init> (Ljava/nio/file/Path;Ldev/tramai/orchestration/PersistenceFailureDiagnosticObserver;)V


### PR DESCRIPTION
## Summary

BCV committed API dumps are the signature authority, but technically-public cross-module machinery was polluting the stable surface. Declarations carrying `@ExperimentalProviderTransportApi` / `@ExperimentalTramaiInternalApi` explicitly state they are **not** stable application-facing API ("may change or move in any release") — yet they entered the committed dumps and thus the 0.5.0 stable freeze. `verify060Architecture` (PR #346) surfaced this as a Contract-2 failure after #349 landed.

## Changes (5 files, +15/−93)

1. **`build.gradle.kts`** — `apiValidation.nonPublicMarkers` registers both markers. The dump now means "supported application-facing API"; `ApiCompatibilityVerifier` untouched. This is the ONLY opt-out: an unmarked new public declaration still enters the dump and Contract-2 still fails.
2. **`ProviderTransport.kt`** — `PROVIDER_SUCCESS_BODY_LIMIT_BYTES` was the one unmarked 10.1d addition; zero cross-module callers (verified) → `private const val`.
3. **Regenerated dumps** — 92 removals / 0 additions / 3 modules: `tramai-core` 47, `tramai-engine` 6, `tramai-orchestration` 39. Every removal is a sanctioned-marked declaration.

## Discriminator evidence

1. ✅ `BoundedBody` + transport helpers absent from `:tramai-core` dump
2. ✅ 164 normal stable core declarations remain
3. ✅ Unmarked probe declaration still appears in dump (live experiment, then reverted) → accidental-expansion guard intact
4. ✅ `@ExperimentalTramaiInternalApi` declarations excluded (core + engine + orchestration)
5. ✅ `apiCheck` green; `spotlessCheck` green; detekt baseline 4780→4780 (0 removed/0 added); build-logic suite 41 classes green (only the known sandbox daemon-teardown artifact on the aggregate run)

## Why not alternatives

- ❌ Downgrade `:tramai-core` to preview — hundreds of legitimate stable contracts lose their guarantee
- ❌ Migration escape hatch for stable changes — Epic 10.2 forbids it
- ❌ Verifier-side annotation reinterpretation — two authorities for "what is API"
- ❌ Waiving the diagnostic — violates the deterministic merge gate

Follow-up: after this merges, #346 rebases; the temporary `34e70b1b` dump regeneration is reconciled against this canonical dump (Contract-1/Contract-2 should see an identical stable surface).