### PR TITLE
10.3c1: routing-core mutation pilot — measurement-only (PIT execution, identity stability, survivor adjudication)

### DIFF
--- a/config/quality/mutation-routing-core-pilot.init.gradle
+++ b/config/quality/mutation-routing-core-pilot.init.gradle
@@ -1,0 +1,93 @@
+// 10.3c1 routing-core mutation pilot — repository-owned reproducer.
+//
+// PURPOSE
+// Reproduce the bounded PIT campaign whose evidence is recorded in
+// docs/EPIC-10.3-coverage-mutation.md §7 ("10.3c1 routing-core mutation
+// pilot"). Measurement only: no enforcement, no baseline, no CI wiring.
+//
+// CANONICAL INVOCATION (from the repository root):
+//   ./gradlew --init-script config/quality/mutation-routing-core-pilot.init.gradle \
+//     pilotMutationProbe --rerun-tasks
+//
+// REPORT OUTPUT
+//   tramai-core/build/mutation-pilot/routing-core/tramai-core/mutations.xml   (authoritative XML)
+//   tramai-core/build/mutation-pilot/routing-core/tramai-core/index.html      (human view)
+//
+// EXPECTED RESULT AT 10.3c1 head (see doc §7):
+//   4 mutations generated, 4 KILLED, 0 survivors, population stable across
+//   identical runs. Identity = MutationIdentity.stableKey() over
+//   module+className+method+mutator+description+block (SHA-256, line excluded).
+//
+// PILOT BOUNDARY (binding)
+//   Targets EXACTLY dev.tramai.core.provider.ProviderRegistry and
+//   dev.tramai.core.provider.ModelProvider on :tramai-core. The authoritative
+//   routing family (config/quality/test-quality.yml) also contains
+//   ModelRegistryEnforcer; it is NOT enrolled until the 10.3c2 follow-up.
+//
+// WHY THIS SHAPE (root-cause findings from the pilot, doc §7 C8):
+//   1. gradle-pitest-plugin 1.19.0 registers its extension inside
+//      plugins.withType(JavaPlugin).configureEach(...). Applying/configure the
+//      plugin from a bare `gradle.beforeProject` hook runs BEFORE the project's
+//      java plugin and fails with "Extension with name 'pitest' does not
+//      exist". The pilot therefore applies+configures inside
+//      `plugins.withId('java')`, matching CanonicalGradleProbe's generated
+//      init script (CanonicalGradleProbe.kt).
+//   2. When targetTests is unset the solidsoft plugin mirrors targetClasses
+//      into the test filter and finds 0 tests. targetTests is pinned to the
+//      provider test package.
+//   3. pitest needs its junit5 companion on the pitest configuration
+//      (dependencies.add('pitest', 'org.pitest:pitest-junit5-plugin:1.2.1'))
+//      and testPlugin 'junit5'.
+initscript {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.19.0'
+        classpath 'org.pitest:pitest-junit5-plugin:1.2.1'
+    }
+}
+
+def pilotModules = [':tramai-core'] as Set
+def pilotClasses = [
+    'dev.tramai.core.provider.ProviderRegistry',
+    'dev.tramai.core.provider.ModelProvider',
+] as Set
+def pilotTests = [
+    'dev.tramai.core.provider.*',
+] as Set
+def mutationTasks = []
+
+gradle.beforeProject { measuredProject ->
+    if (!(measuredProject.path in pilotModules)) return
+    measuredProject.plugins.withId('java') {
+        def pluginClass = initscript.classLoader.loadClass(
+            'info.solidsoft.gradle.pitest.PitestPlugin'
+        )
+        measuredProject.pluginManager.apply(pluginClass)
+        measuredProject.dependencies.add('pitest', 'org.pitest:pitest-junit5-plugin:1.2.1')
+        measuredProject.extensions.configure('pitest') { pitestExt ->
+            pitestExt.testPlugin.set('junit5')
+            pitestExt.targetClasses.set(pilotClasses)
+            pitestExt.targetTests.set(pilotTests)
+            pitestExt.outputFormats.set(['XML', 'HTML'] as Set)
+            pitestExt.timestampedReports.set(false)
+            pitestExt.failWhenNoMutations.set(true)
+            pitestExt.threads.set(2)
+            def moduleSlug = measuredProject.path.substring(1).replace(':', '_')
+            // Root project is unavailable at init-script top level; resolve lazily.
+            pitestExt.reportDir.set(measuredProject.provider {
+                measuredProject.layout.projectDirectory
+                    .dir('build/mutation-pilot/routing-core/' + moduleSlug)
+            })
+        }
+        mutationTasks << measuredProject.tasks.named('pitest')
+    }
+}
+
+gradle.projectsEvaluated {
+    rootProject.tasks.register('pilotMutationProbe') {
+        dependsOn mutationTasks.collect { it.get() }
+    }
+}

