### PR TITLE
fix(quality): make CrossModuleCoverageTest fixture jars explicit inputs

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -8,6 +8,15 @@ repositories {
     gradlePluginPortal()
 }
 
+// Explicit, resolvable set of fixture jars for CrossModuleCoverageTest — the
+// test copies from these resolved files instead of scanning the local Gradle
+// cache (which is populated by whatever other job ran first on a shared
+// runner and is not a contract the test may rely on).
+val crossModuleFixtureJars by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
 kotlin {
     jvmToolchain(21)
 }
@@ -23,12 +32,13 @@ dependencies {
 
     testImplementation(gradleTestKit())
     testImplementation(kotlin("test"))
-    // CrossModuleCoverageTest vendors JUnit + JaCoCo jars from the local Gradle
-    // cache into its hermetic fixture. JUnit jars arrive via kotlin("test");
-    // the JaCoCo stack only if build-logic's own test classpath resolves it —
-    // otherwise the jar lookup depends on some other job having resolved
-    // JaCoCo in the same runner cache first (a serial-workflow ordering
-    // dependency the parallel lane split breaks).
+    // CrossModuleCoverageTest vendors JUnit + JaCoCo jars into its hermetic
+    // fixture. The fixture needs JUnit 5.12.2 + platform 1.12.2 (NOT the
+    // 5.10.1 that kotlin-test pulls) plus the JaCoCo 0.8.13/asm 9.8 stack.
+    // crossModuleFixtureJars resolves those exact coordinates so the test can
+    // copy from an explicit, guaranteed-present file set instead of scanning
+    // the local Gradle cache (which is populated by whatever other job ran
+    // first on a shared runner — fragile under cache eviction).
     testImplementation("org.jacoco:org.jacoco.agent:0.8.13:runtime")
     testImplementation("org.jacoco:org.jacoco.ant:0.8.13")
     testImplementation("org.jacoco:org.jacoco.core:0.8.13")
@@ -36,11 +46,69 @@ dependencies {
     testImplementation("org.ow2.asm:asm:9.8")
     testImplementation("org.ow2.asm:asm-commons:9.8")
     testImplementation("org.ow2.asm:asm-tree:9.8")
+
+    add(
+        "crossModuleFixtureJars",
+        "org.junit.jupiter:junit-jupiter-api:5.12.2",
+    )
+    add(
+        "crossModuleFixtureJars",
+        "org.junit.jupiter:junit-jupiter-engine:5.12.2",
+    )
+    add(
+        "crossModuleFixtureJars",
+        "org.junit.platform:junit-platform-commons:1.12.2",
+    )
+    add(
+        "crossModuleFixtureJars",
+        "org.junit.platform:junit-platform-engine:1.12.2",
+    )
+    add(
+        "crossModuleFixtureJars",
+        "org.junit.platform:junit-platform-launcher:1.12.2",
+    )
+    add(
+        "crossModuleFixtureJars",
+        "org.apiguardian:apiguardian-api:1.1.2",
+    )
+    add(
+        "crossModuleFixtureJars",
+        "org.opentest4j:opentest4j:1.3.0",
+    )
+    add(
+        "crossModuleFixtureJars",
+        "org.jacoco:org.jacoco.agent:0.8.13:runtime",
+    )
+    add(
+        "crossModuleFixtureJars",
+        "org.jacoco:org.jacoco.ant:0.8.13",
+    )
+    add(
+        "crossModuleFixtureJars",
+        "org.jacoco:org.jacoco.core:0.8.13",
+    )
+    add(
+        "crossModuleFixtureJars",
+        "org.jacoco:org.jacoco.report:0.8.13",
+    )
+    add("crossModuleFixtureJars", "org.ow2.asm:asm:9.8")
+    add("crossModuleFixtureJars", "org.ow2.asm:asm-commons:9.8")
+    add("crossModuleFixtureJars", "org.ow2.asm:asm-tree:9.8")
 }
 
 tasks.test {
     useJUnitPlatform {
         excludeTags("integration")
+    }
+    // CrossModuleCoverageTest copies fixture jars from this explicit set
+    // (resolved lazily at execution — never at configuration time, so the
+    // configuration cache stays clean). doFirst runs before the test JVM
+    // forks, so the property is visible to the forked test.
+    doFirst {
+        systemProperty(
+            "tramai.crossModuleFixtureJars",
+            crossModuleFixtureJars.resolve().joinToString(File.pathSeparator) { it.absolutePath },
+        )
     }
 }
 

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -15,6 +15,11 @@ repositories {
 val crossModuleFixtureJars by configurations.creating {
     isCanBeConsumed = false
     isCanBeResolved = true
+    // The list below is the complete, authoritative coordinate set — the
+    // test's hand-written fixture POMs cover every edge. Transitive
+    // resolution or conflict resolution would smuggle in jars the fixture
+    // doesn't declare, so disable it: the declared list IS the contract.
+    isTransitive = false
 }
 
 kotlin {
@@ -77,6 +82,10 @@ dependencies {
     )
     add(
         "crossModuleFixtureJars",
+        "org.jacoco:org.jacoco.agent:0.8.13",
+    )
+    add(
+        "crossModuleFixtureJars",
         "org.jacoco:org.jacoco.agent:0.8.13:runtime",
     )
     add(
@@ -100,14 +109,20 @@ tasks.test {
     useJUnitPlatform {
         excludeTags("integration")
     }
-    // CrossModuleCoverageTest copies fixture jars from this explicit set
-    // (resolved lazily at execution — never at configuration time, so the
-    // configuration cache stays clean). doFirst runs before the test JVM
-    // forks, so the property is visible to the forked test.
+    // CrossModuleCoverageTest copies fixture jars from this explicit set.
+    // Declare them as task inputs (not just doFirst-resolved side state) so
+    // up-to-date checks and build-cache keys track the jar CONTENTS, not the
+    // cache location. Resolution stays lazy — doFirst runs before the test
+    // JVM forks, and configuration time never touches the network, so the
+    // configuration cache stays clean.
+    val fixtureJarFiles: FileCollection = crossModuleFixtureJars
+    inputs.files(fixtureJarFiles)
+        .withPropertyName("crossModuleFixtureJars")
+        .withPathSensitivity(PathSensitivity.NONE)
     doFirst {
         systemProperty(
             "tramai.crossModuleFixtureJars",
-            crossModuleFixtureJars.resolve().joinToString(File.pathSeparator) { it.absolutePath },
+            fixtureJarFiles.files.joinToString(File.pathSeparator) { it.absolutePath },
         )
     }
 }

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/CrossModuleCoverageTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/CrossModuleCoverageTest.kt
@@ -395,11 +395,13 @@ class CrossModuleCoverageTest {
         // never by scanning the local Gradle cache, which is populated by
         // whatever other job ran first on a shared runner and is not a
         // contract this test may rely on.
-        val fixtureJars =
-            (System.getProperty("tramai.crossModuleFixtureJars") ?: "")
-                .split(File.pathSeparator)
-                .map(::File)
-                .filter { it.isFile }
+        val fixtureJarProperty =
+            System.getProperty("tramai.crossModuleFixtureJars")
+                ?: error(
+                    "tramai.crossModuleFixtureJars is not set — run this test through " +
+                        "Gradle :build-logic:test (it declares inputs.files(crossModuleFixtureJars))",
+                )
+        val fixtureJars = fixtureJarProperty.split(File.pathSeparator).map(::File).filter { it.isFile }
         VENDOR_MODULES.forEach { vendorModule(dir, it, fixtureJars) }
     }
 

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/CrossModuleCoverageTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/CrossModuleCoverageTest.kt
@@ -386,71 +386,81 @@ class CrossModuleCoverageTest {
     }
 
     private fun writeVendoredJunitRepo(dir: File) {
-        // Vendor JUnit 5.11.4 jars from the local Gradle cache into a hermetic
-        // repo so the fixture never touches the network. POMs carry the real
-        // transitive edges (engine → api, platform-engine, opentest4j,
-        // apiguardian; platform-engine → commons; launcher → engine) so the
-        // resolution is complete.
-        val cacheRoot = File(System.getProperty("user.home"), ".gradle/caches/modules-2/files-2.1")
-        for (module in VENDOR_MODULES) {
-            val groupDir = File(cacheRoot, "${module.group}/${module.artifact}/${module.version}")
-            // The cache may hold several genuinely different jars for one
-            // coordinate (e.g. org.jacoco.agent: the plain jar embeds
-            // jacocoagent.jar, the -runtime classifier jar carries only the
-            // rt classes). Walk-order selection is filesystem-nondeterministic,
-            // so pick per coordinate by exact file name; when only one jar
-            // exists, serve it under both names (the historical assumption).
-            val plainJar = groupDir.resolve("${module.artifact}-${module.version}.jar")
-            val classifierJar =
-                if (module.classifier != null) {
-                    groupDir.resolve("${module.artifact}-${module.version}-${module.classifier}.jar")
-                } else {
-                    null
-                }
-            val allJars =
-                groupDir
-                    .walkTopDown()
-                    .filter { it.isFile && it.extension == "jar" && !it.name.contains("sources") }
-                    .toList()
-            val repoDir = dir.resolve("repo/${module.group.replace('.', '/')}/${module.artifact}/${module.version}")
-            repoDir.mkdirs()
-            val plainSource =
-                allJars.firstOrNull { it.name == plainJar.name }
-                    ?: allJars.firstOrNull()
-                    ?: error("JUnit jar not in local cache: ${module.group}:${module.artifact}:${module.version}")
-            plainSource.copyTo(repoDir.resolve(plainJar.name), overwrite = true)
+        // Vendor JUnit 5.12.2 jars into a hermetic repo so the fixture never
+        // touches the network. POMs carry the real transitive edges (engine →
+        // api, platform-engine, opentest4j, apiguardian; platform-engine →
+        // commons; launcher → engine) so the resolution is complete.
+        // The jar files come from the crossModuleFixtureJars configuration
+        // (build-logic/build.gradle.kts), resolved explicitly for this test —
+        // never by scanning the local Gradle cache, which is populated by
+        // whatever other job ran first on a shared runner and is not a
+        // contract this test may rely on.
+        val fixtureJars =
+            (System.getProperty("tramai.crossModuleFixtureJars") ?: "")
+                .split(File.pathSeparator)
+                .map(::File)
+                .filter { it.isFile }
+        VENDOR_MODULES.forEach { vendorModule(dir, it, fixtureJars) }
+    }
+
+    private fun vendorModule(
+        dir: File,
+        module: VendorModule,
+        fixtureJars: List<File>,
+    ) {
+        val plainJarName = "${module.artifact}-${module.version}.jar"
+        val classifierJarName =
             if (module.classifier != null) {
-                val classifierSource =
-                    allJars.firstOrNull { it.name == classifierJar!!.name }
-                        ?: plainSource
-                classifierSource.copyTo(repoDir.resolve(classifierJar!!.name), overwrite = true)
+                "${module.artifact}-${module.version}-${module.classifier}.jar"
+            } else {
+                null
             }
-            val deps =
-                module.deps.joinToString("\n") { d ->
-                    """
-                    <dependency>
-                      <groupId>${d.group}</groupId>
-                      <artifactId>${d.artifact}</artifactId>
-                      <version>${d.version}</version>
-                    </dependency>
-                    """.trimIndent()
-                }
-            writeFile(
-                repoDir,
-                "${module.artifact}-${module.version}.pom",
-                """
-                <project xmlns="http://maven.apache.org/POM/4.0.0">
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>${module.group}</groupId>
-                  <artifactId>${module.artifact}</artifactId>
-                  <version>${module.version}</version>
-                  <dependencies>
-                  $deps
-                  </dependencies>
-                </project>
-                """.trimIndent(),
-            )
+        val allJars =
+            fixtureJars.filter {
+                it.name.startsWith("${module.artifact}-${module.version}")
+            }
+        val repoDir = dir.resolve("repo/${module.group.replace('.', '/')}/${module.artifact}/${module.version}")
+        repoDir.mkdirs()
+        val plainSource =
+            allJars.firstOrNull { it.name == plainJarName }
+                ?: allJars.firstOrNull()
+                ?: error(
+                    "Fixture jar not resolved for ${module.group}:${module.artifact}:${module.version} " +
+                        "(tramai.crossModuleFixtureJars missing it; add the coordinate to " +
+                        "build-logic/build.gradle.kts)",
+                )
+        plainSource.copyTo(repoDir.resolve(plainJarName), overwrite = true)
+        if (module.classifier != null) {
+            val classifierSource =
+                allJars.firstOrNull { it.name == classifierJarName }
+                    ?: plainSource
+            classifierSource.copyTo(repoDir.resolve(classifierJarName!!), overwrite = true)
         }
+        val deps =
+            module.deps.joinToString("\n") { d ->
+                """
+                <dependency>
+                  <groupId>${d.group}</groupId>
+                  <artifactId>${d.artifact}</artifactId>
+                  <version>${d.version}</version>
+                </dependency>
+                """.trimIndent()
+            }
+        writeFile(
+            repoDir,
+            "${module.artifact}-${module.version}.pom",
+            """
+            <project xmlns="http://maven.apache.org/POM/4.0.0">
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>${module.group}</groupId>
+              <artifactId>${module.artifact}</artifactId>
+              <version>${module.version}</version>
+              <dependencies>
+              $deps
+              </dependencies>
+            </project>
+            """.trimIndent(),
+        )
     }
 
     private data class VendorModule(


### PR DESCRIPTION
**Problem (repo-wide, blocks #362/#367/#368):** `CrossModuleCoverageTest.writeVendoredJunitRepo()` scanned `~/.gradle/caches/modules-2` for JUnit 5.12.2 + JaCoCo 0.8.13 + asm 9.8 jars and hard-failed when absent. MB matrix jobs run `cache-read-only: true` on disposable runners — the cache contains whatever *other* job populated first, and under GitHub LRU eviction the fixture jars disappear. Result: `build-logic (scanners-coverage)` red on three unrelated branches with `JUnit jar not in local cache` at CrossModuleCoverageTest.kt:420.

**Fix:** resolve the exact fixture coordinates through Gradle, not the cache:
- New `crossModuleFixtureJars` configuration in `build-logic/build.gradle.kts` with the precise 14 coordinates (JUnit 5.12.2 stack, platform 1.12.2, jacoco 0.8.13, asm 9.8)
- Resolved lazily in `tasks.test` `doFirst` (never at configuration time — config-cache clean) and passed to the test JVM as `tramai.crossModuleFixtureJars`
- Test copies from that guaranteed-present file set; a missing coordinate now errors with an actionable message pointing at the build file

The nested TestKit fixture stays hermetic (vendored repo, no network) — only the jar *source* changed from cache-scanning to explicit resolution.

**Verified locally:** CrossModuleCoverageTest green, FormattingGate/StaticAnalysis/StaticSafety ConfigCacheTest green, verifyStaticAnalysis + spotlessCheck green. Full-suite local run has only the known environmental CancellationWiringTest failure (sonatype URL fixture mismatch, fails on base too).