### PR TITLE
feat(core): add workload identity contract vocabulary (0.7.1b)

### DIFF
--- a/docs/roadmap/0.7.0/EPIC-0.7.1-CONTROL-PLANE-AUTHORITY.md
+++ b/docs/roadmap/0.7.0/EPIC-0.7.1-CONTROL-PLANE-AUTHORITY.md
@@ -1,7 +1,7 @@
 # Epic 0.7.1 — Control-Plane Authority & Workload Identity
 
 **Branch:** `epic/0.7.1-control-plane-authority`  
-**Status:** 🟡 Active — 0.7.1a audit recorded in [TASK-0.7.1a-BASELINE-AUTHORITY-AUDIT.md](TASK-0.7.1a-BASELINE-AUTHORITY-AUDIT.md)
+**Status:** 🟡 Active — 0.7.1a audit recorded in [TASK-0.7.1a-BASELINE-AUTHORITY-AUDIT.md](TASK-0.7.1a-BASELINE-AUTHORITY-AUDIT.md); 0.7.1b identity contract implemented in [TASK-0.7.1b-WORKLOAD-IDENTITY-CONTRACT.md](TASK-0.7.1b-WORKLOAD-IDENTITY-CONTRACT.md)
 **Dependencies:** NONE
 
 ## Executive decision

--- a/docs/roadmap/0.7.0/TASK-0.7.1b-WORKLOAD-IDENTITY-CONTRACT.md
+++ b/docs/roadmap/0.7.0/TASK-0.7.1b-WORKLOAD-IDENTITY-CONTRACT.md
@@ -1,0 +1,121 @@
+# Task 0.7.1b — Workload Identity Contract
+
+**Parent:** [Epic 0.7.1 — Control-Plane Authority & Workload Identity](EPIC-0.7.1-CONTROL-PLANE-AUTHORITY.md)
+
+**Branch:** `task/0.7.1b-workload-identity-contract` → `epic/0.7.1-control-plane-authority`
+
+**Baseline:** epic branch at `f9d2e6b4` (epic head containing the 0.7.1a audit)
+
+**Change class:** `public-api` (additive; no breaking change)
+
+**Status:** Implemented; pending exact-head certification.
+
+## Decision
+
+Create the canonical typed identity vocabulary for a governed TramAI workload
+and run — without yet creating lifecycle authority, persistence, registration,
+or propagation. 0.7.1a established the required semantic fields
+(workload, configuration identity/version, environment, deployment, run, plus
+bounded owner/purpose metadata) and explicitly deferred lifecycle versioning
+to 0.7.1c/e.
+
+The vocabulary lives in `tramai-core` under `dev.tramai.core.identity` because
+orchestration, engine and security already expose `tramai-core` as an API
+dependency; later control-plane modules can consume the same types without new
+dependency edges. `tramai-server` is rejected (runtime identity does not belong
+to Spring/server infrastructure) and a new `tramai-control-plane-core` module
+is rejected for six value types before the control-plane boundaries exist.
+
+## Contract
+
+### Atomic ids (opaque, validated, case-preserving)
+
+| Type | Semantics |
+|---|---|
+| `WorkloadId` | Stable identity of one independently governed workload. Not required to be a UUID; generation policy belongs to 0.7.1c. |
+| `ConfigurationId` | Stable identity of a governed configuration family. |
+| `ConfigurationVersion` | One immutable revision of that configuration. Opaque — no SemVer assumption. |
+| `EnvironmentId` | Logical governance environment (dev/staging/production/tenant). Not a deployment. |
+| `DeploymentId` | One independently distinguishable deployment of a workload/configuration in an environment. |
+| `RunId` | One immutable identifier for one authoritative execution. Resume/retry/restart/approval-resume reuse it; a new execution gets a new id. The type never generates ids. Distinct from `EngineExecutionIdentity.correlationId`, which remains the diagnostic/cross-operation correlation. |
+
+Shared fail-closed validation: non-blank; no leading/trailing whitespace;
+no ISO control characters; bounded length (128). No character grammar is
+imposed (`claims`, `org.example.claims`, `production/eu`, `urn:...`, `Payments`
+vs `payments` are all legal distinct values). No silent normalization: inputs
+that differ must never canonicalize to the same key.
+
+### Composition
+
+```text
+WorkloadConfigurationIdentity(configurationId, version)
+WorkloadDeploymentIdentity(workloadId, configuration, environmentId, deploymentId)
+GovernedRunIdentity(deployment, runId)
+```
+
+Invariants encoded by the types:
+
+- distinct deployments never collapse to one identity, even when they share
+  workload, configuration and environment (the 0.7.1a finding-2 invariant);
+- within an authority domain, the same `(configurationId, version)` must never
+  refer to two different governed configurations (declared here; collision
+  enforcement belongs to 0.7.1c, which requires an authority/store);
+- owner/purpose metadata is NOT part of identity equality. `WorkloadMetadata`
+  is a separate bounded type (`owner` ≤ 256, `purpose` ≤ 512, non-blank, no
+  control characters); the authoritative association of metadata to identity
+  belongs to 0.7.1c. No free-form `Map<String, Any?>` — that would recreate
+  the untyped `WorkflowContext.attributes` problem identified by 0.7.1a.
+
+## Non-goals
+
+0.7.1b does NOT:
+
+- register workloads or persist identities;
+- modify `WorkflowContext`, `WorkflowCheckpoint`, `EngineExecutionIdentity`,
+  `ApprovalBinding`, `RuntimeEvidenceRecord`, or scheduler records;
+- add lifecycle state or a lifecycle version;
+- add stale-command preconditions, APIs/controllers, or JSON schemas;
+- add Dashboard behaviour;
+- generate `RunId`s (creation at the execution boundary is 0.7.1d);
+- migrate existing runs;
+- add a new module or dependency edge.
+
+## Verification
+
+- `./gradlew :tramai-core:test` — 328 tests passed (identity suites:
+  `IdentityIdValidationTest`, `WorkloadIdentityCompositionTest`,
+  `WorkloadMetadataTest`).
+- `./gradlew spotlessApply` / `spotlessCheck` — no changes required, passed.
+- `./gradlew :tramai-core:apiDump` — `tramai-core.api` +140 lines, additive only.
+- `./gradlew verifyPr -PchangeClass=public-api` — see completion report.
+
+## Mutation expectations
+
+- remove blank/whitespace/length validation → rejected by
+  `IdentityIdValidationTest`;
+- ignore `deploymentId`/`environmentId`/`configuration`/`runId` in composition
+  equality → rejected by `WorkloadIdentityCompositionTest`;
+- embed metadata into identity equality → rejected by the structural guard in
+  `WorkloadMetadataTest`.
+
+Full Epic adversarial/mutation certification remains assigned to 0.7.1g.
+
+## Evidence index
+
+- `tramai-core/src/main/kotlin/dev/tramai/core/identity/IdentityValidation.kt`
+  — shared fail-closed validation and length bounds.
+- `tramai-core/src/main/kotlin/dev/tramai/core/identity/WorkloadId.kt`,
+  `ConfigurationId.kt`, `ConfigurationVersion.kt`, `EnvironmentId.kt`,
+  `DeploymentId.kt`, `RunId.kt` — atomic ids.
+- `tramai-core/src/main/kotlin/dev/tramai/core/identity/WorkloadConfigurationIdentity.kt`,
+  `WorkloadDeploymentIdentity.kt`, `GovernedRunIdentity.kt` — composition.
+- `tramai-core/src/main/kotlin/dev/tramai/core/identity/WorkloadMetadata.kt`
+  — bounded owner/purpose metadata, separate from identity.
+- Tests: `tramai-core/src/test/kotlin/dev/tramai/core/identity/`.
+
+## Candidate definition of done
+
+0.7.1b is complete when TramAI has exactly one canonical typed vocabulary for
+workload, configuration revision, environment, deployment and run identity,
+with fail-closed validation and documented identity semantics — and no
+lifecycle/store/propagation authority has been introduced.

--- a/docs/roadmap/0.7.0/TASK-0.7.1b-WORKLOAD-IDENTITY-CONTRACT.md
+++ b/docs/roadmap/0.7.0/TASK-0.7.1b-WORKLOAD-IDENTITY-CONTRACT.md
@@ -92,11 +92,15 @@ Invariants encoded by the types:
 
 ## Verification
 
