### PR TITLE
ci(mb): parallelize quality-contracts lane into four JDK 21 partitions

### DIFF
--- a/.github/workflows/maintainability-baseline.yml
+++ b/.github/workflows/maintainability-baseline.yml
@@ -87,14 +87,16 @@ jobs:
           echo "Reports uploaded as artifact: \`maintainability-reports\`" >> $GITHUB_STEP_SUMMARY
 
   # Phase 2: build-logic tests run as a parallel matrix instead of one serial
-  # invocation after the maintainability checks. Same JDK 21 (AGENTS.md rule 6:
-  # build-logic compatibility), same coverage — the four lanes partition the
-  # full 771-test suite by domain, each with its own exact count assertion so
-  # drift between lanes cannot hide (mirrors ci.yml contract-tests matrix).
-  # Counts recomputed from XML on the post-#359 tree: 168 + 144 + 211 + 248 =
-  # 771 (the authoritative full-suite XML total). #359's additions are
-  # enrolled: TypedTaskConfigurationCacheTest (6) in scanners-coverage,
-  # ReleaseVerificationPluginTest (24) in release-sovereign.
+  # invocation after the maintainability checks. JDK 21 (AGENTS.md rule 6:
+  # build-logic compatibility). The lanes partition the build-logic suite by
+  # domain, each with its own exact count assertion so drift between lanes
+  # cannot hide (mirrors ci.yml contract-tests matrix).
+  # The quality-contract suite (FormattingGate/StaticSafety/CancellationWiring/
+  # CompilerWarnings/DependencyHygiene/StaticAnalysis, 179 tests) runs here in
+  # four parallel JDK 21 lanes mirroring ci.yml's contract-tests partitions —
+  # ci.yml runs the same filters on JDK 25, so both compatibility authorities
+  # (rule 6: JDK 21 for build-logic, JDK 25 for production code) stay covered.
+  # Counts: 8 + 71 + 75 + 25 (quality) + 144 + 211 + 248 = 782.
   build-logic-tests:
     name: build-logic (${{ matrix.name }})
     runs-on: ubuntu-latest
@@ -103,13 +105,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: quality-contracts
+          - name: quality-formatting
             test-filter: >-
               --tests 'dev.tramai.build.quality.FormattingGate*Test'
-              --tests 'dev.tramai.build.quality.StaticSafety*Test' --tests 'dev.tramai.build.quality.CancellationWiringTest'
-              --tests 'dev.tramai.build.quality.CompilerWarnings*Test' --tests 'dev.tramai.build.quality.DependencyHygiene*Test'
+            expected: 8
+          - name: quality-static-safety
+            test-filter: >-
+              --tests 'dev.tramai.build.quality.StaticSafety*Test'
+              --tests 'dev.tramai.build.quality.CancellationWiringTest'
+            expected: 71
+          - name: quality-compiler-deps
+            test-filter: >-
+              --tests 'dev.tramai.build.quality.CompilerWarnings*Test'
+              --tests 'dev.tramai.build.quality.DependencyHygiene*Test'
+            expected: 75
+          - name: quality-static-analysis
+            test-filter: >-
               --tests 'dev.tramai.build.quality.StaticAnalysis*Test'
-            expected: 179
+            expected: 25
           - name: release-sovereign
             test-filter: >-
               --tests 'dev.tramai.build.release.*'


### PR DESCRIPTION
The quality-contract suite (FormattingGate / StaticSafety / CancellationWiring / CompilerWarnings / DependencyHygiene / StaticAnalysis, 179 tests) ran as **one serial MB lane (~22m)**, duplicating ci.yml's `contract-tests` matrix on the same filters. But not on the same JDK: MB runs JDK 21 (AGENTS.md rule 6 — build-logic compatibility) while CI runs JDK 25 (production code). Deleting the lane would have silently dropped the JDK 21 compatibility authority for those 179 tests.

This PR **parallelizes instead of deleting**: the serial quality lane becomes the same four partitions ci.yml uses, all still running under JDK 21.

**MB `build-logic-tests` matrix (3 → 7 parallel lanes):**
- `quality-formatting` — FormattingGate\*Test, 8 tests
- `quality-static-safety` — StaticSafety\*Test + CancellationWiringTest, 71 tests
- `quality-compiler-deps` — CompilerWarnings\*Test + DependencyHygiene\*Test, 75 tests
- `quality-static-analysis` — StaticAnalysis\*Test, 25 tests
- `release-sovereign` — 144 tests (unchanged)
- `policy-maintainability` — 211 tests (unchanged)
- `scanners-coverage` — 248 tests (unchanged)

**Both compatibility authorities preserved:**
- 179 quality contracts → JDK 25 (ci.yml `contract-tests`) **and** JDK 21 (this matrix)
- Per-partition count assertions mirror ci.yml exactly (8+71+75+25 = 179), so drift between the JDK 21 and JDK 25 executions cannot hide

**Latency:** MB quality critical path goes from ~22m serial to the slowest partition (~5–6m, same shape as CI's contract lanes). Total MB runtime is now bounded by the slowest of 7 lanes instead of 4 lanes + a 22m serial tail.

Trigger precision (both before and after): CI runs on every PR to master; MB has `paths-ignore`. Whenever MB runs, CI also runs — the property that makes the JDK 21 + JDK 25 dual execution meaningful.

Verified: YAML parses; lane count assertions sum to 179 (quality) matching ci.yml partitions.
