### PR TITLE
ci(mb): enable build-cache writes on build-logic test matrix lanes

### DIFF
--- a/.github/workflows/maintainability-baseline.yml
+++ b/.github/workflows/maintainability-baseline.yml
@@ -183,10 +183,23 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
+      # P3-D: matrix lanes run plain :build-logic:test with fully-declared
+      # inputs (no -P base-ref props), so writing the build cache is safe.
+      # setup-gradle's DEFAULT is branch-based read-only (jobs off the default
+      # branch never write), which is why MB lanes were always cold while CI's
+      # master-push runs warmed CI's cache. MB never runs on master (PR-only
+      # trigger), so without an explicit override NOTHING ever writes MB's
+      # cache namespace. cache-read-only: false lets each PR branch write the
+      # entry its own rebase/rerun iterations restore — repeat runs over
+      # identical build-logic content go FROM-CACHE instead of re-paying
+      # 6-10m compile+test per lane. verify-baseline stays cache-read-only
+      # (default): its gates consume -PchangePolicyBase (configuration-time,
+      # untracked as task inputs), so caching could serve a stale result
+      # computed against a different base SHA.
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          cache-read-only: true
+          cache-read-only: false
 
       - name: Run ${{ matrix.name }} build-logic tests
         run: |

--- a/.github/workflows/maintainability-baseline.yml
+++ b/.github/workflows/maintainability-baseline.yml
@@ -189,17 +189,17 @@ jobs:
       # branch never write), which is why MB lanes were always cold while CI's
       # master-push runs warmed CI's cache. MB never runs on master (PR-only
       # trigger), so without an explicit override NOTHING ever writes MB's
-      # cache namespace. cache-read-only: false lets each PR branch write the
-      # entry its own rebase/rerun iterations restore — repeat runs over
-      # identical build-logic content go FROM-CACHE instead of re-paying
-      # 6-10m compile+test per lane. verify-baseline stays cache-read-only
-      # (default): its gates consume -PchangePolicyBase (configuration-time,
-      # untracked as task inputs), so caching could serve a stale result
-      # computed against a different base SHA.
+      # cache namespace. Write only for same-repository PR branches (repeated
+      # runs/rebases restore FROM-CACHE instead of re-paying 6-10m compile+
+      # test per lane); fork PRs stay read-only so external PRs cannot write
+      # to the repository's cache quota. verify-baseline stays explicitly
+      # cache-read-only: its gates consume -PchangePolicyBase
+      # (configuration-time, untracked as task inputs), so caching could
+      # serve a stale result computed against a different base SHA.
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          cache-read-only: false
+          cache-read-only: ${{ github.event.pull_request.head.repo.fork }}
 
       - name: Run ${{ matrix.name }} build-logic tests
         run: |


### PR DESCRIPTION
## P3-D step 1 — enable Gradle build-cache writes on MB build-logic test lanes

**Measured problem:** CI contract-tests lanes restore `:build-logic:test` **FROM-CACHE in ~20s** on repeat content. MB matrix lanes **re-pay 6–10m compile+test per lane on every PR**, even when build-logic content is identical to a previous run.

**Root cause (log-verified, not the original hypothesis):** `gradle/actions/setup-gradle`'s **default** is branch-based read-only — jobs on non-default branches (every PR) *read but never write* the cache. CI's lanes work because `ci.yml` also triggers on `push: master`, so master runs write entries that later PR runs restore. `maintainability-baseline.yml` triggers **only** on `pull_request`, so nothing in the MB workflow's cache namespace is ever written — every MB lane is permanently cold. The old `cache-read-only: true` on the MB matrix was redundant (the action default already forces it off-master).

**Change:** explicit `cache-read-only: false` on the MB `build-logic-tests` matrix lanes. Each PR branch then writes the cache entry that its own rebase/rerun iterations restore; repeat runs over identical build-logic content go `FROM-CACHE`.

**Why it's safe (never trade correctness for speed):**
- Matrix lanes run plain `:build-logic:test` with fully-declared task inputs (no `-P` base-ref props) — Gradle's build cache keys on those declared inputs, so a restore is only served for byte-identical content.
- #369 already made `CrossModuleCoverageTest` independent of `~/.gradle/caches` contents — cache eviction is a performance concern, not a correctness one.
- `verify-baseline` stays at the read-only default: its gates consume `-PchangePolicyBase` (configuration-time, untracked as task inputs) — caching those tasks could serve a result computed against a stale base SHA. This PR deliberately does not touch that job.

**Verification:** local double-run with wiped outputs + warm local build cache = `8 actionable tasks: 5 executed, 3 from cache` (compileKotlin, compileTestKotlin, test all cached). First MB run per branch still pays full cost (cache must be written once); the same-branch rerun/rebase is the measured win.

**Not in this PR (P3-D step 2, needs its own evidence):** enabling `--configuration-cache` on CI invocations — the repo contract keeps `org.gradle.configuration-cache=false` in gradle.properties, and flipping it requires proving every task in every invocation is CC-clean under `--configuration-cache-problems=fail`. Gate-level CC cleanliness is already proven by the ConfigCacheTest suite; CI-level enablement is a separate decision with a separate PR.
