### PR TITLE
fix(quality): prune verifyCompilerWarnings compile graph by delta impact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,13 @@ jobs:
               "-PtramaiCompilerWarningsBaseRef=$BASE_REF"
               "-PtramaiFormattingBaseRef=$BASE_REF"
             )
+            # P3-C: the compiler-warnings gate needs the name-only diff at
+            # CONFIGURATION time to prune its compile-task graph. It must arrive
+            # as a property (the build never spawns git during configuration —
+            # that would break the configuration cache). Newline-separated,
+            # same shape as `git diff --name-only`.
+            DELTA="$(git diff --name-only "$BASE_REF...HEAD")"
+            GRADLE_ARGS+=("-PtramaiCompilerWarningsDelta=$DELTA")
           fi
 
           CHANGE_CLASS=""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
             expected: 71
           - name: compiler-deps
             test-filter: "--tests 'dev.tramai.build.quality.CompilerWarnings*Test' --tests 'dev.tramai.build.quality.DependencyHygiene*Test'"
-            expected: 72
+            expected: 75
           - name: static-analysis
             test-filter: "--tests 'dev.tramai.build.quality.StaticAnalysis*Test'"
             expected: 25

--- a/.github/workflows/maintainability-baseline.yml
+++ b/.github/workflows/maintainability-baseline.yml
@@ -109,7 +109,7 @@ jobs:
               --tests 'dev.tramai.build.quality.StaticSafety*Test' --tests 'dev.tramai.build.quality.CancellationWiringTest'
               --tests 'dev.tramai.build.quality.CompilerWarnings*Test' --tests 'dev.tramai.build.quality.DependencyHygiene*Test'
               --tests 'dev.tramai.build.quality.StaticAnalysis*Test'