-- `./gradlew :tramai-core:test` — 328 tests passed (identity suites:
+- `./gradlew :tramai-core:test` — passed (identity suites:
   `IdentityIdValidationTest`, `WorkloadIdentityCompositionTest`,
-  `WorkloadMetadataTest`).
+  `WorkloadMetadataTest`, and the Java-source `JavaIdentityInteropTest`).
 - `./gradlew spotlessApply` / `spotlessCheck` — no changes required, passed.
-- `./gradlew :tramai-core:apiDump` — `tramai-core.api` +140 lines, additive only.
+- `./gradlew :tramai-core:apiDump` — regenerated; additive only (net +122 lines
+  vs epic base), with plain JVM `<init>`/getter surface after the Java-interop
+  review fix.
+- `./gradlew :examples:java-consumer-smoke:compileJava` — passed with identity
+  vocabulary usage.
 - `./gradlew verifyPr -PchangeClass=public-api` — see completion report.
 
 ## Mutation expectations

--- a/docs/roadmap/0.7.0/TASK-0.7.1b-WORKLOAD-IDENTITY-CONTRACT.md
+++ b/docs/roadmap/0.7.0/TASK-0.7.1b-WORKLOAD-IDENTITY-CONTRACT.md
@@ -45,6 +45,16 @@ imposed (`claims`, `org.example.claims`, `production/eu`, `urn:...`, `Payments`
 vs `payments` are all legal distinct values). No silent normalization: inputs
 that differ must never canonicalize to the same key.
 
