### PR TITLE
ci(sovereign): drop --rerun-tasks from PR-triggered sovereign closure (10.5 P3-E fix)

### DIFF
--- a/.github/workflows/sovereign-runtime-release-candidate.yml
+++ b/.github/workflows/sovereign-runtime-release-candidate.yml
@@ -92,17 +92,27 @@ jobs:
         timeout-minutes: 30
         # Canonical sovereign verification: the closure aggregate includes the
         # full RC candidate chain plus :examples:spring-sovereign-starter:e2eTest
-        # and the API boundary. --rerun-tasks is kept because this job runs on a
-        # fresh runner and is the single authority for sovereign verification.
-        # The closure pulls verifyStaticAnalysis via check; a bootstrap PR needs
-        # the explicit baseline-migration class (label-gated, like ci.yml).
+        # and the API boundary. The closure pulls verifyStaticAnalysis via check;
+        # a bootstrap PR needs the explicit baseline-migration class
+        # (label-gated, like ci.yml).
+        #
+        # --rerun-tasks applies ONLY to workflow_dispatch (explicit release
+        # certification). PR-triggered runs drop it: the CI quality/tests lanes
+        # already proved the same commit green, and forcing re-execution on a
+        # fresh runner duplicates the full repository test/check graph
+        # (~19-30 min measured on the P3-E benchmark profile, PR #372) on every
+        # release-relevant PR. Gradle remains responsible for deciding what is
+        # up-to-date/cacheable.
         run: |
+          GRADLE_ARGS=(verifySovereignRuntimeClosure --no-configuration-cache -PtramaiPublishReleaseUrl=)
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            GRADLE_ARGS+=(--rerun-tasks)
+          fi
           LABELS='${{ toJson(github.event.pull_request.labels) }}'
           if echo "$LABELS" | grep -q '"baseline-migration"'; then
-            ./gradlew verifySovereignRuntimeClosure --no-configuration-cache --rerun-tasks -PtramaiPublishReleaseUrl= -PchangeClass=baseline-migration
-          else
-            ./gradlew verifySovereignRuntimeClosure --no-configuration-cache --rerun-tasks -PtramaiPublishReleaseUrl=
+            GRADLE_ARGS+=(-PchangeClass=baseline-migration)
           fi
+          ./gradlew "${GRADLE_ARGS[@]}"
 
       - name: Upload test reports on failure
         if: failure()

--- a/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/ProviderTransport.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/provider/transport/ProviderTransport.kt
@@ -15,6 +15,8 @@ import java.net.URI
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 
+// P3-E benchmark marker: comment-only production touch (ordinary-PR measurement path).
+
 /*
  * Low-level HTTP/stream transport machinery shared by provider adapters.
  *


### PR DESCRIPTION
## Epic 10.5 — Sovereign RC per-PR policy (phase 1: remove `--rerun-tasks` on PR trigger)

**This is a measurement PR for the P3-E finding, not a cache-policy change.**

### What changed

`.github/workflows/sovereign-runtime-release-candidate.yml` — the single Gradle step now builds its args:

| Trigger | Command | `--rerun-tasks` |
|---|---|---|
| `pull_request` | `verifySovereignRuntimeClosure --no-configuration-cache -PtramaiPublishReleaseUrl=` | **removed** |
| `workflow_dispatch` (explicit release certification) | same + `--rerun-tasks` | **retained** |

- The PR still runs the exact canonical verification task (`verifySovereignRuntimeClosure` — full RC chain + `check` + spring e2e + closure docs + API boundary). Nothing is skipped explicitly; Gradle decides up-to-date/cacheable.
- Kept: `--no-configuration-cache`, the `baseline-migration` label branch, the 30-min timeout.
- **Not in this PR:** cache-write policy changes (CI or RC), config-cache enablement, timeout changes, mutation/PIT files, build-logic changes.

### Second file: P3-E benchmark marker

`ProviderTransport.kt` (+2 comment lines, identical to #372's marker) reproduces the **same high-fanout core profile** measured in #372 — tramai-core comment touch → full compiler-warnings delta path + RC workflow trigger (core path filter). Per AGENTS.md rule 5 this is benchmark instrumentation with an explicit commit purpose, not a runtime behaviour change; comment-only, no behaviour delta.

### What to compare against P3-E baseline (#372, 06:42:53Z run)

| Metric | #372 baseline | Expected with fix |
|---|---|---|
| CI compiler-warnings lane | ~17.0 min | roughly unchanged |
| CI tests | ~9.4 min | unchanged |
| Maintainability Baseline | ~10.6 min | unchanged |
| Sovereign RC validate | 19.25 min (attempt 2) / **timed out at 30-min ceiling** (attempt 1) | **must materially fall** |
| Merge wall | 19–30+ min | ideally → ~17 min |

### Decision criteria

- **A. RC ≤ 10–12 min, merge wall ≈ 17 min** → accept; classify core changes as high-fanout/compiler-global (~15–18 min target), leaf/ordinary ~8–10 min; close Epic 10.5 and reconcile docs.
- **B. RC ≥ 15 min** → `--rerun-tasks` removal is insufficient; next step is a PR-specific sovereign aggregate (`verifySovereignRuntimePullRequest`) that removes duplication of the repository test/check already proven by mandatory CI, keeping full `verifySovereignRuntimeClosure --rerun-tasks` for release certification. **No speculative cross-workflow caching.**

Green run on this branch is required before merge.
