### PR TITLE
feat(quality): Epic 12.1d — performance/resource regression policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,3 +408,14 @@ jobs:
           name: zero-egress-verification-report
           path: |
             build/zero-egress-report/zero-egress-report.json
+
+  performance-policy-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Epic 12.1d: classification-semantics unit tests are pure logic on
+      # synthetic fixtures — fast, timing-free, runs on every PR.
+      - name: Run performance regression policy unit tests
+        run: python3 scripts/test_performance_regression_verifier.py

--- a/.github/workflows/sovereign-runtime-release-candidate.yml
+++ b/.github/workflows/sovereign-runtime-release-candidate.yml
@@ -168,6 +168,48 @@ jobs:
           path: '**/build/reports/benchmark/*.json'
           if-no-files-found: error
 
+      - name: Compare deep-lane benchmark run against 0.6.0 baseline (Epic 12.1d)
+        # Timing drift is NOT a failure here: candidates are classified, never
+        # auto-rejected. The step fails closed ONLY on structural errors
+        # (INVALID_MEASUREMENT / NON_COMPARABLE) — missing population,
+        # malformed JSON, wrong measured commit, schema/authority mismatch.
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          mkdir -p build
+          set +e
+          python3 scripts/performance_regression_verifier.py verify \
+            --baseline config/quality/performance/0.6.0-performance-baseline.json \
+            --runs '**/build/reports/benchmark/*.json' \
+            --expected-commit "${{ github.sha }}" \
+            --repo-root . --summary \
+            > build/performance-regression-report.json 2>&1
+          code=$?
+          set -e
+          python3 - <<'EOF'
+          import json
+          report = json.load(open('build/performance-regression-report.json'))
+          status = report.get('status', 'INVALID_MEASUREMENT')
+          print(f'## Epic 12.1d deep-run classification: {status}', file=open('summary.txt', 'w'))
+          for op in report.get('operations', []):
+              print(f"- {op['operationId']}: {op['classification']} "
+                    f"(measured {op['measured']:.2f}, envelope {op['envelopeMin']:.2f}..{op['envelopeMax']:.2f})",
+                    file=open('summary.txt', 'a'))
+          EOF
+          cat summary.txt >> $GITHUB_STEP_SUMMARY
+          if [ "$code" -ne 0 ]; then
+            echo "Structural benchmark failure (exit $code): fail closed. See build/performance-regression-report.json"
+            exit "$code"
+          fi
+          echo "Comparable report emitted; candidates require the 3-run confirmation protocol before any release adjudication."
+
+      - name: Upload performance regression report
+        if: github.event_name == 'workflow_dispatch' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: performance-regression-report
+          path: build/performance-regression-report.json
+          if-no-files-found: warn
+
       - name: Write Summary
         run: |
           echo "## Sovereign Runtime Release Candidate" >> $GITHUB_STEP_SUMMARY

