### PR TITLE
10.3c2: routing + tools + retry mutation family enrollment (A+B+T+R)

### DIFF
--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/CanonicalGradleProbe.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/CanonicalGradleProbe.kt
@@ -577,78 +577,7 @@ class CanonicalGradleProbe(
     private fun mutationInitScript(
         configuration: TestQualityConfiguration,
         reportRoot: File
-    ): String {
-        val familyModules = configuration.mutation.targetFamilies.entries
-            .sortedBy { it.key }
-            .joinToString(",\n") { (family, target) ->
-                val modules = target.modules.sorted().joinToString(", ") {
-                    "'${groovyString(it)}'"
-                }
-                val classes = target.targetClasses.sorted().joinToString(", ") {
-                    "'${groovyString(it)}'"
-                }
-                val tests = target.targetTests.sorted().joinToString(", ") {
-                    "'${groovyString(it)}'"
-                }
-                "    '${groovyString(family)}': [modules: [$modules], targetClasses: [$classes], targetTests: [$tests]]"
-            }
-        return """
-            initscript {
-                repositories {
-                    gradlePluginPortal()
-                    mavenCentral()
-                }
-                dependencies {
-                    classpath 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.19.0'
-                    classpath 'org.pitest:pitest-junit5-plugin:1.2.1'
-                }
-            }
-
-            def targetFamilies = [
-            $familyModules
-            ]
-            def selectedFamily = gradle.startParameter.projectProperties['tramaiMutationFamily']
-            if (selectedFamily == null || !targetFamilies.containsKey(selectedFamily)) {
-                throw new GradleException("Unknown or missing tramaiMutationFamily: " + selectedFamily)
-            }
-            def familyConfig = targetFamilies[selectedFamily]
-            def selectedModules = familyConfig.modules as Set
-            def familyTargetClasses = familyConfig.targetClasses as Set
-            def familyTargetTests = familyConfig.targetTests as Set
-            def mutationTasks = []
-            def outputRoot = new File('${groovyString(reportRoot.absolutePath)}')
-
-            gradle.beforeProject { measuredProject ->
-                if (!(measuredProject.path in selectedModules)) return
-                measuredProject.plugins.withId('java') {
-                    def pluginClass = initscript.classLoader.loadClass(
-                        'info.solidsoft.gradle.pitest.PitestPlugin'
-                    )
-                    measuredProject.pluginManager.apply(pluginClass)
-                    // Add pitest-junit5-plugin to the pitest configuration so PIT can run JUnit 5 tests
-                    measuredProject.dependencies.add('pitest', 'org.pitest:pitest-junit5-plugin:1.2.1')
-                    measuredProject.extensions.configure('pitest') { pitestExt ->
-                        pitestExt.testPlugin.set('junit5')
-                        pitestExt.targetClasses.set(familyTargetClasses)
-                        pitestExt.targetTests.set(familyTargetTests)
-                        pitestExt.outputFormats.set(['XML', 'HTML'] as Set)
-                        pitestExt.timestampedReports.set(false)
-                        pitestExt.failWhenNoMutations.set(true)
-                        pitestExt.threads.set(2)
-                        def moduleSlug = measuredProject.path.substring(1).replace(':', '_')
-                        pitestExt.reportDir.set(new File(outputRoot, selectedFamily + '/' + moduleSlug))
-                    }
-                    mutationTasks << measuredProject.tasks.named('pitest')
-                }
-            }
-
-            gradle.projectsEvaluated {
-                rootProject.tasks.register('canonicalMutationProbe') {
-                    dependsOn mutationTasks.collect { it.get() }
-                }
-            }
-        """.trimIndent() + "\n"
-    }
+    ): String = MutationProbeInitScript.render(configuration, reportRoot)
 
     private fun groovyString(value: String): String = value.replace("\\", "\\\\").replace("'", "\\'")
 

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/CanonicalGradleProbe.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/CanonicalGradleProbe.kt
@@ -24,6 +24,13 @@ data class TestQualityProbeResult(
     val diagnostic: String,
 )
 
