### PR TITLE
test(engine): Epic 12.1a benchmark harness — gated proxy-creation timing bench

### DIFF
--- a/.github/workflows/sovereign-runtime-release-candidate.yml
+++ b/.github/workflows/sovereign-runtime-release-candidate.yml
@@ -157,6 +157,17 @@ jobs:
             build/sovereign-runtime-release/evidence-index.md
           if-no-files-found: error
 
+      - name: Upload benchmark reports (deep lane)
+        # Epic 12.1a: timing benchmarks run only on workflow_dispatch
+        # (-Dtramai.benchmark=true); persist their JSON so deep/release
+        # measurements survive the runner. PR runs produce nothing.
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sovereign-benchmark-reports
+          path: '**/build/reports/benchmark/*.json'
+          if-no-files-found: error
+
       - name: Write Summary
         run: |
           echo "## Sovereign Runtime Release Candidate" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/sovereign-runtime-release-candidate.yml
+++ b/.github/workflows/sovereign-runtime-release-candidate.yml
@@ -101,6 +101,10 @@ jobs:
           GRADLE_ARGS=(-PtramaiPublishReleaseUrl=)
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             GRADLE_ARGS+=(verifySovereignRuntimeClosure --no-daemon --no-configuration-cache --rerun-tasks)
+            # Epic 12.1a: deep lane activates the gated timing benchmarks
+            # (-Dtramai.benchmark=true, forwarded by module test tasks). They
+            # stay skipped on every pull_request run.
+            GRADLE_ARGS+=(-Dtramai.benchmark=true)
           else
             GRADLE_ARGS+=(verifySovereignRuntimePullRequest --no-daemon --no-configuration-cache)
           fi

--- a/tramai-engine/build.gradle.kts
+++ b/tramai-engine/build.gradle.kts
@@ -1,4 +1,6 @@
 
+import java.lang.management.ManagementFactory
+
 plugins {
     `java-library`
     id("tramai.test-fixtures")
@@ -38,6 +40,14 @@ tasks.withType<Test>().configureEach {
             "tramai.benchmark.out",
             layout.buildDirectory.dir("reports/benchmark").get().asFile.absolutePath,
         )
+        systemProperty(
+            "tramai.benchmark.gradleJvmArgs",
+            ManagementFactory.getRuntimeMXBean().inputArguments
+                .joinToString(" "),
+        )
+        providers.systemProperty("tramai.benchmark.iterations").orNull?.let {
+            systemProperty("tramai.benchmark.iterations", it)
+        }
     }
 }
 

--- a/tramai-engine/build.gradle.kts
+++ b/tramai-engine/build.gradle.kts
@@ -23,3 +23,21 @@ dependencies {
     testImplementation(libs.jackson.databind)
 }
 
