### PR TITLE
docs(0.7.0): add governed provider-input DLP boundary

### DIFF
--- a/docs/ROADMAP-0.7.0-RELEASE-CUT.md
+++ b/docs/ROADMAP-0.7.0-RELEASE-CUT.md
@@ -20,9 +20,11 @@ After 0.7, an authorized operator can **see, understand, control, and reconstruc
 0.7.0 is successful when the following story is coherent end to end:
 
 ```text
-identify → classify → constrain → authorize → select → execute
+identify → classify → constrain → authorize → select → release → execute
         → evidence → observe → control → reconstruct
 ```
+
+Here `release` means the explicit governed decision about what exact provider-bound representation may cross the selected provider-deployment boundary. It is distinct from provider authorization: an otherwise authorized provider may still require input minimization before invocation.
 
 ---
 
@@ -51,13 +53,42 @@ Every independently governed execution surface in control-plane mode has authori
 
 Distinct deployments must not silently collapse into one authoritative identity.
 
-## P0.2 Classification before provider exposure
+## P0.2 Classification and governed provider-input release before provider exposure
 
 Classification is resolved before provider/model eligibility is finalized.
 
 Explicit stronger classifications cannot be silently downgraded by weaker signals.
 
 Unknown/missing classification state must not be interpreted as permissive where policy requires classification.
+
+For every selected provider deployment, TramAI must make an explicit provider-input data-release decision before invoking that provider. Provider authorization and data release are separate concerns:
+
+```text
+provider authorization: may this deployment/model be used?
+provider data release:  what exact representation may cross into it?
+```
+
+0.7.0 requires a narrow provider-request release/minimization boundary with typed semantics equivalent to at least:
+
+```text
+DENY
+ALLOW_RAW
+ALLOW_WITH_MINIMIZATION
+```
+
+The exact public API shape is an implementation decision, but the semantics are release-authoritative.
+
+Provider-specific minimization/redaction must derive a provider-bound projection from authoritative/canonical execution input. It must not mutate the authoritative/canonical workload input in place.
+
+```text
+providerBoundInput = projection(canonicalInput, selectedDeployment, effectivePolicy)
+```
+
+If retry/fallback changes the concrete provider deployment, TramAI must recompute the release decision and provider-bound projection for that deployment. A projection authorized or minimized for one trust boundary must not be silently reused for another.
+
+Where policy requires minimization/inspection, inability to perform it is fail-closed before provider invocation. Safe evidence may record rule/reason identifiers, counts, digests, or equivalent non-sensitive metadata, but must not persist raw matched sensitive values.
+
+This P0 slice does not require a generalized enterprise DLP platform across every tool, telemetry, persistence, or learning boundary. It establishes the missing provider-request enforcement point and an architecture seam that later releases can generalize without creating a second policy engine.
 
 ## P0.3 Named trust zones and provider-deployment identity
 
