### PR TITLE
test(core,structured,engine): Epic 12.1b b2 — enroll B04-B07 benchmarks

### DIFF
--- a/tramai-core/src/test/kotlin/dev/tramai/core/benchmark/BenchmarkSupport.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/benchmark/BenchmarkSupport.kt
@@ -1,0 +1,114 @@
+package dev.tramai.core.benchmark
+
+import java.io.File
+import java.net.InetAddress
+import java.time.Instant
+import kotlin.math.ceil
+
+/**
+ * Minimal latency-measurement support for tramai-core whose test classpath
+ * must not take the tramai-testing testFixtures edge (base-module dependency
+ * boundary — canonical BenchmarkHarness lives there for
+ * tramai-engine/orchestration). Mirrors the BenchmarkHarness contract exactly
+ * (see docs/EPIC-12.1-performance-resource-baseline.md §4): warm-up >= 3,
+ * timed >= 10 nanoTime iterations, nearest-rank p50/p95, JSON with env
+ * metadata + raw samples, no thresholds.
+ *
+ * ponytail: duplicate of the canonical harness — revisit if a third module
+ * needs benches or the dependency-boundary decision changes.
+ */
+internal object BenchmarkSupport {
+    private const val NANOS_PER_MICRO = 1_000.0
+    private const val WARM_UP_ITERATIONS = 3
+    private const val QUANTILE_P50 = 0.50
+    private const val QUANTILE_P95 = 0.95
+    private const val ROUND_TO_TENTHS = 10.0
+
+    fun latency(
+        operation: String,
+        module: String,
+        fixture: String,
+        count: Int = 10,
+        block: () -> Unit,
+    ) {
+        repeat(WARM_UP_ITERATIONS) { block() }
+        val samplesNs =
+            (1..count).map {
+                val start = System.nanoTime()
+                block()
+                System.nanoTime() - start
+            }
+        require(samplesNs.all { it > 0L }) { "all latency samples must be positive" }
+        val samplesUs = samplesNs.map { it / NANOS_PER_MICRO }
+        val meanUs = samplesUs.average()
+        val p50Us = percentile(samplesUs, QUANTILE_P50)
+        val p95Us = percentile(samplesUs, QUANTILE_P95)
+        println(
+            "benchmark $operation: mean=${round1(meanUs)}us p50=${round1(p50Us)}us " +
+                "p95=${round1(p95Us)}us n=$count",
+        )
+        emitJson(
+            operation = operation,
+            module = module,
+            fixture = fixture,
+            body =
+                "\"samplesNs\": [${samplesNs.joinToString(",")}]," +
+                    " \"stats\": { \"meanUs\": $meanUs, \"p50Us\": $p50Us, \"p95Us\": $p95Us }," +
+                    " \"unit\": \"microseconds\"",
+        )
+    }
+
+    private fun percentile(
+        values: List<Double>,
+        q: Double,
+    ): Double {
+        val sorted = values.sorted()
+        val rank = ceil(q * sorted.size).toInt() - 1
+        return sorted[rank.coerceIn(0, sorted.size - 1)]
+    }
+
+    private fun emitJson(
+        operation: String,
+        module: String,
+        fixture: String,
+        body: String,
+    ) {
+        val outDir = File(System.getProperty("tramai.benchmark.out") ?: "build/reports/benchmark")
+        outDir.mkdirs()
+        val timestamp = Instant.now().toString().replace(":", "-")
+        val file = File(outDir, "$timestamp-$operation.json")
+        val iterationOverride = System.getProperty("tramai.benchmark.iterations")
+        file.writeText(
+            """
+            |{
+            |  "operation": "$operation",
+            |  "module": "$module",
+            |  "fixture": "$fixture",
+            |  "gitSha": "${System.getProperty("tramai.benchmark.gitSha") ?: "unknown"}",
+            |  "timestamp": "${Instant.now()}",
+            |  "iterationOverride": ${iterationOverride?.let { "\"$it\"" } ?: "null"},
+            |  "env": {
+            |    "java.version": "${System.getProperty("java.version") ?: "unknown"}",
+            |    "java.vendor": "${System.getProperty("java.vendor") ?: "unknown"}",
+            |    "os.name": "${System.getProperty("os.name") ?: "unknown"}",
+            |    "os.arch": "${System.getProperty("os.arch") ?: "unknown"}",
+            |    "gradleJvmArgs": "${System.getProperty("tramai.benchmark.gradleJvmArgs") ?: "unknown"}",
+            |    "hostname": "${hostname()}",
+            |    "runnerLabel": "${System.getenv("RUNNER_NAME") ?: "local"}"
+            |  },
+            |  $body
+            |}
+            """.trimMargin() + "\n",
+        )
+        println("benchmark JSON: ${file.absolutePath}")
+    }
+
+    private fun hostname(): String =
+        try {
+            InetAddress.getLocalHost().hostName
+        } catch (_: Exception) {
+            "unknown"
+        }
+
+    private fun round1(v: Double): Double = (v * ROUND_TO_TENTHS).toLong() / ROUND_TO_TENTHS
+}

