### PR TITLE
test(engine,orchestration): Epic 12.1b b3 — enroll B08-B11 benchmarks

### DIFF
--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/ApprovalSuspendResumeBenchmark.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/ApprovalSuspendResumeBenchmark.kt
@@ -1,0 +1,366 @@
+package dev.tramai.engine.benchmark
+
+import dev.tramai.core.approval.ApprovalAuthorization
+import dev.tramai.core.approval.ApprovalChallenge
+import dev.tramai.core.approval.ApprovalContinuation
+import dev.tramai.core.approval.ApprovalContinuationStatus
+import dev.tramai.core.approval.ApprovalContinuationStore
+import dev.tramai.core.approval.ApprovalGateCoordinator
+import dev.tramai.core.approval.ApprovalLifecycleAuditEmitter
+import dev.tramai.core.approval.ApprovalToken
+import dev.tramai.core.approval.ApprovalValidation
+import dev.tramai.core.approval.AuthorizeResumeCommand
+import dev.tramai.core.approval.ClaimedApprovalContinuation
+import dev.tramai.core.approval.CreateApprovalCommand
+import dev.tramai.core.approval.SensitiveToolArguments
+import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.approval.ValidateResumeCommand
+import dev.tramai.core.model.Message
+import dev.tramai.core.model.MessageRole
+import dev.tramai.core.model.ResolvedTool
+import dev.tramai.core.model.SideEffectLevel
+import dev.tramai.core.model.ToolCall
+import dev.tramai.core.model.ToolExecutionContext
+import dev.tramai.core.model.ToolResult
+import dev.tramai.core.policy.PolicyDecision
+import dev.tramai.core.policy.PolicyEngine
+import dev.tramai.core.policy.ToolSecurityMetadata
+import dev.tramai.engine.EngineEventObserver
+import dev.tramai.engine.EngineExecutionIdentity
+import dev.tramai.engine.ExecutionSecurityContext
+import dev.tramai.engine.PolicyEnforcementHelper
+import dev.tramai.engine.ReplayEnvelopeFactory
+import dev.tramai.engine.ResumeApprovalCommand
+import dev.tramai.engine.ResumeOperationReference
+import dev.tramai.engine.ResumeToolDeclarationDigestHelper
+import dev.tramai.engine.ResumeToolReference
+import dev.tramai.engine.SensitiveReplayEnvelope
+import dev.tramai.engine.SuspendedInvocationMetadata
+import dev.tramai.engine.SuspendedInvocationStore
+import dev.tramai.engine.ToolRegistry
+import dev.tramai.engine.approval.ApprovalRegistryService
+import dev.tramai.engine.approval.ApprovalResumeCoordinator
+import dev.tramai.engine.approval.ClaimedResumeExecutionRequest
+import dev.tramai.engine.approval.ClaimedResumeExecutor
+import dev.tramai.engine.approval.ContinuationClaimService
+import dev.tramai.engine.approval.ReplayAuthorizationService
+import dev.tramai.engine.approval.ResumeOperationRegistry
+import dev.tramai.engine.approval.approvalOperation
+import dev.tramai.engine.approval.approvalService
+import dev.tramai.security.approval.Sha256ToolArgumentsDigester
+import dev.tramai.testing.benchmark.BenchmarkHarness
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * B08 — approval suspend/resume. Drives the full resume pipeline of a
+ * suspended tool invocation: continuation inspect -> metadata load -> registry
+ * resolve -> bindings validate -> tool resolve -> token validate -> policy
+ * evaluate -> token authorize -> claim -> replay reveal/verify -> arguments
+ * verify -> executor execute -> continuation complete -> metadata remove.
+ *
+ * Fixture replicates the ApprovalResumeCoordinatorTest happy-path harness
+ * (in-memory collaborator fakes returning a fresh PENDING continuation per
+ * call); coordinator.resume() is timed end-to-end. Mirrors the documented
+ * suspend-then-resume cycle for the same tool call — the suspension half is
+ * construction of the suspended state (metadata + replay envelope) before the
+ * timed region.
+ */
+@EnabledIfSystemProperty(named = "tramai.benchmark", matches = "true")
+class ApprovalSuspendResumeBenchmark {
+    private val digest = Sha256Digest.of("sha256:" + "1".repeat(64))
+    private val input = """{"x":2}"""
+    private val inputDigest = Sha256ToolArgumentsDigester().digest(SensitiveToolArguments.of(input))
+    private val token = ApprovalToken.parsePresented("token-1")
+    private val toolName = "test_tool"
+    private val toolCallId = "call-1"
+    private val approvalId = "approval-1"
+    private val resumedBy = "admin"
+    private val identity = EngineExecutionIdentity("wf-1", "corr-1", digest, "policy-v1", "actor-1")
+    private val command =
+        ResumeApprovalCommand(
+            approvalId,
+            approvalExpectedVersion = 1,
+            continuationExpectedVersion = 3,
+            token,
+            resumedBy,
+        )
+
+    private val tool = BenchFakeTool(toolName)
+    private val toolReference = ResumeToolReference(toolName, ResumeToolDeclarationDigestHelper.compute(tool))
+    private val operation = approvalOperation(ApprovalRegistryService::class.java.getMethod("first"))
+    private val service = approvalService(operation)
+    private val opRef =
+        ResumeOperationReference(
+            serviceInterface = ApprovalRegistryService::class.qualifiedName!!,
+            methodName = "first",
+            jvmMethodDescriptor = "()Ljava/lang/String;",
+            resumeDefinitionDigest =
+                dev.tramai.engine.ResumeDefinitionDigestHelper
+                    .compute(service, operation),
+        )
+
+    private val messages =
+        listOf(
+            Message(MessageRole.USER, "compute"),
+            Message(MessageRole.ASSISTANT, "", toolCalls = listOf(ToolCall(toolCallId, toolName, input))),
+        )
+    private val prepared = ReplayEnvelopeFactory.prepareForSuspension(opRef, messages, toolCallId, toolName, 0)
+
+    private fun metadata() =
+        SuspendedInvocationMetadata(
+            approvalId = approvalId,
+            toolCallId = toolCallId,
+            toolName = toolName,
+            toolCallIndex = 0,
+            correlationId = "corr-1",
+            identity = identity,
+            securityContext = ExecutionSecurityContext(),
+            operationReference = opRef,
+            replayEnvelopeDigest = prepared.digest,
+            conversationId = null,
+            historySize = 0,
+            tokenBudgetSnapshot = null,
+            toolReference = toolReference,
+            toolSecurity = null,
+        )
+
+    private fun continuation() =
+        ApprovalContinuation(
+            approvalId = approvalId,
+            workflowRunId = "wf-1",
+            correlationId = "corr-1",
+            toolCallId = toolCallId,
+            toolName = toolName,
+            argumentsDigest = inputDigest,
+            policyVersion = "policy-v1",
+            workflowDigest = digest,
+            status = ApprovalContinuationStatus.PENDING,
+            createdAt = Instant.EPOCH,
+            approvalExpiresAt = Instant.MAX,
+            claimedBy = null,
+            claimedAt = null,
+            completedAt = null,
+            version = 3L,
+        )
+
+    @Test
+    fun `B08 approval suspend-resume latency`() {
+        val store = BenchContinuationStore(continuation(), input)
+        val suspended = BenchSuspendedStore(metadata(), prepared.envelope)
+        val executor = BenchResumeExecutor()
+        val registry = ResumeOperationRegistry().also { it.register(service, operation, executor) }
+        val gate = BenchGate(token)
+        val audit = BenchAuditEmitter()
+        val observer =
+            object : EngineEventObserver {
+                override fun onEngineEvent(
+                    name: String,
+                    attributes: Map<String, Any?>,
+                ) = Unit
+            }
+        val policy =
+            PolicyEnforcementHelper(
+                policyEngine = PolicyEngine { PolicyDecision.Allow },
+                migrationWarningGuard = AtomicBoolean(false),
+            )
+        val coordinator =
+            ApprovalResumeCoordinator(
+                approvalContinuationStore = store,
+                suspendedInvocationStore = suspended,
+                resumeOperationRegistry = registry,
+                toolRegistry = ToolRegistry(mapOf(toolName to tool)),
+                toolArgumentsDigester = Sha256ToolArgumentsDigester(),
+                approvalLifecycleAuditEmitter = audit,
+                engineEventObserver = observer,
+                claimService = ContinuationClaimService(store),
+                authorizationService = ReplayAuthorizationService(gate, suspended, audit, policy, observer),
+            )
+
+        val probe = runBlocking { coordinator.resume(command) }
+        assertEquals("executed", probe, "resume must complete the suspended invocation")
+
+        val (meanUs, p50Us, p95Us) =
+            BenchmarkHarness.latency(
+                operation = "B08-approval-suspend-resume",
+                module = "tramai-engine",
+                fixture =
+                    "ApprovalResumeCoordinator.resume(ResumeApprovalCommand) full pipeline " +
+                        "over in-memory continuation/suspended stores, policy Allow, executor no-op",
+            ) {
+                val result = runBlocking { coordinator.resume(command) }
+                assertEquals("executed", result)
+            }
+        assertTrue(meanUs > 0.0 && p50Us > 0.0 && p95Us >= p50Us)
+    }
+}
+
+private class BenchContinuationStore(
+    private val value: ApprovalContinuation,
+    private val input: String,
+) : ApprovalContinuationStore {
+    override suspend fun create(
+        continuation: ApprovalContinuation,
+        arguments: SensitiveToolArguments,
+    ): ApprovalContinuation = continuation
+
+    override suspend fun get(approvalId: String): ApprovalContinuation? = value
+
+    override suspend fun claimForExecution(
+        approvalId: String,
+        expectedVersion: Long,
+        claimedBy: String,
+    ): ClaimedApprovalContinuation = ClaimedApprovalContinuation(value, SensitiveToolArguments.of(input))
+
+    override suspend fun complete(
+        approvalId: String,
+        expectedVersion: Long,
+        completedBy: String,
+    ): ApprovalContinuation = value.copy(status = ApprovalContinuationStatus.COMPLETED, version = expectedVersion)
+
+    override suspend fun expire(
+        approvalId: String,
+        expectedVersion: Long,
+    ): ApprovalContinuation = value
+
+    override suspend fun cancel(
+        approvalId: String,
+        expectedVersion: Long,
+    ): ApprovalContinuation = value
+
+    override suspend fun findStaleClaimed(
+        claimedBefore: Instant,
+        limit: Int,
+    ): List<ApprovalContinuation> = emptyList()
+
+    override suspend fun forceCancelClaimed(
+        approvalId: String,
+        expectedVersion: Long,
+        cancelledBy: String,
+        reasonCode: String,
+    ): ApprovalContinuation = value
+
+    override suspend fun sweepExpired(): Int = 0
+}
+
+private class BenchSuspendedStore(
+    private val value: SuspendedInvocationMetadata?,
+    private val envelope: SensitiveReplayEnvelope?,
+) : SuspendedInvocationStore {
+    override suspend fun create(
+        metadata: SuspendedInvocationMetadata,
+        replayEnvelope: SensitiveReplayEnvelope,
+    ) = Unit
+
+    override suspend fun get(approvalId: String): SuspendedInvocationMetadata? = value
+
+    override suspend fun revealReplayEnvelope(approvalId: String): SensitiveReplayEnvelope? = envelope
+
+    override suspend fun remove(approvalId: String): SuspendedInvocationMetadata? = value
+}
+
+private class BenchGate(
+    private val token: ApprovalToken,
+) : ApprovalGateCoordinator {
+    override suspend fun createApproval(command: CreateApprovalCommand): ApprovalChallenge =
+        ApprovalChallenge("approval-1", token, Instant.MAX)
+
+    override suspend fun validateResume(command: ValidateResumeCommand): ApprovalValidation =
+        ApprovalValidation(command.approvalId, command.consumedBy, Instant.EPOCH, 0L)
+
+    override suspend fun authorizeResume(command: AuthorizeResumeCommand): ApprovalAuthorization =
+        ApprovalAuthorization(command.approvalId, command.consumedBy, Instant.EPOCH, 0L, replayed = false)
+
+    override suspend fun cancelApproval(
+        approvalId: String,
+        expectedVersion: Long,
+        reason: String,
+    ) = Unit
+}
+
+private class BenchAuditEmitter : ApprovalLifecycleAuditEmitter {
+    override suspend fun onToolExecutionSuspended(
+        approvalId: String,
+        workflowRunId: String,
+        toolName: String,
+        toolCallId: String,
+        correlationId: String,
+        argumentsDigest: Sha256Digest,
+        expiresAt: Instant,
+    ) = Unit
+
+    override suspend fun onToolExecutionResumed(
+        approvalId: String,
+        workflowRunId: String,
+        toolName: String,
+        resumedBy: String,
+    ) = Unit
+
+    override suspend fun onToolExecutionCompleted(
+        approvalId: String,
+        workflowRunId: String,
+        toolName: String,
+        completedBy: String,
+    ) = Unit
+
+    override suspend fun onUncertainOutcome(
+        approvalId: String,
+        workflowRunId: String,
+        toolName: String,
+        reason: String,
+    ) = Unit
+
+    override suspend fun onSuspensionCancelled(
+        approvalId: String,
+        workflowRunId: String,
+        toolName: String,
+        reason: String,
+    ) = Unit
+
+    override suspend fun onStaleClaimDetected(
+        approvalId: String,
+        workflowRunId: String,
+        toolName: String,
+        claimedAt: Instant,
+    ) = Unit
+
+    override suspend fun onClaimedContinuationForceCancellationRequested(
+        approvalId: String,
+        workflowRunId: String,
+        toolName: String,
+        cancelledBy: String,
+        reasonCode: String,
+    ) = Unit
+
+    override suspend fun onClaimedContinuationForceCancelled(
+        approvalId: String,
+        workflowRunId: String,
+        toolName: String,
+        cancelledBy: String,
+        reasonCode: String,
+    ) = Unit
+}
+
+private class BenchResumeExecutor : ClaimedResumeExecutor {
+    override suspend fun execute(request: ClaimedResumeExecutionRequest): Any? = "executed"
+}
+
+private class BenchFakeTool(
+    override val name: String,
+) : ResolvedTool {
+    override val description: String = "test"
+    override val inputSchemaJson: String = """{"type":"object"}"""
+    override val idempotent: Boolean = false
+    override val sideEffectLevel: SideEffectLevel = SideEffectLevel.READ_ONLY
+    override val security: ToolSecurityMetadata? = null
+
+    override suspend fun execute(
+        input: Any,
+        context: ToolExecutionContext,
+    ): ToolResult = ToolResult.Success("{}")
+}