--- a/docs/EPIC-10.3-coverage-mutation.md
+++ b/docs/EPIC-10.3-coverage-mutation.md
@@ -131,9 +131,24 @@ The §4 planning estimate (10–40 min/family serialized) does **not** hold at r
 
 ### C8 — findings and decision
 
-1. **The dormant production mutation path is broken at first execution** — `mutationInitScript` configures the pitest extension from a `beforeProject` hook, but gradle-pitest-plugin 1.19.0 registers its extension inside `plugins.withType(JavaPlugin).configureEach(...)`, which fires only after the project's `java` plugin is applied. Result: "Extension with name 'pitest' does not exist" at configuration time. Fix in the follow-up: configure inside a `withType(JavaPlugin)` hook (or `afterEvaluate`).
+1. **The dormant production mutation path is broken at first execution** — `mutationInitScript` configures the pitest extension from a `beforeProject` hook, but gradle-pitest-plugin 1.19.0 registers its extension inside `plugins.withType(JavaPlugin).configureEach(...)`, which fires only after the project's `java` plugin is applied. Result: "Extension with name 'pitest' does not exist" at configuration time. Fix in the follow-up: configure inside a `withType(JavaPlugin)` hook (or `afterEvaluate`). `CanonicalGradleProbe`'s generated init script already applies this pattern (it hooks `plugins.withId('java')`).
 2. **`targetTests` must be set explicitly.** When unset, the solidsoft plugin mirrors `targetClasses` into the test filter, so PIT scans for test classes *named like the production classes* → 0 tests found, every mutant NO_COVERAGE. Fix: pin `targetTests` to the module's test package (or the full suite). Without this, even a correctly-applied plugin produces a meaningless all-NO_COVERAGE report.
-3. **The pilot's Groovy closure-delegate quirk:** configuring the extension via `extensions.configure('pitest') { ... }` nested inside `withType(JavaPlugin) { }` leaks the JavaPlugin delegate; configure via `extensions.getByName('pitest')` + property assignment instead.
+3. **The pilot's Groovy closure-delegate quirk:** configuring the extension via `extensions.configure('pitest') { ... }` nested inside `withType(JavaPlugin) { }` leaks the JavaPlugin delegate; configure via `extensions.getByName('pitest')` + property assignment instead (the committed reproducer below uses the closure form with an explicit `pitestExt ->` parameter, which binds the delegate correctly — matching `CanonicalGradleProbe`).
 4. **Identity scheme is empirically durable** for the routing-core pilot: module+className+method+mutator+description+block → SHA-256 is stable across identical runs and under harmless source movement. PIT's `description` and `block` fields were stable in every probe.