@@ -76,6 +107,8 @@ organization ∩ environment ∩ workload = effective policy
 ```
 
 A lower scope cannot silently widen a higher-level denial.
+
+Provider-input release/minimization obligations are derived from the same effective governance authority; they must not be implemented as a parallel policy system.
 
 ## P0.5 Policy-aware provider/model authorization and selection
 
@@ -111,10 +144,11 @@ The runtime emits typed evidence sufficient to explain supported decisions, incl
 - named zone/category;
 - authorization/rejection reason;
 - selected route and reason;
+- provider-input data-release/minimization outcome and safe rule/reason metadata;
 - relevant tool/approval decisions;
 - actor/control correlation.
 
-Raw sensitive payloads remain excluded by default.
+Raw sensitive payloads and raw DLP/minimization matches remain excluded by default.
 
 ## P0.7 Control-plane projection and query API
 
@@ -183,6 +217,7 @@ Minimum supported surface:
 - workload inventory/detail;
 - effective governance posture;
 - provider/model authorization and selection reasons where supported;
+- provider-input data-release/minimization outcome where supported, using safe metadata only;
 - semantic timeline;
 - approval/runtime state where applicable;
 - authorized lifecycle/control actions;
@@ -197,6 +232,10 @@ P0 behavior is protected by deterministic tests, compatibility/TCK coverage wher
 0.7.0 must not ship with a known bypass through:
 
 - classification timing;
+- provider-input release/minimization timing;
+- required minimization failure falling through to raw provider invocation;
+- reuse of a provider-bound projection after fallback/retry changes the selected deployment;
+- mutation of canonical input by provider-specific transformation;
 - policy composition;
 - provider selection/fallback;
 - stale projection presented as authority;
@@ -217,7 +256,7 @@ The following do **not** block 0.7.0 unless implementation proves that a narrow 
 ## Targeted primarily at 0.8.0 — Governance DX & Intelligence
 
 - Workflow DSL 2.0 and broad state/context ergonomics;
-- policy simulation / decision preview;
+- policy simulation / decision preview, including preview of the provider-bound representation a deployment would receive;
 - public deterministic policy replay;
 - developer-local governance debugger;
 - governance contract-testing UX;
@@ -236,6 +275,8 @@ See [`ROADMAP-0.8.0-GOVERNANCE-DX-AND-INTELLIGENCE.md`](ROADMAP-0.8.0-GOVERNANCE
 - Entra/Okta/Keycloak productized compatibility beyond generic OIDC;
 - native/direct SAML stack;
 - key rotation engine and broad KMS/Vault/HSM adapters;
+- enterprise DLP-vendor adapters and organization-wide DLP/control-plane integrations;
+- vault-backed/reversible tokenization services or enterprise secret-substitution infrastructure beyond the narrow P0 provider-input transformation contract;
 - Docker Compose reference product profile;
 - Helm packaging;
 - Kubernetes operator;
@@ -247,6 +288,7 @@ See [`ROADMAP-0.8.0-GOVERNANCE-DX-AND-INTELLIGENCE.md`](ROADMAP-0.8.0-GOVERNANCE
 - governed learning traces;
 - raw-content dataset capture/export;
 - evaluation/training dataset productization;
+- generalized learning-capture data-release/minimization policy beyond preserving the architecture seam in 0.7;
 - rich adaptive routing/FinOps optimization;
 - broad cost/latency/quality/capacity/budget strategies;
 - machine-learned routing;
@@ -294,6 +336,14 @@ Authorization, viability, and optimization remain semantically distinct so later
 
 Every P0 control-plane capability remains usable without Dashboard 2.0.
 
+## I. Trust-boundary data-release continuity
+
+0.7 provider-input minimization is modeled as a source → destination data-release decision bound to effective policy and concrete deployment identity, not as a one-off prompt sanitizer.
+
+The canonical/authoritative execution input remains distinct from provider-specific projections. Later tool-invocation, observability, learning-capture, and enterprise DLP capabilities may reuse/generalize this semantic boundary, but must not introduce a second governance authority.
+
+Existing model-output/tool-result DLP remains valid; 0.7 must preserve compatibility or provide an explicit migration path if implementation changes its public contracts.
+
 ---
 
 # 6. Critical dependency graph
@@ -316,19 +366,24 @@ E. AUTHORIZED CANDIDATE SET + REASON PATHS
 F. POLICY-CONSTRAINED SELECTION
                 │
                 ▼
-G. EXECUTION + AUTHORITATIVE EVIDENCE
+G. PROVIDER-INPUT DATA RELEASE / MINIMIZATION
                 │
                 ▼
-H. CONTROL-PLANE PROJECTION + QUERY API
+H. EXECUTION + AUTHORITATIVE EVIDENCE
+                │
+                ▼
+I. CONTROL-PLANE PROJECTION + QUERY API
                 │
         ┌───────┼───────────┐
         ▼       ▼           ▼
-I. TIMELINE  J. CONTROL  K. RECONSTRUCTION
+J. TIMELINE  K. CONTROL  L. RECONSTRUCTION
         │       │           │
         └───────┼───────────┘
                 ▼
-L. DASHBOARD 2.0 CORE
+M. DASHBOARD 2.0 CORE
 ```