--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/EvidenceExportBenchmark.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/EvidenceExportBenchmark.kt
@@ -1,0 +1,91 @@
+package dev.tramai.engine.benchmark
+
+import dev.tramai.engine.evidence.ProviderRouteDecisionEvidenceSource
+import dev.tramai.engine.evidence.ProviderRouteDecisionKind
+import dev.tramai.engine.evidence.ProviderRoutingRuntimeEvidenceExporter
+import dev.tramai.testing.benchmark.BenchmarkHarness
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import java.time.Instant
+
+/**
+ * B09 — evidence export. Converts a 3-record provider-route batch (SELECTED,
+ * FALLBACK, BLOCKED) into runtime-evidence.v1 records. Mirrors the
+ * ProviderRoutingRuntimeEvidenceExporterTest multi-source fixture; sources
+ * are built once, export is timed.
+ */
+@EnabledIfSystemProperty(named = "tramai.benchmark", matches = "true")
+class EvidenceExportBenchmark {
+    private val exporter = ProviderRoutingRuntimeEvidenceExporter()
+    private val fixedTimestamp = Instant.parse("2026-07-09T10:00:00Z")
+
+    private val selected =
+        ProviderRouteDecisionEvidenceSource(
+            eventId = "route-ev-001",
+            workflowRunId = "wf-route-001",
+            correlationId = "corr-route-001",
+            actor = "tramai-engine",
+            createdAt = fixedTimestamp,
+            decisionKind = ProviderRouteDecisionKind.SELECTED,
+            requestedModelName = "gpt-model-name",
+            selectedProviderName = "primary-provider",
+            selectedModelName = "gpt-model-name",
+            routeIndex = 0,
+            attempt = 1,
+        )
+
+    private val fallback =
+        ProviderRouteDecisionEvidenceSource(
+            eventId = "route-ev-002",
+            workflowRunId = "wf-route-001",
+            correlationId = "corr-route-001",
+            actor = "tramai-engine",
+            createdAt = fixedTimestamp.plusSeconds(5),
+            decisionKind = ProviderRouteDecisionKind.FALLBACK,
+            requestedModelName = "gpt-model-name",
+            selectedProviderName = "fallback-provider",
+            selectedModelName = "gpt-model-name",
+            previousProviderName = "primary-provider",
+            previousModelName = "gpt-model-name",
+            fallbackReason = "circuit-breaker-open",
+            routeIndex = 1,
+            attempt = 2,
+        )
+
+    private val blocked =
+        ProviderRouteDecisionEvidenceSource(
+            eventId = "route-ev-003",
+            workflowRunId = "wf-route-002",
+            correlationId = "corr-route-002",
+            actor = "tramai-engine",
+            createdAt = fixedTimestamp.plusSeconds(10),
+            decisionKind = ProviderRouteDecisionKind.BLOCKED,
+            requestedModelName = "restricted-model",
+            selectedProviderName = null,
+            selectedModelName = null,
+            fallbackReason = "model-registry-blocked",
+        )
+
+    private val batch = listOf(selected, fallback, blocked)
+
+    @Test
+    fun `B09 evidence export latency`() {
+        val probe = exporter.export(batch)
+        assertEquals(3, probe.size, "fixture batch must export three records")
+
+        val (meanUs, p50Us, p95Us) =
+            BenchmarkHarness.latency(
+                operation = "B09-evidence-export",
+                module = "tramai-engine",
+                fixture =
+                    "ProviderRoutingRuntimeEvidenceExporter.export(3-record batch: " +
+                        "SELECTED + FALLBACK + BLOCKED, digests precomputed)",
+            ) {
+                val records = exporter.export(batch)
+                assertEquals(3, records.size)
+            }
+        assertTrue(meanUs > 0.0 && p50Us > 0.0 && p95Us >= p50Us)
+    }
+}

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/benchmark/CheckpointResumeBenchmark.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/benchmark/CheckpointResumeBenchmark.kt
@@ -1,0 +1,48 @@
+package dev.tramai.orchestration.benchmark
+
+import dev.tramai.orchestration.benchmark.WorkerPollingFixture.build
+import dev.tramai.testing.benchmark.BenchmarkHarness
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+
+/**
+ * B10 — checkpoint resume. Latency of one real poll cycle that claims and
+ * executes a single due checkpoint: enumeration -> deterministic ordering ->
+ * active/partition/lease/recovery filtering -> LeaseCoordinator claim ->
+ * WorkflowExecutionSupervisor dispatch + completion drain of the registered
+ * one-step workflow (stable depth: the next cycle observes the same single
+ * pending checkpoint).
+ *
+ * Boundary: workflow step BODIES are trivial deterministic one-step bodies
+ * (no network, no lease renewal in the timed region) — see
+ * WorkerPollingFixture for the full boundary statement.
+ */
+@EnabledIfSystemProperty(named = "tramai.benchmark", matches = "true")
+class CheckpointResumeBenchmark {
+    @Test
+    fun `B10 checkpoint resume latency`() {
+        val fixture = build(dueCount = 1)
+        var cycles = 0
+        try {
+            val (meanUs, p50Us, p95Us) =
+                BenchmarkHarness.latency(
+                    operation = "B10-checkpoint-resume",
+                    module = "tramai-orchestration",
+                    fixture =
+                        "CheckpointPoller poll cycle over 1 due checkpoint: enumerate+order+filter+" +
+                            "lease claim+supervisor dispatch+completion drain (one-step in-process workflow)",
+                ) {
+                    runBlocking { fixture.pollCycleDrained() }
+                    cycles++
+                    assertEquals(cycles, fixture.observer.leaseAcquired.size, "cycle must claim its checkpoint")
+                }
+            assertTrue(meanUs > 0.0 && p50Us > 0.0 && p95Us >= p50Us)
+        } finally {
+            fixture.scope.cancel()
+        }
+    }
+}

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/benchmark/WorkerPollingBenchmark.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/benchmark/WorkerPollingBenchmark.kt
@@ -1,0 +1,76 @@
+package dev.tramai.orchestration.benchmark
+
+import dev.tramai.orchestration.benchmark.WorkerPollingFixture.build
+import dev.tramai.testing.benchmark.BenchmarkHarness
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+
+/**
+ * B11 — worker polling throughput at two queue depths, measured on the real
+ * polling path (CheckpointPoller over in-memory persistence with lease claim
+ * + supervisor dispatch + completion drain; see WorkerPollingFixture).
+ *
+ * - empty queue: poll cycles over a catalog with 0 due checkpoints
+ *   (idle enumeration cadence);
+ * - loaded queue: poll cycles over a catalog with 100 due checkpoints
+ *   (100 claims + dispatches + completions per cycle — depth stays at 100
+ *   across cycles because each drained cycle releases every lease).
+ *
+ * ops/sec = poll cycles per second (1s fixed-duration sampling windows); the
+ * loaded fixture processes 100 checkpoints per cycle, so the equivalent
+ * checkpoint rate is cycles/sec * 100. Workflow step bodies are trivial and
+ * lease renewal is outside the timed region (documented boundary).
+ */
+@EnabledIfSystemProperty(named = "tramai.benchmark", matches = "true")
+class WorkerPollingBenchmark {
+    @Test
+    fun `B11 worker polling - empty queue throughput`() {
+        val fixture = build(dueCount = 0)
+        try {
+            val meanOps =
+                BenchmarkHarness.throughput(
+                    operation = "B11-worker-polling-empty",
+                    module = "tramai-orchestration",
+                    fixture =
+                        "CheckpointPoller poll cycle over EMPTY catalog (0 due): " +
+                            "idle enumerate+filter cycle; ops/sec = poll cycles/sec; " +
+                            "no claims expected per cycle",
+                ) {
+                    runBlocking { fixture.pollCycleDrained() }
+                    assertEquals(0, fixture.observer.leaseAcquired.size, "empty queue must never claim")
+                }
+            assertTrue(meanOps > 0.0)
+        } finally {
+            fixture.scope.cancel()
+        }
+    }
+
+    @Test
+    fun `B11 worker polling - loaded queue throughput`() {
+        val fixture = build(dueCount = 100)
+        var cycles = 0
+        try {
+            val meanOps =
+                BenchmarkHarness.throughput(
+                    operation = "B11-worker-polling-loaded",
+                    module = "tramai-orchestration",
+                    fixture =
+                        "CheckpointPoller poll cycle over catalog with 100 due checkpoints: " +
+                            "100 claims+dispatches+completions per cycle, depth stable across cycles; " +
+                            "ops/sec = poll cycles/sec (x100 = checkpoint claims/sec); " +
+                            "step bodies trivial, lease renewal outside timed region",
+                ) {
+                    runBlocking { fixture.pollCycleDrained() }
+                    cycles++
+                    assertEquals(cycles * 100, fixture.observer.leaseAcquired.size, "every cycle must claim all 100")
+                }
+            assertTrue(meanOps > 0.0)
+        } finally {
+            fixture.scope.cancel()
+        }
+    }
+}

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/benchmark/WorkerPollingFixture.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/benchmark/WorkerPollingFixture.kt
@@ -1,0 +1,163 @@
+package dev.tramai.orchestration.benchmark
+
+import dev.tramai.orchestration.CheckpointPoller
+import dev.tramai.orchestration.InMemoryWorkflowCheckpointStore
+import dev.tramai.orchestration.InMemoryWorkflowLeaseStore
+import dev.tramai.orchestration.LeaseCoordinator
+import dev.tramai.orchestration.LeaseRenewalLoop
+import dev.tramai.orchestration.ModHashPartitionStrategy
+import dev.tramai.orchestration.TramaiWorkerObserver
+import dev.tramai.orchestration.WORKFLOW_DEFINITION_VERSION_METADATA_KEY
+import dev.tramai.orchestration.WorkerConfig
+import dev.tramai.orchestration.WorkflowBindingRegistry
+import dev.tramai.orchestration.WorkflowCheckpoint
+import dev.tramai.orchestration.WorkflowExecutionSupervisor
+import dev.tramai.orchestration.WorkflowPersistence
+import dev.tramai.orchestration.WorkflowRecoveryCoordinator
+import dev.tramai.orchestration.WorkflowStateCodec
+import dev.tramai.orchestration.workflow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Shared real-polling fixture for the orchestration benchmarks (B10/B11).
+ *
+ * Builds the actual worker poll path used in production: CheckpointPoller
+ * over in-memory persistence with a LeaseCoordinator claim and a
+ * WorkflowExecutionSupervisor dispatch of a registered one-step workflow.
+ * Nothing here is a synthetic loop over an in-memory primitive — pollOnce()
+ * runs enumeration -> deterministic ordering -> partition/active/lease/
+ * recovery filtering -> lease claim -> supervisor dispatch for every due
+ * checkpoint.
+ *
+ * Boundary documentation: workflow step BODIES and lease RENEWAL run
+ * asynchronously after dispatch and are intentionally outside the timed
+ * region (deterministic in-process one-step workflows only; the supervisor
+ * scope is attached, so dispatch is real). The measured quantity is the poll
+ * cycle over the due catalog.
+ */
+internal object WorkerPollingFixture {
+    internal data class Fixture(
+        val poller: CheckpointPoller,
+        val observer: ClaimRecordingObserver,
+        val scope: CoroutineScope,
+        val store: InMemoryWorkflowCheckpointStore,
+        val leaseStore: InMemoryWorkflowLeaseStore,
+        val supervisor: WorkflowExecutionSupervisor,
+    ) {
+        /**
+         * One poll cycle at stable depth: poll the due catalog, then drain the
+         * asynchronously-dispatched executions until the supervisor is idle so
+         * the next cycle observes the same pending population (leases released).
+         */
+        suspend fun pollCycleDrained() {
+            poller.pollOnce()
+            withTimeout(15_000) {
+                while (supervisor.activeExecutionCount() > 0) {
+                    delay(1)
+                }
+            }
+        }
+    }
+
+    internal class ClaimRecordingObserver : TramaiWorkerObserver {
+        val leaseAcquired = CopyOnWriteArrayList<String>()
+
+        override fun onLeaseAcquired(
+            workflowId: String,
+            workerId: String,
+        ) {
+            leaseAcquired += workflowId
+        }
+    }
+
+    private data class TickState(
+        val value: String,
+    )
+
+    private object TickCodec : WorkflowStateCodec<TickState> {
+        override fun encode(state: TickState): String = state.value
+
+        override fun decode(payload: String): TickState = TickState(payload)
+    }
+
+    /** One poller + supervisor over [dueCount] due checkpoints (0 = empty queue). */
+    internal fun build(
+        dueCount: Int,
+        workflowName: String = "bench-wf",
+    ): Fixture {
+        val store = InMemoryWorkflowCheckpointStore()
+        val leaseStore = InMemoryWorkflowLeaseStore()
+        val observer = ClaimRecordingObserver()
+        val config =
+            WorkerConfig(
+                workerId = "bench-worker",
+                poolName = "bench-pool",
+                pollIntervalMillis = 10,
+                leaseDurationMillis = 60_000,
+                drainTimeoutMillis = 1_000,
+            )
+        seedCheckpoints(store, workflowName, dueCount)
+        val coordinator = LeaseCoordinator(config, leaseStore, observer)
+        val definition =
+            workflow<TickState>(workflowName, definitionVersion = "v1") {
+                localStep("tick") { state, _ -> state }
+            }.build { it.value }
+        val binding =
+            WorkflowBindingRegistry {
+                bind(definition, WorkflowPersistence(checkpointStore = store, stateCodec = TickCodec))
+            }
+        val supervisor =
+            WorkflowExecutionSupervisor(
+                config = config,
+                leaseStore = leaseStore,
+                checkpointStore = store,
+                stepAttemptStore = store,
+                workflowBindings = binding,
+                observability = observer,
+                leaseCoordinator = coordinator,
+                recoveryCoordinator = WorkflowRecoveryCoordinator(leaseStore, store),
+                leaseRenewalLoop = LeaseRenewalLoop(config, leaseStore, observer),
+                shuttingDownGracefully = { false },
+            )
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        supervisor.attachScope(scope)
+        val poller =
+            CheckpointPoller(
+                config = config,
+                checkpointCatalog = store,
+                workerRegistryStore = leaseStore,
+                partitionStrategy = ModHashPartitionStrategy(),
+                leaseCoordinator = coordinator,
+                executionSupervisor = supervisor,
+                observability = observer,
+                acceptingWork = { true },
+            )
+        return Fixture(poller, observer, scope, store, leaseStore, supervisor)
+    }
+
+    private fun seedCheckpoints(
+        store: InMemoryWorkflowCheckpointStore,
+        workflowName: String,
+        dueCount: Int,
+    ) {
+        repeat(dueCount) { index ->
+            val checkpoint =
+                WorkflowCheckpoint(
+                    workflowName = workflowName,
+                    workflowId = "w-$index",
+                    nextStepIndex = 0,
+                    stepExecutions = 0,
+                    lastCompletedStepName = null,
+                    statePayload = "start",
+                    metadata = mapOf(WORKFLOW_DEFINITION_VERSION_METADATA_KEY to "v1"),
+                )
+            runBlocking { store.save(checkpoint) }
+        }
+    }
+}


