### PR TITLE
feat(control-plane): add authoritative workload registration and state boundary (0.7.1c)

### DIFF
--- a/config/quality/module-catalog.yml
+++ b/config/quality/module-catalog.yml
@@ -114,6 +114,15 @@ modules:
     publishability: published
     apiStability: stable
 
+  - path: ":tramai-control-plane"
+    description: "Authoritative control-plane registration and lifecycle state boundary for governed workloads."
+    <<: *core
+    rationale: "Canonical mutable authority binding workload identity to governed configuration, metadata and lifecycle; consumed by persistence adapters and later 0.7 control-plane candidates."
+    maturity: preview
+    layer: core-contracts
+    publishability: published
+    apiStability: preview
+
   - path: ":tramai-core"
     description: "Core annotations, request models, provider registry, and exception types for Tramai."
     <<: *core

--- a/docs/modules/tramai-control-plane.md
+++ b/docs/modules/tramai-control-plane.md
@@ -1,0 +1,77 @@
+# Module: `tramai-control-plane`
+
+> **One-liner:** authoritative workload-registration and lifecycle-state boundary for the TramAI control plane (Epic 0.7.1).
+> **Classification / maturity / publishability / release:** see [`config/quality/module-catalog.yml`](../../config/quality/module-catalog.yml)
+
+## Architecture
+
+### Responsibility
+
+Owns the first canonical MUTABLE authority of the 0.7 control plane: the registration boundary that binds the immutable identity vocabulary
+(`dev.tramai.core.identity`) to a governed configuration fingerprint, safe owner/purpose metadata, a registration lifecycle and a monotonic
+state version. It answers *"what workload deployment is authoritatively registered, against which governed configuration revision, with what
+lifecycle/metadata and state version?"* — durably and without silent overwrites.
+
+### Public entry points
+
+- `dev.tramai.controlplane.WorkloadRegistrationAuthority` — the rules state machine: register (never an upsert), metadata mutation, lifecycle
+  transitions, stale-writer rejection. Rules live here, never in a persistence implementation.
+- `dev.tramai.controlplane.WorkloadRegistrationStore` — persistence boundary (`find` / atomic `create` / atomic `compareAndSet`), shared by the
+  InMemory reference implementation and the JDBC durable implementation.
+- Types: `RegisteredWorkload`, `ConfigurationFingerprint`, `WorkloadLifecycleState` (ACTIVE/SUSPENDED/RETIRED, RETIRED terminal),
+  `WorkloadStateVersion` (starts at 1, monotonic, overflow-safe).
+
+### Internal extension points
+
+- `InMemoryWorkloadRegistrationStore` — reference implementation used by tests and the authority suite.
+- `WorkloadRegistrationStoreTck` + harness + fixtures (testFixtures source set) — the shared contract executed against every store implementation;
+  a new persistence implementation only needs a runner.
+
+### Significant dependencies
+
+- `api(project(":tramai-core"))` only. No `tramai-server`, `tramai-platform`, Spring, dashboard, Jackson or JDBC in this module.
+- Persistence adapters (`tramai-persistence-jdbc`) depend TOWARD this authority contract, never the reverse.
+
+### Lifecycle ownership
+
+`WorkloadLifecycleState` (ACTIVE/SUSPENDED/RETIRED) is the lifecycle of the REGISTRATION — deliberately distinct from workflow-run lifecycle.
+Suspending/retiring a registration never cancels running workflows. RETIRED is terminal. `WorkloadStateVersion` advances on every successful
+authoritative mutation and never changes identity.
+
+### Thread-safety and concurrency
+
+- Every store mutation is atomic; every authority mutation is a version-guarded compare-and-set — stale writers lose, no last-writer-wins.
+- `InMemoryWorkloadRegistrationStore` serializes under a single lock (reference semantics; `ponytail:` per-scope locks if it ever leaves the
+  reference role).
+- `JdbcWorkloadRegistrationStore` (in `tramai-persistence-jdbc`) runs registration inside an explicit transaction; the database primary keys
+  enforce one registration per deployment scope and one fingerprint per configuration revision.
+
+### Failure semantics
+
+- Registration is not an upsert: identical declaration → `AlreadyRegistered`; conflicting declaration → typed `Rejected` with
+  `RegistrationConflictReason` (configuration rebinding is rejected from ANY deployment scope).
+- Stale mutations return typed `Stale` outcomes; the authoritative record is never partially applied.
+- Database errors are wrapped (fail closed) without leaking SQL/vendor diagnostics; validation failures are `IllegalArgumentException`.
+
+### Contract tests / TCKs
+
+- `WorkloadRegistrationStoreTck` (13 cases) runs against BOTH `InMemoryWorkloadRegistrationStore` and `JdbcWorkloadRegistrationStore`
+  (runners: `InMemoryWorkloadRegistrationStoreTckTest`, `JdbcWorkloadRegistrationStoreTckTest`).
+- `WorkloadRegistrationAuthorityTest` (20 cases) pins registration idempotency/conflict semantics, the lifecycle graph, version semantics and
+  concurrent-writer races.
+- `JdbcWorkloadRegistrationStoreTest` proves durability across store instances (restart) and cross-instance rebinding rejection.
+
+### Do not
+
+- Do not make registration an upsert or a configuration-update mechanism for startup/bootstrap code.
+- Do not cancel running workflows when a registration is suspended/retired.
+- Do not embed `WorkloadStateVersion` in any identity type.
+- Do not replace `WorkflowRegistry` executable-definition lookup.
+- Do not add REST/query surfaces, If-Match/ETag, projection consistency classes or arbitrary metadata maps here (later candidates).
+
+### Related architecture
+
+- Identity vocabulary: `tramai-core` / `dev.tramai.core.identity` (0.7.1b) — immutable ids consumed here.
+- Baseline audit and Epic decomposition: `docs/roadmap/0.7.0/EPIC-0.7.1-CONTROL-PLANE-AUTHORITY.md` and
+  `docs/roadmap/0.7.0/TASK-0.7.1c-AUTHORITATIVE-REGISTRATION-STATE-BOUNDARY.md`.
+- Durable store: `tramai-persistence-jdbc` (migration `V8__control_plane_workload_registration.sql`).

--- a/docs/modules/tramai-control-plane.md
+++ b/docs/modules/tramai-control-plane.md
@@ -55,9 +55,9 @@ authoritative mutation and never changes identity.
 
 ### Contract tests / TCKs
 
-- `WorkloadRegistrationStoreTck` (13 cases) runs against BOTH `InMemoryWorkloadRegistrationStore` and `JdbcWorkloadRegistrationStore`
+- `WorkloadRegistrationStoreTck` (17 cases) runs against BOTH `InMemoryWorkloadRegistrationStore` and `JdbcWorkloadRegistrationStore`
   (runners: `InMemoryWorkloadRegistrationStoreTckTest`, `JdbcWorkloadRegistrationStoreTckTest`).
-- `WorkloadRegistrationAuthorityTest` (20 cases) pins registration idempotency/conflict semantics, the lifecycle graph, version semantics and
+- `WorkloadRegistrationAuthorityTest` (26 cases) pins registration idempotency/conflict semantics, the lifecycle graph, version semantics and
   concurrent-writer races.
 - `JdbcWorkloadRegistrationStoreTest` proves durability across store instances (restart) and cross-instance rebinding rejection.
 

--- a/docs/modules/tramai-control-plane.md
+++ b/docs/modules/tramai-control-plane.md
@@ -55,7 +55,7 @@ authoritative mutation and never changes identity.
 
 ### Contract tests / TCKs
 
-- `WorkloadRegistrationStoreTck` (17 cases) runs against BOTH `InMemoryWorkloadRegistrationStore` and `JdbcWorkloadRegistrationStore`
+- `WorkloadRegistrationStoreTck` (19 cases) runs against BOTH `InMemoryWorkloadRegistrationStore` and `JdbcWorkloadRegistrationStore`
   (runners: `InMemoryWorkloadRegistrationStoreTckTest`, `JdbcWorkloadRegistrationStoreTckTest`).
 - `WorkloadRegistrationAuthorityTest` (26 cases) pins registration idempotency/conflict semantics, the lifecycle graph, version semantics and
   concurrent-writer races.

--- a/docs/modules/tramai-persistence-jdbc.md
+++ b/docs/modules/tramai-persistence-jdbc.md
@@ -7,11 +7,12 @@
 
 ### Responsibility
 
-Implements the sovereign store SPIs on PostgreSQL/JDBC: approval stores, continuation stores, audit store, suspended-invocation store, replay envelope codecs. Consumed directly or via `tramai-spring-boot-starter-sovereign-persistence-jdbc`.
+Implements the sovereign store SPIs on PostgreSQL/JDBC: approval stores, continuation stores, audit store, suspended-invocation store, replay envelope codecs, and the 0.7.1c control-plane workload registration store (`JdbcWorkloadRegistrationStore`, tables in migration `V8__control_plane_workload_registration.sql`). Consumed directly or via `tramai-spring-boot-starter-sovereign-persistence-jdbc`.
 
 ### Public entry points
 
 - `dev.tramai.persistence.jdbc.JdbcApprovalStore`, `JdbcApprovalContinuationStore`, `JdbcAuditStore`, `JdbcSuspendedInvocationStore`
+- `dev.tramai.persistence.jdbc.JdbcWorkloadRegistrationStore` — durable implementation of the [`WorkloadRegistrationStore`](../roadmap/0.7.0/EPIC-0.7.1-CONTROL-PLANE-AUTHORITY.md) contract (Epic 0.7.1c)
 - `JdbcReplayEnvelopeCodec`, `JdbcAuditPayloadCodec`, `JdbcContinuationArgumentsCodec`
 
 Verify the full public surface against `tramai-persistence-jdbc/api/tramai-persistence-jdbc.api` (`SovereignJdbcPersistence` is internal).

--- a/docs/reference/module-matrix.md
+++ b/docs/reference/module-matrix.md
@@ -17,6 +17,7 @@
 | tramai-azure-openai | provider-adapters | preview | preview | Yes | providers | included |
 | tramai-bedrock | provider-adapters | preview | preview | Yes | providers | included |
 | tramai-bom | core-contracts | stable | stable | Yes | core | included |
+| tramai-control-plane | core-contracts | preview | preview | Yes | core | included |
 | tramai-core | core-contracts | stable | stable | Yes | core | included |
 | tramai-dashboard | operations-observability | internal | internal | No | runtime | internal_only |
 | tramai-deepseek | provider-adapters | preview | preview | Yes | providers | included |

--- a/docs/roadmap/0.7.0/EPIC-0.7.1-CONTROL-PLANE-AUTHORITY.md
+++ b/docs/roadmap/0.7.0/EPIC-0.7.1-CONTROL-PLANE-AUTHORITY.md
@@ -1,7 +1,7 @@
 # Epic 0.7.1 — Control-Plane Authority & Workload Identity
 
 **Branch:** `epic/0.7.1-control-plane-authority`  
-**Status:** 🟡 Active — 0.7.1a audit recorded in [TASK-0.7.1a-BASELINE-AUTHORITY-AUDIT.md](TASK-0.7.1a-BASELINE-AUTHORITY-AUDIT.md); 0.7.1b identity contract implemented in [TASK-0.7.1b-WORKLOAD-IDENTITY-CONTRACT.md](TASK-0.7.1b-WORKLOAD-IDENTITY-CONTRACT.md)
+**Status:** 🟡 Active — 0.7.1a audit recorded in [TASK-0.7.1a-BASELINE-AUTHORITY-AUDIT.md](TASK-0.7.1a-BASELINE-AUTHORITY-AUDIT.md); 0.7.1b identity contract implemented in [TASK-0.7.1b-WORKLOAD-IDENTITY-CONTRACT.md](TASK-0.7.1b-WORKLOAD-IDENTITY-CONTRACT.md); 0.7.1c authoritative registration/state boundary implemented in [TASK-0.7.1c-AUTHORITATIVE-REGISTRATION-STATE-BOUNDARY.md](TASK-0.7.1c-AUTHORITATIVE-REGISTRATION-STATE-BOUNDARY.md)
 **Dependencies:** NONE
 
 ## Executive decision

--- a/docs/roadmap/0.7.0/TASK-0.7.1c-AUTHORITATIVE-REGISTRATION-STATE-BOUNDARY.md
+++ b/docs/roadmap/0.7.0/TASK-0.7.1c-AUTHORITATIVE-REGISTRATION-STATE-BOUNDARY.md
@@ -1,0 +1,114 @@
+# Task 0.7.1c — Authoritative Registration / State Boundary
+
+**Parent:** [Epic 0.7.1 — Control-Plane Authority & Workload Identity](EPIC-0.7.1-CONTROL-PLANE-AUTHORITY.md)
+
+**Branch:** `task/0.7.1c-authoritative-registration` → `epic/0.7.1-control-plane-authority`
+
+**Baseline:** epic head `4434b2fa` (0.7.1b identity vocabulary merged)
+
+**Change class:** `public-api` (additive), plus new-module registration (`settings.gradle.kts`, `module-catalog.yml`)
+
+**Status:** Implemented; pending exact-head certification.
+
+## Decision
+
+Introduce exactly one authoritative workload-registration boundary that binds
+the immutable 0.7.1b identity to safe metadata, the governed-configuration
+revision, lifecycle state and a monotonic mutable-state version, with durable
+atomic storage semantics — and no runtime propagation or REST API yet.
+
+New published module `tramai-control-plane` (depends only on `tramai-core`)
+owns the contract and the rules. The JDBC durable implementation lives in the
+existing `tramai-persistence-jdbc` (persistence adapters depend TOWARD the
+authority contract, never the reverse). `tramai-server`, `tramai-platform`,
+Spring, Jackson, the dashboard and JDBC are all absent from the new module.
+
+## Contract
+
+- `RegisteredWorkload` — immutable portion: `WorkloadDeploymentIdentity` +
+  `ConfigurationFingerprint`; mutable authoritative portion: `WorkloadMetadata`,
+  `WorkloadLifecycleState`, `WorkloadStateVersion`. State version is never part
+  of any identity type: a state update cannot change the identity of
+  historical runs.
+- `ConfigurationFingerprint` — opaque, deterministic witness over the complete
+  governed configuration; opaque to the store. Enforces the invariant 0.7.1b
+  deferred: `(configurationId, version)` can never be rebound to a different
+  fingerprint, from ANY deployment scope (database-level authority via the
+  `tramai_configuration_revision` primary key).
+- `WorkloadLifecycleState` — ACTIVE / SUSPENDED / RETIRED only; RETIRED is
+  terminal; suspending never cancels running workflows (registration lifecycle
+  and run lifecycle are separate authorities).
+- `WorkloadStateVersion` — starts at 1; every successful authoritative mutation
+  advances with overflow-safe `addExact`; reads, rejected mutations, stale CAS
+  and idempotent re-registration leave it unchanged.
+- `WorkloadRegistrationAuthority` owns every rule — registration is NOT an
+  upsert, configuration revisions cannot be rebound, one deployment scope has
+  one registration, metadata changes preserve identity, stale writers lose
+  (version-guarded compare-and-set).
+- Store boundary `WorkloadRegistrationStore` (`find` / atomic `create` /
+  atomic `compareAndSet`) implemented by `InMemoryWorkloadRegistrationStore`
+  (reference) and `JdbcWorkloadRegistrationStore` (durable, Postgres
+  migrations `V8__control_plane_workload_registration.sql`).
+
+## Shared contract test
+
+The same store contract runs against both implementations via
+`WorkloadRegistrationStoreTck` (testFixtures of `tramai-control-plane`):
+13 contract cases per store, including the same-environment/different-deployment
+invariant, global configuration-rebinding rejection, stale-CAS rejection and a
+real concurrency race (5 iterations, ready/release handshake on
+`Dispatchers.Default`). JDBC runners execute the full migration chain
+V1→V8 against `postgres:17-alpine`; a second suite proves durability across
+store instances (restart), cross-instance rebinding rejection and DB-level
+atomic create races.
+
+## Non-goals
+
+0.7.1c does NOT: propagate identity into `WorkflowContext`/engine/approval/
+evidence/scheduler (0.7.1d); add REST query/mutation APIs, If-Match/ETag or
+projection consistency classes (0.7.1e); define safe exposure categories
+(0.7.1f); replace `WorkflowRegistry` executable-definition lookup; cancel runs;
+or add arbitrary metadata maps.
+
+## Verification
+
+- `./gradlew :tramai-control-plane:test` — passed (20 authority-rule tests,
+  13 InMemory TCK cases).
+- `./gradlew :tramai-persistence-jdbc:test --tests "*WorkloadRegistration*"` —
+  passed (13 JDBC TCK cases + 5 JDBC-specific tests).
+- `./gradlew :tramai-control-plane:apiDump :tramai-persistence-jdbc:apiDump` —
+  additive.
+- `./gradlew spotlessApply` / `spotlessCheck` — passed.
+- `./gradlew verifyPr -PchangeClass=public-api` — see completion report.
+
+## Mutation expectations
+
+- remove fingerprint/whitespace/length validation → `ConfigurationFingerprint`
+  constructor tests;
+- ignore deployment scope or configuration in idempotency/conflict
+  classification → TCK + authority tests;
+- allow register to silently overwrite an existing registration → `re-register
+  ... is rejected, not upserted` + JDBC `registration is never silently
+  replaced`;
+- allow a `(configurationId, version)` pair to rebind to another fingerprint →
+  global rebinding tests (both stores);
+- permit RETIRED resurrection → lifecycle terminal tests;
+- drop the state-version guard → stale CAS + concurrent-writer tests.
+
+Full Epic adversarial/mutation certification remains assigned to 0.7.1g.
+
+## Evidence index
+
+- `tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/` — authority
+  contract and InMemory store (see module doc).
+- `tramai-control-plane/src/testFixtures/kotlin/dev/tramai/controlplane/testing/`
+  — shared `WorkloadRegistrationStoreTck` + fixtures + harness.
+- `tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcWorkloadRegistrationStore.kt`
+- `tramai-persistence-jdbc/src/main/resources/.../postgres/V8__control_plane_workload_registration.sql`
+
+## Candidate definition of done
+
+0.7.1c is complete when TramAI can durably answer "what workload deployment is
+authoritatively registered, against which governed configuration revision,
+with what lifecycle/metadata and state version?" — and two concurrent or
+conflicting writers cannot silently change that answer.

--- a/docs/roadmap/0.7.0/TASK-0.7.1c-AUTHORITATIVE-REGISTRATION-STATE-BOUNDARY.md
+++ b/docs/roadmap/0.7.0/TASK-0.7.1c-AUTHORITATIVE-REGISTRATION-STATE-BOUNDARY.md
@@ -54,7 +54,7 @@ Spring, Jackson, the dashboard and JDBC are all absent from the new module.
 
 The same store contract runs against both implementations via
 `WorkloadRegistrationStoreTck` (testFixtures of `tramai-control-plane`):
-17 contract cases per store, including the same-environment/different-deployment
+19 contract cases per store, including the same-environment/different-deployment
 invariant, global configuration-rebinding rejection, stale-CAS rejection and a
 real concurrency race (5 iterations, ready/release handshake on
 `Dispatchers.Default`). JDBC runners execute the full migration chain
@@ -73,9 +73,9 @@ or add arbitrary metadata maps.
 ## Verification
 
 - `./gradlew :tramai-control-plane:test` — passed (26 authority-rule tests,
-  17 InMemory TCK cases).
+  19 InMemory TCK cases).
 - `./gradlew :tramai-persistence-jdbc:test --tests "*WorkloadRegistration*"` —
-  passed (17 JDBC TCK cases + 5 JDBC-specific tests).
+  passed (19 JDBC TCK cases + 5 JDBC-specific tests).
 - `./gradlew :tramai-control-plane:apiDump :tramai-persistence-jdbc:apiDump` —
   additive.
 - `./gradlew spotlessApply` / `spotlessCheck` — passed.

--- a/docs/roadmap/0.7.0/TASK-0.7.1c-AUTHORITATIVE-REGISTRATION-STATE-BOUNDARY.md
+++ b/docs/roadmap/0.7.0/TASK-0.7.1c-AUTHORITATIVE-REGISTRATION-STATE-BOUNDARY.md
@@ -54,7 +54,7 @@ Spring, Jackson, the dashboard and JDBC are all absent from the new module.
 
 The same store contract runs against both implementations via
 `WorkloadRegistrationStoreTck` (testFixtures of `tramai-control-plane`):
-13 contract cases per store, including the same-environment/different-deployment
+17 contract cases per store, including the same-environment/different-deployment
 invariant, global configuration-rebinding rejection, stale-CAS rejection and a
 real concurrency race (5 iterations, ready/release handshake on
 `Dispatchers.Default`). JDBC runners execute the full migration chain
@@ -72,10 +72,10 @@ or add arbitrary metadata maps.
 
 ## Verification
 
-- `./gradlew :tramai-control-plane:test` — passed (20 authority-rule tests,
-  13 InMemory TCK cases).
+- `./gradlew :tramai-control-plane:test` — passed (26 authority-rule tests,
+  17 InMemory TCK cases).
 - `./gradlew :tramai-persistence-jdbc:test --tests "*WorkloadRegistration*"` —