+
+Classification/policy work may define provider-input release obligations before selection implementation is complete, but the concrete provider-bound projection is derived for the selected deployment immediately before invocation.
 
 ---
 
@@ -340,13 +395,15 @@ L. DASHBOARD 2.0 CORE
 2. Named trust zones/provider-deployment identity.
 3. Restrictive policy composition.
 4. Classification-before-exposure integration.
+5. Provider-input data-release/minimization contract: canonical input, provider-bound projection, typed release outcomes, fail-closed transformation semantics, safe evidence.
 
 ## Wave B — authoritative decisions
 
 1. Authorized candidate model.
 2. Stable rejection/selection reason families.
 3. Policy-constrained selection/fallback.
-4. Decision/configuration identity/digest where required for evidence.
+4. Provider-specific release/minimization integration immediately before invocation, including recomputation on provider-changing fallback/retry.
+5. Decision/configuration identity/digest where required for evidence.
 
 ## Wave C — evidence and control plane
 
@@ -385,7 +442,15 @@ Organization/environment/workload constraints composed
         ↓
 Authorized provider/model set calculated with reason paths
         ↓
-Only authorized routes may be selected/executed
+Only authorized routes may be selected
+        ↓
+Selected deployment receives an explicit data-release decision
+        ↓
+Required minimization derives a provider-bound projection
+without mutating canonical input
+        ↓
+Only the authorized provider-bound representation may cross
+into the provider invocation
         ↓
 Authoritative decision/evidence emitted
         ↓
@@ -415,6 +480,8 @@ Any proposal to add work to 0.7.0 must answer:
 3. Why is an architecture commitment insufficient?
 4. Why can implementation not move to 0.8.0 or later?
 
+For provider-input data release, the answer is that classification/routing alone can authorize a provider while still allowing raw sensitive values to cross that provider boundary. Because the current DLP contract is output/tool-result oriented, deferring the provider-request enforcement point would freeze an incomplete trust-boundary model into the 0.7 control-plane contract.
+
 If those questions do not have strong answers, the work does not belong in 0.7.0.
 
 ---
@@ -431,6 +498,7 @@ IDENTITY
   → EFFECTIVE POLICY
   → AUTHORIZED CANDIDATES
   → POLICY-CONSTRAINED SELECTION
+  → PROVIDER-INPUT DATA RELEASE / MINIMIZATION
   → EXECUTION
   → EVIDENCE
   → CONTROL PLANE
