### PR TITLE
refactor(quality): module-catalog as single publishability authority (Epic 9.2d-b1)

### DIFF
--- a/build-logic/src/main/kotlin/dev/tramai/build/publishing/TramaiPublishingRepositories.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/publishing/TramaiPublishingRepositories.kt
@@ -1,5 +1,6 @@
 package dev.tramai.build.publishing
 
+import dev.tramai.build.quality.ModuleManifest
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 
@@ -11,7 +12,6 @@ import org.gradle.api.provider.Provider
  * preserving extraction (9.2a); membership is NOT redesigned in this slice.
  */
 object TramaiPublishingRepositories {
-
     const val TRAMAI_REMOTE_NAME = "tramaiRemote"
     const val SOVEREIGN_BUNDLE_LOCAL_NAME = "sovereignBundleLocal"
 
@@ -19,24 +19,45 @@ object TramaiPublishingRepositories {
      * Modules excluded from the sovereign signed runtime bundle. The bundle is
      * the published manifest set minus modules outside its signed runtime scope.
      */
-    val sovereignBundleExcludedProjectNames = setOf(
-        "tramai-anthropic", "tramai-azure-openai", "tramai-bedrock", "tramai-deepseek", "tramai-embedding",
-        "tramai-gemini", "tramai-memory", "tramai-observability", "tramai-ollama", "tramai-openai",
-        "tramai-orchestration", "tramai-platform", "tramai-rag", "tramai-scheduler", "tramai-spring",
-        "tramai-spring-provider-anthropic", "tramai-spring-provider-ollama", "tramai-spring-provider-openai",
-        "tramai-spring-secrets-aws", "tramai-spring-secrets-file", "tramai-spring-secrets-vault", "tramai-testing",
-        "tramai-vectorstore-chroma", "tramai-vectorstore-pgvector", "tramai-vectorstore-spi"
-    )
+    val sovereignBundleExcludedProjectNames =
+        setOf(
+            "tramai-anthropic",
+            "tramai-azure-openai",
+            "tramai-bedrock",
+            "tramai-deepseek",
+            "tramai-embedding",
+            "tramai-gemini",
+            "tramai-memory",
+            "tramai-observability",
+            "tramai-ollama",
+            "tramai-openai",
+            "tramai-orchestration",
+            "tramai-platform",
+            "tramai-rag",
+            "tramai-scheduler",
+            "tramai-spring",
+            "tramai-spring-provider-anthropic",
+            "tramai-spring-provider-ollama",
+            "tramai-spring-provider-openai",
+            "tramai-spring-secrets-aws",
+            "tramai-spring-secrets-file",
+            "tramai-spring-secrets-vault",
+            "tramai-testing",
+            "tramai-vectorstore-chroma",
+            "tramai-vectorstore-pgvector",
+            "tramai-vectorstore-spi",
+        )
 
     /**
      * Sovereign bundle module names for the root build: the publishable set
-     * (published by the root build script as the `tramai.publishableModulePaths`
-     * extra property, manifest-derived) minus the excluded set.
+     * (module-catalog derived — the single canonical authority) minus the
+     * excluded set. TestKit fixtures without a catalog resolve to empty.
      */
     fun sovereignBundleModuleNames(rootProject: Project): Set<String> {
-        val publishable = (rootProject.extensions.extraProperties.properties["tramai.publishableModulePaths"] as? Collection<*>)
-            ?.map { it.toString().removePrefix(":") }
-            .orEmpty()
+        val publishable =
+            runCatching { ModuleManifest.publishableModulePaths(rootProject.rootDir) }
+                .getOrDefault(emptyList())
+                .map { it.removePrefix(":") }
         return publishable.toSet() - sovereignBundleExcludedProjectNames
     }
 
@@ -46,7 +67,8 @@ object TramaiPublishingRepositories {
      * consumer smoke resolution. Do not use tramaiPublishReleaseUrl here.
      */
     fun sovereignBundleRepoUrl(rootProject: Project): Provider<String> =
-        rootProject.layout.buildDirectory.dir("sovereign-runtime-release-verification-repo")
+        rootProject.layout.buildDirectory
+            .dir("sovereign-runtime-release-verification-repo")
             .map { "file://${it.asFile.absolutePath}" }
 
     /**
@@ -54,6 +76,9 @@ object TramaiPublishingRepositories {
      * root script): SNAPSHOT → snapshot URL → release URL fallback; release
      * version → release URL → snapshot URL fallback.
      */
-    fun selectRepositoryUrl(version: String, releaseUrl: String?, snapshotUrl: String?): String? =
-        if (version.endsWith("-SNAPSHOT")) snapshotUrl ?: releaseUrl else releaseUrl ?: snapshotUrl
+    fun selectRepositoryUrl(
+        version: String,
+        releaseUrl: String?,
+        snapshotUrl: String?,
+    ): String? = if (version.endsWith("-SNAPSHOT")) snapshotUrl ?: releaseUrl else releaseUrl ?: snapshotUrl
 }

--- a/build-logic/src/main/kotlin/dev/tramai/build/publishing/TramaiPublishingRepositories.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/publishing/TramaiPublishingRepositories.kt
@@ -51,12 +51,12 @@ object TramaiPublishingRepositories {
     /**
      * Sovereign bundle module names for the root build: the publishable set
      * (module-catalog derived — the single canonical authority) minus the
-     * excluded set. TestKit fixtures without a catalog resolve to empty.
+     * excluded set. A missing or corrupt catalog throws (fail closed).
      */
     fun sovereignBundleModuleNames(rootProject: Project): Set<String> {
         val publishable =
-            runCatching { ModuleManifest.publishableModulePaths(rootProject.rootDir) }
-                .getOrDefault(emptyList())
+            ModuleManifest
+                .publishableModulePaths(rootProject.rootDir)
                 .map { it.removePrefix(":") }
         return publishable.toSet() - sovereignBundleExcludedProjectNames
     }

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
@@ -543,9 +543,8 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                         .map { it.path },
                 )
                 publishedModulePaths.set(
-                    (project.extensions.extraProperties.properties["tramai.publishableModulePaths"] as? Collection<*>)
-                        ?.map { it.toString() }
-                        .orEmpty(),
+                    runCatching { ModuleManifest.publishableModulePaths(project.rootDir) }
+                        .getOrDefault(emptyList()),
                 )
                 val bomProject = project.allprojects.firstOrNull { it.name == "tramai-bom" }
                 bomModulePaths.set(

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
@@ -543,8 +543,7 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                         .map { it.path },
                 )
                 publishedModulePaths.set(
-                    runCatching { ModuleManifest.publishableModulePaths(project.rootDir) }
-                        .getOrDefault(emptyList()),
+                    ModuleManifest.publishableModulePaths(project.rootDir),
                 )
                 val bomProject = project.allprojects.firstOrNull { it.name == "tramai-bom" }
                 bomModulePaths.set(

--- a/build-logic/src/main/kotlin/dev/tramai/build/release/TramaiReleaseVerificationPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/release/TramaiReleaseVerificationPlugin.kt
@@ -23,23 +23,15 @@ class TramaiReleaseVerificationPlugin : Plugin<Project> {
     }
 
     /**
-     * Publishable module set, resolved lazily at task realization. Reads the
-     * root build's manifest-derived extra (`tramai.publishableModulePaths`)
-     * first (the extra is set in the root body AFTER the plugins block), with
-     * a direct module-catalog fallback. Returns empty for TestKit fixtures
-     * that have neither.
+     * Publishable module set, resolved lazily at task realization from the
+     * module catalog — the single canonical publishability authority (9.2d-b1).
+     * Returns empty for TestKit fixtures without a catalog.
      */
-    private fun publishableModuleNames(project: Project): List<String> {
-        val fromExtra =
-            (project.rootProject.extensions.extraProperties.properties["tramai.publishableModulePaths"] as? Collection<*>)
-                ?.map { it.toString().removePrefix(":") }
-                .orEmpty()
-        if (fromExtra.isNotEmpty()) return fromExtra.sorted()
-        return runCatching { ModuleManifest.publishableModulePaths(project.rootDir) }
+    private fun publishableModuleNames(project: Project): List<String> =
+        runCatching { ModuleManifest.publishableModulePaths(project.rootDir) }
             .getOrDefault(emptyList())
             .map { it.removePrefix(":") }
             .sorted()
-    }
 
     private fun jarPublicationModuleNames(project: Project): List<String> = publishableModuleNames(project) - "tramai-bom"
 

--- a/build-logic/src/main/kotlin/dev/tramai/build/release/TramaiReleaseVerificationPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/release/TramaiReleaseVerificationPlugin.kt
@@ -25,11 +25,12 @@ class TramaiReleaseVerificationPlugin : Plugin<Project> {
     /**
      * Publishable module set, resolved lazily at task realization from the
      * module catalog — the single canonical publishability authority (9.2d-b1).
-     * Returns empty for TestKit fixtures without a catalog.
+     * A missing or corrupt catalog throws (fail closed): the authority must
+     * never degrade to an empty module set.
      */
     private fun publishableModuleNames(project: Project): List<String> =
-        runCatching { ModuleManifest.publishableModulePaths(project.rootDir) }
-            .getOrDefault(emptyList())
+        ModuleManifest
+            .publishableModulePaths(project.rootDir)
             .map { it.removePrefix(":") }
             .sorted()
 

--- a/build-logic/src/main/kotlin/dev/tramai/build/sovereign/TramaiSovereignVerificationPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/sovereign/TramaiSovereignVerificationPlugin.kt
@@ -109,11 +109,11 @@ class TramaiSovereignVerificationPlugin : Plugin<Project> {
      * Publishable module set for the sovereign bundle: the module catalog is
      * the single canonical publishability authority (9.2d-b1); the excluded
      * set (runtime-scope trimming) is applied on top. Resolved lazily at task
-     * realization. TestKit fixtures without a catalog resolve to empty.
+     * realization. A missing or corrupt catalog throws (fail closed).
      */
     private fun sovereignBundleModules(project: Project): Set<String> =
-        runCatching { ModuleManifest.publishableModulePaths(project.rootDir) }
-            .getOrDefault(emptyList())
+        ModuleManifest
+            .publishableModulePaths(project.rootDir)
             .map { it.removePrefix(":") }
             .toSet() - TramaiPublishingRepositories.sovereignBundleExcludedProjectNames
 

--- a/build-logic/src/main/kotlin/dev/tramai/build/sovereign/TramaiSovereignVerificationPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/sovereign/TramaiSovereignVerificationPlugin.kt
@@ -5,8 +5,8 @@ import dev.tramai.build.quality.ModuleManifest
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.register
 import org.gradle.api.tasks.Exec
+import org.gradle.kotlin.dsl.register
 import java.io.File
 
 /** Execution args + human-readable display for the consumer smoke invocation. */
@@ -21,15 +21,20 @@ data class ConsumerSmokeInvocation(
  * path. Pure so it can be unit tested with paths containing spaces — the
  * executable arguments must NEVER be derived by splitting the display string.
  */
-fun consumerSmokeInvocation(verificationRepoAbsolutePath: String, tramaiVersion: String): ConsumerSmokeInvocation {
+fun consumerSmokeInvocation(
+    verificationRepoAbsolutePath: String,
+    tramaiVersion: String,
+): ConsumerSmokeInvocation {
     val gradleWrapper = if (System.getProperty("os.name").lowercase().contains("windows")) "gradlew.bat" else "./gradlew"
-    val args = listOf(
-        "-p", "examples/sovereign-runtime-consumer-smoke",
-        "test",
-        "-PtramaiVersion=$tramaiVersion",
-        "-PsovereignRuntimeVerificationRepo=$verificationRepoAbsolutePath",
-        "--no-configuration-cache",
-    )
+    val args =
+        listOf(
+            "-p",
+            "examples/sovereign-runtime-consumer-smoke",
+            "test",
+            "-PtramaiVersion=$tramaiVersion",
+            "-PsovereignRuntimeVerificationRepo=$verificationRepoAbsolutePath",
+            "--no-configuration-cache",
+        )
     return ConsumerSmokeInvocation(
         gradleWrapper = gradleWrapper,
         args = args,
@@ -48,40 +53,41 @@ fun consumerSmokeInvocation(verificationRepoAbsolutePath: String, tramaiVersion:
  * run against a remote server.
  */
 class TramaiSovereignVerificationPlugin : Plugin<Project> {
-
     /** Sovereign runtime publishable modules (test + publishToMavenLocal scope). Preserved exactly. */
-    val sovereignRuntimePublishableModules = listOf(
-        "tramai-security",
-        "tramai-sovereign",
-        "tramai-persistence-file",
-        "tramai-spring-sovereign",
-        "tramai-spring-boot-starter",
-        "tramai-spring-boot-starter-sovereign-persistence-file",
-        "tramai-spring-boot-starter-sovereign-ops",
-        "tramai-spring-boot-starter-sovereign-ops-actuator",
-        "tramai-spring-boot-starter-sovereign-ops-micrometer",
-        "tramai-spring-boot-starter-sovereign-ops-observability",
-    )
+    val sovereignRuntimePublishableModules =
+        listOf(
+            "tramai-security",
+            "tramai-sovereign",
+            "tramai-persistence-file",
+            "tramai-spring-sovereign",
+            "tramai-spring-boot-starter",
+            "tramai-spring-boot-starter-sovereign-persistence-file",
+            "tramai-spring-boot-starter-sovereign-ops",
+            "tramai-spring-boot-starter-sovereign-ops-actuator",
+            "tramai-spring-boot-starter-sovereign-ops-micrometer",
+            "tramai-spring-boot-starter-sovereign-ops-observability",
+        )
 
     /** Sovereign release modules (JAR collection scope). Preserved exactly. */
-    val sovereignReleaseModules = listOf(
-        ":tramai-core",
-        ":tramai-security",
-        ":tramai-structured",
-        ":tramai-engine",
-        ":tramai-standalone",
-        ":tramai-sovereign",
-        ":tramai-persistence-file",
-        ":tramai-spring-core",
-        ":tramai-observability",
-        ":tramai-spring-sovereign",
-        ":tramai-spring-boot-starter",
-        ":tramai-spring-boot-starter-sovereign-persistence-file",
-        ":tramai-spring-boot-starter-sovereign-ops",
-        ":tramai-spring-boot-starter-sovereign-ops-actuator",
-        ":tramai-spring-boot-starter-sovereign-ops-micrometer",
-        ":tramai-spring-boot-starter-sovereign-ops-observability",
-    )
+    val sovereignReleaseModules =
+        listOf(
+            ":tramai-core",
+            ":tramai-security",
+            ":tramai-structured",
+            ":tramai-engine",
+            ":tramai-standalone",
+            ":tramai-sovereign",
+            ":tramai-persistence-file",
+            ":tramai-spring-core",
+            ":tramai-observability",
+            ":tramai-spring-sovereign",
+            ":tramai-spring-boot-starter",
+            ":tramai-spring-boot-starter-sovereign-persistence-file",
+            ":tramai-spring-boot-starter-sovereign-ops",
+            ":tramai-spring-boot-starter-sovereign-ops-actuator",
+            ":tramai-spring-boot-starter-sovereign-ops-micrometer",
+            ":tramai-spring-boot-starter-sovereign-ops-observability",
+        )
 
     override fun apply(project: Project) {
         val sovereignBundleRepoUrl = TramaiPublishingRepositories.sovereignBundleRepoUrl(project.rootProject).get()
@@ -100,39 +106,38 @@ class TramaiSovereignVerificationPlugin : Plugin<Project> {
     }
 
     /**
-     * Publishable module set for the sovereign bundle: the root build's
-     * manifest-derived extra (`tramai.publishableModulePaths`) minus the
-     * excluded set. Resolved lazily at task realization — the extra is set in
-     * the root build body AFTER the plugins block, so it must not be read in
-     * [apply]. Falls back to the module manifest directly.
+     * Publishable module set for the sovereign bundle: the module catalog is
+     * the single canonical publishability authority (9.2d-b1); the excluded
+     * set (runtime-scope trimming) is applied on top. Resolved lazily at task
+     * realization. TestKit fixtures without a catalog resolve to empty.
      */
-    private fun sovereignBundleModules(project: Project): Set<String> {
-        val fromExtra = (project.rootProject.extensions.extraProperties.properties["tramai.publishableModulePaths"] as? Collection<*>)
-            ?.map { it.toString().removePrefix(":") }
-            .orEmpty()
-        return if (fromExtra.isNotEmpty()) {
-            fromExtra.toSet() - TramaiPublishingRepositories.sovereignBundleExcludedProjectNames
-        } else {
-            ModuleManifest.publishableModulePaths(project.rootDir)
-                .map { it.removePrefix(":") }
-                .toSet() - TramaiPublishingRepositories.sovereignBundleExcludedProjectNames
-        }
-    }
+    private fun sovereignBundleModules(project: Project): Set<String> =
+        runCatching { ModuleManifest.publishableModulePaths(project.rootDir) }
+            .getOrDefault(emptyList())
+            .map { it.removePrefix(":") }
+            .toSet() - TramaiPublishingRepositories.sovereignBundleExcludedProjectNames
 
     private fun consumerSmokeInvocation(project: Project): ConsumerSmokeInvocation {
-        val consumerSmokeVersion = project.providers.gradleProperty("tramaiVersion").orElse("0.5.0").get()
-        val verificationRepo = project.layout.buildDirectory
-            .dir("sovereign-runtime-release-verification-repo")
-            .get()
-            .asFile
-            .absolutePath
-        return dev.tramai.build.sovereign.consumerSmokeInvocation(verificationRepo, consumerSmokeVersion)
+        val consumerSmokeVersion =
+            project.providers
+                .gradleProperty("tramaiVersion")
+                .orElse("0.5.0")
+                .get()
+        val verificationRepo =
+            project.layout.buildDirectory
+                .dir("sovereign-runtime-release-verification-repo")
+                .get()
+                .asFile
+                .absolutePath
+        return dev.tramai.build.sovereign
+            .consumerSmokeInvocation(verificationRepo, consumerSmokeVersion)
     }
 
     private fun registerVerifySovereignRuntimePublication(project: Project) {
         project.tasks.register("verifySovereignRuntimePublication") {
             group = "verification"
-            description = "Validates local publishability of sovereign runtime modules — POM metadata, sources/javadoc JARs, and dependency graph. Does not publish remotely."
+            description =
+                "Validates local publishability of sovereign runtime modules — POM metadata, sources/javadoc JARs, and dependency graph. Does not publish remotely."
             // Missing projects (TestKit fixtures) are skipped; production has all modules.
             sovereignRuntimePublishableModules.forEach { moduleName ->
                 if (project.rootProject.findProject(":$moduleName") != null) {
@@ -155,8 +160,17 @@ class TramaiSovereignVerificationPlugin : Plugin<Project> {
         project: Project,
         sovereignBundleRepoUrl: String,
     ) {
-        val wantsSigning = project.providers.gradleProperty("signingKey").orNull.isNullOrBlank().not() &&
-            project.providers.gradleProperty("signingPassword").orNull.isNullOrBlank().not()
+        val wantsSigning =
+            project.providers
+                .gradleProperty("signingKey")
+                .orNull
+                .isNullOrBlank()
+                .not() &&
+                project.providers
+                    .gradleProperty("signingPassword")
+                    .orNull
+                    .isNullOrBlank()
+                    .not()
 
         project.tasks.register<VerifySovereignSignedBundleTask>("verifySovereignRuntimeSignedBundle") {
             group = "verification"
@@ -177,7 +191,7 @@ class TramaiSovereignVerificationPlugin : Plugin<Project> {
                 throw GradleException(
                     "verifySovereignRuntimeSignedBundle only supports file:// repositories for local " +
                         "verification. Got: $userProvidedUrl. The sovereign bundle dry-run publishes " +
-                        "to a dedicated local-only repository and must never contact a remote server."
+                        "to a dedicated local-only repository and must never contact a remote server.",
                 )
             }
 
@@ -189,18 +203,19 @@ class TramaiSovereignVerificationPlugin : Plugin<Project> {
             bundleRepositoryRootPath.set(sovereignBundleRepoUrl)
 
             mavenLocalRepositoryDirectory.fileProvider(
-                project.providers.systemProperty("user.home")
-                    .map { home -> File(home, ".m2/repository/${expectedGroup.get().replace('.', '/')}") }
+                project.providers
+                    .systemProperty("user.home")
+                    .map { home -> File(home, ".m2/repository/${expectedGroup.get().replace('.', '/')}") },
             )
             bundleRepositoryDirectory.set(
-                project.layout.buildDirectory.dir("sovereign-runtime-release-verification-repo")
+                project.layout.buildDirectory.dir("sovereign-runtime-release-verification-repo"),
             )
             bundleManifestFile.set(
-                project.layout.buildDirectory.file("sovereign-runtime-release/bundle-manifest.json")
+                project.layout.buildDirectory.file("sovereign-runtime-release/bundle-manifest.json"),
             )
 
-            dependsOn(bundleModules.map { ":${it}:publishToMavenLocal" })
-            dependsOn(bundleModules.map { ":${it}:publishMavenPublicationToSovereignBundleLocalRepository" })
+            dependsOn(bundleModules.map { ":$it:publishToMavenLocal" })
+            dependsOn(bundleModules.map { ":$it:publishMavenPublicationToSovereignBundleLocalRepository" })
 
             doFirst {
                 if (wantsSigning) {
@@ -220,7 +235,11 @@ class TramaiSovereignVerificationPlugin : Plugin<Project> {
             groupId.set(project.providers.gradleProperty("tramaiGroup").orElse("dev.tramai"))
             version.set(project.providers.gradleProperty("tramaiVersion").orElse("0.5.0"))
             moduleNames.set(sovereignReleaseModules.map { it.removePrefix(":") })
-            gradleVersion.set(org.gradle.util.GradleVersion.current().version)
+            gradleVersion.set(
+                org.gradle.util.GradleVersion
+                    .current()
+                    .version,
+            )
             javaVersion.set(project.providers.systemProperty("java.version").orElse("unknown"))
             artifactsDirectory.set(project.layout.buildDirectory.dir("sovereign-release/artifacts"))
             manifestFile.set(project.layout.buildDirectory.file("sovereign-release/release-artifacts-v1.json"))
@@ -258,7 +277,8 @@ class TramaiSovereignVerificationPlugin : Plugin<Project> {
     private fun registerVerifySovereignReleaseManifest(project: Project) {
         project.tasks.register<VerifySovereignReleaseManifestTask>("verifySovereignReleaseManifest") {
             group = "verification"
-            description = "Verifies that build/sovereign-release/release-artifacts-v1.json is internally consistent with the JAR files in build/sovereign-release/artifacts/."
+            description =
+                "Verifies that build/sovereign-release/release-artifacts-v1.json is internally consistent with the JAR files in build/sovereign-release/artifacts/."
 
             manifestFile.set(project.layout.buildDirectory.file("sovereign-release/release-artifacts-v1.json"))
             artifactsDirectory.set(project.layout.buildDirectory.dir("sovereign-release/artifacts"))
@@ -280,7 +300,10 @@ class TramaiSovereignVerificationPlugin : Plugin<Project> {
         }
     }
 
-    private fun registerVerifySovereignRuntimeConsumerSmoke(project: Project, invocation: ConsumerSmokeInvocation) {
+    private fun registerVerifySovereignRuntimeConsumerSmoke(
+        project: Project,
+        invocation: ConsumerSmokeInvocation,
+    ) {
         project.tasks.register<Exec>("verifySovereignRuntimeConsumerSmoke") {
             group = "verification"
             description = "Runs the standalone sovereign runtime consumer smoke test against the dedicated verification repo."
@@ -292,10 +315,14 @@ class TramaiSovereignVerificationPlugin : Plugin<Project> {
         }
     }
 
-    private fun registerGenerateSovereignReleaseEvidenceIndex(project: Project, invocation: ConsumerSmokeInvocation) {
+    private fun registerGenerateSovereignReleaseEvidenceIndex(
+        project: Project,
+        invocation: ConsumerSmokeInvocation,
+    ) {
         project.tasks.register<GenerateSovereignReleaseEvidenceIndexTask>("generateSovereignReleaseEvidenceIndex") {
             group = "verification"
-            description = "Generates a release evidence index (JSON + Markdown) tying together commit metadata, validation gates, bundle manifest, release artifact manifest, and artifact hashes. Fails if required evidence artifacts are missing."
+            description =
+                "Generates a release evidence index (JSON + Markdown) tying together commit metadata, validation gates, bundle manifest, release artifact manifest, and artifact hashes. Fails if required evidence artifacts are missing."
 
             expectedVersion.set(project.providers.gradleProperty("tramaiVersion").orElse("0.5.0"))
             this.consumerSmokeCommand.set(invocation.display)
@@ -327,23 +354,30 @@ class TramaiSovereignVerificationPlugin : Plugin<Project> {
      * verifySovereignRuntimeReleaseCandidate keep resolving.
      */
     private fun registerVerifySovereignRuntimeApiBoundary(project: Project) {
-        val stableApiSourcePaths = listOf(
-            "tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalStore.kt",
-            "tramai-engine/src/main/kotlin/dev/tramai/engine/SuspendedInvocationStore.kt",
-            "tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalContinuationStore.kt",
-            "tramai-security/src/main/kotlin/dev/tramai/security/audit/AuditStore.kt",
-            "tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxStore.kt",
-            "tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsApprovalMutationStore.kt",
-            "tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/lease/SovereignOpsWorkerLeaseStore.kt",
-        )
+        val stableApiSourcePaths =
+            listOf(
+                "tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalStore.kt",
+                "tramai-engine/src/main/kotlin/dev/tramai/engine/SuspendedInvocationStore.kt",
+                "tramai-core/src/main/kotlin/dev/tramai/core/approval/ApprovalContinuationStore.kt",
+                "tramai-security/src/main/kotlin/dev/tramai/security/audit/AuditStore.kt",
+                "tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsAuditOutboxStore.kt",
+                "tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/outbox/SovereignOpsApprovalMutationStore.kt",
+                "tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/lease/SovereignOpsWorkerLeaseStore.kt",
+            )
         project.tasks.register<SovereignRuntimeApiBoundaryVerifierTask>("verifySovereignRuntimeApiBoundary") {
             group = "verification"
             description = "Verifies the documented Sovereign Runtime API stability boundary."
             manifestFile.set(project.layout.projectDirectory.file("docs/architecture/sovereign-api-stability-manifest.yml"))
             boundaryDoc.set(project.layout.projectDirectory.file("docs/architecture/sovereign-api-stability-boundary.md"))
             statusDoc.set(project.layout.projectDirectory.file("docs/STATUS.md"))
-            mapperFile.set(project.layout.projectDirectory.file("tramai-core/src/main/kotlin/dev/tramai/core/workflow/ApprovalRequestWorkflowResultMappers.kt"))
-            javaFacadeFile.set(project.layout.projectDirectory.file("tramai-core/src/main/kotlin/dev/tramai/core/workflow/ApprovalWorkflowResults.kt"))
+            mapperFile.set(
+                project.layout.projectDirectory.file(
+                    "tramai-core/src/main/kotlin/dev/tramai/core/workflow/ApprovalRequestWorkflowResultMappers.kt",
+                ),
+            )
+            javaFacadeFile.set(
+                project.layout.projectDirectory.file("tramai-core/src/main/kotlin/dev/tramai/core/workflow/ApprovalWorkflowResults.kt"),
+            )
             stableApiFiles.from(stableApiSourcePaths.map { project.layout.projectDirectory.file(it) })
             readmeFile.set(project.layout.projectDirectory.file("README.md"))
             this.projectDir.set(project.layout.projectDirectory.asFile)
@@ -360,13 +394,16 @@ class TramaiSovereignVerificationPlugin : Plugin<Project> {
     private fun registerVerifySovereignOpsObservabilityDocs(project: Project) {
         project.tasks.register<SovereignOpsObservabilityDocsVerifierTask>("verifySovereignOpsObservabilityDocs") {
             group = "verification"
-            description = "Validates sovereign ops worker observability docs against the expected metric contract, API surface, and safe-label rules."
+            description =
+                "Validates sovereign ops worker observability docs against the expected metric contract, API surface, and safe-label rules."
             runbook.set(project.layout.projectDirectory.file("docs/operations/sovereign-ops-worker-observability-runbook.md"))
             promql.set(project.layout.projectDirectory.file("docs/operations/prometheus/sovereign-ops-worker-promql.md"))
             alerts.set(project.layout.projectDirectory.file("docs/operations/prometheus/sovereign-ops-worker-alerts.example.yml"))
             actuatorReadme.set(project.layout.projectDirectory.file("tramai-spring-boot-starter-sovereign-ops-actuator/README.md"))
             micrometerReadme.set(project.layout.projectDirectory.file("tramai-spring-boot-starter-sovereign-ops-micrometer/README.md"))
-            observabilityReadme.set(project.layout.projectDirectory.file("tramai-spring-boot-starter-sovereign-ops-observability/README.md"))
+            observabilityReadme.set(
+                project.layout.projectDirectory.file("tramai-spring-boot-starter-sovereign-ops-observability/README.md"),
+            )
         }
     }
 
@@ -391,12 +428,32 @@ class TramaiSovereignVerificationPlugin : Plugin<Project> {
             resumeDashboard.set(project.layout.projectDirectory.file("docs/observability/grafana-approved-resume-worker-dashboard.json"))
             resumeRunbook.set(project.layout.projectDirectory.file("docs/runbooks/approved-resume-worker-observability.md"))
             goldenPathGuide.set(project.layout.projectDirectory.file("docs/guides/approval-gateway-golden-path.md"))
-            goldenPathTest.set(project.layout.projectDirectory.file("tramai-core/src/test/kotlin/dev/tramai/core/workflow/ApprovalGatewayGoldenPathErgonomicsTest.kt"))
-            springSmokeTest.set(project.layout.projectDirectory.file("examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/ApprovalGatewaySpringGoldenPathSmokeTest.kt"))
-            regulatedFactoryFile.set(project.layout.projectDirectory.file("examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageApprovalGatewayRequestFactory.kt"))
-            gatewayAutoConfig.set(project.layout.projectDirectory.file("tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovalGatewayAutoConfiguration.kt"))
+            goldenPathTest.set(
+                project.layout.projectDirectory.file(
+                    "tramai-core/src/test/kotlin/dev/tramai/core/workflow/ApprovalGatewayGoldenPathErgonomicsTest.kt",
+                ),
+            )
+            springSmokeTest.set(
+                project.layout.projectDirectory.file(
+                    "examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/ApprovalGatewaySpringGoldenPathSmokeTest.kt",
+                ),
+            )
+            regulatedFactoryFile.set(
+                project.layout.projectDirectory.file(
+                    "examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageApprovalGatewayRequestFactory.kt",
+                ),
+            )
+            gatewayAutoConfig.set(
+                project.layout.projectDirectory.file(
+                    "tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovalGatewayAutoConfiguration.kt",
+                ),
+            )
             humanApprovalErgonomics.set(project.layout.projectDirectory.file("docs/architecture/human-approval-workflow-ergonomics.md"))
-            javaInteropTest.set(project.layout.projectDirectory.file("tramai-core/src/test/java/dev/tramai/core/workflow/ApprovalRequestWorkflowResultMappersJavaInteropTest.java"))
+            javaInteropTest.set(
+                project.layout.projectDirectory.file(
+                    "tramai-core/src/test/java/dev/tramai/core/workflow/ApprovalRequestWorkflowResultMappersJavaInteropTest.java",
+                ),
+            )
         }
     }
 }

--- a/build-logic/src/test/kotlin/dev/tramai/build/publishing/TramaiPublishingPluginTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/publishing/TramaiPublishingPluginTest.kt
@@ -52,6 +52,33 @@ class TramaiPublishingPluginTest {
             group=dev.tramai
             """.trimIndent(),
         )
+        // The module catalog is the single publishability authority (9.2d-b1):
+        // publishability-sensitive fixtures must carry a minimal valid catalog
+        // instead of relying on production fail-open behavior. `:sample` is
+        // declared internal so the fixture keeps the no-sovereign-repo / no-
+        // description semantics of the original no-catalog fixtures. Tests
+        // that need a published `:sample` (D6/D7) write their catalog first.
+        val catalogFile = File(dir, "config/quality/module-catalog.yml")
+        if (!catalogFile.isFile) {
+            writeFile(
+                dir,
+                "config/quality/module-catalog.yml",
+                """
+                schemaVersion: "3"
+                dependencyPolicies:
+                  core: { allowedLayers: [core-contracts, testing-support] }
+                entryDefaults:
+                  core: &core { maturity: stable, visibility: public, owner: core, dependencyPolicy: core, releaseInclusion: included, rationale: "Fixture module." }
+                  internal: &internal { maturity: internal, visibility: internal, owner: testing, dependencyPolicy: core, releaseInclusion: internal_only, rationale: "Fixture internal module." }
+                modules:
+                  - path: ":sample"
+                    <<: *internal
+                    layer: core-contracts
+                    publishability: internal
+                    apiStability: internal
+                """.trimIndent(),
+            )
+        }
         writeFile(
             dir,
             "build.gradle.kts",
@@ -415,6 +442,51 @@ class TramaiPublishingPluginTest {
         // tramai-spring is excluded from the sovereign bundle → no sovereignBundleLocal.
         val springProbe = runProbe(dir, task = ":tramai-spring:probe")
         assertFalse(springProbe["repos"]!!.contains("sovereignBundleLocal"), "non-selected project must not get the sovereign repo")
+    }
+
+    @Test
+    fun `P8b sovereign repo selection fails closed on corrupt catalog`(
+        @TempDir tempDir: File,
+    ) {
+        // 9.2d-b1 P1: the module catalog is the single publishability
+        // authority. A corrupt catalog must abort sovereign repo selection,
+        // never silently select an empty module set.
+        val dir = File(tempDir, "p8b")
+        dir.mkdirs()
+        writeFile(
+            dir,
+            "settings.gradle.kts",
+            """
+            rootProject.name = "fixture"
+            include("tramai-core")
+            """.trimIndent(),
+        )
+        writeFile(dir, "build.gradle.kts", "")
+        writeFile(
+            dir,
+            "config/quality/module-catalog.yml",
+            "schemaVersion: \"3\"\nmodules:\n  - malformed\n",
+        )
+        writeFile(
+            dir,
+            "tramai-core/build.gradle.kts",
+            """
+            plugins {
+                `java-library`
+                id("tramai.publishing")
+            }
+            group = "dev.tramai"
+            version = "0.6.0"
+            tasks.register("probe") {
+                doLast { println("PROBE:repos=" + publishing.repositories.map { it.name }.joinToString(",")) }
+            }
+            """.trimIndent(),
+        )
+        val result = runner(dir, ":tramai-core:probe").buildAndFail()
+        assertTrue(
+            result.output.contains("MODULE_CATALOG") || result.output.contains("catalog"),
+            "corrupt catalog must fail closed during repo selection, got: ${result.output.take(1200)}",
+        )
     }
 
     // ── P9 — publication metadata parity ─────────────────────────────────────

--- a/build-logic/src/test/kotlin/dev/tramai/build/publishing/TramaiPublishingPluginTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/publishing/TramaiPublishingPluginTest.kt
@@ -19,10 +19,13 @@ import kotlin.test.assertTrue
  * applies during the plugins block).
  */
 class TramaiPublishingPluginTest {
-
     // ── fixture helpers ──────────────────────────────────────────────────────
 
-    private fun writeFile(base: File, relativePath: String, content: String) {
+    private fun writeFile(
+        base: File,
+        relativePath: String,
+        content: String,
+    ) {
         val target = File(base, relativePath)
         target.parentFile.mkdirs()
         target.writeText(content)
@@ -71,15 +74,24 @@ class TramaiPublishingPluginTest {
         return dir
     }
 
-    private fun runner(dir: File, vararg args: String): GradleRunner =
-        GradleRunner.create()
+    private fun runner(
+        dir: File,
+        vararg args: String,
+    ): GradleRunner =
+        GradleRunner
+            .create()
             .withProjectDir(dir)
             .withPluginClasspath()
             .withArguments(*args)
 
-    private fun runProbe(dir: File, task: String = "probe", vararg args: String): Map<String, String> {
+    private fun runProbe(
+        dir: File,
+        task: String = "probe",
+        vararg args: String,
+    ): Map<String, String> {
         val result = runner(dir, task, "--quiet", *args).build()
-        return result.output.lineSequence()
+        return result.output
+            .lineSequence()
             .filter { it.startsWith("PROBE:") }
             .associate { line ->
                 val (key, value) = line.removePrefix("PROBE:").split("=", limit = 2)
@@ -87,30 +99,34 @@ class TramaiPublishingPluginTest {
             }
     }
 
-    private fun probeRepositoriesBody(): String = """
+    private fun probeRepositoriesBody(): String =
+        """
         val repos = publishing.repositories.map { repo ->
             val artifactRepo = repo as MavenArtifactRepository
             artifactRepo.name + "|" + artifactRepo.url
         }.sorted().joinToString(",")
         println("PROBE:repos=" + repos)
-    """.trimIndent()
+        """.trimIndent()
 
     // ── P1 — java-library publication ────────────────────────────────────────
 
     @Test
-    fun `P1 java-library publication has java component artifactId and javadoc jar`(@TempDir tempDir: File) {
+    fun `P1 java-library publication has java component artifactId and javadoc jar`(
+        @TempDir tempDir: File,
+    ) {
         val dir = File(tempDir, "p1")
         dir.mkdirs()
         singleProjectFixture(
             dir,
             plugins = "java-library",
-            probeBody = """
+            probeBody =
+                """
                 val pub = publishing.publications.getByName("maven") as MavenPublication
                 println("PROBE:pubName=" + pub.name)
                 println("PROBE:artifactId=" + pub.artifactId)
                 println("PROBE:components=" + components.names.sorted().joinToString(","))
                 println("PROBE:hasJavadocJar=" + tasks.names.contains("javadocJar"))
-            """.trimIndent(),
+                """.trimIndent(),
         )
         val probe = runProbe(dir)
         assertEquals("maven", probe["pubName"])
@@ -122,18 +138,21 @@ class TramaiPublishingPluginTest {
     // ── P2 — java-platform publication ───────────────────────────────────────
 
     @Test
-    fun `P2 java-platform publication uses javaPlatform component and pom packaging`(@TempDir tempDir: File) {
+    fun `P2 java-platform publication uses javaPlatform component and pom packaging`(
+        @TempDir tempDir: File,
+    ) {
         val dir = File(tempDir, "p2")
         dir.mkdirs()
         singleProjectFixture(
             dir,
             plugins = "java-platform",
-            probeBody = """
+            probeBody =
+                """
                 val pub = publishing.publications.getByName("maven") as MavenPublication
                 println("PROBE:pubName=" + pub.name)
                 println("PROBE:artifactId=" + pub.artifactId)
                 println("PROBE:components=" + components.names.sorted().joinToString(","))
-            """.trimIndent(),
+                """.trimIndent(),
         )
         val probe = runProbe(dir)
         assertEquals("maven", probe["pubName"])
@@ -150,13 +169,23 @@ class TramaiPublishingPluginTest {
     // ── P3 — release repository selection ────────────────────────────────────
 
     @Test
-    fun `P3 release version selects release URL with snapshot fallback`(@TempDir tempDir: File) {
+    fun `P3 release version selects release URL with snapshot fallback`(
+        @TempDir tempDir: File,
+    ) {
         val dir = File(tempDir, "p3")
         dir.mkdirs()
         singleProjectFixture(dir, version = "0.6.0", probeBody = probeRepositoriesBody())
 
         // Both URLs present → release URL wins.
-        val both = runProbe(dir, args = arrayOf("-PtramaiPublishReleaseUrl=https://release.example.com/repo", "-PtramaiPublishSnapshotUrl=https://snapshot.example.com/repo"))
+        val both =
+            runProbe(
+                dir,
+                args =
+                    arrayOf(
+                        "-PtramaiPublishReleaseUrl=https://release.example.com/repo",
+                        "-PtramaiPublishSnapshotUrl=https://snapshot.example.com/repo",
+                    ),
+            )
         assertEquals("tramaiRemote|https://release.example.com/repo", both["repos"])
 
         // Only snapshot URL → fallback to snapshot URL for a release version.
@@ -171,13 +200,23 @@ class TramaiPublishingPluginTest {
     // ── P4 — snapshot repository selection ───────────────────────────────────
 
     @Test
-    fun `P4 snapshot version selects snapshot URL with release fallback`(@TempDir tempDir: File) {
+    fun `P4 snapshot version selects snapshot URL with release fallback`(
+        @TempDir tempDir: File,
+    ) {
         val dir = File(tempDir, "p4")
         dir.mkdirs()
         singleProjectFixture(dir, version = "0.6.1-SNAPSHOT", probeBody = probeRepositoriesBody())
 
         // Both URLs present → snapshot URL wins.
-        val both = runProbe(dir, args = arrayOf("-PtramaiPublishReleaseUrl=https://release.example.com/repo", "-PtramaiPublishSnapshotUrl=https://snapshot.example.com/repo"))
+        val both =
+            runProbe(
+                dir,
+                args =
+                    arrayOf(
+                        "-PtramaiPublishReleaseUrl=https://release.example.com/repo",
+                        "-PtramaiPublishSnapshotUrl=https://snapshot.example.com/repo",
+                    ),
+            )
         assertEquals("tramaiRemote|https://snapshot.example.com/repo", both["repos"])
 
         // Only release URL → fallback to release URL for a snapshot version.
@@ -192,14 +231,17 @@ class TramaiPublishingPluginTest {
     // ── P5 — no repository configured when both URLs absent ──────────────────
 
     @Test
-    fun `P5 no remote repository is configured when both URLs are absent`(@TempDir tempDir: File) {
+    fun `P5 no remote repository is configured when both URLs are absent`(
+        @TempDir tempDir: File,
+    ) {
         val dir = File(tempDir, "p5")
         dir.mkdirs()
         singleProjectFixture(
             dir,
-            probeBody = """
+            probeBody =
+                """
                 println("PROBE:repos=" + publishing.repositories.map { it.name }.sorted().joinToString(","))
-            """.trimIndent(),
+                """.trimIndent(),
         )
         val probe = runProbe(dir)
         assertEquals("", probe["repos"] ?: "", "no repositories must be configured on a developer machine")
@@ -208,27 +250,32 @@ class TramaiPublishingPluginTest {
     // ── P6 — file repository never receives credentials ──────────────────────
 
     @Test
-    fun `P6 file repository is configured without credentials even when properties are provided`(@TempDir tempDir: File) {
+    fun `P6 file repository is configured without credentials even when properties are provided`(
+        @TempDir tempDir: File,
+    ) {
         val dir = File(tempDir, "p6")
         dir.mkdirs()
         singleProjectFixture(
             dir,
             version = "0.6.0",
-            probeBody = """
+            probeBody =
+                """
                 val repo = publishing.repositories.getByName("tramaiRemote") as MavenArtifactRepository
                 println("PROBE:repoUrl=" + repo.url)
                 println("PROBE:credUser=" + (repo.credentials.username ?: "NULL"))
                 println("PROBE:credPass=" + (repo.credentials.password ?: "NULL"))
-            """.trimIndent(),
+                """.trimIndent(),
         )
-        val probe = runProbe(
-            dir,
-            args = arrayOf(
-                "-PtramaiPublishReleaseUrl=file:///tmp/repo",
-                "-PtramaiPublishUsername=secret-user",
-                "-PtramaiPublishPassword=secret-pass",
-            ),
-        )
+        val probe =
+            runProbe(
+                dir,
+                args =
+                    arrayOf(
+                        "-PtramaiPublishReleaseUrl=file:///tmp/repo",
+                        "-PtramaiPublishUsername=secret-user",
+                        "-PtramaiPublishPassword=secret-pass",
+                    ),
+            )
         assertEquals("file:/tmp/repo", probe["repoUrl"], "file repository URL must remain file-based")
         assertEquals("NULL", probe["credUser"], "file repository must never receive credentials")
         assertEquals("NULL", probe["credPass"], "file repository must never receive credentials")
@@ -237,15 +284,18 @@ class TramaiPublishingPluginTest {
     // ── P7 — signing is optional ─────────────────────────────────────────────
 
     @Test
-    fun `P7 configuration succeeds without signing keys and adds signing tasks with keys`(@TempDir tempDir: File) {
+    fun `P7 configuration succeeds without signing keys and adds signing tasks with keys`(
+        @TempDir tempDir: File,
+    ) {
         // Case 1: no keys → configuration succeeds, no signing tasks.
         val noKeys = File(tempDir, "p7-nokeys")
         noKeys.mkdirs()
         singleProjectFixture(
             noKeys,
-            probeBody = """
+            probeBody =
+                """
                 println("PROBE:signTasks=" + tasks.names.filter { it.contains("sign", ignoreCase = true) }.sorted().joinToString(","))
-            """.trimIndent(),
+                """.trimIndent(),
         )
         val noKeysProbe = runProbe(noKeys)
         assertEquals("", noKeysProbe["signTasks"].orEmpty(), "no signing tasks must exist without signing material")
@@ -255,9 +305,10 @@ class TramaiPublishingPluginTest {
         withKeys.mkdirs()
         singleProjectFixture(
             withKeys,
-            probeBody = """
+            probeBody =
+                """
                 println("PROBE:signTasks=" + tasks.names.filter { it.contains("sign", ignoreCase = true) }.sorted().joinToString(","))
-            """.trimIndent(),
+                """.trimIndent(),
         )
         val withKeysProbe = runProbe(withKeys, args = arrayOf("-PsigningKey=test-key", "-PsigningPassword=test-password"))
         assertTrue(withKeysProbe["signTasks"]!!.contains("signMavenPublication"), "signing tasks must exist when keys are provided")
@@ -266,7 +317,9 @@ class TramaiPublishingPluginTest {
     // ── P8 — sovereign local repository safety ───────────────────────────────
 
     @Test
-    fun `P8 sovereignBundleLocal exists as file repository on selected projects only`(@TempDir tempDir: File) {
+    fun `P8 sovereignBundleLocal exists as file repository on selected projects only`(
+        @TempDir tempDir: File,
+    ) {
         val dir = File(tempDir, "p8")
         dir.mkdirs()
         writeFile(
@@ -281,8 +334,32 @@ class TramaiPublishingPluginTest {
         writeFile(
             dir,
             "build.gradle.kts",
+            "",
+        )
+        writeFile(
+            dir,
+            "config/quality/module-catalog.yml",
             """
-            extra["tramai.publishableModulePaths"] = listOf(":tramai-core", ":tramai-spring")
+            schemaVersion: "3"
+            dependencyPolicies:
+              core: { allowedLayers: [core-contracts, testing-support] }
+              framework: { allowedLayers: [core-contracts, framework-integrations, testing-support] }
+            entryDefaults:
+              core: &core { maturity: stable, visibility: public, owner: core, dependencyPolicy: core, releaseInclusion: included, rationale: "Fixture module." }
+              framework: &framework { maturity: preview, visibility: public, owner: framework, dependencyPolicy: framework, releaseInclusion: included, rationale: "Fixture module." }
+            modules:
+              - path: ":tramai-core"
+                <<: *core
+                layer: core-contracts
+                publishability: published
+                apiStability: stable
+                description: "Fixture core module."
+              - path: ":tramai-spring"
+                <<: *framework
+                layer: framework-integrations
+                publishability: published
+                apiStability: preview
+                description: "Fixture spring module."
             """.trimIndent(),
         )
         writeFile(
@@ -343,7 +420,9 @@ class TramaiPublishingPluginTest {
     // ── P9 — publication metadata parity ─────────────────────────────────────
 
     @Test
-    fun `P9 generated POM carries unchanged publication metadata`(@TempDir tempDir: File) {
+    fun `P9 generated POM carries unchanged publication metadata`(
+        @TempDir tempDir: File,
+    ) {
         val dir = File(tempDir, "p9")
         dir.mkdirs()
         singleProjectFixture(
@@ -375,7 +454,9 @@ class TramaiPublishingPluginTest {
     // ── D6 — publishing consumes the catalog description (9.2c-c) ───────────
 
     @Test
-    fun `D6 generated POM description comes from the module catalog`(@TempDir tempDir: File) {
+    fun `D6 generated POM description comes from the module catalog`(
+        @TempDir tempDir: File,
+    ) {
         val dir = File(tempDir, "d6")
         dir.mkdirs()
         writeFile(
@@ -435,7 +516,9 @@ class TramaiPublishingPluginTest {
     // ── P10 — configuration cache at the convention boundary ─────────────────
 
     @Test
-    fun `P10 configuration cache is reused on second run`(@TempDir tempDir: File) {
+    fun `P10 configuration cache is reused on second run`(
+        @TempDir tempDir: File,
+    ) {
         val dir = File(tempDir, "p10")
         dir.mkdirs()
         singleProjectFixture(dir, plugins = "java-library")
@@ -452,19 +535,21 @@ class TramaiPublishingPluginTest {
 
     @Test
     fun `S1 root build script contains no publishing implementation`() {
-        val repositoryRoot = System.getProperty("tramai.repositoryRoot")
-            ?: error("tramai.repositoryRoot system property must be set")
+        val repositoryRoot =
+            System.getProperty("tramai.repositoryRoot")
+                ?: error("tramai.repositoryRoot system property must be set")
         val rootBuildScript = File(repositoryRoot, "build.gradle.kts")
         assertTrue(rootBuildScript.isFile, "root build.gradle.kts must exist at $repositoryRoot")
         val text = rootBuildScript.readText()
 
-        val forbidden = listOf(
-            "configureTramaiPublishing",
-            "configureSovereignBundleLocalRepo",
-            "import org.gradle.api.publish.PublishingExtension",
-            "import org.gradle.api.publish.maven.MavenPublication",
-            "import org.gradle.plugins.signing.SigningExtension",
-        )
+        val forbidden =
+            listOf(
+                "configureTramaiPublishing",
+                "configureSovereignBundleLocalRepo",
+                "import org.gradle.api.publish.PublishingExtension",
+                "import org.gradle.api.publish.maven.MavenPublication",
+                "import org.gradle.plugins.signing.SigningExtension",
+            )
         forbidden.forEach { identifier ->
             assertFalse(text.contains(identifier), "root build.gradle.kts must not contain $identifier")
         }

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/ModuleTopologyVerificationTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/ModuleTopologyVerificationTest.kt
@@ -106,6 +106,25 @@ class ModuleTopologyVerificationTest {
     }
 
     @Test
+    fun `mutation 3b - corrupt catalog fails closed in the architecture model`() {
+        // 9.2d-b1 P1: MaintainabilityBaselinePlugin.publishedModulePaths is
+        // fed by ModuleManifest.publishableModulePaths(rootDir), which THROWS
+        // on a corrupt catalog. A malformed catalog must abort the gate at
+        // configuration, never silently supply an empty published set.
+        val dir = topologyFixture()
+        writeFile(
+            dir,
+            "config/quality/module-catalog.yml",
+            "schemaVersion: \"3\"\nmodules:\n  - malformed\n",
+        )
+        val result = runner(dir, "verifyModuleManifest").buildAndFail()
+        assertTrue(
+            result.output.contains("MODULE_CATALOG") || result.output.contains("catalog"),
+            "corrupt catalog must fail closed in the architecture model, got: ${result.output.take(800)}",
+        )
+    }
+
+    @Test
     fun `mutation 4 - BOM constraint removed fails`() {
         val dir = topologyFixture(bomModules = listOf("tramai-core"))
         val result = runner(dir, "verifyModuleManifest").buildAndFail()

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/ModuleTopologyVerificationTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/ModuleTopologyVerificationTest.kt
@@ -46,30 +46,62 @@ class ModuleTopologyVerificationTest {
     }
 
     @Test
-    fun `mutation 2 - catalog says published but release snapshot omits it fails`() {
-        // Release task snapshot = extra (set before imperative apply): engine omitted.
-        val dir = topologyFixture(publishableExtra = """listOf(":tramai-core", ":tramai-bom")""")
-        val result = runner(dir, "verifyModuleManifest").buildAndFail()
+    fun `mutation 2 - catalog publishability flip propagates to the release model without drift`() {
+        // 9.2d-b1: the release snapshot is catalog-derived (single authority).
+        // Flip engine published → internal in the catalog (and drop it from the
+        // BOM, which must follow the same authority): verifyModuleManifest must
+        // PASS with no MODULE_CATALOG_PUBLISHING_DRIFT. Under the old
+        // extra-driven authority the stale extra would have kept engine
+        // published and produced drift.
+        val dir = topologyFixture(bomModules = listOf("tramai-core"))
+        // Flip engine published → internal as a full entry (visibility and
+        // releaseInclusion follow the internal anchor — a bare publishability
+        // flip would be invalid against the core default's public visibility).
+        val flipped =
+            catalog(
+                """
+              - path: ":tramai-engine"
+                <<: *internal
+                layer: testing-support
+                publishability: internal
+                apiStability: internal
+            """,
+            )
+        writeFile(dir, "config/quality/module-catalog.yml", flipped)
+        val result = runner(dir, "verifyModuleManifest").build()
         assertTrue(
-            result.output.contains(
-                "[MODULE_CATALOG_PUBLISHING_DRIFT] Publishing drift: configured publication set " +
-                    "[:tramai-bom, :tramai-core] but manifest requires " +
-                    "[:tramai-bom, :tramai-core, :tramai-engine]",
-            ),
-            "expected exact publishing-drift diagnostic: ${result.output.take(800)}",
+            result.task(":verifyModuleManifest")?.outcome == TaskOutcome.SUCCESS,
+            "catalog flip must not produce publishing drift: ${result.output.take(800)}",
         )
     }
 
     @Test
-    fun `mutation 3 - release snapshot includes unexpected published module fails`() {
+    fun `mutation 3 - catalog-declared published module without a project fails closed`() {
+        // 9.2d-b1: the catalog is the ONLY publishability authority, so an
+        // unexpected published module can only originate there. Declaring one
+        // without a Gradle project must fail with the exact unknown-entry
+        // diagnostic — never be silently accepted via a secondary list.
         val dir =
             topologyFixture(
-                publishableExtra = """listOf(":tramai-core", ":tramai-engine", ":tramai-bom", ":tramai-extra")""",
+                engineEntry = """
+              - path: ":tramai-engine"
+                <<: *core
+                layer: core-contracts
+                publishability: published
+                apiStability: stable
+                description: "Fixture engine module."
+              - path: ":tramai-extra"
+                <<: *core
+                layer: core-contracts
+                publishability: published
+                apiStability: preview
+                description: "Phantom published module with no project."
+            """,
             )
         val result = runner(dir, "verifyModuleManifest").buildAndFail()
         assertTrue(
-            result.output.contains("[MODULE_CATALOG_PUBLISHING_DRIFT]") && result.output.contains(":tramai-extra"),
-            "expected publishing drift mentioning :tramai-extra: ${result.output.take(800)}",
+            result.output.contains("[MODULE_CATALOG_UNKNOWN_ENTRY]") && result.output.contains(":tramai-extra"),
+            "expected unknown-entry for phantom published module: ${result.output.take(800)}",
         )
     }
 
@@ -111,11 +143,11 @@ class ModuleTopologyVerificationTest {
     }
 
     @Test
-    fun `publishedPaths come from the release task model when the root extra is absent`() {
-        // No tramai.publishableModulePaths extra anywhere: the release task's
-        // publishableModules falls back to the module catalog, and
-        // verifyModuleManifest still passes (9.2d-b can delete the extra later).
-        val dir = topologyFixture(publishableExtra = null)
+    fun `publishedPaths come from the release task model with no secondary authority`() {
+        // No tramai.publishableModulePaths extra anywhere (9.2d-b1 deleted it):
+        // the release task's publishableModules derives from the module catalog,
+        // and verifyModuleManifest still passes.
+        val dir = topologyFixture()
         val result = runner(dir, "verifyModuleManifest").build()
         assertTrue(result.task(":verifyModuleManifest")?.outcome == TaskOutcome.SUCCESS, result.output.take(800))
     }
@@ -284,7 +316,6 @@ class ModuleTopologyVerificationTest {
     }
 
     private fun topologyFixture(
-        publishableExtra: String? = """listOf(":tramai-core", ":tramai-engine", ":tramai-bom")""",
         bomModules: List<String> = listOf("tramai-core", "tramai-engine"),
         engineEntry: String? = defaultEngineEntry,
         catalogFileOverride: String? = null,
@@ -299,12 +330,6 @@ class ModuleTopologyVerificationTest {
             include(":tramai-core", ":tramai-engine", ":tramai-testing", ":tramai-bom")
             """.trimIndent(),
         )
-        val extraBlock =
-            if (publishableExtra != null) {
-                "extra[\"tramai.publishableModulePaths\"] = $publishableExtra"
-            } else {
-                ""
-            }
         // Exact-file authority override: point moduleCatalogFile at a
         // non-conventional path so the P1 kill-the-old-implementation
         // discriminator can prove the declared file is parsed directly.
@@ -323,10 +348,6 @@ class ModuleTopologyVerificationTest {
             plugins {
                 id("tramai.maintainability-baseline")
             }
-            $extraBlock
-            // Imperative apply AFTER the extra is set: the release task's
-            // publishableModules snapshot only reads the extra when it exists at
-            // apply time, otherwise it falls back to the module catalog.
             ${
                 if (applyReleasePlugin) {
                     "apply(plugin = \"tramai.release-verification\")"

--- a/build-logic/src/test/kotlin/dev/tramai/build/release/ReleaseVerificationPluginTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/release/ReleaseVerificationPluginTest.kt
@@ -447,7 +447,7 @@ class ReleaseVerificationPluginTest {
         )
     }
 
-    // ── T7: incomplete bundle fails closed ───────────────────────────────────
+    // ── T7: incomplete evidence fails closed ───────────────────────────────────
 
     @Test
     fun `T7 incomplete evidence deletes stale manifest`() {
@@ -464,6 +464,45 @@ class ReleaseVerificationPluginTest {
         )
         // The stale manifest must be gone after the failed run
         assertFalse(stale.exists(), "stale bundle-manifest.json must be invalidated on failure; output was: ${result.output.take(1200)}")
+    }
+
+    // ── T7b/T7c: corrupt catalog fails closed (9.2d-b1 P1) ────────────────────
+    // The catalog is the single publishability authority. A corrupt catalog
+    // must STOP the release/sovereign paths, never degrade to an empty module
+    // set (fail-open). One kill test per consumer boundary.
+
+    private fun corruptCatalog(dir: File) {
+        writeFile(
+            dir,
+            "config/quality/module-catalog.yml",
+            "schemaVersion: \"3\"\nmodules:\n  - malformed\n",
+        )
+    }
+
+    @Test
+    fun `T7b release verification fails closed on corrupt catalog`() {
+        val dir = baseFixture()
+        corruptCatalog(dir)
+        // publishableModuleNames is resolved eagerly at plugin apply; a corrupt
+        // catalog must abort configuration instead of verifying "no modules".
+        val result = runner(dir, "verifyPublicationMetadata").buildAndFail()
+        assertTrue(
+            result.output.contains("MODULE_CATALOG") || result.output.contains("catalog"),
+            "corrupt catalog must fail closed with a catalog diagnostic, got: ${result.output.take(1200)}",
+        )
+    }
+
+    @Test
+    fun `T7c sovereign bundle fails closed on corrupt catalog`() {
+        val dir = baseFixture()
+        corruptCatalog(dir)
+        // sovereignBundleModules is resolved lazily at task realization; the
+        // bundle set must never silently become empty.
+        val result = runner(dir, "verifySovereignRuntimeSignedBundle").buildAndFail()
+        assertTrue(
+            result.output.contains("MODULE_CATALOG") || result.output.contains("catalog"),
+            "corrupt catalog must fail closed with a catalog diagnostic, got: ${result.output.take(1200)}",
+        )
     }
 
     // ── T9: evidence index depends on all producers ─────────────────────────

--- a/build-logic/src/test/kotlin/dev/tramai/build/release/ReleaseVerificationPluginTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/release/ReleaseVerificationPluginTest.kt
@@ -20,18 +20,22 @@ import kotlin.test.assertTrue
  * prove zero execution on rejected paths.
  */
 class ReleaseVerificationPluginTest {
-
     @TempDir
     lateinit var tempDir: File
 
-    private fun writeFile(base: File, relativePath: String, content: String) {
+    private fun writeFile(
+        base: File,
+        relativePath: String,
+        content: String,
+    ) {
         val target = File(base, relativePath)
         target.parentFile.mkdirs()
         target.writeText(content)
     }
 
     /** POM fixture content — kept separate so the build-script fixture string stays flat. */
-    private val fixturePom = """
+    private val fixturePom =
+        """
         <?xml version="1.0" encoding="UTF-8"?>
         <project xmlns="http://maven.apache.org/POM/4.0.0">
           <modelVersion>4.0.0</modelVersion>
@@ -47,7 +51,7 @@ class ReleaseVerificationPluginTest {
             <connection>scm:git:https://github.com/GionaGranchelli/tramAI.git</connection>
             <developerConnection>scm:git:ssh://git@github.com/GionaGranchelli/tramAI.git</developerConnection></scm>
         </project>
-    """.trimIndent()
+        """.trimIndent()
 
     /** Triple-quoted form of the POM fixture, embedded inside the fixture build script. */
     private val fixturePomQuoted: String = "\"\"\"" + fixturePom + "\"\"\""
@@ -78,7 +82,6 @@ class ReleaseVerificationPluginTest {
                 id("tramai.release-verification")
                 id("tramai.sovereign-verification")
             }
-            extra["tramai.publishableModulePaths"] = listOf(":tramai-core")
             // verifySovereignOpsObservabilityDocs is provided by tramai.sovereign-verification (9.2d-a3b1 typed extraction)
             // Isolate mavenLocal from the real ~/.m2 so tests are hermetic
             tasks.named<dev.tramai.build.sovereign.VerifySovereignSignedBundleTask>("verifySovereignRuntimeSignedBundle") {
@@ -86,6 +89,20 @@ class ReleaseVerificationPluginTest {
             }
             $extra
             """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "config/quality/module-catalog.yml",
+            fixtureCatalog(
+                """
+                - path: ":tramai-core"
+                  <<: *core
+                  layer: core-contracts
+                  publishability: published
+                  apiStability: stable
+                  description: "Fixture core module."
+                """.trimIndent(),
+            ),
         )
         writeFile(
             dir,
@@ -101,7 +118,7 @@ class ReleaseVerificationPluginTest {
                 doLast {
                     val pom = layout.buildDirectory.file("publications/maven/pom-default.xml").get().asFile
                     pom.parentFile.mkdirs()
-                    pom.writeText(${fixturePomQuoted})
+                    pom.writeText($fixturePomQuoted)
                 }
             }
             tasks.register("publishToMavenLocal") {
@@ -139,8 +156,12 @@ class ReleaseVerificationPluginTest {
         return dir
     }
 
-    private fun runner(dir: File, vararg args: String): GradleRunner =
-        GradleRunner.create()
+    private fun runner(
+        dir: File,
+        vararg args: String,
+    ): GradleRunner =
+        GradleRunner
+            .create()
             .withProjectDir(dir)
             // The repository wrapper is Gradle 9.0.0 (see gradle/wrapper/gradle-wrapper.properties);
             // TestKit must exercise the same version CI runs.
@@ -148,21 +169,39 @@ class ReleaseVerificationPluginTest {
             .withArguments(*args, "--stacktrace")
             .withPluginClasspath()
 
+    /** Minimal schema-3 module catalog with [moduleEntries] appended under the core default. */
+    private fun fixtureCatalog(moduleEntries: String): String =
+        buildString {
+            appendLine("schemaVersion: \"3\"")
+            appendLine("dependencyPolicies:")
+            appendLine("  core: { allowedLayers: [core-contracts, testing-support] }")
+            appendLine("entryDefaults:")
+            appendLine(
+                "  core: &core { maturity: stable, visibility: public, owner: core, " +
+                    "dependencyPolicy: core, releaseInclusion: included, rationale: \"Fixture module.\" }",
+            )
+            appendLine("modules:")
+            // Entries arrive trimmed to column 0 (call-site trimIndent); re-indent
+            // under `modules:` so the merged YAML stays valid.
+            moduleEntries.trimIndent().lines().forEach { appendLine(if (it.isBlank()) it else "  $it") }
+        }
+
     // ── T1: task types ───────────────────────────────────────────────────────
 
     @Test
     fun `T1 task types are typed DefaultTasks not anonymous doLast`() {
         val dir = baseFixture()
-        val result = runner(
-            dir,
-            "verifyPublicationMetadata",
-            "verifyPublishedLocalArtifacts",
-            "verifyReleasePublishInputs",
-            "verifySovereignRuntimeSignedBundle",
-            "prepareSovereignReleaseArtifacts",
-            "verifySovereignReleaseManifest",
-            "generateSovereignReleaseEvidenceIndex",
-        ).buildAndFail()
+        val result =
+            runner(
+                dir,
+                "verifyPublicationMetadata",
+                "verifyPublishedLocalArtifacts",
+                "verifyReleasePublishInputs",
+                "verifySovereignRuntimeSignedBundle",
+                "prepareSovereignReleaseArtifacts",
+                "verifySovereignReleaseManifest",
+                "generateSovereignReleaseEvidenceIndex",
+            ).buildAndFail()
 
         // All tasks must be found as typed tasks. With the sentinel fixture the
         // evidence generators will fail on missing evidence (expected), but the
@@ -191,7 +230,8 @@ class ReleaseVerificationPluginTest {
     // ── W1/W2 — wired description path: catalog → expectedDescriptions → verifier (9.2c-c) ──
 
     /** Minimal schema-v3 catalog with one published module. */
-    private val wiredCatalog = """
+    private val wiredCatalog =
+        """
         schemaVersion: "3"
         dependencyPolicies:
           core: { allowedLayers: [core-contracts] }
@@ -204,23 +244,27 @@ class ReleaseVerificationPluginTest {
             publishability: published
             apiStability: stable
             description: "DESCRIPTION_PLACEHOLDER"
-    """.trimIndent()
+        """.trimIndent()
 
     @Test
     fun `W1 wired expectedDescriptions passes when POM matches the catalog description`() {
-        val dir = baseFixture(extra = """
-            project(":tramai-core") {
-                afterEvaluate {
-                    tasks.named("generatePomFileForMavenPublication") {
-                        doLast {
-                            val pom = layout.buildDirectory.file("publications/maven/pom-default.xml").get().asFile
-                            val text = pom.readText().replace("<description>Test module</description>", "<description>Expected description for :tramai-core.</description>")
-                            pom.writeText(text)
+        val dir =
+            baseFixture(
+                extra =
+                    """
+                    project(":tramai-core") {
+                        afterEvaluate {
+                            tasks.named("generatePomFileForMavenPublication") {
+                                doLast {
+                                    val pom = layout.buildDirectory.file("publications/maven/pom-default.xml").get().asFile
+                                    val text = pom.readText().replace("<description>Test module</description>", "<description>Expected description for :tramai-core.</description>")
+                                    pom.writeText(text)
+                                }
+                            }
                         }
                     }
-                }
-            }
-        """.trimIndent())
+                    """.trimIndent(),
+            )
         writeFile(
             dir,
             "config/quality/module-catalog.yml",
@@ -284,11 +328,12 @@ class ReleaseVerificationPluginTest {
     @Test
     fun `T3b sovereign signed bundle fails before sentinel publish executes`() {
         val dir = baseFixture()
-        val result = runner(
-            dir,
-            "verifySovereignRuntimeSignedBundle",
-            "-PtramaiPublishReleaseUrl=https://repo.example.com",
-        ).buildAndFail()
+        val result =
+            runner(
+                dir,
+                "verifySovereignRuntimeSignedBundle",
+                "-PtramaiPublishReleaseUrl=https://repo.example.com",
+            ).buildAndFail()
         assertTrue(result.output.contains("only supports file://"))
         // Sentinel publish tasks must NOT have executed
         assertFalse(
@@ -306,11 +351,12 @@ class ReleaseVerificationPluginTest {
     @Test
     fun `T4 sovereign file repository reaches task execution`() {
         val dir = baseFixture()
-        val result = runner(
-            dir,
-            "verifySovereignRuntimeSignedBundle",
-            "-PtramaiPublishReleaseUrl=file:///tmp/repo",
-        ).buildAndFail()
+        val result =
+            runner(
+                dir,
+                "verifySovereignRuntimeSignedBundle",
+                "-PtramaiPublishReleaseUrl=file:///tmp/repo",
+            ).buildAndFail()
         // With a file URL the config-time guard passes; the task then fails on
         // missing mavenLocal artifacts — proving the typed task action ran
         // (i.e., the file:// path is accepted and reaches verification).
@@ -354,7 +400,6 @@ class ReleaseVerificationPluginTest {
                 id("tramai.release-verification")
                 id("tramai.sovereign-verification")
             }
-            extra["tramai.publishableModulePaths"] = listOf(":tramai-core", ":tramai-missing")
             // verifySovereignOpsObservabilityDocs is provided by tramai.sovereign-verification (9.2d-a3b1 typed extraction)
             tasks.named<dev.tramai.build.sovereign.VerifySovereignSignedBundleTask>("verifySovereignRuntimeSignedBundle") {
                 mavenLocalRepositoryDirectory.set(layout.buildDirectory.dir("fake-m2/repository/dev/tramai"))
@@ -368,6 +413,29 @@ class ReleaseVerificationPluginTest {
                 }
             }
             """.trimIndent(),
+        )
+        // The catalog (single publishability authority) declares the missing
+        // module as published; the fixture has no such subproject, so the
+        // declared release boundary must fail closed.
+        writeFile(
+            dir,
+            "config/quality/module-catalog.yml",
+            fixtureCatalog(
+                """
+                - path: ":tramai-core"
+                  <<: *core
+                  layer: core-contracts
+                  publishability: published
+                  apiStability: stable
+                  description: "Fixture core module."
+                - path: ":tramai-missing"
+                  <<: *core
+                  layer: core-contracts
+                  publishability: published
+                  apiStability: preview
+                  description: "Fixture module with no subproject."
+                """.trimIndent(),
+            ),
         )
         val result = runner(dir, "prepareSovereignReleaseArtifacts").buildAndFail()
         // The task must fail because :tramai-missing is part of the declared
@@ -447,7 +515,6 @@ class ReleaseVerificationPluginTest {
                 id("tramai.release-verification")
                 id("tramai.sovereign-verification")
             }
-            extra["tramai.publishableModulePaths"] = listOf(":tramai-core")
             // verifySovereignOpsObservabilityDocs is provided by tramai.sovereign-verification (9.2d-a3b1 typed extraction)
             tasks.named<dev.tramai.build.sovereign.VerifySovereignSignedBundleTask>("verifySovereignRuntimeSignedBundle") {
                 mavenLocalRepositoryDirectory.set(layout.buildDirectory.dir("fake-m2/repository/dev/tramai"))
@@ -489,11 +556,12 @@ class ReleaseVerificationPluginTest {
         git(dir, "remote", "add", "origin", "https://github.com/GionaGranchelli/tramAI.git")
         val shaA = git(dir, "rev-parse", "HEAD").trim()
 
-        val args = arrayOf(
-            "generateSovereignReleaseEvidenceIndex",
-            "--configuration-cache",
-            "--configuration-cache-problems=fail",
-        )
+        val args =
+            arrayOf(
+                "generateSovereignReleaseEvidenceIndex",
+                "--configuration-cache",
+                "--configuration-cache-problems=fail",
+            )
         val first = runner(dir, *args).build()
         assertTrue(
             first.task(":generateSovereignReleaseEvidenceIndex") != null,
@@ -529,7 +597,10 @@ class ReleaseVerificationPluginTest {
         )
         assertTrue(
             evidenceCommitSha(dir) == shaB,
-            "evidence must record commit B after a git-only change: ${File(dir, "build/sovereign-runtime-release/evidence-index.json").readText()}",
+            "evidence must record commit B after a git-only change: ${File(
+                dir,
+                "build/sovereign-runtime-release/evidence-index.json",
+            ).readText()}",
         )
     }
 
@@ -578,7 +649,6 @@ class ReleaseVerificationPluginTest {
                 id("tramai.release-verification")
                 id("tramai.sovereign-verification")
             }
-            extra["tramai.publishableModulePaths"] = listOf(":tramai-core")
             // verifySovereignOpsObservabilityDocs is provided by tramai.sovereign-verification (9.2d-a3b1 typed extraction)
             tasks.named<dev.tramai.build.sovereign.VerifySovereignSignedBundleTask>("verifySovereignRuntimeSignedBundle") {
                 mavenLocalRepositoryDirectory.set(layout.buildDirectory.dir("fake-m2/repository/dev/tramai"))
@@ -694,7 +764,6 @@ class ReleaseVerificationPluginTest {
                 id("tramai.release-verification")
                 id("tramai.sovereign-verification")
             }
-            extra["tramai.publishableModulePaths"] = listOf(":tramai-core")
             // verifySovereignOpsObservabilityDocs is provided by tramai.sovereign-verification (9.2d-a3b1 typed extraction)
             tasks.named("generateSovereignReleaseEvidenceIndex") {
                 setDependsOn(emptyList<String>())
@@ -703,10 +772,14 @@ class ReleaseVerificationPluginTest {
         )
     }
 
-    private fun git(dir: File, vararg args: String): String {
-        val process = ProcessBuilder(listOf("git", "-C", dir.absolutePath) + args)
-            .redirectErrorStream(true)
-            .start()
+    private fun git(
+        dir: File,
+        vararg args: String,
+    ): String {
+        val process =
+            ProcessBuilder(listOf("git", "-C", dir.absolutePath) + args)
+                .redirectErrorStream(true)
+                .start()
         val output = process.inputStream.bufferedReader().readText()
         val exit = process.waitFor()
         check(exit == 0) { "git ${args.joinToString(" ")} failed ($exit): $output" }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,3 @@
-import dev.tramai.build.publishing.TramaiPublishingRepositories
-import dev.tramai.build.quality.ModuleManifest
-
 plugins {
     base
     id("tramai.maintainability-baseline")
@@ -168,8 +165,6 @@ val tramaiLicenseUrl = providers.gradleProperty("tramaiLicenseUrl").orElse("http
 val tramaiDeveloperId = providers.gradleProperty("tramaiDeveloperId").orElse("GionaGranchelli")
 val tramaiDeveloperName = providers.gradleProperty("tramaiDeveloperName").orElse("Giona")
 val tramaiDeveloperEmail = providers.gradleProperty("tramaiDeveloperEmail").orElse("opensource@giona.dev")
-val publishableProjectNames = ModuleManifest.publishableModulePaths(rootDir).map { it.removePrefix(":") }
-extra["tramai.publishableModulePaths"] = publishableProjectNames.map { ":$it" }
 
 // Sovereign bundle modules for the dedicated publication dry-run repository.
 // Used by the verifySovereignRuntimeSignedBundle task to publish only to a local

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -619,6 +619,7 @@
     <ID>InvalidPackageDeclaration:BinaryCompatFixture.kt$package dev.tramai.orchestration</ID>
     <ID>LargeClass:ApprovalContinuationStoreTck.kt$ApprovalContinuationStoreTck</ID>
     <ID>LargeClass:ApprovalResumeEngineTest.kt$ApprovalResumeEngineTest</ID>
+    <ID>LargeClass:ReleaseVerificationPluginTest.kt$ReleaseVerificationPluginTest</ID>
     <ID>LargeClass:ApprovalStoreTck.kt$ApprovalStoreTck</ID>
     <ID>LargeClass:AuditEngineTest.kt$AuditEngineTest</ID>
     <ID>LargeClass:BaselineGenerator.kt$BaselineGenerator</ID>
@@ -744,7 +745,7 @@
     <ID>LongMethod:ModuleCatalog.kt$ModuleCatalog$private fun parseEntry( index: Int, raw: Map&lt;String, Any&gt;, policies: Map&lt;String, Set&lt;ModuleLayer&gt;&gt;, modules: MutableMap&lt;String, ModuleEntry&gt;, errors: MutableList&lt;VerificationDiagnostic&gt;, )</ID>
     <ID>LongMethod:ModuleDocContractVerifier.kt$ModuleDocContractVerifier$fun verify(rootDir: File): List&lt;VerificationDiagnostic&gt;</ID>
     <ID>LongMethod:ModuleGraphAnalyzer.kt$ModuleGraphAnalyzer$fun analyze(): GraphResult</ID>
-    <ID>LongMethod:ModuleTopologyVerificationTest.kt$ModuleTopologyVerificationTest$private fun topologyFixture( publishableExtra: String? = """listOf(":tramai-core", ":tramai-engine", ":tramai-bom")""", bomModules: List&lt;String&gt; = listOf("tramai-core", "tramai-engine"), engineEntry: String? = defaultEngineEntry, catalogFileOverride: String? = null, applyReleasePlugin: Boolean = true, ): File</ID>
+    <ID>LongMethod:ModuleTopologyVerificationTest.kt$ModuleTopologyVerificationTest$private fun topologyFixture( bomModules: List&lt;String&gt; = listOf("tramai-core", "tramai-engine"), engineEntry: String? = defaultEngineEntry, catalogFileOverride: String? = null, applyReleasePlugin: Boolean = true, ): File</ID>
     <ID>LongMethod:MutationBaselineVerifier.kt$MutationBaselineVerifier$fun verify(committed: MutationData, current: MutationData): List&lt;VerificationDiagnostic&gt;</ID>
     <ID>LongMethod:MutationBaselineVerifier.kt$MutationBaselineVerifier.Companion$fun aggregate( reports: List&lt;ParsedMutationReport&gt;, analyzerVersion: String = "", measuredCommit: String = "" ): MutationData</ID>
     <ID>LongMethod:MutationClassificationLoader.kt$MutationClassificationLoader$fun load(repositoryRoot: File): MutationClassifications</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -819,7 +819,7 @@
     <ID>LongMethod:TramaiAutoConfigurationTest.kt$TramaiAutoConfigurationTest$@Test fun `creates an openai provider from the built in vault secret resolver`()</ID>
     <ID>LongMethod:TramaiDocsGuardsPlugin.kt$TramaiDocsGuardsPlugin$override fun apply(project: Project)</ID>
     <ID>LongMethod:TramaiPublishingPlugin.kt$TramaiPublishingPlugin$private fun configurePublication( project: Project, componentName: String, )</ID>
-    <ID>LongMethod:TramaiPublishingPluginTest.kt$TramaiPublishingPluginTest$@Test fun `P8 sovereignBundleLocal exists as file repository on selected projects only`(@TempDir tempDir: File)</ID>
+    
     <ID>LongMethod:TramaiWorkerTest.kt$TramaiWorkerTest$@Test fun `operator retryStep enables genuine retry with a new attempt`()</ID>
     <ID>LongMethod:TypedTaskConfigurationCacheTest.kt$TypedTaskConfigurationCacheTest$private fun maintainabilityFixture(): File</ID>
     <ID>LongMethod:VerifySovereignSignedBundleTask.kt$VerifySovereignSignedBundleTask$@TaskAction fun verify()</ID>
@@ -3504,29 +3504,29 @@
     <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$bundleManifestFile.from(project.layout.buildDirectory.file("sovereign-runtime-release/bundle-manifest.json"))</ID>
     <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$description</ID>
     <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$description = "Collects JARs from sovereign release modules, computes SHA-256 digests, and generates release-artifacts-v1.json."</ID>
-    <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$description = "Generates a release evidence index (JSON + Markdown) tying together commit metadata, validation gates, bundle manifest, release artifact manifest, and artifact hashes. Fails if required evidence artifacts are missing."</ID>
+    
     <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$description = "Runs the standalone sovereign runtime consumer smoke test against the dedicated verification repo."</ID>
-    <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$description = "Validates local publishability of sovereign runtime modules — POM metadata, sources/javadoc JARs, and dependency graph. Does not publish remotely."</ID>
-    <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$description = "Validates sovereign ops worker observability docs against the expected metric contract, API surface, and safe-label rules."</ID>
-    <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$description = "Verifies that build/sovereign-release/release-artifacts-v1.json is internally consistent with the JAR files in build/sovereign-release/artifacts/."</ID>
-    <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$gatewayAutoConfig.set(project.layout.projectDirectory.file("tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovalGatewayAutoConfiguration.kt"))</ID>
+    
+    
+    
+    
     <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$goldenPathTest.set(project.layout.projectDirectory.file("tramai-core/src/test/kotlin/dev/tramai/core/workflow/ApprovalGatewayGoldenPathErgonomicsTest.kt"))</ID>
     <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$humanApprovalErgonomics.set(project.layout.projectDirectory.file("docs/architecture/human-approval-workflow-ergonomics.md"))</ID>
-    <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$javaFacadeFile.set(project.layout.projectDirectory.file("tramai-core/src/main/kotlin/dev/tramai/core/workflow/ApprovalWorkflowResults.kt"))</ID>
-    <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$javaInteropTest.set(project.layout.projectDirectory.file("tramai-core/src/test/java/dev/tramai/core/workflow/ApprovalRequestWorkflowResultMappersJavaInteropTest.java"))</ID>
+    
+    
     <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$jdbcRunbook.set(project.layout.projectDirectory.file("docs/runbooks/sovereign-jdbc-production-deployment.md"))</ID>
     <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$manifestFile.set(project.layout.projectDirectory.file("docs/architecture/sovereign-api-stability-manifest.yml"))</ID>
     <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$mapperFile.set(project.layout.projectDirectory.file("tramai-core/src/main/kotlin/dev/tramai/core/workflow/ApprovalRequestWorkflowResultMappers.kt"))</ID>
     <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$micrometerReadme.set(project.layout.projectDirectory.file("tramai-spring-boot-starter-sovereign-ops-micrometer/README.md"))</ID>
-    <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$observabilityReadme.set(project.layout.projectDirectory.file("tramai-spring-boot-starter-sovereign-ops-observability/README.md"))</ID>
+    
     <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$project.tasks</ID>
     <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$promql.set(project.layout.projectDirectory.file("docs/operations/prometheus/sovereign-ops-worker-promql.md"))</ID>
-    <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$regulatedFactoryFile.set(project.layout.projectDirectory.file("examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageApprovalGatewayRequestFactory.kt"))</ID>
+    
     <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$resumeAlerts.set(project.layout.projectDirectory.file("docs/observability/prometheus-approved-resume-worker-alerts.yml"))</ID>
     <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$resumeDashboard.set(project.layout.projectDirectory.file("docs/observability/grafana-approved-resume-worker-dashboard.json"))</ID>
     <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$resumeRunbook.set(project.layout.projectDirectory.file("docs/runbooks/approved-resume-worker-observability.md"))</ID>
     <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$runbook.set(project.layout.projectDirectory.file("docs/operations/sovereign-ops-worker-observability-runbook.md"))</ID>
-    <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$springSmokeTest.set(project.layout.projectDirectory.file("examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/ApprovalGatewaySpringGoldenPathSmokeTest.kt"))</ID>
+    
     <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$val</ID>
     <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$verificationRepositoryDirectory.from(project.layout.buildDirectory.dir("sovereign-runtime-release-verification-repo"))</ID>
     <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$val gradleWrapper = if (System.getProperty("os.name").lowercase().contains("windows")) "gradlew.bat" else "./gradlew"</ID>
@@ -4786,5 +4786,16 @@
     <ID>ReturnCount:ApiCompatibilityVerifier.kt$ApiCompatibilityVerifier$private fun actualTransition( evidence: ApiDumpEvidence, module: String, ): Pair&lt;String, String&gt;?</ID>
     <ID>ThrowsCount:VerifyArchitectureTask.kt$VerifyArchitectureTask$private fun readBaselineDiagnostics(reportFile: File): List&lt;VerificationDiagnostic&gt;</ID>
     <ID>LargeClass:MaintainabilityBaselineVerificationTest.kt$MaintainabilityBaselineVerificationTest</ID>
+    <ID>LongMethod:TramaiPublishingPluginTest.kt$TramaiPublishingPluginTest$@Test fun `P8 sovereignBundleLocal exists as file repository on selected projects only`( @TempDir tempDir: File, )</ID>
+    <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$"Generates a release evidence index (JSON + Markdown) tying together commit metadata, validation gates, bundle manifest, release artifact manifest, and artifact hashes. Fails if required evidence artifacts are missing."</ID>
+    <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$"Validates local publishability of sovereign runtime modules — POM metadata, sources/javadoc JARs, and dependency graph. Does not publish remotely."</ID>
+    <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$"Validates sovereign ops worker observability docs against the expected metric contract, API surface, and safe-label rules."</ID>
+    <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$"Verifies that build/sovereign-release/release-artifacts-v1.json is internally consistent with the JAR files in build/sovereign-release/artifacts/."</ID>
+    <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$"examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/ApprovalGatewaySpringGoldenPathSmokeTest.kt"</ID>
+    <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$"examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/RegulatedClaimTriageApprovalGatewayRequestFactory.kt"</ID>
+    <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$"tramai-core/src/test/java/dev/tramai/core/workflow/ApprovalRequestWorkflowResultMappersJavaInteropTest.java"</ID>
+    <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$"tramai-spring-boot-starter-sovereign-ops/src/main/kotlin/dev/tramai/spring/sovereign/ops/ApprovalGatewayAutoConfiguration.kt"</ID>
+    <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$project.layout.projectDirectory.file("tramai-core/src/main/kotlin/dev/tramai/core/workflow/ApprovalWorkflowResults.kt")</ID>
+    <ID>MaxLineLength:TramaiSovereignVerificationPlugin.kt$TramaiSovereignVerificationPlugin$project.layout.projectDirectory.file("tramai-spring-boot-starter-sovereign-ops-observability/README.md")</ID>
   </CurrentIssues>
 </SmellBaseline>


### PR DESCRIPTION
## 9.2d-b1 — canonical publishability authority

Eliminates the root build's `tramai.publishableModulePaths` extra as a publishability authority. `config/quality/module-catalog.yml` is now the **single** source for all publishable-module consumers.

### Production changes (4 consumers → catalog, fail-closed)

- **`TramaiPublishingRepositories.sovereignBundleModuleNames`** — had **no** catalog fallback (only consumer reading the extra directly); now `ModuleManifest.publishableModulePaths(rootDir)`, catalog-backed and **fail-closed** — a missing/corrupt catalog throws `GradleException`, never an empty set
- **`TramaiReleaseVerificationPlugin.publishableModuleNames`** — dropped extra-preference; catalog-only, fail-closed
- **`TramaiSovereignVerificationPlugin.sovereignBundleModules`** — dropped extra-preference; catalog-only, fail-closed
- **`MaintainabilityBaselinePlugin.publishedModulePaths`** — catalog-backed, fail-closed
- Root `build.gradle.kts`: deleted `publishableProjectNames` + `extra["tramai.publishableModulePaths"]` + now-unused imports

Invariant: valid catalog → consume canonical publishability; invalid/missing catalog → fail with the catalog diagnostic. No `runCatching { … }.getOrDefault(emptyList())` tolerance remains in `build-logic/src/main`.

### Test migration + discriminators (Socratic clause)

- All fixtures migrated from `extra[...] = listOf(...)` to a written `config/quality/module-catalog.yml`
- **Mutation 2 (reworked)**: catalog publishability flip (published → internal, full entry) propagates to the release model with **no drift** — under the old extra-driven authority a stale extra would have produced `MODULE_CATALOG_PUBLISHING_DRIFT`
- **Mutation 3 (reworked)**: catalog-declared published module without a Gradle project fails closed with `MODULE_CATALOG_UNKNOWN_ENTRY` — proves no hidden hard-coded list can re-introduce a secondary authority
- **Fail-closed kill tests (corrupt catalog → build fails, per consumer boundary)**: `T7b` (release verification), `T7c` (sovereign bundle), `P8b` (publishing repo selection), mutation 3b (architecture model)
- Fixture invariants: `publishability: internal` requires the internal anchor (public visibility + included release is an invalid combination); internal entries omit `description` (no synthesized POM description)

### Verification (rebased onto current master, head `4554816a`)

- `:build-logic:test` — affected suites: `ReleaseVerificationPluginTest` + `TramaiPublishingPluginTest` + `ModuleTopologyVerificationTest` 46/46 ✅; `MaintainabilityBaselineVerificationTest` 17/17 ✅; `StaticAnalysis*` contract suite ✅
- `verifyStaticAnalysis` — detekt 4783 → 4784 (+2: signature-drift LongMethod update + LargeClass; −1 old signature), `-PchangeClass=baseline-migration`
- `spotlessCheck` ✅ (full-file normalization of pre-existing non-conformant formatting in sovereign plugin; `git diff -w` shows zero logic change)