### PR TITLE
refactor(quality): root build = composition — 9.2d-b2 responsibility extractions

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -105,6 +105,10 @@ gradlePlugin {
             id = "tramai.static-safety-guards"
             implementationClass = "dev.tramai.build.quality.StaticSafetyGuardsPlugin"
         }
+        create("tramaiSupplyChain") {
+            id = "tramai.supply-chain"
+            implementationClass = "dev.tramai.build.supplychain.TramaiSupplyChainPlugin"
+        }
     }
 }
 

--- a/build-logic/src/main/kotlin/dev/tramai/build/release/TramaiReleaseVerificationPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/release/TramaiReleaseVerificationPlugin.kt
@@ -20,6 +20,7 @@ class TramaiReleaseVerificationPlugin : Plugin<Project> {
         registerVerifyReleasePublishInputs(project)
         registerVerifySignedPublicationBundle(project)
         registerVerifyReleaseReadiness(project)
+        registerVerify050ReleaseReadiness(project)
     }
 
     /**
@@ -228,5 +229,139 @@ class TramaiReleaseVerificationPlugin : Plugin<Project> {
                 "verifySovereignOpsObservabilityDocs",
             )
         }
+    }
+
+    /**
+     * Aggregates all 0.5.0 release-readiness verification tasks (Epic 9.2d-b2).
+     * The document/file inspection implementation moved verbatim from the root
+     * build script into this plugin, so the root build remains composition-only.
+     * Deliberately NOT configuration-cache compatible: it aggregates
+     * execution-time verification tasks (C3 = 1 deliberate, per 9.2d scope).
+     */
+    private fun registerVerify050ReleaseReadiness(project: Project) {
+        project.tasks.register("verify050ReleaseReadiness") {
+            group = "verification"
+            description = "Aggregates all 0.5.0 release-readiness verification tasks."
+            notCompatibleWithConfigurationCache("Release readiness aggregates execution-time verification tasks.")
+
+            dependsOn(
+                "verifyVersionAlignment",
+                "verifyReleaseReadiness",
+                "verifyWorkflowApiStabilityBoundary",
+                "verifySovereignRuntimeApiBoundary",
+                "verifyToolGovernanceExample",
+            )
+
+            doLast {
+                verify050ReadinessDocs(project.rootProject)
+            }
+        }
+    }
+
+    /**
+     * The 0.5.0 release-readiness document/file inspection (moved verbatim
+     * from the root build script; extracted into its own function so the
+     * registration stays short). Fails closed with the exact historical
+     * diagnostics.
+     */
+    private fun verify050ReadinessDocs(rootProject: Project) {
+        val rootDir = rootProject.layout.projectDirectory.asFile
+        val expectedVersion = "0.5.0"
+        val expectedReleaseDate =
+            rootProject.findProperty("tramaiReleaseDate") as? String
+                ?: error("tramaiReleaseDate must be set in gradle.properties")
+
+        // 0.5.0 release-readiness document exists
+        val releaseReadinessDoc = rootDir.resolve("docs/releases/$expectedVersion-release-readiness.md")
+        require(releaseReadinessDoc.isFile) {
+            "Missing $expectedVersion release-readiness document at ${releaseReadinessDoc.path}"
+        }
+
+        // CHANGELOG has 0.5.0 section
+        val changelog = rootDir.resolve("CHANGELOG.md")
+        val changelogText = changelog.readText()
+        require(changelogText.contains("## $expectedVersion - $expectedReleaseDate")) {
+            "CHANGELOG.md must contain ## $expectedVersion - $expectedReleaseDate section"
+        }
+
+        // STATUS and roadmap state are correct
+        val statusDoc = rootDir.resolve("docs/STATUS.md")
+        val statusText = statusDoc.readText()
+        require(statusText.contains("0.5.0 release candidate prepared")) {
+            "STATUS.md must mention 0.5.0 release candidate prepared"
+        }
+
+        val roadmap = rootDir.resolve("docs/POST-SOVEREIGNTY-ROADMAP.md")
+        val roadmapText = roadmap.readText()
+        require(roadmapText.contains("Release prepared — publication pending")) {
+            "Roadmap must indicate release prepared — publication pending"
+        }
+
+        // Publish workflow has tag/version matching
+        val publishWorkflow = rootDir.resolve(".github/workflows/publish.yml")
+        val publishText = publishWorkflow.readText()
+        require(publishText.contains("Verify version alignment") || publishText.contains("version alignment")) {
+            "Publish workflow must contain version alignment check"
+        }
+
+        // No absolute /home/... links in release docs (allow placeholder /home/...)
+        val localHomePath = Regex("""/home/(?!\.\.\.)[^/\s]+/""")
+        val releaseDocs =
+            listOf(
+                rootDir.resolve("docs/reference/release-validation.md"),
+                rootDir.resolve("docs/reference/releasing.md"),
+                rootDir.resolve("docs/releases/$expectedVersion-release-readiness.md"),
+                rootDir.resolve("docs/releases/sovereign-runtime-release-readiness.md"),
+            )
+        for (doc in releaseDocs) {
+            if (!doc.isFile) continue
+            val docText = doc.readText()
+            require(!localHomePath.containsMatchIn(docText)) {
+                "${doc.name} must not contain absolute /home/<user>/ paths — use repository-relative links"
+            }
+        }
+
+        // No duplicate PR entries in the Added section
+        val addedSection = changelogText.substringAfter("### Added").substringBefore("### Changed")
+        val prPattern = Regex("""\(PR #(\d+)\)""")
+        val prCounts =
+            prPattern
+                .findAll(addedSection)
+                .map { it.groupValues[1] }
+                .groupingBy { it }
+                .eachCount()
+        val duplicates = prCounts.filter { it.value > 1 }
+        require(duplicates.isEmpty()) {
+            "Duplicate PR entries in Added section: ${duplicates.keys.joinToString(
+                ", ",
+            ) { "PR #$it appears ${duplicates[it]} times" }}"
+        }
+
+        // No stale "no DB outbox" or "single-node only" claims in sovereign-runtime-release-readiness.md
+        val sovereignReadiness = rootDir.resolve("docs/releases/sovereign-runtime-release-readiness.md")
+        if (sovereignReadiness.isFile) {
+            val sovereignText = sovereignReadiness.readText()
+            require(!sovereignText.contains("Database persistence is future work")) {
+                "sovereign-runtime-release-readiness.md must not claim 'Database persistence is future work'"
+            }
+            require(!sovereignText.contains("No DB-backed outbox")) {
+                "sovereign-runtime-release-readiness.md must not claim 'No DB-backed outbox'"
+            }
+            require(!sovereignText.contains("worker assumes single-node operation")) {
+                "sovereign-runtime-release-readiness.md must not claim 'worker assumes single-node operation'"
+            }
+        }
+
+        rootProject.logger.lifecycle("verify050ReleaseReadiness: all checks passed.")
+        rootProject.logger.lifecycle("  - Version alignment: verified")
+        rootProject.logger.lifecycle("  - Release readiness: verified")
+        rootProject.logger.lifecycle("  - Workflow API stability boundary: verified")
+        rootProject.logger.lifecycle("  - Sovereign runtime API boundary: verified")
+        rootProject.logger.lifecycle("  - Tool governance example: verified")
+        rootProject.logger.lifecycle("  - 0.5.0 release-readiness doc: verified")
+        rootProject.logger.lifecycle("  - CHANGELOG: 0.5.0 section verified")
+        rootProject.logger.lifecycle("  - STATUS/roadmap: release-ready state verified")
+        rootProject.logger.lifecycle("  - Publish workflow: version alignment check verified")
+        rootProject.logger.lifecycle("  - Release docs: no absolute paths or stale claims")
     }
 }

--- a/build-logic/src/main/kotlin/dev/tramai/build/sovereign/SovereignLabVerifierTasks.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/sovereign/SovereignLabVerifierTasks.kt
@@ -6,22 +6,22 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
 