+
+### C9 — reproduction (committed reproducer)
+
+The pilot mechanism is repository-owned so the experiment is reproducible from a clean checkout — the recorded evidence is not an uncommitted-script claim.
+
+**Reproduce the measurement:**
+```
+./gradlew --init-script config/quality/mutation-routing-core-pilot.init.gradle \
+  pilotMutationProbe --rerun-tasks
+```
+Report XML lands at `tramai-core/build/mutation-pilot/routing-core/tramai-core/mutations.xml` (gitignored under `**/build/`). The init script pins: `:tramai-core`; `ProviderRegistry` + `ModelProvider`; explicit `targetTests` (`dev.tramai.core.provider.*`); PIT 1.19.0 / pitest-junit5-plugin 1.2.1; XML output; `failWhenNoMutations` (non-vacuity); non-timestamped deterministic report dir.
+
+**Turn XML into the identity/status set** (reusing the canonical parser, not a second algorithm): `MutationReportParser.parse("tramai-core", "routing-pilot", mutations.xml)` produces records whose `identity` is `MutationIdentity.stableKey()` (SHA-256 over module+className+method+mutator+description+block, line excluded). A small driver is `MutationReportParserTest`; the verifier path in `MutationBaselineVerifier` consumes exactly this shape. For a shell-only check the XML is directly greppable: `status='KILLED'`/`status='NO_COVERAGE'` per `<mutation>` and `<mutatedClass>`/`<mutator>`/`<description>`/`<block>` are the identity inputs.
+
+**Expected at this head:** 4 mutations, 4 KILLED, 0 survivors. The 3× identity/status stability experiment = run the command 3× from the same HEAD with `rm -rf build/mutation-pilot` between runs and diff the normalized identity/status sets; the recorded result is 4/4 identical identities and 4/4 identical statuses. The line-movement probe = add harmless comment lines above `providerId()`/`supportsCapability()` and confirm identities unchanged.
 
 **Decision:** the pilot answers its question affirmatively — bounded PIT execution is deterministic, identities are durable, statuses are repeatable, and the routing-core population is currently fully killed (4/4) with no sanctioned survivors. Proceed to **10.3c2**: complete routing with `ModelRegistryEnforcer`, then expand family-by-family with the same evidence unit (configured targets → nonzero population → survivor adjudication → missing tests added → exact-ID classifications for genuine residuals). Before any enforcement wiring in 10.3c3, fix the two production-path root causes from C8.1/C8.2 and add the C6 discriminators.

--- a/docs/EPIC-10.3-coverage-mutation.md
+++ b/docs/EPIC-10.3-coverage-mutation.md
@@ -70,3 +70,70 @@ The repository already contains the authority machinery; what is missing is **me
 - **10.3d — integration + adversarial closure:** permanent adversarial tests (mutation of the gates themselves), configuration-cache proof, deterministic report identity, CI non-vacuity guard, docs, exact-head certification. 10.5 takes over lane redesign (PR-subset vs nightly/release).
 
 **Boundary discipline:** 10.3a = measurement only, zero enforcement, zero production changes. No percentage thresholds invented before the first real measurement exists.