-  passed (13 JDBC TCK cases + 5 JDBC-specific tests).
+  passed (17 JDBC TCK cases + 5 JDBC-specific tests).
 - `./gradlew :tramai-control-plane:apiDump :tramai-persistence-jdbc:apiDump` —
   additive.
 - `./gradlew spotlessApply` / `spotlessCheck` — passed.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,7 @@ include(
     "tramai-azure-openai",
     "tramai-bedrock",
     "tramai-bom",
+    "tramai-control-plane",
     "tramai-core",
     "tramai-deepseek",
     "tramai-embedding",

--- a/tramai-control-plane/api/tramai-control-plane.api
+++ b/tramai-control-plane/api/tramai-control-plane.api
@@ -1,0 +1,284 @@
+public final class dev/tramai/controlplane/ConfigurationFingerprint {
+	public static final field Companion Ldev/tramai/controlplane/ConfigurationFingerprint$Companion;
+	public static final field FINGERPRINT_MAX_LENGTH I
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Ldev/tramai/controlplane/ConfigurationFingerprint;
+	public static synthetic fun copy$default (Ldev/tramai/controlplane/ConfigurationFingerprint;Ljava/lang/String;ILjava/lang/Object;)Ldev/tramai/controlplane/ConfigurationFingerprint;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/tramai/controlplane/ConfigurationFingerprint$Companion {
+}
+
+public abstract interface class dev/tramai/controlplane/CreateResult {
+}
+
+public final class dev/tramai/controlplane/CreateResult$Conflicting : dev/tramai/controlplane/CreateResult {
+	public fun <init> (Ldev/tramai/controlplane/RegisteredWorkload;Ldev/tramai/controlplane/RegistrationConflictReason;)V
+	public final fun component1 ()Ldev/tramai/controlplane/RegisteredWorkload;
+	public final fun component2 ()Ldev/tramai/controlplane/RegistrationConflictReason;
+	public final fun copy (Ldev/tramai/controlplane/RegisteredWorkload;Ldev/tramai/controlplane/RegistrationConflictReason;)Ldev/tramai/controlplane/CreateResult$Conflicting;
+	public static synthetic fun copy$default (Ldev/tramai/controlplane/CreateResult$Conflicting;Ldev/tramai/controlplane/RegisteredWorkload;Ldev/tramai/controlplane/RegistrationConflictReason;ILjava/lang/Object;)Ldev/tramai/controlplane/CreateResult$Conflicting;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExisting ()Ldev/tramai/controlplane/RegisteredWorkload;
+	public final fun getReason ()Ldev/tramai/controlplane/RegistrationConflictReason;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/tramai/controlplane/CreateResult$Created : dev/tramai/controlplane/CreateResult {
+	public fun <init> (Ldev/tramai/controlplane/RegisteredWorkload;)V
+	public final fun component1 ()Ldev/tramai/controlplane/RegisteredWorkload;
+	public final fun copy (Ldev/tramai/controlplane/RegisteredWorkload;)Ldev/tramai/controlplane/CreateResult$Created;
+	public static synthetic fun copy$default (Ldev/tramai/controlplane/CreateResult$Created;Ldev/tramai/controlplane/RegisteredWorkload;ILjava/lang/Object;)Ldev/tramai/controlplane/CreateResult$Created;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRegistration ()Ldev/tramai/controlplane/RegisteredWorkload;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/tramai/controlplane/CreateResult$Idempotent : dev/tramai/controlplane/CreateResult {
+	public fun <init> (Ldev/tramai/controlplane/RegisteredWorkload;)V
+	public final fun component1 ()Ldev/tramai/controlplane/RegisteredWorkload;
+	public final fun copy (Ldev/tramai/controlplane/RegisteredWorkload;)Ldev/tramai/controlplane/CreateResult$Idempotent;
+	public static synthetic fun copy$default (Ldev/tramai/controlplane/CreateResult$Idempotent;Ldev/tramai/controlplane/RegisteredWorkload;ILjava/lang/Object;)Ldev/tramai/controlplane/CreateResult$Idempotent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRegistration ()Ldev/tramai/controlplane/RegisteredWorkload;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/tramai/controlplane/InMemoryWorkloadRegistrationStore : dev/tramai/controlplane/WorkloadRegistrationStore {
+	public fun <init> ()V
+	public fun compareAndSet (Ldev/tramai/controlplane/RegisteredWorkload;Ldev/tramai/controlplane/RegisteredWorkload;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun create (Ldev/tramai/controlplane/RegisteredWorkload;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun find (Ldev/tramai/core/identity/WorkloadId;Ldev/tramai/core/identity/EnvironmentId;Ldev/tramai/core/identity/DeploymentId;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class dev/tramai/controlplane/LifecycleTransitionOutcome {
+}
+
+public final class dev/tramai/controlplane/LifecycleTransitionOutcome$Applied : dev/tramai/controlplane/LifecycleTransitionOutcome {
+	public fun <init> (Ldev/tramai/controlplane/RegisteredWorkload;)V
+	public final fun component1 ()Ldev/tramai/controlplane/RegisteredWorkload;
+	public final fun copy (Ldev/tramai/controlplane/RegisteredWorkload;)Ldev/tramai/controlplane/LifecycleTransitionOutcome$Applied;
+	public static synthetic fun copy$default (Ldev/tramai/controlplane/LifecycleTransitionOutcome$Applied;Ldev/tramai/controlplane/RegisteredWorkload;ILjava/lang/Object;)Ldev/tramai/controlplane/LifecycleTransitionOutcome$Applied;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRegistration ()Ldev/tramai/controlplane/RegisteredWorkload;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/tramai/controlplane/LifecycleTransitionOutcome$InvalidTransition : dev/tramai/controlplane/LifecycleTransitionOutcome {
+	public fun <init> (Ldev/tramai/controlplane/WorkloadLifecycleState;Ldev/tramai/controlplane/WorkloadLifecycleState;)V
+	public final fun component1 ()Ldev/tramai/controlplane/WorkloadLifecycleState;
+	public final fun component2 ()Ldev/tramai/controlplane/WorkloadLifecycleState;
+	public final fun copy (Ldev/tramai/controlplane/WorkloadLifecycleState;Ldev/tramai/controlplane/WorkloadLifecycleState;)Ldev/tramai/controlplane/LifecycleTransitionOutcome$InvalidTransition;
+	public static synthetic fun copy$default (Ldev/tramai/controlplane/LifecycleTransitionOutcome$InvalidTransition;Ldev/tramai/controlplane/WorkloadLifecycleState;Ldev/tramai/controlplane/WorkloadLifecycleState;ILjava/lang/Object;)Ldev/tramai/controlplane/LifecycleTransitionOutcome$InvalidTransition;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFrom ()Ldev/tramai/controlplane/WorkloadLifecycleState;
+	public final fun getTo ()Ldev/tramai/controlplane/WorkloadLifecycleState;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/tramai/controlplane/LifecycleTransitionOutcome$NotFound : dev/tramai/controlplane/LifecycleTransitionOutcome {
+	public static final field INSTANCE Ldev/tramai/controlplane/LifecycleTransitionOutcome$NotFound;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/tramai/controlplane/LifecycleTransitionOutcome$Stale : dev/tramai/controlplane/LifecycleTransitionOutcome {
+	public fun <init> (Ldev/tramai/controlplane/WorkloadStateVersion;Ldev/tramai/controlplane/WorkloadStateVersion;)V
+	public final fun component1 ()Ldev/tramai/controlplane/WorkloadStateVersion;
+	public final fun component2 ()Ldev/tramai/controlplane/WorkloadStateVersion;
+	public final fun copy (Ldev/tramai/controlplane/WorkloadStateVersion;Ldev/tramai/controlplane/WorkloadStateVersion;)Ldev/tramai/controlplane/LifecycleTransitionOutcome$Stale;
+	public static synthetic fun copy$default (Ldev/tramai/controlplane/LifecycleTransitionOutcome$Stale;Ldev/tramai/controlplane/WorkloadStateVersion;Ldev/tramai/controlplane/WorkloadStateVersion;ILjava/lang/Object;)Ldev/tramai/controlplane/LifecycleTransitionOutcome$Stale;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCurrentVersion ()Ldev/tramai/controlplane/WorkloadStateVersion;
+	public final fun getExpectedVersion ()Ldev/tramai/controlplane/WorkloadStateVersion;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/tramai/controlplane/LifecycleTransitionOutcome$Unchanged : dev/tramai/controlplane/LifecycleTransitionOutcome {
+	public fun <init> (Ldev/tramai/controlplane/RegisteredWorkload;)V
+	public final fun component1 ()Ldev/tramai/controlplane/RegisteredWorkload;
+	public final fun copy (Ldev/tramai/controlplane/RegisteredWorkload;)Ldev/tramai/controlplane/LifecycleTransitionOutcome$Unchanged;
+	public static synthetic fun copy$default (Ldev/tramai/controlplane/LifecycleTransitionOutcome$Unchanged;Ldev/tramai/controlplane/RegisteredWorkload;ILjava/lang/Object;)Ldev/tramai/controlplane/LifecycleTransitionOutcome$Unchanged;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRegistration ()Ldev/tramai/controlplane/RegisteredWorkload;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class dev/tramai/controlplane/MetadataUpdateOutcome {
+}
+
+public final class dev/tramai/controlplane/MetadataUpdateOutcome$Applied : dev/tramai/controlplane/MetadataUpdateOutcome {
+	public fun <init> (Ldev/tramai/controlplane/RegisteredWorkload;)V
+	public final fun component1 ()Ldev/tramai/controlplane/RegisteredWorkload;
+	public final fun copy (Ldev/tramai/controlplane/RegisteredWorkload;)Ldev/tramai/controlplane/MetadataUpdateOutcome$Applied;
+	public static synthetic fun copy$default (Ldev/tramai/controlplane/MetadataUpdateOutcome$Applied;Ldev/tramai/controlplane/RegisteredWorkload;ILjava/lang/Object;)Ldev/tramai/controlplane/MetadataUpdateOutcome$Applied;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRegistration ()Ldev/tramai/controlplane/RegisteredWorkload;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/tramai/controlplane/MetadataUpdateOutcome$NotFound : dev/tramai/controlplane/MetadataUpdateOutcome {
+	public static final field INSTANCE Ldev/tramai/controlplane/MetadataUpdateOutcome$NotFound;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/tramai/controlplane/MetadataUpdateOutcome$Stale : dev/tramai/controlplane/MetadataUpdateOutcome {
+	public fun <init> (Ldev/tramai/controlplane/WorkloadStateVersion;Ldev/tramai/controlplane/WorkloadStateVersion;)V
+	public final fun component1 ()Ldev/tramai/controlplane/WorkloadStateVersion;
+	public final fun component2 ()Ldev/tramai/controlplane/WorkloadStateVersion;
+	public final fun copy (Ldev/tramai/controlplane/WorkloadStateVersion;Ldev/tramai/controlplane/WorkloadStateVersion;)Ldev/tramai/controlplane/MetadataUpdateOutcome$Stale;
+	public static synthetic fun copy$default (Ldev/tramai/controlplane/MetadataUpdateOutcome$Stale;Ldev/tramai/controlplane/WorkloadStateVersion;Ldev/tramai/controlplane/WorkloadStateVersion;ILjava/lang/Object;)Ldev/tramai/controlplane/MetadataUpdateOutcome$Stale;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCurrentVersion ()Ldev/tramai/controlplane/WorkloadStateVersion;
+	public final fun getExpectedVersion ()Ldev/tramai/controlplane/WorkloadStateVersion;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/tramai/controlplane/MetadataUpdateOutcome$Unchanged : dev/tramai/controlplane/MetadataUpdateOutcome {
+	public fun <init> (Ldev/tramai/controlplane/RegisteredWorkload;)V
+	public final fun component1 ()Ldev/tramai/controlplane/RegisteredWorkload;
+	public final fun copy (Ldev/tramai/controlplane/RegisteredWorkload;)Ldev/tramai/controlplane/MetadataUpdateOutcome$Unchanged;
+	public static synthetic fun copy$default (Ldev/tramai/controlplane/MetadataUpdateOutcome$Unchanged;Ldev/tramai/controlplane/RegisteredWorkload;ILjava/lang/Object;)Ldev/tramai/controlplane/MetadataUpdateOutcome$Unchanged;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRegistration ()Ldev/tramai/controlplane/RegisteredWorkload;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class dev/tramai/controlplane/RegisterOutcome {
+}
+
+public final class dev/tramai/controlplane/RegisterOutcome$AlreadyRegistered : dev/tramai/controlplane/RegisterOutcome {
+	public fun <init> (Ldev/tramai/controlplane/RegisteredWorkload;)V
+	public final fun component1 ()Ldev/tramai/controlplane/RegisteredWorkload;
+	public final fun copy (Ldev/tramai/controlplane/RegisteredWorkload;)Ldev/tramai/controlplane/RegisterOutcome$AlreadyRegistered;
+	public static synthetic fun copy$default (Ldev/tramai/controlplane/RegisterOutcome$AlreadyRegistered;Ldev/tramai/controlplane/RegisteredWorkload;ILjava/lang/Object;)Ldev/tramai/controlplane/RegisterOutcome$AlreadyRegistered;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRegistration ()Ldev/tramai/controlplane/RegisteredWorkload;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/tramai/controlplane/RegisterOutcome$Created : dev/tramai/controlplane/RegisterOutcome {
+	public fun <init> (Ldev/tramai/controlplane/RegisteredWorkload;)V
+	public final fun component1 ()Ldev/tramai/controlplane/RegisteredWorkload;
+	public final fun copy (Ldev/tramai/controlplane/RegisteredWorkload;)Ldev/tramai/controlplane/RegisterOutcome$Created;
+	public static synthetic fun copy$default (Ldev/tramai/controlplane/RegisterOutcome$Created;Ldev/tramai/controlplane/RegisteredWorkload;ILjava/lang/Object;)Ldev/tramai/controlplane/RegisterOutcome$Created;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRegistration ()Ldev/tramai/controlplane/RegisteredWorkload;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/tramai/controlplane/RegisterOutcome$Rejected : dev/tramai/controlplane/RegisterOutcome {
+	public fun <init> (Ldev/tramai/controlplane/RegisteredWorkload;Ldev/tramai/controlplane/RegistrationConflictReason;)V
+	public final fun component1 ()Ldev/tramai/controlplane/RegisteredWorkload;
+	public final fun component2 ()Ldev/tramai/controlplane/RegistrationConflictReason;
+	public final fun copy (Ldev/tramai/controlplane/RegisteredWorkload;Ldev/tramai/controlplane/RegistrationConflictReason;)Ldev/tramai/controlplane/RegisterOutcome$Rejected;
+	public static synthetic fun copy$default (Ldev/tramai/controlplane/RegisterOutcome$Rejected;Ldev/tramai/controlplane/RegisteredWorkload;Ldev/tramai/controlplane/RegistrationConflictReason;ILjava/lang/Object;)Ldev/tramai/controlplane/RegisterOutcome$Rejected;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExisting ()Ldev/tramai/controlplane/RegisteredWorkload;
+	public final fun getReason ()Ldev/tramai/controlplane/RegistrationConflictReason;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/tramai/controlplane/RegisteredWorkload {
+	public fun <init> (Ldev/tramai/core/identity/WorkloadDeploymentIdentity;Ldev/tramai/controlplane/ConfigurationFingerprint;Ldev/tramai/core/identity/WorkloadMetadata;Ldev/tramai/controlplane/WorkloadLifecycleState;Ldev/tramai/controlplane/WorkloadStateVersion;)V
+	public final fun component1 ()Ldev/tramai/core/identity/WorkloadDeploymentIdentity;
+	public final fun component2 ()Ldev/tramai/controlplane/ConfigurationFingerprint;
+	public final fun component3 ()Ldev/tramai/core/identity/WorkloadMetadata;
+	public final fun component4 ()Ldev/tramai/controlplane/WorkloadLifecycleState;
+	public final fun component5 ()Ldev/tramai/controlplane/WorkloadStateVersion;
+	public final fun copy (Ldev/tramai/core/identity/WorkloadDeploymentIdentity;Ldev/tramai/controlplane/ConfigurationFingerprint;Ldev/tramai/core/identity/WorkloadMetadata;Ldev/tramai/controlplane/WorkloadLifecycleState;Ldev/tramai/controlplane/WorkloadStateVersion;)Ldev/tramai/controlplane/RegisteredWorkload;
+	public static synthetic fun copy$default (Ldev/tramai/controlplane/RegisteredWorkload;Ldev/tramai/core/identity/WorkloadDeploymentIdentity;Ldev/tramai/controlplane/ConfigurationFingerprint;Ldev/tramai/core/identity/WorkloadMetadata;Ldev/tramai/controlplane/WorkloadLifecycleState;Ldev/tramai/controlplane/WorkloadStateVersion;ILjava/lang/Object;)Ldev/tramai/controlplane/RegisteredWorkload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConfigurationFingerprint ()Ldev/tramai/controlplane/ConfigurationFingerprint;
+	public final fun getIdentity ()Ldev/tramai/core/identity/WorkloadDeploymentIdentity;
+	public final fun getLifecycle ()Ldev/tramai/controlplane/WorkloadLifecycleState;
+	public final fun getMetadata ()Ldev/tramai/core/identity/WorkloadMetadata;
+	public final fun getStateVersion ()Ldev/tramai/controlplane/WorkloadStateVersion;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/tramai/controlplane/RegistrationConflictReason : java/lang/Enum {
+	public static final field CONFIGURATION_REBINDING Ldev/tramai/controlplane/RegistrationConflictReason;
+	public static final field CONFLICTING_REGISTRATION Ldev/tramai/controlplane/RegistrationConflictReason;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/tramai/controlplane/RegistrationConflictReason;
+	public static fun values ()[Ldev/tramai/controlplane/RegistrationConflictReason;
+}
+
+public final class dev/tramai/controlplane/WorkloadDeploymentScope {
+	public fun <init> (Ldev/tramai/core/identity/WorkloadId;Ldev/tramai/core/identity/EnvironmentId;Ldev/tramai/core/identity/DeploymentId;)V
+	public final fun component1 ()Ldev/tramai/core/identity/WorkloadId;
+	public final fun component2 ()Ldev/tramai/core/identity/EnvironmentId;
+	public final fun component3 ()Ldev/tramai/core/identity/DeploymentId;
+	public final fun copy (Ldev/tramai/core/identity/WorkloadId;Ldev/tramai/core/identity/EnvironmentId;Ldev/tramai/core/identity/DeploymentId;)Ldev/tramai/controlplane/WorkloadDeploymentScope;
+	public static synthetic fun copy$default (Ldev/tramai/controlplane/WorkloadDeploymentScope;Ldev/tramai/core/identity/WorkloadId;Ldev/tramai/core/identity/EnvironmentId;Ldev/tramai/core/identity/DeploymentId;ILjava/lang/Object;)Ldev/tramai/controlplane/WorkloadDeploymentScope;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeploymentId ()Ldev/tramai/core/identity/DeploymentId;
+	public final fun getEnvironmentId ()Ldev/tramai/core/identity/EnvironmentId;
+	public final fun getWorkloadId ()Ldev/tramai/core/identity/WorkloadId;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/tramai/controlplane/WorkloadLifecycleState : java/lang/Enum {
+	public static final field ACTIVE Ldev/tramai/controlplane/WorkloadLifecycleState;
+	public static final field RETIRED Ldev/tramai/controlplane/WorkloadLifecycleState;
+	public static final field SUSPENDED Ldev/tramai/controlplane/WorkloadLifecycleState;
+	public final fun canTransitionTo (Ldev/tramai/controlplane/WorkloadLifecycleState;)Z
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/tramai/controlplane/WorkloadLifecycleState;
+	public static fun values ()[Ldev/tramai/controlplane/WorkloadLifecycleState;
+}
+
+public final class dev/tramai/controlplane/WorkloadRegistrationAuthority {
+	public fun <init> (Ldev/tramai/controlplane/WorkloadRegistrationStore;)V
+	public final fun register (Ldev/tramai/core/identity/WorkloadDeploymentIdentity;Ldev/tramai/controlplane/ConfigurationFingerprint;Ldev/tramai/core/identity/WorkloadMetadata;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun transitionLifecycle (Ldev/tramai/core/identity/WorkloadId;Ldev/tramai/core/identity/EnvironmentId;Ldev/tramai/core/identity/DeploymentId;Ldev/tramai/controlplane/WorkloadStateVersion;Ldev/tramai/controlplane/WorkloadLifecycleState;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun updateMetadata (Ldev/tramai/core/identity/WorkloadId;Ldev/tramai/core/identity/EnvironmentId;Ldev/tramai/core/identity/DeploymentId;Ldev/tramai/controlplane/WorkloadStateVersion;Ldev/tramai/core/identity/WorkloadMetadata;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class dev/tramai/controlplane/WorkloadRegistrationStore {
+	public abstract fun compareAndSet (Ldev/tramai/controlplane/RegisteredWorkload;Ldev/tramai/controlplane/RegisteredWorkload;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun create (Ldev/tramai/controlplane/RegisteredWorkload;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun find (Ldev/tramai/core/identity/WorkloadId;Ldev/tramai/core/identity/EnvironmentId;Ldev/tramai/core/identity/DeploymentId;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class dev/tramai/controlplane/WorkloadStateVersion {
+	public static final field Companion Ldev/tramai/controlplane/WorkloadStateVersion$Companion;
+	public fun <init> (J)V
+	public final fun component1 ()J
+	public final fun copy (J)Ldev/tramai/controlplane/WorkloadStateVersion;
+	public static synthetic fun copy$default (Ldev/tramai/controlplane/WorkloadStateVersion;JILjava/lang/Object;)Ldev/tramai/controlplane/WorkloadStateVersion;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()J
+	public fun hashCode ()I
+	public final fun next ()Ldev/tramai/controlplane/WorkloadStateVersion;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/tramai/controlplane/WorkloadStateVersion$Companion {
+	public final fun getINITIAL ()Ldev/tramai/controlplane/WorkloadStateVersion;
+}
+

--- a/tramai-control-plane/build.gradle.kts
+++ b/tramai-control-plane/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    `java-library`
+    id("tramai.test-fixtures")
+    alias(libs.plugins.kotlin.jvm)
+    id("tramai.kotlin-library")
+    id("tramai.testing")
+}
+
+dependencies {
+    api(project(":tramai-core"))
+
+    testFixturesApi(project(":tramai-core"))
+    testFixturesApi(libs.assertj.core)
+    testFixturesApi(platform(libs.junit.bom))
+    testFixturesApi(libs.kotlin.test.junit5)
+    testFixturesApi(libs.coroutines.core)
+}

--- a/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/ConfigurationFingerprint.kt
+++ b/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/ConfigurationFingerprint.kt
@@ -1,0 +1,43 @@
+package dev.tramai.controlplane
+
+/**
+ * Opaque witness over the complete governed configuration of a workload
+ * deployment.
+ *
+ * The registration authority cannot parse a governed configuration (policy,
+ * routing, provider deployment, tool governance and workflow composition all
+ * contribute later); it only needs a deterministic fingerprint to enforce the
+ * 0.7.1b configuration invariant:
+ *
+ * ```text
+ * (configurationId, version) -> exactly one fingerprint, ever
+ * ```
+ *
+ * `C/17/AAA` may be re-registered; `C/17/BBB` must be rejected as
+ * configuration rebinding. Fingerprint values are opaque, non-blank, bounded,
+ * case-preserving and never silently normalized — mirroring the identity
+ * validation rules. How the complete governed configuration is canonicalized
+ * into this fingerprint is deliberately unspecified here.
+ */
+data class ConfigurationFingerprint(
+    val value: String,
+) {
+    init {
+        require(value.isNotBlank()) { "ConfigurationFingerprint must not be blank" }
+        require(value == value.trim()) {
+            "ConfigurationFingerprint must not contain leading or trailing whitespace"
+        }
+        require(value.length <= FINGERPRINT_MAX_LENGTH) {
+            "ConfigurationFingerprint must not exceed $FINGERPRINT_MAX_LENGTH characters"
+        }
+        require(value.none(Char::isISOControl)) {
+            "ConfigurationFingerprint must not contain control characters"
+        }
+    }
+
+    override fun toString(): String = value
+
+    companion object {
+        const val FINGERPRINT_MAX_LENGTH: Int = 128
+    }
+}

--- a/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/InMemoryWorkloadRegistrationStore.kt
+++ b/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/InMemoryWorkloadRegistrationStore.kt
@@ -1,0 +1,103 @@
+package dev.tramai.controlplane
+
+import dev.tramai.core.identity.DeploymentId
+import dev.tramai.core.identity.EnvironmentId
+import dev.tramai.core.identity.WorkloadConfigurationIdentity
+import dev.tramai.core.identity.WorkloadDeploymentIdentity
+import dev.tramai.core.identity.WorkloadId
+
+/**
+ * In-memory [WorkloadRegistrationStore] reference implementation.
+ *
+ * Single lock for the whole store keeps every operation atomic and the
+ * semantics trivially auditable; the store is an authority contract reference,
+ * not a throughput path.
+ *
+ * ponytail: single global lock; per-scope locks would matter only if this
+ * store ever leaves the test/reference role.
+ */
+class InMemoryWorkloadRegistrationStore : WorkloadRegistrationStore {
+    private val lock = Any()
+    private val registrations = LinkedHashMap<WorkloadDeploymentScope, RegisteredWorkload>()
+    private val configurationBindings = HashMap<ConfigurationBindingKey, ConfigurationFingerprint>()
+
+    private data class ConfigurationBindingKey(
+        val configurationId: String,
+        val configurationVersion: String,
+    )
+
+    private fun WorkloadConfigurationIdentity.toBindingKey(): ConfigurationBindingKey = ConfigurationBindingKey(id.value, version.value)
+
+    override suspend fun find(
+        workloadId: WorkloadId,
+        environmentId: EnvironmentId,
+        deploymentId: DeploymentId,
+    ): RegisteredWorkload? =
+        synchronized(lock) {
+            registrations[WorkloadDeploymentScope(workloadId, environmentId, deploymentId)]
+        }
+
+    override suspend fun create(registration: RegisteredWorkload): CreateResult =
+        synchronized(lock) {
+            val scope = registration.identity.toScope()
+            val bindingKey = registration.identity.configuration.toBindingKey()
+
+            // 1) The (configurationId, version) binding is fixed forever, globally:
+            //    the same pair with a different fingerprint fails from ANY scope.
+            configurationBindings[bindingKey]?.let { boundFingerprint ->
+                if (boundFingerprint != registration.configurationFingerprint) {
+                    val context =
+                        registrations[scope]
+                            ?: registrations.entries
+                                .firstOrNull {
+                                    it.value.identity.configuration
+                                        .toBindingKey() == bindingKey
+                                }?.value
+                            ?: error("Corrupt in-memory store: configuration binding exists without an owning registration")
+                    return@synchronized CreateResult.Conflicting(context, RegistrationConflictReason.CONFIGURATION_REBINDING)
+                }
+            }
+
+            // 2) One authoritative registration per deployment scope. Never an
+            //    upsert: identical declaration is idempotent, anything else is a
+            //    conflict.
+            registrations[scope]?.let { existing ->
+                return@synchronized if (existing.isSameDeclaration(registration)) {
+                    CreateResult.Idempotent(existing)
+                } else {
+                    CreateResult.Conflicting(existing, RegistrationConflictReason.CONFLICTING_REGISTRATION)
+                }
+            }
+
+            // 3) Insert both records atomically under the store lock.
+            configurationBindings[bindingKey] = registration.configurationFingerprint
+            registrations[scope] = registration
+            CreateResult.Created(registration)
+        }
+
+    override suspend fun compareAndSet(
+        expected: RegisteredWorkload,
+        updated: RegisteredWorkload,
+    ): Boolean =
+        synchronized(lock) {
+            val scope = expected.identity.toScope()
+            require(updated.identity.toScope() == scope) {
+                "compareAndSet must not change the deployment scope of a registration"
+            }
+            val current = registrations[scope]
+            if (current != expected) {
+                false
+            } else {
+                registrations[scope] = updated
+                true
+            }
+        }
+
+    private fun WorkloadDeploymentIdentity.toScope(): WorkloadDeploymentScope =
+        WorkloadDeploymentScope(workloadId, environmentId, deploymentId)
+
+    private fun RegisteredWorkload.isSameDeclaration(other: RegisteredWorkload): Boolean =
+        identity == other.identity &&
+            configurationFingerprint == other.configurationFingerprint &&
+            metadata == other.metadata
+}

--- a/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/InMemoryWorkloadRegistrationStore.kt
+++ b/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/InMemoryWorkloadRegistrationStore.kt
@@ -99,15 +99,21 @@ class InMemoryWorkloadRegistrationStore : WorkloadRegistrationStore {
                 "compareAndSet must not change configuration fingerprint"
             }
             val scope = expected.identity.toScope()
-            // CAS concurrency token = deployment scope + stateVersion, the same
-            // guard as the JDBC UPDATE. Immutable identity/fingerprint are
-            // enforced by the requires above, not by record equality.
             val current = registrations[scope]
-            if (current == null || current.stateVersion != expected.stateVersion) {
-                false
-            } else {
+            // CAS concurrency token: scope + stateVersion. The immutable
+            // witness (identity + fingerprint) carried by expected must equal
+            // the stored record — a caller may hold stale MUTABLE fields, but
+            // never a fabricated immutable authority at the same version.
+            val tokenAndWitnessMatch =
+                current != null &&
+                    current.stateVersion == expected.stateVersion &&
+                    current.identity == expected.identity &&
+                    current.configurationFingerprint == expected.configurationFingerprint
+            if (tokenAndWitnessMatch) {
                 registrations[scope] = updated
                 true
+            } else {
+                false
             }
         }
 

--- a/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/InMemoryWorkloadRegistrationStore.kt
+++ b/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/InMemoryWorkloadRegistrationStore.kt
@@ -98,11 +98,15 @@ class InMemoryWorkloadRegistrationStore : WorkloadRegistrationStore {
             require(updated.configurationFingerprint == expected.configurationFingerprint) {
                 "compareAndSet must not change configuration fingerprint"
             }
-            val current = registrations[expected.identity.toScope()]
-            if (current != expected) {
+            val scope = expected.identity.toScope()
+            // CAS concurrency token = deployment scope + stateVersion, the same
+            // guard as the JDBC UPDATE. Immutable identity/fingerprint are
+            // enforced by the requires above, not by record equality.
+            val current = registrations[scope]
+            if (current == null || current.stateVersion != expected.stateVersion) {
                 false
             } else {
-                registrations[expected.identity.toScope()] = updated
+                registrations[scope] = updated
                 true
             }
         }

--- a/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/InMemoryWorkloadRegistrationStore.kt
+++ b/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/InMemoryWorkloadRegistrationStore.kt
@@ -26,7 +26,11 @@ class InMemoryWorkloadRegistrationStore : WorkloadRegistrationStore {
         val configurationVersion: String,
     )
 
-    private fun WorkloadConfigurationIdentity.toBindingKey(): ConfigurationBindingKey = ConfigurationBindingKey(id.value, version.value)
+    private fun WorkloadConfigurationIdentity.toBindingKey(): ConfigurationBindingKey =
+        ConfigurationBindingKey(
+            configurationId = id.value,
+            configurationVersion = version.value,
+        )
 
     override suspend fun find(
         workloadId: WorkloadId,
@@ -53,8 +57,16 @@ class InMemoryWorkloadRegistrationStore : WorkloadRegistrationStore {
                                     it.value.identity.configuration
                                         .toBindingKey() == bindingKey
                                 }?.value
-                            ?: error("Corrupt in-memory store: configuration binding exists without an owning registration")
-                    return@synchronized CreateResult.Conflicting(context, RegistrationConflictReason.CONFIGURATION_REBINDING)
+                    if (context == null) {
+                        throw IllegalStateException(
+                            "Corrupt in-memory store: configuration binding exists " +
+                                "without an owning registration",
+                        )
+                    }
+                    return@synchronized CreateResult.Conflicting(
+                        context,
+                        RegistrationConflictReason.CONFIGURATION_REBINDING,
+                    )
                 }
             }
 
@@ -80,15 +92,17 @@ class InMemoryWorkloadRegistrationStore : WorkloadRegistrationStore {
         updated: RegisteredWorkload,
     ): Boolean =
         synchronized(lock) {
-            val scope = expected.identity.toScope()
-            require(updated.identity.toScope() == scope) {
-                "compareAndSet must not change the deployment scope of a registration"
+            require(updated.identity == expected.identity) {
+                "compareAndSet must not change registration identity"
             }
-            val current = registrations[scope]
+            require(updated.configurationFingerprint == expected.configurationFingerprint) {
+                "compareAndSet must not change configuration fingerprint"
+            }
+            val current = registrations[expected.identity.toScope()]
             if (current != expected) {
                 false
             } else {
-                registrations[scope] = updated
+                registrations[expected.identity.toScope()] = updated
                 true
             }
         }

--- a/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/RegisteredWorkload.kt
+++ b/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/RegisteredWorkload.kt
@@ -1,0 +1,29 @@
+package dev.tramai.controlplane
+
+import dev.tramai.core.identity.WorkloadDeploymentIdentity
+import dev.tramai.core.identity.WorkloadMetadata
+
+/**
+ * One authoritative registration record.
+ *
+ * Immutable portion:
+ * - [identity] — workload/configuration/environment/deployment identity;
+ * - [configurationFingerprint] — witness binding [identity.configuration] to
+ *   exactly one governed configuration.
+ *
+ * Mutable authoritative portion (mutated only through
+ * [WorkloadRegistrationAuthority], never through registration):
+ * - [metadata] — owner/purpose, outside identity equality;
+ * - [lifecycle] — registration lifecycle state;
+ * - [stateVersion] — monotonic version advanced by every successful mutation.
+ *
+ * Invariant: [stateVersion] is not part of any identity type; a state update
+ * never changes the identity of historical runs.
+ */
+data class RegisteredWorkload(
+    val identity: WorkloadDeploymentIdentity,
+    val configurationFingerprint: ConfigurationFingerprint,
+    val metadata: WorkloadMetadata,
+    val lifecycle: WorkloadLifecycleState,
+    val stateVersion: WorkloadStateVersion,
+)

--- a/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/WorkloadLifecycleState.kt
+++ b/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/WorkloadLifecycleState.kt
@@ -1,0 +1,39 @@
+package dev.tramai.controlplane
+
+/**
+ * Lifecycle of a workload REGISTRATION — deliberately distinct from the
+ * lifecycle of any individual workflow run. Suspending or retiring a workload
+ * registration does not cancel already-running workflows (that is runtime
+ * control, not registration authority).
+ *
+ * Transition graph:
+ *
+ * ```text
+ * ACTIVE <-> SUSPENDED
+ * ACTIVE    -> RETIRED
+ * SUSPENDED -> RETIRED
+ * RETIRED   -> (terminal)
+ * ```
+ */
+enum class WorkloadLifecycleState {
+    /** Registration is eligible to admit new governed runs. */
+    ACTIVE,
+
+    /** No new governed runs should be admitted. */
+    SUSPENDED,
+
+    /** Terminal registration; cannot admit new runs or reactivate. */
+    RETIRED,
+    ;
+
+    /**
+     * Whether a transition from this state to [target] is part of the
+     * authoritative lifecycle graph.
+     */
+    fun canTransitionTo(target: WorkloadLifecycleState): Boolean =
+        when (this) {
+            ACTIVE -> target == SUSPENDED || target == RETIRED
+            SUSPENDED -> target == ACTIVE || target == RETIRED
+            RETIRED -> false
+        }
+}

--- a/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/WorkloadRegistrationAuthority.kt
+++ b/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/WorkloadRegistrationAuthority.kt
@@ -82,11 +82,6 @@ class WorkloadRegistrationAuthority(
         val current =
             store.find(workloadId, environmentId, deploymentId)
                 ?: return MetadataUpdateOutcome.NotFound
-        val updated =
-            current.copy(
-                metadata = metadata,
-                stateVersion = current.stateVersion.next(),
-            )
         return when {
             current.stateVersion != expectedVersion -> {
                 MetadataUpdateOutcome.Stale(current.stateVersion, expectedVersion)
@@ -96,20 +91,29 @@ class WorkloadRegistrationAuthority(
                 MetadataUpdateOutcome.Unchanged(current)
             }
 
-            store.compareAndSet(current, updated) -> {
-                MetadataUpdateOutcome.Applied(updated)
-            }
-
             else -> {
-                // Lost the race: report the CURRENT authoritative version, not
-                // the version observed before the race (0.7.1e command
-                // preconditions will consume exactly this value).
-                val latest =
-                    store.find(workloadId, environmentId, deploymentId)
-                if (latest != null) {
-                    MetadataUpdateOutcome.Stale(latest.stateVersion, expectedVersion)
+                // next() belongs to the actual mutation: stale and no-op
+                // commands are observational and must never require a future
+                // version — at Long.MAX_VALUE that requirement would overflow
+                // without any mutation happening.
+                val updated =
+                    current.copy(
+                        metadata = metadata,
+                        stateVersion = current.stateVersion.next(),
+                    )
+                if (store.compareAndSet(current, updated)) {
+                    MetadataUpdateOutcome.Applied(updated)
                 } else {
-                    MetadataUpdateOutcome.NotFound
+                    // Lost the race: report the CURRENT authoritative version,
+                    // not the version observed before the race (0.7.1e command
+                    // preconditions will consume exactly this value).
+                    val latest =
+                        store.find(workloadId, environmentId, deploymentId)
+                    if (latest != null) {
+                        MetadataUpdateOutcome.Stale(latest.stateVersion, expectedVersion)
+                    } else {
+                        MetadataUpdateOutcome.NotFound
+                    }
                 }
             }
         }
@@ -129,11 +133,6 @@ class WorkloadRegistrationAuthority(
         val current =
             store.find(workloadId, environmentId, deploymentId)
                 ?: return LifecycleTransitionOutcome.NotFound
-        val updated =
-            current.copy(
-                lifecycle = target,
-                stateVersion = current.stateVersion.next(),
-            )
         return when {
             current.stateVersion != expectedVersion -> {
                 LifecycleTransitionOutcome.Stale(current.stateVersion, expectedVersion)
@@ -147,18 +146,27 @@ class WorkloadRegistrationAuthority(
                 LifecycleTransitionOutcome.InvalidTransition(current.lifecycle, target)
             }
 
-            store.compareAndSet(current, updated) -> {
-                LifecycleTransitionOutcome.Applied(updated)
-            }
-
             else -> {
-                // Lost the race: report the CURRENT authoritative version.
-                val latest =
-                    store.find(workloadId, environmentId, deploymentId)
-                if (latest != null) {
-                    LifecycleTransitionOutcome.Stale(latest.stateVersion, expectedVersion)
+                // next() belongs to the actual mutation: stale, same-state and
+                // invalid commands are observational and must never require a
+                // future version — at Long.MAX_VALUE that requirement would
+                // overflow without any mutation happening.
+                val updated =
+                    current.copy(
+                        lifecycle = target,
+                        stateVersion = current.stateVersion.next(),
+                    )
+                if (store.compareAndSet(current, updated)) {
+                    LifecycleTransitionOutcome.Applied(updated)
                 } else {
-                    LifecycleTransitionOutcome.NotFound
+                    // Lost the race: report the CURRENT authoritative version.
+                    val latest =
+                        store.find(workloadId, environmentId, deploymentId)
+                    if (latest != null) {
+                        LifecycleTransitionOutcome.Stale(latest.stateVersion, expectedVersion)
+                    } else {
+                        LifecycleTransitionOutcome.NotFound
+                    }
                 }
             }
         }

--- a/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/WorkloadRegistrationAuthority.kt
+++ b/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/WorkloadRegistrationAuthority.kt
@@ -82,21 +82,36 @@ class WorkloadRegistrationAuthority(
         val current =
             store.find(workloadId, environmentId, deploymentId)
                 ?: return MetadataUpdateOutcome.NotFound
-        if (current.stateVersion != expectedVersion) {
-            return MetadataUpdateOutcome.Stale(current.stateVersion, expectedVersion)
-        }
-        if (current.metadata == metadata) {
-            return MetadataUpdateOutcome.Unchanged(current)
-        }
         val updated =
             current.copy(
                 metadata = metadata,
                 stateVersion = current.stateVersion.next(),
             )
-        return if (store.compareAndSet(current, updated)) {
-            MetadataUpdateOutcome.Applied(updated)
-        } else {
-            MetadataUpdateOutcome.Stale(current.stateVersion, expectedVersion)
+        return when {
+            current.stateVersion != expectedVersion -> {
+                MetadataUpdateOutcome.Stale(current.stateVersion, expectedVersion)
+            }
+
+            current.metadata == metadata -> {
+                MetadataUpdateOutcome.Unchanged(current)
+            }
+
+            store.compareAndSet(current, updated) -> {
+                MetadataUpdateOutcome.Applied(updated)
+            }
+
+            else -> {
+                // Lost the race: report the CURRENT authoritative version, not
+                // the version observed before the race (0.7.1e command
+                // preconditions will consume exactly this value).
+                val latest =
+                    store.find(workloadId, environmentId, deploymentId)
+                if (latest != null) {
+                    MetadataUpdateOutcome.Stale(latest.stateVersion, expectedVersion)
+                } else {
+                    MetadataUpdateOutcome.NotFound
+                }
+            }
         }
     }
 
@@ -114,24 +129,38 @@ class WorkloadRegistrationAuthority(
         val current =
             store.find(workloadId, environmentId, deploymentId)
                 ?: return LifecycleTransitionOutcome.NotFound
-        if (current.stateVersion != expectedVersion) {
-            return LifecycleTransitionOutcome.Stale(current.stateVersion, expectedVersion)
-        }
-        if (current.lifecycle == target) {
-            return LifecycleTransitionOutcome.Unchanged(current)
-        }
-        if (!current.lifecycle.canTransitionTo(target)) {
-            return LifecycleTransitionOutcome.InvalidTransition(current.lifecycle, target)
-        }
         val updated =
             current.copy(
                 lifecycle = target,
                 stateVersion = current.stateVersion.next(),
             )
-        return if (store.compareAndSet(current, updated)) {
-            LifecycleTransitionOutcome.Applied(updated)
-        } else {
-            LifecycleTransitionOutcome.Stale(current.stateVersion, expectedVersion)
+        return when {
+            current.stateVersion != expectedVersion -> {
+                LifecycleTransitionOutcome.Stale(current.stateVersion, expectedVersion)
+            }
+
+            current.lifecycle == target -> {
+                LifecycleTransitionOutcome.Unchanged(current)
+            }
+
+            !current.lifecycle.canTransitionTo(target) -> {
+                LifecycleTransitionOutcome.InvalidTransition(current.lifecycle, target)
+            }
+
+            store.compareAndSet(current, updated) -> {
+                LifecycleTransitionOutcome.Applied(updated)
+            }
+
+            else -> {
+                // Lost the race: report the CURRENT authoritative version.
+                val latest =
+                    store.find(workloadId, environmentId, deploymentId)
+                if (latest != null) {
+                    LifecycleTransitionOutcome.Stale(latest.stateVersion, expectedVersion)
+                } else {
+                    LifecycleTransitionOutcome.NotFound
+                }
+            }
         }
     }
 }

--- a/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/WorkloadRegistrationAuthority.kt
+++ b/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/WorkloadRegistrationAuthority.kt
@@ -1,0 +1,225 @@
+package dev.tramai.controlplane
+
+import dev.tramai.core.identity.DeploymentId
+import dev.tramai.core.identity.EnvironmentId
+import dev.tramai.core.identity.WorkloadDeploymentIdentity
+import dev.tramai.core.identity.WorkloadId
+import dev.tramai.core.identity.WorkloadMetadata
+
+/**
+ * Authoritative workload-registration rules over a [WorkloadRegistrationStore].
+ *
+ * Every rule lives here, never in a persistence implementation:
+ * - registration is NOT an upsert — establish the fact if absent, verify it if
+ *   present, fail if it conflicts;
+ * - a `(configurationId, version)` pair can never be rebound to a different
+ *   fingerprint;
+ * - one deployment scope has exactly one authoritative registration;
+ * - metadata and lifecycle mutations preserve identity and advance
+ *   [WorkloadStateVersion];
+ * - stale writers lose (every mutation is a compare-and-set on the version
+ *   the caller observed).
+ *
+ * This authority does NOT cancel running workflows, replace [WorkflowRegistry]
+ * executable-definition lookup, or expose any REST/query surface — those
+ * belong to later candidates.
+ */
+class WorkloadRegistrationAuthority(
+    private val store: WorkloadRegistrationStore,
+) {
+    /**
+     * Registers a workload deployment as ACTIVE at state version 1.
+     *
+     * Idempotent for an identical declaration; conflicting declarations are
+     * rejected, never silently applied.
+     */
+    suspend fun register(
+        identity: WorkloadDeploymentIdentity,
+        configurationFingerprint: ConfigurationFingerprint,
+        metadata: WorkloadMetadata,
+    ): RegisterOutcome {
+        val existing = store.find(identity.workloadId, identity.environmentId, identity.deploymentId)
+        if (existing != null) {
+            return if (existing.isSameDeclaration(identity, configurationFingerprint, metadata)) {
+                RegisterOutcome.AlreadyRegistered(existing)
+            } else {
+                RegisterOutcome.Rejected(
+                    existing = existing,
+                    reason = existing.rejectionReason(identity, configurationFingerprint),
+                )
+            }
+        }
+
+        val desired =
+            RegisteredWorkload(
+                identity = identity,
+                configurationFingerprint = configurationFingerprint,
+                metadata = metadata,
+                lifecycle = WorkloadLifecycleState.ACTIVE,
+                stateVersion = WorkloadStateVersion.INITIAL,
+            )
+        return when (val result = store.create(desired)) {
+            is CreateResult.Created -> RegisterOutcome.Created(result.registration)
+            is CreateResult.Idempotent -> RegisterOutcome.AlreadyRegistered(result.registration)
+            is CreateResult.Conflicting -> RegisterOutcome.Rejected(result.existing, result.reason)
+        }
+    }
+
+    /**
+     * Updates owner/purpose metadata of a registration. Identity is
+     * unchanged; a successful change advances the state version.
+     *
+     * @param expectedVersion version observed by the caller — a mutation based
+     *   on a stale version fails with [MetadataUpdateOutcome.Stale].
+     */
+    suspend fun updateMetadata(
+        workloadId: WorkloadId,
+        environmentId: EnvironmentId,
+        deploymentId: DeploymentId,
+        expectedVersion: WorkloadStateVersion,
+        metadata: WorkloadMetadata,
+    ): MetadataUpdateOutcome {
+        val current =
+            store.find(workloadId, environmentId, deploymentId)
+                ?: return MetadataUpdateOutcome.NotFound
+        if (current.stateVersion != expectedVersion) {
+            return MetadataUpdateOutcome.Stale(current.stateVersion, expectedVersion)
+        }
+        if (current.metadata == metadata) {
+            return MetadataUpdateOutcome.Unchanged(current)
+        }
+        val updated =
+            current.copy(
+                metadata = metadata,
+                stateVersion = current.stateVersion.next(),
+            )
+        return if (store.compareAndSet(current, updated)) {
+            MetadataUpdateOutcome.Applied(updated)
+        } else {
+            MetadataUpdateOutcome.Stale(current.stateVersion, expectedVersion)
+        }
+    }
+
+    /**
+     * Applies an authoritative lifecycle transition. RETIRED is terminal;
+     * suspending a workload never touches running workflows.
+     */
+    suspend fun transitionLifecycle(
+        workloadId: WorkloadId,
+        environmentId: EnvironmentId,
+        deploymentId: DeploymentId,
+        expectedVersion: WorkloadStateVersion,
+        target: WorkloadLifecycleState,
+    ): LifecycleTransitionOutcome {
+        val current =
+            store.find(workloadId, environmentId, deploymentId)
+                ?: return LifecycleTransitionOutcome.NotFound
+        if (current.stateVersion != expectedVersion) {
+            return LifecycleTransitionOutcome.Stale(current.stateVersion, expectedVersion)
+        }
+        if (current.lifecycle == target) {
+            return LifecycleTransitionOutcome.Unchanged(current)
+        }
+        if (!current.lifecycle.canTransitionTo(target)) {
+            return LifecycleTransitionOutcome.InvalidTransition(current.lifecycle, target)
+        }
+        val updated =
+            current.copy(
+                lifecycle = target,
+                stateVersion = current.stateVersion.next(),
+            )
+        return if (store.compareAndSet(current, updated)) {
+            LifecycleTransitionOutcome.Applied(updated)
+        } else {
+            LifecycleTransitionOutcome.Stale(current.stateVersion, expectedVersion)
+        }
+    }
+}
+
+/** Outcome of an authoritative [WorkloadRegistrationAuthority.register]. */
+sealed interface RegisterOutcome {
+    /** A new registration was created (ACTIVE, state version 1). */
+    data class Created(
+        val registration: RegisteredWorkload,
+    ) : RegisterOutcome
+
+    /** The identical declaration was already authoritative; nothing changed. */
+    data class AlreadyRegistered(
+        val registration: RegisteredWorkload,
+    ) : RegisterOutcome
+
+    /** The declaration conflicts with the authoritative record; nothing changed. */
+    data class Rejected(
+        val existing: RegisteredWorkload,
+        val reason: RegistrationConflictReason,
+    ) : RegisterOutcome
+}
+
+/** Outcome of [WorkloadRegistrationAuthority.updateMetadata]. */
+sealed interface MetadataUpdateOutcome {
+    /** Metadata changed; identity unchanged; state version advanced. */
+    data class Applied(
+        val registration: RegisteredWorkload,
+    ) : MetadataUpdateOutcome
+
+    /** Requested metadata equals current metadata; no authoritative mutation occurred. */
+    data class Unchanged(
+        val registration: RegisteredWorkload,
+    ) : MetadataUpdateOutcome
+
+    /** Caller's expected version is stale; the store moved on. */
+    data class Stale(
+        val currentVersion: WorkloadStateVersion,
+        val expectedVersion: WorkloadStateVersion,
+    ) : MetadataUpdateOutcome
+
+    data object NotFound : MetadataUpdateOutcome
+}
+
+/** Outcome of [WorkloadRegistrationAuthority.transitionLifecycle]. */
+sealed interface LifecycleTransitionOutcome {
+    /** Lifecycle changed; state version advanced. */
+    data class Applied(
+        val registration: RegisteredWorkload,
+    ) : LifecycleTransitionOutcome
+
+    /** Target state equals current state; no authoritative mutation occurred. */
+    data class Unchanged(
+        val registration: RegisteredWorkload,
+    ) : LifecycleTransitionOutcome
+
+    /** The requested transition is outside the authoritative lifecycle graph. */
+    data class InvalidTransition(
+        val from: WorkloadLifecycleState,
+        val to: WorkloadLifecycleState,
+    ) : LifecycleTransitionOutcome
+
+    /** Caller's expected version is stale; the store moved on. */
+    data class Stale(
+        val currentVersion: WorkloadStateVersion,
+        val expectedVersion: WorkloadStateVersion,
+    ) : LifecycleTransitionOutcome
+
+    data object NotFound : LifecycleTransitionOutcome
+}
+
+private fun RegisteredWorkload.isSameDeclaration(
+    identity: WorkloadDeploymentIdentity,
+    configurationFingerprint: ConfigurationFingerprint,
+    metadata: WorkloadMetadata,
+): Boolean =
+    this.identity == identity &&
+        this.configurationFingerprint == configurationFingerprint &&
+        this.metadata == metadata
+
+private fun RegisteredWorkload.rejectionReason(
+    identity: WorkloadDeploymentIdentity,
+    configurationFingerprint: ConfigurationFingerprint,
+): RegistrationConflictReason =
+    if (this.identity.configuration == identity.configuration &&
+        this.configurationFingerprint != configurationFingerprint
+    ) {
+        RegistrationConflictReason.CONFIGURATION_REBINDING
+    } else {
+        RegistrationConflictReason.CONFLICTING_REGISTRATION
+    }

--- a/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/WorkloadRegistrationStore.kt
+++ b/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/WorkloadRegistrationStore.kt
@@ -33,11 +33,19 @@ interface WorkloadRegistrationStore {
 
     /**
      * Atomically replaces the record stored at [expected]'s deployment scope
-     * with [updated] iff the stored record still carries [expected]'s state
-     * version — deployment scope + state version are the CAS concurrency
-     * token. Mutable fields carried by [expected] (metadata, lifecycle) are
-     * not re-verified; only the token is. Returns false when the scope is
-     * absent or the stored version has moved on.
+     * with [updated] iff:
+     *
+     * - the stored record still carries [expected]'s state version
+     *   (deployment scope + state version are the CAS concurrency token), AND
+     * - the stored immutable authority matches the witness carried by
+     *   [expected] — identity and configuration fingerprint. A caller that
+     *   fabricated a different configuration or fingerprint for the scope
+     *   must not gain mutation authority merely by guessing the version.
+     *
+     * Mutable fields carried by [expected] (metadata, lifecycle) are not
+     * re-verified; only the token and the immutable witness are. Returns
+     * false when the scope is absent, the stored version has moved on, or the
+     * stored immutable authority differs from [expected]'s.
      *
      * The immutable portion — identity and configuration fingerprint — must
      * match between [expected] and [updated]; implementations reject a

--- a/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/WorkloadRegistrationStore.kt
+++ b/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/WorkloadRegistrationStore.kt
@@ -32,9 +32,16 @@ interface WorkloadRegistrationStore {
     suspend fun create(registration: RegisteredWorkload): CreateResult
 
     /**
-     * Atomically replaces [expected] with [updated] iff the stored record is
-     * still exactly [expected] (same deployment scope and state version).
-     * Returns false when the stored record has moved on.
+     * Atomically replaces the record stored at [expected]'s deployment scope
+     * with [updated] iff the stored record still carries [expected]'s state
+     * version — deployment scope + state version are the CAS concurrency
+     * token. Mutable fields carried by [expected] (metadata, lifecycle) are
+     * not re-verified; only the token is. Returns false when the scope is
+     * absent or the stored version has moved on.
+     *
+     * The immutable portion — identity and configuration fingerprint — must
+     * match between [expected] and [updated]; implementations reject a
+     * violation with [IllegalArgumentException].
      */
     suspend fun compareAndSet(
         expected: RegisteredWorkload,

--- a/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/WorkloadRegistrationStore.kt
+++ b/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/WorkloadRegistrationStore.kt
@@ -1,0 +1,87 @@
+package dev.tramai.controlplane
+
+import dev.tramai.core.identity.DeploymentId
+import dev.tramai.core.identity.EnvironmentId
+import dev.tramai.core.identity.WorkloadDeploymentIdentity
+import dev.tramai.core.identity.WorkloadId
+
+/**
+ * Persistence boundary for the authoritative workload registration. Storage
+ * semantics only — registration, configuration-rebinding, lifecycle and
+ * metadata rules live in [WorkloadRegistrationAuthority] so no persistence
+ * implementation ever re-implements the state machine.
+ *
+ * Implementations must provide atomic storage semantics:
+ * - [create] is atomic — two concurrent creates for the same deployment scope
+ *   produce exactly one authoritative outcome;
+ * - [compareAndSet] is atomic — a stale writer never overwrites newer state.
+ */
+interface WorkloadRegistrationStore {
+    /** Returns the authoritative registration for the deployment scope, if any. */
+    suspend fun find(
+        workloadId: WorkloadId,
+        environmentId: EnvironmentId,
+        deploymentId: DeploymentId,
+    ): RegisteredWorkload?
+
+    /**
+     * Creates the registration atomically. Never an upsert: a conflicting
+     * existing registration or configuration binding must be reported, not
+     * silently replaced.
+     */
+    suspend fun create(registration: RegisteredWorkload): CreateResult
+
+    /**
+     * Atomically replaces [expected] with [updated] iff the stored record is
+     * still exactly [expected] (same deployment scope and state version).
+     * Returns false when the stored record has moved on.
+     */
+    suspend fun compareAndSet(
+        expected: RegisteredWorkload,
+        updated: RegisteredWorkload,
+    ): Boolean
+}
+
+/** Outcome of an atomic [WorkloadRegistrationStore.create]. */
+sealed interface CreateResult {
+    /** The record was inserted. */
+    data class Created(
+        val registration: RegisteredWorkload,
+    ) : CreateResult
+
+    /** An identical record (same scope, configuration, fingerprint, metadata) already exists. */
+    data class Idempotent(
+        val registration: RegisteredWorkload,
+    ) : CreateResult
+
+    /** An existing record blocks creation; nothing was written. */
+    data class Conflicting(
+        val existing: RegisteredWorkload,
+        val reason: RegistrationConflictReason,
+    ) : CreateResult
+}
+
+/**
+ * Why an authoritative registration was rejected. The configuration binding is
+ * global: if `(configurationId, version)` was ever registered anywhere with a
+ * fingerprint, re-registering the same pair with a different fingerprint fails
+ * even from a different deployment scope.
+ */
+enum class RegistrationConflictReason {
+    /** Same `(configurationId, version)` pair, different fingerprint — the binding is fixed forever. */
+    CONFIGURATION_REBINDING,
+
+    /** Same deployment scope, different configuration, fingerprint or metadata. */
+    CONFLICTING_REGISTRATION,
+}
+
+/**
+ * The registration slot: one authoritative registration per deployment scope.
+ * This is a store-level key, not a second canonical identity — the
+ * authoritative identity remains [WorkloadDeploymentIdentity].
+ */
+data class WorkloadDeploymentScope(
+    val workloadId: WorkloadId,
+    val environmentId: EnvironmentId,
+    val deploymentId: DeploymentId,
+)

--- a/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/WorkloadStateVersion.kt
+++ b/tramai-control-plane/src/main/kotlin/dev/tramai/controlplane/WorkloadStateVersion.kt
@@ -1,0 +1,43 @@
+package dev.tramai.controlplane
+
+/**
+ * Monotonic version of the authoritative mutable registration record.
+ *
+ * - a fresh registration starts at 1;
+ * - a successful authoritative mutation advances N -> N + 1;
+ * - reads, rejected mutations, failed/stale CAS and idempotent re-registration
+ *   leave N unchanged.
+ *
+ * The version lives on the mutable authoritative record, never on the
+ * immutable [dev.tramai.core.identity.WorkloadDeploymentIdentity] or
+ * [dev.tramai.core.identity.GovernedRunIdentity]: a state update must never
+ * change the identity of historical runs. Metadata changes (e.g. owner team
+ * handover) preserve identity but advance this version.
+ */
+data class WorkloadStateVersion(
+    val value: Long,
+) {
+    init {
+        require(value >= 1L) { "WorkloadStateVersion must be at least 1, got $value" }
+    }
+
+    /**
+     * Advances the version for the next authoritative mutation, failing
+     * closed on overflow rather than silently wrapping.
+     */
+    fun next(): WorkloadStateVersion {
+        val advanced =
+            try {
+                Math.addExact(value, 1L)
+            } catch (e: ArithmeticException) {
+                throw IllegalStateException("WorkloadStateVersion overflow at $value", e)
+            }
+        return WorkloadStateVersion(advanced)
+    }
+
+    override fun toString(): String = value.toString()
+
+    companion object {
+        val INITIAL: WorkloadStateVersion = WorkloadStateVersion(1L)
+    }
+}

--- a/tramai-control-plane/src/test/kotlin/dev/tramai/controlplane/InMemoryWorkloadRegistrationStoreTckTest.kt
+++ b/tramai-control-plane/src/test/kotlin/dev/tramai/controlplane/InMemoryWorkloadRegistrationStoreTckTest.kt
@@ -1,0 +1,15 @@
+package dev.tramai.controlplane
+
+import dev.tramai.controlplane.testing.WorkloadRegistrationStoreTck
+import dev.tramai.controlplane.testing.WorkloadRegistrationStoreTckHarness
+
+/**
+ * The InMemory reference implementation must satisfy the shared
+ * [WorkloadRegistrationStore] contract.
+ */
+class InMemoryWorkloadRegistrationStoreTckTest : WorkloadRegistrationStoreTck() {
+    override val harness =
+        object : WorkloadRegistrationStoreTckHarness {
+            override fun createStore(): WorkloadRegistrationStore = InMemoryWorkloadRegistrationStore()
+        }
+}

--- a/tramai-control-plane/src/test/kotlin/dev/tramai/controlplane/WorkloadRegistrationAuthorityTest.kt
+++ b/tramai-control-plane/src/test/kotlin/dev/tramai/controlplane/WorkloadRegistrationAuthorityTest.kt
@@ -444,6 +444,152 @@ class WorkloadRegistrationAuthorityTest {
             assertThat(current()?.stateVersion).isEqualTo(WorkloadStateVersion(2))
         }
 
+    // ── Version overflow boundary (rejected commands never advance) ─
+
+    /**
+     * Seeds the store at Long.MAX_VALUE — the last representable version.
+     * Authority commands must classify stale/no-op/invalid requests without
+     * ever calling next(); only a genuine mutation may attempt (and fail
+     * closed on) the overflow.
+     */
+    private suspend fun seedAtMaxVersion(lifecycle: WorkloadLifecycleState = WorkloadLifecycleState.ACTIVE): RegisteredWorkload {
+        val seeded =
+            WorkloadRegistrationFixtures.registration(
+                identity = identity,
+                configurationFingerprint = fingerprint,
+                metadata = metadata,
+                lifecycle = lifecycle,
+                stateVersion = WorkloadStateVersion(Long.MAX_VALUE),
+            )
+        assertThat(store.create(seeded)).isInstanceOf(CreateResult.Created::class.java)
+        return seeded
+    }
+
+    @Test
+    fun `metadata update at MAX version with identical metadata is unchanged and does not overflow`() =
+        runBlocking<Unit> {
+            seedAtMaxVersion()
+
+            val outcome =
+                authority.updateMetadata(
+                    identity.workloadId,
+                    identity.environmentId,
+                    identity.deploymentId,
+                    WorkloadStateVersion(Long.MAX_VALUE),
+                    metadata,
+                )
+
+            assertThat(outcome).isInstanceOf(MetadataUpdateOutcome.Unchanged::class.java)
+            assertThat(current()?.stateVersion).isEqualTo(WorkloadStateVersion(Long.MAX_VALUE))
+        }
+
+    @Test
+    fun `metadata update at MAX version with stale expected version is stale and does not overflow`() =
+        runBlocking<Unit> {
+            seedAtMaxVersion()
+
+            val outcome =
+                authority.updateMetadata(
+                    identity.workloadId,
+                    identity.environmentId,
+                    identity.deploymentId,
+                    WorkloadStateVersion.INITIAL,
+                    WorkloadRegistrationFixtures.metadata(owner = "Stale Team"),
+                )
+
+            assertThat(outcome).isInstanceOf(MetadataUpdateOutcome.Stale::class.java)
+            (outcome as MetadataUpdateOutcome.Stale).let {
+                assertThat(it.currentVersion).isEqualTo(WorkloadStateVersion(Long.MAX_VALUE))
+                assertThat(it.expectedVersion).isEqualTo(WorkloadStateVersion.INITIAL)
+            }
+            assertThat(current()?.metadata).isEqualTo(metadata)
+        }
+
+    @Test
+    fun `metadata update at MAX version with a genuine change fails closed on overflow`() =
+        runBlocking<Unit> {
+            seedAtMaxVersion()
+
+            val failure =
+                runCatching {
+                    authority.updateMetadata(
+                        identity.workloadId,
+                        identity.environmentId,
+                        identity.deploymentId,
+                        WorkloadStateVersion(Long.MAX_VALUE),
+                        WorkloadRegistrationFixtures.metadata(owner = "New Team"),
+                    )
+                }.exceptionOrNull()
+
+            assertThat(failure).isInstanceOf(IllegalStateException::class.java)
+            assertThat(failure?.message).contains("overflow")
+            assertThat(current()?.metadata).isEqualTo(metadata)
+            assertThat(current()?.stateVersion).isEqualTo(WorkloadStateVersion(Long.MAX_VALUE))
+        }
+
+    @Test
+    fun `lifecycle transition at MAX version to the same state is unchanged and does not overflow`() =
+        runBlocking<Unit> {
+            seedAtMaxVersion()
+
+            val outcome =
+                authority.transitionLifecycle(
+                    identity.workloadId,
+                    identity.environmentId,
+                    identity.deploymentId,
+                    WorkloadStateVersion(Long.MAX_VALUE),
+                    WorkloadLifecycleState.ACTIVE,
+                )
+
+            assertThat(outcome).isInstanceOf(LifecycleTransitionOutcome.Unchanged::class.java)
+            assertThat(current()?.stateVersion).isEqualTo(WorkloadStateVersion(Long.MAX_VALUE))
+        }
+
+    @Test
+    fun `lifecycle transition at MAX version from RETIRED is invalid and does not overflow`() =
+        runBlocking<Unit> {
+            seedAtMaxVersion(lifecycle = WorkloadLifecycleState.RETIRED)
+
+            val outcome =
+                authority.transitionLifecycle(
+                    identity.workloadId,
+                    identity.environmentId,
+                    identity.deploymentId,
+                    WorkloadStateVersion(Long.MAX_VALUE),
+                    WorkloadLifecycleState.ACTIVE,
+                )
+
+            assertThat(outcome).isInstanceOf(LifecycleTransitionOutcome.InvalidTransition::class.java)
+            (outcome as LifecycleTransitionOutcome.InvalidTransition).let {
+                assertThat(it.from).isEqualTo(WorkloadLifecycleState.RETIRED)
+                assertThat(it.to).isEqualTo(WorkloadLifecycleState.ACTIVE)
+            }
+            assertThat(current()?.lifecycle).isEqualTo(WorkloadLifecycleState.RETIRED)
+            assertThat(current()?.stateVersion).isEqualTo(WorkloadStateVersion(Long.MAX_VALUE))
+        }
+
+    @Test
+    fun `lifecycle transition at MAX version with a genuine change fails closed on overflow`() =
+        runBlocking<Unit> {
+            seedAtMaxVersion()
+
+            val failure =
+                runCatching {
+                    authority.transitionLifecycle(
+                        identity.workloadId,
+                        identity.environmentId,
+                        identity.deploymentId,
+                        WorkloadStateVersion(Long.MAX_VALUE),
+                        WorkloadLifecycleState.SUSPENDED,
+                    )
+                }.exceptionOrNull()
+
+            assertThat(failure).isInstanceOf(IllegalStateException::class.java)
+            assertThat(failure?.message).contains("overflow")
+            assertThat(current()?.lifecycle).isEqualTo(WorkloadLifecycleState.ACTIVE)
+            assertThat(current()?.stateVersion).isEqualTo(WorkloadStateVersion(Long.MAX_VALUE))
+        }
+
     // ── Concurrency ─────────────────────────────────────────────────
 
     @Test

--- a/tramai-control-plane/src/test/kotlin/dev/tramai/controlplane/WorkloadRegistrationAuthorityTest.kt
+++ b/tramai-control-plane/src/test/kotlin/dev/tramai/controlplane/WorkloadRegistrationAuthorityTest.kt
@@ -27,7 +27,12 @@ class WorkloadRegistrationAuthorityTest {
     private val fingerprint = WorkloadRegistrationFixtures.fingerprint()
     private val metadata = WorkloadRegistrationFixtures.metadata()
 
-    private suspend fun current(): RegisteredWorkload? = store.find(identity.workloadId, identity.environmentId, identity.deploymentId)
+    private suspend fun current(): RegisteredWorkload? =
+        store.find(
+            identity.workloadId,
+            identity.environmentId,
+            identity.deploymentId,
+        )
 
     // ── Registration ────────────────────────────────────────────────
 
@@ -474,9 +479,14 @@ class WorkloadRegistrationAuthorityTest {
                     )
 
                 assertThat(outcomes.filterIsInstance<MetadataUpdateOutcome.Applied>()).hasSize(1)
-                assertThat(outcomes.filterIsInstance<MetadataUpdateOutcome.Stale>()).hasSize(1)
+                val stale = outcomes.filterIsInstance<MetadataUpdateOutcome.Stale>().single()
+                // The loser must report the TRUTHFUL current version (2), not
+                // the version it read before the race (1) — 0.7.1e command
+                // preconditions will consume exactly this value.
+                assertThat(stale.expectedVersion).isEqualTo(WorkloadStateVersion.INITIAL)
+                assertThat(stale.currentVersion).isEqualTo(WorkloadStateVersion(2))
                 val finalRecord = store.find(scope.workloadId, scope.environmentId, scope.deploymentId)
-                assertThat(finalRecord?.stateVersion).isEqualTo(WorkloadStateVersion(2))
+                assertThat(finalRecord?.stateVersion).isEqualTo(stale.currentVersion)
                 assertThat(finalRecord?.metadata?.owner).isIn("Writer A", "Writer B")
             }
         }

--- a/tramai-control-plane/src/test/kotlin/dev/tramai/controlplane/WorkloadRegistrationAuthorityTest.kt
+++ b/tramai-control-plane/src/test/kotlin/dev/tramai/controlplane/WorkloadRegistrationAuthorityTest.kt
@@ -452,7 +452,7 @@ class WorkloadRegistrationAuthorityTest {
      * ever calling next(); only a genuine mutation may attempt (and fail
      * closed on) the overflow.
      */
-    private suspend fun seedAtMaxVersion(lifecycle: WorkloadLifecycleState = WorkloadLifecycleState.ACTIVE): RegisteredWorkload {
+    private suspend fun seedAtMax(lifecycle: WorkloadLifecycleState): RegisteredWorkload {
         val seeded =
             WorkloadRegistrationFixtures.registration(
                 identity = identity,
@@ -468,7 +468,7 @@ class WorkloadRegistrationAuthorityTest {
     @Test
     fun `metadata update at MAX version with identical metadata is unchanged and does not overflow`() =
         runBlocking<Unit> {
-            seedAtMaxVersion()
+            seedAtMax(WorkloadLifecycleState.ACTIVE)
 
             val outcome =
                 authority.updateMetadata(
@@ -486,7 +486,7 @@ class WorkloadRegistrationAuthorityTest {
     @Test
     fun `metadata update at MAX version with stale expected version is stale and does not overflow`() =
         runBlocking<Unit> {
-            seedAtMaxVersion()
+            seedAtMax(WorkloadLifecycleState.ACTIVE)
 
             val outcome =
                 authority.updateMetadata(
@@ -508,7 +508,7 @@ class WorkloadRegistrationAuthorityTest {
     @Test
     fun `metadata update at MAX version with a genuine change fails closed on overflow`() =
         runBlocking<Unit> {
-            seedAtMaxVersion()
+            seedAtMax(WorkloadLifecycleState.ACTIVE)
 
             val failure =
                 runCatching {
@@ -530,7 +530,7 @@ class WorkloadRegistrationAuthorityTest {
     @Test
     fun `lifecycle transition at MAX version to the same state is unchanged and does not overflow`() =
         runBlocking<Unit> {
-            seedAtMaxVersion()
+            seedAtMax(WorkloadLifecycleState.ACTIVE)
 
             val outcome =
                 authority.transitionLifecycle(
@@ -548,7 +548,7 @@ class WorkloadRegistrationAuthorityTest {
     @Test
     fun `lifecycle transition at MAX version from RETIRED is invalid and does not overflow`() =
         runBlocking<Unit> {
-            seedAtMaxVersion(lifecycle = WorkloadLifecycleState.RETIRED)
+            seedAtMax(WorkloadLifecycleState.RETIRED)
 
             val outcome =
                 authority.transitionLifecycle(
@@ -571,7 +571,7 @@ class WorkloadRegistrationAuthorityTest {
     @Test
     fun `lifecycle transition at MAX version with a genuine change fails closed on overflow`() =
         runBlocking<Unit> {
-            seedAtMaxVersion()
+            seedAtMax(WorkloadLifecycleState.ACTIVE)
 
             val failure =
                 runCatching {

--- a/tramai-control-plane/src/test/kotlin/dev/tramai/controlplane/WorkloadRegistrationAuthorityTest.kt
+++ b/tramai-control-plane/src/test/kotlin/dev/tramai/controlplane/WorkloadRegistrationAuthorityTest.kt
@@ -1,0 +1,483 @@
+package dev.tramai.controlplane
+
+import dev.tramai.controlplane.testing.WorkloadRegistrationFixtures
+import dev.tramai.controlplane.testing.runInParallel
+import dev.tramai.core.identity.WorkloadMetadata
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Authoritative registration rules (0.7.1c). The state machine lives in
+ * [WorkloadRegistrationAuthority], above the store; these tests pin every
+ * rule in the candidate brief, including the adversarial matrix.
+ */
+class WorkloadRegistrationAuthorityTest {
+    private lateinit var store: InMemoryWorkloadRegistrationStore
+    private lateinit var authority: WorkloadRegistrationAuthority
+
+    @BeforeEach
+    fun setUp() {
+        store = InMemoryWorkloadRegistrationStore()
+        authority = WorkloadRegistrationAuthority(store)
+    }
+
+    private val identity = WorkloadRegistrationFixtures.identity()
+    private val fingerprint = WorkloadRegistrationFixtures.fingerprint()
+    private val metadata = WorkloadRegistrationFixtures.metadata()
+
+    private suspend fun current(): RegisteredWorkload? = store.find(identity.workloadId, identity.environmentId, identity.deploymentId)
+
+    // ── Registration ────────────────────────────────────────────────
+
+    @Test
+    fun `register creates ACTIVE registration at version 1`() =
+        runBlocking<Unit> {
+            val outcome = authority.register(identity, fingerprint, metadata)
+
+            assertThat(outcome).isInstanceOf(RegisterOutcome.Created::class.java)
+            val created = (outcome as RegisterOutcome.Created).registration
+            assertThat(created.lifecycle).isEqualTo(WorkloadLifecycleState.ACTIVE)
+            assertThat(created.stateVersion).isEqualTo(WorkloadStateVersion.INITIAL)
+        }
+
+    @Test
+    fun `registering the identical declaration is idempotent at version 1`() =
+        runBlocking<Unit> {
+            authority.register(identity, fingerprint, metadata)
+
+            val again = authority.register(identity, fingerprint, metadata)
+
+            assertThat(again).isInstanceOf(RegisterOutcome.AlreadyRegistered::class.java)
+            val existing = (again as RegisterOutcome.AlreadyRegistered).registration
+            assertThat(existing.stateVersion).isEqualTo(WorkloadStateVersion.INITIAL)
+            assertThat(existing.lifecycle).isEqualTo(WorkloadLifecycleState.ACTIVE)
+        }
+
+    @Test
+    fun `re-registering the same scope with a different configuration is rejected, not upserted`() =
+        runBlocking<Unit> {
+            authority.register(identity, fingerprint, metadata)
+            val nextConfiguration =
+                identity.copy(
+                    configuration =
+                        identity.configuration.copy(
+                            version =
+                                dev.tramai.core.identity
+                                    .ConfigurationVersion("18"),
+                        ),
+                )
+
+            val outcome = authority.register(nextConfiguration, fingerprint, metadata)
+
+            assertThat(outcome).isInstanceOf(RegisterOutcome.Rejected::class.java)
+            (outcome as RegisterOutcome.Rejected).let { rejected ->
+                assertThat(rejected.reason)
+                    .isEqualTo(RegistrationConflictReason.CONFLICTING_REGISTRATION)
+            }
+            assertThat(current()).isEqualTo(
+                WorkloadRegistrationFixtures.registration(identity = identity),
+            )
+        }
+
+    @Test
+    fun `re-registering with different metadata is rejected, never a silent update`() =
+        runBlocking<Unit> {
+            authority.register(identity, fingerprint, metadata)
+
+            val outcome =
+                authority.register(
+                    identity,
+                    fingerprint,
+                    WorkloadRegistrationFixtures.metadata(owner = "Risk Platform Team"),
+                )
+
+            assertThat(outcome).isInstanceOf(RegisterOutcome.Rejected::class.java)
+            (outcome as RegisterOutcome.Rejected).let { rejected ->
+                assertThat(rejected.reason)
+                    .isEqualTo(RegistrationConflictReason.CONFLICTING_REGISTRATION)
+            }
+            assertThat(current()).isEqualTo(
+                WorkloadRegistrationFixtures.registration(identity = identity),
+            )
+        }
+
+    @Test
+    fun `same configuration pair with a different fingerprint is configuration rebinding`() =
+        runBlocking<Unit> {
+            authority.register(identity, fingerprint, metadata)
+
+            val rebinding =
+                authority.register(
+                    identity,
+                    WorkloadRegistrationFixtures.fingerprint(value = "sha256:bbbb"),
+                    metadata,
+                )
+
+            assertThat(rebinding).isInstanceOf(RegisterOutcome.Rejected::class.java)
+            (rebinding as RegisterOutcome.Rejected).let { rejected ->
+                assertThat(rejected.reason)
+                    .isEqualTo(RegistrationConflictReason.CONFIGURATION_REBINDING)
+            }
+        }
+
+    @Test
+    fun `configuration rebinding is rejected from a different deployment scope`() =
+        runBlocking<Unit> {
+            authority.register(identity, fingerprint, metadata)
+            val frankfurtIdentity =
+                WorkloadRegistrationFixtures.identity(
+                    deployment = "eu-central-frankfurt-01",
+                )
+
+            val outcome =
+                authority.register(
+                    frankfurtIdentity,
+                    WorkloadRegistrationFixtures.fingerprint(value = "sha256:bbbb"),
+                    metadata,
+                )
+
+            assertThat(outcome).isInstanceOf(RegisterOutcome.Rejected::class.java)
+            (outcome as RegisterOutcome.Rejected).let { rejected ->
+                assertThat(rejected.reason)
+                    .isEqualTo(RegistrationConflictReason.CONFIGURATION_REBINDING)
+            }
+        }
+
+    @Test
+    fun `the same configuration on a different deployment registers cleanly`() =
+        runBlocking<Unit> {
+            authority.register(identity, fingerprint, metadata)
+
+            val outcome =
+                authority.register(
+                    WorkloadRegistrationFixtures.identity(deployment = "eu-central-frankfurt-01"),
+                    fingerprint,
+                    metadata,
+                )
+
+            assertThat(outcome).isInstanceOf(RegisterOutcome.Created::class.java)
+        }
+
+    @Test
+    fun `registration survives reads without advancing version`() =
+        runBlocking<Unit> {
+            authority.register(identity, fingerprint, metadata)
+            repeat(3) { current() }
+
+            assertThat(current()?.stateVersion).isEqualTo(WorkloadStateVersion.INITIAL)
+        }
+
+    // ── Metadata mutation ───────────────────────────────────────────
+
+    @Test
+    fun `metadata update preserves identity and advances version`() =
+        runBlocking<Unit> {
+            authority.register(identity, fingerprint, metadata)
+            val newMetadata = WorkloadMetadata(owner = "Risk Platform Team", purpose = "Fraud review")
+
+            val outcome =
+                authority.updateMetadata(
+                    identity.workloadId,
+                    identity.environmentId,
+                    identity.deploymentId,
+                    WorkloadStateVersion.INITIAL,
+                    newMetadata,
+                )
+
+            assertThat(outcome).isInstanceOf(MetadataUpdateOutcome.Applied::class.java)
+            (outcome as MetadataUpdateOutcome.Applied).registration.let { updated ->
+                assertThat(updated.metadata).isEqualTo(newMetadata)
+                assertThat(updated.identity).isEqualTo(identity)
+                assertThat(updated.stateVersion).isEqualTo(WorkloadStateVersion(2))
+            }
+        }
+
+    @Test
+    fun `identical metadata update is unchanged and does not advance version`() =
+        runBlocking<Unit> {
+            authority.register(identity, fingerprint, metadata)
+
+            val outcome =
+                authority.updateMetadata(
+                    identity.workloadId,
+                    identity.environmentId,
+                    identity.deploymentId,
+                    WorkloadStateVersion.INITIAL,
+                    metadata,
+                )
+
+            assertThat(outcome).isInstanceOf(MetadataUpdateOutcome.Unchanged::class.java)
+            assertThat(current()?.stateVersion).isEqualTo(WorkloadStateVersion.INITIAL)
+        }
+
+    @Test
+    fun `stale metadata update is rejected without mutation`() =
+        runBlocking<Unit> {
+            authority.register(identity, fingerprint, metadata)
+            authority.updateMetadata(
+                identity.workloadId,
+                identity.environmentId,
+                identity.deploymentId,
+                WorkloadStateVersion.INITIAL,
+                WorkloadMetadata(owner = "Team A", purpose = "p"),
+            )
+            // current version is now 2; a writer still holding version 1 must lose.
+            val staleOutcome =
+                authority.updateMetadata(
+                    identity.workloadId,
+                    identity.environmentId,
+                    identity.deploymentId,
+                    WorkloadStateVersion.INITIAL,
+                    WorkloadMetadata(owner = "Stale Team", purpose = "p"),
+                )
+
+            assertThat(staleOutcome).isInstanceOf(MetadataUpdateOutcome.Stale::class.java)
+            (staleOutcome as MetadataUpdateOutcome.Stale).let {
+                assertThat(it.currentVersion).isEqualTo(WorkloadStateVersion(2))
+                assertThat(it.expectedVersion).isEqualTo(WorkloadStateVersion.INITIAL)
+            }
+            assertThat(current()?.stateVersion).isEqualTo(WorkloadStateVersion(2))
+            assertThat(current()?.metadata?.owner).isEqualTo("Team A")
+        }
+
+    @Test
+    fun `metadata update on unknown registration is not found`() =
+        runBlocking<Unit> {
+            val outcome =
+                authority.updateMetadata(
+                    identity.workloadId,
+                    identity.environmentId,
+                    identity.deploymentId,
+                    WorkloadStateVersion.INITIAL,
+                    metadata,
+                )
+
+            assertThat(outcome).isEqualTo(MetadataUpdateOutcome.NotFound)
+        }
+
+    // ── Lifecycle transitions ───────────────────────────────────────
+
+    @Test
+    fun `ACTIVE to SUSPENDED to ACTIVE transitions advance version`() =
+        runBlocking<Unit> {
+            authority.register(identity, fingerprint, metadata)
+
+            val suspendOutcome =
+                authority.transitionLifecycle(
+                    identity.workloadId,
+                    identity.environmentId,
+                    identity.deploymentId,
+                    WorkloadStateVersion.INITIAL,
+                    WorkloadLifecycleState.SUSPENDED,
+                )
+            assertThat(suspendOutcome).isInstanceOf(LifecycleTransitionOutcome.Applied::class.java)
+            assertThat((suspendOutcome as LifecycleTransitionOutcome.Applied).registration.stateVersion)
+                .isEqualTo(WorkloadStateVersion(2))
+
+            val resumeOutcome =
+                authority.transitionLifecycle(
+                    identity.workloadId,
+                    identity.environmentId,
+                    identity.deploymentId,
+                    WorkloadStateVersion(2),
+                    WorkloadLifecycleState.ACTIVE,
+                )
+            assertThat(resumeOutcome).isInstanceOf(LifecycleTransitionOutcome.Applied::class.java)
+            assertThat((resumeOutcome as LifecycleTransitionOutcome.Applied).registration.stateVersion)
+                .isEqualTo(WorkloadStateVersion(3))
+            assertThat(current()?.lifecycle).isEqualTo(WorkloadLifecycleState.ACTIVE)
+        }
+
+    @Test
+    fun `ACTIVE may retire directly and RETIRED is terminal`() =
+        runBlocking<Unit> {
+            authority.register(identity, fingerprint, metadata)
+
+            val retire =
+                authority.transitionLifecycle(
+                    identity.workloadId,
+                    identity.environmentId,
+                    identity.deploymentId,
+                    WorkloadStateVersion.INITIAL,
+                    WorkloadLifecycleState.RETIRED,
+                )
+            assertThat(retire).isInstanceOf(LifecycleTransitionOutcome.Applied::class.java)
+
+            val resurrect =
+                authority.transitionLifecycle(
+                    identity.workloadId,
+                    identity.environmentId,
+                    identity.deploymentId,
+                    current()!!.stateVersion,
+                    WorkloadLifecycleState.ACTIVE,
+                )
+            assertThat(resurrect).isInstanceOf(LifecycleTransitionOutcome.InvalidTransition::class.java)
+            (resurrect as LifecycleTransitionOutcome.InvalidTransition).let {
+                assertThat(it.from).isEqualTo(WorkloadLifecycleState.RETIRED)
+                assertThat(it.to).isEqualTo(WorkloadLifecycleState.ACTIVE)
+            }
+            assertThat(current()?.lifecycle).isEqualTo(WorkloadLifecycleState.RETIRED)
+        }
+
+    @Test
+    fun `SUSPENDED may retire and RETIRED remains terminal`() =
+        runBlocking<Unit> {
+            authority.register(identity, fingerprint, metadata)
+            authority.transitionLifecycle(
+                identity.workloadId,
+                identity.environmentId,
+                identity.deploymentId,
+                WorkloadStateVersion.INITIAL,
+                WorkloadLifecycleState.SUSPENDED,
+            )
+
+            val retire =
+                authority.transitionLifecycle(
+                    identity.workloadId,
+                    identity.environmentId,
+                    identity.deploymentId,
+                    current()!!.stateVersion,
+                    WorkloadLifecycleState.RETIRED,
+                )
+            assertThat(retire).isInstanceOf(LifecycleTransitionOutcome.Applied::class.java)
+
+            val resurrect =
+                authority.transitionLifecycle(
+                    identity.workloadId,
+                    identity.environmentId,
+                    identity.deploymentId,
+                    current()!!.stateVersion,
+                    WorkloadLifecycleState.ACTIVE,
+                )
+            assertThat(resurrect).isInstanceOf(LifecycleTransitionOutcome.InvalidTransition::class.java)
+            assertThat(current()?.lifecycle).isEqualTo(WorkloadLifecycleState.RETIRED)
+        }
+
+    @Test
+    fun `retired registration cannot be suspended either`() =
+        runBlocking<Unit> {
+            authority.register(identity, fingerprint, metadata)
+            authority.transitionLifecycle(
+                identity.workloadId,
+                identity.environmentId,
+                identity.deploymentId,
+                WorkloadStateVersion.INITIAL,
+                WorkloadLifecycleState.RETIRED,
+            )
+
+            val outcome =
+                authority.transitionLifecycle(
+                    identity.workloadId,
+                    identity.environmentId,
+                    identity.deploymentId,
+                    current()!!.stateVersion,
+                    WorkloadLifecycleState.SUSPENDED,
+                )
+
+            assertThat(outcome).isInstanceOf(LifecycleTransitionOutcome.InvalidTransition::class.java)
+        }
+
+    @Test
+    fun `same-state transition is unchanged and does not advance version`() =
+        runBlocking<Unit> {
+            authority.register(identity, fingerprint, metadata)
+
+            val outcome =
+                authority.transitionLifecycle(
+                    identity.workloadId,
+                    identity.environmentId,
+                    identity.deploymentId,
+                    WorkloadStateVersion.INITIAL,
+                    WorkloadLifecycleState.ACTIVE,
+                )
+
+            assertThat(outcome).isInstanceOf(LifecycleTransitionOutcome.Unchanged::class.java)
+            assertThat(current()?.stateVersion).isEqualTo(WorkloadStateVersion.INITIAL)
+        }
+
+    @Test
+    fun `lifecycle transitions preserve identity`() =
+        runBlocking<Unit> {
+            authority.register(identity, fingerprint, metadata)
+            authority.transitionLifecycle(
+                identity.workloadId,
+                identity.environmentId,
+                identity.deploymentId,
+                WorkloadStateVersion.INITIAL,
+                WorkloadLifecycleState.SUSPENDED,
+            )
+
+            assertThat(current()?.identity).isEqualTo(identity)
+            assertThat(current()?.configurationFingerprint).isEqualTo(fingerprint)
+        }
+
+    @Test
+    fun `stale lifecycle transition loses and does not mutate`() =
+        runBlocking<Unit> {
+            authority.register(identity, fingerprint, metadata)
+            authority.transitionLifecycle(
+                identity.workloadId,
+                identity.environmentId,
+                identity.deploymentId,
+                WorkloadStateVersion.INITIAL,
+                WorkloadLifecycleState.SUSPENDED,
+            )
+
+            val stale =
+                authority.transitionLifecycle(
+                    identity.workloadId,
+                    identity.environmentId,
+                    identity.deploymentId,
+                    WorkloadStateVersion.INITIAL,
+                    WorkloadLifecycleState.RETIRED,
+                )
+
+            assertThat(stale).isInstanceOf(LifecycleTransitionOutcome.Stale::class.java)
+            assertThat(current()?.lifecycle).isEqualTo(WorkloadLifecycleState.SUSPENDED)
+            assertThat(current()?.stateVersion).isEqualTo(WorkloadStateVersion(2))
+        }
+
+    // ── Concurrency ─────────────────────────────────────────────────
+
+    @Test
+    fun `two concurrent metadata writers produce one winner and one stale loser`() =
+        runBlocking<Unit> {
+            repeat(5) { iteration ->
+                val scope =
+                    WorkloadRegistrationFixtures.identity(
+                        deployment = "meta-race-$iteration",
+                    )
+                authority.register(scope, fingerprint, metadata)
+
+                val outcomes =
+                    runInParallel(
+                        {
+                            authority.updateMetadata(
+                                scope.workloadId,
+                                scope.environmentId,
+                                scope.deploymentId,
+                                WorkloadStateVersion.INITIAL,
+                                WorkloadMetadata(owner = "Writer A", purpose = "a"),
+                            )
+                        },
+                        {
+                            authority.updateMetadata(
+                                scope.workloadId,
+                                scope.environmentId,
+                                scope.deploymentId,
+                                WorkloadStateVersion.INITIAL,
+                                WorkloadMetadata(owner = "Writer B", purpose = "b"),
+                            )
+                        },
+                    )
+
+                assertThat(outcomes.filterIsInstance<MetadataUpdateOutcome.Applied>()).hasSize(1)
+                assertThat(outcomes.filterIsInstance<MetadataUpdateOutcome.Stale>()).hasSize(1)
+                val finalRecord = store.find(scope.workloadId, scope.environmentId, scope.deploymentId)
+                assertThat(finalRecord?.stateVersion).isEqualTo(WorkloadStateVersion(2))
+                assertThat(finalRecord?.metadata?.owner).isIn("Writer A", "Writer B")
+            }
+        }
+}

--- a/tramai-control-plane/src/testFixtures/kotlin/dev/tramai/controlplane/testing/WorkloadRegistrationFixtures.kt
+++ b/tramai-control-plane/src/testFixtures/kotlin/dev/tramai/controlplane/testing/WorkloadRegistrationFixtures.kt
@@ -1,0 +1,60 @@
+package dev.tramai.controlplane.testing
+
+import dev.tramai.controlplane.ConfigurationFingerprint
+import dev.tramai.controlplane.RegisteredWorkload
+import dev.tramai.controlplane.WorkloadLifecycleState
+import dev.tramai.controlplane.WorkloadStateVersion
+import dev.tramai.core.identity.ConfigurationId
+import dev.tramai.core.identity.ConfigurationVersion
+import dev.tramai.core.identity.DeploymentId
+import dev.tramai.core.identity.EnvironmentId
+import dev.tramai.core.identity.WorkloadConfigurationIdentity
+import dev.tramai.core.identity.WorkloadDeploymentIdentity
+import dev.tramai.core.identity.WorkloadId
+import dev.tramai.core.identity.WorkloadMetadata
+
+/**
+ * Deterministic fixtures for the workload-registration store contract.
+ * The TCK owns the identifiers — runners never do.
+ */
+object WorkloadRegistrationFixtures {
+    fun identity(
+        workload: String = "claims",
+        configurationId: String = "claims-prod",
+        configurationVersion: String = "17",
+        environment: String = "production",
+        deployment: String = "eu-west-amsterdam-01",
+    ): WorkloadDeploymentIdentity =
+        WorkloadDeploymentIdentity(
+            workloadId = WorkloadId(workload),
+            configuration =
+                WorkloadConfigurationIdentity(
+                    id = ConfigurationId(configurationId),
+                    version = ConfigurationVersion(configurationVersion),
+                ),
+            environmentId = EnvironmentId(environment),
+            deploymentId = DeploymentId(deployment),
+        )
+
+    fun fingerprint(value: String = "sha256:aaaa"): ConfigurationFingerprint = ConfigurationFingerprint(value)
+
+    fun metadata(
+        owner: String = "Claims Team",
+        purpose: String = "Fraud review",
+    ): WorkloadMetadata = WorkloadMetadata(owner, purpose)
+
+    fun registration(
+        identity: WorkloadDeploymentIdentity = identity(),
+        configurationFingerprint: ConfigurationFingerprint = fingerprint(),
+        metadata: WorkloadMetadata = metadata(),
+        lifecycle: WorkloadLifecycleState = WorkloadLifecycleState.ACTIVE,
+        stateVersion: WorkloadStateVersion = WorkloadStateVersion.INITIAL,
+    ): RegisteredWorkload =
+        RegisteredWorkload(
+            identity = identity,
+            configurationFingerprint = configurationFingerprint,
+            metadata = metadata,
+            lifecycle = lifecycle,
+            stateVersion = stateVersion,
+        )
+}

--- a/tramai-control-plane/src/testFixtures/kotlin/dev/tramai/controlplane/testing/WorkloadRegistrationStoreTck.kt
+++ b/tramai-control-plane/src/testFixtures/kotlin/dev/tramai/controlplane/testing/WorkloadRegistrationStoreTck.kt
@@ -354,10 +354,11 @@ abstract class WorkloadRegistrationStoreTck {
 
 /**
  * Runs the contenders against each other on Dispatchers.Default, releasing
- * them simultaneously once all are parked. Two plain `async` calls inside
- * `runBlocking` do NOT run concurrently — runBlocking's event loop is
- * single-threaded — so the ready/release handshake is mandatory for a real
- * race.
+ * them simultaneously once all are parked. The ready/release handshake is
+ * mandatory for a REAL race: `async { ... }` inside `runBlocking` inherits the
+ * single-threaded runBlocking event loop and would serialize the contenders,
+ * but `async(Dispatchers.Default)` genuinely runs them on the shared pool —
+ * the release gate only guarantees they START together.
  */
 public suspend fun <T> runInParallel(vararg contenders: suspend () -> T): List<T> =
     coroutineScope {

--- a/tramai-control-plane/src/testFixtures/kotlin/dev/tramai/controlplane/testing/WorkloadRegistrationStoreTck.kt
+++ b/tramai-control-plane/src/testFixtures/kotlin/dev/tramai/controlplane/testing/WorkloadRegistrationStoreTck.kt
@@ -1,0 +1,309 @@
+package dev.tramai.controlplane.testing
+
+import dev.tramai.controlplane.CreateResult
+import dev.tramai.controlplane.RegisteredWorkload
+import dev.tramai.controlplane.RegistrationConflictReason
+import dev.tramai.controlplane.WorkloadRegistrationStore
+import dev.tramai.controlplane.WorkloadStateVersion
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Shared [WorkloadRegistrationStore] compatibility contract (0.7.1c).
+ *
+ * Every implementation — InMemory reference, JDBC durable — must satisfy
+ * exactly the same externally observable registration-storage semantics. The
+ * TCK tests the store contract, not implementation internals and not the
+ * authority state machine (which lives above the store and is covered by the
+ * authority test suite).
+ *
+ * Each test gets a FRESH store from [harness].
+ */
+abstract class WorkloadRegistrationStoreTck {
+    abstract val harness: WorkloadRegistrationStoreTckHarness
+
+    protected lateinit var store: WorkloadRegistrationStore
+
+    @BeforeEach
+    fun setUp() {
+        store = harness.createStore()
+    }
+
+    @AfterEach
+    fun tearDown() = runBlocking<Unit> { harness.closeStore(store) }
+
+    // ── Creation / read ─────────────────────────────────────────────
+
+    @Test
+    fun `fresh create round-trips through find`() =
+        runBlocking<Unit> {
+            val registration = WorkloadRegistrationFixtures.registration()
+
+            val result = store.create(registration)
+
+            assertThat(result).isEqualTo(CreateResult.Created(registration))
+            assertThat(
+                store.find(
+                    registration.identity.workloadId,
+                    registration.identity.environmentId,
+                    registration.identity.deploymentId,
+                ),
+            ).isEqualTo(registration)
+        }
+
+    @Test
+    fun `find on unknown deployment scope returns null`() =
+        runBlocking<Unit> {
+            val identity = WorkloadRegistrationFixtures.identity()
+            assertThat(
+                store.find(identity.workloadId, identity.environmentId, identity.deploymentId),
+            ).isNull()
+        }
+
+    // ── Idempotency (register is not an upsert) ─────────────────────
+
+    @Test
+    fun `identical declaration creates once then is idempotent`() =
+        runBlocking<Unit> {
+            val registration = WorkloadRegistrationFixtures.registration()
+
+            val first = store.create(registration)
+            val second = store.create(registration)
+
+            assertThat(first).isEqualTo(CreateResult.Created(registration))
+            assertThat(second).isEqualTo(CreateResult.Idempotent(registration))
+        }
+
+    // ── Deployment scope exclusivity ────────────────────────────────
+
+    @Test
+    fun `same scope with different configuration is a conflicting registration`() =
+        runBlocking<Unit> {
+            store.create(WorkloadRegistrationFixtures.registration())
+
+            val differentConfiguration =
+                WorkloadRegistrationFixtures.registration(
+                    identity = WorkloadRegistrationFixtures.identity(configurationVersion = "18"),
+                )
+
+            val result = store.create(differentConfiguration)
+
+            assertThat(result).isInstanceOf(CreateResult.Conflicting::class.java)
+            result as CreateResult.Conflicting
+            assertThat(result.reason).isEqualTo(RegistrationConflictReason.CONFLICTING_REGISTRATION)
+        }
+
+    @Test
+    fun `same scope with different metadata is a conflicting registration`() =
+        runBlocking<Unit> {
+            store.create(WorkloadRegistrationFixtures.registration())
+
+            val differentMetadata =
+                WorkloadRegistrationFixtures.registration(
+                    metadata = WorkloadRegistrationFixtures.metadata(owner = "Risk Platform Team"),
+                )
+
+            val result = store.create(differentMetadata)
+
+            assertThat(result).isInstanceOf(CreateResult.Conflicting::class.java)
+            result as CreateResult.Conflicting
+            assertThat(result.reason).isEqualTo(RegistrationConflictReason.CONFLICTING_REGISTRATION)
+        }
+
+    @Test
+    fun `distinct deployment ids within one environment stay distinct`() =
+        runBlocking<Unit> {
+            val amsterdam =
+                WorkloadRegistrationFixtures.registration(
+                    identity = WorkloadRegistrationFixtures.identity(deployment = "eu-west-amsterdam-01"),
+                )
+            val frankfurt =
+                WorkloadRegistrationFixtures.registration(
+                    identity = WorkloadRegistrationFixtures.identity(deployment = "eu-central-frankfurt-01"),
+                )
+
+            val amsterdamResult = store.create(amsterdam)
+            val frankfurtResult = store.create(frankfurt)
+
+            assertThat(amsterdamResult).isInstanceOf(CreateResult.Created::class.java)
+            assertThat(frankfurtResult).isInstanceOf(CreateResult.Created::class.java)
+        }
+
+    @Test
+    fun `same deployment id in distinct environments stays distinct`() =
+        runBlocking<Unit> {
+            val production =
+                WorkloadRegistrationFixtures.registration(
+                    identity = WorkloadRegistrationFixtures.identity(environment = "production"),
+                )
+            val staging =
+                WorkloadRegistrationFixtures.registration(
+                    identity = WorkloadRegistrationFixtures.identity(environment = "staging"),
+                )
+
+            assertThat(store.create(production)).isInstanceOf(CreateResult.Created::class.java)
+            assertThat(store.create(staging)).isInstanceOf(CreateResult.Created::class.java)
+        }
+
+    // ── Configuration binding is fixed forever ──────────────────────
+
+    @Test
+    fun `same configuration pair with different fingerprint is rejected from another deployment`() =
+        runBlocking<Unit> {
+            val original = WorkloadRegistrationFixtures.registration()
+            store.create(original)
+
+            // Same (configurationId=claims-prod, version=17), different fingerprint,
+            // DIFFERENT deployment scope: must still fail — the binding is global.
+            val rebindingAttempt =
+                WorkloadRegistrationFixtures.registration(
+                    identity = WorkloadRegistrationFixtures.identity(deployment = "eu-central-frankfurt-01"),
+                    configurationFingerprint = WorkloadRegistrationFixtures.fingerprint(value = "sha256:bbbb"),
+                )
+
+            val result = store.create(rebindingAttempt)
+
+            assertThat(result).isInstanceOf(CreateResult.Conflicting::class.java)
+            result as CreateResult.Conflicting
+            assertThat(result.reason).isEqualTo(RegistrationConflictReason.CONFIGURATION_REBINDING)
+        }
+
+    @Test
+    fun `same configuration pair with same fingerprint is allowed from another deployment`() =
+        runBlocking<Unit> {
+            val original = WorkloadRegistrationFixtures.registration()
+            store.create(original)
+
+            val sameConfiguration =
+                WorkloadRegistrationFixtures.registration(
+                    identity = WorkloadRegistrationFixtures.identity(deployment = "eu-central-frankfurt-01"),
+                )
+
+            val result = store.create(sameConfiguration)
+
+            assertThat(result).isInstanceOf(CreateResult.Created::class.java)
+        }
+
+    // ── compareAndSet ───────────────────────────────────────────────
+
+    @Test
+    fun `compareAndSet applies when expected is current`() =
+        runBlocking<Unit> {
+            val registration = WorkloadRegistrationFixtures.registration()
+            store.create(registration)
+
+            val updated = registration.copy(stateVersion = WorkloadStateVersion(2))
+
+            assertThat(store.compareAndSet(registration, updated)).isTrue()
+            assertThat(
+                store.find(
+                    registration.identity.workloadId,
+                    registration.identity.environmentId,
+                    registration.identity.deploymentId,
+                ),
+            ).isEqualTo(updated)
+        }
+
+    @Test
+    fun `stale compareAndSet is rejected and state is untouched`() =
+        runBlocking<Unit> {
+            val registration = WorkloadRegistrationFixtures.registration()
+            store.create(registration)
+            val winner = registration.copy(stateVersion = WorkloadStateVersion(2))
+            assertThat(store.compareAndSet(registration, winner)).isTrue()
+
+            // A stale writer still holds the original version-1 snapshot.
+            val staleWriter = registration.copy(metadata = WorkloadRegistrationFixtures.metadata(owner = "Stale Team"))
+
+            assertThat(store.compareAndSet(registration, staleWriter)).isFalse()
+            assertThat(
+                store.find(
+                    registration.identity.workloadId,
+                    registration.identity.environmentId,
+                    registration.identity.deploymentId,
+                ),
+            ).isEqualTo(winner)
+        }
+
+    @Test
+    fun `compareAndSet must not change the deployment scope`() =
+        runBlocking<Unit> {
+            val registration = WorkloadRegistrationFixtures.registration()
+            store.create(registration)
+
+            val scopeChange =
+                registration.copy(
+                    identity = WorkloadRegistrationFixtures.identity(deployment = "eu-central-frankfurt-01"),
+                )
+
+            assertThat(
+                runCatching { store.compareAndSet(registration, scopeChange) }.exceptionOrNull(),
+            ).isInstanceOf(IllegalArgumentException::class.java)
+        }
+
+    // ── Concurrency ─────────────────────────────────────────────────
+
+    @Test
+    fun `two concurrent creates for one scope yield exactly one authoritative outcome`() =
+        runBlocking<Unit> {
+            repeat(5) { iteration ->
+                val registration =
+                    WorkloadRegistrationFixtures.registration(
+                        identity =
+                            WorkloadRegistrationFixtures.identity(
+                                deployment = "race-$iteration",
+                            ),
+                    )
+
+                val results =
+                    runInParallel(
+                        { store.create(registration) },
+                        { store.create(registration) },
+                    )
+
+                val created = results.filterIsInstance<CreateResult.Created>()
+                val idempotent = results.filterIsInstance<CreateResult.Idempotent>()
+                assertThat(created.size + idempotent.size).isEqualTo(2)
+                assertThat(created.size).isEqualTo(1)
+                assertThat(
+                    store.find(
+                        registration.identity.workloadId,
+                        registration.identity.environmentId,
+                        registration.identity.deploymentId,
+                    ),
+                ).isEqualTo(registration)
+            }
+        }
+}
+
+/**
+ * Runs the contenders against each other on Dispatchers.Default, releasing
+ * them simultaneously once all are parked. Two plain `async` calls inside
+ * `runBlocking` do NOT run concurrently — runBlocking's event loop is
+ * single-threaded — so the ready/release handshake is mandatory for a real
+ * race.
+ */
+public suspend fun <T> runInParallel(vararg contenders: suspend () -> T): List<T> =
+    coroutineScope {
+        val ready = Channel<Unit>(capacity = contenders.size)
+        val release = CompletableDeferred<Unit>()
+        val results =
+            contenders.map { op ->
+                async(Dispatchers.Default) {
+                    ready.send(Unit)
+                    release.await()
+                    op()
+                }
+            }
+        repeat(contenders.size) { ready.receive() }
+        release.complete(Unit)
+        results.map { it.await() }
+    }

--- a/tramai-control-plane/src/testFixtures/kotlin/dev/tramai/controlplane/testing/WorkloadRegistrationStoreTck.kt
+++ b/tramai-control-plane/src/testFixtures/kotlin/dev/tramai/controlplane/testing/WorkloadRegistrationStoreTck.kt
@@ -26,7 +26,15 @@ import org.junit.jupiter.api.Test
  * authority test suite).
  *
  * Each test gets a FRESH store from [harness].
+ *
+ * Suppressed rules: JUnit human-readable backtick test names are treated as
+ * production function names by Detekt because testFixtures sources are not on
+ * the ordinary test path, and the iteration literals of the race probes are
+ * intentional. The TramAI Detekt policy keeps one repository-wide
+ * configuration; these are narrow, documented class-level suppressions for a
+ * reusable TCK, not global config changes.
  */
+@Suppress("FunctionNaming", "MagicNumber", "TooManyFunctions")
 abstract class WorkloadRegistrationStoreTck {
     abstract val harness: WorkloadRegistrationStoreTckHarness
 
@@ -40,6 +48,13 @@ abstract class WorkloadRegistrationStoreTck {
     @AfterEach
     fun tearDown() = runBlocking<Unit> { harness.closeStore(store) }
 
+    private suspend fun current(registration: RegisteredWorkload): RegisteredWorkload? =
+        store.find(
+            registration.identity.workloadId,
+            registration.identity.environmentId,
+            registration.identity.deploymentId,
+        )
+
     // ── Creation / read ─────────────────────────────────────────────
 
     @Test
@@ -50,13 +65,7 @@ abstract class WorkloadRegistrationStoreTck {
             val result = store.create(registration)
 
             assertThat(result).isEqualTo(CreateResult.Created(registration))
-            assertThat(
-                store.find(
-                    registration.identity.workloadId,
-                    registration.identity.environmentId,
-                    registration.identity.deploymentId,
-                ),
-            ).isEqualTo(registration)
+            assertThat(current(registration)).isEqualTo(registration)
         }
 
     @Test
@@ -130,11 +139,8 @@ abstract class WorkloadRegistrationStoreTck {
                     identity = WorkloadRegistrationFixtures.identity(deployment = "eu-central-frankfurt-01"),
                 )
 
-            val amsterdamResult = store.create(amsterdam)
-            val frankfurtResult = store.create(frankfurt)
-
-            assertThat(amsterdamResult).isInstanceOf(CreateResult.Created::class.java)
-            assertThat(frankfurtResult).isInstanceOf(CreateResult.Created::class.java)
+            assertThat(store.create(amsterdam)).isInstanceOf(CreateResult.Created::class.java)
+            assertThat(store.create(frankfurt)).isInstanceOf(CreateResult.Created::class.java)
         }
 
     @Test
@@ -161,8 +167,8 @@ abstract class WorkloadRegistrationStoreTck {
             val original = WorkloadRegistrationFixtures.registration()
             store.create(original)
 
-            // Same (configurationId=claims-prod, version=17), different fingerprint,
-            // DIFFERENT deployment scope: must still fail — the binding is global.
+            // Same (configurationId, version), different fingerprint, DIFFERENT
+            // deployment scope: must still fail — the binding is global.
             val rebindingAttempt =
                 WorkloadRegistrationFixtures.registration(
                     identity = WorkloadRegistrationFixtures.identity(deployment = "eu-central-frankfurt-01"),
@@ -187,9 +193,7 @@ abstract class WorkloadRegistrationStoreTck {
                     identity = WorkloadRegistrationFixtures.identity(deployment = "eu-central-frankfurt-01"),
                 )
 
-            val result = store.create(sameConfiguration)
-
-            assertThat(result).isInstanceOf(CreateResult.Created::class.java)
+            assertThat(store.create(sameConfiguration)).isInstanceOf(CreateResult.Created::class.java)
         }
 
     // ── compareAndSet ───────────────────────────────────────────────
@@ -203,13 +207,62 @@ abstract class WorkloadRegistrationStoreTck {
             val updated = registration.copy(stateVersion = WorkloadStateVersion(2))
 
             assertThat(store.compareAndSet(registration, updated)).isTrue()
+            assertThat(current(registration)).isEqualTo(updated)
+        }
+
+    @Test
+    fun `compareAndSet cannot change registration identity`() =
+        runBlocking<Unit> {
+            val registration = WorkloadRegistrationFixtures.registration()
+            store.create(registration)
+
+            val identityChange =
+                registration.copy(
+                    identity = WorkloadRegistrationFixtures.identity(deployment = "eu-central-frankfurt-01"),
+                    stateVersion = WorkloadStateVersion(2),
+                )
+
             assertThat(
-                store.find(
-                    registration.identity.workloadId,
-                    registration.identity.environmentId,
-                    registration.identity.deploymentId,
-                ),
-            ).isEqualTo(updated)
+                runCatching { store.compareAndSet(registration, identityChange) }.exceptionOrNull(),
+            ).isInstanceOf(IllegalArgumentException::class.java)
+            assertThat(current(registration)).isEqualTo(registration)
+        }
+
+    @Test
+    fun `compareAndSet cannot change the configuration inside identity`() =
+        runBlocking<Unit> {
+            val registration = WorkloadRegistrationFixtures.registration()
+            store.create(registration)
+
+            val configurationChange =
+                registration.copy(
+                    identity = WorkloadRegistrationFixtures.identity(configurationVersion = "18"),
+                    stateVersion = WorkloadStateVersion(2),
+                )
+
+            assertThat(
+                runCatching { store.compareAndSet(registration, configurationChange) }.exceptionOrNull(),
+            ).isInstanceOf(IllegalArgumentException::class.java)
+            assertThat(current(registration)).isEqualTo(registration)
+        }
+
+    @Test
+    fun `compareAndSet cannot change the configuration fingerprint`() =
+        runBlocking<Unit> {
+            val registration = WorkloadRegistrationFixtures.registration()
+            store.create(registration)
+
+            val fingerprintChange =
+                registration.copy(
+                    configurationFingerprint = WorkloadRegistrationFixtures.fingerprint(value = "sha256:ffff"),
+                    stateVersion = WorkloadStateVersion(2),
+                )
+
+            assertThat(
+                runCatching { store.compareAndSet(registration, fingerprintChange) }.exceptionOrNull(),
+            ).isInstanceOf(IllegalArgumentException::class.java)
+            // The CAS never applied, so the record — and its fingerprint — are untouched.
+            assertThat(current(registration)).isEqualTo(registration)
         }
 
     @Test
@@ -221,32 +274,13 @@ abstract class WorkloadRegistrationStoreTck {
             assertThat(store.compareAndSet(registration, winner)).isTrue()
 
             // A stale writer still holds the original version-1 snapshot.
-            val staleWriter = registration.copy(metadata = WorkloadRegistrationFixtures.metadata(owner = "Stale Team"))
-
-            assertThat(store.compareAndSet(registration, staleWriter)).isFalse()
-            assertThat(
-                store.find(
-                    registration.identity.workloadId,
-                    registration.identity.environmentId,
-                    registration.identity.deploymentId,
-                ),
-            ).isEqualTo(winner)
-        }
-
-    @Test
-    fun `compareAndSet must not change the deployment scope`() =
-        runBlocking<Unit> {
-            val registration = WorkloadRegistrationFixtures.registration()
-            store.create(registration)
-
-            val scopeChange =
+            val staleWriter =
                 registration.copy(
-                    identity = WorkloadRegistrationFixtures.identity(deployment = "eu-central-frankfurt-01"),
+                    metadata = WorkloadRegistrationFixtures.metadata(owner = "Stale Team"),
                 )
 
-            assertThat(
-                runCatching { store.compareAndSet(registration, scopeChange) }.exceptionOrNull(),
-            ).isInstanceOf(IllegalArgumentException::class.java)
+            assertThat(store.compareAndSet(registration, staleWriter)).isFalse()
+            assertThat(current(registration)).isEqualTo(winner)
         }
 
     // ── Concurrency ─────────────────────────────────────────────────
@@ -254,12 +288,12 @@ abstract class WorkloadRegistrationStoreTck {
     @Test
     fun `two concurrent creates for one scope yield exactly one authoritative outcome`() =
         runBlocking<Unit> {
-            repeat(5) { iteration ->
+            repeat(RACE_ITERATIONS) { iteration ->
                 val registration =
                     WorkloadRegistrationFixtures.registration(
                         identity =
                             WorkloadRegistrationFixtures.identity(
-                                deployment = "race-$iteration",
+                                deployment = "create-race-$iteration",
                             ),
                     )
 
@@ -273,15 +307,49 @@ abstract class WorkloadRegistrationStoreTck {
                 val idempotent = results.filterIsInstance<CreateResult.Idempotent>()
                 assertThat(created.size + idempotent.size).isEqualTo(2)
                 assertThat(created.size).isEqualTo(1)
-                assertThat(
-                    store.find(
-                        registration.identity.workloadId,
-                        registration.identity.environmentId,
-                        registration.identity.deploymentId,
-                    ),
-                ).isEqualTo(registration)
+                assertThat(current(registration)).isEqualTo(registration)
             }
         }
+
+    @Test
+    fun `two concurrent CAS writers yield exactly one winner and final version 2`() =
+        runBlocking<Unit> {
+            repeat(RACE_ITERATIONS) { iteration ->
+                val registration =
+                    WorkloadRegistrationFixtures.registration(
+                        identity =
+                            WorkloadRegistrationFixtures.identity(
+                                deployment = "cas-race-$iteration",
+                            ),
+                    )
+                store.create(registration)
+                val winnerUpdate =
+                    registration.copy(
+                        metadata = WorkloadRegistrationFixtures.metadata(owner = "Winner"),
+                        stateVersion = WorkloadStateVersion(2),
+                    )
+                val loserUpdate =
+                    registration.copy(
+                        metadata = WorkloadRegistrationFixtures.metadata(owner = "Loser"),
+                        stateVersion = WorkloadStateVersion(2),
+                    )
+
+                val results =
+                    runInParallel(
+                        { store.compareAndSet(registration, winnerUpdate) },
+                        { store.compareAndSet(registration, loserUpdate) },
+                    )
+
+                assertThat(results.filter { it }.size).isEqualTo(1)
+                assertThat(results.filter { !it }.size).isEqualTo(1)
+                assertThat(current(registration)?.stateVersion).isEqualTo(WorkloadStateVersion(2))
+            }
+        }
+
+    companion object {
+        /** How many times each concurrency race runs on fresh deployment scopes. */
+        private const val RACE_ITERATIONS: Int = 5
+    }
 }
 
 /**

--- a/tramai-control-plane/src/testFixtures/kotlin/dev/tramai/controlplane/testing/WorkloadRegistrationStoreTck.kt
+++ b/tramai-control-plane/src/testFixtures/kotlin/dev/tramai/controlplane/testing/WorkloadRegistrationStoreTck.kt
@@ -307,6 +307,47 @@ abstract class WorkloadRegistrationStoreTck {
             assertThat(current(registration)).isEqualTo(updated)
         }
 
+    @Test
+    fun `compareAndSet rejects expected with a fabricated configuration for the scope`() =
+        runBlocking<Unit> {
+            val registration = WorkloadRegistrationFixtures.registration()
+            store.create(registration)
+
+            // Same scope + version, but the expected claims a DIFFERENT
+            // configuration than the stored authoritative record: the
+            // immutable witness must fail the CAS even though the version
+            // token matches.
+            val fabricatedConfiguration =
+                registration.copy(
+                    identity = WorkloadRegistrationFixtures.identity(configurationVersion = "18"),
+                )
+            val updated =
+                fabricatedConfiguration.copy(stateVersion = WorkloadStateVersion(2))
+
+            assertThat(store.compareAndSet(fabricatedConfiguration, updated)).isFalse()
+            assertThat(current(registration)).isEqualTo(registration)
+        }
+
+    @Test
+    fun `compareAndSet rejects expected with a fabricated fingerprint for the scope`() =
+        runBlocking<Unit> {
+            val registration = WorkloadRegistrationFixtures.registration()
+            store.create(registration)
+
+            // Same scope + version + configuration, but the expected claims a
+            // DIFFERENT fingerprint: the immutable witness must fail the CAS.
+            val fabricatedFingerprint =
+                registration.copy(
+                    configurationFingerprint =
+                        WorkloadRegistrationFixtures.fingerprint(value = "sha256:ffff"),
+                )
+            val updated =
+                fabricatedFingerprint.copy(stateVersion = WorkloadStateVersion(2))
+
+            assertThat(store.compareAndSet(fabricatedFingerprint, updated)).isFalse()
+            assertThat(current(registration)).isEqualTo(registration)
+        }
+
     // ── Concurrency ─────────────────────────────────────────────────
 
     @Test

--- a/tramai-control-plane/src/testFixtures/kotlin/dev/tramai/controlplane/testing/WorkloadRegistrationStoreTck.kt
+++ b/tramai-control-plane/src/testFixtures/kotlin/dev/tramai/controlplane/testing/WorkloadRegistrationStoreTck.kt
@@ -283,6 +283,30 @@ abstract class WorkloadRegistrationStoreTck {
             assertThat(current(registration)).isEqualTo(winner)
         }
 
+    @Test
+    fun `compareAndSet token is deployment scope plus state version, not the whole mutable record`() =
+        runBlocking<Unit> {
+            val registration = WorkloadRegistrationFixtures.registration()
+            store.create(registration)
+
+            // Expected carries the same scope + version but STALE metadata:
+            // the CAS concurrency token is (deployment scope, stateVersion).
+            // Both implementations must agree — a full-record comparison in
+            // one store would let InMemory and JDBC drift apart.
+            val staleMetadataExpected =
+                registration.copy(
+                    metadata = WorkloadRegistrationFixtures.metadata(owner = "Stale Owner"),
+                )
+            val updated =
+                registration.copy(
+                    metadata = WorkloadRegistrationFixtures.metadata(owner = "New Owner"),
+                    stateVersion = WorkloadStateVersion(2),
+                )
+
+            assertThat(store.compareAndSet(staleMetadataExpected, updated)).isTrue()
+            assertThat(current(registration)).isEqualTo(updated)
+        }
+
     // ── Concurrency ─────────────────────────────────────────────────
 
     @Test

--- a/tramai-control-plane/src/testFixtures/kotlin/dev/tramai/controlplane/testing/WorkloadRegistrationStoreTckHarness.kt
+++ b/tramai-control-plane/src/testFixtures/kotlin/dev/tramai/controlplane/testing/WorkloadRegistrationStoreTckHarness.kt
@@ -1,0 +1,16 @@
+package dev.tramai.controlplane.testing
+
+import dev.tramai.controlplane.WorkloadRegistrationStore
+
+/**
+ * Storage-technology hook for the [WorkloadRegistrationStore] contract.
+ *
+ * The runner owns everything implementation-specific: datasources, schema,
+ * store construction, cleanup. Every call to [createStore] must return a
+ * FRESH, isolated store.
+ */
+interface WorkloadRegistrationStoreTckHarness {
+    fun createStore(): WorkloadRegistrationStore
+
+    suspend fun closeStore(store: WorkloadRegistrationStore) = Unit
+}

--- a/tramai-persistence-jdbc/api/tramai-persistence-jdbc.api
+++ b/tramai-persistence-jdbc/api/tramai-persistence-jdbc.api
@@ -120,3 +120,10 @@ public final class dev/tramai/persistence/jdbc/JdbcSuspendedInvocationStore : de
 public final class dev/tramai/persistence/jdbc/JdbcSuspendedInvocationStore$Companion {
 }
 
+public final class dev/tramai/persistence/jdbc/JdbcWorkloadRegistrationStore : dev/tramai/controlplane/WorkloadRegistrationStore {
+	public fun <init> (Ljavax/sql/DataSource;)V
+	public fun compareAndSet (Ldev/tramai/controlplane/RegisteredWorkload;Ldev/tramai/controlplane/RegisteredWorkload;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun create (Ldev/tramai/controlplane/RegisteredWorkload;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun find (Ldev/tramai/core/identity/WorkloadId;Ldev/tramai/core/identity/EnvironmentId;Ldev/tramai/core/identity/DeploymentId;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+

--- a/tramai-persistence-jdbc/build.gradle.kts
+++ b/tramai-persistence-jdbc/build.gradle.kts
@@ -11,11 +11,13 @@ dependencies {
     api(project(":tramai-core"))
     api(project(":tramai-engine"))
     api(project(":tramai-security"))
+    api(project(":tramai-control-plane"))
     implementation(libs.jackson.databind)
     implementation(libs.jackson.module.kotlin)
     implementation(libs.jackson.datatype.jsr310)
 
     testImplementation(testFixtures(project(":tramai-testing")))
+    testImplementation(testFixtures(project(":tramai-control-plane")))
         testImplementation(platform(libs.testcontainers.bom))
             testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation(libs.testcontainers.postgresql)

--- a/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcWorkloadRegistrationStore.kt
+++ b/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcWorkloadRegistrationStore.kt
@@ -1,0 +1,306 @@
+package dev.tramai.persistence.jdbc
+
+import dev.tramai.controlplane.ConfigurationFingerprint
+import dev.tramai.controlplane.CreateResult
+import dev.tramai.controlplane.RegisteredWorkload
+import dev.tramai.controlplane.RegistrationConflictReason
+import dev.tramai.controlplane.WorkloadLifecycleState
+import dev.tramai.controlplane.WorkloadRegistrationStore
+import dev.tramai.controlplane.WorkloadStateVersion
+import dev.tramai.core.identity.ConfigurationId
+import dev.tramai.core.identity.ConfigurationVersion
+import dev.tramai.core.identity.DeploymentId
+import dev.tramai.core.identity.EnvironmentId
+import dev.tramai.core.identity.WorkloadConfigurationIdentity
+import dev.tramai.core.identity.WorkloadDeploymentIdentity
+import dev.tramai.core.identity.WorkloadId
+import dev.tramai.core.identity.WorkloadMetadata
+import java.sql.Connection
+import java.sql.ResultSet
+import java.sql.SQLException
+import javax.sql.DataSource
+
+/**
+ * JDBC-backed [WorkloadRegistrationStore] (Epic 0.7.1c) over the
+ * `tramai_workload_registration` and `tramai_configuration_revision` tables
+ * (migration V8).
+ *
+ * ## Atomicity
+ * [create] runs inside an explicit transaction: the configuration-revision
+ * binding is established/verified and the registration inserted in one commit.
+ * A Postgres unique violation aborts the transaction, so classification of an
+ * existing registration happens on a fresh connection after rollback — never
+ * inside the aborted transaction.
+ *
+ * ## Database-level authority
+ * The primary keys themselves enforce one registration per deployment scope
+ * and one immutable fingerprint per `(configuration_id, configuration_version)`
+ * — two JDBC store instances pointing at the same database cannot race around
+ * the contract.
+ *
+ * The store never implements authority rules; it only stores what
+ * [dev.tramai.controlplane.WorkloadRegistrationAuthority] decides.
+ */
+class JdbcWorkloadRegistrationStore(
+    private val dataSource: DataSource,
+) : WorkloadRegistrationStore {
+    override suspend fun find(
+        workloadId: WorkloadId,
+        environmentId: EnvironmentId,
+        deploymentId: DeploymentId,
+    ): RegisteredWorkload? =
+        withSafeJdbc({ "Database operation failed while reading a workload registration" }) {
+            readScope(workloadId, environmentId, deploymentId)
+        }
+
+    private fun readScope(
+        workloadId: WorkloadId,
+        environmentId: EnvironmentId,
+        deploymentId: DeploymentId,
+    ): RegisteredWorkload? =
+        dataSource.connection.use { conn ->
+            conn
+                .prepareStatement(
+                    """
+                    SELECT r.workload_id, r.environment_id, r.deployment_id,
+                           r.configuration_id, r.configuration_version,
+                           cr.fingerprint,
+                           r.owner, r.purpose, r.lifecycle_state, r.state_version
+                    FROM tramai_workload_registration r
+                    JOIN tramai_configuration_revision cr
+                      ON cr.configuration_id = r.configuration_id
+                     AND cr.configuration_version = r.configuration_version
+                    WHERE r.workload_id = ? AND r.environment_id = ? AND r.deployment_id = ?
+                    """.trimIndent(),
+                ).use { statement ->
+                    statement.setString(1, workloadId.value)
+                    statement.setString(2, environmentId.value)
+                    statement.setString(3, deploymentId.value)
+                    statement.executeQuery().use { rs ->
+                        if (rs.next()) rs.toRegisteredWorkload() else null
+                    }
+                }
+        }
+
+    override suspend fun create(registration: RegisteredWorkload): CreateResult =
+        withSafeJdbc(
+            {
+                "Database operation failed while registering workload " +
+                    "${registration.identity.workloadId.value} in " +
+                    "${registration.identity.environmentId.value}/${registration.identity.deploymentId.value}"
+            },
+        ) {
+            var connection: Connection? = null
+            try {
+                connection = dataSource.connection
+                connection.autoCommit = false
+                createWithinTransaction(connection, registration)
+            } catch (e: SQLException) {
+                connection?.rollbackQuietly()
+                if (isUniqueViolation(e)) {
+                    // Scope already registered — classify on a fresh connection.
+                    return@withSafeJdbc classifyExisting(registration)
+                }
+                throw e
+            } finally {
+                connection?.closeQuietly()
+            }
+        }
+
+    private fun createWithinTransaction(
+        conn: Connection,
+        registration: RegisteredWorkload,
+    ): CreateResult {
+        val configurationId = registration.identity.configuration.id.value
+        val configurationVersion = registration.identity.configuration.version.value
+
+        // 1) Establish the global configuration binding if absent.
+        conn
+            .prepareStatement(
+                """
+                INSERT INTO tramai_configuration_revision (configuration_id, configuration_version, fingerprint)
+                VALUES (?, ?, ?)
+                ON CONFLICT (configuration_id, configuration_version) DO NOTHING
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setString(1, configurationId)
+                statement.setString(2, configurationVersion)
+                statement.setString(3, registration.configurationFingerprint.value)
+                statement.executeUpdate()
+            }
+
+        // 2) Verify the binding: a (configurationId, version) pair can never be
+        //    rebound to a different fingerprint.
+        conn
+            .prepareStatement(
+                """
+                SELECT fingerprint FROM tramai_configuration_revision
+                WHERE configuration_id = ? AND configuration_version = ?
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setString(1, configurationId)
+                statement.setString(2, configurationVersion)
+                statement.executeQuery().use { rs ->
+                    if (rs.next()) {
+                        val boundFingerprint = rs.getString(1)
+                        if (boundFingerprint != registration.configurationFingerprint.value) {
+                            conn.rollbackQuietly()
+                            return CreateResult.Conflicting(
+                                existing = boundRegistrationFor(configurationId, configurationVersion),
+                                reason = RegistrationConflictReason.CONFIGURATION_REBINDING,
+                            )
+                        }
+                    }
+                }
+            }
+
+        // 3) Insert the registration for the deployment scope.
+        conn
+            .prepareStatement(
+                """
+                INSERT INTO tramai_workload_registration (
+                    workload_id, environment_id, deployment_id,
+                    configuration_id, configuration_version,
+                    owner, purpose, lifecycle_state, state_version
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setString(1, registration.identity.workloadId.value)
+                statement.setString(2, registration.identity.environmentId.value)
+                statement.setString(3, registration.identity.deploymentId.value)
+                statement.setString(4, configurationId)
+                statement.setString(5, configurationVersion)
+                statement.setString(6, registration.metadata.owner)
+                statement.setString(7, registration.metadata.purpose)
+                statement.setString(8, registration.lifecycle.name)
+                statement.setLong(9, registration.stateVersion.value)
+                statement.executeUpdate()
+            }
+        conn.commit()
+        return CreateResult.Created(registration)
+    }
+
+    /** Runs on a fresh connection (the failed transaction is aborted). */
+    private fun classifyExisting(registration: RegisteredWorkload): CreateResult {
+        val scope = registration.identity
+        val existing =
+            readScope(scope.workloadId, scope.environmentId, scope.deploymentId)
+                ?: error("Unique violation reported but no registration exists for the scope")
+        return if (existing.isSameDeclaration(registration)) {
+            CreateResult.Idempotent(existing)
+        } else {
+            CreateResult.Conflicting(existing, RegistrationConflictReason.CONFLICTING_REGISTRATION)
+        }
+    }
+
+    private fun boundRegistrationFor(
+        configurationId: String,
+        configurationVersion: String,
+    ): RegisteredWorkload =
+        dataSource.connection.use { conn ->
+            conn
+                .prepareStatement(
+                    """
+                    SELECT r.workload_id, r.environment_id, r.deployment_id,
+                           r.configuration_id, r.configuration_version,
+                           cr.fingerprint,
+                           r.owner, r.purpose, r.lifecycle_state, r.state_version
+                    FROM tramai_workload_registration r
+                    JOIN tramai_configuration_revision cr
+                      ON cr.configuration_id = r.configuration_id
+                     AND cr.configuration_version = r.configuration_version
+                    WHERE r.configuration_id = ? AND r.configuration_version = ?
+                    ORDER BY r.workload_id, r.environment_id, r.deployment_id
+                    LIMIT 1
+                    """.trimIndent(),
+                ).use { statement ->
+                    statement.setString(1, configurationId)
+                    statement.setString(2, configurationVersion)
+                    statement.executeQuery().use { rs ->
+                        if (rs.next()) {
+                            rs.toRegisteredWorkload()
+                        } else {
+                            error("Configuration binding exists without an owning registration")
+                        }
+                    }
+                }
+        }
+
+    override suspend fun compareAndSet(
+        expected: RegisteredWorkload,
+        updated: RegisteredWorkload,
+    ): Boolean =
+        withSafeJdbc(
+            {
+                "Database operation failed while updating workload registration " +
+                    "${expected.identity.workloadId.value}/${expected.identity.environmentId.value}/${expected.identity.deploymentId.value}"
+            },
+        ) {
+            val scope = expected.identity
+            require(updated.identity == scope) {
+                "compareAndSet must not change the deployment scope of a registration"
+            }
+            dataSource.connection.use { conn ->
+                conn
+                    .prepareStatement(
+                        """
+                        UPDATE tramai_workload_registration
+                        SET configuration_id = ?, configuration_version = ?,
+                            owner = ?, purpose = ?, lifecycle_state = ?, state_version = ?
+                        WHERE workload_id = ? AND environment_id = ? AND deployment_id = ?
+                          AND state_version = ?
+                        """.trimIndent(),
+                    ).use { statement ->
+                        statement.setString(1, updated.identity.configuration.id.value)
+                        statement.setString(2, updated.identity.configuration.version.value)
+                        statement.setString(3, updated.metadata.owner)
+                        statement.setString(4, updated.metadata.purpose)
+                        statement.setString(5, updated.lifecycle.name)
+                        statement.setLong(6, updated.stateVersion.value)
+                        statement.setString(7, scope.workloadId.value)
+                        statement.setString(8, scope.environmentId.value)
+                        statement.setString(9, scope.deploymentId.value)
+                        statement.setLong(10, expected.stateVersion.value)
+                        statement.executeUpdate() == 1
+                    }
+            }
+        }
+
+    private fun ResultSet.toRegisteredWorkload(): RegisteredWorkload =
+        RegisteredWorkload(
+            identity =
+                WorkloadDeploymentIdentity(
+                    workloadId = WorkloadId(getString("workload_id")),
+                    configuration =
+                        WorkloadConfigurationIdentity(
+                            id = ConfigurationId(getString("configuration_id")),
+                            version = ConfigurationVersion(getString("configuration_version")),
+                        ),
+                    environmentId = EnvironmentId(getString("environment_id")),
+                    deploymentId = DeploymentId(getString("deployment_id")),
+                ),
+            configurationFingerprint = ConfigurationFingerprint(getString("fingerprint")),
+            metadata =
+                WorkloadMetadata(
+                    owner = getString("owner"),
+                    purpose = getString("purpose"),
+                ),
+            lifecycle = WorkloadLifecycleState.valueOf(getString("lifecycle_state")),
+            stateVersion = WorkloadStateVersion(getLong("state_version")),
+        )
+
+    private fun Connection.rollbackQuietly() {
+        runCatching { rollback() }
+    }
+
+    private fun Connection.closeQuietly() {
+        runCatching { close() }
+    }
+
+    private fun isUniqueViolation(e: SQLException): Boolean = e.sqlState == "23505"
+
+    private fun RegisteredWorkload.isSameDeclaration(other: RegisteredWorkload): Boolean =
+        identity == other.identity &&
+            configurationFingerprint == other.configurationFingerprint &&
+            metadata == other.metadata
+}

--- a/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcWorkloadRegistrationStore.kt
+++ b/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcWorkloadRegistrationStore.kt
@@ -210,7 +210,10 @@ class JdbcWorkloadRegistrationStore(
                     statement.setString(index++, expected.identity.workloadId.value)
                     statement.setString(index++, expected.identity.environmentId.value)
                     statement.setString(index++, expected.identity.deploymentId.value)
-                    statement.setLong(index, expected.stateVersion.value)
+                    statement.setString(index++, expected.identity.configuration.id.value)
+                    statement.setString(index++, expected.identity.configuration.version.value)
+                    statement.setLong(index++, expected.stateVersion.value)
+                    statement.setString(index, expected.configurationFingerprint.value)
                     statement.executeUpdate() == 1
                 }
             }
@@ -317,7 +320,15 @@ private const val UPDATE_WORKLOAD_REGISTRATION =
     UPDATE tramai_workload_registration
     SET owner = ?, purpose = ?, lifecycle_state = ?, state_version = ?
     WHERE workload_id = ? AND environment_id = ? AND deployment_id = ?
+      AND configuration_id = ? AND configuration_version = ?
       AND state_version = ?
+      AND EXISTS (
+          SELECT 1
+          FROM tramai_configuration_revision cr
+          WHERE cr.configuration_id = tramai_workload_registration.configuration_id
+            AND cr.configuration_version = tramai_workload_registration.configuration_version
+            AND cr.fingerprint = ?
+      )
     """
 
 private const val SELECT_REGISTRATION_WHERE_SCOPE =

--- a/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcWorkloadRegistrationStore.kt
+++ b/tramai-persistence-jdbc/src/main/kotlin/dev/tramai/persistence/jdbc/JdbcWorkloadRegistrationStore.kt
@@ -16,6 +16,7 @@ import dev.tramai.core.identity.WorkloadDeploymentIdentity
 import dev.tramai.core.identity.WorkloadId
 import dev.tramai.core.identity.WorkloadMetadata
 import java.sql.Connection
+import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.sql.SQLException
 import javax.sql.DataSource
@@ -40,7 +41,12 @@ import javax.sql.DataSource
  *
  * The store never implements authority rules; it only stores what
  * [dev.tramai.controlplane.WorkloadRegistrationAuthority] decides.
+ *
+ * TooManyFunctions: the class carries the persistence-SPI surface plus small
+ * per-query resource/row helpers; splitting them into a separate helper class
+ * would spread one storage concern across files.
  */
+@Suppress("TooManyFunctions")
 class JdbcWorkloadRegistrationStore(
     private val dataSource: DataSource,
 ) : WorkloadRegistrationStore {
@@ -58,126 +64,99 @@ class JdbcWorkloadRegistrationStore(
         environmentId: EnvironmentId,
         deploymentId: DeploymentId,
     ): RegisteredWorkload? =
-        dataSource.connection.use { conn ->
-            conn
-                .prepareStatement(
-                    """
-                    SELECT r.workload_id, r.environment_id, r.deployment_id,
-                           r.configuration_id, r.configuration_version,
-                           cr.fingerprint,
-                           r.owner, r.purpose, r.lifecycle_state, r.state_version
-                    FROM tramai_workload_registration r
-                    JOIN tramai_configuration_revision cr
-                      ON cr.configuration_id = r.configuration_id
-                     AND cr.configuration_version = r.configuration_version
-                    WHERE r.workload_id = ? AND r.environment_id = ? AND r.deployment_id = ?
-                    """.trimIndent(),
-                ).use { statement ->
-                    statement.setString(1, workloadId.value)
-                    statement.setString(2, environmentId.value)
-                    statement.setString(3, deploymentId.value)
-                    statement.executeQuery().use { rs ->
-                        if (rs.next()) rs.toRegisteredWorkload() else null
-                    }
-                }
+        queryRegistration(SELECT_REGISTRATION_WHERE_SCOPE) { statement ->
+            var index = 1
+            statement.setString(index++, workloadId.value)
+            statement.setString(index++, environmentId.value)
+            statement.setString(index, deploymentId.value)
         }
 
     override suspend fun create(registration: RegisteredWorkload): CreateResult =
         withSafeJdbc(
             {
                 "Database operation failed while registering workload " +
-                    "${registration.identity.workloadId.value} in " +
+                    "${registration.identity.workloadId.value}/" +
                     "${registration.identity.environmentId.value}/${registration.identity.deploymentId.value}"
             },
         ) {
-            var connection: Connection? = null
+            val connection = dataSource.connection
             try {
-                connection = dataSource.connection
                 connection.autoCommit = false
-                createWithinTransaction(connection, registration)
+                ensureConfigurationBinding(connection, registration)?.let { return@withSafeJdbc it }
+                insertRegistration(connection, registration)
+                connection.commit()
+                CreateResult.Created(registration)
             } catch (e: SQLException) {
-                connection?.rollbackQuietly()
+                connection.rollbackQuietly()
                 if (isUniqueViolation(e)) {
                     // Scope already registered — classify on a fresh connection.
-                    return@withSafeJdbc classifyExisting(registration)
+                    classifyExisting(registration)
+                } else {
+                    throw e
                 }
-                throw e
             } finally {
-                connection?.closeQuietly()
+                connection.closeQuietly()
             }
         }
 
-    private fun createWithinTransaction(
+    /**
+     * Establishes the global configuration binding (insert-if-absent) and
+     * verifies it cannot be rebound. Returns a [CreateResult.Conflicting]
+     * when the pair is already bound to a different fingerprint; null when the
+     * binding matches and registration may proceed.
+     */
+    private fun ensureConfigurationBinding(
         conn: Connection,
         registration: RegisteredWorkload,
-    ): CreateResult {
+    ): CreateResult? {
         val configurationId = registration.identity.configuration.id.value
         val configurationVersion = registration.identity.configuration.version.value
+        val requestedFingerprint = registration.configurationFingerprint.value
 
-        // 1) Establish the global configuration binding if absent.
-        conn
-            .prepareStatement(
-                """
-                INSERT INTO tramai_configuration_revision (configuration_id, configuration_version, fingerprint)
-                VALUES (?, ?, ?)
-                ON CONFLICT (configuration_id, configuration_version) DO NOTHING
-                """.trimIndent(),
-            ).use { statement ->
-                statement.setString(1, configurationId)
-                statement.setString(2, configurationVersion)
-                statement.setString(3, registration.configurationFingerprint.value)
-                statement.executeUpdate()
-            }
+        conn.prepareStatement(INSERT_CONFIGURATION_REVISION).use { statement ->
+            var index = 1
+            statement.setString(index++, configurationId)
+            statement.setString(index++, configurationVersion)
+            statement.setString(index, requestedFingerprint)
+            statement.executeUpdate()
+        }
 
-        // 2) Verify the binding: a (configurationId, version) pair can never be
-        //    rebound to a different fingerprint.
-        conn
-            .prepareStatement(
-                """
-                SELECT fingerprint FROM tramai_configuration_revision
-                WHERE configuration_id = ? AND configuration_version = ?
-                """.trimIndent(),
-            ).use { statement ->
-                statement.setString(1, configurationId)
-                statement.setString(2, configurationVersion)
+        val boundFingerprint =
+            conn.prepareStatement(SELECT_CONFIGURATION_FINGERPRINT).use { statement ->
+                var index = 1
+                statement.setString(index++, configurationId)
+                statement.setString(index, configurationVersion)
                 statement.executeQuery().use { rs ->
-                    if (rs.next()) {
-                        val boundFingerprint = rs.getString(1)
-                        if (boundFingerprint != registration.configurationFingerprint.value) {
-                            conn.rollbackQuietly()
-                            return CreateResult.Conflicting(
-                                existing = boundRegistrationFor(configurationId, configurationVersion),
-                                reason = RegistrationConflictReason.CONFIGURATION_REBINDING,
-                            )
-                        }
-                    }
+                    if (rs.next()) rs.getString(1) else requestedFingerprint
                 }
             }
+        if (boundFingerprint != requestedFingerprint) {
+            conn.rollbackQuietly()
+            return CreateResult.Conflicting(
+                existing = boundRegistrationFor(configurationId, configurationVersion),
+                reason = RegistrationConflictReason.CONFIGURATION_REBINDING,
+            )
+        }
+        return null
+    }
 
-        // 3) Insert the registration for the deployment scope.
-        conn
-            .prepareStatement(
-                """
-                INSERT INTO tramai_workload_registration (
-                    workload_id, environment_id, deployment_id,
-                    configuration_id, configuration_version,
-                    owner, purpose, lifecycle_state, state_version
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """.trimIndent(),
-            ).use { statement ->
-                statement.setString(1, registration.identity.workloadId.value)
-                statement.setString(2, registration.identity.environmentId.value)
-                statement.setString(3, registration.identity.deploymentId.value)
-                statement.setString(4, configurationId)
-                statement.setString(5, configurationVersion)
-                statement.setString(6, registration.metadata.owner)
-                statement.setString(7, registration.metadata.purpose)
-                statement.setString(8, registration.lifecycle.name)
-                statement.setLong(9, registration.stateVersion.value)
-                statement.executeUpdate()
-            }
-        conn.commit()
-        return CreateResult.Created(registration)
+    private fun insertRegistration(
+        conn: Connection,
+        registration: RegisteredWorkload,
+    ) {
+        conn.prepareStatement(INSERT_WORKLOAD_REGISTRATION).use { statement ->
+            var index = 1
+            statement.setString(index++, registration.identity.workloadId.value)
+            statement.setString(index++, registration.identity.environmentId.value)
+            statement.setString(index++, registration.identity.deploymentId.value)
+            statement.setString(index++, registration.identity.configuration.id.value)
+            statement.setString(index++, registration.identity.configuration.version.value)
+            statement.setString(index++, registration.metadata.owner)
+            statement.setString(index++, registration.metadata.purpose)
+            statement.setString(index++, registration.lifecycle.name)
+            statement.setLong(index, registration.stateVersion.value)
+            statement.executeUpdate()
+        }
     }
 
     /** Runs on a fresh connection (the failed transaction is aborted). */
@@ -196,75 +175,81 @@ class JdbcWorkloadRegistrationStore(
     private fun boundRegistrationFor(
         configurationId: String,
         configurationVersion: String,
-    ): RegisteredWorkload =
-        dataSource.connection.use { conn ->
-            conn
-                .prepareStatement(
-                    """
-                    SELECT r.workload_id, r.environment_id, r.deployment_id,
-                           r.configuration_id, r.configuration_version,
-                           cr.fingerprint,
-                           r.owner, r.purpose, r.lifecycle_state, r.state_version
-                    FROM tramai_workload_registration r
-                    JOIN tramai_configuration_revision cr
-                      ON cr.configuration_id = r.configuration_id
-                     AND cr.configuration_version = r.configuration_version
-                    WHERE r.configuration_id = ? AND r.configuration_version = ?
-                    ORDER BY r.workload_id, r.environment_id, r.deployment_id
-                    LIMIT 1
-                    """.trimIndent(),
-                ).use { statement ->
-                    statement.setString(1, configurationId)
-                    statement.setString(2, configurationVersion)
-                    statement.executeQuery().use { rs ->
-                        if (rs.next()) {
-                            rs.toRegisteredWorkload()
-                        } else {
-                            error("Configuration binding exists without an owning registration")
-                        }
-                    }
-                }
+    ): RegisteredWorkload {
+        val registration =
+            queryRegistration(SELECT_REGISTRATION_WHERE_CONFIGURATION) { statement ->
+                var index = 1
+                statement.setString(index++, configurationId)
+                statement.setString(index, configurationVersion)
+            }
+        return checkNotNull(registration) {
+            "Configuration binding exists without an owning registration"
         }
+    }
 
     override suspend fun compareAndSet(
         expected: RegisteredWorkload,
         updated: RegisteredWorkload,
-    ): Boolean =
-        withSafeJdbc(
-            {
-                "Database operation failed while updating workload registration " +
-                    "${expected.identity.workloadId.value}/${expected.identity.environmentId.value}/${expected.identity.deploymentId.value}"
-            },
+    ): Boolean {
+        require(updated.identity == expected.identity) {
+            "compareAndSet must not change registration identity"
+        }
+        require(updated.configurationFingerprint == expected.configurationFingerprint) {
+            "compareAndSet must not change configuration fingerprint"
+        }
+        return withSafeJdbc(
+            { "Database operation failed while updating workload registration " + expected.identity.scopeKey() },
         ) {
-            val scope = expected.identity
-            require(updated.identity == scope) {
-                "compareAndSet must not change the deployment scope of a registration"
-            }
             dataSource.connection.use { conn ->
-                conn
-                    .prepareStatement(
-                        """
-                        UPDATE tramai_workload_registration
-                        SET configuration_id = ?, configuration_version = ?,
-                            owner = ?, purpose = ?, lifecycle_state = ?, state_version = ?
-                        WHERE workload_id = ? AND environment_id = ? AND deployment_id = ?
-                          AND state_version = ?
-                        """.trimIndent(),
-                    ).use { statement ->
-                        statement.setString(1, updated.identity.configuration.id.value)
-                        statement.setString(2, updated.identity.configuration.version.value)
-                        statement.setString(3, updated.metadata.owner)
-                        statement.setString(4, updated.metadata.purpose)
-                        statement.setString(5, updated.lifecycle.name)
-                        statement.setLong(6, updated.stateVersion.value)
-                        statement.setString(7, scope.workloadId.value)
-                        statement.setString(8, scope.environmentId.value)
-                        statement.setString(9, scope.deploymentId.value)
-                        statement.setLong(10, expected.stateVersion.value)
-                        statement.executeUpdate() == 1
-                    }
+                conn.prepareStatement(UPDATE_WORKLOAD_REGISTRATION).use { statement ->
+                    var index = 1
+                    statement.setString(index++, updated.metadata.owner)
+                    statement.setString(index++, updated.metadata.purpose)
+                    statement.setString(index++, updated.lifecycle.name)
+                    statement.setLong(index++, updated.stateVersion.value)
+                    statement.setString(index++, expected.identity.workloadId.value)
+                    statement.setString(index++, expected.identity.environmentId.value)
+                    statement.setString(index++, expected.identity.deploymentId.value)
+                    statement.setLong(index, expected.stateVersion.value)
+                    statement.executeUpdate() == 1
+                }
             }
         }
+    }
+
+    /**
+     * Executes a registration SELECT with the given parameter binder and maps
+     * the first row, or null when no row matches. Resource handling is
+     * sequential try/finally so nesting stays flat.
+     */
+    private fun queryRegistration(
+        selectSql: String,
+        bind: (PreparedStatement) -> Unit,
+    ): RegisteredWorkload? {
+        val connection = dataSource.connection
+        connection.use { conn ->
+            return queryOnConnection(conn, selectSql, bind)
+        }
+    }
+
+    private fun queryOnConnection(
+        conn: Connection,
+        selectSql: String,
+        bind: (PreparedStatement) -> Unit,
+    ): RegisteredWorkload? =
+        conn.prepareStatement(selectSql).use { statement ->
+            bind(statement)
+            statement.executeQuery().use { rs ->
+                if (rs.next()) rs.toRegisteredWorkload() else null
+            }
+        }
+
+    private fun WorkloadDeploymentIdentity.scopeKey(): String {
+        val workload = workloadId.value
+        val environment = environmentId.value
+        val deployment = deploymentId.value
+        return "$workload/$environment/$deployment"
+    }
 
     private fun ResultSet.toRegisteredWorkload(): RegisteredWorkload =
         RegisteredWorkload(
@@ -304,3 +289,61 @@ class JdbcWorkloadRegistrationStore(
             configurationFingerprint == other.configurationFingerprint &&
             metadata == other.metadata
 }
+
+private const val INSERT_CONFIGURATION_REVISION =
+    """
+    INSERT INTO tramai_configuration_revision (configuration_id, configuration_version, fingerprint)
+    VALUES (?, ?, ?)
+    ON CONFLICT (configuration_id, configuration_version) DO NOTHING
+    """
+
+private const val SELECT_CONFIGURATION_FINGERPRINT =
+    """
+    SELECT fingerprint FROM tramai_configuration_revision
+    WHERE configuration_id = ? AND configuration_version = ?
+    """
+
+private const val INSERT_WORKLOAD_REGISTRATION =
+    """
+    INSERT INTO tramai_workload_registration (
+        workload_id, environment_id, deployment_id,
+        configuration_id, configuration_version,
+        owner, purpose, lifecycle_state, state_version
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """
+
+private const val UPDATE_WORKLOAD_REGISTRATION =
+    """
+    UPDATE tramai_workload_registration
+    SET owner = ?, purpose = ?, lifecycle_state = ?, state_version = ?
+    WHERE workload_id = ? AND environment_id = ? AND deployment_id = ?
+      AND state_version = ?
+    """
+
+private const val SELECT_REGISTRATION_WHERE_SCOPE =
+    """
+    SELECT r.workload_id, r.environment_id, r.deployment_id,
+           r.configuration_id, r.configuration_version,
+           cr.fingerprint,
+           r.owner, r.purpose, r.lifecycle_state, r.state_version
+    FROM tramai_workload_registration r
+    JOIN tramai_configuration_revision cr
+      ON cr.configuration_id = r.configuration_id
+     AND cr.configuration_version = r.configuration_version
+    WHERE r.workload_id = ? AND r.environment_id = ? AND r.deployment_id = ?
+    """
+
+private const val SELECT_REGISTRATION_WHERE_CONFIGURATION =
+    """
+    SELECT r.workload_id, r.environment_id, r.deployment_id,
+           r.configuration_id, r.configuration_version,
+           cr.fingerprint,
+           r.owner, r.purpose, r.lifecycle_state, r.state_version
+    FROM tramai_workload_registration r
+    JOIN tramai_configuration_revision cr
+      ON cr.configuration_id = r.configuration_id
+     AND cr.configuration_version = r.configuration_version
+    WHERE r.configuration_id = ? AND r.configuration_version = ?
+    ORDER BY r.workload_id, r.environment_id, r.deployment_id
+    LIMIT 1
+    """

--- a/tramai-persistence-jdbc/src/main/resources/tramai/persistence/jdbc/postgres/V8__control_plane_workload_registration.sql
+++ b/tramai-persistence-jdbc/src/main/resources/tramai/persistence/jdbc/postgres/V8__control_plane_workload_registration.sql
@@ -1,0 +1,44 @@
+-- Control-plane workload registration (Epic 0.7.1c)
+--
+-- Two tables:
+--   tramai_configuration_revision — global authority over
+--       (configuration_id, configuration_version) -> fingerprint. A pair can
+--       never be rebound to a different fingerprint, from any deployment.
+--   tramai_workload_registration — one authoritative registration per
+--       deployment scope (workload_id, environment_id, deployment_id), bound
+--       to the exact governed configuration revision.
+
+CREATE TABLE IF NOT EXISTS tramai_configuration_revision (
+    configuration_id      TEXT NOT NULL,
+    configuration_version TEXT NOT NULL,
+    fingerprint           TEXT NOT NULL,
+    PRIMARY KEY (configuration_id, configuration_version),
+    CONSTRAINT ck_configuration_revision_fingerprint CHECK (
+        length(fingerprint) BETWEEN 1 AND 128
+    )
+);
+
+CREATE TABLE IF NOT EXISTS tramai_workload_registration (
+    workload_id           TEXT NOT NULL,
+    environment_id        TEXT NOT NULL,
+    deployment_id         TEXT NOT NULL,
+    configuration_id      TEXT NOT NULL,
+    configuration_version TEXT NOT NULL,
+    owner                 TEXT NOT NULL,
+    purpose               TEXT NOT NULL,
+    lifecycle_state       TEXT NOT NULL,
+    state_version         BIGINT NOT NULL,
+    PRIMARY KEY (workload_id, environment_id, deployment_id),
+    CONSTRAINT fk_workload_registration_configuration
+        FOREIGN KEY (configuration_id, configuration_version)
+        REFERENCES tramai_configuration_revision (configuration_id, configuration_version),
+    CONSTRAINT ck_workload_registration_lifecycle CHECK (
+        lifecycle_state IN ('ACTIVE', 'SUSPENDED', 'RETIRED')
+    ),
+    CONSTRAINT ck_workload_registration_state_version CHECK (
+        state_version >= 1
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_workload_registration_configuration
+    ON tramai_workload_registration (configuration_id, configuration_version);

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcWorkloadRegistrationStoreTckTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcWorkloadRegistrationStoreTckTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
 import org.postgresql.ds.PGSimpleDataSource
-import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.postgresql.PostgreSQLContainer
 import javax.sql.DataSource
 
 /**
@@ -17,7 +17,7 @@ import javax.sql.DataSource
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class JdbcWorkloadRegistrationStoreTckTest : WorkloadRegistrationStoreTck() {
-    private lateinit var postgres: PostgreSQLContainer<*>
+    private lateinit var postgres: PostgreSQLContainer
     private lateinit var dataSource: DataSource
 
     @BeforeAll

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcWorkloadRegistrationStoreTckTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcWorkloadRegistrationStoreTckTest.kt
@@ -1,0 +1,84 @@
+package dev.tramai.persistence.jdbc
+
+import dev.tramai.controlplane.WorkloadRegistrationStore
+import dev.tramai.controlplane.testing.WorkloadRegistrationStoreTck
+import dev.tramai.controlplane.testing.WorkloadRegistrationStoreTckHarness
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import org.postgresql.ds.PGSimpleDataSource
+import org.testcontainers.containers.PostgreSQLContainer
+import javax.sql.DataSource
+
+/**
+ * The JDBC durable implementation must satisfy the shared
+ * [WorkloadRegistrationStore] contract (Epic 0.7.1c). The runner owns the
+ * datasource + schema; storage technology never contaminates the contract.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JdbcWorkloadRegistrationStoreTckTest : WorkloadRegistrationStoreTck() {
+    private lateinit var postgres: PostgreSQLContainer<*>
+    private lateinit var dataSource: DataSource
+
+    @BeforeAll
+    fun setUpAll() {
+        postgres =
+            PostgreSQLContainer("postgres:17-alpine")
+                .withDatabaseName("control_plane_tck")
+                .withUsername("test")
+                .withPassword("test")
+        postgres.start()
+        dataSource =
+            PGSimpleDataSource().apply {
+                setUrl(postgres.jdbcUrl)
+                user = postgres.username
+                password = postgres.password
+            }
+        executeSchema(dataSource)
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        runCatching { postgres.stop() }
+    }
+
+    override val harness =
+        object : WorkloadRegistrationStoreTckHarness {
+            override fun createStore(): WorkloadRegistrationStore {
+                // Fresh isolated storage per case.
+                dataSource.connection.use { conn ->
+                    conn.createStatement().use { stmt ->
+                        stmt.execute("DELETE FROM tramai_workload_registration")
+                        stmt.execute("DELETE FROM tramai_configuration_revision")
+                    }
+                }
+                return JdbcWorkloadRegistrationStore(dataSource)
+            }
+        }
+
+    companion object {
+        internal fun executeSchema(dataSource: DataSource) {
+            dataSource.connection.use { conn ->
+                val migrations =
+                    listOf(
+                        "V1__sovereign_persistence.sql",
+                        "V2__approval_continuations.sql",
+                        "V3__audit_events_hardening.sql",
+                        "V4__audit_outbox_hardening.sql",
+                        "V5__worker_leases_hardening.sql",
+                        "V6__approval_resume_credential_custody.sql",
+                        "V7__approval_continuations_resume_retry.sql",
+                        "V8__control_plane_workload_registration.sql",
+                    )
+                for (migration in migrations) {
+                    val sql =
+                        JdbcWorkloadRegistrationStoreTckTest::class.java.classLoader
+                            .getResource("tramai/persistence/jdbc/postgres/$migration")
+                            ?.readText()
+                            ?: throw IllegalStateException("Schema SQL resource not found: $migration")
+                    conn.createStatement().use { stmt -> stmt.execute(sql) }
+                }
+            }
+        }
+    }
+}

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcWorkloadRegistrationStoreTckTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcWorkloadRegistrationStoreTckTest.kt
@@ -75,7 +75,7 @@ class JdbcWorkloadRegistrationStoreTckTest : WorkloadRegistrationStoreTck() {
                         JdbcWorkloadRegistrationStoreTckTest::class.java.classLoader
                             .getResource("tramai/persistence/jdbc/postgres/$migration")
                             ?.readText()
-                            ?: throw IllegalStateException("Schema SQL resource not found: $migration")
+                            ?: error("Schema SQL resource not found: $migration")
                     conn.createStatement().use { stmt -> stmt.execute(sql) }
                 }
             }

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcWorkloadRegistrationStoreTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcWorkloadRegistrationStoreTest.kt
@@ -1,0 +1,196 @@
+package dev.tramai.persistence.jdbc
+
+import dev.tramai.controlplane.ConfigurationFingerprint
+import dev.tramai.controlplane.CreateResult
+import dev.tramai.controlplane.RegisteredWorkload
+import dev.tramai.controlplane.RegistrationConflictReason
+import dev.tramai.controlplane.WorkloadLifecycleState
+import dev.tramai.controlplane.WorkloadRegistrationAuthority
+import dev.tramai.controlplane.WorkloadRegistrationStore
+import dev.tramai.controlplane.WorkloadStateVersion
+import dev.tramai.controlplane.testing.WorkloadRegistrationFixtures
+import dev.tramai.controlplane.testing.runInParallel
+import dev.tramai.core.identity.WorkloadMetadata
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.postgresql.ds.PGSimpleDataSource
+import org.testcontainers.containers.PostgreSQLContainer
+import javax.sql.DataSource
+
+/**
+ * JDBC-specific proofs the shared TCK cannot show: durability across store
+ * instances (restart), configuration-rebinding enforcement between two
+ * independent JDBC stores on the same database, and DB-level atomic create
+ * races across store instances.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JdbcWorkloadRegistrationStoreTest {
+    private lateinit var postgres: PostgreSQLContainer<*>
+    private lateinit var dataSource: DataSource
+
+    private fun newStore(): WorkloadRegistrationStore = JdbcWorkloadRegistrationStore(dataSource)
+
+    @BeforeAll
+    fun setUpAll() {
+        postgres =
+            PostgreSQLContainer("postgres:17-alpine")
+                .withDatabaseName("control_plane_test")
+                .withUsername("test")
+                .withPassword("test")
+        postgres.start()
+        dataSource =
+            PGSimpleDataSource().apply {
+                setUrl(postgres.jdbcUrl)
+                user = postgres.username
+                password = postgres.password
+            }
+        JdbcWorkloadRegistrationStoreTckTest.executeSchema(dataSource)
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        runCatching { postgres.stop() }
+    }
+
+    private fun wipe() {
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.execute("DELETE FROM tramai_workload_registration")
+                stmt.execute("DELETE FROM tramai_configuration_revision")
+            }
+        }
+    }
+
+    @Test
+    fun `registration state survives store restart`() =
+        runBlocking<Unit> {
+            wipe()
+            val identity = WorkloadRegistrationFixtures.identity()
+            val registration = WorkloadRegistrationFixtures.registration(identity = identity)
+            assertThat(newStore().create(registration)).isInstanceOf(CreateResult.Created::class.java)
+
+            // A brand-new store instance over the same database is a restart.
+            val restarted = newStore()
+            assertThat(
+                restarted.find(identity.workloadId, identity.environmentId, identity.deploymentId),
+            ).isEqualTo(registration)
+
+            // Authority rules survive the restart too.
+            val authority = WorkloadRegistrationAuthority(newStore())
+            val outcome =
+                authority.updateMetadata(
+                    identity.workloadId,
+                    identity.environmentId,
+                    identity.deploymentId,
+                    WorkloadStateVersion.INITIAL,
+                    WorkloadMetadata(owner = "Restart Team", purpose = "Fraud review"),
+                )
+            assertThat(outcome).isInstanceOf(dev.tramai.controlplane.MetadataUpdateOutcome.Applied::class.java)
+        }
+
+    @Test
+    fun `configuration rebinding is rejected across independent JDBC stores`() =
+        runBlocking<Unit> {
+            wipe()
+            val first = WorkloadRegistrationFixtures.identity(deployment = "eu-west-amsterdam-01")
+            val second = WorkloadRegistrationFixtures.identity(deployment = "eu-central-frankfurt-01")
+            assertThat(
+                newStore().create(WorkloadRegistrationFixtures.registration(identity = first)),
+            ).isInstanceOf(CreateResult.Created::class.java)
+
+            // A DIFFERENT store instance attempts the same (config, version) with a
+            // different fingerprint: database-level authority rejects it.
+            val result =
+                newStore().create(
+                    WorkloadRegistrationFixtures.registration(
+                        identity = second,
+                        configurationFingerprint = ConfigurationFingerprint("sha256:ffff"),
+                    ),
+                )
+
+            assertThat(result).isInstanceOf(CreateResult.Conflicting::class.java)
+            result as CreateResult.Conflicting
+            assertThat(result.reason).isEqualTo(RegistrationConflictReason.CONFIGURATION_REBINDING)
+        }
+
+    @Test
+    fun `concurrent creates across two store instances yield one authoritative outcome`() =
+        runBlocking<Unit> {
+            repeat(5) { iteration ->
+                wipe()
+                val identity = WorkloadRegistrationFixtures.identity(deployment = "race-$iteration")
+                val registration = WorkloadRegistrationFixtures.registration(identity = identity)
+
+                val results =
+                    runInParallel(
+                        { newStore().create(registration) },
+                        { newStore().create(registration) },
+                    )
+
+                val created = results.filterIsInstance<CreateResult.Created>()
+                val idempotent = results.filterIsInstance<CreateResult.Idempotent>()
+                assertThat(created.size).isEqualTo(1)
+                assertThat(created.size + idempotent.size).isEqualTo(2)
+            }
+        }
+
+    @Test
+    fun `registration is never silently replaced across store instances`() =
+        runBlocking<Unit> {
+            wipe()
+            val identity = WorkloadRegistrationFixtures.identity()
+            val original = WorkloadRegistrationFixtures.registration(identity = identity)
+            newStore().create(original)
+
+            // A second store tries to claim the same scope with a different
+            // configuration version: must conflict, never overwrite.
+            val conflicting =
+                WorkloadRegistrationFixtures.registration(
+                    identity = WorkloadRegistrationFixtures.identity(configurationVersion = "99"),
+                )
+            val result = newStore().create(conflicting)
+
+            assertThat(result).isInstanceOf(CreateResult.Conflicting::class.java)
+            result as CreateResult.Conflicting
+            assertThat(result.reason).isEqualTo(RegistrationConflictReason.CONFLICTING_REGISTRATION)
+            assertThat(
+                newStore().find(identity.workloadId, identity.environmentId, identity.deploymentId),
+            ).isEqualTo(original)
+        }
+
+    @Test
+    fun `retired registration remains terminal after restart`() =
+        runBlocking<Unit> {
+            wipe()
+            val identity = WorkloadRegistrationFixtures.identity()
+            newStore().create(WorkloadRegistrationFixtures.registration(identity = identity))
+            val authority = WorkloadRegistrationAuthority(newStore())
+            authority.transitionLifecycle(
+                identity.workloadId,
+                identity.environmentId,
+                identity.deploymentId,
+                WorkloadStateVersion.INITIAL,
+                WorkloadLifecycleState.RETIRED,
+            )
+
+            val resurrectedAuthority = WorkloadRegistrationAuthority(newStore())
+            val restarted =
+                resurrectedAuthority.transitionLifecycle(
+                    identity.workloadId,
+                    identity.environmentId,
+                    identity.deploymentId,
+                    WorkloadStateVersion(2),
+                    WorkloadLifecycleState.ACTIVE,
+                )
+
+            assertThat(restarted)
+                .isInstanceOf(dev.tramai.controlplane.LifecycleTransitionOutcome.InvalidTransition::class.java)
+            val record = newStore().find(identity.workloadId, identity.environmentId, identity.deploymentId)
+            assertThat(record?.lifecycle).isEqualTo(WorkloadLifecycleState.RETIRED)
+            assertThat(record?.stateVersion).isEqualTo(WorkloadStateVersion(2))
+        }
+}

--- a/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcWorkloadRegistrationStoreTest.kt
+++ b/tramai-persistence-jdbc/src/test/kotlin/dev/tramai/persistence/jdbc/JdbcWorkloadRegistrationStoreTest.kt
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.postgresql.ds.PGSimpleDataSource
-import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.postgresql.PostgreSQLContainer
 import javax.sql.DataSource
 
 /**
@@ -29,7 +29,7 @@ import javax.sql.DataSource
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class JdbcWorkloadRegistrationStoreTest {
-    private lateinit var postgres: PostgreSQLContainer<*>
+    private lateinit var postgres: PostgreSQLContainer
     private lateinit var dataSource: DataSource
 
     private fun newStore(): WorkloadRegistrationStore = JdbcWorkloadRegistrationStore(dataSource)


### PR DESCRIPTION
## Purpose

Implement candidate 0.7.1c of Epic 0.7.1: the first canonical MUTABLE authority of the 0.7 control plane — an authoritative workload-registration boundary that binds the immutable 0.7.1b identity to a governed-configuration fingerprint, safe owner/purpose metadata, a registration lifecycle and a monotonic state version, with durable atomic storage semantics. No runtime propagation and no REST API yet (0.7.1d/0.7.1e).

## Scope

- Change class: `public-api` (additive; no breaking change), plus new-module registration
- Branch: `task/0.7.1c-authoritative-registration` → `epic/0.7.1-control-plane-authority`
- New published module `tramai-control-plane` (depends ONLY on `tramai-core`):
  - `dev.tramai.controlplane` — `RegisteredWorkload`, `ConfigurationFingerprint`, `WorkloadLifecycleState`, `WorkloadStateVersion`, `WorkloadRegistrationStore` (find/atomic create/atomic compareAndSet), `WorkloadRegistrationAuthority` (rules state machine), `InMemoryWorkloadRegistrationStore` (reference)
  - testFixtures `WorkloadRegistrationStoreTck` + harness + fixtures (shared store contract)
- `tramai-persistence-jdbc`: `JdbcWorkloadRegistrationStore` + migration `V8__control_plane_workload_registration.sql` (two tables: global configuration-revision binding + one registration per deployment scope, DB-level PK/CHECK/FK authority)
- Registration wiring: `settings.gradle.kts`, `config/quality/module-catalog.yml`, generated `docs/reference/module-matrix.md`
- Docs: `docs/modules/tramai-control-plane.md`, module card updates, `docs/roadmap/0.7.0/TASK-0.7.1c-...`, Epic status line

## Behavioural Contract

Authoritative registration rules (all in `WorkloadRegistrationAuthority`, never in stores): registration is NOT an upsert — identical declaration is idempotent, conflicting declaration is a typed rejection; a `(configurationId, version)` pair can never be rebound to a different fingerprint from ANY deployment scope (global, DB-enforced); one deployment scope (`workloadId`+`environmentId`+`deploymentId`) has one registration; metadata/lifecycle mutations preserve identity and advance `WorkloadStateVersion` (starts 1, `addExact`-safe); every mutation is a version-guarded compare-and-set so stale writers lose. `WorkloadLifecycleState` is ACTIVE/SUSPENDED/RETIRED, RETIRED terminal; suspending never cancels runs.

## Architecture Impact

- [x] No new dependency edge outside the declared direction: `tramai-core → tramai-control-plane → tramai-persistence-jdbc` (adapters depend toward the authority contract)
- [x] Core does not depend on an adapter/framework
- [x] No ownership/lifecycle change to existing authorities — `WorkflowRegistry` executable lookup is untouched
- [x] No global mutable state introduced
- [x] No duplicate of an existing authoritative model — this is the authority the 0.7.1a audit found missing; no JSON/attributes map (the untyped-metadata trap is avoided)

## Compatibility

- [x] Stable public API unchanged (additive only; existing declarations untouched)
- [x] Preview API unchanged
- [x] Persisted representation unchanged — new tables only (`V8` migration), no existing table/schema modified
- [x] Event/reason/error code unchanged
- [x] Configuration semantics unchanged

## Correctness & Concurrency

- [x] Cancellation behaviour unaffected (no runtime wiring; `withSafeJdbc` preserves coroutine cancellation)
- [x] Retry behaviour unaffected
- [x] Concurrency: covered by design (version-guarded CAS, explicit JDBC transactions, DB PK authority) and proven by races
- [x] Evidence/audit/telemetry emission unaffected
- [x] Change is replay-safe
- Contract tests: shared `WorkloadRegistrationStoreTck` (19 cases, incl. immutable-CAS rejection, immutable-witness CAS rejection, scope+version token semantics and concurrent-CAS race) run against BOTH stores; `WorkloadRegistrationAuthorityTest` (26 cases, incl. truthful stale-version assertions and Long.MAX_VALUE overflow-boundary coverage); `JdbcWorkloadRegistrationStoreTest` (5 JDBC durability/cross-instance cases)

## Verification

- [x] Review round (CAS immutability, truthful stale versions, static-analysis cleanup) addressed in `e1503d22` and `cd1191ce2` and the follow-up chore commit; all 3 Copilot threads replied and resolved
- [x] `./gradlew :tramai-control-plane:test` — passed (26 authority + 19 InMemory TCK)
- [x] `./gradlew :tramai-persistence-jdbc:test --tests "*WorkloadRegistration*"` — passed (19 JDBC TCK + 5 JDBC-specific, Postgres 17 testcontainers, migrations V1→V8)
- [x] `./gradlew generateModuleMatrix` + `spotlessCheck` — passed
- [x] `./gradlew :tramai-control-plane:apiCheck :tramai-persistence-jdbc:apiCheck` — passed (dumps additive and unchanged by the fix round)
- [x] `./gradlew :verifyStaticAnalysis` — **passed**: Detekt baseline OK (base 4793 → current 4793, 0 added); the 45 initial new findings were cleaned in code (documented class-level TCK suppression + production refactors), no baseline/config change
- [x] `./gradlew verifyChangePolicy -PchangeClass=public-api` — PASSED (no policy violations)
- [ ] `./gradlew verifyPr` — full local run not executed for this candidate; CI on the pushed head is the certifier (known local-only `build-logic` TestKit flake documented in prior candidates)

## Quality Impact

- [x] No baseline regeneration
- [x] No deviation ceiling increase
- [x] No quality gate weakened

## Remaining Risks

- Coverage/mutation baselines are module-scoped; a brand-new module's inclusion in CI baseline gates (critical coverage, maintainability) will be observed on this PR's exact-head run and handled without regenerating canonical baselines.
- `architectureContractEnrollmentTest` covers existing TCK families in `tramai-testing`; the 0.7.1c store contract deliberately lives in `tramai-control-plane` testFixtures (its own family registry), documented in the module card.

## Non-Claims

This PR does NOT:
- propagate identity into `WorkflowContext`/engine/approval/evidence/scheduler (0.7.1d);
- add REST query/mutation APIs, If-Match/ETag, or projection consistency classes (0.7.1e);
- define safe exposure categories (0.7.1f) or perform full Epic 0.7.1g mutation certification;
- replace `WorkflowRegistry`, cancel running workflows, or add arbitrary metadata maps.

This PR needs review before merge.