-            expected: 176
+            expected: 179
           - name: release-sovereign
             test-filter: >-
               --tests 'dev.tramai.build.release.*'

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsImpact.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsImpact.kt
@@ -131,6 +131,33 @@ internal fun resolveVerifyModules(
 }
 
 /**
+ * P3-C: the module set whose compile tasks must run before verify can execute.
+ *
+ * Wiring-time companion to [resolveVerifyModules]. The verify task used to
+ * depend on every module's compile tasks unconditionally — a workflow/docs-only
+ * PR paid the full ~190-task compile graph merely to learn at execution time
+ * that the gate had nothing to verify. Configuration-time classification
+ * prunes the graph: NONE wires zero compile tasks (the action early-returns),
+ * MODULES wires the affected closure only, FULL wires everything.
+ *
+ * This is an optimization, never the authority: the task action re-derives the
+ * impact from the same diff at execution time and falls back to FULL on any
+ * unknown/empty selection (see [resolveVerifyModules]), so a stale wiring can
+ * only cost extra compilation or a fail-closed kotlinc error — never a silent
+ * pass.
+ */
+internal fun compileTaskModulePaths(
+    impact: CompilerWarningsImpact,
+    baselineChanged: Boolean,
+    allModulePaths: Set<String>,
+): Set<String> =
+    when {
+        impact is CompilerWarningsImpact.None && !baselineChanged -> emptySet()
+        impact is CompilerWarningsImpact.Modules -> resolveVerifyModules(impact, false, allModulePaths)
+        else -> allModulePaths
+    }
+
+/**
  * Global build/compiler configuration: a change here can alter every module's
  * compile classpath, args, jvm target, or the compiler itself.
  */

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsPlugin.kt
@@ -111,19 +111,25 @@ class CompilerWarningsPlugin : Plugin<Project> {
         val allModulePaths = collected.map { it.modulePath }.toSet()
         val dependents = computeDependentsByModule(project)
         val dependentsMap = dependents.associate { it.modulePath to it.dependents.toSet() }
-        val diff = configTimeGitDiff(project)
-        if (diff == null) {
-            project.logger.lifecycle(
-                "compiler-warnings: cannot read diff at configuration time — wiring all compile tasks (fail-closed)",
-            )
-        }
+        // P3-C: the delta is read from a Gradle PROPERTY, never from git at
+        // configuration time — spawning git during configuration is a
+        // configuration-cache problem (enforced by FormattingGate/StaticAnalysis/
+        // StaticSafety ConfigCacheTest). CI computes the name-only diff in a
+        // shell step (git is available there) and passes it as
+        // -PtramaiCompilerWarningsDelta=<paths>. An ABSENT property is
+        // indistinguishable from "CI forgot to pass it" and wires FULL
+        // (fail-closed — identical to the pre-P3-C graph).
+        val delta = project.providers.gradleProperty("tramaiCompilerWarningsDelta").orNull
         val baselineChanged =
-            diff?.lineSequence()?.any { it.contains("config/warnings/baseline.json") } == true
+            delta?.lineSequence()?.any { it.contains("config/warnings/baseline.json") } == true
         val impact =
-            if (diff == null) {
+            if (delta == null) {
+                project.logger.lifecycle(
+                    "compiler-warnings: no delta property at configuration time — wiring all compile tasks (fail-closed)",
+                )
                 CompilerWarningsImpact.Full
             } else {
-                resolveCompilerWarningsImpact(diff, dependentsMap)
+                resolveCompilerWarningsImpact(delta, dependentsMap)
             }
         val wiredPaths = compileTaskModulePaths(impact, baselineChanged, allModulePaths)
 
@@ -178,42 +184,6 @@ class CompilerWarningsPlugin : Plugin<Project> {
             classpathSources.addAll(wiring.classpathSources)
         }
         return WiredProjects(compileTasks, classpathSources)
-    }
-
-    /** Returns the git name-only diff vs baseRef, or null when unavailable. */
-    private fun configTimeGitDiff(project: Project): String? {
-        val baseRef =
-            project.providers
-                .gradleProperty("tramaiCompilerWarningsBaseRef")
-                .orElse("origin/master")
-                .get()
-        val root = project.rootDir
-        return try {
-            val rev = runGit(root, "rev-parse", "--verify", "--quiet", "$baseRef^{commit}")
-            if (rev.exitCode != 0) return null
-            val diff = runGit(root, "diff", "--name-only", "$baseRef...HEAD")
-            if (diff.exitCode != 0) null else diff.output
-        } catch (_: Exception) {
-            null
-        }
-    }
-
-    private data class GitResult(
-        val exitCode: Int,
-        val output: String,
-    )
-
-    private fun runGit(
-        root: File,
-        vararg args: String,
-    ): GitResult {
-        val proc =
-            ProcessBuilder(listOf("git") + args)
-                .directory(root)
-                .redirectErrorStream(true)
-                .start()
-        val out = proc.inputStream.bufferedReader().readText()
-        return GitResult(proc.waitFor(), out)
     }
 
     /**

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsPlugin.kt
@@ -128,28 +128,15 @@ class CompilerWarningsPlugin : Plugin<Project> {
         val wiredPaths = compileTaskModulePaths(impact, baselineChanged, allModulePaths)
 
         val wiredProjects = allProjects.filter { it.path in wiredPaths }
-        val verifyCompileTasks = mutableListOf<Task>()
-        val verifyClasspathSources = mutableListOf<Any>()
-        wiredProjects.forEach { p ->
-            val wiring = collectProjectWiring(p)
-            verifyCompileTasks.addAll(wiring.compileTasks)
-            verifyClasspathSources.addAll(wiring.classpathSources)
-        }
+        val verifyWiring = collectWiring(wiredProjects)
         // NOTE (P3-C): classpath scoping is REQUIRED, not cosmetic. A file
         // collection built from a source-set compileClasspath carries built-by
         // task dependencies — including ALL modules' classpaths in the verify
         // task's @Classpath input would force every module to compile even when
         // zero compile tasks are wired via dependsOn.
-        val verifyClasspath = project.files(verifyClasspathSources)
-
-        val bootstrapCompileTasks = mutableListOf<Task>()
-        val bootstrapClasspathSources = mutableListOf<Any>()
-        allProjects.forEach { p ->
-            val wiring = collectProjectWiring(p)
-            bootstrapCompileTasks.addAll(wiring.compileTasks)
-            bootstrapClasspathSources.addAll(wiring.classpathSources)
-        }
-        val bootstrapClasspath = project.files(bootstrapClasspathSources)
+        val verifyClasspath = project.files(verifyWiring.classpathSources)
+        val bootstrapWiring = collectWiring(allProjects)
+        val bootstrapClasspath = project.files(bootstrapWiring.classpathSources)
 
         val sourceTreeList = mutableListOf<Any>()
         allProjects.forEach { p ->
@@ -159,7 +146,7 @@ class CompilerWarningsPlugin : Plugin<Project> {
             }
         }
         project.tasks.named("verifyCompilerWarnings") {
-            dependsOn(verifyCompileTasks)
+            dependsOn(verifyWiring.compileTasks)
             (this as VerifyCompilerWarningsTask).compileClasspath.from(verifyClasspath)
             (this as VerifyCompilerWarningsTask).sourceTrees.from(sourceTreeList)
             (this as VerifyCompilerWarningsTask).moduleDependents.set(dependents)
@@ -167,14 +154,30 @@ class CompilerWarningsPlugin : Plugin<Project> {
         project.tasks.named("bootstrapCompilerWarningsBaseline") {
             // Bootstrap regenerates the FULL baseline — it must always compile
             // everything, regardless of the delta.
-            dependsOn(bootstrapCompileTasks)
+            dependsOn(bootstrapWiring.compileTasks)
             (this as BootstrapCompilerWarningsBaselineTask).compileClasspath.from(bootstrapClasspath)
             (this as BootstrapCompilerWarningsBaselineTask).sourceTrees.from(sourceTreeList)
         }
         project.logger.lifecycle(
             "compiler-warnings: collected ${collected.size} compile units, " +
-                "${verifyCompileTasks.size}/${bootstrapCompileTasks.size} compile tasks wired for verify",
+                "${verifyWiring.compileTasks.size}/${bootstrapWiring.compileTasks.size} compile tasks wired for verify",
         )
+    }
+
+    private data class WiredProjects(
+        val compileTasks: List<Task>,
+        val classpathSources: List<Any>,
+    )
+
+    private fun collectWiring(projects: List<Project>): WiredProjects {
+        val compileTasks = mutableListOf<Task>()
+        val classpathSources = mutableListOf<Any>()
+        projects.forEach { p ->
+            val wiring = collectProjectWiring(p)
+            compileTasks.addAll(wiring.compileTasks)
+            classpathSources.addAll(wiring.classpathSources)
+        }
+        return WiredProjects(compileTasks, classpathSources)
     }
 
     /** Returns the git name-only diff vs baseRef, or null when unavailable. */
@@ -195,9 +198,15 @@ class CompilerWarningsPlugin : Plugin<Project> {
         }
     }
 
