### PR TITLE
test(engine,testing): Epic 12.1b b1 — shared benchmark harness + B01-B03 enrollment

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.lang.management.ManagementFactory
+
 plugins {
     base
     id("tramai.maintainability-baseline")
@@ -182,6 +184,32 @@ subprojects {
     // tramai.publishing convention plugin. The plugin reacts to java-library
     // and java-platform itself (no plugin ordering dependency).
     apply(plugin = "tramai.publishing")
+
+    // Epic 12.1a/b benchmark harness: forward the deep-lane activation flag
+    // (-Dtramai.benchmark=true) and run metadata to every module's test worker
+    // JVMs. Absent the flag nothing is forwarded and benchmark classes stay
+    // skipped, so ordinary PR CI remains timing-free.
+    tasks.withType<Test>().configureEach {
+        providers.systemProperty("tramai.benchmark").orNull?.let { flag ->
+            systemProperty("tramai.benchmark", flag)
+            systemProperty(
+                "tramai.benchmark.gitSha",
+                providers.exec { commandLine("git", "rev-parse", "HEAD") }
+                    .standardOutput.asText.get().trim(),
+            )
+            systemProperty(
+                "tramai.benchmark.out",
+                layout.buildDirectory.dir("reports/benchmark").get().asFile.absolutePath,
+            )
+            systemProperty(
+                "tramai.benchmark.gradleJvmArgs",
+                ManagementFactory.getRuntimeMXBean().inputArguments.joinToString(" "),
+            )
+            providers.systemProperty("tramai.benchmark.iterations").orNull?.let {
+                systemProperty("tramai.benchmark.iterations", it)
+            }
+        }
+    }
 }
 // ──────────────────────────────────────────────
 // Task: verifySovereignRuntimeReleaseCandidate

--- a/tramai-engine/build.gradle.kts
+++ b/tramai-engine/build.gradle.kts
@@ -1,6 +1,4 @@
 
-import java.lang.management.ManagementFactory
-
 plugins {
     `java-library`
     id("tramai.test-fixtures")
@@ -8,7 +6,6 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
     id("tramai.kotlin-library")
 }
-
 
 
 dependencies {
@@ -23,31 +20,5 @@ dependencies {
     testImplementation(testFixtures(project(":tramai-testing")))
     testImplementation(libs.coroutines.test)
     testImplementation(libs.jackson.databind)
-}
-
-// Epic 12.1a benchmark harness: forward the deep-lane activation flag
-// (-Dtramai.benchmark=true) and run metadata to test worker JVMs. Absent the
-// flag nothing is forwarded and benchmark classes stay skipped.
-tasks.withType<Test>().configureEach {
-    providers.systemProperty("tramai.benchmark").orNull?.let { flag ->
-        systemProperty("tramai.benchmark", flag)
-        systemProperty(
-            "tramai.benchmark.gitSha",
-            providers.exec { commandLine("git", "rev-parse", "HEAD") }
-                .standardOutput.asText.get().trim(),
-        )
-        systemProperty(
-            "tramai.benchmark.out",
-            layout.buildDirectory.dir("reports/benchmark").get().asFile.absolutePath,
-        )
-        systemProperty(
-            "tramai.benchmark.gradleJvmArgs",
-            ManagementFactory.getRuntimeMXBean().inputArguments
-                .joinToString(" "),
-        )
-        providers.systemProperty("tramai.benchmark.iterations").orNull?.let {
-            systemProperty("tramai.benchmark.iterations", it)
-        }
-    }
 }
 

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/CachedInvocationDispatchBenchmark.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/CachedInvocationDispatchBenchmark.kt
@@ -1,0 +1,70 @@
+package dev.tramai.engine.benchmark
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.provider.ModelProvider
+import dev.tramai.engine.InMemoryOperationResponseCache
+import dev.tramai.engine.TramaiEngine
+import dev.tramai.engine.create
+import dev.tramai.testing.benchmark.BenchmarkHarness
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * B03 — cached invocation dispatch. First call populates the in-memory cache;
+ * timed iterations hit the cache (provider untouched — asserted). Mirrors the
+ * cacheable-op fixture used across engine tests.
+ */
+@EnabledIfSystemProperty(named = "tramai.benchmark", matches = "true")
+class CachedInvocationDispatchBenchmark {
+    @Test
+    fun `B03 cached invocation dispatch latency`() {
+        val provider = CountingProvider()
+        val engine = TramaiEngine(provider, responseCache = InMemoryOperationResponseCache())
+        try {
+            val service = engine.create<BenchCacheService>()
+            // Probe: identical input must be served from cache after the first call.
+            val first = runBlocking { service.respond("same-input") }
+            val cached = runBlocking { service.respond("same-input") }
+            assertEquals(first, cached)
+            assertEquals(1, provider.calls.get(), "second identical call must hit the cache")
+
+            val (meanUs, p50Us, p95Us) =
+                BenchmarkHarness.latency(
+                    operation = "B03-cached-invocation-dispatch",
+                    module = "tramai-engine",
+                    fixture =
+                        "engine.create<BenchCacheService>().respond('same-input') with " +
+                            "InMemoryOperationResponseCache, cacheable=true (warm, cache-hit)",
+                ) {
+                    val result = runBlocking { service.respond("same-input") }
+                    assertTrue(result.isNotEmpty())
+                }
+            assertEquals(1, provider.calls.get(), "cache must absorb every timed iteration")
+            assertTrue(meanUs > 0.0 && p50Us > 0.0 && p95Us >= p50Us)
+        } finally {
+            engine.close()
+        }
+    }
+
+    private class CountingProvider : ModelProvider {
+        val calls = AtomicInteger(0)
+
+        override suspend fun complete(request: ModelRequest): ModelResponse {
+            calls.incrementAndGet()
+            return ModelResponse("cached-response")
+        }
+    }
+}
+
+@AiService
+private interface BenchCacheService {
+    @Operation(prompt = "Respond", model = "test-model", cacheable = true, cacheTtlMillis = 60_000, providerRetries = 0)
+    suspend fun respond(input: String): String
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/OperationPlanCompilationBenchmark.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/OperationPlanCompilationBenchmark.kt
@@ -1,0 +1,55 @@
+package dev.tramai.engine.benchmark
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.engine.ToolRegistry
+import dev.tramai.engine.planning.OperationDefinitionCompiler
+import dev.tramai.engine.planning.OperationFingerprintFactory
+import dev.tramai.engine.planning.ServiceDefinitionCompiler
+import dev.tramai.testing.benchmark.BenchmarkHarness
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+
+/**
+ * B02 — operation-plan compilation (ServiceDefinitionCompiler.compile on a
+ * validated @AiService interface; mirrors EnginePlanningIntegrationTest's
+ * repeated-compilation fixture, no engine construction inside the timed loop).
+ */
+@EnabledIfSystemProperty(named = "tramai.benchmark", matches = "true")
+class OperationPlanCompilationBenchmark {
+    @Test
+    fun `B02 operation-plan compilation latency`() {
+        val compiler =
+            ServiceDefinitionCompiler(
+                OperationDefinitionCompiler(
+                    toolRegistry = ToolRegistry(),
+                    promptSanitizer = null,
+                    fingerprintFactory = OperationFingerprintFactory(),
+                ),
+            )
+        val probe = compiler.compile(BenchPlanService::class)
+        assertEquals(2, probe.operations.size, "fixture must compile two operations")
+
+        val (meanUs, p50Us, p95Us) =
+            BenchmarkHarness.latency(
+                operation = "B02-operation-plan-compilation",
+                module = "tramai-engine",
+                fixture = "ServiceDefinitionCompiler.compile<BenchPlanService>() (2 ops, no tools)",
+            ) {
+                val plan = compiler.compile(BenchPlanService::class)
+                assertEquals(2, plan.operations.size)
+            }
+        assertTrue(meanUs > 0.0 && p50Us > 0.0 && p95Us >= p50Us)
+    }
+}
+
+@AiService
+private interface BenchPlanService {
+    @Operation(prompt = "Classify the document", model = "test-model")
+    suspend fun classify(text: String): String
+
+    @Operation(prompt = "Summarize the document", model = "test-model", providerRetries = 1)
+    suspend fun summarize(text: String): String
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/ServiceProxyCreationBenchmark.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/ServiceProxyCreationBenchmark.kt
@@ -7,127 +7,48 @@ import dev.tramai.core.model.ModelResponse
 import dev.tramai.core.provider.ModelProvider
 import dev.tramai.engine.TramaiEngine
 import dev.tramai.engine.create
+import dev.tramai.testing.benchmark.BenchmarkHarness
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty
-import java.io.File
 import java.lang.reflect.Proxy
-import java.net.InetAddress
-import java.time.Instant
-import kotlin.math.ceil
-import kotlin.math.roundToLong
 
 /**
- * Epic 12.1a benchmark harness — first enrolled operation: service proxy creation.
+ * B01 — service proxy creation (engine.create warm path).
  *
- * Gated by `-Dtramai.benchmark=true` (forwarded to the test worker JVM by the
- * module build): ordinary `test` runs report this class as skipped, so PR CI
- * stays timing-free. The deep/release lane activates it (see
- * `.github/workflows/sovereign-runtime-release-candidate.yml`, dispatch branch).
- *
- * Methodology (docs/EPIC-12.1-performance-resource-baseline.md §4):
- * warm-up >= 3 iterations, then >= 10 individually timed iterations with
- * System.nanoTime(); report mean / p50 / p95; emit one JSON document with
- * environment metadata and raw samples to build/reports/benchmark/. No
- * thresholds — 12.1b records the committed baseline, 12.1d defines policy.
+ * Fixture mirrors the behavioural surface of TramaiEngineTest: single stub
+ * provider, one @AiService interface; measures `create<T>()` after warm-up
+ * (JIT + definition-compiler caches). Gated by `tramai.benchmark=true`; see
+ * BenchmarkHarness for the measurement contract.
  */
 @EnabledIfSystemProperty(named = "tramai.benchmark", matches = "true")
 class ServiceProxyCreationBenchmark {
-    private val iterations: Int =
-        System.getProperty("tramai.benchmark.iterations")?.toIntOrNull() ?: 10
-
     @Test
-    fun `service proxy creation - warm engine path latency`() {
+    fun `B01 service proxy creation - warm engine path latency`() {
         val provider =
             object : ModelProvider {
                 override suspend fun complete(request: ModelRequest): ModelResponse = ModelResponse("benchmark")
             }
         val engine = TramaiEngine(provider)
         try {
-            // Warm-up: JIT + proxy class generation + definition-compiler caches.
-            repeat(3) { engine.create<BenchAskService>() }
+            // Probe: create() must return a dynamic proxy (real check, not a type tautology).
+            val probe = engine.create<BenchAskService>()
+            assertTrue(Proxy.isProxyClass(probe.javaClass), "create() must return a dynamic proxy")
 
-            val samplesNs =
-                (1..iterations).map {
-                    val start = System.nanoTime()
+            val (meanUs, p50Us, p95Us) =
+                BenchmarkHarness.latency(
+                    operation = "B01-service-proxy-creation",
+                    module = "tramai-engine",
+                    fixture = "engine.create<BenchAskService>() on single stub provider (warm path)",
+                ) {
                     val proxy = engine.create<BenchAskService>()
                     assertTrue(Proxy.isProxyClass(proxy.javaClass), "create() must return a dynamic proxy")
-                    System.nanoTime() - start
                 }
-            assertTrue(samplesNs.all { it > 0L }, "all samples must be positive")
-
-            val samplesUs = samplesNs.map { it / 1_000.0 }
-            val meanUs = samplesUs.average()
-            val p50Us = percentile(samplesUs, 0.50)
-            val p95Us = percentile(samplesUs, 0.95)
-            println(
-                "benchmark service-proxy-creation: " +
-                    "mean=${round1(meanUs)}us p50=${round1(p50Us)}us " +
-                    "p95=${round1(p95Us)}us n=$iterations",
-            )
-            emitJson(meanUs, p50Us, p95Us, samplesNs)
+            assertTrue(meanUs > 0.0 && p50Us > 0.0 && p95Us >= p50Us)
         } finally {
             engine.close()
         }
     }
-
-    private fun emitJson(
-        meanUs: Double,
-        p50Us: Double,
-        p95Us: Double,
-        samplesNs: List<Long>,
-    ) {
-        val outDir = File(System.getProperty("tramai.benchmark.out") ?: "build/reports/benchmark")
-        outDir.mkdirs()
-        // Filesystem-safe timestamp: GitHub artifact upload rejects ':' in names.
-        val timestamp = Instant.now().toString().replace(":", "-")
-        val file = File(outDir, "$timestamp-service-proxy-creation.json")
-        val iterationOverride = System.getProperty("tramai.benchmark.iterations")
-        file.writeText(
-            """
-            |{
-            |  "operation": "service-proxy-creation",
-            |  "module": "tramai-engine",
-            |  "fixture": "engine.create<BenchAskService>() on single stub provider (warm path)",
-            |  "gitSha": "${System.getProperty("tramai.benchmark.gitSha") ?: "unknown"}",
-            |  "timestamp": "${Instant.now()}",
-            |  "iterationOverride": ${iterationOverride?.let { "\"$it\"" } ?: "null"},
-            |  "env": {
-            |    "java.version": "${System.getProperty("java.version") ?: "unknown"}",
-            |    "java.vendor": "${System.getProperty("java.vendor") ?: "unknown"}",
-            |    "os.name": "${System.getProperty("os.name") ?: "unknown"}",
-            |    "os.arch": "${System.getProperty("os.arch") ?: "unknown"}",
-            |    "gradleJvmArgs": "${System.getProperty("tramai.benchmark.gradleJvmArgs") ?: "unknown"}",
-            |    "hostname": "${hostname()}",
-            |    "runnerLabel": "${System.getenv("RUNNER_NAME") ?: "local"}"
-            |  },
-            |  "samplesNs": [${samplesNs.joinToString(",")}],
-            |  "stats": { "meanUs": $meanUs, "p50Us": $p50Us, "p95Us": $p95Us },
-            |  "unit": "microseconds"
-            |}
-            """.trimMargin() + "\n",
-        )
-        println("benchmark JSON: ${file.absolutePath}")
-    }
-
-    private fun hostname(): String =
-        try {
-            InetAddress.getLocalHost().hostName
-        } catch (_: Exception) {
-            "unknown"
-        }
-
-    /** Nearest-rank percentile (see EPIC-12.1 doc §4): ceil(q * n) - 1, bounded. */
-    private fun percentile(
-        sortedable: List<Double>,
-        q: Double,
-    ): Double {
-        val sorted = sortedable.sorted()
-        val rank = ceil(q * sorted.size).toInt() - 1
-        return sorted[rank.coerceIn(0, sorted.size - 1)]
-    }
-
-    private fun round1(v: Double): Double = (v * 10.0).roundToLong() / 10.0
 }
 
 @AiService

--- a/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/benchmark/BenchmarkHarness.kt
+++ b/tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/benchmark/BenchmarkHarness.kt
@@ -1,0 +1,187 @@
+package dev.tramai.testing.benchmark
+
+import java.io.File
+import java.net.InetAddress
+import java.time.Instant
+import kotlin.math.ceil
+
+/**
+ * Epic 12.1b shared measurement harness (test-side only, no production deps).
+ *
+ * Contract (docs/EPIC-12.1-performance-resource-baseline.md §4, established by
+ * the 12.1a harness PR #379):
+ *  - latency: warm-up >= 3, then >= 10 individually timed iterations
+ *    (`System.nanoTime()`), mean / p50 / p95 with nearest-rank percentiles;
+ *  - throughput: fixed-duration sampling windows counted in ops/sec;
+ *  - one JSON document per run with full environment/provenance metadata and
+ *    raw samples, emitted to `build/reports/benchmark/` (deep lane uploads);
+ *  - no thresholds — 12.1b records the reference point, 12.1d owns policy.
+ *
+ * Activated only when `-Dtramai.benchmark=true` is forwarded to the test
+ * worker JVM (see root `build.gradle.kts`); benchmark classes carry
+ * `@EnabledIfSystemProperty`, so ordinary `test` runs stay timing-free.
+ */
+@Suppress("TooManyFunctions") // cohesive measurement API; splitting for the threshold would hurt readability
+object BenchmarkHarness {
+    private const val NANOS_PER_MILLI = 1_000_000L
+    private const val NANOS_PER_SECOND = 1_000_000_000.0
+    private const val NANOS_PER_MICRO = 1_000.0
+    private const val WARM_UP_ITERATIONS = 3
+    private const val WARM_UP_WINDOW_MILLIS = 1_000L
+    private const val QUANTILE_P50 = 0.50
+    private const val QUANTILE_P95 = 0.95
+    private const val ROUND_TO_TENTHS = 10.0
+
+    /** Iteration count: `-Dtramai.benchmark.iterations` override, else default. */
+    fun iterations(default: Int = 10): Int = System.getProperty("tramai.benchmark.iterations")?.toIntOrNull() ?: default
+
+    /** Runs [warmUp] un-timed iterations, then [count] timed ones; raw ns samples. */
+    fun sampleLatencyNs(
+        warmUp: Int = WARM_UP_ITERATIONS,
+        count: Int = iterations(),
+        block: () -> Unit,
+    ): List<Long> {
+        repeat(warmUp) { block() }
+        return (1..count).map {
+            val start = System.nanoTime()
+            block()
+            System.nanoTime() - start
+        }
+    }
+
+    /** ops/sec over repeated sampling windows (warm-up window first). */
+    fun sampleThroughputOpsPerSec(
+        windows: Int = 5,
+        windowMillis: Long = WARM_UP_WINDOW_MILLIS,
+        block: () -> Unit,
+    ): List<Double> {
+        fun oneWindow(): Double {
+            val start = System.nanoTime()
+            val deadline = start + windowMillis * NANOS_PER_MILLI
+            var ops = 0L
+            while (System.nanoTime() < deadline) {
+                block()
+                ops++
+            }
+            return ops / ((System.nanoTime() - start) / NANOS_PER_SECOND)
+        }
+        oneWindow() // warm-up window (JIT/caches)
+        return (1..windows).map { oneWindow() }
+    }
+
+    /**
+     * Latency benchmark: warms up [WARM_UP_ITERATIONS], samples [count] timed
+     * iterations, emits the JSON document and prints a summary. Returns
+     * (mean, p50, p95) in microseconds.
+     */
+    fun latency(
+        operation: String,
+        module: String,
+        fixture: String,
+        count: Int = iterations(),
+        block: () -> Unit,
+    ): Triple<Double, Double, Double> {
+        val samplesNs = sampleLatencyNs(count = count, block = block)
+        require(samplesNs.all { it > 0L }) { "all latency samples must be positive" }
+        val samplesUs = samplesNs.map { it / NANOS_PER_MICRO }
+        val meanUs = samplesUs.average()
+        val p50Us = percentile(samplesUs, QUANTILE_P50)
+        val p95Us = percentile(samplesUs, QUANTILE_P95)
+        println(
+            "benchmark $operation: mean=${round1(meanUs)}us p50=${round1(p50Us)}us " +
+                "p95=${round1(p95Us)}us n=$count",
+        )
+        emitJson(
+            operation = operation,
+            module = module,
+            fixture = fixture,
+            body =
+                "\"samplesNs\": [${samplesNs.joinToString(",")}]," +
+                    " \"stats\": { \"meanUs\": $meanUs, \"p50Us\": $p50Us, \"p95Us\": $p95Us }," +
+                    " \"unit\": \"microseconds\"",
+        )
+        return Triple(meanUs, p50Us, p95Us)
+    }
+
+    /** Throughput benchmark: [windows] ops/sec windows; emits JSON. Returns mean ops/sec. */
+    fun throughput(
+        operation: String,
+        module: String,
+        fixture: String,
+        windows: Int = 5,
+        block: () -> Unit,
+    ): Double {
+        val opsPerSec = sampleThroughputOpsPerSec(windows = windows, block = block)
+        require(opsPerSec.all { it >= 0.0 }) { "throughput samples must be non-negative" }
+        val mean = opsPerSec.average()
+        val p50 = percentile(opsPerSec, QUANTILE_P50)
+        val p95 = percentile(opsPerSec, QUANTILE_P95)
+        println("benchmark $operation: mean=${round1(mean)} ops/sec windows=${opsPerSec.size}")
+        emitJson(
+            operation = operation,
+            module = module,
+            fixture = fixture,
+            body =
+                "\"samplesOpsPerSec\": [${opsPerSec.joinToString(",")}]," +
+                    " \"stats\": { \"meanOpsPerSec\": $mean, \"p50OpsPerSec\": $p50," +
+                    " \"p95OpsPerSec\": $p95 }, \"unit\": \"ops/sec\"",
+        )
+        return mean
+    }
+
+    /** Nearest-rank percentile (ceil(q * n) - 1, bounded) — see EPIC-12.1 doc §4. */
+    fun percentile(
+        values: List<Double>,
+        q: Double,
+    ): Double {
+        val sorted = values.sorted()
+        val rank = ceil(q * sorted.size).toInt() - 1
+        return sorted[rank.coerceIn(0, sorted.size - 1)]
+    }
+
+    private fun emitJson(
+        operation: String,
+        module: String,
+        fixture: String,
+        body: String,
+    ) {
+        val outDir = File(System.getProperty("tramai.benchmark.out") ?: "build/reports/benchmark")
+        outDir.mkdirs()
+        // Filesystem-safe timestamp: GitHub artifact upload rejects ':' in names.
+        val timestamp = Instant.now().toString().replace(":", "-")
+        val file = File(outDir, "$timestamp-$operation.json")
+        val iterationOverride = System.getProperty("tramai.benchmark.iterations")
+        file.writeText(
+            """
+            |{
+            |  "operation": "$operation",
+            |  "module": "$module",
+            |  "fixture": "$fixture",
+            |  "gitSha": "${System.getProperty("tramai.benchmark.gitSha") ?: "unknown"}",
+            |  "timestamp": "${Instant.now()}",
+            |  "iterationOverride": ${iterationOverride?.let { "\"$it\"" } ?: "null"},
+            |  "env": {
+            |    "java.version": "${System.getProperty("java.version") ?: "unknown"}",
+            |    "java.vendor": "${System.getProperty("java.vendor") ?: "unknown"}",
+            |    "os.name": "${System.getProperty("os.name") ?: "unknown"}",
+            |    "os.arch": "${System.getProperty("os.arch") ?: "unknown"}",
+            |    "gradleJvmArgs": "${System.getProperty("tramai.benchmark.gradleJvmArgs") ?: "unknown"}",
+            |    "hostname": "${hostname()}",
+            |    "runnerLabel": "${System.getenv("RUNNER_NAME") ?: "local"}"
+            |  },
+            |  $body
+            |}
+            """.trimMargin() + "\n",
+        )
+        println("benchmark JSON: ${file.absolutePath}")
+    }
+
+    private fun hostname(): String =
+        try {
+            InetAddress.getLocalHost().hostName
+        } catch (_: Exception) {
+            "unknown"
+        }
+
+    private fun round1(v: Double): Double = (v * ROUND_TO_TENTHS).toLong() / ROUND_TO_TENTHS
+}


### PR DESCRIPTION
## Epic 12.1b b1 — shared benchmark harness + B01–B03 enrollment

First enrollment slice of the canonical runtime performance baseline. Harness proven by #379; this PR extracts the shared measurement utility and enrolls the three tramai-engine latency operations.

**Changes**
- `tramai-testing` testFixtures: **`BenchmarkHarness`** — latency sampling (warm-up ≥3, timed ≥10, `System.nanoTime()`), throughput ops/sec windows, nearest-rank percentiles, JSON emission with the full #379 contract (raw samples, env/provenance metadata, filesystem-safe names). No thresholds.
- Root `build.gradle.kts`: benchmark-flag forwarding centralized in `subprojects` (was tramai-engine-local in #379) — every module's test workers get `-Dtramai.benchmark=true` + metadata only when the deep lane sets it; default runs stay timing-free.
- **B01** service-proxy-creation refactored onto the harness (operation id `B01-service-proxy-creation`).
- **B02** operation-plan compilation (`ServiceDefinitionCompiler.compile`, 2-op fixture — mirrors EnginePlanningIntegrationTest).
- **B03** cached invocation dispatch (`cacheable=true` + `InMemoryOperationResponseCache`; provider-call-count probe asserts every timed iteration is a cache hit).

**Verified locally**
- Default `test`: all 3 benchmark classes report `skipped=1` (timing-free).
- `-Dtramai.benchmark=true`: all 3 execute; 3/3 JSON docs with `samplesNs[10]`, stats, env; operation ids B01–B03.
- `spotlessKotlinCheck` + `verifyStaticAnalysis` (detekt 1.23.8 CLI) green.

**No production change, no thresholds, no mutation/PIT/config-quality files.** Enrollment continues in b2 (structured/core) and b3 (orchestration incl. B11 throughput) before the 3-run measurement + baseline freeze.
