### PR TITLE
fix(quality): narrow verifyCompilerWarnings impact to changed modules + dependents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
             expected: 71
           - name: compiler-deps
             test-filter: "--tests 'dev.tramai.build.quality.CompilerWarnings*Test' --tests 'dev.tramai.build.quality.DependencyHygiene*Test'"
-            expected: 64
+            expected: 69
           - name: static-analysis
             test-filter: "--tests 'dev.tramai.build.quality.StaticAnalysis*Test'"
             expected: 25

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
             expected: 71
           - name: compiler-deps
             test-filter: "--tests 'dev.tramai.build.quality.CompilerWarnings*Test' --tests 'dev.tramai.build.quality.DependencyHygiene*Test'"
-            expected: 69
+            expected: 72
           - name: static-analysis
             test-filter: "--tests 'dev.tramai.build.quality.StaticAnalysis*Test'"
             expected: 25

--- a/.github/workflows/maintainability-baseline.yml
+++ b/.github/workflows/maintainability-baseline.yml
@@ -109,7 +109,7 @@ jobs:
               --tests 'dev.tramai.build.quality.StaticSafety*Test' --tests 'dev.tramai.build.quality.CancellationWiringTest'
               --tests 'dev.tramai.build.quality.CompilerWarnings*Test' --tests 'dev.tramai.build.quality.DependencyHygiene*Test'
               --tests 'dev.tramai.build.quality.StaticAnalysis*Test'
-            expected: 173
+            expected: 176
           - name: release-sovereign
             test-filter: >-
               --tests 'dev.tramai.build.release.*'

--- a/.github/workflows/maintainability-baseline.yml
+++ b/.github/workflows/maintainability-baseline.yml
@@ -109,7 +109,7 @@ jobs:
               --tests 'dev.tramai.build.quality.StaticSafety*Test' --tests 'dev.tramai.build.quality.CancellationWiringTest'
               --tests 'dev.tramai.build.quality.CompilerWarnings*Test' --tests 'dev.tramai.build.quality.DependencyHygiene*Test'
               --tests 'dev.tramai.build.quality.StaticAnalysis*Test'