@@ -441,4 +509,4 @@ IDENTITY
   → DASHBOARD 2.0
 ```
 
-> **0.7.0 proves that governed AI execution can be operated, explained, controlled, and reconstructed. It does not attempt to finish every future governance capability.**
+> **0.7.0 proves that governed AI execution can be operated, explained, controlled, reconstructed, and prevented from crossing a provider trust boundary with an unauthorized data representation. It does not attempt to finish every future governance capability.**

--- a/docs/roadmap/0.7.0/EPIC-0.7.2-POLICY-TRUST-ZONES.md
+++ b/docs/roadmap/0.7.0/EPIC-0.7.2-POLICY-TRUST-ZONES.md
@@ -6,7 +6,7 @@
 
 ## Executive decision
 
-Resolve classification, concrete provider-deployment trust topology, and effective policy before provider/model exposure can become authorized.
+Resolve classification, concrete provider-deployment trust topology, effective policy, and the provider-bound data-release decision before a model invocation can cross a trust boundary. Authorization answers whether a provider may be used; the provider-input release boundary separately answers what exact representation of the governed input that provider may receive.
 
 ## Scope
 
@@ -16,6 +16,13 @@ Resolve classification, concrete provider-deployment trust topology, and effecti
 - provider-deployment identity distinct from provider brand;
 - named organization-defined trust zones plus portable `LOCAL`, `EU_CLOUD`, `GLOBAL_CLOUD` categories;
 - restrictive organization/environment/workload policy composition;
+- mandatory governed data-release checkpoint immediately before provider invocation;
+- distinguish authoritative/canonical execution input from the provider-bound projection derived for one selected deployment;
+- support at least `DENY`, `ALLOW_RAW`, and `ALLOW_WITH_MINIMIZATION` provider-input release outcomes, or semantically equivalent typed outcomes chosen during implementation;
+- apply required provider-input minimization/redaction without mutating authoritative/canonical workload state;
+- recompute the provider-bound projection for fallback/retry when the concrete provider deployment changes rather than reusing a projection authorized for another trust boundary;
+- fail closed before invocation when required input minimization/inspection cannot be completed;
+- emit safe typed evidence for provider-input release/minimization without persisting raw matched sensitive values;
 - stable safe reason paths for denial/constraint decisions;
 - typed evidence sufficient for downstream projection/reconstruction.
 
@@ -24,7 +31,12 @@ Resolve classification, concrete provider-deployment trust topology, and effecti
 - rich classification UX/ML classification;
 - Governance Vocabulary/Facts public foundation;
 - broad policy simulation/authoring;
-- policy DSL redesign.
+- policy DSL redesign;
+- a generalized enterprise DLP product spanning every application, tool, telemetry, storage, and learning boundary;
+- enterprise DLP-vendor integrations, vault-backed tokenization, or organization-wide discovery/classification products;
+- redesigning existing model-output/tool-result DLP unless compatibility work is required to preserve one coherent boundary model.
+
+The 0.7 mandatory slice is the missing **provider-request** release/minimization boundary. Later releases may generalize the same source → destination trust-boundary semantics to tool invocation, observability, learning capture, and external DLP integrations without inventing a second policy engine.
 
 ## Core invariants
 
@@ -34,24 +46,40 @@ explicit stronger classification is not silently downgraded
 provider brand != proof of trust/residency/locality
 organization ∩ environment ∩ workload = effective policy
 lower scope cannot widen higher-level denial
+
+provider invocation requires an explicit data-release outcome
+providerBoundInput = projection(canonicalInput, selectedDeployment, effectivePolicy)
+providerBoundInput transformation never mutates canonicalInput
+fallback to a different deployment => derive a new providerBoundInput
+required minimization/inspection failure => no provider invocation
+safe evidence never contains raw matched sensitive values
 ```
+
+The provider-input release decision is distinct from provider authorization. A provider may be authorized for a workload while policy still requires minimization of particular data before that concrete invocation.
 
 ## Tasks
 
 | ID | Candidate | Required result |
 |---|---|---|
-| 0.7.2a | Baseline classification/policy audit | Characterize existing classifiers, routing policy, provider metadata and trust assumptions |
+| 0.7.2a | Baseline classification/policy/data-boundary audit | Characterize existing classifiers, routing policy, provider metadata, trust assumptions, current output/tool-result DLP, and the missing provider-request release boundary |
 | 0.7.2b | Provider deployment + named zone contract | Introduce/normalize deployment identity and named-zone/category association |
 | 0.7.2c | Classification-before-exposure integration | Move/guard orchestration ordering so required classification precedes eligibility/exposure |
-| 0.7.2d | Restrictive policy composition | Deterministic org/environment/workload intersection with no widening path |
-| 0.7.2e | Missing/unknown semantics | Fail-closed behavior where classification/topology is required |
-| 0.7.2f | Reason/evidence model | Stable safe reasons for classification/trust/policy outcomes |
-| 0.7.2g | Adversarial/TCK/mutation proof | Prove ordering, no downgrade, no brand trust, no widening |
-| 0.7.2h | Integration/docs | Final cross-module docs/evidence and Epic gate |
+| 0.7.2d | Provider-input data-release/minimization contract | Define canonical input vs provider-bound projection, typed release outcomes, fail-closed transformation semantics, provider-specific recomputation, and safe evidence |
+| 0.7.2e | Restrictive policy composition | Deterministic org/environment/workload intersection with no widening path; provider-input release obligations derive from the same effective policy authority |
+| 0.7.2f | Missing/unknown/failure semantics | Fail closed where classification/topology or required provider-input minimization/inspection is unavailable |
+| 0.7.2g | Reason/evidence model | Stable safe reasons for classification/trust/policy/data-release outcomes without raw sensitive values |
+| 0.7.2h | Adversarial/TCK/mutation proof | Prove ordering, no downgrade, no brand trust, no widening, no pre-release invocation, no cross-provider projection reuse, and no fail-open sanitizer path |
+| 0.7.2i | Integration/docs | Final cross-module docs/evidence and Epic gate |
 
 ## Acceptance criteria
 
 - No policy-required request reaches an ineligible provider before classification resolves.