+
+---
+
+## 7. 10.3c1 — routing-core mutation pilot (experiment report)
+
+**Slice:** 10.3c1 — measurement-only routing-core pilot. **Branch:** `epic/10.3c1-routing-mutation-pilot` · **Master:** `e73512ab` · **Date:** 2026-09-02.
+
+**Question this slice answers:** can TramAI execute a bounded PIT campaign deterministically, identify each mutant durably, and repeat the same measurement?
+
+> **Boundary honored:** this pilot measures. It does not invent enforcement policy, touch `mutation-classifications.yml`, modify any baseline, wire PIT into `check`/PR, or introduce a percentage floor. `ModelRegistryEnforcer` is deliberately excluded — the authoritative routing family (`test-quality.yml`) contains it and is not considered enrolled until the 10.3c2 follow-up expansion.
+
+### C1 — PIT execution
+
+- **Toolchain:** gradle-pitest-plugin 1.19.0 (PIT core 1.22.1, pitest-junit5-plugin 1.2.1), JDK 21 (Temurin 21.0.12), Gradle wrapper 9.0.0, Kotlin 2.3.0, JUnit 5.12.2.
+- **Targets:** `:tramai-core` → `dev.tramai.core.provider.ProviderRegistry`, `dev.tramai.core.provider.ModelProvider` (2 classes).
+- **Pilot path:** bounded init-script campaign (`pilotMutationProbe`) restricted to the two routing-core classes. The dormant production machinery (`generateCriticalMutationBaseline` → `mutationInitScript`) was found to be **broken at first real execution** and was not used; the pilot reproduced its intended shape in an init script (see C8 findings for the two root causes that must be fixed before the production path is wired).
+- **Result:** BUILD SUCCESSFUL; 79 test classes examined, 81 tests discovered, **4 mutations generated** (population non-empty, see C2).
+
+### C2 — non-vacuity
+
+- Target classes resolved: 2/2. Mutants generated: 4 > 0. XML mutation records: 4 > 0.
+- Every record's `mutatedClass` ∈ {`dev.tramai.core.provider.ProviderRegistry`, `dev.tramai.core.provider.ModelProvider`}. No unexpected module/class mutated. `failWhenNoMutations` is set (zero population would fail the build).
+- Status counts (after the C5 missing-test fix): **KILLED 4 · SURVIVED 0 · NO_COVERAGE 0 · TIMED_OUT 0**.
+
+### C3 — identity stability
+
+- **3/3 identical runs** (same HEAD, same targetClasses, same tests, clean outputs): identity set equal across all runs (`Set<MutationIdentity>` 4/4 identical); SHA-256 over `module+className+method+mutator+description+block` is deterministic.
+- **Source-movement probe:** adding harmless comment lines above the mutated methods shifted source lines (28→32, 34→40) with **zero identity or status change** — line numbers are correctly excluded from identity, and PIT's `block` index is stable under pure source movement.
+
+### C4 — status determinism
+
+- 3/3 identical runs: status map (`Map<MutationIdentity, status>`) identical — the same 4 IDs reported KILLED every run. No KILLED↔SURVIVED/NO_COVERAGE flapping. No TIMED_OUT observed; PIT `timeoutConstant=4000`/`timeoutFactor=1.25` defaults in effect.
+
+### C5 — survivor adjudication (every survivor)
+
+Initial population (pre-fix): 4 mutants — 1 KILLED, **3 NO_COVERAGE survivors**, all on `ModelProvider` default interface method bodies:
+
+| Mutant | Method | Why it survived | Adjudication |
+|---|---|---|---|
+| NegateConditionalsMutator (`?:` → "unknown" path) | `ModelProvider.providerId()` | Every test provider **overrides** `providerId()`, so the default body never executed | **Missing test** — default contract unpinned |
+| EmptyObjectReturnValsMutator (return "") | `ModelProvider.providerId()` | Same | **Missing test** |
+| BooleanTrueReturnValsMutator (return true) | `ModelProvider.supportsCapability()` | No test calls the default `= false` implementation | **Missing test** — a default-return-true would silently grant VISION/TOOL_CALLING etc. |
+| EmptyObjectReturnValsMutator (return emptyList) | `ProviderRegistry.resolveCandidates` | KILLED by `ProviderRegistryTest.resolve candidates returns primary route plus configured fallbacks` | Killed |
+
+None were equivalent mutants, tool limitations, or ambiguous production behavior. **Fix (value of the exercise):** added `ModelProviderDefaultContractTest` (2 tests) pinning the default contract — `providerId()` returns the class simple name; `supportsCapability()` is false for every capability. Re-run: **4/4 KILLED (100%)**, population still 4, `Ran 4 tests (1 test per mutation)`. Classifications file remains empty by design — no survivor needed an exemption.
+
+### C6 — kill-the-mutation-system discriminators
+
+Deferred to the 10.3c3 authority slice (zero-population-fails, unexpected-target-fails, duplicate/identity discriminators, malformed-XML-fails-closed, path rejection, identity movement/semantics-change checks). The parser's existing absolute-path rejection and fail-on-missing/malformed-report behavior were confirmed present by inspection; the pilot exercised `failWhenNoMutations` (would fail on zero). Permanent discriminator tests are out of scope for this measurement slice per the directive.
+
+### C7 — cost (measured, replacing the §4 estimate)
+
+- **Cold execution (clean output dir, `--no-daemon`, no build cache):** ~15 s wall per campaign (2-worker). Includes PIT's coverage pre-scan of 79 test classes + mutation execution of 4 mutants + XML/HTML report generation. Phase split from verbose log: coverage + dependency analysis < 1 s; mutation build < 1 s; test execution < 1 s (4 mutants, 1 test each).
+- **Warm/repeat:** ~13 s wall per campaign.
+- **Mutation generation:** trivial at this population; the dominant cost is JVM/daemon startup + test-class pre-scan, not mutation itself.
+- **Report/aggregation overhead:** negligible (< 1 s) at this scale.
+
+The §4 planning estimate (10–40 min/family serialized) does **not** hold at routing-core scale — the pilot family is PR-viable at ~15 s cold. Per-family cost for the larger families (policy/approval/evidence with engines) must still be measured in 10.3c2; no CI lane decision is made here.
+
+### C8 — findings and decision
+
+1. **The dormant production mutation path is broken at first execution** — `mutationInitScript` configures the pitest extension from a `beforeProject` hook, but gradle-pitest-plugin 1.19.0 registers its extension inside `plugins.withType(JavaPlugin).configureEach(...)`, which fires only after the project's `java` plugin is applied. Result: "Extension with name 'pitest' does not exist" at configuration time. Fix in the follow-up: configure inside a `withType(JavaPlugin)` hook (or `afterEvaluate`).
+2. **`targetTests` must be set explicitly.** When unset, the solidsoft plugin mirrors `targetClasses` into the test filter, so PIT scans for test classes *named like the production classes* → 0 tests found, every mutant NO_COVERAGE. Fix: pin `targetTests` to the module's test package (or the full suite). Without this, even a correctly-applied plugin produces a meaningless all-NO_COVERAGE report.
+3. **The pilot's Groovy closure-delegate quirk:** configuring the extension via `extensions.configure('pitest') { ... }` nested inside `withType(JavaPlugin) { }` leaks the JavaPlugin delegate; configure via `extensions.getByName('pitest')` + property assignment instead.
+4. **Identity scheme is empirically durable** for the routing-core pilot: module+className+method+mutator+description+block → SHA-256 is stable across identical runs and under harmless source movement. PIT's `description` and `block` fields were stable in every probe.
+
+**Decision:** the pilot answers its question affirmatively — bounded PIT execution is deterministic, identities are durable, statuses are repeatable, and the routing-core population is currently fully killed (4/4) with no sanctioned survivors. Proceed to **10.3c2**: complete routing with `ModelRegistryEnforcer`, then expand family-by-family with the same evidence unit (configured targets → nonzero population → survivor adjudication → missing tests added → exact-ID classifications for genuine residuals). Before any enforcement wiring in 10.3c3, fix the two production-path root causes from C8.1/C8.2 and add the C6 discriminators.