-            expected: 168
+            expected: 173
           - name: release-sovereign
             test-filter: >-
               --tests 'dev.tramai.build.release.*'

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsImpact.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsImpact.kt
@@ -1,0 +1,179 @@
+package dev.tramai.build.quality
+
+/**
+ * P3-A: fail-closed impact selection for verifyCompilerWarnings.
+ *
+ * Replaces the round-4 binary rule ("any build-logic/global change => verify
+ * everything") with a classifier over the git diff plus the real module
+ * dependency graph. The contract is unchanged: verify every module whose
+ * compile-warning inventory CAN have changed, never fewer; on any uncertain
+ * classification fall back to FULL.
+ *
+ * What changes a module's warning inventory:
+ *  - its own Kotlin/Java sources or its build script (dependencies/args),
+ *  - the compiled classes of any module it depends on (a newly @Deprecated
+ *    API in :tramai-core surfaces as a warning in every consumer's compile),
+ *  - global compiler configuration (Kotlin/Gradle version, compiler args,
+ *    jvmTarget, version catalog, BOM/module-catalog constraints),
+ *  - the gate's own semantics (CompilerWarnings code).
+ *
+ * Pure scanners/verifiers in build-logic (mutation measurement, coverage,
+ * static analysis, release, docs...) do NOT configure module compilation;
+ * a change confined to them leaves every module inventory identical, so the
+ * gate passes with zero standalone compiles.
+ */
+internal sealed interface CompilerWarningsImpact {
+    /** No module's warning inventory can have changed — nothing to verify. */
+    data object None : CompilerWarningsImpact
+
+    /** Exhaustive verification of every compile unit. */
+    data object Full : CompilerWarningsImpact
+
+    /** The changed modules plus their transitive dependents. */
+    data class Modules(
+        val modulePaths: Set<String>,
+    ) : CompilerWarningsImpact
+}
+
+/**
+ * Classifies the name-only diff between base and HEAD.
+ *
+ * @param diff git diff --name-only output
+ * @param dependents reverse dependency edges: module path -> modules whose
+ *   compile classpath includes it (production + test scopes). If A changes,
+ *   every B in dependents[A] (and their dependents) must be recompiled because
+ *   B compiles against A's new classes.
+ */
+internal fun resolveCompilerWarningsImpact(
+    diff: String,
+    dependents: Map<String, Set<String>>,
+): CompilerWarningsImpact {
+    var full = false
+    val roots = mutableSetOf<String>()
+    for (line in diff.lineSequence()) {
+        val trimmed = line.trim()
+        if (trimmed.isEmpty()) continue
+        when {
+            isGlobalCompileConfig(trimmed) -> {
+                full = true
+            }
+
+            isCompilerAffectingBuildLogic(trimmed) -> {
+                full = true
+            }
+
+            // build-logic/ files that are NOT compiler-affecting (scanners,
+            // verifiers, gates other than CompilerWarnings) are inert — they
+            // never configure module compilation. Must be excluded before the
+            // module matcher, which would otherwise map them to ":build-logic".
+            trimmed.startsWith("build-logic/") -> {
+                Unit
+            }
+
+            isModuleChange(trimmed) -> {
+                moduleOf(trimmed)?.let { roots += it }
+            }
+
+            else -> {
+                // docs, scripts, workflow files, non-compile config, plain
+                // verifier code: no module inventory can change.
+            }
+        }
+    }
+    return when {
+        full -> CompilerWarningsImpact.Full
+        roots.isEmpty() -> CompilerWarningsImpact.None
+        else -> CompilerWarningsImpact.Modules(affectedModules(roots, dependents))
+    }
+}
+
+/** Roots plus their transitive dependents (reverse closure over the graph). */
+internal fun affectedModules(
+    roots: Set<String>,
+    dependents: Map<String, Set<String>>,
+): Set<String> {
+    val affected = roots.toMutableSet()
+    val queue = ArrayDeque(roots)
+    val seen = roots.toMutableSet()
+    while (queue.isNotEmpty()) {
+        val module = queue.removeFirst()
+        for (dependent in dependents[module].orEmpty()) {
+            if (seen.add(dependent)) {
+                affected += dependent
+                queue.addLast(dependent)
+            }
+        }
+    }
+    return affected
+}
+
+/**
+ * Global build/compiler configuration: a change here can alter every module's
+ * compile classpath, args, jvm target, or the compiler itself.
+ */
+internal fun isGlobalCompileConfig(line: String): Boolean =
+    line == "gradle/libs.versions.toml" ||
+        line == "gradle.properties" ||
+        line == "settings.gradle.kts" ||
+        line == "settings.gradle" ||
+        line == "build.gradle.kts" ||
+        line == "build.gradle" ||
+        line == "gradle/wrapper/gradle-wrapper.properties" ||
+        line.startsWith("gradle/wrapper/") ||
+        // BOM constraints (TramaiJavaPlatformPlugin api constraints) are derived
+        // from module-catalog.yml through quality.ModuleManifest — a catalog
+        // change alters the BOM surface every module resolves against.
+        line == "config/quality/module-catalog.yml"
+
+/**
+ * Build-logic code that CAN change module compilation.
+ *
+ * Verified coupling surface (import scan over conventions/ + publishing/):
+ *  - conventions package — the only plugins applied per-module (compile args,
+ *    jvm target, toolchains, dependencies),
+ *  - publishing package — applied to every subproject from the root subprojects
+ *    block; publication metadata derives from the module catalog,
+ *  - quality/ModuleManifest.kt + ModuleCatalog.kt — imported by conventions
+ *    (TramaiJavaPlatformPlugin) and publishing for BOM/publication module
+ *    sets; a change can alter the constraint surface modules resolve against,
+ *  - quality/CompilerWarnings* — the gate itself (parser/compiler pin),
+ *  - build-logic's own build files (plugin declarations / classpath).
+ *
+ * Every other build-logic source (scanners, verifiers, maintainability,
+ * static analysis, dependency hygiene, release, docs, supplychain,
+ * sovereign) is applied at the ROOT only and never configures module
+ * compilation — a change there leaves every module inventory identical.
+ *
+ * Fail-closed note: if a future convention/publishing plugin starts importing
+ * a helper from another package, this list MUST grow to keep the gate sound —
+ * the wiring contract test asserts exactly this surface.
+ */
+internal fun isCompilerAffectingBuildLogic(line: String): Boolean {
+    if (!line.startsWith("build-logic/")) return false
+    return line.endsWith("build.gradle.kts") ||
+        line.endsWith("settings.gradle.kts") ||
+        line.endsWith("gradle.properties") ||
+        line.contains("/conventions/") ||
+        line.contains("/publishing/") ||
+        line.contains("/quality/ModuleManifest.kt") ||
+        line.contains("/quality/ModuleCatalog.kt") ||
+        line.contains("/quality/CompilerWarnings")
+}
+
+/** A .kt/.java/module build-script change inside a module directory. */
+internal fun isModuleChange(line: String): Boolean =
+    line.endsWith(".kt") ||
+        line.endsWith(".java") ||
+        line.endsWith("build.gradle.kts") ||
+        line.endsWith("build.gradle")
+
+internal fun moduleOf(line: String): String? {
+    val parts = line.split("/")
+    return when {
+        parts.size >= MIN_DELTA_SEGMENTS && parts[0] == "examples" -> ":examples:${parts[1]}"
+        parts.size >= 2 -> ":" + parts[0]
+        else -> null
+    }
+}
+
+private const val MIN_DELTA_SEGMENTS = 3

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsImpact.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsImpact.kt
@@ -108,6 +108,29 @@ internal fun affectedModules(
 }
 
 /**
+ * P0 non-vacuity guard: maps an impact (+ baseline edit) to the module set the
+ * gate must verify.
+ *
+ * A Modules impact whose paths do not correspond to collected compile units —
+ * or which selects nothing at all — falls back to FULL. A classification or
+ * graph bug must never yield a zero-unit verification that passes vacuously.
+ */
+internal fun resolveVerifyModules(
+    impact: CompilerWarningsImpact,
+    baselineChanged: Boolean,
+    allModulePaths: Set<String>,
+): Set<String> {
+    if (baselineChanged || impact is CompilerWarningsImpact.Full) return allModulePaths
+    val requested = (impact as? CompilerWarningsImpact.Modules)?.modulePaths.orEmpty()
+    val unknown = requested - allModulePaths
+    return if (requested.isEmpty() || unknown.isNotEmpty()) {
+        allModulePaths
+    } else {
+        requested
+    }
+}
+
+/**
  * Global build/compiler configuration: a change here can alter every module's
  * compile classpath, args, jvm target, or the compiler itself.
  */