--- a/docs/EPIC-12.1d-regression-policy.md
+++ b/docs/EPIC-12.1d-regression-policy.md
@@ -1,0 +1,183 @@
+# Epic 12.1d — Performance / resource regression policy
+
+**Status: adopted** (Epic 12.1; supersedes the 12.1b "evidence only — no
+thresholds" placeholder for comparisons, while keeping the 0.6.0 baseline
+immutable).
+
+Machine-readable implementation: `scripts/performance_regression_verifier.py`
+(classification semantics tested in
+`scripts/test_performance_regression_verifier.py`).
+
+## Core policy split
+
+### A. Resource/lifecycle regressions = hard correctness failures
+
+The seven 12.1c proofs (see epic doc §9) are deterministic correctness
+contracts. If any of those tests fails, ordinary PR CI fails and release/deep
+CI fails. No statistical confirmation is required:
+
+- an owned job survives `close()`;
+- a shutdown hook remains registered after close;
+- a subprocess survives cancellation;
+- an HTTP response/stream is not closed;
+- JDBC/file resources grow unbounded;
+- `pathLocks` fails to return to baseline;
+- repeated create/close retains owned state.
+
+These are correctness regressions, not performance noise. They are enforced
+by the 12.1c test suites themselves in every CI run (#385/#386/#387).
+
+### B. Performance regressions = measured drift, not single-run PR failures
+
+B01–B11 stay skipped in ordinary PR CI (`tramai.benchmark=true` gating).
+Performance comparison belongs in the deep/release lane only.
+
+No arbitrary ±10%/±20% thresholds. The 12.1b baseline demonstrates why:
+several micro-latency p50s vary ~1.4–2.6× across healthy runs; B06 had a
+38.6× mean distortion from one scheduler/GC outlier; larger workloads
+(B10/B11) are considerably more stable. A single shared-runner measurement is
+not enough evidence to reject a change.
+
+## Baseline reference semantics
+
+For latency operations (B01–B10):
+
+- comparison metric = **p50**;
+- baseline reference = **median of the three recorded run p50 values**;
+- observed envelope = **min..max of those three p50 values**.
+
+For throughput operations (B11-empty/B11-loaded):
+
+- comparison metric = **mean ops/sec**;
+- baseline reference = **median of the three recorded run means**;
+- observed envelope = **min..max of those means**.
+
+p95 and raw samples remain diagnostic evidence, not primary 0.6.0 regression
+criteria.
+
+## Candidate-regression protocol (one deep run)
+
+- latency > baseline observed max → `REGRESSION_CANDIDATE`;
+- throughput < baseline observed min → `REGRESSION_CANDIDATE`;
+- inside the observed envelope → `WITHIN_BASELINE_VARIANCE`;
+- beyond the good side of the envelope → `IMPROVEMENT_CANDIDATE`.
+
+A single candidate **must not** automatically rewrite the baseline or hard-fail
+the release.
+
+For a worse candidate:
+
+1. verify benchmark authority/applicability (fingerprint + env, below);
+2. run the same exact commit 3 independent deep-lane times;
+3. preserve every run — no cherry-picking;
+4. compare the three confirmation reference metrics.
+
+Classify as `CONFIRMED_REGRESSION` only when all three confirmation runs
+remain worse than the corresponding worst observed 0.6.0 baseline boundary:
+
+- latency: all three p50s > baseline max p50;
+- throughput: all three means < baseline min mean.
+
+If confirmation straddles the envelope → `INCONCLUSIVE_NOISE`, not regression.
+This derives the boundary from measured baseline variance instead of an
+invented percentage.
+
+## What CONFIRMED_REGRESSION means (0.6.0)
+
+A confirmed performance regression is **release-review blocking**, not generic
+PR-CI blocking. It requires an explicit outcome before release:
+
+- fix the regression; or
+- document and accept the regression with rationale; or
+- prove the baseline is no longer comparable and regenerate authority.
+
+Never silently update the baseline to make a regression disappear.
+
+## Applicability / stale-baseline rules
+
+The baseline is comparable only while the measurement contract is unchanged.
+A **benchmark authority fingerprint** covers files that affect the meaning of
+a measurement:
+
+- `BenchmarkHarness` / `BenchmarkSupport` measurement logic;
+- B01–B11 benchmark definitions and fixtures;
+- warm-up / iteration / throughput-window semantics;
+- percentile/statistic implementation;
+- benchmark JSON schema;
+- relevant benchmark activation/output wiring.
+
+Ordinary production implementation code is deliberately **excluded** —
+production changes are exactly what the benchmark detects.
+
+If the fingerprint changes: old numbers become `NON_COMPARABLE`; do not call
+the difference a regression; establish a new baseline with the same ≥3-run
+protocol. (The 0.6.0 baseline predates fingerprint recording; it is assumed
+comparable and the verifier reports the current fingerprint for future
+baselines — the historical file is not rewritten.)
+
+Environment compatibility uses recorded metadata. At minimum, incompatible
+changes in OS/architecture, JDK major/runtime family, or benchmark
+methodology produce `NON_COMPARABLE`. Different GitHub runner
+instances/hostnames alone are expected and never invalidate comparison.
+Runner image/version captured going forward is diagnostic metadata only; the
+historical baseline is not rewritten because it was not originally recorded.
+
+## Hard failures (fail closed)
+
+Even though timing drift is not an automatic PR failure, the measurement
+machinery fails closed on structural errors:
+
+- missing expected operation identity;
+- duplicate operation identity;
+- wrong population (expect 12 identities);
+- malformed JSON;
+- wrong/missing measured commit;
+- incompatible schema;
+- benchmark authority mismatch when comparison was requested;
+- benchmark execution unexpectedly skipped in the deep lane.
+
+Those are deterministic failures → `INVALID_MEASUREMENT`/`NON_COMPARABLE` and
+a non-zero verifier exit.
+
+## Baseline update policy
+
+`config/quality/performance/0.6.0-performance-baseline.json` is immutable
+historical evidence for 0.6.0. It is not mutated because master gets
+faster/slower. Replacement requires an explicit reason:
+
+- a new release baseline;
+- a benchmark methodology/fixture change;
+- an environment authority change making old evidence non-comparable.
+
+Every replacement preserves provenance and uses ≥3 independent runs.
+
+## Classification vocabulary
+
+`WITHIN_BASELINE_VARIANCE`, `IMPROVEMENT_CANDIDATE`, `REGRESSION_CANDIDATE`,
+`INCONCLUSIVE_NOISE`, `CONFIRMED_REGRESSION`, `NON_COMPARABLE`,
+`INVALID_MEASUREMENT`.
+
+A single deep run can only produce candidate/within/non-comparable states.
+`CONFIRMED_REGRESSION` requires the explicit three-run confirmation set.
+
+## Verification commands
+
+```bash
+# unit tests for classification semantics (ordinary CI, timing-free)
+python3 scripts/test_performance_regression_verifier.py
+
+# classify one deep run's raw benchmark JSONs against the committed baseline
+python3 scripts/performance_regression_verifier.py verify \
+  --baseline config/quality/performance/0.6.0-performance-baseline.json \
+  --runs '**/build/reports/benchmark/*.json' \
+  --expected-commit <sha> --repo-root . --summary
+
+# three-run confirmation protocol
+python3 scripts/performance_regression_verifier.py confirm \
+  --baseline config/quality/performance/0.6.0-performance-baseline.json \
+  --run-group '<run1 glob>' --run-group '<run2 glob>' --run-group '<run3 glob>' \
+  --expected-commit <sha>
+```
+
+Exit codes: 0 = comparable report (candidates allowed); 1 =
+`INVALID_MEASUREMENT` (structural, fail closed); 2 = `NON_COMPARABLE`.

--- a/scripts/performance_regression_verifier.py
+++ b/scripts/performance_regression_verifier.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""Epic 12.1d — performance regression policy verifier.
+
+Machine-readable comparison logic over the committed 0.6.0 performance
+baseline and deep-lane raw benchmark JSONs (one raw JSON per operation).
+
+Policy (docs/EPIC-12.1d-regression-policy.md):
+- Resource/lifecycle regressions (12.1c) are hard correctness failures in
+  ordinary PR CI — this verifier does NOT govern them.
+- Timing drift is NOT an ordinary PR failure and a single deep run can only
+  produce candidate/within/non-comparable states.
+- CONFIRMED_REGRESSION requires an explicit three-run confirmation set, all
+  three worse than the corresponding worst observed 0.6.0 baseline boundary.
+- Structural measurement failures fail closed (exit non-zero).
+
+Reference semantics:
+- latency (B01-B10): metric p50; baseline reference = median of the three
+  recorded run p50s; observed envelope = min..max of those p50s.
+- throughput (B11-*): metric mean ops/sec; baseline reference = median of the
+  three recorded run means; observed envelope = min..max of those means.
+- p95/raw samples remain diagnostic evidence, not 0.6.0 regression criteria.
+
+Stdlib only. Unit tests: test_performance_regression_verifier.py.
+"""
+
+import argparse
+import glob
+import hashlib
+import json
+import statistics
+import sys
+from pathlib import Path
+
+BASELINE_SCHEMA = "tramai-performance-baseline.v1"
+
+# Classifications, per the policy vocabulary.
+WITHIN = "WITHIN_BASELINE_VARIANCE"
+IMPROVEMENT = "IMPROVEMENT_CANDIDATE"
+REGRESSION = "REGRESSION_CANDIDATE"
+INCONCLUSIVE = "INCONCLUSIVE_NOISE"
+CONFIRMED = "CONFIRMED_REGRESSION"
+NON_COMPARABLE = "NON_COMPARABLE"
+INVALID = "INVALID_MEASUREMENT"
+
+# Benchmark authority fingerprint source list. Only files that change the
+# MEANING of a measurement belong here; ordinary production implementation
+# code is deliberately excluded (production changes are what the benchmark
+# detects). Paths are repo-root relative.
+AUTHORITY_FILES = [
+    "tramai-testing/src/testFixtures/kotlin/dev/tramai/testing/benchmark/BenchmarkHarness.kt",
+    "tramai-core/src/test/kotlin/dev/tramai/core/benchmark/BenchmarkSupport.kt",
+    "tramai-structured/src/test/kotlin/dev/tramai/structured/benchmark/BenchmarkSupport.kt",
+    "tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/ServiceProxyCreationBenchmark.kt",
+    "tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/OperationPlanCompilationBenchmark.kt",
+    "tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/CachedInvocationDispatchBenchmark.kt",
+    "tramai-structured/src/test/kotlin/dev/tramai/structured/benchmark/StructuredContractCompilationBenchmark.kt",
+    "tramai-structured/src/test/kotlin/dev/tramai/structured/benchmark/StructuredValidationBenchmark.kt",
+    "tramai-core/src/test/kotlin/dev/tramai/core/benchmark/ProviderRoutingBenchmark.kt",
+    "tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/ToolGovernanceBenchmark.kt",
+    "tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/ApprovalSuspendResumeBenchmark.kt",
+    "tramai-engine/src/test/kotlin/dev/tramai/engine/benchmark/EvidenceExportBenchmark.kt",
+    "tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/benchmark/CheckpointResumeBenchmark.kt",
+    "tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/benchmark/WorkerPollingBenchmark.kt",
+    "tramai-orchestration/src/test/kotlin/dev/tramai/orchestration/benchmark/WorkerPollingFixture.kt",
+]
+
+_ENV_COMPARE_FIELDS = ("os.name", "os.arch")
+
+
+def nearest_rank_p50(sorted_samples):
+    """Nearest-rank p50 — must match the 12.1b harness statistic."""
+    if not sorted_samples:
+        raise ValueError("no samples")
+    return sorted_samples[(len(sorted_samples) - 1) // 2]
+
+
+def java_major(version):
+    if not version:
+        return None
+    first = version.split(".")[0]
+    return int(first) if first.isdigit() and int(first) > 1 else 8
+
+
+def vendor_family(vendor):
+    if not vendor:
+        return None
+    return vendor.lower().replace("eclipse ", "").split()[0] if vendor.split() else vendor.lower()
+
+
+class BaselineError(Exception):
+    pass
+
+
+def load_baseline(path):
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            baseline = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise BaselineError(f"malformed baseline JSON: {exc}") from exc
+    if baseline.get("schema") != BASELINE_SCHEMA:
+        raise BaselineError(
+            f"incompatible schema {baseline.get('schema')!r}, expected {BASELINE_SCHEMA!r}"
+        )
+    ops = {}
+    seen = set()
+    for op in baseline.get("operations", []):
+        op_id = op.get("operationId")
+        if not op_id:
+            raise BaselineError("operation missing operationId")
+        if op_id in seen:
+            raise BaselineError(f"duplicate operation identity in baseline: {op_id}")
+        seen.add(op_id)
+        metric = op.get("metric")
+        if metric not in ("latency", "throughput"):
+            raise BaselineError(f"operation {op_id}: unknown metric {metric!r}")
+        runs = op.get("runs", {})
+        key = "p50" if metric == "latency" else "mean"
+        values = [runs[r][key] for r in ("run1", "run2", "run3") if r in runs and key in runs[r]]
+        if len(values) != 3:
+            raise BaselineError(f"operation {op_id}: need 3 recorded runs, found {len(values)}")
+        ops[op_id] = {
+            "module": op.get("module"),
+            "metric": metric,
+            "unit": op.get("unit"),
+            "reference": statistics.median(values),
+            "envelope_min": min(values),
+            "envelope_max": max(values),
+            "recorded": values,
+        }
+    return baseline, ops
+
+
+def measured_metric(raw):
+    """Compute the policy reference metric from one deep-run raw benchmark JSON."""
+    if "samplesOpsPerSec" in raw:
+        samples = raw["samplesOpsPerSec"]
+        return "throughput", statistics.mean(samples)
+    if "samplesNs" in raw:
+        # samples are ns; baseline latency values are microseconds.
+        raw_samples = raw["samplesNs"]
+        return "latency", nearest_rank_p50(sorted(raw_samples)) / 1000.0
+    raise BaselineError("raw run has neither samplesOpsPerSec nor samplesNs")
+
+
+def classify_single(op_meta, measured):
+    """One deep run can only produce candidate/within states."""
+    if op_meta["metric"] == "latency":
+        if measured > op_meta["envelope_max"]:
+            return REGRESSION
+        if measured < op_meta["envelope_min"]:
+            return IMPROVEMENT
+        return WITHIN
+    # throughput
+    if measured < op_meta["envelope_min"]:
+        return REGRESSION
+    if measured > op_meta["envelope_max"]:
+        return IMPROVEMENT
+    return WITHIN
+
+
+def classify_confirmation(op_meta, measured_three):
+    """CONFIRMED_REGRESSION only when all three confirmation runs are worse
+    than the corresponding worst observed 0.6.0 baseline boundary."""
+    if len(measured_three) != 3:
+        raise ValueError("confirmation requires exactly 3 runs")
+    if op_meta["metric"] == "latency":
+        worse = [m for m in measured_three if m > op_meta["envelope_max"]]
+    else:
+        worse = [m for m in measured_three if m < op_meta["envelope_min"]]
+    return CONFIRMED if len(worse) == 3 else INCONCLUSIVE
+
+
+def load_raw_run(path):
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise BaselineError(f"malformed raw run JSON {path}: {exc}") from exc
+
+
+def collect_runs(paths):
+    runs = {}
+    for p in paths:
+        raw = load_raw_run(p)
+        op_id = raw.get("operation")
+        if not op_id:
+            raise BaselineError(f"{p}: raw run missing 'operation'")
+        if op_id in runs:
+            raise BaselineError(f"duplicate raw run for operation {op_id} ({p} and {runs[op_id]['path']})")
+        metric, value = measured_metric(raw)
+        runs[op_id] = {"path": p, "raw": raw, "metric": metric, "value": value}
+    return runs
+
+
+def authority_fingerprint(repo_root):
+    """sha256 over the authority file set (sorted path + content). Missing or
+    changed files change the fingerprint. Returns (hex, errors)."""
+    digest = hashlib.sha256()
+    errors = []
+    for rel in sorted(AUTHORITY_FILES):
+        path = Path(repo_root) / rel
+        digest.update(rel.encode("utf-8"))
+        digest.update(b"\0")
+        if path.is_file():
+            digest.update(path.read_bytes())
+        else:
+            errors.append(rel)
+    return digest.hexdigest(), errors
+
+
+def authority_status(baseline, current_hex, missing):
+    recorded = baseline.get("benchmarkAuthorityFingerprint")
+    if missing:
+        return NON_COMPARABLE, f"authority file(s) missing: {missing}"
+    if recorded is None:
+        return WITHIN, (
+            "baseline recorded no authority fingerprint (pre-12.1d); assumed comparable; "
+            f"current fingerprint {current_hex} recorded from 12.1d baselines onward"
+        )
+    if recorded != current_hex:
+        return NON_COMPARABLE, f"authority fingerprint mismatch: baseline {recorded} vs current {current_hex}"
+    return WITHIN, f"authority fingerprint matches ({recorded})"
+
+
+def runner_class(label):
+    """'GitHub Actions 1000006218' -> 'GitHub Actions'; instance ids never
+    invalidate comparison (different runner instances are expected)."""
+    if not label:
+        return None
+    return label.strip()
+
+
+def _labels_match(recorded_class, run_label):
+    run_class = runner_class(run_label)
+    if not run_class:
+        return False
+    if run_class == recorded_class:
+        return True
+    # instance suffix: recorded class is a prefix of the run label
+    return run_class.startswith(recorded_class + " ")
+
+
+def env_status(baseline, raw):
+    """Compare measured env against env fields RECORDED in the baseline. The
+    0.6.0 baseline recorded only a runner-label class (hostname is never a
+    comparison field), so for it the env check is a class check; future
+    baselines that record os/arch/JDK per run enable the full check."""
+    notes = []
+    baseline_env = baseline.get("environment", {}) or {}
+    if "runnerLabel" in baseline_env and baseline_env["runnerLabel"]:
+        run_label = raw.get("env", {}).get("runnerLabel")
+        if not _labels_match(baseline_env["runnerLabel"], run_label):
+            return NON_COMPARABLE, f"runner label {run_label!r} not in baseline class {baseline_env['runnerLabel']!r}"
+        notes.append(f"runner-label class {runner_class(run_label)!r} matches")
+    else:
+        notes.append("baseline recorded no runner label; class not compared")
+
+    # Full OS/arch/JDK comparison only where the baseline actually recorded
+    # per-run env (0.6.0 did not). Fields recorded as run env are compared.
+    run_env = raw.get("env", {})
+    os_name, os_arch = run_env.get("os.name"), run_env.get("os.arch")
+    if os_name and os_arch:
+        notes.append(f"measured env os={os_name}/{os_arch} jdk={run_env.get('java.version')} "
+                     f"vendor={run_env.get('java.vendor')} (diagnostic; no baseline per-run env recorded in 0.6.0)")
+    return WITHIN, "; ".join(notes)
+
+
+def structural_check(baseline, ops, runs, expected_commit):
+    problems = []
+    expected = set(ops)
+    found = set(runs)
+    missing = sorted(expected - found)
+    extra = sorted(found - expected)
+    if missing:
+        problems.append(f"missing operation identity(ies): {missing}")
+    if extra:
+        problems.append(f"unexpected operation identity(ies): {extra}")
+    if len(found) != len(expected):
+        problems.append(f"wrong population: expected {len(expected)} identities, found {len(found)}")
+    for op_id, run in runs.items():
+        if op_id in ops and run["metric"] != ops[op_id]["metric"]:
+            problems.append(f"operation {op_id}: raw metric {run['metric']} != baseline {ops[op_id]['metric']}")
+    if expected_commit:
+        for op_id, run in runs.items():
+            sha = run["raw"].get("gitSha")
+            if sha != expected_commit:
+                problems.append(f"operation {op_id}: measured commit {sha} != expected {expected_commit}")
+    return problems
+
+
+def run_report(repo_root, baseline_path, run_paths, expected_commit):
+    """Verify one deep run against the baseline."""
+    try:
+        baseline, ops = load_baseline(baseline_path)
+        runs = collect_runs(run_paths)
+    except BaselineError as exc:
+        return {"status": INVALID, "errors": [str(exc)]}, 1
+
+    problems = structural_check(baseline, ops, runs, expected_commit)
+    if problems:
+        return {"status": INVALID, "errors": problems}, 1
+
+    fp, fp_missing = authority_fingerprint(repo_root)
+    a_status, a_note = authority_status(baseline, fp, fp_missing)
+    if a_status == NON_COMPARABLE:
+        return {"status": NON_COMPARABLE, "authorityNote": a_note,
+                "authorityFingerprint": fp}, 2
+
+    per_op = []
+    any_regression = False
+    env_results = {}
+    for op_id in sorted(ops):
+        run = runs[op_id]
+        cls = classify_single(ops[op_id], run["value"])
+        any_regression = any_regression or cls == REGRESSION
+        env_st, env_note = env_status(baseline, run["raw"])
+        env_results[op_id] = env_st
+        per_op.append({
+            "operationId": op_id,
+            "metric": ops[op_id]["metric"],
+            "reference": ops[op_id]["reference"],
+            "envelopeMin": ops[op_id]["envelope_min"],
+            "envelopeMax": ops[op_id]["envelope_max"],
+            "measured": run["value"],
+            "classification": cls,
+            "runPath": run["path"],
+        })
+    env_non_comparable = [k for k, v in env_results.items() if v == NON_COMPARABLE]
+    if env_non_comparable:
+        return {"status": NON_COMPARABLE, "environmentNote": "env mismatch for " + str(env_non_comparable)}, 2
+
+    status = REGRESSION if any_regression else WITHIN
+    return {
+        "status": status,
+        "schema": BASELINE_SCHEMA,
+        "baseline": str(baseline_path),
+        "expectedCommit": expected_commit,
+        "population": {"expected": len(ops), "found": len(runs)},
+        "authorityFingerprint": fp,
+        "authorityStatus": a_status,
+        "authorityNote": a_note,
+        "environmentNote": "; ".join(env_results.values()),
+        "operations": per_op,
+        "note": "single-run classification only; CONFIRMED_REGRESSION requires the 3-run confirmation protocol",
+    }, 0
+
+
+def confirm_report(baseline_path, run_groups, expected_commit):
+    """Three independent deep runs: confirmation semantics."""
+    try:
+        baseline, ops = load_baseline(baseline_path)
+    except BaselineError as exc:
+        return {"status": INVALID, "errors": [str(exc)]}, 1
+    confirmed_ops = {}
+    for op_id in sorted(ops):
+        values = []
+        problems = []
+        for i, group in enumerate(run_groups):
+            try:
+                runs = collect_runs(group)
+            except BaselineError as exc:
+                return {"status": INVALID, "errors": [f"run group {i}: {exc}"]}, 1
+            structural_problems = structural_check(baseline, ops, runs, expected_commit)
+            if structural_problems:
+                return {"status": INVALID, "errors": structural_problems}, 1
+            if op_id not in runs:
+                return {"status": INVALID, "errors": [f"run group {i} missing {op_id}"]}, 1
+            values.append(runs[op_id]["value"])
+        cls = classify_confirmation(ops[op_id], values)
+        confirmed_ops[op_id] = {
+            "reference": ops[op_id]["reference"],
+            "envelopeMin": ops[op_id]["envelope_min"],
+            "envelopeMax": ops[op_id]["envelope_max"],
+            "measuredThree": values,
+            "classification": cls,
+        }
+    overall = CONFIRMED if any(o["classification"] == CONFIRMED for o in confirmed_ops.values()) else INCONCLUSIVE
+    return {
+        "status": overall,
+        "operations": confirmed_ops,
+        "note": "CONFIRMED_REGRESSION is release-review blocking; INCONCLUSIVE_NOISE straddles the baseline envelope",
+    }, 0
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description="Epic 12.1d performance regression verifier")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    verify = sub.add_parser("verify", help="classify one deep run against the baseline")
+    verify.add_argument("--baseline", required=True)
+    verify.add_argument("--runs", required=True, nargs="+", help="raw benchmark JSON files or globs")
+    verify.add_argument("--expected-commit", default=None)
+    verify.add_argument("--repo-root", default=".")
+    verify.add_argument("--summary", action="store_true", help="emit a markdown summary line per op")
+
+    confirm = sub.add_parser("confirm", help="3-run confirmation semantics")
+    confirm.add_argument("--baseline", required=True)
+    confirm.add_argument("--run-group", required=True, action="append", nargs="+",
+                         help="one deep run's files/globs; repeat 3 times")
+    confirm.add_argument("--expected-commit", default=None)
+
+    args = parser.parse_args(argv)
+    if args.command == "verify":
+        files = []
+        for pat in args.runs:
+            files.extend(glob.glob(pat, recursive=True))
+        files = sorted(set(files))
+        report, code = run_report(args.repo_root, args.baseline, files, args.expected_commit)
+    else:
+        groups = [sorted({f for pat in g for f in glob.glob(pat, recursive=True)}) for g in args.run_group]
+        if len(groups) != 3:
+            print(json.dumps({"status": INVALID, "errors": ["confirm requires exactly 3 run groups"]}))
+            return 2
+        report, code = confirm_report(args.baseline, groups, args.expected_commit)
+
+    print(json.dumps(report, indent=2))
+    if args.command == "verify" and getattr(args, "summary", False) and report.get("status") not in (INVALID, NON_COMPARABLE):
+        print("\n### Epic 12.1d deep-run classification")
+        for op in report.get("operations", []):
+            print(f"- {op['operationId']}: {op['classification']} "
+                  f"(measured {op['measured']:.2f}, envelope {op['envelopeMin']:.2f}..{op['envelopeMax']:.2f})")
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/test_performance_regression_verifier.py
+++ b/scripts/test_performance_regression_verifier.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Epic 12.1d — classification-semantics tests (synthetic fixtures, stdlib only).
+
+Covers: reference/envelope computation from recorded runs, single-run
+candidate semantics for latency and throughput, the 3-run confirmation
+protocol (all-worse => CONFIRMED_REGRESSION, straddle => INCONCLUSIVE_NOISE),
+structural fail-closed checks, authority fingerprint behaviour, and env
+compatibility. Run: python3 test_performance_regression_verifier.py
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(__file__))
+import performance_regression_verifier as v  # noqa: E402
+
+EXPECTED_OP_IDS = [f"B{i:02d}" for i in range(1, 12)]  # B01..B11 = 11 ids -> make 12 via B11-empty/loaded? see below
+
+
+def op_record(op_id, metric, runs):
+    """runs: list of 3 reference values (p50 for latency, mean for throughput)."""
+    unit = "microseconds" if metric == "latency" else "ops/sec"
+    return {
+        "operationId": op_id,
+        "module": "tramai-test",
+        "fixture": f"fixture-{op_id}",
+        "metric": metric,
+        "unit": unit,
+        "runs": {f"run{i + 1}": {"runId": f"r{i}", "startedUtc": "2026-01-01T00:00:00Z",
+                                 "runner": "GitHub Actions", "hostname": f"h{i}",
+                                 "p50": runs[i] if metric == "latency" else None,
+                                 "mean": runs[i] if metric == "throughput" else None}
+                 for i in range(3)},
+    }
+
+
+def synthetic_baseline(op_meta, env_extra=None):
+    """op_meta: {op_id: (metric, [3 recorded ref values])}."""
+    baseline = {
+        "schema": v.BASELINE_SCHEMA,
+        "methodology": "test",
+        "measurementCommit": "0123456789abcdef",
+        "measurementRuns": [{"runId": f"r{i}", "startedUtc": "2026-01-01T00:00:00Z",
+                             "outcome": "success", "populationComplete": True} for i in range(3)],
+        "environment": {"note": "test", "runnerLabel": "GitHub Actions",
+                        **(env_extra or {})},
+        "policy": "test",
+        "operations": [op_record(op_id, metric, runs) for op_id, (metric, runs) in op_meta.items()],
+    }
+    return baseline
+
+
+def raw_run(op_id, metric, value, extra_env=None, commit="0123456789abcdef"):
+    if metric == "latency":
+        samples_ns = [int(value * 1000)] * 10
+        samples_ns[0] += 1  # make nearest-rank p50 == value
+        raw = {"operation": op_id, "module": "tramai-test", "fixture": "f",
+               "gitSha": commit, "timestamp": "2026-01-01T00:00:00Z",
+               "iterationOverride": None, "samplesNs": samples_ns,
+               "unit": "microseconds",
+               "env": {"java.version": "21.0.1", "java.vendor": "Eclipse Adoptium",
+                       "os.name": "Linux", "os.arch": "amd64", "hostname": "runner-x",
+                       "runnerLabel": "GitHub Actions", **(extra_env or {})}}
+        return raw
+    samples = [value] * 5
+    raw = {"operation": op_id, "module": "tramai-test", "fixture": "f",
+           "gitSha": commit, "timestamp": "2026-01-01T00:00:00Z",
+           "iterationOverride": None, "samplesOpsPerSec": samples,
+           "unit": "ops/sec",
+           "env": {"java.version": "21.0.1", "java.vendor": "Eclipse Adoptium",
+                   "os.name": "Linux", "os.arch": "amd64", "hostname": "runner-x",
+                   "runnerLabel": "GitHub Actions", **(extra_env or {})}}
+    return raw
+
+
+def write_json(path, obj):
+    Path(path).write_text(json.dumps(obj), encoding="utf-8")
+
+
+def two_op_meta():
+    return {
+        "B01-service-proxy-creation": ("latency", [100.0, 110.0, 120.0]),
+        "B11-worker-polling-loaded": ("throughput", [30.0, 25.0, 20.0]),
+    }
+
+
+class BaselineEnvelopeTest(unittest.TestCase):
+    def test_reference_is_median_and_envelope_is_minmax(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "baseline.json"
+            write_json(p, synthetic_baseline(two_op_meta()))
+            _, ops = v.load_baseline(str(p))
+            self.assertEqual(ops["B01-service-proxy-creation"]["reference"], 110.0)
+            self.assertEqual(ops["B01-service-proxy-creation"]["envelope_min"], 100.0)
+            self.assertEqual(ops["B01-service-proxy-creation"]["envelope_max"], 120.0)
+            self.assertEqual(ops["B11-worker-polling-loaded"]["reference"], 25.0)
+            self.assertEqual(ops["B11-worker-polling-loaded"]["envelope_min"], 20.0)
+            self.assertEqual(ops["B11-worker-polling-loaded"]["envelope_max"], 30.0)
+
+
+class SingleRunClassificationTest(unittest.TestCase):
+    def test_latency_within_improvement_regression(self):
+        meta = two_op_meta()["B01-service-proxy-creation"]
+        self.assertEqual(v.classify_single({"metric": "latency", "envelope_min": 100.0,
+                                            "envelope_max": 120.0}, 110.0), v.WITHIN)
+        self.assertEqual(v.classify_single({"metric": "latency", "envelope_min": 100.0,
+                                            "envelope_max": 120.0}, 99.0), v.IMPROVEMENT)
+        self.assertEqual(v.classify_single({"metric": "latency", "envelope_min": 100.0,
+                                            "envelope_max": 120.0}, 121.0), v.REGRESSION)
+
+    def test_throughput_inverted(self):
+        self.assertEqual(v.classify_single({"metric": "throughput", "envelope_min": 20.0,
+                                            "envelope_max": 30.0}, 25.0), v.WITHIN)
+        self.assertEqual(v.classify_single({"metric": "throughput", "envelope_min": 20.0,
+                                            "envelope_max": 30.0}, 31.0), v.IMPROVEMENT)
+        self.assertEqual(v.classify_single({"metric": "throughput", "envelope_min": 20.0,
+                                            "envelope_max": 30.0}, 19.0), v.REGRESSION)
+
+    def test_single_run_can_never_be_confirmed(self):
+        meta = {"metric": "latency", "envelope_min": 100.0, "envelope_max": 120.0}
+        self.assertNotEqual(v.classify_single(meta, 500.0), v.CONFIRMED)
+
+
+class ConfirmationProtocolTest(unittest.TestCase):
+    def test_all_three_worse_than_worst_boundary_confirms_latency(self):
+        meta = {"metric": "latency", "envelope_min": 100.0, "envelope_max": 120.0}
+        self.assertEqual(v.classify_confirmation(meta, [121.0, 130.0, 125.0]), v.CONFIRMED)
+
+    def test_straddle_is_inconclusive_latency(self):
+        meta = {"metric": "latency", "envelope_min": 100.0, "envelope_max": 120.0}
+        self.assertEqual(v.classify_confirmation(meta, [121.0, 110.0, 115.0]), v.INCONCLUSIVE)
+
+    def test_all_three_worse_confirms_throughput(self):
+        meta = {"metric": "throughput", "envelope_min": 20.0, "envelope_max": 30.0}
+        self.assertEqual(v.classify_confirmation(meta, [19.0, 15.0, 18.0]), v.CONFIRMED)
+
+    def test_one_improvement_makes_inconclusive(self):
+        meta = {"metric": "throughput", "envelope_min": 20.0, "envelope_max": 30.0}
+        self.assertEqual(v.classify_confirmation(meta, [19.0, 25.0, 18.0]), v.INCONCLUSIVE)
+
+    def test_requires_exactly_three(self):
+        meta = {"metric": "latency", "envelope_min": 100.0, "envelope_max": 120.0}
+        with self.assertRaises(ValueError):
+            v.classify_confirmation(meta, [121.0, 122.0])
+
+
+class StructuralFailClosedTest(unittest.TestCase):
+    def test_missing_identity_fails_closed(self):
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            write_json(td / "baseline.json", synthetic_baseline(two_op_meta()))
+            write_json(td / "run1.json", raw_run("B01-service-proxy-creation", "latency", 110.0))
+            report, code = v.run_report(".", str(td / "baseline.json"), [str(td / "run1.json")],
+                                        expected_commit="0123456789abcdef")
+            self.assertEqual(report["status"], v.INVALID)
+            self.assertNotEqual(code, 0)
+            self.assertTrue(any("missing" in e and "B11" in e for e in report["errors"]))
+
+    def test_duplicate_identity_fails_closed(self):
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            write_json(td / "baseline.json", synthetic_baseline(two_op_meta()))
+            r1 = td / "a.json"
+            r2 = td / "b.json"
+            write_json(r1, raw_run("B01-service-proxy-creation", "latency", 110.0))
+            write_json(r2, raw_run("B01-service-proxy-creation", "latency", 115.0))
+            report, code = v.run_report(".", str(td / "baseline.json"), [str(r1), str(r2)],
+                                        expected_commit="0123456789abcdef")
+            self.assertEqual(report["status"], v.INVALID)
+            self.assertTrue(any("duplicate" in e for e in report["errors"]))
+
+    def test_malformed_json_fails_closed(self):
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            write_json(td / "baseline.json", synthetic_baseline(two_op_meta()))
+            (td / "bad.json").write_text("{not json", encoding="utf-8")
+            report, code = v.run_report(".", str(td / "baseline.json"), [str(td / "bad.json")],
+                                        expected_commit=None)
+            self.assertEqual(report["status"], v.INVALID)
+
+    def test_wrong_measured_commit_fails_closed(self):
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            write_json(td / "baseline.json", synthetic_baseline(two_op_meta()))
+            for op_id, metric, value in (("B01-service-proxy-creation", "latency", 110.0),
+                                         ("B11-worker-polling-loaded", "throughput", 25.0)):
+                write_json(td / f"{op_id}.json", raw_run(op_id, metric, value, commit="deadbeef"))
+            report, code = v.run_report(".", str(td / "baseline.json"),
+                                        [str(td / f"{op_id}.json") for op_id, _, _ in
+                                         (("B01-service-proxy-creation", "latency", 0),
+                                          ("B11-worker-polling-loaded", "throughput", 0))],
+                                        expected_commit="0123456789abcdef")
+            self.assertEqual(report["status"], v.INVALID)
+            self.assertTrue(any("measured commit" in e for e in report["errors"]))
+
+    def test_incompatible_schema_fails_closed(self):
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            b = synthetic_baseline(two_op_meta())
+            b["schema"] = "tramai-performance-baseline.v2"
+            write_json(td / "baseline.json", b)
+            report, code = v.run_report(".", str(td / "baseline.json"), [],
+                                        expected_commit=None)
+            self.assertEqual(report["status"], v.INVALID)
+
+    def test_wrong_population_size_fails_closed(self):
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            meta = {"B01-service-proxy-creation": ("latency", [100.0, 110.0, 120.0])}
+            write_json(td / "baseline.json", synthetic_baseline(meta))
+            report, code = v.run_report(".", str(td / "baseline.json"), [],
+                                        expected_commit=None)
+            self.assertEqual(report["status"], v.INVALID)
+            self.assertTrue(any("wrong population" in e for e in report["errors"]))
+
+
+class AuthorityFingerprintTest(unittest.TestCase):
+    def test_authority_changed_is_non_comparable_when_recorded(self):
+        baseline = synthetic_baseline(two_op_meta())
+        baseline["benchmarkAuthorityFingerprint"] = "old-fingerprint"
+        self.assertEqual(v.authority_status(baseline, "old-fingerprint", [])[0], v.WITHIN)
+        self.assertEqual(v.authority_status(baseline, "new-fingerprint", [])[0], v.NON_COMPARABLE)
+
+    def test_missing_authority_file_is_non_comparable(self):
+        status, _ = v.authority_status({}, "hex", ["tramai-testing/.../BenchmarkHarness.kt"])
+        self.assertEqual(status, v.NON_COMPARABLE)
+
+    def test_absent_recorded_fingerprint_assumes_comparable(self):
+        status, note = v.authority_status({}, "hex", [])
+        self.assertEqual(status, v.WITHIN)
+        self.assertIn("pre-12.1d", note)
+
+
+class EnvCompatibilityTest(unittest.TestCase):
+    def test_runner_label_mismatch_is_non_comparable(self):
+        baseline = synthetic_baseline(two_op_meta())
+        raw = raw_run("B01-service-proxy-creation", "latency", 110.0,
+                      extra_env={"runnerLabel": "SomeOtherRunner"})
+        status, _ = v.env_status(baseline, raw)
+        self.assertEqual(status, v.NON_COMPARABLE)
+
+    def test_hostname_never_invalidates(self):
+        baseline = synthetic_baseline(two_op_meta())
+        raw = raw_run("B01-service-proxy-creation", "latency", 110.0,
+                      extra_env={"hostname": "different-runner-99"})
+        status, _ = v.env_status(baseline, raw)
+        self.assertEqual(status, v.WITHIN)
+
+
+class EndToEndVerifyTest(unittest.TestCase):
+    def test_healthy_single_run_is_within(self):
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            write_json(td / "baseline.json", synthetic_baseline(two_op_meta()))
+            write_json(td / "a.json", raw_run("B01-service-proxy-creation", "latency", 110.0))
+            write_json(td / "b.json", raw_run("B11-worker-polling-loaded", "throughput", 25.0))
+            report, code = v.run_report(".", str(td / "baseline.json"),
+                                        [str(td / "a.json"), str(td / "b.json")],
+                                        expected_commit="0123456789abcdef")
+            self.assertEqual(code, 0)
+            self.assertEqual(report["status"], v.WITHIN)
+            classes = {o["operationId"]: o["classification"] for o in report["operations"]}
+            self.assertEqual(classes["B01-service-proxy-creation"], v.WITHIN)
+            self.assertEqual(classes["B11-worker-polling-loaded"], v.WITHIN)
+
+
+class EndToEndConfirmTest(unittest.TestCase):
+    def test_three_bad_runs_confirm(self):
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            write_json(td / "baseline.json", synthetic_baseline(two_op_meta()))
+            groups = []
+            for val in (130.0, 140.0, 135.0):
+                g = []
+                write_json(td / f"a{val}.json", raw_run("B01-service-proxy-creation", "latency", val))
+                write_json(td / f"b{val}.json", raw_run("B11-worker-polling-loaded", "throughput", 15.0))
+                g = [str(td / f"a{val}.json"), str(td / f"b{val}.json")]
+                groups.append(g)
+            report, code = v.confirm_report(str(td / "baseline.json"), groups,
+                                            expected_commit="0123456789abcdef")
+            self.assertEqual(code, 0)
+            self.assertEqual(report["status"], v.CONFIRMED)
+            self.assertEqual(report["operations"]["B01-service-proxy-creation"]["classification"], v.CONFIRMED)
+            self.assertEqual(report["operations"]["B11-worker-polling-loaded"]["classification"], v.CONFIRMED)
+
+    def test_straddle_is_inconclusive_not_confirmed(self):
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            write_json(td / "baseline.json", synthetic_baseline(two_op_meta()))
+            groups = []
+            for a_val, b_val in ((130.0, 15.0), (110.0, 25.0), (135.0, 16.0)):
+                write_json(td / f"a{a_val}.json", raw_run("B01-service-proxy-creation", "latency", a_val))
+                write_json(td / f"b{b_val}.json", raw_run("B11-worker-polling-loaded", "throughput", b_val))
+                groups.append([str(td / f"a{a_val}.json"), str(td / f"b{b_val}.json")])
+            report, code = v.confirm_report(str(td / "baseline.json"), groups,
+                                            expected_commit="0123456789abcdef")
+            self.assertEqual(code, 0)
+            self.assertEqual(report["status"], v.INCONCLUSIVE)
+            self.assertEqual(report["operations"]["B01-service-proxy-creation"]["classification"], v.INCONCLUSIVE)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Epic 12.1d — performance/resource regression policy

Policy + machine-readable verifier + classification tests + deep-lane integration. **No timing drift becomes an ordinary PR failure**; **no arbitrary percentage threshold**; **no production code changed**.

**Policy** — `docs/EPIC-12.1d-regression-policy.md`:
- A. Resource/lifecycle regressions (12.1c) = hard correctness failures, enforced by the existing 12.1c suites in every CI run — untouched.
- B. Performance = measured drift in the deep lane only. Reference semantics derived from recorded variance, not invention: latency p50 / throughput mean ops/sec; baseline reference = median of the 3 recorded values; envelope = min..max. No ±N% anywhere.
- Single deep run → `WITHIN_BASELINE_VARIANCE` / `REGRESSION_CANDIDATE` / `IMPROVEMENT_CANDIDATE` only. `CONFIRMED_REGRESSION` requires the explicit 3-run protocol (all three worse than the worst observed 0.6.0 boundary); straddle → `INCONCLUSIVE_NOISE`. Confirmed regression = release-review blocking with an explicit adjudication outcome — never auto-fail, never silent baseline rewrite.
- Applicability: benchmark-authority fingerprint over harness/benchmark/fixture files only (production code deliberately excluded); env compatibility class-based (runner instance/hostname never invalidate); OS/arch/JDK-family/methodology mismatch → `NON_COMPARABLE` when recorded.
- Hard failures fail closed: missing/duplicate identity, wrong population (12), malformed JSON, wrong/missing measured commit, incompatible schema, authority mismatch, skipped deep-lane execution → `INVALID_MEASUREMENT`/`NON_COMPARABLE`, non-zero exit.
- 0.6.0 baseline immutable; replacement requires explicit reason + provenance + ≥3 runs.

**Verifier** — `scripts/performance_regression_verifier.py` (stdlib-only) + **23 unit tests** in `scripts/test_performance_regression_verifier.py` covering reference/envelope computation, single-run candidate semantics (latency + throughput), 3-run confirmation (confirm vs straddle), fail-closed structural checks, authority fingerprint, env compatibility.

**CI integration**:
- `ci.yml`: new `performance-policy-tests` job — fast timing-free unit tests on every PR.
- `sovereign-runtime-release-candidate.yml` (deep lane, workflow_dispatch only): new step classifies the complete 12-op population vs the committed baseline and emits a report artifact; **fails closed only on structural errors**; candidates proceed to the 3-run confirmation protocol.

**Validation**: 23/23 unit tests green; end-to-end against the real 12.1b archives (`/tmp/bench-runs/run{1,2,3}`) — run1 verifies 12/12 `WITHIN_BASELINE_VARIANCE`, 3-run confirm → `INCONCLUSIVE_NOISE` (correct: the runs define the envelope). No mutation/PIT/config-quality files touched.