--- a/tramai-core/src/test/kotlin/dev/tramai/core/provider/ModelProviderDefaultContractTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/provider/ModelProviderDefaultContractTest.kt
@@ -31,9 +31,8 @@ class ModelProviderDefaultContractTest {
     @Test
     fun `default supportsCapability is false for every capability`() {
         val provider = DefaultProvider()
-        assertThat(provider.supportsCapability(ProviderCapability.VISION)).isFalse()
-        assertThat(provider.supportsCapability(ProviderCapability.TOOL_CALLING)).isFalse()
-        assertThat(provider.supportsCapability(ProviderCapability.STRUCTURED_OUTPUT)).isFalse()
-        assertThat(provider.supportsCapability(ProviderCapability.STREAMING)).isFalse()
+        ProviderCapability.entries.forEach { capability ->
+            assertThat(provider.supportsCapability(capability)).isFalse()
+        }
     }
 }

--- a/tramai-core/src/test/kotlin/dev/tramai/core/provider/ModelProviderDefaultContractTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/provider/ModelProviderDefaultContractTest.kt
@@ -1,0 +1,39 @@
+package dev.tramai.core.provider
+
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import org.assertj.core.api.Assertions.assertThat
+import kotlin.test.Test
+
+/**
+ * Exercises the ModelProvider DEFAULT interface method bodies.
+ *
+ * 10.3c1 routing-core mutation pilot: PIT found three NO_COVERAGE survivors on
+ * these defaults (providerId() null-coalesce/empty-return, supportsCapability()
+ * false-return). Every other test provider overrides both methods, so the
+ * default implementations had zero execution coverage. These tests pin the
+ * default contract so the mutants are killed.
+ */
+class ModelProviderDefaultContractTest {
+    private class DefaultProvider : ModelProvider {
+        // Deliberately does NOT override providerId() or supportsCapability().
+        override suspend fun complete(request: ModelRequest): ModelResponse {
+            error("unused")
+        }
+    }
+
+    @Test
+    fun `default providerId returns the class simple name`() {
+        val provider = DefaultProvider()
+        assertThat(provider.providerId()).isEqualTo("DefaultProvider")
+    }
+
+    @Test
+    fun `default supportsCapability is false for every capability`() {
+        val provider = DefaultProvider()
+        assertThat(provider.supportsCapability(ProviderCapability.VISION)).isFalse()
+        assertThat(provider.supportsCapability(ProviderCapability.TOOL_CALLING)).isFalse()
+        assertThat(provider.supportsCapability(ProviderCapability.STRUCTURED_OUTPUT)).isFalse()
+        assertThat(provider.supportsCapability(ProviderCapability.STREAMING)).isFalse()
+    }
+}


