### PR TITLE
refactor(quality): 9.2d-b3 — developer-lifecycle configuration-cache closure

### DIFF
--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
@@ -711,19 +711,24 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                 "-PtramaiCancellationBaseSha for PR base SHA comparison."
             rootDir.set(project.rootDir)
             baseSha.set(project.providers.gradleProperty("tramaiCancellationBaseSha"))
-            // FileTree base is rootDir; exclude task-output dirs (build/, api/)
-            // or Gradle 9 flags the input as overlapping a task output. The
-            // scanner inspects src/main sources plus settings/catalog (module
-            // discovery), so excluding outputs changes no semantics.
+            // Candidate population must match the historical verifier:
+            // ordinary non-example Gradle subprojects only. Recursively
+            // matching rootDir's **/src/main/** would also capture
+            // includeBuild("build-logic") sources (not a settings include, so
+            // absent from the base-side population), breaking candidate/base
+            // parity. Build the collection from project.allprojects instead.
+            // Exclude task-output dirs (build/, api/) or Gradle 9 flags the
+            // input as overlapping a task output.
             scanInputs.from(
-                project.fileTree(project.rootDir) {
-                    include("settings.gradle.kts", "config/quality/module-catalog.yml")
-                    exclude("**/build/**", "**/api/**")
-                },
-                project.fileTree(project.rootDir) {
-                    include("**/src/main/**/*.kt", "**/src/main/**/*.java")
-                    exclude("**/build/**", "**/api/**")
-                },
+                project.allprojects
+                    .filter { it != project }
+                    .filterNot { it.path.startsWith(":examples:") }
+                    .map { subproject ->
+                        project.fileTree(subproject.projectDir) {
+                            include("src/main/**/*.kt", "src/main/**/*.java")
+                            exclude("**/build/**", "**/api/**")
+                        }
+                    },
             )
         }
 

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
@@ -703,165 +703,28 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
             reportFile.set(project.layout.buildDirectory.file("reports/maintainability/runtime-nondeterminism-verification.json"))
         }
 
