### PR TITLE
docs(engine): P3-E benchmark marker — comment-only production touch

### DIFF
--- a/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
+++ b/tramai-engine/src/main/kotlin/dev/tramai/engine/TramaiEngine.kt
@@ -703,6 +703,10 @@ data class OperationDefinition(
      * Operation-static cache eligibility (no chat memory, no tools, no streaming,
      * no custom [dev.tramai.core.observation.OperationInterceptor]).
      *
+     * P3-E benchmark marker: comment-only production touch exercising the
+     * ordinary-PR verification path (compiler-warnings MODULES scope, full
+     * test + maintainability lanes) without behavioural change.
+     *
      * The interceptor-aware portion of the check lives on the cache coordinator
      * because the interceptor is engine-scoped, not operation-scoped. Use the
      * coordinator when evaluating an actual cache read/write.


### PR DESCRIPTION
## P3-E — end-to-end pipeline measurement (ordinary PR profile)

**This is a measurement PR, not a code change.** The diff is a comment-only KDoc addition to a production file in `:tramai-engine` (no behavioural change). It exercises the *ordinary PR* classification: Kotlin source touched → compiler-warnings MODULES scope (engine + transitive dependents), full test suite, full MB matrix — the profile the 8–10m target applies to.

Purpose: measure the current end-to-end critical path on master config (`da0dc3b3`, post #370 cache-write merge) against the plan target of **≤8–10m for ordinary PRs** / 15–18m for compiler-global PRs.

Will be closed without merging after the run completes and timings are recorded.