+- No provider invocation occurs before the selected deployment has an explicit provider-input data-release outcome.
+- When policy requires minimization, only the transformed provider-bound projection crosses the provider boundary.
+- Canonical/authoritative workload input remains unchanged by provider-specific minimization.
+- Changing provider deployment through fallback/retry causes a fresh release/minimization decision and projection for that deployment.
+- Required minimization/inspection failure cannot silently fall through to raw provider invocation.
+- Data-release evidence exposes stable rule/reason metadata while excluding raw matched sensitive values.
 - Concrete provider deployments, not brands, carry trust-zone assignment.
 - Lower scope cannot authorize something denied above it.
 - Missing required classification/topology cannot silently become permissive.
@@ -59,8 +87,8 @@ lower scope cannot widen higher-level denial
 
 ## Adversarial proof
 
-Reject implementations that classify after exposure, downgrade an explicit strong class, infer EU/local trust from vendor name, union policies instead of intersecting them, or treat unknown as allow.
+Reject implementations that classify after exposure, downgrade an explicit strong class, infer EU/local trust from vendor name, union policies instead of intersecting them, treat unknown as allow, invoke the provider before the release/minimization decision, mutate canonical input in place, reuse an OpenAI-authorized/minimized projection after fallback to a different provider deployment, expose raw matched values in evidence, or pass raw input through when required DLP/minimization fails.
 
 ## Mutation expectations
 
-High-value mutations: intersection→union, deny→allow default, comparison weakening, classification ordering bypass, explicit-class precedence removal.
+High-value mutations: intersection→union, deny→allow default, comparison weakening, classification ordering bypass, explicit-class precedence removal, provider-release checkpoint bypass, release outcome `DENY`→`ALLOW_RAW`, minimization failure→pass-through, selected-deployment identity ignored during projection derivation, and canonical-input aliasing that allows in-place mutation.

--- a/docs/roadmap/0.7.0/QUALITY-GATES.md
+++ b/docs/roadmap/0.7.0/QUALITY-GATES.md
@@ -14,6 +14,10 @@ Prove:
 
 - workload/configuration/run identity has one authoritative source;
 - classification required by policy occurs before provider exposure;
+- provider authorization and provider-input data release/minimization are explicit distinct decisions;
+- every selected provider invocation has an explicit data-release outcome before content crosses that deployment boundary;
+- provider-bound input is derived from canonical input + selected deployment + effective policy without mutating canonical workload state;
+- fallback/retry to a different deployment recomputes the provider-bound projection under that deployment's policy instead of reusing a prior projection;
 - lower policy scopes cannot widen higher-level denial;
 - authorization, viability, and selection remain separate;
 - privileged controls cross server-side authorization/runtime authority;
@@ -25,6 +29,8 @@ Required negative cases include, where applicable:
 
 - missing/unknown classification;
 - missing/unknown provider deployment/trust zone;
+- missing provider-input release decision;
+- required provider-input minimization/inspection failure;
 - stale version/precondition;
 - reordered/duplicate evidence;
 - unavailable projection source;
@@ -44,6 +50,10 @@ Generic control-plane/query/telemetry surfaces do not expose by default:
 - document bodies;
 - equivalent protected payloads.
 
+Provider-bound content obeys the selected deployment's effective data-release policy. When policy requires minimization, raw protected values must not cross the provider boundary merely because the provider itself is otherwise authorized.
+
+Provider-input release/minimization evidence must contain safe rule/reason metadata only; raw matched sensitive values are not valid evidence fields.
+
 Explicit payload surfaces, if any are required, need separate authorization and tests.
 
 ## G4 — Compatibility
