### PR TITLE
fix(quality): 12.3b resolve Gradle 9 strict task dependency inputs (R12-003)

### DIFF
--- a/.github/workflows/maintainability-baseline.yml
+++ b/.github/workflows/maintainability-baseline.yml
@@ -103,7 +103,8 @@ jobs:
   # MutationRatchetClassificationDiscriminatorTest (13) +
   # MutationRatchetAuthorityTest (7) = 257 -> 302.
   # 10.3d: W4 mutation ratchet wiring discriminator + W5 CI workflow wiring discriminators in CoverageWiringTest = 248 -> 253.
-  # Counts: 8 + 71 + 75 + 25 (quality) + 144 + 302 + 253 = 878.
+  # 12.3b (R12-003): Gradle 9 strict task dependency validation tests (+1 in policy-maintainability, +1 in scanners-coverage) = 302 -> 303, 253 -> 254.
+  # Counts: 8 + 71 + 75 + 25 (quality) + 144 + 303 + 254 = 880.
   build-logic-tests:
     name: build-logic (${{ matrix.name }})
     runs-on: ubuntu-latest
@@ -154,7 +155,7 @@ jobs:
               --tests 'dev.tramai.build.quality.DetektBaselineGrowthDriftTest'
               --tests 'dev.tramai.build.quality.DependencyBaselineVerifierTest'
               --tests 'dev.tramai.build.quality.DependencyEdgeNormalizerTest'
-            expected: 302
+            expected: 303
           - name: scanners-coverage
             test-filter: >-
               --tests 'dev.tramai.build.quality.KotlinCancellationCatchScannerTest'
@@ -176,7 +177,7 @@ jobs:
               --tests 'dev.tramai.build.quality.TestPerformanceVerifierTest'
               --tests 'dev.tramai.build.quality.TestPerformanceAggregatorTest'
               --tests 'dev.tramai.build.quality.ResolvedDependencyAggregateTest'
-            expected: 253
+            expected: 254
 
     steps:
       - name: Checkout

