### PR TITLE
ci(rc): run sovereign closure with --no-daemon

### DIFF
--- a/.github/workflows/sovereign-runtime-release-candidate.yml
+++ b/.github/workflows/sovereign-runtime-release-candidate.yml
@@ -99,9 +99,9 @@ jobs:
         run: |
           LABELS='${{ toJson(github.event.pull_request.labels) }}'
           if echo "$LABELS" | grep -q '"baseline-migration"'; then
-            ./gradlew verifySovereignRuntimeClosure --no-configuration-cache --rerun-tasks -PtramaiPublishReleaseUrl= -PchangeClass=baseline-migration
+            ./gradlew verifySovereignRuntimeClosure --no-daemon --no-configuration-cache --rerun-tasks -PtramaiPublishReleaseUrl= -PchangeClass=baseline-migration
           else
-            ./gradlew verifySovereignRuntimeClosure --no-configuration-cache --rerun-tasks -PtramaiPublishReleaseUrl=
+            ./gradlew verifySovereignRuntimeClosure --no-daemon --no-configuration-cache --rerun-tasks -PtramaiPublishReleaseUrl=
           fi
 
       - name: Upload test reports on failure


### PR DESCRIPTION
## Controlled experiment: `--no-daemon` on RC validate

**Hypothesis:** RC validate's ~9.5-minute dead tail after `BUILD SUCCESSFUL` is the Gradle daemon holding the runner's stdout pipe open, blowing the 30-minute step timeout.

**Evidence (P3-E probe #372, run 33724511708):** build finished 07:04:13 (`BUILD SUCCESSFUL`), step killed 07:13:47 by `timeout-minutes: 30`. Historical RC runs at 27–29m show the same mechanism brushing the cap. RC is the only workflow without `--no-daemon` (ci.yml: 6 uses, MB: 4, RC: 0).

**Change:** exactly one flag added to both branches of the invocation in `sovereign-runtime-release-candidate.yml`:
```
./gradlew verifySovereignRuntimeClosure --no-daemon --no-configuration-cache --rerun-tasks ...
```

**Deliberately NOT changed (controlled experiment):**
- `timeout-minutes: 30` stays
- no build caching added
- `--rerun-tasks` stays
- no sovereign task changes
- no compiler-warning logic touched
- no ktlint debt fixes
- no production changes

**Acceptance criteria:**
1. Exact-head CI green
2. Exact-head MB green
3. Exact-head Sovereign RC green
4. Timing: `BUILD SUCCESSFUL` reached; shell step terminates shortly after; no repeat of the ~9.5-minute dead tail

If the tail persists, stop here — no stacked workarounds; next step is instrumenting the process tree/file descriptors to identify which child retains stdout/stderr.