@@ -51,28 +61,36 @@ Explicit payload surfaces, if any are required, need separate authorization and 
 - Public API changes obey existing compatibility policy.
 - Cross-provider/store/module contracts use TCK/contract tests where appropriate.
 - Structured reason/evidence IDs are deterministic and intentionally versioned.
-- 0.7 implementation does not couple core semantics to future DSL, vendor IdP, dashboard, or deployment packaging.
+- 0.7 implementation does not couple core semantics to future DSL, vendor IdP, dashboard, deployment packaging, or a specific enterprise DLP vendor.
+- The provider-request data-release boundary must preserve a seam for later tool-invocation, observability, learning-capture, and external-DLP integrations without requiring a second policy engine.
 
 ## G5 — Adversarial proof
 
 Every high-value invariant must have a discriminator that fails if the semantic rule is weakened. Examples:
 
 ```text
-classify-after-exposure      => FAIL
-lower-scope policy widening  => FAIL
-selected outside authorized  => FAIL
-UI-only authorization        => FAIL
-resume after cancellation    => FAIL
-reconstruction side effect   => FAIL
+classify-after-exposure       => FAIL
+provider-call-before-release  => FAIL
+required-minimization-bypass  => FAIL
+cross-provider projection reuse => FAIL
+canonical-input mutation      => FAIL
+lower-scope policy widening   => FAIL
+selected outside authorized   => FAIL
+UI-only authorization         => FAIL
+resume after cancellation     => FAIL
+reconstruction side effect    => FAIL
 ```
 
 ## G6 — Mutation proof
 
 Use mutation testing selectively for authority/correctness semantics where a plausible one-line mutation could bypass a rule. Surviving relevant mutants require either stronger proof or an explicit justified classification.
 
+For provider-input release/minimization, prioritize mutations that remove the pre-invocation checkpoint, convert deny to allow, convert required-transform failure to raw pass-through, ignore selected-deployment identity, or permit in-place mutation/aliasing of canonical input.
+
 ## G7 — Determinism & reconstruction
 
 - reason/evidence output used for authority is deterministic for the same authoritative input;
+- provider-bound projection semantics are deterministic for the same canonical input, selected deployment, effective policy/configuration, and deterministic transformer set;
 - projections are idempotent;
 - ordering/version semantics are explicit;
 - reconstruction never invokes provider/tool/approval/network/workflow side effects;
@@ -94,6 +112,8 @@ Before `epic/0.7.x → release/0.7.0`:
 Before `release/0.7.0 → master`, run the complete repository/release verification at the exact candidate head, including all existing release-critical lanes plus:
 
 - reference governed-control-plane scenario;
+- provider-input release/minimization scenario proving raw-vs-minimized policy behavior across at least two trust/deployment contexts;
+- provider fallback/retry scenario proving the provider-bound projection is recomputed for the new deployment;
 - persisted suspended-run cancellation scenario;
 - dashboard/headless parity for supported operations;
 - safe payload exposure checks;

--- a/docs/roadmap/0.7.0/README.md
+++ b/docs/roadmap/0.7.0/README.md
@@ -15,9 +15,11 @@ The roadmap defines **what** ships. This directory defines **how 0.7.0 is execut
 Supported-profile loop:
 
 ```text
-identify → classify → constrain → authorize → select → execute
+identify → classify → constrain → authorize → select → release → execute
         → evidence → observe → control → reconstruct
 ```
+
+`release` is the provider-input data-release decision: what exact provider-bound representation may cross into the selected provider deployment. It is separate from provider authorization.
 
 ## Working model
 
@@ -43,7 +45,7 @@ See [`WAY-OF-WORKING.md`](WAY-OF-WORKING.md).
 | Epic | Outcome | Dependency | Status |
 |---|---|---|---|
 | [0.7.1](EPIC-0.7.1-CONTROL-PLANE-AUTHORITY.md) | Authoritative control-plane/workload identity boundary | — | 🟡 Active |