### PR DESCRIPTION
## 10.3c1 — routing-core mutation pilot (measurement-only)

Closes the first slice of Epic 10.3c: prove PIT can execute a bounded campaign deterministically on the routing-core pilot targets, identify each mutant durably, adjudicate every survivor, and repeat the measurement. **No enforcement wiring, no baseline/classification changes, no percentage floor.**

### What the pilot proved

| Question | Result |
|---|---|
| PIT executes? | ✅ 79 test classes → 81 tests → 4 mutations, BUILD SUCCESSFUL |
| Non-vacuity? | ✅ 2/2 targets resolved, 4 mutants > 0, all records in-pilot |
| Identity stability? | ✅ 3/3 identical runs: same `Set<MutationIdentity>` (SHA-256 over module+class+method+mutator+description+block) |
| Line-movement safety? | ✅ comments added above methods (lines 28→32, 34→40): zero identity/status change |
| Status determinism? | ✅ 3/3 runs: same 4 IDs, same statuses; no flapping |
| Survivors adjudicated? | ✅ 3/3 NO_COVERAGE survivors were **missing tests** on `ModelProvider` default methods → tests written → **4/4 KILLED** |
| Cost? | ✅ ~13–15s cold per campaign (coverage pre-scan < 1s, mutation < 1s) |

### Key findings

1. **The dormant production mutation path is broken at first execution**: `mutationInitScript` configures the pitest extension from a `beforeProject` hook, but gradle-pitest-plugin 1.19.0 registers its extension inside `plugins.withType(JavaPlugin).configureEach(...)` — "Extension with name 'pitest' does not exist". Also: when `targetTests` is unset the plugin mirrors `targetClasses` into the test filter → 0 tests found → meaningless all-NO_COVERAGE report. Both must be fixed before any enforcement wiring (10.3c3).
2. **Every survivor was a real missing test** — the exercise's value: `ModelProviderDefaultContractTest` pins the default contract (`providerId()` → class simple name; `supportsCapability()` → false for all capabilities). A default-return-true would silently grant VISION/TOOL_CALLING/STRUCTURED_OUTPUT/STREAMING.
3. Identity scheme is empirically durable; routing-core population is fully killed with **zero sanctioned survivors** — no classification entries needed.

### Changes

- `tramai-core/src/test/kotlin/dev/tramai/core/provider/ModelProviderDefaultContractTest.kt` — new: exercises ModelProvider default method bodies (the only change to production-adjacent code; no `src/main` touched)
- `docs/EPIC-10.3-coverage-mutation.md` — §7 experiment report (HEAD, toolchain, population, status counts, C1–C8 evidence)

### Explicitly NOT done (per directive)

No `check`/PR wiring · no baseline update · no `mutation-classifications.yml` changes · no ModelRegistryEnforcer · no percentage floor · no production `src/main` change (only a temporary comment probe, reverted).

Local gates: `:tramai-core:test` ✅, `spotlessCheck` ✅, `verifyStaticAnalysis` (detekt 4794→4794) ✅, pilot re-run on final commit 4/4 KILLED ✅.