+// Epic 12.1a benchmark harness: forward the deep-lane activation flag
+// (-Dtramai.benchmark=true) and run metadata to test worker JVMs. Absent the
+// flag nothing is forwarded and benchmark classes stay skipped.
+tasks.withType<Test>().configureEach {
+    providers.systemProperty("tramai.benchmark").orNull?.let { flag ->
+        systemProperty("tramai.benchmark", flag)
+        systemProperty(
+            "tramai.benchmark.gitSha",
+            providers.exec { commandLine("git", "rev-parse", "HEAD") }
+                .standardOutput.asText.get().trim(),
+        )
+        systemProperty(
+            "tramai.benchmark.out",
+            layout.buildDirectory.dir("reports/benchmark").get().asFile.absolutePath,
+        )
+    }
+}
+

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/ServiceProxyCreationBenchmark.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/ServiceProxyCreationBenchmark.kt
@@ -1,0 +1,118 @@
+package dev.tramai.engine.benchmark
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.provider.ModelProvider
+import dev.tramai.engine.TramaiEngine
+import dev.tramai.engine.create
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import java.io.File
+import java.net.InetAddress
+import java.time.Instant
+import kotlin.math.roundToLong
+
+/**
+ * Epic 12.1a benchmark harness — first enrolled operation: service proxy creation.
+ *
+ * Gated by `-Dtramai.benchmark=true` (forwarded to the test worker JVM by the
+ * module build): ordinary `test` runs report this class as skipped, so PR CI
+ * stays timing-free. The deep/release lane activates it (see
+ * `.github/workflows/sovereign-runtime-release-candidate.yml`, dispatch branch).
+ *
+ * Methodology (docs/EPIC-12.1-performance-resource-baseline.md §4):
+ * warm-up >= 3 iterations, then >= 10 individually timed iterations with
+ * System.nanoTime(); report mean / p50 / p95; emit one JSON document with
+ * environment metadata to build/reports/benchmark/. No thresholds — 12.1b
+ * records the committed baseline, 12.1d defines regression policy.
+ */
+@EnabledIfSystemProperty(named = "tramai.benchmark", matches = "true")
+class ServiceProxyCreationBenchmark {
+
+    private val iterations: Int =
+        System.getProperty("tramai.benchmark.iterations")?.toIntOrNull() ?: 10
+
+    @Test
+    fun `service proxy creation - warm engine path latency`() {
+        val provider =
+            object : ModelProvider {
+                override suspend fun complete(request: ModelRequest): ModelResponse =
+                    ModelResponse(content = "benchmark")
+            }
+        val engine = TramaiEngine(provider)
+        try {
+            // Warm-up: JIT + proxy class generation + definition-compiler caches.
+            repeat(3) { engine.create<BenchAskService>() }
+
+            val samples = (1..iterations).map {
+                val start = System.nanoTime()
+                val proxy = engine.create<BenchAskService>()
+                assertTrue(proxy is BenchAskService, "create() must return a working proxy")
+                System.nanoTime() - start
+            }
+
+            val nanos = samples.map { it.toDouble() }
+            val meanUs = nanos.average() / 1_000.0
+            val p50Us = percentile(nanos, 0.50) / 1_000.0
+            val p95Us = percentile(nanos, 0.95) / 1_000.0
+            assertTrue(samples.all { it > 0L }, "all samples must be positive")
+
+            println("benchmark service-proxy-creation: mean=${roundTo(meanUs)}us p50=${roundTo(p50Us)}us p95=${roundTo(p95Us)}us n=$iterations")
+            emitJson(meanUs, p50Us, p95Us, samples)
+        } finally {
+            engine.close()
+        }
+    }
+
+    private fun emitJson(meanUs: Double, p50Us: Double, p95Us: Double, samplesNs: List<Long>) {
+        val outDir = File(System.getProperty("tramai.benchmark.out") ?: "build/reports/benchmark")
+        outDir.mkdirs()
+        val file = File(outDir, "${Instant.now()}-service-proxy-creation.json")
+        file.writeText(
+            """
+            {
+              "operation": "service-proxy-creation",
+              "module": "tramai-engine",
+              "fixture": "engine.create<BenchAskService>() on single stub provider (warm path)",
+              "gitSha": "${System.getProperty("tramai.benchmark.gitSha") ?: "unknown"}",
+              "timestamp": "${Instant.now()}",
+              "env": {
+                "java.version": "${System.getProperty("java.version")}",
+                "java.vendor": "${System.getProperty("java.vendor")}",
+                "os.name": "${System.getProperty("os.name")}",
+                "os.arch": "${System.getProperty("os.arch")}",
+                "hostname": "${hostname()}"
+              },
+              "iterations": $iterations,
+              "stats": { "meanUs": $meanUs, "p50Us": $p50Us, "p95Us": $p95Us },
+              "unit": "microseconds"
+            }
+            """.trimIndent() + "\n",
+        )
+        println("benchmark JSON: ${file.absolutePath}")
+    }
+
+    private fun hostname(): String =
+        try {
+            InetAddress.getLocalHost().hostName
+        } catch (_: Exception) {
+            "unknown"
+        }
+
+    private fun percentile(sortedable: List<Double>, q: Double): Double {
+        val sorted = sortedable.sorted()
+        val rank = (q * (sorted.size - 1)).roundToLong().toInt()
+        return sorted[rank]
+    }
+
+    private fun roundTo(v: Double): Double = (v * 10.0).roundToLong() / 10.0
+}
+
+@AiService
+private interface BenchAskService {
+    @Operation(prompt = "Answer concisely", model = "claude-sonnet-4-20250514")
+    suspend fun ask(question: String): String
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/ServiceProxyCreationBenchmark.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/ServiceProxyCreationBenchmark.kt
@@ -11,8 +11,10 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty
 import java.io.File
+import java.lang.reflect.Proxy
 import java.net.InetAddress
 import java.time.Instant
+import kotlin.math.ceil
 import kotlin.math.roundToLong
 
 /**
@@ -26,12 +28,11 @@ import kotlin.math.roundToLong
  * Methodology (docs/EPIC-12.1-performance-resource-baseline.md §4):
  * warm-up >= 3 iterations, then >= 10 individually timed iterations with
  * System.nanoTime(); report mean / p50 / p95; emit one JSON document with
- * environment metadata to build/reports/benchmark/. No thresholds — 12.1b
- * records the committed baseline, 12.1d defines regression policy.
+ * environment metadata and raw samples to build/reports/benchmark/. No
+ * thresholds — 12.1b records the committed baseline, 12.1d defines policy.
  */
 @EnabledIfSystemProperty(named = "tramai.benchmark", matches = "true")
 class ServiceProxyCreationBenchmark {
-
     private val iterations: Int =
         System.getProperty("tramai.benchmark.iterations")?.toIntOrNull() ?: 10
 
@@ -39,58 +40,70 @@ class ServiceProxyCreationBenchmark {
     fun `service proxy creation - warm engine path latency`() {
         val provider =
             object : ModelProvider {
-                override suspend fun complete(request: ModelRequest): ModelResponse =
-                    ModelResponse(content = "benchmark")
+                override suspend fun complete(request: ModelRequest): ModelResponse = ModelResponse("benchmark")
             }
         val engine = TramaiEngine(provider)
         try {
             // Warm-up: JIT + proxy class generation + definition-compiler caches.
             repeat(3) { engine.create<BenchAskService>() }
 
-            val samples = (1..iterations).map {
-                val start = System.nanoTime()
-                val proxy = engine.create<BenchAskService>()
-                assertTrue(proxy is BenchAskService, "create() must return a working proxy")
-                System.nanoTime() - start
-            }
+            val samplesNs =
+                (1..iterations).map {
+                    val start = System.nanoTime()
+                    val proxy = engine.create<BenchAskService>()
+                    assertTrue(Proxy.isProxyClass(proxy.javaClass), "create() must return a dynamic proxy")
+                    System.nanoTime() - start
+                }
+            assertTrue(samplesNs.all { it > 0L }, "all samples must be positive")
 
-            val nanos = samples.map { it.toDouble() }
-            val meanUs = nanos.average() / 1_000.0
-            val p50Us = percentile(nanos, 0.50) / 1_000.0
-            val p95Us = percentile(nanos, 0.95) / 1_000.0
-            assertTrue(samples.all { it > 0L }, "all samples must be positive")
-
-            println("benchmark service-proxy-creation: mean=${roundTo(meanUs)}us p50=${roundTo(p50Us)}us p95=${roundTo(p95Us)}us n=$iterations")
-            emitJson(meanUs, p50Us, p95Us, samples)
+            val samplesUs = samplesNs.map { it / 1_000.0 }
+            val meanUs = samplesUs.average()
+            val p50Us = percentile(samplesUs, 0.50)
+            val p95Us = percentile(samplesUs, 0.95)
+            println(
+                "benchmark service-proxy-creation: " +
+                    "mean=${round1(meanUs)}us p50=${round1(p50Us)}us " +
+                    "p95=${round1(p95Us)}us n=$iterations",
+            )
+            emitJson(meanUs, p50Us, p95Us, samplesNs)
         } finally {
             engine.close()
         }
     }
 
-    private fun emitJson(meanUs: Double, p50Us: Double, p95Us: Double, samplesNs: List<Long>) {
+    private fun emitJson(
+        meanUs: Double,
+        p50Us: Double,
+        p95Us: Double,
+        samplesNs: List<Long>,
+    ) {
         val outDir = File(System.getProperty("tramai.benchmark.out") ?: "build/reports/benchmark")
         outDir.mkdirs()
         val file = File(outDir, "${Instant.now()}-service-proxy-creation.json")
+        val iterationOverride = System.getProperty("tramai.benchmark.iterations")
         file.writeText(
             """
-            {
-              "operation": "service-proxy-creation",
-              "module": "tramai-engine",
-              "fixture": "engine.create<BenchAskService>() on single stub provider (warm path)",
-              "gitSha": "${System.getProperty("tramai.benchmark.gitSha") ?: "unknown"}",
-              "timestamp": "${Instant.now()}",
-              "env": {
-                "java.version": "${System.getProperty("java.version")}",
-                "java.vendor": "${System.getProperty("java.vendor")}",
-                "os.name": "${System.getProperty("os.name")}",
-                "os.arch": "${System.getProperty("os.arch")}",
-                "hostname": "${hostname()}"
-              },
-              "iterations": $iterations,
-              "stats": { "meanUs": $meanUs, "p50Us": $p50Us, "p95Us": $p95Us },
-              "unit": "microseconds"
-            }
-            """.trimIndent() + "\n",
+            |{
+            |  "operation": "service-proxy-creation",
+            |  "module": "tramai-engine",
+            |  "fixture": "engine.create<BenchAskService>() on single stub provider (warm path)",
+            |  "gitSha": "${System.getProperty("tramai.benchmark.gitSha") ?: "unknown"}",
+            |  "timestamp": "${Instant.now()}",
+            |  "iterationOverride": ${iterationOverride?.let { "\"$it\"" } ?: "null"},
+            |  "env": {
+            |    "java.version": "${System.getProperty("java.version") ?: "unknown"}",
+            |    "java.vendor": "${System.getProperty("java.vendor") ?: "unknown"}",
+            |    "os.name": "${System.getProperty("os.name") ?: "unknown"}",
+            |    "os.arch": "${System.getProperty("os.arch") ?: "unknown"}",
+            |    "gradleJvmArgs": "${System.getProperty("tramai.benchmark.gradleJvmArgs") ?: "unknown"}",
+            |    "hostname": "${hostname()}",
+            |    "runnerLabel": "${System.getenv("RUNNER_NAME") ?: "local"}"
+            |  },
+            |  "samplesNs": [${samplesNs.joinToString(",")}],
+            |  "stats": { "meanUs": $meanUs, "p50Us": $p50Us, "p95Us": $p95Us },
+            |  "unit": "microseconds"
+            |}
+            """.trimMargin() + "\n",
         )
         println("benchmark JSON: ${file.absolutePath}")
     }
@@ -102,13 +115,17 @@ class ServiceProxyCreationBenchmark {
             "unknown"
         }
 
-    private fun percentile(sortedable: List<Double>, q: Double): Double {
+    /** Nearest-rank percentile (see EPIC-12.1 doc §4): ceil(q * n) - 1, bounded. */
+    private fun percentile(
+        sortedable: List<Double>,
+        q: Double,
+    ): Double {
         val sorted = sortedable.sorted()
-        val rank = (q * (sorted.size - 1)).roundToLong().toInt()
-        return sorted[rank]
+        val rank = ceil(q * sorted.size).toInt() - 1
+        return sorted[rank.coerceIn(0, sorted.size - 1)]
     }
 
-    private fun roundTo(v: Double): Double = (v * 10.0).roundToLong() / 10.0
+    private fun round1(v: Double): Double = (v * 10.0).roundToLong() / 10.0
 }
 
 @AiService

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/ServiceProxyCreationBenchmark.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/ServiceProxyCreationBenchmark.kt
@@ -79,7 +79,9 @@ class ServiceProxyCreationBenchmark {
     ) {
         val outDir = File(System.getProperty("tramai.benchmark.out") ?: "build/reports/benchmark")
         outDir.mkdirs()
-        val file = File(outDir, "${Instant.now()}-service-proxy-creation.json")
+        // Filesystem-safe timestamp: GitHub artifact upload rejects ':' in names.
+        val timestamp = Instant.now().toString().replace(":", "-")
+        val file = File(outDir, "$timestamp-service-proxy-creation.json")
         val iterationOverride = System.getProperty("tramai.benchmark.iterations")
         file.writeText(
             """


### PR DESCRIPTION
## Epic 12.1a — benchmark harness PR (first implementation slice)

Small, deliberate first slice per the 12.1a audit (#377, docs/EPIC-12.1-performance-resource-baseline.md §4). No thresholds, no 11-op enrollment, no production-code change.

**Files**
- `tramai-engine/.../benchmark/ServiceProxyCreationBenchmark.kt` — JUnit-5 timing bench, class-gated `@EnabledIfSystemProperty(tramai.benchmark=true)`.
- `tramai-engine/build.gradle.kts` — forwards the flag + run metadata (`gitSha`, output dir) to test worker JVMs; absent the flag nothing is forwarded.
- `.github/workflows/sovereign-runtime-release-candidate.yml` — dispatch (deep/release) branch appends `-Dtramai.benchmark=true`; PR branch untouched.

**Proven locally (evidence in PR):**
- Default `test` run: `skipped=1`, 0.0s — ordinary PR CI stays timing-free.
- Flagged run (`-Dtramai.benchmark=true`): executed, 3 warm-up + 10 timed iterations, mean/p50/p95 reported, JSON emitted to `build/reports/benchmark/<ts>-service-proxy-creation.json` with env metadata (java.version/vendor, os, hostname) + gitSha.
- Repeatability: two forced executions → mean 1199.7 µs vs 1235.3 µs (2 runs, distinct JSON docs). Dispatch runs use `--rerun-tasks`, so each deep-lane certification re-executes the benches.

**Methodology contract followed:** warm-up ≥3 → timed ≥10, `System.nanoTime()` per iteration, mean/p50/p95 (nearest-rank), JSON output shape as pinned in the audit, no thresholds (12.1d).

Bench scope: single latency op (`engine.create<T>()` warm path). Remaining 10 ops + throughput shape enroll in the next slice (12.1b) once this survives review and repeated deep-lane measurements.