-| [0.7.2](EPIC-0.7.2-POLICY-TRUST-ZONES.md) | Classification-before-exposure, named trust topology, restrictive policy | 0.7.1 soft | ⚪ Planned |
+| [0.7.2](EPIC-0.7.2-POLICY-TRUST-ZONES.md) | Classification-before-exposure, named trust topology, restrictive policy, governed provider-input release/minimization | 0.7.1 soft | ⚪ Planned |
 | [0.7.3](EPIC-0.7.3-AUTHORIZED-SELECTION.md) | Explainable authorized/viable/selected provider-model decision | 0.7.2 hard | ⚪ Planned |
 | [0.7.4](EPIC-0.7.4-EVIDENCE-PROJECTION.md) | Typed governance evidence + authoritative read model/query API | 0.7.1 hard; 0.7.2/3 soft | ⚪ Planned |
 | [0.7.5](EPIC-0.7.5-TIMELINE-RECONSTRUCTION.md) | Semantic timeline + side-effect-free forensic reconstruction | 0.7.4 hard | ⚪ Planned |
@@ -57,7 +59,7 @@ Status values: `⚪ Planned` · `🟡 Active` · `🟣 Review` · `✅ Complete`
 
 ### Wave A — Governance foundations
 - 0.7.1 Control-plane authority & workload identity
-- 0.7.2 Classification, trust zones & restrictive policy
+- 0.7.2 Classification, trust zones, restrictive policy & provider-input release/minimization
 
 ### Wave B — Authoritative decisions
 - 0.7.3 Authorized provider/model selection
@@ -80,6 +82,11 @@ classification before provider exposure
 organization ∩ environment ∩ workload = effective policy
 selected ∈ viable
 viable ⊆ authorized
+provider invocation requires explicit data-release outcome
+providerBoundInput = projection(canonicalInput, selectedDeployment, effectivePolicy)
+provider-specific transformation never mutates canonicalInput
+provider-changing fallback => recompute providerBoundInput
+required minimization/inspection failure => no provider invocation
 cancelled(run) => no subsequent authoritative execution(run)
 reconstruction != re-execution
 Dashboard != policy authority
@@ -92,7 +99,7 @@ Dashboard != policy authority
 1. all eight Epic specs are satisfied;
 2. all Epic acceptance/adversarial proofs are green;
 3. [`QUALITY-GATES.md`](QUALITY-GATES.md) is green at the exact release head;
-4. the reference control-plane scenario and persisted-cancellation scenario pass end to end;
+4. the reference control-plane scenario, provider-input release/minimization scenario, and persisted-cancellation scenario pass end to end;
 5. no deferred 0.8/0.9/0.10 scope has leaked into the release without an explicit release-cut change;
 6. `release/0.7.0 → master` is a certification/promotion PR, not a first-time integration event.
 


### PR DESCRIPTION
## Purpose

Amend the authoritative 0.7.0 release boundary so TramAI governs not only **whether** a provider/model may be used, but also **what exact representation of governed input may cross into that concrete provider deployment**.

The current DLP contract is output/tool-result oriented. 0.7 already requires classification before provider exposure, trust-zone-aware routing, and restrictive policy, but it does not explicitly require a provider-request data-release/minimization checkpoint. That leaves a gap where an otherwise authorized provider could receive raw sensitive values even when policy should require minimization.

This PR closes that roadmap/spec gap before the 0.7 governance contracts harden.

## Scope

- Change class: documentation
- Files touched:
  - `docs/ROADMAP-0.7.0-RELEASE-CUT.md`
  - `docs/roadmap/0.7.0/EPIC-0.7.2-POLICY-TRUST-ZONES.md`
  - `docs/roadmap/0.7.0/QUALITY-GATES.md`
  - `docs/roadmap/0.7.0/README.md`

The 0.7 mandatory slice is intentionally narrow:

```text
canonical input
    ↓
classification / effective policy
    ↓
provider authorization + selection
    ↓
explicit provider-input data-release decision
    ↓
provider-specific projection/minimization
    ↓
provider invocation
```

Required semantics are equivalent to at least:

```text
DENY
ALLOW_RAW
ALLOW_WITH_MINIMIZATION
```

The exact public API/type shape remains an implementation decision for Epic 0.7.2.

## Behavioural Contract

No runtime behaviour changes in this PR; it changes the 0.7 release/spec contract.