-    private data class GitResult(val exitCode: Int, val output: String)
+    private data class GitResult(
+        val exitCode: Int,
+        val output: String,
+    )
 
-    private fun runGit(root: File, vararg args: String): GitResult {
+    private fun runGit(
+        root: File,
+        vararg args: String,
+    ): GitResult {
         val proc =
             ProcessBuilder(listOf("git") + args)
                 .directory(root)

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsPlugin.kt
@@ -125,7 +125,8 @@ class CompilerWarningsPlugin : Plugin<Project> {
         val impact =
             if (delta == null) {
                 project.logger.lifecycle(
-                    "compiler-warnings: no delta property at configuration time — wiring all compile tasks (fail-closed)",
+                    "compiler-warnings: no delta property at configuration time — " +
+                        "wiring all compile tasks (fail-closed)",
                 )
                 CompilerWarningsImpact.Full
             } else {

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsPlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/CompilerWarningsPlugin.kt
@@ -100,39 +100,111 @@ class CompilerWarningsPlugin : Plugin<Project> {
     ) {
         val collected = collectCompileUnits(project)
         units.set(collected)
-        val compileTasks = mutableListOf<Task>()
-        val classpathSources = mutableListOf<Any>()
-        collectProjects(project).forEach { p ->
-            val wiring = collectProjectWiring(p)
-            compileTasks.addAll(wiring.compileTasks)
-            classpathSources.addAll(wiring.classpathSources)
+        val allProjects = collectProjects(project)
+        // P3-C: decide the compile closure at CONFIGURATION time so the verify
+        // task does not drag the whole repository's compile graph behind a
+        // workflow/docs-only delta. NONE -> zero compile tasks; MODULES -> the
+        // affected closure only; FULL -> everything (same as before). The task
+        // action still re-derives the impact at execution time as the
+        // authority, so a stale classification can only cost compilation, not
+        // correctness.
+        val allModulePaths = collected.map { it.modulePath }.toSet()
+        val dependents = computeDependentsByModule(project)
+        val dependentsMap = dependents.associate { it.modulePath to it.dependents.toSet() }
+        val diff = configTimeGitDiff(project)
+        if (diff == null) {
+            project.logger.lifecycle(
+                "compiler-warnings: cannot read diff at configuration time — wiring all compile tasks (fail-closed)",
+            )
         }
-        val unionClasspath = project.files(classpathSources)
+        val baselineChanged =
+            diff?.lineSequence()?.any { it.contains("config/warnings/baseline.json") } == true
+        val impact =
+            if (diff == null) {
+                CompilerWarningsImpact.Full
+            } else {
+                resolveCompilerWarningsImpact(diff, dependentsMap)
+            }
+        val wiredPaths = compileTaskModulePaths(impact, baselineChanged, allModulePaths)
+
+        val wiredProjects = allProjects.filter { it.path in wiredPaths }
+        val verifyCompileTasks = mutableListOf<Task>()
+        val verifyClasspathSources = mutableListOf<Any>()
+        wiredProjects.forEach { p ->
+            val wiring = collectProjectWiring(p)
+            verifyCompileTasks.addAll(wiring.compileTasks)
+            verifyClasspathSources.addAll(wiring.classpathSources)
+        }
+        // NOTE (P3-C): classpath scoping is REQUIRED, not cosmetic. A file
+        // collection built from a source-set compileClasspath carries built-by
+        // task dependencies — including ALL modules' classpaths in the verify
+        // task's @Classpath input would force every module to compile even when
+        // zero compile tasks are wired via dependsOn.
+        val verifyClasspath = project.files(verifyClasspathSources)
+
+        val bootstrapCompileTasks = mutableListOf<Task>()
+        val bootstrapClasspathSources = mutableListOf<Any>()
+        allProjects.forEach { p ->
+            val wiring = collectProjectWiring(p)
+            bootstrapCompileTasks.addAll(wiring.compileTasks)
+            bootstrapClasspathSources.addAll(wiring.classpathSources)
+        }
+        val bootstrapClasspath = project.files(bootstrapClasspathSources)
+
         val sourceTreeList = mutableListOf<Any>()
-        collectProjects(project).forEach { p ->
+        allProjects.forEach { p ->
             listOf("main", "test", "testFixtures").forEach { ss ->
                 val dir = File(p.projectDir, "src/$ss/kotlin")
                 if (dir.isDirectory) sourceTreeList.add(p.fileTree(dir))
             }
         }
-        // P3-A: reverse dependency edges from the real Gradle model (production
-        // + test scopes, mirroring ModuleGraphAnalyzer) so the impact closure
-        // covers every module compiling against a changed module.
-        val dependents = computeDependentsByModule(project)
         project.tasks.named("verifyCompilerWarnings") {
-            dependsOn(compileTasks)
-            (this as VerifyCompilerWarningsTask).compileClasspath.from(unionClasspath)
+            dependsOn(verifyCompileTasks)
+            (this as VerifyCompilerWarningsTask).compileClasspath.from(verifyClasspath)
             (this as VerifyCompilerWarningsTask).sourceTrees.from(sourceTreeList)
             (this as VerifyCompilerWarningsTask).moduleDependents.set(dependents)
         }
         project.tasks.named("bootstrapCompilerWarningsBaseline") {
-            dependsOn(compileTasks)
-            (this as BootstrapCompilerWarningsBaselineTask).compileClasspath.from(unionClasspath)
+            // Bootstrap regenerates the FULL baseline — it must always compile
+            // everything, regardless of the delta.
+            dependsOn(bootstrapCompileTasks)
+            (this as BootstrapCompilerWarningsBaselineTask).compileClasspath.from(bootstrapClasspath)
             (this as BootstrapCompilerWarningsBaselineTask).sourceTrees.from(sourceTreeList)
         }
         project.logger.lifecycle(
-            "compiler-warnings: collected ${collected.size} compile units, ${compileTasks.size} compile tasks",
+            "compiler-warnings: collected ${collected.size} compile units, " +
+                "${verifyCompileTasks.size}/${bootstrapCompileTasks.size} compile tasks wired for verify",
         )
+    }
+
+    /** Returns the git name-only diff vs baseRef, or null when unavailable. */
+    private fun configTimeGitDiff(project: Project): String? {
+        val baseRef =
+            project.providers
+                .gradleProperty("tramaiCompilerWarningsBaseRef")
+                .orElse("origin/master")
+                .get()
+        val root = project.rootDir
+        return try {
+            val rev = runGit(root, "rev-parse", "--verify", "--quiet", "$baseRef^{commit}")
+            if (rev.exitCode != 0) return null
+            val diff = runGit(root, "diff", "--name-only", "$baseRef...HEAD")
+            if (diff.exitCode != 0) null else diff.output
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private data class GitResult(val exitCode: Int, val output: String)
+
+    private fun runGit(root: File, vararg args: String): GitResult {
+        val proc =
+            ProcessBuilder(listOf("git") + args)
+                .directory(root)
+                .redirectErrorStream(true)
+                .start()
+        val out = proc.inputStream.bufferedReader().readText()
+        return GitResult(proc.waitFor(), out)
     }
 
     /**

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/CompilerWarningsWiringTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/CompilerWarningsWiringTest.kt
@@ -241,4 +241,54 @@ class CompilerWarningsWiringTest : StaticAnalysisContractTestBase() {
         assertEquals(known, resolveVerifyModules(CompilerWarningsImpact.Full, false, known))
         assertEquals(known, resolveVerifyModules(CompilerWarningsImpact.None, true, known))
     }
+
+    // ── P3-C: compile-task graph follows the impact ─────────────────────
+    @Test
+    fun `none impact wires zero compile tasks`() {
+        val known = setOf(":tramai-core", ":tramai-engine")
+        assertEquals(
+            emptySet(),
+            compileTaskModulePaths(CompilerWarningsImpact.None, false, known),
+        )
+        // Baseline edit forces the full compile graph even when impact is None.
+        assertEquals(
+            known,
+            compileTaskModulePaths(CompilerWarningsImpact.None, true, known),
+        )
+    }
+
+    @Test
+    fun `modules impact wires the affected closure only`() {
+        val known = setOf(":tramai-core", ":tramai-engine", ":tramai-server")
+        assertEquals(
+            setOf(":tramai-core", ":tramai-engine"),
+            compileTaskModulePaths(
+                CompilerWarningsImpact.Modules(setOf(":tramai-core", ":tramai-engine")),
+                false,
+                known,
+            ),
+        )
+        // Unknown/empty selections fall back to the full graph (never vacuous).
+        assertEquals(
+            known,
+            compileTaskModulePaths(CompilerWarningsImpact.Modules(setOf(":phantom")), false, known),
+        )
+        assertEquals(
+            known,
+            compileTaskModulePaths(CompilerWarningsImpact.Modules(emptySet()), false, known),
+        )
+    }
+
+    @Test
+    fun `full impact wires the whole repository`() {
+        val known = setOf(":tramai-core", ":tramai-engine")
+        assertEquals(
+            known,
+            compileTaskModulePaths(CompilerWarningsImpact.Full, false, known),
+        )
+        assertEquals(
+            known,
+            compileTaskModulePaths(CompilerWarningsImpact.Full, true, known),
+        )
+    }
 }


### PR DESCRIPTION
P3-C of the CI-pipeline improvement track (P3-A #364, P3-B #365 merged).

**Problem (measured on #365):** a workflow/docs-only PR spent 4m01s and executed 195 tasks (190 executed) in the compiler-warnings CI lane — compiling a large part of TramAI — only to reach the verify action and discover `impact = NONE, nothing to verify`. Root cause: the verify task statically `dependsOn` every module's compile tasks, AND its `@Classpath` input was a file collection built from every module's source-set compileClasspath — which carries built-by task dependencies that force the whole compile graph regardless of dependsOn.

**Change:** classify the delta at CONFIGURATION time and scope both wiring dimensions:
- `dependsOn`: only the affected closure's compile tasks (NONE → zero)
- `@Classpath`: only affected modules' source-set compileClasspaths (scoping is required — an unscoped classpath collection forces every module to compile anyway)

Measured locally:
- no-op delta (workflow/docs): **0/234 compile tasks wired** (was: all)
- leaf-module delta (tramai-bedrock): **4/234** (was: all)
- core delta: 232/234 via the reverse-dependents closure — correct, core is depended on by nearly everything
- bootstrap unchanged: always full compile (full baseline regeneration)

**Fail-closed:** config-time classification failure → FULL; unknown/empty module selection → FULL (`resolveVerifyModules`); the task action still re-derives impact at execution as the authority. A stale wiring can only cost extra compilation, never a silent pass.