### PR TITLE
ci(sovereign): PR-specific verifySovereignRuntimePullRequest aggregate (10.5 P3-E decision B)

### DIFF
--- a/.github/workflows/sovereign-runtime-release-candidate.yml
+++ b/.github/workflows/sovereign-runtime-release-candidate.yml
@@ -90,19 +90,21 @@ jobs:
 
       - name: Verify sovereign runtime release candidate
         timeout-minutes: 30
-        # Canonical sovereign verification: the closure aggregate includes the
-        # full RC candidate chain plus :examples:spring-sovereign-starter:e2eTest
-        # and the API boundary. --rerun-tasks is kept because this job runs on a
-        # fresh runner and is the single authority for sovereign verification.
-        # The closure pulls verifyStaticAnalysis via check; a bootstrap PR needs
-        # the explicit baseline-migration class (label-gated, like ci.yml).
+        # PR trigger: verifySovereignRuntimePullRequest — the sovereign-specific
+        # release-chain proof WITHOUT the repository test/check graph. Mandatory
+        # CI already proves tests/quality/compiler-warnings/coverage on the
+        # exact commit; re-running them here duplicated the full CI stack
+        # (~19-30 min measured on the P3-E profile, #372/#374, decision B).
+        # workflow_dispatch (explicit release certification) keeps the full
+        # independent verifySovereignRuntimeClosure with --rerun-tasks.
         run: |
-          LABELS='${{ toJson(github.event.pull_request.labels) }}'
-          if echo "$LABELS" | grep -q '"baseline-migration"'; then
-            ./gradlew verifySovereignRuntimeClosure --no-daemon --no-configuration-cache --rerun-tasks -PtramaiPublishReleaseUrl= -PchangeClass=baseline-migration
+          GRADLE_ARGS=(-PtramaiPublishReleaseUrl=)
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            GRADLE_ARGS+=(verifySovereignRuntimeClosure --no-daemon --no-configuration-cache --rerun-tasks)
           else
-            ./gradlew verifySovereignRuntimeClosure --no-daemon --no-configuration-cache --rerun-tasks -PtramaiPublishReleaseUrl=
+            GRADLE_ARGS+=(verifySovereignRuntimePullRequest --no-daemon --no-configuration-cache)
           fi
+          ./gradlew "${GRADLE_ARGS[@]}"
 
       - name: Upload test reports on failure
         if: failure()

--- a/.github/workflows/sovereign-runtime-release-candidate.yml
+++ b/.github/workflows/sovereign-runtime-release-candidate.yml
@@ -140,6 +140,11 @@ jobs:
           if-no-files-found: error
 
       - name: Upload evidence index
