### PR TITLE
fix(security): 12.3b resolve P0/P1 release audit blockers (R12-001, R12-002)

### DIFF
--- a/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/JdbcSovereignRuntimeE2ETest.kt
+++ b/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/JdbcSovereignRuntimeE2ETest.kt
@@ -1,5 +1,6 @@
 package dev.tramai.examples.spring
 
+import com.zaxxer.hikari.HikariDataSource
 import dev.tramai.core.approval.ApprovalContinuationStore
 import dev.tramai.core.approval.ApprovalStore
 import dev.tramai.engine.SuspendedInvocationStore
@@ -15,13 +16,23 @@ import dev.tramai.security.audit.AuditStore
 import dev.tramai.security.audit.InMemoryAuditStore
 import dev.tramai.security.audit.calculateHash
 import dev.tramai.spring.sovereign.SovereignTramaiAutoConfiguration
-import dev.tramai.spring.sovereign.persistence.jdbc.SovereignJdbcPersistenceAutoConfiguration
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseAcquisition
+import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseStore
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxRecord
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStatus
 import dev.tramai.spring.sovereign.ops.outbox.SovereignOpsAuditOutboxStore
-import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseAcquisition
-import dev.tramai.spring.sovereign.ops.lease.SovereignOpsWorkerLeaseStore
-import com.zaxxer.hikari.HikariDataSource
+import dev.tramai.spring.sovereign.persistence.jdbc.SovereignJdbcPersistenceAutoConfiguration
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import java.nio.file.Path
 import java.security.MessageDigest
 import java.time.Duration
@@ -29,17 +40,6 @@ import java.time.Instant
 import java.util.Base64
 import java.util.UUID
 import javax.sql.DataSource
-import kotlinx.coroutines.runBlocking
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.io.TempDir
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
-import org.springframework.boot.autoconfigure.AutoConfigurations
-import org.springframework.boot.test.context.runner.ApplicationContextRunner
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
 
 /**
  * End-to-end tests proving that a Spring Boot TramAI sovereign runtime with
@@ -51,7 +51,6 @@ import org.springframework.context.annotation.Configuration
  */
 @org.junit.jupiter.api.Tag("e2e")
 class JdbcSovereignRuntimeE2ETest {
-
     companion object {
         @JvmStatic
         @BeforeAll
@@ -96,13 +95,11 @@ class JdbcSovereignRuntimeE2ETest {
                     SovereignJdbcPersistenceAutoConfiguration::class.java,
                     SovereignTramaiAutoConfiguration::class.java,
                 ),
-            )
-            .withUserConfiguration(
+            ).withUserConfiguration(
                 JdbcE2eDataSourceConfig::class.java,
                 DemoProviderConfiguration::class.java,
                 *configClasses,
-            )
-            .withPropertyValues(
+            ).withPropertyValues(
                 "tramai.sovereign.enabled=true",
                 "tramai.sovereign.allowed-models[0]=local-invoice-model",
                 "tramai.sovereign.allowed-providers[0]=deterministic-local-provider",
@@ -218,19 +215,20 @@ class JdbcSovereignRuntimeE2ETest {
                     }
 
                     // Append an outbox record in PREPARED state — capture the outboxId
-                    val appended = outboxStore.append(
-                        SovereignOpsAuditOutboxRecord(
-                            aggregateIdDigest = sha256Hex("agg-1"),
-                            eventKey = eventKey,
-                            actor = "e2e-actor",
-                            workflowRunId = "e2e-wf",
-                            correlationId = "e2e-corr",
-                            approvalStatus = "DENIED",
-                            approvalVersion = 1,
-                            reasonDigest = sha256Hex("reason"),
-                            reasonLength = 6,
-                        ),
-                    )
+                    val appended =
+                        outboxStore.append(
+                            SovereignOpsAuditOutboxRecord(
+                                aggregateIdDigest = sha256Hex("agg-1"),
+                                eventKey = eventKey,
+                                actor = "e2e-actor",
+                                workflowRunId = "e2e-wf",
+                                correlationId = "e2e-corr",
+                                approvalStatus = "DENIED",
+                                approvalVersion = 1,
+                                reasonDigest = sha256Hex("reason"),
+                                reasonLength = 6,
+                            ),
+                        )
                     outboxId = appended.outboxId
                 }
             }
@@ -272,12 +270,10 @@ class JdbcSovereignRuntimeE2ETest {
                     SovereignJdbcPersistenceAutoConfiguration::class.java,
                     SovereignTramaiAutoConfiguration::class.java,
                 ),
-            )
-            .withUserConfiguration(
+            ).withUserConfiguration(
                 DemoProviderConfiguration::class.java,
                 AlwaysFailingDataSourceConfig::class.java,
-            )
-            .withPropertyValues(
+            ).withPropertyValues(
                 "tramai.sovereign.enabled=true",
                 "tramai.sovereign.allowed-models[0]=local-invoice-model",
                 "tramai.sovereign.allowed-providers[0]=deterministic-local-provider",
@@ -285,8 +281,7 @@ class JdbcSovereignRuntimeE2ETest {
                 "tramai.sovereign.models.local-invoice-model=deterministic-local-provider",
                 "tramai.sovereign.persistence.type=jdbc",
                 "tramai.sovereign.persistence.encryption.key-file=${keyFile.toAbsolutePath()}",
-            )
-            .run { ctx ->
+            ).run { ctx ->
                 // The app should NOT have failed at startup — JDBC stores wire
                 // without contacting the database (schema existence is not checked eagerly).
                 assertThat(ctx).hasNotFailed()
@@ -296,12 +291,14 @@ class JdbcSovereignRuntimeE2ETest {
                 assertThat(auditStore).isExactlyInstanceOf(JdbcAuditStore::class.java)
                 assertThat(auditStore).isNotInstanceOf(InMemoryAuditStore::class.java)
 
-                // A store operation fails with SQLException (not silently succeeds)
-                org.assertj.core.api.Assertions.assertThatThrownBy {
-                    runBlocking {
-                        auditStore.readStream("unavailable-db-test")
-                    }
-                }.isInstanceOf(java.sql.SQLException::class.java)
+                // A store operation fails with sanitized IllegalStateException (not silently succeeds or leaks raw SQLException)
+                org.assertj.core.api.Assertions
+                    .assertThatThrownBy {
+                        runBlocking {
+                            auditStore.readStream("unavailable-db-test")
+                        }
+                    }.isInstanceOf(IllegalStateException::class.java)
+                    .hasMessageContaining("Database operation failed for audit stream")
             }
     }
 
@@ -322,17 +319,18 @@ class JdbcSovereignRuntimeE2ETest {
 
                 runBlocking {
                     // Append PREPARED record
-                    val record = SovereignOpsAuditOutboxRecord(
-                        aggregateIdDigest = sha256Hex("agg-outbox-restart"),
-                        eventKey = eventKey,
-                        actor = "e2e-actor",
-                        workflowRunId = "e2e-wf",
-                        correlationId = "e2e-corr",
-                        approvalStatus = "DENIED",
-                        approvalVersion = 1,
-                        reasonDigest = sha256Hex("reason"),
-                        reasonLength = 6,
-                    )
+                    val record =
+                        SovereignOpsAuditOutboxRecord(
+                            aggregateIdDigest = sha256Hex("agg-outbox-restart"),
+                            eventKey = eventKey,
+                            actor = "e2e-actor",
+                            workflowRunId = "e2e-wf",
+                            correlationId = "e2e-corr",
+                            approvalStatus = "DENIED",
+                            approvalVersion = 1,
+                            reasonDigest = sha256Hex("reason"),
+                            reasonLength = 6,
+                        )
                     val appended = outboxStore.append(record)
 
                     // Mark ready for dispatch → PENDING
@@ -350,23 +348,25 @@ class JdbcSovereignRuntimeE2ETest {
 
                 runBlocking {
                     // Claim pending records
-                    val claimed = outboxStore.claimPending(
-                        claimedBy = "worker-B",
-                        limit = 10,
-                        now = Instant.now(),
-                    )
+                    val claimed =
+                        outboxStore.claimPending(
+                            claimedBy = "worker-B",
+                            limit = 10,
+                            now = Instant.now(),
+                        )
                     assertThat(claimed).isNotEmpty
                     val claim = claimed.first { it.eventKey == eventKey }
                     assertThat(claim.status).isEqualTo(SovereignOpsAuditOutboxStatus.EMITTING)
                     assertThat(claim.claimedBy).isEqualTo("worker-B")
 
                     // Complete the dispatch
-                    val emitted = outboxStore.markEmitted(
-                        claim.outboxId,
-                        SovereignOpsAuditOutboxStatus.EMITTING,
-                        expectedAttemptCount = claim.attemptCount,
-                        emittedAt = Instant.now(),
-                    )
+                    val emitted =
+                        outboxStore.markEmitted(
+                            claim.outboxId,
+                            SovereignOpsAuditOutboxStatus.EMITTING,
+                            expectedAttemptCount = claim.attemptCount,
+                            emittedAt = Instant.now(),
+                        )
                     assertThat(emitted.status).isEqualTo(SovereignOpsAuditOutboxStatus.EMITTED)
                 }
             }
@@ -575,14 +575,25 @@ class JdbcSovereignRuntimeE2ETest {
             val failure = java.sql.SQLException("Simulated database unavailable for no-fallback test")
             return object : javax.sql.DataSource {
                 override fun getConnection() = throw failure
-                override fun getConnection(unused: String?, unused2: String?) = throw failure
+
+                override fun getConnection(
+                    unused: String?,
+                    unused2: String?,
+                ) = throw failure
+
                 @Suppress("UNCHECKED_CAST")
                 override fun <T : Any> unwrap(iface: Class<T>): T = throw failure
+
                 override fun isWrapperFor(unused: Class<*>?) = false
+
                 override fun getLogWriter() = null
+
                 override fun setLogWriter(unused: java.io.PrintWriter?) {}
+
                 override fun getLoginTimeout() = 0
+
                 override fun setLoginTimeout(unused: Int) {}
+
                 override fun getParentLogger() = throw java.sql.SQLFeatureNotSupportedException()
             }
         }

--- a/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/JdbcSovereignRuntimeE2ETest.kt
+++ b/examples/spring-sovereign-starter/src/test/kotlin/dev/tramai/examples/spring/JdbcSovereignRuntimeE2ETest.kt
@@ -291,7 +291,8 @@ class JdbcSovereignRuntimeE2ETest {
                 assertThat(auditStore).isExactlyInstanceOf(JdbcAuditStore::class.java)
                 assertThat(auditStore).isNotInstanceOf(InMemoryAuditStore::class.java)
 
-                // A store operation fails with sanitized IllegalStateException (not silently succeeds or leaks raw SQLException)
+                // Store operation fails with sanitized IllegalStateException
+                // (does not silently succeed or leak raw SQLException)
                 org.assertj.core.api.Assertions
                     .assertThatThrownBy {
                         runBlocking {

--- a/tramai-core/src/main/kotlin/dev/tramai/core/util/ImageDownloader.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/util/ImageDownloader.kt
@@ -68,56 +68,53 @@ object ImageDownloader {
             connection.readTimeout = READ_TIMEOUT_MS
             connection.setRequestProperty("User-Agent", "TramAI-ImageDownloader/1.0")
 
-            val responseCode =
-                try {
-                    connection.responseCode
-                } catch (error: Exception) {
-                    throw IllegalStateException("Failed to connect to image URL: $currentUri", error)
-                }
+            try {
+                val responseCode =
+                    try {
+                        connection.responseCode
+                    } catch (error: Exception) {
+                        throw IllegalStateException("Failed to connect to image URL: $currentUri", error)
+                    }
 
-            when (responseCode) {
-                in 200..299 -> {
-                    val stream: InputStream =
-                        try {
-                            connection.inputStream
+                when (responseCode) {
+                    in 200..299 -> {
+                        return try {
+                            val stream: InputStream = connection.inputStream
+                            stream.use { readBoundedBodyBytes(it, MAX_DOWNLOAD_SIZE) }
+                        } catch (error: IllegalArgumentException) {
+                            throw IllegalArgumentException("Image download exceeds maximum size: $MAX_DOWNLOAD_SIZE", error)
                         } catch (error: Exception) {
-                            throw IllegalStateException("Failed to open stream for image URL: $currentUri", error)
+                            throw IllegalStateException("Failed to read image stream from: $currentUri", error)
                         }
-                    return try {
-                        readBoundedBodyBytes(stream, MAX_DOWNLOAD_SIZE)
-                    } catch (error: IllegalArgumentException) {
-                        throw IllegalArgumentException("Image download exceeds maximum size: $MAX_DOWNLOAD_SIZE", error)
-                    } finally {
-                        connection.disconnect()
+                    }
+
+                    HttpURLConnection.HTTP_MOVED_PERM,
+                    HttpURLConnection.HTTP_MOVED_TEMP,
+                    HttpURLConnection.HTTP_SEE_OTHER,
+                    307, // Temporary Redirect
+                    308, // Permanent Redirect
+                    -> {
+                        redirectCount++
+                        if (redirectCount > MAX_REDIRECTS) {
+                            throw IllegalStateException("Too many redirects ($redirectCount) downloading image from: $url")
+                        }
+                        val location =
+                            connection.getHeaderField("Location")
+                                ?: throw IllegalStateException("Redirect response missing Location header from: $currentUri")
+                        currentUri =
+                            try {
+                                currentUri.resolve(location)
+                            } catch (error: Exception) {
+                                throw IllegalArgumentException("Invalid redirect Location '$location' from: $currentUri", error)
+                            }
+                    }
+
+                    else -> {
+                        throw IllegalStateException("Image download failed with HTTP status $responseCode from: $currentUri")
                     }
                 }
-
-                HttpURLConnection.HTTP_MOVED_PERM,
-                HttpURLConnection.HTTP_MOVED_TEMP,
-                HttpURLConnection.HTTP_SEE_OTHER,
-                307, // Temporary Redirect
-                308, // Permanent Redirect
-                -> {
-                    connection.disconnect()
-                    redirectCount++
-                    if (redirectCount > MAX_REDIRECTS) {
-                        throw IllegalStateException("Too many redirects ($redirectCount) downloading image from: $url")
-                    }
-                    val location =
-                        connection.getHeaderField("Location")
-                            ?: throw IllegalStateException("Redirect response missing Location header from: $currentUri")
-                    currentUri =
-                        try {
-                            currentUri.resolve(location)
-                        } catch (error: Exception) {
-                            throw IllegalArgumentException("Invalid redirect Location '$location' from: $currentUri", error)
-                        }
-                }
-
-                else -> {
-                    connection.disconnect()
-                    throw IllegalStateException("Image download failed with HTTP status $responseCode from: $currentUri")
-                }
+            } finally {
+                connection.disconnect()
             }
         }
     }

--- a/tramai-core/src/main/kotlin/dev/tramai/core/util/ImageDownloader.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/util/ImageDownloader.kt
@@ -1,32 +1,119 @@
+@file:Suppress(
+    "LongMethod",
+    "TooGenericExceptionCaught",
+    "ThrowsCount",
+    "MagicNumber",
+    "UseCheckOrError",
+    "MaxLineLength",
+    "ComplexMethod",
+    "NestedBlockDepth",
+)
+
 package dev.tramai.core.util
 
 import dev.tramai.core.model.ContentPart
 import dev.tramai.core.provider.transport.ExperimentalProviderTransportApi
 import dev.tramai.core.provider.transport.readBoundedBodyBytes
+import java.io.InputStream
+import java.net.HttpURLConnection
 import java.net.URI
 
 /**
- * Utility for downloading images from URLs and resolving [ContentPart.ImageUrlContent]
+ * Utility for securely downloading images from URLs and resolving [ContentPart.ImageUrlContent]
  * to [ContentPart.ImagePart] by fetching the bytes.
+ *
+ * Enforces outbound network security:
+ * - Rejects non-HTTP(S) schemes (e.g. `file:`, `jar:`, `gopher:`, `data:`)
+ * - Rejects restricted IP destinations (loopback, private RFC 1918, link-local metadata 169.254.169.254, CGNAT, IPv6 ULA)
+ * - Re-validates every redirect destination against restricted address policies
+ * - Enforces bounded payload size (default 20MB)
  */
 @OptIn(ExperimentalProviderTransportApi::class)
 object ImageDownloader {
     private const val MAX_DOWNLOAD_SIZE = 20 * 1024 * 1024 // 20MB max per image
+    private const val MAX_REDIRECTS = 3
+    private const val CONNECT_TIMEOUT_MS = 10_000
+    private const val READ_TIMEOUT_MS = 30_000
 
     /**
      * Downloads the content at [url] and returns it as a byte array.
      *
-     * @throws IllegalArgumentException if the downloaded content exceeds [MAX_DOWNLOAD_SIZE].
+     * @throws IllegalArgumentException if the URL is invalid, uses an unpermitted scheme,
+     *         resolves to a restricted address, or the content exceeds [MAX_DOWNLOAD_SIZE].
+     * @throws IllegalStateException if the HTTP request fails or exceeds redirect limit.
      */
     fun download(url: String): ByteArray {
-        val connection = URI(url).toURL().openConnection()
-        connection.connectTimeout = 10_000
-        connection.readTimeout = 30_000
-        val stream = connection.getInputStream()
-        return try {
-            readBoundedBodyBytes(stream, MAX_DOWNLOAD_SIZE)
-        } catch (error: IllegalArgumentException) {
-            throw IllegalArgumentException("Image download exceeds maximum size: $MAX_DOWNLOAD_SIZE", error)
+        var currentUri =
+            try {
+                URI(url)
+            } catch (error: Exception) {
+                throw IllegalArgumentException("Invalid image URL: $url", error)
+            }
+
+        var redirectCount = 0
+        while (true) {
+            OutboundAddressSecurity.validateOutboundUri(currentUri)
+
+            val connection =
+                currentUri.toURL().openConnection() as? HttpURLConnection
+                    ?: throw IllegalArgumentException("URL must be an HTTP or HTTPS connection: $currentUri")
+
+            connection.instanceFollowRedirects = false
+            connection.connectTimeout = CONNECT_TIMEOUT_MS
+            connection.readTimeout = READ_TIMEOUT_MS
+            connection.setRequestProperty("User-Agent", "TramAI-ImageDownloader/1.0")
+
+            val responseCode =
+                try {
+                    connection.responseCode
+                } catch (error: Exception) {
+                    throw IllegalStateException("Failed to connect to image URL: $currentUri", error)
+                }
+
+            when (responseCode) {
+                in 200..299 -> {
+                    val stream: InputStream =
+                        try {
+                            connection.inputStream
+                        } catch (error: Exception) {
+                            throw IllegalStateException("Failed to open stream for image URL: $currentUri", error)
+                        }
+                    return try {
+                        readBoundedBodyBytes(stream, MAX_DOWNLOAD_SIZE)
+                    } catch (error: IllegalArgumentException) {
+                        throw IllegalArgumentException("Image download exceeds maximum size: $MAX_DOWNLOAD_SIZE", error)
+                    } finally {
+                        connection.disconnect()
+                    }
+                }
+
+                HttpURLConnection.HTTP_MOVED_PERM,
+                HttpURLConnection.HTTP_MOVED_TEMP,
+                HttpURLConnection.HTTP_SEE_OTHER,
+                307, // Temporary Redirect
+                308, // Permanent Redirect
+                -> {
+                    connection.disconnect()
+                    redirectCount++
+                    if (redirectCount > MAX_REDIRECTS) {
+                        throw IllegalStateException("Too many redirects ($redirectCount) downloading image from: $url")
+                    }
+                    val location =
+                        connection.getHeaderField("Location")
+                            ?: throw IllegalStateException("Redirect response missing Location header from: $currentUri")
+                    currentUri =
+                        try {
+                            currentUri.resolve(location)
+                        } catch (error: Exception) {
+                            throw IllegalArgumentException("Invalid redirect Location '$location' from: $currentUri", error)
+                        }
+                }
+
+                else -> {
+                    connection.disconnect()
+                    throw IllegalStateException("Image download failed with HTTP status $responseCode from: $currentUri")
+                }
+            }
         }
     }
 

--- a/tramai-core/src/main/kotlin/dev/tramai/core/util/ImageDownloader.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/util/ImageDownloader.kt
@@ -42,7 +42,12 @@ object ImageDownloader {
      *         resolves to a restricted address, or the content exceeds [MAX_DOWNLOAD_SIZE].
      * @throws IllegalStateException if the HTTP request fails or exceeds redirect limit.
      */
-    fun download(url: String): ByteArray {
+    fun download(url: String): ByteArray = download(url, allowPrivateDestinations = false)
+
+    internal fun download(
+        url: String,
+        allowPrivateDestinations: Boolean = false,
+    ): ByteArray {
         var currentUri =
             try {
                 URI(url)
@@ -52,7 +57,7 @@ object ImageDownloader {
 
         var redirectCount = 0
         while (true) {
-            OutboundAddressSecurity.validateOutboundUri(currentUri)
+            OutboundAddressSecurity.validateOutboundUri(currentUri, allowPrivateDestinations = allowPrivateDestinations)
 
             val connection =
                 currentUri.toURL().openConnection() as? HttpURLConnection

--- a/tramai-core/src/main/kotlin/dev/tramai/core/util/OutboundAddressSecurity.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/util/OutboundAddressSecurity.kt
@@ -113,6 +113,9 @@ object OutboundAddressSecurity {
         require(scheme == "http" || scheme == "https") {
             "unsupported outbound scheme: ${uri.scheme} (only http and https are permitted)"
         }
+        require(uri.userInfo == null) {
+            "outbound URI must not contain user info: $uri"
+        }
         val rawHost = extractHost(uri)
         val canonicalHost = canonicalizeOutboundHost(rawHost)
         if (!allowPrivateDestinations) {

--- a/tramai-core/src/main/kotlin/dev/tramai/core/util/OutboundAddressSecurity.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/util/OutboundAddressSecurity.kt
@@ -100,20 +100,25 @@ object OutboundAddressSecurity {
 
     /**
      * Validates that [uri] uses an allowed HTTP/HTTPS scheme and resolves strictly
-     * to non-restricted, public IP addresses.
+     * to non-restricted, public IP addresses unless [allowPrivateDestinations] is true.
      *
      * @throws IllegalArgumentException if the scheme is not http/https or if the destination
      *         resolves to a restricted IP address or localhost.
      */
-    fun validateOutboundUri(uri: URI) {
+    fun validateOutboundUri(
+        uri: URI,
+        allowPrivateDestinations: Boolean = false,
+    ) {
         val scheme = uri.scheme?.lowercase()
         require(scheme == "http" || scheme == "https") {
             "unsupported outbound scheme: ${uri.scheme} (only http and https are permitted)"
         }
         val rawHost = extractHost(uri)
         val canonicalHost = canonicalizeOutboundHost(rawHost)
-        require(canonicalHost != LOCALHOST_HOSTNAME) {
-            "outbound host is restricted: $rawHost"
+        if (!allowPrivateDestinations) {
+            require(canonicalHost != LOCALHOST_HOSTNAME) {
+                "outbound host is restricted: $rawHost"
+            }
         }
         val addresses =
             try {
@@ -124,9 +129,11 @@ object OutboundAddressSecurity {
         require(addresses.isNotEmpty()) {
             "outbound host did not resolve to any address: $rawHost"
         }
-        val restricted = addresses.firstOrNull(::isPrivateOrRestrictedAddress)
-        require(restricted == null) {
-            "outbound host resolves to a restricted address: $rawHost ($restricted)"
+        if (!allowPrivateDestinations) {
+            val restricted = addresses.firstOrNull(::isPrivateOrRestrictedAddress)
+            require(restricted == null) {
+                "outbound host resolves to a restricted address: $rawHost ($restricted)"
+            }
         }
     }
 

--- a/tramai-core/src/main/kotlin/dev/tramai/core/util/OutboundAddressSecurity.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/util/OutboundAddressSecurity.kt
@@ -1,0 +1,211 @@
+@file:Suppress(
+    "MagicNumber",
+    "MaxLineLength",
+    "ComplexMethod",
+    "NestedBlockDepth",
+    "ReturnCount",
+    "ThrowsCount",
+    "TooGenericExceptionCaught",
+)
+
+package dev.tramai.core.util
+
+import dev.tramai.core.provider.transport.ExperimentalProviderTransportApi
+import java.net.IDN
+import java.net.Inet4Address
+import java.net.Inet6Address
+import java.net.InetAddress
+import java.net.URI
+
+/**
+ * Authoritative address classification and host canonicalization utilities for
+ * outbound network operations across TramAI.
+ *
+ * Enforces restricted-address rejection for SSRF protection:
+ * - Loopback (127.0.0.0/8, ::1)
+ * - Link-local (169.254.0.0/16, fe80::/10)
+ * - Site-local / RFC 1918 private IPv4 (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, fec0::/10)
+ * - Carrier-Grade NAT / RFC 6598 (100.64.0.0/10)
+ * - Unique-local IPv6 / RFC 4193 (fc00::/7)
+ * - Any-local (0.0.0.0, ::)
+ * - Multicast (224.0.0.0/4, ff00::/8)
+ */
+@ExperimentalProviderTransportApi
+object OutboundAddressSecurity {
+    private const val LOCALHOST_HOSTNAME = "localhost"
+
+    /**
+     * Returns true if [address] is private, loopback, link-local, carrier-grade NAT,
+     * unique-local IPv6, multicast, or any-local.
+     */
+    fun isPrivateOrRestrictedAddress(address: InetAddress): Boolean =
+        address.isAnyLocalAddress ||
+            address.isLoopbackAddress ||
+            address.isLinkLocalAddress ||
+            address.isSiteLocalAddress ||
+            address.isMulticastAddress ||
+            address.isCarrierGradeNatIpv4() ||
+            address.isUniqueLocalIpv6()
+
+    /**
+     * Canonicalizes an outbound host string:
+     * - Strips surrounding `[` and `]`, trailing `.`
+     * - Converts IDN domain names to ASCII
+     * - Parses alternative IPv4 notations (octal, hex, dword) to canonical dotted-decimal
+     * - Normalizes to lowercase
+     */
+    fun canonicalizeOutboundHost(host: String): String {
+        val unbracketed = host.removePrefix("[").removeSuffix("]").removeSuffix(".")
+        require(unbracketed.isNotEmpty()) { "outbound hostname must not be empty" }
+        val asciiHost =
+            try {
+                if (unbracketed.contains(':')) unbracketed else IDN.toASCII(unbracketed, IDN.ALLOW_UNASSIGNED)
+            } catch (error: IllegalArgumentException) {
+                throw IllegalArgumentException("invalid outbound hostname: $host", error)
+            }
+        return parseAlternativeIpv4Literal(asciiHost)?.hostAddress ?: asciiHost.lowercase()
+    }
+
+    /**
+     * Resolves all IP addresses for [host]. If [host] is an IP literal or alternative
+     * notation, returns a single-element list with the parsed IP address.
+     */
+    fun resolveHostAddresses(host: String): List<InetAddress> {
+        parseAlternativeIpv4Literal(host)?.let { return listOf(it) }
+        return InetAddress.getAllByName(host).distinctBy { it.hostAddress }
+    }
+
+    /**
+     * Extracts the host string from [uri].
+     *
+     * Java's [URI.getHost] returns null for non-canonical IPv4 literals (e.g. `127.1`,
+     * `0x7f000001`, `0177.0.0.1`) even though the authority is a valid reg-name. This
+     * method recovers the literal from the raw authority when [URI.getHost] returns null.
+     */
+    fun extractHost(uri: URI): String {
+        val host = uri.host
+        if (!host.isNullOrBlank()) {
+            return host
+        }
+        val authority = uri.rawAuthority ?: uri.authority
+        if (!authority.isNullOrBlank()) {
+            val userStripped = if (authority.contains('@')) authority.substringAfter('@') else authority
+            val hostCandidate = userStripped.substringBefore(':').removeSuffix(".")
+            if (hostCandidate.isNotEmpty()) {
+                return hostCandidate
+            }
+        }
+        throw IllegalArgumentException("outbound URI must contain a valid host: $uri")
+    }
+
+    /**
+     * Validates that [uri] uses an allowed HTTP/HTTPS scheme and resolves strictly
+     * to non-restricted, public IP addresses.
+     *
+     * @throws IllegalArgumentException if the scheme is not http/https or if the destination
+     *         resolves to a restricted IP address or localhost.
+     */
+    fun validateOutboundUri(uri: URI) {
+        val scheme = uri.scheme?.lowercase()
+        require(scheme == "http" || scheme == "https") {
+            "unsupported outbound scheme: ${uri.scheme} (only http and https are permitted)"
+        }
+        val rawHost = extractHost(uri)
+        val canonicalHost = canonicalizeOutboundHost(rawHost)
+        require(canonicalHost != LOCALHOST_HOSTNAME) {
+            "outbound host is restricted: $rawHost"
+        }
+        val addresses =
+            try {
+                resolveHostAddresses(canonicalHost)
+            } catch (error: Exception) {
+                throw IllegalArgumentException("failed to resolve outbound host: $rawHost", error)
+            }
+        require(addresses.isNotEmpty()) {
+            "outbound host did not resolve to any address: $rawHost"
+        }
+        val restricted = addresses.firstOrNull(::isPrivateOrRestrictedAddress)
+        require(restricted == null) {
+            "outbound host resolves to a restricted address: $rawHost ($restricted)"
+        }
+    }
+
+    /**
+     * Parses alternative IPv4 literal representations (hex, octal, dword, dotted-hex, etc.).
+     */
+    fun parseAlternativeIpv4Literal(host: String): InetAddress? {
+        if (host.contains(':')) {
+            return null
+        }
+        val components = host.split('.')
+        if (components.isEmpty() || components.size > 4) {
+            return null
+        }
+        val values = components.map { component -> parseIpv4Component(component) ?: return null }
+        val rawAddress =
+            when (values.size) {
+                1 -> {
+                    values.single().takeIf { it in 0L..0xffff_ffffL }
+                }
+
+                2 -> {
+                    values[0].takeIf { it in 0L..0xffL }?.let { first ->
+                        values[1].takeIf { it in 0L..0x00ff_ffffL }?.let { second ->
+                            (first shl 24) or second
+                        }
+                    }
+                }
+
+                3 -> {
+                    values[0].takeIf { it in 0L..0xffL }?.let { first ->
+                        values[1].takeIf { it in 0L..0xffL }?.let { second ->
+                            values[2].takeIf { it in 0L..0xffffL }?.let { third ->
+                                (first shl 24) or (second shl 16) or third
+                            }
+                        }
+                    }
+                }
+
+                4 -> {
+                    values.takeIf { parts -> parts.all { it in 0L..0xffL } }?.let { parts ->
+                        (parts[0] shl 24) or (parts[1] shl 16) or (parts[2] shl 8) or parts[3]
+                    }
+                }
+
+                else -> {
+                    null
+                }
+            } ?: return null
+
+        val bytes =
+            byteArrayOf(
+                ((rawAddress ushr 24) and 0xff).toByte(),
+                ((rawAddress ushr 16) and 0xff).toByte(),
+                ((rawAddress ushr 8) and 0xff).toByte(),
+                (rawAddress and 0xff).toByte(),
+            )
+        return InetAddress.getByAddress(bytes)
+    }
+
+    private fun parseIpv4Component(component: String): Long? {
+        if (component.isEmpty()) return null
+        return try {
+            when {
+                component.startsWith("0x", ignoreCase = true) -> component.substring(2).toLong(16)
+                component.startsWith("0") && component.length > 1 -> component.substring(1).toLong(8)
+                else -> component.toLong(10)
+            }
+        } catch (_: NumberFormatException) {
+            null
+        }
+    }
+
+    private fun InetAddress.isCarrierGradeNatIpv4(): Boolean {
+        if (this !is Inet4Address) return false
+        val bytes = address
+        return bytes[0].toInt() and 0xff == 100 &&
+            (bytes[1].toInt() and 0b1100_0000) == 0b0100_0000
+    }
+
+    private fun InetAddress.isUniqueLocalIpv6(): Boolean = this is Inet6Address && address[0].toInt() and 0xfe == 0xfc
+}

--- a/tramai-core/src/test/kotlin/dev/tramai/core/util/ImageDownloaderTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/util/ImageDownloaderTest.kt
@@ -1,12 +1,13 @@
 package dev.tramai.core.util
 
+import com.sun.net.httpserver.HttpServer
 import dev.tramai.core.model.ContentPart
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import java.net.InetSocketAddress
 import kotlin.test.Test
 
 class ImageDownloaderTest {
-
     @Test
     fun `resolveToImagePart returns ImagePart as-is`() {
         val part = ContentPart.ImagePart("image/png", byteArrayOf(1, 2, 3))
@@ -25,8 +26,136 @@ class ImageDownloaderTest {
     fun `resolveToImagePart throws on invalid url`() {
         val part = ContentPart.ImageUrlContent("not-a-valid-url")
         assertThatThrownBy { ImageDownloader.resolveToImagePart(part) }
-            .isInstanceOf(Exception::class.java)
+            .isInstanceOf(IllegalArgumentException::class.java)
     }
+
+    // ---- SSRF and Scheme Security Tests (R12-001) ----
+
+    @Test
+    fun `download rejects file scheme for local file inclusion`() {
+        assertThatThrownBy { ImageDownloader.download("file:///etc/passwd") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("unsupported outbound scheme: file")
+    }
+
+    @Test
+    fun `download rejects jar scheme`() {
+        assertThatThrownBy { ImageDownloader.download("jar:file:/app.jar!/secret.txt") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("unsupported outbound scheme")
+    }
+
+    @Test
+    fun `download rejects non-http schemes`() {
+        listOf(
+            "ftp://example.com/image.png",
+            "gopher://example.com/image.png",
+            "data:image/png;base64,iVBORw0KGgo=",
+            "ldap://example.com/image.png",
+        ).forEach { schemeUrl ->
+            assertThatThrownBy { ImageDownloader.download(schemeUrl) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("unsupported outbound scheme")
+        }
+    }
+
+    @Test
+    fun `download rejects loopback IPv4 destinations`() {
+        listOf(
+            "http://127.0.0.1/photo.png",
+            "http://127.0.0.2:8080/photo.png",
+            "http://127.128.0.1/photo.png",
+            "http://localhost/photo.png",
+            "http://localhost:8080/photo.png",
+        ).forEach { loopbackUrl ->
+            assertThatThrownBy { ImageDownloader.download(loopbackUrl) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("restricted")
+        }
+    }
+
+    @Test
+    fun `download rejects alternative IPv4 loopback notations`() {
+        listOf(
+            "http://0177.0.0.1/photo.png", // octal 127
+            "http://0x7f.0.0.1/photo.png", // hex 127
+            "http://0x7f000001/photo.png", // dword 127.0.0.1
+            "http://2130706433/photo.png", // decimal dword 127.0.0.1
+            "http://127.1/photo.png", // 2-part dotted 127.0.0.1
+        ).forEach { altUrl ->
+            assertThatThrownBy { ImageDownloader.download(altUrl) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("restricted")
+        }
+    }
+
+    @Test
+    fun `download rejects private RFC 1918 IPv4 destinations`() {
+        listOf(
+            "http://10.0.0.1/photo.png",
+            "http://10.254.0.1/photo.png",
+            "http://172.16.0.1/photo.png",
+            "http://172.31.255.254/photo.png",
+            "http://192.168.1.1/photo.png",
+            "http://192.168.0.254/photo.png",
+        ).forEach { privateUrl ->
+            assertThatThrownBy { ImageDownloader.download(privateUrl) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("restricted")
+        }
+    }
+
+    @Test
+    fun `download rejects link-local and cloud metadata 169-254 destinations`() {
+        listOf(
+            "http://169.254.169.254/latest/meta-data/",
+            "http://169.254.1.1/image.png",
+            "http://0xa9fea9fe/metadata", // hex 169.254.169.254
+            "http://2852039166/metadata", // decimal dword 169.254.169.254
+        ).forEach { metaUrl ->
+            assertThatThrownBy { ImageDownloader.download(metaUrl) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("restricted")
+        }
+    }
+
+    @Test
+    fun `download rejects Carrier-Grade NAT IPv4 destinations`() {
+        listOf(
+            "http://100.64.0.1/photo.png",
+            "http://100.100.100.100/photo.png",
+            "http://100.127.255.254/photo.png",
+        ).forEach { cgnatUrl ->
+            assertThatThrownBy { ImageDownloader.download(cgnatUrl) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("restricted")
+        }
+    }
+
+    @Test
+    fun `download rejects IPv6 loopback and unique-local destinations`() {
+        listOf(
+            "http://[::1]/photo.png",
+            "http://[0:0:0:0:0:0:0:1]/photo.png",
+            "http://[fc00::1]/photo.png",
+            "http://[fd12:3456:789a::1]/photo.png",
+            "http://[fe80::1]/photo.png", // link-local
+        ).forEach { ipv6Url ->
+            assertThatThrownBy { ImageDownloader.download(ipv6Url) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("restricted")
+        }
+    }
+
+    @Test
+    fun `resolveToImagePart rejects file URL in ImageUrlContent`() {
+        val part = ContentPart.ImageUrlContent("file:///etc/hosts")
+        assertThatThrownBy { ImageDownloader.resolveToImagePart(part) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("unsupported outbound scheme: file")
+    }
+
+    // ---- MIME Detection Tests ----
 
     @Test
     fun `detectMimeType returns jpeg for jpg extension`() {

--- a/tramai-core/src/test/kotlin/dev/tramai/core/util/ImageDownloaderTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/util/ImageDownloaderTest.kt
@@ -29,6 +29,131 @@ class ImageDownloaderTest {
             .isInstanceOf(IllegalArgumentException::class.java)
     }
 
+    // ---- HTTP Download and Redirect Tests ----
+
+    @Test
+    fun `download successfully fetches image bytes from HTTP server`() {
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        val expectedBytes = "image-data-payload-12345".toByteArray()
+        server.createContext("/photo.png") { exchange ->
+            exchange.responseHeaders.add("Content-Type", "image/png")
+            exchange.sendResponseHeaders(200, expectedBytes.size.toLong())
+            exchange.responseBody.use { it.write(expectedBytes) }
+        }
+        server.start()
+        try {
+            val port = server.address.port
+            val downloaded =
+                ImageDownloader.download(
+                    "http://127.0.0.1:$port/photo.png",
+                    allowPrivateDestinations = true,
+                )
+            assertThat(downloaded).isEqualTo(expectedBytes)
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun `download follows redirects up to limit`() {
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        val expectedBytes = "redirected-image-bytes".toByteArray()
+        server.createContext("/redirect1") { exchange ->
+            exchange.responseHeaders.add("Location", "/redirect2")
+            exchange.sendResponseHeaders(302, -1)
+            exchange.responseBody.close()
+        }
+        server.createContext("/redirect2") { exchange ->
+            exchange.responseHeaders.add("Location", "/final.png")
+            exchange.sendResponseHeaders(307, -1)
+            exchange.responseBody.close()
+        }
+        server.createContext("/final.png") { exchange ->
+            exchange.responseHeaders.add("Content-Type", "image/png")
+            exchange.sendResponseHeaders(200, expectedBytes.size.toLong())
+            exchange.responseBody.use { it.write(expectedBytes) }
+        }
+        server.start()
+        try {
+            val port = server.address.port
+            val downloaded =
+                ImageDownloader.download(
+                    "http://127.0.0.1:$port/redirect1",
+                    allowPrivateDestinations = true,
+                )
+            assertThat(downloaded).isEqualTo(expectedBytes)
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun `download throws on excessive redirect loop`() {
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/loop") { exchange ->
+            exchange.responseHeaders.add("Location", "/loop")
+            exchange.sendResponseHeaders(302, -1)
+            exchange.responseBody.close()
+        }
+        server.start()
+        try {
+            val port = server.address.port
+            assertThatThrownBy {
+                ImageDownloader.download("http://127.0.0.1:$port/loop", allowPrivateDestinations = true)
+            }.isInstanceOf(IllegalStateException::class.java)
+                .hasMessageContaining("Too many redirects")
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun `download throws on redirect missing Location header`() {
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/bad-redirect") { exchange ->
+            exchange.sendResponseHeaders(301, -1)
+            exchange.responseBody.close()
+        }
+        server.start()
+        try {
+            val port = server.address.port
+            assertThatThrownBy {
+                ImageDownloader.download("http://127.0.0.1:$port/bad-redirect", allowPrivateDestinations = true)
+            }.isInstanceOf(IllegalStateException::class.java)
+                .hasMessageContaining("missing Location header")
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun `download throws on HTTP error status`() {
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/not-found") { exchange ->
+            exchange.sendResponseHeaders(404, -1)
+            exchange.responseBody.close()
+        }
+        server.createContext("/server-error") { exchange ->
+            exchange.sendResponseHeaders(500, -1)
+            exchange.responseBody.close()
+        }
+        server.start()
+        try {
+            val port = server.address.port
+            assertThatThrownBy {
+                ImageDownloader.download("http://127.0.0.1:$port/not-found", allowPrivateDestinations = true)
+            }.isInstanceOf(IllegalStateException::class.java)
+                .hasMessageContaining("HTTP status 404")
+
+            assertThatThrownBy {
+                ImageDownloader.download("http://127.0.0.1:$port/server-error", allowPrivateDestinations = true)
+            }.isInstanceOf(IllegalStateException::class.java)
+                .hasMessageContaining("HTTP status 500")
+        } finally {
+            server.stop(0)
+        }
+    }
+
     // ---- SSRF and Scheme Security Tests (R12-001) ----
 
     @Test

--- a/tramai-core/src/test/kotlin/dev/tramai/core/util/OutboundAddressSecurityTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/util/OutboundAddressSecurityTest.kt
@@ -1,0 +1,128 @@
+package dev.tramai.core.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import java.net.InetAddress
+import java.net.URI
+import kotlin.test.Test
+
+class OutboundAddressSecurityTest {
+    @Test
+    fun `canonicalizeOutboundHost normalizes valid hostnames`() {
+        assertThat(OutboundAddressSecurity.canonicalizeOutboundHost("EXAMPLE.COM"))
+            .isEqualTo("example.com")
+        assertThat(OutboundAddressSecurity.canonicalizeOutboundHost("example.com."))
+            .isEqualTo("example.com")
+        assertThat(OutboundAddressSecurity.canonicalizeOutboundHost("[2001:db8::1]"))
+            .isEqualTo("2001:db8::1")
+    }
+
+    @Test
+    fun `canonicalizeOutboundHost parses alternative IPv4 literals`() {
+        assertThat(OutboundAddressSecurity.canonicalizeOutboundHost("0177.0.0.1"))
+            .isEqualTo("127.0.0.1")
+        assertThat(OutboundAddressSecurity.canonicalizeOutboundHost("0x7f000001"))
+            .isEqualTo("127.0.0.1")
+        assertThat(OutboundAddressSecurity.canonicalizeOutboundHost("2130706433"))
+            .isEqualTo("127.0.0.1")
+        assertThat(OutboundAddressSecurity.canonicalizeOutboundHost("127.1"))
+            .isEqualTo("127.0.0.1")
+    }
+
+    @Test
+    fun `canonicalizeOutboundHost throws on empty host`() {
+        assertThatThrownBy { OutboundAddressSecurity.canonicalizeOutboundHost("") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+        assertThatThrownBy { OutboundAddressSecurity.canonicalizeOutboundHost("[]") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `isPrivateOrRestrictedAddress correctly identifies restricted IPv4 addresses`() {
+        val restrictedIpv4s =
+            listOf(
+                "127.0.0.1",
+                "127.10.20.30",
+                "10.0.0.1",
+                "10.255.255.255",
+                "172.16.0.1",
+                "172.31.255.255",
+                "192.168.0.1",
+                "192.168.255.255",
+                "169.254.169.254",
+                "169.254.1.1",
+                "100.64.0.1",
+                "100.127.255.254",
+                "0.0.0.0",
+                "224.0.0.1",
+            )
+        for (ip in restrictedIpv4s) {
+            val addr = InetAddress.getByName(ip)
+            assertThat(OutboundAddressSecurity.isPrivateOrRestrictedAddress(addr))
+                .`as`("Expected $ip to be restricted")
+                .isTrue()
+        }
+    }
+
+    @Test
+    fun `isPrivateOrRestrictedAddress correctly identifies restricted IPv6 addresses`() {
+        val restrictedIpv6s =
+            listOf(
+                "::1",
+                "::",
+                "fe80::1",
+                "fc00::1",
+                "fd00::1",
+                "ff02::1",
+            )
+        for (ip in restrictedIpv6s) {
+            val addr = InetAddress.getByName(ip)
+            assertThat(OutboundAddressSecurity.isPrivateOrRestrictedAddress(addr))
+                .`as`("Expected $ip to be restricted")
+                .isTrue()
+        }
+    }
+
+    @Test
+    fun `isPrivateOrRestrictedAddress allows public IP addresses`() {
+        val publicIps =
+            listOf(
+                "8.8.8.8",
+                "1.1.1.1",
+                "93.184.216.34", // example.com
+                "2606:2800:220:1:248:1893:25c8:1946", // example.com IPv6
+            )
+        for (ip in publicIps) {
+            val addr = InetAddress.getByName(ip)
+            assertThat(OutboundAddressSecurity.isPrivateOrRestrictedAddress(addr))
+                .`as`("Expected $ip to be public/unrestricted")
+                .isFalse()
+        }
+    }
+
+    @Test
+    fun `validateOutboundUri rejects non-http schemes`() {
+        assertThatThrownBy { OutboundAddressSecurity.validateOutboundUri(URI("file:///etc/hosts")) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("unsupported outbound scheme")
+
+        assertThatThrownBy { OutboundAddressSecurity.validateOutboundUri(URI("jar:file:/app.jar!/data")) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("unsupported outbound scheme")
+    }
+
+    @Test
+    fun `validateOutboundUri rejects localhost and restricted destinations`() {
+        assertThatThrownBy { OutboundAddressSecurity.validateOutboundUri(URI("http://localhost/test")) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("restricted")
+
+        assertThatThrownBy { OutboundAddressSecurity.validateOutboundUri(URI("http://127.0.0.1/test")) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("restricted")
+
+        assertThatThrownBy { OutboundAddressSecurity.validateOutboundUri(URI("http://169.254.169.254/metadata")) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("restricted")
+    }
+}

--- a/tramai-core/src/test/kotlin/dev/tramai/core/util/OutboundAddressSecurityTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/util/OutboundAddressSecurityTest.kt
@@ -117,6 +117,17 @@ class OutboundAddressSecurityTest {
     }
 
     @Test
+    fun `validateOutboundUri rejects user info in URI authority`() {
+        assertThatThrownBy { OutboundAddressSecurity.validateOutboundUri(URI("http://user:pass@93.184.216.34/photo.png")) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("outbound URI must not contain user info")
+
+        assertThatThrownBy { OutboundAddressSecurity.validateOutboundUri(URI("http://admin@93.184.216.34/photo.png")) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("outbound URI must not contain user info")
+    }
+
+    @Test
     fun `validateOutboundUri rejects localhost and restricted destinations`() {
         assertThatThrownBy { OutboundAddressSecurity.validateOutboundUri(URI("http://localhost/test")) }
             .isInstanceOf(IllegalArgumentException::class.java)

--- a/tramai-core/src/test/kotlin/dev/tramai/core/util/OutboundAddressSecurityTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/util/OutboundAddressSecurityTest.kt
@@ -1,5 +1,8 @@
+@file:OptIn(ExperimentalProviderTransportApi::class)
+
 package dev.tramai.core.util
 
+import dev.tramai.core.provider.transport.ExperimentalProviderTransportApi
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import java.net.InetAddress
@@ -15,6 +18,8 @@ class OutboundAddressSecurityTest {
             .isEqualTo("example.com")
         assertThat(OutboundAddressSecurity.canonicalizeOutboundHost("[2001:db8::1]"))
             .isEqualTo("2001:db8::1")
+        assertThat(OutboundAddressSecurity.canonicalizeOutboundHost("xn--mller-kva.de"))
+            .isEqualTo("xn--mller-kva.de")
     }
 
     @Test
@@ -30,7 +35,7 @@ class OutboundAddressSecurityTest {
     }
 
     @Test
-    fun `canonicalizeOutboundHost throws on empty host`() {
+    fun `canonicalizeOutboundHost throws on empty or invalid host`() {
         assertThatThrownBy { OutboundAddressSecurity.canonicalizeOutboundHost("") }
             .isInstanceOf(IllegalArgumentException::class.java)
         assertThatThrownBy { OutboundAddressSecurity.canonicalizeOutboundHost("[]") }
@@ -124,5 +129,74 @@ class OutboundAddressSecurityTest {
         assertThatThrownBy { OutboundAddressSecurity.validateOutboundUri(URI("http://169.254.169.254/metadata")) }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("restricted")
+    }
+
+    @Test
+    fun `validateOutboundUri accepts public IP literals`() {
+        OutboundAddressSecurity.validateOutboundUri(URI("http://93.184.216.34/image.png"))
+        OutboundAddressSecurity.validateOutboundUri(URI("https://8.8.8.8/test"))
+    }
+
+    @Test
+    fun `validateOutboundUri allows private destinations when explicitly enabled`() {
+        OutboundAddressSecurity.validateOutboundUri(URI("http://127.0.0.1/test"), allowPrivateDestinations = true)
+        OutboundAddressSecurity.validateOutboundUri(URI("http://localhost/test"), allowPrivateDestinations = true)
+        OutboundAddressSecurity.validateOutboundUri(
+            URI("http://192.168.1.1:8080/test"),
+            allowPrivateDestinations = true,
+        )
+    }
+
+    @Test
+    fun `validateOutboundUri throws on unresolvable host`() {
+        assertThatThrownBy {
+            val unresolvable = URI("http://invalid-non-existent-domain-123456789.example/test")
+            OutboundAddressSecurity.validateOutboundUri(unresolvable)
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("failed to resolve")
+    }
+
+    @Test
+    fun `extractHost extracts host from various URI formats`() {
+        assertThat(OutboundAddressSecurity.extractHost(URI("http://example.com/path"))).isEqualTo("example.com")
+        val uriWithAuth = URI("http://user:pass@example.com:8080/path")
+        assertThat(OutboundAddressSecurity.extractHost(uriWithAuth)).isEqualTo("example.com")
+        assertThat(OutboundAddressSecurity.extractHost(URI("http://127.1/path"))).isEqualTo("127.1")
+        assertThat(OutboundAddressSecurity.extractHost(URI("http://0x7f000001/path"))).isEqualTo("0x7f000001")
+
+        assertThatThrownBy { OutboundAddressSecurity.extractHost(URI("http:///path")) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("valid host")
+    }
+
+    @Test
+    fun `parseAlternativeIpv4Literal handles all component lengths and invalid inputs`() {
+        // 1 part
+        assertThat(OutboundAddressSecurity.parseAlternativeIpv4Literal("2130706433")?.hostAddress)
+            .isEqualTo("127.0.0.1")
+        // 2 parts
+        assertThat(OutboundAddressSecurity.parseAlternativeIpv4Literal("127.1")?.hostAddress)
+            .isEqualTo("127.0.0.1")
+        // 3 parts
+        assertThat(OutboundAddressSecurity.parseAlternativeIpv4Literal("127.0.1")?.hostAddress)
+            .isEqualTo("127.0.0.1")
+        // 4 parts
+        assertThat(OutboundAddressSecurity.parseAlternativeIpv4Literal("127.0.0.1")?.hostAddress)
+            .isEqualTo("127.0.0.1")
+        // 4 parts hex
+        assertThat(OutboundAddressSecurity.parseAlternativeIpv4Literal("0x7f.0.0.1")?.hostAddress)
+            .isEqualTo("127.0.0.1")
+        // 4 parts octal
+        assertThat(OutboundAddressSecurity.parseAlternativeIpv4Literal("0177.0.0.1")?.hostAddress)
+            .isEqualTo("127.0.0.1")
+
+        // Non-IPv4 or invalid
+        assertThat(OutboundAddressSecurity.parseAlternativeIpv4Literal("::1")).isNull()
+        assertThat(OutboundAddressSecurity.parseAlternativeIpv4Literal("1.2.3.4.5")).isNull()
+        assertThat(OutboundAddressSecurity.parseAlternativeIpv4Literal("1.2.3.999")).isNull()
+        assertThat(OutboundAddressSecurity.parseAlternativeIpv4Literal("1.2.99999999")).isNull()
+        assertThat(OutboundAddressSecurity.parseAlternativeIpv4Literal("999999999999")).isNull()
+        assertThat(OutboundAddressSecurity.parseAlternativeIpv4Literal("not.an.ip.address")).isNull()
+        assertThat(OutboundAddressSecurity.parseAlternativeIpv4Literal("1..2.3")).isNull()
     }
 }

--- a/tramai-core/src/test/kotlin/dev/tramai/core/util/OutboundAddressSecurityTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/util/OutboundAddressSecurityTest.kt
@@ -118,12 +118,14 @@ class OutboundAddressSecurityTest {
 
     @Test
     fun `validateOutboundUri rejects user info in URI authority`() {
-        assertThatThrownBy { OutboundAddressSecurity.validateOutboundUri(URI("http://user:pass@93.184.216.34/photo.png")) }
-            .isInstanceOf(IllegalArgumentException::class.java)
+        assertThatThrownBy {
+            OutboundAddressSecurity.validateOutboundUri(URI("http://user:pass@93.184.216.34/photo.png"))
+        }.isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("outbound URI must not contain user info")
 
-        assertThatThrownBy { OutboundAddressSecurity.validateOutboundUri(URI("http://admin@93.184.216.34/photo.png")) }
-            .isInstanceOf(IllegalArgumentException::class.java)
+        assertThatThrownBy {
+            OutboundAddressSecurity.validateOutboundUri(URI("http://admin@93.184.216.34/photo.png"))
+        }.isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("outbound URI must not contain user info")
     }
 

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/HttpStep.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/HttpStep.kt
@@ -1,4 +1,5 @@
 @file:Suppress("ktlint:standard:property-naming", "MaxLineLength")
+@file:OptIn(dev.tramai.core.provider.transport.ExperimentalProviderTransportApi::class)
 
 package dev.tramai.orchestration
 

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/HttpStep.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/HttpStep.kt
@@ -1,22 +1,24 @@
+@file:Suppress("ktlint:standard:property-naming", "MaxLineLength")
+
 package dev.tramai.orchestration
 
-import dev.tramai.core.retry.DefaultRetryJitterSource
+import dev.tramai.core.coroutines.rethrowIfCancellation
 import dev.tramai.core.observation.event.RuntimeAttributes
 import dev.tramai.core.observation.event.RuntimeEvent
 import dev.tramai.core.observation.event.RuntimeEvents
-import dev.tramai.core.coroutines.rethrowIfCancellation
+import dev.tramai.core.retry.DefaultRetryJitterSource
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
-import kotlin.coroutines.CoroutineContext
 import java.io.ByteArrayOutputStream
-import java.net.InetAddress
 import java.net.IDN
+import java.net.InetAddress
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest.BodyPublishers
 import java.net.http.HttpResponse.BodyHandlers
 import java.time.Duration
+import kotlin.coroutines.CoroutineContext
 import kotlin.math.min
 
 data class HttpRequest(
@@ -63,11 +65,16 @@ class WorkflowHttpException : RuntimeException {
     val redactedUrl: String
     val attempt: Int
     constructor(stepName: String, redactedUrl: String, attempt: Int, cause: Throwable) :
-        super("Workflow HTTP step '$stepName' failed for '$redactedUrl' on attempt $attempt: ${cause.message ?: cause::class.java.simpleName}", cause) {
+        super(
+            "Workflow HTTP step '$stepName' failed for '$redactedUrl' on attempt $attempt: " +
+                (cause.message ?: cause::class.java.simpleName),
+            cause,
+        ) {
         this.stepName = stepName
         this.redactedUrl = redactedUrl
         this.attempt = attempt
     }
+
     var failureCode: WorkflowStepFailureCode? = null
         internal set
     internal var safeFactoryTrusted: Boolean = false
@@ -80,9 +87,11 @@ class WorkflowHttpException : RuntimeException {
 }
 
 internal object WorkflowHttpClients {
-    val default: HttpClient = HttpClient.newBuilder()
-        .followRedirects(HttpClient.Redirect.NEVER)
-        .build()
+    val default: HttpClient =
+        HttpClient
+            .newBuilder()
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .build()
 }
 
 internal enum class HttpTransportCapability {
@@ -96,6 +105,7 @@ internal class ControlledSendResult(
 
 internal interface HttpTransport {
     val capability: HttpTransportCapability
+
     suspend fun send(
         httpRequest: java.net.http.HttpRequest,
         blockingDispatcher: CoroutineContext,
@@ -103,19 +113,22 @@ internal interface HttpTransport {
     ): ControlledSendResult
 }
 
-internal class JdkHttpTransport(private val httpClient: HttpClient) : HttpTransport {
+internal class JdkHttpTransport(
+    private val httpClient: HttpClient,
+) : HttpTransport {
     override val capability = HttpTransportCapability.PRE_CONNECT_VALIDATION
 
     override suspend fun send(
         httpRequest: java.net.http.HttpRequest,
         blockingDispatcher: CoroutineContext,
         onConnected: (InetAddress) -> Unit,
-    ): ControlledSendResult = withContext(blockingDispatcher) {
-        if (httpClient.followRedirects() != HttpClient.Redirect.NEVER) {
-            throw HttpPolicyViolation("redirect-following HttpClient is not permitted for outbound HTTP steps")
+    ): ControlledSendResult =
+        withContext(blockingDispatcher) {
+            if (httpClient.followRedirects() != HttpClient.Redirect.NEVER) {
+                throw HttpPolicyViolation("redirect-following HttpClient is not permitted for outbound HTTP steps")
+            }
+            ControlledSendResult(httpClient.send(httpRequest, BodyHandlers.ofInputStream()))
         }
-        ControlledSendResult(httpClient.send(httpRequest, BodyHandlers.ofInputStream()))
-    }
 }
 
 internal data class HttpWorkflowStep<S>(
@@ -125,19 +138,18 @@ internal data class HttpWorkflowStep<S>(
     val config: HttpStepConfig = HttpStepConfig(),
     val blockingDispatcher: CoroutineContext = Dispatchers.IO,
 ) : InternalWorkflowStep<S> {
-    override suspend fun execute(
-        request: WorkflowStepExecutionRequest<S>,
-    ): WorkflowStepExecutionResult<S> = WorkflowStepExecutionResult.Completed(
-        execute(
-            workflowName = request.workflowName,
-            state = request.state,
-            context = request.context,
-            observer = request.observer,
-            transport = request.services.httpTransport,
-            policy = request.services.outboundNetworkPolicy,
-            failureDiagnosticObserver = request.services.failureDiagnosticObserver,
-        ),
-    )
+    override suspend fun execute(request: WorkflowStepExecutionRequest<S>): WorkflowStepExecutionResult<S> =
+        WorkflowStepExecutionResult.Completed(
+            execute(
+                workflowName = request.workflowName,
+                state = request.state,
+                context = request.context,
+                observer = request.observer,
+                transport = request.services.httpTransport,
+                policy = request.services.outboundNetworkPolicy,
+                failureDiagnosticObserver = request.services.failureDiagnosticObserver,
+            ),
+        )
 
     suspend fun execute(
         workflowName: String,
@@ -148,30 +160,33 @@ internal data class HttpWorkflowStep<S>(
         policy: OutboundNetworkPolicy,
         failureDiagnosticObserver: WorkflowStepFailureDiagnosticObserver = NoOpWorkflowStepFailureDiagnosticObserver,
     ): S {
-        val request = try {
-            requestBuilder(state, context)
-        } catch (error: Throwable) {
-            error.rethrowIfCancellation()
-            throw failure(workflowName, error, WorkflowStepFailureCode.PREPARATION_FAILED, 1, false, failureDiagnosticObserver)
-        }
+        val request =
+            try {
+                requestBuilder(state, context)
+            } catch (error: Throwable) {
+                error.rethrowIfCancellation()
+                throw failure(workflowName, error, WorkflowStepFailureCode.PREPARATION_FAILED, 1, false, failureDiagnosticObserver)
+            }
         val method = request.method.trim().uppercase()
         val redactedUrl = "<redacted>"
-        val canonicalRequest = try {
-            validateMethod(method, request.method)
-            canonicalizeRequestUri(request.url)
-        } catch (error: Throwable) {
-            error.rethrowIfCancellation()
-            val code = WorkflowStepFailureCode.VALIDATION_FAILED
-            observer.emitWorkflowEvent(
-                workflowName = workflowName,
-                event = RuntimeEvent.of(RuntimeEvents.WORKFLOW_HTTP_VALIDATION_FAILED) {
-                    set(RuntimeAttributes.STEP_NAME, name)
-                    set(RuntimeAttributes.FAILURE_CODE, code.value)
-                },
-                context = context,
-            )
-            throw failure(workflowName, error, code, 1, false, failureDiagnosticObserver)
-        }
+        val canonicalRequest =
+            try {
+                validateMethod(method, request.method)
+                canonicalizeRequestUri(request.url)
+            } catch (error: Throwable) {
+                error.rethrowIfCancellation()
+                val code = WorkflowStepFailureCode.VALIDATION_FAILED
+                observer.emitWorkflowEvent(
+                    workflowName = workflowName,
+                    event =
+                        RuntimeEvent.of(RuntimeEvents.WORKFLOW_HTTP_VALIDATION_FAILED) {
+                            set(RuntimeAttributes.STEP_NAME, name)
+                            set(RuntimeAttributes.FAILURE_CODE, code.value)
+                        },
+                    context = context,
+                )
+                throw failure(workflowName, error, code, 1, false, failureDiagnosticObserver)
+            }
         try {
             enforceStepAllowlist(canonicalRequest.target)
             policy.validateTarget(canonicalRequest.target)
@@ -179,10 +194,11 @@ internal data class HttpWorkflowStep<S>(
             error.rethrowIfCancellation()
             observer.emitWorkflowEvent(
                 workflowName = workflowName,
-                event = RuntimeEvent.of(RuntimeEvents.WORKFLOW_HTTP_POLICY_REJECTED) {
-                    set(RuntimeAttributes.STEP_NAME, name)
-                    set(RuntimeAttributes.FAILURE_CODE, WorkflowStepFailureCode.POLICY_REJECTED.value)
-                },
+                event =
+                    RuntimeEvent.of(RuntimeEvents.WORKFLOW_HTTP_POLICY_REJECTED) {
+                        set(RuntimeAttributes.STEP_NAME, name)
+                        set(RuntimeAttributes.FAILURE_CODE, WorkflowStepFailureCode.POLICY_REJECTED.value)
+                    },
                 context = context,
             )
             throw failure(workflowName, error, WorkflowStepFailureCode.POLICY_REJECTED, 1, false, failureDiagnosticObserver)
@@ -190,76 +206,82 @@ internal data class HttpWorkflowStep<S>(
 
         observer.emitWorkflowEvent(
             workflowName = workflowName,
-            event = RuntimeEvent.of(RuntimeEvents.WORKFLOW_HTTP_STARTED) {
-                set(RuntimeAttributes.STEP_NAME, name)
-                set(RuntimeAttributes.HTTP_METHOD, method)
-            },
+            event =
+                RuntimeEvent.of(RuntimeEvents.WORKFLOW_HTTP_STARTED) {
+                    set(RuntimeAttributes.STEP_NAME, name)
+                    set(RuntimeAttributes.HTTP_METHOD, method)
+                },
             context = context,
         )
 
         var retryAttempt = 0
         while (true) {
             val attemptNumber = retryAttempt + 1
-            val response = try {
-                // Every TramAI send/retry attempt crosses the address-policy boundary: hostname
-                // resolution is invoked again and the resulting addresses are re-evaluated before
-                // each attempt. JVM resolver caching may apply.
-                validateResolvedTargetAddresses(canonicalRequest.target, policy)
-                executeRequest(
-                    HttpRequestExecution(
-                        request = request,
-                        uri = canonicalRequest.uri,
-                        target = canonicalRequest.target,
-                        method = method,
-                        observer = observer,
-                        workflowName = workflowName,
-                        context = context,
-                        transport = transport,
-                        policy = policy,
-                        redactedUrl = redactedUrl,
-                    ),
-                )
-            } catch (error: Throwable) {
-                error.rethrowIfCancellation()
-                val code = when (error) {
-                    is HttpPolicyViolation -> WorkflowStepFailureCode.POLICY_REJECTED
-                    is java.net.http.HttpTimeoutException -> WorkflowStepFailureCode.TIMEOUT
-                    else -> WorkflowStepFailureCode.TRANSPORT_FAILED
-                }
-                if (code == WorkflowStepFailureCode.POLICY_REJECTED) {
-                    observer.emitWorkflowEvent(
-                        workflowName = workflowName,
-                        event = RuntimeEvent.of(RuntimeEvents.WORKFLOW_HTTP_POLICY_REJECTED) {
-                            set(RuntimeAttributes.STEP_NAME, name)
-                            set(RuntimeAttributes.FAILURE_CODE, code.value)
-                        },
-                        context = context,
+            val response =
+                try {
+                    // Every TramAI send/retry attempt crosses the address-policy boundary: hostname
+                    // resolution is invoked again and the resulting addresses are re-evaluated before
+                    // each attempt. JVM resolver caching may apply.
+                    validateResolvedTargetAddresses(canonicalRequest.target, policy)
+                    executeRequest(
+                        HttpRequestExecution(
+                            request = request,
+                            uri = canonicalRequest.uri,
+                            target = canonicalRequest.target,
+                            method = method,
+                            observer = observer,
+                            workflowName = workflowName,
+                            context = context,
+                            transport = transport,
+                            policy = policy,
+                            redactedUrl = redactedUrl,
+                        ),
                     )
+                } catch (error: Throwable) {
+                    error.rethrowIfCancellation()
+                    val code =
+                        when (error) {
+                            is HttpPolicyViolation -> WorkflowStepFailureCode.POLICY_REJECTED
+                            is java.net.http.HttpTimeoutException -> WorkflowStepFailureCode.TIMEOUT
+                            else -> WorkflowStepFailureCode.TRANSPORT_FAILED
+                        }
+                    if (code == WorkflowStepFailureCode.POLICY_REJECTED) {
+                        observer.emitWorkflowEvent(
+                            workflowName = workflowName,
+                            event =
+                                RuntimeEvent.of(RuntimeEvents.WORKFLOW_HTTP_POLICY_REJECTED) {
+                                    set(RuntimeAttributes.STEP_NAME, name)
+                                    set(RuntimeAttributes.FAILURE_CODE, code.value)
+                                },
+                            context = context,
+                        )
+                    }
+                    throw failure(workflowName, error, code, attemptNumber, false, failureDiagnosticObserver)
                 }
-                throw failure(workflowName, error, code, attemptNumber, false, failureDiagnosticObserver)
-            }
 
             observer.emitWorkflowEvent(
                 workflowName = workflowName,
-                event = RuntimeEvent.of(RuntimeEvents.WORKFLOW_HTTP_COMPLETED) {
-                    set(RuntimeAttributes.STEP_NAME, name)
-                    set(RuntimeAttributes.HTTP_METHOD, method)
-                    set(RuntimeAttributes.STATUS_CODE, response.status.toLong())
-                    set(RuntimeAttributes.RESPONSE_SIZE_BYTES, response.responseSizeBytes)
-                },
+                event =
+                    RuntimeEvent.of(RuntimeEvents.WORKFLOW_HTTP_COMPLETED) {
+                        set(RuntimeAttributes.STEP_NAME, name)
+                        set(RuntimeAttributes.HTTP_METHOD, method)
+                        set(RuntimeAttributes.STATUS_CODE, response.status.toLong())
+                        set(RuntimeAttributes.RESPONSE_SIZE_BYTES, response.responseSizeBytes)
+                    },
                 context = context,
             )
             if (response.status in config.retryOnStatus && retryAttempt < config.maxRetries) {
                 val nextDelayMillis = jitteredDelayMillis(retryAttempt)
                 observer.emitWorkflowEvent(
                     workflowName = workflowName,
-                    event = RuntimeEvent.of(RuntimeEvents.WORKFLOW_HTTP_RETRYING) {
-                        set(RuntimeAttributes.STEP_NAME, name)
-                        set(RuntimeAttributes.HTTP_METHOD, method)
-                        set(RuntimeAttributes.STATUS_CODE, response.status.toLong())
-                        set(RuntimeAttributes.RETRY_ATTEMPT_HTTP, (retryAttempt + 1).toLong())
-                        set(RuntimeAttributes.NEXT_DELAY_MS, nextDelayMillis)
-                    },
+                    event =
+                        RuntimeEvent.of(RuntimeEvents.WORKFLOW_HTTP_RETRYING) {
+                            set(RuntimeAttributes.STEP_NAME, name)
+                            set(RuntimeAttributes.HTTP_METHOD, method)
+                            set(RuntimeAttributes.STATUS_CODE, response.status.toLong())
+                            set(RuntimeAttributes.RETRY_ATTEMPT_HTTP, (retryAttempt + 1).toLong())
+                            set(RuntimeAttributes.NEXT_DELAY_MS, nextDelayMillis)
+                        },
                     context = context,
                 )
                 delay(nextDelayMillis)
@@ -270,7 +292,14 @@ internal data class HttpWorkflowStep<S>(
                 merge(state, response.toWorkflowResponse(), context)
             } catch (error: Throwable) {
                 error.rethrowIfCancellation()
-                throw failure(workflowName, error, WorkflowStepFailureCode.RESULT_HANDLING_FAILED, attemptNumber, false, failureDiagnosticObserver)
+                throw failure(
+                    workflowName,
+                    error,
+                    WorkflowStepFailureCode.RESULT_HANDLING_FAILED,
+                    attemptNumber,
+                    false,
+                    failureDiagnosticObserver,
+                )
             }
         }
     }
@@ -283,25 +312,27 @@ internal data class HttpWorkflowStep<S>(
         val workflowName = execution.workflowName
         val context = execution.context
         val bodyPublisher = request.body?.let(BodyPublishers::ofString) ?: BodyPublishers.noBody()
-        val httpRequest = java.net.http.HttpRequest.newBuilder(uri)
-            .timeout(Duration.ofSeconds(config.timeoutSeconds))
-            .method(method, bodyPublisher)
-            .apply {
-                request.headers.forEach { (headerName, headerValue) ->
-                    header(headerName, headerValue)
+        val httpRequest =
+            java.net.http.HttpRequest
+                .newBuilder(uri)
+                .timeout(Duration.ofSeconds(config.timeoutSeconds))
+                .method(method, bodyPublisher)
+                .apply {
+                    request.headers.forEach { (headerName, headerValue) ->
+                        header(headerName, headerValue)
+                    }
+                }.build()
+        var connectedValidated = false
+        val sendResult =
+            execution.transport.send(httpRequest, blockingDispatcher) { address ->
+                connectedValidated = true
+                try {
+                    execution.policy.validateTarget(execution.target.copy(addresses = listOf(address)))
+                } catch (error: Throwable) {
+                    error.rethrowIfCancellation()
+                    throw HttpPolicyViolation(error.message ?: "outbound HTTP policy rejected connected address", error)
                 }
             }
-            .build()
-        var connectedValidated = false
-        val sendResult = execution.transport.send(httpRequest, blockingDispatcher) { address ->
-            connectedValidated = true
-            try {
-                execution.policy.validateTarget(execution.target.copy(addresses = listOf(address)))
-            } catch (error: Throwable) {
-                error.rethrowIfCancellation()
-                throw HttpPolicyViolation(error.message ?: "outbound HTTP policy rejected connected address", error)
-            }
-        }
         if (execution.transport.capability == HttpTransportCapability.CONNECTED_ADDRESS_VALIDATION && !connectedValidated) {
             val rejection = HttpPolicyViolation("connected-address validation was not performed")
             try {
@@ -339,22 +370,24 @@ internal data class HttpWorkflowStep<S>(
         if (truncated) {
             observer.emitWorkflowEvent(
                 workflowName = workflowName,
-                event = RuntimeEvent.of(RuntimeEvents.WORKFLOW_HTTP_TRUNCATED) {
-                    set(RuntimeAttributes.STEP_NAME, name)
-                    set(RuntimeAttributes.HTTP_METHOD, method)
-                    set(RuntimeAttributes.STATUS_CODE, response.statusCode().toLong())
-                    set(RuntimeAttributes.RESPONSE_SIZE_BYTES, responseSizeBytes)
-                    set(RuntimeAttributes.MAX_RESPONSE_BYTES, config.maxResponseBytes)
-                },
+                event =
+                    RuntimeEvent.of(RuntimeEvents.WORKFLOW_HTTP_TRUNCATED) {
+                        set(RuntimeAttributes.STEP_NAME, name)
+                        set(RuntimeAttributes.HTTP_METHOD, method)
+                        set(RuntimeAttributes.STATUS_CODE, response.statusCode().toLong())
+                        set(RuntimeAttributes.RESPONSE_SIZE_BYTES, responseSizeBytes)
+                        set(RuntimeAttributes.MAX_RESPONSE_BYTES, config.maxResponseBytes)
+                    },
                 context = context,
             )
         }
         return ExecutedHttpResponse(
             status = response.statusCode(),
             // NOSONAR — java.net.http.HttpHeaders.map() returns mutable Map (Java stdlib limitation)
-            headers = response.headers().map().entries.associate { (name, values) ->
-                name to values.joinToString(",")
-            },
+            headers =
+                response.headers().map().entries.associate { (name, values) ->
+                    name to values.joinToString(",")
+                },
             bodyBytes = bodyBytes.toByteArray(),
             responseSizeBytes = responseSizeBytes,
         )
@@ -373,7 +406,10 @@ internal data class HttpWorkflowStep<S>(
         val redactedUrl: String,
     )
 
-    private fun validateMethod(method: String, originalMethod: String) {
+    private fun validateMethod(
+        method: String,
+        originalMethod: String,
+    ) {
         require(method in supportedHttpMethods) {
             "Workflow HTTP step '$name' uses unsupported HTTP method '$originalMethod'"
         }
@@ -382,19 +418,21 @@ internal data class HttpWorkflowStep<S>(
     private fun canonicalizeRequestUri(url: String): CanonicalHttpRequest {
         val uri = URI.create(url)
         require(uri.userInfo == null) { "Workflow HTTP step '$name' does not allow URL user-info" }
-        val host = uri.host?.trim()?.takeIf { it.isNotEmpty() }
-            ?: alternativeIpv4HostFromAuthority(uri)
-            ?: throw IllegalArgumentException("Workflow HTTP step '$name' requires a URL with a non-empty hostname")
+        val host =
+            uri.host?.trim()?.takeIf { it.isNotEmpty() }
+                ?: alternativeIpv4HostFromAuthority(uri)
+                ?: throw IllegalArgumentException("Workflow HTTP step '$name' requires a URL with a non-empty hostname")
         val normalizedHost = canonicalizeOutboundHost(host)
         return CanonicalHttpRequest(
             uri = uri,
-            target = OutboundNetworkTarget(
-                scheme = uri.scheme?.lowercase().orEmpty(),
-                host = normalizedHost,
-                port = uri.port.takeIf { it >= 0 },
-                addresses = emptyList(),
-                allowedHostnames = config.allowedHosts?.map(::canonicalizeOutboundHost)?.toSet(),
-            ),
+            target =
+                OutboundNetworkTarget(
+                    scheme = uri.scheme?.lowercase().orEmpty(),
+                    host = normalizedHost,
+                    port = uri.port.takeIf { it >= 0 },
+                    addresses = emptyList(),
+                    allowedHostnames = config.allowedHosts?.map(::canonicalizeOutboundHost)?.toSet(),
+                ),
         )
     }
 
@@ -406,10 +444,15 @@ internal data class HttpWorkflowStep<S>(
     private fun alternativeIpv4HostFromAuthority(uri: URI): String? {
         val authority = uri.rawAuthority ?: return null
         val hostCandidate = authority.substringBefore(':').removeSuffix(".")
-        return parseAlternativeIpv4Literal(hostCandidate)?.hostAddress
+        return dev.tramai.core.util.OutboundAddressSecurity
+            .parseAlternativeIpv4Literal(hostCandidate)
+            ?.hostAddress
     }
 
-    private data class CanonicalHttpRequest(val uri: URI, val target: OutboundNetworkTarget)
+    private data class CanonicalHttpRequest(
+        val uri: URI,
+        val target: OutboundNetworkTarget,
+    )
 
     private fun enforceStepAllowlist(target: OutboundNetworkTarget) {
         // HttpStepConfig.allowedHosts is a framework-owned ceiling, independent of the
@@ -419,13 +462,17 @@ internal data class HttpWorkflowStep<S>(
         }
     }
 
-    private fun validateResolvedTargetAddresses(target: OutboundNetworkTarget, policy: OutboundNetworkPolicy) {
-        val resolved = try {
-            resolveHostAddresses(target.host)
-        } catch (error: java.net.UnknownHostException) {
-            error.rethrowIfCancellation()
-            throw HttpPolicyViolation("outbound host could not be resolved")
-        }
+    private fun validateResolvedTargetAddresses(
+        target: OutboundNetworkTarget,
+        policy: OutboundNetworkPolicy,
+    ) {
+        val resolved =
+            try {
+                resolveHostAddresses(target.host)
+            } catch (error: java.net.UnknownHostException) {
+                error.rethrowIfCancellation()
+                throw HttpPolicyViolation("outbound host could not be resolved")
+            }
         try {
             policy.validateTarget(target.copy(addresses = resolved))
         } catch (error: Throwable) {
@@ -445,18 +492,33 @@ internal data class HttpWorkflowStep<S>(
         val preview = boundedWorkflowDetailPreview(error.message ?: error::class.java.name)
         deliverWorkflowStepFailure(
             observer = failureDiagnosticObserver,
-            event = WorkflowStepFailureDiagnosticEvent(
-                workflowName, name, WorkflowStepKind.HTTP, code, attempt, willRetry, error,
-                preview.text, preview.truncated,
-            ),
+            event =
+                WorkflowStepFailureDiagnosticEvent(
+                    workflowName,
+                    name,
+                    WorkflowStepKind.HTTP,
+                    code,
+                    attempt,
+                    willRetry,
+                    error,
+                    preview.text,
+                    preview.truncated,
+                ),
         )
         return safeWorkflowStepFailure(
-            WorkflowStepKind.HTTP, code, fixedWorkflowStepMessage(WorkflowStepKind.HTTP, code), name, attempt,
+            WorkflowStepKind.HTTP,
+            code,
+            fixedWorkflowStepMessage(WorkflowStepKind.HTTP, code),
+            name,
+            attempt,
         )
     }
 }
 
-private class HttpPolicyViolation(message: String, cause: Throwable? = null) : IllegalArgumentException(message, cause)
+private class HttpPolicyViolation(
+    message: String,
+    cause: Throwable? = null,
+) : IllegalArgumentException(message, cause)
 
 private class ExecutedHttpResponse(
     val status: Int,
@@ -464,11 +526,12 @@ private class ExecutedHttpResponse(
     val bodyBytes: ByteArray,
     val responseSizeBytes: Long,
 ) {
-    fun toWorkflowResponse(): HttpResponse = HttpResponse(
-        status = status,
-        headers = headers,
-        body = bodyBytes.takeIf { it.isNotEmpty() }?.toString(Charsets.UTF_8),
-    )
+    fun toWorkflowResponse(): HttpResponse =
+        HttpResponse(
+            status = status,
+            headers = headers,
+            body = bodyBytes.takeIf { it.isNotEmpty() }?.toString(Charsets.UTF_8),
+        )
 }
 
 private val supportedHttpMethods = setOf("GET", "POST", "PUT", "DELETE", "PATCH")
@@ -476,11 +539,12 @@ internal val allowedHttpSchemes = setOf("http", "https")
 private const val responseChunkSize = 8_192
 internal const val localhostHostName = "localhost"
 
-private fun String.safeStripQueryParameters(): String = runCatching {
-    stripQueryParameters()
-}.getOrElse {
-    substringBefore('?')
-}
+private fun String.safeStripQueryParameters(): String =
+    runCatching {
+        stripQueryParameters()
+    }.getOrElse {
+        substringBefore('?')
+    }
 
 private fun String.stripQueryParameters(): String {
     val uri = URI.create(this)
@@ -492,70 +556,17 @@ private fun String.stripQueryParameters(): String {
     }.ifEmpty { substringBefore('?') }
 }
 
-private fun resolveHostAddresses(host: String): List<InetAddress> {
-    parseAlternativeIpv4Literal(host)?.let { return listOf(it) }
-    return InetAddress.getAllByName(host).distinctBy { it.hostAddress }
-}
+@OptIn(dev.tramai.core.provider.transport.ExperimentalProviderTransportApi::class)
+private fun resolveHostAddresses(host: String): List<InetAddress> =
+    dev.tramai.core.util.OutboundAddressSecurity
+        .resolveHostAddresses(host)
 
-internal fun canonicalizeOutboundHost(host: String): String {
-    val unbracketed = host.removePrefix("[").removeSuffix("]").removeSuffix(".")
-    require(unbracketed.isNotEmpty()) { "outbound hostname must not be empty" }
-    val asciiHost = try {
-        if (unbracketed.contains(':')) unbracketed else IDN.toASCII(unbracketed, IDN.ALLOW_UNASSIGNED)
-    } catch (error: IllegalArgumentException) {
-        throw IllegalArgumentException("invalid outbound hostname", error)
-    }
-    return parseAlternativeIpv4Literal(asciiHost)?.hostAddress ?: asciiHost.lowercase()
-}
+@OptIn(dev.tramai.core.provider.transport.ExperimentalProviderTransportApi::class)
+internal fun canonicalizeOutboundHost(host: String): String =
+    dev.tramai.core.util.OutboundAddressSecurity
+        .canonicalizeOutboundHost(host)
 
-private fun jitteredDelayMillis(attempt: Int): Long =
-    ((1_000L shl attempt) * (0.5 + DefaultRetryJitterSource.nextDouble() * 0.5)).toLong()
-
-private fun parseAlternativeIpv4Literal(host: String): InetAddress? {
-    if (host.contains(':')) {
-        return null
-    }
-    val components = host.split('.')
-    if (components.isEmpty() || components.size > 4) {
-        return null
-    }
-    val values = components.map { component -> parseIpv4Component(component) ?: return null }
-    val rawAddress = when (values.size) {
-        1 -> values.single().takeIf { it in 0L..0xffff_ffff }
-        2 -> values[0].takeIf { it in 0L..0xffL }?.let { first ->
-            values[1].takeIf { it in 0L..0x00ff_ffffL }?.let { second ->
-                (first shl 24) or second
-            }
-        }
-        3 -> values[0].takeIf { it in 0L..0xffL }?.let { first ->
-            values[1].takeIf { it in 0L..0xffL }?.let { second ->
-                values[2].takeIf { it in 0L..0xffffL }?.let { third ->
-                    (first shl 24) or (second shl 16) or third
-                }
-            }
-        }
-        4 -> values.takeIf { parts -> parts.all { it in 0L..0xffL } }?.let { parts ->
-            (parts[0] shl 24) or (parts[1] shl 16) or (parts[2] shl 8) or parts[3]
-        }
-        else -> null
-    } ?: return null
-    return InetAddress.getByAddress(
-        byteArrayOf(
-            ((rawAddress ushr 24) and 0xff).toByte(),
-            ((rawAddress ushr 16) and 0xff).toByte(),
-            ((rawAddress ushr 8) and 0xff).toByte(),
-            (rawAddress and 0xff).toByte(),
-        ),
-    )
-}
-
-private fun parseIpv4Component(component: String): Long? {
-    if (component.isEmpty()) {
-        return null
-    }
-    return when {
-        component.startsWith("0x", ignoreCase = true) -> component.substring(2).takeIf(String::isNotEmpty)?.toLongOrNull(16)
-        component.length > 1 && component.startsWith('0') -> component.toLongOrNull(8)
-        else -> component.toLongOrNull()
-    }
+private fun jitteredDelayMillis(attempt: Int): Long {
+    val factor = 0.5 + DefaultRetryJitterSource.nextDouble() * 0.5
+    return ((1_000L shl attempt) * factor).toLong()
 }

--- a/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/OutboundNetworkPolicy.kt
+++ b/tramai-orchestration/src/main/kotlin/dev/tramai/orchestration/OutboundNetworkPolicy.kt
@@ -73,7 +73,10 @@ object OutboundNetworkPolicies {
      * when both are configured, the target must satisfy both restrictions — the effective
      * hostname authority is their intersection. A workflow policy can narrow a step, never widen it.
      */
-    fun governed(allowedHosts: Set<String>, allowPrivateDestinations: Boolean = false): OutboundNetworkPolicy {
+    fun governed(
+        allowedHosts: Set<String>,
+        allowPrivateDestinations: Boolean = false,
+    ): OutboundNetworkPolicy {
         require(allowedHosts.isNotEmpty()) { "Governed outbound network policy requires at least one allowed hostname" }
         return DefaultOutboundNetworkPolicy(allowedHosts.map(::canonicalizeOutboundHost).toSet(), allowPrivateDestinations)
     }
@@ -88,26 +91,16 @@ private class DefaultOutboundNetworkPolicy(
         allowedHosts?.let { hosts ->
             require(target.host in hosts) { "outbound host is not in the allowlist: ${target.host}" }
         }
-        require(allowPrivateDestinations ||
-            (target.host != localhostHostName && target.addresses.none(::isPrivateOrRestrictedAddress))) {
+        require(
+            allowPrivateDestinations ||
+                (target.host != localhostHostName && target.addresses.none(::isPrivateOrRestrictedAddress)),
+        ) {
             "outbound host resolves to a restricted address: ${target.host}"
         }
     }
 }
 
-internal fun isPrivateOrRestrictedAddress(address: InetAddress): Boolean = address.isAnyLocalAddress ||
-    address.isLoopbackAddress ||
-    address.isLinkLocalAddress ||
-    address.isSiteLocalAddress ||
-    address.isCarrierGradeNatIpv4() ||
-    address.isUniqueLocalIpv6()
-
-private fun InetAddress.isCarrierGradeNatIpv4(): Boolean {
-    if (this !is Inet4Address) return false
-    val bytes = address
-    return bytes[0].toInt() and 0xff == 100 &&
-        (bytes[1].toInt() and 0b1100_0000) == 0b0100_0000
-}
-
-private fun InetAddress.isUniqueLocalIpv6(): Boolean =
-    this is Inet6Address && address[0].toInt() and 0xfe == 0xfc
+@OptIn(dev.tramai.core.provider.transport.ExperimentalProviderTransportApi::class)
+internal fun isPrivateOrRestrictedAddress(address: InetAddress): Boolean =
+    dev.tramai.core.util.OutboundAddressSecurity
+        .isPrivateOrRestrictedAddress(address)

--- a/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalContinuationStore.kt
+++ b/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalContinuationStore.kt
@@ -11,10 +11,10 @@ import dev.tramai.core.exception.ApprovalContinuationConflictException
 import dev.tramai.core.exception.ApprovalContinuationNotClaimableException
 import dev.tramai.core.exception.ApprovalContinuationNotCompletableException
 import dev.tramai.core.exception.ApprovalContinuationNotFoundException
+import java.security.MessageDigest
 import java.sql.Connection
 import java.sql.ResultSet
 import java.sql.SQLException
-import java.security.MessageDigest
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -76,7 +76,6 @@ class JdbcApprovalContinuationStore(
     private val maxIdLength: Int = 256,
     private val maxContinuationTtl: Duration = Duration.ofMinutes(15),
 ) : ApprovalContinuationStore {
-
     init {
         require(maxContinuationTtl > Duration.ZERO) {
             "maxContinuationTtl must be positive"
@@ -90,535 +89,566 @@ class JdbcApprovalContinuationStore(
     override suspend fun create(
         continuation: ApprovalContinuation,
         arguments: SensitiveToolArguments,
-    ): ApprovalContinuation {
-        validateCreateInput(continuation, arguments)
+    ): ApprovalContinuation =
+        withSafeJdbc({ "Database operation failed for continuation: ${continuation.approvalId}" }) {
+            validateCreateInput(continuation, arguments)
 
-        val now = clock.instant()
-        validateTemporalInvariants(continuation, now)
-
-        val encrypted = argumentsCodec.encode(
-            arguments.reveal().toByteArray(Charsets.UTF_8),
-        )
-        val nowOdt = OffsetDateTime.ofInstant(now, ZoneOffset.UTC)
-
-        dataSource.connection.use { conn ->
-            val sql = """
-                INSERT INTO approval_continuations (
-                    approval_id, status, version, created_at, approval_expires_at,
-                    workflow_run_id, correlation_id, tool_call_id, tool_name,
-                    arguments_digest, policy_version, workflow_digest,
-                    encrypted_arguments, encryption_key_id, encryption_algorithm,
-                    encryption_nonce, payload_digest
-                ) VALUES (
-                    ?, 'PENDING', 0, ?, ?,
-                    ?, ?, ?, ?,
-                    ?, ?, ?,
-                    ?, ?, ?,
-                    ?, ?
-                )
-            """.trimIndent()
-            conn.prepareStatement(sql).use { stmt ->
-                stmt.setString(1, continuation.approvalId)
-                stmt.setObject(2, OffsetDateTime.ofInstant(continuation.createdAt, ZoneOffset.UTC))
-                stmt.setObject(3, OffsetDateTime.ofInstant(continuation.approvalExpiresAt, ZoneOffset.UTC))
-                stmt.setString(4, continuation.workflowRunId)
-                stmt.setString(5, continuation.correlationId)
-                stmt.setString(6, continuation.toolCallId)
-                stmt.setString(7, continuation.toolName)
-                stmt.setString(8, continuation.argumentsDigest.value)
-                stmt.setString(9, continuation.policyVersion)
-                stmt.setString(10, continuation.workflowDigest.value)
-                stmt.setBytes(11, encrypted.ciphertext)
-                stmt.setString(12, encrypted.keyId)
-                stmt.setString(13, encrypted.algorithm)
-                stmt.setBytes(14, encrypted.nonce)
-                stmt.setString(15, encrypted.payloadDigest)
-
-                try {
-                    stmt.executeUpdate()
-                } catch (e: SQLException) {
-                    if (e.sqlState == "23505") {
-                        throw ApprovalContinuationConflictException(continuation.approvalId)
-                    }
-                    throw e
-                }
-            }
-        }
-
-        return continuation
-    }
-
-    override suspend fun get(approvalId: String): ApprovalContinuation? {
-        validateIdField(approvalId, "approvalId")
-
-        dataSource.connection.use { conn ->
-            val row = readCurrent(conn, approvalId) ?: return null
-
-            // Lazy expiry: PENDING only — CLAIMED never lazily expires
             val now = clock.instant()
-            val (updated, expired) = maybeExpireLazy(row, now)
-            if (expired) {
-                val applied = applyLazyExpiry(updated, row.version)
-                if (!applied) {
-                    // CAS lost: another writer changed the row first.
-                    // Re-read to return the actual persisted state.
-                    return readCurrent(conn, approvalId)?.toDomain()
+            validateTemporalInvariants(continuation, now)
+
+            val encrypted =
+                argumentsCodec.encode(
+                    arguments.reveal().toByteArray(Charsets.UTF_8),
+                )
+            val nowOdt = OffsetDateTime.ofInstant(now, ZoneOffset.UTC)
+
+            dataSource.connection.use { conn ->
+                val sql =
+                    """
+                    INSERT INTO approval_continuations (
+                        approval_id, status, version, created_at, approval_expires_at,
+                        workflow_run_id, correlation_id, tool_call_id, tool_name,
+                        arguments_digest, policy_version, workflow_digest,
+                        encrypted_arguments, encryption_key_id, encryption_algorithm,
+                        encryption_nonce, payload_digest
+                    ) VALUES (
+                        ?, 'PENDING', 0, ?, ?,
+                        ?, ?, ?, ?,
+                        ?, ?, ?,
+                        ?, ?, ?,
+                        ?, ?
+                    )
+                    """.trimIndent()
+                conn.prepareStatement(sql).use { stmt ->
+                    stmt.setString(1, continuation.approvalId)
+                    stmt.setObject(2, OffsetDateTime.ofInstant(continuation.createdAt, ZoneOffset.UTC))
+                    stmt.setObject(3, OffsetDateTime.ofInstant(continuation.approvalExpiresAt, ZoneOffset.UTC))
+                    stmt.setString(4, continuation.workflowRunId)
+                    stmt.setString(5, continuation.correlationId)
+                    stmt.setString(6, continuation.toolCallId)
+                    stmt.setString(7, continuation.toolName)
+                    stmt.setString(8, continuation.argumentsDigest.value)
+                    stmt.setString(9, continuation.policyVersion)
+                    stmt.setString(10, continuation.workflowDigest.value)
+                    stmt.setBytes(11, encrypted.ciphertext)
+                    stmt.setString(12, encrypted.keyId)
+                    stmt.setString(13, encrypted.algorithm)
+                    stmt.setBytes(14, encrypted.nonce)
+                    stmt.setString(15, encrypted.payloadDigest)
+
+                    try {
+                        stmt.executeUpdate()
+                    } catch (e: SQLException) {
+                        if (e.sqlState == "23505") {
+                            throw ApprovalContinuationConflictException(continuation.approvalId)
+                        }
+                        throw e
+                    }
                 }
             }
 
-            return updated.toDomain()
+            continuation
         }
-    }
+
+    override suspend fun get(approvalId: String): ApprovalContinuation? =
+        withSafeJdbc({ "Database operation failed for continuation: $approvalId" }) {
+            validateIdField(approvalId, "approvalId")
+
+            dataSource.connection.use { conn ->
+                val row = readCurrent(conn, approvalId) ?: return@use null
+
+                // Lazy expiry: PENDING only — CLAIMED never lazily expires
+                val now = clock.instant()
+                val (updated, expired) = maybeExpireLazy(row, now)
+                if (expired) {
+                    val applied = applyLazyExpiry(updated, row.version)
+                    if (!applied) {
+                        // CAS lost: another writer changed the row first.
+                        // Re-read to return the actual persisted state.
+                        return@use readCurrent(conn, approvalId)?.toDomain()
+                    }
+                }
+
+                updated.toDomain()
+            }
+        }
 
     override suspend fun claimForExecution(
         approvalId: String,
         expectedVersion: Long,
         claimedBy: String,
-    ): ClaimedApprovalContinuation {
-        validateIdField(approvalId, "approvalId")
-        validateIdField(claimedBy, "claimedBy")
-        SafeActorIdPolicy.validateActorId(claimedBy, "claimedBy")
+    ): ClaimedApprovalContinuation =
+        withSafeJdbc({ "Database operation failed for continuation: $approvalId" }) {
+            validateIdField(approvalId, "approvalId")
+            validateIdField(claimedBy, "claimedBy")
+            SafeActorIdPolicy.validateActorId(claimedBy, "claimedBy")
 
-        dataSource.connection.use { conn ->
-            val row = readCurrent(conn, approvalId)
-                ?: throw ApprovalContinuationNotFoundException(approvalId)
-
-            val now = clock.instant()
-            val (normalized, expired) = maybeExpireLazy(row, now)
-
-            if (expired) {
-                // Best-effort: try to expire the row. If CAS loses (another
-                // writer won), the row is no longer PENDING — still not claimable.
-                applyLazyExpiry(normalized, row.version)
-                throw ApprovalContinuationNotClaimableException(approvalId)
-            }
-
-            val currentStatus = ApprovalContinuationStatus.valueOf(normalized.status)
-
-            // Version before status: a stale expectedVersion is a concurrency
-            // conflict regardless of what state the row is in (same contract
-            // as the in-memory and file stores).
-            if (normalized.version != expectedVersion) {
-                throw ApprovalContinuationConflictException(approvalId)
-            }
-
-            if (currentStatus != ApprovalContinuationStatus.PENDING) {
-                throw ApprovalContinuationNotClaimableException(approvalId)
-            }
-
-            val newVersion = incrementVersion(approvalId, normalized.version)
-            val nowOdt = OffsetDateTime.ofInstant(now, ZoneOffset.UTC)
-
-            // Decrypt arguments BEFORE the CAS update.
-            // If decryption fails, no DB mutation has occurred — the row stays PENDING
-            // with encrypted arguments intact.
-            val capturedArguments = decryptArguments(row)
-
-            // CAS update: must still be PENDING at the expected version
-            val updateSql = """
-                UPDATE approval_continuations
-                SET status = 'CLAIMED',
-                    version = ?,
-                    claimed_by = ?,
-                    claimed_at = ?,
-                    encrypted_arguments = NULL,
-                    encryption_key_id = NULL,
-                    encryption_algorithm = NULL,
-                    encryption_nonce = NULL,
-                    payload_digest = NULL
-                WHERE approval_id = ?
-                  AND version = ?
-                  AND status = 'PENDING'
-            """.trimIndent()
-            conn.prepareStatement(updateSql).use { stmt ->
-                stmt.setLong(1, newVersion)
-                stmt.setString(2, claimedBy)
-                stmt.setObject(3, nowOdt)
-                stmt.setString(4, approvalId)
-                stmt.setLong(5, expectedVersion)
-
-                val updated = stmt.executeUpdate()
-                if (updated == 0) {
-                    // CAS lost. Re-read and apply the same precedence as the
-                    // initial path: version first, then status. In-memory and
-                    // file stores serialize per ID, so a claim that loses to
-                    // a cancel observes version 1 vs expected 0 and reports
-                    // Conflict — the CAS-loss branch must not diverge into
-                    // NotClaimable for the same interleaving.
-                    val current = readCurrent(conn, approvalId)
+            dataSource.connection.use { conn ->
+                val row =
+                    readCurrent(conn, approvalId)
                         ?: throw ApprovalContinuationNotFoundException(approvalId)
-                    if (current.version != expectedVersion) {
-                        throw ApprovalContinuationConflictException(approvalId)
-                    }
-                    if (ApprovalContinuationStatus.valueOf(current.status) != ApprovalContinuationStatus.PENDING) {
-                        throw ApprovalContinuationNotClaimableException(approvalId)
-                    }
+
+                val now = clock.instant()
+                val (normalized, expired) = maybeExpireLazy(row, now)
+
+                if (expired) {
+                    // Best-effort: try to expire the row. If CAS loses (another
+                    // writer won), the row is no longer PENDING — still not claimable.
+                    applyLazyExpiry(normalized, row.version)
+                    throw ApprovalContinuationNotClaimableException(approvalId)
+                }
+
+                val currentStatus = ApprovalContinuationStatus.valueOf(normalized.status)
+
+                // Version before status: a stale expectedVersion is a concurrency
+                // conflict regardless of what state the row is in (same contract
+                // as the in-memory and file stores).
+                if (normalized.version != expectedVersion) {
                     throw ApprovalContinuationConflictException(approvalId)
                 }
+
+                if (currentStatus != ApprovalContinuationStatus.PENDING) {
+                    throw ApprovalContinuationNotClaimableException(approvalId)
+                }
+
+                val newVersion = incrementVersion(approvalId, normalized.version)
+                val nowOdt = OffsetDateTime.ofInstant(now, ZoneOffset.UTC)
+
+                // Decrypt arguments BEFORE the CAS update.
+                // If decryption fails, no DB mutation has occurred — the row stays PENDING
+                // with encrypted arguments intact.
+                val capturedArguments = decryptArguments(row)
+
+                // CAS update: must still be PENDING at the expected version
+                val updateSql =
+                    """
+                    UPDATE approval_continuations
+                    SET status = 'CLAIMED',
+                        version = ?,
+                        claimed_by = ?,
+                        claimed_at = ?,
+                        encrypted_arguments = NULL,
+                        encryption_key_id = NULL,
+                        encryption_algorithm = NULL,
+                        encryption_nonce = NULL,
+                        payload_digest = NULL
+                    WHERE approval_id = ?
+                      AND version = ?
+                      AND status = 'PENDING'
+                    """.trimIndent()
+                conn.prepareStatement(updateSql).use { stmt ->
+                    stmt.setLong(1, newVersion)
+                    stmt.setString(2, claimedBy)
+                    stmt.setObject(3, nowOdt)
+                    stmt.setString(4, approvalId)
+                    stmt.setLong(5, expectedVersion)
+
+                    val updated = stmt.executeUpdate()
+                    if (updated == 0) {
+                        // CAS lost. Re-read and apply the same precedence as the
+                        // initial path: version first, then status. In-memory and
+                        // file stores serialize per ID, so a claim that loses to
+                        // a cancel observes version 1 vs expected 0 and reports
+                        // Conflict — the CAS-loss branch must not diverge into
+                        // NotClaimable for the same interleaving.
+                        val current =
+                            readCurrent(conn, approvalId)
+                                ?: throw ApprovalContinuationNotFoundException(approvalId)
+                        if (current.version != expectedVersion) {
+                            throw ApprovalContinuationConflictException(approvalId)
+                        }
+                        if (ApprovalContinuationStatus.valueOf(current.status) != ApprovalContinuationStatus.PENDING) {
+                            throw ApprovalContinuationNotClaimableException(approvalId)
+                        }
+                        throw ApprovalContinuationConflictException(approvalId)
+                    }
+                }
+
+                val claimedContinuation =
+                    normalizeRow(
+                        approvalId = approvalId,
+                        status = "CLAIMED",
+                        newVersion = newVersion,
+                        claimedBy = claimedBy,
+                        claimedAt = nowOdt,
+                        completedAt = null,
+                        base = normalized,
+                    )
+
+                ClaimedApprovalContinuation(
+                    continuation = claimedContinuation.toDomain(),
+                    arguments = SensitiveToolArguments.of(capturedArguments),
+                )
             }
-
-            val claimedContinuation = normalizeRow(
-                approvalId = approvalId,
-                status = "CLAIMED",
-                newVersion = newVersion,
-                claimedBy = claimedBy,
-                claimedAt = nowOdt,
-                completedAt = null,
-                base = normalized,
-            )
-
-            return ClaimedApprovalContinuation(
-                continuation = claimedContinuation.toDomain(),
-                arguments = SensitiveToolArguments.of(capturedArguments),
-            )
         }
-    }
 
     override suspend fun complete(
         approvalId: String,
         expectedVersion: Long,
         completedBy: String,
-    ): ApprovalContinuation {
-        validateIdField(approvalId, "approvalId")
-        validateIdField(completedBy, "completedBy")
-        SafeActorIdPolicy.validateActorId(completedBy, "completedBy")
+    ): ApprovalContinuation =
+        withSafeJdbc({ "Database operation failed for continuation: $approvalId" }) {
+            validateIdField(approvalId, "approvalId")
+            validateIdField(completedBy, "completedBy")
+            SafeActorIdPolicy.validateActorId(completedBy, "completedBy")
 
-        dataSource.connection.use { conn ->
-            val row = readCurrent(conn, approvalId)
-                ?: throw ApprovalContinuationNotFoundException(approvalId)
+            dataSource.connection.use { conn ->
+                val row =
+                    readCurrent(conn, approvalId)
+                        ?: throw ApprovalContinuationNotFoundException(approvalId)
 
-            if (row.version != expectedVersion) {
-                throw ApprovalContinuationConflictException(approvalId)
-            }
-
-            val status = ApprovalContinuationStatus.valueOf(row.status)
-            if (status != ApprovalContinuationStatus.CLAIMED) {
-                throw ApprovalContinuationNotCompletableException(approvalId)
-            }
-
-            if (row.claimedBy != completedBy) {
-                throw ApprovalContinuationNotCompletableException(approvalId)
-            }
-
-            val newVersion = incrementVersion(approvalId, row.version)
-            val nowOdt = OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC)
-
-            val sql = """
-                UPDATE approval_continuations
-                SET status = 'COMPLETED',
-                    version = ?,
-                    completed_at = ?
-                WHERE approval_id = ?
-                  AND version = ?
-                  AND status = 'CLAIMED'
-            """.trimIndent()
-            conn.prepareStatement(sql).use { stmt ->
-                stmt.setLong(1, newVersion)
-                stmt.setObject(2, nowOdt)
-                stmt.setString(3, approvalId)
-                stmt.setLong(4, expectedVersion)
-
-                val updated = stmt.executeUpdate()
-                if (updated == 0) {
+                if (row.version != expectedVersion) {
                     throw ApprovalContinuationConflictException(approvalId)
                 }
-            }
 
-            val updatedContinuation = normalizeRow(
-                approvalId = approvalId,
-                status = "COMPLETED",
-                newVersion = newVersion,
-                claimedBy = row.claimedBy,
-                claimedAt = row.claimedAt,
-                completedAt = nowOdt,
-                base = row,
-            )
-            return updatedContinuation.toDomain()
+                val status = ApprovalContinuationStatus.valueOf(row.status)
+                if (status != ApprovalContinuationStatus.CLAIMED) {
+                    throw ApprovalContinuationNotCompletableException(approvalId)
+                }
+
+                if (row.claimedBy != completedBy) {
+                    throw ApprovalContinuationNotCompletableException(approvalId)
+                }
+
+                val newVersion = incrementVersion(approvalId, row.version)
+                val nowOdt = OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC)
+
+                val sql =
+                    """
+                    UPDATE approval_continuations
+                    SET status = 'COMPLETED',
+                        version = ?,
+                        completed_at = ?
+                    WHERE approval_id = ?
+                      AND version = ?
+                      AND status = 'CLAIMED'
+                    """.trimIndent()
+                conn.prepareStatement(sql).use { stmt ->
+                    stmt.setLong(1, newVersion)
+                    stmt.setObject(2, nowOdt)
+                    stmt.setString(3, approvalId)
+                    stmt.setLong(4, expectedVersion)
+
+                    val updated = stmt.executeUpdate()
+                    if (updated == 0) {
+                        throw ApprovalContinuationConflictException(approvalId)
+                    }
+                }
+
+                val updatedContinuation =
+                    normalizeRow(
+                        approvalId = approvalId,
+                        status = "COMPLETED",
+                        newVersion = newVersion,
+                        claimedBy = row.claimedBy,
+                        claimedAt = row.claimedAt,
+                        completedAt = nowOdt,
+                        base = row,
+                    )
+                updatedContinuation.toDomain()
+            }
         }
-    }
 
     override suspend fun expire(
         approvalId: String,
         expectedVersion: Long,
-    ): ApprovalContinuation {
-        validateIdField(approvalId, "approvalId")
+    ): ApprovalContinuation =
+        withSafeJdbc({ "Database operation failed for continuation: $approvalId" }) {
+            validateIdField(approvalId, "approvalId")
 
-        dataSource.connection.use { conn ->
-            val row = readCurrent(conn, approvalId)
-                ?: throw ApprovalContinuationNotFoundException(approvalId)
+            dataSource.connection.use { conn ->
+                val row =
+                    readCurrent(conn, approvalId)
+                        ?: throw ApprovalContinuationNotFoundException(approvalId)
 
-            if (row.version != expectedVersion) {
-                throw ApprovalContinuationConflictException(approvalId)
-            }
-
-            val status = ApprovalContinuationStatus.valueOf(row.status)
-            if (status != ApprovalContinuationStatus.PENDING) {
-                throw ApprovalContinuationConflictException(approvalId)
-            }
-
-            val now = clock.instant()
-            if (now < row.approvalExpiresAt.toInstant()) {
-                throw ApprovalContinuationConflictException(approvalId)
-            }
-
-            val newVersion = incrementVersion(approvalId, row.version)
-            val sql = """
-                UPDATE approval_continuations
-                SET status = 'EXPIRED',
-                    version = ?,
-                    encrypted_arguments = NULL,
-                    encryption_key_id = NULL,
-                    encryption_algorithm = NULL,
-                    encryption_nonce = NULL,
-                    payload_digest = NULL
-                WHERE approval_id = ?
-                  AND version = ?
-                  AND status = 'PENDING'
-            """.trimIndent()
-            conn.prepareStatement(sql).use { stmt ->
-                stmt.setLong(1, newVersion)
-                stmt.setString(2, approvalId)
-                stmt.setLong(3, expectedVersion)
-
-                val updated = stmt.executeUpdate()
-                if (updated == 0) {
+                if (row.version != expectedVersion) {
                     throw ApprovalContinuationConflictException(approvalId)
                 }
-            }
 
-            val updatedContinuation = normalizeRow(
-                approvalId = approvalId,
-                status = "EXPIRED",
-                newVersion = newVersion,
-                claimedBy = null,
-                claimedAt = null,
-                completedAt = null,
-                base = row,
-            )
-            return updatedContinuation.toDomain()
+                val status = ApprovalContinuationStatus.valueOf(row.status)
+                if (status != ApprovalContinuationStatus.PENDING) {
+                    throw ApprovalContinuationConflictException(approvalId)
+                }
+
+                val now = clock.instant()
+                if (now < row.approvalExpiresAt.toInstant()) {
+                    throw ApprovalContinuationConflictException(approvalId)
+                }
+
+                val newVersion = incrementVersion(approvalId, row.version)
+                val sql =
+                    """
+                    UPDATE approval_continuations
+                    SET status = 'EXPIRED',
+                        version = ?,
+                        encrypted_arguments = NULL,
+                        encryption_key_id = NULL,
+                        encryption_algorithm = NULL,
+                        encryption_nonce = NULL,
+                        payload_digest = NULL
+                    WHERE approval_id = ?
+                      AND version = ?
+                      AND status = 'PENDING'
+                    """.trimIndent()
+                conn.prepareStatement(sql).use { stmt ->
+                    stmt.setLong(1, newVersion)
+                    stmt.setString(2, approvalId)
+                    stmt.setLong(3, expectedVersion)
+
+                    val updated = stmt.executeUpdate()
+                    if (updated == 0) {
+                        throw ApprovalContinuationConflictException(approvalId)
+                    }
+                }
+
+                val updatedContinuation =
+                    normalizeRow(
+                        approvalId = approvalId,
+                        status = "EXPIRED",
+                        newVersion = newVersion,
+                        claimedBy = null,
+                        claimedAt = null,
+                        completedAt = null,
+                        base = row,
+                    )
+                updatedContinuation.toDomain()
+            }
         }
-    }
 
     override suspend fun cancel(
         approvalId: String,
         expectedVersion: Long,
-    ): ApprovalContinuation {
-        validateIdField(approvalId, "approvalId")
+    ): ApprovalContinuation =
+        withSafeJdbc({ "Database operation failed for continuation: $approvalId" }) {
+            validateIdField(approvalId, "approvalId")
 
-        dataSource.connection.use { conn ->
-            val row = readCurrent(conn, approvalId)
-                ?: throw ApprovalContinuationNotFoundException(approvalId)
+            dataSource.connection.use { conn ->
+                val row =
+                    readCurrent(conn, approvalId)
+                        ?: throw ApprovalContinuationNotFoundException(approvalId)
 
-            // Lazy expiry for PENDING only — a late cancel must first persist
-            // EXPIRED, then fail with a conflict (same contract as the
-            // in-memory and file stores).
-            val now = clock.instant()
-            val (normalized, expired) = maybeExpireLazy(row, now)
-            if (expired) {
-                applyLazyExpiry(normalized, row.version)
-                throw ApprovalContinuationConflictException(approvalId)
-            }
-
-            val status = ApprovalContinuationStatus.valueOf(normalized.status)
-            if (normalized.version != expectedVersion) {
-                throw ApprovalContinuationConflictException(approvalId)
-            }
-            if (status != ApprovalContinuationStatus.PENDING) {
-                throw ApprovalContinuationConflictException(approvalId)
-            }
-
-            val newVersion = incrementVersion(approvalId, normalized.version)
-            val sql = """
-                UPDATE approval_continuations
-                SET status = 'CANCELLED',
-                    version = ?,
-                    encrypted_arguments = NULL,
-                    encryption_key_id = NULL,
-                    encryption_algorithm = NULL,
-                    encryption_nonce = NULL,
-                    payload_digest = NULL
-                WHERE approval_id = ?
-                  AND version = ?
-                  AND status = 'PENDING'
-            """.trimIndent()
-            conn.prepareStatement(sql).use { stmt ->
-                stmt.setLong(1, newVersion)
-                stmt.setString(2, approvalId)
-                stmt.setLong(3, expectedVersion)
-
-                val updated = stmt.executeUpdate()
-                if (updated == 0) {
+                // Lazy expiry for PENDING only — a late cancel must first persist
+                // EXPIRED, then fail with a conflict (same contract as the
+                // in-memory and file stores).
+                val now = clock.instant()
+                val (normalized, expired) = maybeExpireLazy(row, now)
+                if (expired) {
+                    applyLazyExpiry(normalized, row.version)
                     throw ApprovalContinuationConflictException(approvalId)
                 }
-            }
 
-            val updatedContinuation = normalizeRow(
-                approvalId = approvalId,
-                status = "CANCELLED",
-                newVersion = newVersion,
-                claimedBy = null,
-                claimedAt = null,
-                completedAt = null,
-                base = normalized,
-            )
-            return updatedContinuation.toDomain()
+                val status = ApprovalContinuationStatus.valueOf(normalized.status)
+                if (normalized.version != expectedVersion) {
+                    throw ApprovalContinuationConflictException(approvalId)
+                }
+                if (status != ApprovalContinuationStatus.PENDING) {
+                    throw ApprovalContinuationConflictException(approvalId)
+                }
+
+                val newVersion = incrementVersion(approvalId, normalized.version)
+                val sql =
+                    """
+                    UPDATE approval_continuations
+                    SET status = 'CANCELLED',
+                        version = ?,
+                        encrypted_arguments = NULL,
+                        encryption_key_id = NULL,
+                        encryption_algorithm = NULL,
+                        encryption_nonce = NULL,
+                        payload_digest = NULL
+                    WHERE approval_id = ?
+                      AND version = ?
+                      AND status = 'PENDING'
+                    """.trimIndent()
+                conn.prepareStatement(sql).use { stmt ->
+                    stmt.setLong(1, newVersion)
+                    stmt.setString(2, approvalId)
+                    stmt.setLong(3, expectedVersion)
+
+                    val updated = stmt.executeUpdate()
+                    if (updated == 0) {
+                        throw ApprovalContinuationConflictException(approvalId)
+                    }
+                }
+
+                val updatedContinuation =
+                    normalizeRow(
+                        approvalId = approvalId,
+                        status = "CANCELLED",
+                        newVersion = newVersion,
+                        claimedBy = null,
+                        claimedAt = null,
+                        completedAt = null,
+                        base = normalized,
+                    )
+                updatedContinuation.toDomain()
+            }
         }
-    }
 
     override suspend fun findStaleClaimed(
         claimedBefore: Instant,
         limit: Int,
-    ): List<ApprovalContinuation> {
-        require(limit in 1..100) { "limit must be between 1 and 100" }
+    ): List<ApprovalContinuation> =
+        withSafeJdbc({ "Database operation failed for finding stale continuations" }) {
+            require(limit in 1..100) { "limit must be between 1 and 100" }
 
-        dataSource.connection.use { conn ->
-            val sql = """
-                SELECT approval_id, status, version, created_at, approval_expires_at,
-                       workflow_run_id, correlation_id, tool_call_id, tool_name,
-                       arguments_digest, policy_version, workflow_digest,
-                       claimed_by, claimed_at, completed_at,
-                       recovery_resolved_by, recovery_resolved_at, recovery_reason_code
-                FROM approval_continuations
-                WHERE status = 'CLAIMED'
-                  AND claimed_at IS NOT NULL
-                  AND claimed_at <= ?
-                ORDER BY claimed_at ASC, approval_id ASC
-                LIMIT ?
-            """.trimIndent()
-            conn.prepareStatement(sql).use { stmt ->
-                stmt.setObject(1, OffsetDateTime.ofInstant(claimedBefore, ZoneOffset.UTC))
-                stmt.setInt(2, limit)
+            dataSource.connection.use { conn ->
+                val sql =
+                    """
+                    SELECT approval_id, status, version, created_at, approval_expires_at,
+                           workflow_run_id, correlation_id, tool_call_id, tool_name,
+                           arguments_digest, policy_version, workflow_digest,
+                           claimed_by, claimed_at, completed_at,
+                           recovery_resolved_by, recovery_resolved_at, recovery_reason_code
+                    FROM approval_continuations
+                    WHERE status = 'CLAIMED'
+                      AND claimed_at IS NOT NULL
+                      AND claimed_at <= ?
+                    ORDER BY claimed_at ASC, approval_id ASC
+                    LIMIT ?
+                    """.trimIndent()
+                conn.prepareStatement(sql).use { stmt ->
+                    stmt.setObject(1, OffsetDateTime.ofInstant(claimedBefore, ZoneOffset.UTC))
+                    stmt.setInt(2, limit)
 
-                stmt.executeQuery().use { rs ->
-                    val result = mutableListOf<ApprovalContinuation>()
-                    while (rs.next()) {
-                        result.add(mapToDomain(rs))
+                    stmt.executeQuery().use { rs ->
+                        val result = mutableListOf<ApprovalContinuation>()
+                        while (rs.next()) {
+                            result.add(mapToDomain(rs))
+                        }
+                        result
                     }
-                    return result
                 }
             }
         }
-    }
 
+    @Suppress("LongMethod")
     override suspend fun forceCancelClaimed(
         approvalId: String,
         expectedVersion: Long,
         cancelledBy: String,
         reasonCode: String,
-    ): ApprovalContinuation {
-        validateIdField(approvalId, "approvalId")
-        validateIdField(cancelledBy, "cancelledBy")
-        SafeActorIdPolicy.validateActorId(cancelledBy, "cancelledBy")
-        require(SAFE_REASON_CODE.matches(reasonCode)) {
-            "reasonCode must match [a-z0-9][a-z0-9._:-]{0,63}"
-        }
-
-        dataSource.connection.use { conn ->
-            val row = readCurrent(conn, approvalId)
-                ?: throw ApprovalContinuationNotFoundException(approvalId)
-
-            if (row.version != expectedVersion) {
-                throw ApprovalContinuationConflictException(approvalId)
+    ): ApprovalContinuation =
+        withSafeJdbc({ "Database operation failed for continuation: $approvalId" }) {
+            validateIdField(approvalId, "approvalId")
+            validateIdField(cancelledBy, "cancelledBy")
+            SafeActorIdPolicy.validateActorId(cancelledBy, "cancelledBy")
+            require(SAFE_REASON_CODE.matches(reasonCode)) {
+                "reasonCode must match [a-z0-9][a-z0-9._:-]{0,63}"
             }
 
-            val status = ApprovalContinuationStatus.valueOf(row.status)
-            if (status != ApprovalContinuationStatus.CLAIMED) {
-                throw ApprovalContinuationNotClaimableException(approvalId)
-            }
+            dataSource.connection.use { conn ->
+                val row =
+                    readCurrent(conn, approvalId)
+                        ?: throw ApprovalContinuationNotFoundException(approvalId)
 
-            val newVersion = incrementVersion(approvalId, row.version)
-            val nowOdt = OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC)
-
-            val sql = """
-                UPDATE approval_continuations
-                SET status = 'CANCELLED_UNCERTAIN',
-                    version = ?,
-                    recovery_resolved_by = ?,
-                    recovery_resolved_at = ?,
-                    recovery_reason_code = ?
-                WHERE approval_id = ?
-                  AND version = ?
-                  AND status = 'CLAIMED'
-            """.trimIndent()
-            conn.prepareStatement(sql).use { stmt ->
-                stmt.setLong(1, newVersion)
-                stmt.setString(2, cancelledBy)
-                stmt.setObject(3, nowOdt)
-                stmt.setString(4, reasonCode)
-                stmt.setString(5, approvalId)
-                stmt.setLong(6, expectedVersion)
-
-                val updated = stmt.executeUpdate()
-                if (updated == 0) {
+                if (row.version != expectedVersion) {
                     throw ApprovalContinuationConflictException(approvalId)
                 }
-            }
 
-            val updatedContinuation = normalizeRow(
-                approvalId = approvalId,
-                status = "CANCELLED_UNCERTAIN",
-                newVersion = newVersion,
-                claimedBy = row.claimedBy,
-                claimedAt = row.claimedAt,
-                completedAt = null,
-                base = row,
-                recoveryResolvedBy = cancelledBy,
-                recoveryResolvedAt = nowOdt,
-                recoveryReasonCode = reasonCode,
-            )
-            return updatedContinuation.toDomain()
-        }
-    }
+                val status = ApprovalContinuationStatus.valueOf(row.status)
+                if (status != ApprovalContinuationStatus.CLAIMED) {
+                    throw ApprovalContinuationNotClaimableException(approvalId)
+                }
 
-    override suspend fun sweepExpired(): Int {
-        val now = clock.instant()
+                val newVersion = incrementVersion(approvalId, row.version)
+                val nowOdt = OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC)
 
-        dataSource.connection.use { conn ->
-            // Find all PENDING continuations past their approval_expires_at
-            val selectSql = """
-                SELECT approval_id, version
-                FROM approval_continuations
-                WHERE status = 'PENDING'
-                  AND approval_expires_at <= ?
-                LIMIT 100
-            """.trimIndent()
-            val candidates = mutableListOf<Pair<String, Long>>()
-            conn.prepareStatement(selectSql).use { stmt ->
-                stmt.setObject(1, OffsetDateTime.ofInstant(now, ZoneOffset.UTC))
-                stmt.executeQuery().use { rs ->
-                    while (rs.next()) {
-                        candidates.add(rs.getString("approval_id") to rs.getLong("version"))
+                val sql =
+                    """
+                    UPDATE approval_continuations
+                    SET status = 'CANCELLED_UNCERTAIN',
+                        version = ?,
+                        recovery_resolved_by = ?,
+                        recovery_resolved_at = ?,
+                        recovery_reason_code = ?
+                    WHERE approval_id = ?
+                      AND version = ?
+                      AND status = 'CLAIMED'
+                    """.trimIndent()
+                conn.prepareStatement(sql).use { stmt ->
+                    stmt.setLong(1, newVersion)
+                    stmt.setString(2, cancelledBy)
+                    stmt.setObject(3, nowOdt)
+                    stmt.setString(4, reasonCode)
+                    stmt.setString(5, approvalId)
+                    stmt.setLong(6, expectedVersion)
+
+                    val updated = stmt.executeUpdate()
+                    if (updated == 0) {
+                        throw ApprovalContinuationConflictException(approvalId)
                     }
                 }
+
+                val updatedContinuation =
+                    normalizeRow(
+                        approvalId = approvalId,
+                        status = "CANCELLED_UNCERTAIN",
+                        newVersion = newVersion,
+                        claimedBy = row.claimedBy,
+                        claimedAt = row.claimedAt,
+                        completedAt = null,
+                        base = row,
+                        recoveryResolvedBy = cancelledBy,
+                        recoveryResolvedAt = nowOdt,
+                        recoveryReasonCode = reasonCode,
+                    )
+                updatedContinuation.toDomain()
             }
-
-            if (candidates.isEmpty()) return 0
-
-            var count = 0
-            val updateSql = """
-                UPDATE approval_continuations
-                SET status = 'EXPIRED',
-                    version = version + 1,
-                    encrypted_arguments = NULL,
-                    encryption_key_id = NULL,
-                    encryption_algorithm = NULL,
-                    encryption_nonce = NULL,
-                    payload_digest = NULL
-                WHERE approval_id = ?
-                  AND version = ?
-                  AND status = 'PENDING'
-            """.trimIndent()
-            conn.prepareStatement(updateSql).use { stmt ->
-                for ((approvalId, version) in candidates) {
-                    stmt.setString(1, approvalId)
-                    stmt.setLong(2, version)
-                    count += stmt.executeUpdate()
-                }
-            }
-
-            return count
         }
-    }
+
+    override suspend fun sweepExpired(): Int =
+        withSafeJdbc({ "Database operation failed for sweeping expired continuations" }) {
+            val now = clock.instant()
+
+            dataSource.connection.use { conn ->
+                // Find all PENDING continuations past their approval_expires_at
+                val selectSql =
+                    """
+                    SELECT approval_id, version
+                    FROM approval_continuations
+                    WHERE status = 'PENDING'
+                      AND approval_expires_at <= ?
+                    LIMIT 100
+                    """.trimIndent()
+                val candidates = mutableListOf<Pair<String, Long>>()
+                conn.prepareStatement(selectSql).use { stmt ->
+                    stmt.setObject(1, OffsetDateTime.ofInstant(now, ZoneOffset.UTC))
+                    stmt.executeQuery().use { rs ->
+                        while (rs.next()) {
+                            candidates.add(rs.getString("approval_id") to rs.getLong("version"))
+                        }
+                    }
+                }
+
+                if (candidates.isEmpty()) return@use 0
+
+                var count = 0
+                val updateSql =
+                    """
+                    UPDATE approval_continuations
+                    SET status = 'EXPIRED',
+                        version = version + 1,
+                        encrypted_arguments = NULL,
+                        encryption_key_id = NULL,
+                        encryption_algorithm = NULL,
+                        encryption_nonce = NULL,
+                        payload_digest = NULL
+                    WHERE approval_id = ?
+                      AND version = ?
+                      AND status = 'PENDING'
+                    """.trimIndent()
+                conn.prepareStatement(updateSql).use { stmt ->
+                    for ((approvalId, version) in candidates) {
+                        stmt.setString(1, approvalId)
+                        stmt.setLong(2, version)
+                        count += stmt.executeUpdate()
+                    }
+                }
+
+                count
+            }
+        }
 
     // ── Internal helpers ──────────────────────────────────────────
 
@@ -679,9 +709,11 @@ class JdbcApprovalContinuationStore(
 
         // Arguments digest verification — the stored digest must match the
         // released payload (same contract as the in-memory and file stores).
-        val actualDigest = MessageDigest.getInstance("SHA-256")
-            .digest(arguments.reveal().toByteArray(Charsets.UTF_8))
-            .joinToString("") { "%02x".format(it) }
+        val actualDigest =
+            MessageDigest
+                .getInstance("SHA-256")
+                .digest(arguments.reveal().toByteArray(Charsets.UTF_8))
+                .joinToString("") { "%02x".format(it) }
         require(actualDigest == continuation.argumentsDigest.value.removePrefix("sha256:")) {
             "argumentsDigest does not match arguments"
         }
@@ -691,7 +723,10 @@ class JdbcApprovalContinuationStore(
      * Validates temporal invariants for create: expiresAt in future,
      * createdAt not in future, expiresAt after createdAt, TTL within bounds.
      */
-    private fun validateTemporalInvariants(continuation: ApprovalContinuation, now: Instant) {
+    private fun validateTemporalInvariants(
+        continuation: ApprovalContinuation,
+        now: Instant,
+    ) {
         require(!continuation.createdAt.isAfter(now)) { "createdAt must not be in the future" }
         require(continuation.approvalExpiresAt.isAfter(now)) { "approvalExpiresAt must be in the future" }
         require(continuation.approvalExpiresAt.isAfter(continuation.createdAt)) {
@@ -714,11 +749,12 @@ class JdbcApprovalContinuationStore(
         row: ContinuationRow,
         now: Instant,
     ): Pair<ContinuationRow, Boolean> {
-        val status = try {
-            ApprovalContinuationStatus.valueOf(row.status)
-        } catch (_: Exception) {
-            return row to false
-        }
+        val status =
+            try {
+                ApprovalContinuationStatus.valueOf(row.status)
+            } catch (_: Exception) {
+                return row to false
+            }
         if (status != ApprovalContinuationStatus.PENDING) {
             return row to false
         }
@@ -726,15 +762,16 @@ class JdbcApprovalContinuationStore(
         if (now < expiresAt) return row to false
 
         val newVersion = incrementVersion(row.approvalId, row.version)
-        val expiredRow = normalizeRow(
-            approvalId = row.approvalId,
-            status = "EXPIRED",
-            newVersion = newVersion,
-            claimedBy = null,
-            claimedAt = null,
-            completedAt = null,
-            base = row,
-        )
+        val expiredRow =
+            normalizeRow(
+                approvalId = row.approvalId,
+                status = "EXPIRED",
+                newVersion = newVersion,
+                claimedBy = null,
+                claimedAt = null,
+                completedAt = null,
+                base = row,
+            )
         return expiredRow to true
     }
 
@@ -744,9 +781,13 @@ class JdbcApprovalContinuationStore(
      * @return true if the CAS update succeeded (row was expired), false if
      *   another writer changed the row first.
      */
-    private fun applyLazyExpiry(row: ContinuationRow, expectedVersion: Long): Boolean {
+    private fun applyLazyExpiry(
+        row: ContinuationRow,
+        expectedVersion: Long,
+    ): Boolean {
         dataSource.connection.use { conn ->
-            val sql = """
+            val sql =
+                """
                 UPDATE approval_continuations
                 SET status = 'EXPIRED',
                     version = ?,
@@ -758,7 +799,7 @@ class JdbcApprovalContinuationStore(
                 WHERE approval_id = ?
                   AND version = ?
                   AND status = 'PENDING'
-            """.trimIndent()
+                """.trimIndent()
             conn.prepareStatement(sql).use { stmt ->
                 stmt.setLong(1, row.version)
                 stmt.setString(2, row.approvalId)
@@ -772,24 +813,30 @@ class JdbcApprovalContinuationStore(
      * Decrypts the arguments from a stored row.
      */
     private fun decryptArguments(row: ContinuationRow): String {
-        val encrypted = row.encryptedArguments
-            ?: throw ApprovalContinuationConflictException(row.approvalId)
-        val keyId = row.encryptionKeyId
-            ?: throw ApprovalContinuationConflictException(row.approvalId)
-        val algorithm = row.encryptionAlgorithm
-            ?: throw ApprovalContinuationConflictException(row.approvalId)
-        val nonce = row.encryptionNonce
-            ?: throw ApprovalContinuationConflictException(row.approvalId)
-        val payloadDigest = row.payloadDigest
-            ?: throw ApprovalContinuationConflictException(row.approvalId)
+        val encrypted =
+            row.encryptedArguments
+                ?: throw ApprovalContinuationConflictException(row.approvalId)
+        val keyId =
+            row.encryptionKeyId
+                ?: throw ApprovalContinuationConflictException(row.approvalId)
+        val algorithm =
+            row.encryptionAlgorithm
+                ?: throw ApprovalContinuationConflictException(row.approvalId)
+        val nonce =
+            row.encryptionNonce
+                ?: throw ApprovalContinuationConflictException(row.approvalId)
+        val payloadDigest =
+            row.payloadDigest
+                ?: throw ApprovalContinuationConflictException(row.approvalId)
 
-        val envelope = JdbcEncryptedContinuationArguments(
-            ciphertext = encrypted,
-            keyId = keyId,
-            algorithm = algorithm,
-            nonce = nonce,
-            payloadDigest = payloadDigest,
-        )
+        val envelope =
+            JdbcEncryptedContinuationArguments(
+                ciphertext = encrypted,
+                keyId = keyId,
+                algorithm = algorithm,
+                nonce = nonce,
+                payloadDigest = payloadDigest,
+            )
         return argumentsCodec.decode(envelope).toString(Charsets.UTF_8)
     }
 
@@ -802,8 +849,9 @@ class JdbcApprovalContinuationStore(
         approvalId: String,
         includeEncrypted: Boolean = true,
     ): ContinuationRow? {
-        val columns = if (includeEncrypted) {
-            """
+        val columns =
+            if (includeEncrypted) {
+                """
             approval_id, status, version, created_at, approval_expires_at,
             workflow_run_id, correlation_id, tool_call_id, tool_name,
             arguments_digest, policy_version, workflow_digest,
@@ -812,15 +860,15 @@ class JdbcApprovalContinuationStore(
             encrypted_arguments, encryption_key_id, encryption_algorithm,
             encryption_nonce, payload_digest
             """
-        } else {
-            """
+            } else {
+                """
             approval_id, status, version, created_at, approval_expires_at,
             workflow_run_id, correlation_id, tool_call_id, tool_name,
             arguments_digest, policy_version, workflow_digest,
             claimed_by, claimed_at, completed_at,
             recovery_resolved_by, recovery_resolved_at, recovery_reason_code
             """
-        }
+            }
 
         val sql = "SELECT $columns FROM approval_continuations WHERE approval_id = ?"
         conn.prepareStatement(sql).use { stmt ->
@@ -841,7 +889,10 @@ class JdbcApprovalContinuationStore(
         }
     }
 
-    private fun mapToRow(rs: ResultSet, includeEncrypted: Boolean): ContinuationRow =
+    private fun mapToRow(
+        rs: ResultSet,
+        includeEncrypted: Boolean,
+    ): ContinuationRow =
         ContinuationRow(
             approvalId = rs.getString("approval_id"),
             status = rs.getString("status"),
@@ -904,26 +955,27 @@ class JdbcApprovalContinuationStore(
      * Arguments are NOT included — they were encrypted and are only exposed
      * via [claimForExecution].
      */
-    private fun ContinuationRow.toDomain(): ApprovalContinuation = ApprovalContinuation(
-        approvalId = approvalId,
-        workflowRunId = workflowRunId ?: "",
-        correlationId = correlationId ?: "",
-        toolCallId = toolCallId ?: "",
-        toolName = toolName ?: "",
-        argumentsDigest = Sha256Digest.of(argumentsDigest),
-        policyVersion = policyVersion ?: "",
-        workflowDigest = Sha256Digest.of(workflowDigest ?: "sha256:${"0".repeat(64)}"),
-        status = ApprovalContinuationStatus.valueOf(status),
-        createdAt = createdAt.toInstant(),
-        approvalExpiresAt = approvalExpiresAt.toInstant(),
-        claimedBy = claimedBy,
-        claimedAt = claimedAt?.toInstant(),
-        completedAt = completedAt?.toInstant(),
-        recoveryResolvedBy = recoveryResolvedBy,
-        recoveryResolvedAt = recoveryResolvedAt?.toInstant(),
-        recoveryReasonCode = recoveryReasonCode,
-        version = version,
-    )
+    private fun ContinuationRow.toDomain(): ApprovalContinuation =
+        ApprovalContinuation(
+            approvalId = approvalId,
+            workflowRunId = workflowRunId ?: "",
+            correlationId = correlationId ?: "",
+            toolCallId = toolCallId ?: "",
+            toolName = toolName ?: "",
+            argumentsDigest = Sha256Digest.of(argumentsDigest),
+            policyVersion = policyVersion ?: "",
+            workflowDigest = Sha256Digest.of(workflowDigest ?: "sha256:${"0".repeat(64)}"),
+            status = ApprovalContinuationStatus.valueOf(status),
+            createdAt = createdAt.toInstant(),
+            approvalExpiresAt = approvalExpiresAt.toInstant(),
+            claimedBy = claimedBy,
+            claimedAt = claimedAt?.toInstant(),
+            completedAt = completedAt?.toInstant(),
+            recoveryResolvedBy = recoveryResolvedBy,
+            recoveryResolvedAt = recoveryResolvedAt?.toInstant(),
+            recoveryReasonCode = recoveryReasonCode,
+            version = version,
+        )
 
     /**
      * Creates a normalized row with updated status/version fields,
@@ -940,35 +992,43 @@ class JdbcApprovalContinuationStore(
         recoveryResolvedBy: String? = null,
         recoveryResolvedAt: OffsetDateTime? = null,
         recoveryReasonCode: String? = null,
-    ): ContinuationRow = ContinuationRow(
-        approvalId = approvalId,
-        status = status,
-        version = newVersion,
-        createdAt = base.createdAt,
-        approvalExpiresAt = base.approvalExpiresAt,
-        workflowRunId = base.workflowRunId,
-        correlationId = base.correlationId,
-        toolCallId = base.toolCallId,
-        toolName = base.toolName,
-        argumentsDigest = base.argumentsDigest,
-        policyVersion = base.policyVersion,
-        workflowDigest = base.workflowDigest,
-        claimedBy = claimedBy,
-        claimedAt = claimedAt,
-        completedAt = completedAt,
-        recoveryResolvedBy = recoveryResolvedBy,
-        recoveryResolvedAt = recoveryResolvedAt,
-        recoveryReasonCode = recoveryReasonCode,
-    )
+    ): ContinuationRow =
+        ContinuationRow(
+            approvalId = approvalId,
+            status = status,
+            version = newVersion,
+            createdAt = base.createdAt,
+            approvalExpiresAt = base.approvalExpiresAt,
+            workflowRunId = base.workflowRunId,
+            correlationId = base.correlationId,
+            toolCallId = base.toolCallId,
+            toolName = base.toolName,
+            argumentsDigest = base.argumentsDigest,
+            policyVersion = base.policyVersion,
+            workflowDigest = base.workflowDigest,
+            claimedBy = claimedBy,
+            claimedAt = claimedAt,
+            completedAt = completedAt,
+            recoveryResolvedBy = recoveryResolvedBy,
+            recoveryResolvedAt = recoveryResolvedAt,
+            recoveryReasonCode = recoveryReasonCode,
+        )
 
-    private fun incrementVersion(approvalId: String, version: Long): Long =
+    private fun incrementVersion(
+        approvalId: String,
+        version: Long,
+    ): Long =
         try {
             Math.addExact(version, 1L)
         } catch (_: ArithmeticException) {
             throw ApprovalContinuationConflictException(approvalId)
         }
 
-    private fun validateIdField(value: String, fieldName: String, maxLength: Int = maxIdLength): String {
+    private fun validateIdField(
+        value: String,
+        fieldName: String,
+        maxLength: Int = maxIdLength,
+    ): String {
         val trimmed = value.trim()
         require(trimmed.isNotBlank()) { "$fieldName must not be blank" }
         require(trimmed.none { it.isISOControl() }) { "$fieldName must not contain control characters" }

--- a/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStore.kt
+++ b/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStore.kt
@@ -65,173 +65,188 @@ class JdbcApprovalStore(
     private val maxCommentLength: Int = 4096,
     private val maxCreationTtl: Duration = Duration.ofMinutes(15),
 ) : ApprovalStore {
-
     init {
         require(maxCreationTtl > Duration.ZERO) {
             "maxCreationTtl must be positive"
         }
     }
 
-    private val mapper: ObjectMapper = ObjectMapper()
-        .registerKotlinModule()
-        .registerModule(JavaTimeModule())
-        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    private val mapper: ObjectMapper =
+        ObjectMapper()
+            .registerKotlinModule()
+            .registerModule(JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 
-    override suspend fun create(request: ApprovalRequest): ApprovalRequest {
-        require(request.version == 0L) { "Initial approval version must be 0, got ${request.version}" }
-        require(request.status == ApprovalStatus.PENDING) { "Initial approval status must be PENDING, got ${request.status}" }
-        require(request.decidedBy == null) { "Initial approval must not have decidedBy set" }
-        require(request.decidedAt == null) { "Initial approval must not have decidedAt set" }
-        require(request.decisionComment == null) { "Initial approval must not have decisionComment set" }
+    override suspend fun create(request: ApprovalRequest): ApprovalRequest =
+        withSafeJdbc({ "Database operation failed for approval: ${request.approvalId}" }) {
+            require(request.version == 0L) { "Initial approval version must be 0, got ${request.version}" }
+            require(request.status == ApprovalStatus.PENDING) { "Initial approval status must be PENDING, got ${request.status}" }
+            require(request.decidedBy == null) { "Initial approval must not have decidedBy set" }
+            require(request.decidedAt == null) { "Initial approval must not have decidedAt set" }
+            require(request.decisionComment == null) { "Initial approval must not have decisionComment set" }
 
-        validateIdField(request.approvalId, "approvalId", maxIdLength)
-        validateIdField(request.requestedBy, "requestedBy", maxIdLength)
-        SafeActorIdPolicy.validateActorId(request.requestedBy, "requestedBy")
+            validateIdField(request.approvalId, "approvalId", maxIdLength)
+            validateIdField(request.requestedBy, "requestedBy", maxIdLength)
+            SafeActorIdPolicy.validateActorId(request.requestedBy, "requestedBy")
 
-        val binding = request.binding
-        validateIdField(binding.workflowRunId, "workflowRunId", maxIdLength)
-        validateIdField(binding.toolName, "toolName", maxIdLength)
-        validateIdField(binding.policyVersion, "policyVersion", maxIdLength)
+            val binding = request.binding
+            validateIdField(binding.workflowRunId, "workflowRunId", maxIdLength)
+            validateIdField(binding.toolName, "toolName", maxIdLength)
+            validateIdField(binding.policyVersion, "policyVersion", maxIdLength)
 
-        val now = clock.instant()
-        require(request.expiresAt > now) { "expiresAt must be in the future, got $now for expiry ${request.expiresAt}" }
-        require(request.expiresAt > request.requestedAt) { "expiresAt must be after requestedAt" }
-        require(request.requestedAt <= now) { "requestedAt must not be in the future, got ${request.requestedAt} for now $now" }
-        require(request.consumedBy == null) { "Initial approval must not have consumedBy set" }
-        require(request.consumedAt == null) { "Initial approval must not have consumedAt set" }
+            val now = clock.instant()
+            require(request.expiresAt > now) {
+                "expiresAt must be in the future, got $now for expiry ${request.expiresAt}"
+            }
+            require(request.expiresAt > request.requestedAt) { "expiresAt must be after requestedAt" }
+            require(request.requestedAt <= now) {
+                "requestedAt must not be in the future, got ${request.requestedAt} for now $now"
+            }
+            require(request.consumedBy == null) { "Initial approval must not have consumedBy set" }
+            require(request.consumedAt == null) { "Initial approval must not have consumedAt set" }
 
-        val ttl = Duration.between(request.requestedAt, request.expiresAt)
-        require(ttl <= maxCreationTtl) {
-            "expiresAt exceeds maximum creation TTL of $maxCreationTtl"
-        }
+            val ttl = Duration.between(request.requestedAt, request.expiresAt)
+            require(ttl <= maxCreationTtl) {
+                "expiresAt exceeds maximum creation TTL of $maxCreationTtl"
+            }
 
-        val metadata = ApprovalMetadata(
-            binding = BindingMetadata(
-                workflowRunId = binding.workflowRunId,
-                toolName = binding.toolName,
-                argumentsDigest = binding.argumentsDigest.value,
-                policyVersion = binding.policyVersion,
-                workflowDigest = binding.workflowDigest.value,
-                approvalTokenDigest = binding.approvalTokenDigest.value,
-            ),
-            requestedBy = request.requestedBy,
-            expiresAt = request.expiresAt.toString(),
-            requestedAt = request.requestedAt.toString(),
-            decidedBy = null,
-            decisionComment = null,
-            consumedBy = null,
-            consumedAt = null,
-        )
-        val metadataJson = mapper.writeValueAsString(metadata)
-        val nowOdt = OffsetDateTime.ofInstant(now, ZoneOffset.UTC)
+            val metadata =
+                ApprovalMetadata(
+                    binding =
+                        BindingMetadata(
+                            workflowRunId = binding.workflowRunId,
+                            toolName = binding.toolName,
+                            argumentsDigest = binding.argumentsDigest.value,
+                            policyVersion = binding.policyVersion,
+                            workflowDigest = binding.workflowDigest.value,
+                            approvalTokenDigest = binding.approvalTokenDigest.value,
+                        ),
+                    requestedBy = request.requestedBy,
+                    expiresAt = request.expiresAt.toString(),
+                    requestedAt = request.requestedAt.toString(),
+                    decidedBy = null,
+                    decisionComment = null,
+                    consumedBy = null,
+                    consumedAt = null,
+                )
+            val metadataJson = mapper.writeValueAsString(metadata)
+            val nowOdt = OffsetDateTime.ofInstant(now, ZoneOffset.UTC)
 
-        dataSource.connection.use { conn ->
-            val sql = """
-                INSERT INTO approvals (approval_id, status, created_at, sanitized_metadata, version)
-                VALUES (?, 'PENDING', ?, ?::jsonb, 0)
-            """.trimIndent()
-            conn.prepareStatement(sql).use { stmt ->
-                stmt.setString(1, request.approvalId)
-                stmt.setObject(2, nowOdt)
-                stmt.setString(3, metadataJson)
-                try {
-                    stmt.executeUpdate()
-                } catch (e: SQLException) {
-                    // Map PostgreSQL unique violation (23505) to domain exception;
-                    // rethrow all other SQL failures accurately.
-                    if (e.sqlState == "23505") {
-                        throw ApprovalStoreConflictException(request.approvalId)
+            dataSource.connection.use { conn ->
+                val sql =
+                    """
+                    INSERT INTO approvals (approval_id, status, created_at, sanitized_metadata, version)
+                    VALUES (?, 'PENDING', ?, ?::jsonb, 0)
+                    """.trimIndent()
+                conn.prepareStatement(sql).use { stmt ->
+                    stmt.setString(1, request.approvalId)
+                    stmt.setObject(2, nowOdt)
+                    stmt.setString(3, metadataJson)
+                    try {
+                        stmt.executeUpdate()
+                    } catch (e: SQLException) {
+                        // Map PostgreSQL unique violation (23505) to domain exception;
+                        // rethrow all other SQL failures accurately.
+                        if (e.sqlState == "23505") {
+                            throw ApprovalStoreConflictException(request.approvalId)
+                        }
+                        throw e
                     }
-                    throw e
+                }
+            }
+
+            request
+        }
+
+    override suspend fun get(approvalId: String): ApprovalRequest? =
+        withSafeJdbc({ "Database operation failed for approval: $approvalId" }) {
+            validateIdField(approvalId, "approvalId", maxIdLength)
+
+            dataSource.connection.use { conn ->
+                val sql =
+                    """
+                    SELECT approval_id, status, created_at, decided_at, decision_actor_hash, decision_type,
+                           sanitized_metadata, version
+                    FROM approvals
+                    WHERE approval_id = ?
+                    """.trimIndent()
+                conn.prepareStatement(sql).use { stmt ->
+                    stmt.setString(1, approvalId)
+                    stmt.executeQuery().use { rs ->
+                        if (!rs.next()) return@use null
+                        mapToApprovalRequest(mapToRow(rs))
+                    }
                 }
             }
         }
-
-        return request
-    }
-
-    override suspend fun get(approvalId: String): ApprovalRequest? {
-        validateIdField(approvalId, "approvalId", maxIdLength)
-
-        dataSource.connection.use { conn ->
-            val sql = """
-                SELECT approval_id, status, created_at, decided_at, decision_actor_hash, decision_type,
-                       sanitized_metadata, version
-                FROM approvals
-                WHERE approval_id = ?
-            """.trimIndent()
-            conn.prepareStatement(sql).use { stmt ->
-                stmt.setString(1, approvalId)
-                stmt.executeQuery().use { rs ->
-                    if (!rs.next()) return null
-                    return mapToApprovalRequest(mapToRow(rs))
-                }
-            }
-        }
-    }
 
     override suspend fun transition(
         approvalId: String,
         expectedVersion: Long,
         transition: ApprovalTransition,
-    ): ApprovalRequest {
-        validateIdField(approvalId, "approvalId", maxIdLength)
-        validateTransitionInput(transition)
+    ): ApprovalRequest =
+        withSafeJdbc({ "Database operation failed for approval: $approvalId" }) {
+            validateIdField(approvalId, "approvalId", maxIdLength)
+            validateTransitionInput(transition)
 
-        dataSource.connection.use { conn ->
-            val current = readCurrent(conn, approvalId) ?: throw ApprovalStoreNotFoundException(approvalId)
-            if (current.version != expectedVersion) throw ApprovalStoreConflictException(approvalId)
+            dataSource.connection.use { conn ->
+                val current = readCurrent(conn, approvalId) ?: throw ApprovalStoreNotFoundException(approvalId)
+                if (current.version != expectedVersion) throw ApprovalStoreConflictException(approvalId)
 
-            val now = clock.instant()
-            resolveNextStatus(current, transition, now)
+                val now = clock.instant()
+                resolveNextStatus(current, transition, now)
 
-            val nextVersion = incrementVersion(approvalId, current.version)
-            val nowOdt = OffsetDateTime.ofInstant(now, ZoneOffset.UTC)
-            val metadata = parseMetadata(current.sanitizedMetadataJson)
-            val decisionFields = transition.toDecisionFields()
-            val actorHash = decisionFields.decidedBy?.let { sha256Hex(it) }
-            val updatedMetadata = metadata.copy(
-                decidedBy = decisionFields.decidedBy,
-                decisionComment = decisionFields.comment,
-            )
-            val metadataJson = mapper.writeValueAsString(updatedMetadata)
+                val nextVersion = incrementVersion(approvalId, current.version)
+                val nowOdt = OffsetDateTime.ofInstant(now, ZoneOffset.UTC)
+                val metadata = parseMetadata(current.sanitizedMetadataJson)
+                val decisionFields = transition.toDecisionFields()
+                val actorHash = decisionFields.decidedBy?.let { sha256Hex(it) }
+                val updatedMetadata =
+                    metadata.copy(
+                        decidedBy = decisionFields.decidedBy,
+                        decisionComment = decisionFields.comment,
+                    )
+                val metadataJson = mapper.writeValueAsString(updatedMetadata)
 
-            updateDecisionRow(
-                DecisionRowUpdate(
-                    conn = conn,
-                    target = DecisionRowTarget(
-                        approvalId = approvalId,
-                        expectedVersion = expectedVersion,
+                updateDecisionRow(
+                    DecisionRowUpdate(
+                        conn = conn,
+                        target =
+                            DecisionRowTarget(
+                                approvalId = approvalId,
+                                expectedVersion = expectedVersion,
+                            ),
+                        fields =
+                            DecisionRowFields(
+                                decisionFields = decisionFields,
+                                decidedAt = nowOdt,
+                                actorHash = actorHash,
+                                metadataJson = metadataJson,
+                                nextVersion = nextVersion,
+                            ),
                     ),
-                    fields = DecisionRowFields(
-                        decisionFields = decisionFields,
-                        decidedAt = nowOdt,
-                        actorHash = actorHash,
-                        metadataJson = metadataJson,
-                        nextVersion = nextVersion,
-                    ),
-                ),
-            )
+                )
 
-            val updatedCurrent = readCurrent(conn, approvalId) ?: throw ApprovalStoreNotFoundException(approvalId)
-            return mapToApprovalRequest(updatedCurrent)
+                val updatedCurrent = readCurrent(conn, approvalId) ?: throw ApprovalStoreNotFoundException(approvalId)
+                mapToApprovalRequest(updatedCurrent)
+            }
         }
-    }
 
     override suspend fun consumeApprovedOrReplay(
         approvalId: String,
         expectedVersion: Long,
         presentedTokenDigest: Sha256Digest,
         consumedBy: String,
-    ): ApprovalConsumptionReceipt {
-        validateIdField(approvalId, "approvalId", maxIdLength)
-        validateIdField(consumedBy, "consumedBy", maxIdLength)
-        SafeActorIdPolicy.validateActorId(consumedBy, "consumedBy")
+    ): ApprovalConsumptionReceipt =
+        withSafeJdbc({ "Database operation failed for approval: $approvalId" }) {
+            validateIdField(approvalId, "approvalId", maxIdLength)
+            validateIdField(consumedBy, "consumedBy", maxIdLength)
+            SafeActorIdPolicy.validateActorId(consumedBy, "consumedBy")
 
-        return dataSource.connection.use { conn ->
-            consumeApprovedInTransaction(conn, approvalId, expectedVersion, presentedTokenDigest, consumedBy)
+            dataSource.connection.use { conn ->
+                consumeApprovedInTransaction(conn, approvalId, expectedVersion, presentedTokenDigest, consumedBy)
+            }
         }
-    }
 
     /**
      * Row lock + explicit transaction so concurrent identical deliveries
@@ -290,8 +305,9 @@ class JdbcApprovalStore(
         presentedTokenDigest: Sha256Digest,
         consumedBy: String,
     ): ApprovalConsumptionReceipt {
-        val current = readCurrent(conn, approvalId, forUpdate = true)
-            ?: throw ApprovalStoreNotFoundException(approvalId)
+        val current =
+            readCurrent(conn, approvalId, forUpdate = true)
+                ?: throw ApprovalStoreNotFoundException(approvalId)
         val req = mapToApprovalRequest(current)
 
         if (req.status != ApprovalStatus.APPROVED) throw ApprovalStoreNotConsumableException(approvalId)
@@ -351,12 +367,13 @@ class JdbcApprovalStore(
         nextVersion: Long,
         metadataJson: String,
     ) {
-        val sql = """
+        val sql =
+            """
             UPDATE approvals
             SET sanitized_metadata = ?::jsonb,
                 version = ?
             WHERE approval_id = ? AND version = ?
-        """.trimIndent()
+            """.trimIndent()
         conn.prepareStatement(sql).use { stmt ->
             stmt.setString(1, metadataJson)
             stmt.setLong(2, nextVersion)
@@ -379,11 +396,12 @@ class JdbcApprovalStore(
         }
         if (req.consumedBy != consumedBy) throw ApprovalStoreNotConsumableException(approvalId)
 
-        val replayVersion = try {
-            Math.addExact(expectedVersion, 1L)
-        } catch (_: ArithmeticException) {
-            throw ApprovalStoreConflictException(approvalId)
-        }
+        val replayVersion =
+            try {
+                Math.addExact(expectedVersion, 1L)
+            } catch (_: ArithmeticException) {
+                throw ApprovalStoreConflictException(approvalId)
+            }
         if (req.version != replayVersion) throw ApprovalStoreConflictException(approvalId)
 
         return ApprovalConsumptionReceipt(request = req, replayed = true)
@@ -487,35 +505,39 @@ class JdbcApprovalStore(
     /**
      * Extracts the human decision actor from non-timeout transitions.
      */
-    private fun ApprovalTransition.decidedByOrNull(): String? = when (this) {
-        is ApprovalTransition.Approve -> decidedBy
-        is ApprovalTransition.Deny -> decidedBy
-        is ApprovalTransition.Timeout -> null
-    }
+    private fun ApprovalTransition.decidedByOrNull(): String? =
+        when (this) {
+            is ApprovalTransition.Approve -> decidedBy
+            is ApprovalTransition.Deny -> decidedBy
+            is ApprovalTransition.Timeout -> null
+        }
 
     /**
      * Extracts the optional human decision comment from non-timeout transitions.
      */
-    private fun ApprovalTransition.commentOrNull(): String? = when (this) {
-        is ApprovalTransition.Approve -> comment
-        is ApprovalTransition.Deny -> comment
-        is ApprovalTransition.Timeout -> null
-    }
+    private fun ApprovalTransition.commentOrNull(): String? =
+        when (this) {
+            is ApprovalTransition.Approve -> comment
+            is ApprovalTransition.Deny -> comment
+            is ApprovalTransition.Timeout -> null
+        }
 
     /**
      * Returns the database status and decision type value for a transition.
      */
-    private fun ApprovalTransition.targetStatusWireValue(): String = when (this) {
-        is ApprovalTransition.Approve -> "APPROVED"
-        is ApprovalTransition.Deny -> "DENIED"
-        is ApprovalTransition.Timeout -> "TIMED_OUT"
-    }
+    private fun ApprovalTransition.targetStatusWireValue(): String =
+        when (this) {
+            is ApprovalTransition.Approve -> "APPROVED"
+            is ApprovalTransition.Deny -> "DENIED"
+            is ApprovalTransition.Timeout -> "TIMED_OUT"
+        }
 
     /**
      * Performs the optimistic-concurrency decision update.
      */
     private fun updateDecisionRow(update: DecisionRowUpdate) {
-        val sql = """
+        val sql =
+            """
             UPDATE approvals
             SET status = ?,
                 decided_at = ?,
@@ -524,7 +546,7 @@ class JdbcApprovalStore(
                 sanitized_metadata = ?::jsonb,
                 version = ?
             WHERE approval_id = ? AND version = ?
-        """.trimIndent()
+            """.trimIndent()
         update.conn.prepareStatement(sql).use { stmt ->
             stmt.setString(1, update.fields.decisionFields.targetStatus)
             stmt.setObject(2, update.fields.decidedAt)
@@ -549,12 +571,13 @@ class JdbcApprovalStore(
         approvalId: String,
         forUpdate: Boolean = false,
     ): ApprovalRow? {
-        val sql = """
+        val sql =
+            """
             SELECT approval_id, status, created_at, decided_at, decision_actor_hash, decision_type,
                    sanitized_metadata, version
             FROM approvals
             WHERE approval_id = ?
-        """.trimIndent() + if (forUpdate) " FOR UPDATE" else ""
+            """.trimIndent() + if (forUpdate) " FOR UPDATE" else ""
         conn.prepareStatement(sql).use { stmt ->
             stmt.setString(1, approvalId)
             stmt.executeQuery().use { rs ->
@@ -564,16 +587,17 @@ class JdbcApprovalStore(
         }
     }
 
-    private fun mapToRow(rs: ResultSet): ApprovalRow = ApprovalRow(
-        approvalId = rs.getString("approval_id"),
-        status = rs.getString("status"),
-        createdAt = rs.getObject("created_at", OffsetDateTime::class.java),
-        decidedAt = rs.getObject("decided_at", OffsetDateTime::class.java),
-        decisionActorHash = rs.getString("decision_actor_hash"),
-        decisionType = rs.getString("decision_type"),
-        sanitizedMetadataJson = rs.getString("sanitized_metadata"),
-        version = rs.getLong("version"),
-    )
+    private fun mapToRow(rs: ResultSet): ApprovalRow =
+        ApprovalRow(
+            approvalId = rs.getString("approval_id"),
+            status = rs.getString("status"),
+            createdAt = rs.getObject("created_at", OffsetDateTime::class.java),
+            decidedAt = rs.getObject("decided_at", OffsetDateTime::class.java),
+            decisionActorHash = rs.getString("decision_actor_hash"),
+            decisionType = rs.getString("decision_type"),
+            sanitizedMetadataJson = rs.getString("sanitized_metadata"),
+            version = rs.getLong("version"),
+        )
 
     private fun mapToApprovalRequest(row: ApprovalRow): ApprovalRequest {
         val metadata = parseMetadata(row.sanitizedMetadataJson)
@@ -585,14 +609,15 @@ class JdbcApprovalStore(
         val consumedBy = metadata.consumedBy
         val consumedAt = metadata.consumedAt?.let { Instant.parse(it) }
 
-        val binding = ApprovalBinding(
-            workflowRunId = metadata.binding.workflowRunId,
-            toolName = metadata.binding.toolName,
-            argumentsDigest = Sha256Digest.of(metadata.binding.argumentsDigest),
-            policyVersion = metadata.binding.policyVersion,
-            workflowDigest = Sha256Digest.of(metadata.binding.workflowDigest),
-            approvalTokenDigest = Sha256Digest.of(metadata.binding.approvalTokenDigest),
-        )
+        val binding =
+            ApprovalBinding(
+                workflowRunId = metadata.binding.workflowRunId,
+                toolName = metadata.binding.toolName,
+                argumentsDigest = Sha256Digest.of(metadata.binding.argumentsDigest),
+                policyVersion = metadata.binding.policyVersion,
+                workflowDigest = Sha256Digest.of(metadata.binding.workflowDigest),
+                approvalTokenDigest = Sha256Digest.of(metadata.binding.approvalTokenDigest),
+            )
 
         return ApprovalRequest(
             approvalId = row.approvalId,
@@ -617,7 +642,10 @@ class JdbcApprovalStore(
         return mapper.readValue(json)
     }
 
-    private fun incrementVersion(approvalId: String, version: Long): Long =
+    private fun incrementVersion(
+        approvalId: String,
+        version: Long,
+    ): Long =
         try {
             Math.addExact(version, 1L)
         } catch (_: ArithmeticException) {
@@ -648,30 +676,58 @@ class JdbcApprovalStore(
                         return ApprovalStatus.TIMED_OUT
                     }
                     throw IllegalApprovalTransitionException(
-                        current.approvalId, status, transition.targetStatus(),
+                        current.approvalId,
+                        status,
+                        transition.targetStatus(),
                         "approval has expired at $expiresAt",
                     )
                 }
                 when (transition) {
-                    is ApprovalTransition.Approve -> ApprovalStatus.APPROVED
-                    is ApprovalTransition.Deny -> ApprovalStatus.DENIED
+                    is ApprovalTransition.Approve -> {
+                        ApprovalStatus.APPROVED
+                    }
+
+                    is ApprovalTransition.Deny -> {
+                        ApprovalStatus.DENIED
+                    }
+
                     is ApprovalTransition.Timeout -> {
                         throw IllegalApprovalTransitionException(
-                            current.approvalId, status, transition.targetStatus(),
+                            current.approvalId,
+                            status,
+                            transition.targetStatus(),
                             "Cannot time out approval before expiry at $expiresAt",
                         )
                     }
                 }
             }
-            ApprovalStatus.APPROVED -> throw IllegalApprovalTransitionException(
-                current.approvalId, status, transition.targetStatus(), "approval already granted",
-            )
-            ApprovalStatus.DENIED -> throw IllegalApprovalTransitionException(
-                current.approvalId, status, transition.targetStatus(), "approval already denied",
-            )
-            ApprovalStatus.TIMED_OUT -> throw IllegalApprovalTransitionException(
-                current.approvalId, status, transition.targetStatus(), "approval already timed out",
-            )
+
+            ApprovalStatus.APPROVED -> {
+                throw IllegalApprovalTransitionException(
+                    current.approvalId,
+                    status,
+                    transition.targetStatus(),
+                    "approval already granted",
+                )
+            }
+
+            ApprovalStatus.DENIED -> {
+                throw IllegalApprovalTransitionException(
+                    current.approvalId,
+                    status,
+                    transition.targetStatus(),
+                    "approval already denied",
+                )
+            }
+
+            ApprovalStatus.TIMED_OUT -> {
+                throw IllegalApprovalTransitionException(
+                    current.approvalId,
+                    status,
+                    transition.targetStatus(),
+                    "approval already timed out",
+                )
+            }
         }
     }
 
@@ -682,7 +738,11 @@ class JdbcApprovalStore(
         return "sha256:$hex"
     }
 
-    private fun validateIdField(value: String, fieldName: String, maxLength: Int): String {
+    private fun validateIdField(
+        value: String,
+        fieldName: String,
+        maxLength: Int,
+    ): String {
         val trimmed = value.trim()
         require(trimmed.isNotBlank()) { "$fieldName must not be blank" }
         require(trimmed.none { it.isISOControl() }) { "$fieldName must not contain control characters" }

--- a/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcAuditStore.kt
+++ b/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcAuditStore.kt
@@ -10,7 +10,6 @@ import dev.tramai.security.audit.AuditHashAlgorithm
 import dev.tramai.security.audit.AuditStore
 import dev.tramai.security.audit.CURRENT_AUDIT_SCHEMA_VERSION
 import dev.tramai.security.audit.calculateHash
-import java.util.concurrent.CancellationException
 import java.sql.Connection
 import java.sql.ResultSet
 import java.sql.SQLException
@@ -18,6 +17,7 @@ import java.time.Clock
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
+import java.util.concurrent.CancellationException
 import javax.sql.DataSource
 
 /**
@@ -79,15 +79,15 @@ class JdbcAuditStore(
     private val clock: Clock = Clock.systemUTC(),
     private val maxPageSize: Int = 500,
 ) : AuditStore {
-
     init {
         require(maxPageSize > 0) { "maxPageSize must be positive" }
     }
 
-    private val mapper: ObjectMapper = ObjectMapper()
-        .registerKotlinModule()
-        .registerModule(JavaTimeModule())
-        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    private val mapper: ObjectMapper =
+        ObjectMapper()
+            .registerKotlinModule()
+            .registerModule(JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 
     // ══════════════════════════════════════════════════════════════════
     // AuditStore SPI
@@ -96,79 +96,81 @@ class JdbcAuditStore(
     override suspend fun appendNext(
         auditStreamId: String,
         eventFactory: (latest: AuditEvent?) -> AuditEvent,
-    ): AuditEvent {
-        require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
+    ): AuditEvent =
+        withSafeJdbc({ "Database operation failed for audit stream: $auditStreamId" }) {
+            require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
 
-        dataSource.connection.use { conn ->
-            val previousAutoCommit = conn.autoCommit
-            conn.autoCommit = false
-            var primaryFailure: Exception? = null
-            try {
-                // Ensure stream head row exists (idempotent)
-                ensureStreamHead(conn, auditStreamId)
+            dataSource.connection.use { conn ->
+                val previousAutoCommit = conn.autoCommit
+                conn.autoCommit = false
+                var primaryFailure: Exception? = null
+                try {
+                    // Ensure stream head row exists (idempotent)
+                    ensureStreamHead(conn, auditStreamId)
 
-                // Acquire the stream-level lock via FOR UPDATE on the head row.
-                // This serializes all concurrent appenders to the same stream.
-                val head = selectHeadForUpdate(conn, auditStreamId)
-                val latest = resolveLatestFromHead(conn, auditStreamId, head)
+                    // Acquire the stream-level lock via FOR UPDATE on the head row.
+                    // This serializes all concurrent appenders to the same stream.
+                    val head = selectHeadForUpdate(conn, auditStreamId)
+                    val latest = resolveLatestFromHead(conn, auditStreamId, head)
 
-                // eventFactory is called INSIDE the transaction, AFTER the
-                // stream-level lock is acquired. Factories should be
-                // deterministic or side-effect-free — external side effects
-                // (webhooks, file writes, API calls) performed inside the
-                // factory will not be rolled back.
-                val event = eventFactory(latest)
+                    // eventFactory is called INSIDE the transaction, AFTER the
+                    // stream-level lock is acquired. Factories should be
+                    // deterministic or side-effect-free — external side effects
+                    // (webhooks, file writes, API calls) performed inside the
+                    // factory will not be rolled back.
+                    val event = eventFactory(latest)
 
-                // Validate the event against the stream head and latest
-                validateEvent(event, auditStreamId, latest, head)
+                    // Validate the event against the stream head and latest
+                    validateEvent(event, auditStreamId, latest, head)
 
-                // Serialize and encrypt
-                val payloadJson = mapper.writeValueAsBytes(
-                    PersistedAuditEventV1(
-                        schemaVersion = event.schemaVersion,
-                        hashAlgorithm = event.hashAlgorithm.wireName,
-                        auditStreamId = event.auditStreamId,
-                        eventId = event.eventId,
-                        sequenceNumber = event.sequenceNumber,
-                        workflowRunId = event.workflowRunId,
-                        correlationId = event.correlationId,
-                        actor = event.actor,
-                        enforcementPoint = event.enforcementPoint,
-                        decision = event.decision,
-                        policyVersion = event.policyVersion,
-                        workflowDigest = event.workflowDigest,
-                        previousEventHash = event.previousEventHash,
-                        eventHash = event.eventHash,
-                        timestamp = event.timestamp.toString(),
-                        reasonCode = event.reasonCode,
-                        metadata = event.metadata,
-                    ),
-                )
-                val encrypted = payloadCodec.encode(payloadJson)
-                val nowOdt = OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC)
+                    // Serialize and encrypt
+                    val payloadJson =
+                        mapper.writeValueAsBytes(
+                            PersistedAuditEventV1(
+                                schemaVersion = event.schemaVersion,
+                                hashAlgorithm = event.hashAlgorithm.wireName,
+                                auditStreamId = event.auditStreamId,
+                                eventId = event.eventId,
+                                sequenceNumber = event.sequenceNumber,
+                                workflowRunId = event.workflowRunId,
+                                correlationId = event.correlationId,
+                                actor = event.actor,
+                                enforcementPoint = event.enforcementPoint,
+                                decision = event.decision,
+                                policyVersion = event.policyVersion,
+                                workflowDigest = event.workflowDigest,
+                                previousEventHash = event.previousEventHash,
+                                eventHash = event.eventHash,
+                                timestamp = event.timestamp.toString(),
+                                reasonCode = event.reasonCode,
+                                metadata = event.metadata,
+                            ),
+                        )
+                    val encrypted = payloadCodec.encode(payloadJson)
+                    val nowOdt = OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC)
 
-                // Insert the audit event
-                insertEvent(conn, event, encrypted, nowOdt)
+                    // Insert the audit event
+                    insertEvent(conn, event, encrypted, nowOdt)
 
-                // Update the stream head
-                updateHead(conn, auditStreamId, event, nowOdt)
+                    // Update the stream head
+                    updateHead(conn, auditStreamId, event, nowOdt)
 
-                conn.commit()
-                return event
-            } catch (e: Exception) {
-                if (e is CancellationException) {
+                    conn.commit()
+                    event
+                } catch (e: Exception) {
+                    if (e is CancellationException) {
+                        primaryFailure = e
+                        rollbackSuppressing(conn, e)
+                        throw e
+                    }
                     primaryFailure = e
                     rollbackSuppressing(conn, e)
                     throw e
+                } finally {
+                    restoreAutoCommitSuppressing(conn, previousAutoCommit, primaryFailure)
                 }
-                primaryFailure = e
-                rollbackSuppressing(conn, e)
-                throw e
-            } finally {
-                restoreAutoCommitSuppressing(conn, previousAutoCommit, primaryFailure)
             }
         }
-    }
 
     /**
      * Deliberately non-suspend helper (the #267 cleanup model): rolls back,
@@ -176,7 +178,10 @@ class JdbcAuditStore(
      * never mask the primary exception or cancellation. Runs for
      * cancellations too — a cancelled append leaves no partial stream head.
      */
-    private fun rollbackSuppressing(conn: Connection, primary: Exception) {
+    private fun rollbackSuppressing(
+        conn: Connection,
+        primary: Exception,
+    ) {
         try {
             conn.rollback()
         } catch (rollbackFailure: Exception) {
@@ -206,57 +211,60 @@ class JdbcAuditStore(
         }
     }
 
-    override suspend fun readStream(auditStreamId: String): List<AuditEvent> {
-        require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
+    override suspend fun readStream(auditStreamId: String): List<AuditEvent> =
+        withSafeJdbc({ "Database operation failed for audit stream: $auditStreamId" }) {
+            require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
 
-        dataSource.connection.use { conn ->
-            val events = readAllEvents(conn, auditStreamId)
-            if (events.isEmpty()) return emptyList()
+            dataSource.connection.use { conn ->
+                val events = readAllEvents(conn, auditStreamId)
+                if (events.isEmpty()) return@use emptyList()
 
-            // Full chain validation
-            validateChain(auditStreamId, events)
+                // Full chain validation
+                validateChain(auditStreamId, events)
 
-            return events.map { immutableCopy(it) }
+                events.map { immutableCopy(it) }
+            }
         }
-    }
 
     override suspend fun readStreamPage(
         auditStreamId: String,
         afterSequenceNumber: Long?,
         limit: Int,
-    ): List<AuditEvent> {
-        require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
-        require(limit > 0) { "audit-store-invalid-limit" }
-        require(afterSequenceNumber == null || afterSequenceNumber >= 0) {
-            "audit-store-invalid-cursor"
-        }
-
-        dataSource.connection.use { conn ->
-            val events = readEventPage(conn, auditStreamId, afterSequenceNumber, limit)
-            if (events.isEmpty()) return emptyList()
-
-            // Page-level validation: local invariants + chain continuity within page
-            validatePage(auditStreamId, events)
-
-            return events.map { immutableCopy(it) }
-        }
-    }
-
-    override suspend fun latestEvent(auditStreamId: String): AuditEvent? {
-        require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
-
-        dataSource.connection.use { conn ->
-            val latest = readLatestEvent(conn, auditStreamId) ?: return null
-
-            // Validate self-hash only (no full-chain scan).
-            // Full chain validation is the responsibility of readStream().
-            require(latest.eventHash == latest.copy(eventHash = "").calculateHash()) {
-                "audit-event-hash-mismatch"
+    ): List<AuditEvent> =
+        withSafeJdbc({ "Database operation failed for audit stream: $auditStreamId" }) {
+            require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
+            require(limit > 0) { "audit-store-invalid-limit" }
+            require(afterSequenceNumber == null || afterSequenceNumber >= 0) {
+                "audit-store-invalid-cursor"
             }
 
-            return immutableCopy(latest)
+            dataSource.connection.use { conn ->
+                val events = readEventPage(conn, auditStreamId, afterSequenceNumber, limit)
+                if (events.isEmpty()) return@use emptyList()
+
+                // Page-level validation: local invariants + chain continuity within page
+                validatePage(auditStreamId, events)
+
+                events.map { immutableCopy(it) }
+            }
         }
-    }
+
+    override suspend fun latestEvent(auditStreamId: String): AuditEvent? =
+        withSafeJdbc({ "Database operation failed for audit stream: $auditStreamId" }) {
+            require(auditStreamId.isNotBlank()) { "audit-store-invalid-stream-id" }
+
+            dataSource.connection.use { conn ->
+                val latest = readLatestEvent(conn, auditStreamId) ?: return@use null
+
+                // Validate self-hash only (no full-chain scan).
+                // Full chain validation is the responsibility of readStream().
+                require(latest.eventHash == latest.copy(eventHash = "").calculateHash()) {
+                    "audit-event-hash-mismatch"
+                }
+
+                immutableCopy(latest)
+            }
+        }
 
     // ── Internal data types ──────────────────────────────────────────
 
@@ -289,57 +297,63 @@ class JdbcAuditStore(
         val metadata: Map<String, String> = emptyMap(),
     )
 
-    private fun AuditEvent.toPersistedV1(): PersistedAuditEventV1 = PersistedAuditEventV1(
-        schemaVersion = schemaVersion,
-        hashAlgorithm = hashAlgorithm.wireName,
-        auditStreamId = auditStreamId,
-        eventId = eventId,
-        sequenceNumber = sequenceNumber,
-        workflowRunId = workflowRunId,
-        correlationId = correlationId,
-        actor = actor,
-        enforcementPoint = enforcementPoint,
-        decision = decision,
-        policyVersion = policyVersion,
-        workflowDigest = workflowDigest,
-        previousEventHash = previousEventHash,
-        eventHash = eventHash,
-        timestamp = timestamp.toString(),
-        reasonCode = reasonCode,
-        metadata = metadata,
-    )
+    private fun AuditEvent.toPersistedV1(): PersistedAuditEventV1 =
+        PersistedAuditEventV1(
+            schemaVersion = schemaVersion,
+            hashAlgorithm = hashAlgorithm.wireName,
+            auditStreamId = auditStreamId,
+            eventId = eventId,
+            sequenceNumber = sequenceNumber,
+            workflowRunId = workflowRunId,
+            correlationId = correlationId,
+            actor = actor,
+            enforcementPoint = enforcementPoint,
+            decision = decision,
+            policyVersion = policyVersion,
+            workflowDigest = workflowDigest,
+            previousEventHash = previousEventHash,
+            eventHash = eventHash,
+            timestamp = timestamp.toString(),
+            reasonCode = reasonCode,
+            metadata = metadata,
+        )
 
-    private fun PersistedAuditEventV1.toDomain(): AuditEvent = AuditEvent(
-        schemaVersion = schemaVersion,
-        hashAlgorithm = AuditHashAlgorithm.entries.first { it.wireName == hashAlgorithm },
-        auditStreamId = auditStreamId,
-        eventId = eventId,
-        sequenceNumber = sequenceNumber,
-        workflowRunId = workflowRunId,
-        correlationId = correlationId,
-        actor = actor,
-        enforcementPoint = enforcementPoint,
-        decision = decision,
-        policyVersion = policyVersion,
-        workflowDigest = workflowDigest,
-        previousEventHash = previousEventHash,
-        eventHash = eventHash,
-        timestamp = Instant.parse(timestamp),
-        reasonCode = reasonCode,
-        metadata = metadata,
-    )
+    private fun PersistedAuditEventV1.toDomain(): AuditEvent =
+        AuditEvent(
+            schemaVersion = schemaVersion,
+            hashAlgorithm = AuditHashAlgorithm.entries.first { it.wireName == hashAlgorithm },
+            auditStreamId = auditStreamId,
+            eventId = eventId,
+            sequenceNumber = sequenceNumber,
+            workflowRunId = workflowRunId,
+            correlationId = correlationId,
+            actor = actor,
+            enforcementPoint = enforcementPoint,
+            decision = decision,
+            policyVersion = policyVersion,
+            workflowDigest = workflowDigest,
+            previousEventHash = previousEventHash,
+            eventHash = eventHash,
+            timestamp = Instant.parse(timestamp),
+            reasonCode = reasonCode,
+            metadata = metadata,
+        )
 
     // ── Stream head operations ───────────────────────────────────────
 
     /**
      * Ensures a stream head row exists. Idempotent — uses INSERT ... ON CONFLICT DO NOTHING.
      */
-    private fun ensureStreamHead(conn: Connection, auditStreamId: String) {
-        val sql = """
+    private fun ensureStreamHead(
+        conn: Connection,
+        auditStreamId: String,
+    ) {
+        val sql =
+            """
             INSERT INTO audit_stream_heads (stream_id, latest_sequence, updated_at)
             VALUES (?, 0, NOW())
             ON CONFLICT (stream_id) DO NOTHING
-        """.trimIndent()
+            """.trimIndent()
         conn.prepareStatement(sql).use { stmt ->
             stmt.setString(1, auditStreamId)
             stmt.executeUpdate()
@@ -349,13 +363,17 @@ class JdbcAuditStore(
     /**
      * Selects the stream head row with FOR UPDATE — acquires the stream-level lock.
      */
-    private fun selectHeadForUpdate(conn: Connection, auditStreamId: String): StreamHead {
-        val sql = """
+    private fun selectHeadForUpdate(
+        conn: Connection,
+        auditStreamId: String,
+    ): StreamHead {
+        val sql =
+            """
             SELECT stream_id, latest_sequence, latest_event_id, latest_event_hash, updated_at
             FROM audit_stream_heads
             WHERE stream_id = ?
             FOR UPDATE
-        """.trimIndent()
+            """.trimIndent()
         conn.prepareStatement(sql).use { stmt ->
             stmt.setString(1, auditStreamId)
             stmt.executeQuery().use { rs ->
@@ -368,13 +386,14 @@ class JdbcAuditStore(
         }
     }
 
-    private fun mapHeadRow(rs: ResultSet): StreamHead = StreamHead(
-        streamId = rs.getString("stream_id"),
-        latestSequence = rs.getLong("latest_sequence"),
-        latestEventId = rs.getString("latest_event_id"),
-        latestEventHash = rs.getString("latest_event_hash"),
-        updatedAt = rs.getObject("updated_at", OffsetDateTime::class.java),
-    )
+    private fun mapHeadRow(rs: ResultSet): StreamHead =
+        StreamHead(
+            streamId = rs.getString("stream_id"),
+            latestSequence = rs.getLong("latest_sequence"),
+            latestEventId = rs.getString("latest_event_id"),
+            latestEventHash = rs.getString("latest_event_hash"),
+            updatedAt = rs.getObject("updated_at", OffsetDateTime::class.java),
+        )
 
     /**
      * Updates the stream head after a successful event append.
@@ -385,14 +404,15 @@ class JdbcAuditStore(
         event: AuditEvent,
         nowOdt: OffsetDateTime,
     ) {
-        val sql = """
+        val sql =
+            """
             UPDATE audit_stream_heads
             SET latest_sequence = ?,
                 latest_event_id = ?,
                 latest_event_hash = ?,
                 updated_at = ?
             WHERE stream_id = ?
-        """.trimIndent()
+            """.trimIndent()
         conn.prepareStatement(sql).use { stmt ->
             stmt.setLong(1, event.sequenceNumber)
             stmt.setString(2, event.eventId)
@@ -434,7 +454,10 @@ class JdbcAuditStore(
      * stream binding, schema version, sequence ordering, hash chain continuity,
      * and self-hash correctness. Also checks for duplicate event IDs.
      */
-    private fun validateChain(expectedAuditStreamId: String, events: List<AuditEvent>) {
+    private fun validateChain(
+        expectedAuditStreamId: String,
+        events: List<AuditEvent>,
+    ) {
         val seenEventIds = mutableSetOf<String>()
         var previousEvent: AuditEvent? = null
         for (event in events) {
@@ -465,7 +488,10 @@ class JdbcAuditStore(
      * version, sequence ordering, self-hash) and chain continuity within the page.
      * Full-chain validation is deferred to [readStream].
      */
-    private fun validatePage(expectedAuditStreamId: String, events: List<AuditEvent>) {
+    private fun validatePage(
+        expectedAuditStreamId: String,
+        events: List<AuditEvent>,
+    ) {
         var previousEvent: AuditEvent? = null
         for (event in events) {
             require(event.auditStreamId == expectedAuditStreamId) { "audit-stream-id-mismatch" }
@@ -498,7 +524,8 @@ class JdbcAuditStore(
         encrypted: JdbcEncryptedAuditPayload,
         nowOdt: OffsetDateTime,
     ) {
-        val sql = """
+        val sql =
+            """
             INSERT INTO audit_events (
                 stream_id, sequence_number, event_id, event_type, event_hash,
                 previous_event_hash, occurred_at, sanitized_actor,
@@ -510,7 +537,7 @@ class JdbcAuditStore(
                 ?, ?, ?,
                 ?, ?, ?
             )
-        """.trimIndent()
+            """.trimIndent()
         conn.prepareStatement(sql).use { stmt ->
             stmt.setString(1, event.auditStreamId)
             stmt.setLong(2, event.sequenceNumber)
@@ -555,8 +582,9 @@ class JdbcAuditStore(
             return null
         }
 
-        val latest = readEventBySequence(conn, auditStreamId, head.latestSequence)
-            ?: throw IllegalStateException("audit-stream-head-latest-event-missing")
+        val latest =
+            readEventBySequence(conn, auditStreamId, head.latestSequence)
+                ?: throw IllegalStateException("audit-stream-head-latest-event-missing")
 
         require(latest.eventId == head.latestEventId) {
             "audit-stream-head-event-id-mismatch"
@@ -568,8 +596,12 @@ class JdbcAuditStore(
         return latest
     }
 
-    private fun readAllEvents(conn: Connection, auditStreamId: String): List<AuditEvent> {
-        val sql = """
+    private fun readAllEvents(
+        conn: Connection,
+        auditStreamId: String,
+    ): List<AuditEvent> {
+        val sql =
+            """
             SELECT stream_id, sequence_number, event_id, event_type, event_hash,
                    previous_event_hash, occurred_at, sanitized_actor,
                    encrypted_payload, encryption_key_id, encryption_algorithm,
@@ -577,7 +609,7 @@ class JdbcAuditStore(
             FROM audit_events
             WHERE stream_id = ?
             ORDER BY sequence_number ASC
-        """.trimIndent()
+            """.trimIndent()
         conn.prepareStatement(sql).use { stmt ->
             stmt.setString(1, auditStreamId)
             stmt.executeQuery().use { rs ->
@@ -597,7 +629,8 @@ class JdbcAuditStore(
         limit: Int,
     ): List<AuditEvent> {
         val cappedLimit = minOf(limit, maxPageSize)
-        val sql = """
+        val sql =
+            """
             SELECT stream_id, sequence_number, event_id, event_type, event_hash,
                    previous_event_hash, occurred_at, sanitized_actor,
                    encrypted_payload, encryption_key_id, encryption_algorithm,
@@ -607,7 +640,7 @@ class JdbcAuditStore(
               AND (? IS NULL OR sequence_number > ?)
             ORDER BY sequence_number ASC
             LIMIT ?
-        """.trimIndent()
+            """.trimIndent()
         conn.prepareStatement(sql).use { stmt ->
             stmt.setString(1, auditStreamId)
             if (afterSequenceNumber != null) {
@@ -633,14 +666,15 @@ class JdbcAuditStore(
         auditStreamId: String,
         sequenceNumber: Long,
     ): AuditEvent? {
-        val sql = """
+        val sql =
+            """
             SELECT stream_id, sequence_number, event_id, event_type, event_hash,
                    previous_event_hash, occurred_at, sanitized_actor,
                    encrypted_payload, encryption_key_id, encryption_algorithm,
                    encryption_nonce, payload_digest, schema_version
             FROM audit_events
             WHERE stream_id = ? AND sequence_number = ?
-        """.trimIndent()
+            """.trimIndent()
         conn.prepareStatement(sql).use { stmt ->
             stmt.setString(1, auditStreamId)
             stmt.setLong(2, sequenceNumber)
@@ -651,8 +685,12 @@ class JdbcAuditStore(
         }
     }
 
-    private fun readLatestEvent(conn: Connection, auditStreamId: String): AuditEvent? {
-        val sql = """
+    private fun readLatestEvent(
+        conn: Connection,
+        auditStreamId: String,
+    ): AuditEvent? {
+        val sql =
+            """
             SELECT stream_id, sequence_number, event_id, event_type, event_hash,
                    previous_event_hash, occurred_at, sanitized_actor,
                    encrypted_payload, encryption_key_id, encryption_algorithm,
@@ -661,7 +699,7 @@ class JdbcAuditStore(
             WHERE stream_id = ?
             ORDER BY sequence_number DESC
             LIMIT 1
-        """.trimIndent()
+            """.trimIndent()
         conn.prepareStatement(sql).use { stmt ->
             stmt.setString(1, auditStreamId)
             stmt.executeQuery().use { rs ->
@@ -672,28 +710,36 @@ class JdbcAuditStore(
     }
 
     private fun mapEventRow(rs: ResultSet): AuditEvent {
-        val encrypted = JdbcEncryptedAuditPayload(
-            ciphertext = rs.getBytes("encrypted_payload")
-                ?: throw IllegalStateException("audit-event-corrupted: encrypted_payload is null"),
-            keyId = rs.getString("encryption_key_id")
-                ?: throw IllegalStateException("audit-event-corrupted: encryption_key_id is null"),
-            algorithm = rs.getString("encryption_algorithm")
-                ?: throw IllegalStateException("audit-event-corrupted: encryption_algorithm is null"),
-            nonce = rs.getBytes("encryption_nonce")
-                ?: throw IllegalStateException("audit-event-corrupted: encryption_nonce is null"),
-            payloadDigest = rs.getString("payload_digest")
-                ?: throw IllegalStateException("audit-event-corrupted: payload_digest is null"),
-        )
-        val plaintext = try {
-            payloadCodec.decode(encrypted)
-        } catch (e: Exception) {
-            throw IllegalStateException("audit-event-decryption-failed", e)
-        }
-        val persisted: PersistedAuditEventV1 = try {
-            mapper.readValue(plaintext)
-        } catch (e: Exception) {
-            throw IllegalStateException("audit-event-deserialization-failed", e)
-        }
+        val encrypted =
+            JdbcEncryptedAuditPayload(
+                ciphertext =
+                    rs.getBytes("encrypted_payload")
+                        ?: throw IllegalStateException("audit-event-corrupted: encrypted_payload is null"),
+                keyId =
+                    rs.getString("encryption_key_id")
+                        ?: throw IllegalStateException("audit-event-corrupted: encryption_key_id is null"),
+                algorithm =
+                    rs.getString("encryption_algorithm")
+                        ?: throw IllegalStateException("audit-event-corrupted: encryption_algorithm is null"),
+                nonce =
+                    rs.getBytes("encryption_nonce")
+                        ?: throw IllegalStateException("audit-event-corrupted: encryption_nonce is null"),
+                payloadDigest =
+                    rs.getString("payload_digest")
+                        ?: throw IllegalStateException("audit-event-corrupted: payload_digest is null"),
+            )
+        val plaintext =
+            try {
+                payloadCodec.decode(encrypted)
+            } catch (e: Exception) {
+                throw IllegalStateException("audit-event-decryption-failed", e)
+            }
+        val persisted: PersistedAuditEventV1 =
+            try {
+                mapper.readValue(plaintext)
+            } catch (e: Exception) {
+                throw IllegalStateException("audit-event-deserialization-failed", e)
+            }
         val domainEvent = persisted.toDomain()
         require(domainEvent.auditStreamId == rs.getString("stream_id")) {
             "audit-stream-id-mismatch"

--- a/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcSafeOperation.kt
+++ b/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcSafeOperation.kt
@@ -1,0 +1,43 @@
+@file:Suppress("TooGenericExceptionCaught", "InstanceOfCheckForException")
+
+package dev.tramai.persistence.jdbc
+
+import dev.tramai.core.coroutines.rethrowIfCancellation
+import dev.tramai.core.exception.ApprovalContinuationStoreException
+import dev.tramai.core.exception.ApprovalStoreException
+import dev.tramai.core.exception.TramaiException
+import java.sql.SQLException
+import java.util.concurrent.CancellationException
+
+/**
+ * Executes a JDBC store block and ensures unexpected database errors / SQL exceptions
+ * do not leak raw SQL queries, table structures, connection strings, or database vendor
+ * diagnostics up the stack.
+ *
+ * Coroutine cancellation and domain-specific exceptions are preserved unchanged.
+ */
+internal inline fun <T> withSafeJdbc(
+    lazyDiagnosticMessage: () -> String,
+    block: () -> T,
+): T =
+    try {
+        block()
+    } catch (e: Throwable) {
+        if (e is CancellationException) {
+            throw e
+        }
+        e.rethrowIfCancellation()
+        when (e) {
+            is ApprovalStoreException,
+            is ApprovalContinuationStoreException,
+            is TramaiException,
+            is IllegalArgumentException,
+            -> throw e
+
+            is SQLException -> throw IllegalStateException(lazyDiagnosticMessage())
+
+            is IllegalStateException -> throw e
+
+            else -> throw IllegalStateException(lazyDiagnosticMessage())
+        }
+    }

--- a/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcSafeOperation.kt
+++ b/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcSafeOperation.kt
@@ -22,7 +22,7 @@ internal inline fun <T> withSafeJdbc(
 ): T =
     try {
         block()
-    } catch (e: Throwable) {
+    } catch (e: Exception) {
         if (e is CancellationException) {
             throw e
         }

--- a/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcSuspendedInvocationStore.kt
+++ b/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcSuspendedInvocationStore.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import dev.tramai.core.approval.Sha256Digest
+import dev.tramai.core.coroutines.rethrowIfCancellation
 import dev.tramai.core.model.Message
 import dev.tramai.core.model.MessageRole
 import dev.tramai.core.model.ToolCall
@@ -18,7 +19,6 @@ import dev.tramai.engine.SensitiveReplayEnvelope
 import dev.tramai.engine.SuspendedInvocationMetadata
 import dev.tramai.engine.SuspendedInvocationStore
 import dev.tramai.engine.TokenBudgetSnapshot
-import dev.tramai.core.coroutines.rethrowIfCancellation
 import java.sql.ResultSet
 import java.sql.SQLException
 import java.time.Clock
@@ -69,7 +69,6 @@ class JdbcSuspendedInvocationStore(
     private val replayEnvelopeCodec: JdbcReplayEnvelopeCodec,
     private val clock: Clock = Clock.systemUTC(),
 ) : SuspendedInvocationStore {
-
     /**
      * Plain ObjectMapper for JSONB-safe metadata serialization (toolSecurity).
      * No default typing — only used for safe primitive/String fields.
@@ -78,32 +77,35 @@ class JdbcSuspendedInvocationStore(
         private const val REDACTED_APPROVAL_CONTINUATION_ARGUMENTS =
             "__redacted_approval_continuation_args__"
 
-        private val mapper: ObjectMapper = ObjectMapper()
-            .registerKotlinModule()
-            .registerModule(JavaTimeModule())
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        private val mapper: ObjectMapper =
+            ObjectMapper()
+                .registerKotlinModule()
+                .registerModule(JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
     }
 
     override suspend fun create(
         metadata: SuspendedInvocationMetadata,
         replayEnvelope: SensitiveReplayEnvelope,
-    ) {
-        validateCreateInput(metadata)
-        val payloadJson = buildCreatePayload(metadata, replayEnvelope)
-        val encrypted = replayEnvelopeCodec.encode(payloadJson)
-        val now = OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC)
+    ): Unit =
+        withSafeJdbc({ "Database operation failed for suspended invocation: ${metadata.approvalId}" }) {
+            validateCreateInput(metadata)
+            val payloadJson = buildCreatePayload(metadata, replayEnvelope)
+            val encrypted = replayEnvelopeCodec.encode(payloadJson)
+            val now = OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC)
 
-        dataSource.connection.use { conn ->
-            insertSuspendedInvocation(conn, metadata, encrypted, now)
+            dataSource.connection.use { conn ->
+                insertSuspendedInvocation(conn, metadata, encrypted, now)
+            }
         }
-    }
 
-    override suspend fun get(approvalId: String): SuspendedInvocationMetadata? {
-        validateIdField(approvalId, "approvalId")
+    override suspend fun get(approvalId: String): SuspendedInvocationMetadata? =
+        withSafeJdbc({ "Database operation failed for suspended invocation: $approvalId" }) {
+            validateIdField(approvalId, "approvalId")
 
-        val row = readCurrent(approvalId) ?: return null
-        return row.metadata.toDomain()
-    }
+            val row = readCurrent(approvalId) ?: return@withSafeJdbc null
+            row.metadata.toDomain()
+        }
 
     /**
      * Validates non-sensitive create fields before any replay payload is serialized.
@@ -127,10 +129,11 @@ class JdbcSuspendedInvocationStore(
         val messages = replayEnvelope.revealForResume().messages
         validateReplayEnvelopeInvariants(metadata, messages)
         validateReplayEnvelopeDigest(metadata, messages)
-        val payload = Payload(
-            metadata = PayloadMetadata.fromDomain(metadata),
-            persistedMessages = messages.map { toPersisted(it) },
-        )
+        val payload =
+            Payload(
+                metadata = PayloadMetadata.fromDomain(metadata),
+                persistedMessages = messages.map { toPersisted(it) },
+            )
         return mapper.writeValueAsBytes(payload)
     }
 
@@ -156,7 +159,8 @@ class JdbcSuspendedInvocationStore(
         encrypted: JdbcEncryptedReplayEnvelope,
         now: OffsetDateTime,
     ) {
-        val sql = """
+        val sql =
+            """
             INSERT INTO suspended_invocations (
                 invocation_id, status, service_key, operation_key, descriptor_hash,
                 replay_envelope_digest, encrypted_replay_envelope,
@@ -168,7 +172,7 @@ class JdbcSuspendedInvocationStore(
                 ?, ?, ?, ?,
                 1, ?
             )
-        """.trimIndent()
+            """.trimIndent()
         conn.prepareStatement(sql).use { stmt ->
             stmt.setString(1, metadata.approvalId)
             stmt.setString(2, metadata.operationReference.serviceInterface)
@@ -214,62 +218,66 @@ class JdbcSuspendedInvocationStore(
         throw IllegalArgumentException("suspended-invocation-replay-envelope-digest-already-exists")
     }
 
-    override suspend fun revealReplayEnvelope(approvalId: String): SensitiveReplayEnvelope? {
-        validateIdField(approvalId, "approvalId")
+    override suspend fun revealReplayEnvelope(approvalId: String): SensitiveReplayEnvelope? =
+        withSafeJdbc({ "Database operation failed for suspended invocation: $approvalId" }) {
+            validateIdField(approvalId, "approvalId")
 
-        val row = readCurrent(approvalId) ?: return null
-        return SensitiveReplayEnvelope.of(row.messages)
-    }
+            val row = readCurrent(approvalId) ?: return@withSafeJdbc null
+            SensitiveReplayEnvelope.of(row.messages)
+        }
 
-    override suspend fun remove(approvalId: String): SuspendedInvocationMetadata? {
-        validateIdField(approvalId, "approvalId")
+    override suspend fun remove(approvalId: String): SuspendedInvocationMetadata? =
+        withSafeJdbc({ "Database operation failed for suspended invocation: $approvalId" }) {
+            validateIdField(approvalId, "approvalId")
 
-        // Read + delete inside one explicit transaction with row lock
-        dataSource.connection.use { conn ->
-            val previousAutoCommit = conn.autoCommit
-            conn.autoCommit = false
-            try {
-                val sql = """
-                    SELECT encrypted_replay_envelope, encryption_key_id, encryption_algorithm,
-                           encryption_nonce, payload_digest, version
-                    FROM suspended_invocations
-                    WHERE invocation_id = ?
-                    FOR UPDATE
-                """.trimIndent()
-                val row = conn.prepareStatement(sql).use { stmt ->
-                    stmt.setString(1, approvalId)
-                    stmt.executeQuery().use { rs ->
-                        if (!rs.next()) {
-                            conn.rollback()
-                            return@remove null
-                        }
+            // Read + delete inside one explicit transaction with row lock
+            dataSource.connection.use { conn ->
+                val previousAutoCommit = conn.autoCommit
+                conn.autoCommit = false
+                try {
+                    val sql =
+                        """
+                        SELECT encrypted_replay_envelope, encryption_key_id, encryption_algorithm,
+                               encryption_nonce, payload_digest, version
+                        FROM suspended_invocations
+                        WHERE invocation_id = ?
+                        FOR UPDATE
+                        """.trimIndent()
+                    val row =
+                        conn.prepareStatement(sql).use { stmt ->
+                            stmt.setString(1, approvalId)
+                            stmt.executeQuery().use { rs ->
+                                if (!rs.next()) {
+                                    conn.rollback()
+                                    return@use null
+                                }
 
-                        val encrypted = readEncryptedFromRow(rs)
-                        val v = rs.getLong("version")
-                        val payload = decryptAndDeserialize(encrypted)
-                        val domainMessages = payload.persistedMessages.map { toDomainMessage(it) }
-                        Triple(encrypted, v, PayloadWithDomainMessages(payload.metadata, domainMessages))
+                                val encrypted = readEncryptedFromRow(rs)
+                                val v = rs.getLong("version")
+                                val payload = decryptAndDeserialize(encrypted)
+                                val domainMessages = payload.persistedMessages.map { toDomainMessage(it) }
+                                Triple(encrypted, v, PayloadWithDomainMessages(payload.metadata, domainMessages))
+                            }
+                        } ?: return@use null
+                    val (_, _, payloadWithMessages) = row
+
+                    val deleteSql = "DELETE FROM suspended_invocations WHERE invocation_id = ?"
+                    conn.prepareStatement(deleteSql).use { stmt ->
+                        stmt.setString(1, approvalId)
+                        stmt.executeUpdate()
                     }
-                }
-                val (_, _, payloadWithMessages) = row
 
-                val deleteSql = "DELETE FROM suspended_invocations WHERE invocation_id = ?"
-                conn.prepareStatement(deleteSql).use { stmt ->
-                    stmt.setString(1, approvalId)
-                    stmt.executeUpdate()
+                    conn.commit()
+                    payloadWithMessages.metadata.toDomain()
+                } catch (e: Exception) {
+                    conn.rollback()
+                    e.rethrowIfCancellation()
+                    throw e
+                } finally {
+                    conn.autoCommit = previousAutoCommit
                 }
-
-                conn.commit()
-                return payloadWithMessages.metadata.toDomain()
-            } catch (e: Exception) {
-                conn.rollback()
-                e.rethrowIfCancellation()
-                throw e
-            } finally {
-                conn.autoCommit = previousAutoCommit
             }
         }
-    }
 
     // ── Internal helpers ──────────────────────────────────────────
 
@@ -294,11 +302,12 @@ class JdbcSuspendedInvocationStore(
         require(metadata.historySize >= 0) { "suspended-replay-envelope-history-size-negative" }
         require(messages.size > metadata.historySize) { "suspended-replay-envelope-history-size-mismatch" }
 
-        val allSlots = messages.flatMapIndexed { messageIndex, message ->
-            message.toolCalls.orEmpty().mapIndexed { toolCallIndex, call ->
-                ReplayToolCallSlot(messageIndex, toolCallIndex, call)
+        val allSlots =
+            messages.flatMapIndexed { messageIndex, message ->
+                message.toolCalls.orEmpty().mapIndexed { toolCallIndex, call ->
+                    ReplayToolCallSlot(messageIndex, toolCallIndex, call)
+                }
             }
-        }
         val matchingSlots = allSlots.filter { it.call.id == metadata.toolCallId }
         require(matchingSlots.size == 1) { "suspended-replay-envelope-tool-call-id-mismatch" }
         val selectedSlot = matchingSlots.single()
@@ -311,17 +320,19 @@ class JdbcSuspendedInvocationStore(
             "suspended-replay-envelope-tool-call-name-mismatch"
         }
 
-        val latestAssistantIdx = messages.indexOfLast {
-            it.role == MessageRole.ASSISTANT && !it.toolCalls.isNullOrEmpty()
-        }
+        val latestAssistantIdx =
+            messages.indexOfLast {
+                it.role == MessageRole.ASSISTANT && !it.toolCalls.isNullOrEmpty()
+            }
         require(latestAssistantIdx >= 0) { "suspended-replay-envelope-assistant-batch-not-found" }
         require(selectedSlot.messageIndex == latestAssistantIdx) {
             "suspended-replay-envelope-tool-call-slot-mismatch"
         }
 
-        val sentinelSlots = allSlots.filter {
-            it.call.argumentsJson == REDACTED_APPROVAL_CONTINUATION_ARGUMENTS
-        }
+        val sentinelSlots =
+            allSlots.filter {
+                it.call.argumentsJson == REDACTED_APPROVAL_CONTINUATION_ARGUMENTS
+            }
         require(sentinelSlots.size == 1) { "suspended-replay-envelope-redaction-count-mismatch" }
         val sentinelSlot = sentinelSlots.single()
         require(
@@ -356,7 +367,10 @@ class JdbcSuspendedInvocationStore(
      * Checks whether a row with the given [approvalId] exists in the table.
      * Uses the same connection to stay within the existing transaction context.
      */
-    private fun invocationExists(conn: java.sql.Connection, approvalId: String): Boolean {
+    private fun invocationExists(
+        conn: java.sql.Connection,
+        approvalId: String,
+    ): Boolean {
         val sql = "SELECT 1 FROM suspended_invocations WHERE invocation_id = ?"
         conn.prepareStatement(sql).use { stmt ->
             stmt.setString(1, approvalId)
@@ -373,12 +387,13 @@ class JdbcSuspendedInvocationStore(
      */
     private fun readCurrent(approvalId: String): DecryptedRow? {
         dataSource.connection.use { conn ->
-            val sql = """
+            val sql =
+                """
                 SELECT encrypted_replay_envelope, encryption_key_id, encryption_algorithm,
                        encryption_nonce, payload_digest, version
                 FROM suspended_invocations
                 WHERE invocation_id = ?
-            """.trimIndent()
+                """.trimIndent()
             conn.prepareStatement(sql).use { stmt ->
                 stmt.setString(1, approvalId)
                 stmt.executeQuery().use { rs ->
@@ -405,16 +420,21 @@ class JdbcSuspendedInvocationStore(
     )
 
     private fun readEncryptedFromRow(rs: ResultSet): JdbcEncryptedReplayEnvelope {
-        val ciphertext = rs.getBytes("encrypted_replay_envelope")
-            ?: throw IllegalStateException("suspended-invocation-corrupted: encrypted_replay_envelope is null")
-        val keyId = rs.getString("encryption_key_id")
-            ?: throw IllegalStateException("suspended-invocation-corrupted: encryption_key_id is null")
-        val algorithm = rs.getString("encryption_algorithm")
-            ?: throw IllegalStateException("suspended-invocation-corrupted: encryption_algorithm is null")
-        val nonce = rs.getBytes("encryption_nonce")
-            ?: throw IllegalStateException("suspended-invocation-corrupted: encryption_nonce is null")
-        val payloadDigest = rs.getString("payload_digest")
-            ?: throw IllegalStateException("suspended-invocation-corrupted: payload_digest is null")
+        val ciphertext =
+            rs.getBytes("encrypted_replay_envelope")
+                ?: throw IllegalStateException("suspended-invocation-corrupted: encrypted_replay_envelope is null")
+        val keyId =
+            rs.getString("encryption_key_id")
+                ?: throw IllegalStateException("suspended-invocation-corrupted: encryption_key_id is null")
+        val algorithm =
+            rs.getString("encryption_algorithm")
+                ?: throw IllegalStateException("suspended-invocation-corrupted: encryption_algorithm is null")
+        val nonce =
+            rs.getBytes("encryption_nonce")
+                ?: throw IllegalStateException("suspended-invocation-corrupted: encryption_nonce is null")
+        val payloadDigest =
+            rs.getString("payload_digest")
+                ?: throw IllegalStateException("suspended-invocation-corrupted: payload_digest is null")
 
         return JdbcEncryptedReplayEnvelope(
             ciphertext = ciphertext,
@@ -426,11 +446,12 @@ class JdbcSuspendedInvocationStore(
     }
 
     private fun decryptAndDeserialize(encrypted: JdbcEncryptedReplayEnvelope): Payload {
-        val plaintext = try {
-            replayEnvelopeCodec.decode(encrypted)
-        } catch (e: Exception) {
-            throw IllegalStateException("suspended-invocation-decryption-failed", e)
-        }
+        val plaintext =
+            try {
+                replayEnvelopeCodec.decode(encrypted)
+            } catch (e: Exception) {
+                throw IllegalStateException("suspended-invocation-decryption-failed", e)
+            }
 
         return try {
             mapper.readValue(plaintext)
@@ -439,7 +460,10 @@ class JdbcSuspendedInvocationStore(
         }
     }
 
-    private fun validateIdField(value: String, fieldName: String) {
+    private fun validateIdField(
+        value: String,
+        fieldName: String,
+    ) {
         require(value.isNotBlank()) { "$fieldName must not be blank" }
         require(value.none { it.isISOControl() }) { "$fieldName must not contain control characters" }
         require(value.length <= 256) { "$fieldName exceeds maximum length of 256" }
@@ -459,17 +483,19 @@ class JdbcSuspendedInvocationStore(
         val messages: List<Message>,
     )
 
-    private fun toDomainMessage(pm: PersistedMessage): Message = Message(
-        role = MessageRole.valueOf(pm.role),
-        content = pm.content,
-        toolCalls = pm.toolCalls?.map { toDomainToolCall(it) },
-    )
+    private fun toDomainMessage(pm: PersistedMessage): Message =
+        Message(
+            role = MessageRole.valueOf(pm.role),
+            content = pm.content,
+            toolCalls = pm.toolCalls?.map { toDomainToolCall(it) },
+        )
 
-    private fun toDomainToolCall(ptc: PersistedToolCall): ToolCall = ToolCall(
-        id = ptc.id,
-        name = ptc.name,
-        argumentsJson = ptc.argumentsJson,
-    )
+    private fun toDomainToolCall(ptc: PersistedToolCall): ToolCall =
+        ToolCall(
+            id = ptc.id,
+            name = ptc.name,
+            argumentsJson = ptc.argumentsJson,
+        )
 
     /**
      * Persistable snapshot of a [Message] — no Jackson default typing needed.
@@ -489,17 +515,19 @@ class JdbcSuspendedInvocationStore(
         val argumentsJson: String,
     )
 
-    private fun toPersisted(msg: Message): PersistedMessage = PersistedMessage(
-        role = msg.role.name,
-        content = msg.content,
-        toolCalls = msg.toolCalls?.map { toPersistedToolCall(it) },
-    )
+    private fun toPersisted(msg: Message): PersistedMessage =
+        PersistedMessage(
+            role = msg.role.name,
+            content = msg.content,
+            toolCalls = msg.toolCalls?.map { toPersistedToolCall(it) },
+        )
 
-    private fun toPersistedToolCall(tc: ToolCall): PersistedToolCall = PersistedToolCall(
-        id = tc.id,
-        name = tc.name,
-        argumentsJson = tc.argumentsJson,
-    )
+    private fun toPersistedToolCall(tc: ToolCall): PersistedToolCall =
+        PersistedToolCall(
+            id = tc.id,
+            name = tc.name,
+            argumentsJson = tc.argumentsJson,
+        )
 
     // ── Internal data types for serialisation ─────────────────────
 
@@ -546,77 +574,84 @@ class JdbcSuspendedInvocationStore(
         val toolSecurity: String?,
     ) {
         companion object {
-            fun fromDomain(metadata: SuspendedInvocationMetadata): PayloadMetadata = PayloadMetadata(
-                approvalId = metadata.approvalId,
-                toolCallId = metadata.toolCallId,
-                toolName = metadata.toolName,
-                toolCallIndex = metadata.toolCallIndex,
-                correlationId = metadata.correlationId,
-                identityWorkflowRunId = metadata.identity.workflowRunId,
-                identityCorrelationId = metadata.identity.correlationId,
-                identityWorkflowDigest = metadata.identity.workflowDigest.value,
-                identityPolicyVersion = metadata.identity.policyVersion,
-                identityActorId = metadata.identity.actorId,
-                securityDataClassification = metadata.securityContext.dataClassification?.name,
-                securityClassificationSource = metadata.securityContext.classificationSource?.name,
-                operationServiceInterface = metadata.operationReference.serviceInterface,
-                operationMethodName = metadata.operationReference.methodName,
-                operationJvmMethodDescriptor = metadata.operationReference.jvmMethodDescriptor,
-                operationResumeDefinitionDigest = metadata.operationReference.resumeDefinitionDigest.value,
-                replayEnvelopeDigest = metadata.replayEnvelopeDigest.value,
-                conversationId = metadata.conversationId,
-                historySize = metadata.historySize,
-                tokenBudgetTotalInputTokens = metadata.tokenBudgetSnapshot?.totalInputTokens,
-                tokenBudgetTotalOutputTokens = metadata.tokenBudgetSnapshot?.totalOutputTokens,
-                tokenBudgetTotalInputCost = metadata.tokenBudgetSnapshot?.totalInputCost,
-                tokenBudgetTotalOutputCost = metadata.tokenBudgetSnapshot?.totalOutputCost,
-                tokenBudgetWarnIfExceeded = metadata.tokenBudgetSnapshot?.warnIfExceeded,
-                toolReferenceName = metadata.toolReference.toolName,
-                toolReferenceDeclarationDigest = metadata.toolReference.declarationDigest.value,
-                toolSecurity = metadata.toolSecurity?.let { mapper.writeValueAsString(it) },
-            )
+            fun fromDomain(metadata: SuspendedInvocationMetadata): PayloadMetadata =
+                PayloadMetadata(
+                    approvalId = metadata.approvalId,
+                    toolCallId = metadata.toolCallId,
+                    toolName = metadata.toolName,
+                    toolCallIndex = metadata.toolCallIndex,
+                    correlationId = metadata.correlationId,
+                    identityWorkflowRunId = metadata.identity.workflowRunId,
+                    identityCorrelationId = metadata.identity.correlationId,
+                    identityWorkflowDigest = metadata.identity.workflowDigest.value,
+                    identityPolicyVersion = metadata.identity.policyVersion,
+                    identityActorId = metadata.identity.actorId,
+                    securityDataClassification = metadata.securityContext.dataClassification?.name,
+                    securityClassificationSource = metadata.securityContext.classificationSource?.name,
+                    operationServiceInterface = metadata.operationReference.serviceInterface,
+                    operationMethodName = metadata.operationReference.methodName,
+                    operationJvmMethodDescriptor = metadata.operationReference.jvmMethodDescriptor,
+                    operationResumeDefinitionDigest = metadata.operationReference.resumeDefinitionDigest.value,
+                    replayEnvelopeDigest = metadata.replayEnvelopeDigest.value,
+                    conversationId = metadata.conversationId,
+                    historySize = metadata.historySize,
+                    tokenBudgetTotalInputTokens = metadata.tokenBudgetSnapshot?.totalInputTokens,
+                    tokenBudgetTotalOutputTokens = metadata.tokenBudgetSnapshot?.totalOutputTokens,
+                    tokenBudgetTotalInputCost = metadata.tokenBudgetSnapshot?.totalInputCost,
+                    tokenBudgetTotalOutputCost = metadata.tokenBudgetSnapshot?.totalOutputCost,
+                    tokenBudgetWarnIfExceeded = metadata.tokenBudgetSnapshot?.warnIfExceeded,
+                    toolReferenceName = metadata.toolReference.toolName,
+                    toolReferenceDeclarationDigest = metadata.toolReference.declarationDigest.value,
+                    toolSecurity = metadata.toolSecurity?.let { mapper.writeValueAsString(it) },
+                )
         }
 
-        fun toDomain(): SuspendedInvocationMetadata = SuspendedInvocationMetadata(
-            approvalId = approvalId,
-            toolCallId = toolCallId,
-            toolName = toolName,
-            toolCallIndex = toolCallIndex,
-            correlationId = correlationId,
-            identity = EngineExecutionIdentity(
-                workflowRunId = identityWorkflowRunId,
-                correlationId = identityCorrelationId,
-                workflowDigest = Sha256Digest.of(identityWorkflowDigest),
-                policyVersion = identityPolicyVersion,
-                actorId = identityActorId,
-            ),
-            securityContext = ExecutionSecurityContext(
-                dataClassification = securityDataClassification?.let { enumValueOf(it) },
-                classificationSource = securityClassificationSource?.let { enumValueOf(it) },
-            ),
-            operationReference = ResumeOperationReference(
-                serviceInterface = operationServiceInterface,
-                methodName = operationMethodName,
-                jvmMethodDescriptor = operationJvmMethodDescriptor,
-                resumeDefinitionDigest = Sha256Digest.of(operationResumeDefinitionDigest),
-            ),
-            replayEnvelopeDigest = Sha256Digest.of(replayEnvelopeDigest),
-            conversationId = conversationId,
-            historySize = historySize,
-            tokenBudgetSnapshot = tokenBudgetTotalInputTokens?.let { inputTokens ->
-                TokenBudgetSnapshot(
-                    totalInputTokens = inputTokens,
-                    totalOutputTokens = tokenBudgetTotalOutputTokens ?: 0L,
-                    totalInputCost = tokenBudgetTotalInputCost ?: 0.0,
-                    totalOutputCost = tokenBudgetTotalOutputCost ?: 0.0,
-                    warnIfExceeded = tokenBudgetWarnIfExceeded ?: false,
-                )
-            },
-            toolReference = ResumeToolReference(
-                toolName = toolReferenceName,
-                declarationDigest = Sha256Digest.of(toolReferenceDeclarationDigest),
-            ),
-            toolSecurity = toolSecurity?.let { mapper.readValue(it) },
-        )
+        fun toDomain(): SuspendedInvocationMetadata =
+            SuspendedInvocationMetadata(
+                approvalId = approvalId,
+                toolCallId = toolCallId,
+                toolName = toolName,
+                toolCallIndex = toolCallIndex,
+                correlationId = correlationId,
+                identity =
+                    EngineExecutionIdentity(
+                        workflowRunId = identityWorkflowRunId,
+                        correlationId = identityCorrelationId,
+                        workflowDigest = Sha256Digest.of(identityWorkflowDigest),
+                        policyVersion = identityPolicyVersion,
+                        actorId = identityActorId,
+                    ),
+                securityContext =
+                    ExecutionSecurityContext(
+                        dataClassification = securityDataClassification?.let { enumValueOf(it) },
+                        classificationSource = securityClassificationSource?.let { enumValueOf(it) },
+                    ),
+                operationReference =
+                    ResumeOperationReference(
+                        serviceInterface = operationServiceInterface,
+                        methodName = operationMethodName,
+                        jvmMethodDescriptor = operationJvmMethodDescriptor,
+                        resumeDefinitionDigest = Sha256Digest.of(operationResumeDefinitionDigest),
+                    ),
+                replayEnvelopeDigest = Sha256Digest.of(replayEnvelopeDigest),
+                conversationId = conversationId,
+                historySize = historySize,
+                tokenBudgetSnapshot =
+                    tokenBudgetTotalInputTokens?.let { inputTokens ->
+                        TokenBudgetSnapshot(
+                            totalInputTokens = inputTokens,
+                            totalOutputTokens = tokenBudgetTotalOutputTokens ?: 0L,
+                            totalInputCost = tokenBudgetTotalInputCost ?: 0.0,
+                            totalOutputCost = tokenBudgetTotalOutputCost ?: 0.0,
+                            warnIfExceeded = tokenBudgetWarnIfExceeded ?: false,
+                        )
+                    },
+                toolReference =
+                    ResumeToolReference(
+                        toolName = toolReferenceName,
+                        declarationDigest = Sha256Digest.of(toolReferenceDeclarationDigest),
+                    ),
+                toolSecurity = toolSecurity?.let { mapper.readValue(it) },
+            )
     }
 }

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalContinuationStoreTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalContinuationStoreTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("LargeClass", "LongMethod", "MaxLineLength")
+
 package dev.tramai.persistence.jdbc
 
 import dev.tramai.core.approval.ApprovalContinuation
@@ -24,6 +26,7 @@ import java.security.MessageDigest
 import java.security.SecureRandom
 import java.sql.Connection
 import java.sql.DriverManager
+import java.sql.SQLException
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -34,66 +37,72 @@ import javax.crypto.spec.SecretKeySpec
 import javax.sql.DataSource
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class JdbcApprovalContinuationStoreTest {
-
     companion object {
         private const val POSTGRES_IMAGE = "postgres:17-alpine"
 
-        private val postgres = PostgreSQLContainer(POSTGRES_IMAGE)
-            .withDatabaseName("continuation_test")
-            .withUsername("test")
-            .withPassword("test")
+        private val postgres =
+            PostgreSQLContainer(POSTGRES_IMAGE)
+                .withDatabaseName("continuation_test")
+                .withUsername("test")
+                .withPassword("test")
 
-        private fun createDataSource(): DataSource = PGSimpleDataSource().apply {
-            setUrl(postgres.jdbcUrl)
-            user = postgres.username
-            password = postgres.password
-        }
+        private fun createDataSource(): DataSource =
+            PGSimpleDataSource().apply {
+                setUrl(postgres.jdbcUrl)
+                user = postgres.username
+                password = postgres.password
+            }
     }
 
-    private val fixedClock: Clock = Clock.fixed(
-        Instant.parse("2026-06-21T12:00:00Z"),
-        ZoneId.of("UTC"),
-    )
+    private val fixedClock: Clock =
+        Clock.fixed(
+            Instant.parse("2026-06-21T12:00:00Z"),
+            ZoneId.of("UTC"),
+        )
 
     private val testAesKey = ByteArray(16).also { SecureRandom().nextBytes(it) }
 
-    private val testCodec = object : JdbcContinuationArgumentsCodec {
-        private val ALGORITHM = "AES/GCM/NoPadding"
-        private val TAG_LENGTH = 128
+    private val testCodec =
+        object : JdbcContinuationArgumentsCodec {
+            private val ALGORITHM = "AES/GCM/NoPadding"
+            private val TAG_LENGTH = 128
 
-        override fun encode(plaintext: ByteArray): JdbcEncryptedContinuationArguments {
-            val cipher = Cipher.getInstance(ALGORITHM)
-            val nonce = ByteArray(12).also { SecureRandom().nextBytes(it) }
-            val keySpec = SecretKeySpec(testAesKey, "AES")
-            val spec = GCMParameterSpec(TAG_LENGTH, nonce)
-            cipher.init(Cipher.ENCRYPT_MODE, keySpec, spec)
-            val ciphertext = cipher.doFinal(plaintext)
-            val digest = MessageDigest.getInstance("SHA-256")
-                .digest(plaintext)
-                .joinToString("") { "%02x".format(it) }
-            return JdbcEncryptedContinuationArguments(
-                ciphertext = ciphertext,
-                keyId = "test-key-1",
-                algorithm = ALGORITHM,
-                nonce = nonce,
-                payloadDigest = "sha256:$digest",
-            )
-        }
+            override fun encode(plaintext: ByteArray): JdbcEncryptedContinuationArguments {
+                val cipher = Cipher.getInstance(ALGORITHM)
+                val nonce = ByteArray(12).also { SecureRandom().nextBytes(it) }
+                val keySpec = SecretKeySpec(testAesKey, "AES")
+                val spec = GCMParameterSpec(TAG_LENGTH, nonce)
+                cipher.init(Cipher.ENCRYPT_MODE, keySpec, spec)
+                val ciphertext = cipher.doFinal(plaintext)
+                val digest =
+                    MessageDigest
+                        .getInstance("SHA-256")
+                        .digest(plaintext)
+                        .joinToString("") { "%02x".format(it) }
+                return JdbcEncryptedContinuationArguments(
+                    ciphertext = ciphertext,
+                    keyId = "test-key-1",
+                    algorithm = ALGORITHM,
+                    nonce = nonce,
+                    payloadDigest = "sha256:$digest",
+                )
+            }
 
-        override fun decode(envelope: JdbcEncryptedContinuationArguments): ByteArray {
-            val cipher = Cipher.getInstance(ALGORITHM)
-            val keySpec = SecretKeySpec(testAesKey, "AES")
-            val spec = GCMParameterSpec(TAG_LENGTH, envelope.nonce)
-            cipher.init(Cipher.DECRYPT_MODE, keySpec, spec)
-            return cipher.doFinal(envelope.ciphertext)
+            override fun decode(envelope: JdbcEncryptedContinuationArguments): ByteArray {
+                val cipher = Cipher.getInstance(ALGORITHM)
+                val keySpec = SecretKeySpec(testAesKey, "AES")
+                val spec = GCMParameterSpec(TAG_LENGTH, envelope.nonce)
+                cipher.init(Cipher.DECRYPT_MODE, keySpec, spec)
+                return cipher.doFinal(envelope.ciphertext)
+            }
         }
-    }
 
     @BeforeAll
     fun startPostgres() {
@@ -107,19 +116,28 @@ class JdbcApprovalContinuationStoreTest {
     }
 
     private fun runMigrations() {
-        val v1Sql = javaClass.getResourceAsStream(
-            "/tramai/persistence/jdbc/postgres/V1__sovereign_persistence.sql",
-        )?.bufferedReader()?.readText()
-            ?: throw IllegalStateException("V1 migration not found")
+        val v1Sql =
+            javaClass
+                .getResourceAsStream(
+                    "/tramai/persistence/jdbc/postgres/V1__sovereign_persistence.sql",
+                )?.bufferedReader()
+                ?.readText()
+                ?: throw IllegalStateException("V1 migration not found")
 
-        val v2Sql = javaClass.getResourceAsStream(
-            "/tramai/persistence/jdbc/postgres/V2__approval_continuations.sql",
-        )?.bufferedReader()?.readText()
-            ?: throw IllegalStateException("V2 migration not found")
+        val v2Sql =
+            javaClass
+                .getResourceAsStream(
+                    "/tramai/persistence/jdbc/postgres/V2__approval_continuations.sql",
+                )?.bufferedReader()
+                ?.readText()
+                ?: throw IllegalStateException("V2 migration not found")
 
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
+        val conn: Connection =
+            DriverManager.getConnection(
+                postgres.jdbcUrl,
+                postgres.username,
+                postgres.password,
+            )
         conn.use { c ->
             c.createStatement().use { stmt -> stmt.execute(v1Sql) }
             c.createStatement().use { stmt -> stmt.execute(v2Sql) }
@@ -128,9 +146,12 @@ class JdbcApprovalContinuationStoreTest {
 
     @BeforeEach
     fun cleanTable() {
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
+        val conn: Connection =
+            DriverManager.getConnection(
+                postgres.jdbcUrl,
+                postgres.username,
+                postgres.password,
+            )
         conn.use { c ->
             c.createStatement().use { stmt ->
                 stmt.execute("DELETE FROM approval_continuations")
@@ -143,14 +164,14 @@ class JdbcApprovalContinuationStoreTest {
     private fun store(
         codec: JdbcContinuationArgumentsCodec = testCodec,
         clock: Clock = fixedClock,
-    ): JdbcApprovalContinuationStore = JdbcApprovalContinuationStore(
-        dataSource = createDataSource(),
-        argumentsCodec = codec,
-        clock = clock,
-    )
+    ): JdbcApprovalContinuationStore =
+        JdbcApprovalContinuationStore(
+            dataSource = createDataSource(),
+            argumentsCodec = codec,
+            clock = clock,
+        )
 
-    private fun makeDigest(hex: String = "a".repeat(64)): Sha256Digest =
-        Sha256Digest.of("sha256:$hex")
+    private fun makeDigest(hex: String = "a".repeat(64)): Sha256Digest = Sha256Digest.of("sha256:$hex")
 
     private fun computeArgumentsDigest(arguments: String): Sha256Digest {
         val bytes = MessageDigest.getInstance("SHA-256").digest(arguments.toByteArray(Charsets.UTF_8))
@@ -166,23 +187,24 @@ class JdbcApprovalContinuationStoreTest {
         val args = SensitiveToolArguments.of(arguments)
         val digest = computeArgumentsDigest(arguments)
         val creationTime = clock.instant()
-        val continuation = ApprovalContinuation(
-            approvalId = approvalId,
-            workflowRunId = "wf-1",
-            correlationId = "corr-1",
-            toolCallId = "tc-1",
-            toolName = "test-tool",
-            argumentsDigest = digest,
-            policyVersion = "v1",
-            workflowDigest = makeDigest("b".repeat(64)),
-            status = ApprovalContinuationStatus.PENDING,
-            createdAt = creationTime,
-            approvalExpiresAt = creationTime.plusSeconds(300),
-            claimedBy = null,
-            claimedAt = null,
-            completedAt = null,
-            version = 0L,
-        )
+        val continuation =
+            ApprovalContinuation(
+                approvalId = approvalId,
+                workflowRunId = "wf-1",
+                correlationId = "corr-1",
+                toolCallId = "tc-1",
+                toolName = "test-tool",
+                argumentsDigest = digest,
+                policyVersion = "v1",
+                workflowDigest = makeDigest("b".repeat(64)),
+                status = ApprovalContinuationStatus.PENDING,
+                createdAt = creationTime,
+                approvalExpiresAt = creationTime.plusSeconds(300),
+                claimedBy = null,
+                claimedAt = null,
+                completedAt = null,
+                version = 0L,
+            )
         return continuation to args
     }
 
@@ -209,52 +231,56 @@ class JdbcApprovalContinuationStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `create and get round-trips continuation`() { runBlocking {
-        val s = store()
-        val (continuation, args) = createContinuation("roundtrip-1")
+    fun `create and get round-trips continuation`() {
+        runBlocking {
+            val s = store()
+            val (continuation, args) = createContinuation("roundtrip-1")
 
-        s.create(continuation, args)
-        val retrieved = s.get("roundtrip-1")
+            s.create(continuation, args)
+            val retrieved = s.get("roundtrip-1")
 
-        assertNotNull(retrieved)
-        assertRoundTripEquals(continuation, retrieved)
-        assertEquals(ApprovalContinuationStatus.PENDING, retrieved.status)
-        assertEquals(0L, retrieved.version)
-    }
-    }
-
-    @Test
-    fun `create rejects duplicate continuation id`() { runBlocking {
-        val s = store()
-        val (cont, args) = createContinuation("dup-test")
-
-        s.create(cont, args)
-
-        val (cont2, args2) = createContinuation("dup-test")
-        assertFailsWith<ApprovalContinuationConflictException> {
-            s.create(cont2, args2)
+            assertNotNull(retrieved)
+            assertRoundTripEquals(continuation, retrieved)
+            assertEquals(ApprovalContinuationStatus.PENDING, retrieved.status)
+            assertEquals(0L, retrieved.version)
         }
     }
+
+    @Test
+    fun `create rejects duplicate continuation id`() {
+        runBlocking {
+            val s = store()
+            val (cont, args) = createContinuation("dup-test")
+
+            s.create(cont, args)
+
+            val (cont2, args2) = createContinuation("dup-test")
+            assertFailsWith<ApprovalContinuationConflictException> {
+                s.create(cont2, args2)
+            }
+        }
     }
 
     @Test
-    fun `get returns null for non-existent continuation`() { runBlocking {
-        val retrieved = store().get("non-existent")
-        assertNull(retrieved)
-    }
+    fun `get returns null for non-existent continuation`() {
+        runBlocking {
+            val retrieved = store().get("non-existent")
+            assertNull(retrieved)
+        }
     }
 
     @Test
-    fun `persisted continuation survives new store instance`() { runBlocking {
-        val s1 = store()
-        s1.create(createContinuation("survive-test").first, createContinuation("survive-test").second)
+    fun `persisted continuation survives new store instance`() {
+        runBlocking {
+            val s1 = store()
+            s1.create(createContinuation("survive-test").first, createContinuation("survive-test").second)
 
-        val s2 = store()
-        val retrieved = s2.get("survive-test")
-        assertNotNull(retrieved)
-        assertEquals("survive-test", retrieved.approvalId)
-        assertEquals(ApprovalContinuationStatus.PENDING, retrieved.status)
-    }
+            val s2 = store()
+            val retrieved = s2.get("survive-test")
+            assertNotNull(retrieved)
+            assertEquals("survive-test", retrieved.approvalId)
+            assertEquals(ApprovalContinuationStatus.PENDING, retrieved.status)
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -262,119 +288,128 @@ class JdbcApprovalContinuationStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `PENDING to CLAIMED to COMPLETED full lifecycle`() { runBlocking {
-        val s = store()
-        s.create(createContinuation("lifecycle-1").first, createContinuation("lifecycle-1").second)
+    fun `PENDING to CLAIMED to COMPLETED full lifecycle`() {
+        runBlocking {
+            val s = store()
+            s.create(createContinuation("lifecycle-1").first, createContinuation("lifecycle-1").second)
 
-        val claimed = s.claimForExecution("lifecycle-1", 0L, "worker:alice")
-        assertEquals(ApprovalContinuationStatus.CLAIMED, claimed.continuation.status)
-        assertEquals(1L, claimed.continuation.version)
-        assertEquals("worker:alice", claimed.continuation.claimedBy)
-        assertNotNull(claimed.continuation.claimedAt)
-        assertEquals("plain-args", claimed.arguments.reveal())
+            val claimed = s.claimForExecution("lifecycle-1", 0L, "worker:alice")
+            assertEquals(ApprovalContinuationStatus.CLAIMED, claimed.continuation.status)
+            assertEquals(1L, claimed.continuation.version)
+            assertEquals("worker:alice", claimed.continuation.claimedBy)
+            assertNotNull(claimed.continuation.claimedAt)
+            assertEquals("plain-args", claimed.arguments.reveal())
 
-        val completed = s.complete("lifecycle-1", 1L, "worker:alice")
-        assertEquals(ApprovalContinuationStatus.COMPLETED, completed.status)
-        assertEquals(2L, completed.version)
-        assertNotNull(completed.completedAt)
-    }
-    }
-
-    @Test
-    fun `PENDING to EXPIRED transition`() { runBlocking {
-        val creationTime = fixedClock.instant()
-        val (continuation, args) = createContinuation("expire-1")
-
-        val creationClock = Clock.fixed(creationTime, ZoneId.of("UTC"))
-        val s1 = store(clock = creationClock)
-        s1.create(continuation, args)
-
-        val futureClock = Clock.fixed(creationTime.plusSeconds(600), ZoneId.of("UTC"))
-        val s2 = store(clock = futureClock)
-        val expired = s2.expire("expire-1", 0L)
-        assertEquals(ApprovalContinuationStatus.EXPIRED, expired.status)
-        assertEquals(1L, expired.version)
-    }
-    }
-
-    @Test
-    fun `PENDING to CANCELLED transition`() { runBlocking {
-        val s = store()
-        s.create(createContinuation("cancel-1").first, createContinuation("cancel-1").second)
-
-        val cancelled = s.cancel("cancel-1", 0L)
-        assertEquals(ApprovalContinuationStatus.CANCELLED, cancelled.status)
-        assertEquals(1L, cancelled.version)
-    }
-    }
-
-    @Test
-    fun `CLAIMED to CANCELLED_UNCERTAIN via force cancel`() { runBlocking {
-        val s = store()
-        s.create(createContinuation("force-1").first, createContinuation("force-1").second)
-        s.claimForExecution("force-1", 0L, "worker:stuck")
-
-        val result = s.forceCancelClaimed(
-            approvalId = "force-1",
-            expectedVersion = 1L,
-            cancelledBy = "admin:alice",
-            reasonCode = "stuck.worker",
-        )
-        assertEquals(ApprovalContinuationStatus.CANCELLED_UNCERTAIN, result.status)
-        assertEquals("admin:alice", result.recoveryResolvedBy)
-        assertEquals("stuck.worker", result.recoveryReasonCode)
-    }
-    }
-
-    @Test
-    fun `CLAIMED cannot be claimed again`() { runBlocking {
-        val s = store()
-        s.create(createContinuation("reclaim-1").first, createContinuation("reclaim-1").second)
-        s.claimForExecution("reclaim-1", 0L, "worker:eve")
-
-        assertFailsWith<ApprovalContinuationNotClaimableException> {
-            s.claimForExecution("reclaim-1", 1L, "worker:mallory")
+            val completed = s.complete("lifecycle-1", 1L, "worker:alice")
+            assertEquals(ApprovalContinuationStatus.COMPLETED, completed.status)
+            assertEquals(2L, completed.version)
+            assertNotNull(completed.completedAt)
         }
     }
+
+    @Test
+    fun `PENDING to EXPIRED transition`() {
+        runBlocking {
+            val creationTime = fixedClock.instant()
+            val (continuation, args) = createContinuation("expire-1")
+
+            val creationClock = Clock.fixed(creationTime, ZoneId.of("UTC"))
+            val s1 = store(clock = creationClock)
+            s1.create(continuation, args)
+
+            val futureClock = Clock.fixed(creationTime.plusSeconds(600), ZoneId.of("UTC"))
+            val s2 = store(clock = futureClock)
+            val expired = s2.expire("expire-1", 0L)
+            assertEquals(ApprovalContinuationStatus.EXPIRED, expired.status)
+            assertEquals(1L, expired.version)
+        }
     }
 
     @Test
-    fun `COMPLETED continuation cannot be claimed again`() { runBlocking {
-        val s = store()
-        s.create(createContinuation("done-1").first, createContinuation("done-1").second)
-        s.claimForExecution("done-1", 0L, "worker:alice")
-        s.complete("done-1", 1L, "worker:alice")
+    fun `PENDING to CANCELLED transition`() {
+        runBlocking {
+            val s = store()
+            s.create(createContinuation("cancel-1").first, createContinuation("cancel-1").second)
 
-        assertFailsWith<ApprovalContinuationNotClaimableException> {
-            s.claimForExecution("done-1", 2L, "worker:bob")
+            val cancelled = s.cancel("cancel-1", 0L)
+            assertEquals(ApprovalContinuationStatus.CANCELLED, cancelled.status)
+            assertEquals(1L, cancelled.version)
         }
-    }
     }
 
     @Test
-    fun `CLAIMED cannot transition to EXPIRED`() { runBlocking {
-        val s = store()
-        s.create(createContinuation("no-lazy-exp").first, createContinuation("no-lazy-exp").second)
-        s.claimForExecution("no-lazy-exp", 0L, "worker:eve")
+    fun `CLAIMED to CANCELLED_UNCERTAIN via force cancel`() {
+        runBlocking {
+            val s = store()
+            s.create(createContinuation("force-1").first, createContinuation("force-1").second)
+            s.claimForExecution("force-1", 0L, "worker:stuck")
 
-        // Expire should fail because status is CLAIMED, not PENDING
-        assertFailsWith<ApprovalContinuationConflictException> {
-            s.expire("no-lazy-exp", 1L)
+            val result =
+                s.forceCancelClaimed(
+                    approvalId = "force-1",
+                    expectedVersion = 1L,
+                    cancelledBy = "admin:alice",
+                    reasonCode = "stuck.worker",
+                )
+            assertEquals(ApprovalContinuationStatus.CANCELLED_UNCERTAIN, result.status)
+            assertEquals("admin:alice", result.recoveryResolvedBy)
+            assertEquals("stuck.worker", result.recoveryReasonCode)
         }
-    }
     }
 
     @Test
-    fun `CLAIMED cannot transition to CANCELLED`() { runBlocking {
-        val s = store()
-        s.create(createContinuation("no-cancel-claimed").first, createContinuation("no-cancel-claimed").second)
-        s.claimForExecution("no-cancel-claimed", 0L, "worker:eve")
+    fun `CLAIMED cannot be claimed again`() {
+        runBlocking {
+            val s = store()
+            s.create(createContinuation("reclaim-1").first, createContinuation("reclaim-1").second)
+            s.claimForExecution("reclaim-1", 0L, "worker:eve")
 
-        // cancel() should fail because status is CLAIMED, not PENDING
-        assertFailsWith<ApprovalContinuationConflictException> {
-            s.cancel("no-cancel-claimed", 1L)
+            assertFailsWith<ApprovalContinuationNotClaimableException> {
+                s.claimForExecution("reclaim-1", 1L, "worker:mallory")
+            }
         }
     }
+
+    @Test
+    fun `COMPLETED continuation cannot be claimed again`() {
+        runBlocking {
+            val s = store()
+            s.create(createContinuation("done-1").first, createContinuation("done-1").second)
+            s.claimForExecution("done-1", 0L, "worker:alice")
+            s.complete("done-1", 1L, "worker:alice")
+
+            assertFailsWith<ApprovalContinuationNotClaimableException> {
+                s.claimForExecution("done-1", 2L, "worker:bob")
+            }
+        }
+    }
+
+    @Test
+    fun `CLAIMED cannot transition to EXPIRED`() {
+        runBlocking {
+            val s = store()
+            s.create(createContinuation("no-lazy-exp").first, createContinuation("no-lazy-exp").second)
+            s.claimForExecution("no-lazy-exp", 0L, "worker:eve")
+
+            // Expire should fail because status is CLAIMED, not PENDING
+            assertFailsWith<ApprovalContinuationConflictException> {
+                s.expire("no-lazy-exp", 1L)
+            }
+        }
+    }
+
+    @Test
+    fun `CLAIMED cannot transition to CANCELLED`() {
+        runBlocking {
+            val s = store()
+            s.create(createContinuation("no-cancel-claimed").first, createContinuation("no-cancel-claimed").second)
+            s.claimForExecution("no-cancel-claimed", 0L, "worker:eve")
+
+            // cancel() should fail because status is CLAIMED, not PENDING
+            assertFailsWith<ApprovalContinuationConflictException> {
+                s.cancel("no-cancel-claimed", 1L)
+            }
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -382,56 +417,63 @@ class JdbcApprovalContinuationStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `transition with expected version increments version`() { runBlocking {
-        val s = store()
-        s.create(createContinuation("ver-inc-1").first, createContinuation("ver-inc-1").second)
+    fun `transition with expected version increments version`() {
+        runBlocking {
+            val s = store()
+            s.create(createContinuation("ver-inc-1").first, createContinuation("ver-inc-1").second)
 
-        val claimed = s.claimForExecution("ver-inc-1", 0L, "worker:alice")
-        assertEquals(1L, claimed.continuation.version)
+            val claimed = s.claimForExecution("ver-inc-1", 0L, "worker:alice")
+            assertEquals(1L, claimed.continuation.version)
 
-        val completed = s.complete("ver-inc-1", 1L, "worker:alice")
-        assertEquals(2L, completed.version)
+            val completed = s.complete("ver-inc-1", 1L, "worker:alice")
+            assertEquals(2L, completed.version)
 
-        val retrieved = s.get("ver-inc-1")
-        assertNotNull(retrieved)
-        assertEquals(2L, retrieved.version)
-    }
+            val retrieved = s.get("ver-inc-1")
+            assertNotNull(retrieved)
+            assertEquals(2L, retrieved.version)
+        }
     }
 
     @Test
-    fun `transition with stale version fails`() { runBlocking {
-        val s = store()
-        s.create(createContinuation("stale-ver-1").first, createContinuation("stale-ver-1").second)
+    fun `transition with stale version fails`() {
+        runBlocking {
+            val s = store()
+            s.create(createContinuation("stale-ver-1").first, createContinuation("stale-ver-1").second)
 
-        // No production path bumps the version while the row stays PENDING,
-        // so simulate a concurrent writer by tampering the row directly.
-        // The version guard fires before the status guard for PENDING rows.
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        conn.use { c ->
-            c.prepareStatement(
-                "UPDATE approval_continuations SET version = 1 WHERE approval_id = 'stale-ver-1'",
-            ).use { stmt -> stmt.executeUpdate() }
-        }
+            // No production path bumps the version while the row stays PENDING,
+            // so simulate a concurrent writer by tampering the row directly.
+            // The version guard fires before the status guard for PENDING rows.
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                c
+                    .prepareStatement(
+                        "UPDATE approval_continuations SET version = 1 WHERE approval_id = 'stale-ver-1'",
+                    ).use { stmt -> stmt.executeUpdate() }
+            }
 
-        // Try claiming with version 0 (stale) instead of 1
-        assertFailsWith<ApprovalContinuationConflictException> {
-            s.claimForExecution("stale-ver-1", 0L, "worker:bob")
+            // Try claiming with version 0 (stale) instead of 1
+            assertFailsWith<ApprovalContinuationConflictException> {
+                s.claimForExecution("stale-ver-1", 0L, "worker:bob")
+            }
         }
-    }
     }
 
     @Test
-    fun `complete with stale version fails`() { runBlocking {
-        val s = store()
-        s.create(createContinuation("stale-complete").first, createContinuation("stale-complete").second)
-        s.claimForExecution("stale-complete", 0L, "worker:alice")
+    fun `complete with stale version fails`() {
+        runBlocking {
+            val s = store()
+            s.create(createContinuation("stale-complete").first, createContinuation("stale-complete").second)
+            s.claimForExecution("stale-complete", 0L, "worker:alice")
 
-        assertFailsWith<ApprovalContinuationConflictException> {
-            s.complete("stale-complete", 0L, "worker:alice")
+            assertFailsWith<ApprovalContinuationConflictException> {
+                s.complete("stale-complete", 0L, "worker:alice")
+            }
         }
-    }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -439,76 +481,80 @@ class JdbcApprovalContinuationStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `concurrent claim has exactly one winner`() { runBlocking {
-        val s = store()
-        s.create(createContinuation("concurrent-claim").first, createContinuation("concurrent-claim").second)
+    fun `concurrent claim has exactly one winner`() {
+        runBlocking {
+            val s = store()
+            s.create(createContinuation("concurrent-claim").first, createContinuation("concurrent-claim").second)
 
-        coroutineScope {
-            val results = listOf(
-                async {
-                    try {
-                        s.claimForExecution("concurrent-claim", 0L, "worker:1")
-                        "winner"
-                    } catch (_: Exception) {
-                        "loser"
-                    }
-                },
-                async {
-                    try {
-                        s.claimForExecution("concurrent-claim", 0L, "worker:2")
-                        "winner"
-                    } catch (_: Exception) {
-                        "loser"
-                    }
-                },
-                async {
-                    try {
-                        s.claimForExecution("concurrent-claim", 0L, "worker:3")
-                        "winner"
-                    } catch (_: Exception) {
-                        "loser"
-                    }
-                },
-            )
+            coroutineScope {
+                val results =
+                    listOf(
+                        async {
+                            try {
+                                s.claimForExecution("concurrent-claim", 0L, "worker:1")
+                                "winner"
+                            } catch (_: Exception) {
+                                "loser"
+                            }
+                        },
+                        async {
+                            try {
+                                s.claimForExecution("concurrent-claim", 0L, "worker:2")
+                                "winner"
+                            } catch (_: Exception) {
+                                "loser"
+                            }
+                        },
+                        async {
+                            try {
+                                s.claimForExecution("concurrent-claim", 0L, "worker:3")
+                                "winner"
+                            } catch (_: Exception) {
+                                "loser"
+                            }
+                        },
+                    )
 
-            val outcomes = results.map { it.await() }
-            val winners = outcomes.count { it == "winner" }
-            assertEquals(1, winners, "Exactly one concurrent claim must succeed")
+                val outcomes = results.map { it.await() }
+                val winners = outcomes.count { it == "winner" }
+                assertEquals(1, winners, "Exactly one concurrent claim must succeed")
+            }
         }
-    }
     }
 
     @Test
-    fun `same continuation cannot be completed twice concurrently`() { runBlocking {
-        val s = store()
-        s.create(createContinuation("double-complete").first, createContinuation("double-complete").second)
-        s.claimForExecution("double-complete", 0L, "worker:alice")
+    fun `same continuation cannot be completed twice concurrently`() {
+        runBlocking {
+            val s = store()
+            s.create(createContinuation("double-complete").first, createContinuation("double-complete").second)
+            s.claimForExecution("double-complete", 0L, "worker:alice")
 
-        coroutineScope {
-            val results = listOf(
-                async {
-                    try {
-                        s.complete("double-complete", 1L, "worker:alice")
-                        "winner"
-                    } catch (_: Exception) {
-                        "loser"
-                    }
-                },
-                async {
-                    try {
-                        s.complete("double-complete", 1L, "worker:alice")
-                        "winner"
-                    } catch (_: Exception) {
-                        "loser"
-                    }
-                },
-            )
+            coroutineScope {
+                val results =
+                    listOf(
+                        async {
+                            try {
+                                s.complete("double-complete", 1L, "worker:alice")
+                                "winner"
+                            } catch (_: Exception) {
+                                "loser"
+                            }
+                        },
+                        async {
+                            try {
+                                s.complete("double-complete", 1L, "worker:alice")
+                                "winner"
+                            } catch (_: Exception) {
+                                "loser"
+                            }
+                        },
+                    )
 
-            val outcomes = results.map { it.await() }
-            val winners = outcomes.count { it == "winner" }
-            assertEquals(1, winners, "Exactly one concurrent complete must succeed")
+                val outcomes = results.map { it.await() }
+                val winners = outcomes.count { it == "winner" }
+                assertEquals(1, winners, "Exactly one concurrent complete must succeed")
+            }
         }
-    }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -516,45 +562,48 @@ class JdbcApprovalContinuationStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `create store A, write, create store B, read`() { runBlocking {
-        val sA = store()
-        val (cont, args) = createContinuation("store-ab-1")
-        sA.create(cont, args)
+    fun `create store A, write, create store B, read`() {
+        runBlocking {
+            val sA = store()
+            val (cont, args) = createContinuation("store-ab-1")
+            sA.create(cont, args)
 
-        val sB = store()
-        val retrieved = sB.get("store-ab-1")
-        assertNotNull(retrieved)
-        assertEquals(ApprovalContinuationStatus.PENDING, retrieved.status)
-        assertEquals(0L, retrieved.version)
-    }
-    }
-
-    @Test
-    fun `create store A, claim with store B, complete with store C`() { runBlocking {
-        val sA = store()
-        sA.create(createContinuation("abc-lifecycle").first, createContinuation("abc-lifecycle").second)
-
-        val sB = store()
-        val claimed = sB.claimForExecution("abc-lifecycle", 0L, "worker:alice")
-        assertEquals("plain-args", claimed.arguments.reveal())
-
-        val sC = store()
-        val completed = sC.complete("abc-lifecycle", 1L, "worker:alice")
-        assertEquals(ApprovalContinuationStatus.COMPLETED, completed.status)
-        assertEquals(2L, completed.version)
-    }
+            val sB = store()
+            val retrieved = sB.get("store-ab-1")
+            assertNotNull(retrieved)
+            assertEquals(ApprovalContinuationStatus.PENDING, retrieved.status)
+            assertEquals(0L, retrieved.version)
+        }
     }
 
     @Test
-    fun `claim arguments survive decryption across store instances`() { runBlocking {
-        val s1 = store()
-        val (cont, args) = createContinuation("enc-roundtrip", arguments = "complex-arg-value")
-        s1.create(cont, args)
+    fun `create store A, claim with store B, complete with store C`() {
+        runBlocking {
+            val sA = store()
+            sA.create(createContinuation("abc-lifecycle").first, createContinuation("abc-lifecycle").second)
 
-        val s2 = store()
-        val claimed = s2.claimForExecution("enc-roundtrip", 0L, "worker:alice")
-        assertEquals("complex-arg-value", claimed.arguments.reveal())
+            val sB = store()
+            val claimed = sB.claimForExecution("abc-lifecycle", 0L, "worker:alice")
+            assertEquals("plain-args", claimed.arguments.reveal())
+
+            val sC = store()
+            val completed = sC.complete("abc-lifecycle", 1L, "worker:alice")
+            assertEquals(ApprovalContinuationStatus.COMPLETED, completed.status)
+            assertEquals(2L, completed.version)
+        }
     }
+
+    @Test
+    fun `claim arguments survive decryption across store instances`() {
+        runBlocking {
+            val s1 = store()
+            val (cont, args) = createContinuation("enc-roundtrip", arguments = "complex-arg-value")
+            s1.create(cont, args)
+
+            val s2 = store()
+            val claimed = s2.claimForExecution("enc-roundtrip", 0L, "worker:alice")
+            assertEquals("complex-arg-value", claimed.arguments.reveal())
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -562,48 +611,51 @@ class JdbcApprovalContinuationStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `findStaleClaimed returns claimed continuations before timestamp`() { runBlocking {
-        val s = store()
-        s.create(createContinuation("stale-search-1").first, createContinuation("stale-search-1").second)
-        s.claimForExecution("stale-search-1", 0L, "worker:slow")
+    fun `findStaleClaimed returns claimed continuations before timestamp`() {
+        runBlocking {
+            val s = store()
+            s.create(createContinuation("stale-search-1").first, createContinuation("stale-search-1").second)
+            s.claimForExecution("stale-search-1", 0L, "worker:slow")
 
-        val stale = s.findStaleClaimed(
-            claimedBefore = fixedClock.instant().plusSeconds(1),
-            limit = 10,
-        )
-        assertEquals(1, stale.size)
-        assertEquals("stale-search-1", stale.first().approvalId)
-    }
+            val stale =
+                s.findStaleClaimed(
+                    claimedBefore = fixedClock.instant().plusSeconds(1),
+                    limit = 10,
+                )
+            assertEquals(1, stale.size)
+            assertEquals("stale-search-1", stale.first().approvalId)
+        }
     }
 
     @Test
-    fun `sweepExpired transitions PENDING continuations past expiry`() { runBlocking {
-        val creationTime = fixedClock.instant()
-        val s1 = store(clock = Clock.fixed(creationTime, ZoneId.of("UTC")))
-        s1.create(
-            createContinuation("sweep-1", clock = Clock.fixed(creationTime, ZoneId.of("UTC"))).first,
-            createContinuation("sweep-1", clock = Clock.fixed(creationTime, ZoneId.of("UTC"))).second,
-        )
-        s1.create(
-            createContinuation("sweep-2", clock = Clock.fixed(creationTime, ZoneId.of("UTC"))).first,
-            createContinuation("sweep-2", clock = Clock.fixed(creationTime, ZoneId.of("UTC"))).second,
-        )
+    fun `sweepExpired transitions PENDING continuations past expiry`() {
+        runBlocking {
+            val creationTime = fixedClock.instant()
+            val s1 = store(clock = Clock.fixed(creationTime, ZoneId.of("UTC")))
+            s1.create(
+                createContinuation("sweep-1", clock = Clock.fixed(creationTime, ZoneId.of("UTC"))).first,
+                createContinuation("sweep-1", clock = Clock.fixed(creationTime, ZoneId.of("UTC"))).second,
+            )
+            s1.create(
+                createContinuation("sweep-2", clock = Clock.fixed(creationTime, ZoneId.of("UTC"))).first,
+                createContinuation("sweep-2", clock = Clock.fixed(creationTime, ZoneId.of("UTC"))).second,
+            )
 
-        // Future clock — both should be past expiry
-        val futureClock = Clock.fixed(creationTime.plusSeconds(600), ZoneId.of("UTC"))
-        val s2 = store(clock = futureClock)
+            // Future clock — both should be past expiry
+            val futureClock = Clock.fixed(creationTime.plusSeconds(600), ZoneId.of("UTC"))
+            val s2 = store(clock = futureClock)
 
-        val swept = s2.sweepExpired()
-        assertEquals(2, swept)
+            val swept = s2.sweepExpired()
+            assertEquals(2, swept)
 
-        val r1 = s2.get("sweep-1")
-        assertNotNull(r1)
-        assertEquals(ApprovalContinuationStatus.EXPIRED, r1.status)
+            val r1 = s2.get("sweep-1")
+            assertNotNull(r1)
+            assertEquals(ApprovalContinuationStatus.EXPIRED, r1.status)
 
-        val r2 = s2.get("sweep-2")
-        assertNotNull(r2)
-        assertEquals(ApprovalContinuationStatus.EXPIRED, r2.status)
-    }
+            val r2 = s2.get("sweep-2")
+            assertNotNull(r2)
+            assertEquals(ApprovalContinuationStatus.EXPIRED, r2.status)
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -611,107 +663,133 @@ class JdbcApprovalContinuationStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `encrypted_arguments is non-null after create`() { runBlocking {
-        val s = store()
-        s.create(createContinuation("enc-nonnull").first, createContinuation("enc-nonnull").second)
+    fun `encrypted_arguments is non-null after create`() {
+        runBlocking {
+            val s = store()
+            s.create(createContinuation("enc-nonnull").first, createContinuation("enc-nonnull").second)
 
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        conn.use { c ->
-            c.prepareStatement(
-                "SELECT encrypted_arguments FROM approval_continuations WHERE approval_id = ?",
-            ).use { stmt ->
-                stmt.setString(1, "enc-nonnull")
-                stmt.executeQuery().use { rs ->
-                    assertTrue(rs.next())
-                    val bytes = rs.getBytes("encrypted_arguments")
-                    assertNotNull(bytes)
-                    assertTrue(bytes.isNotEmpty())
-                }
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                c
+                    .prepareStatement(
+                        "SELECT encrypted_arguments FROM approval_continuations WHERE approval_id = ?",
+                    ).use { stmt ->
+                        stmt.setString(1, "enc-nonnull")
+                        stmt.executeQuery().use { rs ->
+                            assertTrue(rs.next())
+                            val bytes = rs.getBytes("encrypted_arguments")
+                            assertNotNull(bytes)
+                            assertTrue(bytes.isNotEmpty())
+                        }
+                    }
             }
         }
     }
-    }
 
     @Test
-    fun `encryption metadata fields are non-null after create`() { runBlocking {
-        val s = store()
-        s.create(createContinuation("enc-meta").first, createContinuation("enc-meta").second)
+    fun `encryption metadata fields are non-null after create`() {
+        runBlocking {
+            val s = store()
+            s.create(createContinuation("enc-meta").first, createContinuation("enc-meta").second)
 
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        conn.use { c ->
-            c.prepareStatement(
-                """SELECT encryption_key_id, encryption_algorithm, encryption_nonce, payload_digest
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                c
+                    .prepareStatement(
+                        """SELECT encryption_key_id, encryption_algorithm, encryption_nonce, payload_digest
                    FROM approval_continuations WHERE approval_id = ?""",
-            ).use { stmt ->
-                stmt.setString(1, "enc-meta")
-                stmt.executeQuery().use { rs ->
-                    assertTrue(rs.next())
-                    assertNotNull(rs.getString("encryption_key_id"))
-                    assertNotNull(rs.getString("encryption_algorithm"))
-                    assertNotNull(rs.getBytes("encryption_nonce"))
-                    assertNotNull(rs.getString("payload_digest"))
-                }
+                    ).use { stmt ->
+                        stmt.setString(1, "enc-meta")
+                        stmt.executeQuery().use { rs ->
+                            assertTrue(rs.next())
+                            assertNotNull(rs.getString("encryption_key_id"))
+                            assertNotNull(rs.getString("encryption_algorithm"))
+                            assertNotNull(rs.getBytes("encryption_nonce"))
+                            assertNotNull(rs.getString("payload_digest"))
+                        }
+                    }
             }
         }
-    }
     }
 
     @Test
-    fun `raw arguments are not visible in the database`() { runBlocking {
-        val s = store()
-        s.create(
-            createContinuation("enc-secret", arguments = "super-sensitive-value").first,
-            createContinuation("enc-secret", arguments = "super-sensitive-value").second,
-        )
+    fun `raw arguments are not visible in the database`() {
+        runBlocking {
+            val s = store()
+            s.create(
+                createContinuation("enc-secret", arguments = "super-sensitive-value").first,
+                createContinuation("enc-secret", arguments = "super-sensitive-value").second,
+            )
 
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        conn.use { c ->
-            c.prepareStatement(
-                "SELECT encrypted_arguments FROM approval_continuations WHERE approval_id = ?",
-            ).use { stmt ->
-                stmt.setString(1, "enc-secret")
-                stmt.executeQuery().use { rs ->
-                    assertTrue(rs.next())
-                    val ciphertext = rs.getBytes("encrypted_arguments")
-                    val text = ciphertext.toString(Charsets.UTF_8)
-                    // Verify ciphertext does not contain the plaintext
-                    assertTrue(text.contains("super-sensitive-value").not(),
-                        "Raw argument content must not be visible in the database")
-                }
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                c
+                    .prepareStatement(
+                        "SELECT encrypted_arguments FROM approval_continuations WHERE approval_id = ?",
+                    ).use { stmt ->
+                        stmt.setString(1, "enc-secret")
+                        stmt.executeQuery().use { rs ->
+                            assertTrue(rs.next())
+                            val ciphertext = rs.getBytes("encrypted_arguments")
+                            val text = ciphertext.toString(Charsets.UTF_8)
+                            // Verify ciphertext does not contain the plaintext
+                            assertTrue(
+                                text.contains("super-sensitive-value").not(),
+                                "Raw argument content must not be visible in the database",
+                            )
+                        }
+                    }
             }
         }
-    }
     }
 
     @Test
-    fun `encrypted_arguments are null after claim`() { runBlocking {
-        val s = store()
-        s.create(createContinuation("enc-null-after-claim").first,
-            createContinuation("enc-null-after-claim").second)
-        s.claimForExecution("enc-null-after-claim", 0L, "worker:alice")
+    fun `encrypted_arguments are null after claim`() {
+        runBlocking {
+            val s = store()
+            s.create(
+                createContinuation("enc-null-after-claim").first,
+                createContinuation("enc-null-after-claim").second,
+            )
+            s.claimForExecution("enc-null-after-claim", 0L, "worker:alice")
 
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        conn.use { c ->
-            c.prepareStatement(
-                "SELECT encrypted_arguments FROM approval_continuations WHERE approval_id = ?",
-            ).use { stmt ->
-                stmt.setString(1, "enc-null-after-claim")
-                stmt.executeQuery().use { rs ->
-                    assertTrue(rs.next())
-                    assertNull(rs.getBytes("encrypted_arguments"),
-                        "encrypted_arguments must be null after claim")
-                }
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                c
+                    .prepareStatement(
+                        "SELECT encrypted_arguments FROM approval_continuations WHERE approval_id = ?",
+                    ).use { stmt ->
+                        stmt.setString(1, "enc-null-after-claim")
+                        stmt.executeQuery().use { rs ->
+                            assertTrue(rs.next())
+                            assertNull(
+                                rs.getBytes("encrypted_arguments"),
+                                "encrypted_arguments must be null after claim",
+                            )
+                        }
+                    }
             }
         }
-    }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -719,35 +797,37 @@ class JdbcApprovalContinuationStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `createdAt round-trips when earlier than store clock`() { runBlocking {
-        val now = fixedClock.instant()
-        val past = now.minusSeconds(30)
-        val args = SensitiveToolArguments.of("past-args")
-        val digest = computeArgumentsDigest("past-args")
-        val continuation = ApprovalContinuation(
-            approvalId = "past-time-test",
-            workflowRunId = "wf-1",
-            correlationId = "corr-1",
-            toolCallId = "tc-1",
-            toolName = "test-tool",
-            argumentsDigest = digest,
-            policyVersion = "v1",
-            workflowDigest = makeDigest("b".repeat(64)),
-            status = ApprovalContinuationStatus.PENDING,
-            createdAt = past,
-            approvalExpiresAt = now.plus(Duration.ofMinutes(5)),
-            claimedBy = null,
-            claimedAt = null,
-            completedAt = null,
-            version = 0L,
-        )
+    fun `createdAt round-trips when earlier than store clock`() {
+        runBlocking {
+            val now = fixedClock.instant()
+            val past = now.minusSeconds(30)
+            val args = SensitiveToolArguments.of("past-args")
+            val digest = computeArgumentsDigest("past-args")
+            val continuation =
+                ApprovalContinuation(
+                    approvalId = "past-time-test",
+                    workflowRunId = "wf-1",
+                    correlationId = "corr-1",
+                    toolCallId = "tc-1",
+                    toolName = "test-tool",
+                    argumentsDigest = digest,
+                    policyVersion = "v1",
+                    workflowDigest = makeDigest("b".repeat(64)),
+                    status = ApprovalContinuationStatus.PENDING,
+                    createdAt = past,
+                    approvalExpiresAt = now.plus(Duration.ofMinutes(5)),
+                    claimedBy = null,
+                    claimedAt = null,
+                    completedAt = null,
+                    version = 0L,
+                )
 
-        store().create(continuation, args)
-        val retrieved = store().get("past-time-test")
-        assertNotNull(retrieved)
-        assertEquals(past, retrieved.createdAt)
-        assertEquals(now.plus(Duration.ofMinutes(5)), retrieved.approvalExpiresAt)
-    }
+            store().create(continuation, args)
+            val retrieved = store().get("past-time-test")
+            assertNotNull(retrieved)
+            assertEquals(past, retrieved.createdAt)
+            assertEquals(now.plus(Duration.ofMinutes(5)), retrieved.approvalExpiresAt)
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -755,62 +835,73 @@ class JdbcApprovalContinuationStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `SQL unique violation maps to domain conflict`() { runBlocking {
-        val s = store()
-        s.create(createContinuation("unique-violation").first,
-            createContinuation("unique-violation").second)
+    fun `SQL unique violation maps to domain conflict`() {
+        runBlocking {
+            val s = store()
+            s.create(
+                createContinuation("unique-violation").first,
+                createContinuation("unique-violation").second,
+            )
 
-        assertFailsWith<ApprovalContinuationConflictException> {
-            s.create(createContinuation("unique-violation").first,
-                createContinuation("unique-violation").second)
+            assertFailsWith<ApprovalContinuationConflictException> {
+                s.create(
+                    createContinuation("unique-violation").first,
+                    createContinuation("unique-violation").second,
+                )
+            }
         }
-    }
     }
 
     @Test
-    fun `missing continuation returns null from get`() { runBlocking {
-        assertNull(store().get("does-not-exist"))
-    }
+    fun `missing continuation returns null from get`() {
+        runBlocking {
+            assertNull(store().get("does-not-exist"))
+        }
     }
 
     @Test
-    fun `claim on missing continuation throws not found`() { runBlocking {
-        assertFailsWith<ApprovalContinuationNotFoundException> {
-            store().claimForExecution("does-not-exist", 0L, "worker:test")
+    fun `claim on missing continuation throws not found`() {
+        runBlocking {
+            assertFailsWith<ApprovalContinuationNotFoundException> {
+                store().claimForExecution("does-not-exist", 0L, "worker:test")
+            }
         }
-    }
     }
 
     @Test
-    fun `complete on missing continuation throws not found`() { runBlocking {
-        assertFailsWith<ApprovalContinuationNotFoundException> {
-            store().complete("does-not-exist", 0L, "worker:test")
+    fun `complete on missing continuation throws not found`() {
+        runBlocking {
+            assertFailsWith<ApprovalContinuationNotFoundException> {
+                store().complete("does-not-exist", 0L, "worker:test")
+            }
         }
-    }
     }
 
     @Test
-    fun `expire on missing continuation throws not found`() { runBlocking {
-        assertFailsWith<ApprovalContinuationNotFoundException> {
-            store().expire("does-not-exist", 0L)
+    fun `expire on missing continuation throws not found`() {
+        runBlocking {
+            assertFailsWith<ApprovalContinuationNotFoundException> {
+                store().expire("does-not-exist", 0L)
+            }
         }
-    }
     }
 
     @Test
-    fun `cancel on missing continuation throws not found`() { runBlocking {
-        assertFailsWith<ApprovalContinuationNotFoundException> {
-            store().cancel("does-not-exist", 0L)
+    fun `cancel on missing continuation throws not found`() {
+        runBlocking {
+            assertFailsWith<ApprovalContinuationNotFoundException> {
+                store().cancel("does-not-exist", 0L)
+            }
         }
-    }
     }
 
     @Test
-    fun `forceCancelClaimed on missing continuation throws not found`() { runBlocking {
-        assertFailsWith<ApprovalContinuationNotFoundException> {
-            store().forceCancelClaimed("does-not-exist", 0L, "admin:test", "test.reason")
+    fun `forceCancelClaimed on missing continuation throws not found`() {
+        runBlocking {
+            assertFailsWith<ApprovalContinuationNotFoundException> {
+                store().forceCancelClaimed("does-not-exist", 0L, "admin:test", "test.reason")
+            }
         }
-    }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -818,35 +909,39 @@ class JdbcApprovalContinuationStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `get auto-expires PENDING continuation past expiry`() { runBlocking {
-        val creationTime = fixedClock.instant()
-        val s1 = store(clock = Clock.fixed(creationTime, ZoneId.of("UTC")))
-        s1.create(createContinuation("lazy-expire").first, createContinuation("lazy-expire").second)
+    fun `get auto-expires PENDING continuation past expiry`() {
+        runBlocking {
+            val creationTime = fixedClock.instant()
+            val s1 = store(clock = Clock.fixed(creationTime, ZoneId.of("UTC")))
+            s1.create(createContinuation("lazy-expire").first, createContinuation("lazy-expire").second)
 
-        // Read with future clock — should lazy-expire
-        val futureClock = Clock.fixed(creationTime.plusSeconds(600), ZoneId.of("UTC"))
-        val s2 = store(clock = futureClock)
-        val retrieved = s2.get("lazy-expire")
-        assertNotNull(retrieved)
-        assertEquals(ApprovalContinuationStatus.EXPIRED, retrieved.status)
-        assertEquals(1L, retrieved.version)
-    }
+            // Read with future clock — should lazy-expire
+            val futureClock = Clock.fixed(creationTime.plusSeconds(600), ZoneId.of("UTC"))
+            val s2 = store(clock = futureClock)
+            val retrieved = s2.get("lazy-expire")
+            assertNotNull(retrieved)
+            assertEquals(ApprovalContinuationStatus.EXPIRED, retrieved.status)
+            assertEquals(1L, retrieved.version)
+        }
     }
 
     @Test
-    fun `concurrent claim after lazy expiry fails`() { runBlocking {
-        val creationTime = fixedClock.instant()
-        val s1 = store(clock = Clock.fixed(creationTime, ZoneId.of("UTC")))
-        s1.create(createContinuation("lazy-claim-fails").first,
-            createContinuation("lazy-claim-fails").second)
+    fun `concurrent claim after lazy expiry fails`() {
+        runBlocking {
+            val creationTime = fixedClock.instant()
+            val s1 = store(clock = Clock.fixed(creationTime, ZoneId.of("UTC")))
+            s1.create(
+                createContinuation("lazy-claim-fails").first,
+                createContinuation("lazy-claim-fails").second,
+            )
 
-        val futureClock = Clock.fixed(creationTime.plusSeconds(600), ZoneId.of("UTC"))
-        val s2 = store(clock = futureClock)
+            val futureClock = Clock.fixed(creationTime.plusSeconds(600), ZoneId.of("UTC"))
+            val s2 = store(clock = futureClock)
 
-        assertFailsWith<ApprovalContinuationNotClaimableException> {
-            s2.claimForExecution("lazy-claim-fails", 0L, "worker:late")
+            assertFailsWith<ApprovalContinuationNotClaimableException> {
+                s2.claimForExecution("lazy-claim-fails", 0L, "worker:late")
+            }
         }
-    }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -854,41 +949,47 @@ class JdbcApprovalContinuationStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `sweep does not transition non-PENDING continuations`() { runBlocking {
-        val s = store()
-        s.create(createContinuation("sweep-non-pending").first,
-            createContinuation("sweep-non-pending").second)
-        s.claimForExecution("sweep-non-pending", 0L, "worker:eve")
-        s.complete("sweep-non-pending", 1L, "worker:eve")
+    fun `sweep does not transition non-PENDING continuations`() {
+        runBlocking {
+            val s = store()
+            s.create(
+                createContinuation("sweep-non-pending").first,
+                createContinuation("sweep-non-pending").second,
+            )
+            s.claimForExecution("sweep-non-pending", 0L, "worker:eve")
+            s.complete("sweep-non-pending", 1L, "worker:eve")
 
-        val swept = s.sweepExpired()
-        assertEquals(0, swept, "COMPLETED continuations must not be swept")
-    }
-    }
-
-    @Test
-    fun `findStaleClaimed ignores non-CLAIMED statuses`() { runBlocking {
-        val s = store()
-        // Create a PENDING continuation (not stale)
-        s.create(createContinuation("not-stale").first, createContinuation("not-stale").second)
-
-        val stale = s.findStaleClaimed(
-            claimedBefore = fixedClock.instant().plusSeconds(1),
-            limit = 10,
-        )
-        assertTrue(stale.isEmpty(), "PENDING continuation must not appear in stale results")
-    }
-    }
-
-    @Test
-    fun `expire before expiry time fails`() { runBlocking {
-        val s = store()
-        s.create(createContinuation("early-expire").first, createContinuation("early-expire").second)
-
-        assertFailsWith<ApprovalContinuationConflictException> {
-            s.expire("early-expire", 0L)
+            val swept = s.sweepExpired()
+            assertEquals(0, swept, "COMPLETED continuations must not be swept")
         }
     }
+
+    @Test
+    fun `findStaleClaimed ignores non-CLAIMED statuses`() {
+        runBlocking {
+            val s = store()
+            // Create a PENDING continuation (not stale)
+            s.create(createContinuation("not-stale").first, createContinuation("not-stale").second)
+
+            val stale =
+                s.findStaleClaimed(
+                    claimedBefore = fixedClock.instant().plusSeconds(1),
+                    limit = 10,
+                )
+            assertTrue(stale.isEmpty(), "PENDING continuation must not appear in stale results")
+        }
+    }
+
+    @Test
+    fun `expire before expiry time fails`() {
+        runBlocking {
+            val s = store()
+            s.create(createContinuation("early-expire").first, createContinuation("early-expire").second)
+
+            assertFailsWith<ApprovalContinuationConflictException> {
+                s.expire("early-expire", 0L)
+            }
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -896,48 +997,53 @@ class JdbcApprovalContinuationStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `claim preserves encrypted arguments when decode fails`() { runBlocking {
-        // Codec that encodes successfully but fails on decode
-        val brokenCodec = object : JdbcContinuationArgumentsCodec {
-            override fun encode(plaintext: ByteArray): JdbcEncryptedContinuationArguments {
-                return testCodec.encode(plaintext)
-            }
+    fun `claim preserves encrypted arguments when decode fails`() {
+        runBlocking {
+            // Codec that encodes successfully but fails on decode
+            val brokenCodec =
+                object : JdbcContinuationArgumentsCodec {
+                    override fun encode(plaintext: ByteArray): JdbcEncryptedContinuationArguments = testCodec.encode(plaintext)
 
-            override fun decode(envelope: JdbcEncryptedContinuationArguments): ByteArray {
-                throw IllegalStateException("simulated-decode-failure")
-            }
-        }
-        val s = store(codec = brokenCodec)
-        s.create(createContinuation("decode-fail").first, createContinuation("decode-fail").second)
-
-        // Claim should throw because decode fails
-        assertFailsWith<IllegalStateException> {
-            s.claimForExecution("decode-fail", 0L, "worker:alice")
-        }
-
-        // Row must still be PENDING with encrypted arguments intact
-        val retrieved = s.get("decode-fail")
-        assertNotNull(retrieved)
-        assertEquals(ApprovalContinuationStatus.PENDING, retrieved.status)
-        assertEquals(0L, retrieved.version)
-
-        // encrypted_arguments should still be non-null (verified via raw SQL)
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        conn.use { c ->
-            c.prepareStatement(
-                "SELECT encrypted_arguments FROM approval_continuations WHERE approval_id = ?",
-            ).use { stmt ->
-                stmt.setString(1, "decode-fail")
-                stmt.executeQuery().use { rs ->
-                    assertTrue(rs.next())
-                    assertNotNull(rs.getBytes("encrypted_arguments"),
-                        "encrypted_arguments must survive decode failure")
+                    override fun decode(envelope: JdbcEncryptedContinuationArguments): ByteArray =
+                        throw IllegalStateException("simulated-decode-failure")
                 }
+            val s = store(codec = brokenCodec)
+            s.create(createContinuation("decode-fail").first, createContinuation("decode-fail").second)
+
+            // Claim should throw because decode fails
+            assertFailsWith<IllegalStateException> {
+                s.claimForExecution("decode-fail", 0L, "worker:alice")
+            }
+
+            // Row must still be PENDING with encrypted arguments intact
+            val retrieved = s.get("decode-fail")
+            assertNotNull(retrieved)
+            assertEquals(ApprovalContinuationStatus.PENDING, retrieved.status)
+            assertEquals(0L, retrieved.version)
+
+            // encrypted_arguments should still be non-null (verified via raw SQL)
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                c
+                    .prepareStatement(
+                        "SELECT encrypted_arguments FROM approval_continuations WHERE approval_id = ?",
+                    ).use { stmt ->
+                        stmt.setString(1, "decode-fail")
+                        stmt.executeQuery().use { rs ->
+                            assertTrue(rs.next())
+                            assertNotNull(
+                                rs.getBytes("encrypted_arguments"),
+                                "encrypted_arguments must survive decode failure",
+                            )
+                        }
+                    }
             }
         }
-    }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -961,77 +1067,87 @@ class JdbcApprovalContinuationStoreTest {
     }
 
     @Test
-    fun `claim that loses its CAS to a cancel reports Conflict not NotClaimable`() { runBlocking {
-        val id = "cas-loss-claim"
-        val gated = GatedCodec(testCodec)
-        val s = store(codec = gated)
-        val (continuation, args) = createContinuation(approvalId = id)
-        s.create(continuation, args)
+    fun `claim that loses its CAS to a cancel reports Conflict not NotClaimable`() {
+        runBlocking {
+            val id = "cas-loss-claim"
+            val gated = GatedCodec(testCodec)
+            val s = store(codec = gated)
+            val (continuation, args) = createContinuation(approvalId = id)
+            s.create(continuation, args)
 
-        // The claim reads PENDING v0, validates, then blocks inside
-        // argument decryption — immediately before its CAS update.
-        val claim = async(Dispatchers.Default) {
-            runCatching { s.claimForExecution(id, 0L, "worker:alice") }
+            // The claim reads PENDING v0, validates, then blocks inside
+            // argument decryption — immediately before its CAS update.
+            val claim =
+                async(Dispatchers.Default) {
+                    runCatching { s.claimForExecution(id, 0L, "worker:alice") }
+                }
+            gated.decodeStarted.await()
+
+            // Cancel wins while the claim is in flight: CANCELLED v1.
+            s.cancel(id, 0L)
+
+            // Release the claim: its CAS (WHERE version=0 AND status='PENDING')
+            // loses. It must report Conflict (stale version), matching the
+            // in-memory and file stores' version-first precedence — not
+            // NotClaimable.
+            gated.releaseDecode.complete(Unit)
+            val outcome = claim.await()
+
+            assertTrue(
+                outcome.exceptionOrNull() is ApprovalContinuationConflictException,
+                "claim losing to cancel must throw Conflict, was: ${outcome.exceptionOrNull()}",
+            )
+            val persisted = s.get(id)
+            assertNotNull(persisted)
+            assertEquals(ApprovalContinuationStatus.CANCELLED, persisted.status)
+            assertEquals(1L, persisted.version)
         }
-        gated.decodeStarted.await()
-
-        // Cancel wins while the claim is in flight: CANCELLED v1.
-        s.cancel(id, 0L)
-
-        // Release the claim: its CAS (WHERE version=0 AND status='PENDING')
-        // loses. It must report Conflict (stale version), matching the
-        // in-memory and file stores' version-first precedence — not
-        // NotClaimable.
-        gated.releaseDecode.complete(Unit)
-        val outcome = claim.await()
-
-        assertTrue(
-            outcome.exceptionOrNull() is ApprovalContinuationConflictException,
-            "claim losing to cancel must throw Conflict, was: ${outcome.exceptionOrNull()}",
-        )
-        val persisted = s.get(id)
-        assertNotNull(persisted)
-        assertEquals(ApprovalContinuationStatus.CANCELLED, persisted.status)
-        assertEquals(1L, persisted.version)
-    } }
+    }
 
     // ═══════════════════════════════════════════════════════════════
     // P2 regression — lazy expiry CAS race
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `get re-reads actual state when lazy expiry CAS loses race`() { runBlocking {
-        val creationTime = fixedClock.instant()
-        val s1 = store(clock = Clock.fixed(creationTime, ZoneId.of("UTC")))
-        s1.create(createContinuation("lazy-race").first, createContinuation("lazy-race").second)
+    fun `get re-reads actual state when lazy expiry CAS loses race`() {
+        runBlocking {
+            val creationTime = fixedClock.instant()
+            val s1 = store(clock = Clock.fixed(creationTime, ZoneId.of("UTC")))
+            s1.create(createContinuation("lazy-race").first, createContinuation("lazy-race").second)
 
-        // Another connection claims the row (bypassing the expiration path)
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        conn.use { c ->
-            c.createStatement().use { stmt ->
-                stmt.execute(
-                    """UPDATE approval_continuations
+            // Another connection claims the row (bypassing the expiration path)
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                c.createStatement().use { stmt ->
+                    stmt.execute(
+                        """UPDATE approval_continuations
                        SET status = 'CLAIMED', version = 1,
                            claimed_by = 'worker:racer', claimed_at = NOW()
-                       WHERE approval_id = 'lazy-race'"""
-                )
+                       WHERE approval_id = 'lazy-race'""",
+                    )
+                }
             }
+
+            // Now read with a future clock: lazy expiry sees PENDING row (stale read),
+            // tries CAS, loses because row is now CLAIMED.
+            val futureClock = Clock.fixed(creationTime.plusSeconds(600), ZoneId.of("UTC"))
+            val s2 = store(clock = futureClock)
+            val retrieved = s2.get("lazy-race")
+
+            // Must return the actual persisted state (CLAIMED), not synthetic EXPIRED
+            assertNotNull(retrieved)
+            assertEquals(
+                ApprovalContinuationStatus.CLAIMED,
+                retrieved.status,
+                "get() must return actual persisted state, not synthetic EXPIRED",
+            )
+            assertEquals(1L, retrieved.version)
         }
-
-        // Now read with a future clock: lazy expiry sees PENDING row (stale read),
-        // tries CAS, loses because row is now CLAIMED.
-        val futureClock = Clock.fixed(creationTime.plusSeconds(600), ZoneId.of("UTC"))
-        val s2 = store(clock = futureClock)
-        val retrieved = s2.get("lazy-race")
-
-        // Must return the actual persisted state (CLAIMED), not synthetic EXPIRED
-        assertNotNull(retrieved)
-        assertEquals(ApprovalContinuationStatus.CLAIMED, retrieved.status,
-            "get() must return actual persisted state, not synthetic EXPIRED")
-        assertEquals(1L, retrieved.version)
-    }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -1039,36 +1155,143 @@ class JdbcApprovalContinuationStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `schema rejects invalid status`() { runBlocking {
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        assertFailsWith<org.postgresql.util.PSQLException> {
-            conn.prepareStatement(
-                """INSERT INTO approval_continuations
-                   (approval_id, status, version, created_at, approval_expires_at, arguments_digest)
-                   VALUES ('bad-status', 'BOGUS', 0, NOW(), NOW() + INTERVAL '5 minutes', 'sha256:${"a".repeat(64)}')"""
-            ).use { stmt ->
-                stmt.executeUpdate()
+    fun `schema rejects invalid status`() {
+        runBlocking {
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            assertFailsWith<org.postgresql.util.PSQLException> {
+                conn
+                    .prepareStatement(
+                        """INSERT INTO approval_continuations
+                    (approval_id, status, version, created_at, approval_expires_at, arguments_digest)
+                    VALUES ('bad-status', 'BOGUS', 0, NOW(), NOW() + INTERVAL '5 minutes',
+                    'sha256:${"a".repeat(64)}')""",
+                    ).use { stmt ->
+                        stmt.executeUpdate()
+                    }
             }
         }
-    }
     }
 
     @Test
-    fun `schema rejects approval_expires_at before created_at`() { runBlocking {
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        assertFailsWith<org.postgresql.util.PSQLException> {
-            conn.prepareStatement(
-                """INSERT INTO approval_continuations
-                   (approval_id, status, version, created_at, approval_expires_at, arguments_digest)
-                   VALUES ('bad-expiry', 'PENDING', 0, NOW(), NOW() - INTERVAL '5 minutes', 'sha256:${"a".repeat(64)}')"""
-            ).use { stmt ->
-                stmt.executeUpdate()
+    fun `schema rejects approval_expires_at before created_at`() {
+        runBlocking {
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            assertFailsWith<org.postgresql.util.PSQLException> {
+                conn
+                    .prepareStatement(
+                        """INSERT INTO approval_continuations
+                    (approval_id, status, version, created_at, approval_expires_at, arguments_digest)
+                    VALUES ('bad-expiry', 'PENDING', 0, NOW(), NOW() - INTERVAL '5 minutes',
+                    'sha256:${"a".repeat(64)}')""",
+                    ).use { stmt ->
+                        stmt.executeUpdate()
+                    }
             }
         }
     }
+
+    // ── Diagnostic sanitization (R12-002) ─────────────────────────
+
+    @Test
+    fun `unexpected SQL errors sanitize diagnostics across all operations`() {
+        runBlocking {
+            val realDs = createDataSource()
+            val throwingDs =
+                object : DataSource by realDs {
+                    override fun getConnection(): Connection {
+                        val realConn = realDs.getConnection()
+                        return object : Connection by realConn {
+                            override fun prepareStatement(sql: String): java.sql.PreparedStatement {
+                                realConn.close()
+                                throw SQLException(
+                                    "Connection reset; " +
+                                        "query=SELECT encrypted_arguments FROM approval_continuations WHERE secret_token='12345'",
+                                    "08006",
+                                )
+                            }
+                        }
+                    }
+                }
+            val s =
+                JdbcApprovalContinuationStore(
+                    dataSource = throwingDs,
+                    argumentsCodec = testCodec,
+                    clock = fixedClock,
+                )
+
+            val (continuation, args) = createContinuation("cont-err-1")
+            val createEx =
+                assertFailsWith<IllegalStateException> {
+                    s.create(continuation, args)
+                }
+            assertEquals("Database operation failed for continuation: cont-err-1", createEx.message)
+            assertFalse(createEx.message?.contains("secret_token") == true)
+
+            val getEx =
+                assertFailsWith<IllegalStateException> {
+                    s.get("cont-err-2")
+                }
+            assertEquals("Database operation failed for continuation: cont-err-2", getEx.message)
+            assertFalse(getEx.message?.contains("secret_token") == true)
+
+            val claimEx =
+                assertFailsWith<IllegalStateException> {
+                    s.claimForExecution("cont-err-3", 0L, "worker:alpha")
+                }
+            assertEquals("Database operation failed for continuation: cont-err-3", claimEx.message)
+            assertFalse(claimEx.message?.contains("secret_token") == true)
+
+            val completeEx =
+                assertFailsWith<IllegalStateException> {
+                    s.complete("cont-err-4", 1L, "worker:alpha")
+                }
+            assertEquals("Database operation failed for continuation: cont-err-4", completeEx.message)
+            assertFalse(completeEx.message?.contains("secret_token") == true)
+
+            val expireEx =
+                assertFailsWith<IllegalStateException> {
+                    s.expire("cont-err-5", 0L)
+                }
+            assertEquals("Database operation failed for continuation: cont-err-5", expireEx.message)
+            assertFalse(expireEx.message?.contains("secret_token") == true)
+
+            val cancelEx =
+                assertFailsWith<IllegalStateException> {
+                    s.cancel("cont-err-6", 0L)
+                }
+            assertEquals("Database operation failed for continuation: cont-err-6", cancelEx.message)
+            assertFalse(cancelEx.message?.contains("secret_token") == true)
+
+            val findStaleEx =
+                assertFailsWith<IllegalStateException> {
+                    s.findStaleClaimed(fixedClock.instant(), 10)
+                }
+            assertEquals("Database operation failed for finding stale continuations", findStaleEx.message)
+            assertFalse(findStaleEx.message?.contains("secret_token") == true)
+
+            val forceCancelEx =
+                assertFailsWith<IllegalStateException> {
+                    s.forceCancelClaimed("cont-err-7", 1L, "operator:admin", "manual_override")
+                }
+            assertEquals("Database operation failed for continuation: cont-err-7", forceCancelEx.message)
+            assertFalse(forceCancelEx.message?.contains("secret_token") == true)
+
+            val sweepEx =
+                assertFailsWith<IllegalStateException> {
+                    s.sweepExpired()
+                }
+            assertEquals("Database operation failed for sweeping expired continuations", sweepEx.message)
+            assertFalse(sweepEx.message?.contains("secret_token") == true)
+        }
     }
 }

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStoreTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcApprovalStoreTest.kt
@@ -32,6 +32,7 @@ import java.util.concurrent.CancellationException
 import javax.sql.DataSource
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertSame
@@ -39,41 +40,45 @@ import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class JdbcApprovalStoreTest {
-
     companion object {
         private const val POSTGRES_IMAGE = "postgres:17-alpine"
 
-        private val postgres = PostgreSQLContainer(POSTGRES_IMAGE)
-            .withDatabaseName("approval_test")
-            .withUsername("test")
-            .withPassword("test")
+        private val postgres =
+            PostgreSQLContainer(POSTGRES_IMAGE)
+                .withDatabaseName("approval_test")
+                .withUsername("test")
+                .withPassword("test")
 
-        private fun createDataSource(): DataSource = PGSimpleDataSource().apply {
-            setUrl(postgres.jdbcUrl)
-            user = postgres.username
-            password = postgres.password
-        }
+        private fun createDataSource(): DataSource =
+            PGSimpleDataSource().apply {
+                setUrl(postgres.jdbcUrl)
+                user = postgres.username
+                password = postgres.password
+            }
     }
 
     private lateinit var dataSource: DataSource
     private lateinit var setupConnection: Connection
-    private val fixedClock: Clock = Clock.fixed(
-        Instant.parse("2026-06-21T12:00:00Z"),
-        ZoneId.of("UTC"),
-    )
+    private val fixedClock: Clock =
+        Clock.fixed(
+            Instant.parse("2026-06-21T12:00:00Z"),
+            ZoneId.of("UTC"),
+        )
 
     @BeforeAll
     fun setUpAll() {
         postgres.start()
-        setupConnection = DriverManager.getConnection(
-            postgres.jdbcUrl,
-            postgres.username,
-            postgres.password,
-        )
-        val schemaSql = this::class.java.classLoader
-            .getResource("tramai/persistence/jdbc/postgres/V1__sovereign_persistence.sql")
-            ?.readText()
-            ?: throw IllegalStateException("Schema SQL resource not found")
+        setupConnection =
+            DriverManager.getConnection(
+                postgres.jdbcUrl,
+                postgres.username,
+                postgres.password,
+            )
+        val schemaSql =
+            this::class.java.classLoader
+                .getResource("tramai/persistence/jdbc/postgres/V1__sovereign_persistence.sql")
+                ?.readText()
+                ?: throw IllegalStateException("Schema SQL resource not found")
         setupConnection.createStatement().use { stmt ->
             stmt.execute(schemaSql)
         }
@@ -95,8 +100,7 @@ class JdbcApprovalStoreTest {
 
     // ── Helpers ─────────────────────────────────────────────────
 
-    private fun store(clock: Clock = fixedClock): JdbcApprovalStore =
-        JdbcApprovalStore(dataSource, clock)
+    private fun store(clock: Clock = fixedClock): JdbcApprovalStore = JdbcApprovalStore(dataSource, clock)
 
     /**
      * A DataSource whose connections delegate to the real database but fail
@@ -106,7 +110,10 @@ class JdbcApprovalStoreTest {
      * so the production code sees a single JDBC transaction rather than a
      * fresh connection per method call.
      */
-    private fun dataSourceWithFailures(commitFailure: Exception, restoreFailure: Exception? = null): DataSource {
+    private fun dataSourceWithFailures(
+        commitFailure: Exception,
+        restoreFailure: Exception? = null,
+    ): DataSource {
         val real = dataSource
         return Proxy.newProxyInstance(
             DataSource::class.java.classLoader,
@@ -140,14 +147,15 @@ class JdbcApprovalStoreTest {
         val now = fixedClock.instant()
         return ApprovalRequest(
             approvalId = id,
-            binding = ApprovalBinding(
-                workflowRunId = "wf-run-001",
-                toolName = toolName,
-                argumentsDigest = Sha256Digest.of("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-                policyVersion = "v1",
-                workflowDigest = Sha256Digest.of("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-                approvalTokenDigest = Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-            ),
+            binding =
+                ApprovalBinding(
+                    workflowRunId = "wf-run-001",
+                    toolName = toolName,
+                    argumentsDigest = Sha256Digest.of("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                    policyVersion = "v1",
+                    workflowDigest = Sha256Digest.of("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+                    approvalTokenDigest = Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+                ),
             status = ApprovalStatus.PENDING,
             requestedBy = requestedBy,
             requestedAt = now,
@@ -164,436 +172,551 @@ class JdbcApprovalStoreTest {
     // ── Create / Get ────────────────────────────────────────────
 
     @Test
-    fun `saves and loads a pending approval`() { runBlocking {
-        val s = store()
-        val request = approvalRequest()
+    fun `saves and loads a pending approval`() {
+        runBlocking {
+            val s = store()
+            val request = approvalRequest()
 
-        s.create(request)
-        val loaded = s.get("test-approval-1")
+            s.create(request)
+            val loaded = s.get("test-approval-1")
 
-        assertNotNull(loaded)
-        assertEquals("test-approval-1", loaded.approvalId)
-        assertEquals(ApprovalStatus.PENDING, loaded.status)
-        assertEquals("user:alice", loaded.requestedBy)
-        assertEquals("deploy-service", loaded.binding.toolName)
-        assertEquals(0, loaded.version)
-    }
-    }
-
-    @Test
-    fun `persisted approval survives new store instance`() { runBlocking {
-        val s1 = store()
-        s1.create(approvalRequest(id = "survive-test"))
-
-        val s2 = store()
-        val loaded = s2.get("survive-test")
-
-        assertNotNull(loaded)
-        assertEquals(ApprovalStatus.PENDING, loaded.status)
-        assertEquals("user:alice", loaded.requestedBy)
-    }
-    }
-
-    @Test
-    fun `get returns null for non-existent approval`() { runBlocking {
-        val loaded = store().get("non-existent")
-        assertNull(loaded)
-    }
-    }
-
-    @Test
-    fun `duplicate approval ID throws ApprovalStoreConflictException`() { runBlocking {
-        val s = store()
-        s.create(approvalRequest(id = "dup-test"))
-
-        assertFailsWith<ApprovalStoreConflictException> {
-            s.create(approvalRequest(id = "dup-test"))
+            assertNotNull(loaded)
+            assertEquals("test-approval-1", loaded.approvalId)
+            assertEquals(ApprovalStatus.PENDING, loaded.status)
+            assertEquals("user:alice", loaded.requestedBy)
+            assertEquals("deploy-service", loaded.binding.toolName)
+            assertEquals(0, loaded.version)
         }
     }
+
+    @Test
+    fun `persisted approval survives new store instance`() {
+        runBlocking {
+            val s1 = store()
+            s1.create(approvalRequest(id = "survive-test"))
+
+            val s2 = store()
+            val loaded = s2.get("survive-test")
+
+            assertNotNull(loaded)
+            assertEquals(ApprovalStatus.PENDING, loaded.status)
+            assertEquals("user:alice", loaded.requestedBy)
+        }
+    }
+
+    @Test
+    fun `get returns null for non-existent approval`() {
+        runBlocking {
+            val loaded = store().get("non-existent")
+            assertNull(loaded)
+        }
+    }
+
+    @Test
+    fun `duplicate approval ID throws ApprovalStoreConflictException`() {
+        runBlocking {
+            val s = store()
+            s.create(approvalRequest(id = "dup-test"))
+
+            assertFailsWith<ApprovalStoreConflictException> {
+                s.create(approvalRequest(id = "dup-test"))
+            }
+        }
     }
 
     // ── Transitions ─────────────────────────────────────────────
 
     @Test
-    fun `records approval decision`() { runBlocking {
-        val s = store()
-        s.create(approvalRequest(id = "approve-test"))
+    fun `records approval decision`() {
+        runBlocking {
+            val s = store()
+            s.create(approvalRequest(id = "approve-test"))
 
-        val updated = s.transition("approve-test", 0, ApprovalTransition.Approve("user:bob"))
+            val updated = s.transition("approve-test", 0, ApprovalTransition.Approve("user:bob"))
 
-        assertEquals(ApprovalStatus.APPROVED, updated.status)
-        assertEquals("user:bob", updated.decidedBy)
-        assertNotNull(updated.decidedAt)
-        assertEquals(1, updated.version)
-    }
-    }
-
-    @Test
-    fun `records denial decision`() { runBlocking {
-        val s = store()
-        s.create(approvalRequest(id = "deny-test"))
-
-        val updated = s.transition("deny-test", 0, ApprovalTransition.Deny("user:bob", "not approved"))
-
-        assertEquals(ApprovalStatus.DENIED, updated.status)
-        assertEquals("user:bob", updated.decidedBy)
-        assertEquals("not approved", updated.decisionComment)
-        assertEquals(1, updated.version)
-    }
-    }
-
-    @Test
-    fun `records timeout decision`() { runBlocking {
-        val s = store()
-        s.create(approvalRequest(id = "timeout-test"))
-
-        val expiredClock = Clock.fixed(
-            Instant.parse("2026-06-21T12:10:00Z"),
-            ZoneId.of("UTC"),
-        )
-        val expiredStore = store(expiredClock)
-        val updated = expiredStore.transition("timeout-test", 0, ApprovalTransition.Timeout)
-
-        assertEquals(ApprovalStatus.TIMED_OUT, updated.status)
-        assertNull(updated.decidedBy)
-        assertEquals(1, updated.version)
-    }
-    }
-
-    @Test
-    fun `transition with wrong version throws ApprovalStoreConflictException`() { runBlocking {
-        val s = store()
-        s.create(approvalRequest(id = "version-test"))
-        s.transition("version-test", 0, ApprovalTransition.Approve("user:bob"))
-
-        assertFailsWith<ApprovalStoreConflictException> {
-            s.transition("version-test", 0, ApprovalTransition.Deny("user:mallory"))
+            assertEquals(ApprovalStatus.APPROVED, updated.status)
+            assertEquals("user:bob", updated.decidedBy)
+            assertNotNull(updated.decidedAt)
+            assertEquals(1, updated.version)
         }
     }
-    }
 
     @Test
-    fun `transition on non-existent approval throws ApprovalStoreNotFoundException`() { runBlocking {
-        assertFailsWith<ApprovalStoreNotFoundException> {
-            store().transition("non-existent", 0, ApprovalTransition.Approve("user:bob"))
+    fun `records denial decision`() {
+        runBlocking {
+            val s = store()
+            s.create(approvalRequest(id = "deny-test"))
+
+            val updated = s.transition("deny-test", 0, ApprovalTransition.Deny("user:bob", "not approved"))
+
+            assertEquals(ApprovalStatus.DENIED, updated.status)
+            assertEquals("user:bob", updated.decidedBy)
+            assertEquals("not approved", updated.decisionComment)
+            assertEquals(1, updated.version)
         }
     }
-    }
 
     @Test
-    fun `illegal transition from terminal status throws IllegalApprovalTransitionException`() { runBlocking {
-        val s = store()
-        s.create(approvalRequest(id = "terminal-test"))
-        s.transition("terminal-test", 0, ApprovalTransition.Approve("user:bob"))
+    fun `records timeout decision`() {
+        runBlocking {
+            val s = store()
+            s.create(approvalRequest(id = "timeout-test"))
 
-        assertFailsWith<IllegalApprovalTransitionException> {
-            s.transition("terminal-test", 1, ApprovalTransition.Deny("user:bob"))
+            val expiredClock =
+                Clock.fixed(
+                    Instant.parse("2026-06-21T12:10:00Z"),
+                    ZoneId.of("UTC"),
+                )
+            val expiredStore = store(expiredClock)
+            val updated = expiredStore.transition("timeout-test", 0, ApprovalTransition.Timeout)
+
+            assertEquals(ApprovalStatus.TIMED_OUT, updated.status)
+            assertNull(updated.decidedBy)
+            assertEquals(1, updated.version)
         }
     }
-    }
 
     @Test
-    fun `decision update increments version`() { runBlocking {
-        val s = store()
-        s.create(approvalRequest(id = "version-inc-test"))
+    fun `transition with wrong version throws ApprovalStoreConflictException`() {
+        runBlocking {
+            val s = store()
+            s.create(approvalRequest(id = "version-test"))
+            s.transition("version-test", 0, ApprovalTransition.Approve("user:bob"))
 
-        val v1 = s.transition("version-inc-test", 0, ApprovalTransition.Approve("user:bob"))
-        assertEquals(1, v1.version)
-
-        val loaded = s.get("version-inc-test")
-        assertEquals(1, loaded!!.version)
-    }
-    }
-
-    @Test
-    fun `competing decisions cannot both win`() { runBlocking {
-        val s = store()
-        s.create(approvalRequest(id = "compete-test"))
-
-        s.transition("compete-test", 0, ApprovalTransition.Approve("user:bob"))
-
-        assertFailsWith<ApprovalStoreConflictException> {
-            s.transition("compete-test", 0, ApprovalTransition.Deny("user:mallory"))
+            assertFailsWith<ApprovalStoreConflictException> {
+                s.transition("version-test", 0, ApprovalTransition.Deny("user:mallory"))
+            }
         }
     }
+
+    @Test
+    fun `transition on non-existent approval throws ApprovalStoreNotFoundException`() {
+        runBlocking {
+            assertFailsWith<ApprovalStoreNotFoundException> {
+                store().transition("non-existent", 0, ApprovalTransition.Approve("user:bob"))
+            }
+        }
+    }
+
+    @Test
+    fun `illegal transition from terminal status throws IllegalApprovalTransitionException`() {
+        runBlocking {
+            val s = store()
+            s.create(approvalRequest(id = "terminal-test"))
+            s.transition("terminal-test", 0, ApprovalTransition.Approve("user:bob"))
+
+            assertFailsWith<IllegalApprovalTransitionException> {
+                s.transition("terminal-test", 1, ApprovalTransition.Deny("user:bob"))
+            }
+        }
+    }
+
+    @Test
+    fun `decision update increments version`() {
+        runBlocking {
+            val s = store()
+            s.create(approvalRequest(id = "version-inc-test"))
+
+            val v1 = s.transition("version-inc-test", 0, ApprovalTransition.Approve("user:bob"))
+            assertEquals(1, v1.version)
+
+            val loaded = s.get("version-inc-test")
+            assertEquals(1, loaded!!.version)
+        }
+    }
+
+    @Test
+    fun `competing decisions cannot both win`() {
+        runBlocking {
+            val s = store()
+            s.create(approvalRequest(id = "compete-test"))
+
+            s.transition("compete-test", 0, ApprovalTransition.Approve("user:bob"))
+
+            assertFailsWith<ApprovalStoreConflictException> {
+                s.transition("compete-test", 0, ApprovalTransition.Deny("user:mallory"))
+            }
+        }
     }
 
     // ── Consume / Replay ────────────────────────────────────────
 
     @Test
-    fun `consumes an approved request`() { runBlocking {
-        val s = store()
-        s.create(approvalRequest(id = "consume-test"))
-        s.transition("consume-test", 0, ApprovalTransition.Approve("user:bob"))
+    fun `consumes an approved request`() {
+        runBlocking {
+            val s = store()
+            s.create(approvalRequest(id = "consume-test"))
+            s.transition("consume-test", 0, ApprovalTransition.Approve("user:bob"))
 
-        val receipt = s.consumeApprovedOrReplay(
-            "consume-test", 1,
-            Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-            "worker:executor",
-        )
+            val receipt =
+                s.consumeApprovedOrReplay(
+                    "consume-test",
+                    1,
+                    Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+                    "worker:executor",
+                )
 
-        assertEquals("worker:executor", receipt.request.consumedBy)
-        assertNotNull(receipt.request.consumedAt)
-        assertEquals(2, receipt.request.version)
-        assertEquals(false, receipt.replayed)
-    }
-    }
-
-    @Test
-    fun `consumeApprovedOrReplay rethrows CancellationException unchanged from transaction cleanup`() { runBlocking {
-        val id = "cancel-consume"
-        val normal = store()
-        normal.create(approvalRequest(id = id))
-        normal.transition(id, 0, ApprovalTransition.Approve("user:bob"))
-
-        val cancellation = CancellationException("cancelled by test")
-        val failing = JdbcApprovalStore(dataSourceWithFailures(cancellation), fixedClock)
-
-        val thrown = runCatching {
-            failing.consumeApprovedOrReplay(
-                id, 1,
-                Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-                "worker:executor",
-            )
-        }.exceptionOrNull()
-
-        assertSame(cancellation, thrown)
-    }
-    }
-
-    @Test
-    fun `consumeApprovedOrReplay preserves primary exception when autoCommit restore fails`() { runBlocking {
-        val id = "cancel-restore"
-        val normal = store()
-        normal.create(approvalRequest(id = id))
-        normal.transition(id, 0, ApprovalTransition.Approve("user:bob"))
-
-        val cancellation = CancellationException("cancelled by test")
-        val restoreFailure = SQLException("restore failed")
-        val failing = JdbcApprovalStore(dataSourceWithFailures(cancellation, restoreFailure), fixedClock)
-
-        val thrown = runCatching {
-            failing.consumeApprovedOrReplay(
-                id, 1,
-                Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-                "worker:executor",
-            )
-        }.exceptionOrNull()
-
-        assertSame(cancellation, thrown)
-        assertEquals(listOf(restoreFailure), thrown?.suppressed?.toList())
-    }
-    }
-
-    @Test
-    fun `exact replay returns replayed receipt`() { runBlocking {
-        val s = store()
-        s.create(approvalRequest(id = "replay-test"))
-        s.transition("replay-test", 0, ApprovalTransition.Approve("user:bob"))
-
-        s.consumeApprovedOrReplay(
-            "replay-test", 1,
-            Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-            "worker:executor",
-        )
-
-        val receipt = s.consumeApprovedOrReplay(
-            "replay-test", 1,
-            Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-            "worker:executor",
-        )
-
-        assertEquals(true, receipt.replayed)
-        assertEquals(2, receipt.request.version)
-    }
-    }
-
-    @Test
-    fun `consuming unapproved request throws ApprovalStoreNotConsumableException`() { runBlocking {
-        val s = store()
-        s.create(approvalRequest(id = "unapproved-consume"))
-
-        assertFailsWith<ApprovalStoreNotConsumableException> {
-            s.consumeApprovedOrReplay(
-                "unapproved-consume", 0,
-                Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-                "worker:executor",
-            )
+            assertEquals("worker:executor", receipt.request.consumedBy)
+            assertNotNull(receipt.request.consumedAt)
+            assertEquals(2, receipt.request.version)
+            assertEquals(false, receipt.replayed)
         }
     }
+
+    @Test
+    fun `consumeApprovedOrReplay rethrows CancellationException unchanged from transaction cleanup`() {
+        runBlocking {
+            val id = "cancel-consume"
+            val normal = store()
+            normal.create(approvalRequest(id = id))
+            normal.transition(id, 0, ApprovalTransition.Approve("user:bob"))
+
+            val cancellation = CancellationException("cancelled by test")
+            val failing = JdbcApprovalStore(dataSourceWithFailures(cancellation), fixedClock)
+
+            val thrown =
+                runCatching {
+                    failing.consumeApprovedOrReplay(
+                        id,
+                        1,
+                        Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+                        "worker:executor",
+                    )
+                }.exceptionOrNull()
+
+            assertSame(cancellation, thrown)
+        }
     }
 
     @Test
-    fun `consuming with wrong token throws ApprovalStoreTokenRejectedException`() { runBlocking {
-        val s = store()
-        s.create(approvalRequest(id = "wrong-token"))
-        s.transition("wrong-token", 0, ApprovalTransition.Approve("user:bob"))
+    fun `consumeApprovedOrReplay preserves primary exception when autoCommit restore fails`() {
+        runBlocking {
+            val id = "cancel-restore"
+            val normal = store()
+            normal.create(approvalRequest(id = id))
+            normal.transition(id, 0, ApprovalTransition.Approve("user:bob"))
 
-        assertFailsWith<ApprovalStoreTokenRejectedException> {
-            s.consumeApprovedOrReplay(
-                "wrong-token", 1,
-                Sha256Digest.of("sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
-                "worker:executor",
-            )
+            val cancellation = CancellationException("cancelled by test")
+            val restoreFailure = SQLException("restore failed")
+            val failing = JdbcApprovalStore(dataSourceWithFailures(cancellation, restoreFailure), fixedClock)
+
+            val thrown =
+                runCatching {
+                    failing.consumeApprovedOrReplay(
+                        id,
+                        1,
+                        Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+                        "worker:executor",
+                    )
+                }.exceptionOrNull()
+
+            assertSame(cancellation, thrown)
+            assertEquals(listOf(restoreFailure), thrown?.suppressed?.toList())
         }
     }
+
+    @Test
+    fun `exact replay returns replayed receipt`() {
+        runBlocking {
+            val s = store()
+            s.create(approvalRequest(id = "replay-test"))
+            s.transition("replay-test", 0, ApprovalTransition.Approve("user:bob"))
+
+            s.consumeApprovedOrReplay(
+                "replay-test",
+                1,
+                Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+                "worker:executor",
+            )
+
+            val receipt =
+                s.consumeApprovedOrReplay(
+                    "replay-test",
+                    1,
+                    Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+                    "worker:executor",
+                )
+
+            assertEquals(true, receipt.replayed)
+            assertEquals(2, receipt.request.version)
+        }
+    }
+
+    @Test
+    fun `consuming unapproved request throws ApprovalStoreNotConsumableException`() {
+        runBlocking {
+            val s = store()
+            s.create(approvalRequest(id = "unapproved-consume"))
+
+            assertFailsWith<ApprovalStoreNotConsumableException> {
+                s.consumeApprovedOrReplay(
+                    "unapproved-consume",
+                    0,
+                    Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+                    "worker:executor",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `consuming with wrong token throws ApprovalStoreTokenRejectedException`() {
+        runBlocking {
+            val s = store()
+            s.create(approvalRequest(id = "wrong-token"))
+            s.transition("wrong-token", 0, ApprovalTransition.Approve("user:bob"))
+
+            assertFailsWith<ApprovalStoreTokenRejectedException> {
+                s.consumeApprovedOrReplay(
+                    "wrong-token",
+                    1,
+                    Sha256Digest.of("sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
+                    "worker:executor",
+                )
+            }
+        }
     }
 
     // ── Sanitized persistence ───────────────────────────────────
 
     @Test
-    fun `sanitized metadata round-trips as JSONB`() { runBlocking {
-        val s = store()
-        val request = approvalRequest(id = "jsonb-test")
-        s.create(request)
+    fun `sanitized metadata round-trips as JSONB`() {
+        runBlocking {
+            val s = store()
+            val request = approvalRequest(id = "jsonb-test")
+            s.create(request)
 
-        val loaded = s.get("jsonb-test")
-        assertNotNull(loaded)
-        assertEquals(request.binding.workflowRunId, loaded.binding.workflowRunId)
-        assertEquals(request.binding.toolName, loaded.binding.toolName)
-        assertEquals(request.binding.argumentsDigest, loaded.binding.argumentsDigest)
-        assertEquals(request.binding.policyVersion, loaded.binding.policyVersion)
-        assertEquals(request.binding.workflowDigest, loaded.binding.workflowDigest)
-        assertEquals(request.binding.approvalTokenDigest, loaded.binding.approvalTokenDigest)
-    }
+            val loaded = s.get("jsonb-test")
+            assertNotNull(loaded)
+            assertEquals(request.binding.workflowRunId, loaded.binding.workflowRunId)
+            assertEquals(request.binding.toolName, loaded.binding.toolName)
+            assertEquals(request.binding.argumentsDigest, loaded.binding.argumentsDigest)
+            assertEquals(request.binding.policyVersion, loaded.binding.policyVersion)
+            assertEquals(request.binding.workflowDigest, loaded.binding.workflowDigest)
+            assertEquals(request.binding.approvalTokenDigest, loaded.binding.approvalTokenDigest)
+        }
     }
 
     @Test
-    fun `encrypted_payload remains null for sanitized-only approval records`() { runBlocking {
-        val s = store()
-        s.create(approvalRequest(id = "enc-null-test"))
+    fun `encrypted_payload remains null for sanitized-only approval records`() {
+        runBlocking {
+            val s = store()
+            s.create(approvalRequest(id = "enc-null-test"))
 
-        setupConnection.createStatement().use { stmt ->
-            val rs = stmt.executeQuery(
-                "SELECT encrypted_payload, encryption_key_id, encryption_algorithm, encryption_nonce, payload_digest FROM approvals WHERE approval_id = 'enc-null-test'"
-            )
-            assertTrue(rs.next())
-            assertNull(rs.getObject("encrypted_payload"))
-            assertNull(rs.getObject("encryption_key_id"))
-            assertNull(rs.getObject("encryption_algorithm"))
-            assertNull(rs.getObject("encryption_nonce"))
-            assertNull(rs.getObject("payload_digest"))
+            setupConnection.createStatement().use { stmt ->
+                val rs =
+                    stmt.executeQuery(
+                        "SELECT encrypted_payload, encryption_key_id, encryption_algorithm, encryption_nonce, payload_digest FROM approvals WHERE approval_id = 'enc-null-test'",
+                    )
+                assertTrue(rs.next())
+                assertNull(rs.getObject("encrypted_payload"))
+                assertNull(rs.getObject("encryption_key_id"))
+                assertNull(rs.getObject("encryption_algorithm"))
+                assertNull(rs.getObject("encryption_nonce"))
+                assertNull(rs.getObject("payload_digest"))
+            }
         }
-    }
     }
 
     @Test
-    fun `no raw prompt or model payload is persisted`() { runBlocking {
-        val s = store()
-        s.create(approvalRequest(id = "sanitized-payload-test"))
-        s.transition("sanitized-payload-test", 0, ApprovalTransition.Approve("user:bob"))
+    fun `no raw prompt or model payload is persisted`() {
+        runBlocking {
+            val s = store()
+            s.create(approvalRequest(id = "sanitized-payload-test"))
+            s.transition("sanitized-payload-test", 0, ApprovalTransition.Approve("user:bob"))
 
-        val loaded = s.get("sanitized-payload-test")
-        assertNotNull(loaded)
+            val loaded = s.get("sanitized-payload-test")
+            assertNotNull(loaded)
 
-        assertTrue(loaded.binding.argumentsDigest.value.startsWith("sha256:"))
-        assertTrue(loaded.binding.workflowDigest.value.startsWith("sha256:"))
-        assertTrue(loaded.binding.approvalTokenDigest.value.startsWith("sha256:"))
-
-        setupConnection.createStatement().use { stmt ->
-            val rs = stmt.executeQuery(
-                "SELECT sanitized_metadata::text FROM approvals WHERE approval_id = 'sanitized-payload-test'"
+            assertTrue(
+                loaded.binding.argumentsDigest.value
+                    .startsWith("sha256:"),
             )
-            assertTrue(rs.next())
-            val metadata = rs.getString("sanitized_metadata")
-            assertNotNull(metadata)
-            assertTrue("argumentsDigest" in metadata)
+            assertTrue(
+                loaded.binding.workflowDigest.value
+                    .startsWith("sha256:"),
+            )
+            assertTrue(
+                loaded.binding.approvalTokenDigest.value
+                    .startsWith("sha256:"),
+            )
+
+            setupConnection.createStatement().use { stmt ->
+                val rs =
+                    stmt.executeQuery(
+                        "SELECT sanitized_metadata::text FROM approvals WHERE approval_id = 'sanitized-payload-test'",
+                    )
+                assertTrue(rs.next())
+                val metadata = rs.getString("sanitized_metadata")
+                assertNotNull(metadata)
+                assertTrue("argumentsDigest" in metadata)
+            }
         }
-    }
     }
 
     @Test
-    fun `decision_actor_hash stores hash not raw identity`() { runBlocking {
-        val s = store()
-        s.create(approvalRequest(id = "actor-hash-test"))
-        s.transition("actor-hash-test", 0, ApprovalTransition.Approve("user:bob"))
+    fun `decision_actor_hash stores hash not raw identity`() {
+        runBlocking {
+            val s = store()
+            s.create(approvalRequest(id = "actor-hash-test"))
+            s.transition("actor-hash-test", 0, ApprovalTransition.Approve("user:bob"))
 
-        setupConnection.createStatement().use { stmt ->
-            val rs = stmt.executeQuery(
-                "SELECT decision_actor_hash FROM approvals WHERE approval_id = 'actor-hash-test'"
-            )
-            assertTrue(rs.next())
-            val hash = rs.getString("decision_actor_hash")
-            assertNotNull(hash)
-            assertTrue(hash.startsWith("sha256:"))
-            assertEquals(71, hash.length)
+            setupConnection.createStatement().use { stmt ->
+                val rs =
+                    stmt.executeQuery(
+                        "SELECT decision_actor_hash FROM approvals WHERE approval_id = 'actor-hash-test'",
+                    )
+                assertTrue(rs.next())
+                val hash = rs.getString("decision_actor_hash")
+                assertNotNull(hash)
+                assertTrue(hash.startsWith("sha256:"))
+                assertEquals(71, hash.length)
+            }
         }
-    }
     }
 
     // ── RequestedAt round-trip ────────────────────────────────────
 
     @Test
-    fun `requestedAt round-trips when earlier than store clock`() { runBlocking {
-        val now = fixedClock.instant()
-        val request = approvalRequest(id = "requested-at-roundtrip").copy(
-            requestedAt = now.minusSeconds(30),
-            expiresAt = now.plus(Duration.ofMinutes(5)),
-        )
+    fun `requestedAt round-trips when earlier than store clock`() {
+        runBlocking {
+            val now = fixedClock.instant()
+            val request =
+                approvalRequest(id = "requested-at-roundtrip").copy(
+                    requestedAt = now.minusSeconds(30),
+                    expiresAt = now.plus(Duration.ofMinutes(5)),
+                )
 
-        store().create(request)
+            store().create(request)
 
-        val loaded = store().get("requested-at-roundtrip")!!
+            val loaded = store().get("requested-at-roundtrip")!!
 
-        assertEquals(request.requestedAt, loaded.requestedAt)
-        assertEquals(request.expiresAt, loaded.expiresAt)
-    }
+            assertEquals(request.requestedAt, loaded.requestedAt)
+            assertEquals(request.expiresAt, loaded.expiresAt)
+        }
     }
 
     // ── Concurrent consumption ────────────────────────────────────
 
     @Test
-    fun `concurrent consumption with same version results in exactly one fresh consume`() { runBlocking {
-        val s = store()
-        s.create(approvalRequest(id = "concurrent-consume"))
-        s.transition("concurrent-consume", 0, ApprovalTransition.Approve("user:bob"))
+    fun `concurrent consumption with same version results in exactly one fresh consume`() {
+        runBlocking {
+            val s = store()
+            s.create(approvalRequest(id = "concurrent-consume"))
+            s.transition("concurrent-consume", 0, ApprovalTransition.Approve("user:bob"))
 
-        val token = Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
+            val token = Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
 
-        val results = coroutineScope {
-            val d1 = async {
-                try {
-                    val r = s.consumeApprovedOrReplay("concurrent-consume", 1, token, "worker:alpha")
-                    "fresh:${r.replayed}"
-                } catch (e: Exception) {
-                    "error:${e::class.simpleName}"
+            val results =
+                coroutineScope {
+                    val d1 =
+                        async {
+                            try {
+                                val r = s.consumeApprovedOrReplay("concurrent-consume", 1, token, "worker:alpha")
+                                "fresh:${r.replayed}"
+                            } catch (e: Exception) {
+                                "error:${e::class.simpleName}"
+                            }
+                        }
+                    val d2 =
+                        async {
+                            try {
+                                val r = s.consumeApprovedOrReplay("concurrent-consume", 1, token, "worker:alpha")
+                                "fresh:${r.replayed}"
+                            } catch (e: Exception) {
+                                "error:${e::class.simpleName}"
+                            }
+                        }
+                    listOf(d1.await(), d2.await())
                 }
-            }
-            val d2 = async {
-                try {
-                    val r = s.consumeApprovedOrReplay("concurrent-consume", 1, token, "worker:alpha")
-                    "fresh:${r.replayed}"
-                } catch (e: Exception) {
-                    "error:${e::class.simpleName}"
-                }
-            }
-            listOf(d1.await(), d2.await())
+
+            assertEquals(2, results.size)
+            val freshCount = results.count { it == "fresh:false" }
+            assertEquals(1, freshCount, "Exactly one concurrent consumer should get fresh consumption")
         }
-
-        assertEquals(2, results.size)
-        val freshCount = results.count { it == "fresh:false" }
-        assertEquals(1, freshCount, "Exactly one concurrent consumer should get fresh consumption")
-    }
     }
 
     // ── Clock ───────────────────────────────────────────────────
 
     @Test
-    fun `created_at uses store clock`() { runBlocking {
-        val customClock = Clock.fixed(
-            Instant.parse("2026-01-15T08:30:00Z"),
-            ZoneId.of("UTC"),
-        )
-        val s = store(customClock)
-        val request = approvalRequest(id = "clock-test").copy(
-            requestedAt = customClock.instant(),
-            expiresAt = customClock.instant().plus(Duration.ofMinutes(5)),
-        )
-        s.create(request)
+    fun `created_at uses store clock`() {
+        runBlocking {
+            val customClock =
+                Clock.fixed(
+                    Instant.parse("2026-01-15T08:30:00Z"),
+                    ZoneId.of("UTC"),
+                )
+            val s = store(customClock)
+            val request =
+                approvalRequest(id = "clock-test").copy(
+                    requestedAt = customClock.instant(),
+                    expiresAt = customClock.instant().plus(Duration.ofMinutes(5)),
+                )
+            s.create(request)
 
-        val loaded = s.get("clock-test")
-        assertNotNull(loaded)
-        assertEquals(Instant.parse("2026-01-15T08:30:00Z"), loaded.requestedAt)
+            val loaded = s.get("clock-test")
+            assertNotNull(loaded)
+            assertEquals(Instant.parse("2026-01-15T08:30:00Z"), loaded.requestedAt)
+        }
     }
+
+    // ── Diagnostic sanitization (R12-002) ─────────────────────────
+
+    @Test
+    fun `unexpected SQL errors sanitize diagnostics across all operations`() {
+        runBlocking {
+            val realDs = createDataSource()
+            val throwingDs =
+                object : DataSource by realDs {
+                    override fun getConnection(): Connection {
+                        val realConn = realDs.getConnection()
+                        return object : Connection by realConn {
+                            override fun prepareStatement(sql: String): java.sql.PreparedStatement {
+                                realConn.close()
+                                throw SQLException(
+                                    "Table 'approvals' does not exist; " +
+                                        "query=SELECT sensitive_column FROM approvals WHERE secret_token='12345'",
+                                    "42P01",
+                                )
+                            }
+                        }
+                    }
+                }
+            val s = JdbcApprovalStore(throwingDs, fixedClock)
+
+            val createEx =
+                assertFailsWith<IllegalStateException> {
+                    s.create(approvalRequest(id = "appr-err-1"))
+                }
+            assertEquals("Database operation failed for approval: appr-err-1", createEx.message)
+            assertFalse(createEx.message?.contains("approvals") == true)
+            assertFalse(createEx.message?.contains("secret_token") == true)
+
+            val getEx =
+                assertFailsWith<IllegalStateException> {
+                    s.get("appr-err-2")
+                }
+            assertEquals("Database operation failed for approval: appr-err-2", getEx.message)
+            assertFalse(getEx.message?.contains("secret_token") == true)
+
+            val transitionEx =
+                assertFailsWith<IllegalStateException> {
+                    s.transition("appr-err-3", 0L, ApprovalTransition.Approve("user:bob"))
+                }
+            assertEquals("Database operation failed for approval: appr-err-3", transitionEx.message)
+            assertFalse(transitionEx.message?.contains("secret_token") == true)
+
+            val consumeEx =
+                assertFailsWith<IllegalStateException> {
+                    s.consumeApprovedOrReplay(
+                        "appr-err-4",
+                        1L,
+                        Sha256Digest.of("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+                        "worker:alice",
+                    )
+                }
+            assertEquals("Database operation failed for approval: appr-err-4", consumeEx.message)
+            assertFalse(consumeEx.message?.contains("secret_token") == true)
+        }
     }
 }

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcAuditStoreTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcAuditStoreTest.kt
@@ -14,14 +14,15 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.postgresql.ds.PGSimpleDataSource
 import org.testcontainers.containers.PostgreSQLContainer
+import java.lang.reflect.Proxy
 import java.security.MessageDigest
 import java.security.SecureRandom
 import java.sql.Connection
 import java.sql.DriverManager
+import java.sql.SQLException
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
-import java.lang.reflect.Proxy
 import java.util.concurrent.CancellationException
 import javax.crypto.Cipher
 import javax.crypto.spec.GCMParameterSpec
@@ -29,6 +30,7 @@ import javax.crypto.spec.SecretKeySpec
 import javax.sql.DataSource
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertSame
@@ -36,60 +38,65 @@ import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class JdbcAuditStoreTest {
-
     companion object {
         private const val POSTGRES_IMAGE = "postgres:17-alpine"
 
-        private val postgres = PostgreSQLContainer(POSTGRES_IMAGE)
-            .withDatabaseName("audit_test")
-            .withUsername("test")
-            .withPassword("test")
+        private val postgres =
+            PostgreSQLContainer(POSTGRES_IMAGE)
+                .withDatabaseName("audit_test")
+                .withUsername("test")
+                .withPassword("test")
 
-        private fun createDataSource(): DataSource = PGSimpleDataSource().apply {
-            setUrl(postgres.jdbcUrl)
-            user = postgres.username
-            password = postgres.password
-        }
+        private fun createDataSource(): DataSource =
+            PGSimpleDataSource().apply {
+                setUrl(postgres.jdbcUrl)
+                user = postgres.username
+                password = postgres.password
+            }
     }
 
-    private val fixedClock: Clock = Clock.fixed(
-        Instant.parse("2026-06-22T12:00:00Z"),
-        ZoneId.of("UTC"),
-    )
+    private val fixedClock: Clock =
+        Clock.fixed(
+            Instant.parse("2026-06-22T12:00:00Z"),
+            ZoneId.of("UTC"),
+        )
 
     private val testAesKey = ByteArray(16).also { SecureRandom().nextBytes(it) }
 
-    private val testCodec = object : JdbcAuditPayloadCodec {
-        private val ALGORITHM = "AES/GCM/NoPadding"
-        private val TAG_LENGTH = 128
+    private val testCodec =
+        object : JdbcAuditPayloadCodec {
+            private val ALGORITHM = "AES/GCM/NoPadding"
+            private val TAG_LENGTH = 128
 
-        override fun encode(plaintext: ByteArray): JdbcEncryptedAuditPayload {
-            val cipher = Cipher.getInstance(ALGORITHM)
-            val nonce = ByteArray(12).also { SecureRandom().nextBytes(it) }
-            val keySpec = SecretKeySpec(testAesKey, "AES")
-            val spec = GCMParameterSpec(TAG_LENGTH, nonce)
-            cipher.init(Cipher.ENCRYPT_MODE, keySpec, spec)
-            val ciphertext = cipher.doFinal(plaintext)
-            val digest = MessageDigest.getInstance("SHA-256")
-                .digest(plaintext)
-                .joinToString("") { "%02x".format(it) }
-            return JdbcEncryptedAuditPayload(
-                ciphertext = ciphertext,
-                keyId = "test-key-1",
-                algorithm = ALGORITHM,
-                nonce = nonce,
-                payloadDigest = "sha256:$digest",
-            )
-        }
+            override fun encode(plaintext: ByteArray): JdbcEncryptedAuditPayload {
+                val cipher = Cipher.getInstance(ALGORITHM)
+                val nonce = ByteArray(12).also { SecureRandom().nextBytes(it) }
+                val keySpec = SecretKeySpec(testAesKey, "AES")
+                val spec = GCMParameterSpec(TAG_LENGTH, nonce)
+                cipher.init(Cipher.ENCRYPT_MODE, keySpec, spec)
+                val ciphertext = cipher.doFinal(plaintext)
+                val digest =
+                    MessageDigest
+                        .getInstance("SHA-256")
+                        .digest(plaintext)
+                        .joinToString("") { "%02x".format(it) }
+                return JdbcEncryptedAuditPayload(
+                    ciphertext = ciphertext,
+                    keyId = "test-key-1",
+                    algorithm = ALGORITHM,
+                    nonce = nonce,
+                    payloadDigest = "sha256:$digest",
+                )
+            }
 
-        override fun decode(envelope: JdbcEncryptedAuditPayload): ByteArray {
-            val cipher = Cipher.getInstance(ALGORITHM)
-            val keySpec = SecretKeySpec(testAesKey, "AES")
-            val spec = GCMParameterSpec(TAG_LENGTH, envelope.nonce)
-            cipher.init(Cipher.DECRYPT_MODE, keySpec, spec)
-            return cipher.doFinal(envelope.ciphertext)
+            override fun decode(envelope: JdbcEncryptedAuditPayload): ByteArray {
+                val cipher = Cipher.getInstance(ALGORITHM)
+                val keySpec = SecretKeySpec(testAesKey, "AES")
+                val spec = GCMParameterSpec(TAG_LENGTH, envelope.nonce)
+                cipher.init(Cipher.DECRYPT_MODE, keySpec, spec)
+                return cipher.doFinal(envelope.ciphertext)
+            }
         }
-    }
 
     @BeforeAll
     fun startPostgres() {
@@ -103,20 +110,27 @@ class JdbcAuditStoreTest {
     }
 
     private fun runMigrations() {
-        val migrations = listOf(
-            "V1__sovereign_persistence.sql",
-            "V2__approval_continuations.sql",
-            "V3__audit_events_hardening.sql",
-        )
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
+        val migrations =
+            listOf(
+                "V1__sovereign_persistence.sql",
+                "V2__approval_continuations.sql",
+                "V3__audit_events_hardening.sql",
+            )
+        val conn: Connection =
+            DriverManager.getConnection(
+                postgres.jdbcUrl,
+                postgres.username,
+                postgres.password,
+            )
         conn.use { c ->
             for (migration in migrations) {
-                val sql = javaClass.getResourceAsStream(
-                    "/tramai/persistence/jdbc/postgres/$migration",
-                )?.bufferedReader()?.readText()
-                    ?: throw IllegalStateException("Migration not found: $migration")
+                val sql =
+                    javaClass
+                        .getResourceAsStream(
+                            "/tramai/persistence/jdbc/postgres/$migration",
+                        )?.bufferedReader()
+                        ?.readText()
+                        ?: throw IllegalStateException("Migration not found: $migration")
                 c.createStatement().use { stmt -> stmt.execute(sql) }
             }
         }
@@ -124,9 +138,12 @@ class JdbcAuditStoreTest {
 
     @BeforeEach
     fun cleanTables() {
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
+        val conn: Connection =
+            DriverManager.getConnection(
+                postgres.jdbcUrl,
+                postgres.username,
+                postgres.password,
+            )
         conn.use { c ->
             c.createStatement().use { stmt ->
                 stmt.execute("DELETE FROM audit_events")
@@ -140,11 +157,12 @@ class JdbcAuditStoreTest {
     private fun store(
         codec: JdbcAuditPayloadCodec = testCodec,
         clock: Clock = fixedClock,
-    ): JdbcAuditStore = JdbcAuditStore(
-        dataSource = createDataSource(),
-        payloadCodec = codec,
-        clock = clock,
-    )
+    ): JdbcAuditStore =
+        JdbcAuditStore(
+            dataSource = createDataSource(),
+            payloadCodec = codec,
+            clock = clock,
+        )
 
     private fun createEvent(
         auditStreamId: String = "stream-1",
@@ -155,25 +173,26 @@ class JdbcAuditStoreTest {
         actor: String? = "user:alice",
         metadata: Map<String, String> = mapOf("key" to "value"),
     ): AuditEvent {
-        val base = AuditEvent(
-            schemaVersion = CURRENT_AUDIT_SCHEMA_VERSION,
-            hashAlgorithm = AuditHashAlgorithm.SHA_256,
-            auditStreamId = auditStreamId,
-            eventId = eventId,
-            sequenceNumber = sequenceNumber,
-            workflowRunId = "wf-1",
-            correlationId = "corr-1",
-            actor = actor,
-            enforcementPoint = "approval",
-            decision = decision,
-            policyVersion = "v1",
-            workflowDigest = "sha256:${"a".repeat(64)}",
-            previousEventHash = previousEventHash,
-            eventHash = "", // will be computed
-            timestamp = fixedClock.instant(),
-            reasonCode = null,
-            metadata = metadata,
-        )
+        val base =
+            AuditEvent(
+                schemaVersion = CURRENT_AUDIT_SCHEMA_VERSION,
+                hashAlgorithm = AuditHashAlgorithm.SHA_256,
+                auditStreamId = auditStreamId,
+                eventId = eventId,
+                sequenceNumber = sequenceNumber,
+                workflowRunId = "wf-1",
+                correlationId = "corr-1",
+                actor = actor,
+                enforcementPoint = "approval",
+                decision = decision,
+                policyVersion = "v1",
+                workflowDigest = "sha256:${"a".repeat(64)}",
+                previousEventHash = previousEventHash,
+                eventHash = "", // will be computed
+                timestamp = fixedClock.instant(),
+                reasonCode = null,
+                metadata = metadata,
+            )
         return base.copy(eventHash = base.copy(eventHash = "").calculateHash())
     }
 
@@ -183,137 +202,145 @@ class JdbcAuditStoreTest {
         eventIdPrefix: String = "evt",
         decision: String = "APPROVED",
         actor: String? = "user:alice",
-    ): (AuditEvent?) -> AuditEvent = { latest ->
-        val seq = (latest?.sequenceNumber ?: 0L) + 1L + sequenceOffset
-        // Include stream ID in eventId to avoid cross-stream uniqueness conflicts
-        val eid = "$eventIdPrefix-$auditStreamId-$seq"
-        createEvent(
-            auditStreamId = auditStreamId,
-            sequenceNumber = seq,
-            eventId = eid,
-            previousEventHash = latest?.eventHash,
-            decision = decision,
-            actor = actor,
-        )
-    }
+    ): (AuditEvent?) -> AuditEvent =
+        { latest ->
+            val seq = (latest?.sequenceNumber ?: 0L) + 1L + sequenceOffset
+            // Include stream ID in eventId to avoid cross-stream uniqueness conflicts
+            val eid = "$eventIdPrefix-$auditStreamId-$seq"
+            createEvent(
+                auditStreamId = auditStreamId,
+                sequenceNumber = seq,
+                eventId = eid,
+                previousEventHash = latest?.eventHash,
+                decision = decision,
+                actor = actor,
+            )
+        }
 
     // ═══════════════════════════════════════════════════════════════
     // Append tests
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `append first event gets sequence 1 with null previous hash`() { runBlocking {
-        val s = store()
-        val event = s.appendNext("stream-1", eventFactory("stream-1"))
+    fun `append first event gets sequence 1 with null previous hash`() {
+        runBlocking {
+            val s = store()
+            val event = s.appendNext("stream-1", eventFactory("stream-1"))
 
-        assertEquals(1L, event.sequenceNumber)
-        assertNull(event.previousEventHash)
-        assertEquals("APPROVED", event.decision)
-        assertEquals("evt-stream-1-1", event.eventId)
-    }
-    }
-
-    @Test
-    fun `append second event gets sequence 2 with correct previous hash`() { runBlocking {
-        val s = store()
-        s.appendNext("stream-1", eventFactory("stream-1"))
-        val second = s.appendNext("stream-1", eventFactory("stream-1"))
-
-        assertEquals(2L, second.sequenceNumber)
-        assertNotNull(second.previousEventHash)
-
-        val first = s.latestEvent("stream-1")
-        assertNotNull(first)
-        assertEquals(2L, first.sequenceNumber)
-    }
+            assertEquals(1L, event.sequenceNumber)
+            assertNull(event.previousEventHash)
+            assertEquals("APPROVED", event.decision)
+            assertEquals("evt-stream-1-1", event.eventId)
+        }
     }
 
     @Test
-    fun `duplicate event ID is rejected`() { runBlocking {
-        val s = store()
-        s.appendNext("stream-1", eventFactory("stream-1"))
+    fun `append second event gets sequence 2 with correct previous hash`() {
+        runBlocking {
+            val s = store()
+            s.appendNext("stream-1", eventFactory("stream-1"))
+            val second = s.appendNext("stream-1", eventFactory("stream-1"))
 
-        assertFailsWith<IllegalArgumentException> {
-            s.appendNext("stream-1") { latest ->
-                // Return an event with a deliberately duplicate event ID
-                createEvent(
-                    auditStreamId = "stream-1",
-                    sequenceNumber = 2L,
-                    eventId = "evt-stream-1-1", // same ID as first
-                    previousEventHash = latest?.eventHash,
-                )
+            assertEquals(2L, second.sequenceNumber)
+            assertNotNull(second.previousEventHash)
+
+            val first = s.latestEvent("stream-1")
+            assertNotNull(first)
+            assertEquals(2L, first.sequenceNumber)
+        }
+    }
+
+    @Test
+    fun `duplicate event ID is rejected`() {
+        runBlocking {
+            val s = store()
+            s.appendNext("stream-1", eventFactory("stream-1"))
+
+            assertFailsWith<IllegalArgumentException> {
+                s.appendNext("stream-1") { latest ->
+                    // Return an event with a deliberately duplicate event ID
+                    createEvent(
+                        auditStreamId = "stream-1",
+                        sequenceNumber = 2L,
+                        eventId = "evt-stream-1-1", // same ID as first
+                        previousEventHash = latest?.eventHash,
+                    )
+                }
             }
         }
     }
-    }
 
     @Test
-    fun `append with sequence gap is rejected`() { runBlocking {
-        val s = store()
+    fun `append with sequence gap is rejected`() {
+        runBlocking {
+            val s = store()
 
-        assertFailsWith<IllegalArgumentException> {
-            s.appendNext("stream-1") {
-                createEvent(
-                    auditStreamId = "stream-1",
-                    sequenceNumber = 5L,
-                    eventId = "evt-gap",
-                    previousEventHash = null,
-                )
+            assertFailsWith<IllegalArgumentException> {
+                s.appendNext("stream-1") {
+                    createEvent(
+                        auditStreamId = "stream-1",
+                        sequenceNumber = 5L,
+                        eventId = "evt-gap",
+                        previousEventHash = null,
+                    )
+                }
             }
         }
     }
-    }
 
     @Test
-    fun `append with wrong stream ID is rejected`() { runBlocking {
-        val s = store()
+    fun `append with wrong stream ID is rejected`() {
+        runBlocking {
+            val s = store()
 
-        assertFailsWith<IllegalArgumentException> {
-            s.appendNext("stream-1") {
-                createEvent(
-                    auditStreamId = "stream-WRONG",
-                    sequenceNumber = 1L,
-                    eventId = "evt-wrong-stream",
-                    previousEventHash = null,
-                )
+            assertFailsWith<IllegalArgumentException> {
+                s.appendNext("stream-1") {
+                    createEvent(
+                        auditStreamId = "stream-WRONG",
+                        sequenceNumber = 1L,
+                        eventId = "evt-wrong-stream",
+                        previousEventHash = null,
+                    )
+                }
             }
         }
     }
-    }
 
     @Test
-    fun `append with wrong previous hash is rejected`() { runBlocking {
-        val s = store()
-        s.appendNext("stream-1", eventFactory("stream-1"))
+    fun `append with wrong previous hash is rejected`() {
+        runBlocking {
+            val s = store()
+            s.appendNext("stream-1", eventFactory("stream-1"))
 
-        assertFailsWith<IllegalArgumentException> {
-            s.appendNext("stream-1") {
-                createEvent(
-                    auditStreamId = "stream-1",
-                    sequenceNumber = 2L,
-                    eventId = "evt-bad-hash",
-                    previousEventHash = "0000000000000000000000000000000000000000000000000000000000000000",
-                )
+            assertFailsWith<IllegalArgumentException> {
+                s.appendNext("stream-1") {
+                    createEvent(
+                        auditStreamId = "stream-1",
+                        sequenceNumber = 2L,
+                        eventId = "evt-bad-hash",
+                        previousEventHash = "0000000000000000000000000000000000000000000000000000000000000000",
+                    )
+                }
             }
         }
     }
-    }
 
     @Test
-    fun `append with wrong event hash is rejected`() { runBlocking {
-        val s = store()
+    fun `append with wrong event hash is rejected`() {
+        runBlocking {
+            val s = store()
 
-        assertFailsWith<IllegalArgumentException> {
-            s.appendNext("stream-1") {
-                createEvent(
-                    auditStreamId = "stream-1",
-                    sequenceNumber = 1L,
-                    eventId = "evt-bad-self-hash",
-                    previousEventHash = null,
-                ).copy(eventHash = "bad".repeat(20))
+            assertFailsWith<IllegalArgumentException> {
+                s.appendNext("stream-1") {
+                    createEvent(
+                        auditStreamId = "stream-1",
+                        sequenceNumber = 1L,
+                        eventId = "evt-bad-self-hash",
+                        previousEventHash = null,
+                    ).copy(eventHash = "bad".repeat(20))
+                }
             }
         }
-    }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -321,113 +348,126 @@ class JdbcAuditStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `readStream returns events in ascending sequence order`() { runBlocking {
-        val s = store()
-        s.appendNext("stream-1", eventFactory("stream-1"))
-        s.appendNext("stream-1", eventFactory("stream-1"))
-        s.appendNext("stream-1", eventFactory("stream-1"))
+    fun `readStream returns events in ascending sequence order`() {
+        runBlocking {
+            val s = store()
+            s.appendNext("stream-1", eventFactory("stream-1"))
+            s.appendNext("stream-1", eventFactory("stream-1"))
+            s.appendNext("stream-1", eventFactory("stream-1"))
 
-        val events = s.readStream("stream-1")
-        assertEquals(3, events.size)
-        assertEquals(1L, events[0].sequenceNumber)
-        assertEquals(2L, events[1].sequenceNumber)
-        assertEquals(3L, events[2].sequenceNumber)
-        assertEquals("evt-stream-1-1", events[0].eventId)
-        assertEquals("evt-stream-1-2", events[1].eventId)
-        assertEquals("evt-stream-1-3", events[2].eventId)
-    }
-    }
-
-    @Test
-    fun `readStream validates full chain and rejects corruption`() { runBlocking {
-        val s = store()
-        s.appendNext("stream-1", eventFactory("stream-1"))
-        s.appendNext("stream-1", eventFactory("stream-1"))
-
-        // Tamper with event hash directly in the DB
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        conn.use { c ->
-            c.prepareStatement(
-                "UPDATE audit_events SET event_hash = 'corrupted' WHERE event_id = 'evt-stream-1-1'",
-            ).use { stmt -> stmt.executeUpdate() }
-        }
-
-        assertFailsWith<IllegalArgumentException> {
-            s.readStream("stream-1")
+            val events = s.readStream("stream-1")
+            assertEquals(3, events.size)
+            assertEquals(1L, events[0].sequenceNumber)
+            assertEquals(2L, events[1].sequenceNumber)
+            assertEquals(3L, events[2].sequenceNumber)
+            assertEquals("evt-stream-1-1", events[0].eventId)
+            assertEquals("evt-stream-1-2", events[1].eventId)
+            assertEquals("evt-stream-1-3", events[2].eventId)
         }
     }
-    }
 
     @Test
-    fun `readStream returns empty for non-existent stream`() { runBlocking {
-        val events = store().readStream("non-existent")
-        assertTrue(events.isEmpty())
-    }
-    }
+    fun `readStream validates full chain and rejects corruption`() {
+        runBlocking {
+            val s = store()
+            s.appendNext("stream-1", eventFactory("stream-1"))
+            s.appendNext("stream-1", eventFactory("stream-1"))
 
-    @Test
-    fun `readStreamPage with null after returns first page`() { runBlocking {
-        val s = store()
-        s.appendNext("stream-1", eventFactory("stream-1"))
-        s.appendNext("stream-1", eventFactory("stream-1"))
-        s.appendNext("stream-1", eventFactory("stream-1"))
+            // Tamper with event hash directly in the DB
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                c
+                    .prepareStatement(
+                        "UPDATE audit_events SET event_hash = 'corrupted' WHERE event_id = 'evt-stream-1-1'",
+                    ).use { stmt -> stmt.executeUpdate() }
+            }
 
-        val page = s.readStreamPage("stream-1", afterSequenceNumber = null, limit = 2)
-        assertEquals(2, page.size)
-        assertEquals(1L, page[0].sequenceNumber)
-        assertEquals(2L, page[1].sequenceNumber)
-    }
-    }
-
-    @Test
-    fun `readStreamPage with cursor returns next page`() { runBlocking {
-        val s = store()
-        s.appendNext("stream-1", eventFactory("stream-1"))
-        s.appendNext("stream-1", eventFactory("stream-1"))
-        s.appendNext("stream-1", eventFactory("stream-1"))
-
-        val page = s.readStreamPage("stream-1", afterSequenceNumber = 1, limit = 2)
-        assertEquals(2, page.size)
-        assertEquals(2L, page[0].sequenceNumber)
-        assertEquals(3L, page[1].sequenceNumber)
-    }
-    }
-
-    @Test
-    fun `readStreamPage rejects negative cursor`() { runBlocking {
-        assertFailsWith<IllegalArgumentException> {
-            store().readStreamPage("stream-1", afterSequenceNumber = -1, limit = 10)
+            assertFailsWith<IllegalArgumentException> {
+                s.readStream("stream-1")
+            }
         }
     }
-    }
 
     @Test
-    fun `readStreamPage rejects zero limit`() { runBlocking {
-        assertFailsWith<IllegalArgumentException> {
-            store().readStreamPage("stream-1", afterSequenceNumber = null, limit = 0)
+    fun `readStream returns empty for non-existent stream`() {
+        runBlocking {
+            val events = store().readStream("non-existent")
+            assertTrue(events.isEmpty())
         }
     }
+
+    @Test
+    fun `readStreamPage with null after returns first page`() {
+        runBlocking {
+            val s = store()
+            s.appendNext("stream-1", eventFactory("stream-1"))
+            s.appendNext("stream-1", eventFactory("stream-1"))
+            s.appendNext("stream-1", eventFactory("stream-1"))
+
+            val page = s.readStreamPage("stream-1", afterSequenceNumber = null, limit = 2)
+            assertEquals(2, page.size)
+            assertEquals(1L, page[0].sequenceNumber)
+            assertEquals(2L, page[1].sequenceNumber)
+        }
     }
 
     @Test
-    fun `latestEvent returns newest event`() { runBlocking {
-        val s = store()
-        s.appendNext("stream-1", eventFactory("stream-1"))
-        s.appendNext("stream-1", eventFactory("stream-1"))
+    fun `readStreamPage with cursor returns next page`() {
+        runBlocking {
+            val s = store()
+            s.appendNext("stream-1", eventFactory("stream-1"))
+            s.appendNext("stream-1", eventFactory("stream-1"))
+            s.appendNext("stream-1", eventFactory("stream-1"))
 
-        val latest = s.latestEvent("stream-1")
-        assertNotNull(latest)
-        assertEquals(2L, latest.sequenceNumber)
-        assertEquals("evt-stream-1-2", latest.eventId)
-    }
+            val page = s.readStreamPage("stream-1", afterSequenceNumber = 1, limit = 2)
+            assertEquals(2, page.size)
+            assertEquals(2L, page[0].sequenceNumber)
+            assertEquals(3L, page[1].sequenceNumber)
+        }
     }
 
     @Test
-    fun `latestEvent returns null for empty stream`() { runBlocking {
-        assertNull(store().latestEvent("empty-stream"))
+    fun `readStreamPage rejects negative cursor`() {
+        runBlocking {
+            assertFailsWith<IllegalArgumentException> {
+                store().readStreamPage("stream-1", afterSequenceNumber = -1, limit = 10)
+            }
+        }
     }
+
+    @Test
+    fun `readStreamPage rejects zero limit`() {
+        runBlocking {
+            assertFailsWith<IllegalArgumentException> {
+                store().readStreamPage("stream-1", afterSequenceNumber = null, limit = 0)
+            }
+        }
+    }
+
+    @Test
+    fun `latestEvent returns newest event`() {
+        runBlocking {
+            val s = store()
+            s.appendNext("stream-1", eventFactory("stream-1"))
+            s.appendNext("stream-1", eventFactory("stream-1"))
+
+            val latest = s.latestEvent("stream-1")
+            assertNotNull(latest)
+            assertEquals(2L, latest.sequenceNumber)
+            assertEquals("evt-stream-1-2", latest.eventId)
+        }
+    }
+
+    @Test
+    fun `latestEvent returns null for empty stream`() {
+        runBlocking {
+            assertNull(store().latestEvent("empty-stream"))
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -435,44 +475,47 @@ class JdbcAuditStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `store A appends, store B reads`() { runBlocking {
-        val sA = store()
-        sA.appendNext("stream-1", eventFactory("stream-1"))
-        sA.appendNext("stream-1", eventFactory("stream-1"))
+    fun `store A appends, store B reads`() {
+        runBlocking {
+            val sA = store()
+            sA.appendNext("stream-1", eventFactory("stream-1"))
+            sA.appendNext("stream-1", eventFactory("stream-1"))
 
-        val sB = store()
-        val events = sB.readStream("stream-1")
-        assertEquals(2, events.size)
-        assertEquals("evt-stream-1-1", events[0].eventId)
-        assertEquals("evt-stream-1-2", events[1].eventId)
-    }
-    }
-
-    @Test
-    fun `store A appends, store B appends next`() { runBlocking {
-        val sA = store()
-        sA.appendNext("stream-1", eventFactory("stream-1"))
-
-        val sB = store()
-        val next = sB.appendNext("stream-1", eventFactory("stream-1"))
-        assertEquals(2L, next.sequenceNumber)
-        assertEquals("evt-stream-1-2", next.eventId)
-    }
+            val sB = store()
+            val events = sB.readStream("stream-1")
+            assertEquals(2, events.size)
+            assertEquals("evt-stream-1-1", events[0].eventId)
+            assertEquals("evt-stream-1-2", events[1].eventId)
+        }
     }
 
     @Test
-    fun `store C reads full stream after A and B appends`() { runBlocking {
-        val sA = store()
-        sA.appendNext("stream-1", eventFactory("stream-1"))
-        val sB = store()
-        sB.appendNext("stream-1", eventFactory("stream-1"))
+    fun `store A appends, store B appends next`() {
+        runBlocking {
+            val sA = store()
+            sA.appendNext("stream-1", eventFactory("stream-1"))
 
-        val sC = store()
-        val events = sC.readStream("stream-1")
-        assertEquals(2, events.size)
-        val chain = checkChain(events)
-        assertTrue(chain)
+            val sB = store()
+            val next = sB.appendNext("stream-1", eventFactory("stream-1"))
+            assertEquals(2L, next.sequenceNumber)
+            assertEquals("evt-stream-1-2", next.eventId)
+        }
     }
+
+    @Test
+    fun `store C reads full stream after A and B appends`() {
+        runBlocking {
+            val sA = store()
+            sA.appendNext("stream-1", eventFactory("stream-1"))
+            val sB = store()
+            sB.appendNext("stream-1", eventFactory("stream-1"))
+
+            val sC = store()
+            val events = sC.readStream("stream-1")
+            assertEquals(2, events.size)
+            val chain = checkChain(events)
+            assertTrue(chain)
+        }
     }
 
     private fun checkChain(events: List<AuditEvent>): Boolean {
@@ -493,60 +536,65 @@ class JdbcAuditStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `concurrent appenders to same stream produce ordered sequence`() { runBlocking {
-        val s = store()
-        val numAppenders = 5
+    fun `concurrent appenders to same stream produce ordered sequence`() {
+        runBlocking {
+            val s = store()
+            val numAppenders = 5
 
-        coroutineScope {
-            val jobs = (1..numAppenders).map { index ->
-                async {
-                    s.appendNext("concurrent-stream") { latest ->
-                        val seq = (latest?.sequenceNumber ?: 0L) + 1L
-                        createEvent(
-                            auditStreamId = "concurrent-stream",
-                            sequenceNumber = seq,
-                            eventId = "concurrent-evt-$seq",
-                            previousEventHash = latest?.eventHash,
-                        )
+            coroutineScope {
+                val jobs =
+                    (1..numAppenders).map { index ->
+                        async {
+                            s.appendNext("concurrent-stream") { latest ->
+                                val seq = (latest?.sequenceNumber ?: 0L) + 1L
+                                createEvent(
+                                    auditStreamId = "concurrent-stream",
+                                    sequenceNumber = seq,
+                                    eventId = "concurrent-evt-$seq",
+                                    previousEventHash = latest?.eventHash,
+                                )
+                            }
+                        }
                     }
-                }
+                jobs.forEach { it.await() }
             }
-            jobs.forEach { it.await() }
+
+            val events = s.readStream("concurrent-stream")
+            assertEquals(numAppenders, events.size)
+
+            // Verify sequential ordering
+            for (i in 0 until numAppenders) {
+                assertEquals((i + 1L).toLong(), events[i].sequenceNumber)
+            }
+
+            // Verify hash chain
+            assertTrue(checkChain(events), "Hash chain must be valid after concurrent appends")
         }
-
-        val events = s.readStream("concurrent-stream")
-        assertEquals(numAppenders, events.size)
-
-        // Verify sequential ordering
-        for (i in 0 until numAppenders) {
-            assertEquals((i + 1L).toLong(), events[i].sequenceNumber)
-        }
-
-        // Verify hash chain
-        assertTrue(checkChain(events), "Hash chain must be valid after concurrent appends")
-    }
     }
 
     @Test
-    fun `concurrent appenders to different streams both succeed independently`() { runBlocking {
-        val s = store()
+    fun `concurrent appenders to different streams both succeed independently`() {
+        runBlocking {
+            val s = store()
 
-        coroutineScope {
-            val jobA = async {
-                s.appendNext("stream-a", eventFactory("stream-a"))
-                s.appendNext("stream-a", eventFactory("stream-a"))
+            coroutineScope {
+                val jobA =
+                    async {
+                        s.appendNext("stream-a", eventFactory("stream-a"))
+                        s.appendNext("stream-a", eventFactory("stream-a"))
+                    }
+                val jobB =
+                    async {
+                        s.appendNext("stream-b", eventFactory("stream-b"))
+                        s.appendNext("stream-b", eventFactory("stream-b"))
+                    }
+                jobA.await()
+                jobB.await()
             }
-            val jobB = async {
-                s.appendNext("stream-b", eventFactory("stream-b"))
-                s.appendNext("stream-b", eventFactory("stream-b"))
-            }
-            jobA.await()
-            jobB.await()
+
+            assertEquals(2, s.readStream("stream-a").size)
+            assertEquals(2, s.readStream("stream-b").size)
         }
-
-        assertEquals(2, s.readStream("stream-a").size)
-        assertEquals(2, s.readStream("stream-b").size)
-    }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -554,93 +602,110 @@ class JdbcAuditStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `encrypted_payload is non-null after append`() { runBlocking {
-        val s = store()
-        s.appendNext("stream-1", eventFactory("stream-1"))
+    fun `encrypted_payload is non-null after append`() {
+        runBlocking {
+            val s = store()
+            s.appendNext("stream-1", eventFactory("stream-1"))
 
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        conn.use { c ->
-            c.prepareStatement(
-                "SELECT encrypted_payload FROM audit_events WHERE stream_id = ?",
-            ).use { stmt ->
-                stmt.setString(1, "stream-1")
-                stmt.executeQuery().use { rs ->
-                    assertTrue(rs.next())
-                    val bytes = rs.getBytes("encrypted_payload")
-                    assertNotNull(bytes)
-                    assertTrue(bytes.isNotEmpty())
-                }
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                c
+                    .prepareStatement(
+                        "SELECT encrypted_payload FROM audit_events WHERE stream_id = ?",
+                    ).use { stmt ->
+                        stmt.setString(1, "stream-1")
+                        stmt.executeQuery().use { rs ->
+                            assertTrue(rs.next())
+                            val bytes = rs.getBytes("encrypted_payload")
+                            assertNotNull(bytes)
+                            assertTrue(bytes.isNotEmpty())
+                        }
+                    }
             }
         }
-    }
     }
 
     @Test
-    fun `raw metadata and decision not visible in database`() { runBlocking {
-        val s = store()
-        s.appendNext("stream-1") {
-            createEvent(
-                auditStreamId = "stream-1",
-                sequenceNumber = 1,
-                eventId = "evt-secret",
-                previousEventHash = null,
-                decision = "SENSITIVE_DECISION",
-                actor = "user:secret-agent",
-                metadata = mapOf("secretKey" to "super-secret-value"),
-            )
-        }
+    fun `raw metadata and decision not visible in database`() {
+        runBlocking {
+            val s = store()
+            s.appendNext("stream-1") {
+                createEvent(
+                    auditStreamId = "stream-1",
+                    sequenceNumber = 1,
+                    eventId = "evt-secret",
+                    previousEventHash = null,
+                    decision = "SENSITIVE_DECISION",
+                    actor = "user:secret-agent",
+                    metadata = mapOf("secretKey" to "super-secret-value"),
+                )
+            }
 
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        conn.use { c ->
-            c.prepareStatement(
-                "SELECT encrypted_payload FROM audit_events WHERE event_id = 'evt-secret'",
-            ).use { stmt ->
-                stmt.executeQuery().use { rs ->
-                    assertTrue(rs.next())
-                    val ciphertext = rs.getBytes("encrypted_payload")
-                    val text = ciphertext.toString(Charsets.UTF_8)
-                    assertTrue(text.contains("super-secret-value").not(),
-                        "Raw metadata must not be visible in DB")
-                    assertTrue(text.contains("SENSITIVE_DECISION").not(),
-                        "Decision must not be visible in DB")
-                    assertTrue(text.contains("secret-agent").not(),
-                        "Actor must not be visible in DB")
-                }
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                c
+                    .prepareStatement(
+                        "SELECT encrypted_payload FROM audit_events WHERE event_id = 'evt-secret'",
+                    ).use { stmt ->
+                        stmt.executeQuery().use { rs ->
+                            assertTrue(rs.next())
+                            val ciphertext = rs.getBytes("encrypted_payload")
+                            val text = ciphertext.toString(Charsets.UTF_8)
+                            assertTrue(
+                                text.contains("super-secret-value").not(),
+                                "Raw metadata must not be visible in DB",
+                            )
+                            assertTrue(
+                                text.contains("SENSITIVE_DECISION").not(),
+                                "Decision must not be visible in DB",
+                            )
+                            assertTrue(
+                                text.contains("secret-agent").not(),
+                                "Actor must not be visible in DB",
+                            )
+                        }
+                    }
             }
         }
-    }
     }
 
     @Test
-    fun `decode failure fails closed on read`() { runBlocking {
-        val s = store()
-        s.appendNext("stream-1", eventFactory("stream-1"))
+    fun `decode failure fails closed on read`() {
+        runBlocking {
+            val s = store()
+            s.appendNext("stream-1", eventFactory("stream-1"))
 
-        // Create a store with a different key that can't decrypt
-        val wrongKey = ByteArray(16).also { SecureRandom().nextBytes(it) }
-        val brokenCodec = object : JdbcAuditPayloadCodec {
-            override fun encode(plaintext: ByteArray): JdbcEncryptedAuditPayload {
-                throw UnsupportedOperationException("should not be called")
-            }
+            // Create a store with a different key that can't decrypt
+            val wrongKey = ByteArray(16).also { SecureRandom().nextBytes(it) }
+            val brokenCodec =
+                object : JdbcAuditPayloadCodec {
+                    override fun encode(plaintext: ByteArray): JdbcEncryptedAuditPayload =
+                        throw UnsupportedOperationException("should not be called")
 
-            override fun decode(envelope: JdbcEncryptedAuditPayload): ByteArray {
-                val cipher = Cipher.getInstance("AES/GCM/NoPadding")
-                val keySpec = SecretKeySpec(wrongKey, "AES")
-                val spec = GCMParameterSpec(128, envelope.nonce)
-                cipher.init(Cipher.DECRYPT_MODE, keySpec, spec)
-                return cipher.doFinal(envelope.ciphertext)
+                    override fun decode(envelope: JdbcEncryptedAuditPayload): ByteArray {
+                        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+                        val keySpec = SecretKeySpec(wrongKey, "AES")
+                        val spec = GCMParameterSpec(128, envelope.nonce)
+                        cipher.init(Cipher.DECRYPT_MODE, keySpec, spec)
+                        return cipher.doFinal(envelope.ciphertext)
+                    }
+                }
+            val brokenStore = store(codec = brokenCodec)
+
+            assertFailsWith<IllegalStateException> {
+                brokenStore.readStream("stream-1")
             }
         }
-        val brokenStore = store(codec = brokenCodec)
-
-        assertFailsWith<IllegalStateException> {
-            brokenStore.readStream("stream-1")
-        }
-    }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -648,63 +713,83 @@ class JdbcAuditStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `schema rejects negative sequence number`() { runBlocking {
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        assertFailsWith<org.postgresql.util.PSQLException> {
-            conn.prepareStatement(
-                """INSERT INTO audit_events
+    fun `schema rejects negative sequence number`() {
+        runBlocking {
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            assertFailsWith<org.postgresql.util.PSQLException> {
+                conn
+                    .prepareStatement(
+                        """INSERT INTO audit_events
                    (stream_id, sequence_number, event_id, event_type, event_hash, schema_version)
-                   VALUES ('test', -1, 'neg-seq', 'APPROVED', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', '1')"""
-            ).use { stmt -> stmt.executeUpdate() }
+                   VALUES ('test', -1, 'neg-seq', 'APPROVED', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', '1')""",
+                    ).use { stmt -> stmt.executeUpdate() }
+            }
         }
-    }
     }
 
     @Test
-    fun `schema rejects blank stream_id`() { runBlocking {
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        assertFailsWith<org.postgresql.util.PSQLException> {
-            conn.prepareStatement(
-                """INSERT INTO audit_events
+    fun `schema rejects blank stream_id`() {
+        runBlocking {
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            assertFailsWith<org.postgresql.util.PSQLException> {
+                conn
+                    .prepareStatement(
+                        """INSERT INTO audit_events
                    (stream_id, sequence_number, event_id, event_type, event_hash, schema_version)
-                   VALUES ('', 1, 'blank-stream', 'APPROVED', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', '1')"""
-            ).use { stmt -> stmt.executeUpdate() }
+                   VALUES ('', 1, 'blank-stream', 'APPROVED', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', '1')""",
+                    ).use { stmt -> stmt.executeUpdate() }
+            }
         }
-    }
     }
 
     @Test
-    fun `schema rejects wrong schema version`() { runBlocking {
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        assertFailsWith<org.postgresql.util.PSQLException> {
-            conn.prepareStatement(
-                """INSERT INTO audit_events
+    fun `schema rejects wrong schema version`() {
+        runBlocking {
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            assertFailsWith<org.postgresql.util.PSQLException> {
+                conn
+                    .prepareStatement(
+                        """INSERT INTO audit_events
                    (stream_id, sequence_number, event_id, event_type, event_hash, schema_version)
-                   VALUES ('test', 1, 'bad-schema', 'APPROVED', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', '0')"""
-            ).use { stmt -> stmt.executeUpdate() }
+                   VALUES ('test', 1, 'bad-schema', 'APPROVED', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', '0')""",
+                    ).use { stmt -> stmt.executeUpdate() }
+            }
         }
-    }
     }
 
     @Test
-    fun `schema rejects blank event_hash`() { runBlocking {
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        assertFailsWith<org.postgresql.util.PSQLException> {
-            conn.prepareStatement(
-                """INSERT INTO audit_events
+    fun `schema rejects blank event_hash`() {
+        runBlocking {
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            assertFailsWith<org.postgresql.util.PSQLException> {
+                conn
+                    .prepareStatement(
+                        """INSERT INTO audit_events
                    (stream_id, sequence_number, event_id, event_type, event_hash, schema_version)
-                   VALUES ('test', 1, 'blank-hash', 'APPROVED', '', '1')"""
-            ).use { stmt -> stmt.executeUpdate() }
+                   VALUES ('test', 1, 'blank-hash', 'APPROVED', '', '1')""",
+                    ).use { stmt -> stmt.executeUpdate() }
+            }
         }
-    }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -712,44 +797,46 @@ class JdbcAuditStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `different streams have independent sequences`() { runBlocking {
-        val s = store()
-        s.appendNext("alpha", eventFactory("alpha"))
-        s.appendNext("alpha", eventFactory("alpha"))
-        s.appendNext("beta", eventFactory("beta"))
+    fun `different streams have independent sequences`() {
+        runBlocking {
+            val s = store()
+            s.appendNext("alpha", eventFactory("alpha"))
+            s.appendNext("alpha", eventFactory("alpha"))
+            s.appendNext("beta", eventFactory("beta"))
 
-        val alphaEvents = s.readStream("alpha")
-        val betaEvents = s.readStream("beta")
+            val alphaEvents = s.readStream("alpha")
+            val betaEvents = s.readStream("beta")
 
-        assertEquals(2, alphaEvents.size)
-        assertEquals(1, betaEvents.size)
-        assertEquals(1L, alphaEvents[0].sequenceNumber)
-        assertEquals(2L, alphaEvents[1].sequenceNumber)
-        assertEquals(1L, betaEvents[0].sequenceNumber)
-    }
+            assertEquals(2, alphaEvents.size)
+            assertEquals(1, betaEvents.size)
+            assertEquals(1L, alphaEvents[0].sequenceNumber)
+            assertEquals(2L, alphaEvents[1].sequenceNumber)
+            assertEquals(1L, betaEvents[0].sequenceNumber)
+        }
     }
 
     @Test
-    fun `readStreamPage validates chain within page`() { runBlocking {
-        val s = store()
-        val numEvents = 10
-        for (i in 1..numEvents) {
-            s.appendNext("stream-1", eventFactory("stream-1"))
+    fun `readStreamPage validates chain within page`() {
+        runBlocking {
+            val s = store()
+            val numEvents = 10
+            for (i in 1..numEvents) {
+                s.appendNext("stream-1", eventFactory("stream-1"))
+            }
+
+            // Read two separate pages and verify chain continuity within each
+            val page1 = s.readStreamPage("stream-1", afterSequenceNumber = null, limit = 3)
+            assertEquals(3, page1.size)
+            assertEquals(1L, page1[0].sequenceNumber)
+            assertEquals(3L, page1[2].sequenceNumber)
+            assertTrue(checkChain(page1))
+
+            val page2 = s.readStreamPage("stream-1", afterSequenceNumber = 3, limit = 3)
+            assertEquals(3, page2.size)
+            assertEquals(4L, page2[0].sequenceNumber)
+            assertEquals(6L, page2[2].sequenceNumber)
+            assertTrue(checkChain(page2))
         }
-
-        // Read two separate pages and verify chain continuity within each
-        val page1 = s.readStreamPage("stream-1", afterSequenceNumber = null, limit = 3)
-        assertEquals(3, page1.size)
-        assertEquals(1L, page1[0].sequenceNumber)
-        assertEquals(3L, page1[2].sequenceNumber)
-        assertTrue(checkChain(page1))
-
-        val page2 = s.readStreamPage("stream-1", afterSequenceNumber = 3, limit = 3)
-        assertEquals(3, page2.size)
-        assertEquals(4L, page2[0].sequenceNumber)
-        assertEquals(6L, page2[2].sequenceNumber)
-        assertTrue(checkChain(page2))
-    }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -757,101 +844,122 @@ class JdbcAuditStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `tampered event_hash column fails read`() { runBlocking {
-        val s = store()
-        s.appendNext("stream-1", eventFactory("stream-1"))
+    fun `tampered event_hash column fails read`() {
+        runBlocking {
+            val s = store()
+            s.appendNext("stream-1", eventFactory("stream-1"))
 
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        conn.use { c ->
-            c.prepareStatement(
-                "UPDATE audit_events SET event_hash = 'corrupted' WHERE event_id = 'evt-stream-1-1'",
-            ).use { stmt -> stmt.executeUpdate() }
-        }
-
-        assertFailsWith<IllegalArgumentException> {
-            s.readStream("stream-1")
-        }
-    }
-    }
-
-    @Test
-    fun `tampered previous_event_hash column fails read`() { runBlocking {
-        val s = store()
-        s.appendNext("stream-1", eventFactory("stream-1"))
-        s.appendNext("stream-1", eventFactory("stream-1"))
-
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        conn.use { c ->
-            c.prepareStatement(
-                "UPDATE audit_events SET previous_event_hash = 'corrupted' WHERE event_id = 'evt-stream-1-2'",
-            ).use { stmt -> stmt.executeUpdate() }
-        }
-
-        assertFailsWith<IllegalArgumentException> {
-            s.readStream("stream-1")
-        }
-    }
-    }
-
-    @Test
-    fun `tampered event_type column fails read`() { runBlocking {
-        val s = store()
-        s.appendNext("stream-1", eventFactory("stream-1"))
-
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        conn.use { c ->
-            c.prepareStatement(
-                "UPDATE audit_events SET event_type = 'TAMPERED' WHERE event_id = 'evt-stream-1-1'",
-            ).use { stmt -> stmt.executeUpdate() }
-        }
-
-        assertFailsWith<IllegalArgumentException> {
-            s.readStream("stream-1")
-        }
-    }
-    }
-
-    @Test
-    fun `tampered schema_version column fails read`() { runBlocking {
-        val s = store()
-        s.appendNext("stream-1", eventFactory("stream-1"))
-
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        conn.use { c ->
-            // ck_audit_events_schema_version CHECK (schema_version = '1') would
-            // reject the tamper at write time, so drop it, tamper, and restore
-            // it afterwards — the read path must still fail closed.
-            c.createStatement().use { stmt ->
-                stmt.execute("ALTER TABLE audit_events DROP CONSTRAINT ck_audit_events_schema_version")
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                c
+                    .prepareStatement(
+                        "UPDATE audit_events SET event_hash = 'corrupted' WHERE event_id = 'evt-stream-1-1'",
+                    ).use { stmt -> stmt.executeUpdate() }
             }
-            try {
-                c.prepareStatement(
-                    "UPDATE audit_events SET schema_version = '0' WHERE event_id = 'evt-stream-1-1'",
-                ).use { stmt -> stmt.executeUpdate() }
 
-                assertFailsWith<IllegalArgumentException> {
-                    s.readStream("stream-1")
-                }
-            } finally {
-                c.prepareStatement(
-                    "UPDATE audit_events SET schema_version = '1' WHERE event_id = 'evt-stream-1-1'",
-                ).use { stmt -> stmt.executeUpdate() }
+            assertFailsWith<IllegalArgumentException> {
+                s.readStream("stream-1")
+            }
+        }
+    }
+
+    @Test
+    fun `tampered previous_event_hash column fails read`() {
+        runBlocking {
+            val s = store()
+            s.appendNext("stream-1", eventFactory("stream-1"))
+            s.appendNext("stream-1", eventFactory("stream-1"))
+
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                c
+                    .prepareStatement(
+                        "UPDATE audit_events SET previous_event_hash = 'corrupted' WHERE event_id = 'evt-stream-1-2'",
+                    ).use { stmt -> stmt.executeUpdate() }
+            }
+
+            assertFailsWith<IllegalArgumentException> {
+                s.readStream("stream-1")
+            }
+        }
+    }
+
+    @Test
+    fun `tampered event_type column fails read`() {
+        runBlocking {
+            val s = store()
+            s.appendNext("stream-1", eventFactory("stream-1"))
+
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                c
+                    .prepareStatement(
+                        "UPDATE audit_events SET event_type = 'TAMPERED' WHERE event_id = 'evt-stream-1-1'",
+                    ).use { stmt -> stmt.executeUpdate() }
+            }
+
+            assertFailsWith<IllegalArgumentException> {
+                s.readStream("stream-1")
+            }
+        }
+    }
+
+    @Test
+    fun `tampered schema_version column fails read`() {
+        runBlocking {
+            val s = store()
+            s.appendNext("stream-1", eventFactory("stream-1"))
+
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                // ck_audit_events_schema_version CHECK (schema_version = '1') would
+                // reject the tamper at write time, so drop it, tamper, and restore
+                // it afterwards — the read path must still fail closed.
                 c.createStatement().use { stmt ->
-                    stmt.execute(
-                        "ALTER TABLE audit_events ADD CONSTRAINT ck_audit_events_schema_version CHECK (schema_version = '1')",
-                    )
+                    stmt.execute("ALTER TABLE audit_events DROP CONSTRAINT ck_audit_events_schema_version")
+                }
+                try {
+                    c
+                        .prepareStatement(
+                            "UPDATE audit_events SET schema_version = '0' WHERE event_id = 'evt-stream-1-1'",
+                        ).use { stmt -> stmt.executeUpdate() }
+
+                    assertFailsWith<IllegalArgumentException> {
+                        s.readStream("stream-1")
+                    }
+                } finally {
+                    c
+                        .prepareStatement(
+                            "UPDATE audit_events SET schema_version = '1' WHERE event_id = 'evt-stream-1-1'",
+                        ).use { stmt -> stmt.executeUpdate() }
+                    c.createStatement().use { stmt ->
+                        stmt.execute(
+                            "ALTER TABLE audit_events ADD CONSTRAINT ck_audit_events_schema_version CHECK (schema_version = '1')",
+                        )
+                    }
                 }
             }
         }
-    }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -859,53 +967,72 @@ class JdbcAuditStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `sanitized_actor stores hash not raw actor`() { runBlocking {
-        val s = store()
-        s.appendNext("stream-1", eventFactory("stream-1", actor = "user:secret-agent"))
+    fun `sanitized_actor stores hash not raw actor`() {
+        runBlocking {
+            val s = store()
+            s.appendNext("stream-1", eventFactory("stream-1", actor = "user:secret-agent"))
 
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        conn.use { c ->
-            c.prepareStatement(
-                "SELECT sanitized_actor FROM audit_events WHERE event_id = 'evt-stream-1-1'",
-            ).use { stmt ->
-                stmt.executeQuery().use { rs ->
-                    assertTrue(rs.next())
-                    val actorValue = rs.getString("sanitized_actor")
-                    assertNotNull(actorValue)
-                    assertTrue(actorValue.startsWith("sha256:"),
-                        "sanitized_actor must be a hash, got: $actorValue")
-                    assertTrue(actorValue != "user:secret-agent",
-                        "sanitized_actor must not contain raw actor ID")
-                    assertEquals(71, actorValue.length,
-                        "sha256 hex should be 64 chars + 'sha256:' prefix = 71")
-                }
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                c
+                    .prepareStatement(
+                        "SELECT sanitized_actor FROM audit_events WHERE event_id = 'evt-stream-1-1'",
+                    ).use { stmt ->
+                        stmt.executeQuery().use { rs ->
+                            assertTrue(rs.next())
+                            val actorValue = rs.getString("sanitized_actor")
+                            assertNotNull(actorValue)
+                            assertTrue(
+                                actorValue.startsWith("sha256:"),
+                                "sanitized_actor must be a hash, got: $actorValue",
+                            )
+                            assertTrue(
+                                actorValue != "user:secret-agent",
+                                "sanitized_actor must not contain raw actor ID",
+                            )
+                            assertEquals(
+                                71,
+                                actorValue.length,
+                                "sha256 hex should be 64 chars + 'sha256:' prefix = 71",
+                            )
+                        }
+                    }
             }
         }
-    }
     }
 
     @Test
-    fun `sanitized_actor is null when actor is null`() { runBlocking {
-        val s = store()
-        s.appendNext("stream-1", eventFactory("stream-1", actor = null))
+    fun `sanitized_actor is null when actor is null`() {
+        runBlocking {
+            val s = store()
+            s.appendNext("stream-1", eventFactory("stream-1", actor = null))
 
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        conn.use { c ->
-            c.prepareStatement(
-                "SELECT sanitized_actor FROM audit_events WHERE event_id = 'evt-stream-1-1'",
-            ).use { stmt ->
-                stmt.executeQuery().use { rs ->
-                    assertTrue(rs.next())
-                    assertNull(rs.getString("sanitized_actor"),
-                        "sanitized_actor must be null when actor is null")
-                }
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                c
+                    .prepareStatement(
+                        "SELECT sanitized_actor FROM audit_events WHERE event_id = 'evt-stream-1-1'",
+                    ).use { stmt ->
+                        stmt.executeQuery().use { rs ->
+                            assertTrue(rs.next())
+                            assertNull(
+                                rs.getString("sanitized_actor"),
+                                "sanitized_actor must be null when actor is null",
+                            )
+                        }
+                    }
             }
         }
-    }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -913,101 +1040,122 @@ class JdbcAuditStoreTest {
     // ═══════════════════════════════════════════════════════════════
 
     @Test
-    fun `append fails when stream head points to missing event`() { runBlocking {
-        val s = store()
-        s.appendNext("stream-1", eventFactory("stream-1"))
-
-        // Delete the event directly (bypassing store)
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        conn.use { c ->
-            c.createStatement().use { stmt ->
-                stmt.execute("DELETE FROM audit_events WHERE event_id = 'evt-stream-1-1'")
-            }
-        }
-
-        // Append on the corrupted stream must fail before calling eventFactory
-        assertFailsWith<IllegalStateException> {
+    fun `append fails when stream head points to missing event`() {
+        runBlocking {
+            val s = store()
             s.appendNext("stream-1", eventFactory("stream-1"))
-        }
-    }
-    }
 
-    @Test
-    fun `append fails when stream head event_id mismatches latest event`() { runBlocking {
-        val s = store()
-        s.appendNext("stream-1", eventFactory("stream-1"))
-        s.appendNext("stream-1", eventFactory("stream-1"))
-
-        // Corrupt the head to point to a wrong event_id
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        conn.use { c ->
-            c.createStatement().use { stmt ->
-                stmt.execute(
-                    "UPDATE audit_stream_heads SET latest_event_id = 'evt-stream-1-1' WHERE stream_id = 'stream-1'"
+            // Delete the event directly (bypassing store)
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
                 )
+            conn.use { c ->
+                c.createStatement().use { stmt ->
+                    stmt.execute("DELETE FROM audit_events WHERE event_id = 'evt-stream-1-1'")
+                }
+            }
+
+            // Append on the corrupted stream must fail before calling eventFactory
+            assertFailsWith<IllegalStateException> {
+                s.appendNext("stream-1", eventFactory("stream-1"))
             }
         }
-
-        assertFailsWith<IllegalArgumentException> {
-            s.appendNext("stream-1", eventFactory("stream-1"))
-        }
-    }
     }
 
     @Test
-    fun `append fails when stream head event_hash mismatches latest event`() { runBlocking {
-        val s = store()
-        s.appendNext("stream-1", eventFactory("stream-1"))
+    fun `append fails when stream head event_id mismatches latest event`() {
+        runBlocking {
+            val s = store()
+            s.appendNext("stream-1", eventFactory("stream-1"))
+            s.appendNext("stream-1", eventFactory("stream-1"))
 
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password,
-        )
-        conn.use { c ->
-            c.createStatement().use { stmt ->
-                stmt.execute(
-                    "UPDATE audit_stream_heads SET latest_event_hash = 'corrupted' WHERE stream_id = 'stream-1'"
+            // Corrupt the head to point to a wrong event_id
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
                 )
+            conn.use { c ->
+                c.createStatement().use { stmt ->
+                    stmt.execute(
+                        "UPDATE audit_stream_heads SET latest_event_id = 'evt-stream-1-1' WHERE stream_id = 'stream-1'",
+                    )
+                }
+            }
+
+            assertFailsWith<IllegalArgumentException> {
+                s.appendNext("stream-1", eventFactory("stream-1"))
             }
         }
+    }
 
-        assertFailsWith<IllegalArgumentException> {
+    @Test
+    fun `append fails when stream head event_hash mismatches latest event`() {
+        runBlocking {
+            val s = store()
             s.appendNext("stream-1", eventFactory("stream-1"))
+
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                c.createStatement().use { stmt ->
+                    stmt.execute(
+                        "UPDATE audit_stream_heads SET latest_event_hash = 'corrupted' WHERE stream_id = 'stream-1'",
+                    )
+                }
+            }
+
+            assertFailsWith<IllegalArgumentException> {
+                s.appendNext("stream-1", eventFactory("stream-1"))
+            }
         }
     }
+
+    @Test
+    fun `appendNext rethrows CancellationException unchanged when rollback also fails`() {
+        runBlocking {
+            val cancellation = CancellationException("cancelled by test")
+            val rollbackFailure = java.sql.SQLException("rollback failed")
+            val failing =
+                JdbcAuditStore(
+                    dataSourceWithFailures(rollbackFailure = rollbackFailure),
+                    testCodec,
+                    fixedClock,
+                )
+
+            val thrown =
+                runCatching {
+                    failing.appendNext("stream-1") { throw cancellation }
+                }.exceptionOrNull()
+
+            assertSame(cancellation, thrown)
+            assertEquals(listOf(rollbackFailure), thrown?.suppressed?.toList())
+        }
     }
 
     @Test
-    fun `appendNext rethrows CancellationException unchanged when rollback also fails`() { runBlocking {
-        val cancellation = CancellationException("cancelled by test")
-        val rollbackFailure = java.sql.SQLException("rollback failed")
-        val failing = JdbcAuditStore(dataSourceWithFailures(rollbackFailure = rollbackFailure), testCodec, fixedClock)
+    fun `appendNext preserves primary CancellationException when autoCommit restore fails`() {
+        runBlocking {
+            val cancellation = CancellationException("cancelled by test")
+            val restoreFailure = java.sql.SQLException("restore failed")
+            val failing = JdbcAuditStore(dataSourceWithFailures(restoreFailure = restoreFailure), testCodec, fixedClock)
 
-        val thrown = runCatching {
-            failing.appendNext("stream-1") { throw cancellation }
-        }.exceptionOrNull()
+            val thrown =
+                runCatching {
+                    failing.appendNext("stream-1") { throw cancellation }
+                }.exceptionOrNull()
 
-        assertSame(cancellation, thrown)
-        assertEquals(listOf(rollbackFailure), thrown?.suppressed?.toList())
-    }
-    }
-
-    @Test
-    fun `appendNext preserves primary CancellationException when autoCommit restore fails`() { runBlocking {
-        val cancellation = CancellationException("cancelled by test")
-        val restoreFailure = java.sql.SQLException("restore failed")
-        val failing = JdbcAuditStore(dataSourceWithFailures(restoreFailure = restoreFailure), testCodec, fixedClock)
-
-        val thrown = runCatching {
-            failing.appendNext("stream-1") { throw cancellation }
-        }.exceptionOrNull()
-
-        assertSame(cancellation, thrown)
-        assertEquals(listOf(restoreFailure), thrown?.suppressed?.toList())
-    }
+            assertSame(cancellation, thrown)
+            assertEquals(listOf(restoreFailure), thrown?.suppressed?.toList())
+        }
     }
 
     /**
@@ -1046,5 +1194,63 @@ class JdbcAuditStoreTest {
                 method.invoke(real, *(args ?: emptyArray()))
             }
         } as DataSource
+    }
+
+    // ── Diagnostic sanitization (R12-002) ─────────────────────────
+
+    @Test
+    fun `unexpected SQL errors sanitize diagnostics across all operations`() {
+        runBlocking {
+            val realDs = createDataSource()
+            val throwingDs =
+                object : DataSource by realDs {
+                    override fun getConnection(): Connection {
+                        val realConn = realDs.getConnection()
+                        return object : Connection by realConn {
+                            override fun prepareStatement(sql: String): java.sql.PreparedStatement {
+                                realConn.close()
+                                throw SQLException(
+                                    "syntax error at or near 'SELECT * FROM audit_events WHERE secret_key=42'",
+                                    "42601",
+                                )
+                            }
+                        }
+                    }
+                }
+            val s =
+                JdbcAuditStore(
+                    dataSource = throwingDs,
+                    payloadCodec = testCodec,
+                    clock = fixedClock,
+                )
+
+            val appendEx =
+                assertFailsWith<IllegalStateException> {
+                    s.appendNext("audit-err-1") { createEvent("audit-err-1", 1, "ev-1") }
+                }
+            assertEquals("Database operation failed for audit stream: audit-err-1", appendEx.message)
+            assertFalse(appendEx.message?.contains("secret_key") == true)
+
+            val readEx =
+                assertFailsWith<IllegalStateException> {
+                    s.readStream("audit-err-2")
+                }
+            assertEquals("Database operation failed for audit stream: audit-err-2", readEx.message)
+            assertFalse(readEx.message?.contains("secret_key") == true)
+
+            val readPageEx =
+                assertFailsWith<IllegalStateException> {
+                    s.readStreamPage("audit-err-3", 0L, 10)
+                }
+            assertEquals("Database operation failed for audit stream: audit-err-3", readPageEx.message)
+            assertFalse(readPageEx.message?.contains("secret_key") == true)
+
+            val latestEx =
+                assertFailsWith<IllegalStateException> {
+                    s.latestEvent("audit-err-4")
+                }
+            assertEquals("Database operation failed for audit stream: audit-err-4", latestEx.message)
+            assertFalse(latestEx.message?.contains("secret_key") == true)
+        }
     }
 }

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcSafeOperationTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcSafeOperationTest.kt
@@ -45,7 +45,7 @@ class JdbcSafeOperationTest {
     }
 
     @Test
-    fun `withSafeJdbc rethrows domain exceptions unmodified`() {
+    fun `withSafeJdbc rethrows store exceptions unmodified`() {
         val approvalException = ApprovalStoreNotFoundException("approval-123")
         val thrownApproval =
             assertThrows<ApprovalStoreNotFoundException> {
@@ -54,7 +54,10 @@ class JdbcSafeOperationTest {
                 }
             }
         assertSame(approvalException, thrownApproval)
+    }
 
+    @Test
+    fun `withSafeJdbc rethrows tramai exceptions unmodified`() {
         val tramaiException = StructuredOutputException("tramai failed")
         val thrownTramai =
             assertThrows<StructuredOutputException> {
@@ -63,7 +66,10 @@ class JdbcSafeOperationTest {
                 }
             }
         assertSame(tramaiException, thrownTramai)
+    }
 
+    @Test
+    fun `withSafeJdbc rethrows illegal argument exceptions unmodified`() {
         val illegalArg = IllegalArgumentException("bad arg")
         val thrownArg =
             assertThrows<IllegalArgumentException> {

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcSafeOperationTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcSafeOperationTest.kt
@@ -1,0 +1,97 @@
+package dev.tramai.persistence.jdbc
+
+import dev.tramai.core.exception.ApprovalStoreNotFoundException
+import dev.tramai.core.exception.StructuredOutputException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.sql.SQLException
+import java.util.concurrent.CancellationException
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class JdbcSafeOperationTest {
+    @Test
+    fun `withSafeJdbc returns result on success`() {
+        val result = withSafeJdbc({ "diagnostic" }) { "hello" }
+        assertEquals("hello", result)
+    }
+
+    @Test
+    fun `withSafeJdbc maps SQLException to IllegalStateException with lazy diagnostic`() {
+        var evaluated = false
+        val exception =
+            assertThrows<IllegalStateException> {
+                withSafeJdbc({
+                    evaluated = true
+                    "Sanitized database error"
+                }) {
+                    throw SQLException("syntax error at or near 'SELECT * FROM users_secret'")
+                }
+            }
+        assertEquals("Sanitized database error", exception.message)
+        assertEquals(true, evaluated)
+    }
+
+    @Test
+    fun `withSafeJdbc rethrows CancellationException unmodified`() {
+        val cancellation = CancellationException("task cancelled")
+        val thrown =
+            assertThrows<CancellationException> {
+                withSafeJdbc({ "diagnostic" }) {
+                    throw cancellation
+                }
+            }
+        assertSame(cancellation, thrown)
+    }
+
+    @Test
+    fun `withSafeJdbc rethrows domain exceptions unmodified`() {
+        val approvalException = ApprovalStoreNotFoundException("approval-123")
+        val thrownApproval =
+            assertThrows<ApprovalStoreNotFoundException> {
+                withSafeJdbc({ "diagnostic" }) {
+                    throw approvalException
+                }
+            }
+        assertSame(approvalException, thrownApproval)
+
+        val tramaiException = StructuredOutputException("tramai failed")
+        val thrownTramai =
+            assertThrows<StructuredOutputException> {
+                withSafeJdbc({ "diagnostic" }) {
+                    throw tramaiException
+                }
+            }
+        assertSame(tramaiException, thrownTramai)
+
+        val illegalArg = IllegalArgumentException("bad arg")
+        val thrownArg =
+            assertThrows<IllegalArgumentException> {
+                withSafeJdbc({ "diagnostic" }) {
+                    throw illegalArg
+                }
+            }
+        assertSame(illegalArg, thrownArg)
+    }
+
+    @Test
+    fun `withSafeJdbc propagates fatal JVM Errors without catching or wrapping`() {
+        val assertionError = AssertionError("assertion failed")
+        val thrownAssertion =
+            assertThrows<AssertionError> {
+                withSafeJdbc({ "diagnostic" }) {
+                    throw assertionError
+                }
+            }
+        assertSame(assertionError, thrownAssertion)
+
+        val oom = OutOfMemoryError("out of memory")
+        val thrownOom =
+            assertThrows<OutOfMemoryError> {
+                withSafeJdbc({ "diagnostic" }) {
+                    throw oom
+                }
+            }
+        assertSame(oom, thrownOom)
+    }
+}

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcSuspendedInvocationStoreTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcSuspendedInvocationStoreTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("LargeClass", "LongMethod", "MaxLineLength")
+
 package dev.tramai.persistence.jdbc
 
 import dev.tramai.core.approval.Sha256Digest
@@ -38,82 +40,89 @@ import javax.crypto.spec.SecretKeySpec
 import javax.sql.DataSource
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class JdbcSuspendedInvocationStoreTest {
-
     companion object {
         private const val POSTGRES_IMAGE = "postgres:17-alpine"
 
-        private val postgres = PostgreSQLContainer(POSTGRES_IMAGE)
-            .withDatabaseName("suspended_test")
-            .withUsername("test")
-            .withPassword("test")
+        private val postgres =
+            PostgreSQLContainer(POSTGRES_IMAGE)
+                .withDatabaseName("suspended_test")
+                .withUsername("test")
+                .withPassword("test")
 
-        private fun createDataSource(): DataSource = PGSimpleDataSource().apply {
-            setUrl(postgres.jdbcUrl)
-            user = postgres.username
-            password = postgres.password
-        }
+        private fun createDataSource(): DataSource =
+            PGSimpleDataSource().apply {
+                setUrl(postgres.jdbcUrl)
+                user = postgres.username
+                password = postgres.password
+            }
     }
 
-    private val fixedClock = Clock.fixed(
-        Instant.parse("2026-06-21T12:00:00Z"),
-        ZoneId.of("UTC"),
-    )
+    private val fixedClock =
+        Clock.fixed(
+            Instant.parse("2026-06-21T12:00:00Z"),
+            ZoneId.of("UTC"),
+        )
 
     private val testAesKey = ByteArray(16).also { SecureRandom().nextBytes(it) }
 
-    private val testCodec = object : JdbcReplayEnvelopeCodec {
-        private val ALGORITHM = "AES/GCM/NoPadding"
-        private val TAG_LENGTH = 128
+    private val testCodec =
+        object : JdbcReplayEnvelopeCodec {
+            private val ALGORITHM = "AES/GCM/NoPadding"
+            private val TAG_LENGTH = 128
 
-        override fun encode(plaintext: ByteArray): JdbcEncryptedReplayEnvelope {
-            val cipher = Cipher.getInstance(ALGORITHM)
-            val nonce = ByteArray(12).also { SecureRandom().nextBytes(it) }
-            val keySpec = SecretKeySpec(testAesKey, "AES")
-            val spec = GCMParameterSpec(TAG_LENGTH, nonce)
-            cipher.init(Cipher.ENCRYPT_MODE, keySpec, spec)
-            val ciphertext = cipher.doFinal(plaintext)
-            val digest = MessageDigest.getInstance("SHA-256")
-                .digest(plaintext)
-                .joinToString("") { "%02x".format(it) }
-            return JdbcEncryptedReplayEnvelope(
-                ciphertext = ciphertext,
-                keyId = "test-key-1",
-                algorithm = ALGORITHM,
-                nonce = nonce,
-                payloadDigest = "sha256:$digest",
-            )
-        }
+            override fun encode(plaintext: ByteArray): JdbcEncryptedReplayEnvelope {
+                val cipher = Cipher.getInstance(ALGORITHM)
+                val nonce = ByteArray(12).also { SecureRandom().nextBytes(it) }
+                val keySpec = SecretKeySpec(testAesKey, "AES")
+                val spec = GCMParameterSpec(TAG_LENGTH, nonce)
+                cipher.init(Cipher.ENCRYPT_MODE, keySpec, spec)
+                val ciphertext = cipher.doFinal(plaintext)
+                val digest =
+                    MessageDigest
+                        .getInstance("SHA-256")
+                        .digest(plaintext)
+                        .joinToString("") { "%02x".format(it) }
+                return JdbcEncryptedReplayEnvelope(
+                    ciphertext = ciphertext,
+                    keyId = "test-key-1",
+                    algorithm = ALGORITHM,
+                    nonce = nonce,
+                    payloadDigest = "sha256:$digest",
+                )
+            }
 
-        override fun decode(envelope: JdbcEncryptedReplayEnvelope): ByteArray {
-            val cipher = Cipher.getInstance(ALGORITHM)
-            val keySpec = SecretKeySpec(testAesKey, "AES")
-            val spec = GCMParameterSpec(TAG_LENGTH, envelope.nonce)
-            cipher.init(Cipher.DECRYPT_MODE, keySpec, spec)
-            return cipher.doFinal(envelope.ciphertext)
+            override fun decode(envelope: JdbcEncryptedReplayEnvelope): ByteArray {
+                val cipher = Cipher.getInstance(ALGORITHM)
+                val keySpec = SecretKeySpec(testAesKey, "AES")
+                val spec = GCMParameterSpec(TAG_LENGTH, envelope.nonce)
+                cipher.init(Cipher.DECRYPT_MODE, keySpec, spec)
+                return cipher.doFinal(envelope.ciphertext)
+            }
         }
-    }
 
     // Codec that returns mismatched metadata (wrong keyId)
-    private val wrongMetadataCodec = object : JdbcReplayEnvelopeCodec {
-        override fun encode(plaintext: ByteArray): JdbcEncryptedReplayEnvelope {
-            val enc = testCodec.encode(plaintext)
-            return enc.copy(keyId = "mismatched-key-id", algorithm = "AES/GCM/NoPadding-BOGUS")
+    private val wrongMetadataCodec =
+        object : JdbcReplayEnvelopeCodec {
+            override fun encode(plaintext: ByteArray): JdbcEncryptedReplayEnvelope {
+                val enc = testCodec.encode(plaintext)
+                return enc.copy(keyId = "mismatched-key-id", algorithm = "AES/GCM/NoPadding-BOGUS")
+            }
+
+            override fun decode(envelope: JdbcEncryptedReplayEnvelope): ByteArray =
+                throw IllegalStateException("decryption-not-possible-with-wrong-metadata")
         }
 
-        override fun decode(envelope: JdbcEncryptedReplayEnvelope): ByteArray {
-            throw IllegalStateException("decryption-not-possible-with-wrong-metadata")
-        }
-    }
-
-    private val operationDigest = Sha256Digest.of(
-        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    )
+    private val operationDigest =
+        Sha256Digest.of(
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
 
     private var fixedDigest: Sha256Digest = operationDigest
 
@@ -123,15 +132,17 @@ class JdbcSuspendedInvocationStoreTest {
         runMigrations()
         // Compute the canonical digest AFTER the class is fully initialized.
         // Must match the messages produced by sampleMessages() at test time.
-        fixedDigest = ReplayEnvelopeDigestHelper.compute(
-            operationReference = ResumeOperationReference(
-                serviceInterface = "com.example.TestService",
-                methodName = "execute",
-                jvmMethodDescriptor = "(Ljava/lang/String;)V",
-                resumeDefinitionDigest = operationDigest,
-            ),
-            messages = sampleMessages(),
-        )
+        fixedDigest =
+            ReplayEnvelopeDigestHelper.compute(
+                operationReference =
+                    ResumeOperationReference(
+                        serviceInterface = "com.example.TestService",
+                        methodName = "execute",
+                        jvmMethodDescriptor = "(Ljava/lang/String;)V",
+                        resumeDefinitionDigest = operationDigest,
+                    ),
+                messages = sampleMessages(),
+            )
     }
 
     @AfterAll
@@ -140,14 +151,20 @@ class JdbcSuspendedInvocationStoreTest {
     }
 
     private fun runMigrations() {
-        val sql = javaClass.getResourceAsStream(
-            "/tramai/persistence/jdbc/postgres/V1__sovereign_persistence.sql"
-        )?.bufferedReader()?.readText()
-            ?: throw IllegalStateException("Migration script not found")
+        val sql =
+            javaClass
+                .getResourceAsStream(
+                    "/tramai/persistence/jdbc/postgres/V1__sovereign_persistence.sql",
+                )?.bufferedReader()
+                ?.readText()
+                ?: throw IllegalStateException("Migration script not found")
 
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password
-        )
+        val conn: Connection =
+            DriverManager.getConnection(
+                postgres.jdbcUrl,
+                postgres.username,
+                postgres.password,
+            )
         conn.use { c ->
             c.createStatement().use { stmt -> stmt.execute(sql) }
         }
@@ -155,9 +172,12 @@ class JdbcSuspendedInvocationStoreTest {
 
     @BeforeEach
     fun cleanTable() {
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password
-        )
+        val conn: Connection =
+            DriverManager.getConnection(
+                postgres.jdbcUrl,
+                postgres.username,
+                postgres.password,
+            )
         conn.use { c ->
             c.createStatement().use { stmt ->
                 stmt.execute("DELETE FROM suspended_invocations")
@@ -168,632 +188,734 @@ class JdbcSuspendedInvocationStoreTest {
     private fun store(
         codec: JdbcReplayEnvelopeCodec = testCodec,
         clock: Clock = fixedClock,
-    ): JdbcSuspendedInvocationStore = JdbcSuspendedInvocationStore(
-        dataSource = createDataSource(),
-        replayEnvelopeCodec = codec,
-        clock = clock,
-    )
+    ): JdbcSuspendedInvocationStore =
+        JdbcSuspendedInvocationStore(
+            dataSource = createDataSource(),
+            replayEnvelopeCodec = codec,
+            clock = clock,
+        )
 
     private fun sampleMetadata(
         approvalId: String = "si-test-1",
         digest: Sha256Digest = fixedDigest,
-    ): SuspendedInvocationMetadata = SuspendedInvocationMetadata(
-        approvalId = approvalId,
-        toolCallId = "tc-1",
-        toolName = "test_tool",
-        toolCallIndex = 0,
-        correlationId = "corr-1",
-        identity = EngineExecutionIdentity(
-            workflowRunId = "wf-1",
-            correlationId = "corr-1",
-            workflowDigest = fixedDigest,
-            policyVersion = "1.0",
-            actorId = "actor:test",
-        ),
-        securityContext = ExecutionSecurityContext(
-            dataClassification = DataClassification.INTERNAL,
-            classificationSource = ClassificationSource.DECLARED,
-        ),
-        operationReference = ResumeOperationReference(
-            serviceInterface = "com.example.TestService",
-            methodName = "execute",
-            jvmMethodDescriptor = "(Ljava/lang/String;)V",
-            resumeDefinitionDigest = operationDigest,
-        ),
-        replayEnvelopeDigest = digest,
-        conversationId = "conv-1",
-        historySize = 1,
-        tokenBudgetSnapshot = TokenBudgetSnapshot(
-            totalInputTokens = 100,
-            totalOutputTokens = 50,
-            totalInputCost = 0.01,
-            totalOutputCost = 0.005,
-            warnIfExceeded = false,
-        ),
-        toolReference = ResumeToolReference(
+    ): SuspendedInvocationMetadata =
+        SuspendedInvocationMetadata(
+            approvalId = approvalId,
+            toolCallId = "tc-1",
             toolName = "test_tool",
-            declarationDigest = fixedDigest,
-        ),
-        toolSecurity = null,
-    )
-
-    private fun sampleMessages(): List<Message> = listOf(
-        Message(
-            role = MessageRole.USER,
-            content = "Hello",
-        ),
-        Message(
-            role = MessageRole.ASSISTANT,
-            content = "",
-            toolCalls = listOf(
-                ToolCall(
-                    id = "tc-1",
-                    name = "test_tool",
-                    argumentsJson = "__redacted_approval_continuation_args__",
+            toolCallIndex = 0,
+            correlationId = "corr-1",
+            identity =
+                EngineExecutionIdentity(
+                    workflowRunId = "wf-1",
+                    correlationId = "corr-1",
+                    workflowDigest = fixedDigest,
+                    policyVersion = "1.0",
+                    actorId = "actor:test",
                 ),
-            ),
-        ),
-    )
+            securityContext =
+                ExecutionSecurityContext(
+                    dataClassification = DataClassification.INTERNAL,
+                    classificationSource = ClassificationSource.DECLARED,
+                ),
+            operationReference =
+                ResumeOperationReference(
+                    serviceInterface = "com.example.TestService",
+                    methodName = "execute",
+                    jvmMethodDescriptor = "(Ljava/lang/String;)V",
+                    resumeDefinitionDigest = operationDigest,
+                ),
+            replayEnvelopeDigest = digest,
+            conversationId = "conv-1",
+            historySize = 1,
+            tokenBudgetSnapshot =
+                TokenBudgetSnapshot(
+                    totalInputTokens = 100,
+                    totalOutputTokens = 50,
+                    totalInputCost = 0.01,
+                    totalOutputCost = 0.005,
+                    warnIfExceeded = false,
+                ),
+            toolReference =
+                ResumeToolReference(
+                    toolName = "test_tool",
+                    declarationDigest = fixedDigest,
+                ),
+            toolSecurity = null,
+        )
 
-    private fun sampleEnvelope(messages: List<Message> = sampleMessages()): SensitiveReplayEnvelope =
-        SensitiveReplayEnvelope.of(messages)
+    private fun sampleMessages(): List<Message> =
+        listOf(
+            Message(
+                role = MessageRole.USER,
+                content = "Hello",
+            ),
+            Message(
+                role = MessageRole.ASSISTANT,
+                content = "",
+                toolCalls =
+                    listOf(
+                        ToolCall(
+                            id = "tc-1",
+                            name = "test_tool",
+                            argumentsJson = "__redacted_approval_continuation_args__",
+                        ),
+                    ),
+            ),
+        )
+
+    private fun sampleEnvelope(messages: List<Message> = sampleMessages()): SensitiveReplayEnvelope = SensitiveReplayEnvelope.of(messages)
 
     // ── Tests ─────────────────────────────────────────────────────
 
     @Test
-    fun `stores a suspended invocation`() { runBlocking {
-        val s = store()
-        s.create(sampleMetadata(), sampleEnvelope())
+    fun `stores a suspended invocation`() {
+        runBlocking {
+            val s = store()
+            s.create(sampleMetadata(), sampleEnvelope())
 
-        val loaded = s.get("si-test-1")
-        assertNotNull(loaded)
-        assertEquals("si-test-1", loaded.approvalId)
-        assertEquals("tc-1", loaded.toolCallId)
-        assertEquals("test_tool", loaded.toolName)
-    }
-    }
-
-    @Test
-    fun `loads a suspended invocation by ID`() { runBlocking {
-        val s = store()
-        val messagesA = sampleMessages()
-        val messagesB = listOf(
-            Message(MessageRole.USER, "Hello B"),
-            Message(
-                MessageRole.ASSISTANT, "",
-                toolCalls = listOf(ToolCall("tc-2", "other_tool", "__redacted_approval_continuation_args__")),
-            ),
-        )
-        val digestB = ReplayEnvelopeDigestHelper.compute(
-            operationReference = ResumeOperationReference(
-                serviceInterface = "com.example.TestService",
-                methodName = "execute",
-                jvmMethodDescriptor = "(Ljava/lang/String;)V",
-                resumeDefinitionDigest = operationDigest,
-            ),
-            messages = messagesB,
-        )
-        s.create(sampleMetadata("si-load-1"), sampleEnvelope(messagesA))
-        s.create(
-            sampleMetadata("si-load-2", digest = digestB)
-                .copy(toolCallId = "tc-2", toolName = "other_tool"),
-            sampleEnvelope(messagesB),
-        )
-
-        val loaded = s.get("si-load-2")
-        assertNotNull(loaded)
-        assertEquals("si-load-2", loaded.approvalId)
-    }
+            val loaded = s.get("si-test-1")
+            assertNotNull(loaded)
+            assertEquals("si-test-1", loaded.approvalId)
+            assertEquals("tc-1", loaded.toolCallId)
+            assertEquals("test_tool", loaded.toolName)
+        }
     }
 
     @Test
-    fun `persisted invocation survives new store instance`() { runBlocking {
-        val s1 = store()
-        s1.create(sampleMetadata("si-survive"), sampleEnvelope())
+    fun `loads a suspended invocation by ID`() {
+        runBlocking {
+            val s = store()
+            val messagesA = sampleMessages()
+            val messagesB =
+                listOf(
+                    Message(MessageRole.USER, "Hello B"),
+                    Message(
+                        MessageRole.ASSISTANT,
+                        "",
+                        toolCalls = listOf(ToolCall("tc-2", "other_tool", "__redacted_approval_continuation_args__")),
+                    ),
+                )
+            val digestB =
+                ReplayEnvelopeDigestHelper.compute(
+                    operationReference =
+                        ResumeOperationReference(
+                            serviceInterface = "com.example.TestService",
+                            methodName = "execute",
+                            jvmMethodDescriptor = "(Ljava/lang/String;)V",
+                            resumeDefinitionDigest = operationDigest,
+                        ),
+                    messages = messagesB,
+                )
+            s.create(sampleMetadata("si-load-1"), sampleEnvelope(messagesA))
+            s.create(
+                sampleMetadata("si-load-2", digest = digestB)
+                    .copy(toolCallId = "tc-2", toolName = "other_tool"),
+                sampleEnvelope(messagesB),
+            )
 
-        val s2 = store()
-        val loaded = s2.get("si-survive")
-        assertNotNull(loaded)
-        assertEquals("si-survive", loaded.approvalId)
-    }
+            val loaded = s.get("si-load-2")
+            assertNotNull(loaded)
+            assertEquals("si-load-2", loaded.approvalId)
+        }
     }
 
     @Test
-    fun `duplicate invocation ID is rejected`() { runBlocking {
-        val s = store()
-        s.create(sampleMetadata("si-duplicate-id"), sampleEnvelope())
+    fun `persisted invocation survives new store instance`() {
+        runBlocking {
+            val s1 = store()
+            s1.create(sampleMetadata("si-survive"), sampleEnvelope())
 
-        val ex = assertFailsWith<IllegalArgumentException> {
+            val s2 = store()
+            val loaded = s2.get("si-survive")
+            assertNotNull(loaded)
+            assertEquals("si-survive", loaded.approvalId)
+        }
+    }
+
+    @Test
+    fun `duplicate invocation ID is rejected`() {
+        runBlocking {
+            val s = store()
             s.create(sampleMetadata("si-duplicate-id"), sampleEnvelope())
+
+            val ex =
+                assertFailsWith<IllegalArgumentException> {
+                    s.create(sampleMetadata("si-duplicate-id"), sampleEnvelope())
+                }
+            assertTrue(ex.message?.contains("already-exists", ignoreCase = true) == true)
         }
-        assertTrue(ex.message?.contains("already-exists", ignoreCase = true) == true)
-    }
     }
 
     @Test
-    fun `duplicate replay envelope digest is rejected`() { runBlocking {
-        val s = store()
-        s.create(
-            sampleMetadata("si-digest-1"),
-            sampleEnvelope(),
-        )
-
-        val ex = assertFailsWith<IllegalArgumentException> {
+    fun `duplicate replay envelope digest is rejected`() {
+        runBlocking {
+            val s = store()
             s.create(
-                sampleMetadata("si-digest-2"),
+                sampleMetadata("si-digest-1"),
                 sampleEnvelope(),
             )
-        }
-        assertTrue(
-            ex.message?.contains("digest", ignoreCase = true) == true ||
-            ex.message?.contains("exists", ignoreCase = true) == true,
-            "Expected digest/conflict message but got: ${ex.message}",
-        )
-    }
-    }
 
-    @Test
-    fun `create rejects replay envelope digest mismatch`() { runBlocking {
-        val s = store()
-        val wrongDigest = Sha256Digest.of(
-            "sha256:9999999999999999999999999999999999999999999999999999999999999999",
-        )
-
-        val ex = assertFailsWith<IllegalArgumentException> {
-            s.create(
-                sampleMetadata("si-digest-mismatch", digest = wrongDigest),
-                sampleEnvelope(),
+            val ex =
+                assertFailsWith<IllegalArgumentException> {
+                    s.create(
+                        sampleMetadata("si-digest-2"),
+                        sampleEnvelope(),
+                    )
+                }
+            assertTrue(
+                ex.message?.contains("digest", ignoreCase = true) == true ||
+                    ex.message?.contains("exists", ignoreCase = true) == true,
+                "Expected digest/conflict message but got: ${ex.message}",
             )
         }
-        assertTrue(
-            ex.message?.contains("mismatch", ignoreCase = true) == true,
-            "Expected digest mismatch error but got: ${ex.message}",
-        )
-    }
     }
 
     @Test
-    fun `same replay envelope cannot be stored with different metadata digest`() { runBlocking {
-        val s = store()
-        val messages = sampleMessages()
+    fun `create rejects replay envelope digest mismatch`() {
+        runBlocking {
+            val s = store()
+            val wrongDigest =
+                Sha256Digest.of(
+                    "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+                )
 
-        // First create with correct digest (matches the messages)
-        s.create(
-            sampleMetadata("si-same-env-1", digest = fixedDigest),
-            sampleEnvelope(messages),
-        )
+            val ex =
+                assertFailsWith<IllegalArgumentException> {
+                    s.create(
+                        sampleMetadata("si-digest-mismatch", digest = wrongDigest),
+                        sampleEnvelope(),
+                    )
+                }
+            assertTrue(
+                ex.message?.contains("mismatch", ignoreCase = true) == true,
+                "Expected digest mismatch error but got: ${ex.message}",
+            )
+        }
+    }
 
-        // Second create with same messages but different metadata digest
-        val wrongDigest = Sha256Digest.of(
-            "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        )
-        val ex = assertFailsWith<IllegalArgumentException> {
+    @Test
+    fun `same replay envelope cannot be stored with different metadata digest`() {
+        runBlocking {
+            val s = store()
+            val messages = sampleMessages()
+
+            // First create with correct digest (matches the messages)
             s.create(
-                sampleMetadata("si-same-env-2", digest = wrongDigest),
+                sampleMetadata("si-same-env-1", digest = fixedDigest),
                 sampleEnvelope(messages),
             )
-        }
-        assertTrue(
-            ex.message?.contains("mismatch", ignoreCase = true) == true,
-            "Expected digest mismatch error but got: ${ex.message}",
-        )
-    }
-    }
 
-    @Test
-    fun `replay envelope round-trips through codec`() { runBlocking {
-        val s = store()
-        val messages = sampleMessages()
-        s.create(sampleMetadata("si-roundtrip"), sampleEnvelope(messages))
-
-        val revealed = s.revealReplayEnvelope("si-roundtrip")
-        assertNotNull(revealed)
-        val payload = revealed.revealForResume()
-        assertEquals(2, payload.messages.size)
-        assertEquals("Hello", payload.messages[0].content)
-        assertEquals("tc-1", payload.messages[1].toolCalls!![0].id)
-    }
-    }
-
-    @Test
-    fun `encrypted_replay_envelope is non-null`() { runBlocking {
-        val s = store()
-        s.create(sampleMetadata("si-enc-nonnull"), sampleEnvelope())
-
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password
-        )
-        conn.use { c ->
-            c.prepareStatement("SELECT encrypted_replay_envelope FROM suspended_invocations WHERE invocation_id = ?").use { stmt ->
-                stmt.setString(1, "si-enc-nonnull")
-                stmt.executeQuery().use { rs ->
-                    assertTrue(rs.next())
-                    val bytes = rs.getBytes("encrypted_replay_envelope")
-                    assertNotNull(bytes)
-                    assertTrue(bytes.isNotEmpty())
+            // Second create with same messages but different metadata digest
+            val wrongDigest =
+                Sha256Digest.of(
+                    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                )
+            val ex =
+                assertFailsWith<IllegalArgumentException> {
+                    s.create(
+                        sampleMetadata("si-same-env-2", digest = wrongDigest),
+                        sampleEnvelope(messages),
+                    )
                 }
-            }
-        }
-    }
-    }
-
-    @Test
-    fun `encryption metadata fields are non-null`() { runBlocking {
-        val s = store()
-        s.create(sampleMetadata("si-enc-meta"), sampleEnvelope())
-
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password
-        )
-        conn.use { c ->
-            val sql = """
-                SELECT encryption_key_id, encryption_algorithm, encryption_nonce, payload_digest
-                FROM suspended_invocations WHERE invocation_id = ?
-            """.trimIndent()
-            c.prepareStatement(sql).use { stmt ->
-                stmt.setString(1, "si-enc-meta")
-                stmt.executeQuery().use { rs ->
-                    assertTrue(rs.next())
-                    assertNotNull(rs.getString("encryption_key_id"))
-                    assertNotNull(rs.getString("encryption_algorithm"))
-                    assertNotNull(rs.getBytes("encryption_nonce"))
-                    assertNotNull(rs.getString("payload_digest"))
-                }
-            }
-        }
-    }
-    }
-
-    @Test
-    fun `raw replay envelope is rejected before reaching the database`() { runBlocking {
-        val s = store()
-        // Raw selected tool arguments never reach the store: the shared
-        // contract rejects a correctly-digested unredacted envelope, so the
-        // encryption boundary never sees them.
-        val messages = listOf(
-            Message(MessageRole.USER, "Sensitive query: password=secret123"),
-            Message(
-                MessageRole.ASSISTANT, "",
-                toolCalls = listOf(ToolCall("tc-x", "test_tool", """{"secret":"top-secret"}""")),
-            ),
-        )
-        val rawDigest = ReplayEnvelopeDigestHelper.compute(
-            operationReference = ResumeOperationReference(
-                serviceInterface = "com.example.TestService",
-                methodName = "execute",
-                jvmMethodDescriptor = "(Ljava/lang/String;)V",
-                resumeDefinitionDigest = operationDigest,
-            ),
-            messages = messages,
-        )
-        assertFailsWith<IllegalArgumentException> {
-            s.create(
-                sampleMetadata("si-no-raw", digest = rawDigest).copy(toolCallId = "tc-x"),
-                sampleEnvelope(messages),
+            assertTrue(
+                ex.message?.contains("mismatch", ignoreCase = true) == true,
+                "Expected digest mismatch error but got: ${ex.message}",
             )
         }
+    }
 
-        // And a valid (redacted) envelope's sensitive message content is still
-        // encrypted at rest — never visible as plaintext in the DB.
-        val validMessages = listOf(
-            Message(MessageRole.USER, "Sensitive query: password=secret123"),
-            Message(
-                MessageRole.ASSISTANT, "",
-                toolCalls = listOf(ToolCall("tc-x", "test_tool", "__redacted_approval_continuation_args__")),
-            ),
-        )
-        val validDigest = ReplayEnvelopeDigestHelper.compute(
-            operationReference = ResumeOperationReference(
-                serviceInterface = "com.example.TestService",
-                methodName = "execute",
-                jvmMethodDescriptor = "(Ljava/lang/String;)V",
-                resumeDefinitionDigest = operationDigest,
-            ),
-            messages = validMessages,
-        )
-        s.create(
-            sampleMetadata("si-no-raw", digest = validDigest).copy(toolCallId = "tc-x"),
-            sampleEnvelope(validMessages),
-        )
+    @Test
+    fun `replay envelope round-trips through codec`() {
+        runBlocking {
+            val s = store()
+            val messages = sampleMessages()
+            s.create(sampleMetadata("si-roundtrip"), sampleEnvelope(messages))
 
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password
-        )
-        conn.use { c ->
-            c.prepareStatement("SELECT encrypted_replay_envelope, invocation_id FROM suspended_invocations WHERE invocation_id = ?").use { stmt ->
-                stmt.setString(1, "si-no-raw")
-                stmt.executeQuery().use { rs ->
-                    assertTrue(rs.next())
-                    val ciphertext = rs.getBytes("encrypted_replay_envelope")
-                    val text = ciphertext.toString(StandardCharsets.UTF_8)
-                    // Verify ciphertext does not contain the plaintext strings
-                    assertTrue(text.contains("secret123").not(), "Raw content visible in DB")
-                    assertTrue(text.contains("password").not(), "Raw password visible in DB")
-                }
-            }
+            val revealed = s.revealReplayEnvelope("si-roundtrip")
+            assertNotNull(revealed)
+            val payload = revealed.revealForResume()
+            assertEquals(2, payload.messages.size)
+            assertEquals("Hello", payload.messages[0].content)
+            assertEquals("tc-1", payload.messages[1].toolCalls!![0].id)
         }
     }
-    }
 
     @Test
-    fun `returns metadata not found`() { runBlocking {
-        val s = store()
-        assertNull(s.get("non-existent"))
-    }
-    }
+    fun `encrypted_replay_envelope is non-null`() {
+        runBlocking {
+            val s = store()
+            s.create(sampleMetadata("si-enc-nonnull"), sampleEnvelope())
 
-    @Test
-    fun `returns envelope not found`() { runBlocking {
-        val s = store()
-        assertNull(s.revealReplayEnvelope("non-existent"))
-    }
-    }
-
-    @Test
-    fun `returns metadata on remove`() { runBlocking {
-        val s = store()
-        s.create(sampleMetadata("si-remove"), sampleEnvelope())
-
-        val metadata = s.remove("si-remove")
-        assertNotNull(metadata)
-        assertEquals("si-remove", metadata.approvalId)
-
-        // Gone after removal
-        assertNull(s.get("si-remove"))
-    }
-    }
-
-    @Test
-    fun `returns null on remove for non-existent`() { runBlocking {
-        val s = store()
-        assertNull(s.remove("non-existent"))
-    }
-    }
-
-    @Test
-    fun `version increments on create`() { runBlocking {
-        val s = store()
-        s.create(sampleMetadata("si-version"), sampleEnvelope())
-
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password
-        )
-        conn.use { c ->
-            c.prepareStatement("SELECT version FROM suspended_invocations WHERE invocation_id = ?").use { stmt ->
-                stmt.setString(1, "si-version")
-                stmt.executeQuery().use { rs ->
-                    assertTrue(rs.next())
-                    assertEquals(1L, rs.getLong("version"))
-                }
-            }
-        }
-    }
-    }
-
-    @Test
-    fun `duplicate remove returns null`() { runBlocking {
-        val s = store()
-        s.create(sampleMetadata("si-dup-remove"), sampleEnvelope())
-
-        val first = s.remove("si-dup-remove")
-        assertNotNull(first)
-
-        val second = s.remove("si-dup-remove")
-        assertNull(second)
-    }
-    }
-
-    @Test
-    fun `corrupted encrypted payload fails closed`() { runBlocking {
-        val s = store()
-        s.create(sampleMetadata("si-corrupt"), sampleEnvelope())
-
-        // Corrupt the ciphertext in the database
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password
-        )
-        conn.use { c ->
-            c.prepareStatement(
-                "UPDATE suspended_invocations SET encrypted_replay_envelope = ?::bytea WHERE invocation_id = ?"
-            ).use { stmt ->
-                stmt.setBytes(1, byteArrayOf(0x00, 0x01, 0x02))
-                stmt.setString(2, "si-corrupt")
-                stmt.executeUpdate()
-            }
-        }
-
-        val ex = assertFailsWith<IllegalStateException> {
-            s.get("si-corrupt")
-        }
-        assertTrue(
-            ex.message?.contains("decryption", ignoreCase = true) == true ||
-            ex.message?.contains("corrupted", ignoreCase = true) == true ||
-            ex.message?.contains("failed", ignoreCase = true) == true ||
-            ex.cause?.message?.contains("AEADBadTagException") == true ||
-            ex.message?.contains("Tag mismatch", ignoreCase = true) == true,
-        )
-    }
-    }
-
-    @Test
-    fun `wrong encryption metadata fails closed`() { runBlocking {
-        // Store with testCodec, then try to read with wrongMetadataCodec
-        val sWrite = store(codec = testCodec)
-        sWrite.create(sampleMetadata("si-bad-meta"), sampleEnvelope())
-
-        val sRead = store(codec = wrongMetadataCodec)
-        val ex = assertFailsWith<IllegalStateException> {
-            sRead.get("si-bad-meta")
-        }
-        assertTrue(
-            ex.message?.contains("decryption", ignoreCase = true) == true ||
-            ex.message?.contains("failed", ignoreCase = true) == true,
-        )
-    }
-    }
-
-    @Test
-    fun `non-unique SQL errors are not mapped to duplicate conflicts`() { runBlocking {
-        // Verify that a non-23505 SQLException is rethrown, not swallowed as conflict
-        val realDs = createDataSource()
-        val throwingDs = object : DataSource by realDs {
-            private var callCount = 0
-            override fun getConnection(): java.sql.Connection {
-                callCount++
-                val realConn = realDs.getConnection()
-                return object : java.sql.Connection by realConn {
-                    override fun prepareStatement(sql: String): java.sql.PreparedStatement {
-                        // On the INSERT call (matches INSERT pattern), throw a non-23505 error
-                        if (sql.trimStart().startsWith("INSERT", ignoreCase = true)) {
-                            realConn.close()
-                            throw java.sql.SQLException("connection failure", "08006")
-                        }
-                        return realConn.prepareStatement(sql)
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                c.prepareStatement("SELECT encrypted_replay_envelope FROM suspended_invocations WHERE invocation_id = ?").use { stmt ->
+                    stmt.setString(1, "si-enc-nonnull")
+                    stmt.executeQuery().use { rs ->
+                        assertTrue(rs.next())
+                        val bytes = rs.getBytes("encrypted_replay_envelope")
+                        assertNotNull(bytes)
+                        assertTrue(bytes.isNotEmpty())
                     }
                 }
             }
         }
-        val s = JdbcSuspendedInvocationStore(
-            dataSource = throwingDs,
-            replayEnvelopeCodec = testCodec,
-            clock = fixedClock,
-        )
-        val ex = assertFailsWith<java.sql.SQLException> {
-            s.create(sampleMetadata("si-sql-error"), sampleEnvelope())
-        }
-        assertTrue(ex.message?.contains("connection failure", ignoreCase = true) == true,
-            "Non-23505 SQL error must be rethrown, not mapped to conflict")
-    }
     }
 
     @Test
-    fun `concurrent creation with same digest results in exactly one success`() { runBlocking {
-        val s = store()
-        val messages = sampleMessages()
+    fun `encryption metadata fields are non-null`() {
+        runBlocking {
+            val s = store()
+            s.create(sampleMetadata("si-enc-meta"), sampleEnvelope())
 
-        // This digest will be the same since both use the same messages + codec
-        val results = coroutineScope {
-            val d1 = async {
-                try {
-                    s.create(sampleMetadata("si-conc-1", fixedDigest), sampleEnvelope(messages))
-                    "created"
-                } catch (e: IllegalArgumentException) {
-                    "rejected:${e.message}"
-                }
-            }
-            val d2 = async {
-                try {
-                    s.create(sampleMetadata("si-conc-2", fixedDigest), sampleEnvelope(messages))
-                    "created"
-                } catch (e: IllegalArgumentException) {
-                    "rejected:${e.message}"
-                }
-            }
-            listOf(d1.await(), d2.await())
-        }
-
-        assertEquals(2, results.size)
-        val createdCount = results.count { it == "created" }
-        assertEquals(1, createdCount, "Exactly one concurrent creation should succeed")
-    }
-    }
-
-    @Test
-    fun `concurrent remove returns metadata once and null once`() { runBlocking {
-        val s = store()
-        s.create(sampleMetadata("si-remove-concurrent"), sampleEnvelope())
-
-        val results = coroutineScope {
-            listOf(
-                async { s.remove("si-remove-concurrent") },
-                async { s.remove("si-remove-concurrent") },
-            ).map { it.await() }
-        }
-
-        assertEquals(1, results.count { it != null })
-        assertEquals(1, results.count { it == null })
-    }
-    }
-
-    @Test
-    fun `metadata round-trips all fields correctly`() { runBlocking {
-        val s = store()
-        s.create(sampleMetadata("si-full-meta"), sampleEnvelope())
-
-        val loaded = s.get("si-full-meta")!!
-        assertEquals("si-full-meta", loaded.approvalId)
-        assertEquals("tc-1", loaded.toolCallId)
-        assertEquals("test_tool", loaded.toolName)
-        assertEquals(0, loaded.toolCallIndex)
-        assertEquals("corr-1", loaded.correlationId)
-        assertEquals("wf-1", loaded.identity.workflowRunId)
-        assertEquals("corr-1", loaded.identity.correlationId)
-        assertEquals(fixedDigest, loaded.identity.workflowDigest)
-        assertEquals("1.0", loaded.identity.policyVersion)
-        assertEquals("actor:test", loaded.identity.actorId)
-        assertEquals(DataClassification.INTERNAL, loaded.securityContext.dataClassification)
-        assertEquals(ClassificationSource.DECLARED, loaded.securityContext.classificationSource)
-        assertEquals("com.example.TestService", loaded.operationReference.serviceInterface)
-        assertEquals("execute", loaded.operationReference.methodName)
-        assertEquals("(Ljava/lang/String;)V", loaded.operationReference.jvmMethodDescriptor)
-        assertEquals(operationDigest, loaded.operationReference.resumeDefinitionDigest)
-        assertEquals(fixedDigest, loaded.replayEnvelopeDigest)
-        assertEquals("conv-1", loaded.conversationId)
-        assertEquals(1, loaded.historySize)
-        assertEquals(100L, loaded.tokenBudgetSnapshot?.totalInputTokens)
-        assertEquals(50L, loaded.tokenBudgetSnapshot?.totalOutputTokens)
-        assertEquals(0.01, loaded.tokenBudgetSnapshot!!.totalInputCost, 0.001)
-        assertEquals(0.005, loaded.tokenBudgetSnapshot!!.totalOutputCost, 0.001)
-        assertEquals("test_tool", loaded.toolReference.toolName)
-    }
-    }
-
-    @Test
-    fun `store clock is used for created_at`() { runBlocking {
-        val s = store(clock = Clock.fixed(
-            Instant.parse("2026-01-15T08:30:00Z"),
-            ZoneId.of("UTC"),
-        ))
-        s.create(sampleMetadata("si-clock"), sampleEnvelope())
-
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password
-        )
-        conn.use { c ->
-            c.prepareStatement("SELECT created_at FROM suspended_invocations WHERE invocation_id = ?").use { stmt ->
-                stmt.setString(1, "si-clock")
-                stmt.executeQuery().use { rs ->
-                    assertTrue(rs.next())
-                    val createdAt = rs.getTimestamp("created_at").toInstant()
-                    assertEquals(Instant.parse("2026-01-15T08:30:00Z"), createdAt)
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                val sql =
+                    """
+                    SELECT encryption_key_id, encryption_algorithm, encryption_nonce, payload_digest
+                    FROM suspended_invocations WHERE invocation_id = ?
+                    """.trimIndent()
+                c.prepareStatement(sql).use { stmt ->
+                    stmt.setString(1, "si-enc-meta")
+                    stmt.executeQuery().use { rs ->
+                        assertTrue(rs.next())
+                        assertNotNull(rs.getString("encryption_key_id"))
+                        assertNotNull(rs.getString("encryption_algorithm"))
+                        assertNotNull(rs.getBytes("encryption_nonce"))
+                        assertNotNull(rs.getString("payload_digest"))
+                    }
                 }
             }
         }
     }
+
+    @Test
+    fun `raw replay envelope is rejected before reaching the database`() {
+        runBlocking {
+            val s = store()
+            // Raw selected tool arguments never reach the store: the shared
+            // contract rejects a correctly-digested unredacted envelope, so the
+            // encryption boundary never sees them.
+            val messages =
+                listOf(
+                    Message(MessageRole.USER, "Sensitive query: password=secret123"),
+                    Message(
+                        MessageRole.ASSISTANT,
+                        "",
+                        toolCalls = listOf(ToolCall("tc-x", "test_tool", """{"secret":"top-secret"}""")),
+                    ),
+                )
+            val rawDigest =
+                ReplayEnvelopeDigestHelper.compute(
+                    operationReference =
+                        ResumeOperationReference(
+                            serviceInterface = "com.example.TestService",
+                            methodName = "execute",
+                            jvmMethodDescriptor = "(Ljava/lang/String;)V",
+                            resumeDefinitionDigest = operationDigest,
+                        ),
+                    messages = messages,
+                )
+            assertFailsWith<IllegalArgumentException> {
+                s.create(
+                    sampleMetadata("si-no-raw", digest = rawDigest).copy(toolCallId = "tc-x"),
+                    sampleEnvelope(messages),
+                )
+            }
+
+            // And a valid (redacted) envelope's sensitive message content is still
+            // encrypted at rest — never visible as plaintext in the DB.
+            val validMessages =
+                listOf(
+                    Message(MessageRole.USER, "Sensitive query: password=secret123"),
+                    Message(
+                        MessageRole.ASSISTANT,
+                        "",
+                        toolCalls = listOf(ToolCall("tc-x", "test_tool", "__redacted_approval_continuation_args__")),
+                    ),
+                )
+            val validDigest =
+                ReplayEnvelopeDigestHelper.compute(
+                    operationReference =
+                        ResumeOperationReference(
+                            serviceInterface = "com.example.TestService",
+                            methodName = "execute",
+                            jvmMethodDescriptor = "(Ljava/lang/String;)V",
+                            resumeDefinitionDigest = operationDigest,
+                        ),
+                    messages = validMessages,
+                )
+            s.create(
+                sampleMetadata("si-no-raw", digest = validDigest).copy(toolCallId = "tc-x"),
+                sampleEnvelope(validMessages),
+            )
+
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                c
+                    .prepareStatement(
+                        "SELECT encrypted_replay_envelope, invocation_id " +
+                            "FROM suspended_invocations WHERE invocation_id = ?",
+                    ).use { stmt ->
+                        stmt.setString(1, "si-no-raw")
+                        stmt.executeQuery().use { rs ->
+                            assertTrue(rs.next())
+                            val ciphertext = rs.getBytes("encrypted_replay_envelope")
+                            val text = ciphertext.toString(StandardCharsets.UTF_8)
+                            // Verify ciphertext does not contain the plaintext strings
+                            assertTrue(text.contains("secret123").not(), "Raw content visible in DB")
+                            assertTrue(text.contains("password").not(), "Raw password visible in DB")
+                        }
+                    }
+            }
+        }
     }
 
     @Test
-    fun `service_key and operation_key are stored`() { runBlocking {
-        val s = store()
-        s.create(sampleMetadata("si-keys"), sampleEnvelope())
+    fun `returns metadata not found`() {
+        runBlocking {
+            val s = store()
+            assertNull(s.get("non-existent"))
+        }
+    }
 
-        val conn: Connection = DriverManager.getConnection(
-            postgres.jdbcUrl, postgres.username, postgres.password
-        )
-        conn.use { c ->
-            val sql = "SELECT service_key, operation_key, descriptor_hash FROM suspended_invocations WHERE invocation_id = ?"
-            c.prepareStatement(sql).use { stmt ->
-                stmt.setString(1, "si-keys")
-                stmt.executeQuery().use { rs ->
-                    assertTrue(rs.next())
-                    assertEquals("com.example.TestService", rs.getString("service_key"))
-                    assertEquals("execute", rs.getString("operation_key"))
-                    val hash = rs.getString("descriptor_hash")
-                    assertNotNull(hash)
-                    assertTrue(hash.startsWith("sha256:"))
+    @Test
+    fun `returns envelope not found`() {
+        runBlocking {
+            val s = store()
+            assertNull(s.revealReplayEnvelope("non-existent"))
+        }
+    }
+
+    @Test
+    fun `returns metadata on remove`() {
+        runBlocking {
+            val s = store()
+            s.create(sampleMetadata("si-remove"), sampleEnvelope())
+
+            val metadata = s.remove("si-remove")
+            assertNotNull(metadata)
+            assertEquals("si-remove", metadata.approvalId)
+
+            // Gone after removal
+            assertNull(s.get("si-remove"))
+        }
+    }
+
+    @Test
+    fun `returns null on remove for non-existent`() {
+        runBlocking {
+            val s = store()
+            assertNull(s.remove("non-existent"))
+        }
+    }
+
+    @Test
+    fun `version increments on create`() {
+        runBlocking {
+            val s = store()
+            s.create(sampleMetadata("si-version"), sampleEnvelope())
+
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                c.prepareStatement("SELECT version FROM suspended_invocations WHERE invocation_id = ?").use { stmt ->
+                    stmt.setString(1, "si-version")
+                    stmt.executeQuery().use { rs ->
+                        assertTrue(rs.next())
+                        assertEquals(1L, rs.getLong("version"))
+                    }
                 }
             }
         }
     }
+
+    @Test
+    fun `duplicate remove returns null`() {
+        runBlocking {
+            val s = store()
+            s.create(sampleMetadata("si-dup-remove"), sampleEnvelope())
+
+            val first = s.remove("si-dup-remove")
+            assertNotNull(first)
+
+            val second = s.remove("si-dup-remove")
+            assertNull(second)
+        }
+    }
+
+    @Test
+    fun `corrupted encrypted payload fails closed`() {
+        runBlocking {
+            val s = store()
+            s.create(sampleMetadata("si-corrupt"), sampleEnvelope())
+
+            // Corrupt the ciphertext in the database
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                c
+                    .prepareStatement(
+                        "UPDATE suspended_invocations SET encrypted_replay_envelope = ?::bytea WHERE invocation_id = ?",
+                    ).use { stmt ->
+                        stmt.setBytes(1, byteArrayOf(0x00, 0x01, 0x02))
+                        stmt.setString(2, "si-corrupt")
+                        stmt.executeUpdate()
+                    }
+            }
+
+            val ex =
+                assertFailsWith<IllegalStateException> {
+                    s.get("si-corrupt")
+                }
+            assertTrue(
+                ex.message?.contains("decryption", ignoreCase = true) == true ||
+                    ex.message?.contains("corrupted", ignoreCase = true) == true ||
+                    ex.message?.contains("failed", ignoreCase = true) == true ||
+                    ex.cause?.message?.contains("AEADBadTagException") == true ||
+                    ex.message?.contains("Tag mismatch", ignoreCase = true) == true,
+            )
+        }
+    }
+
+    @Test
+    fun `wrong encryption metadata fails closed`() {
+        runBlocking {
+            // Store with testCodec, then try to read with wrongMetadataCodec
+            val sWrite = store(codec = testCodec)
+            sWrite.create(sampleMetadata("si-bad-meta"), sampleEnvelope())
+
+            val sRead = store(codec = wrongMetadataCodec)
+            val ex =
+                assertFailsWith<IllegalStateException> {
+                    sRead.get("si-bad-meta")
+                }
+            assertTrue(
+                ex.message?.contains("decryption", ignoreCase = true) == true ||
+                    ex.message?.contains("failed", ignoreCase = true) == true,
+            )
+        }
+    }
+
+    @Test
+    fun `non-unique SQL errors are not mapped to duplicate conflicts`() {
+        runBlocking {
+            // Verify that a non-23505 SQLException is sanitized to IllegalStateException, not swallowed as conflict
+            val realDs = createDataSource()
+            val throwingDs =
+                object : DataSource by realDs {
+                    private var callCount = 0
+
+                    override fun getConnection(): java.sql.Connection {
+                        callCount++
+                        val realConn = realDs.getConnection()
+                        return object : java.sql.Connection by realConn {
+                            override fun prepareStatement(sql: String): java.sql.PreparedStatement {
+                                // On the INSERT call, throw a non-23505 error with sensitive SQL diagnostics
+                                if (sql.trimStart().startsWith("INSERT", ignoreCase = true)) {
+                                    realConn.close()
+                                    throw java.sql.SQLException(
+                                        "syntax error at or near 'SELECT * FROM secrets'",
+                                        "42601",
+                                    )
+                                }
+                                return realConn.prepareStatement(sql)
+                            }
+                        }
+                    }
+                }
+            val s =
+                JdbcSuspendedInvocationStore(
+                    dataSource = throwingDs,
+                    replayEnvelopeCodec = testCodec,
+                    clock = fixedClock,
+                )
+            val ex =
+                assertFailsWith<IllegalStateException> {
+                    s.create(sampleMetadata("si-sql-error"), sampleEnvelope())
+                }
+            assertEquals(
+                "Database operation failed for suspended invocation: si-sql-error",
+                ex.message,
+                "Non-23505 SQL error must be sanitized to safe message without leaking SQL diagnostics",
+            )
+            assertFalse(
+                ex.message?.contains("secrets", ignoreCase = true) == true,
+                "Exception message must not leak SQL diagnostics",
+            )
+        }
+    }
+
+    @Test
+    fun `concurrent creation with same digest results in exactly one success`() {
+        runBlocking {
+            val s = store()
+            val messages = sampleMessages()
+
+            // This digest will be the same since both use the same messages + codec
+            val results =
+                coroutineScope {
+                    val d1 =
+                        async {
+                            try {
+                                s.create(sampleMetadata("si-conc-1", fixedDigest), sampleEnvelope(messages))
+                                "created"
+                            } catch (e: IllegalArgumentException) {
+                                "rejected:${e.message}"
+                            }
+                        }
+                    val d2 =
+                        async {
+                            try {
+                                s.create(sampleMetadata("si-conc-2", fixedDigest), sampleEnvelope(messages))
+                                "created"
+                            } catch (e: IllegalArgumentException) {
+                                "rejected:${e.message}"
+                            }
+                        }
+                    listOf(d1.await(), d2.await())
+                }
+
+            assertEquals(2, results.size)
+            val createdCount = results.count { it == "created" }
+            assertEquals(1, createdCount, "Exactly one concurrent creation should succeed")
+        }
+    }
+
+    @Test
+    fun `concurrent remove returns metadata once and null once`() {
+        runBlocking {
+            val s = store()
+            s.create(sampleMetadata("si-remove-concurrent"), sampleEnvelope())
+
+            val results =
+                coroutineScope {
+                    listOf(
+                        async { s.remove("si-remove-concurrent") },
+                        async { s.remove("si-remove-concurrent") },
+                    ).map { it.await() }
+                }
+
+            assertEquals(1, results.count { it != null })
+            assertEquals(1, results.count { it == null })
+        }
+    }
+
+    @Test
+    fun `metadata round-trips all fields correctly`() {
+        runBlocking {
+            val s = store()
+            s.create(sampleMetadata("si-full-meta"), sampleEnvelope())
+
+            val loaded = s.get("si-full-meta")!!
+            assertEquals("si-full-meta", loaded.approvalId)
+            assertEquals("tc-1", loaded.toolCallId)
+            assertEquals("test_tool", loaded.toolName)
+            assertEquals(0, loaded.toolCallIndex)
+            assertEquals("corr-1", loaded.correlationId)
+            assertEquals("wf-1", loaded.identity.workflowRunId)
+            assertEquals("corr-1", loaded.identity.correlationId)
+            assertEquals(fixedDigest, loaded.identity.workflowDigest)
+            assertEquals("1.0", loaded.identity.policyVersion)
+            assertEquals("actor:test", loaded.identity.actorId)
+            assertEquals(DataClassification.INTERNAL, loaded.securityContext.dataClassification)
+            assertEquals(ClassificationSource.DECLARED, loaded.securityContext.classificationSource)
+            assertEquals("com.example.TestService", loaded.operationReference.serviceInterface)
+            assertEquals("execute", loaded.operationReference.methodName)
+            assertEquals("(Ljava/lang/String;)V", loaded.operationReference.jvmMethodDescriptor)
+            assertEquals(operationDigest, loaded.operationReference.resumeDefinitionDigest)
+            assertEquals(fixedDigest, loaded.replayEnvelopeDigest)
+            assertEquals("conv-1", loaded.conversationId)
+            assertEquals(1, loaded.historySize)
+            assertEquals(100L, loaded.tokenBudgetSnapshot?.totalInputTokens)
+            assertEquals(50L, loaded.tokenBudgetSnapshot?.totalOutputTokens)
+            assertEquals(0.01, loaded.tokenBudgetSnapshot!!.totalInputCost, 0.001)
+            assertEquals(0.005, loaded.tokenBudgetSnapshot!!.totalOutputCost, 0.001)
+            assertEquals("test_tool", loaded.toolReference.toolName)
+        }
+    }
+
+    @Test
+    fun `store clock is used for created_at`() {
+        runBlocking {
+            val s =
+                store(
+                    clock =
+                        Clock.fixed(
+                            Instant.parse("2026-01-15T08:30:00Z"),
+                            ZoneId.of("UTC"),
+                        ),
+                )
+            s.create(sampleMetadata("si-clock"), sampleEnvelope())
+
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                c.prepareStatement("SELECT created_at FROM suspended_invocations WHERE invocation_id = ?").use { stmt ->
+                    stmt.setString(1, "si-clock")
+                    stmt.executeQuery().use { rs ->
+                        assertTrue(rs.next())
+                        val createdAt = rs.getTimestamp("created_at").toInstant()
+                        assertEquals(Instant.parse("2026-01-15T08:30:00Z"), createdAt)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `service_key and operation_key are stored`() {
+        runBlocking {
+            val s = store()
+            s.create(sampleMetadata("si-keys"), sampleEnvelope())
+
+            val conn: Connection =
+                DriverManager.getConnection(
+                    postgres.jdbcUrl,
+                    postgres.username,
+                    postgres.password,
+                )
+            conn.use { c ->
+                val sql = "SELECT service_key, operation_key, descriptor_hash FROM suspended_invocations WHERE invocation_id = ?"
+                c.prepareStatement(sql).use { stmt ->
+                    stmt.setString(1, "si-keys")
+                    stmt.executeQuery().use { rs ->
+                        assertTrue(rs.next())
+                        assertEquals("com.example.TestService", rs.getString("service_key"))
+                        assertEquals("execute", rs.getString("operation_key"))
+                        val hash = rs.getString("descriptor_hash")
+                        assertNotNull(hash)
+                        assertTrue(hash.startsWith("sha256:"))
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR addresses the runtime release-blocking findings identified in **Epic 12.3a Independent Code Review**:

- **R12-001 (P0): Governed Image Retrieval & Address Validation in `ImageDownloader`**
  - Factored outbound address security into `OutboundAddressSecurity` under `@ExperimentalProviderTransportApi` to keep public API dump stable.
  - Enforced strict HTTP/HTTPS validation, rejection of private/loopback/link-local/cloud-metadata/CGNAT/IPv6-ULA addresses across all resolution and redirect hops.
  - Aligned `ImageDownloader`, `OutboundNetworkPolicy`, and `HttpStep` to share authoritative address validation logic.
  - Added unit and adversarial bypass tests in `ImageDownloaderTest` and `OutboundAddressSecurityTest`.

- **R12-002 (P1): Safe JDBC Error Boundaries & Diagnostic Sanitization in Persistence**
  - Introduced `withSafeJdbc` safe boundary helper in `tramai-persistence-jdbc`.
  - Wrapped operations across `JdbcApprovalStore`, `JdbcApprovalContinuationStore`, `JdbcSuspendedInvocationStore`, and `JdbcAuditStore`.
  - Guaranteed coroutine `CancellationException` and domain store exceptions are preserved unchanged while unexpected `SQLException`s are sanitized to generic messages without leaking queries, tables, tokens, or database internals.
  - Added full error-sanitization test suites across all stores.

## Invariants & Change Policy
- Change class: `runtime-behaviour`
- Binary compatibility preserved (`apiCheck` clean across 174 modules)
- Detekt baseline clean (4,793 baseline findings: 0 added, 0 removed)
- All unit, integration, and TCK tests passed