@@ -136,8 +159,11 @@ internal fun isGlobalCompileConfig(line: String): Boolean =
  *  - quality/ModuleManifest.kt + ModuleCatalog.kt — imported by conventions
  *    (TramaiJavaPlatformPlugin) and publishing for BOM/publication module
  *    sets; a change can alter the constraint surface modules resolve against,
- *  - quality/CompilerWarnings* — the gate itself (parser/compiler pin),
- *  - build-logic's own build files (plugin declarations / classpath).
+ *  - quality/CompilerWarnings* PRODUCTION sources only — the gate itself
+ *    (parser/compiler pin); src/test files and fixture build scripts do NOT
+ *    configure module compilation,
+ *  - build-logic's own build files (plugin declarations / classpath), matched
+ *    by exact path so test fixtures named *.gradle.kts stay inert.
  *
  * Every other build-logic source (scanners, verifiers, maintainability,
  * static analysis, dependency hygiene, release, docs, supplychain,
@@ -150,14 +176,16 @@ internal fun isGlobalCompileConfig(line: String): Boolean =
  */
 internal fun isCompilerAffectingBuildLogic(line: String): Boolean {
     if (!line.startsWith("build-logic/")) return false
-    return line.endsWith("build.gradle.kts") ||
-        line.endsWith("settings.gradle.kts") ||
-        line.endsWith("gradle.properties") ||
-        line.contains("/conventions/") ||
-        line.contains("/publishing/") ||
-        line.contains("/quality/ModuleManifest.kt") ||
-        line.contains("/quality/ModuleCatalog.kt") ||
-        line.contains("/quality/CompilerWarnings")
+    return line == "build-logic/build.gradle.kts" ||
+        line == "build-logic/build.gradle" ||
+        line == "build-logic/settings.gradle.kts" ||
+        line == "build-logic/settings.gradle" ||
+        line == "build-logic/gradle.properties" ||
+        line.startsWith("build-logic/src/main/kotlin/dev/tramai/build/conventions/") ||
+        line.startsWith("build-logic/src/main/kotlin/dev/tramai/build/publishing/") ||
+        line == "build-logic/src/main/kotlin/dev/tramai/build/quality/ModuleManifest.kt" ||
+        line == "build-logic/src/main/kotlin/dev/tramai/build/quality/ModuleCatalog.kt" ||
+        line.startsWith("build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarnings")
 }
 
 /** A .kt/.java/module build-script change inside a module directory. */

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsPlugin.kt
@@ -144,25 +144,33 @@ class CompilerWarningsPlugin : Plugin<Project> {
         val productionConfigs = setOf("api", "implementation", "compileOnly", "runtimeOnly")
         val testConfigs = setOf("testApi", "testImplementation", "testCompileOnly", "testRuntimeOnly")
         val dependents = mutableMapOf<String, MutableSet<String>>()
-        collectProjects(project).forEach { consumer ->
+        for (consumer in collectProjects(project)) {
             val consumerPath = consumer.path
-            (productionConfigs + testConfigs).forEach { configName ->
-                val config = consumer.configurations.findByName(configName) ?: return@forEach
-                try {
-                    config.dependencies
-                        .withType(org.gradle.api.artifacts.ProjectDependency::class.java)
-                        .forEach { dep ->
-                            val depPath = (dep as org.gradle.api.artifacts.ProjectDependency).path
-                            dependents.getOrPut(depPath) { mutableSetOf() }.add(consumerPath)
-                        }
-                } catch (_: Exception) {
-                    // Configuration not resolvable at configuration time — skip edge.
-                }
+            for (configName in productionConfigs + testConfigs) {
+                val config = consumer.configurations.findByName(configName) ?: continue
+                addProjectDependents(config, consumerPath, dependents)
             }
         }
         return dependents
             .map { (modulePath, deps) -> ModuleDependentsSpec(modulePath, deps.sorted()) }
             .sortedBy { it.modulePath }
+    }
+
+    private fun addProjectDependents(
+        config: org.gradle.api.artifacts.Configuration,
+        consumerPath: String,
+        dependents: MutableMap<String, MutableSet<String>>,
+    ) {
+        try {
+            config.dependencies
+                .withType(org.gradle.api.artifacts.ProjectDependency::class.java)
+                .forEach { dep ->
+                    val depPath = (dep as org.gradle.api.artifacts.ProjectDependency).path
+                    dependents.getOrPut(depPath) { mutableSetOf() }.add(consumerPath)
+                }
+        } catch (_: Exception) {
+            // Configuration not resolvable at configuration time — skip edge.
+        }
     }
 
     private data class ProjectWiring(

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsPlugin.kt
@@ -141,8 +141,12 @@ class CompilerWarningsPlugin : Plugin<Project> {
      * output (config-cache + up-to-date safe).
      */
     private fun computeDependentsByModule(project: Project): List<ModuleDependentsSpec> {
-        val productionConfigs = setOf("api", "implementation", "compileOnly", "runtimeOnly")
-        val testConfigs = setOf("testApi", "testImplementation", "testCompileOnly", "testRuntimeOnly")
+        // Compile-relevant scopes only. runtimeOnly/testRuntimeOnly are not on
+        // the consumer's compile classpath, so they cannot surface a warning in
+        // a dependent's compile and only enlarge the closure (P3-A is about
+        // avoiding unnecessary compilation without losing coverage).
+        val productionConfigs = setOf("api", "implementation", "compileOnly")
+        val testConfigs = setOf("testApi", "testImplementation", "testCompileOnly")
         val dependents = mutableMapOf<String, MutableSet<String>>()
         for (consumer in collectProjects(project)) {
             val consumerPath = consumer.path
@@ -161,16 +165,16 @@ class CompilerWarningsPlugin : Plugin<Project> {
         consumerPath: String,
         dependents: MutableMap<String, MutableSet<String>>,
     ) {
-        try {
-            config.dependencies
-                .withType(org.gradle.api.artifacts.ProjectDependency::class.java)
-                .forEach { dep ->
-                    val depPath = (dep as org.gradle.api.artifacts.ProjectDependency).path
-                    dependents.getOrPut(depPath) { mutableSetOf() }.add(consumerPath)
-                }
-        } catch (_: Exception) {
-            // Configuration not resolvable at configuration time — skip edge.
-        }
+        // FAIL-CLOSED (P3-A): reading declared project dependencies never
+        // resolves the configuration; if it still throws, propagating the
+        // failure beats silently dropping a reverse edge — a dropped edge could
+        // leave a dependent unverified when a changed module recompiles.
+        config.dependencies
+            .withType(org.gradle.api.artifacts.ProjectDependency::class.java)
+            .forEach { dep ->
+                val depPath = (dep as org.gradle.api.artifacts.ProjectDependency).path
+                dependents.getOrPut(depPath) { mutableSetOf() }.add(consumerPath)
+            }
     }
 
     private data class ProjectWiring(

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsPlugin.kt
@@ -115,10 +115,15 @@ class CompilerWarningsPlugin : Plugin<Project> {
                 if (dir.isDirectory) sourceTreeList.add(p.fileTree(dir))
             }
         }
+        // P3-A: reverse dependency edges from the real Gradle model (production
+        // + test scopes, mirroring ModuleGraphAnalyzer) so the impact closure
+        // covers every module compiling against a changed module.
+        val dependents = computeDependentsByModule(project)
         project.tasks.named("verifyCompilerWarnings") {
             dependsOn(compileTasks)
             (this as VerifyCompilerWarningsTask).compileClasspath.from(unionClasspath)
             (this as VerifyCompilerWarningsTask).sourceTrees.from(sourceTreeList)
+            (this as VerifyCompilerWarningsTask).moduleDependents.set(dependents)
         }
         project.tasks.named("bootstrapCompilerWarningsBaseline") {
             dependsOn(compileTasks)
@@ -128,6 +133,36 @@ class CompilerWarningsPlugin : Plugin<Project> {
         project.logger.lifecycle(
             "compiler-warnings: collected ${collected.size} compile units, ${compileTasks.size} compile tasks",
         )
+    }
+
+    /**
+     * Reverse edges: for every module that declares a project dependency, record
+     * the dependency as key and the consumer as dependent. Deterministic sorted
+     * output (config-cache + up-to-date safe).
+     */
+    private fun computeDependentsByModule(project: Project): List<ModuleDependentsSpec> {
+        val productionConfigs = setOf("api", "implementation", "compileOnly", "runtimeOnly")
+        val testConfigs = setOf("testApi", "testImplementation", "testCompileOnly", "testRuntimeOnly")
+        val dependents = mutableMapOf<String, MutableSet<String>>()
+        collectProjects(project).forEach { consumer ->
+            val consumerPath = consumer.path
+            (productionConfigs + testConfigs).forEach { configName ->
+                val config = consumer.configurations.findByName(configName) ?: return@forEach
+                try {
+                    config.dependencies
+                        .withType(org.gradle.api.artifacts.ProjectDependency::class.java)
+                        .forEach { dep ->
+                            val depPath = (dep as org.gradle.api.artifacts.ProjectDependency).path
+                            dependents.getOrPut(depPath) { mutableSetOf() }.add(consumerPath)
+                        }
+                } catch (_: Exception) {
+                    // Configuration not resolvable at configuration time — skip edge.
+                }
+            }
+        }
+        return dependents
+            .map { (modulePath, deps) -> ModuleDependentsSpec(modulePath, deps.sorted()) }
+            .sortedBy { it.modulePath }
     }
 
     private data class ProjectWiring(

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsTasks.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsTasks.kt
@@ -428,10 +428,9 @@ abstract class VerifyCompilerWarningsTask : DefaultTask() {
         )
     }
 
-    // spotless re-joins single-expression functions; the resulting line exceeds
-    // 120 cols, so detekt is told to look the other way.
-    @Suppress("MaxLineLength")
-    private fun baselineChanged(diff: String): Boolean = diff.lineSequence().any { it.contains("config/warnings/baseline.json") }
+    // Substring check is sufficient: git --name-only output has one path per
+    // line and the baseline path is a single token (never spans a line break).
+    private fun baselineChanged(diff: String): Boolean = diff.contains("config/warnings/baseline.json")
 
     /** P3-A: module path -> modules whose compile classpath includes it. */
     private fun dependentsByModule(): Map<String, Set<String>> =

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsTasks.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsTasks.kt
@@ -35,6 +35,16 @@ data class CompileUnitSpec(
     @get:Input val jvmTarget: String,
 )
 
+/**
+ * Reverse dependency edge for P3-A impact closure: modulePath -> the modules
+ * whose compile classpath includes it (production + test scopes). Captured at
+ * configuration time from the real Gradle model; serializable for config cache.
+ */
+data class ModuleDependentsSpec(
+    @get:Input val modulePath: String,
+    @get:Input val dependents: List<String>,
+)
+
 /** Runs the standalone compiler and parses warnings (shared by verify + bootstrap). */
 internal object KotlincRunner {
     private const val TIMEOUT_MINUTES = 10L
@@ -248,6 +258,10 @@ abstract class VerifyCompilerWarningsTask : DefaultTask() {
     @get:Nested
     abstract val compileUnits: ListProperty<CompileUnitSpec>
 
+    /** P3-A: reverse dependency edges (module -> modules compiling against it). */
+    @get:Nested
+    abstract val moduleDependents: ListProperty<ModuleDependentsSpec>
+
     @get:InputFiles
     @get:Optional
     @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -269,9 +283,11 @@ abstract class VerifyCompilerWarningsTask : DefaultTask() {
         val baseline = loadBaseline()
 
         val diff = gitDiff(root, baseRef.get())
-        val deltaModules = deltaModules(diff)
-        val globalInvalidation = globalConfigInvalidated(diff)
-        if (deltaModules.isEmpty() && !baselineChanged(diff) && !globalInvalidation) {
+        // P3-A impact selection: classify the diff and close over dependents
+        // instead of the round-4 binary global-vs-delta rule.
+        val impact = resolveCompilerWarningsImpact(diff, dependentsByModule())
+        val baselineChanged = baselineChanged(diff)
+        if (impact is CompilerWarningsImpact.None && !baselineChanged) {
             File(reportDir, "summary.txt").writeText(
                 "No modules, baseline, or global build configuration changed in the delta — nothing to verify.\n",
             )
@@ -283,25 +299,34 @@ abstract class VerifyCompilerWarningsTask : DefaultTask() {
         // same applies to global compiler/build configuration (versions.toml,
         // settings, gradle.properties, build-logic conventions): a Java-only or
         // build-script-only change can introduce Kotlin warnings indirectly.
+        val allModulePaths = compileUnits.get().map { it.modulePath }.toSet()
         val verifyModules =
-            if (baselineChanged(diff) || globalInvalidation) {
-                logger.lifecycle(
-                    if (baselineChanged(diff)) {
-                        "compiler-warnings: baseline changed in delta — full verification"
-                    } else {
-                        "compiler-warnings: global build/version configuration changed in delta — full verification"
-                    },
-                )
-                compileUnits.get().map { it.modulePath }.toSet()
-            } else {
-                deltaModules
+            when {
+                baselineChanged -> {
+                    logger.lifecycle("compiler-warnings: baseline changed in delta — full verification")
+                    allModulePaths
+                }
+
+                impact is CompilerWarningsImpact.Full -> {
+                    logger.lifecycle("compiler-warnings: global build/version configuration changed in delta — full verification")
+                    allModulePaths
+                }
+
+                impact is CompilerWarningsImpact.Modules -> {
+                    logger.lifecycle("compiler-warnings: impacted modules ${impact.modulePaths.sorted().joinToString()}")
+                    impact.modulePaths
+                }
+
+                else -> {
+                    allModulePaths
+                } // None with baselineChanged handled above
             }
         logger.lifecycle("compiler-warnings: verifying modules ${verifyModules.sorted().joinToString()}")
 
         val current = collectCurrent(root, reportDir, verifyModules)
 
         val violations = CompilerWarningsBaselineVerifier.compare(current, baseline)
-        writeReports(reportDir, current, baseline, deltaModules, violations)
+        writeReports(reportDir, current, baseline, compilerDeltaModules(diff), violations)
         if (violations.isNotEmpty()) {
             val more =
                 if (violations.size > MAX_VIOLATIONS_REPORTED) {
@@ -420,12 +445,13 @@ abstract class VerifyCompilerWarningsTask : DefaultTask() {
         )
     }
 
-    // spotless re-joins single-expression functions; the resulting line exceeds
-    // 120 cols, so detekt is told to look the other way.
-    @Suppress("MaxLineLength")
     private fun baselineChanged(diff: String): Boolean = diff.lineSequence().any { it.contains("config/warnings/baseline.json") }
 
-    private fun deltaModules(diff: String): Set<String> = compilerDeltaModules(diff)
+    /** P3-A: module path -> modules whose compile classpath includes it. */
+    private fun dependentsByModule(): Map<String, Set<String>> =
+        moduleDependents
+            .get()
+            .associate { it.modulePath to it.dependents.toSet() }
 
     private fun gitDiff(
         root: File,
@@ -551,6 +577,8 @@ abstract class BootstrapCompilerWarningsBaselineTask : DefaultTask() {
  * (10.1c round-4): a Java-only change can still introduce Kotlin warnings
  * (e.g. a deprecated Java API used from Kotlin), so .java is in scope too.
  * Top-level so the selection logic is unit-testable without a task instance.
+ * Retained for reporting/tests; impact selection now uses
+ * [resolveCompilerWarningsImpact] (P3-A) which closes over dependents.
  */
 internal fun compilerDeltaModules(diff: String): Set<String> =
     diff
@@ -561,32 +589,5 @@ internal fun compilerDeltaModules(diff: String): Set<String> =
         }.mapNotNull { line -> moduleOf(line) }
         .toSet()
 
-private fun moduleOf(line: String): String? {
-    val parts = line.split("/")
-    return when {
-        parts.size >= MIN_DELTA_SEGMENTS && parts[0] == "examples" -> ":examples:${parts[1]}"
-        parts.size >= 2 -> ":" + parts[0]
-        else -> null
-    }
-}
-
-private const val MIN_DELTA_SEGMENTS = 3
 private const val MIN_COMPILE_PARALLELISM = 2
 private const val MAX_COMPILE_PARALLELISM = 4
-
-/**
- * True when the delta touches global compiler/build configuration: a future
- * version-catalog or convention change can introduce Kotlin warnings indirectly
- * (upgraded library annotations, changed compiler options), so the whole
- * repository must be re-verified (10.1c round-4).
- */
-internal fun globalConfigInvalidated(diff: String): Boolean =
-    diff.lineSequence().any { line ->
-        line == "gradle/libs.versions.toml" ||
-            line == "gradle.properties" ||
-            line == "settings.gradle.kts" ||
-            line == "settings.gradle" ||
-            line == "build.gradle.kts" ||
-            line == "build.gradle" ||
-            line.startsWith("build-logic/")
-    }

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsTasks.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsTasks.kt
@@ -300,31 +300,11 @@ abstract class VerifyCompilerWarningsTask : DefaultTask() {
         // settings, gradle.properties, build-logic conventions): a Java-only or
         // build-script-only change can introduce Kotlin warnings indirectly.
         val allModulePaths = compileUnits.get().map { it.modulePath }.toSet()
-        val verifyModules =
-            when {
-                baselineChanged -> {
-                    logger.lifecycle("compiler-warnings: baseline changed in delta — full verification")
-                    allModulePaths
-                }
-
-                impact is CompilerWarningsImpact.Full -> {
-                    logger.lifecycle(
-                        "compiler-warnings: global build/version configuration changed in delta — full verification",
-                    )
-                    allModulePaths
-                }
-
-                impact is CompilerWarningsImpact.Modules -> {
-                    val impacted = impact.modulePaths.sorted().joinToString()
-                    logger.lifecycle("compiler-warnings: impacted modules $impacted")
-                    impact.modulePaths
-                }
-
-                else -> {
-                    allModulePaths
-                } // None with baselineChanged handled above
-            }
-        logger.lifecycle("compiler-warnings: verifying modules ${verifyModules.sorted().joinToString()}")
+        // P0 non-vacuity: resolveVerifyModules falls back to FULL when a Modules
+        // impact names paths with no compile unit or selects nothing — a graph
+        // bug must never verify zero units and pass vacuously.
+        val verifyModules = resolveVerifyModules(impact, baselineChanged, allModulePaths)
+        logger.lifecycle("compiler-warnings: verifying ${verifyModules.size} module paths")
 
         val current = collectCurrent(root, reportDir, verifyModules)
 

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsTasks.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsTasks.kt
@@ -308,12 +308,15 @@ abstract class VerifyCompilerWarningsTask : DefaultTask() {
                 }
 
                 impact is CompilerWarningsImpact.Full -> {
-                    logger.lifecycle("compiler-warnings: global build/version configuration changed in delta — full verification")
+                    logger.lifecycle(
+                        "compiler-warnings: global build/version configuration changed in delta — full verification",
+                    )
                     allModulePaths
                 }
 
                 impact is CompilerWarningsImpact.Modules -> {
-                    logger.lifecycle("compiler-warnings: impacted modules ${impact.modulePaths.sorted().joinToString()}")
+                    val impacted = impact.modulePaths.sorted().joinToString()
+                    logger.lifecycle("compiler-warnings: impacted modules $impacted")
                     impact.modulePaths
                 }
 
@@ -445,6 +448,9 @@ abstract class VerifyCompilerWarningsTask : DefaultTask() {
         )
     }
 
+    // spotless re-joins single-expression functions; the resulting line exceeds
+    // 120 cols, so detekt is told to look the other way.
+    @Suppress("MaxLineLength")
     private fun baselineChanged(diff: String): Boolean = diff.lineSequence().any { it.contains("config/warnings/baseline.json") }
 
     /** P3-A: module path -> modules whose compile classpath includes it. */

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/CompilerWarningsWiringTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/CompilerWarningsWiringTest.kt
@@ -174,4 +174,71 @@ class CompilerWarningsWiringTest : StaticAnalysisContractTestBase() {
             ),
         )
     }
+
+    // ── P3-A review round: production-only build-logic matching ─────────
+    @Test
+    fun `compiler-warnings test sources do not trigger full verification`() {
+        // The gate's own test file and fixture build scripts configure no module
+        // compilation — classifying them as FULL is exactly the unnecessary
+        // rebuild P3-A exists to eliminate.
+        assertEquals(
+            CompilerWarningsImpact.None,
+            resolveCompilerWarningsImpact(
+                "build-logic/src/test/kotlin/dev/tramai/build/quality/CompilerWarningsWiringTest.kt\n",
+                emptyMap(),
+            ),
+        )
+        assertEquals(
+            CompilerWarningsImpact.None,
+            resolveCompilerWarningsImpact(
+                "build-logic/src/test/resources/canonical-probe-fixture/build.gradle.kts\n",
+                emptyMap(),
+            ),
+        )
+    }
+
+    @Test
+    fun `compiler-warnings production sources still trigger full verification`() {
+        assertEquals(
+            CompilerWarningsImpact.Full,
+            resolveCompilerWarningsImpact(
+                "build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsTasks.kt\n",
+                emptyMap(),
+            ),
+        )
+        assertEquals(
+            CompilerWarningsImpact.Full,
+            resolveCompilerWarningsImpact(
+                "build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsPlugin.kt\n",
+                emptyMap(),
+            ),
+        )
+        assertEquals(
+            CompilerWarningsImpact.Full,
+            resolveCompilerWarningsImpact("build-logic/build.gradle.kts\n", emptyMap()),
+        )
+    }
+
+    // ── P3-A review round: non-vacuity guard ────────────────────────────
+    @Test
+    fun `modules impact verifies its compile units or falls back to full`() {
+        val known = setOf(":tramai-core", ":tramai-engine")
+        assertEquals(
+            setOf(":tramai-core"),
+            resolveVerifyModules(CompilerWarningsImpact.Modules(setOf(":tramai-core")), false, known),
+        )
+        // A path with no matching compile unit must never be silently dropped.
+        assertEquals(
+            known,
+            resolveVerifyModules(CompilerWarningsImpact.Modules(setOf(":phantom")), false, known),
+        )
+        // Zero selected units would pass vacuously — fall back to full.
+        assertEquals(
+            known,
+            resolveVerifyModules(CompilerWarningsImpact.Modules(emptySet()), false, known),
+        )
+        // Full impact and baseline edits are always exhaustive.
+        assertEquals(known, resolveVerifyModules(CompilerWarningsImpact.Full, false, known))
+        assertEquals(known, resolveVerifyModules(CompilerWarningsImpact.None, true, known))
+    }
 }

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/CompilerWarningsWiringTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/CompilerWarningsWiringTest.kt
@@ -3,7 +3,6 @@ package dev.tramai.build.quality
 import org.junit.jupiter.api.Test
 import java.io.File
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -43,7 +42,7 @@ class CompilerWarningsWiringTest : StaticAnalysisContractTestBase() {
         )
     }
 
-    // ── Delta invalidation (10.1c round-4, M12) ───────────────────────────
+    // ── Delta invalidation (10.1c round-4, M12; P3-A impact selection) ────
     @Test
     fun `java-only delta selects the module`() {
         val modules = compilerDeltaModules("tramai-core/src/main/java/dev/tramai/core/Foo.java\n")
@@ -58,12 +57,121 @@ class CompilerWarningsWiringTest : StaticAnalysisContractTestBase() {
 
     @Test
     fun `global version or convention delta invalidates the whole repository`() {
-        assertTrue(globalConfigInvalidated("gradle/libs.versions.toml\n"))
-        assertTrue(globalConfigInvalidated("gradle.properties\n"))
-        assertTrue(globalConfigInvalidated("settings.gradle.kts\n"))
-        assertTrue(globalConfigInvalidated("build.gradle.kts\n"))
-        assertTrue(globalConfigInvalidated("build-logic/src/main/kotlin/Conventions.kt\n"))
-        assertFalse(globalConfigInvalidated("tramai-core/src/main/kotlin/dev/tramai/core/X.kt\n"))
-        assertFalse(globalConfigInvalidated("tramai-core/build.gradle.kts\n"))
+        val noDeps = emptyMap<String, Set<String>>()
+        assertEquals(
+            CompilerWarningsImpact.Full,
+            resolveCompilerWarningsImpact("gradle/libs.versions.toml\n", noDeps),
+        )
+        assertEquals(
+            CompilerWarningsImpact.Full,
+            resolveCompilerWarningsImpact("gradle.properties\n", noDeps),
+        )
+        assertEquals(
+            CompilerWarningsImpact.Full,
+            resolveCompilerWarningsImpact("settings.gradle.kts\n", noDeps),
+        )
+        assertEquals(
+            CompilerWarningsImpact.Full,
+            resolveCompilerWarningsImpact("build.gradle.kts\n", noDeps),
+        )
+        assertEquals(
+            CompilerWarningsImpact.Full,
+            resolveCompilerWarningsImpact(
+                "build-logic/src/main/kotlin/dev/tramai/build/conventions/TramaiKotlinLibraryPlugin.kt\n",
+                noDeps,
+            ),
+        )
+        assertEquals(
+            CompilerWarningsImpact.Modules(setOf(":tramai-core")),
+            resolveCompilerWarningsImpact("tramai-core/src/main/kotlin/dev/tramai/core/X.kt\n", noDeps),
+        )
+        assertEquals(
+            CompilerWarningsImpact.Modules(setOf(":tramai-core")),
+            resolveCompilerWarningsImpact("tramai-core/build.gradle.kts\n", noDeps),
+        )
+    }
+
+    // ── P3-A: build-logic scanner/verifier changes are NOT global ─────────
+    @Test
+    fun `build-logic scanner change leaves no module impacted`() {
+        // The #362 case: mutation-measurement scanner code does not configure
+        // module compilation — no module inventory can change, gate passes.
+        assertEquals(
+            CompilerWarningsImpact.None,
+            resolveCompilerWarningsImpact(
+                "build-logic/src/main/kotlin/dev/tramai/build/quality/MutationPopulationAggregator.kt\n",
+                emptyMap(),
+            ),
+        )
+        assertEquals(
+            CompilerWarningsImpact.None,
+            resolveCompilerWarningsImpact(
+                "build-logic/src/main/kotlin/dev/tramai/build/release/ReleaseVerificationPlugin.kt\n",
+                emptyMap(),
+            ),
+        )
+    }
+
+    @Test
+    fun `convention-imported module manifest change is global`() {
+        // TramaiJavaPlatformPlugin imports quality.ModuleManifest for BOM
+        // constraints — a change can alter what every module resolves against.
+        assertEquals(
+            CompilerWarningsImpact.Full,
+            resolveCompilerWarningsImpact(
+                "build-logic/src/main/kotlin/dev/tramai/build/quality/ModuleManifest.kt\n",
+                emptyMap(),
+            ),
+        )
+        assertEquals(
+            CompilerWarningsImpact.Full,
+            resolveCompilerWarningsImpact(
+                "build-logic/src/main/kotlin/dev/tramai/build/quality/ModuleCatalog.kt\n",
+                emptyMap(),
+            ),
+        )
+    }
+
+    @Test
+    fun `module-catalog and wrapper changes are global`() {
+        assertEquals(
+            CompilerWarningsImpact.Full,
+            resolveCompilerWarningsImpact("config/quality/module-catalog.yml\n", emptyMap()),
+        )
+        assertEquals(
+            CompilerWarningsImpact.Full,
+            resolveCompilerWarningsImpact("gradle/wrapper/gradle-wrapper.properties\n", emptyMap()),
+        )
+    }
+
+    @Test
+    fun `module change closes over transitive dependents`() {
+        val dependents =
+            mapOf(
+                ":tramai-core" to setOf(":tramai-engine", ":tramai-structured"),
+                ":tramai-structured" to setOf(":tramai-server"),
+            )
+        val impact =
+            resolveCompilerWarningsImpact(
+                "tramai-core/src/main/kotlin/dev/tramai/core/X.kt\n",
+                dependents,
+            )
+        assertEquals(
+            CompilerWarningsImpact.Modules(
+                setOf(":tramai-core", ":tramai-engine", ":tramai-structured", ":tramai-server"),
+            ),
+            impact,
+        )
+    }
+
+    @Test
+    fun `docs and workflow changes are inert`() {
+        assertEquals(
+            CompilerWarningsImpact.None,
+            resolveCompilerWarningsImpact(
+                "docs/specs/ci-parallelization-p0-p1.md\n.github/workflows/ci.yml\n",
+                emptyMap(),
+            ),
+        )
     }
 }


### PR DESCRIPTION
P3-A from the pipeline plan: replace the round-4 binary rule (any global/build-logic change => recompile the whole repository) with a fail-closed impact resolver.

**What changed**
- `CompilerWarningsImpact` classifier: global triggers (versions.toml, gradle.properties, settings, root build, wrapper, module-catalog.yml, conventions/, publishing/, ModuleManifest/ModuleCatalog, gate code) => FULL; module source/build change => changed module + transitive dependents; docs/workflows/pure scanner build-logic => None.
- Task closes over dependents: consumers of a changed module are recompiled (a new @Deprecated in core surfaces as warnings in dependents).
- Plugin captures reverse dep edges (production+test) at configuration time.
- Fixes two under-verification holes: module-catalog.yml and gradle-wrapper changes previously passed trivially.

**Proof**
- Local end-to-end on no-op diff: gate passes trivially, zero kotlinc runs (was ~13 min full compile on the #362 case).
- Wiring tests updated to the new contract; scanner-only changes now verify zero modules.

This PR is build-logic-only (no analyzer output/schema/baseline changes).