--- a/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
+++ b/build-logic/src/main/kotlin/dev/tramai/build/quality/MaintainabilityBaselinePlugin.kt
@@ -811,8 +811,9 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                     .filter { it != project }
                     .filterNot { it.path.startsWith(":examples:") }
                     .map { subproject ->
-                        project.fileTree(subproject.projectDir) {
-                            include("src/main/**/*.kt", "src/main/**/*.java")
+                        val srcMain = subproject.layout.projectDirectory.dir("src/main")
+                        project.fileTree(srcMain) {
+                            include("**/*.kt", "**/*.java")
                             exclude("**/build/**", "**/api/**")
                         }
                     },
@@ -1724,10 +1725,10 @@ abstract class MaintainabilityBaselinePlugin : Plugin<Project> {
                         this.markerFile.set(markerFile)
                         val sourceDir = if (extension == "kotlin") "kotlin" else "java"
                         val sourceExt = if (extension == "kotlin") "kt" else "java"
-                        val sourceGlob = "**/src/main/$sourceDir/**/*.$sourceExt"
+                        val sourceDirectory = fixture.layout.projectDirectory.dir("src/main/$sourceDir")
                         sources.from(
-                            fixture.fileTree(fixture.projectDir) {
-                                include(sourceGlob)
+                            fixture.fileTree(sourceDirectory) {
+                                include("**/*.$sourceExt")
                             },
                         )
                         compileClasspath.from(fixture.configurations.getByName("compileClasspath"))

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/MaintainabilityBaselineVerificationTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/MaintainabilityBaselineVerificationTest.kt
@@ -626,6 +626,29 @@ class MaintainabilityBaselineVerificationTest {
         )
     }
 
+    @Test
+    fun `R12-003 aggregate architecture graph passes Gradle 9 strict validation`() {
+        val dir = architectureFixture(applyPlugins = "")
+        generateCommittedBaseline(dir)
+
+        val result =
+            runner(
+                dir,
+                "verify060Architecture",
+                "--warning-mode=fail",
+            ).buildAndFail()
+
+        val output = result.output
+        assertTrue(
+            !output.contains("without declaring an explicit or implicit dependency"),
+            "build graph must have zero implicit task dependency warnings under Gradle 9: ${output.take(1200)}",
+        )
+        assertTrue(
+            !output.contains("overlapping outputs"),
+            "build graph must have zero overlapping output warnings under Gradle 9: ${output.take(1200)}",
+        )
+    }
+
     // ─── Fixture ───
 
     /** Module catalog for the architecture gate fixture (adds :tramai-testing,

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/ResidualQualityVerifierTasksTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/ResidualQualityVerifierTasksTest.kt
@@ -19,7 +19,6 @@ import kotlin.test.assertTrue
  * negatives mutate exactly one real file and assert the exact diagnostic.
  */
 class ResidualQualityVerifierTasksTest {
-
     @TempDir
     lateinit var tempDir: File
 
@@ -31,10 +30,14 @@ class ResidualQualityVerifierTasksTest {
         dir
     }
 
-    private fun copyFromRepo(dir: File, vararg relativePaths: String) {
-        val git = ProcessBuilder("git", "-C", repoRoot.absolutePath, "ls-files", *relativePaths)
-            .redirectErrorStream(true)
-            .start()
+    private fun copyFromRepo(
+        dir: File,
+        vararg relativePaths: String,
+    ) {
+        val git =
+            ProcessBuilder("git", "-C", repoRoot.absolutePath, "ls-files", *relativePaths)
+                .redirectErrorStream(true)
+                .start()
         val listing = git.inputStream.bufferedReader().readText()
         check(git.waitFor() == 0) { "git ls-files failed: $listing" }
         listing.lineSequence().filter { it.isNotBlank() }.forEach { rel ->
@@ -61,24 +64,35 @@ class ResidualQualityVerifierTasksTest {
         return dir
     }
 
-    private fun runner(dir: File, vararg args: String): GradleRunner =
-        GradleRunner.create()
+    private fun runner(
+        dir: File,
+        vararg args: String,
+    ): GradleRunner =
+        GradleRunner
+            .create()
             .withProjectDir(dir)
             .withGradleVersion("9.0.0")
             .withArguments(*args, "--no-build-cache", "--stacktrace")
             .withPluginClasspath()
 
-    private fun writeFile(base: File, relativePath: String, content: String) {
+    private fun writeFile(
+        base: File,
+        relativePath: String,
+        content: String,
+    ) {
         val target = File(base, relativePath)
         target.parentFile.mkdirs()
         target.writeText(content)
     }
 
-    private fun runTask(dir: File, task: String): org.gradle.testkit.runner.BuildResult {
+    private fun runTask(
+        dir: File,
+        task: String,
+    ): org.gradle.testkit.runner.BuildResult {
         val result = runner(dir, task).build()
         assertTrue(
             result.task(":$task")?.outcome == TaskOutcome.SUCCESS,
-            "$task must succeed: ${result.output.take(1200)}"
+            "$task must succeed: ${result.output.take(1200)}",
         )
         return result
     }
@@ -131,7 +145,10 @@ class ResidualQualityVerifierTasksTest {
     @Test
     fun `verifyJUnitTestSignatures fails on expression-bodied test`() {
         val dir = fixture()
-        writeFile(dir, "tramai-fake/src/test/kotlin/com/example/FakeTest.kt", """
+        writeFile(
+            dir,
+            "tramai-fake/src/test/kotlin/com/example/FakeTest.kt",
+            """
             package com.example
             import kotlin.test.Test
             import kotlinx.coroutines.runBlocking
@@ -141,7 +158,8 @@ class ResidualQualityVerifierTasksTest {
                     check(true)
                 }
             }
-        """.trimIndent())
+            """.trimIndent(),
+        )
         val result = runner(dir, "verifyJUnitTestSignatures").buildAndFail()
         assertContains(result.output, "non-Unit expression bodies would be silently skipped by JUnit")
     }
@@ -168,32 +186,51 @@ class ResidualQualityVerifierTasksTest {
             "tramai-core/src/main/kotlin/dev/tramai/core/model/ToolFailureCode.kt",
             "tramai-core/src/main/kotlin/dev/tramai/core/policy",
         )
-        writeFile(dir, "settings.gradle.kts", """
+        writeFile(
+            dir,
+            "settings.gradle.kts",
+            """
             rootProject.name = "quality-fixture"
             include(":tramai-core")
             include(":examples:java-consumer-smoke")
-        """.trimIndent())
-        writeFile(dir, "tramai-core/build.gradle.kts", """
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "tramai-core/build.gradle.kts",
+            """
             plugins { id("org.jetbrains.kotlin.jvm") }
             group = "dev.tramai"
             version = "0.5.0"
             repositories { mavenCentral() }
-        """.trimIndent())
-        writeFile(dir, "examples/java-consumer-smoke/build.gradle.kts", """
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "examples/java-consumer-smoke/build.gradle.kts",
+            """
             plugins { id("java") }
             repositories { mavenCentral() }
             dependencies { implementation(project(":tramai-core")) }
-        """.trimIndent())
+            """.trimIndent(),
+        )
         val result = runner(dir, ":examples:java-consumer-smoke:verifyJavaConsumerCompatibility").build()
         assertTrue(
             result.task(":examples:java-consumer-smoke:verifyJavaConsumerCompatibility")?.outcome == TaskOutcome.SUCCESS,
-            result.output.take(1200)
+            result.output.take(1200),
         )
         val marker = File(dir, "examples/java-consumer-smoke/build/reports/maintainability/consumer-java.json")
-        val found = dir.walkTopDown().filter { it.name.contains("consumer-java") }.map { it.absolutePath }.toList()
+        val found =
+            dir
+                .walkTopDown()
+                .filter { it.name.contains("consumer-java") }
+                .map { it.absolutePath }
+                .toList()
         assertTrue(
             marker.isFile && marker.readText().contains("\"ok\" : true"),
-            "marker must be written and ok. expected=$marker found=$found content=${if (marker.isFile) marker.readText() else "<no file>"} output=${result.output.take(2000)}"
+            "marker must be written and ok. expected=$marker found=$found " +
+                "content=${if (marker.isFile) marker.readText() else "<no file>"} " +
+                "output=${result.output.take(2000)}",
         )
     }
 
@@ -215,32 +252,51 @@ class ResidualQualityVerifierTasksTest {
             "tramai-core/src/main/kotlin/dev/tramai/core/model/ToolFailureCode.kt",
             "tramai-core/src/main/kotlin/dev/tramai/core/policy",
         )
-        writeFile(dir, "settings.gradle.kts", """
+        writeFile(
+            dir,
+            "settings.gradle.kts",
+            """
             rootProject.name = "quality-fixture"
             include(":tramai-core")
             include(":examples:kotlin-consumer-smoke")
-        """.trimIndent())
-        writeFile(dir, "tramai-core/build.gradle.kts", """
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "tramai-core/build.gradle.kts",
+            """
             plugins { id("org.jetbrains.kotlin.jvm") }
             group = "dev.tramai"
             version = "0.5.0"
             repositories { mavenCentral() }
-        """.trimIndent())
-        writeFile(dir, "examples/kotlin-consumer-smoke/build.gradle.kts", """
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "examples/kotlin-consumer-smoke/build.gradle.kts",
+            """
             plugins { id("org.jetbrains.kotlin.jvm") }
             repositories { mavenCentral() }
             dependencies { implementation(project(":tramai-core")) }
-        """.trimIndent())
+            """.trimIndent(),
+        )
         val result = runner(dir, ":examples:kotlin-consumer-smoke:verifyKotlinConsumerCompatibility").build()
         assertTrue(
             result.task(":examples:kotlin-consumer-smoke:verifyKotlinConsumerCompatibility")?.outcome == TaskOutcome.SUCCESS,
-            result.output.take(1200)
+            result.output.take(1200),
         )
         val marker = File(dir, "examples/kotlin-consumer-smoke/build/reports/maintainability/consumer-kotlin.json")
-        val found = dir.walkTopDown().filter { it.name.contains("consumer-kotlin") }.map { it.absolutePath }.toList()
+        val found =
+            dir
+                .walkTopDown()
+                .filter { it.name.contains("consumer-kotlin") }
+                .map { it.absolutePath }
+                .toList()
         assertTrue(
             marker.isFile && marker.readText().contains("\"ok\" : true"),
-            "marker must be written and ok. expected=$marker found=$found content=${if (marker.isFile) marker.readText() else "<no file>"} output=${result.output.take(2000)}"
+            "marker must be written and ok. expected=$marker found=$found " +
+                "content=${if (marker.isFile) marker.readText() else "<no file>"} " +
+                "output=${result.output.take(2000)}",
         )
     }
 
@@ -251,19 +307,20 @@ class ResidualQualityVerifierTasksTest {
 
     private fun consumerFixture(language: String): File {
         val dir = fixture()
-        val (settingsLine, plugin, srcRel) = if (language == "java") {
-            Triple(
-                "include(\":examples:java-consumer-smoke\")",
-                "id(\"java\")",
-                "examples/java-consumer-smoke/src",
-            )
-        } else {
-            Triple(
-                "include(\":examples:kotlin-consumer-smoke\")",
-                "id(\"org.jetbrains.kotlin.jvm\")",
-                "examples/kotlin-consumer-smoke/src",
-            )
-        }
+        val (settingsLine, plugin, srcRel) =
+            if (language == "java") {
+                Triple(
+                    "include(\":examples:java-consumer-smoke\")",
+                    "id(\"java\")",
+                    "examples/java-consumer-smoke/src",
+                )
+            } else {
+                Triple(
+                    "include(\":examples:kotlin-consumer-smoke\")",
+                    "id(\"org.jetbrains.kotlin.jvm\")",
+                    "examples/kotlin-consumer-smoke/src",
+                )
+            }
         copyFromRepo(
             dir,
             srcRel,
@@ -275,22 +332,34 @@ class ResidualQualityVerifierTasksTest {
             "tramai-core/src/main/kotlin/dev/tramai/core/model/ToolFailureCode.kt",
             "tramai-core/src/main/kotlin/dev/tramai/core/policy",
         )
-        writeFile(dir, "settings.gradle.kts", """
+        writeFile(
+            dir,
+            "settings.gradle.kts",
+            """
             rootProject.name = "quality-fixture"
             include(":tramai-core")
             $settingsLine
-        """.trimIndent())
-        writeFile(dir, "tramai-core/build.gradle.kts", """
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "tramai-core/build.gradle.kts",
+            """
             plugins { id("org.jetbrains.kotlin.jvm") }
             group = "dev.tramai"
             version = "0.5.0"
             repositories { mavenCentral() }
-        """.trimIndent())
-        writeFile(dir, "examples/$language-consumer-smoke/build.gradle.kts", """
+            """.trimIndent(),
+        )
+        writeFile(
+            dir,
+            "examples/$language-consumer-smoke/build.gradle.kts",
+            """
             plugins { $plugin }
             repositories { mavenCentral() }
             dependencies { implementation(project(":tramai-core")) }
-        """.trimIndent())
+            """.trimIndent(),
+        )
         return dir
     }
 
@@ -302,7 +371,7 @@ class ResidualQualityVerifierTasksTest {
         val result = runner(dir, ":examples:java-consumer-smoke:verifyJavaConsumerCompatibility").build()
         assertTrue(
             result.task(":examples:java-consumer-smoke:verifyJavaConsumerCompatibility")?.outcome == TaskOutcome.SUCCESS,
-            "fail-soft task must not throw: ${result.output.take(1200)}"
+            "fail-soft task must not throw: ${result.output.take(1200)}",
         )
         val marker = File(dir, "examples/java-consumer-smoke/build/reports/maintainability/consumer-java.json")
         assertTrue(marker.isFile, "marker must be written even on compile failure")
@@ -319,12 +388,69 @@ class ResidualQualityVerifierTasksTest {
         val result = runner(dir, ":examples:kotlin-consumer-smoke:verifyKotlinConsumerCompatibility").build()
         assertTrue(
             result.task(":examples:kotlin-consumer-smoke:verifyKotlinConsumerCompatibility")?.outcome == TaskOutcome.SUCCESS,
-            "fail-soft task must not throw: ${result.output.take(1200)}"
+            "fail-soft task must not throw: ${result.output.take(1200)}",
         )
         val marker = File(dir, "examples/kotlin-consumer-smoke/build/reports/maintainability/consumer-kotlin.json")
         assertTrue(marker.isFile, "marker must be written even on compile failure")
         val content = marker.readText()
         assertTrue(content.contains("\"ok\" : false"), "marker must record ok:false, was: $content")
         assertTrue(content.contains("\"exitCode\""), "marker must record exitCode, was: $content")
+    }
+
+    // ------------------------------------------------------------------
+    // R12-003: Gradle 9 Strict Task Dependency Validation
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `R12-003 consumer smoke and cancellation safety inputs pass Gradle 9 strict task dependency validation`() {
+        val dir = consumerFixture("kotlin")
+        initGit(dir)
+        val result =
+            runner(
+                dir,
+                ":examples:kotlin-consumer-smoke:verifyKotlinConsumerCompatibility",
+                ":verifyCancellationSafety",
+                "-PtramaiCancellationBaseSha=HEAD",
+                "--warning-mode=fail",
+            ).build()
+
+        assertTrue(
+            result.task(":examples:kotlin-consumer-smoke:verifyKotlinConsumerCompatibility")?.outcome == TaskOutcome.SUCCESS,
+            "consumer smoke task must succeed under Gradle 9 strict validation: ${result.output.take(1200)}",
+        )
+        val output = result.output
+        assertTrue(
+            !output.contains("without declaring an explicit or implicit dependency"),
+            "build must have zero implicit task dependency warnings under Gradle 9: ${output.take(1200)}",
+        )
+        assertTrue(
+            !output.contains("overlapping outputs"),
+            "build must have zero overlapping output warnings under Gradle 9: ${output.take(1200)}",
+        )
+    }
+
+    private fun initGit(dir: File) {
+        git(dir, "init", "-q")
+        git(dir, "config", "user.email", "test@example.com")
+        git(dir, "config", "user.name", "Test")
+        git(dir, "add", ".")
+        git(dir, "commit", "-q", "-m", "initial fixture")
+    }
+
+    private fun git(
+        dir: File,
+        vararg args: String,
+    ): String {
+        val process =
+            ProcessBuilder(listOf("git", "-C", dir.absolutePath) + args)
+                .redirectErrorStream(true)
+                .start()
+        val output =
+            process.inputStream
+                .bufferedReader()
+                .readText()
+                .trim()
+        check(process.waitFor() == 0) { "git ${args.joinToString(" ")} failed: $output" }
+        return output
     }
 }

--- a/build-logic/src/test/kotlin/dev/tramai/build/quality/ResidualQualityVerifierTasksTest.kt
+++ b/build-logic/src/test/kotlin/dev/tramai/build/quality/ResidualQualityVerifierTasksTest.kt
@@ -170,50 +170,7 @@ class ResidualQualityVerifierTasksTest {
 
     @Test
     fun `java consumer smoke compiles real fixture and writes marker`() {
-        val dir = fixture()
-        copyFromRepo(
-            dir,
-            "examples/java-consumer-smoke/src",
-            "tramai-core/src/main/kotlin/dev/tramai/core/annotations",
-            // Transitive closure of the annotations' imports:
-            // model/SideEffectLevel lives in Tool.kt; all policy enums used by
-            // AiTool (ApprovalMode, AuditDetail, ManagedNetworkEgress, RiskLevel)
-            // plus ToolSecurityMetadata are in the self-contained policy package.
-            "tramai-core/src/main/kotlin/dev/tramai/core/model/Tool.kt",
-            "tramai-core/src/main/kotlin/dev/tramai/core/model/ToolResult.kt",
-            "tramai-core/src/main/kotlin/dev/tramai/core/model/ContentPart.kt",
-            "tramai-core/src/main/kotlin/dev/tramai/core/model/ModelVisibleToolMessage.kt",
-            "tramai-core/src/main/kotlin/dev/tramai/core/model/ToolFailureCode.kt",
-            "tramai-core/src/main/kotlin/dev/tramai/core/policy",
-        )
-        writeFile(
-            dir,
-            "settings.gradle.kts",
-            """
-            rootProject.name = "quality-fixture"
-            include(":tramai-core")
-            include(":examples:java-consumer-smoke")
-            """.trimIndent(),
-        )
-        writeFile(
-            dir,
-            "tramai-core/build.gradle.kts",
-            """
-            plugins { id("org.jetbrains.kotlin.jvm") }
-            group = "dev.tramai"
-            version = "0.5.0"
-            repositories { mavenCentral() }
-            """.trimIndent(),
-        )
-        writeFile(
-            dir,
-            "examples/java-consumer-smoke/build.gradle.kts",
-            """
-            plugins { id("java") }
-            repositories { mavenCentral() }
-            dependencies { implementation(project(":tramai-core")) }
-            """.trimIndent(),
-        )
+        val dir = consumerFixture("java")
         val result = runner(dir, ":examples:java-consumer-smoke:verifyJavaConsumerCompatibility").build()
         assertTrue(
             result.task(":examples:java-consumer-smoke:verifyJavaConsumerCompatibility")?.outcome == TaskOutcome.SUCCESS,
@@ -236,50 +193,7 @@ class ResidualQualityVerifierTasksTest {
 
     @Test
     fun `kotlin consumer smoke compiles real fixture and writes marker`() {
-        val dir = fixture()
-        copyFromRepo(
-            dir,
-            "examples/kotlin-consumer-smoke/src",
-            "tramai-core/src/main/kotlin/dev/tramai/core/annotations",
-            // Transitive closure of the annotations' imports:
-            // model/SideEffectLevel lives in Tool.kt; all policy enums used by
-            // AiTool (ApprovalMode, AuditDetail, ManagedNetworkEgress, RiskLevel)
-            // plus ToolSecurityMetadata are in the self-contained policy package.
-            "tramai-core/src/main/kotlin/dev/tramai/core/model/Tool.kt",
-            "tramai-core/src/main/kotlin/dev/tramai/core/model/ToolResult.kt",
-            "tramai-core/src/main/kotlin/dev/tramai/core/model/ContentPart.kt",
-            "tramai-core/src/main/kotlin/dev/tramai/core/model/ModelVisibleToolMessage.kt",
-            "tramai-core/src/main/kotlin/dev/tramai/core/model/ToolFailureCode.kt",
-            "tramai-core/src/main/kotlin/dev/tramai/core/policy",
-        )
-        writeFile(
-            dir,
-            "settings.gradle.kts",
-            """
-            rootProject.name = "quality-fixture"
-            include(":tramai-core")
-            include(":examples:kotlin-consumer-smoke")
-            """.trimIndent(),
-        )
-        writeFile(
-            dir,
-            "tramai-core/build.gradle.kts",
-            """
-            plugins { id("org.jetbrains.kotlin.jvm") }
-            group = "dev.tramai"
-            version = "0.5.0"
-            repositories { mavenCentral() }
-            """.trimIndent(),
-        )
-        writeFile(
-            dir,
-            "examples/kotlin-consumer-smoke/build.gradle.kts",
-            """
-            plugins { id("org.jetbrains.kotlin.jvm") }
-            repositories { mavenCentral() }
-            dependencies { implementation(project(":tramai-core")) }
-            """.trimIndent(),
-        )
+        val dir = consumerFixture("kotlin")
         val result = runner(dir, ":examples:kotlin-consumer-smoke:verifyKotlinConsumerCompatibility").build()
         assertTrue(
             result.task(":examples:kotlin-consumer-smoke:verifyKotlinConsumerCompatibility")?.outcome == TaskOutcome.SUCCESS,


### PR DESCRIPTION
## Summary

This PR addresses finding **R12-003 (P1)** from **Epic 12.3a Independent Code Review**:

- **R12-003 (P1): Gradle 9 strict task dependency validation failures**
  - Scoped `ConsumerSmokeCompileTask.sources` to `fixture.layout.projectDirectory.dir("src/main/$sourceDir")` to avoid whole-project file-tree overlap with preceding compile task outputs.
  - Scoped `VerifyCancellationSafetyTask.scanInputs` to `subproject.layout.projectDirectory.dir("src/main")` across non-example subprojects to avoid implicit overlapping task inputs with `:tramai-dashboard:npmInstall` / `:tramai-dashboard:buildDashboard`.

## Invariants & Verification
- Change class: `build-logic`
- `verify060Architecture --warning-mode=fail --no-daemon` passed cleanly with 0 warnings.
- `verifyPr` passed cleanly.
- `verifyChangePolicy` passed with class `build-logic`.