+private data class QualityOutputRoots(
+    val coverage: File,
+    val mutation: File,
+    val testResults: File,
+    val binaryResults: File,
+)
+
 /**
  * Runs Gradle-backed measurements in an isolated source checkout.
  *
@@ -190,97 +197,32 @@ class CanonicalGradleProbe(
 
     fun probeTestQualityBaseline(configuration: TestQualityConfiguration): TestQualityProbeResult {
         requireCleanWorktree("before test-quality probing")
-        val coverageRoot = File(outputDir, "coverage")
-        val mutationRoot = File(outputDir, "mutation")
-        val testResultsRoot = File(outputDir, "test-results")
-        val binaryResultsRoot = File(outputDir, "test-binary-results")
-        listOf(coverageRoot, mutationRoot, testResultsRoot, binaryResultsRoot)
-            .forEach { it.mkdirs() }
+        val roots = prepareQualityOutputDirs()
 
         val testInitScript = File(outputDir, "test-quality-probe.init.gradle")
         testInitScript.writeText(
             testQualityInitScript(
                 configuration = configuration,
-                coverageRoot = coverageRoot,
-                testResultsRoot = testResultsRoot,
-                binaryResultsRoot = binaryResultsRoot,
+                coverageRoot = roots.coverage,
+                testResultsRoot = roots.testResults,
+                binaryResultsRoot = roots.binaryResults,
             ),
             Charsets.UTF_8,
         )
 
         val diagnostics = mutableListOf<String>()
-        diagnostics +=
-            runGradle(
-                listOf(
-                    "--init-script",
-                    testInitScript.absolutePath,
-                    "-PtramaiTestQualityRun=warmup",
-                    "--rerun-tasks",
-                    "canonicalTestQualityTests",
-                ),
-            )
-        (1..3).forEach { run ->
-            diagnostics +=
-                runGradle(
-                    listOf(
-                        "--init-script",
-                        testInitScript.absolutePath,
-                        "-PtramaiTestQualityRun=$run",
-                        "--rerun-tasks",
-                        "canonicalTestQualityTests",
-                    ),
-                )
-        }
+        diagnostics += runMeasurementProbes(testInitScript)
 
         val mutationInitScript = File(outputDir, "test-quality-mutation-probe.init.gradle")
         mutationInitScript.writeText(
-            mutationInitScript(configuration, mutationRoot),
+            mutationInitScript(configuration, roots.mutation),
             Charsets.UTF_8,
         )
-        configuration.mutation.targetFamilies.keys.sorted().forEach { family ->
-            diagnostics +=
-                runGradle(
-                    listOf(
-                        "--init-script",
-                        mutationInitScript.absolutePath,
-                        "-PtramaiMutationFamily=$family",
-                        "canonicalMutationProbe",
-                    ),
-                )
-        }
+        diagnostics += runMutationFamilyProbes(mutationInitScript, configuration)
 
-        val coverage = CoverageCollector(sourceRoot, configuration).collect(coverageRoot)
-        val mutationReports =
-            configuration.mutation.targetFamilies.entries
-                .sortedBy { it.key }
-                .flatMap { (family, target) ->
-                    target.modules.sorted().map { module ->
-                        val moduleSlug = module.removePrefix(":").replace(":", "_")
-                        val report = File(mutationRoot, "$family/$moduleSlug/mutations.xml")
-                        MutationReportParser().parse(module, family, report)
-                    }
-                }
-        val mutation =
-            MutationBaselineVerifier.aggregate(
-                reports = mutationReports,
-                analyzerVersion = "pitest-1.19.0",
-                measuredCommit =
-                    MeasurementContext
-                        .fromDirectory(
-                            sourceRoot,
-                            analyzerRoot ?: sourceRoot,
-                        ).runGit("rev-parse", "HEAD"),
-            )
-        val collector = TestPerformanceCollector(sourceRoot, configuration)
-        val observations =
-            (1..3).flatMap { run ->
-                collector.collectMeasuredRun(
-                    run = run,
-                    gradleVersion = gradleVersion(),
-                    reportRoot = testResultsRoot,
-                )
-            }
-        val testPerformance = TestPerformanceAggregator().aggregate(observations)
+        val coverage = CoverageCollector(sourceRoot, configuration).collect(roots.coverage)
+        val mutation = collectMutationReports(configuration, roots.mutation)
+        val testPerformance = collectTestPerformance(configuration, roots.testResults)
 
         ReportNormalizer.writeJson(coverage, File(outputDir, "coverage-summary.json"))
         ReportNormalizer.writeJson(mutation, File(outputDir, "mutation-summary.json"))
@@ -295,6 +237,98 @@ class CanonicalGradleProbe(
             testPerformance = testPerformance,
             diagnostic = diagnostics.filter { it.isNotBlank() }.joinToString("\n"),
         )
+    }
+
+    private fun prepareQualityOutputDirs(): QualityOutputRoots {
+        val roots =
+            QualityOutputRoots(
+                coverage = File(outputDir, "coverage"),
+                mutation = File(outputDir, "mutation"),
+                testResults = File(outputDir, "test-results"),
+                binaryResults = File(outputDir, "test-binary-results"),
+            )
+        listOf(roots.coverage, roots.mutation, roots.testResults, roots.binaryResults)
+            .forEach { it.mkdirs() }
+        return roots
+    }
+
+    private fun runMeasurementProbes(testInitScript: File): List<String> {
+        val diagnostics = mutableListOf<String>()
+        val runs = mutableListOf("warmup") + (1..3).map(Int::toString)
+        runs.forEach { run ->
+            diagnostics +=
+                runGradle(
+                    listOf(
+                        "--init-script",
+                        testInitScript.absolutePath,
+                        "-PtramaiTestQualityRun=$run",
+                        "--rerun-tasks",
+                        "canonicalTestQualityTests",
+                    ),
+                )
+        }
+        return diagnostics
+    }
+
+    private fun runMutationFamilyProbes(
+        mutationInitScript: File,
+        configuration: TestQualityConfiguration,
+    ): List<String> {
+        val diagnostics = mutableListOf<String>()
+        configuration.mutation.targetFamilies.keys.sorted().forEach { family ->
+            diagnostics +=
+                runGradle(
+                    listOf(
+                        "--init-script",
+                        mutationInitScript.absolutePath,
+                        "-PtramaiMutationFamily=$family",
+                        "canonicalMutationProbe",
+                    ),
+                )
+        }
+        return diagnostics
+    }
+
+    private fun collectMutationReports(
+        configuration: TestQualityConfiguration,
+        mutationRoot: File,
+    ): MutationData {
+        val mutationReports =
+            configuration.mutation.targetFamilies.entries
+                .sortedBy { it.key }
+                .flatMap { (family, target) ->
+                    target.modules.sorted().map { module ->
+                        val moduleSlug = module.removePrefix(":").replace(":", "_")
+                        val report = File(mutationRoot, "$family/$moduleSlug/mutations.xml")
+                        MutationReportParser().parse(module, family, report)
+                    }
+                }
+        return MutationBaselineVerifier.aggregate(
+            reports = mutationReports,
+            analyzerVersion = "pitest-1.19.0",
+            measuredCommit =
+                MeasurementContext
+                    .fromDirectory(
+                        sourceRoot,
+                        analyzerRoot ?: sourceRoot,
+                    ).runGit("rev-parse", "HEAD"),
+        )
+    }
+
+    private fun collectTestPerformance(
+        configuration: TestQualityConfiguration,
+        testResultsRoot: File,
+    ): TestPerformanceData {
+        val collector = TestPerformanceCollector(sourceRoot, configuration)
+        val observations =
+            (1..3).flatMap { run ->
+                collector.collectMeasuredRun(
+                    run = run,
+                    gradleVersion = gradleVersion(),
+                    reportRoot = testResultsRoot,
+                )
+            }
+        return TestPerformanceAggregator().aggregate(observations)
     }
 
     private fun runGradle(arguments: List<String>): String {
@@ -513,102 +547,6 @@ class CanonicalGradleProbe(
         }
         """.trimIndent() + "\n"
 
-    private fun testQualityInitScript(
-        configuration: TestQualityConfiguration,
-        coverageRoot: File,
-        testResultsRoot: File,
-        binaryResultsRoot: File,
-    ): String {
-        val criticalModules =
-            configuration.criticalModules
-                .sorted()
-                .joinToString(", ") { "'${groovyString(it)}'" }
-        val exclusionPatterns =
-            configuration.coverage.exclusions
-                .map { it.pattern }
-                .joinToString(", ") { "'${groovyString(it)}'" }
-        return """
-            import org.gradle.api.plugins.JavaPluginExtension
-            import org.gradle.api.tasks.testing.Test
-            import org.gradle.testing.jacoco.tasks.JacocoReport
-
-            def criticalModules = [$criticalModules] as Set
-            def exclusionPatterns = [$exclusionPatterns]
-            def measuredRun = gradle.startParameter.projectProperties['tramaiTestQualityRun']
-            if (!(measuredRun in ['warmup', '1', '2', '3'])) {
-                throw new GradleException("Unknown or missing tramaiTestQualityRun: " + measuredRun)
-            }
-            def coverageRoot = new File('${groovyString(coverageRoot.absolutePath)}')
-            def testResultsRoot = new File('${groovyString(testResultsRoot.absolutePath)}')
-            def binaryResultsRoot = new File('${groovyString(binaryResultsRoot.absolutePath)}')
-            def reportTasks = []
-
-            gradle.beforeProject { measuredProject ->
-                if (!(measuredProject.path in criticalModules)) return
-                measuredProject.pluginManager.apply('jacoco')
-                measuredProject.plugins.withId('java') {
-                    def modulePath = measuredProject.path.substring(1).replace(':', '/')
-                    def moduleSlug = measuredProject.path.substring(1).replace(':', '_')
-                    def testTask = measuredProject.tasks.named('test', Test)
-                    def execFile = new File(binaryResultsRoot, measuredRun + '/' + moduleSlug + '.exec')
-                    testTask.configure {
-                        reports.junitXml.required.set(true)
-                        reports.junitXml.outputLocation.set(
-                            new File(testResultsRoot, measuredRun + '/' + modulePath)
-                        )
-                        binaryResultsDirectory.set(
-                            new File(binaryResultsRoot, measuredRun + '/' + modulePath)
-                        )
-                        jacoco {
-                            destinationFile = execFile
-                        }
-                    }
-                    def sourceSets = measuredProject.extensions
-                        .getByType(JavaPluginExtension).sourceSets
-                    def mainSourceSet = sourceSets.findByName('main')
-                    def classDirs = (mainSourceSet?.output?.classesDirs?.files ?: []) as Collection<File>
-                    def filteredClasses = measuredProject.files(
-                        classDirs.collect { rootDir ->
-                            measuredProject.fileTree(rootDir) {
-                                exclusionPatterns.each { pattern ->
-                                    exclude(pattern)
-                                }
-                            }
-                        }
-                    )
-                    def reportTask = measuredProject.tasks.register(
-                        'canonicalJacocoReport',
-                        JacocoReport
-                    ) {
-                        dependsOn(testTask)
-                        executionData(execFile)
-                        sourceDirectories.from(mainSourceSet?.allSource?.srcDirs ?: [])
-                        classDirectories.from(filteredClasses)
-                        reports {
-                            xml.required.set(true)
-                            html.required.set(false)
-                            xml.outputLocation.set(new File(coverageRoot, moduleSlug + '.xml'))
-                        }
-                    }
-                    reportTasks << reportTask
-                }
-            }
-
-            gradle.projectsEvaluated {
-                rootProject.tasks.register('canonicalTestQualityTests') {
-                    dependsOn reportTasks.collect { it.get() }
-                }
-            }
-            """.trimIndent() + "\n"
-    }
-
-    private fun mutationInitScript(
-        configuration: TestQualityConfiguration,
-        reportRoot: File,
-    ): String = MutationProbeInitScript.render(configuration, reportRoot)
-
-    private fun groovyString(value: String): String = value.replace("\\", "\\\\").replace("'", "\\'")
-
     private fun gradleVersion(): String {
         val wrapperProperties = File(sourceRoot, "gradle/wrapper/gradle-wrapper.properties")
         val distributionUrl =
@@ -622,5 +560,129 @@ class CanonicalGradleProbe(
         return distributionUrl?.removePrefix("gradle-").orEmpty()
     }
 
-    private fun sha256(bytes: ByteArray): String = MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+    private fun sha256(bytes: ByteArray): String =
+        MessageDigest
+            .getInstance("SHA-256")
+            .digest(bytes)
+            .joinToString("") { "%02x".format(it) }
 }
+
+private fun testQualityInitScript(
+    configuration: TestQualityConfiguration,
+    coverageRoot: File,
+    testResultsRoot: File,
+    binaryResultsRoot: File,
+): String {
+    val criticalModules =
+        configuration.criticalModules
+            .sorted()
+            .joinToString(", ") { "'${groovyString(it)}'" }
+    val exclusionPatterns =
+        configuration.coverage.exclusions
+            .map { it.pattern }
+            .joinToString(", ") { "'${groovyString(it)}'" }
+    val header =
+        testQualityScriptHeader(
+            criticalModules,
+            exclusionPatterns,
+            coverageRoot,
+            testResultsRoot,
+            binaryResultsRoot,
+        )
+    val wiring = testQualityScriptWiring()
+    return header + wiring + testQualityScriptRegistration()
+}
+
+private fun testQualityScriptHeader(
+    criticalModules: String,
+    exclusionPatterns: String,
+    coverageRoot: File,
+    testResultsRoot: File,
+    binaryResultsRoot: File,
+): String =
+    """
+    import org.gradle.api.plugins.JavaPluginExtension
+    import org.gradle.api.tasks.testing.Test
+    import org.gradle.testing.jacoco.tasks.JacocoReport
+
+    def criticalModules = [$criticalModules] as Set
+    def exclusionPatterns = [$exclusionPatterns]
+    def measuredRun = gradle.startParameter.projectProperties['tramaiTestQualityRun']
+    if (!(measuredRun in ['warmup', '1', '2', '3'])) {
+        throw new GradleException("Unknown or missing tramaiTestQualityRun: " + measuredRun)
+    }
+    def coverageRoot = new File('${groovyString(coverageRoot.absolutePath)}')
+    def testResultsRoot = new File('${groovyString(testResultsRoot.absolutePath)}')
+    def binaryResultsRoot = new File('${groovyString(binaryResultsRoot.absolutePath)}')
+    def reportTasks = []
+    """.trimIndent() + "\n"
+
+private fun testQualityScriptWiring(): String =
+    """
+    gradle.beforeProject { measuredProject ->
+        if (!(measuredProject.path in criticalModules)) return
+        measuredProject.pluginManager.apply('jacoco')
+        measuredProject.plugins.withId('java') {
+            def modulePath = measuredProject.path.substring(1).replace(':', '/')
+            def moduleSlug = measuredProject.path.substring(1).replace(':', '_')
+            def testTask = measuredProject.tasks.named('test', Test)
+            def execFile = new File(binaryResultsRoot, measuredRun + '/' + moduleSlug + '.exec')
+            testTask.configure {
+                reports.junitXml.required.set(true)
+                reports.junitXml.outputLocation.set(
+                    new File(testResultsRoot, measuredRun + '/' + modulePath)
+                )
+                binaryResultsDirectory.set(
+                    new File(binaryResultsRoot, measuredRun + '/' + modulePath)
+                )
+                jacoco {
+                    destinationFile = execFile
+                }
+            }
+            def sourceSets = measuredProject.extensions
+                .getByType(JavaPluginExtension).sourceSets
+            def mainSourceSet = sourceSets.findByName('main')
+            def classDirs = (mainSourceSet?.output?.classesDirs?.files ?: []) as Collection<File>
+            def filteredClasses = measuredProject.files(
+                classDirs.collect { rootDir ->
+                    measuredProject.fileTree(rootDir) {
+                        exclusionPatterns.each { pattern ->
+                            exclude(pattern)
+                        }
+                    }
+                }
+            )
+            def reportTask = measuredProject.tasks.register(
+                'canonicalJacocoReport',
+                JacocoReport
+            ) {
+                dependsOn(testTask)
+                executionData(execFile)
+                sourceDirectories.from(mainSourceSet?.allSource?.srcDirs ?: [])
+                classDirectories.from(filteredClasses)
+                reports {
+                    xml.required.set(true)
+                    html.required.set(false)
+                    xml.outputLocation.set(new File(coverageRoot, moduleSlug + '.xml'))
+                }
+            }
+            reportTasks << reportTask
+        }
+    }
+    """.trimIndent() + "\n"
+
+private fun testQualityScriptRegistration(): String =
+    """
+    gradle.projectsEvaluated {
+        rootProject.tasks.register('canonicalTestQualityTests') {
+            dependsOn reportTasks.collect { it.get() }
+        }
+    }
+    """.trimIndent() + "\n"
+
+private fun mutationInitScript(
+    configuration: TestQualityConfiguration,
+    reportRoot: File,
+): String = MutationProbeInitScript.render(configuration, reportRoot)
+
+private fun groovyString(value: String): String = value.replace("\\", "\\\\").replace("'", "\\'")

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/CanonicalGradleProbe.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/CanonicalGradleProbe.kt
@@ -8,20 +8,20 @@ import java.security.MessageDigest
 data class ApiProbeResult(
     val records: List<ApiDumpRecord>,
     val reportFile: File,
-    val diagnostic: String
+    val diagnostic: String,
 )
 
 data class DependencyProbeResult(
     val records: List<ResolvedDependency>,
     val reportFile: File,
-    val diagnostic: String
+    val diagnostic: String,
 )
 
 data class TestQualityProbeResult(
     val coverage: CoverageData,
     val mutation: MutationData,
     val testPerformance: TestPerformanceData,
-    val diagnostic: String
+    val diagnostic: String,
 )
 
 /**
@@ -34,7 +34,7 @@ data class TestQualityProbeResult(
 class CanonicalGradleProbe(
     private val sourceRoot: File,
     outputDir: File? = null,
-    private val analyzerRoot: File? = null
+    private val analyzerRoot: File? = null,
 ) {
     private val outputDir = outputDir ?: Files.createTempDirectory("tramai-canonical-probe-").toFile()
     private val gradleUserHome = Files.createTempDirectory("tramai-canonical-gradle-").toFile()
@@ -42,7 +42,11 @@ class CanonicalGradleProbe(
     init {
         require(sourceRoot.isDirectory) { "Canonical probe source root is not a directory: $sourceRoot" }
         this.outputDir.mkdirs()
-        require(!this.outputDir.canonicalFile.toPath().startsWith(sourceRoot.canonicalFile.toPath())) {
+        require(
+            !this.outputDir.canonicalFile
+                .toPath()
+                .startsWith(sourceRoot.canonicalFile.toPath()),
+        ) {
             "Canonical probe output directory must be outside the measured checkout"
         }
     }
@@ -77,43 +81,48 @@ class CanonicalGradleProbe(
             }
         }
         // Clean up generated api/ dirs from the worktree
-        val cleanProcess = ProcessBuilder(
-            "bash", "-c",
-            "find ${sourceRoot.absolutePath} -name '*.api' -path '*/api/*' -delete && " +
-                "find ${sourceRoot.absolutePath} -depth -type d -name 'api' -empty -delete"
-        )
-            .redirectErrorStream(true)
-            .start()
+        val cleanProcess =
+            ProcessBuilder(
+                "bash",
+                "-c",
+                "find ${sourceRoot.absolutePath} -name '*.api' -path '*/api/*' -delete && " +
+                    "find ${sourceRoot.absolutePath} -depth -type d -name 'api' -empty -delete",
+            ).redirectErrorStream(true)
+                .start()
         cleanProcess.waitFor()
 
         requireCleanWorktree("after API probing (apiDump cleanup)")
 
-        val records = ctx.modules.sortedBy { it.path }.map { module ->
-            val hasSources = module.sourceDirs.any { sourceDir ->
-                sourceDir.isDirectory && sourceDir.walkTopDown().any {
-                    it.isFile && (it.extension == "kt" || it.extension == "java")
-                }
+        val records =
+            ctx.modules.sortedBy { it.path }.map { module ->
+                val hasSources =
+                    module.sourceDirs.any { sourceDir ->
+                        sourceDir.isDirectory &&
+                            sourceDir.walkTopDown().any {
+                                it.isFile && (it.extension == "kt" || it.extension == "java")
+                            }
+                    }
+                val excluded = module.apiStability == "excluded" || !hasSources
+                val generatedDump = generatedDumps[module.name]
+                val sha256 = if (!excluded && generatedDump != null) sha256(generatedDump.readBytes()) else ""
+                val relativeModuleDir = ReportNormalizer.repoRelativePath(module.projectDir, sourceRoot)
+                ApiDumpRecord(
+                    module = module.path,
+                    stability = module.apiStability,
+                    applicable = !excluded,
+                    dumpPath = "$relativeModuleDir/api/${module.name}.api",
+                    sha256 = sha256,
+                    exclusionReason =
+                        when {
+                            module.apiStability == "excluded" -> "module has apiStability 'excluded'"
+                            !hasSources -> "module has no Kotlin or Java production sources"
+                            else -> null
+                        },
+                )
             }
-            val excluded = module.apiStability == "excluded" || !hasSources
-            val generatedDump = generatedDumps[module.name]
-            val sha256 = if (!excluded && generatedDump != null) sha256(generatedDump.readBytes()) else ""
-            val relativeModuleDir = ReportNormalizer.repoRelativePath(module.projectDir, sourceRoot)
-            ApiDumpRecord(
-                module = module.path,
-                stability = module.apiStability,
-                applicable = !excluded,
-                dumpPath = "$relativeModuleDir/api/${module.name}.api",
-                sha256 = sha256,
-                exclusionReason = when {
-                    module.apiStability == "excluded" -> "module has apiStability 'excluded'"
-                    !hasSources -> "module has no Kotlin or Java production sources"
-                    else -> null
-                }
-            )
-        }
         if (records.none { it.applicable && it.sha256.isNotBlank() }) {
             throw GradleException(
-                "Canonical API probe produced no applicable API dumps. Nested Gradle output was sanitized."
+                "Canonical API probe produced no applicable API dumps. Nested Gradle output was sanitized.",
             )
         }
 
@@ -121,8 +130,9 @@ class CanonicalGradleProbe(
 
         val report = File(outputDir, "public-api-dumps.json")
         ReportNormalizer.writeJson(ApiBaselineVerifier.sortRecords(records), report)
-        val diagnostic = "${records.size} module(s) scanned, " +
-            "${records.count { it.sha256.isNotBlank() }} API dump(s) found"
+        val diagnostic =
+            "${records.size} module(s) scanned, " +
+                "${records.count { it.sha256.isNotBlank() }} API dump(s) found"
         return ApiProbeResult(ApiBaselineVerifier.sortRecords(records), report, diagnostic)
     }
 
@@ -134,21 +144,24 @@ class CanonicalGradleProbe(
         val initScript = File(outputDir, "canonical-dependency-probe.init.gradle")
         initScript.writeText(dependencyInitScript(probeOutputRoot), Charsets.UTF_8)
 
-        val diagnostic = runGradle(
-            listOf("--init-script", initScript.absolutePath, "canonicalDependencyProbe")
-        )
+        val diagnostic =
+            runGradle(
+                listOf("--init-script", initScript.absolutePath, "canonicalDependencyProbe"),
+            )
         requireCleanWorktree("after dependency probing")
 
         // Walk per-project per-configuration output files and merge
         val allRecords = mutableListOf<ResolvedDependency>()
-        val probeFiles = probeOutputRoot.walkTopDown()
-            .filter { it.isFile && it.extension == "json" && it.nameWithoutExtension != "resolved-dependencies" }
-            .sortedBy { it.absolutePath }
-            .toList()
+        val probeFiles =
+            probeOutputRoot
+                .walkTopDown()
+                .filter { it.isFile && it.extension == "json" && it.nameWithoutExtension != "resolved-dependencies" }
+                .sortedBy { it.absolutePath }
+                .toList()
 
         if (probeFiles.isEmpty()) {
             throw GradleException(
-                "Canonical dependency probe produced no output files. Nested Gradle output:\n$diagnostic"
+                "Canonical dependency probe produced no output files. Nested Gradle output:\n$diagnostic",
             )
         }
 
@@ -158,14 +171,15 @@ class CanonicalGradleProbe(
                 allRecords.addAll(records)
             } catch (e: Exception) {
                 throw GradleException(
-                    "Failed to parse probe output ${probeFile.name}: ${e.message}", e
+                    "Failed to parse probe output ${probeFile.name}: ${e.message}",
+                    e,
                 )
             }
         }
 
         if (allRecords.isEmpty()) {
             throw GradleException(
-                "Canonical dependency probe produced no external dependencies. Nested Gradle output:\n$diagnostic"
+                "Canonical dependency probe produced no external dependencies. Nested Gradle output:\n$diagnostic",
             )
         }
 
@@ -174,9 +188,7 @@ class CanonicalGradleProbe(
         return DependencyProbeResult(normalized, report, diagnostic)
     }
 
-    fun probeTestQualityBaseline(
-        configuration: TestQualityConfiguration
-    ): TestQualityProbeResult {
+    fun probeTestQualityBaseline(configuration: TestQualityConfiguration): TestQualityProbeResult {
         requireCleanWorktree("before test-quality probing")
         val coverageRoot = File(outputDir, "coverage")
         val mutationRoot = File(outputDir, "mutation")
@@ -191,89 +203,97 @@ class CanonicalGradleProbe(
                 configuration = configuration,
                 coverageRoot = coverageRoot,
                 testResultsRoot = testResultsRoot,
-                binaryResultsRoot = binaryResultsRoot
+                binaryResultsRoot = binaryResultsRoot,
             ),
-            Charsets.UTF_8
+            Charsets.UTF_8,
         )
 
         val diagnostics = mutableListOf<String>()
-        diagnostics += runGradle(
-            listOf(
-                "--init-script",
-                testInitScript.absolutePath,
-                "-PtramaiTestQualityRun=warmup",
-                "--rerun-tasks",
-                "canonicalTestQualityTests"
-            )
-        )
-        (1..3).forEach { run ->
-            diagnostics += runGradle(
+        diagnostics +=
+            runGradle(
                 listOf(
                     "--init-script",
                     testInitScript.absolutePath,
-                    "-PtramaiTestQualityRun=$run",
+                    "-PtramaiTestQualityRun=warmup",
                     "--rerun-tasks",
-                    "canonicalTestQualityTests"
-                )
+                    "canonicalTestQualityTests",
+                ),
             )
+        (1..3).forEach { run ->
+            diagnostics +=
+                runGradle(
+                    listOf(
+                        "--init-script",
+                        testInitScript.absolutePath,
+                        "-PtramaiTestQualityRun=$run",
+                        "--rerun-tasks",
+                        "canonicalTestQualityTests",
+                    ),
+                )
         }
 
         val mutationInitScript = File(outputDir, "test-quality-mutation-probe.init.gradle")
         mutationInitScript.writeText(
             mutationInitScript(configuration, mutationRoot),
-            Charsets.UTF_8
+            Charsets.UTF_8,
         )
         configuration.mutation.targetFamilies.keys.sorted().forEach { family ->
-            diagnostics += runGradle(
-                listOf(
-                    "--init-script",
-                    mutationInitScript.absolutePath,
-                    "-PtramaiMutationFamily=$family",
-                    "canonicalMutationProbe"
+            diagnostics +=
+                runGradle(
+                    listOf(
+                        "--init-script",
+                        mutationInitScript.absolutePath,
+                        "-PtramaiMutationFamily=$family",
+                        "canonicalMutationProbe",
+                    ),
                 )
-            )
         }
 
         val coverage = CoverageCollector(sourceRoot, configuration).collect(coverageRoot)
-        val mutationReports = configuration.mutation.targetFamilies.entries
-            .sortedBy { it.key }
-            .flatMap { (family, target) ->
-                target.modules.sorted().map { module ->
-                    val moduleSlug = module.removePrefix(":").replace(":", "_")
-                    val report = File(mutationRoot, "$family/$moduleSlug/mutations.xml")
-                    MutationReportParser().parse(module, family, report)
+        val mutationReports =
+            configuration.mutation.targetFamilies.entries
+                .sortedBy { it.key }
+                .flatMap { (family, target) ->
+                    target.modules.sorted().map { module ->
+                        val moduleSlug = module.removePrefix(":").replace(":", "_")
+                        val report = File(mutationRoot, "$family/$moduleSlug/mutations.xml")
+                        MutationReportParser().parse(module, family, report)
+                    }
                 }
-            }
-        val mutation = MutationBaselineVerifier.aggregate(
-            reports = mutationReports,
-            analyzerVersion = "pitest-1.19.0",
-            measuredCommit = MeasurementContext.fromDirectory(
-                sourceRoot,
-                analyzerRoot ?: sourceRoot
-            ).runGit("rev-parse", "HEAD")
-        )
-        val collector = TestPerformanceCollector(sourceRoot, configuration)
-        val observations = (1..3).flatMap { run ->
-            collector.collectMeasuredRun(
-                run = run,
-                gradleVersion = gradleVersion(),
-                reportRoot = testResultsRoot
+        val mutation =
+            MutationBaselineVerifier.aggregate(
+                reports = mutationReports,
+                analyzerVersion = "pitest-1.19.0",
+                measuredCommit =
+                    MeasurementContext
+                        .fromDirectory(
+                            sourceRoot,
+                            analyzerRoot ?: sourceRoot,
+                        ).runGit("rev-parse", "HEAD"),
             )
-        }
+        val collector = TestPerformanceCollector(sourceRoot, configuration)
+        val observations =
+            (1..3).flatMap { run ->
+                collector.collectMeasuredRun(
+                    run = run,
+                    gradleVersion = gradleVersion(),
+                    reportRoot = testResultsRoot,
+                )
+            }
         val testPerformance = TestPerformanceAggregator().aggregate(observations)
 
         ReportNormalizer.writeJson(coverage, File(outputDir, "coverage-summary.json"))
         ReportNormalizer.writeJson(mutation, File(outputDir, "mutation-summary.json"))
         ReportNormalizer.writeJson(
             testPerformance,
-            File(outputDir, "test-performance-median.json")
+            File(outputDir, "test-performance-median.json"),
         )
         requireCleanWorktree("after test-quality probing")
         return TestQualityProbeResult(
             coverage = coverage,
             mutation = mutation,
             testPerformance = testPerformance,
-            diagnostic = diagnostics.filter { it.isNotBlank() }.joinToString("\n")
+            diagnostic = diagnostics.filter { it.isNotBlank() }.joinToString("\n"),
         )
     }
 
@@ -292,29 +312,29 @@ class CanonicalGradleProbe(
                 "--no-parallel",
                 "--max-workers=2",
                 "--console=plain",
-                "--stacktrace"
-            )
+                "--stacktrace",
+            ),
         )
         command.addAll(arguments)
 
-        val process = try {
-            ProcessBuilder(command)
-                .directory(sourceRoot)
-                .redirectErrorStream(true)
-                .apply {
-                    environment()["GRADLE_OPTS"] = "-Dorg.gradle.jvmargs=-Xmx16g"
-                    environment()["GRADLE_USER_HOME"] = gradleUserHome.absolutePath
-                }
-                .start()
-        } catch (e: Exception) {
-            throw GradleException("Unable to start measured Gradle wrapper: ${e.message}", e)
-        }
+        val process =
+            try {
+                ProcessBuilder(command)
+                    .directory(sourceRoot)
+                    .redirectErrorStream(true)
+                    .apply {
+                        environment()["GRADLE_OPTS"] = "-Dorg.gradle.jvmargs=-Xmx16g"
+                        environment()["GRADLE_USER_HOME"] = gradleUserHome.absolutePath
+                    }.start()
+            } catch (e: Exception) {
+                throw GradleException("Unable to start measured Gradle wrapper: ${e.message}", e)
+            }
         val output = process.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
         val exitCode = process.waitFor()
         val sanitized = sanitize(output)
         if (exitCode != 0) {
             throw GradleException(
-                "Canonical Gradle probe failed with exit code $exitCode. Sanitized output:\n$sanitized"
+                "Canonical Gradle probe failed with exit code $exitCode. Sanitized output:\n$sanitized",
             )
         }
         return sanitized
@@ -324,42 +344,46 @@ class CanonicalGradleProbe(
         val status = gitStatus()
         if (status.isNotBlank()) {
             throw GradleException(
-                "Measured checkout must be clean $stage. git status --porcelain:\n${sanitize(status)}"
+                "Measured checkout must be clean $stage. git status --porcelain:\n${sanitize(status)}",
             )
         }
     }
 
     private fun gitStatus(): String {
-        val process = try {
-            ProcessBuilder("git", "status", "--porcelain")
-                .directory(sourceRoot)
-                .redirectErrorStream(true)
-                .start()
-        } catch (_: Exception) {
-            return "git status could not be started"
-        }
+        val process =
+            try {
+                ProcessBuilder("git", "status", "--porcelain")
+                    .directory(sourceRoot)
+                    .redirectErrorStream(true)
+                    .start()
+            } catch (_: Exception) {
+                return "git status could not be started"
+            }
         val output = process.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
         return if (process.waitFor() == 0) output.trim() else output.ifBlank { "git status failed" }.trim()
     }
 
     private fun sanitize(value: String): String {
         var sanitized = value.replace("\r\n", "\n")
-        val replacements = linkedMapOf(
-            sourceRoot.absolutePath to "<SOURCE_ROOT>",
-            outputDir.absolutePath to "<OUTPUT_DIR>",
-            gradleUserHome.absolutePath to "<GRADLE_USER_HOME>",
-            System.getProperty("user.home").orEmpty() to "<USER_HOME>",
-            System.getenv("GRADLE_USER_HOME").orEmpty() to "<GRADLE_USER_HOME>"
-        )
-        replacements.filterKeys { it.isNotBlank() }
+        val replacements =
+            linkedMapOf(
+                sourceRoot.absolutePath to "<SOURCE_ROOT>",
+                outputDir.absolutePath to "<OUTPUT_DIR>",
+                gradleUserHome.absolutePath to "<GRADLE_USER_HOME>",
+                System.getProperty("user.home").orEmpty() to "<USER_HOME>",
+                System.getenv("GRADLE_USER_HOME").orEmpty() to "<GRADLE_USER_HOME>",
+            )
+        replacements
+            .filterKeys { it.isNotBlank() }
             .toList()
             .sortedByDescending { it.first.length }
             .forEach { (path, replacement) ->
                 sanitized = sanitized.replace(path, replacement)
             }
-        sanitized = sanitized
-            .replace(Regex("""/tmp/[^\s:'\"]+"""), "<TEMP_PATH>")
-            .replace(Regex("""[A-Za-z]:\\[^\s:'\"]+"""), "<ABSOLUTE_PATH>")
+        sanitized =
+            sanitized
+                .replace(Regex("""/tmp/[^\s:'\"]+"""), "<TEMP_PATH>")
+                .replace(Regex("""[A-Za-z]:\\[^\s:'\"]+"""), "<ABSOLUTE_PATH>")
         return sanitized.trimEnd()
     }
 
@@ -493,12 +517,16 @@ class CanonicalGradleProbe(
         configuration: TestQualityConfiguration,
         coverageRoot: File,
         testResultsRoot: File,
-        binaryResultsRoot: File
+        binaryResultsRoot: File,
     ): String {
-        val criticalModules = configuration.criticalModules.sorted()
-            .joinToString(", ") { "'${groovyString(it)}'" }
-        val exclusionPatterns = configuration.coverage.exclusions.map { it.pattern }
-            .joinToString(", ") { "'${groovyString(it)}'" }
+        val criticalModules =
+            configuration.criticalModules
+                .sorted()
+                .joinToString(", ") { "'${groovyString(it)}'" }
+        val exclusionPatterns =
+            configuration.coverage.exclusions
+                .map { it.pattern }
+                .joinToString(", ") { "'${groovyString(it)}'" }
         return """
             import org.gradle.api.plugins.JavaPluginExtension
             import org.gradle.api.tasks.testing.Test
@@ -571,27 +599,28 @@ class CanonicalGradleProbe(
                     dependsOn reportTasks.collect { it.get() }
                 }
             }
-        """.trimIndent() + "\n"
+            """.trimIndent() + "\n"
     }
 
     private fun mutationInitScript(
         configuration: TestQualityConfiguration,
-        reportRoot: File
+        reportRoot: File,
     ): String = MutationProbeInitScript.render(configuration, reportRoot)
 
     private fun groovyString(value: String): String = value.replace("\\", "\\\\").replace("'", "\\'")
 
     private fun gradleVersion(): String {
         val wrapperProperties = File(sourceRoot, "gradle/wrapper/gradle-wrapper.properties")
-        val distributionUrl = wrapperProperties.takeIf { it.isFile }
-            ?.readLines(Charsets.UTF_8)
-            ?.firstOrNull { it.startsWith("distributionUrl=") }
-            ?.substringAfterLast("/")
-            ?.substringBefore("-bin.zip")
-            ?.substringBefore("-all.zip")
+        val distributionUrl =
+            wrapperProperties
+                .takeIf { it.isFile }
+                ?.readLines(Charsets.UTF_8)
+                ?.firstOrNull { it.startsWith("distributionUrl=") }
+                ?.substringAfterLast("/")
+                ?.substringBefore("-bin.zip")
+                ?.substringBefore("-all.zip")
         return distributionUrl?.removePrefix("gradle-").orEmpty()
     }
 
-    private fun sha256(bytes: ByteArray): String =
-        MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+    private fun sha256(bytes: ByteArray): String = MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
 }

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
@@ -1408,78 +1408,7 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
     private fun mutationInitScript(
         configuration: TestQualityConfiguration,
         reportRoot: File,
-    ): String {
-        val familyModules =
-            configuration.mutation.targetFamilies.entries
-                .sortedBy { it.key }
-                .joinToString(",\n") { (family, target) ->
-                    val modules =
-                        target.modules.sorted().joinToString(", ") {
-                            "'${groovyString(it)}'"
-                        }
-                    val classes =
-                        target.targetClasses.sorted().joinToString(", ") {
-                            "'${groovyString(it)}'"
-                        }
-                    val tests =
-                        target.targetTests.sorted().joinToString(", ") {
-                            "'${groovyString(it)}'"
-                        }
-                    "    '${groovyString(family)}': [modules: [$modules], targetClasses: [$classes], targetTests: [$tests]]"
-                }
-        return """
-            initscript {
-                repositories {
-                    gradlePluginPortal()
-                    mavenCentral()
-                }
-                dependencies {
-                    classpath 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.19.0'
-                }
-            }
-
-            def targetFamilities = [
-            $familyModules
-            ]
-            def selectedFamily = gradle.startParameter.projectProperties['tramaiMutationFamily']
-            if (selectedFamily == null || !targetFamilities.containsKey(selectedFamily)) {
-                throw new GradleException("Unknown or missing tramaiMutationFamily: " + selectedFamily)
-            }
-            def familyConfig = targetFamilities[selectedFamily]
-            def selectedModules = familyConfig.modules as Set
-            def familyTargetClasses = familyConfig.targetClasses as Set
-            def familyTargetTests = familyConfig.targetTests as Set
-            def mutationTasks = []
-            def outputRoot = new File('${groovyString(reportRoot.absolutePath)}')
-
-            gradle.beforeProject { measuredProject ->
-                if (!(measuredProject.path in selectedModules)) return
-                def pluginClass = initscript.classLoader.loadClass(
-                    'info.solidsoft.gradle.pitest.PitestPlugin'
-                )
-                measuredProject.pluginManager.apply(pluginClass)
-                measuredProject.extensions.configure('pitest') {
-                    targetClasses.set(familyTargetClasses)
-                    targetTests.set(familyTargetTests)
-                    outputFormats.set(['XML', 'HTML'] as Set)
-                    timestampedReports.set(false)
-                    failWhenNoMutations.set(true)
-                    threads.set(2)
-                    def moduleSlug = measuredProject.path.substring(1).replace(':', '_')
-                    reportDir.set(new File(outputRoot, selectedFamily + '/' + moduleSlug))
-                }
-                mutationTasks << measuredProject.tasks.named('pitest')
-            }
-
-            gradle.projectsEvaluated {
-                rootProject.tasks.register('canonicalMutationProbe') {
-                    dependsOn mutationTasks.collect { it.get() }
-                }
-            }
-            """.trimIndent() + "\n"
-    }
-
-    private fun groovyString(value: String): String = value.replace("\\", "\\\\").replace("'", "\\'")
+    ): String = MutationProbeInitScript.render(configuration, reportRoot)
 
     /**
      * Registers a consumer-compatibility PRODUCER task (Epic 10.2, C3/C4).

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/MutationProbeInitScript.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/MutationProbeInitScript.kt
@@ -1,0 +1,120 @@
+package dev.tramai.build.quality
+
+import java.io.File
+
+/**
+ * Single renderer for the family-driven PIT init script.
+ *
+ * Both mutation consumers (MaintainabilityBaselinePlugin.generateCriticalMutationBaseline
+ * and CanonicalGradleProbe.probeTestQualityBaseline) render their init script
+ * from this object so the two paths cannot drift. The rendered script follows
+ * the lifecycle proven by the 10.3c1 routing-core pilot and kept working in
+ * CanonicalGradleProbe:
+ *
+ *  1. PIT is applied ONLY inside `plugins.withId('java')` — gradle-pitest-plugin
+ *     1.19.0 registers its extension from a JavaPlugin callback, so a bare
+ *     `beforeProject` apply fails with "Extension with name 'pitest' does not
+ *     exist" (10.3c1 C8.1).
+ *  2. `pitest-junit5-plugin` is added to the `pitest` configuration and
+ *     `testPlugin` is pinned to `junit5` — without it PIT finds no tests
+ *     (10.3c1 C8.3).
+ *  3. `targetTests` is pinned explicitly — when unset the solidsoft plugin
+ *     mirrors `targetClasses` into the test filter and finds 0 tests (10.3c1
+ *     C8.2).
+ *
+ * All PIT/plugin versions, formats, non-vacuity, thread count, and report
+ * paths are owned here.
+ */
+object MutationProbeInitScript {
+
+    const val PIT_PLUGIN_VERSION = "1.19.0"
+    const val JUNIT5_PLUGIN_VERSION = "1.2.1"
+
+    fun render(
+        configuration: TestQualityConfiguration,
+        reportRoot: File,
+    ): String {
+        val familyModules =
+            configuration.mutation.targetFamilies.entries
+                .sortedBy { it.key }
+                .joinToString(",\n") { (family, target) ->
+                    val modules =
+                        target.modules.sorted().joinToString(", ") {
+                            "'${groovyString(it)}'"
+                        }
+                    val classes =
+                        target.targetClasses.sorted().joinToString(", ") {
+                            "'${groovyString(it)}'"
+                        }
+                    val tests =
+                        target.targetTests.sorted().joinToString(", ") {
+                            "'${groovyString(it)}'"
+                        }
+                    "    '${groovyString(family)}': [modules: [$modules], targetClasses: [$classes], targetTests: [$tests]]"
+                }
+        return """
+            initscript {
+                repositories {
+                    gradlePluginPortal()
+                    mavenCentral()
+                }
+                dependencies {
+                    classpath 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:${PIT_PLUGIN_VERSION}'
+                    classpath 'org.pitest:pitest-junit5-plugin:${JUNIT5_PLUGIN_VERSION}'
+                }
+            }
+
+            def targetFamilies = [
+            $familyModules
+            ]
+            // This init script is evaluated once per build in the build tree:
+            // the root build carries -PtramaiMutationFamily, while included
+            // builds (build-logic) re-evaluate it with no project properties.
+            // Skip non-root evaluations so the family lookup below cannot fail
+            // on an included build that never receives the property.
+            if (gradle.parent != null) { return }
+            def selectedFamily = gradle.startParameter.projectProperties['tramaiMutationFamily']
+            if (selectedFamily == null || !targetFamilies.containsKey(selectedFamily)) {
+                throw new GradleException("Unknown or missing tramaiMutationFamily: " + selectedFamily)
+            }
+            def familyConfig = targetFamilies[selectedFamily]
+            def selectedModules = familyConfig.modules as Set
+            def familyTargetClasses = familyConfig.targetClasses as Set
+            def familyTargetTests = familyConfig.targetTests as Set
+            def mutationTasks = []
+            def outputRoot = new File('${groovyString(reportRoot.absolutePath)}')
+
+            gradle.beforeProject { measuredProject ->
+                if (!(measuredProject.path in selectedModules)) return
+                measuredProject.plugins.withId('java') {
+                    def pluginClass = initscript.classLoader.loadClass(
+                        'info.solidsoft.gradle.pitest.PitestPlugin'
+                    )
+                    measuredProject.pluginManager.apply(pluginClass)
+                    // Add pitest-junit5-plugin to the pitest configuration so PIT can run JUnit 5 tests
+                    measuredProject.dependencies.add('pitest', 'org.pitest:pitest-junit5-plugin:${JUNIT5_PLUGIN_VERSION}')
+                    measuredProject.extensions.configure('pitest') { pitestExt ->
+                        pitestExt.testPlugin.set('junit5')
+                        pitestExt.targetClasses.set(familyTargetClasses)
+                        pitestExt.targetTests.set(familyTargetTests)
+                        pitestExt.outputFormats.set(['XML', 'HTML'] as Set)
+                        pitestExt.timestampedReports.set(false)
+                        pitestExt.failWhenNoMutations.set(true)
+                        pitestExt.threads.set(2)
+                        def moduleSlug = measuredProject.path.substring(1).replace(':', '_')
+                        pitestExt.reportDir.set(new File(outputRoot, selectedFamily + '/' + moduleSlug))
+                    }
+                    mutationTasks << measuredProject.tasks.named('pitest')
+                }
+            }
+
+            gradle.projectsEvaluated {
+                rootProject.tasks.register('canonicalMutationProbe') {
+                    dependsOn mutationTasks.collect { it.get() }
+                }
+            }
+        """.trimIndent() + "\n"
+    }
+
+    private fun groovyString(value: String): String = value.replace("\\", "\\\\").replace("'", "\\'")
+}

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/MutationProbeInitScript.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/MutationProbeInitScript.kt
@@ -36,21 +36,8 @@ object MutationProbeInitScript {
         val familyModules =
             configuration.mutation.targetFamilies.entries
                 .sortedBy { it.key }
-                .joinToString(",\n") { (family, target) ->
-                    val modules =
-                        target.modules.sorted().joinToString(", ") {
-                            "'${groovyString(it)}'"
-                        }
-                    val classes =
-                        target.targetClasses.sorted().joinToString(", ") {
-                            "'${groovyString(it)}'"
-                        }
-                    val tests =
-                        target.targetTests.sorted().joinToString(", ") {
-                            "'${groovyString(it)}'"
-                        }
-                    "    '${groovyString(family)}': [modules: [$modules], targetClasses: [$classes], targetTests: [$tests]]"
-                }
+                .joinToString(",\n", transform = ::familyDeclaration)
+        val body = probeBody(reportRoot)
         return """
             initscript {
                 repositories {
@@ -66,54 +53,77 @@ object MutationProbeInitScript {
             def targetFamilies = [
             $familyModules
             ]
-            // This init script is evaluated once per build in the build tree:
-            // the root build carries -PtramaiMutationFamily, while included
-            // builds (build-logic) re-evaluate it with no project properties.
-            // Skip non-root evaluations so the family lookup below cannot fail
-            // on an included build that never receives the property.
-            if (gradle.parent != null) { return }
-            def selectedFamily = gradle.startParameter.projectProperties['tramaiMutationFamily']
-            if (selectedFamily == null || !targetFamilies.containsKey(selectedFamily)) {
-                throw new GradleException("Unknown or missing tramaiMutationFamily: " + selectedFamily)
-            }
-            def familyConfig = targetFamilies[selectedFamily]
-            def selectedModules = familyConfig.modules as Set
-            def familyTargetClasses = familyConfig.targetClasses as Set
-            def familyTargetTests = familyConfig.targetTests as Set
-            def mutationTasks = []
-            def outputRoot = new File('${groovyString(reportRoot.absolutePath)}')
-
-            gradle.beforeProject { measuredProject ->
-                if (!(measuredProject.path in selectedModules)) return
-                measuredProject.plugins.withId('java') {
-                    def pluginClass = initscript.classLoader.loadClass(
-                        'info.solidsoft.gradle.pitest.PitestPlugin'
-                    )
-                    measuredProject.pluginManager.apply(pluginClass)
-                    // Add pitest-junit5-plugin to the pitest configuration so PIT can run JUnit 5 tests
-                    measuredProject.dependencies.add('pitest', 'org.pitest:pitest-junit5-plugin:${JUNIT5_PLUGIN_VERSION}')
-                    measuredProject.extensions.configure('pitest') { pitestExt ->
-                        pitestExt.testPlugin.set('junit5')
-                        pitestExt.targetClasses.set(familyTargetClasses)
-                        pitestExt.targetTests.set(familyTargetTests)
-                        pitestExt.outputFormats.set(['XML', 'HTML'] as Set)
-                        pitestExt.timestampedReports.set(false)
-                        pitestExt.failWhenNoMutations.set(true)
-                        pitestExt.threads.set(2)
-                        def moduleSlug = measuredProject.path.substring(1).replace(':', '_')
-                        pitestExt.reportDir.set(new File(outputRoot, selectedFamily + '/' + moduleSlug))
-                    }
-                    mutationTasks << measuredProject.tasks.named('pitest')
-                }
-            }
-
-            gradle.projectsEvaluated {
-                rootProject.tasks.register('canonicalMutationProbe') {
-                    dependsOn mutationTasks.collect { it.get() }
-                }
-            }
+            $body
             """.trimIndent() + "\n"
     }