+        # Evidence index is produced only by generateSovereignReleaseEvidenceIndex,
+        # which runs in the full release-certification aggregate
+        # (verifySovereignRuntimeClosure) — not in the PR-scoped
+        # verifySovereignRuntimePullRequest. Upload only on workflow_dispatch.
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: sovereign-release-evidence-index

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -229,6 +229,56 @@ tasks.register("verifySovereignRuntimeReleaseCandidate") {
 
 
 // ──────────────────────────────────────────────
+// Task: verifySovereignRuntimePullRequest
+// ──────────────────────────────────────────────
+// PR-scoped sovereign verification (Epic 10.5 P3-E, decision B): proves the
+// sovereign-specific release chain on a pull request WITHOUT re-running the
+// repository test/check graph — mandatory CI already proves tests, quality
+// gates, compiler warnings, coverage, cancellation, and publishToMavenLocal
+// on the exact commit. Including `check` / the all-subproject test fan-out
+// here duplicated the full CI stack on the RC lane (~19-30 min measured,
+// #372/#374). The full independent certification remains
+// verifySovereignRuntimeClosure --rerun-tasks for workflow_dispatch/release.
+
+tasks.register("verifySovereignRuntimePullRequest") {
+    group = "verification"
+    description =
+        "Runs the sovereign-specific release-chain proof for a pull request (bundle dry-run, " +
+            "verification-repo closure, consumer smoke, doc-intel evidence run, spring e2e, API " +
+            "boundary, closure docs). Does NOT re-run repository tests/quality gates — CI proves " +
+            "those on the same commit."
+
+    notCompatibleWithConfigurationCache(
+        "Sovereign runtime PR verification aggregates execution-time verification tasks.",
+    )
+
+    dependsOn(
+        "verifySovereignRuntimeSignedBundle",
+        "verifySovereignRuntimeVerificationRepoClosure",
+        "verifySovereignRuntimeConsumerSmoke",
+        "verifySovereignDocumentIntelligenceEvidenceRun",
+        ":examples:spring-sovereign-starter:e2eTest",
+        "verifySovereignRuntimeApiBoundary",
+        "verifySovereignRuntimeClosureDocs",
+        "verifySovereignOpsObservabilityDocs",
+    )
+
+    doLast {
+        logger.lifecycle("Sovereign runtime PR verification complete.")
+        logger.lifecycle("Validated:")
+        logger.lifecycle("  - signed bundle dry-run (local file repo only)")
+        logger.lifecycle("  - verification repo closure")
+        logger.lifecycle("  - standalone consumer smoke")
+        logger.lifecycle("  - sovereign document-intelligence evidence run")
+        logger.lifecycle("  - :examples:spring-sovereign-starter:e2eTest")
+        logger.lifecycle("  - verifySovereignRuntimeApiBoundary (API stability boundary)")
+        logger.lifecycle("  - verifySovereignRuntimeClosureDocs (documentation consistency)")
+        logger.lifecycle("No remote repository was published to.")
+    }
+}
+
+
+// ──────────────────────────────────────────────
 // Task: verifySovereignRuntimeClosure
 // ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Epic 10.5 — Sovereign RC per-PR aggregate (phase 2, decision B)

Follows the phase-1 experiment (#374, closed as superseded): removing `--rerun-tasks` alone did **not** reduce the RC wall (25.4 min vs 19.25–30+ baseline) — on a fresh runner Gradle re-executes everything regardless, and the closure aggregate pulls `check`, re-running the whole CI quality stack (verifyCompilerWarnings ~20 min, verifyStaticAnalysis, full module-test fan-out) inside the RC lane.

### What changed

**New root aggregate `verifySovereignRuntimePullRequest`** (`build.gradle.kts`): sovereign-specific release-chain proof only —
- `verifySovereignRuntimeSignedBundle` (local file-repo dry-run)
- `verifySovereignRuntimeVerificationRepoClosure` + `verifySovereignRuntimeConsumerSmoke`
- `verifySovereignDocumentIntelligenceEvidenceRun`
- `:examples:spring-sovereign-starter:e2eTest` (not run by CI)
- `verifySovereignRuntimeApiBoundary`, `verifySovereignRuntimeClosureDocs`, `verifySovereignOpsObservabilityDocs`

**Explicitly NOT included** (already proven by mandatory CI on the exact commit): `check`, the all-subproject test fan-out, publication/readiness chains that force module tests, evidence-index generation (a release-certification artifact; still produced on dispatch/release runs). No production, mutation, or PIT files touched. No cache-write policy. No timeout change.

**Workflow** (`sovereign-runtime-release-candidate.yml`):
| Trigger | Command |
|---|---|
| `pull_request` | `verifySovereignRuntimePullRequest --no-configuration-cache` |
| `workflow_dispatch` / release certification | `verifySovereignRuntimeClosure --no-configuration-cache --rerun-tasks` (unchanged full independent certification) |

### Measurement

Second file: the identical P3-E `ProviderTransport.kt` comment marker reproduces the same high-fanout core profile as #372/#374 (CI compiler-warnings ~17 min lane + RC trigger) so results are comparable.

| Metric | #372 (closure --rerun-tasks) | #374 (closure, no rerun) | #375 expected |
|---|---|---|---|
| CI | 17.0 min | 18.0 min | unchanged |
| MB | 10.6 min | 12.8 min | unchanged |
| RC validate | 19.25 / >30 min | 25.4 min | **target ≤ 10–12 min** |
| Merge wall | 19–30+ min | ~25 min | **≈ CI ~17 min** |

### Decision criteria
- RC ≤ 10–12 min, merge wall ≈ 17 min → accept; classify core changes high-fanout/compiler-global (~15–18 min), leaf/ordinary ~8–10 min; close Epic 10.5 and reconcile docs.
- RC still ≥ 15 min → the missing piece is cache warmth across lanes; revisit (measured) cache-write policy or further decomposition.

Green run on this branch required before merge.