+All identity types are plain JVM classes, not `@JvmInline` value classes.
+The vocabulary is the canonical public tramai-core contract that 0.7.1d will
+push to execution boundaries, and TramAI is Kotlin-first but Java-friendly:
+`new WorkloadId("claims")`, getters, and equality must work naturally from
+Java. Inline value classes would make the contract Kotlin-only or dependent on
+experimental boxed exposure (`@JvmExposeBoxed`) — rejected for a stable public
+surface. Enforced by `JavaIdentityInteropTest` (compiles and runs in
+`:tramai-core:test`) and by identity usage in the `java-consumer-smoke`
+example.
+
 ### Composition
 
 ```text

--- a/examples/java-consumer-smoke/src/main/java/dev/tramai/examples/javaconsumer/JavaConsumerSmoke.java
+++ b/examples/java-consumer-smoke/src/main/java/dev/tramai/examples/javaconsumer/JavaConsumerSmoke.java
@@ -5,6 +5,15 @@ import dev.tramai.core.annotations.AiMinItems;
 import dev.tramai.core.annotations.AiRange;
 import dev.tramai.core.annotations.AiService;
 import dev.tramai.core.annotations.AiTool;
+import dev.tramai.core.identity.ConfigurationId;
+import dev.tramai.core.identity.ConfigurationVersion;
+import dev.tramai.core.identity.DeploymentId;
+import dev.tramai.core.identity.EnvironmentId;
+import dev.tramai.core.identity.GovernedRunIdentity;
+import dev.tramai.core.identity.RunId;
+import dev.tramai.core.identity.WorkloadConfigurationIdentity;
+import dev.tramai.core.identity.WorkloadDeploymentIdentity;
+import dev.tramai.core.identity.WorkloadId;
 
 import java.util.List;
 
@@ -30,4 +39,26 @@ public final class JavaConsumerSmoke {
 
     public static final String MARKER =
             GreetingService.class.getAnnotation(AiService.class) != null ? "ok" : "missing";
+
+    /**
+     * Java consumer proof for the 0.7.1b identity vocabulary: plain JVM
+     * classes are constructible and readable from Java with normal semantics.
+     * The discriminator assertion mirrors the canonical same-environment
+     * deployment invariant.
+     */
+    public static final String IDENTITY_MARKER = identityVocabularyWorks() ? "ok" : "missing";
+
+    private static boolean identityVocabularyWorks() {
+        WorkloadId workload = new WorkloadId("claims");
+        WorkloadConfigurationIdentity configuration = new WorkloadConfigurationIdentity(
+                new ConfigurationId("claims-prod"), new ConfigurationVersion("17"));
+        WorkloadDeploymentIdentity amsterdam = new WorkloadDeploymentIdentity(
+                workload, configuration, new EnvironmentId("production"),
+                new DeploymentId("eu-west-amsterdam-01"));
+        WorkloadDeploymentIdentity frankfurt = new WorkloadDeploymentIdentity(
+                workload, configuration, new EnvironmentId("production"),
+                new DeploymentId("eu-central-frankfurt-01"));
+        GovernedRunIdentity run = new GovernedRunIdentity(amsterdam, new RunId("run-1"));
+        return !amsterdam.equals(frankfurt) && run.getDeployment().equals(amsterdam);
+    }
 }

--- a/tramai-core/api/tramai-core.api
+++ b/tramai-core/api/tramai-core.api
@@ -1028,6 +1028,146 @@ public final class dev/tramai/core/exception/TramaiExceptionKt {
 	public static final fun safeStructuredOutputFailure (Ldev/tramai/core/structured/StructuredOutputFailureCode;I)Ldev/tramai/core/exception/StructuredOutputException;
 }
 
+public final class dev/tramai/core/identity/ConfigurationId {
+	public static final synthetic fun box-impl (Ljava/lang/String;)Ldev/tramai/core/identity/ConfigurationId;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final class dev/tramai/core/identity/ConfigurationVersion {
+	public static final synthetic fun box-impl (Ljava/lang/String;)Ldev/tramai/core/identity/ConfigurationVersion;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final class dev/tramai/core/identity/DeploymentId {
+	public static final synthetic fun box-impl (Ljava/lang/String;)Ldev/tramai/core/identity/DeploymentId;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final class dev/tramai/core/identity/EnvironmentId {
+	public static final synthetic fun box-impl (Ljava/lang/String;)Ldev/tramai/core/identity/EnvironmentId;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final class dev/tramai/core/identity/GovernedRunIdentity {
+	public synthetic fun <init> (Ldev/tramai/core/identity/WorkloadDeploymentIdentity;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/tramai/core/identity/WorkloadDeploymentIdentity;
+	public final fun component2-QHadeyo ()Ljava/lang/String;
+	public final fun copy-o08grzM (Ldev/tramai/core/identity/WorkloadDeploymentIdentity;Ljava/lang/String;)Ldev/tramai/core/identity/GovernedRunIdentity;
+	public static synthetic fun copy-o08grzM$default (Ldev/tramai/core/identity/GovernedRunIdentity;Ldev/tramai/core/identity/WorkloadDeploymentIdentity;Ljava/lang/String;ILjava/lang/Object;)Ldev/tramai/core/identity/GovernedRunIdentity;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeployment ()Ldev/tramai/core/identity/WorkloadDeploymentIdentity;
+	public final fun getRunId-QHadeyo ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/tramai/core/identity/RunId {
+	public static final synthetic fun box-impl (Ljava/lang/String;)Ldev/tramai/core/identity/RunId;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final class dev/tramai/core/identity/WorkloadConfigurationIdentity {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-Ubl22ak ()Ljava/lang/String;
+	public final fun component2-ICV4KlY ()Ljava/lang/String;
+	public final fun copy-3TpVCTg (Ljava/lang/String;Ljava/lang/String;)Ldev/tramai/core/identity/WorkloadConfigurationIdentity;
+	public static synthetic fun copy-3TpVCTg$default (Ldev/tramai/core/identity/WorkloadConfigurationIdentity;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/tramai/core/identity/WorkloadConfigurationIdentity;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId-Ubl22ak ()Ljava/lang/String;
+	public final fun getVersion-ICV4KlY ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/tramai/core/identity/WorkloadDeploymentIdentity {
+	public synthetic fun <init> (Ljava/lang/String;Ldev/tramai/core/identity/WorkloadConfigurationIdentity;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-KobOwN0 ()Ljava/lang/String;
+	public final fun component2 ()Ldev/tramai/core/identity/WorkloadConfigurationIdentity;
+	public final fun component3-ITz9WHM ()Ljava/lang/String;
+	public final fun component4-dUXjPS0 ()Ljava/lang/String;
+	public final fun copy-VLa-PRA (Ljava/lang/String;Ldev/tramai/core/identity/WorkloadConfigurationIdentity;Ljava/lang/String;Ljava/lang/String;)Ldev/tramai/core/identity/WorkloadDeploymentIdentity;
+	public static synthetic fun copy-VLa-PRA$default (Ldev/tramai/core/identity/WorkloadDeploymentIdentity;Ljava/lang/String;Ldev/tramai/core/identity/WorkloadConfigurationIdentity;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/tramai/core/identity/WorkloadDeploymentIdentity;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConfiguration ()Ldev/tramai/core/identity/WorkloadConfigurationIdentity;
+	public final fun getDeploymentId-dUXjPS0 ()Ljava/lang/String;
+	public final fun getEnvironmentId-ITz9WHM ()Ljava/lang/String;
+	public final fun getWorkloadId-KobOwN0 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/tramai/core/identity/WorkloadId {
+	public static final synthetic fun box-impl (Ljava/lang/String;)Ldev/tramai/core/identity/WorkloadId;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final class dev/tramai/core/identity/WorkloadMetadata {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Ldev/tramai/core/identity/WorkloadMetadata;
+	public static synthetic fun copy$default (Ldev/tramai/core/identity/WorkloadMetadata;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/tramai/core/identity/WorkloadMetadata;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOwner ()Ljava/lang/String;
+	public final fun getPurpose ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class dev/tramai/core/memory/ChatMemory {
 	public abstract fun add (Ljava/lang/String;Ldev/tramai/core/model/Message;)V
 	public abstract fun add (Ljava/lang/String;Ljava/util/List;)V

--- a/tramai-core/api/tramai-core.api
+++ b/tramai-core/api/tramai-core.api
@@ -1029,130 +1029,112 @@ public final class dev/tramai/core/exception/TramaiExceptionKt {
 }
 
 public final class dev/tramai/core/identity/ConfigurationId {
-	public static final synthetic fun box-impl (Ljava/lang/String;)Ldev/tramai/core/identity/ConfigurationId;
-	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Ldev/tramai/core/identity/ConfigurationId;
+	public static synthetic fun copy$default (Ldev/tramai/core/identity/ConfigurationId;Ljava/lang/String;ILjava/lang/Object;)Ldev/tramai/core/identity/ConfigurationId;
 	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
-	public static fun hashCode-impl (Ljava/lang/String;)I
 	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Ljava/lang/String;
 }
 
 public final class dev/tramai/core/identity/ConfigurationVersion {
-	public static final synthetic fun box-impl (Ljava/lang/String;)Ldev/tramai/core/identity/ConfigurationVersion;
-	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Ldev/tramai/core/identity/ConfigurationVersion;
+	public static synthetic fun copy$default (Ldev/tramai/core/identity/ConfigurationVersion;Ljava/lang/String;ILjava/lang/Object;)Ldev/tramai/core/identity/ConfigurationVersion;
 	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
-	public static fun hashCode-impl (Ljava/lang/String;)I
 	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Ljava/lang/String;
 }
 
 public final class dev/tramai/core/identity/DeploymentId {
-	public static final synthetic fun box-impl (Ljava/lang/String;)Ldev/tramai/core/identity/DeploymentId;
-	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Ldev/tramai/core/identity/DeploymentId;
+	public static synthetic fun copy$default (Ldev/tramai/core/identity/DeploymentId;Ljava/lang/String;ILjava/lang/Object;)Ldev/tramai/core/identity/DeploymentId;
 	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
-	public static fun hashCode-impl (Ljava/lang/String;)I
 	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Ljava/lang/String;
 }
 
 public final class dev/tramai/core/identity/EnvironmentId {
-	public static final synthetic fun box-impl (Ljava/lang/String;)Ldev/tramai/core/identity/EnvironmentId;
-	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Ldev/tramai/core/identity/EnvironmentId;
+	public static synthetic fun copy$default (Ldev/tramai/core/identity/EnvironmentId;Ljava/lang/String;ILjava/lang/Object;)Ldev/tramai/core/identity/EnvironmentId;
 	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
-	public static fun hashCode-impl (Ljava/lang/String;)I
 	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Ljava/lang/String;
 }
 
 public final class dev/tramai/core/identity/GovernedRunIdentity {
-	public synthetic fun <init> (Ldev/tramai/core/identity/WorkloadDeploymentIdentity;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ldev/tramai/core/identity/WorkloadDeploymentIdentity;Ldev/tramai/core/identity/RunId;)V
 	public final fun component1 ()Ldev/tramai/core/identity/WorkloadDeploymentIdentity;
-	public final fun component2-QHadeyo ()Ljava/lang/String;
-	public final fun copy-o08grzM (Ldev/tramai/core/identity/WorkloadDeploymentIdentity;Ljava/lang/String;)Ldev/tramai/core/identity/GovernedRunIdentity;
-	public static synthetic fun copy-o08grzM$default (Ldev/tramai/core/identity/GovernedRunIdentity;Ldev/tramai/core/identity/WorkloadDeploymentIdentity;Ljava/lang/String;ILjava/lang/Object;)Ldev/tramai/core/identity/GovernedRunIdentity;
+	public final fun component2 ()Ldev/tramai/core/identity/RunId;
+	public final fun copy (Ldev/tramai/core/identity/WorkloadDeploymentIdentity;Ldev/tramai/core/identity/RunId;)Ldev/tramai/core/identity/GovernedRunIdentity;
+	public static synthetic fun copy$default (Ldev/tramai/core/identity/GovernedRunIdentity;Ldev/tramai/core/identity/WorkloadDeploymentIdentity;Ldev/tramai/core/identity/RunId;ILjava/lang/Object;)Ldev/tramai/core/identity/GovernedRunIdentity;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDeployment ()Ldev/tramai/core/identity/WorkloadDeploymentIdentity;
-	public final fun getRunId-QHadeyo ()Ljava/lang/String;
+	public final fun getRunId ()Ldev/tramai/core/identity/RunId;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class dev/tramai/core/identity/RunId {
-	public static final synthetic fun box-impl (Ljava/lang/String;)Ldev/tramai/core/identity/RunId;
-	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Ldev/tramai/core/identity/RunId;
+	public static synthetic fun copy$default (Ldev/tramai/core/identity/RunId;Ljava/lang/String;ILjava/lang/Object;)Ldev/tramai/core/identity/RunId;
 	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
-	public static fun hashCode-impl (Ljava/lang/String;)I
 	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Ljava/lang/String;
 }
 
 public final class dev/tramai/core/identity/WorkloadConfigurationIdentity {
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1-Ubl22ak ()Ljava/lang/String;
-	public final fun component2-ICV4KlY ()Ljava/lang/String;
-	public final fun copy-3TpVCTg (Ljava/lang/String;Ljava/lang/String;)Ldev/tramai/core/identity/WorkloadConfigurationIdentity;
-	public static synthetic fun copy-3TpVCTg$default (Ldev/tramai/core/identity/WorkloadConfigurationIdentity;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/tramai/core/identity/WorkloadConfigurationIdentity;
+	public fun <init> (Ldev/tramai/core/identity/ConfigurationId;Ldev/tramai/core/identity/ConfigurationVersion;)V
+	public final fun component1 ()Ldev/tramai/core/identity/ConfigurationId;
+	public final fun component2 ()Ldev/tramai/core/identity/ConfigurationVersion;
+	public final fun copy (Ldev/tramai/core/identity/ConfigurationId;Ldev/tramai/core/identity/ConfigurationVersion;)Ldev/tramai/core/identity/WorkloadConfigurationIdentity;
+	public static synthetic fun copy$default (Ldev/tramai/core/identity/WorkloadConfigurationIdentity;Ldev/tramai/core/identity/ConfigurationId;Ldev/tramai/core/identity/ConfigurationVersion;ILjava/lang/Object;)Ldev/tramai/core/identity/WorkloadConfigurationIdentity;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getId-Ubl22ak ()Ljava/lang/String;
-	public final fun getVersion-ICV4KlY ()Ljava/lang/String;
+	public final fun getId ()Ldev/tramai/core/identity/ConfigurationId;
+	public final fun getVersion ()Ldev/tramai/core/identity/ConfigurationVersion;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class dev/tramai/core/identity/WorkloadDeploymentIdentity {
-	public synthetic fun <init> (Ljava/lang/String;Ldev/tramai/core/identity/WorkloadConfigurationIdentity;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1-KobOwN0 ()Ljava/lang/String;
+	public fun <init> (Ldev/tramai/core/identity/WorkloadId;Ldev/tramai/core/identity/WorkloadConfigurationIdentity;Ldev/tramai/core/identity/EnvironmentId;Ldev/tramai/core/identity/DeploymentId;)V
+	public final fun component1 ()Ldev/tramai/core/identity/WorkloadId;
 	public final fun component2 ()Ldev/tramai/core/identity/WorkloadConfigurationIdentity;
-	public final fun component3-ITz9WHM ()Ljava/lang/String;
-	public final fun component4-dUXjPS0 ()Ljava/lang/String;
-	public final fun copy-VLa-PRA (Ljava/lang/String;Ldev/tramai/core/identity/WorkloadConfigurationIdentity;Ljava/lang/String;Ljava/lang/String;)Ldev/tramai/core/identity/WorkloadDeploymentIdentity;
-	public static synthetic fun copy-VLa-PRA$default (Ldev/tramai/core/identity/WorkloadDeploymentIdentity;Ljava/lang/String;Ldev/tramai/core/identity/WorkloadConfigurationIdentity;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/tramai/core/identity/WorkloadDeploymentIdentity;
+	public final fun component3 ()Ldev/tramai/core/identity/EnvironmentId;
+	public final fun component4 ()Ldev/tramai/core/identity/DeploymentId;
+	public final fun copy (Ldev/tramai/core/identity/WorkloadId;Ldev/tramai/core/identity/WorkloadConfigurationIdentity;Ldev/tramai/core/identity/EnvironmentId;Ldev/tramai/core/identity/DeploymentId;)Ldev/tramai/core/identity/WorkloadDeploymentIdentity;
+	public static synthetic fun copy$default (Ldev/tramai/core/identity/WorkloadDeploymentIdentity;Ldev/tramai/core/identity/WorkloadId;Ldev/tramai/core/identity/WorkloadConfigurationIdentity;Ldev/tramai/core/identity/EnvironmentId;Ldev/tramai/core/identity/DeploymentId;ILjava/lang/Object;)Ldev/tramai/core/identity/WorkloadDeploymentIdentity;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConfiguration ()Ldev/tramai/core/identity/WorkloadConfigurationIdentity;
-	public final fun getDeploymentId-dUXjPS0 ()Ljava/lang/String;
-	public final fun getEnvironmentId-ITz9WHM ()Ljava/lang/String;
-	public final fun getWorkloadId-KobOwN0 ()Ljava/lang/String;
+	public final fun getDeploymentId ()Ldev/tramai/core/identity/DeploymentId;
+	public final fun getEnvironmentId ()Ldev/tramai/core/identity/EnvironmentId;
+	public final fun getWorkloadId ()Ldev/tramai/core/identity/WorkloadId;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class dev/tramai/core/identity/WorkloadId {
-	public static final synthetic fun box-impl (Ljava/lang/String;)Ldev/tramai/core/identity/WorkloadId;
-	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Ldev/tramai/core/identity/WorkloadId;
+	public static synthetic fun copy$default (Ldev/tramai/core/identity/WorkloadId;Ljava/lang/String;ILjava/lang/Object;)Ldev/tramai/core/identity/WorkloadId;
 	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
-	public static fun hashCode-impl (Ljava/lang/String;)I
 	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Ljava/lang/String;
 }
 
 public final class dev/tramai/core/identity/WorkloadMetadata {

--- a/tramai-core/src/main/kotlin/dev/tramai/core/identity/ConfigurationId.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/identity/ConfigurationId.kt
@@ -8,11 +8,12 @@ package dev.tramai.core.identity
  * meaning (e.g. `customer-support-agent`, `fraud-review-policy`) but must not
  * be parsed by consumers.
  */
-@JvmInline
-value class ConfigurationId(
+data class ConfigurationId(
     val value: String,
 ) {
     init {
         validateIdentity("ConfigurationId", value)
     }
+
+    override fun toString(): String = value
 }

--- a/tramai-core/src/main/kotlin/dev/tramai/core/identity/ConfigurationId.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/identity/ConfigurationId.kt
@@ -1,0 +1,18 @@
+package dev.tramai.core.identity
+
+/**
+ * Stable identity of a governed configuration family.
+ *
+ * Paired with [ConfigurationVersion] it identifies the exact governed
+ * configuration of a workload. The id is opaque: it may encode product/domain
+ * meaning (e.g. `customer-support-agent`, `fraud-review-policy`) but must not
+ * be parsed by consumers.
+ */
+@JvmInline
+value class ConfigurationId(
+    val value: String,
+) {
+    init {
+        validateIdentity("ConfigurationId", value)
+    }
+}

--- a/tramai-core/src/main/kotlin/dev/tramai/core/identity/ConfigurationVersion.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/identity/ConfigurationVersion.kt
@@ -1,0 +1,18 @@
+package dev.tramai.core.identity
+
+/**
+ * Version of one immutable governed-configuration revision.
+ *
+ * The version is opaque and must not be assumed to be SemVer. Legitimate
+ * values include datestamped revisions (`2026-09-09.3`), content digests
+ * (`sha256:abcd...`) and monotonic counters. Together with its
+ * [ConfigurationId] it names one exact governed configuration.
+ */
+@JvmInline
+value class ConfigurationVersion(
+    val value: String,
+) {
+    init {
+        validateIdentity("ConfigurationVersion", value)
+    }
+}

--- a/tramai-core/src/main/kotlin/dev/tramai/core/identity/ConfigurationVersion.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/identity/ConfigurationVersion.kt
@@ -8,11 +8,12 @@ package dev.tramai.core.identity
  * (`sha256:abcd...`) and monotonic counters. Together with its
  * [ConfigurationId] it names one exact governed configuration.
  */
-@JvmInline
-value class ConfigurationVersion(
+data class ConfigurationVersion(
     val value: String,
 ) {
     init {
         validateIdentity("ConfigurationVersion", value)
     }
+
+    override fun toString(): String = value
 }

--- a/tramai-core/src/main/kotlin/dev/tramai/core/identity/DeploymentId.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/identity/DeploymentId.kt
@@ -10,11 +10,12 @@ package dev.tramai.core.identity
  * (`eu-west-amsterdam-01` vs `eu-central-frankfurt-01`) are different
  * [WorkloadDeploymentIdentity] values.
  */
-@JvmInline
-value class DeploymentId(
+data class DeploymentId(
     val value: String,
 ) {
     init {
         validateIdentity("DeploymentId", value)
     }
+
+    override fun toString(): String = value
 }

--- a/tramai-core/src/main/kotlin/dev/tramai/core/identity/DeploymentId.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/identity/DeploymentId.kt
@@ -1,0 +1,20 @@
+package dev.tramai.core.identity
+
+/**
+ * Identity of one independently distinguishable deployment of a
+ * workload/configuration in an environment.
+ *
+ * Distinct deployments must never collapse into one identity, even when they
+ * share the same workload, configuration and environment. Example: two
+ * clusters running the same production configuration
+ * (`eu-west-amsterdam-01` vs `eu-central-frankfurt-01`) are different
+ * [WorkloadDeploymentIdentity] values.
+ */
+@JvmInline
+value class DeploymentId(
+    val value: String,
+) {
+    init {
+        validateIdentity("DeploymentId", value)
+    }
+}

--- a/tramai-core/src/main/kotlin/dev/tramai/core/identity/EnvironmentId.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/identity/EnvironmentId.kt
@@ -8,11 +8,12 @@ package dev.tramai.core.identity
  * workload/configuration can both legitimately live in `production` and must
  * remain distinguishable through [DeploymentId].
  */
-@JvmInline
-value class EnvironmentId(
+data class EnvironmentId(
     val value: String,
 ) {
     init {
         validateIdentity("EnvironmentId", value)
     }
+
+    override fun toString(): String = value
 }

--- a/tramai-core/src/main/kotlin/dev/tramai/core/identity/EnvironmentId.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/identity/EnvironmentId.kt
@@ -1,0 +1,18 @@
+package dev.tramai.core.identity
+
+/**
+ * Logical governance environment of a deployment.
+ *
+ * Examples: `dev`, `staging`, `production`, or a tenant-specific environment.
+ * An environment is NOT a deployment: two independent deployments of the same
+ * workload/configuration can both legitimately live in `production` and must
+ * remain distinguishable through [DeploymentId].
+ */
+@JvmInline
+value class EnvironmentId(
+    val value: String,
+) {
+    init {
+        validateIdentity("EnvironmentId", value)
+    }
+}

--- a/tramai-core/src/main/kotlin/dev/tramai/core/identity/GovernedRunIdentity.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/identity/GovernedRunIdentity.kt
@@ -1,0 +1,21 @@
+package dev.tramai.core.identity
+
+/**
+ * Identity of one authoritative execution of a governed workload deployment:
+ *
+ * ```text
+ * WorkloadDeploymentIdentity + RunId = GovernedRunIdentity
+ * ```
+ *
+ * This is the canonical structure later candidates (approval, policy evidence,
+ * routing evidence, checkpoints, scheduler ticks, engine invocation,
+ * control-plane projection, reconstruction) reference instead of inventing
+ * their own identity tuple. It only represents identity: propagation through
+ * orchestration/engine/approval/evidence belongs to the run attribution
+ * candidate (Epic 0.7.1 candidate 0.7.1d), and no identifier is generated
+ * here.
+ */
+data class GovernedRunIdentity(
+    val deployment: WorkloadDeploymentIdentity,
+    val runId: RunId,
+)

--- a/tramai-core/src/main/kotlin/dev/tramai/core/identity/IdentityValidation.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/identity/IdentityValidation.kt
@@ -1,0 +1,44 @@
+package dev.tramai.core.identity
+
+/**
+ * Maximum length of an identity value. Identity strings are opaque identifiers,
+ * not human-readable descriptions: bounded length protects persistence and
+ * projection surfaces without imposing a restrictive character grammar.
+ */
+internal const val ID_MAX_LENGTH: Int = 128
+
+/**
+ * Maximum length of an [owner][WorkloadMetadata.owner] value.
+ */
+internal const val OWNER_MAX_LENGTH: Int = 256
+
+/**
+ * Maximum length of a [purpose][WorkloadMetadata.purpose] value.
+ */
+internal const val PURPOSE_MAX_LENGTH: Int = 512
+
+/**
+ * Fail-closed validation shared by every typed identity value.
+ *
+ * Rules are intentionally conservative:
+ * - non-blank;
+ * - no leading or trailing whitespace (no silent normalization on the way in);
+ * - bounded length;
+ * - no ISO control characters.
+ *
+ * Case is preserved and no character grammar is imposed: identifiers such as
+ * `payments`, `Payments`, `org.example.claims`, `urn:company:workload:claims`,
+ * `production-eu` and `deployment_2026_09` are all legal distinct values.
+ * Silent canonicalization (e.g. trimming, lowercasing, regex shaping) is
+ * deliberately absent: identity systems become dangerous when different inputs
+ * silently collapse to the same key.
+ */
+internal fun validateIdentity(
+    kind: String,
+    value: String,
+) {
+    require(value.isNotBlank()) { "$kind must not be blank" }
+    require(value == value.trim()) { "$kind must not contain leading or trailing whitespace" }
+    require(value.length <= ID_MAX_LENGTH) { "$kind must not exceed $ID_MAX_LENGTH characters" }
+    require(value.none(Char::isISOControl)) { "$kind must not contain control characters" }
+}

--- a/tramai-core/src/main/kotlin/dev/tramai/core/identity/RunId.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/identity/RunId.kt
@@ -16,11 +16,12 @@ package dev.tramai.core.identity
  * diagnostic/cross-operation correlation id, which TramAI already models in
  * `EngineExecutionIdentity.correlationId`.
  */
-@JvmInline
-value class RunId(
+data class RunId(
     val value: String,
 ) {
     init {
         validateIdentity("RunId", value)
     }
+
+    override fun toString(): String = value
 }

--- a/tramai-core/src/main/kotlin/dev/tramai/core/identity/RunId.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/identity/RunId.kt
@@ -1,0 +1,26 @@
+package dev.tramai.core.identity
+
+/**
+ * One immutable identifier for one authoritative execution of a governed
+ * workload deployment.
+ *
+ * Run semantics:
+ * - resume of the same authoritative run keeps the same [RunId];
+ * - retry/restart within the same authoritative run keeps the same [RunId];
+ * - approval-resume keeps the same [RunId];
+ * - a genuinely new execution receives a new [RunId].
+ *
+ * This type only REPRESENTS run identity; it never generates identifiers.
+ * Creation of the id at the supported execution boundary belongs to the run
+ * attribution candidate (Epic 0.7.1 candidate 0.7.1d). It is distinct from a
+ * diagnostic/cross-operation correlation id, which TramAI already models in
+ * `EngineExecutionIdentity.correlationId`.
+ */
+@JvmInline
+value class RunId(
+    val value: String,
+) {
+    init {
+        validateIdentity("RunId", value)
+    }
+}

--- a/tramai-core/src/main/kotlin/dev/tramai/core/identity/WorkloadConfigurationIdentity.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/identity/WorkloadConfigurationIdentity.kt
@@ -1,0 +1,21 @@
+package dev.tramai.core.identity
+
+/**
+ * Identity of one exact governed configuration: a stable configuration family
+ * ([ConfigurationId]) pinned to one immutable revision ([ConfigurationVersion]).
+ *
+ * Invariant: within an authority domain, the same `(configurationId, version)`
+ * pair must never refer to two different governed configurations. This type
+ * declares the invariant; collision/rebinding enforcement belongs to the
+ * registration/state authority (Epic 0.7.1 candidate 0.7.1c) because it
+ * requires an authoritative store.
+ *
+ * Note: a governed configuration is broader than a workflow definition. It may
+ * later include workflow definition, policy, classification profile, provider
+ * deployment configuration, trust-zone assignments and tool governance. Do not
+ * equate [ConfigurationVersion] with the workflow `definitionVersion`.
+ */
+data class WorkloadConfigurationIdentity(
+    val id: ConfigurationId,
+    val version: ConfigurationVersion,
+)

--- a/tramai-core/src/main/kotlin/dev/tramai/core/identity/WorkloadDeploymentIdentity.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/identity/WorkloadDeploymentIdentity.kt
@@ -1,0 +1,20 @@
+package dev.tramai.core.identity
+
+/**
+ * Identity of one governed workload/configuration as deployed in one place:
+ * which workload, which exact configuration, and where it runs.
+ *
+ * Distinct deployments must never collapse into one identity. Two deployments
+ * that share workload, configuration and environment but differ in
+ * [deploymentId] (e.g. `eu-west-amsterdam-01` and `eu-central-frankfurt-01`)
+ * are different identities. Owner/purpose metadata is deliberately NOT part of
+ * this type: ownership may change without changing workload identity. The
+ * authoritative association of metadata to identity belongs to the
+ * registration/state authority (Epic 0.7.1 candidate 0.7.1c).
+ */
+data class WorkloadDeploymentIdentity(
+    val workloadId: WorkloadId,
+    val configuration: WorkloadConfigurationIdentity,
+    val environmentId: EnvironmentId,
+    val deploymentId: DeploymentId,
+)

--- a/tramai-core/src/main/kotlin/dev/tramai/core/identity/WorkloadId.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/identity/WorkloadId.kt
@@ -8,12 +8,20 @@ package dev.tramai.core.identity
  * The identifier is stable and case-preserving; it is not required to be a
  * random UUID. Generation policy belongs to the registration authority
  * (Epic 0.7.1 candidate 0.7.1c), not to this type.
+ *
+ * Plain JVM class, not an inline class: the identity vocabulary is part of the
+ * canonical public tramai-core contract, so every type in this package is
+ * constructible and readable from Java (`new WorkloadId("claims")`,
+ * `getValue()`). Do not convert these boundary types to `@JvmInline` value
+ * classes — that would make the canonical contract Kotlin-only (or dependent
+ * on experimental boxed exposure).
  */
-@JvmInline
-value class WorkloadId(
+data class WorkloadId(
     val value: String,
 ) {
     init {
         validateIdentity("WorkloadId", value)
     }
+
+    override fun toString(): String = value
 }

--- a/tramai-core/src/main/kotlin/dev/tramai/core/identity/WorkloadId.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/identity/WorkloadId.kt
@@ -1,0 +1,19 @@
+package dev.tramai.core.identity
+
+/**
+ * Stable identity of one independently governed workload.
+ *
+ * A workload is the governed application/business capability that owns
+ * workflow executions (e.g. `payments-fraud-review`, `com.acme.claims-assistant`).
+ * The identifier is stable and case-preserving; it is not required to be a
+ * random UUID. Generation policy belongs to the registration authority
+ * (Epic 0.7.1 candidate 0.7.1c), not to this type.
+ */
+@JvmInline
+value class WorkloadId(
+    val value: String,
+) {
+    init {
+        validateIdentity("WorkloadId", value)
+    }
+}

--- a/tramai-core/src/main/kotlin/dev/tramai/core/identity/WorkloadMetadata.kt
+++ b/tramai-core/src/main/kotlin/dev/tramai/core/identity/WorkloadMetadata.kt
@@ -1,0 +1,32 @@
+package dev.tramai.core.identity
+
+/**
+ * Bounded, safe operational metadata about a governed workload.
+ *
+ * [owner] and [purpose] describe responsibility and intent. They are NOT part
+ * of identity equality: ownership may change (e.g. from one team to another)
+ * without creating a different workload identity. The authoritative association
+ * between a [WorkloadDeploymentIdentity] and its metadata belongs to the
+ * registration/state authority (Epic 0.7.1 candidate 0.7.1c).
+ *
+ * This type is safe operational metadata only. It is NOT a place for prompts,
+ * credentials, PII, tool arguments, user content or secrets. A free-form
+ * `Map<String, Any?>` is deliberately not provided: it would recreate the
+ * untyped attribute problem identified by the 0.7.1a audit.
+ */
+data class WorkloadMetadata(
+    val owner: String,
+    val purpose: String,
+) {
+    init {
+        require(owner.isNotBlank()) { "owner must not be blank" }
+        require(owner == owner.trim()) { "owner must not contain leading or trailing whitespace" }
+        require(owner.length <= OWNER_MAX_LENGTH) { "owner must not exceed $OWNER_MAX_LENGTH characters" }
+        require(owner.none(Char::isISOControl)) { "owner must not contain control characters" }
+
+        require(purpose.isNotBlank()) { "purpose must not be blank" }
+        require(purpose == purpose.trim()) { "purpose must not contain leading or trailing whitespace" }
+        require(purpose.length <= PURPOSE_MAX_LENGTH) { "purpose must not exceed $PURPOSE_MAX_LENGTH characters" }
+        require(purpose.none(Char::isISOControl)) { "purpose must not contain control characters" }
+    }
+}

--- a/tramai-core/src/test/java/dev/tramai/core/identity/JavaIdentityInteropTest.java
+++ b/tramai-core/src/test/java/dev/tramai/core/identity/JavaIdentityInteropTest.java
@@ -1,0 +1,61 @@
+package dev.tramai.core.identity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Java-visible proof for the 0.7.1b identity contract.
+ *
+ * The identity vocabulary is plain JVM classes by design: this test compiles
+ * and runs real Java source against the canonical public tramai-core identity
+ * surface. It fails if the types are ever converted back to @JvmInline value
+ * classes (which are not naturally constructible from Java) or if the
+ * composition/equality semantics regress.
+ */
+class JavaIdentityInteropTest {
+
+    private WorkloadDeploymentIdentity deployment(
+            String workload, String version, String environment, String deployment) {
+        return new WorkloadDeploymentIdentity(
+                new WorkloadId(workload),
+                new WorkloadConfigurationIdentity(
+                        new ConfigurationId(workload + "-prod"),
+                        new ConfigurationVersion(version)),
+                new EnvironmentId(environment),
+                new DeploymentId(deployment));
+    }
+
+    @Test
+    void constructsIdentityVocabularyFromJava() {
+        WorkloadDeploymentIdentity amsterdam =
+                deployment("claims", "17", "production", "eu-west-amsterdam-01");
+        GovernedRunIdentity run = new GovernedRunIdentity(amsterdam, new RunId("run-1"));
+
+        assertEquals("claims", amsterdam.getWorkloadId().getValue());
+        assertEquals("17", amsterdam.getConfiguration().getVersion().getValue());
+        assertEquals("production", amsterdam.getEnvironmentId().getValue());
+        assertEquals("eu-west-amsterdam-01", amsterdam.getDeploymentId().getValue());
+        assertEquals("run-1", run.getRunId().getValue());
+        assertEquals(amsterdam, run.getDeployment());
+    }
+
+    @Test
+    void sameEnvironmentDifferentDeploymentDoesNotCollapseFromJava() {
+        WorkloadDeploymentIdentity amsterdam =
+                deployment("claims", "17", "production", "eu-west-amsterdam-01");
+        WorkloadDeploymentIdentity frankfurt =
+                deployment("claims", "17", "production", "eu-central-frankfurt-01");
+
+        assertNotEquals(amsterdam, frankfurt);
+    }
+
+    @Test
+    void validationFailsClosedFromJava() {
+        assertThrows(IllegalArgumentException.class, () -> new WorkloadId(" "));
+        assertThrows(IllegalArgumentException.class, () -> new RunId("run\nid"));
+        assertThrows(IllegalArgumentException.class, () -> new WorkloadMetadata(" ", "purpose"));
+    }
+}

--- a/tramai-core/src/test/kotlin/dev/tramai/core/identity/IdentityIdValidationTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/identity/IdentityIdValidationTest.kt
@@ -1,0 +1,112 @@
+package dev.tramai.core.identity
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import kotlin.test.Test
+
+/**
+ * Atomic id validation. Every typed id must fail closed on the same malformed
+ * inputs and accept opaque, case-preserving identifiers without grammar
+ * restrictions or silent normalization.
+ */
+class IdentityIdValidationTest {
+    private val overLimit = "a".repeat(129)
+
+    private fun assertRejected(
+        construct: (String) -> Any,
+        vararg invalid: String,
+    ) {
+        for (raw in invalid) {
+            assertThatThrownBy { construct(raw) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("must not")
+        }
+    }
+
+    @Test
+    fun `blank id is rejected`() {
+        assertRejected({ WorkloadId(it) }, "", "   ", "\t")
+    }
+
+    @Test
+    fun `leading or trailing whitespace is rejected`() {
+        assertRejected({ WorkloadId(it) }, " workload", "workload ", " workload ")
+    }
+
+    @Test
+    fun `control characters are rejected`() {
+        assertRejected({ WorkloadId(it) }, "work\nload", "work\u0000load", "work\rload")
+    }
+
+    @Test
+    fun `over-limit id is rejected`() {
+        assertThatThrownBy { WorkloadId(overLimit) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("128")
+    }
+
+    @Test
+    fun `every atomic id type validates its own value`() {
+        val constructs =
+            listOf<(String) -> Any>(
+                { WorkloadId(it) },
+                { ConfigurationId(it) },
+                { ConfigurationVersion(it) },
+                { EnvironmentId(it) },
+                { DeploymentId(it) },
+                { RunId(it) },
+            )
+        for (construct in constructs) {
+            assertThatThrownBy { construct(" ") }
+                .isInstanceOf(IllegalArgumentException::class.java)
+            assertThatThrownBy { construct(overLimit) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+            assertThatThrownBy { construct("bad\u0000id") }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Test
+    fun `opaque identifiers without restricted grammar are accepted`() {
+        val accepted =
+            listOf(
+                "claims",
+                "claims-v2",
+                "org.example.claims",
+                "production/eu",
+                "deployment_01",
+                "urn:company:workload:claims",
+                "customer-support/v3",
+            )
+        for (raw in accepted) {
+            assertThat(WorkloadId(raw).value).isEqualTo(raw)
+            assertThat(RunId(raw).value).isEqualTo(raw)
+        }
+    }
+
+    @Test
+    fun `boundary length id is accepted and over-limit rejected`() {
+        val atLimit = "a".repeat(128)
+        assertThat(WorkloadId(atLimit).value).isEqualTo(atLimit)
+        assertRejected({ WorkloadId(it) }, overLimit)
+    }
+
+    @Test
+    fun `case is preserved and not normalized`() {
+        val upper = WorkloadId("Payments")
+        val lower = WorkloadId("payments")
+
+        assertThat(upper.value).isEqualTo("Payments")
+        assertThat(lower.value).isEqualTo("payments")
+        assertThat(upper).isNotEqualTo(lower)
+    }
+
+    @Test
+    fun `equal values produce equal ids and same hash`() {
+        val a = WorkloadId("claims")
+        val b = WorkloadId("claims")
+
+        assertThat(a).isEqualTo(b)
+        assertThat(a.hashCode()).isEqualTo(b.hashCode())
+    }
+}

--- a/tramai-core/src/test/kotlin/dev/tramai/core/identity/WorkloadIdentityCompositionTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/identity/WorkloadIdentityCompositionTest.kt
@@ -1,0 +1,99 @@
+package dev.tramai.core.identity
+
+import org.assertj.core.api.Assertions.assertThat
+import kotlin.test.Test
+
+/**
+ * Composition and discrimination semantics of the identity vocabulary.
+ *
+ * The critical adversarial proof: two deployments of the same workload and
+ * configuration in the SAME environment must not collapse into one identity.
+ */
+class WorkloadIdentityCompositionTest {
+    private fun deployment(
+        workload: String = "claims",
+        configId: String = "claims-prod",
+        configVersion: String = "17",
+        environment: String = "production",
+        deployment: String,
+    ): WorkloadDeploymentIdentity =
+        WorkloadDeploymentIdentity(
+            workloadId = WorkloadId(workload),
+            configuration =
+                WorkloadConfigurationIdentity(
+                    id = ConfigurationId(configId),
+                    version = ConfigurationVersion(configVersion),
+                ),
+            environmentId = EnvironmentId(environment),
+            deploymentId = DeploymentId(deployment),
+        )
+
+    @Test
+    fun `deployments in the same environment do not collapse`() {
+        val amsterdam = deployment(deployment = "eu-west-amsterdam-01")
+        val frankfurt = deployment(deployment = "eu-central-frankfurt-01")
+
+        assertThat(amsterdam).isNotEqualTo(frankfurt)
+    }
+
+    @Test
+    fun `deployments in different environments do not collapse`() {
+        val production = deployment(environment = "production", deployment = "ams-01")
+        val staging = deployment(environment = "staging", deployment = "ams-01")
+
+        assertThat(production).isNotEqualTo(staging)
+    }
+
+    @Test
+    fun `different workloads do not collapse`() {
+        val claims = deployment(workload = "claims", deployment = "ams-01")
+        val fraud = deployment(workload = "fraud-review", deployment = "ams-01")
+
+        assertThat(claims).isNotEqualTo(fraud)
+    }
+
+    @Test
+    fun `configuration version discriminates`() {
+        val v17 = deployment(configVersion = "17", deployment = "ams-01")
+        val v18 = deployment(configVersion = "18", deployment = "ams-01")
+
+        assertThat(v17).isNotEqualTo(v18)
+    }
+
+    @Test
+    fun `configuration id discriminates`() {
+        val prod = deployment(configId = "claims-prod", deployment = "ams-01")
+        val canary = deployment(configId = "claims-canary", deployment = "ams-01")
+
+        assertThat(prod).isNotEqualTo(canary)
+    }
+
+    @Test
+    fun `identical fields produce one identity`() {
+        val a = deployment(deployment = "ams-01")
+        val b = deployment(deployment = "ams-01")
+
+        assertThat(a).isEqualTo(b)
+        assertThat(a.hashCode()).isEqualTo(b.hashCode())
+    }
+
+    @Test
+    fun `run identity discriminates runs within one deployment`() {
+        val deployment = deployment(deployment = "ams-01")
+        val runA = GovernedRunIdentity(deployment = deployment, runId = RunId("run-a"))
+        val runB = GovernedRunIdentity(deployment = deployment, runId = RunId("run-b"))
+        val sameAsA = GovernedRunIdentity(deployment = deployment, runId = RunId("run-a"))
+
+        assertThat(runA).isNotEqualTo(runB)
+        assertThat(runA).isEqualTo(sameAsA)
+    }
+
+    @Test
+    fun `run identity carries the deployment identity unchanged`() {
+        val deployment = deployment(deployment = "ams-01")
+        val run = GovernedRunIdentity(deployment = deployment, runId = RunId("run-a"))
+
+        assertThat(run.deployment).isEqualTo(deployment)
+        assertThat(run.runId.value).isEqualTo("run-a")
+    }
+}

--- a/tramai-core/src/test/kotlin/dev/tramai/core/identity/WorkloadMetadataTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/identity/WorkloadMetadataTest.kt
@@ -1,0 +1,78 @@
+package dev.tramai.core.identity
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import kotlin.jvm.internal.DefaultConstructorMarker
+import kotlin.test.Test
+
+/**
+ * Metadata validation plus the structural proof that owner/purpose metadata is
+ * separate from identity equality: identity composition types must not embed a
+ * [WorkloadMetadata] field, so ownership changes can never alter identity.
+ */
+class WorkloadMetadataTest {
+    @Test
+    fun `valid metadata constructs`() {
+        val metadata = WorkloadMetadata(owner = "Payments Team", purpose = "Fraud review")
+
+        assertThat(metadata.owner).isEqualTo("Payments Team")
+        assertThat(metadata.purpose).isEqualTo("Fraud review")
+    }
+
+    @Test
+    fun `blank owner or purpose is rejected`() {
+        assertThatThrownBy { WorkloadMetadata(owner = " ", purpose = "Fraud review") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("owner")
+        assertThatThrownBy { WorkloadMetadata(owner = "Payments Team", purpose = "  ") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("purpose")
+    }
+
+    @Test
+    fun `control characters are rejected in metadata`() {
+        assertThatThrownBy { WorkloadMetadata(owner = "Payments\u0000Team", purpose = "Fraud review") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+        assertThatThrownBy { WorkloadMetadata(owner = "Payments Team", purpose = "Fraud\nreview") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `over-limit owner or purpose is rejected`() {
+        assertThatThrownBy { WorkloadMetadata(owner = "a".repeat(257), purpose = "Fraud review") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("256")
+        assertThatThrownBy { WorkloadMetadata(owner = "Payments Team", purpose = "a".repeat(513)) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("512")
+    }
+
+    @Test
+    fun `identity composition types do not embed metadata`() {
+        // Value-class parameters erase to their underlying type (String) at the
+        // JVM level; the synthetic default-argument constructor carries a
+        // marker. The guard asserts slot count/shape and the absence of
+        // WorkloadMetadata rather than erased parameter names.
+        val deploymentParams = primaryParameters(WorkloadDeploymentIdentity::class.java)
+        assertThat(deploymentParams).hasSize(4)
+        assertThat(deploymentParams).doesNotContain(WorkloadMetadata::class.java)
+        assertThat(deploymentParams).contains(WorkloadConfigurationIdentity::class.java)
+
+        val runParams = primaryParameters(GovernedRunIdentity::class.java)
+        assertThat(runParams).hasSize(2)
+        assertThat(runParams).doesNotContain(WorkloadMetadata::class.java)
+        assertThat(runParams).contains(WorkloadDeploymentIdentity::class.java)
+
+        val configurationParams = primaryParameters(WorkloadConfigurationIdentity::class.java)
+        assertThat(configurationParams).hasSize(2)
+        assertThat(configurationParams).doesNotContain(WorkloadMetadata::class.java)
+    }
+
+    private fun primaryParameters(clazz: Class<*>): List<Class<*>> {
+        val constructors = clazz.constructors
+        val primary = constructors.maxBy { it.parameterCount }
+        return primary.parameterTypes
+            .filter { it != DefaultConstructorMarker::class.java }
+            .toList()
+    }
+}

--- a/tramai-core/src/test/kotlin/dev/tramai/core/identity/WorkloadMetadataTest.kt
+++ b/tramai-core/src/test/kotlin/dev/tramai/core/identity/WorkloadMetadataTest.kt
@@ -2,7 +2,6 @@ package dev.tramai.core.identity
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import kotlin.jvm.internal.DefaultConstructorMarker
 import kotlin.test.Test
 
 /**
@@ -49,30 +48,39 @@ class WorkloadMetadataTest {
 
     @Test
     fun `identity composition types do not embed metadata`() {
-        // Value-class parameters erase to their underlying type (String) at the
-        // JVM level; the synthetic default-argument constructor carries a
-        // marker. The guard asserts slot count/shape and the absence of
-        // WorkloadMetadata rather than erased parameter names.
-        val deploymentParams = primaryParameters(WorkloadDeploymentIdentity::class.java)
-        assertThat(deploymentParams).hasSize(4)
-        assertThat(deploymentParams).doesNotContain(WorkloadMetadata::class.java)
-        assertThat(deploymentParams).contains(WorkloadConfigurationIdentity::class.java)
+        // Plain JVM classes expose their real parameter types — no value-class
+        // erasure. The guard asserts the exact constructor shape and the
+        // absence of WorkloadMetadata: ownership can never alter identity.
+        val deploymentParams =
+            WorkloadDeploymentIdentity::class.java.constructors
+                .single()
+                .parameterTypes
+                .toList()
+        assertThat(deploymentParams).containsExactly(
+            WorkloadId::class.java,
+            WorkloadConfigurationIdentity::class.java,
+            EnvironmentId::class.java,
+            DeploymentId::class.java,
+        )
 
-        val runParams = primaryParameters(GovernedRunIdentity::class.java)
-        assertThat(runParams).hasSize(2)
-        assertThat(runParams).doesNotContain(WorkloadMetadata::class.java)
-        assertThat(runParams).contains(WorkloadDeploymentIdentity::class.java)
+        val runParams =
+            GovernedRunIdentity::class.java.constructors
+                .single()
+                .parameterTypes
+                .toList()
+        assertThat(runParams).containsExactly(
+            WorkloadDeploymentIdentity::class.java,
+            RunId::class.java,
+        )
 
-        val configurationParams = primaryParameters(WorkloadConfigurationIdentity::class.java)
-        assertThat(configurationParams).hasSize(2)
-        assertThat(configurationParams).doesNotContain(WorkloadMetadata::class.java)
-    }
-
-    private fun primaryParameters(clazz: Class<*>): List<Class<*>> {
-        val constructors = clazz.constructors
-        val primary = constructors.maxBy { it.parameterCount }
-        return primary.parameterTypes
-            .filter { it != DefaultConstructorMarker::class.java }
-            .toList()
+        val configurationParams =
+            WorkloadConfigurationIdentity::class.java.constructors
+                .single()
+                .parameterTypes
+                .toList()
+        assertThat(configurationParams).containsExactly(
+            ConfigurationId::class.java,
+            ConfigurationVersion::class.java,
+        )
     }
 }


### PR DESCRIPTION
## Purpose

Implement candidate 0.7.1b of Epic 0.7.1: the canonical typed identity vocabulary for a governed TramAI workload and run, as derived by the 0.7.1a baseline authority audit. This candidate is deliberately a type-system/contract change only — no lifecycle authority, persistence, registration, propagation, or runtime wiring.

## Scope

- Change class: `public-api` (additive only; no breaking change)
- Branch: `task/0.7.1b-workload-identity-contract` → `epic/0.7.1-control-plane-authority`
- Files touched:
  - `tramai-core/src/main/kotlin/dev/tramai/core/identity/` — new package: `IdentityValidation.kt`, `WorkloadId.kt`, `ConfigurationId.kt`, `ConfigurationVersion.kt`, `EnvironmentId.kt`, `DeploymentId.kt`, `RunId.kt`, `WorkloadConfigurationIdentity.kt`, `WorkloadDeploymentIdentity.kt`, `GovernedRunIdentity.kt`, `WorkloadMetadata.kt`
  - `tramai-core/src/test/kotlin/dev/tramai/core/identity/` — `IdentityIdValidationTest.kt`, `WorkloadIdentityCompositionTest.kt`, `WorkloadMetadataTest.kt`
  - `tramai-core/api/tramai-core.api` — additive only (net +122 vs epic base), plain JVM constructor/getter surface
  - `docs/roadmap/0.7.0/TASK-0.7.1b-WORKLOAD-IDENTITY-CONTRACT.md` (new task record)
  - `docs/roadmap/0.7.0/EPIC-0.7.1-CONTROL-PLANE-AUTHORITY.md` (status line references 0.7.1b task)

## Behavioural Contract

Six opaque, fail-closed validated atomic ids (`WorkloadId`, `ConfigurationId`, `ConfigurationVersion`, `EnvironmentId`, `DeploymentId`, `RunId`) composed into `WorkloadConfigurationIdentity` → `WorkloadDeploymentIdentity` → `GovernedRunIdentity`. Validation rejects blank, surrounding-whitespace, control-character, and over-limit (128) values; case is preserved with no silent normalization. `WorkloadMetadata` (owner ≤ 256, purpose ≤ 512) is a separate bounded type and is NOT part of identity equality. No identifier is generated by any type; `RunId` semantics (resume reuses, new execution new id) are documented, with creation deferred to 0.7.1d.

Java surface: all identity types are **plain JVM classes** (not `@JvmInline` value classes) — deliberately decided in 0.7.1b, not inherited from Kotlin's inline-class compilation model. The vocabulary is the canonical public tramai-core contract that 0.7.1d pushes to execution boundaries; `new WorkloadId("claims")`, getters and equality work naturally from Java. The API dump exposes plain `<init>(String)` constructors (no `box-impl`/mangled `-QHadeyo` members). Enforced by `JavaIdentityInteropTest` (compiled and run in `:tramai-core:test`) and by identity usage in the `java-consumer-smoke` example.

## Architecture Impact

- [x] No new dependency edge introduced (types live in existing published `tramai-core`, which orchestration/engine/security already depend on)
- [x] Core does not depend on an adapter/framework
- [x] No ownership/lifecycle change
- [x] No global mutable state introduced
- [x] No duplicate of an existing authoritative model — this is the single canonical identity vocabulary the 0.7.1a audit concluded was missing; the existing `EngineExecutionIdentity.correlationId` concept is deliberately not duplicated

## Compatibility

- [x] Stable public API unchanged — additive only; no existing declaration modified or removed
- [x] Preview API unchanged
- [x] Persisted representation unchanged
- [x] Event/reason/error code unchanged
- [x] Configuration semantics unchanged

## Correctness & Concurrency

- [x] Cancellation behaviour unaffected (no runtime wiring)
- [x] Retry behaviour unaffected
- [x] Concurrency unaffected
- [x] Evidence/audit/telemetry emission unaffected
- [x] Change is replay-safe
- Contract tests proving the change: `IdentityIdValidationTest`, `WorkloadIdentityCompositionTest`, `WorkloadMetadataTest`.

## Verification

- [x] `./gradlew :tramai-core:test` — passed (identity suites green, incl. `JavaIdentityInteropTest` — 3 Java-source tests)
- [x] `./gradlew :examples:java-consumer-smoke:compileJava` — passed with identity vocabulary usage
- [x] `./gradlew spotlessCheck` — passed (no reformatting needed)
- [x] `./gradlew :tramai-core:apiDump` — passed; api dump delta after Java-interop fix: +45/−63 (inline `box-impl` machinery replaced by plain `<init>`/getter surface)
- [x] Review round (Java interop decision) addressed in `68d4e97a`; Copilot `maxBy` thread resolved (guard now uses `constructors.single()`)
- [x] `./gradlew verifyChangePolicy -PchangeClass=public-api` — PASSED (no policy violations)
- [ ] `./gradlew verifyPr -PchangeClass=public-api` — **not green locally, classified environment-mismatch**: the sole failing gate is `:build-logic:test` (Gradle TestKit suites — `ReleaseVerificationPluginTest`, `TramaiDocsGuardsPluginTest`, `CancellationWiringTest`). Same family failed on the docs-only 0.7.1a run before any of this code existed; CI executes these partitions green on the exact epic head. All content gates in the same verifyPr run passed: every module test suite (incl. `tramai-core`), critical coverage baseline, dependency hygiene, static-safety guards, formatting, API compatibility.
- [x] Skipped checks and why: no production, analyzer, baseline, deviation, or CI file is touched; exact-head CI on this PR is the certifier.

## Quality Impact

- [x] No baseline regeneration
- [x] No deviation ceiling increase
- [x] No quality gate weakened

## Remaining Risks

- Deferred by design to later candidates: collision/rebinding enforcement of `(configurationId, version)` and metadata-to-identity association (0.7.1c), run attribution/propagation (0.7.1d), query/command + stale-precondition semantics (0.7.1e), evidence/compatibility proof incl. full mutation campaign (0.7.1g).

## Non-Claims

This PR does NOT:
- register workloads, persist identities, add lifecycle state/version or stale-command preconditions;
- modify `WorkflowContext`, `WorkflowCheckpoint`, `EngineExecutionIdentity`, `ApprovalBinding`, `RuntimeEvidenceRecord`, or scheduler records;
- add APIs/controllers, JSON schemas, or Dashboard behaviour;
- generate `RunId`s or migrate existing runs;
- introduce a new module or dependency edge;
- perform the full Epic 0.7.1g mutation/adversarial certification.

This PR needs review before merge.