The implementation required by the amended release cut must preserve these invariants:

```text
provider invocation requires an explicit data-release outcome
providerBoundInput = projection(canonicalInput, selectedDeployment, effectivePolicy)
provider-specific transformation never mutates canonicalInput
provider-changing fallback/retry => recompute providerBoundInput
required minimization/inspection failure => no provider invocation
safe evidence never contains raw matched sensitive values
```

Provider authorization and provider-input data release are explicitly separate decisions.

## Architecture Impact

- [x] No new dependency edge introduced by this documentation-only change
- [x] Core does not depend on an adapter/framework
- [x] No runtime ownership/lifecycle change in this PR
- [x] No global mutable state introduced
- [x] No duplicate runtime authority introduced

The amended architecture requires provider-input release/minimization obligations to derive from the **same effective policy authority** used for classification/trust/routing. It explicitly rejects a second DLP policy engine.

The canonical/authoritative workload input is separated conceptually from provider-specific projections so future tool-invocation, observability, learning-capture, and enterprise DLP work can reuse the trust-boundary model without mutating execution authority.

## Compatibility

- [x] Stable public API unchanged
- [x] Preview API unchanged
- [x] Persisted representation unchanged
- [x] Event/reason/error code unchanged
- [x] Configuration semantics unchanged

Future Epic 0.7.2 implementation must preserve compatibility with the current model-output/tool-result DLP contract or provide an explicit reviewed migration path if public contracts need to evolve.

## Correctness & Concurrency

- [x] Cancellation behaviour unaffected by this PR
- [x] Retry behaviour unchanged in this PR; future semantics are clarified so provider-changing retry/fallback must recompute the provider-bound projection
- [x] Concurrency unaffected by this PR
- [x] Evidence/audit/telemetry emission unchanged in this PR; future safe evidence requirements are specified
- [x] Change is replay-safe because it changes documentation/specification only

Required future adversarial proof now includes:

- provider invocation before release decision → fail;
- required minimization failure falling through to raw invocation → fail;
- provider-specific transformation mutating canonical input → fail;
- provider-bound projection reused after fallback to a different deployment → fail;
- raw DLP matches appearing in evidence → fail.

## Verification

- [x] Compared branch against `release/0.7.0`: exactly four documentation files changed
- [x] Branch is based directly on current `release/0.7.0` head `606b16b786426498e72f683dc781dee7dec0c82b`
- [ ] `./gradlew verifyPr`: not run from this connector session
- [ ] Documentation verification: left to PR CI
- Specialized gates: not applicable to this documentation-only scope amendment

## Quality Impact

- [x] No baseline regeneration
- [x] No deviation ceiling increase
- [x] No quality gate weakened

`QUALITY-GATES.md` is strengthened with explicit provider-input release/minimization, fallback recomputation, fail-closed, evidence-safety, and mutation requirements.

## Cross-release boundary

This PR deliberately does **not** pull the full enterprise DLP product into 0.7:

- **0.7:** mandatory provider-request release/minimization boundary + evidence/invariants;
- **0.8:** governance authoring/simulation/debugging may preview what a provider would receive;
- **0.9:** enterprise DLP-vendor adapters, vault/tokenization integrations, deployment/security productization;
- **0.10:** apply the same minimization/data-release semantics to governed learning/evaluation capture.

## Remaining Risks

The main implementation-design question is whether the existing output-oriented `DlpInterceptor` should evolve into a broader boundary contract or whether provider-request release should use a new compatible abstraction. This PR intentionally does not pre-decide that API before the 0.7.2 baseline audit.

The implementation must also define precisely which provider-changing retries/fallbacks require reprojection and how deterministic transformation identity/configuration is represented in evidence.

## Non-Claims

This PR does **not**:

- implement provider-input DLP;
- generalize DLP to every tool/telemetry/storage boundary;
- add enterprise DLP integrations;
- redesign the existing output/tool-result DLP API;
- add new runtime, API, persistence, or configuration behaviour.

It makes the missing provider-input data-release/minimization boundary an explicit, testable **0.7.0 P0 requirement** owned by Epic 0.7.2.