-        project.tasks.register("verifyCancellationSafety") {
+        project.tasks.register<VerifyCancellationSafetyTask>("verifyCancellationSafety") {
             group = "maintainability"
             description =
                 "Scans all production source for broad catches in suspend-capable code and rejects " +
                 "newly introduced critical/high findings and risk worsenings. Accepts " +
                 "-PtramaiCancellationBaseSha for PR base SHA comparison."
-            doLast {
-                val scanningCtx = MeasurementContext.fromProject(project)
-                val inventory = CancellationCatchInventory(scanningCtx)
-                val findings = inventory.inventory()
-
-                // Derive scope from all non-example modules
-                val scopedModules =
-                    scanningCtx.modules
-                        .map { it.path }
-                        .filterNot { it.startsWith(":examples:") }
-                        .toSet()
-
-                val scopedFindings = findings.filter { it.module in scopedModules }
-
-                // Determine comparison mode
-                val baseSha = project.findProperty("tramaiCancellationBaseSha")?.toString()
-
-                if (baseSha != null) {
-                    // ── PR mode: compare against base SHA ──
-                    val worktreeDir =
-                        java.nio.file.Files
-                            .createTempDirectory("tramai-base-${baseSha.take(8)}-")
-                            .toFile()
-                    val baseCatches: List<CancellationCatchFinding>
-                    var worktreeCreated = false
-
-                    try {
-                        // Create temporary git worktree at base SHA
-                        val addProcess =
-                            ProcessBuilder(
-                                "git",
-                                "worktree",
-                                "add",
-                                worktreeDir.absolutePath,
-                                baseSha,
-                                "--detach",
-                            ).directory(project.rootDir)
-                                .redirectErrorStream(true)
-                                .start()
-                        val addOutput = addProcess.inputStream.bufferedReader().readText()
-                        val addExit = addProcess.waitFor()
-                        if (addExit != 0) throw GradleException("Failed to create worktree at $baseSha: $addOutput")
-                        worktreeCreated = true
-
-                        // Scan base sources with same scanner + scoped module filter
-                        val baseCtx = MeasurementContext.fromDirectory(worktreeDir)
-                        val baseInventory = CancellationCatchInventory(baseCtx)
-                        val baseAllFindings = baseInventory.inventory()
-                        baseCatches = baseAllFindings.filter { it.module in scopedModules }
-                    } finally {
-                        if (worktreeCreated) {
-                            ProcessBuilder("git", "worktree", "remove", "--force", worktreeDir.absolutePath)
-                                .directory(project.rootDir)
-                                .start()
-                                .waitFor()
-                            ProcessBuilder("git", "worktree", "prune")
-                                .directory(project.rootDir)
-                                .start()
-                                .waitFor()
-                        }
-                        worktreeDir.deleteRecursively()
-                    }
-
-                    // ── Risk population matching comparison ──
-                    val delta = CancellationDeltaComparator.compare(baseCatches, scopedFindings)
-
-                    if (delta.newCriticalHigh.isNotEmpty() || delta.worsened.isNotEmpty()) {
-                        throw GradleException(delta.diagnostics.joinToString("\n"))
-                    }
-
-                    println(delta.diagnostics.joinToString("\n"))
-                    println("verifyCancellationSafety PASSED: no new critical/high findings or risk worsenings against base SHA.")
-                } else {
-                    // ── Local dev mode: auto-resolve merge base against origin/master ──
-                    val resolveProcess =
-                        ProcessBuilder("git", "merge-base", "HEAD", "origin/master")
-                            .directory(project.rootDir)
-                            .redirectErrorStream(true)
-                            .start()
-                    val resolveOutput =
-                        resolveProcess.inputStream
-                            .bufferedReader()
-                            .readText()
-                            .trim()
-                    val resolveExit = resolveProcess.waitFor()
-                    if (resolveExit != 0) {
-                        throw GradleException(
-                            "verifyCancellationSafety requires -PtramaiCancellationBaseSha when origin/master is not available.\n" +
-                                "Usage: ./gradlew verifyCancellationSafety -PtramaiCancellationBaseSha=<sha>\n" +
-                                "In CI this is auto-wired. Locally, use the base branch SHA.",
-                        )
-                    }
-
-                    val baseShaLocal = resolveOutput
-                    println("verifyCancellationSafety: auto-resolved merge base against origin/master = ${baseShaLocal.take(8)}")
-
-                    // Scan merge base using the same worktree approach
-                    val worktreeDir =
-                        java.nio.file.Files
-                            .createTempDirectory("tramai-base-${baseShaLocal.take(8)}-")
-                            .toFile()
-                    val localBaseCatches: List<CancellationCatchFinding>
-                    var worktreeCreated = false
-
-                    try {
-                        val addProcess =
-                            ProcessBuilder(
-                                "git",
-                                "worktree",
-                                "add",
-                                worktreeDir.absolutePath,
-                                baseShaLocal,
-                                "--detach",
-                            ).directory(project.rootDir)
-                                .redirectErrorStream(true)
-                                .start()
-                        val addOutput = addProcess.inputStream.bufferedReader().readText()
-                        val addExit = addProcess.waitFor()
-                        if (addExit != 0) throw GradleException("Failed to create worktree at $baseShaLocal: $addOutput")
-                        worktreeCreated = true
-
-                        val baseCtx = MeasurementContext.fromDirectory(worktreeDir)
-                        val baseInventory = CancellationCatchInventory(baseCtx)
-                        val baseAllFindings = baseInventory.inventory()
-                        localBaseCatches = baseAllFindings.filter { it.module in scopedModules }
-                    } finally {
-                        if (worktreeCreated) {
-                            ProcessBuilder("git", "worktree", "remove", "--force", worktreeDir.absolutePath)
-                                .directory(project.rootDir)
-                                .start()
-                                .waitFor()
-                            ProcessBuilder("git", "worktree", "prune")
-                                .directory(project.rootDir)
-                                .start()
-                                .waitFor()
-                        }
-                        worktreeDir.deleteRecursively()
-                    }
-
-                    // Same risk population matching comparison
-                    val delta = CancellationDeltaComparator.compare(localBaseCatches, scopedFindings)
-
-                    if (delta.newCriticalHigh.isNotEmpty() || delta.worsened.isNotEmpty()) {
-                        throw GradleException(delta.diagnostics.joinToString("\n"))
-                    }
-
-                    println(delta.diagnostics.joinToString("\n"))
-                    println(
-                        "verifyCancellationSafety PASSED: ${scopedFindings.size} findings in scoped modules, " +
-                            "no new critical/high findings or risk worsenings against origin/master.",
-                    )
-                }
-            }
+            rootDir.set(project.rootDir)
+            baseSha.set(project.providers.gradleProperty("tramaiCancellationBaseSha"))
+            // FileTree base is rootDir; exclude task-output dirs (build/, api/)
+            // or Gradle 9 flags the input as overlapping a task output. The
+            // scanner inspects src/main sources plus settings/catalog (module
+            // discovery), so excluding outputs changes no semantics.
+            scanInputs.from(
+                project.fileTree(project.rootDir) {
+                    include("settings.gradle.kts", "config/quality/module-catalog.yml")
+                    exclude("**/build/**", "**/api/**")
+                },
+                project.fileTree(project.rootDir) {
+                    include("**/src/main/**/*.kt", "**/src/main/**/*.java")
+                    exclude("**/build/**", "**/api/**")
+                },
+            )
         }
 
         project.tasks.register("verifyCriticalCoverage") {

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/VerifyCancellationSafetyTask.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/VerifyCancellationSafetyTask.kt
@@ -21,8 +21,10 @@ import java.io.File
  * in the normal developer `check` lifecycle (9.2d-b3: C5 = 0).
  *
  * PR mode compares against `tramaiCancellationBaseSha`; local dev mode
- * auto-resolves the merge base against origin/master. The scan itself is a
- * pure directory walk via [MeasurementContext.fromDirectory] — no Gradle
+ * auto-resolves the merge base against origin/master. The current-tree scan
+ * consumes the declared [scanInputs] directly (declared input = execution
+ * authority); the base-side scan materializes a worktree at the base SHA,
+ * which is itself the declared authority for that immutable tree. No Gradle
  * project model access at execution time.
  */
 abstract class VerifyCancellationSafetyTask : DefaultTask() {
@@ -55,18 +57,27 @@ abstract class VerifyCancellationSafetyTask : DefaultTask() {
     @TaskAction
     fun verify() {
         val repoRoot = rootDir.get().asFile
-        val scanningCtx = MeasurementContext.fromDirectory(repoRoot)
-        val inventory = CancellationCatchInventory(scanningCtx)
-        val findings = inventory.inventory()
 
-        // Derive scope from all non-example modules
+        // The declared candidate inputs are the execution authority: the
+        // current-tree scan consumes scanInputs directly (module identity
+        // derived from each file's location), never rediscovering the tree
+        // through MeasurementContext.
         val scopedModules =
-            scanningCtx.modules
-                .map { it.path }
+            scanInputs.files
+                .mapNotNull { moduleOf(repoRoot, it) }
                 .filterNot { it.startsWith(":examples:") }
                 .toSet()
-
-        val scopedFindings = findings.filter { it.module in scopedModules }
+        val scopedFindings =
+            scanInputs.files
+                .asSequence()
+                .filter { it.isFile && it.extension == "kt" }
+                .mapNotNull { file ->
+                    val module = moduleOf(repoRoot, file) ?: return@mapNotNull null
+                    if (module !in scopedModules) return@mapNotNull null
+                    val relativePath = ReportNormalizer.repoRelativePath(file, repoRoot)
+                    KotlinCancellationCatchScanner.scan(file.readText(), module, relativePath)
+                }.flatten()
+                .toList()
 
         val configuredBaseSha = baseSha.orNull
 
@@ -106,6 +117,24 @@ abstract class VerifyCancellationSafetyTask : DefaultTask() {
                     "worsenings against origin/master.",
             )
         }
+    }
+
+    /**
+     * Derives the module path (":a:b") for a declared candidate file from its
+     * location relative to the repository root, using the conventional
+     * "<module>/src/..." layout. Returns null for files outside any module
+     * source tree (e.g. settings.gradle.kts, catalog).
+     */
+    private fun moduleOf(
+        repoRoot: File,
+        file: File,
+    ): String? {
+        val relative = file.toRelativeString(repoRoot).replace(File.separatorChar, '/')
+        val srcSegment = "src"
+        val segments = relative.split("/")
+        val srcIndex = segments.indexOf(srcSegment)
+        if (srcIndex <= 0) return null
+        return ":" + segments.subList(0, srcIndex).joinToString(":")
     }
 
     private fun compareAndReport(

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/VerifyCancellationSafetyTask.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/VerifyCancellationSafetyTask.kt
@@ -1,0 +1,168 @@
+package dev.tramai.build.quality
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Scans all production source for broad catches in suspend-capable code and
+ * rejects newly introduced critical/high findings and risk worsenings (Epic
+ * 10.1d gate). Typed so it is configuration-cache compatible and participates
+ * in the normal developer `check` lifecycle (9.2d-b3: C5 = 0).
+ *
+ * PR mode compares against `tramaiCancellationBaseSha`; local dev mode
+ * auto-resolves the merge base against origin/master. The scan itself is a
+ * pure directory walk via [MeasurementContext.fromDirectory] — no Gradle
+ * project model access at execution time.
+ */
+abstract class VerifyCancellationSafetyTask : DefaultTask() {
+    companion object {
+        private const val SHA_ABBREV_LENGTH = 8
+    }
+
+    /** Repository root; the git worktree commands are rooted here. */
+    @get:Internal
+    abstract val rootDir: DirectoryProperty
+
+    /** Production sources + settings + catalog actually scanned by the task. */
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val scanInputs: ConfigurableFileCollection
+
+    /** PR base SHA for comparison mode; absent = local dev mode (merge-base). */
+    @get:Optional
+    @get:Input
+    abstract val baseSha: Property<String>
+
+    /** Git executable; default resolved from PATH. */
+    @get:Internal
+    abstract val gitExecutable: Property<String>
+
+    init {
+        gitExecutable.convention("git")
+    }
+
+    @TaskAction
+    fun verify() {
+        val repoRoot = rootDir.get().asFile
+        val scanningCtx = MeasurementContext.fromDirectory(repoRoot)
+        val inventory = CancellationCatchInventory(scanningCtx)
+        val findings = inventory.inventory()
+
+        // Derive scope from all non-example modules
+        val scopedModules =
+            scanningCtx.modules
+                .map { it.path }
+                .filterNot { it.startsWith(":examples:") }
+                .toSet()
+
+        val scopedFindings = findings.filter { it.module in scopedModules }
+
+        val configuredBaseSha = baseSha.orNull
+
+        if (configuredBaseSha != null) {
+            // ── PR mode: compare against base SHA ──
+            val baseCatches = scanWorktree(repoRoot, configuredBaseSha, scopedModules)
+            compareAndReport(
+                baseCatches,
+                scopedFindings,
+                "verifyCancellationSafety PASSED: no new critical/high findings " +
+                    "or risk worsenings against base SHA.",
+            )
+        } else {
+            // ── Local dev mode: auto-resolve merge base against origin/master ──
+            val resolveOutput = git(repoRoot, "merge-base", "HEAD", "origin/master")
+            val baseShaLocal = resolveOutput.trim()
+            if (baseShaLocal.isEmpty()) {
+                throw GradleException(
+                    "verifyCancellationSafety requires -PtramaiCancellationBaseSha " +
+                        "when origin/master is not available.\n" +
+                        "Usage: ./gradlew verifyCancellationSafety -PtramaiCancellationBaseSha=<sha>\n" +
+                        "In CI this is auto-wired. Locally, use the base branch SHA.",
+                )
+            }
+
+            println(
+                "verifyCancellationSafety: auto-resolved merge base against " +
+                    "origin/master = ${baseShaLocal.take(SHA_ABBREV_LENGTH)}",
+            )
+
+            val localBaseCatches = scanWorktree(repoRoot, baseShaLocal, scopedModules)
+            compareAndReport(
+                localBaseCatches,
+                scopedFindings,
+                "verifyCancellationSafety PASSED: ${scopedFindings.size} findings " +
+                    "in scoped modules, no new critical/high findings or risk " +
+                    "worsenings against origin/master.",
+            )
+        }
+    }
+
+    private fun compareAndReport(
+        baseCatches: List<CancellationCatchFinding>,
+        scopedFindings: List<CancellationCatchFinding>,
+        passMessage: String,
+    ) {
+        val delta = CancellationDeltaComparator.compare(baseCatches, scopedFindings)
+
+        if (delta.newCriticalHigh.isNotEmpty() || delta.worsened.isNotEmpty()) {
+            throw GradleException(delta.diagnostics.joinToString("\n"))
+        }
+
+        println(delta.diagnostics.joinToString("\n"))
+        println(passMessage)
+    }
+
+    private fun scanWorktree(
+        repoRoot: File,
+        baseSha: String,
+        scopedModules: Set<String>,
+    ): List<CancellationCatchFinding> {
+        val worktreeDir =
+            java.nio.file.Files
+                .createTempDirectory("tramai-base-${baseSha.take(SHA_ABBREV_LENGTH)}-")
+                .toFile()
+        var worktreeCreated = false
+
+        try {
+            git(repoRoot, "worktree", "add", worktreeDir.absolutePath, baseSha, "--detach")
+            worktreeCreated = true
+
+            val baseCtx = MeasurementContext.fromDirectory(worktreeDir)
+            val baseInventory = CancellationCatchInventory(baseCtx)
+            val baseAllFindings = baseInventory.inventory()
+            return baseAllFindings.filter { it.module in scopedModules }
+        } finally {
+            if (worktreeCreated) {
+                git(repoRoot, "worktree", "remove", "--force", worktreeDir.absolutePath)
+                git(repoRoot, "worktree", "prune")
+            }
+            worktreeDir.deleteRecursively()
+        }
+    }
+
+    private fun git(
+        repoRoot: File,
+        vararg args: String,
+    ): String {
+        val process =
+            ProcessBuilder(listOf(gitExecutable.get()) + args)
+                .directory(repoRoot)
+                .redirectErrorStream(true)
+                .start()
+        val output = process.inputStream.bufferedReader().readText()
+        val exit = process.waitFor()
+        if (exit != 0) throw GradleException("git ${args.joinToString(" ")} failed (exit $exit): $output")
+        return output
+    }
+}

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/TypedTaskConfigurationCacheTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/TypedTaskConfigurationCacheTest.kt
@@ -79,6 +79,71 @@ class TypedTaskConfigurationCacheTest {
         assertTrue(second.output.contains("Reusing configuration cache"), "second run must reuse cache: ${second.output.take(800)}")
     }
 
+    @Test
+    fun `verify cancellation safety scans declared inputs not rediscovered sources`() {
+        // Authority discriminator (9.2d-b3 P1): the declared scanInputs must be
+        // the execution authority. The base commit is clean. Module B (sample)
+        // then receives a forbidden broad catch as an UNCOMMITTED working-tree
+        // change (present on disk, absent from base). Redirecting scanInputs to
+        // clean module A must pass even though B's forbidden source exists on
+        // disk; redirecting to B must fail. A rediscovery-based implementation
+        // would always scan B regardless of the declared input.
+        val dir = maintainabilityFixture()
+        git(dir, "init", "-q")
+        git(dir, "config", "user.email", "test@example.com")
+        git(dir, "config", "user.name", "Test")
+        writeFile(dir, "tramai-core/src/main/kotlin/example/Good.kt", "package example\nclass Good\n")
+        git(dir, "add", ".")
+        git(dir, "commit", "-q", "-m", "initial fixture")
+        git(dir, "remote", "add", "origin", "https://example.invalid/tramai.git")
+        git(dir, "update-ref", "refs/remotes/origin/master", "HEAD")
+
+        // Uncommitted forbidden catch in module B's conventional source tree.
+        writeFile(
+            dir,
+            "sample/src/main/kotlin/example/Bad.kt",
+            """
+            package example
+
+            suspend fun riskyOperation() {
+                try {
+                    doSomething()
+                } catch (e: Exception) {
+                    logError(e)
+                }
+            }
+            """.trimIndent(),
+        )
+
+        fun configureInputs(module: String) {
+            val buildScript = File(dir, "build.gradle.kts").readText()
+            File(dir, "build.gradle.kts").writeText(
+                buildScript +
+                    """
+                |tasks.named<dev.tramai.build.quality.VerifyCancellationSafetyTask>("verifyCancellationSafety") {
+                |    scanInputs.setFrom(layout.projectDirectory.dir("$module/src/main/kotlin").asFileTree)
+                |}
+                |
+                    """.trimMargin(),
+            )
+        }
+
+        // Point at clean module A: must pass even though module B on disk
+        // contains an uncommitted forbidden catch.
+        configureInputs("tramai-core")
+        val passing = runner(dir, "verifyCancellationSafety").build()
+        assertTrue(passing.output.contains("PASSED"), "clean declared source must pass: ${passing.output.take(800)}")
+
+        // Invert: point at forbidden module B: the uncommitted catch is new
+        // against the clean base and must fail.
+        configureInputs("sample")
+        val failing = runner(dir, "verifyCancellationSafety").buildAndFail()
+        assertTrue(
+            failing.output.contains("PASSED").not(),
+            "declared forbidden source must fail: ${failing.output.take(800)}",
+        )
+    }
+
     private fun assertConfigurationCacheReuse(
         dir: File,
         task: String,

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/TypedTaskConfigurationCacheTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/TypedTaskConfigurationCacheTest.kt
@@ -144,6 +144,77 @@ class TypedTaskConfigurationCacheTest {
         )
     }
 
+    @Test
+    fun `verify cancellation safety scope matches historical subproject population`() {
+        // Scope-parity discriminator (9.2d-b3 P1.5): the candidate population
+        // must match the historical verifier — ordinary non-example Gradle
+        // subprojects only. An included build (like build-logic, declared via
+        // includeBuild, absent from the settings include(...) population the
+        // base side discovers) and :examples modules must be excluded; a
+        // normal module must still be scanned.
+        val dir = maintainabilityFixture()
+        // Register an included build with a forbidden catch.
+        writeFile(dir, "tooling/settings.gradle.kts", "rootProject.name = \"tooling\"\n")
+        writeForbiddenCatch(dir, "tooling/src/main/kotlin/tooling/IncludedBad.kt", "tooling", "includedRisky")
+        val settingsFile = File(dir, "settings.gradle.kts")
+        settingsFile.writeText(settingsFile.readText() + "\nincludeBuild(\"tooling\")\n")
+        // Forbidden catch in an example module: excluded like the historical
+        // filterNot(":examples:").
+        writeForbiddenCatch(
+            dir,
+            "examples/java-consumer-smoke/src/main/kotlin/example/ExampleBad.kt",
+            "example",
+            "exampleRisky",
+        )
+        writeFile(dir, "tramai-core/src/main/kotlin/example/Good.kt", "package example\nclass Good\n")
+        git(dir, "init", "-q")
+        git(dir, "config", "user.email", "test@example.com")
+        git(dir, "config", "user.name", "Test")
+        git(dir, "add", ".")
+        git(dir, "commit", "-q", "-m", "initial fixture")
+        git(dir, "remote", "add", "origin", "https://example.invalid/tramai.git")
+        git(dir, "update-ref", "refs/remotes/origin/master", "HEAD")
+
+        // Both excluded populations carry forbidden catches, yet must not be
+        // scanned: the task passes with zero findings.
+        val passing = runner(dir, "verifyCancellationSafety").build()
+        assertTrue(
+            passing.output.contains("0 findings") && passing.output.contains("PASSED"),
+            "included-build and examples sources must be excluded: ${passing.output.take(800)}",
+        )
+
+        // A normal module's forbidden catch must still be detected.
+        writeForbiddenCatch(dir, "tramai-core/src/main/kotlin/example/NowBad.kt", "example", "nowRisky")
+        val failing = runner(dir, "verifyCancellationSafety").buildAndFail()
+        assertTrue(
+            failing.output.contains("PASSED").not(),
+            "normal module source must still be scanned: ${failing.output.take(800)}",
+        )
+    }
+
+    private fun writeForbiddenCatch(
+        dir: File,
+        relativePath: String,
+        pkg: String,
+        functionName: String,
+    ) {
+        writeFile(
+            dir,
+            relativePath,
+            """
+            package $pkg
+
+            suspend fun $functionName() {
+                try {
+                    doSomething()
+                } catch (e: Exception) {
+                    logError(e)
+                }
+            }
+            """.trimIndent(),
+        )
+    }
+
     private fun assertConfigurationCacheReuse(
         dir: File,
         task: String,

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/TypedTaskConfigurationCacheTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/TypedTaskConfigurationCacheTest.kt
@@ -11,7 +11,6 @@ import kotlin.test.assertTrue
  * configuration cache without accessing Task.project during execution.
  */
 class TypedTaskConfigurationCacheTest {
-
     @TempDir
     lateinit var tempDir: File
 
@@ -47,14 +46,44 @@ class TypedTaskConfigurationCacheTest {
         val args = configurationCacheArguments("verifyChangePolicy")
         val first = runner(dir, *args).build()
         assertTrue(first.task(":verifyChangePolicy") != null, "task must execute: ${first.output.take(800)}")
-        assertTrue(first.output.contains("verifyChangePolicy: no changes detected"), "clean repository must pass: ${first.output.take(800)}")
+        assertTrue(
+            first.output.contains("verifyChangePolicy: no changes detected"),
+            "clean repository must pass: ${first.output.take(800)}",
+        )
         assertTrue(first.output.contains("Configuration cache entry stored"), "first run must store cache: ${first.output.take(800)}")
 
         val second = runner(dir, *args).build()
         assertTrue(second.output.contains("Reusing configuration cache"), "second run must reuse cache: ${second.output.take(800)}")
     }
 
-    private fun assertConfigurationCacheReuse(dir: File, task: String, reportPath: String) {
+    @Test
+    fun `verify cancellation safety reuses configuration cache`() {
+        val dir = maintainabilityFixture()
+        git(dir, "init", "-q")
+        git(dir, "config", "user.email", "test@example.com")
+        git(dir, "config", "user.name", "Test")
+        // A scoped module with a catch-free source file; no findings either way.
+        writeFile(dir, "sample/src/main/kotlin/example/Plain.kt", "package example\nclass Plain\n")
+        git(dir, "add", ".")
+        git(dir, "commit", "-q", "-m", "initial fixture")
+        git(dir, "remote", "add", "origin", "https://example.invalid/tramai.git")
+        git(dir, "update-ref", "refs/remotes/origin/master", "HEAD")
+
+        val args = configurationCacheArguments("verifyCancellationSafety")
+        val first = runner(dir, *args).build()
+        assertTrue(first.task(":verifyCancellationSafety") != null, "task must execute: ${first.output.take(800)}")
+        assertTrue(first.output.contains("PASSED"), "clean repository must pass: ${first.output.take(800)}")
+        assertTrue(first.output.contains("Configuration cache entry stored"), "first run must store cache: ${first.output.take(800)}")
+
+        val second = runner(dir, *args).build()
+        assertTrue(second.output.contains("Reusing configuration cache"), "second run must reuse cache: ${second.output.take(800)}")
+    }
+
+    private fun assertConfigurationCacheReuse(
+        dir: File,
+        task: String,
+        reportPath: String,
+    ) {
         val args = configurationCacheArguments(task)
         val first = runner(dir, *args).build()
         assertTrue(first.task(task) != null, "$task must execute: ${first.output.take(800)}")
@@ -63,11 +92,17 @@ class TypedTaskConfigurationCacheTest {
         val report = File(dir, reportPath)
         assertTrue(report.isFile, "report must exist after first run: $reportPath")
         val firstContent = report.readText()
-        val parsed = com.fasterxml.jackson.databind.ObjectMapper().readTree(firstContent)
-        assertTrue(parsed.isArray && parsed.size() >= 1, "fixture :sample resolves com.example:fake:1.0, report must contain records: $firstContent")
+        val parsed =
+            com.fasterxml.jackson.databind
+                .ObjectMapper()
+                .readTree(firstContent)
+        assertTrue(
+            parsed.isArray && parsed.size() >= 1,
+            "fixture :sample resolves com.example:fake:1.0, report must contain records: $firstContent",
+        )
         assertTrue(
             parsed.any { it.get("group").asText() == "com.example" && it.get("artifact").asText() == "fake" },
-            "report must contain the fake module: $firstContent"
+            "report must contain the fake module: $firstContent",
         )
         assertTrue(!firstContent.contains("resolutionFailed"), "probe must not report a swallowed failure: $firstContent")
 
@@ -78,31 +113,47 @@ class TypedTaskConfigurationCacheTest {
         assertTrue(firstContent == secondContent, "cold and warm outputs must be byte-identical")
     }
 
-    private fun configurationCacheArguments(task: String) = arrayOf(
-        task,
-        "--configuration-cache",
-        "--configuration-cache-problems=fail",
-    )
+    private fun configurationCacheArguments(task: String) =
+        arrayOf(
+            task,
+            "--configuration-cache",
+            "--configuration-cache-problems=fail",
+        )
 
     private fun maintainabilityFixture(): File {
         val dir = File(tempDir, "fixture-${tempDir.listFiles()?.size ?: 0}").apply { mkdirs() }
-        writeFile(dir, "settings.gradle.kts", """
+        writeFile(
+            dir,
+            "settings.gradle.kts",
+            """
             rootProject.name = "typed-task-configuration-cache"
             include(":sample", ":tramai-core", ":examples:java-consumer-smoke", ":examples:kotlin-consumer-smoke")
-        """.trimIndent())
-        writeFile(dir, "build.gradle.kts", """
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "build.gradle.kts",
+            """
             plugins { id("tramai.maintainability-baseline") }
-        """.trimIndent())
-        writeFile(dir, "sample/build.gradle.kts", """
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "sample/build.gradle.kts",
+            """
             plugins { `java-library` }
             repositories { maven { url = uri(rootDir.resolve("repo")) } }
             dependencies { implementation("com.example:fake:1.0") }
-        """.trimIndent())
+            """.trimIndent(),
+        )
         writeFile(dir, "tramai-core/build.gradle.kts", "plugins { `java-library` }")
         writeFile(dir, "examples/java-consumer-smoke/build.gradle.kts", "plugins { `java-library` }")
         writeFile(dir, "examples/kotlin-consumer-smoke/build.gradle.kts", "plugins { `java-library` }")
         writeFile(dir, ".gitignore", ".gradle/\nbuild/\nsample/build/\n")
-        writeFile(dir, "config/quality/module-catalog.yml", """
+        writeFile(
+            dir,
+            "config/quality/module-catalog.yml",
+            """
             schemaVersion: "3"
             dependencyPolicies:
               testing:
@@ -127,8 +178,12 @@ class TypedTaskConfigurationCacheTest {
                 <<: *internal
               - path: ":examples:kotlin-consumer-smoke"
                 <<: *internal
-        """.trimIndent())
-        writeFile(dir, "config/quality/test-quality.yml", """
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "config/quality/test-quality.yml",
+            """
             schemaVersion: "1"
             criticalModules: [":sample"]
             coverage:
@@ -141,7 +196,8 @@ class TypedTaskConfigurationCacheTest {
                   modules: [":sample"]
                   targetClasses: ["example.*"]
                   targetTests: ["example.*"]
-        """.trimIndent())
+            """.trimIndent(),
+        )
 
         // Minimal local Maven repo so :sample resolves a real external module.
         // Deliberately a file repo (not mavenCentral): the test must be
@@ -159,29 +215,43 @@ class TypedTaskConfigurationCacheTest {
               <artifactId>fake</artifactId>
               <version>1.0</version>
             </project>
-            """.trimIndent()
+            """.trimIndent(),
         )
-        java.util.zip.ZipOutputStream(File(repoModule, "fake-1.0.jar").outputStream()).use { it.close() }
+        java.util.zip
+            .ZipOutputStream(File(repoModule, "fake-1.0.jar").outputStream())
+            .use { it.close() }
         return dir
     }
 
-    private fun runner(dir: File, vararg args: String): GradleRunner =
-        GradleRunner.create()
+    private fun runner(
+        dir: File,
+        vararg args: String,
+    ): GradleRunner =
+        GradleRunner
+            .create()
             .withProjectDir(dir)
             .withGradleVersion("9.0.0")
             .withArguments(*args, "--stacktrace")
             .withPluginClasspath()
 
-    private fun writeFile(base: File, relativePath: String, content: String) {
+    private fun writeFile(
+        base: File,
+        relativePath: String,
+        content: String,
+    ) {
         val target = File(base, relativePath)
         target.parentFile.mkdirs()
         target.writeText(content)
     }
 
-    private fun git(dir: File, vararg args: String): String {
-        val process = ProcessBuilder(listOf("git", "-C", dir.absolutePath) + args)
-            .redirectErrorStream(true)
-            .start()
+    private fun git(
+        dir: File,
+        vararg args: String,
+    ): String {
+        val process =
+            ProcessBuilder(listOf("git", "-C", dir.absolutePath) + args)
+                .redirectErrorStream(true)
+                .start()
         val output = process.inputStream.bufferedReader().readText()
         check(process.waitFor() == 0) { "git ${args.joinToString(" ")} failed: $output" }
         return output

--- a/build-logic/src/test/kotlin/dev/tramai/build/release/ReleaseVerificationPluginTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/release/ReleaseVerificationPluginTest.kt
@@ -970,18 +970,21 @@ class ReleaseVerificationPluginTest {
     }
 
     @Test
-    fun `T18 root build script no longer carries the release-readiness implementation`() {
+    fun `T18 root build script no longer wires release readiness into check or carries the implementation`() {
         val prop =
             System.getProperty("tramai.repositoryRoot")
                 ?: error("tramai.repositoryRoot system property not set (wired by build-logic/build.gradle.kts)")
         val rootBuildScript = File(prop, "build.gradle.kts").readText()
 
-        // The root may compose the task into `check`…
-        assertTrue(
+        // 9.2d-b3: the release-only gate must NOT contaminate the normal
+        // developer check lifecycle (which must stay configuration-cache
+        // reusable). The task itself remains registered by the plugin and is
+        // invoked explicitly by release tooling.
+        assertFalse(
             rootBuildScript.contains("dependsOn(\"verify050ReleaseReadiness\")"),
-            "root must still wire verify050ReleaseReadiness into check",
+            "root build.gradle.kts must not wire verify050ReleaseReadiness into check (release-only, CC-incompatible)",
         )
-        // …but must not contain the moved implementation markers.
+        // …and must not contain the moved implementation markers.
         for (marker in listOf(
             "Missing \$expectedVersion release-readiness document",
             "Duplicate PR entries in Added section",
@@ -991,6 +994,78 @@ class ReleaseVerificationPluginTest {
             assertFalse(
                 rootBuildScript.contains(marker),
                 "root build.gradle.kts must not contain release-readiness implementation marker: $marker",
+            )
+        }
+
+        // 9.2d-b3: the release gate stays reachable via release tooling.
+        // Pin the workflow contract so a future cleanup cannot accidentally
+        // make verify050ReleaseReadiness unreachable from the release path.
+        val publishWorkflow = File(prop, ".github/workflows/publish.yml")
+        assertTrue(publishWorkflow.isFile, "publish workflow must exist")
+        val publishText = publishWorkflow.readText()
+        assertTrue(
+            publishText.contains("verify050ReleaseReadiness --no-configuration-cache"),
+            "publish workflow must invoke verify050ReleaseReadiness with --no-configuration-cache",
+        )
+    }
+
+    @Test
+    fun `T19 verify050ReleaseReadiness retains its release dependencies when invoked explicitly`() {
+        // 9.2d-b3 discriminator: removing the check wiring must not have
+        // removed the task's own release dependencies. Each dependency is a
+        // sentinel that writes a marker; running the task explicitly must
+        // execute all five, proving the aggregation survived intact.
+        val dir =
+            readinessFixture(
+                """
+                val depMarkers = layout.buildDirectory.dir("dep-markers")
+                fun markerTask(name: String) = tasks.named(name) {
+                    doLast {
+                        depMarkers.get().asFile.resolve(name).apply {
+                            parentFile.mkdirs()
+                            writeText("ran")
+                        }
+                    }
+                }
+                markerTask("verifyVersionAlignment")
+                markerTask("verifyWorkflowApiStabilityBoundary")
+                markerTask("verifySovereignRuntimeApiBoundary")
+                markerTask("verifyToolGovernanceExample")
+                """.trimIndent(),
+            )
+        // readinessFixture neutralizes verifyReleaseReadiness's real deps; add
+        // its marker here (it is plugin-registered, so use named not register).
+        writeFile(
+            dir,
+            "build.gradle.kts",
+            File(dir, "build.gradle.kts").readText() +
+                "\n" +
+                """
+                tasks.named("verifyReleaseReadiness") {
+                    setDependsOn(emptyList<String>())
+                    doLast {
+                        depMarkers.get().asFile.resolve("verifyReleaseReadiness").apply {
+                            parentFile.mkdirs()
+                            writeText("ran")
+                        }
+                    }
+                }
+                """.trimIndent(),
+        )
+
+        val result = runner(dir, "verify050ReleaseReadiness").build()
+        assertTrue(result.output.contains("all checks passed."), "completion marker required")
+        for (name in listOf(
+            "verifyVersionAlignment",
+            "verifyWorkflowApiStabilityBoundary",
+            "verifySovereignRuntimeApiBoundary",
+            "verifyToolGovernanceExample",
+            "verifyReleaseReadiness",
+        )) {
+            val marker = File(dir, "build/dep-markers/$name")
+            assertTrue(
+                marker.isFile,
+                "release dependency $name must run when verify050ReleaseReadiness is invoked explicitly",
             )
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -285,7 +285,10 @@ tasks.named("check") {
 
 // ──────────────────────────────────────────────
 // Task: check
-
-tasks.named("check") {
-    dependsOn("verify050ReleaseReadiness")
-}
+//
+// verify050ReleaseReadiness is deliberately NOT wired into the normal
+// developer check lifecycle: it is release-only orchestration and stays
+// notCompatibleWithConfigurationCache (C3 = 1 deliberate). Normal test/check
+// must remain configuration-cache reusable; the release gate is invoked
+// explicitly by release tooling (see .github/workflows/publish.yml, which
+// runs it with --no-configuration-cache).

--- a/docs/EPIC-9.2-build-logic.md
+++ b/docs/EPIC-9.2-build-logic.md
@@ -210,10 +210,20 @@ cleanly as `build-logic` with no baseline-migration exemption.
     invocation with `--no-configuration-cache`.
   - Final offender matrix: **C4 = 0** (no execution-time `Task.project`),
     **C5 = 0** (no remaining typed-task execution-model offender),
-    **C3 = 1 deliberate** (release-orchestration exclusion).
+    **C3 = 1 deliberate** (release-orchestration exclusion). The last C5
+    offender — `verifyCancellationSafety`, wired into `check` by 10.1d after
+    the a-series matrix — was converted to a typed task whose declared
+    `@InputFiles` candidate sources are the execution authority (the scanner
+    consumes `scanInputs` directly; module identity derives from each file's
+    location, never rediscovered from the tree). Base-side comparison
+    materializes a worktree at the base SHA, which is itself the declared
+    authority for that immutable tree.
   - CC closure proof: `test` cold → stored → warm reused; `check` cold →
     stored → warm reused (both with `--configuration-cache-problems=fail`).
   - Kill discriminators: T18 (root no longer wires release readiness into
     `check`; publish workflow still invokes it with
     `--no-configuration-cache`), T19 (release dependencies retained when
-    invoked explicitly).
+    invoked explicitly), `TypedTaskConfigurationCacheTest` (CC reuse **and**
+    input-authority: redirecting `scanInputs` to a clean module passes while
+    a forbidden uncommitted catch sits in an unscanned module's conventional
+    source tree; redirecting to the forbidden module fails).

--- a/docs/EPIC-9.2-build-logic.md
+++ b/docs/EPIC-9.2-build-logic.md
@@ -215,9 +215,13 @@ cleanly as `build-logic` with no baseline-migration exemption.
     the a-series matrix — was converted to a typed task whose declared
     `@InputFiles` candidate sources are the execution authority (the scanner
     consumes `scanInputs` directly; module identity derives from each file's
-    location, never rediscovered from the tree). Base-side comparison
-    materializes a worktree at the base SHA, which is itself the declared
-    authority for that immutable tree.
+    location, never rediscovered from the tree). The declared population is
+    the ordinary non-example Gradle subprojects (built from
+    `project.allprojects` at configuration time), matching the base-side
+    settings `include(...)` population — `includeBuild("build-logic")` and
+    `:examples` are excluded on both sides, preserving candidate/base
+    parity. Base-side comparison materializes a worktree at the base SHA,
+    which is itself the declared authority for that immutable tree.
   - CC closure proof: `test` cold → stored → warm reused; `check` cold →
     stored → warm reused (both with `--configuration-cache-problems=fail`).
   - Kill discriminators: T18 (root no longer wires release readiness into
@@ -226,4 +230,6 @@ cleanly as `build-logic` with no baseline-migration exemption.
     invoked explicitly), `TypedTaskConfigurationCacheTest` (CC reuse **and**
     input-authority: redirecting `scanInputs` to a clean module passes while
     a forbidden uncommitted catch sits in an unscanned module's conventional
-    source tree; redirecting to the forbidden module fails).
+    source tree; redirecting to the forbidden module fails **and**
+    scope-parity: forbidden catches under an `includeBuild` and under
+    `:examples` are excluded while a normal module's catch still fails).

--- a/docs/EPIC-9.2-build-logic.md
+++ b/docs/EPIC-9.2-build-logic.md
@@ -20,7 +20,7 @@ published module) is extracted first.
 | 9.2c-a | `tramai.kotlin-library` / `tramai.java-platform` / `tramai.test-fixtures` | ✅ done — PR #319 |
 | 9.2c-b | `tramai.testing` convention — common test-dependency baseline | ✅ done — PR #322 |
 | 9.2c-c | manifest-derived publication descriptions (module-catalog.yml schema v3 `description` + analyzer/parser + independent publication verifier input) | ✅ done — PR #325 |
-| 9.2d | configuration-cache closure; root build reduced to composition | ✅ complete — PR #353 (b1), PR #357 (b2), PR #358 (b3) |
+| 9.2d | configuration-cache closure; root build reduced to composition | ✅ complete — PR #353 (b1), PR #357 (b2), PR #359 (b3) |
 
 The `tramai.integration-test` convention is **deferred** until a dedicated
 integration-test source set exists in at least one production module — a
@@ -200,7 +200,7 @@ cleanly as `build-logic` with no baseline-migration exemption.
   `tramai.supply-chain`, sovereign-lab verification → `tramai.sovereign-lab-
   verification`, `verify050ReleaseReadiness` → `tramai.release-verification`;
   root `build.gradle.kts` reduced to composition.
-- **b3 — PR #358** — developer-lifecycle CC closure:
+- **b3 — PR #359** — developer-lifecycle CC closure:
   - Release-only `verify050ReleaseReadiness` detached from `check` (the
     normal developer `test`/`check` lifecycle no longer traverses the
     deliberate CC-incompatible release boundary).

--- a/docs/EPIC-9.2-build-logic.md
+++ b/docs/EPIC-9.2-build-logic.md
@@ -3,7 +3,7 @@
 **Goal:** Make Gradle configuration modular, typed, testable, and mostly declarative.
 
 **Owner:** build-logic conventions
-**Status:** in progress (9.2a, 9.2b done; 9.2c in progress)
+**Status:** ✅ complete (9.2a, 9.2b, 9.2c, 9.2d)
 
 ## Slicing
 
@@ -20,7 +20,7 @@ published module) is extracted first.
 | 9.2c-a | `tramai.kotlin-library` / `tramai.java-platform` / `tramai.test-fixtures` | ✅ done — PR #319 |
 | 9.2c-b | `tramai.testing` convention — common test-dependency baseline | ✅ done — PR #322 |
 | 9.2c-c | manifest-derived publication descriptions (module-catalog.yml schema v3 `description` + analyzer/parser + independent publication verifier input) | ✅ done — PR #325 |
-| 9.2d | configuration-cache closure; root build reduced to composition | planned |
+| 9.2d | configuration-cache closure; root build reduced to composition | ✅ complete — PR #353 (b1), PR #357 (b2), PR #358 (b3) |
 
 The `tramai.integration-test` convention is **deferred** until a dedicated
 integration-test source set exists in at least one production module — a
@@ -189,5 +189,31 @@ cleanly as `build-logic` with no baseline-migration exemption.
 
 ## 9.2d — configuration-cache closure
 
-- Normal developer tasks (`test`, `check`) configuration-cache compatible.
-- Root build reduced to high-level composition.
+✅ **COMPLETE** — closure lineage:
+
+- **a-series** — typed/config-cache conversions of verification tasks;
+  C1 `help`, C2 `test`, C6 `verifyPublicationMetadata` are
+  configuration-cache reusable.
+- **b1 — PR #353** — module-catalog.yml as the single publishability
+  authority; all four consumers fail closed on a missing/corrupt catalog.
+- **b2 — PR #357** — root responsibility extraction: SBOM →
+  `tramai.supply-chain`, sovereign-lab verification → `tramai.sovereign-lab-
+  verification`, `verify050ReleaseReadiness` → `tramai.release-verification`;
+  root `build.gradle.kts` reduced to composition.
+- **b3 — PR #358** — developer-lifecycle CC closure:
+  - Release-only `verify050ReleaseReadiness` detached from `check` (the
+    normal developer `test`/`check` lifecycle no longer traverses the
+    deliberate CC-incompatible release boundary).
+  - The task itself is unchanged: same name, dependencies, diagnostics,
+    fail-closed document inspection, `notCompatibleWithConfigurationCache`
+    (C3 = 1 deliberate), explicit release invocation, and publish workflow
+    invocation with `--no-configuration-cache`.
+  - Final offender matrix: **C4 = 0** (no execution-time `Task.project`),
+    **C5 = 0** (no remaining typed-task execution-model offender),
+    **C3 = 1 deliberate** (release-orchestration exclusion).
+  - CC closure proof: `test` cold → stored → warm reused; `check` cold →
+    stored → warm reused (both with `--configuration-cache-problems=fail`).
+  - Kill discriminators: T18 (root no longer wires release readiness into
+    `check`; publish workflow still invokes it with
+    `--no-configuration-cache`), T19 (release dependencies retained when
+    invoked explicitly).

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1467,7 +1467,7 @@ repair feedback. No layer maintains its own independent fixture lists.
     `tramai.supply-chain`, sovereign-lab → `tramai.sovereign-lab-
     verification`, `verify050ReleaseReadiness` → `tramai.release-
     verification`; root is composition-only.
-  - **b3 — PR #358** — developer lifecycle CC closure: release-only
+  - **b3 — PR #359** — developer lifecycle CC closure: release-only
     `verify050ReleaseReadiness` detached from `check` (C3 = 1 deliberate,
     invoked explicitly by publish workflow with `--no-configuration-cache`);
     final offender matrix C4 = 0, C5 = 0; `test` CC cold → stored →

--- a/docs/ROADMAP-0.6.0.md
+++ b/docs/ROADMAP-0.6.0.md
@@ -1438,9 +1438,9 @@ repair feedback. No layer maintains its own independent fixture lists.
 **Goal:** Make Gradle configuration modular, typed, testable, and mostly declarative.
 
 > **Slicing:** see [docs/EPIC-9.2-build-logic.md](./EPIC-9.2-build-logic.md).
-> 9.2a (`tramai.publishing` convention plugin) is done; 9.2b–9.2d are planned slices.
+> 9.2a–9.2d complete.
 
-### Status: 🔄 In progress (9.2a ✅, 9.2b–9.2d planned)
+### Status: ✅ Complete (9.2a, 9.2b, 9.2c, 9.2d)
 
 - **9.2a — `tramai.publishing` convention plugin** — ✅ PR #308: extracted
   publication/signing/repository/POM configuration from the root
@@ -1450,9 +1450,28 @@ repair feedback. No layer maintains its own independent fixture lists.
   semantics, and sovereignBundleLocal membership. Discriminator suite
   P1–P10 + S1 in `TramaiPublishingPluginTest`; `verifyChangePolicy`
   auto-classifies as `build-logic`.
-- **9.2b** — typed release/evidence tasks (`tramai.release-verification`).
-- **9.2c** — quality/test conventions + manifest-derived metadata.
-- **9.2d** — configuration-cache closure; root reduced to composition.
+- **9.2b — typed release/evidence tasks** (`tramai.release-verification`,
+  `tramai.sovereign-verification`) — ✅ PR #313: typed/cache-aware release
+  and evidence tasks extracted from root `doLast` closures.
+- **9.2c — quality/test conventions + manifest-derived metadata** —
+  ✅ PR #319 (`tramai.kotlin-library`/`tramai.java-platform`/
+  `tramai.test-fixtures`), PR #322 (`tramai.testing`), PR #325
+  (module-catalog.yml schema v3 descriptions).
+- **9.2d — configuration-cache closure; root reduced to composition** —
+  ✅ COMPLETE:
+  - **a-series** — typed/config-cache conversions of verification tasks
+    (C1 `help`/C2 `test`/C6 `verifyPublicationMetadata` CC-reusable).
+  - **b1 — PR #353** — module-catalog.yml as single publishability
+    authority (4 consumers fail-closed).
+  - **b2 — PR #357** — root responsibility extraction: SBOM →
+    `tramai.supply-chain`, sovereign-lab → `tramai.sovereign-lab-
+    verification`, `verify050ReleaseReadiness` → `tramai.release-
+    verification`; root is composition-only.
+  - **b3 — PR #358** — developer lifecycle CC closure: release-only
+    `verify050ReleaseReadiness` detached from `check` (C3 = 1 deliberate,
+    invoked explicitly by publish workflow with `--no-configuration-cache`);
+    final offender matrix C4 = 0, C5 = 0; `test` CC cold → stored →
+    reused; `check` CC cold → stored → reused.
 
 ### Target convention plugins
 

--- a/examples/kotlin-consumer-smoke/api/kotlin-consumer-smoke.api
+++ b/examples/kotlin-consumer-smoke/api/kotlin-consumer-smoke.api
@@ -1,0 +1,10 @@
+public final class dev/tramai/examples/kotlinconsumer/KotlinConsumerSmoke {
+	public static final field INSTANCE Ldev/tramai/examples/kotlinconsumer/KotlinConsumerSmoke;
+	public final fun getMarker ()Ljava/lang/String;
+}
+
+public abstract interface class dev/tramai/examples/kotlinconsumer/KotlinConsumerSmoke$GreetingService {
+	public abstract fun greet (Ljava/lang/String;I)Ljava/lang/String;
+	public abstract fun summarize (Ljava/util/List;)Ljava/util/List;
+}
+


### PR DESCRIPTION
## 9.2d-b3 — developer-lifecycle configuration-cache closure

**Epic 9.2d final slice.** Normal developer `test`/`check` are now genuinely configuration-cache reusable; release-only verification no longer contaminates the developer lifecycle.

### Changes
- **B3-A** — removed `verify050ReleaseReadiness` from `check` wiring. Task itself untouched: same name, dependencies, diagnostics, fail-closed inspection, `notCompatibleWithConfigurationCache` (C3 = 1 deliberate), explicit release invocation, publish-workflow invocation with `--no-configuration-cache`.
- **B3-C real fix** — converted `verifyCancellationSafety` (10.1d gate wired into `check` by PR #351, after the a-series matrix) from an untyped Project-capturing `DefaultTask` to typed `VerifyCancellationSafetyTask` with declared inputs. This was the final C5 offender; `check --configuration-cache --configuration-cache-problems=fail` failed on it before this change.
- **B3-B** — CC closure proofs (both `--configuration-cache-problems=fail`):
  - `test`: cold **stored** (56s) → warm **reused** (2s)
  - `check`: cold **stored** (55s) → warm **reused** (2s)
- **B3-C final matrix** — C4 = 0, C5 = 0, C3 = 1 deliberate.
- **B3-D** — root remains semantic composition (audited; no implementation markers).
- **B3-E** — `docs/EPIC-9.2-build-logic.md` + `docs/ROADMAP-0.6.0.md` updated; Epic 9.2 marked complete with full closure lineage.
- **Kill discriminators** — T18 flipped (root no longer wires release readiness into check; publish workflow still invokes it with `--no-configuration-cache`), T19 (release deps retained on explicit invocation), new `TypedTaskConfigurationCacheTest` case (verifyCancellationSafety CC reuse).

### Also in this PR (required by the check proof)
Two previously-missing bcv api dumps (`examples/kotlin-consumer-smoke`, `tramai-spring-boot-starter`) committed. Pre-existing gap: root applies binary-compatibility-validator to all modules, these kotlin modules never had dumps, and CI runs `test` not `check` so it never surfaced. Generated by `apiDump`; no gate weakened.

### Gates
- `:build-logic:test` — 724 tests green (13m37s)
- `verifyStaticAnalysis` — green, **Detekt baseline unchanged 4794 → 4794 (0 added, 0 removed)**
- `spotlessApply` — applied
- CC proofs above
- `verifyPr` — run locally before merge

### Post-Epic (separate, out of scope)
- CI-topology duplication audit
- P3 test-file KDoc wording fix (`@InputFile` → `@Internal`)