-/**
- * Typed CC-safe replacements for the five root build.gradle.kts lab/evidence
- * closures (Epic 9.2d-a3b2a). Each task declares the EXACT files it reads as
- * [InputFiles] (never a directory), has no project access at execution, and
- * preserves the historical diagnostics byte-for-byte (every require() message
- * and the failure order are unchanged).
+/*
+ * Typed CC-safe replacements for the root build.gradle.kts lab/evidence
+ * closures. Each task declares the EXACT files it reads as inputs (never a
+ * directory), has no project access at execution, and preserves the historical
+ * diagnostics byte-for-byte (every require() message and the failure order are
+ * unchanged).
  *
- * Missing-file inputs are marked [Optional] deliberately: the historical
+ * Missing-file inputs are marked Optional deliberately: the historical
  * closures fail closed with their OWN require() diagnostics (e.g.
  * "sovereign-evidence-missing-evidence-pack"), and non-optional input
  * validation would replace those messages with Gradle's generic
@@ -36,7 +36,6 @@ import org.gradle.work.DisableCachingByDefault
  */
 @DisableCachingByDefault(because = "Verification task has no output artifact")
 abstract class SovereignLabProfileVerifierTask : DefaultTask() {
-
     @get:InputFiles
     @get:Optional
     @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -171,8 +170,8 @@ abstract class SovereignLabProfileVerifierTask : DefaultTask() {
         }
         require(
             evidenceText.contains("no cloud", ignoreCase = true) ||
-            evidenceText.contains("zero egress", ignoreCase = true) ||
-            evidenceText.contains("No Cloud", ignoreCase = true),
+                evidenceText.contains("zero egress", ignoreCase = true) ||
+                evidenceText.contains("No Cloud", ignoreCase = true),
         ) {
             "Sovereign lab evidence guide must explain no-cloud / zero-egress proof."
         }
@@ -187,7 +186,7 @@ abstract class SovereignLabProfileVerifierTask : DefaultTask() {
         }
         require(
             evidenceText.contains("does not define production performance thresholds", ignoreCase = true) ||
-            evidenceText.contains("does not define production performance", ignoreCase = true),
+                evidenceText.contains("does not define production performance", ignoreCase = true),
         ) {
             "Sovereign lab evidence guide must state the benchmark is diagnostic, not a production threshold."
         }
@@ -210,7 +209,7 @@ abstract class SovereignLabProfileVerifierTask : DefaultTask() {
         val bundleScriptText = evidenceBundleScript.readText()
         require(
             bundleScriptText.contains("does not certify", ignoreCase = true) ||
-            bundleScriptText.contains("does not define production", ignoreCase = true),
+                bundleScriptText.contains("does not define production", ignoreCase = true),
         ) {
             "Evidence bundle helper must avoid implying certification or production guarantees."
         }
@@ -356,7 +355,7 @@ abstract class SovereignLabProfileVerifierTask : DefaultTask() {
             require(
                 labReadmeText.contains(required) ||
                     evidenceText.contains(required) ||
-                    reviewerGuideText.contains(required)
+                    reviewerGuideText.contains(required),
             ) {
                 "Sovereign lab archive export docs must mention $required."
             }
@@ -409,7 +408,7 @@ abstract class SovereignLabProfileVerifierTask : DefaultTask() {
                 labReadmeText.contains(required) ||
                     evidenceChainText.contains(required) ||
                     reviewerGuideText.contains(required) ||
-                    readinessText.contains(required)
+                    readinessText.contains(required),
             ) {
                 "Sovereign lab archive verifier docs must mention $required."
             }
@@ -452,7 +451,6 @@ abstract class SovereignLabProfileVerifierTask : DefaultTask() {
  * root closure (sovereign-evidence-missing-* require messages).
  */
 abstract class PrepareSovereignEvidenceBundleTask : DefaultTask() {
-
     @get:InputFiles
     @get:Optional
     @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -514,9 +512,10 @@ abstract class PrepareSovereignEvidenceBundleTask : DefaultTask() {
         require(releaseArtifactsSrc.isDirectory()) { "sovereign-evidence-missing-release-artifacts-dir" }
         // Declared input authority: artifactsJars determines the JAR inputs,
         // NOT whatever happens to be in the directory (9.2d input-model rule).
-        val jarFiles = artifactsJars.files
-            .filter { it.isFile && it.extension == "jar" }
-            .sortedBy { it.name }
+        val jarFiles =
+            artifactsJars.files
+                .filter { it.isFile && it.extension == "jar" }
+                .sortedBy { it.name }
         require(jarFiles.isNotEmpty()) { "sovereign-evidence-empty-release-artifacts-dir" }
 
         // Clean output
@@ -549,7 +548,6 @@ abstract class PrepareSovereignEvidenceBundleTask : DefaultTask() {
  */
 @DisableCachingByDefault(because = "Verification task has no output artifact")
 abstract class VerifySovereignEvidenceBundleReleaseManifestTask : DefaultTask() {
-
     @get:InputFiles
     @get:Optional
     @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -577,7 +575,6 @@ abstract class VerifySovereignEvidenceBundleReleaseManifestTask : DefaultTask() 
  */
 @DisableCachingByDefault(because = "Verification task has no output artifact")
 abstract class VerifySovereignEvidencePackContainsReleaseBundleTask : DefaultTask() {
-
     @get:InputFiles
     @get:Optional
     @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -592,14 +589,51 @@ abstract class VerifySovereignEvidencePackContainsReleaseBundleTask : DefaultTas
         }
 
         val text = evidencePackPath.readText()
-        val hasReleaseBundle = text.contains("\"releaseBundle\":") &&
-            !text.contains("\"releaseBundle\": null") &&
-            !text.contains("\"releaseBundle\": null,")
+        val hasReleaseBundle =
+            text.contains("\"releaseBundle\":") &&
+                !text.contains("\"releaseBundle\": null") &&
+                !text.contains("\"releaseBundle\": null,")
 
         require(hasReleaseBundle) {
             "sovereign-evidence-pack-missing-release-bundle: ${evidencePackPath.absolutePath}"
         }
 
         logger.lifecycle("Evidence pack contains releaseBundle: ${evidencePackPath.absolutePath}")
+    }
+}
+
+/**
+ * Verifies the sovereign lab runtime smoke test report produced by
+ * :examples:spring-sovereign-starter:e2eTest (Epic 9.2d-b2 slice B). Moved
+ * verbatim from the root build script: the task requires the JUnit XML report
+ * to exist and to carry failures="0" errors="0". Typed CC-safe replacement,
+ * with the report file declared as an [InputFiles] input so the execution
+ * model stays honest (the historical closure read the file at execution time
+ * without declaring it).
+ */
+@DisableCachingByDefault(because = "Verification task has no output artifact")
+abstract class VerifySovereignLabRuntimeSmokeTask : DefaultTask() {
+    @get:InputFiles
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val smokeReportFile: RegularFileProperty
+
+    @TaskAction
+    fun verify() {
+        val reportFile = smokeReportFile.get().asFile
+
+        require(reportFile.exists()) {
+            "SovereignLabProfileSmokeTest did not run. " +
+                "verifySovereignLabRuntimeSmoke must prove the lab smoke test executed.\n" +
+                "Expected report: ${reportFile.absolutePath}"
+        }
+
+        val xml = reportFile.readText()
+        require(xml.contains("failures=\"0\"") && xml.contains("errors=\"0\"")) {
+            "SovereignLabProfileSmokeTest did not pass cleanly. " +
+                "Check the test report at:\n  ${reportFile.absolutePath}"
+        }
+
+        logger.lifecycle("verifySovereignLabRuntimeSmoke: sovereign lab runtime smoke tests passed.")
     }
 }

--- a/build-logic/src/main/kotlin/dev/tramai/build/sovereign/TramaiSovereignLabVerificationPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/sovereign/TramaiSovereignLabVerificationPlugin.kt
@@ -20,7 +20,6 @@ import org.gradle.kotlin.dsl.register
  * because prepare writes its inputs (Gradle 9 undeclared-output validation).
  */
 class TramaiSovereignLabVerificationPlugin : Plugin<Project> {
-
     override fun apply(project: Project) {
         registerVerifySovereignLabProfile(project)
         registerVerifySovereignLabEvidenceBundle(project)
@@ -28,13 +27,18 @@ class TramaiSovereignLabVerificationPlugin : Plugin<Project> {
         registerVerifySovereignEvidenceBundleReleaseManifest(project)
         registerVerifySovereignEvidencePackContainsReleaseBundle(project)
         registerVerifySovereignDocumentIntelligenceEvidenceRun(project)
+        registerVerifySovereignLabRuntimeSmoke(project)
+        registerVerifySovereignLabLocalModel(project)
+        registerBenchmarkSovereignLabLocalModel(project)
     }
 
     private fun registerVerifySovereignLabProfile(project: Project) {
         project.tasks.register<SovereignLabProfileVerifierTask>("verifySovereignLabProfile") {
             group = "verification"
             description = "Verifies the physical sovereign lab profile and documentation exist."
-            labProfileFile.set(project.layout.projectDirectory.file("examples/spring-sovereign-starter/src/main/resources/application-sovereign-lab.yml"))
+            labProfileFile.set(
+                project.layout.projectDirectory.file("examples/spring-sovereign-starter/src/main/resources/application-sovereign-lab.yml"),
+            )
             labReadmeFile.set(project.layout.projectDirectory.file("examples/sovereign-lab/README.md"))
             evidenceFile.set(project.layout.projectDirectory.file("examples/sovereign-lab/EVIDENCE.md"))
             benchmarkTemplateFile.set(project.layout.projectDirectory.file("examples/sovereign-lab/evidence-template/benchmark.md"))
@@ -65,7 +69,7 @@ class TramaiSovereignLabVerificationPlugin : Plugin<Project> {
             evidenceTemplates.from(
                 project.fileTree("examples/sovereign-lab/evidence-template") {
                     include("*.md")
-                }
+                },
             )
             workingDirectory.set(project.layout.projectDirectory.dir("examples/sovereign-lab/build"))
         }
@@ -83,8 +87,9 @@ class TramaiSovereignLabVerificationPlugin : Plugin<Project> {
             releaseManifestFile.set(project.layout.buildDirectory.file("sovereign-release/release-artifacts-v1.json"))
             releaseArtifactsDirectory.set(project.layout.buildDirectory.dir("sovereign-release/artifacts"))
             artifactsJars.from(
-                project.layout.buildDirectory.dir("sovereign-release/artifacts")
-                    .map { dir -> dir.asFileTree.matching { include("*.jar") } }
+                project.layout.buildDirectory
+                    .dir("sovereign-release/artifacts")
+                    .map { dir -> dir.asFileTree.matching { include("*.jar") } },
             )
             outputDirectory.set(project.layout.buildDirectory.dir("sovereign-evidence"))
 
@@ -99,12 +104,14 @@ class TramaiSovereignLabVerificationPlugin : Plugin<Project> {
     private fun registerVerifySovereignEvidenceBundleReleaseManifest(project: Project) {
         project.tasks.register<VerifySovereignEvidenceBundleReleaseManifestTask>("verifySovereignEvidenceBundleReleaseManifest") {
             group = "verification"
-            description = "Verifies that build/sovereign-evidence/release/release-artifacts-v1.json is internally consistent with the JAR files in build/sovereign-evidence/release/artifacts/."
+            description =
+                "Verifies that build/sovereign-evidence/release/release-artifacts-v1.json is internally consistent with the JAR files in build/sovereign-evidence/release/artifacts/."
 
             manifestFile.set(project.layout.buildDirectory.file("sovereign-evidence/release/release-artifacts-v1.json"))
             artifactJars.from(
-                project.layout.buildDirectory.dir("sovereign-evidence/release/artifacts")
-                    .map { dir -> dir.asFileTree.matching { include("*.jar") } }
+                project.layout.buildDirectory
+                    .dir("sovereign-evidence/release/artifacts")
+                    .map { dir -> dir.asFileTree.matching { include("*.jar") } },
             )
             // Required edge: prepareSovereignEvidenceBundle WRITES this task's
             // inputs (release/artifacts + manifest). Without the explicit
@@ -125,23 +132,94 @@ class TramaiSovereignLabVerificationPlugin : Plugin<Project> {
     }
 
     private fun registerVerifySovereignDocumentIntelligenceEvidenceRun(project: Project) {
-        val documentIntelligenceRunCommand = listOf(
-            if (System.getProperty("os.name").lowercase().contains("windows")) "gradlew.bat" else "./gradlew",
-            ":examples:sovereign-document-intelligence:run",
-            "--no-configuration-cache",
-            "--args=--release-bundle-manifest=${project.rootProject.layout.buildDirectory.get().asFile.absolutePath}/sovereign-release/release-artifacts-v1.json",
-        )
+        val documentIntelligenceRunCommand =
+            listOf(
+                if (System.getProperty("os.name").lowercase().contains("windows")) "gradlew.bat" else "./gradlew",
+                ":examples:sovereign-document-intelligence:run",
+                "--no-configuration-cache",
+                "--args=--release-bundle-manifest=${project.rootProject.layout.buildDirectory.get().asFile.absolutePath}/sovereign-release/release-artifacts-v1.json",
+            )
 
         project.tasks.register<Exec>("verifySovereignDocumentIntelligenceEvidenceRun") {
             group = "verification"
             description =
                 "Runs the sovereign document intelligence reference example against the generated release bundle " +
-                    "manifest. Validates evidence pack generation against release artifacts."
+                "manifest. Validates evidence pack generation against release artifacts."
 
             dependsOn("prepareSovereignReleaseArtifacts", "verifySovereignReleaseManifest")
 
             workingDir = project.projectDir
             commandLine(documentIntelligenceRunCommand)
+        }
+    }
+
+    /**
+     * Sovereign lab runtime smoke (Epic 9.2d-b2 slice B). Moved from the root
+     * build script; the XML report inspection is now a typed CC-safe task with
+     * the report file declared as an input. dependsOn preserved exactly.
+     */
+    private fun registerVerifySovereignLabRuntimeSmoke(project: Project) {
+        project.tasks.register<VerifySovereignLabRuntimeSmokeTask>("verifySovereignLabRuntimeSmoke") {
+            group = "verification"
+            description = "Runs the sovereign lab runtime smoke test against embedded PostgreSQL."
+
+            dependsOn(":examples:spring-sovereign-starter:e2eTest")
+
+            smokeReportFile.set(
+                project.layout.projectDirectory.file(
+                    "examples/spring-sovereign-starter/build/test-results/e2eTest/TEST-dev.tramai.examples.spring.SovereignLabProfileSmokeTest.xml",
+                ),
+            )
+        }
+    }
+
+    /**
+     * Opt-in sovereign lab local-model invocation proof (Epic 9.2d-b2 slice B).
+     * Env-gate + dependsOn moved verbatim from the root build script; the
+     * plugin owns the registration, the root build stays composition-only.
+     */
+    private fun registerVerifySovereignLabLocalModel(project: Project) {
+        project.tasks.register("verifySovereignLabLocalModel") {
+            group = "verification"
+            description = "Runs the opt-in sovereign lab local-model invocation proof (requires a real local OpenAI-compatible endpoint)."
+
+            dependsOn(":examples:spring-sovereign-starter:localModelTest")
+
+            doFirst {
+                if (System.getenv("TRAMAI_ENABLE_LOCAL_MODEL_TEST") != "true") {
+                    logger.lifecycle(
+                        "verifySovereignLabLocalModel requires TRAMAI_ENABLE_LOCAL_MODEL_TEST=true.",
+                    )
+                    logger.lifecycle(
+                        "Set it and ensure a local OpenAI-compatible endpoint is running.",
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Opt-in sovereign lab local-model benchmark diagnostics (Epic 9.2d-b2
+     * slice B). Env-gate + dependsOn moved verbatim from the root build
+     * script.
+     */
+    private fun registerBenchmarkSovereignLabLocalModel(project: Project) {
+        project.tasks.register("benchmarkSovereignLabLocalModel") {
+            group = "verification"
+            description = "Runs opt-in sovereign lab local-model benchmark diagnostics."
+
+            dependsOn(":examples:spring-sovereign-starter:localModelBenchmark")
+
+            doFirst {
+                if (System.getenv("TRAMAI_ENABLE_LOCAL_MODEL_BENCHMARK") != "true") {
+                    logger.lifecycle(
+                        "benchmarkSovereignLabLocalModel requires TRAMAI_ENABLE_LOCAL_MODEL_BENCHMARK=true.",
+                    )
+                    logger.lifecycle(
+                        "Set it and ensure a local OpenAI-compatible endpoint is running.",
+                    )
+                }
+            }
         }
     }
 }

--- a/build-logic/src/main/kotlin/dev/tramai/build/supplychain/PrepareCycloneDxBomTask.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/supplychain/PrepareCycloneDxBomTask.kt
@@ -1,0 +1,73 @@
+package dev.tramai.build.supplychain
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import java.security.MessageDigest
+
+/**
+ * Runs cyclonedxBom and places the result plus digest under
+ * build/supply-chain/sbom/ (Epic 9.2d-b2 slice A). Moved verbatim from the
+ * root build script into the supply-chain convention plugin. The action
+ * consumes the declared source-BOM property rather than rediscovering the
+ * historical root path.
+ *
+ * The CycloneDX plugin itself (org.cyclonedx.bom) stays applied at the root;
+ * this task is the post-processing owner (copy + SHA-256 digest).
+ */
+@DisableCachingByDefault(because = "Verification/supply-chain task reads the generated BOM and writes a digest")
+abstract class PrepareCycloneDxBomTask : DefaultTask() {
+    /**
+     * Generated CycloneDX BOM: build/reports/cyclonedx/bom.json.
+     *
+     * [Internal]: the historical root closure performed NO input validation and
+     * self-checked existence with its own warn-and-skip diagnostic. Declaring
+     * this as an [org.gradle.api.tasks.InputFile] (even Optional) makes Gradle
+     * fail validation when the file is absent, replacing the historical
+     * fail-soft contract with a generic error — exactly what the a3b2a typed
+     * tasks avoid. The action keeps the historical existence check.
+     */
+    @get:Internal
+    abstract val sourceBomFile: RegularFileProperty
+
+    /** Output directory: build/supply-chain/sbom/. */
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
+
+    init {
+        // The source BOM is deliberately @Internal (historical fail-soft
+        // warn-and-skip contract; @InputFile/@Optional fails Gradle validation
+        // on an absent file). Without a tracked input, Gradle's up-to-date
+        // check would skip this task once the output exists, even when
+        // cyclonedxBom regenerates the BOM — the historical root closure
+        // always re-ran. Force execution to preserve that contract.
+        outputs.upToDateWhen { false }
+    }
+
+    @TaskAction
+    fun prepare() {
+        val sbomDir = outputDirectory.get().asFile
+        sbomDir.mkdirs()
+        val sourceBom = sourceBomFile.get().asFile
+        val targetBom = sbomDir.resolve("tramai-cyclonedx-sbom.json")
+        if (sourceBom.exists()) {
+            sourceBom.copyTo(targetBom, overwrite = true)
+            val digest = MessageDigest.getInstance("SHA-256")
+            val hex =
+                digest
+                    .digest(targetBom.readBytes())
+                    .joinToString("") { "%02x".format(it) }
+            sbomDir
+                .resolve("tramai-cyclonedx-sbom.sha256")
+                .writeText("sha256:$hex")
+            logger.lifecycle("SBOM generated: ${targetBom.absolutePath}")
+            logger.lifecycle("SBOM digest: build/supply-chain/sbom/tramai-cyclonedx-sbom.sha256")
+        } else {
+            logger.warn("cyclonedxBom did not produce reports/cyclonedx/bom.json in the build directory; skipping SBOM copy.")
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/dev/tramai/build/supplychain/TramaiSupplyChainPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/supplychain/TramaiSupplyChainPlugin.kt
@@ -1,0 +1,33 @@
+package dev.tramai.build.supplychain
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.register
+
+/**
+ * Supply-chain / CycloneDX convention plugin (Epic 9.2d-b2 slice A). Applied
+ * to the root project. Owns the SBOM post-processing implementation
+ * (prepareCycloneDxBom: copy + SHA-256 digest) that previously lived in the
+ * root build script, so the root build remains composition-only.
+ *
+ * The external org.cyclonedx.bom plugin stays applied at the root; this
+ * plugin registers the task that consumes its generated BOM.
+ */
+class TramaiSupplyChainPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        if (project != project.rootProject) return
+        project.tasks.register<PrepareCycloneDxBomTask>("prepareCycloneDxBom") {
+            group = "verification"
+            description = "Run cyclonedxBom and place the result plus digest under build/supply-chain/sbom/"
+
+            dependsOn("cyclonedxBom")
+
+            sourceBomFile.set(
+                project.layout.buildDirectory.file("reports/cyclonedx/bom.json"),
+            )
+            outputDirectory.set(
+                project.layout.buildDirectory.dir("supply-chain/sbom"),
+            )
+        }
+    }
+}

--- a/build-logic/src/test/kotlin/dev/tramai/build/release/ReleaseVerificationPluginTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/release/ReleaseVerificationPluginTest.kt
@@ -837,4 +837,161 @@ class ReleaseVerificationPluginTest {
             "stable TramAI diagnostic required, got: ${result.output.take(1200)}",
         )
     }
+
+    // ── T16–T18: verify050ReleaseReadiness extraction (9.2d-b2 slice C) ─────
+    // The document/file inspection implementation moved from the root build
+    // script into TramaiReleaseVerificationPlugin. These tests prove the
+    // plugin — not a residual root convention — executes the behavior, and
+    // that the root build script no longer carries the implementation.
+
+    /**
+     * Fixture where the aggregation dependencies (provided by other plugins in
+     * the real build) are registered as no-ops, so running
+     * verify050ReleaseReadiness reaches ONLY the moved doLast implementation.
+     */
+    private fun readinessFixture(extra: String = ""): File {
+        val dir = baseFixture()
+        writeFile(
+            dir,
+            "build.gradle.kts",
+            """
+            plugins {
+                id("tramai.release-verification")
+            }
+            // The real build provides these dependencies from other plugins;
+            // register no-ops so the aggregation reaches the moved doLast.
+            tasks.register("verifyVersionAlignment")
+            tasks.register("verifyWorkflowApiStabilityBoundary")
+            tasks.register("verifySovereignRuntimeApiBoundary")
+            tasks.register("verifyToolGovernanceExample")
+            // verifyReleaseReadiness is a plugin-registered aggregation whose
+            // deps run real verification (POM/artifacts); neutralize them so
+            // the fixture isolates the moved verify050ReleaseReadiness doLast.
+            tasks.named("verifyReleaseReadiness") {
+                setDependsOn(emptyList<String>())
+            }
+            $extra
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "gradle.properties",
+            """
+            tramaiVersion=0.6.0
+            tramaiGroup=dev.tramai
+            tramaiReleaseDate=2026-08-31
+            """.trimIndent(),
+        )
+        // Valid 0.5.0 release-readiness evidence: doc, changelog, status,
+        // roadmap, publish workflow — matching exactly what the moved
+        // implementation requires.
+        writeFile(
+            dir,
+            "docs/releases/0.5.0-release-readiness.md",
+            """
+            # 0.5.0 Release Readiness
+            All checks passed.
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "CHANGELOG.md",
+            """
+            # Changelog
+
+            ## 0.5.0 - 2026-08-31
+
+            ### Added
+
+            - Feature one (PR #10)
+            - Feature two (PR #11)
+
+            ### Changed
+
+            - Refactor one
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "docs/STATUS.md",
+            """
+            # Status
+
+            0.5.0 release candidate prepared
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "docs/POST-SOVEREIGNTY-ROADMAP.md",
+            """
+            # Roadmap
+
+            Release prepared — publication pending
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            ".github/workflows/publish.yml",
+            """
+            name: publish
+            on: [workflow_dispatch]
+            jobs:
+              publish:
+                steps:
+                  - run: echo "Verify version alignment"
+            """.trimIndent(),
+        )
+        return dir
+    }
+
+    @Test
+    fun `T16 verify050ReleaseReadiness fails closed on missing release-readiness evidence`() {
+        val dir = readinessFixture()
+        // Delete the required doc: the moved implementation must fail with the
+        // exact historical diagnostic.
+        File(dir, "docs/releases/0.5.0-release-readiness.md").delete()
+        val result = runner(dir, "verify050ReleaseReadiness").buildAndFail()
+        assertTrue(
+            result.output.contains("Missing 0.5.0 release-readiness document at"),
+            "exact release-readiness diagnostic required, got: ${result.output.take(1200)}",
+        )
+    }
+
+    @Test
+    fun `T17 verify050ReleaseReadiness passes with valid evidence from the plugin implementation`() {
+        val dir = readinessFixture()
+        // No evidence may be missing: the moved implementation must pass and
+        // log the completion marker exactly as the root script did.
+        val result = runner(dir, "verify050ReleaseReadiness").build()
+        assertTrue(
+            result.output.contains("verify050ReleaseReadiness: all checks passed."),
+            "completion marker required, got: ${result.output.take(1200)}",
+        )
+    }
+
+    @Test
+    fun `T18 root build script no longer carries the release-readiness implementation`() {
+        val prop =
+            System.getProperty("tramai.repositoryRoot")
+                ?: error("tramai.repositoryRoot system property not set (wired by build-logic/build.gradle.kts)")
+        val rootBuildScript = File(prop, "build.gradle.kts").readText()
+
+        // The root may compose the task into `check`…
+        assertTrue(
+            rootBuildScript.contains("dependsOn(\"verify050ReleaseReadiness\")"),
+            "root must still wire verify050ReleaseReadiness into check",
+        )
+        // …but must not contain the moved implementation markers.
+        for (marker in listOf(
+            "Missing \$expectedVersion release-readiness document",
+            "Duplicate PR entries in Added section",
+            "sovereign-runtime-release-readiness.md must not claim",
+            "verify050ReleaseReadiness: all checks passed.",
+        )) {
+            assertFalse(
+                rootBuildScript.contains(marker),
+                "root build.gradle.kts must not contain release-readiness implementation marker: $marker",
+            )
+        }
+    }
 }

--- a/build-logic/src/test/kotlin/dev/tramai/build/sovereign/SovereignLabVerifierTasksTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/sovereign/SovereignLabVerifierTasksTest.kt
@@ -30,7 +30,6 @@ import kotlin.test.assertTrue
  * reused").
  */
 class SovereignLabVerifierTasksTest {
-
     @TempDir
     lateinit var tempDir: File
 
@@ -42,10 +41,14 @@ class SovereignLabVerifierTasksTest {
         dir
     }
 
-    private fun copyFromRepo(dir: File, vararg relativePaths: String) {
-        val git = ProcessBuilder("git", "-C", repoRoot.absolutePath, "ls-files", *relativePaths)
-            .redirectErrorStream(true)
-            .start()
+    private fun copyFromRepo(
+        dir: File,
+        vararg relativePaths: String,
+    ) {
+        val git =
+            ProcessBuilder("git", "-C", repoRoot.absolutePath, "ls-files", *relativePaths)
+                .redirectErrorStream(true)
+                .start()
         val listing = git.inputStream.bufferedReader().readText()
         check(git.waitFor() == 0) { "git ls-files failed: $listing" }
         listing.lineSequence().filter { it.isNotBlank() }.forEach { rel ->
@@ -65,45 +68,57 @@ class SovereignLabVerifierTasksTest {
         return dir
     }
 
-    private fun runner(dir: File, vararg args: String): GradleRunner =
-        GradleRunner.create()
+    private fun runner(
+        dir: File,
+        vararg args: String,
+    ): GradleRunner =
+        GradleRunner
+            .create()
             .withProjectDir(dir)
             .withGradleVersion("9.0.0")
             .withArguments(*args, "--no-build-cache", "--stacktrace")
             .withPluginClasspath()
 
-    private fun writeFile(base: File, relativePath: String, content: String) {
+    private fun writeFile(
+        base: File,
+        relativePath: String,
+        content: String,
+    ) {
         val target = File(base, relativePath)
         target.parentFile.mkdirs()
         target.writeText(content)
     }
 
-    private fun runTask(dir: File, task: String): org.gradle.testkit.runner.BuildResult {
+    private fun runTask(
+        dir: File,
+        task: String,
+    ): org.gradle.testkit.runner.BuildResult {
         val result = runner(dir, task).build()
         assertTrue(
             result.task(":$task")?.outcome == TaskOutcome.SUCCESS,
-            "$task must succeed: ${result.output.take(1200)}"
+            "$task must succeed: ${result.output.take(1200)}",
         )
         return result
     }
 
     /** All files read by verifySovereignLabProfile — committed repo files (real oracles). */
-    private val labProfileFiles = listOf(
-        "examples/spring-sovereign-starter/src/main/resources/application-sovereign-lab.yml",
-        "examples/sovereign-lab/README.md",
-        "examples/sovereign-lab/EVIDENCE.md",
-        "examples/sovereign-lab/evidence-template/benchmark.md",
-        "examples/sovereign-lab/create-evidence-bundle.sh",
-        "examples/sovereign-lab/evidence-template/MANIFEST.md",
-        "examples/sovereign-lab/evidence-template/command-log.md",
-        "examples/sovereign-lab/finalize-evidence-bundle.sh",
-        "examples/sovereign-lab/RELEASE-READINESS.md",
-        "examples/sovereign-lab/REVIEWER-GUIDE.md",
-        "examples/sovereign-lab/EVIDENCE-CHAIN.md",
-        "examples/sovereign-lab/package-evidence-bundle.sh",
-        "examples/sovereign-lab/verify-evidence-archive.sh",
-        "examples/sovereign-lab/ARCHIVE-SIGNING.md",
-    )
+    private val labProfileFiles =
+        listOf(
+            "examples/spring-sovereign-starter/src/main/resources/application-sovereign-lab.yml",
+            "examples/sovereign-lab/README.md",
+            "examples/sovereign-lab/EVIDENCE.md",
+            "examples/sovereign-lab/evidence-template/benchmark.md",
+            "examples/sovereign-lab/create-evidence-bundle.sh",
+            "examples/sovereign-lab/evidence-template/MANIFEST.md",
+            "examples/sovereign-lab/evidence-template/command-log.md",
+            "examples/sovereign-lab/finalize-evidence-bundle.sh",
+            "examples/sovereign-lab/RELEASE-READINESS.md",
+            "examples/sovereign-lab/REVIEWER-GUIDE.md",
+            "examples/sovereign-lab/EVIDENCE-CHAIN.md",
+            "examples/sovereign-lab/package-evidence-bundle.sh",
+            "examples/sovereign-lab/verify-evidence-archive.sh",
+            "examples/sovereign-lab/ARCHIVE-SIGNING.md",
+        )
 
     /**
      * The REAL sovereign-evidence-pack-v1.json produced by
@@ -113,7 +128,8 @@ class SovereignLabVerifierTasksTest {
      * releaseBundle key, exactly as the document-intelligence evidence run
      * attaches it.
      */
-    private val evidencePackWithNullReleaseBundle = """
+    private val evidencePackWithNullReleaseBundle =
+        """
         {
             "schemaVersion": 1,
             "deploymentMode": "OFFLINE",
@@ -164,14 +180,16 @@ class SovereignLabVerifierTasksTest {
             "attestation": null,
             "generatedAt": "2026-08-25T19:06:28.737090617Z"
         }
-    """.trimIndent()
+        """.trimIndent()
 
-    private val evidencePackWithReleaseBundle: String = evidencePackWithNullReleaseBundle.replace(
-        "\"releaseBundle\": null,",
-        "\"releaseBundle\": { \"schemaVersion\": 1, \"releaseManifestFileName\": \"release-artifacts-v1.json\", \"releaseManifestSha256\": \"sha256:4aea20c0c82afe32230ef9a8332f7a854ed399238fedc9674aebdbe923b6ab02\", \"artifactCount\": 1 },",
-    )
+    private val evidencePackWithReleaseBundle: String =
+        evidencePackWithNullReleaseBundle.replace(
+            "\"releaseBundle\": null,",
+            "\"releaseBundle\": { \"schemaVersion\": 1, \"releaseManifestFileName\": \"release-artifacts-v1.json\", \"releaseManifestSha256\": \"sha256:4aea20c0c82afe32230ef9a8332f7a854ed399238fedc9674aebdbe923b6ab02\", \"artifactCount\": 1 },",
+        )
 
-    private val zeroEgressReport = """
+    private val zeroEgressReport =
+        """
         {
             "schemaVersion": 1,
             "deploymentMode": "OFFLINE",
@@ -186,9 +204,10 @@ class SovereignLabVerifierTasksTest {
             "artifactVerificationReceiptCount": 1,
             "auditChainValid": true
         }
-    """.trimIndent()
+        """.trimIndent()
 
-    private val minimalSbom = """
+    private val minimalSbom =
+        """
         {
             "bomFormat": "CycloneDX",
             "specVersion": "1.6",
@@ -202,18 +221,21 @@ class SovereignLabVerifierTasksTest {
             },
             "components": []
         }
-    """.trimIndent()
+        """.trimIndent()
 
     private fun sha256Hex(bytes: ByteArray): String =
         MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
 
     /** release-artifacts-v1.json whose entries carry digest+size computed from the jar bytes. */
     private fun releaseManifestJson(vararg entries: Pair<String, ByteArray>): String {
-        val artifacts = entries.map { (name, bytes) ->
-            val sha = sha256Hex(bytes)
-            """{"groupId": "dev.tramai", "artifactId": "tramai-core", "version": "0.1.0", "classifier": null, "extension": "jar", "fileName": "$name", "sha256": "sha256:$sha", "sizeBytes": ${bytes.size}}"""
-        }
-        return """{"schemaVersion": 1, "buildTool": "Gradle", "javaVersion": "21", "gradleVersion": "9.0.0", "artifacts": [${artifacts.joinToString(",")}]}"""
+        val artifacts =
+            entries.map { (name, bytes) ->
+                val sha = sha256Hex(bytes)
+                """{"groupId": "dev.tramai", "artifactId": "tramai-core", "version": "0.1.0", "classifier": null, "extension": "jar", "fileName": "$name", "sha256": "sha256:$sha", "sizeBytes": ${bytes.size}}"""
+            }
+        return """{"schemaVersion": 1, "buildTool": "Gradle", "javaVersion": "21", "gradleVersion": "9.0.0", "artifacts": [${artifacts.joinToString(
+            ",",
+        )}]}"""
     }
 
     /**
@@ -233,7 +255,11 @@ class SovereignLabVerifierTasksTest {
         }
         writeFile(dir, "build/zero-egress-report/zero-egress-report.json", zeroEgressReport)
         writeFile(dir, "build/supply-chain/sbom/tramai-cyclonedx-sbom.json", minimalSbom)
-        writeFile(dir, "build/supply-chain/sbom/tramai-cyclonedx-sbom.sha256", "sha256:4aea20c0c82afe32230ef9a8332f7a854ed399238fedc9674aebdbe923b6ab02\n")
+        writeFile(
+            dir,
+            "build/supply-chain/sbom/tramai-cyclonedx-sbom.sha256",
+            "sha256:4aea20c0c82afe32230ef9a8332f7a854ed399238fedc9674aebdbe923b6ab02\n",
+        )
         writeFile(dir, "build/sovereign-release/release-artifacts-v1.json", manifest)
         jars.forEach { (name, bytes) ->
             File(dir, "build/sovereign-release/artifacts/$name").apply {
@@ -312,10 +338,11 @@ class SovereignLabVerifierTasksTest {
         val bBytes = "jar-b".toByteArray()
         writeEvidenceBundleInputs(
             dir,
-            jars = mapOf(
-                "a-0.1.0.jar" to aBytes,
-                "b-0.1.0.jar" to bBytes,
-            ),
+            jars =
+                mapOf(
+                    "a-0.1.0.jar" to aBytes,
+                    "b-0.1.0.jar" to bBytes,
+                ),
         )
         writeFile(
             dir,
@@ -370,10 +397,11 @@ class SovereignLabVerifierTasksTest {
         val manifest = releaseManifestJson("a-0.1.0.jar" to aBytes)
         writeEvidenceBundleInputs(
             dir,
-            jars = mapOf(
-                "a-0.1.0.jar" to aBytes,
-                "b-0.1.0.jar" to bBytes,
-            ),
+            jars =
+                mapOf(
+                    "a-0.1.0.jar" to aBytes,
+                    "b-0.1.0.jar" to bBytes,
+                ),
             manifest = manifest,
         )
         writeFile(
@@ -435,5 +463,193 @@ class SovereignLabVerifierTasksTest {
             """.trimIndent(),
         )
         runTask(dir, "execRegistrationSmoke")
+    }
+
+    // ------------------------------------------------------------------
+    // 9.2d-b2 slice B: verifySovereignLabRuntimeSmoke / LocalModel / benchmark
+    // moved from the root build script into this plugin.
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `verifySovereignLabRuntimeSmoke passes on a clean JUnit report`() {
+        val dir = fixture()
+        writeFile(
+            dir,
+            "examples/spring-sovereign-starter/build/test-results/e2eTest/TEST-dev.tramai.examples.spring.SovereignLabProfileSmokeTest.xml",
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <testsuite name="SovereignLabProfileSmokeTest" tests="1" failures="0" errors="0">
+              <testcase name="smoke" classname="dev.tramai.examples.spring.SovereignLabProfileSmokeTest"/>
+            </testsuite>
+            """.trimIndent(),
+        )
+        // dependsOn :examples:spring-sovereign-starter:e2eTest must still
+        // resolve: include the subproject and register a no-op e2eTest so the
+        // fixture reaches the moved typed verification action.
+        writeFile(
+            dir,
+            "settings.gradle.kts",
+            """
+            rootProject.name = "sovereign-lab-fixture"
+            include("examples:spring-sovereign-starter")
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "examples/spring-sovereign-starter/build.gradle.kts",
+            """
+            tasks.register("e2eTest") { doLast { logger.lifecycle("fixture e2eTest ran") } }
+            """.trimIndent(),
+        )
+        val result = runner(dir, "verifySovereignLabRuntimeSmoke").build()
+        assertTrue(result.output.contains("sovereign lab runtime smoke tests passed"))
+    }
+
+    @Test
+    fun `verifySovereignLabRuntimeSmoke fails closed on missing report`() {
+        val dir = fixture()
+        writeFile(
+            dir,
+            "settings.gradle.kts",
+            """
+            rootProject.name = "sovereign-lab-fixture"
+            include("examples:spring-sovereign-starter")
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "examples/spring-sovereign-starter/build.gradle.kts",
+            """
+            tasks.register("e2eTest") { doLast { logger.lifecycle("fixture e2eTest ran") } }
+            """.trimIndent(),
+        )
+        val result = runner(dir, "verifySovereignLabRuntimeSmoke").buildAndFail()
+        assertContains(result.output, "SovereignLabProfileSmokeTest did not run")
+    }
+
+    @Test
+    fun `verifySovereignLabRuntimeSmoke fails on non-clean report`() {
+        val dir = fixture()
+        writeFile(
+            dir,
+            "examples/spring-sovereign-starter/build/test-results/e2eTest/TEST-dev.tramai.examples.spring.SovereignLabProfileSmokeTest.xml",
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <testsuite name="SovereignLabProfileSmokeTest" tests="1" failures="1" errors="0">
+              <testcase name="smoke" classname="dev.tramai.examples.spring.SovereignLabProfileSmokeTest">
+                <failure message="boom"/>
+              </testcase>
+            </testsuite>
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "settings.gradle.kts",
+            """
+            rootProject.name = "sovereign-lab-fixture"
+            include("examples:spring-sovereign-starter")
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "examples/spring-sovereign-starter/build.gradle.kts",
+            """
+            tasks.register("e2eTest") { doLast { logger.lifecycle("fixture e2eTest ran") } }
+            """.trimIndent(),
+        )
+        val result = runner(dir, "verifySovereignLabRuntimeSmoke").buildAndFail()
+        assertContains(result.output, "SovereignLabProfileSmokeTest did not pass cleanly")
+    }
+
+    @Test
+    fun `sovereign lab local model tasks keep their names and env-gate semantics`() {
+        val dir = fixture()
+        writeFile(
+            dir,
+            "build.gradle.kts",
+            """
+            plugins { id("tramai.sovereign-lab-verification") }
+            tasks.register("labRegistrationSmoke") {
+                doLast {
+                    val smoke = tasks.named("verifySovereignLabRuntimeSmoke").get()
+                    check(smoke.group == "verification") { "smoke group" }
+                    check(smoke.description!!.contains("embedded PostgreSQL")) { "smoke description" }
+                    val local = tasks.named("verifySovereignLabLocalModel").get()
+                    check(local.group == "verification") { "local group" }
+                    check(local.description!!.contains("opt-in sovereign lab local-model")) { "local description" }
+                    val bench = tasks.named("benchmarkSovereignLabLocalModel").get()
+                    check(bench.group == "verification") { "bench group" }
+                    check(bench.description!!.contains("benchmark diagnostics")) { "bench description" }
+                }
+            }
+            """.trimIndent(),
+        )
+        runTask(dir, "labRegistrationSmoke")
+    }
+
+    @Test
+    fun `sovereign lab local model env-gate fires when disabled`() {
+        val dir = fixture()
+        writeFile(
+            dir,
+            "settings.gradle.kts",
+            """
+            rootProject.name = "sovereign-lab-fixture"
+            include("examples:spring-sovereign-starter")
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "examples/spring-sovereign-starter/build.gradle.kts",
+            """
+            tasks.register("localModelTest") { doLast { logger.lifecycle("fixture localModelTest ran") } }
+            """.trimIndent(),
+        )
+        // No TRAMAI_ENABLE_LOCAL_MODEL_TEST: the moved doFirst env-gate must
+        // fire and log the guidance message.
+        val result = runner(dir, "verifySovereignLabLocalModel").build()
+        assertTrue(result.output.contains("verifySovereignLabLocalModel requires TRAMAI_ENABLE_LOCAL_MODEL_TEST=true"))
+    }
+
+    @Test
+    fun `benchmark sovereign lab local model env-gate fires when disabled`() {
+        val dir = fixture()
+        writeFile(
+            dir,
+            "settings.gradle.kts",
+            """
+            rootProject.name = "sovereign-lab-fixture"
+            include("examples:spring-sovereign-starter")
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "examples/spring-sovereign-starter/build.gradle.kts",
+            """
+            tasks.register("localModelBenchmark") { doLast { logger.lifecycle("fixture localModelBenchmark ran") } }
+            """.trimIndent(),
+        )
+        val result = runner(dir, "benchmarkSovereignLabLocalModel").build()
+        assertTrue(result.output.contains("benchmarkSovereignLabLocalModel requires TRAMAI_ENABLE_LOCAL_MODEL_BENCHMARK=true"))
+    }
+
+    @Test
+    fun `root build script no longer carries sovereign lab execution implementation`() {
+        val prop =
+            System.getProperty("tramai.repositoryRoot")
+                ?: error("tramai.repositoryRoot system property not set (wired by build-logic/build.gradle.kts)")
+        val rootBuildScript = File(prop, "build.gradle.kts").readText()
+
+        for (marker in listOf(
+            "verifySovereignLabRuntimeSmoke must prove the lab smoke test executed",
+            "SovereignLabProfileSmokeTest did not pass cleanly",
+            "verifySovereignLabLocalModel requires TRAMAI_ENABLE_LOCAL_MODEL_TEST",
+            "benchmarkSovereignLabLocalModel requires TRAMAI_ENABLE_LOCAL_MODEL_BENCHMARK",
+        )) {
+            assertTrue(
+                !rootBuildScript.contains(marker),
+                "root build.gradle.kts must not contain sovereign-lab implementation marker: $marker",
+            )
+        }
     }
 }

--- a/build-logic/src/test/kotlin/dev/tramai/build/supplychain/TramaiSupplyChainPluginTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/supplychain/TramaiSupplyChainPluginTest.kt
@@ -1,0 +1,194 @@
+package dev.tramai.build.supplychain
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Discriminating TestKit tests for the 9.2d-b2 slice A extraction:
+ * prepareCycloneDxBom moved from the root build script into the
+ * tramai.supply-chain convention plugin.
+ *
+ * The Socratic discriminator: perturb the declared BOM input and prove the
+ * extracted task consumes THAT input (the declared @InputFile), not a
+ * rediscovered historical root path.
+ */
+class TramaiSupplyChainPluginTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    private fun writeFile(
+        base: File,
+        relativePath: String,
+        content: String,
+    ) {
+        val target = File(base, relativePath)
+        target.parentFile.mkdirs()
+        target.writeText(content)
+    }
+
+    private fun fixture(
+        bomContent: String,
+        writeBom: Boolean = true,
+    ): File {
+        val dir = File(tempDir, "fixture-${System.nanoTime()}").apply { mkdirs() }
+        writeFile(dir, "settings.gradle.kts", "rootProject.name = \"supply-chain-fixture\"\n")
+        // The real build applies org.cyclonedx.bom which provides
+        // cyclonedxBom; register a sentinel that writes the BOM under the
+        // DECLARED input path, so the fixture can perturb it.
+        val bomContentLiteral = "\"\"\"" + bomContent + "\"\"\""
+        writeFile(
+            dir,
+            "build.gradle.kts",
+            """
+            plugins { id("tramai.supply-chain") }
+            tasks.register("cyclonedxBom") {
+                doLast {
+                    ${if (writeBom) {
+                "val bom = layout.buildDirectory.file(\"reports/cyclonedx/bom.json\").get().asFile\n                    bom.parentFile.mkdirs()\n                    bom.writeText($bomContentLiteral)"
+            } else {
+                "logger.lifecycle(\"fixture cyclonedxBom ran (no BOM written)\")"
+            }}
+                }
+            }
+            """.trimIndent(),
+        )
+        return dir
+    }
+
+    private fun runner(
+        dir: File,
+        vararg args: String,
+    ): GradleRunner =
+        GradleRunner
+            .create()
+            .withProjectDir(dir)
+            .withGradleVersion("9.0.0")
+            .withArguments(*args, "--no-build-cache", "--stacktrace")
+            .withPluginClasspath()
+
+    @Test
+    fun `prepareCycloneDxBom copies the declared BOM input and writes a digest`() {
+        val dir = fixture("""{"bomFormat":"CycloneDX","specVersion":"1.6","version":1}""")
+        val result = runner(dir, "prepareCycloneDxBom").build()
+
+        assertTrue(result.output.contains("SBOM generated:"), "copy marker required")
+        val sbom = File(dir, "build/supply-chain/sbom/tramai-cyclonedx-sbom.json")
+        assertTrue(sbom.isFile, "SBOM must be copied under build/supply-chain/sbom/")
+        assertEquals("""{"bomFormat":"CycloneDX","specVersion":"1.6","version":1}""", sbom.readText())
+        val digestFile = File(dir, "build/supply-chain/sbom/tramai-cyclonedx-sbom.sha256")
+        assertTrue(digestFile.isFile, "SHA-256 digest must be written")
+        assertContains(digestFile.readText(), "sha256:")
+    }
+
+    @Test
+    fun `SBOM authority mutation - task consumes the declared input, not a hardcoded path`() {
+        val dir = fixture("""{"bomFormat":"CycloneDX","version":1,"content":"FIRST"}""")
+        runner(dir, "prepareCycloneDxBom").build()
+
+        // Perturb the DECLARED input: the next run must reflect the new
+        // content in the copied SBOM — proving the task reads the @Internal
+        // declared input property, not a rediscovered historical root path.
+        // -x cyclonedxBom keeps the sentinel from re-writing FIRST.
+        writeFile(
+            dir,
+            "build/reports/cyclonedx/bom.json",
+            """{"bomFormat":"CycloneDX","version":1,"content":"SECOND"}""",
+        )
+        runner(dir, "prepareCycloneDxBom", "--rerun-tasks", "-x", "cyclonedxBom").build()
+
+        val sbom = File(dir, "build/supply-chain/sbom/tramai-cyclonedx-sbom.json")
+        assertEquals("""{"bomFormat":"CycloneDX","version":1,"content":"SECOND"}""", sbom.readText())
+        val digestFile = File(dir, "build/supply-chain/sbom/tramai-cyclonedx-sbom.sha256")
+        val firstDigest =
+            java.security.MessageDigest
+                .getInstance("SHA-256")
+                .digest("""{"bomFormat":"CycloneDX","version":1,"content":"FIRST"}""".toByteArray())
+                .joinToString("") { "%02x".format(it) }
+        val secondDigest =
+            java.security.MessageDigest
+                .getInstance("SHA-256")
+                .digest("""{"bomFormat":"CycloneDX","version":1,"content":"SECOND"}""".toByteArray())
+                .joinToString("") { "%02x".format(it) }
+        assertContains(digestFile.readText(), secondDigest)
+        assertTrue(firstDigest != secondDigest, "mutated input must change the digest")
+    }
+
+    @Test
+    fun `prepareCycloneDxBom warns and skips when the BOM input is absent`() {
+        val dir = fixture("unused", writeBom = false)
+        // The sentinel cyclonedxBom writes nothing: the historical root
+        // behavior warns and skips (no failure). The typed task must preserve
+        // that fail-soft diagnostic contract.
+        val result = runner(dir, "prepareCycloneDxBom").build()
+        assertTrue(
+            result.output.contains("skipping SBOM copy"),
+            "fail-soft warn marker required, got: ${result.output.take(800)}",
+        )
+    }
+
+    @Test
+    fun `prepareCycloneDxBom re-runs when outputs already exist and the BOM changed`() {
+        // Regression for the Copilot finding: with @OutputDirectory and an
+        // @Internal source (deliberate, fail-soft), Gradle's up-to-date check
+        // would skip the task once outputs exist — even after cyclonedxBom
+        // regenerates the BOM. The historical root closure always re-ran.
+        val dir = fixture("""{"bomFormat":"CycloneDX","version":1,"content":"FIRST"}""")
+        runner(dir, "prepareCycloneDxBom").build()
+        val sbom = File(dir, "build/supply-chain/sbom/tramai-cyclonedx-sbom.json")
+        assertTrue(sbom.isFile)
+
+        writeFile(
+            dir,
+            "build/reports/cyclonedx/bom.json",
+            """{"bomFormat":"CycloneDX","version":1,"content":"SECOND"}""",
+        )
+        // No --rerun-tasks: the task must execute on its own (outputs exist).
+        // -x cyclonedxBom keeps the sentinel from re-writing FIRST.
+        val result = runner(dir, "prepareCycloneDxBom", "-x", "cyclonedxBom").build()
+        assertTrue(result.output.contains("SBOM generated:"), "task must re-run, not be UP-TO-DATE")
+        assertEquals("""{"bomFormat":"CycloneDX","version":1,"content":"SECOND"}""", sbom.readText())
+    }
+
+    @Test
+    fun `supply-chain plugin is root-only - no prepareCycloneDxBom in subprojects`() {
+        val dir = File(tempDir, "fixture-${System.nanoTime()}").apply { mkdirs() }
+        writeFile(dir, "settings.gradle.kts", "rootProject.name = \"multi\"\ninclude(\":sub\")\n")
+        writeFile(dir, "build.gradle.kts", "")
+        writeFile(
+            dir,
+            "sub/build.gradle.kts",
+            """
+            plugins { id("tramai.supply-chain") }
+            """.trimIndent(),
+        )
+        val result = runner(dir, "sub:tasks", "--all").build()
+        assertTrue(
+            !result.output.contains("prepareCycloneDxBom"),
+            "plugin must no-op on subprojects (root-only guard), got: ${result.output.take(800)}",
+        )
+    }
+
+    @Test
+    fun `root build script no longer carries the CycloneDX copy implementation`() {
+        val prop =
+            System.getProperty("tramai.repositoryRoot")
+                ?: error("tramai.repositoryRoot system property not set (wired by build-logic/build.gradle.kts)")
+        val rootBuildScript = File(prop, "build.gradle.kts").readText()
+
+        for (marker in listOf(
+            "tasks.register(\"prepareCycloneDxBom\")",
+            "tramai-cyclonedx-sbom.sha256",
+            "MessageDigest.getInstance(\"SHA-256\")",
+        )) {
+            assertTrue(
+                !rootBuildScript.contains(marker),
+                "root build.gradle.kts must not contain CycloneDX implementation marker: $marker",
+            )
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     id("tramai.release-verification")
     id("tramai.sovereign-verification")
     id("tramai.sovereign-lab-verification")
+    id("tramai.supply-chain")
     id("tramai.docs-guards")
     id("tramai.static-analysis")
     id("tramai.compiler-warnings")
@@ -183,38 +184,6 @@ subprojects {
     apply(plugin = "tramai.publishing")
 }
 // ──────────────────────────────────────────────
-// Task: prepareCycloneDxBom
-// ──────────────────────────────────────────────
-// Plugin is applied above via: alias(libs.plugins.cyclonedx.bom)
-// Default output goes to build/reports/cyclonedx/bom.json and is post-processed
-// by the copy task below, avoiding typed extension resolution issues.
-
-tasks.register("prepareCycloneDxBom") {
-    group = "verification"
-    description = "Run cyclonedxBom and place the result plus digest under build/supply-chain/sbom/"
-    dependsOn("cyclonedxBom")
-    doLast {
-        val sbomDir = rootProject.layout.buildDirectory.dir("supply-chain/sbom").get().asFile
-        sbomDir.mkdirs()
-        val sourceBom = rootProject.layout.buildDirectory.file("reports/cyclonedx/bom.json").get().asFile
-        val targetBom = sbomDir.resolve("tramai-cyclonedx-sbom.json")
-        if (sourceBom.exists()) {
-            sourceBom.copyTo(targetBom, overwrite = true)
-            val digest = java.security.MessageDigest.getInstance("SHA-256")
-            val hex = digest.digest(targetBom.readBytes())
-                .joinToString("") { "%02x".format(it) }
-            sbomDir.resolve("tramai-cyclonedx-sbom.sha256")
-                .writeText("sha256:$hex")
-            logger.lifecycle("SBOM generated: ${targetBom.absolutePath}")
-            logger.lifecycle("SBOM digest: build/supply-chain/sbom/tramai-cyclonedx-sbom.sha256")
-        } else {
-            logger.warn("cyclonedxBom did not produce reports/cyclonedx/bom.json in the build directory; skipping SBOM copy.")
-        }
-    }
-}
-
-
-// ──────────────────────────────────────────────
 // Task: verifySovereignRuntimeReleaseCandidate
 // ──────────────────────────────────────────────
 
@@ -258,88 +227,6 @@ tasks.register("verifySovereignRuntimeReleaseCandidate") {
     }
 }
 
-
-// ──────────────────────────────────────────────
-// Task: verifySovereignLabEvidenceBundle
-// ──────────────────────────────────────────────
-
-// ──────────────────────────────────────────────
-// Task: verifySovereignLabRuntimeSmoke
-// ──────────────────────────────────────────────
-
-tasks.register("verifySovereignLabRuntimeSmoke") {
-    group = "verification"
-    description = "Runs the sovereign lab runtime smoke test against embedded PostgreSQL."
-
-    dependsOn(":examples:spring-sovereign-starter:e2eTest")
-
-    doLast {
-        val reportDir = file(
-            "examples/spring-sovereign-starter/build/test-results/e2eTest/"
-        )
-        val reportFile = reportDir.resolve(
-            "TEST-dev.tramai.examples.spring.SovereignLabProfileSmokeTest.xml"
-        )
-
-        require(reportFile.exists()) {
-            "SovereignLabProfileSmokeTest did not run. " +
-                "verifySovereignLabRuntimeSmoke must prove the lab smoke test executed.\n" +
-                "Expected report: ${reportFile.absolutePath}"
-        }
-
-        val xml = reportFile.readText()
-        require(xml.contains("failures=\"0\"") && xml.contains("errors=\"0\"")) {
-            "SovereignLabProfileSmokeTest did not pass cleanly. " +
-                "Check the test report at:\n  ${reportFile.absolutePath}"
-        }
-
-        logger.lifecycle("verifySovereignLabRuntimeSmoke: sovereign lab runtime smoke tests passed.")
-    }
-}
-
-// ──────────────────────────────────────────────
-// Task: verifySovereignLabLocalModel
-// ──────────────────────────────────────────────
-
-tasks.register("verifySovereignLabLocalModel") {
-    group = "verification"
-    description = "Runs the opt-in sovereign lab local-model invocation proof (requires a real local OpenAI-compatible endpoint)."
-
-    dependsOn(":examples:spring-sovereign-starter:localModelTest")
-
-    doFirst {
-        if (System.getenv("TRAMAI_ENABLE_LOCAL_MODEL_TEST") != "true") {
-            logger.lifecycle(
-                "verifySovereignLabLocalModel requires TRAMAI_ENABLE_LOCAL_MODEL_TEST=true."
-            )
-            logger.lifecycle(
-                "Set it and ensure a local OpenAI-compatible endpoint is running."
-            )
-        }
-    }
-}
-
-// ──────────────────────────────────────────────
-// Task: benchmarkSovereignLabLocalModel
-// ──────────────────────────────────────────────
-
-tasks.register("benchmarkSovereignLabLocalModel") {
-    group = "verification"
-    description = "Runs opt-in sovereign lab local-model benchmark diagnostics."
-
-    dependsOn(":examples:spring-sovereign-starter:localModelBenchmark")
-
-    doFirst {
-        if (System.getenv("TRAMAI_ENABLE_LOCAL_MODEL_BENCHMARK") != "true") {
-            logger.lifecycle(
-                "benchmarkSovereignLabLocalModel requires TRAMAI_ENABLE_LOCAL_MODEL_BENCHMARK=true."
-            )
-            logger.lifecycle(
-                "Set it and ensure a local OpenAI-compatible endpoint is running."
-            )
-        }
-    }
-}
 
 // ──────────────────────────────────────────────
 // Task: verifySovereignRuntimeClosure
@@ -395,116 +282,6 @@ tasks.named("check") {
     dependsOn("verifyJvmAiFrameworkComparison")
 }
 
-
-// ──────────────────────────────────────────────
-// Task: verify050ReleaseReadiness
-// ──────────────────────────────────────────────
-
-tasks.register("verify050ReleaseReadiness") {
-    group = "verification"
-    description = "Aggregates all 0.5.0 release-readiness verification tasks."
-    notCompatibleWithConfigurationCache("Release readiness aggregates execution-time verification tasks.")
-
-    dependsOn(
-        "verifyVersionAlignment",
-        "verifyReleaseReadiness",
-        "verifyWorkflowApiStabilityBoundary",
-        "verifySovereignRuntimeApiBoundary",
-        "verifyToolGovernanceExample",
-    )
-
-    doLast {
-        val rootDir = rootProject.layout.projectDirectory.asFile
-        val expectedVersion = "0.5.0"
-        val expectedReleaseDate = project.findProperty("tramaiReleaseDate") as? String
-            ?: error("tramaiReleaseDate must be set in gradle.properties")
-
-        // 0.5.0 release-readiness document exists
-        val releaseReadinessDoc = rootDir.resolve("docs/releases/$expectedVersion-release-readiness.md")
-        require(releaseReadinessDoc.isFile) {
-            "Missing $expectedVersion release-readiness document at ${releaseReadinessDoc.path}"
-        }
-
-        // CHANGELOG has 0.5.0 section
-        val changelog = rootDir.resolve("CHANGELOG.md")
-        val changelogText = changelog.readText()
-        require(changelogText.contains("## $expectedVersion - $expectedReleaseDate")) {
-            "CHANGELOG.md must contain ## $expectedVersion - $expectedReleaseDate section"
-        }
-
-        // STATUS and roadmap state are correct
-        val statusDoc = rootDir.resolve("docs/STATUS.md")
-        val statusText = statusDoc.readText()
-        require(statusText.contains("0.5.0 release candidate prepared")) {
-            "STATUS.md must mention 0.5.0 release candidate prepared"
-        }
-
-        val roadmap = rootDir.resolve("docs/POST-SOVEREIGNTY-ROADMAP.md")
-        val roadmapText = roadmap.readText()
-        require(roadmapText.contains("Release prepared — publication pending")) {
-            "Roadmap must indicate release prepared — publication pending"
-        }
-
-        // Publish workflow has tag/version matching
-        val publishWorkflow = rootDir.resolve(".github/workflows/publish.yml")
-        val publishText = publishWorkflow.readText()
-        require(publishText.contains("Verify version alignment") || publishText.contains("version alignment")) {
-            "Publish workflow must contain version alignment check"
-        }
-
-        // No absolute /home/... links in release docs (allow placeholder /home/...)
-        val localHomePath = Regex("""/home/(?!\.\.\.)[^/\s]+/""")
-        val releaseDocs = listOf(
-            rootDir.resolve("docs/reference/release-validation.md"),
-            rootDir.resolve("docs/reference/releasing.md"),
-            rootDir.resolve("docs/releases/$expectedVersion-release-readiness.md"),
-            rootDir.resolve("docs/releases/sovereign-runtime-release-readiness.md"),
-        )
-        for (doc in releaseDocs) {
-            if (!doc.isFile) continue
-            val docText = doc.readText()
-            require(!localHomePath.containsMatchIn(docText)) {
-                "${doc.name} must not contain absolute /home/<user>/ paths — use repository-relative links"
-            }
-        }
-
-        // No duplicate PR entries in the Added section
-        val addedSection = changelogText.substringAfter("### Added").substringBefore("### Changed")
-        val prPattern = Regex("""\(PR #(\d+)\)""")
-        val prCounts = prPattern.findAll(addedSection).map { it.groupValues[1] }.groupingBy { it }.eachCount()
-        val duplicates = prCounts.filter { it.value > 1 }
-        require(duplicates.isEmpty()) {
-            "Duplicate PR entries in Added section: ${duplicates.keys.joinToString(", ") { "PR #$it appears ${duplicates[it]} times" }}"
-        }
-
-        // No stale "no DB outbox" or "single-node only" claims in sovereign-runtime-release-readiness.md
-        val sovereignReadiness = rootDir.resolve("docs/releases/sovereign-runtime-release-readiness.md")
-        if (sovereignReadiness.isFile) {
-            val sovereignText = sovereignReadiness.readText()
-            require(!sovereignText.contains("Database persistence is future work")) {
-                "sovereign-runtime-release-readiness.md must not claim 'Database persistence is future work'"
-            }
-            require(!sovereignText.contains("No DB-backed outbox")) {
-                "sovereign-runtime-release-readiness.md must not claim 'No DB-backed outbox'"
-            }
-            require(!sovereignText.contains("worker assumes single-node operation")) {
-                "sovereign-runtime-release-readiness.md must not claim 'worker assumes single-node operation'"
-            }
-        }
-
-        logger.lifecycle("verify050ReleaseReadiness: all checks passed.")
-        logger.lifecycle("  - Version alignment: verified")
-        logger.lifecycle("  - Release readiness: verified")
-        logger.lifecycle("  - Workflow API stability boundary: verified")
-        logger.lifecycle("  - Sovereign runtime API boundary: verified")
-        logger.lifecycle("  - Tool governance example: verified")
-        logger.lifecycle("  - 0.5.0 release-readiness doc: verified")
-        logger.lifecycle("  - CHANGELOG: 0.5.0 section verified")
-        logger.lifecycle("  - STATUS/roadmap: release-ready state verified")
-        logger.lifecycle("  - Publish workflow: version alignment check verified")
-        logger.lifecycle("  - Release docs: no absolute paths or stale claims")
-    }
-}
 
 // ──────────────────────────────────────────────
 // Task: check

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -2,6 +2,16 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
+    <ID>LongMethod:ReleaseVerificationPluginTest.kt$ReleaseVerificationPluginTest$private fun readinessFixture(extra: String = ""): File</ID>
+    <ID>LongMethod:TramaiReleaseVerificationPlugin.kt$TramaiReleaseVerificationPlugin$private fun verify050ReadinessDocs(rootProject: Project)</ID>
+    <ID>MaxLineLength:PrepareCycloneDxBomTask.kt$PrepareCycloneDxBomTask$logger.warn("cyclonedxBom did not produce reports/cyclonedx/bom.json in the build directory; skipping SBOM copy.")</ID>
+    <ID>MaxLineLength:SovereignLabVerifierTasksTest.kt$SovereignLabVerifierTasksTest$"examples/spring-sovereign-starter/build/test-results/e2eTest/TEST-dev.tramai.examples.spring.SovereignLabProfileSmokeTest.xml"</ID>
+    <ID>MaxLineLength:SovereignLabVerifierTasksTest.kt$SovereignLabVerifierTasksTest$assertTrue(result.output.contains("benchmarkSovereignLabLocalModel requires TRAMAI_ENABLE_LOCAL_MODEL_BENCHMARK=true"))</ID>
+    <ID>MaxLineLength:TramaiSovereignLabVerificationPlugin.kt$TramaiSovereignLabVerificationPlugin$"Verifies that build/sovereign-evidence/release/release-artifacts-v1.json is internally consistent with the JAR files in build/sovereign-evidence/release/artifacts/."</ID>
+    <ID>MaxLineLength:TramaiSovereignLabVerificationPlugin.kt$TramaiSovereignLabVerificationPlugin$"examples/spring-sovereign-starter/build/test-results/e2eTest/TEST-dev.tramai.examples.spring.SovereignLabProfileSmokeTest.xml"</ID>
+    <ID>MaxLineLength:TramaiSovereignLabVerificationPlugin.kt$TramaiSovereignLabVerificationPlugin$description = "Runs the opt-in sovereign lab local-model invocation proof (requires a real local OpenAI-compatible endpoint)."</ID>
+    <ID>MaxLineLength:TramaiSovereignLabVerificationPlugin.kt$TramaiSovereignLabVerificationPlugin$project.layout.projectDirectory.file("examples/spring-sovereign-starter/src/main/resources/application-sovereign-lab.yml")</ID>
+    <ID>TooManyFunctions:TramaiReleaseVerificationPlugin.kt$TramaiReleaseVerificationPlugin : Plugin</ID>
     <ID>ComplexCondition:ApiCompatibilityVerifier.kt$ApiCompatibilityEvidenceReader$fromSha256.isBlank() || toSha256.isBlank() || !SHA256_HEX.matches(fromSha256) || !SHA256_HEX.matches(toSha256)</ID>
     <ID>ComplexCondition:ApiCompatibilityVerifier.kt$ApiCompatibilityEvidenceReader$module.isBlank() || targetVersion.isBlank() || rationale.isBlank() || migration.isBlank()</ID>
     <ID>ComplexCondition:ChangePolicyEvaluator.kt$ChangePolicyEvaluator$reasonBlank || phaseBlank || dateBlank || ownerBlank</ID>


### PR DESCRIPTION
## 9.2d-b2 — root build = composition (three responsibility extractions)

The root `build.gradle.kts` is now understandable as **composition**: it applies plugins and wires lifecycle aggregators. A reviewer no longer needs to read how SBOM generation, sovereign verification, or release-readiness validation work to understand the root release lifecycle. This is the second acceptance criterion of Epic 9.2d.

One PR, executed as three independently verified extractions (per the b2 scope doc: no generic RootBuildPlugin, no task renames, no CC remediation of deliberate release tasks, no root aesthetic cleanup).

### Slice C — `verify050ReleaseReadiness` → `TramaiReleaseVerificationPlugin`
- ~100-line document/file inspection moved verbatim from the root build script
- Preserved exactly: task name, `dependsOn` set, group/description, every `require()` diagnostic byte-for-byte, fail-closed semantics, and the **deliberate** `notCompatibleWithConfigurationCache` (C3 = 1 deliberate, not zero)
- Root keeps only the `check` wiring (`dependsOn("verify050ReleaseReadiness")`)
- Kill tests: **T16** missing evidence → exact "Missing 0.5.0 release-readiness document" failure; **T17** valid evidence passes with the completion marker; **T18** root script carries no implementation markers

### Slice B — sovereign-lab tasks → `TramaiSovereignLabVerificationPlugin`
- `verifySovereignLabRuntimeSmoke` → typed CC-safe `VerifySovereignLabRuntimeSmokeTask` with the JUnit report declared as an input; `dependsOn :examples:spring-sovereign-starter:e2eTest` preserved
- `verifySovereignLabLocalModel` + `benchmarkSovereignLabLocalModel` moved with exact names, cross-project deps, and `TRAMAI_ENABLE_*` env-gates
- Kill tests: clean/missing/dirty report paths, env-gate firing, name+description preservation, root structural guard

### Slice A — `prepareCycloneDxBom` → new `tramai.supply-chain` plugin
- Copy + SHA-256 digest implementation moved verbatim; root keeps `org.cyclonedx.bom` application (composition)
- Source BOM is a declared `@Internal` property — deliberately NOT `@InputFile`: an Optional InputFile still fails Gradle validation on an absent file, which would break the historical **fail-soft** warn-and-skip contract (same reasoning as the a3b2a typed tasks)
- **SBOM authority-mutation discriminator**: perturb the declared input → task output + digest follow the mutation, proving it consumes the declared input, not a rediscovered historical root path

### Structural guards (source-string, paired with behavioral kill tests per the b2 doc)
Each slice has a test asserting the root build script no longer contains that responsibility's implementation markers:
- CycloneDX copy/hash (`MessageDigest`, `tramai-cyclonedx-sbom.sha256`, `tasks.register("prepareCycloneDxBom")`)
- sovereign-lab execution (`SovereignLabProfileSmokeTest did not pass cleanly`, env-gate messages)
- release-readiness inspection (`Duplicate PR entries`, stale-claims diagnostics)

### Verification
- `:build-logic:test` — full suite GREEN (15m03s), 494+ tests including 15 new b2 discriminators
- `verifyStaticAnalysis` — detekt baseline 4784 → **4794** (10 added, 0 removed) under `-PchangeClass=baseline-migration`
  - All 10 new IDs are verbatim-moved long string literals / the inherent length of the moved readiness block / the plugin now legitimately owning more functions — none are new defects, no diagnostics changed
- `spotlessApply` ✅ (including a pre-existing dangling top-level KDoc in `SovereignLabVerifierTasks.kt` that the formatting ratchet exposed once the file was touched)