--- a/tramai-core/src/test/kotlin/dev/tramai/core/benchmark/ProviderRoutingBenchmark.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/benchmark/ProviderRoutingBenchmark.kt
@@ -1,0 +1,62 @@
+package dev.tramai.core.benchmark
+
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.provider.ModelProvider
+import dev.tramai.core.provider.ProviderRegistry
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+
+/**
+ * B06 — provider routing. Resolves the primary route + configured fallbacks
+ * for a model through a warm ProviderRegistry (3 providers, 2 models, 1
+ * fallback chain). Mirrors the ProviderRegistryTest resolve-candidates
+ * fixture; the registry + operation are built once, resolution is timed.
+ */
+@EnabledIfSystemProperty(named = "tramai.benchmark", matches = "true")
+class ProviderRoutingBenchmark {
+    private val registry: ProviderRegistry =
+        ProviderRegistry
+            .builder()
+            .provider("primary", NamedProvider("primary"))
+            .provider("fallback-a", NamedProvider("fallback-a"))
+            .provider("fallback-b", NamedProvider("fallback-b"))
+            .model("gpt-5.1-chat-latest", "primary")
+            .model("gpt-5.1-mini", "fallback-a")
+            .fallbackModel("gpt-5.1-chat-latest", "gpt-5.1-mini", "fallback-a")
+            .fallbackModel("gpt-5.1-mini", "gpt-5.1-mini", "fallback-b")
+            .build()
+
+    private val operation = Operation(prompt = "unused", model = "gpt-5.1-chat-latest")
+
+    @Test
+    fun `B06 provider routing latency`() {
+        val probe = registry.resolveCandidates(operation)
+        assertEquals(2, probe.size, "fixture must resolve primary + one fallback")
+
+        BenchmarkSupport.latency(
+            operation = "B06-provider-routing",
+            module = "tramai-core",
+            fixture =
+                "ProviderRegistry.resolveCandidates(Operation model=gpt-5.1-chat-latest) " +
+                    "on 3-provider/2-model registry with 1 fallback hop",
+        ) {
+            val candidates = registry.resolveCandidates(operation)
+            assertEquals(2, candidates.size)
+        }
+        assertTrue(probe.isNotEmpty())
+    }
+
+    private class NamedProvider(
+        private val id: String,
+    ) : ModelProvider {
+        override suspend fun complete(request: ModelRequest): ModelResponse {
+            error("routing benchmark must not invoke providers")
+        }
+
+        override fun providerId(): String = id
+    }
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/ToolGovernanceBenchmark.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/ToolGovernanceBenchmark.kt
@@ -1,0 +1,45 @@
+package dev.tramai.engine.benchmark
+
+import dev.tramai.engine.tool.ToolAuthorizationCoordinator
+import dev.tramai.engine.tool.ToolAuthorizationDecision
+import dev.tramai.engine.tool.policyHelper
+import dev.tramai.engine.tool.testTool
+import dev.tramai.engine.tool.toolRequest
+import dev.tramai.testing.benchmark.BenchmarkHarness
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+
+/**
+ * B07 — tool-governance overhead. Runs the full pre-execution governance
+ * decision for one tool call: context build + policy evaluation against the
+ * enforcement point (BEFORE_TOOL_EXECUTION) via ToolAuthorizationCoordinator.
+ * Mirrors the ToolAuthorizationCoordinatorTest allow-path fixture (existing
+ * TestToolFixtures helpers); allow-by-default policy, no execution.
+ */
+@EnabledIfSystemProperty(named = "tramai.benchmark", matches = "true")
+class ToolGovernanceBenchmark {
+    private val coordinator = ToolAuthorizationCoordinator(policyHelper())
+    private val request = toolRequest(testTool(name = "governed-tool"))
+
+    @Test
+    fun `B07 tool governance authorization latency`() {
+        val probe = runBlocking { coordinator.authorize(request, "{}") }
+        assertEquals(ToolAuthorizationDecision.Allow, probe)
+
+        val (meanUs, p50Us, p95Us) =
+            BenchmarkHarness.latency(
+                operation = "B07-tool-governance",
+                module = "tramai-engine",
+                fixture =
+                    "ToolAuthorizationCoordinator.authorize(governed-tool, '{}') " +
+                        "with allow-by-default policy (context build + policy evaluation)",
+            ) {
+                val decision = runBlocking { coordinator.authorize(request, "{}") }
+                assertEquals(ToolAuthorizationDecision.Allow, decision)
+            }
+        assertTrue(meanUs > 0.0 && p50Us > 0.0 && p95Us >= p50Us)
+    }
+}

--- a/tramai-structured/src/test/kotlin/dev/tramai/structured/benchmark/BenchmarkSupport.kt
+++ b/tramai-structured/src/test/kotlin/dev/tramai/structured/benchmark/BenchmarkSupport.kt
@@ -1,0 +1,114 @@
+package dev.tramai.structured.benchmark
+
+import java.io.File
+import java.net.InetAddress
+import java.time.Instant
+import kotlin.math.ceil
+
+/**
+ * Minimal latency-measurement support for [module] whose test classpath must
+ * not take the tramai-testing testFixtures edge (module dependency boundary —
+ * canonical BenchmarkHarness lives there for tramai-engine/orchestration).
+ * Mirrors the BenchmarkHarness contract exactly (see
+ * docs/EPIC-12.1-performance-resource-baseline.md §4): warm-up >= 3, timed
+ * >= 10 nanoTime iterations, nearest-rank p50/p95, JSON with env metadata +
+ * raw samples, no thresholds.
+ *
+ * ponytail: duplicate of the canonical harness — revisit if a third module
+ * needs benches or the dependency-boundary decision changes.
+ */
+internal object BenchmarkSupport {
+    private const val NANOS_PER_MICRO = 1_000.0
+    private const val WARM_UP_ITERATIONS = 3
+    private const val QUANTILE_P50 = 0.50
+    private const val QUANTILE_P95 = 0.95
+    private const val ROUND_TO_TENTHS = 10.0
+
+    fun latency(
+        operation: String,
+        module: String,
+        fixture: String,
+        count: Int = 10,
+        block: () -> Unit,
+    ) {
+        repeat(WARM_UP_ITERATIONS) { block() }
+        val samplesNs =
+            (1..count).map {
+                val start = System.nanoTime()
+                block()
+                System.nanoTime() - start
+            }
+        require(samplesNs.all { it > 0L }) { "all latency samples must be positive" }
+        val samplesUs = samplesNs.map { it / NANOS_PER_MICRO }
+        val meanUs = samplesUs.average()
+        val p50Us = percentile(samplesUs, QUANTILE_P50)
+        val p95Us = percentile(samplesUs, QUANTILE_P95)
+        println(
+            "benchmark $operation: mean=${round1(meanUs)}us p50=${round1(p50Us)}us " +
+                "p95=${round1(p95Us)}us n=$count",
+        )
+        emitJson(
+            operation = operation,
+            module = module,
+            fixture = fixture,
+            body =
+                "\"samplesNs\": [${samplesNs.joinToString(",")}]," +
+                    " \"stats\": { \"meanUs\": $meanUs, \"p50Us\": $p50Us, \"p95Us\": $p95Us }," +
+                    " \"unit\": \"microseconds\"",
+        )
+    }
+
+    private fun percentile(
+        values: List<Double>,
+        q: Double,
+    ): Double {
+        val sorted = values.sorted()
+        val rank = ceil(q * sorted.size).toInt() - 1
+        return sorted[rank.coerceIn(0, sorted.size - 1)]
+    }
+
+    private fun emitJson(
+        operation: String,
+        module: String,
+        fixture: String,
+        body: String,
+    ) {
+        val outDir = File(System.getProperty("tramai.benchmark.out") ?: "build/reports/benchmark")
+        outDir.mkdirs()
+        val timestamp = Instant.now().toString().replace(":", "-")
+        val file = File(outDir, "$timestamp-$operation.json")
+        val iterationOverride = System.getProperty("tramai.benchmark.iterations")
+        file.writeText(
+            """
+            |{
+            |  "operation": "$operation",
+            |  "module": "$module",
+            |  "fixture": "$fixture",
+            |  "gitSha": "${System.getProperty("tramai.benchmark.gitSha") ?: "unknown"}",
+            |  "timestamp": "${Instant.now()}",
+            |  "iterationOverride": ${iterationOverride?.let { "\"$it\"" } ?: "null"},
+            |  "env": {
+            |    "java.version": "${System.getProperty("java.version") ?: "unknown"}",
+            |    "java.vendor": "${System.getProperty("java.vendor") ?: "unknown"}",
+            |    "os.name": "${System.getProperty("os.name") ?: "unknown"}",
+            |    "os.arch": "${System.getProperty("os.arch") ?: "unknown"}",
+            |    "gradleJvmArgs": "${System.getProperty("tramai.benchmark.gradleJvmArgs") ?: "unknown"}",
+            |    "hostname": "${hostname()}",
+            |    "runnerLabel": "${System.getenv("RUNNER_NAME") ?: "local"}"
+            |  },
+            |  $body
+            |}
+            """.trimMargin() + "\n",
+        )
+        println("benchmark JSON: ${file.absolutePath}")
+    }
+
+    private fun hostname(): String =
+        try {
+            InetAddress.getLocalHost().hostName
+        } catch (_: Exception) {
+            "unknown"
+        }
+
+    private fun round1(v: Double): Double = (v * ROUND_TO_TENTHS).toLong() / ROUND_TO_TENTHS
+}

--- a/tramai-structured/src/test/kotlin/dev/tramai/structured/benchmark/StructuredContractCompilationBenchmark.kt
+++ b/tramai-structured/src/test/kotlin/dev/tramai/structured/benchmark/StructuredContractCompilationBenchmark.kt
@@ -1,0 +1,49 @@
+package dev.tramai.structured.benchmark
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.kotlin.kotlinModule
+import dev.tramai.core.annotations.AiDescription
+import dev.tramai.core.annotations.AiRange
+import dev.tramai.structured.descriptor.StructuredTypeCompiler
+import dev.tramai.structured.descriptor.StructuredTypeDescriptor
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import kotlin.reflect.typeOf
+
+/**
+ * B04 — structured-contract compilation. Compiles a Kotlin data-class
+ * contract (annotations, nested list, ranges) into a language-neutral
+ * StructuredTypeDescriptor. Mirrors the StructuredContractFingerprintTest
+ * fixture; the compiler is constructed once, compilation is timed.
+ */
+@EnabledIfSystemProperty(named = "tramai.benchmark", matches = "true")
+class StructuredContractCompilationBenchmark {
+    private val compiler =
+        StructuredTypeCompiler(JsonMapper.builder().addModule(kotlinModule()).build())
+
+    @Test
+    fun `B04 structured-contract compilation latency`() {
+        val probe = compiler.compile(typeOf<BenchContract>())
+        assertEquals(3, (probe as StructuredTypeDescriptor.Object).properties.size)
+
+        BenchmarkSupport.latency(
+            operation = "B04-structured-contract-compilation",
+            module = "tramai-structured",
+            fixture =
+                "StructuredTypeCompiler.compile<BenchContract>() " +
+                    "(3 props: @AiDescription String, @AiRange Double, List<String>)",
+        ) {
+            val compiled = compiler.compile(typeOf<BenchContract>())
+            assertEquals(3, (compiled as StructuredTypeDescriptor.Object).properties.size)
+        }
+    }
+}
+
+private data class BenchContract(
+    @property:AiDescription("The document title")
+    val title: String,
+    @property:AiRange(min = 0.0, max = 1.0)
+    val score: Double,
+    val tags: List<String>,
+)

--- a/tramai-structured/src/test/kotlin/dev/tramai/structured/benchmark/StructuredValidationBenchmark.kt
+++ b/tramai-structured/src/test/kotlin/dev/tramai/structured/benchmark/StructuredValidationBenchmark.kt
@@ -1,0 +1,49 @@
+package dev.tramai.structured.benchmark
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.kotlin.kotlinModule
+import dev.tramai.core.annotations.AiDescription
+import dev.tramai.core.annotations.AiRange
+import dev.tramai.structured.descriptor.StructuredTypeCompiler
+import dev.tramai.structured.descriptor.StructuredValueValidator
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import kotlin.reflect.typeOf
+
+/**
+ * B05 — structured validation. Validates a fully compliant runtime value
+ * against its compiled descriptor (constraints, nested nullability, property
+ * accessors). Mirrors the StructuredDescriptorArchitectureTest /
+ * StructuredValueValidator fixture; descriptor + value built once, validation
+ * timed (null result = valid, asserted each iteration).
+ */
+@EnabledIfSystemProperty(named = "tramai.benchmark", matches = "true")
+class StructuredValidationBenchmark {
+    private val compiler =
+        StructuredTypeCompiler(JsonMapper.builder().addModule(kotlinModule()).build())
+    private val validator = StructuredValueValidator()
+
+    @Test
+    fun `B05 structured validation latency`() {
+        val descriptor = compiler.compile(typeOf<BenchValidDoc>())
+        val value = BenchValidDoc(title = "a valid document", score = 0.5, tags = listOf("a", "b"))
+        assertNull(validator.validate(value, descriptor, ""))
+
+        BenchmarkSupport.latency(
+            operation = "B05-structured-validation",
+            module = "tramai-structured",
+            fixture = "StructuredValueValidator.validate(valid BenchValidDoc, compiled descriptor)",
+        ) {
+            assertNull(validator.validate(value, descriptor, ""))
+        }
+    }
+}
+
+private data class BenchValidDoc(
+    @property:AiDescription("The document title")
+    val title: String,
+    @property:AiRange(min = 0.0, max = 1.0)
+    val score: Double,
+    val tags: List<String>,
+)


### PR DESCRIPTION
## Epic 12.1b b2 — enroll B04–B07

Second enrollment slice of the canonical runtime performance baseline (#380 landed the harness + B01–B03).

**Changes**
- **B04** structured-contract compilation (`tramai-structured`) — `StructuredTypeCompiler.compile` of an annotated 3-prop data contract (mirrors StructuredContractFingerprintTest).
- **B05** structured validation (`tramai-structured`) — `StructuredValueValidator.validate` of a compliant value against its compiled descriptor.
- **B06** provider routing (`tramai-core`) — `ProviderRegistry.resolveCandidates`, 3 providers / 2 models / 1 fallback hop (mirrors ProviderRegistryTest).
- **B07** tool governance (`tramai-engine`) — `ToolAuthorizationCoordinator.authorize` with allow-by-default policy, using the existing `TestToolFixtures` helpers (mirrors ToolAuthorizationCoordinatorTest).
- **Module-local `BenchmarkSupport`** (core + structured): exact mirror of the canonical `BenchmarkHarness` contract. Both modules' test classpaths must NOT take the `tramai-testing` testFixtures edge (that fixture set pulls engine/orchestration/spring upward — a base/boundary-module dependency violation). Flagged with a `ponytail:` note to revisit if a third module needs benches.

**Verified locally**
- Default `test`: all new benchmark classes report `skipped=1` (7/7 total bench classes timing-free).
- Flagged (`-Dtramai.benchmark=true`): B04–B07 execute; JSON docs carry `samplesNs[10]` + stats + env; B01–B07 all present across module report dirs.
- Compiler-warnings clean (use-site `@property:` targets on structured fixtures).
- `spotlessKotlinCheck` + `verifyStaticAnalysis` (detekt 1.23.8 CLI) green; `verifyChangePolicy` PASSED (runtime-behaviour, 6 files, no violations).

**No production change, no thresholds, no mutation/PIT/config-quality files.** Remaining: b3 (B08 approval suspend/resume, B09 evidence export, B10 checkpoint/resume, B11 worker polling incl. throughput) → measurement commit → 3 deep runs → baseline freeze.
