### PR TITLE
docs(provider): P3-E benchmark marker — comment-only production touch

### DIFF
--- a/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/ProviderTransport.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/ProviderTransport.kt
@@ -15,6 +15,8 @@ import java.net.URI
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 
+// P3-E benchmark marker: comment-only production touch (ordinary-PR measurement path).
+
 /*
  * Low-level HTTP/stream transport machinery shared by provider adapters.
  *


### PR DESCRIPTION
## P3-E — end-to-end pipeline measurement (ordinary PR profile)

**This is a measurement PR, not a code change.** The diff is a comment-only marker (`// P3-E benchmark marker`) added to a production file in `:tramai-core` ([ProviderTransport.kt]). No behavioural change.

**Why this file:** it was last touched in #349/#352 (Aug 31, after the ktlint 1.8 + formatting-ratchet change #339 landed Aug 29 23:26), so it is verified clean under the current formatting rules. A first probe targeting `TramaiEngine.kt` (last touched pre-ratchet) surfaced **latent ktlint violations masked by the ratchet** — to be filed separately; it is not this PR's subject.

**What gets measured:** full end-to-end critical path for an ordinary code-touching PR on current master (CI + MB + RC where they trigger) vs the P3 target of ~8–10 min ordinary / 15–18 min compiler-global. The change is comment-only → compiler-warnings classify it as MODULES scope for `:tramai-core` consumers, exercising the real PR delta path without adding warnings.