### PR DESCRIPTION
## Epic 12.1b b3 — enroll B08–B11

Final enrollment slice (#380 harness+B01–B03, #381 B04–B07). After this, the full B01–B11 roadmap population exists on master.

**Changes**
- **B08** approval suspend/resume (`tramai-engine`) — full `ApprovalResumeCoordinator.resume()` pipeline (continuation inspect → metadata load → registry resolve → bindings → token validate → policy → authorize → claim → replay reveal/verify → args verify → executor → complete → remove) over in-memory collaborator fakes. Fixture mirrors the `ApprovalResumeCoordinatorTest` happy-path wiring.
- **B09** evidence export (`tramai-engine`) — `ProviderRoutingRuntimeEvidenceExporter.export` over a fixed SELECTED+FALLBACK+BLOCKED 3-record batch (mirrors the multi-source exporter test).
- **B10** checkpoint resume (`tramai-orchestration`) — latency of one real poll cycle claiming + dispatching + completion-draining a single due checkpoint.
- **B11** worker polling (`tramai-orchestration`) — throughput at **empty** and **loaded (100 due)** depth: `ops/sec` = poll cycles/sec over 1s fixed windows, on the **real polling path** (`CheckpointPoller` over in-memory persistence → `LeaseCoordinator` claim → `WorkflowExecutionSupervisor` dispatch of a registered one-step workflow). Not a synthetic queue loop.
- Shared `WorkerPollingFixture` (fixture kept in its owning module per #377 rule).

**Sharing decision (ponytail fired — orchestration is the third module)**
Orchestration **already** depends on `tramai-testing` testFixtures (like tramai-engine), so B10/B11 use the **canonical `BenchmarkHarness`** — no third local copy was added. The two module-local `BenchmarkSupport` copies in tramai-core/tramai-structured remain a **documented bounded exception for 0.6.0**: those base modules cannot take the upward testFixtures edge without violating the module dependency boundary (#377 "no benchmark module" decision also preserved — nothing new was created).

**B11 measured-boundary documentation (in fixture + operation JSONs)**
The measured quantity is the poll cycle over the due catalog: enumeration → deterministic ordering → partition/active/lease/recovery filtering → lease claim → supervisor dispatch. Workflow step bodies are trivial deterministic one-step bodies; lease renewal and step execution are asynchronous and **outside the timed region**. `ops/sec` = poll cycles/sec; the loaded fixture processes 100 checkpoints per cycle, so checkpoint rate = cycles/sec × 100 (depth stays at 100 because each drained cycle releases every lease — proven empirically: without the drain, full-speed re-claim degenerates to 0 claims/cycle, so a raw `pollOnce` loop would have measured an empty scan, not loaded polling).

**Verified locally**
- Default `test`: B08–B11 all `skipped=1` (12/12 bench methods timing-free across the repo).
- Flagged run: B08/B09/B10 latency JSONs (`samplesNs[10]`) + B11-empty/B11-loaded throughput JSONs (`samplesOpsPerSec[5]`, ops/sec) emitted with full env/provenance metadata; real steady-state claims asserted in-loop (leaseAcquired grows by dueCount per drained cycle).
- `spotlessKotlinCheck` + `verifyStaticAnalysis` (detekt 1.23.8) green; `verifyChangePolicy` PASSED (runtime-behaviour, 5 files).

**No production change, no thresholds, no mutation/PIT/config-quality files.** Enrollment complete → next: merge b3, then the 12.1b measurement authority (exact commit with B01–B11), ≥3 independent deep-lane runs, variance review, and the `0.6.0-performance-baseline.json` freeze with `measuredCommit` provenance.
