### PR TITLE
test(engine,orchestration): Epic 12.1c c1 — deterministic lifecycle ownership (probes 1, 2, 7)

### DIFF
--- a/tramai-engine/src/test/kotlin/dev/tramai/engine/RuntimeCloseOwnedJobContractTest.kt
+++ b/tramai-engine/src/test/kotlin/dev/tramai/engine/RuntimeCloseOwnedJobContractTest.kt
@@ -1,0 +1,138 @@
+package dev.tramai.engine
+
+import dev.tramai.core.annotations.AiService
+import dev.tramai.core.annotations.Operation
+import dev.tramai.core.model.ModelRequest
+import dev.tramai.core.model.ModelResponse
+import dev.tramai.core.provider.ModelProvider
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Epic 12.1c probe 1 + 7 (engine portion) — named, repeatable proof that the
+ * TramaiEngine runtime owns its jobs to completion on close().
+ *
+ * Ownership boundary: close() cancels the engine-owned lifecycleJob AND every
+ * tracked suspend invocation (activeInvocationJobs), then JOINS them when
+ * called from a non-engine thread (TramaiEngine.close). "Zero owned jobs after
+ * close" is therefore observable as: close() returns only after the parked
+ * invocation and its cleanup terminated, a second close() is a no-op, and
+ * repeated create/close cycles leave no retained engine state behind.
+ *
+ * Deterministic (latch-based) — no sleeps, no timing thresholds. Complements
+ * the existing close suites in TramaiEngineTest (mid-stream cancel, caller-job
+ * no-deadlock, self-close) with the explicit owned-job contract framing.
+ */
+class RuntimeCloseOwnedJobContractTest {
+    @AiService
+    private interface SummarizerService {
+        @Operation(prompt = "Summarize the raw input", model = "test-model")
+        suspend fun summarize(rawInput: String): String
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    fun `close returns only after a parked invocation terminates and repeated close is a no-op`() {
+        val providerEntered = CompletableDeferred<Unit>()
+        val providerReleased = CompletableDeferred<Unit>()
+        val providerCalls = AtomicInteger()
+        val provider =
+            object : ModelProvider {
+                override suspend fun complete(request: ModelRequest): ModelResponse {
+                    providerCalls.incrementAndGet()
+                    providerEntered.complete(Unit)
+                    // Cancellable suspension: close() cancels the tracked invocation
+                    // and join() waits for this await to abort.
+                    providerReleased.await()
+                    return ModelResponse(content = "never")
+                }
+            }
+        val engine = TramaiEngine(provider)
+        val service = engine.create<SummarizerService>()
+
+        val callerFinished = CompletableDeferred<Throwable?>()
+        val caller =
+            Thread {
+                val outcome = runCatching { runBlocking { service.summarize("raw") } }
+                callerFinished.complete(outcome.exceptionOrNull())
+            }
+        caller.start()
+
+        // Admission gate: the invocation is parked inside the provider — the
+        // engine owns exactly one in-flight tracked job at this point.
+        runBlocking { providerEntered.await() }
+
+        // close() must cancel + join the parked invocation and return while the
+        // provider gate is STILL latched (the call never completes normally).
+        engine.close()
+
+        // The parked call terminated with cancellation (close joined it).
+        val outcome = runBlocking { callerFinished.await() }
+        assertThat(outcome).isInstanceOf(kotlinx.coroutines.CancellationException::class.java)
+        caller.join(5_000)
+        assertThat(caller.isAlive).isFalse()
+
+        // The provider was entered exactly once and never resumed past the gate.
+        assertThat(providerCalls.get()).isEqualTo(1)
+
+        // Repeated close is safe and idempotent (closed.compareAndSet guard).
+        engine.close()
+
+        // Post-close the runtime rejects new work — no owned job can be admitted.
+        assertThatThrownBy { runBlocking { service.summarize("late") } }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("Tramai runtime is closed")
+        providerReleased.complete(Unit)
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    fun `repeated create close cycles retain no owned state`() {
+        repeat(CYCLES) { cycle ->
+            val providerCalls = AtomicInteger()
+            val engine =
+                TramaiEngine(
+                    provider =
+                        object : ModelProvider {
+                            override suspend fun complete(request: ModelRequest): ModelResponse {
+                                providerCalls.incrementAndGet()
+                                return ModelResponse(content = "ok-$cycle")
+                            }
+                        },
+                )
+            val service = engine.create<SummarizerService>()
+            val result = runBlocking { service.summarize("cycle-$cycle") }
+            assertThat(result).isEqualTo("ok-$cycle")
+            assertThat(providerCalls.get()).isEqualTo(1)
+
+            engine.close()
+            // Idempotent second close: proves the first close drained the owned
+            // jobs and no half-closed state is retained for the next cycle.
+            engine.close()
+        }
+        // A fresh runtime still works after CYCLES teardowns (no global state).
+        val finalEngine = TramaiEngine(provider = ImmediateProvider("final"))
+        try {
+            val result = runBlocking { finalEngine.create<SummarizerService>().summarize("after") }
+            assertThat(result).isEqualTo("final")
+        } finally {
+            finalEngine.close()
+        }
+    }
+
+    private companion object {
+        const val CYCLES = 25
+    }
+
+    private class ImmediateProvider(
+        private val content: String,
+    ) : ModelProvider {
+        override suspend fun complete(request: ModelRequest): ModelResponse = ModelResponse(content = content)
+    }
+}

--- a/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkerShutdownCoordinatorTest.kt
+++ b/tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/WorkerShutdownCoordinatorTest.kt
@@ -16,14 +16,14 @@ import org.junit.jupiter.api.Test
 import java.util.concurrent.CopyOnWriteArrayList
 
 class WorkerShutdownCoordinatorTest {
-
-    private val config = WorkerConfig(
-        workerId = "shutdown-test",
-        poolName = "tests",
-        pollIntervalMillis = 20,
-        leaseDurationMillis = 5_000,
-        drainTimeoutMillis = 60_000,
-    )
+    private val config =
+        WorkerConfig(
+            workerId = "shutdown-test",
+            poolName = "tests",
+            pollIntervalMillis = 20,
+            leaseDurationMillis = 5_000,
+            drainTimeoutMillis = 60_000,
+        )
 
     private class RecordingObserver : TramaiWorkerObserver {
         val events = CopyOnWriteArrayList<String>()
@@ -32,7 +32,11 @@ class WorkerShutdownCoordinatorTest {
             events += "shutdownStarted"
         }
 
-        override fun onDrainProgress(workerId: String, done: Int, pending: Int) {
+        override fun onDrainProgress(
+            workerId: String,
+            done: Int,
+            pending: Int,
+        ) {
             events += "drainProgress($done,$pending)"
         }
 
@@ -44,23 +48,45 @@ class WorkerShutdownCoordinatorTest {
             events += "workerStopped"
         }
 
-        override fun onLeaseAcquired(workflowId: String, workerId: String) {
+        override fun onLeaseAcquired(
+            workflowId: String,
+            workerId: String,
+        ) {
             events += "leaseAcquired"
         }
 
-        override fun onLeaseReleased(workflowId: String, workerId: String) {
+        override fun onLeaseReleased(
+            workflowId: String,
+            workerId: String,
+        ) {
             events += "leaseReleased"
         }
 
-        override fun onStepAttemptStarted(runId: String, stepName: String, attemptId: String, workerId: String) {
+        override fun onStepAttemptStarted(
+            runId: String,
+            stepName: String,
+            attemptId: String,
+            workerId: String,
+        ) {
             events += "attemptStarted"
         }
 
-        override fun onStepAttemptCompleted(runId: String, stepName: String, attemptId: String, workerId: String) {
+        override fun onStepAttemptCompleted(
+            runId: String,
+            stepName: String,
+            attemptId: String,
+            workerId: String,
+        ) {
             events += "attemptCompleted"
         }
 
-        override fun onStepAttemptFailed(runId: String, stepName: String, attemptId: String, workerId: String, error: Throwable) {
+        override fun onStepAttemptFailed(
+            runId: String,
+            stepName: String,
+            attemptId: String,
+            workerId: String,
+            error: Throwable,
+        ) {
             events += "attemptFailed"
         }
     }
@@ -79,20 +105,22 @@ class WorkerShutdownCoordinatorTest {
         // the coordinator is assigned right after (same pattern as the
         // lifecycle controller). Only invoked during execution, so lateinit is safe.
         lateinit var coordinator: WorkerShutdownCoordinator
-        val supervisor = WorkflowExecutionSupervisor(
-            config = config,
-            leaseStore = leaseStore,
-            checkpointStore = store,
-            stepAttemptStore = store,
-            workflowBindings = WorkflowBindingRegistry {
-                bind(workflow, WorkflowPersistence(checkpointStore = store, stateCodec = TestCodec))
-            },
-            observability = observer,
-            leaseCoordinator = leaseCoordinator,
-            recoveryCoordinator = WorkflowRecoveryCoordinator(leaseStore, store),
-            leaseRenewalLoop = LeaseRenewalLoop(config, leaseStore, observer),
-            shuttingDownGracefully = { coordinator.isShuttingDownGracefully() },
-        )
+        val supervisor =
+            WorkflowExecutionSupervisor(
+                config = config,
+                leaseStore = leaseStore,
+                checkpointStore = store,
+                stepAttemptStore = store,
+                workflowBindings =
+                    WorkflowBindingRegistry {
+                        bind(workflow, WorkflowPersistence(checkpointStore = store, stateCodec = TestCodec))
+                    },
+                observability = observer,
+                leaseCoordinator = leaseCoordinator,
+                recoveryCoordinator = WorkflowRecoveryCoordinator(leaseStore, store),
+                leaseRenewalLoop = LeaseRenewalLoop(config, leaseStore, observer),
+                shuttingDownGracefully = { coordinator.isShuttingDownGracefully() },
+            )
         coordinator = WorkerShutdownCoordinator(config, observer, supervisor, leaseStore)
         val rootSupervisor = SupervisorJob()
         val scope = CoroutineScope(rootSupervisor + Dispatchers.Default)
@@ -137,26 +165,32 @@ class WorkerShutdownCoordinatorTest {
     @Test
     fun `shutdown drains a running execution to completion before finishing`() {
         val gate = CompletableDeferred<Unit>()
-        val workflow = workflow<TestState>("wf", definitionVersion = "v1") {
-            localStep("mark") { state, _ -> gate.await(); state.copy(value = "done") }
-        }.build { it.value }
+        val workflow =
+            workflow<TestState>("wf", definitionVersion = "v1") {
+                localStep("mark") { state, _ ->
+                    gate.await()
+                    state.copy(value = "done")
+                }
+            }.build { it.value }
         val h = harness(workflow = workflow)
         h.start()
         h.registerWorker()
 
-        val cp = WorkflowCheckpoint(
-            workflowName = "wf",
-            workflowId = "w-1",
-            nextStepIndex = 0,
-            stepExecutions = 0,
-            lastCompletedStepName = null,
-            statePayload = TestCodec.encode(TestState("start")),
-            metadata = workflow.checkpointMetadata(),
-        )
+        val cp =
+            WorkflowCheckpoint(
+                workflowName = "wf",
+                workflowId = "w-1",
+                nextStepIndex = 0,
+                stepExecutions = 0,
+                lastCompletedStepName = null,
+                statePayload = TestCodec.encode(TestState("start")),
+                metadata = workflow.checkpointMetadata(),
+            )
         val saved = runBlocking { h.store.save(cp) }
-        val lease = runBlocking {
-            h.leaseStore.claim("wf", "w-1", "shutdown-test", saved.revision, 5_000)
-        }
+        val lease =
+            runBlocking {
+                h.leaseStore.claim("wf", "w-1", "shutdown-test", saved.revision, 5_000)
+            }
         h.supervisor.launch(saved, lease)
 
         runBlocking {
@@ -194,28 +228,34 @@ class WorkerShutdownCoordinatorTest {
     @Test
     fun `drain timeout cancels the remaining execution`() {
         val never = CompletableDeferred<Unit>()
-        val workflow = workflow<TestState>("wf", definitionVersion = "v1") {
-            localStep("mark") { state, _ -> never.await(); state }
-        }.build { it.value }
+        val workflow =
+            workflow<TestState>("wf", definitionVersion = "v1") {
+                localStep("mark") { state, _ ->
+                    never.await()
+                    state
+                }
+            }.build { it.value }
         val h = harness(drainTimeoutMillis = 150, workflow = workflow)
         h.start()
 
-        val saved = runBlocking {
-            h.store.save(
-                WorkflowCheckpoint(
-                    workflowName = "wf",
-                    workflowId = "w-1",
-                    nextStepIndex = 0,
-                    stepExecutions = 0,
-                    lastCompletedStepName = null,
-                    statePayload = TestCodec.encode(TestState("start")),
-                    metadata = workflow.checkpointMetadata(),
-                ),
-            )
-        }
-        val lease = runBlocking {
-            h.leaseStore.claim("wf", "w-1", "shutdown-test", saved.revision, 5_000)
-        }
+        val saved =
+            runBlocking {
+                h.store.save(
+                    WorkflowCheckpoint(
+                        workflowName = "wf",
+                        workflowId = "w-1",
+                        nextStepIndex = 0,
+                        stepExecutions = 0,
+                        lastCompletedStepName = null,
+                        statePayload = TestCodec.encode(TestState("start")),
+                        metadata = workflow.checkpointMetadata(),
+                    ),
+                )
+            }
+        val lease =
+            runBlocking {
+                h.leaseStore.claim("wf", "w-1", "shutdown-test", saved.revision, 5_000)
+            }
         h.supervisor.launch(saved, lease)
         runBlocking {
             withTimeout(10_000) {
@@ -236,9 +276,10 @@ class WorkerShutdownCoordinatorTest {
         val hook = Thread { }
         Runtime.getRuntime().addShutdownHook(hook)
         try {
-            val workflow = workflow<TestState>("wf", definitionVersion = "v1") {
-                localStep("mark") { state, _ -> state }
-            }.build { it.value }
+            val workflow =
+                workflow<TestState>("wf", definitionVersion = "v1") {
+                    localStep("mark") { state, _ -> state }
+                }.build { it.value }
             val h = harness(workflow = workflow)
             h.start(hook)
 
@@ -265,9 +306,10 @@ class WorkerShutdownCoordinatorTest {
 
     @Test
     fun `repeated shutdown is idempotent`() {
-        val workflow = workflow<TestState>("wf", definitionVersion = "v1") {
-            localStep("mark") { state, _ -> state }
-        }.build { it.value }
+        val workflow =
+            workflow<TestState>("wf", definitionVersion = "v1") {
+                localStep("mark") { state, _ -> state }
+            }.build { it.value }
         val h = harness(workflow = workflow)
         h.start()
         runBlocking {
@@ -280,10 +322,88 @@ class WorkerShutdownCoordinatorTest {
         h.scope.cancel()
     }
 
-    private data class TestState(val value: String)
+    /**
+     * Epic 12.1c probe 2 — hook registration/removal symmetry across a full
+     * live cycle: the hook is registered while the owned worker is live,
+     * removed on normal shutdown, and no hook survives after the cycle.
+     * Deterministic: the coordinator's stored-hook flag plus the JVM-level
+     * deregistration probe (removeShutdownHook returns false once the hook is
+     * gone) — no sleeps.
+     */
+    @Test
+    fun `hook is registered while live and deregistered on shutdown`() {
+        val hook = Thread { }
+        val workflow =
+            workflow<TestState>("wf", definitionVersion = "v1") {
+                localStep("mark") { state, _ -> state }
+            }.build { it.value }
+        val h = harness(workflow = workflow)
+        try {
+            h.start(hook)
+            // Registered while the owned worker is live.
+            assertThat(h.coordinator.hasShutdownHook()).isTrue()
+
+            runBlocking {
+                withTimeout(10_000) { h.coordinator.shutdown(h.rootSupervisor) }
+            }
+
+            // Removed on normal shutdown: coordinator dropped the reference...
+            assertThat(h.coordinator.hasShutdownHook()).isFalse()
+            // ...and the JVM hook is deregistered (false = not still registered).
+            assertThat(Runtime.getRuntime().removeShutdownHook(hook)).isFalse()
+        } finally {
+            runCatching { Runtime.getRuntime().removeShutdownHook(hook) }
+            h.scope.cancel()
+        }
+    }
+
+    /**
+     * Epic 12.1c probe 7 (hook component) — repeated create/close cycles do
+     * not accumulate JVM shutdown hooks. Each cycle registers a distinct hook
+     * while the worker is live and must fully deregister it on shutdown; if
+     * hooks accumulated, a later cycle's deregistration probe would find the
+     * earlier hooks still registered (removeShutdownHook returning true).
+     */
+    @Test
+    fun `repeated create close cycles do not accumulate shutdown hooks`() {
+        val workflow =
+            workflow<TestState>("wf", definitionVersion = "v1") {
+                localStep("mark") { state, _ -> state }
+            }.build { it.value }
+        repeat(HOOK_CYCLE_COUNT) { cycle ->
+            val hook = Thread { }
+            val h = harness(workflow = workflow)
+            try {
+                h.start(hook)
+                assertThat(h.coordinator.hasShutdownHook()).isTrue()
+                runBlocking {
+                    withTimeout(10_000) { h.coordinator.shutdown(h.rootSupervisor) }
+                }
+                assertThat(h.coordinator.hasShutdownHook()).isFalse()
+                // Cycle's own hook must be gone from the JVM. A true return
+                // here would mean this hook (or an earlier cycle's leak) is
+                // still registered.
+                assertThat(Runtime.getRuntime().removeShutdownHook(hook))
+                    .describedAs("cycle %d left its shutdown hook registered", cycle)
+                    .isFalse()
+            } finally {
+                runCatching { Runtime.getRuntime().removeShutdownHook(hook) }
+                h.scope.cancel()
+            }
+        }
+    }
+
+    private data class TestState(
+        val value: String,
+    )
+
+    private companion object {
+        const val HOOK_CYCLE_COUNT = 10
+    }
 
     private object TestCodec : WorkflowStateCodec<TestState> {
         override fun encode(state: TestState): String = state.value
+
         override fun decode(payload: String): TestState = TestState(payload)
     }
 }


### PR DESCRIPTION
## Epic 12.1c c1 — deterministic lifecycle ownership (probes 1, 2, 7)

First 12.1c slice: named, repeatable resource/lifecycle proofs for owned jobs, shutdown hooks, and create/close composition. Test-only; no production change; no timing thresholds; latch-based determinism (no sleeps-as-correctness).

**Probe 1 — Runtime close → zero owned jobs (tramai-engine)**
`RuntimeCloseOwnedJobContractTest` (new):
- close() returns only after a provider-parked suspend invocation terminates — the invocation is cancelled+joined (caller observes `CancellationException`, provider entered exactly once, never resumed past its gate);
- repeated close() is a safe no-op (idempotent `closed` CAS guard);
- post-close work is rejected (`"Tramai runtime is closed"`);
- probe 7 composition (engine part): create → invoke → close → close again × **25 cycles**, then a fresh runtime still works — no retained engine state. The existing TramaiEngineTest close suites (mid-stream cancel, caller-job no-deadlock, self-close) remain the behavioural base; this file adds the explicit owned-job contract framing.

**Probe 2 — Shutdown-hook cleanup (tramai-orchestration)**
Two tests added to `WorkerShutdownCoordinatorTest` (reusing its private harness — zero duplication):
- hook is registered while the owned worker is live (`hasShutdownHook()` true), removed on normal shutdown, and the JVM-level deregistration probe confirms it (`removeShutdownHook` returns false);
- probe 7 composition (hook part): **10 create/close cycles**, each with a distinct hook, each fully deregistered — if hooks accumulated, a later cycle's probe would find an earlier hook still registered.

**Probe 7 — repeated create/close × N**: composition across both runtime types above (25 engine cycles + 10 worker-hook cycles), asserting only real ownership signals (job join, hook deregistration) — no heap/GC assertions.

**Verified locally**: engine 2/2 + orchestration 6/6 tests green; `spotlessKotlinCheck` + `verifyStaticAnalysis` (detekt 1.23.8) green; `verifyChangePolicy` PASSED (2 files, runtime-behaviour). No mutation/PIT/config-quality files touched.