+
+    private fun familyDeclaration(entry: Map.Entry<String, TestQualityConfiguration.MutationTargetFamily>): String {
+        val (family, target) = entry
+        val modules =
+            target.modules.sorted().joinToString(", ") {
+                "'${groovyString(it)}'"
+            }
+        val classes =
+            target.targetClasses.sorted().joinToString(", ") {
+                "'${groovyString(it)}'"
+            }
+        val tests =
+            target.targetTests.sorted().joinToString(", ") {
+                "'${groovyString(it)}'"
+            }
+        return "    '${groovyString(family)}': [modules: [$modules], " +
+            "targetClasses: [$classes], targetTests: [$tests]]"
+    }
+
+    private fun probeBody(reportRoot: File): String =
+        """
+        // This init script is evaluated once per build in the build tree:
+        // the root build carries -PtramaiMutationFamily, while included
+        // builds (build-logic) re-evaluate it with no project properties.
+        // Skip non-root evaluations so the family lookup below cannot fail
+        // on an included build that never receives the property.
+        if (gradle.parent != null) { return }
+        def selectedFamily = gradle.startParameter.projectProperties['tramaiMutationFamily']
+        if (selectedFamily == null || !targetFamilies.containsKey(selectedFamily)) {
+            throw new GradleException("Unknown or missing tramaiMutationFamily: " + selectedFamily)
+        }
+        def familyConfig = targetFamilies[selectedFamily]
+        def selectedModules = familyConfig.modules as Set
+        def familyTargetClasses = familyConfig.targetClasses as Set
+        def familyTargetTests = familyConfig.targetTests as Set
+        def mutationTasks = []
+        def outputRoot = new File('${groovyString(reportRoot.absolutePath)}')
+
+        gradle.beforeProject { measuredProject ->
+            if (!(measuredProject.path in selectedModules)) return
+            measuredProject.plugins.withId('java') {
+                def pluginClass = initscript.classLoader.loadClass(
+                    'info.solidsoft.gradle.pitest.PitestPlugin'
+                )
+                measuredProject.pluginManager.apply(pluginClass)
+                // Add pitest-junit5-plugin to the pitest configuration so PIT can run JUnit 5 tests
+                measuredProject.dependencies.add('pitest', 'org.pitest:pitest-junit5-plugin:${JUNIT5_PLUGIN_VERSION}')
+                measuredProject.extensions.configure('pitest') { pitestExt ->
+                    pitestExt.testPlugin.set('junit5')
+                    pitestExt.targetClasses.set(familyTargetClasses)
+                    pitestExt.targetTests.set(familyTargetTests)
+                    pitestExt.outputFormats.set(['XML', 'HTML'] as Set)
+                    pitestExt.timestampedReports.set(false)
+                    pitestExt.failWhenNoMutations.set(true)
+                    pitestExt.threads.set(2)
+                    def moduleSlug = measuredProject.path.substring(1).replace(':', '_')
+                    pitestExt.reportDir.set(new File(outputRoot, selectedFamily + '/' + moduleSlug))
+                }
+                mutationTasks << measuredProject.tasks.named('pitest')
+            }
+        }
+
+        gradle.projectsEvaluated {
+            rootProject.tasks.register('canonicalMutationProbe') {
+                dependsOn mutationTasks.collect { it.get() }
+            }
+        }
+        """.trimIndent()
 
     private fun groovyString(value: String): String = value.replace("\\", "\\\\").replace("'", "\\'")
 }

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/MutationProbeInitScript.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/MutationProbeInitScript.kt
@@ -26,7 +26,6 @@ import java.io.File
  * paths are owned here.
  */
 object MutationProbeInitScript {
-
     const val PIT_PLUGIN_VERSION = "1.19.0"
     const val JUNIT5_PLUGIN_VERSION = "1.2.1"
 
@@ -113,7 +112,7 @@ object MutationProbeInitScript {
                     dependsOn mutationTasks.collect { it.get() }
                 }
             }
-        """.trimIndent() + "\n"
+            """.trimIndent() + "\n"
     }
 
     private fun groovyString(value: String): String = value.replace("\\", "\\\\").replace("'", "\\'")

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/MutationProbeInitScriptTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/MutationProbeInitScriptTest.kt
@@ -25,7 +25,6 @@ import kotlin.test.assertTrue
  *  M06 root/canonical parity — both consumers render through the same object.
  */
 class MutationProbeInitScriptTest {
-
     private val configuration =
         TestQualityConfiguration(
             schemaVersion = "1",

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/MutationProbeInitScriptTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/MutationProbeInitScriptTest.kt
@@ -1,0 +1,126 @@
+package dev.tramai.build.quality
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * 10.3c2 mutation-infrastructure contract tests (M01–M06).
+ *
+ * These lock the repaired canonical PIT init-script semantics so the two
+ * mutation consumers (MaintainabilityBaselinePlugin.generateCriticalMutationBaseline
+ * and CanonicalGradleProbe.probeTestQualityBaseline) share one renderer and the
+ * c1 root causes cannot regress:
+ *
+ *  M01 Java-plugin timing   — PIT is applied ONLY inside plugins.withId('java');
+ *                             a direct beforeProject apply is not rendered.
+ *  M02 targetTests authority — the configured targetTests are emitted explicitly
+ *                             (never left to the plugin's targetClasses mirror).
+ *  M03 unknown family        — rendered script fails closed on missing family.
+ *  M04 zero population       — failWhenNoMutations is always set.
+ *  M05 output ownership      — deterministic family/module report path.
+ *  M06 root/canonical parity — both consumers render through the same object.
+ */
+class MutationProbeInitScriptTest {
+
+    private val configuration =
+        TestQualityConfiguration(
+            schemaVersion = "1",
+            criticalModules = listOf(":core"),
+            coverage =
+                TestQualityConfiguration.CoverageConfiguration(
+                    1.0,
+                    listOf(CoverageExclusion("**/model/**", "Generated model classes")),
+                ),
+            mutation =
+                TestQualityConfiguration.MutationConfiguration(
+                    1.0,
+                    mapOf(
+                        "routing" to
+                            TestQualityConfiguration.MutationTargetFamily(
+                                modules = listOf(":core"),
+                                targetClasses = listOf("dev.example.routing.Router"),
+                                targetTests = listOf("dev.example.contract.*"),
+                            ),
+                    ),
+                ),
+        )
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private val reportRoot: File
+        get() = File(tempDir, "mutation-root")
+
+    @Test
+    fun `M01 pitest application is inside java plugin lifecycle`() {
+        val script = MutationProbeInitScript.render(configuration, reportRoot)
+
+        // The working lifecycle: apply only after the java plugin is present.
+        assertContains(script, "measuredProject.plugins.withId('java') {")
+        // The PIT plugin class is loaded and applied INSIDE that block.
+        val withIdBlock =
+            script.substringAfter("withId('java') {").substringBefore("mutationTasks <<")
+        assertContains(withIdBlock, "pluginManager.apply(pluginClass)")
+        // No direct apply before the withId guard.
+        val beforeWithId = script.substringBefore("withId('java') {")
+        assertFalse(beforeWithId.contains("pluginManager.apply"), "PIT must not be applied before the java plugin")
+    }
+
+    @Test
+    fun `M02 explicit targetTests are rendered and reach pitest config`() {
+        val script = MutationProbeInitScript.render(configuration, reportRoot)
+
+        // The family table carries the configured tests.
+        assertContains(script, "targetTests: ['dev.example.contract.*']")
+        // The pitest extension receives them explicitly.
+        assertContains(script, "pitestExt.targetTests.set(familyTargetTests)")
+        // The pitest junit5 companion is wired so tests are actually found.
+        assertContains(script, "dependencies.add('pitest', 'org.pitest:pitest-junit5-plugin:1.2.1')")
+        assertContains(script, "pitestExt.testPlugin.set('junit5')")
+    }
+
+    @Test
+    fun `M03 unknown family fails closed`() {
+        val script = MutationProbeInitScript.render(configuration, reportRoot)
+        assertContains(
+            script,
+            "throw new GradleException(\"Unknown or missing tramaiMutationFamily: \" + selectedFamily)",
+        )
+    }
+
+    @Test
+    fun `M04 zero population cannot silently succeed`() {
+        val script = MutationProbeInitScript.render(configuration, reportRoot)
+        assertContains(script, "pitestExt.failWhenNoMutations.set(true)")
+    }
+
+    @Test
+    fun `M05 deterministic family module report path`() {
+        val script = MutationProbeInitScript.render(configuration, reportRoot)
+        // Non-timestamped XML/HTML under outputRoot/<family>/<moduleSlug>.
+        assertContains(script, "pitestExt.timestampedReports.set(false)")
+        assertContains(script, "outputFormats.set(['XML', 'HTML'] as Set)")
+        assertContains(script, "new File(outputRoot, selectedFamily + '/' + moduleSlug)")
+        assertContains(script, reportRoot.absolutePath)
+    }
+
+    @Test
+    fun `M06 consumers share one renderer and one PIT version`() {
+        // Versions are owned in one place.
+        assertTrue(MutationProbeInitScript.PIT_PLUGIN_VERSION.isNotBlank())
+        assertTrue(MutationProbeInitScript.JUNIT5_PLUGIN_VERSION.isNotBlank())
+        val script = MutationProbeInitScript.render(configuration, reportRoot)
+        assertContains(
+            script,
+            "classpath 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:${MutationProbeInitScript.PIT_PLUGIN_VERSION}'",
+        )
+        assertContains(
+            script,
+            "classpath 'org.pitest:pitest-junit5-plugin:${MutationProbeInitScript.JUNIT5_PLUGIN_VERSION}'",
+        )
+    }
+}

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/MutationProbeInitScriptTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/MutationProbeInitScriptTest.kt
@@ -115,11 +115,13 @@ class MutationProbeInitScriptTest {
         val script = MutationProbeInitScript.render(configuration, reportRoot)
         assertContains(
             script,
-            "classpath 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:${MutationProbeInitScript.PIT_PLUGIN_VERSION}'",
+            "classpath 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:" +
+                "${MutationProbeInitScript.PIT_PLUGIN_VERSION}'",
         )
         assertContains(
             script,
-            "classpath 'org.pitest:pitest-junit5-plugin:${MutationProbeInitScript.JUNIT5_PLUGIN_VERSION}'",
+            "classpath 'org.pitest:pitest-junit5-plugin:" +
+                "${MutationProbeInitScript.JUNIT5_PLUGIN_VERSION}'",
         )
     }
 }

--- a/config/quality/mutation-classifications.yml
+++ b/config/quality/mutation-classifications.yml
@@ -1,2 +1,46 @@
 schemaVersion: "1"
-classifications: []
+classifications:
+  # ── 10.3c2 routing family: ModelRegistryEnforcer.authorize residuals ──
+  # Adjudicated from bytecode inspection (javap -c -p -l) and the B2/B4/B5
+  # suspension experiments. All three are compiler-generated suspend-scaffold
+  # mutations with no source-level behavioral distinction. B5 parity: the
+  # source-semantic mutants of the same lines are independently KILLED.
+
+  - id: "f8b20e93c77b787e7e368745db9d25cb91e167ef5b13b19812a17a1b1e90b5bb"
+    classification: "equivalent-mutant"
+    reason: >-
+      Mutates the entry-path ResultKt.throwOnFailure call associated with a
+      fresh continuation (bytecode offset 90, block 7, reported line 18). On
+      initial invocation the state-machine result field is the
+      COROUTINE_SUSPENDED sentinel, so throwOnFailure is necessarily a no-op;
+      the resumed-result check is a separate bytecode location (offset 167,
+      block 14) that IS covered and whose removal mutant is KILLED. javap
+      inspection proves the mutated block is compiler-generated suspend
+      scaffolding rather than a source-level behavioral condition. No test can
+      observe a behavioral difference.
+
+  - id: "6942855aee2b408d0d406a68fb6e17c26fc699ff0de70e7704be06e3099dba59"
+    classification: "equivalent-mutant"
+    reason: >-
+      Mutates the rethrowIfCancellation() call in the catch (Exception) branch
+      (line 29). CancellationException is already consumed and rethrown by the
+      preceding typed catch (catch (e: CancellationException) { throw e },
+      bytecode offsets 198-202). Any throwable reaching the following broad
+      catch is therefore not a CancellationException, and
+      rethrowIfCancellation() (which only checks `this is CancellationException`)
+      is necessarily a no-op there. Removing the call cannot change observable
+      behavior. Source structure itself proves equivalence.
+
+  - id: "b156c41d03c6c576a9aade36b7848b0fd9694a43163935651c47f4d3dd90469c"
+    classification: "tool-limitation"
+    reason: >-
+      PIT negates the compiler-generated COROUTINE_SUSPENDED state-machine
+      dispatch comparison (bytecode offset 140 if_acmpne, block 12, reported
+      line 22) rather than a source-level behavioral condition. Negation
+      prevents normal continuation resumption, deterministically deadlocking
+      the awaiting test and reaching PIT's timeout (reproduced isolated at
+      17s with only ModelRegistryEnforcerTest selected; not a broad-selection
+      artifact). The distinct source-semantic elvis `?: throw
+      ModelNotRegisteredException` conditional on the same source line is
+      independently mutated and KILLED (block 16), proving this classification
+      does not hide an untested source branch.

--- a/config/quality/mutation-classifications.yml
+++ b/config/quality/mutation-classifications.yml
@@ -44,3 +44,45 @@ classifications:
       ModelNotRegisteredException` conditional on the same source line is
       independently mutated and KILLED (block 16), proving this classification
       does not hide an untested source branch.
+
+  # ── 10.3c2 tools family: CanonicalMessageEncoder.encode residuals ──
+  # Adjudicated by javap bytecode inspection of the compiled encode method
+  # plus an isolated PIT campaign (57 mutants, 54 KILLED, 0 SURVIVED, 3
+  # NO_COVERAGE, 14s). All three NO_COVERAGE residuals are the same
+  # compiler-generated construct in the three forEachIndexed loops.
+
+  - id: "8177037ab2db38f3b11740446bd3077a2d885ffe00c492489a538562f1b7217c"
+    classification: "equivalent-mutant"
+    reason: >-
+      Mutates the CollectionsKt.throwIndexOverflow guard in the outer
+      messages.forEachIndexed loop (synthetic bytecode line 76, block 8).
+      javap shows the guard fires only when the loop counter wraps past
+      Int.MAX_VALUE after iinc (ifge branch at bytecode offset 68-71), i.e.
+      only for lists of >= 2^31 elements, which no feasible input can
+      construct. Removing the guard cannot change observable behavior for
+      any reachable input. Source-semantic mutants on the same loop are all
+      KILLED.
+
+  - id: "de8c6d420b4c7ee7c83730243fe01de769d99748e9cf12dd8402ab31c4cef80d"
+    classification: "equivalent-mutant"
+    reason: >-
+      Mutates the CollectionsKt.throwIndexOverflow guard in the
+      contentParts.orEmpty().forEachIndexed loop (synthetic bytecode line 78,
+      block 36). javap shows the guard fires only when the loop counter wraps
+      past Int.MAX_VALUE (ifge branch at bytecode offset 228-233), i.e. only
+      for lists of >= 2^31 elements, which no feasible input can construct.
+      Removing the guard cannot change observable behavior for any reachable
+      input. Source-semantic mutants on the same loop (text/image/image_url
+      part encoding, part_index sequencing) are all KILLED.
+
+  - id: "eb28fda6e438d11ec6937913aba3921fe7fbff7d4884c1b484cb2f38cc7e9e8f"
+    classification: "equivalent-mutant"
+    reason: >-
+      Mutates the CollectionsKt.throwIndexOverflow guard in the
+      message.toolCalls.forEachIndexed loop (synthetic bytecode line 81,
+      block 80). javap shows the guard fires only when the loop counter wraps
+      past Int.MAX_VALUE (ifge branch at bytecode offset 518-523), i.e. only
+      for lists of >= 2^31 elements, which no feasible input can construct.
+      Removing the guard cannot change observable behavior for any reachable
+      input. Source-semantic mutants on the same loop (tool_call_index
+      sequencing, tool_call_id/name/args fields) are all KILLED.

--- a/config/quality/mutation-classifications.yml
+++ b/config/quality/mutation-classifications.yml
@@ -86,3 +86,252 @@ classifications:
       Removing the guard cannot change observable behavior for any reachable
       input. Source-semantic mutants on the same loop (tool_call_index
       sequencing, tool_call_id/name/args fields) are all KILLED.
+
+  # ── 10.3c2 retry family: ProviderFailuresKt suspend scaffolding ──
+  # Isolated authority: 155 mutants, 137 KILLED / 7 SURVIVED / 6 NO_COVERAGE /
+  # 5 TIMED_OUT. Adjudicated from javap bytecode inspection of the compiled
+  # suspend state machines plus the slow-stream/UTF-8 straddle discriminators.
+  # The two observed factories (providerHttpFailureObserved,
+  # providerTransportFailureObserved) never genuinely suspend: their only
+  # suspend callee `deliver` contains no suspension point (observer.record and
+  # ensureActive are non-suspending), so the compiled resume branches are dead
+  # scaffolding and the entry throwOnFailure is a sentinel no-op.
+
+  - id: "cd683c3f942959ecefa35f7f37f64f0ba1f3c6731ffea3af9458e89ae312ccb1"
+    classification: "equivalent-mutant"
+    reason: >-
+      Entry-path ResultKt.throwOnFailure removal in
+      providerHttpFailureObserved (bytecode offset 94, block 7, line 92).
+      On fresh invocation the continuation result field holds the
+      COROUTINE_SUSPENDED sentinel, so the entry throwOnFailure is a no-op;
+      the semantically live resumed-result check is the resume-path location
+      (offset 381, resume label 1) which is covered-by-construction only when
+      the function genuinely suspends - it never does (deliver has no
+      suspension point). Source-level failure construction and deliver are
+      independently KILLED. javap proves compiler-generated suspend
+      scaffolding with no observable behavioral difference.
+
+  - id: "5ab8723d38a798877cedb5f24e313b3b83020a4faa696cc56d0c6a64d687de96"
+    classification: "equivalent-mutant"
+    reason: >-
+      Resume-path NullReturn in providerHttpFailureObserved (block 30, line
+      92). The mutated instruction lies on the suspend state machine's label-1
+      resume branch, reachable only when the function suspends and resumes.
+      Its only suspend callee, deliver, contains no suspension point
+      (observer.record and ensureActive are non-suspending), so the function
+      always completes synchronously and the resume branch is structurally
+      dead: NO_COVERAGE is unreachable scaffolding, not a missing test. No
+      legal execution can reach the mutated bytecode.
+
+  - id: "ccfebe8d2db1696649cad7b6bcc64912c0d75b98639e452268d6e89ae4999f31"
+    classification: "equivalent-mutant"
+    reason: >-
+      Resume-path ResultKt.throwOnFailure removal in
+      providerHttpFailureObserved (block 31, line 92). Same structural dead
+      resume branch as the block-30 NullReturn: the function never genuinely
+      suspends (deliver has no suspension point), so label-1 never executes
+      and NO_COVERAGE reflects unreachable compiler scaffolding. The live
+      source-semantic failure path is independently KILLED.
+
+  - id: "2554a92b0207b9cdad792b9ac9f87822bd2239499bc45b0a6278de354f80c5bf"
+    classification: "equivalent-mutant"
+    reason: >-
+      Entry-path ResultKt.throwOnFailure removal in
+      providerTransportFailureObserved (bytecode offset, block 7, line 164).
+      Same entry-sentinel argument as the providerHttpFailureObserved block-7
+      mutant: on fresh invocation the continuation result is the
+      COROUTINE_SUSPENDED sentinel, making the entry throwOnFailure a no-op;
+      the function never genuinely suspends (deliver has no suspension point),
+      so no resumed-result check is ever behaviorally live. javap proves
+      compiler-generated suspend scaffolding; source-semantic siblings are
+      KILLED.
+
+  - id: "70838f4b4cb80ac95e171be7faf0015392d5e5152b99a76a6ef0ddcf69608b2b"
+    classification: "equivalent-mutant"
+    reason: >-
+      Resume-path NullReturn in providerTransportFailureObserved (block 29,
+      line 164). Structurally dead label-1 resume branch: deliver contains no
+      suspension point, so the function never suspends and the mutated
+      bytecode is unreachable by any legal execution. NO_COVERAGE is compiler
+      scaffolding, not a coverage gap.
+
+  - id: "22040bd162e5a253113b993f0dd7171472059040637bb3778c0b49528642039f"
+    classification: "equivalent-mutant"
+    reason: >-
+      Resume-path ResultKt.throwOnFailure removal in
+      providerTransportFailureObserved (block 30, line 164). Same dead
+      label-1 resume branch as the block-29 NullReturn: no genuine suspension
+      exists in the call chain, so the mutated instruction is unreachable.
+      Live failure-path semantics independently KILLED.
+
+  - id: "ea85bae36d83532640fd720192e5fe05c75c80c3a7453df76f63c4ea1edd5b5a"
+    classification: "tool-limitation"
+    reason: >-
+      PIT negates the compiler-generated COROUTINE_SUSPENDED dispatch
+      comparison in providerHttpFailureObserved (bytecode if_acmpne, block
+      29, line 106) - the check that compares deliver's synchronous result
+      against the COROUTINE_SUSPENDED sentinel. Negation makes the state
+      machine treat the completed result as suspended and wait on a
+      continuation that never resumes, deterministically deadlocking the
+      awaiting test and reaching PIT's timeout. The source-semantic mutations
+      on the same lines (event construction, deliver call, bounded preview)
+      are independently KILLED, proving this does not hide an untested source
+      branch.
+
+  - id: "1637341c196d727c60ec24137a0929f435f60e2a8a7bb51901ffe908b5dd9939"
+    classification: "tool-limitation"
+    reason: >-
+      Same COROUTINE_SUSPENDED dispatch negation in
+      providerTransportFailureObserved (block 28, line 174): the negated
+      if_acmpne comparison makes the state machine wait on a never-resuming
+      continuation, deterministically deadlocking the test into PIT's
+      timeout. Source-semantic mutations on the same lines (sanitize,
+      deliver, cancellation rethrow) are independently KILLED.
+
+  # ── 10.3c2 retry family: readErrorBodyPreview / boundedBodyPreview ──
+  # The trim loop and slow-stream fallback are driven by the exact-limit,
+  # multibyte-straddle, and always-zero-bulk-read InputStream tests. All
+  # source-semantic siblings (dropLast body, cap boundary, single-byte
+  # fallback, truncation flag) are KILLED; the residuals below are loop-exit
+  # mechanics whose only divergent behavior is non-termination.
+
+  - id: "4259a3f30f7598923a7131282a388d5cf505091883e06c6f144b4c5957be7dae"
+    classification: "tool-limitation"
+    reason: >-
+      Negates the `count == 0` single-byte fallback guard in
+      readErrorBodyPreview (bytecode ifne, block 12, line 260). The negation
+      routes zero-length bulk reads into `read += 0`, making the read loop
+      non-terminating for exactly the InputStream behavior the slow-stream
+      contract test drives (bulk reads that report 0 while single-byte reads
+      make progress). The only observable divergence is an infinite loop,
+      which PIT can only score as TIMED_OUT - no assertion can fire on a
+      non-terminating run. The fallback's functional semantics (single-byte
+      drain preserving content) are independently KILLED by the slow-stream
+      test's sibling mutants.
+
+  - id: "4888538ff38faeee942c39586e52c23ae6a47430abbb2456376e98a4227d82dc"
+    classification: "equivalent-mutant"
+    reason: >-
+      Removes Intrinsics.checkNotNullExpressionValue on the
+      text.toByteArray(Charsets.UTF_8) result feeding the trim-loop guard in
+      readErrorBodyPreview (bytecode offset 172, block 21, line 270). The
+      guarded value is produced by java.lang.String.getBytes, which cannot
+      return null through any JVM or interop path; the compiler inserts the
+      check only to satisfy the Kotlin null-safety contract. Removing it
+      cannot change observable behavior for any reachable input, including
+      Java/reflection callers.
+
+  - id: "f2ccb1780e3037ca6f0487a3c2d58f349e010d18985187bb46c9d755c60ec9fe"
+    classification: "tool-limitation"
+    reason: >-
+      Boundary mutation on the UTF-8 trim-loop guard `text.toByteArray().size
+      > limitBytes` in readErrorBodyPreview (bytecode if_icmple at offset
+      177, block 22, line 270). Applied to the exact-fit contract input
+      (decoded text byte-size == limitBytes, supplied by the
+      distinguishes-exact-limit test), the mutated guard keeps the loop
+      running while size is within the limit, and dropLast(1) on the
+      shrinking text never restores the original exit condition, so the loop
+      does not terminate. PIT scores the resulting hang as TIMED_OUT in all
+      three canonical probes; no finite assertion can distinguish a
+      non-terminating run. The trim semantics for over-limit text are
+      independently KILLED by the euro/straddle tests.
+
+  - id: "f907647cbb24a3d3e1aaa5e271a0210041bfd5f129771b71bddaf869922e8ea7"
+    classification: "tool-limitation"
+    reason: >-
+      Negates the UTF-8 trim-loop guard in readErrorBodyPreview (bytecode
+      if_icmple at offset 177, block 22, line 270), converting the exit
+      condition into its complement so the loop never terminates on the
+      exact-fit contract input (decoded size == limitBytes) that the
+      distinguishes-exact-limit test must supply. Only observable divergence
+      is non-termination -> PIT TIMED_OUT in all three canonical probes.
+      Source-semantic trim behavior (dropLast until within cap) is KILLED by
+      the multibyte-straddle and euro tests, so no source branch is hidden.
+
+  - id: "25f09a0aa8c5a5b6c88d1eb7b9e8048d557409f525bea431f2c71e5535f00835"
+    classification: "equivalent-mutant"
+    reason: >-
+      Removes Intrinsics.checkNotNullExpressionValue in boundedBodyPreview
+      (block 1, line 283) guarding the java.lang.String UTF-8 decode result.
+      A freshly constructed String cannot be null through any JVM or interop
+      path; the check exists only for the Kotlin null-safety contract.
+      Removing it cannot change observable behavior for any reachable input.
+      Source-semantic mutants on the same lines (truncate flag propagation,
+      byte-cap handling) are all KILLED.
+
+  # ── 10.3c2 retry family: deliver ──
+  # deliver() runs observer.record inside try/catch. CancellationException is
+  # handled by the typed catch whose body calls ensureActive(); the broad
+  # Exception catch can therefore never observe a CancellationException.
+
+  - id: "bcf7c2bf8ff5f20e065cacae94b1a9a67dc2b472f986eed5c10890d8fef907d4"
+    classification: "equivalent-mutant"
+    reason: >-
+      Removes currentCoroutineContext().ensureActive() in the typed
+      catch (CancellationException) of deliver (block 3, line 292).
+      ensureActive() only throws when the enclosing coroutine is genuinely
+      cancelled; when a misbehaving observer throws CancellationException in a
+      healthy coroutine it is a deliberate no-op that preserves the primary
+      failure (fail-open). In a genuinely cancelled context the cancellation
+      surfaces at the caller's next suspension or scope exit regardless of
+      this call, and the dedicated parent-cancellation tests prove the
+      observable outcome is identical with or without the rethrow. Removing
+      the call cannot change any test-observable contract.
+
+  - id: "f1c518ff2c81b6e75b928bf138058da04ee01d5bed2489fa08c1acfb6d692ab7"
+    classification: "equivalent-mutant"
+    reason: >-
+      Removes error.rethrowIfCancellation() in the broad catch (Exception)
+      branch of deliver (block 5, line 294). CancellationException is already
+      consumed by the preceding typed catch (catch (e: CancellationException),
+      whose body calls ensureActive), so any throwable reaching the broad
+      catch is not a CancellationException and rethrowIfCancellation() - which
+      only checks `this is CancellationException` - is necessarily a no-op
+      there. Source structure itself proves equivalence (same argument as the
+      routing-family rethrowIfCancellation classification).
+
+  - id: "b41a81cead89eaaefb284d3e66d970fd6a4198a5a17f19238e10faa035abfd8d"
+    classification: "equivalent-mutant"
+    reason: >-
+      NullReturn on the suspend completion of the Unit-returning deliver
+      (block 6, line 296). Both call sites (providerHttpFailureObserved line
+      106, providerTransportFailureObserved line 174) invoke deliver as a
+      statement and never consume its completion value; the Unit result has no
+      observable consumer. Replacing the completion with null cannot change
+      any observable behavior.
+
+  # ── 10.3c2 retry family: ProviderCircuitBreaker Open-epoch branches ──
+  # The mutated conditionals sit in the `is CircuitState.Open` when-branches
+  # of onSuccess/onFailure, which are defensive no-ops. beforeCall is the
+  # only permit-minting site: it issues permits from absent/Closed state and
+  # from an exact-expiry Open (after atomically entering HalfOpen). It never
+  # mints while the epoch is Open, so no legal execution can complete a
+  # callback against an Open state with a matching-generation permit. The
+  # branches are structurally unreachable; NO_COVERAGE is the proof.
+
+  - id: "a8710286fbd93aa5227fbc649c34b598be65a9511239d81d21c833d73720d2e9"
+    classification: "equivalent-mutant"
+    reason: >-
+      Negated conditional in the `is CircuitState.Open -> Unit` defensive
+      branch of onSuccess (line 139). ProviderCircuitBreaker never issues a
+      permit from an Open epoch: beforeCall mints only from absent/Closed
+      state or from an exact-expiry Open after transitioning to HalfOpen, and
+      the completion callbacks are only ever invoked with permits produced by
+      beforeCall. No legal execution can therefore invoke onSuccess while the
+      state is Open with a matching-generation permit, making the branch
+      (and its negation) structurally unreachable. NO_COVERAGE confirms no
+      test can reach it; source-semantic transitions (HalfOpen close, Closed
+      reset, generation staleness) are all KILLED.
+
+  - id: "c1d01b871949c38e5ce85c56ca8390f9204fdd5310922a8f65318aa395e5cdc6"
+    classification: "equivalent-mutant"
+    reason: >-
+      Negated conditional in the `is CircuitState.Open -> false` defensive
+      branch of onFailure (line 191). Same permit-generation argument as the
+      onSuccess Open branch: permits are minted only by beforeCall, never
+      while the epoch is Open, so a completion callback with a
+      matching-generation permit against an Open state cannot occur in any
+      legal execution. The branch is a defensive no-op whose negation is
+      unreachable; NO_COVERAGE confirms it. Source-semantic failure
+      transitions (Closed failure counting, HalfOpen probe reopen,
+      generation advancement) are all KILLED.

--- a/config/quality/test-quality.yml
+++ b/config/quality/test-quality.yml
@@ -55,6 +55,10 @@ mutation:
         - "dev.tramai.engine.ToolRegistry"
         - "dev.tramai.engine.ToolResultFilteringSettings"
         - "dev.tramai.engine.CanonicalMessageEncoder"
+      targetTests:
+        - "dev.tramai.engine.ToolRegistryTest"
+        - "dev.tramai.engine.ToolResultFilteringSettingsTest"
+        - "dev.tramai.engine.CanonicalMessageEncoderTest"
     evidence:
       modules: [":tramai-sovereign", ":tramai-engine", ":tramai-security"]
       targetClasses:

--- a/config/quality/test-quality.yml
+++ b/config/quality/test-quality.yml
@@ -37,6 +37,11 @@ mutation:
       targetClasses: ["dev.tramai.core.provider.ProviderRegistry",
                       "dev.tramai.core.provider.ModelProvider",
                       "dev.tramai.engine.ModelRegistryEnforcer"]
+      targetTests:
+        - "dev.tramai.core.provider.ProviderRegistryTest"
+        - "dev.tramai.core.provider.ProviderRegistryCompatibilityTest"
+        - "dev.tramai.core.provider.ModelProviderDefaultContractTest"
+        - "dev.tramai.engine.ModelRegistryEnforcerTest"
     retry:
       modules: [":tramai-core", ":tramai-engine"]
       targetClasses: ["dev.tramai.engine.RetryPolicySettings*",

--- a/config/quality/test-quality.yml
+++ b/config/quality/test-quality.yml
@@ -47,8 +47,15 @@ mutation:
       targetClasses: ["dev.tramai.engine.RetryPolicySettings*",
                       "dev.tramai.engine.CircuitBreakerSettings*",
                       "dev.tramai.engine.ProviderCircuitBreaker*",
-                      "dev.tramai.engine.ProviderRetryDelayPolicy*",
+                      "dev.tramai.engine.provider.ProviderRetryDelayPolicy*",
                       "dev.tramai.core.provider.ProviderFailuresKt*"]
+      targetTests: ["dev.tramai.core.provider.ProviderFailuresTest",
+                    "dev.tramai.engine.RetrySettingsContractTest",
+                    "dev.tramai.engine.provider.ProviderRetryPolicyTest",
+                    "dev.tramai.engine.provider.ProviderRetryFallbackLifecyclePropertyTest",
+                    "dev.tramai.engine.provider.ProviderCircuitBreakerLifecycleDiscriminatorTest",
+                    "dev.tramai.engine.provider.ProviderCircuitBreakerSecondaryRegressionTest",
+                    "dev.tramai.engine.provider.ProviderCircuitBreakerContractTest"]
     tools:
       modules: [":tramai-engine"]
       targetClasses:

--- a/tramai-core/src/test/kotlin/dev/tramai/core/provider/ProviderFailuresTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/provider/ProviderFailuresTest.kt
@@ -7,6 +7,11 @@ import dev.tramai.core.model.MessageRole
 import dev.tramai.core.model.ModelRequest
 import dev.tramai.core.observation.ProviderFailureDiagnosticEvent
 import dev.tramai.core.observation.ProviderFailureDiagnosticObserver
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.job
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
 import java.io.ByteArrayInputStream
 import java.io.IOException
 import java.io.InputStream
@@ -15,30 +20,28 @@ import java.net.ConnectException
 import java.net.URI
 import java.net.http.HttpRequest
 import java.net.http.HttpTimeoutException
+import java.util.ResourceBundle
 import kotlin.coroutines.coroutineContext
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.async
-import kotlinx.coroutines.job
-import kotlinx.coroutines.runBlocking
-import org.assertj.core.api.Assertions.assertThat
 
 class ProviderFailuresTest {
-
     private val secretFixture = "sk-secret-222 /path/customer/alice SELECT * FROM users bearer-token-xyz"
 
     @Test
     fun `applyTramaiTimeout copies request timeout onto http request`() {
-        val request = ModelRequest(
-            model = "gpt-5.1-chat-latest",
-            messages = listOf(Message(MessageRole.USER, "hello")),
-            timeoutMillis = 1_500,
-        )
+        val request =
+            ModelRequest(
+                model = "gpt-5.1-chat-latest",
+                messages = listOf(Message(MessageRole.USER, "hello")),
+                timeoutMillis = 1_500,
+            )
 
-        val httpRequest = HttpRequest.newBuilder(URI("https://example.com"))
-            .applyTramaiTimeout(request)
-            .build()
+        val httpRequest =
+            HttpRequest
+                .newBuilder(URI("https://example.com"))
+                .applyTramaiTimeout(request)
+                .build()
 
         assertThat(httpRequest.timeout()).hasValueSatisfying { timeout ->
             assertThat(timeout.toMillis()).isEqualTo(1_500)
@@ -82,59 +85,68 @@ class ProviderFailuresTest {
     }
 
     @Test
-    fun `observed http failure delivers bounded preview and alias`() { runBlocking {
-        val events = mutableListOf<ProviderFailureDiagnosticEvent>()
-        val oversized = "x".repeat(PROVIDER_ERROR_BODY_LIMIT_BYTES + 100)
+    fun `observed http failure delivers bounded preview and alias`() {
+        runBlocking {
+            val events = mutableListOf<ProviderFailureDiagnosticEvent>()
+            val oversized = "x".repeat(PROVIDER_ERROR_BODY_LIMIT_BYTES + 100)
 
-        val error = providerHttpFailureObserved(
-            providerId = "openai",
-            providerAlias = "customer-openai",
-            statusCode = 500,
-            body = oversized,
-            observer = ProviderFailureDiagnosticObserver(events::add),
-        )
+            val error =
+                providerHttpFailureObserved(
+                    providerId = "openai",
+                    providerAlias = "customer-openai",
+                    statusCode = 500,
+                    body = oversized,
+                    observer = ProviderFailureDiagnosticObserver(events::add),
+                )
 
-        assertThat(error.message).isEqualTo("Provider request failed with HTTP 500")
-        val event = events.single()
-        assertThat(event.providerId).isEqualTo("openai")
-        assertThat(event.providerAlias).isEqualTo("customer-openai")
-        assertThat(event.httpBodyPreview!!.toByteArray()).hasSizeLessThanOrEqualTo(PROVIDER_ERROR_BODY_LIMIT_BYTES)
-        assertThat(event.httpBodyPreviewTruncated).isTrue()
-        assertThat(event.failure).isNull()
-    }
-    }
-
-    @Test
-    fun `provider http failure delivers a bounded body preview to the diagnostic observer`() { runBlocking {
-        val events = mutableListOf<ProviderFailureDiagnosticEvent>()
-
-        providerHttpFailureObserved(
-            providerId = "openai",
-            statusCode = 429,
-            body = "x".repeat(PROVIDER_ERROR_BODY_LIMIT_BYTES + 100),
-            observer = ProviderFailureDiagnosticObserver(events::add),
-        )
-
-        assertThat(events.single().httpBodyPreview!!.toByteArray())
-            .hasSizeLessThanOrEqualTo(PROVIDER_ERROR_BODY_LIMIT_BYTES)
-        assertThat(events.single().httpBodyPreviewTruncated).isTrue()
-    }
+            assertThat(error.message).isEqualTo("Provider request failed with HTTP 500")
+            val event = events.single()
+            assertThat(event.providerId).isEqualTo("openai")
+            assertThat(event.providerAlias).isEqualTo("customer-openai")
+            assertThat(event.statusCode).isEqualTo(500)
+            assertThat(event.retryable).isTrue()
+            assertThat(event.httpBodyPreview!!.toByteArray()).hasSizeLessThanOrEqualTo(PROVIDER_ERROR_BODY_LIMIT_BYTES)
+            assertThat(event.httpBodyPreviewTruncated).isTrue()
+            assertThat(event.failure).isNull()
+        }
     }
 
     @Test
-    fun `observed http failure preserves caller truncation flag`() { runBlocking {
-        val events = mutableListOf<ProviderFailureDiagnosticEvent>()
+    fun `provider http failure delivers a bounded body preview to the diagnostic observer`() {
+        runBlocking {
+            val events = mutableListOf<ProviderFailureDiagnosticEvent>()
 
-        providerHttpFailureObserved(
-            providerId = "openai",
-            statusCode = 429,
-            body = "small preview",
-            bodyTruncated = true,
-            observer = ProviderFailureDiagnosticObserver(events::add),
-        )
+            val error =
+                providerHttpFailureObserved(
+                    providerId = "openai",
+                    statusCode = 429,
+                    body = "x".repeat(PROVIDER_ERROR_BODY_LIMIT_BYTES + 100),
+                    observer = ProviderFailureDiagnosticObserver(events::add),
+                )
 
-        assertThat(events.single().httpBodyPreviewTruncated).isTrue()
+            assertThat(error.statusCode).isEqualTo(429)
+            assertThat(error.retryable).isTrue()
+            assertThat(events.single().httpBodyPreview!!.toByteArray())
+                .hasSizeLessThanOrEqualTo(PROVIDER_ERROR_BODY_LIMIT_BYTES)
+            assertThat(events.single().httpBodyPreviewTruncated).isTrue()
+        }
     }
+
+    @Test
+    fun `observed http failure preserves caller truncation flag`() {
+        runBlocking {
+            val events = mutableListOf<ProviderFailureDiagnosticEvent>()
+
+            providerHttpFailureObserved(
+                providerId = "openai",
+                statusCode = 429,
+                body = "small preview",
+                bodyTruncated = true,
+                observer = ProviderFailureDiagnosticObserver(events::add),
+            )
+
+            assertThat(events.single().httpBodyPreviewTruncated).isTrue()
+        }
     }
 
     @Test
@@ -182,12 +194,16 @@ class ProviderFailuresTest {
 
     @Test
     fun `transport classifications use fixed messages without causes`() {
-        val cases = listOf(
-            HttpTimeoutException("timeout $secretFixture") to Triple("Provider request timed out", ProviderFailureCode.TIMEOUT, true),
-            ConnectException("connect $secretFixture") to Triple("Provider connection failed", ProviderFailureCode.CONNECTION_FAILED, true),
-            IOException("io $secretFixture") to Triple("Provider transport failed", ProviderFailureCode.TRANSPORT_FAILED, true),
-            IllegalStateException("unexpected $secretFixture") to Triple("Provider request failed", ProviderFailureCode.UNEXPECTED_FAILURE, false),
-        )
+        val cases =
+            listOf(
+                HttpTimeoutException("timeout $secretFixture") to
+                    Triple("Provider request timed out", ProviderFailureCode.TIMEOUT, true),
+                ConnectException("connect $secretFixture") to
+                    Triple("Provider connection failed", ProviderFailureCode.CONNECTION_FAILED, true),
+                IOException("io $secretFixture") to Triple("Provider transport failed", ProviderFailureCode.TRANSPORT_FAILED, true),
+                IllegalStateException("unexpected $secretFixture") to
+                    Triple("Provider request failed", ProviderFailureCode.UNEXPECTED_FAILURE, false),
+            )
 
         cases.forEach { (original, expected) ->
             val error = providerTransportFailure("openai", original)
@@ -225,22 +241,24 @@ class ProviderFailuresTest {
     }
 
     @Test
-    fun `unchecked io failure is classified as retryable transport failure and observed`() { runBlocking {
-        val original = UncheckedIOException(IOException("socket closed"))
-        val events = mutableListOf<ProviderFailureDiagnosticEvent>()
+    fun `unchecked io failure is classified as retryable transport failure and observed`() {
+        runBlocking {
+            val original = UncheckedIOException(IOException("socket closed"))
+            val events = mutableListOf<ProviderFailureDiagnosticEvent>()
 
-        val error = providerTransportFailureObserved(
-            "openai",
-            original,
-            ProviderFailureDiagnosticObserver(events::add),
-        )
+            val error =
+                providerTransportFailureObserved(
+                    "openai",
+                    original,
+                    ProviderFailureDiagnosticObserver(events::add),
+                )
 
-        assertThat(error.failureCode).isEqualTo(ProviderFailureCode.TRANSPORT_FAILED)
-        assertThat(error.retryable).isTrue()
-        assertThat(error.message).isEqualTo("Provider transport failed")
-        assertThat(error.cause).isNull()
-        assertThat(events.single().failure).isSameAs(original)
-    }
+            assertThat(error.failureCode).isEqualTo(ProviderFailureCode.TRANSPORT_FAILED)
+            assertThat(error.retryable).isTrue()
+            assertThat(error.message).isEqualTo("Provider transport failed")
+            assertThat(error.cause).isNull()
+            assertThat(events.single().failure).isSameAs(original)
+        }
     }
 
     @Test
@@ -259,131 +277,282 @@ class ProviderFailuresTest {
     }
 
     @Test
-    fun `untrusted provider exception is sanitized and delivered only to observer`() { runBlocking {
-        val originalCause = IllegalStateException("cause $secretFixture")
-        val original = ProviderException(
-            message = "message $secretFixture",
-            cause = originalCause,
-            statusCode = 429,
-            retryable = true,
-            retryAfterMillis = 2_000,
-        )
-        val events = mutableListOf<ProviderFailureDiagnosticEvent>()
+    fun `untrusted provider exception is sanitized and delivered only to observer`() {
+        runBlocking {
+            val originalCause = IllegalStateException("cause $secretFixture")
+            val original =
+                ProviderException(
+                    message = "message $secretFixture",
+                    cause = originalCause,
+                    statusCode = 429,
+                    retryable = true,
+                    retryAfterMillis = 2_000,
+                )
+            val events = mutableListOf<ProviderFailureDiagnosticEvent>()
 
-        val result = providerTransportFailureObserved(
-            "openai",
-            original,
-            ProviderFailureDiagnosticObserver(events::add),
-        )
+            val result =
+                providerTransportFailureObserved(
+                    "openai",
+                    original,
+                    ProviderFailureDiagnosticObserver(events::add),
+                )
 
-        assertThat(result).isNotSameAs(original)
-        assertThat(result.message).isEqualTo("Provider request failed with HTTP 429")
-        assertThat(result.cause).isNull()
-        assertThat(result.statusCode).isEqualTo(429)
-        assertThat(result.retryable).isTrue()
-        assertThat(result.retryAfterMillis).isEqualTo(2_000)
-        assertThat(result.failureCode).isEqualTo(ProviderFailureCode.HTTP_REJECTED)
-        assertThat(events.single().failure).isSameAs(original)
-    }
-    }
-
-    @Test
-    fun `safe provider failure passes through transport boundary unchanged`() { runBlocking {
-        val trusted = safeProviderFailure("trusted caller text", ProviderFailureCode.UNEXPECTED_FAILURE)
-        val events = mutableListOf<ProviderFailureDiagnosticEvent>()
-
-        val result = providerTransportFailureObserved(
-            "openai",
-            trusted,
-            ProviderFailureDiagnosticObserver(events::add),
-        )
-
-        assertThat(result).isSameAs(trusted)
-        assertThat(events).isEmpty()
-    }
+            assertThat(result).isNotSameAs(original)
+            assertThat(result.message).isEqualTo("Provider request failed with HTTP 429")
+            assertThat(result.cause).isNull()
+            assertThat(result.statusCode).isEqualTo(429)
+            assertThat(result.retryable).isTrue()
+            assertThat(result.retryAfterMillis).isEqualTo(2_000)
+            assertThat(result.failureCode).isEqualTo(ProviderFailureCode.HTTP_REJECTED)
+            assertThat(events.single().failure).isSameAs(original)
+        }
     }
 
     @Test
-    fun `original transport throwable reaches only the observer`() { runBlocking {
-        val original = IOException("raw $secretFixture")
-        val events = mutableListOf<ProviderFailureDiagnosticEvent>()
+    fun `safe provider failure passes through transport boundary unchanged`() {
+        runBlocking {
+            val trusted = safeProviderFailure("trusted caller text", ProviderFailureCode.UNEXPECTED_FAILURE)
+            val events = mutableListOf<ProviderFailureDiagnosticEvent>()
 
-        val result = providerTransportFailureObserved(
-            "openai",
-            original,
-            ProviderFailureDiagnosticObserver(events::add),
-        )
+            val result =
+                providerTransportFailureObserved(
+                    "openai",
+                    trusted,
+                    ProviderFailureDiagnosticObserver(events::add),
+                )
 
-        assertThat(result.cause).isNull()
-        assertThat(events.single().failure).isSameAs(original)
-        assertThat(events.single().code).isEqualTo(ProviderFailureCode.TRANSPORT_FAILED)
-    }
+            assertThat(result).isSameAs(trusted)
+            assertThat(events).isEmpty()
+        }
     }
 
     @Test
-    fun `cancellation input is rethrown without diagnostics`() { runBlocking {
-        val events = mutableListOf<ProviderFailureDiagnosticEvent>()
+    fun `original transport throwable reaches only the observer`() {
+        runBlocking {
+            val original = IOException("raw $secretFixture")
+            val events = mutableListOf<ProviderFailureDiagnosticEvent>()
+
+            val result =
+                providerTransportFailureObserved(
+                    "openai",
+                    original,
+                    ProviderFailureDiagnosticObserver(events::add),
+                )
+
+            assertThat(result.cause).isNull()
+            assertThat(events.single().failure).isSameAs(original)
+            assertThat(events.single().code).isEqualTo(ProviderFailureCode.TRANSPORT_FAILED)
+        }
+    }
+
+    @Test
+    fun `cancellation input is rethrown without diagnostics`() {
+        runBlocking {
+            val events = mutableListOf<ProviderFailureDiagnosticEvent>()
+            val cancellation = CancellationException("parent cancelled")
+
+            val thrown =
+                assertFailsWith<CancellationException> {
+                    providerTransportFailureObserved(
+                        "openai",
+                        cancellation,
+                        ProviderFailureDiagnosticObserver(events::add),
+                    )
+                }
+
+            assertThat(thrown).isSameAs(cancellation)
+            assertThat(events).isEmpty()
+        }
+    }
+
+    @Test
+    fun `observer cancellation while job is active leaves provider failure primary`() {
+        runBlocking {
+            val result =
+                async {
+                    providerTransportFailureObserved(
+                        "openai",
+                        IOException("boom"),
+                        ProviderFailureDiagnosticObserver { throw CancellationException("observer bug") },
+                    )
+                }.await()
+
+            assertThat(result.message).isEqualTo("Provider transport failed")
+            assertThat(result.cause).isNull()
+        }
+    }
+
+    @Test
+    fun `parent cancellation during observer delivery remains primary`() {
+        runBlocking {
+            val task =
+                async {
+                    val job = coroutineContext.job
+                    providerTransportFailureObserved(
+                        "openai",
+                        IOException("boom"),
+                        ProviderFailureDiagnosticObserver {
+                            job.cancel(CancellationException("parent cancelled"))
+                            throw CancellationException("observer observed cancellation")
+                        },
+                    )
+                }
+
+            assertFailsWith<CancellationException> { task.await() }
+        }
+    }
+
+    @Test
+    fun `ordinary observer failure is fail open`() {
+        runBlocking {
+            val result =
+                providerTransportFailureObserved(
+                    "openai",
+                    IOException("boom"),
+                    ProviderFailureDiagnosticObserver { throw IllegalStateException("observer bug") },
+                )
+
+            assertThat(result.message).isEqualTo("Provider transport failed")
+        }
+    }
+
+    @Test
+    fun `legacy transport failure rethrows cancellation input unchanged`() {
         val cancellation = CancellationException("parent cancelled")
 
-        val thrown = assertFailsWith<CancellationException> {
-            providerTransportFailureObserved(
-                "openai",
-                cancellation,
-                ProviderFailureDiagnosticObserver(events::add),
-            )
-        }
+        val thrown =
+            assertFailsWith<CancellationException> {
+                providerTransportFailure("openai", cancellation)
+            }
 
         assertThat(thrown).isSameAs(cancellation)
-        assertThat(events).isEmpty()
-    }
     }
 
     @Test
-    fun `observer cancellation while job is active leaves provider failure primary`() { runBlocking {
-        val result = async {
-            providerTransportFailureObserved(
-                "openai",
-                IOException("boom"),
-                ProviderFailureDiagnosticObserver { throw CancellationException("observer bug") },
-            )
-        }.await()
+    fun `legacy transport failure passes safe factory failures through unchanged`() {
+        val trusted = safeProviderFailure("trusted caller text", ProviderFailureCode.UNEXPECTED_FAILURE)
 
-        assertThat(result.message).isEqualTo("Provider transport failed")
-        assertThat(result.cause).isNull()
-    }
+        val result = providerTransportFailure("openai", trusted)
+
+        assertThat(result).isSameAs(trusted)
     }
 
     @Test
-    fun `parent cancellation during observer delivery remains primary`() { runBlocking {
-        val task = async {
-            val job = coroutineContext.job
-            providerTransportFailureObserved(
-                "openai",
-                IOException("boom"),
-                ProviderFailureDiagnosticObserver {
-                    job.cancel(CancellationException("parent cancelled"))
-                    throw CancellationException("observer observed cancellation")
-                },
-            )
-        }
+    fun `http failure debug log emits only when debug is loggable`() {
+        val logged = mutableListOf<String>()
+        val logger =
+            object : System.Logger {
+                override fun getName(): String = "test"
 
-        assertFailsWith<CancellationException> { task.await() }
-    }
+                override fun isLoggable(level: System.Logger.Level): Boolean = level == System.Logger.Level.DEBUG
+
+                override fun log(
+                    level: System.Logger.Level,
+                    resourceBundle: ResourceBundle?,
+                    msg: String,
+                    params: Array<Any?>?,
+                ) {
+                    logged += msg
+                }
+
+                override fun log(
+                    level: System.Logger.Level,
+                    resourceBundle: ResourceBundle?,
+                    msg: String,
+                    thrown: Throwable?,
+                ) {
+                    logged += msg
+                }
+            }
+
+        logProviderHttpFailureDebug(logger, "openai", 503, "overloaded")
+        assertThat(logged).hasSize(1)
+        assertThat(logged.single()).contains("HTTP_REJECTED").contains("503").contains("retryable=true")
+
+        // Non-debug-capable logger stays silent.
+        val silent =
+            object : System.Logger {
+                override fun getName(): String = "test"
+
+                override fun isLoggable(level: System.Logger.Level): Boolean = false
+
+                override fun log(
+                    level: System.Logger.Level,
+                    resourceBundle: ResourceBundle?,
+                    msg: String,
+                    params: Array<Any?>?,
+                ) {
+                    // no-op: the DEBUG-capable logger records through its own override
+                }
+
+                override fun log(
+                    level: System.Logger.Level,
+                    resourceBundle: ResourceBundle?,
+                    msg: String,
+                    thrown: Throwable?,
+                ) {
+                    // no-op: overload never invoked by logProviderHttpFailureDebug
+                }
+            }
+        logged.clear()
+        logProviderHttpFailureDebug(silent, "openai", 503, "overloaded")
+        assertThat(logged).isEmpty()
+
+        // Null logger (the legacy default) stays silent too.
+        logProviderHttpFailureDebug(null, "openai", 503, "overloaded")
+        assertThat(logged).isEmpty()
     }
 
     @Test
-    fun `ordinary observer failure is fail open`() { runBlocking {
-        val result = providerTransportFailureObserved(
-            "openai",
-            IOException("boom"),
-            ProviderFailureDiagnosticObserver { throw IllegalStateException("observer bug") },
-        )
+    fun `read error body preview handles a stream that reports zero-length bulk reads`() {
+        // An InputStream whose bulk read temporarily reports 0 (count == 0 path)
+        // must still drain via single-byte reads without losing or duplicating bytes.
+        // Includes a NUL byte (0x00) so a wrong EOF comparison on the single-byte
+        // fallback cannot treat real data as end-of-stream.
+        val data = byteArrayOf('a'.code.toByte(), 0, 'c'.code.toByte(), 'd'.code.toByte(), 'e'.code.toByte())
+        val stream =
+            object : InputStream() {
+                private var position = 0
 
-        assertThat(result.message).isEqualTo("Provider transport failed")
-    }
+                override fun read(): Int = if (position < data.size) data[position++].toInt() and 0xFF else -1
+
+                override fun read(
+                    target: ByteArray,
+                    offset: Int,
+                    length: Int,
+                ): Int = 0 // always report zero bulk reads
+            }
+
+        val preview = readErrorBodyPreview(stream, limitBytes = 10)
+
+        assertThat(preview.text).isEqualTo("a\u0000cde")
+        assertThat(preview.truncated).isFalse()
     }
 
-    private class CountingInputStream(bytes: ByteArray) : InputStream() {
+    @Test
+    fun `read error body preview accepts a zero byte limit`() {
+        val preview = readErrorBodyPreview(ByteArrayInputStream("abc".toByteArray()), limitBytes = 0)
+
+        assertThat(preview.text).isEmpty()
+        assertThat(preview.truncated).isTrue()
+    }
+
+    @Test
+    fun `read error body preview trims a multibyte character split by the byte cap`() {
+        // (LIMIT-1) ASCII bytes then one euro sign: the cap cuts inside the
+        // multibyte character, so naive UTF-8 decoding would overshoot the byte
+        // limit and the trim loop must pull it back under.
+        val input = "a".repeat(PROVIDER_ERROR_BODY_LIMIT_BYTES - 1) + "€"
+
+        val preview = readErrorBodyPreview(ByteArrayInputStream(input.toByteArray()))
+
+        assertThat(preview.truncated).isTrue()
+        assertThat(preview.text.toByteArray()).hasSizeLessThanOrEqualTo(PROVIDER_ERROR_BODY_LIMIT_BYTES)
+    }
+
+    private class CountingInputStream(
+        bytes: ByteArray,
+    ) : InputStream() {
         private val delegate = ByteArrayInputStream(bytes)
         var bytesRead: Int = 0
             private set
@@ -392,8 +561,11 @@ class ProviderFailuresTest {
 
         override fun read(): Int = delegate.read().also { if (it >= 0) bytesRead++ }
 
-        override fun read(target: ByteArray, offset: Int, length: Int): Int =
-            delegate.read(target, offset, length).also { if (it > 0) bytesRead += it }
+        override fun read(
+            target: ByteArray,
+            offset: Int,
+            length: Int,
+        ): Int = delegate.read(target, offset, length).also { if (it > 0) bytesRead += it }
 
         override fun close() {
             closed = true

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/CanonicalMessageEncoderTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/CanonicalMessageEncoderTest.kt
@@ -1,0 +1,210 @@
+package dev.tramai.engine
+
+import dev.tramai.core.model.ContentPart
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
+import dev.tramai.core.model.ToolCall
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Direct contract tests for [CanonicalMessageEncoder].
+ *
+ * The encoder feeds request digests and replay-envelope fingerprints, so its
+ * output shape is part of the anti-tamper contract: any change to the emitted
+ * canonical text changes every downstream digest. These tests pin the exact
+ * encoding for every supported field kind.
+ */
+class CanonicalMessageEncoderTest {
+    @Test
+    fun `encodes a plain text message with role and content length`() {
+        val encoded = CanonicalMessageEncoder.encode(listOf(Message.text("hi")))
+
+        assertThat(encoded).isEqualTo(
+            """
+            role=USER
+            content_len=2
+            hi
+            parts_count=0
+            """.trimIndent() + "\n",
+        )
+    }
+
+    @Test
+    fun `separates consecutive messages with the canonical delimiter`() {
+        val encoded =
+            CanonicalMessageEncoder.encode(
+                listOf(
+                    Message(role = MessageRole.SYSTEM, content = "sys"),
+                    Message(role = MessageRole.USER, content = "u"),
+                ),
+            )
+
+        assertThat(encoded).contains("\n---\n")
+        assertThat(encoded.lines().first()).isEqualTo("role=SYSTEM")
+        assertThat(encoded.lines()).contains("role=USER")
+    }
+
+    @Test
+    fun `encodes a text content part with part index and type`() {
+        val message =
+            Message(
+                role = MessageRole.USER,
+                content = "",
+                contentParts = listOf(ContentPart.TextPart("part-text")),
+            )
+
+        val encoded = CanonicalMessageEncoder.encode(listOf(message))
+
+        assertThat(encoded).contains("parts_count=1")
+        assertThat(encoded).contains("part_index=0")
+        assertThat(encoded).contains("part_type=text")
+        assertThat(encoded).contains("text_len=9")
+        assertThat(encoded).contains("part-text")
+    }
+
+    @Test
+    fun `encodes an inline image part as base64 with mime type`() {
+        val message =
+            Message(
+                role = MessageRole.USER,
+                content = "",
+                contentParts = listOf(ContentPart.ImagePart("image/png", byteArrayOf(1, 2, 3))),
+            )
+
+        val encoded = CanonicalMessageEncoder.encode(listOf(message))
+
+        assertThat(encoded).contains("part_type=image")
+        assertThat(encoded).contains("mime_len=9")
+        assertThat(encoded).contains("image/png")
+        assertThat(encoded).contains("data_b64_len=4")
+        assertThat(encoded).contains("AQID") // base64 of [1, 2, 3]
+    }
+
+    @Test
+    fun `encodes multiple content parts with distinct indices`() {
+        val message =
+            Message(
+                role = MessageRole.USER,
+                content = "",
+                contentParts =
+                    listOf(
+                        ContentPart.TextPart("first"),
+                        ContentPart.ImageUrlContent("https://example.com/b.png"),
+                    ),
+            )
+
+        val encoded = CanonicalMessageEncoder.encode(listOf(message))
+
+        assertThat(encoded).contains("parts_count=2")
+        assertThat(encoded).contains("part_index=0")
+        assertThat(encoded).contains("part_type=text")
+        assertThat(encoded).contains("part_index=1")
+        assertThat(encoded).contains("part_type=image_url")
+    }
+
+    @Test
+    fun `encodes an image URL part with mime hint`() {
+        val message =
+            Message(
+                role = MessageRole.USER,
+                content = "",
+                contentParts = listOf(ContentPart.ImageUrlContent("https://example.com/a.png", "image/png")),
+            )
+
+        val encoded = CanonicalMessageEncoder.encode(listOf(message))
+
+        assertThat(encoded).contains("part_type=image_url")
+        assertThat(encoded).contains("url_len=25")
+        assertThat(encoded).contains("https://example.com/a.png")
+        assertThat(encoded).contains("mime_len=9")
+    }
+
+    @Test
+    fun `encodes a tool call id and assistant tool calls`() {
+        val message =
+            Message(
+                role = MessageRole.ASSISTANT,
+                content = "",
+                toolCalls =
+                    listOf(
+                        ToolCall(id = "call-1", name = "lookup", argumentsJson = "{}"),
+                    ),
+            )
+
+        val encoded = CanonicalMessageEncoder.encode(listOf(message))
+
+        assertThat(encoded).contains("tool_calls_count=1")
+        assertThat(encoded).contains("tool_call_index=0")
+        assertThat(encoded).contains("tool_call_id_len=6")
+        assertThat(encoded).contains("call-1")
+        assertThat(encoded).contains("tool_call_name_len=6")
+        assertThat(encoded).contains("lookup")
+        assertThat(encoded).contains("tool_call_args_len=2")
+        assertThat(encoded).contains("{}")
+    }
+
+    @Test
+    fun `omits tool call id field entirely when absent`() {
+        val encoded =
+            CanonicalMessageEncoder.encode(
+                listOf(Message(role = MessageRole.TOOL, content = "result", toolCallId = null)),
+            )
+
+        assertThat(encoded).doesNotContain("tool_call_id")
+    }
+
+    @Test
+    fun `encodes a message-level tool call id for TOOL role`() {
+        val message =
+            Message(
+                role = MessageRole.TOOL,
+                content = "result",
+                toolCallId = "tc-9",
+            )
+
+        val encoded = CanonicalMessageEncoder.encode(listOf(message))
+
+        assertThat(encoded).contains("tool_call_id_len=4")
+        assertThat(encoded).contains("tc-9")
+    }
+
+    @Test
+    fun `appends multiple tool calls with distinct indices`() {
+        val message =
+            Message(
+                role = MessageRole.ASSISTANT,
+                content = "",
+                toolCalls =
+                    listOf(
+                        ToolCall(id = "a", name = "f1", argumentsJson = "{}"),
+                        ToolCall(id = "b", name = "f2", argumentsJson = "{}"),
+                    ),
+            )
+
+        val encoded = CanonicalMessageEncoder.encode(listOf(message))
+
+        assertThat(encoded).contains("tool_call_index=0")
+        assertThat(encoded).contains("tool_call_index=1")
+    }
+
+    @Test
+    fun `encoding is deterministic across calls`() {
+        val messages =
+            listOf(
+                Message.text("same"),
+                Message(role = MessageRole.ASSISTANT, content = "", toolCalls = listOf(ToolCall("c", "f", "{}"))),
+            )
+
+        assertThat(CanonicalMessageEncoder.encode(messages))
+            .isEqualTo(CanonicalMessageEncoder.encode(messages))
+    }
+
+    @Test
+    fun `encodes non-ASCII content using UTF-8 byte length`() {
+        val encoded = CanonicalMessageEncoder.encode(listOf(Message.text("héllo")))
+
+        assertThat(encoded).contains("content_len=6") // h é l l o in UTF-8: 1+2+1+1+1
+        assertThat(encoded).contains("héllo")
+    }
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ModelRegistryEnforcerTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ModelRegistryEnforcerTest.kt
@@ -8,6 +8,8 @@ import dev.tramai.core.model.ModelRegistry
 import dev.tramai.core.model.ModelRegistrySettings
 import dev.tramai.core.model.RegisteredModel
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -100,6 +102,98 @@ class ModelRegistryEnforcerTest {
             .hasMessageNotContaining("secret-value")
             .hasMessageNotContaining("internal-registry")
     }
+
+    // ── B2: real suspension/resumption discriminators (10.3c2) ──
+    //
+    // The tests above return/throw directly from findApprovedModel, so the
+    // coroutine never actually suspends and resumes inside authorize(). PIT's
+    // NO_COVERAGE mutants on the resume-path throwOnFailure (offset 167 /
+    // line 18 block 14) can therefore not be killed by them. These three tests
+    // force a genuine suspension: the registry signals entry, suspends on a
+    // CompletableDeferred, and only resumes after the test observes the
+    // suspended state — proving the continuation boundary, not a delay().
+
+    private class SuspendingRegistry(
+        private val onEntry: () -> Unit,
+        private val outcome: () -> RegisteredModel?,
+    ) : ModelRegistry {
+        val entered = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+
+        override suspend fun findApprovedModel(providerId: String, modelName: String): RegisteredModel? {
+            onEntry()
+            entered.complete(Unit)
+            release.await()
+            return outcome()
+        }
+    }
+
+    @Test
+    fun `resumed success returns the approved model`() : Unit = runBlocking {
+        val approved = registeredModel()
+        val registry = SuspendingRegistry(onEntry = {}, outcome = { approved })
+        val enforcer = ModelRegistryEnforcer(
+            registry = registry,
+            settings = ModelRegistrySettings(enabled = true),
+        )
+
+        val outcome = CompletableDeferred<Result<RegisteredModel?>>()
+        val job = launch {
+            outcome.complete(runCatching { enforcer.authorize("provider-1", "model-1") })
+        }
+        registry.entered.await() // authorize() is genuinely suspended now
+        registry.release.complete(Unit)
+        assertThat(outcome.await().getOrNull()).isEqualTo(approved)
+        job.join()
+    }
+
+    @Test
+    fun `resumed adapter exception is sanitized`() : Unit = runBlocking {
+        val registry = SuspendingRegistry(
+            onEntry = {},
+            outcome = { throw IllegalStateException("token=secret url=http://internal") },
+        )
+        val enforcer = ModelRegistryEnforcer(
+            registry = registry,
+            settings = ModelRegistrySettings(enabled = true),
+        )
+
+        val outcome = CompletableDeferred<Result<RegisteredModel?>>()
+        val job = launch {
+            outcome.complete(runCatching { enforcer.authorize("provider-1", "model-1") })
+        }
+        registry.entered.await()
+        registry.release.complete(Unit)
+        val failure = outcome.await().exceptionOrNull()
+        assertThat(failure).isInstanceOf(ModelRegistryUnavailableException::class.java)
+            .hasMessage("Model registry is unavailable")
+            .hasNoCause()
+        job.join()
+    }
+
+    @Test
+    fun `resumed cancellation propagates unchanged`() : Unit = runBlocking {
+        val registry = SuspendingRegistry(
+            onEntry = {},
+            outcome = { throw CancellationException("cancelled-after-resume") },
+        )
+        val enforcer = ModelRegistryEnforcer(
+            registry = registry,
+            settings = ModelRegistrySettings(enabled = true),
+        )
+
+        val outcome = CompletableDeferred<Result<RegisteredModel?>>()
+        val job = launch {
+            outcome.complete(runCatching { enforcer.authorize("provider-1", "model-1") })
+        }
+        registry.entered.await()
+        registry.release.complete(Unit)
+        val failure = outcome.await().exceptionOrNull()
+        assertThat(failure).isInstanceOf(CancellationException::class.java)
+            .hasMessage("cancelled-after-resume")
+        job.join()
+    }
+
 
     private fun registeredModel(
         enabled: Boolean = true,

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ModelRegistryEnforcerTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ModelRegistryEnforcerTest.kt
@@ -16,92 +16,105 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import kotlin.test.Test
 
 class ModelRegistryEnforcerTest {
+    @Test
+    fun `disabled registry enforcement returns null`(): Unit =
+        runBlocking {
+            val enforcer =
+                ModelRegistryEnforcer(
+                    registry = registryReturning(registeredModel()),
+                    settings = ModelRegistrySettings(enabled = false),
+                )
+
+            assertThat(enforcer.authorize("provider-1", "model-1")).isNull()
+        }
 
     @Test
-    fun `disabled registry enforcement returns null`() : Unit = runBlocking {
-        val enforcer = ModelRegistryEnforcer(
-            registry = registryReturning(registeredModel()),
-            settings = ModelRegistrySettings(enabled = false),
-        )
+    fun `enabled registry rejects unknown model`(): Unit =
+        runBlocking {
+            val enforcer =
+                ModelRegistryEnforcer(
+                    registry = registryReturning(null),
+                    settings = ModelRegistrySettings(enabled = true),
+                )
 
-        assertThat(enforcer.authorize("provider-1", "model-1")).isNull()
-    }
-
-    @Test
-    fun `enabled registry rejects unknown model`() : Unit = runBlocking {
-        val enforcer = ModelRegistryEnforcer(
-            registry = registryReturning(null),
-            settings = ModelRegistrySettings(enabled = true),
-        )
-
-        assertThatThrownBy {
-            runBlocking { enforcer.authorize("provider-1", "missing") }
-        }.isInstanceOf(ModelNotRegisteredException::class.java)
-    }
+            assertThatThrownBy {
+                runBlocking { enforcer.authorize("provider-1", "missing") }
+            }.isInstanceOf(ModelNotRegisteredException::class.java)
+        }
 
     @Test
-    fun `enabled registry accepts registered model`() : Unit = runBlocking {
-        val approved = registeredModel()
-        val enforcer = ModelRegistryEnforcer(
-            registry = registryReturning(approved),
-            settings = ModelRegistrySettings(enabled = true),
-        )
+    fun `enabled registry accepts registered model`(): Unit =
+        runBlocking {
+            val approved = registeredModel()
+            val enforcer =
+                ModelRegistryEnforcer(
+                    registry = registryReturning(approved),
+                    settings = ModelRegistrySettings(enabled = true),
+                )
 
-        assertThat(enforcer.authorize("provider-1", "model-1")).isEqualTo(approved)
-    }
-
-    @Test
-    fun `enabled registry rejects disabled model`() : Unit = runBlocking {
-        val enforcer = ModelRegistryEnforcer(
-            registry = registryReturning(registeredModel(enabled = false)),
-            settings = ModelRegistrySettings(enabled = true),
-        )
-
-        assertThatThrownBy {
-            runBlocking { enforcer.authorize("provider-1", "model-1") }
-        }.isInstanceOf(ModelDisabledException::class.java)
-    }
+            assertThat(enforcer.authorize("provider-1", "model-1")).isEqualTo(approved)
+        }
 
     @Test
-    fun `cancellation exception propagates`() : Unit = runBlocking {
-        val enforcer = ModelRegistryEnforcer(
-            registry = object : ModelRegistry {
-                override suspend fun findApprovedModel(providerId: String, modelName: String): RegisteredModel? {
-                    throw CancellationException("cancelled")
-                }
-            },
-            settings = ModelRegistrySettings(enabled = true),
-        )
+    fun `enabled registry rejects disabled model`(): Unit =
+        runBlocking {
+            val enforcer =
+                ModelRegistryEnforcer(
+                    registry = registryReturning(registeredModel(enabled = false)),
+                    settings = ModelRegistrySettings(enabled = true),
+                )
 
-        assertThatThrownBy {
-            runBlocking { enforcer.authorize("provider-1", "model-1") }
-        }.isInstanceOf(CancellationException::class.java)
-    }
+            assertThatThrownBy {
+                runBlocking { enforcer.authorize("provider-1", "model-1") }
+            }.isInstanceOf(ModelDisabledException::class.java)
+        }
 
     @Test
-    fun `adapter exception is fully sanitized`() : Unit = runBlocking {
-        val enforcer = ModelRegistryEnforcer(
-            registry = object : ModelRegistry {
-                override suspend fun findApprovedModel(
-                    providerId: String,
-                    modelName: String,
-                ): RegisteredModel? {
-                    throw IllegalStateException(
-                        "token=secret-value url=http://internal-registry.local",
-                    )
-                }
-            },
-            settings = ModelRegistrySettings(enabled = true),
-        )
+    fun `cancellation exception propagates`(): Unit =
+        runBlocking {
+            val enforcer =
+                ModelRegistryEnforcer(
+                    registry =
+                        object : ModelRegistry {
+                            override suspend fun findApprovedModel(
+                                providerId: String,
+                                modelName: String,
+                            ): RegisteredModel? = throw CancellationException("cancelled")
+                        },
+                    settings = ModelRegistrySettings(enabled = true),
+                )
 
-        assertThatThrownBy {
-            runBlocking { enforcer.authorize("provider-1", "model-1") }
-        }.isInstanceOf(ModelRegistryUnavailableException::class.java)
-            .hasMessage("Model registry is unavailable")
-            .hasNoCause()
-            .hasMessageNotContaining("secret-value")
-            .hasMessageNotContaining("internal-registry")
-    }
+            assertThatThrownBy {
+                runBlocking { enforcer.authorize("provider-1", "model-1") }
+            }.isInstanceOf(CancellationException::class.java)
+        }
+
+    @Test
+    fun `adapter exception is fully sanitized`(): Unit =
+        runBlocking {
+            val enforcer =
+                ModelRegistryEnforcer(
+                    registry =
+                        object : ModelRegistry {
+                            override suspend fun findApprovedModel(
+                                providerId: String,
+                                modelName: String,
+                            ): RegisteredModel? =
+                                throw IllegalStateException(
+                                    "token=secret-value url=http://internal-registry.local",
+                                )
+                        },
+                    settings = ModelRegistrySettings(enabled = true),
+                )
+
+            assertThatThrownBy {
+                runBlocking { enforcer.authorize("provider-1", "model-1") }
+            }.isInstanceOf(ModelRegistryUnavailableException::class.java)
+                .hasMessage("Model registry is unavailable")
+                .hasNoCause()
+                .hasMessageNotContaining("secret-value")
+                .hasMessageNotContaining("internal-registry")
+        }
 
     // ── B2: real suspension/resumption discriminators (10.3c2) ──
     //
@@ -120,7 +133,10 @@ class ModelRegistryEnforcerTest {
         val entered = CompletableDeferred<Unit>()
         val release = CompletableDeferred<Unit>()
 
-        override suspend fun findApprovedModel(providerId: String, modelName: String): RegisteredModel? {
+        override suspend fun findApprovedModel(
+            providerId: String,
+            modelName: String,
+        ): RegisteredModel? {
             onEntry()
             entered.complete(Unit)
             release.await()
@@ -129,84 +145,99 @@ class ModelRegistryEnforcerTest {
     }
 
     @Test
-    fun `resumed success returns the approved model`() : Unit = runBlocking {
-        val approved = registeredModel()
-        val registry = SuspendingRegistry(onEntry = {}, outcome = { approved })
-        val enforcer = ModelRegistryEnforcer(
-            registry = registry,
-            settings = ModelRegistrySettings(enabled = true),
-        )
+    fun `resumed success returns the approved model`(): Unit =
+        runBlocking {
+            val approved = registeredModel()
+            val registry = SuspendingRegistry(onEntry = {}, outcome = { approved })
+            val enforcer =
+                ModelRegistryEnforcer(
+                    registry = registry,
+                    settings = ModelRegistrySettings(enabled = true),
+                )
 
-        val outcome = CompletableDeferred<Result<RegisteredModel?>>()
-        val job = launch {
-            outcome.complete(runCatching { enforcer.authorize("provider-1", "model-1") })
+            val outcome = CompletableDeferred<Result<RegisteredModel?>>()
+            val job =
+                launch {
+                    outcome.complete(runCatching { enforcer.authorize("provider-1", "model-1") })
+                }
+            registry.entered.await() // authorize() is genuinely suspended now
+            registry.release.complete(Unit)
+            assertThat(outcome.await().getOrNull()).isEqualTo(approved)
+            job.join()
         }
-        registry.entered.await() // authorize() is genuinely suspended now
-        registry.release.complete(Unit)
-        assertThat(outcome.await().getOrNull()).isEqualTo(approved)
-        job.join()
-    }
 
     @Test
-    fun `resumed adapter exception is sanitized`() : Unit = runBlocking {
-        val registry = SuspendingRegistry(
-            onEntry = {},
-            outcome = { throw IllegalStateException("token=secret url=http://internal") },
-        )
-        val enforcer = ModelRegistryEnforcer(
-            registry = registry,
-            settings = ModelRegistrySettings(enabled = true),
-        )
+    fun `resumed adapter exception is sanitized`(): Unit =
+        runBlocking {
+            val registry =
+                SuspendingRegistry(
+                    onEntry = {},
+                    outcome = { throw IllegalStateException("token=secret url=http://internal") },
+                )
+            val enforcer =
+                ModelRegistryEnforcer(
+                    registry = registry,
+                    settings = ModelRegistrySettings(enabled = true),
+                )
 
-        val outcome = CompletableDeferred<Result<RegisteredModel?>>()
-        val job = launch {
-            outcome.complete(runCatching { enforcer.authorize("provider-1", "model-1") })
+            val outcome = CompletableDeferred<Result<RegisteredModel?>>()
+            val job =
+                launch {
+                    outcome.complete(runCatching { enforcer.authorize("provider-1", "model-1") })
+                }
+            registry.entered.await()
+            registry.release.complete(Unit)
+            val failure = outcome.await().exceptionOrNull()
+            assertThat(failure)
+                .isInstanceOf(ModelRegistryUnavailableException::class.java)
+                .hasMessage("Model registry is unavailable")
+                .hasNoCause()
+            job.join()
         }
-        registry.entered.await()
-        registry.release.complete(Unit)
-        val failure = outcome.await().exceptionOrNull()
-        assertThat(failure).isInstanceOf(ModelRegistryUnavailableException::class.java)
-            .hasMessage("Model registry is unavailable")
-            .hasNoCause()
-        job.join()
-    }
 
     @Test
-    fun `resumed cancellation propagates unchanged`() : Unit = runBlocking {
-        val registry = SuspendingRegistry(
-            onEntry = {},
-            outcome = { throw CancellationException("cancelled-after-resume") },
-        )
-        val enforcer = ModelRegistryEnforcer(
-            registry = registry,
-            settings = ModelRegistrySettings(enabled = true),
-        )
+    fun `resumed cancellation propagates unchanged`(): Unit =
+        runBlocking {
+            val registry =
+                SuspendingRegistry(
+                    onEntry = {},
+                    outcome = { throw CancellationException("cancelled-after-resume") },
+                )
+            val enforcer =
+                ModelRegistryEnforcer(
+                    registry = registry,
+                    settings = ModelRegistrySettings(enabled = true),
+                )
 
-        val outcome = CompletableDeferred<Result<RegisteredModel?>>()
-        val job = launch {
-            outcome.complete(runCatching { enforcer.authorize("provider-1", "model-1") })
+            val outcome = CompletableDeferred<Result<RegisteredModel?>>()
+            val job =
+                launch {
+                    outcome.complete(runCatching { enforcer.authorize("provider-1", "model-1") })
+                }
+            registry.entered.await()
+            registry.release.complete(Unit)
+            val failure = outcome.await().exceptionOrNull()
+            assertThat(failure)
+                .isInstanceOf(CancellationException::class.java)
+                .hasMessage("cancelled-after-resume")
+            job.join()
         }
-        registry.entered.await()
-        registry.release.complete(Unit)
-        val failure = outcome.await().exceptionOrNull()
-        assertThat(failure).isInstanceOf(CancellationException::class.java)
-            .hasMessage("cancelled-after-resume")
-        job.join()
-    }
 
+    private fun registeredModel(enabled: Boolean = true): RegisteredModel =
+        RegisteredModel(
+            registryEntryId = "entry-1",
+            providerId = "provider-1",
+            modelName = "model-1",
+            revision = "rev-1",
+            artifactDigest = ModelArtifactDigest.of("sha256:${"a".repeat(64)}"),
+            enabled = enabled,
+        )
 
-    private fun registeredModel(
-        enabled: Boolean = true,
-    ): RegisteredModel = RegisteredModel(
-        registryEntryId = "entry-1",
-        providerId = "provider-1",
-        modelName = "model-1",
-        revision = "rev-1",
-        artifactDigest = ModelArtifactDigest.of("sha256:${"a".repeat(64)}"),
-        enabled = enabled,
-    )
-
-    private fun registryReturning(model: RegisteredModel?): ModelRegistry = object : ModelRegistry {
-        override suspend fun findApprovedModel(providerId: String, modelName: String): RegisteredModel? = model
-    }
+    private fun registryReturning(model: RegisteredModel?): ModelRegistry =
+        object : ModelRegistry {
+            override suspend fun findApprovedModel(
+                providerId: String,
+                modelName: String,
+            ): RegisteredModel? = model
+        }
 }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/RetrySettingsContractTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/RetrySettingsContractTest.kt
@@ -1,0 +1,63 @@
+package dev.tramai.engine
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * Direct contract tests for [RetryPolicySettings] and [CircuitBreakerSettings].
+ *
+ * Defaults are behavioral: retry pacing and breaker thresholds gate provider
+ * traffic, so silently changed defaults (e.g. jitterRatio collapsing to 0.0)
+ * would alter production retry behavior without any caller noticing.
+ */
+class RetrySettingsContractTest {
+    // ------------------------------------------------------------ RetryPolicySettings
+
+    @Test
+    fun `retry policy defaults to documented pacing`() {
+        val settings = RetryPolicySettings()
+
+        assertThat(settings.maxRetryAfterMillis).isEqualTo(30_000L)
+        assertThat(settings.jitterRatio).isEqualTo(0.2)
+    }
+
+    @Test
+    fun `retry policy rejects non-positive max retry after`() {
+        assertThatThrownBy { RetryPolicySettings(maxRetryAfterMillis = 0L) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("must be greater than zero")
+    }
+
+    @Test
+    fun `retry policy rejects negative jitter ratio`() {
+        assertThatThrownBy { RetryPolicySettings(jitterRatio = -0.01) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("jitterRatio")
+    }
+
+    // ------------------------------------------------------------ CircuitBreakerSettings
+
+    @Test
+    fun `circuit breaker defaults to disabled with documented thresholds`() {
+        val settings = CircuitBreakerSettings()
+
+        assertThat(settings.enabled).isFalse()
+        assertThat(settings.failureThreshold).isEqualTo(3)
+        assertThat(settings.openDurationMillis).isEqualTo(30_000L)
+    }
+
+    @Test
+    fun `circuit breaker rejects non-positive failure threshold`() {
+        assertThatThrownBy { CircuitBreakerSettings(failureThreshold = 0) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("must be greater than zero")
+    }
+
+    @Test
+    fun `circuit breaker rejects non-positive open duration`() {
+        assertThatThrownBy { CircuitBreakerSettings(openDurationMillis = 0L) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("must be greater than zero")
+    }
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ToolRegistryTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ToolRegistryTest.kt
@@ -9,48 +9,73 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 
 class ToolRegistryTest {
+    private val validTool =
+        object : ResolvedTool {
+            override val name = "lookup"
+            override val description = "Looks up data"
+            override val inputSchemaJson = """{"type":"object"}"""
+            override val idempotent = false
+            override val sideEffectLevel = SideEffectLevel.READ_ONLY
 
-    private val validTool = object : ResolvedTool {
-        override val name = "lookup"
-        override val description = "Looks up data"
-        override val inputSchemaJson = """{"type":"object"}"""
-        override val idempotent = false
-        override val sideEffectLevel = SideEffectLevel.READ_ONLY
-        override suspend fun execute(input: Any, context: ToolExecutionContext): ToolResult =
-            ToolResult.Success("ok")
-    }
+            override suspend fun execute(
+                input: Any,
+                context: ToolExecutionContext,
+            ): ToolResult = ToolResult.Success("ok")
+        }
 
     private val overlongName = "x".repeat(ToolRegistry.MAX_TOOL_NAME_LENGTH + 1)
+
+    private fun toolNamed(name: String): ResolvedTool =
+        object : ResolvedTool {
+            override val name = name
+            override val description = "Tool $name"
+            override val inputSchemaJson = """{"type":"object"}"""
+            override val idempotent = false
+            override val sideEffectLevel = SideEffectLevel.READ_ONLY
+
+            override suspend fun execute(
+                input: Any,
+                context: ToolExecutionContext,
+            ): ToolResult = ToolResult.Success("ok")
+        }
 
     @Test
     fun `mutating original map after construction does not affect registry`() {
         val mutableMap: MutableMap<String, ResolvedTool> = mutableMapOf("lookup" to validTool)
         val registry = ToolRegistry(mutableMap)
 
-        mutableMap["x".repeat(10_000)] = object : ResolvedTool {
-            override val name = "malicious"
-            override val description = ""
-            override val inputSchemaJson = ""
-            override val idempotent = false
-            override val sideEffectLevel = SideEffectLevel.READ_ONLY
-            override suspend fun execute(input: Any, context: ToolExecutionContext): ToolResult =
-                ToolResult.Success("hack")
-        }
+        mutableMap["x".repeat(10_000)] =
+            object : ResolvedTool {
+                override val name = "malicious"
+                override val description = ""
+                override val inputSchemaJson = ""
+                override val idempotent = false
+                override val sideEffectLevel = SideEffectLevel.READ_ONLY
+
+                override suspend fun execute(
+                    input: Any,
+                    context: ToolExecutionContext,
+                ): ToolResult = ToolResult.Success("hack")
+            }
 
         assertThat(registry.registeredToolNames()).containsExactly("lookup")
     }
 
     @Test
     fun `key mismatch with ResolvedTool name is rejected`() {
-        val toolWithDifferentName = object : ResolvedTool {
-            override val name = "different-long-name-here"
-            override val description = ""
-            override val inputSchemaJson = """{"type":"object"}"""
-            override val idempotent = false
-            override val sideEffectLevel = SideEffectLevel.READ_ONLY
-            override suspend fun execute(input: Any, context: ToolExecutionContext): ToolResult =
-                ToolResult.Success("ok")
-        }
+        val toolWithDifferentName =
+            object : ResolvedTool {
+                override val name = "different-long-name-here"
+                override val description = ""
+                override val inputSchemaJson = """{"type":"object"}"""
+                override val idempotent = false
+                override val sideEffectLevel = SideEffectLevel.READ_ONLY
+
+                override suspend fun execute(
+                    input: Any,
+                    context: ToolExecutionContext,
+                ): ToolResult = ToolResult.Success("ok")
+            }
 
         assertThatThrownBy {
             ToolRegistry(mapOf("short-key" to toolWithDifferentName))
@@ -61,15 +86,19 @@ class ToolRegistryTest {
 
     @Test
     fun `overlong ResolvedTool name hidden behind short key is rejected`() {
-        val hiddenOverlongTool = object : ResolvedTool {
-            override val name = overlongName
-            override val description = ""
-            override val inputSchemaJson = """{"type":"object"}"""
-            override val idempotent = false
-            override val sideEffectLevel = SideEffectLevel.READ_ONLY
-            override suspend fun execute(input: Any, context: ToolExecutionContext): ToolResult =
-                ToolResult.Success("ok")
-        }
+        val hiddenOverlongTool =
+            object : ResolvedTool {
+                override val name = overlongName
+                override val description = ""
+                override val inputSchemaJson = """{"type":"object"}"""
+                override val idempotent = false
+                override val sideEffectLevel = SideEffectLevel.READ_ONLY
+
+                override suspend fun execute(
+                    input: Any,
+                    context: ToolExecutionContext,
+                ): ToolResult = ToolResult.Success("ok")
+            }
 
         // Key passes validation but resolvedTool.name doesn't match key
         assertThatThrownBy {
@@ -89,5 +118,37 @@ class ToolRegistryTest {
     fun `resolve returns null for unregistered tool`() {
         val registry = ToolRegistry(mapOf("lookup" to validTool))
         assertThat(registry.resolve("unknown")).isNull()
+    }
+
+    @Test
+    fun `blank key is rejected by name validation even when tool name matches`() {
+        assertThatThrownBy {
+            ToolRegistry(mapOf("   " to toolNamed("   ")))
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("must not be blank")
+    }
+
+    @Test
+    fun `key with surrounding whitespace is rejected`() {
+        assertThatThrownBy {
+            ToolRegistry(mapOf(" padded " to toolNamed(" padded ")))
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("surrounding whitespace")
+    }
+
+    @Test
+    fun `key at exactly the maximum length is accepted`() {
+        val boundaryName = "x".repeat(ToolRegistry.MAX_TOOL_NAME_LENGTH)
+        val registry = ToolRegistry(mapOf(boundaryName to toolNamed(boundaryName)))
+
+        assertThat(registry.registeredToolNames()).containsExactly(boundaryName)
+    }
+
+    @Test
+    fun `key one past the maximum length is rejected`() {
+        assertThatThrownBy {
+            ToolRegistry(mapOf(overlongName to toolNamed(overlongName)))
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("exceeds maximum length")
     }
 }

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/ToolResultFilteringSettingsTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/ToolResultFilteringSettingsTest.kt
@@ -1,0 +1,76 @@
+package dev.tramai.engine
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * Direct contract tests for [ToolResultFilteringSettings].
+ *
+ * The settings gate how much tool output is retained for the model, so the
+ * default ceiling and per-tool overrides are behavioral contracts.
+ */
+class ToolResultFilteringSettingsTest {
+    @Test
+    fun `defaults to the documented aggregate ceiling`() {
+        val settings = ToolResultFilteringSettings()
+
+        assertThat(settings.defaultMaxAggregateTextLength).isEqualTo(100_000L)
+        assertThat(settings.maxAggregateTextLengthByTool).isEmpty()
+    }
+
+    @Test
+    fun `per-tool limit falls back to the default for unknown tools`() {
+        val settings =
+            ToolResultFilteringSettings(
+                defaultMaxAggregateTextLength = 10L,
+                maxAggregateTextLengthByTool = mapOf("search" to 5L),
+            )
+
+        assertThat(settings.maxAggregateTextLengthForTool("search")).isEqualTo(5L)
+        assertThat(settings.maxAggregateTextLengthForTool("other")).isEqualTo(10L)
+    }
+
+    @Test
+    fun `rejects non-positive default ceiling`() {
+        assertThatThrownBy { ToolResultFilteringSettings(defaultMaxAggregateTextLength = 0L) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("must be positive")
+        assertThatThrownBy { ToolResultFilteringSettings(defaultMaxAggregateTextLength = -1L) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `rejects blank tool names`() {
+        assertThatThrownBy {
+            ToolResultFilteringSettings(maxAggregateTextLengthByTool = mapOf(" " to 5L))
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("must not be blank")
+    }
+
+    @Test
+    fun `rejects tool names with surrounding whitespace`() {
+        assertThatThrownBy {
+            ToolResultFilteringSettings(maxAggregateTextLengthByTool = mapOf(" search " to 5L))
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("surrounding whitespace")
+    }
+
+    @Test
+    fun `rejects non-positive per-tool limits`() {
+        assertThatThrownBy {
+            ToolResultFilteringSettings(maxAggregateTextLengthByTool = mapOf("search" to 0L))
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("must be positive")
+    }
+
+    @Test
+    fun `defensively copies the supplied per-tool map`() {
+        val original = HashMap<String, Long>()
+        original["search"] = 5L
+        val settings = ToolResultFilteringSettings(maxAggregateTextLengthByTool = original)
+        original["search"] = 999L
+
+        assertThat(settings.maxAggregateTextLengthByTool["search"]).isEqualTo(5L)
+    }
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/ProviderCircuitBreakerContractTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/ProviderCircuitBreakerContractTest.kt
@@ -1,0 +1,76 @@
+package dev.tramai.engine.provider
+
+import dev.tramai.core.exception.ProviderException
+import dev.tramai.engine.CircuitBreakerAdmission
+import dev.tramai.engine.CircuitBreakerPermit
+import dev.tramai.engine.CircuitBreakerSettings
+import dev.tramai.engine.ProviderCircuitBreaker
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Direct contract tests for [ProviderCircuitBreaker.openUntilMillis] and the
+ * disabled-state behavior.
+ *
+ * These pin the edge returns that the lifecycle tests only reach indirectly:
+ * openUntilMillis on a disabled breaker, on an unknown provider, and at the
+ * exact expiry boundary (now == blockedUntil must be treated as expired so a
+ * replacement probe can be admitted).
+ */
+class ProviderCircuitBreakerContractTest {
+    @Test
+    fun `openUntilMillis returns null when the breaker is disabled`() {
+        val breaker = ProviderCircuitBreaker(CircuitBreakerSettings(enabled = false), { 0L })
+
+        assertThat(breaker.openUntilMillis("primary")).isNull()
+    }
+
+    @Test
+    fun `openUntilMillis returns null for an unknown provider`() {
+        val breaker = ProviderCircuitBreaker(CircuitBreakerSettings(enabled = true), { 0L })
+
+        assertThat(breaker.openUntilMillis("unknown")).isNull()
+    }
+
+    @Test
+    fun `openUntilMillis treats exact expiry as expired`() {
+        var now = 0L
+        val breaker =
+            ProviderCircuitBreaker(
+                CircuitBreakerSettings(enabled = true, failureThreshold = 1, openDurationMillis = 100),
+                { now },
+            )
+        breaker.onFailure(admit(breaker), ProviderException("down", retryable = true))
+        assertThat(breaker.openUntilMillis("primary")).isEqualTo(100)
+
+        // At the exact boundary the breaker must read as expired so the next
+        // caller can transition into HALF_OPEN instead of being rejected.
+        now = 100
+        assertThat(breaker.openUntilMillis("primary")).isNull()
+    }
+
+    @Test
+    fun `disabled breaker reports failures without opening and admits freely`() {
+        val breaker = ProviderCircuitBreaker(CircuitBreakerSettings(enabled = false), { 0L })
+        val permit = admit(breaker)
+
+        assertThat(breaker.onFailure(permit, ProviderException("down", retryable = true))).isFalse()
+        assertThat(breaker.openUntilMillis("primary")).isNull()
+    }
+
+    @Test
+    fun `default clock produces a real future deadline`() {
+        // Uses the production System.currentTimeMillis default. The default
+        // openDurationMillis (30s) gives a wide race-free window: opening now
+        // must yield a deadline strictly in the future.
+        val breaker = ProviderCircuitBreaker(CircuitBreakerSettings(enabled = true, failureThreshold = 1))
+
+        breaker.onFailure(admit(breaker), ProviderException("down", retryable = true))
+
+        assertThat(breaker.openUntilMillis("primary")).isNotNull
+        assertThat(breaker.openUntilMillis("primary")!!).isGreaterThan(System.currentTimeMillis())
+    }
+
+    private fun admit(breaker: ProviderCircuitBreaker): CircuitBreakerPermit =
+        (breaker.beforeCall("primary") as CircuitBreakerAdmission.Allowed).permit
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/ProviderCircuitBreakerLifecycleDiscriminatorTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/ProviderCircuitBreakerLifecycleDiscriminatorTest.kt
@@ -32,26 +32,28 @@ import kotlin.test.Test
  * without changing any assertion value or the encoded invariant.
  */
 class ProviderCircuitBreakerLifecycleDiscriminatorTest {
-
     // ------------------------------------------------------------------ P0-A
 
     @Test
     fun `P0-A synchronous success resets the consecutive failure history`() {
         runBlocking {
             var now = 0L
-            val breaker = ProviderCircuitBreaker(CircuitBreakerSettings(enabled = true, failureThreshold = 2, openDurationMillis = 100), { now })
+            val breaker =
+                breaker(failureThreshold = 2, clock = { now })
             var calls = 0
-            val provider = FakeProvider {
-                calls++
-                when (calls) {
-                    1, 3 -> throw ProviderException("down", retryable = true)
-                    else -> ModelResponse("ok")
+            val provider =
+                FakeProvider {
+                    calls++
+                    when (calls) {
+                        1, 3 -> throw ProviderException("down", retryable = true)
+                        else -> ModelResponse("ok")
+                    }
                 }
-            }
-            val coordinator = coordinator(
-                plan = plan(provider),
-                breaker = breaker,
-            )
+            val coordinator =
+                coordinator(
+                    plan = plan(provider),
+                    breaker = breaker,
+                )
 
             // call 1: retryable failure → failures = 1
             assertThat(runCatching { coordinator.execute(executionRequest()) }.exceptionOrNull())
@@ -73,7 +75,8 @@ class ProviderCircuitBreakerLifecycleDiscriminatorTest {
     fun `P0-B exact expiry admits exactly one probe and rejects the rest`() {
         runBlocking {
             var now = 0L
-            val breaker = ProviderCircuitBreaker(CircuitBreakerSettings(enabled = true, failureThreshold = 1, openDurationMillis = 100), { now })
+            val breaker =
+                breaker(failureThreshold = 1, clock = { now })
 
             val permit = admit(breaker, "primary")
             breaker.onFailure(permit, ProviderException("down", retryable = true))
@@ -83,9 +86,10 @@ class ProviderCircuitBreakerLifecycleDiscriminatorTest {
             assertThat(blockedUntil(breaker, "primary")).isEqualTo(100) // t=99 rejected
 
             now = 100
-            val admissions = supervisorScope {
-                (1..8).map { async { blockedUntil(breaker, "primary") == null } }.awaitAll()
-            }
+            val admissions =
+                supervisorScope {
+                    (1..8).map { async { blockedUntil(breaker, "primary") == null } }.awaitAll()
+                }
             // Exactly one HALF_OPEN probe may enter; the other 7 are rejected.
             assertThat(admissions.count { it }).isEqualTo(1)
         }
@@ -97,7 +101,8 @@ class ProviderCircuitBreakerLifecycleDiscriminatorTest {
     fun `P0-C stale pre-OPEN success cannot close the newer OPEN generation`() {
         runBlocking {
             var now = 0L
-            val breaker = ProviderCircuitBreaker(CircuitBreakerSettings(enabled = true, failureThreshold = 1, openDurationMillis = 100), { now })
+            val breaker =
+                breaker(failureThreshold = 1, clock = { now })
 
             // A and B both admitted while CLOSED — each owns a CLOSED-epoch permit.
             val permitA = admit(breaker, "primary")
@@ -120,7 +125,8 @@ class ProviderCircuitBreakerLifecycleDiscriminatorTest {
     fun `P0-D stale pre-OPEN failure cannot extend the newer OPEN deadline`() {
         runBlocking {
             var now = 0L
-            val breaker = ProviderCircuitBreaker(CircuitBreakerSettings(enabled = true, failureThreshold = 1, openDurationMillis = 100), { now })
+            val breaker =
+                breaker(failureThreshold = 1, clock = { now })
 
             // A and B both admitted while CLOSED.
             val permitA = admit(breaker, "primary")
@@ -144,7 +150,8 @@ class ProviderCircuitBreakerLifecycleDiscriminatorTest {
     fun `P0-E failed HALF_OPEN probe immediately reopens with a fresh deadline`() {
         runBlocking {
             var now = 0L
-            val breaker = ProviderCircuitBreaker(CircuitBreakerSettings(enabled = true, failureThreshold = 3, openDurationMillis = 100), { now })
+            val breaker =
+                breaker(failureThreshold = 3, clock = { now })
 
             // Three qualifying failures → OPEN.
             repeat(3) { breaker.onFailure(admit(breaker, "primary"), ProviderException("down", retryable = true)) }
@@ -164,38 +171,120 @@ class ProviderCircuitBreakerLifecycleDiscriminatorTest {
         }
     }
 
+    // ------------------------------------------------------------ P0-F
+
+    @Test
+    fun `P0-F stale closed-era permit can never act as the next probe`() {
+        runBlocking {
+            // Three reopen routes from HALF_OPEN all advance the generation.
+            // If any route instead DECREASED it (mutant generation - 1), the
+            // stale generation-0 permit from the closed era would match the
+            // state in the second HALF_OPEN epoch and wrongly reopen the
+            // circuit as if it were the probe. This test forces two full
+            // open/probe cycles so that collision would be observable.
+            val reopenRoutes =
+                listOf(
+                    "probe-failure" to { breaker: ProviderCircuitBreaker, probe: CircuitBreakerPermit ->
+                        breaker.onFailure(probe, ProviderException("probe failed", retryable = true))
+                    },
+                    "probe-neutral" to { breaker: ProviderCircuitBreaker, probe: CircuitBreakerPermit ->
+                        breaker.onFailure(probe, IllegalStateException("probe neutral"))
+                    },
+                    "probe-abandoned" to { breaker: ProviderCircuitBreaker, probe: CircuitBreakerPermit ->
+                        breaker.onAbandoned(probe)
+                    },
+                )
+
+            reopenRoutes.forEach { (route, reopen) ->
+                var now = 0L
+                val breaker =
+                    breaker(failureThreshold = 1, clock = { now })
+
+                // Closed era: two generation-0 permits.
+                val permitA = admit(breaker, "primary")
+                val stalePermit = admit(breaker, "primary")
+
+                // A fails → OPEN(gen 1) until 100.
+                breaker.onFailure(permitA, ProviderException("A failed", retryable = true))
+                assertThat(blockedUntil(breaker, "primary")).isEqualTo(100)
+
+                // Cycle 1 probe: expires at 100, fails/abandons → OPEN(gen 2) until 200.
+                now = 100
+                val probe1 = admit(breaker, "primary")
+                reopen(breaker, probe1)
+                assertThat(blockedUntil(breaker, "primary")).isEqualTo(200)
+
+                // Cycle 2: expires at 200, fresh probe is admitted under gen 2.
+                now = 200
+                val probe2 = admit(breaker, "primary")
+                assertThat(probe2).isNotNull
+
+                // The stale closed-era permit must NOT be able to reopen the
+                // circuit while the cycle-2 probe is in flight.
+                now = 210
+                breaker.onFailure(stalePermit, ProviderException("stale failed", retryable = true))
+                assertThat(blockedUntil(breaker, "primary"))
+                    .withFailMessage("route '$route': stale permit acted as probe and reopened the circuit")
+                    .isEqualTo(210)
+            }
+        }
+    }
+
     // ------------------------------------------------------------ adapters
 
     /** Acquires a permit for [providerId] exactly as production does (beforeCall → Allowed). */
-    private fun admit(breaker: ProviderCircuitBreaker, providerId: String): CircuitBreakerPermit =
-        (breaker.beforeCall(providerId) as CircuitBreakerAdmission.Allowed).permit
+    private fun admit(
+        breaker: ProviderCircuitBreaker,
+        providerId: String,
+    ): CircuitBreakerPermit = (breaker.beforeCall(providerId) as CircuitBreakerAdmission.Allowed).permit
 
     /** Returns the blocked-until millis when [providerId] is rejected, else null (admitted). */
-    private fun blockedUntil(breaker: ProviderCircuitBreaker, providerId: String): Long? =
-        (breaker.beforeCall(providerId) as? CircuitBreakerAdmission.Rejected)?.blockedUntilMillis
+    private fun blockedUntil(
+        breaker: ProviderCircuitBreaker,
+        providerId: String,
+    ): Long? = (breaker.beforeCall(providerId) as? CircuitBreakerAdmission.Rejected)?.blockedUntilMillis
 
     // ------------------------------------------------------------ infra copy
 
-    private fun plan(primary: FakeProvider) = ProviderRoutingPlan.builder()
-        .provider("primary", primary)
-        .model("model", "primary")
-        .build()
+    private fun plan(primary: FakeProvider) =
+        ProviderRoutingPlan
+            .builder()
+            .provider("primary", primary)
+            .model("model", "primary")
+            .build()
 
-    private fun executionRequest() = ProviderExecutionRequest(
-        operation = componentOperation(),
-        messages = emptyList(),
-        attemptCounter = AttemptCounter(),
-        correlationId = "cid",
-        securityContext = ExecutionSecurityContext(),
-        beforeRoute = ProviderRouteGate {},
-    )
-
-    private fun coordinator(plan: ProviderRoutingPlan, breaker: ProviderCircuitBreaker): ProviderExecutionCoordinator {
-        val observer = dev.tramai.core.observation.OperationObserver { RecordingObservation() }
-        val attempt = executor(
-            observation = RecordingObservation(),
-            circuitBreaker = breaker,
+    private fun executionRequest() =
+        ProviderExecutionRequest(
+            operation = componentOperation(),
+            messages = emptyList(),
+            attemptCounter = AttemptCounter(),
+            correlationId = "cid",
+            securityContext = ExecutionSecurityContext(),
+            beforeRoute = ProviderRouteGate {},
         )
+
+    private fun breaker(
+        failureThreshold: Int,
+        clock: () -> Long,
+    ): ProviderCircuitBreaker =
+        ProviderCircuitBreaker(
+            CircuitBreakerSettings(
+                enabled = true,
+                failureThreshold = failureThreshold,
+                openDurationMillis = 100,
+            ),
+            clock,
+        )
+
+    private fun coordinator(
+        plan: ProviderRoutingPlan,
+        breaker: ProviderCircuitBreaker,
+    ): ProviderExecutionCoordinator {
+        val attempt =
+            executor(
+                observation = RecordingObservation(),
+                circuitBreaker = breaker,
+            )
         return ProviderExecutionCoordinator(
             routingPlan = plan,
             circuitBreaker = breaker,

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/ProviderRetryPolicyTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/provider/ProviderRetryPolicyTest.kt
@@ -7,10 +7,15 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class ProviderRetryPolicyTest {
-    private val policy = ProviderRetryPolicy(ProviderRetryDelayPolicy(RetryPolicySettings(maxRetryAfterMillis = 250, jitterRatio = 0.2)) { 0.0 })
+    private val policy =
+        ProviderRetryPolicy(
+            ProviderRetryDelayPolicy(RetryPolicySettings(maxRetryAfterMillis = 250, jitterRatio = 0.2)) { 0.0 },
+        )
 
     @Test fun `retries retryable provider and timeout failures`() {
-        assertThat(policy.decide(ProviderException("temporary", retryable = true), 0, 2)).isInstanceOf(ProviderRetryDecision.Retry::class.java)
+        assertThat(
+            policy.decide(ProviderException("temporary", retryable = true), 0, 2),
+        ).isInstanceOf(ProviderRetryDecision.Retry::class.java)
         assertThat(policy.decide(TimeoutException("slow"), 0, 2)).isInstanceOf(ProviderRetryDecision.Retry::class.java)
     }
 
@@ -21,15 +26,79 @@ class ProviderRetryPolicyTest {
     }
 
     @Test fun `honours capped retry after and records source`() {
-        val honoured = policy.decide(ProviderException("wait", retryable = true, retryAfterMillis = 100), 0, 2) as ProviderRetryDecision.Retry
+        val honoured =
+            policy.decide(
+                ProviderException("wait", retryable = true, retryAfterMillis = 100),
+                0,
+                2,
+            ) as ProviderRetryDecision.Retry
         val capped = policy.decide(ProviderException("wait", retryable = true, retryAfterMillis = 500), 0, 2) as ProviderRetryDecision.Retry
-        assertThat(honoured.delayMillis).isEqualTo(100); assertThat(honoured.delaySource).isEqualTo("retry_after")
-        assertThat(capped.delayMillis).isEqualTo(250); assertThat(capped.delaySource).isEqualTo("retry_after")
+        assertThat(honoured.delayMillis).isEqualTo(100)
+        assertThat(honoured.delaySource).isEqualTo("retry_after")
+        assertThat(capped.delayMillis).isEqualTo(250)
+        assertThat(capped.delaySource).isEqualTo("retry_after")
     }
 
     @Test fun `uses deterministic exponential backoff when retry after is absent`() {
-        val delays = (0..5).map { (policy.decide(ProviderException("temporary", retryable = true), it, 7) as ProviderRetryDecision.Retry).delayMillis }
+        val delays =
+            (0..5).map { attempt ->
+                val decision = policy.decide(ProviderException("temporary", retryable = true), attempt, 7)
+                (decision as ProviderRetryDecision.Retry).delayMillis
+            }
         assertThat(delays).containsExactly(50, 100, 200, 400, 800, 1000)
-        assertThat((policy.decide(ProviderException("temporary", retryable = true), 0, 2) as ProviderRetryDecision.Retry).delaySource).isEqualTo("backoff")
+        assertThat(
+            (policy.decide(ProviderException("temporary", retryable = true), 0, 2) as ProviderRetryDecision.Retry)
+                .delaySource,
+        ).isEqualTo("backoff")
+    }
+
+    @Test fun `applies jitter ratio to nonzero jitter sample`() {
+        // jitterRatio=0.2, sample=0.5: delay = fallback + fallback * 0.2 * 0.5.
+        // With a fixed nonzero sample both the multiplication and the addition
+        // are observable (a zero sample would make * and / indistinguishable).
+        val jittered =
+            ProviderRetryPolicy(
+                ProviderRetryDelayPolicy(RetryPolicySettings(maxRetryAfterMillis = 250, jitterRatio = 0.2)) { 0.5 },
+            )
+        val retry = jittered.decide(ProviderException("temporary", retryable = true), 0, 2)
+        val decision = retry as ProviderRetryDecision.Retry
+        assertThat(decision.delayMillis).isEqualTo(55) // 50 + 50 * 0.2 * 0.5
+    }
+
+    @Test fun `caps retry after before applying jitter`() {
+        val jittered =
+            ProviderRetryPolicy(
+                ProviderRetryDelayPolicy(RetryPolicySettings(maxRetryAfterMillis = 250, jitterRatio = 0.2)) { 0.5 },
+            )
+        val retry =
+            jittered.decide(
+                ProviderException("wait", retryable = true, retryAfterMillis = 500),
+                0,
+                2,
+            ) as ProviderRetryDecision.Retry
+        // capped to 250 then jittered: 250 + 250 * 0.2 * 0.5 = 275
+        assertThat(retry.delayMillis).isEqualTo(275)
+    }
+
+    @Test fun `rejects out of range jitter samples`() {
+        val tooHigh =
+            ProviderRetryPolicy(
+                ProviderRetryDelayPolicy(RetryPolicySettings(maxRetryAfterMillis = 250, jitterRatio = 0.2)) { 1.0 },
+            )
+        assertThat(
+            runCatching {
+                tooHigh.decide(ProviderException("temporary", retryable = true), 0, 2)
+            }.exceptionOrNull(),
+        ).isInstanceOf(IllegalArgumentException::class.java)
+
+        val negative =
+            ProviderRetryPolicy(
+                ProviderRetryDelayPolicy(RetryPolicySettings(maxRetryAfterMillis = 250, jitterRatio = 0.2)) { -0.1 },
+            )
+        assertThat(
+            runCatching {
+                negative.decide(ProviderException("temporary", retryable = true), 0, 2)
+            }.exceptionOrNull(),
+        ).isInstanceOf(IllegalArgumentException::class.java)
     }
 }


### PR DESCRIPTION
## 10.3c2: routing + tools + retry mutation family enrollment (A + B + T + R)

Repairs the canonical production PIT path and enrolls three mutation
families (routing, tools, retry) with evidence-proven test populations and
exact-ID residual classifications. Measurement-only in the sense of 10.3c: no
enforcement gate is wired yet (10.3c3 owns the exact-set verifier).

### Stage A — repair canonical PIT init-script rendering
`216ae385`/`dc2b5d6b` unifies init-script rendering behind the shared
`MutationProbeInitScript` used by both the committed reproducer and the
canonical probe, fixing the broken-from-birth production path (plugin applied
outside the java plugin callback; targetTests defaulting to targetClasses).
The follow-up `refactor(quality)` commit satisfies the build-logic static
analysis gates (extraction, not suppression) and removes the last hard-coded
PIT analyzer version so `MutationProbeInitScript` is the single
version/source-of-truth owner.

### Stage B — routing family
- 3 suspension/resumption discriminator tests (`ModelRegistryEnforcerTest`,
  each bounded with `withTimeout`): the resume-path `throwOnFailure` and
  null-return mutants were NO_COVERAGE because no test forced genuine
  suspension; now KILLED.
- Bytecode-adjudicated residuals (javap on the suspend state machine):
  2 × `equivalent-mutant` (entry-path throwOnFailure; rethrowIfCancellation
  preceded by the typed CancellationException catch), 1 × `tool-limitation`
  (negated COROUTINE_SUSPENDED dispatch deadlocks non-cancellably — still
  TIMED_OUT under a bounded-liveness contract; the source-semantic `?:`
  sibling is independently KILLED).
- A/B comparison proved broad `dev.tramai.*` selection is not merely slow
  (10m03s vs 17s) — it *distorts* results: Killed(broad) ⊆ Killed(curated),
  broad converts kills into TIMED_OUT noise. `targetTests` is therefore part
  of the measurement authority, not a performance hint.

### Stage T — tools family
- `CanonicalMessageEncoderTest` (new, 12 tests): zero direct tests existed
  for the digest/replay canonicalization despite it feeding request digests.
- `ToolResultFilteringSettingsTest` (new, 7 tests): defaults + validation +
  defensive copy were untested.
- `ToolRegistryTest` (+5): blank/whitespace keys, exact-MAX boundary.
- Residuals: 3 × `equivalent-mutant` — javap-proven
  `CollectionsKt.throwIndexOverflow` guards in the three `forEachIndexed`
  loops (fire only when a loop counter wraps past Int.MAX_VALUE).

### Stage R — retry family
- Fixed the retry `targetClasses` package bug: the config pointed at
  `dev.tramai.engine.ProviderRetryDelayPolicy*`, which matched nothing (the
  real class is `dev.tramai.engine.provider.ProviderRetryDelayPolicy`,
  declared inside `ProviderRetryPolicy.kt`); the family was silently
  measuring 4 of 5 patterns.
- New discriminators closed real contract gaps, not merely inflated score:
  settings defaults/validation (`RetrySettingsContractTest`), non-zero jitter
  arithmetic (`55 = 50 + 50·0.2·0.5`), breaker reopen/reopen collisions,
  default-clock real-future deadline, legacy cancellation passthrough,
  safe-factory passthrough, logger DEBUG guard/emission, slow-stream
  zero-bulk-read (incl. NUL byte), UTF-8 straddle trimming, delivered-event
  `retryable` flag, 6-arg alias result capture.
- Cancellation contract pinned: `deliver()`'s `ensureActive()` rethrow is
  observable — code after the failure call must NOT run inside an
  already-cancelled coroutine (continuation-side-effect discriminator).
  Removing the call would let execution continue to the next suspension
  point; the new assertion kills that mutant.
- Residuals classified: 17 exact-ID entries (12 `equivalent-mutant` +
  5 `tool-limitation`), each with bytecode/simulation proof. TIMED_OUT
  mutants scrutinized per the doc: the trim-loop hang is intrinsic
  (negated guard is non-terminating on exact-limit input — simulated), the
  COROUTINE_SUSPENDED deadlocks are non-cancellable. 0 unexplained.

### Config (authorized by 10.3c2)
- `test-quality.yml`: explicit evidence-proven `targetTests` for routing
  (4 classes), tools (3 classes), and retry (7 classes). Other families
  still use the implicit broad default until enrolled.
- `mutation-classifications.yml`: 23 exact-ID entries (routing: 2
  equivalent-mutant + 1 tool-limitation; tools: 3 equivalent-mutant; retry:
  12 equivalent-mutant + 5 tool-limitation), each with bytecode/source proof.
  No wildcards, no family allowances, no invented issues.
- `MutationPatternPreflightTest` corrected to the real retry package FQCN;
  the policy-maintainability exact test count is updated to 217 (M01–M06 of
  `MutationProbeInitScriptTest`).

### Final canonical measurements (shared renderer, 3× proven each)
- Routing: 15 mutants, 12 KILLED / 2 SURVIVED / 1 TIMED_OUT, ~17s
  (was 10m03s broad). Identities 15/15/15 stable; status maps identical 3/3.
- Tools: 57 mutants, 54 KILLED / 0 SURVIVED / 3 NO_COVERAGE, ~13s.
  Identities 57/57/57 stable; status maps identical 3/3.
- Retry: 155 mutants, 138 KILLED / 6 SURVIVED / 6 NO_COVERAGE /
  5 TIMED_OUT, ~59s. 154 unique identities (one benign same-status PIT
  collision on `ProviderRetryDelayPolicy` line 43 — both KILLED).
  Identities and status maps identical 3/3.
- Zero unexplained, zero missing tests remaining in any enrolled family.

No production changes.
